### PR TITLE
Allows for non-standard (not usr/local) homebrew base.

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -67,7 +67,7 @@ linux)
   PROTOC=${PROTOC:-third_party/protobuf/protoc.amd64}
   ;;
 darwin)
-  homebrew_header=$(ls -1 /usr/local/Cellar/libarchive/*/include/archive.h 2>/dev/null | head -n1)
+  homebrew_header=$(ls -1 `brew --prefix 2>/dev/null`/Cellar/libarchive/*/include/archive.h 2>/dev/null | head -n1)
   if [[ -e $homebrew_header ]]; then
     # For use with Homebrew.
     archive_dir=$(dirname $(dirname $homebrew_header))


### PR DESCRIPTION
The current compile.sh assumes that homebrew is installed to /usr/local - for various reasons, mine's installed to /opt/homebrew - this PR uses brew's own --prefix command to find nonstandard brew installations.
