### PR TITLE
initial checkin of sass_binary support for bazel.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -95,3 +95,17 @@ new_http_archive(
     sha256 = "aa76bb83c38b3f7495516eb08977fc9700c664d7a945ba3ac3c0004a6a8509f2",
     build_file = "tools/build_defs/d/dmd.BUILD",
 )
+
+new_http_archive(
+    name = "libsass",
+    url = "https://github.com/sass/libsass/archive/3.3.0-beta1.tar.gz",
+    sha256 = "6a4da39cc0b585f7a6ee660dc522916f0f417c890c3c0ac7ebbf6a85a16d220f",
+    build_file = "tools/build_defs/sass/libsass.BUILD",
+)
+
+new_http_archive(
+    name = "sassc",
+    url = "https://github.com/sass/sassc/archive/3.3.0-beta1.tar.gz",
+    sha256 = "87494218eea2441a7a24b40f227330877dbba75c5fa9014ac6188711baed53f6",
+    build_file = "tools/build_defs/sass/sassc.BUILD",
+)

--- a/examples/sass/hello_world/BUILD
+++ b/examples/sass/hello_world/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("/tools/build_defs/sass/sass", "sass_binary")
+
+# Import our shared colors and fonts so we can generate a CSS file.
+sass_binary(
+    name = "hello_world",
+    src = "main.scss",
+    deps = [
+         "//examples/sass/shared:colors",
+         "//examples/sass/shared:fonts",
+    ],
+)

--- a/examples/sass/hello_world/main.scss
+++ b/examples/sass/hello_world/main.scss
@@ -1,0 +1,12 @@
+@import "examples/sass/shared/fonts";
+@import "examples/sass/shared/colors";
+
+html {
+  body {
+    font-family: $default-font-stack;
+    h1 {
+      font-family: $modern-font-stack;
+      color: $example-red;
+    }
+  }
+}

--- a/examples/sass/shared/BUILD
+++ b/examples/sass/shared/BUILD
@@ -1,0 +1,14 @@
+package(default_visibility = ["//visibility:public"])
+
+# make a :colors target that any sass_binary rules can depend on.
+filegroup(
+    name = "colors",
+    srcs = ["_colors.scss"],
+)
+
+# make a :fonts target that any sass_binary rules can depend on.
+filegroup(
+    name = "fonts",
+    srcs = ["_fonts.scss"],
+)
+

--- a/examples/sass/shared/_colors.sass
+++ b/examples/sass/shared/_colors.sass
@@ -1,0 +1,5 @@
+// Colors that all Sass code can share.
+
+$example-blue: #0000ff;
+$example-red: #ff0000;
+$example-green: #008000;

--- a/examples/sass/shared/_fonts.sass
+++ b/examples/sass/shared/_fonts.sass
@@ -1,0 +1,5 @@
+// Fonts that all Sass code can share.
+
+$default-font-stack: Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif;
+
+$modern-font-stack: Constantia, "Lucida Bright", Lucidabright, "Lucida Serif", Lucida, "DejaVu Serif", "Bitstream Vera Serif", "Liberation Serif", Georgia, serif;

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -24,6 +24,7 @@ filegroup(
     srcs = glob(["**"]) + [
         "//tools/build_defs/d:srcs",
         "//tools/build_defs/docker:srcs",
+        "//tools/build_defs/sass:srcs",
         "//tools/build_rules/appengine:srcs",
         "//tools/build_rules/closure:srcs",
         "//tools/build_rules/rust:srcs",

--- a/tools/build_defs/sass/BUILD
+++ b/tools/build_defs/sass/BUILD
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//tools:__pkg__"],
+)
+            
+filegroup(
+    name = "sassc",
+    srcs = ["@sassc//:sassc"],
+)

--- a/tools/build_defs/sass/README.md
+++ b/tools/build_defs/sass/README.md
@@ -1,0 +1,158 @@
+# Sass Rules for Bazel
+
+## Overview
+These build rules are used for building [Sass][sass] projects with Bazel.
+
+* [Setup](#setup)
+* [Basic Example](#basic-example)
+* [Reference](#reference)
+  * [`sass_binary`](#reference-sass_binary)
+
+[sass]: http://www.sass-lang.com
+
+<a name="setup"></a>
+## Setup
+To  use the Sass rules, simply copy the contents of `sass.WORKSPACE` to your own top level `WORKSPACE` file.
+
+<a name="basic-example"></a>
+## Basic Example
+Suppose you have the following directory structure for a simple Sass project:
+```
+[workspace]/
+    WORKSPACE
+    hello_world/
+        BUILD
+        main.scss
+    shared/
+        BUILD
+        _fonts.scss
+        _colors.scss
+```
+`shared/_fonts.scss`
+```scss
+$default-font-stack: Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", ser
+if;
+$modern-font-stack: Constantia, "Lucida Bright", Lucidabright, "Lucida Serif", Lucida, "DejaVu Serif", "Bitstream Vera Serif", "Liber
+ation Serif", Georgia, serif;
+```
+`shared/_colors.scss`
+```scss
+$example-blue: #0000ff;
+$example-red: #ff0000;
+```
+
+`shared/BUILD`
+```python
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "colors",
+    srcs = ["_colors.scss"],
+)
+
+filegroup(
+    name = "fonts",
+    srcs = ["_fonts.scss"],
+)
+```
+`hello_world/main.scss`:
+```scss
+@import "examples/sass/shared/fonts";
+@import "examples/sass/shared/colors";
+
+html {
+  body {
+    font-family: $default-font-stack;
+    h1 {
+      font-family: $modern-font-stack;
+      colors: $example-red;
+    }
+  }
+}
+```
+`hello_world/BUILD:`
+```python
+package(default_visibility = ["//visibility:public"])
+
+load("/tools/build_defs/sass/sass", "sass_binary")
+
+sass_binary(
+    name = "hello_world",
+    src = "main.scss",
+    deps = [
+         "//shared:colors",
+         "//shared:fonts",
+    ],
+)
+```
+Build the binary:
+```
+$ bazel build //hello_world
+INFO: Found 1 target...
+Target //hello_world:hello_world up-to-date:
+  bazel-bin/hello_world/hello_world.css
+  bazel-bin/hello_world/hello_world.css.map
+INFO: Elapsed time: 1.911s, Critical Path: 0.01s
+```
+
+<a name="reference"></a>
+## Build Rule Reference
+
+<a name="reference-sass_binary"></a>
+### `sass_binary`
+`sass_binary(name, src, deps=[], output_style="compressed")`
+Used to generate a CSS file (and CSS source map file) from a given `src`.
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <code>Name, required</code>
+        <p>A unique name for this rule.</p>
+        <p>
+          This name will also be used as the name of the generated CSS and source map file of
+          this rule.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>src</code></td>
+      <td>
+        <code>Main source file, required</code>
+        <p>The primary Sass source file that will be compiled to CSS.</p>
+        <p>
+        <code>sass_binary</code> assumes a 1:1 mapping of src to output CSS file (and source map).
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>deps</code></td>
+      <td>
+        <code>list of labels, optional</code>
+        <p></p>
+        <p>
+        Each target should be defined using a <code>filegroup</code> rule and should only include "_" prefixed files that are referenced via <code>@import</code> in the target's source file.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>output_style</code></td>
+      <td>
+        <code>string; optional</code>
+        <p>Defaults to <code>compressed</code>.</p>
+        <p>
+        Can be set to <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style">one of the following</a> output styles defined by <code>sassc</code>.
+        </p>
+      </td>
+    </tr>
+    </tbody>
+    </table>
+
+

--- a/tools/build_defs/sass/libsass.BUILD
+++ b/tools/build_defs/sass/libsass.BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["@sassc//:__pkg__"])
+
+BASE_DIR = "libsass-3.3.0-beta1/"
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+         BASE_DIR + "src/**/*.h*",
+         BASE_DIR + "src/**/*.c*",
+    ]),
+)

--- a/tools/build_defs/sass/sass.WORKSPACE
+++ b/tools/build_defs/sass/sass.WORKSPACE
@@ -1,0 +1,13 @@
+new_http_archive(
+    name = "libsass",
+    url = "https://github.com/sass/libsass/archive/3.3.0-beta1.tar.gz",
+    sha256 = "6a4da39cc0b585f7a6ee660dc522916f0f417c890c3c0ac7ebbf6a85a16d220f",
+    build_file = "tools/build_defs/sass/libsass.BUILD",
+)
+
+new_http_archive(
+    name = "sassc",
+    url = "https://github.com/sass/sassc/archive/3.3.0-beta1.tar.gz",
+    sha256 = "87494218eea2441a7a24b40f227330877dbba75c5fa9014ac6188711baed53f6",
+    build_file = "tools/build_defs/sass/sassc.BUILD",
+)

--- a/tools/build_defs/sass/sass.bzl
+++ b/tools/build_defs/sass/sass.bzl
@@ -1,0 +1,62 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SASS_FILETYPES = FileType([".sass", ".scss"])
+
+def _sass_binary_impl(ctx):
+    # Reference the sass compiler and define the default options
+    # that sass_binary uses.
+    sassc = ctx.file._sassc        
+    options = [
+        "--style={0}".format(ctx.attr.output_style),
+        "--sourcemap",
+    ]
+
+    # Dynamically include all dependencies as part of the options.
+    includes = set()
+    for dep in ctx.attr.deps:
+        for file in dep.files:
+            includes = includes | [file]
+    for include in includes:
+        options = options + ["-I={0}".format(include)]
+                             
+    ctx.action(
+        inputs = [sassc, ctx.file.src],
+        executable = sassc,
+        arguments = options + [ctx.file.src.path, ctx.outputs.css_file.path],
+        mnemonic = "SassCompiler",
+        outputs = [ctx.outputs.css_file, ctx.outputs.css_map_file],
+    )
+
+sass_binary = rule(
+    implementation = _sass_binary_impl,
+    attrs = {
+        "src": attr.label(
+            allow_files = SASS_FILETYPES,
+            mandatory = True,
+            single_file = True,
+        ),
+        "output_style": attr.string(default = "compressed"),
+        "deps": attr.label_list(allow_files = SASS_FILETYPES),
+        "_sassc": attr.label(
+            default = Label("//tools/build_defs/sass:sassc"),
+            executable = True,
+            single_file = True,
+        ),
+    },
+    outputs = {
+        "css_file": "%{name}.css",
+        "css_map_file": "%{name}.css.map",
+    },
+)

--- a/tools/build_defs/sass/sassc.BUILD
+++ b/tools/build_defs/sass/sassc.BUILD
@@ -1,0 +1,14 @@
+package(default_visibility = ["//tools/build_defs/sass:__pkg__"])
+
+BASE_DIR = "sassc-3.3.0-beta1/"
+
+cc_binary(
+    name = "sassc",
+    srcs = [
+        "@libsass//:srcs",
+        BASE_DIR + "sassc.c",
+    ],
+    linkopts = ["-ldl -lm"],
+    # TODO(perezd): Hack, is there a better way to reference this via libsass.BUILD?
+    includes = ["../libsass/libsass-3.3.0-beta1/include"],
+)

--- a/tools/build_defs/sass/test/BUILD
+++ b/tools/build_defs/sass/test/BUILD
@@ -1,0 +1,3 @@
+load("sass_rule_test", "sass_rule_test")
+
+sass_rule_test("//examples/sass")

--- a/tools/build_defs/sass/test/sass_rule_test.bzl
+++ b/tools/build_defs/sass/test/sass_rule_test.bzl
@@ -1,0 +1,31 @@
+load(
+    "/tools/build_defs/sass/sass",
+    "sass_binary",
+)
+
+load(
+    "/tools/build_rules/test_rules",
+    "success_target",
+    "successful_test",
+    "failure_target",
+    "failed_test",
+    "assert_",
+    "strip_prefix",
+    "expectation_description",
+    "check_results",
+    "load_results",
+    "analysis_results",
+    "rule_test",
+    "file_test",
+)
+
+def _sass_binary_test(package):
+    rule_test(
+        name = "hello_world_rule_test",
+        generates = ["hello_world.css", "hello_world.css.map"],
+        rule = package + "/hello_world:hello_world",
+    )
+
+def sass_rule_test(package):
+    """Issue simple tests on sass rules."""
+    _sass_binary_test(package)


### PR DESCRIPTION
This PR enables Bazel to generate CSS "binaries" from Sass source code.

Learn more about Sass, an extremely popular Stylesheet authoring tool, at http://www.sass-lang.com.