### PR TITLE
Extract MountMap to a top-level class.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/MountMap.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/MountMap.java
@@ -1,0 +1,52 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.sandbox;
+
+import com.google.common.collect.ForwardingMap;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A map that throws an exception when trying to replace a key (i.e. once a key gets a value,
+ * any additional attempt of putting a value on the same key will throw an exception).
+ */
+final class MountMap<K, V> extends ForwardingMap<K, V> {
+  final LinkedHashMap<K, V> delegate = new LinkedHashMap<>();
+
+  @Override
+  protected Map<K, V> delegate() {
+    return delegate;
+  }
+
+  @Override
+  public V put(K key, V value) {
+    V previousValue = get(key);
+    if (previousValue == null) {
+      return super.put(key, value);
+    } else if (previousValue.equals(value)) {
+      return value;
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Cannot mount both '%s' and '%s' onto '%s'", previousValue, value, key));
+    }
+  }
+
+  @Override
+  public void putAll(Map<? extends K, ? extends V> map) {
+    for (Entry<? extends K, ? extends V> entry : map.entrySet()) {
+      put(entry.getKey(), entry.getValue());
+    }
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedStrategyTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.fail;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.devtools.build.lib.sandbox.LinuxSandboxedStrategy.MountMap;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;


### PR DESCRIPTION
Extract MountMap to a top-level class for sharing with the upcoming OSX sandbox.

Change-Id: I26cf10accaa6f62014c65f41637a36fbeab42b0a