### PR TITLE
Added support for resources in the scala library/binary rules.

### DIFF
--- a/tools/build_defs/scala/scala.bzl
+++ b/tools/build_defs/scala/scala.bzl
@@ -62,7 +62,7 @@ jar cmf {manifest} {out} -C {out}_tmp .
 
 
 def _write_manifest(ctx):
-  cp = _scala_lib
+  cp = "/usr/share/java/scala-library.jar"
   manifest = "Class-Path: %s\n" % cp
   if getattr(ctx.attr, "main_class", ""):
     manifest += "Main-Class: %s\n" % ctx.attr.main_class


### PR DESCRIPTION
Deals with resources root dir the same way that java library/binary does (based on docs). Fixes #469.