### PR TITLE
Fix for 510 SIOCGIFINDEX undefined on Mac

### DIFF
--- a/src/main/tools/network-tools.c
+++ b/src/main/tools/network-tools.c
@@ -36,7 +36,8 @@ void BringupInterface(const char *name) {
   memset(&ifr, 0, sizeof(ifr));
   strncpy(ifr.ifr_name, name, IF_NAMESIZE);
 
-  CHECK_CALL(ioctl(fd, SIOCGIFINDEX, &ifr));
+  // Verify that name is valid.
+  CHECK_CALL(if_nametoindex(ifr.ifr_name));
 
   // Enable the interface
   ifr.ifr_flags |= IFF_UP;


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/510

This compiles with the assumption that all we were using SIOCGIFINDEX for was to verify
that the name was valid. I think the code as written before was actually wrong as the
index value, and the flags value for a ifreq structure actually shared memory, so we were
potentially setting flags that we didn't want to set based on the actual index returned.