### PR TITLE
Ignore the empty path when searching for python interpetor

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/stub_template.txt
@@ -11,6 +11,7 @@ PYTHON_BINARY = '%python_binary%'
 def SearchPath(name):
   search_path = os.getenv('PATH', os.defpath).split(os.pathsep)
   for directory in search_path:
+    if directory == '': continue
     path = os.path.join(directory, name)
     if os.path.exists(path):
       return path


### PR DESCRIPTION
Bazel mistakes local packages named `python` (i.e. python/BUILD) for the python interpreter when it searches the path. Which causes permission issues.

For example I get the following exception when using a docker rule

```
Traceback (most recent call last):
  File "bazel-out/host/bin/tools/build_defs/docker/build_layer", line 104, in <module>
    Main()
  File "bazel-out/host/bin/tools/build_defs/docker/build_layer", line 96, in Main
    os.execv(program, args)
OSError: [Errno 13] Permission denied: 'python'
```

This patch fixes it.