### PR TITLE
Improve the scala skylark rule: support macros, don't use system scalac

### DIFF
--- a/tools/build_defs/scala/WORKSPACE
+++ b/tools/build_defs/scala/WORKSPACE
@@ -1,0 +1,7 @@
+new_http_archive(
+    name = "scala",
+    strip_prefix = "scala-2.11.7",
+    sha256 = "ffe4196f13ee98a66cf54baffb0940d29432b2bd820bd0781a8316eec22926d0",
+    url = "http://downloads.typesafe.com/scala/2.11.7/scala-2.11.7.tgz",
+    build_file = "scala.BUILD",
+)

--- a/tools/build_defs/scala/scala.BUILD
+++ b/tools/build_defs/scala/scala.BUILD
@@ -1,0 +1,20 @@
+# scala.BUILD
+exports_files([
+  "bin/scala",
+  "bin/scalac",
+  "bin/scaladoc",
+  "lib/config-1.2.1.jar",
+  "lib/jline-2.12.1.jar",
+  "lib/kka-actor_2.11-2.3.10.jar",
+  "lib/scala-actors-2.11.0.jar",
+  "lib/scala-actors-migration_2.11-1.1.0.jar",
+  "lib/scala-compiler.jar",
+  "lib/scala-continuations-library_2.11-1.0.2.jar",
+  "lib/scala-continuations-plugin_2.11.7-1.0.2.jar",
+  "lib/scala-library.jar",
+  "lib/scala-parser-comscala-2.11.7/binators_2.11-1.0.4.jar",
+  "lib/scala-reflect.jar",
+  "lib/scala-swing_2.11-1.0.2.jar",
+  "lib/scala-xml_2.11-1.0.4.jar",
+  "lib/scalap-2.11.7.jar",
+])

--- a/tools/build_defs/scala/scala.bzl
+++ b/tools/build_defs/scala/scala.bzl
@@ -17,10 +17,6 @@
 
 _scala_filetype = FileType([".scala"])
 
-# TODO(bazel-team): Add local_repository to properly declare the dependency.
-_scala_library_path = "/usr/share/java/scala-library.jar"
-_scalac_path = "/usr/bin/scalac"
-
 def _adjust_resources_path(path):
   dir_1, dir_2, rel_path = path.partition("resources")
   if rel_path:
@@ -30,40 +26,49 @@ def _adjust_resources_path(path):
     return dir_1 + dir_2, rel_path
   return "", path
 
-def _compile(ctx, jars):
+def _compile(ctx, jars, buildijar):
   res_cmd = ""
   for f in ctx.files.resources:
     c_dir, res_path = _adjust_resources_path(f.path)
     change_dir = "-C " + c_dir if c_dir else ""
     res_cmd = "\njar uf {out} " + change_dir + " " + res_path
+  ijar_cmd = ""
+  if buildijar:
+    #ijar_cmd = "\n_bin/ijar {out} {ijar_out}".format(
+    ijar_cmd = "\n{ijar} {out} {ijar_out}".format(
+      ijar=ctx.file._ijar.path,
+      out=ctx.outputs.jar.path,
+      ijar_out=ctx.outputs.ijar.path)
   cmd = """
 set -e
 mkdir -p {out}_tmp
 {scalac} {scala_opts} {jvm_flags} -classpath "{jars}" $@ -d {out}_tmp
 # Make jar file deterministic by setting the timestamp of files
-touch -t 198001010000 $(find {out}_tmp)
+find {out}_tmp -exec touch -t 198001010000 {escape} \;
 touch -t 198001010000 {manifest}
 jar cmf {manifest} {out} -C {out}_tmp .
-""" + res_cmd
+""" + ijar_cmd + res_cmd
   cmd = cmd.format(
-      scalac=_scalac_path,
+      scalac=ctx.file._scalac.path,
       scala_opts=" ".join(ctx.attr.scalacopts),
       jvm_flags=" ".join(["-J" + flag for flag in ctx.attr.jvm_flags]),
       out=ctx.outputs.jar.path,
+      escape="{}", # just a hack here.
       manifest=ctx.outputs.manifest.path,
-      jars=":".join([j.path for j in jars]))
-
+      jars=":".join([j.path for j in jars]),)
+  outs = [ctx.outputs.jar]
+  if buildijar:
+    outs.extend([ctx.outputs.ijar])
   ctx.action(
       inputs=list(jars) + ctx.files.srcs + [ctx.outputs.manifest],
-      outputs=[ctx.outputs.jar],
+      outputs=outs,
       command=cmd,
       progress_message="scala %s" % ctx.label,
       arguments=[f.path for f in ctx.files.srcs])
 
-
 def _write_manifest(ctx):
-  cp = "/usr/share/java/scala-library.jar"
-  manifest = "Class-Path: %s\n" % cp
+  # TODO: I don't think this classpath is what you want
+  manifest = "Class-Path: %s\n" % ctx.file._scalalib.path
   if getattr(ctx.attr, "main_class", ""):
     manifest += "Main-Class: %s\n" % ctx.attr.main_class
 
@@ -85,42 +90,61 @@ java -cp {cp} {name} "$@"
       output=ctx.outputs.executable,
       content=content)
 
-
-def _collect_jars(ctx):
-  jars = set()
+def _collect_comp_run_jars(ctx):
+  compile_jars = set()
+  runtime_jars = set()
   for target in ctx.attr.deps:
-    if hasattr(target, "jar_files"):
-      jars += target.jar_files
-    elif hasattr(target, "java"):
-      jars += target.java.transitive_runtime_deps
-  return jars
-
+    if hasattr(target, "runtime_jar_files"):
+      runtime_jars += target.runtime_jar_files
+    if hasattr(target, "interface_jar_files"):
+      compile_jars += target.interface_jar_files
+    if hasattr(target, "java"):
+      runtime_jars += target.java.transitive_runtime_deps
+      #see JavaSkylarkApiProvider.java, this is just the compile-time deps
+      compile_jars += target.java.transitive_deps
+  return (compile_jars, runtime_jars)
 
 def _scala_library_impl(ctx):
-  jars = _collect_jars(ctx)
+  (cjars, rjars) = _collect_comp_run_jars(ctx)
   _write_manifest(ctx)
-  _compile(ctx, jars)
+  _compile(ctx, cjars, True)
 
-  jars += [ctx.outputs.jar]
+  cjars += [ctx.outputs.ijar]
+  rjars += [ctx.outputs.jar]
   runfiles = ctx.runfiles(
-      files = list(jars),
+      files = list(rjars),
       collect_data = True)
   return struct(
-      files=jars,
-      jar_files=jars,
+      runtime_jar_files=rjars,
+      interface_jar_files=cjars,
       runfiles=runfiles)
 
+def _scala_macro_library_impl(ctx):
+  (cjars, rjars) = _collect_comp_run_jars(ctx)
+  _write_manifest(ctx)
+  _compile(ctx, cjars, False)
+
+  rjars += [ctx.outputs.jar]
+  # macro code needs to be available at compiletime
+  cjars += [ctx.outputs.jar]
+  runfiles = ctx.runfiles(
+      files = list(rjars),
+      collect_data = True)
+  return struct(
+      runtime_jar_files=rjars,
+      interface_jar_files=cjars,
+      runfiles=runfiles)
 
 def _scala_binary_impl(ctx):
-  jars = _collect_jars(ctx)
+  (cjars, rjars) = _collect_comp_run_jars(ctx)
   _write_manifest(ctx)
-  _compile(ctx, jars)
+  _compile(ctx, cjars, False)
 
-  jars += [ctx.outputs.jar]
-  _write_launcher(ctx, jars)
+  rjars += [ctx.outputs.jar, ctx.file._scalalib]
+  _write_launcher(ctx, rjars)
 
   runfiles = ctx.runfiles(
-      files = list(jars) + [ctx.outputs.executable],
+      files = list(rjars) + [ctx.outputs.executable],
       collect_data = True)
   return struct(
       files=set([ctx.outputs.executable]),
@@ -139,6 +163,33 @@ scala_library = rule(
       "resources": attr.label_list(allow_files=True),
       "scalacopts": attr.string_list(),
       "jvm_flags": attr.string_list(),
+      "_ijar": attr.label(executable=True, default=Label("@bazel_tools//tools/jdk:ijar"), single_file=True, allow_files=True),
+      "_scalac": attr.label(executable=True, default=Label("@scala//:bin/scalac"), single_file=True, allow_files=True),
+      "_scalalib": attr.label(default=Label("@scala//:lib/scala-library.jar"), single_file=True, allow_files=True),
+      },
+  outputs={
+      "jar": "%{name}_deploy.jar",
+      "ijar": "%{name}_ijar.jar",
+      "manifest": "%{name}_MANIFEST.MF",
+      },
+)
+
+scala_macro_library = rule(
+  implementation=_scala_macro_library_impl,
+  attrs={
+      "main_class": attr.string(),
+      "srcs": attr.label_list(
+          allow_files=_scala_filetype,
+          non_empty=True),
+      "deps": attr.label_list(),
+      "data": attr.label_list(allow_files=True, cfg=DATA_CFG),
+      "resources": attr.label_list(allow_files=True),
+      "scalacopts": attr.string_list(),
+      "jvm_flags": attr.string_list(),
+      "_ijar": attr.label(executable=True, default=Label("@bazel_tools//tools/jdk:ijar"), single_file=True, allow_files=True),
+      "_scalac": attr.label(executable=True, default=Label("@scala//:bin/scalac"), single_file=True, allow_files=True),
+      "_scalalib": attr.label(default=Label("@scala//:lib/scala-library.jar"), single_file=True, allow_files=True),
+      "_scala-reflect": attr.label(default=Label("@scala//:lib/scala-reflect.jar"), single_file=True, allow_files=True),
       },
   outputs={
       "jar": "%{name}_deploy.jar",
@@ -158,6 +209,8 @@ scala_binary = rule(
       "resources": attr.label_list(allow_files=True),
       "scalacopts":attr.string_list(),
       "jvm_flags": attr.string_list(),
+      "_scalac": attr.label(executable=True, default=Label("@scala//:bin/scalac"), single_file=True, allow_files=True),
+      "_scalalib": attr.label(default=Label("@scala//:lib/scala-library.jar"), single_file=True, allow_files=True),
       },
   outputs={
       "jar": "%{name}_deploy.jar",

--- a/tools/build_defs/scala/test/BUILD
+++ b/tools/build_defs/scala/test/BUILD
@@ -1,4 +1,4 @@
-load("/tools/build_defs/scala/scala", "scala_binary", "scala_library")
+load("/scala", "scala_binary", "scala_library")
 
 # The examples below show how to combine Scala and Java rules.
 # ScalaBinary is the Scala equivalent of JavaBinary.


### PR DESCRIPTION
This is a step forward for a better scala rule.

1. It uses ijar to avoid recompiling downstream targets if there have been no API changes.
2. It supports scala macros somewhat (which can't be ijared because they have code that runs at compile time). You must use `scala_macro_library` for a target that includes macros.
3. It uses a scala version that is downloaded by bazel, not the system scalac.

Issues:
1. It does not yet support tests. I am thinking scalatest, which seems to be the most popular scala test framework, but it has a number of dependencies which will need to be added to WORKSPACE or perhaps we need a tgz file with all the binary deps, but then someone will need to maintain those.
2. The skylark code is bit duplicative. I'm not 100% sure what operations are supported on the data structures, so there are probably much cleaner ways to implement this code.