### PR TITLE
Clarify that add-apt-repository depends on software-common-properties

### DIFF
--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -31,6 +31,8 @@ $ sudo apt-get update
 $ sudo apt-get install oracle-java8-installer
 ```
 
+Note: You might need to `sudo apt-get install software-properties-common` if you don't have the `add-apt-repository` command. See [here](http://manpages.ubuntu.com/manpages/wily/man1/add-apt-repository.1.html).
+
 **Ubuntu Wily (15.10).** To install OpenJDK 8:
 
 ```


### PR DESCRIPTION
I got the "command not found" error for 'add-apt-repository' on a clean Ubuntu installation and I think that the docs can be friendlier if they specify this :)