### PR TITLE
fix custom search styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -338,3 +338,10 @@ colgroup .col-description {
 .blog-post .blog-post-meta {
   margin-bottom: 20px;
 }
+.gsc-control-cse *,
+.gsc-control-cse *:before,
+.gsc-control-cse *:after {
+  -webkit-box-sizing: content-box !important;
+  -moz-box-sizing: content-box !important;
+  box-sizing: content-box !important;
+}


### PR DESCRIPTION
Not sure if this needs to follow the steps in contributing but I've provided a CLA.

Currently the Bazel website fails to correctly render components of the custom search engine. This is a result of using bootstrap css alongside the custom search engine. 

This PR fixes the rendering errors:

**Search button:**

*Current:*
![screenshot 2015-12-16 22 36 23](https://cloud.githubusercontent.com/assets/74310/11863081/b51610bc-a445-11e5-839c-e9c5354baabc.png)

*Fixed:*
![screenshot 2015-12-16 22 37 22](https://cloud.githubusercontent.com/assets/74310/11863080/b511992e-a445-11e5-8cdb-f70723262dda.png)

**Order dropdown ( happens after you do a search )**

*Current:*
![screenshot 2015-12-16 22 36 28](https://cloud.githubusercontent.com/assets/74310/11863083/b519179e-a445-11e5-8d92-fb861574bb74.png)

*Fixed:*
![screenshot 2015-12-16 22 37 17](https://cloud.githubusercontent.com/assets/74310/11863082/b518b402-a445-11e5-9f9b-4b0e445ee416.png)

We ran into this in our own project and someone noted that bazel.io had the same rendering errors we did, so I thought a PR might be in order. 