### PR TITLE
Reset state before test_fetch

### DIFF
--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -500,6 +500,7 @@ EOF
 }
 
 function test_fetch() {
+  bazel clean --expunge || fail "Clean failed"
   serve_jar
 
   cat > WORKSPACE <<EOF


### PR DESCRIPTION
In general the external integration tests shouldn't need to reset state
between tests, but test_fetch is explicitly assuming a clean environment
to start off with. Fixes #769 (I think, I can't actually test it due to #770).

Change-Id: I63eef924c5b7bff3225c6b67a300d57a7675aeda