### PR TITLE
Turn off wrapping for debian package depends

### DIFF
--- a/tools/build_defs/pkg/make_deb.py
+++ b/tools/build_defs/pkg/make_deb.py
@@ -23,6 +23,12 @@ import time
 
 from third_party.py import gflags
 
+# TODO (ajorgensen): Wrapping does not take into account - characters and can split
+# dependencies rendering the control file invalid. The wrapping
+# should be fixed to take this into account for Depends,
+# Recommends, Suggests, and Enhances. The wrapping has been
+# temporarily turned off for these.
+
 # list of debian fields : (name, mandatory, wrap[, default])
 # see http://www.debian.org/doc/debian-policy/ch-controlfields.html
 DEBIAN_FIELDS = [
@@ -32,9 +38,9 @@ DEBIAN_FIELDS = [
     ('Priority', False, False, 'optional'),
     ('Architecture', True, False, 'all'),
     ('Depends', False, False, []),
-    ('Recommends', False, True, []),
-    ('Suggests', False, True, []),
-    ('Enhances', False, True, []),
+    ('Recommends', False, False, []),
+    ('Suggests', False, False, []),
+    ('Enhances', False, False, []),
     ('Pre-Depends', False, True, []),
     ('Installed-Size', False, False),
     ('Maintainer', True, False),

--- a/tools/build_defs/pkg/make_deb.py
+++ b/tools/build_defs/pkg/make_deb.py
@@ -31,7 +31,7 @@ DEBIAN_FIELDS = [
     ('Section', False, False, 'contrib/devel'),
     ('Priority', False, False, 'optional'),
     ('Architecture', True, False, 'all'),
-    ('Depends', False, True, []),
+    ('Depends', False, False, []),
     ('Recommends', False, True, []),
     ('Suggests', False, True, []),
     ('Enhances', False, True, []),


### PR DESCRIPTION
Wrapping can split on `-` characters which creates the chance that any
dependency with a `-` in it that falls near the wrap threshold will get
split along two lines and render the control file invalid.

Resolves https://github.com/bazelbuild/bazel/issues/772