### PR TITLE
Dont break long words for debian control fields

### DIFF
--- a/tools/build_defs/pkg/make_deb.py
+++ b/tools/build_defs/pkg/make_deb.py
@@ -101,7 +101,7 @@ def MakeDebianControlField(name, value, wrap=False):
     value = ', '.join(value)
   if wrap:
     result += ' '.join(value.split('\n'))
-    result = textwrap.fill(result, break_long_words=False)
+    result = textwrap.fill(result, break_on_hyphens=False, break_long_words=False)
   else:
     result += value
   return result.replace('\n', '\n ') + '\n'

--- a/tools/build_defs/pkg/make_deb.py
+++ b/tools/build_defs/pkg/make_deb.py
@@ -101,7 +101,7 @@ def MakeDebianControlField(name, value, wrap=False):
     value = ', '.join(value)
   if wrap:
     result += ' '.join(value.split('\n'))
-    result = textwrap.fill(result)
+    result = textwrap.fill(result, break_long_words=False)
   else:
     result += value
   return result.replace('\n', '\n ') + '\n'


### PR DESCRIPTION
By default wrapping can split on `-` characters which creates the chance that any
dependency with a `-` in it that falls near the wrap threshold will get
split along two lines and render the control file invalid.

> Text is preferably wrapped on whitespaces and right after the hyphens
> in hyphenated words; only then will long words be broken if necessary,
> unless TextWrapper.break_long_words is set to false.
https://docs.python.org/3.1/library/textwrap.html#textwrap.TextWrapper.break_long_words

This supersede https://github.com/bazelbuild/bazel/pull/773 and closes https://github.com/bazelbuild/bazel/issues/772