### PR TITLE
Use general java jdk dependency for bazel debian package

### DIFF
--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -167,12 +167,10 @@ pkg_deb(
     data = ":debian-data",
     depends = select({
         ":jdk7": [
-            "openjdk-7-jdk",
-            "openjdk-7-source",
+            "java7-jdk",
         ],
         "//conditions:default": [
-            "openjdk-8-jdk",
-            "openjdk-8-source",
+            "java8-jdk",
         ],
     }) + [
         "pkg-config",


### PR DESCRIPTION
Using java8-jdk will match both openjdk-8-jdk and oracle-java8-jdk similarly with java7-jdk. If
either of them are installed on the system allowing bazel to be installed in either case. Also the jdk source is not needed to create the bazel deb pacakge.