### PR TITLE
Fix include for the cpp example on the website

### DIFF
--- a/site/docs/cpp.md
+++ b/site/docs/cpp.md
@@ -251,7 +251,7 @@ Then create a BUILD file for your tests:
 cc_test(
     name = "my_test",
     srcs = ["my_test.cc"],
-    copts = ["-Iexternal/gtest"],
+    copts = ["-Iexternal/gtest/include"],
     deps = ["@gtest//:main"],
 )
 ```


### PR DESCRIPTION
The precedent commit of this file fix the same problem for the compilation of Gtest, this one correct the same issue (headers are in the /include directory) for the Google Test example.

Fix issue : https://groups.google.com/forum/#!topic/bazel-discuss/xPe-oaqWZ6s