### PR TITLE
Docs: fix minor typo

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPyRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPyRuleClasses.java
@@ -60,7 +60,7 @@ public final class BazelPyRuleClasses {
           These can be
           <a href="#py_binary"><code>py_binary</code></a> rules,
           <a href="#py_library"><code>py_library</code></a> rules or
-          <a href="c-cpp.html#cc_library"><code>cc_library</code></a> rules,
+          <a href="c-cpp.html#cc_library"><code>cc_library</code></a> rules.
           <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
           .override(builder.copy("deps")
               .allowedRuleClasses(ALLOWED_RULES_IN_DEPS)

--- a/tools/build_defs/pkg/README.md
+++ b/tools/build_defs/pkg/README.md
@@ -160,7 +160,7 @@ Creates a tar file from a list of inputs.
         <code>List of files, optional</code>
         <p>File to add to the layer.</p>
         <p>
-          A list of files that should be included in the docker image.
+          A list of files that should be included in the tarball.
         </p>
       </td>
     </tr>


### PR DESCRIPTION
It also looks like the docs need to be rebuilt, because the thing I was originally looking to fix was fixed a few days ago in ab868ac09b06705ea6a60348ff440bf19edcc636.