### PR TITLE
Load `appengine_war` rule in `BUILD`

### DIFF
--- a/site/docs/tutorial/backend-server.md
+++ b/site/docs/tutorial/backend-server.md
@@ -222,6 +222,8 @@ for the `main_class` attribute.
 Add the following to your `BUILD` file:
 
 ```python
+load("/tools/build_rules/appengine/appengine", "appengine_war")
+
 appengine_war(
     name = "backend",
     data = [":webapp"],


### PR DESCRIPTION
Because `appengine_war` is not defined by default, `bazel build` fails unless loading. It would be nice to add the code to load the rule in the tutorial.