### PR TITLE
Update buildenv.sh to detect aarch64 as ARM

### DIFF
--- a/scripts/bootstrap/buildenv.sh
+++ b/scripts/bootstrap/buildenv.sh
@@ -32,7 +32,7 @@ if [ "${MACHINE_TYPE}" = 'amd64' -o "${MACHINE_TYPE}" = 'x86_64' ]; then
 fi
 
 MACHINE_IS_ARM='no'
-if [ "${MACHINE_TYPE}" = 'arm' -o "${MACHINE_TYPE}" = 'armv7l' ]; then
+if [ "${MACHINE_TYPE}" = 'arm' -o "${MACHINE_TYPE}" = 'armv7l' -o "${MACHINE_TYPE}" = 'aarch64' ]; then
   MACHINE_IS_ARM='yes'
 fi
 


### PR DESCRIPTION
Update buildenv.sh to detect aarch64 as on Nvidias Jetson TX1 as ARM architecture. Final goal is to build tensorflow on jetson tx1