### PR TITLE
Building legal maven_jar names in generate_workspace.

### DIFF
--- a/src/tools/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/Rule.java
+++ b/src/tools/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/Rule.java
@@ -102,7 +102,7 @@ public final class Rule implements Comparable<Rule> {
    * A unique name for this artifact to use in maven_jar's name attribute.
    */
   public static String name(String groupId, String artifactId) {
-    return groupId + "_" + artifactId;
+    return groupId.replaceAll("[.-]", "_") + "_" + artifactId.replaceAll("[.-]", "_");
   }
 
   public Artifact getArtifact() {

--- a/src/tools/generate_workspace/src/test/java/com/google/devtools/build/workspace/WorkspaceFileGeneratorTest.java
+++ b/src/tools/generate_workspace/src/test/java/com/google/devtools/build/workspace/WorkspaceFileGeneratorTest.java
@@ -76,7 +76,7 @@ public class WorkspaceFileGeneratorTest {
         + "# " + pom + "\n\n\n"
         + "# com.google.appengine.demos:appengine-try-java:jar:1.0\n"
         + "maven_jar(\n"
-        + "    name = \"com.google.appengine_appengine-api-1.0-sdk\",\n"
+        + "    name = \"com_google_appengine_appengine_api_1_0_sdk\",\n"
         + "    artifact = \"com.google.appengine:appengine-api-1.0-sdk:1.9.20\",\n"
         + ")\n\n", new String(Files.readAllBytes(Paths.get(outputFile))));
     // We can't recursively fetch deps over the network.


### PR DESCRIPTION
generate_workspace was previously leaving '.'s and '-'s in the generated
maven_jar names. This change replaces those characters with '_'s.