### PR TITLE
Trim sha1 in generate_workspace.

### DIFF
--- a/src/tools/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/Rule.java
+++ b/src/tools/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/Rule.java
@@ -133,7 +133,7 @@ public final class Rule implements Comparable<Rule> {
         HttpURLConnection connection = (HttpURLConnection) new URL(jarSha1Url).openConnection();
         connection.setInstanceFollowRedirects(true);
         connection.connect();
-        this.sha1 = CharStreams.toString(new InputStreamReader(connection.getInputStream()));
+        this.sha1 = CharStreams.toString(new InputStreamReader(connection.getInputStream())).trim();
       } catch (IOException e) {
         handler.handle(Event.warn("Failed to download the sha1 at " + jarSha1Url));
       }


### PR DESCRIPTION
Sometimes, sha1 values in the generated maven rules contains newlines as
shown in the example below, which breaks the build.

maven_jar(
    name = "com_google_code_findbugs_jsr305",
    artifact = "com.google.code.findbugs:jsr305:1.3.9",
    sha1 = "40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf
",
)

This change fixes that.