### PR TITLE
Link to Maven coordinates in the maven_jar documentation.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/MavenJarRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/MavenJarRule.java
@@ -36,7 +36,7 @@ public class MavenJarRule implements RuleDefinition {
   public RuleClass build(Builder builder, RuleDefinitionEnvironment environment) {
     return builder
         /* <!-- #BLAZE_RULE(maven_jar).ATTRIBUTE(artifact) -->
-        A description of a Maven artifact.
+        A description of a Maven artifact using <a href="https://maven.apache.org/pom.html#Maven_Coordinates">Maven coordinates</a>.
 
         <p>These descriptions are of the form &lt;groupId&gt:&lt;artifactId&gt;:&lt;version&gt;,
         see <a href="#maven_jar_examples">the documentation below</a> for an example.


### PR DESCRIPTION
[Maven coordinates](https://maven.apache.org/pom.html#Maven_Coordinates) can be more sophisticated than we want to document here (alternate packaging/classifiers).

Specifically, I needed to link to `json-lib-2.4-jdk15.jar` at https://repo1.maven.org/maven2/net/sf/json-lib/json-lib/2.4/json-lib-2.4-jdk15.jar. In Maven, you'd refer to that like this:

```
<dependency>
  <groupId>net.sf.json-lib</groupId>
  <artifactId>json-lib</artifactId>
  <version>2.4</version>
  <classifier>jdk15</classifier>
</dependency>
```

It turns out that this works great in Bazel, too, if you use Maven coordinates.

```
maven_jar (
	name = "net.sf.json-lib_json-lib",
	artifact = "net.sf.json-lib:json-lib:jar:jdk15:2.4",
)
```

But it took me some effort to find it. Adding this link would have helped me, and will probably help somebody else, too.