### PR TITLE
Add allow_files to cookbook example for using a binary.

### DIFF
--- a/site/docs/skylark/cookbook.md
+++ b/site/docs/skylark/cookbook.md
@@ -309,7 +309,8 @@ concat = rule(
   attrs={
       "srcs": attr.label_list(allow_files=True),
       "out": attr.output(mandatory=True),
-      "_merge_tool": attr.label(executable=True, default=Label("//pkg:merge"))
+      "_merge_tool": attr.label(executable=True, allow_files=True,
+                                default=Label("//pkg:merge"))
   }
 )
 ```


### PR DESCRIPTION
The example implies that this works for an existing binary, but if the rule is a file then it doesn't work. This changes it so that users will know that the allow_files option exists and they likely want it in this case.