### PR TITLE
Fix issues with commit 650533fffccb97910338f335939de76922c9f679

### DIFF
--- a/tools/build_rules/closure/closure_js_binary.bzl
+++ b/tools/build_rules/closure/closure_js_binary.bzl
@@ -71,9 +71,8 @@ def _impl(ctx):
     srcs += dep.transitive_js_srcs
 
   args = [
-      "--closure_entry_point=%s" % ctx.attr.main,
+      "--entry_point=goog:%s" % ctx.attr.main,
       "--js_output_file=%s" % ctx.outputs.out.path,
-      "--language_in=ECMASCRIPT5_STRICT",
       "--dependency_mode=LOOSE",
       "--warning_level=VERBOSE",
   ] + (["--js=%s" % src.path for src in srcs] +


### PR DESCRIPTION
Change --closure_entry_point to the new --entry_point that is required to be used with --dependency_mode.
    
Remove the default --language_in=ECMASCRIPT5_STRICT. Closure Compiler now defaults to ECMASCRIPT6.