### PR TITLE
Add missing instructions to Windows build docs

### DIFF
--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -15,7 +15,7 @@ To bootstrap Bazel on Windows, you will need:
 
 *    Java JDK 8 or later
 *    [msys2](https://msys2.github.io/) (need to be installed at ``C:\msys64\``).
-*    Several MSYS packages (gcc, git, curl): use ``pacman`` command
+*    Several MSYS packages (gcc, git, curl, zip, unzip): use ``pacman`` command
      to install those.
 
 To build Bazel:


### PR DESCRIPTION
The zip and unzip packages are required, but not installed by default on msys2.

~~Since compilation creates hard links, it needs admin privileges.~~