### PR TITLE
Add `-*- mode: python; -*- lines to .bzl files

### DIFF
--- a/scripts/packages/self_extract_binary.bzl
+++ b/scripts/packages/self_extract_binary.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Self-extracting binary.
 
 Generate a binary suitable for self-extraction:

--- a/src/test/java/com/google/devtools/build/lib/ideinfo/intellij_info.bzl
+++ b/src/test/java/com/google/devtools/build/lib/ideinfo/intellij_info.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_defs/d/d.bzl
+++ b/tools/build_defs/d/d.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_defs/docker/docker.bzl
+++ b/tools/build_defs/docker/docker.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_defs/dotnet/csharp.bzl
+++ b/tools/build_defs/dotnet/csharp.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_defs/groovy/groovy.bzl
+++ b/tools/build_defs/groovy/groovy.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_defs/jsonnet/jsonnet.bzl
+++ b/tools/build_defs/jsonnet/jsonnet.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_defs/pkg/pkg.bzl
+++ b/tools/build_defs/pkg/pkg.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_defs/sass/sass.bzl
+++ b/tools/build_defs/sass/sass.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_defs/sass/test/sass_rule_test.bzl
+++ b/tools/build_defs/sass/test/sass_rule_test.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_defs/scala/scala.bzl
+++ b/tools/build_defs/scala/scala.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/appengine/appengine.bzl
+++ b/tools/build_rules/appengine/appengine.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/closure/closure_js_binary.bzl
+++ b/tools/build_rules/closure/closure_js_binary.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/closure/closure_js_library.bzl
+++ b/tools/build_rules/closure/closure_js_library.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/closure/closure_repositories.bzl
+++ b/tools/build_rules/closure/closure_repositories.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/closure/closure_stylesheet_library.bzl
+++ b/tools/build_rules/closure/closure_stylesheet_library.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/closure/closure_template_library.bzl
+++ b/tools/build_rules/closure/closure_template_library.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/genproto.bzl
+++ b/tools/build_rules/genproto.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2014 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/go/def.bzl
+++ b/tools/build_rules/go/def.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2014 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/java_rules_skylark.bzl
+++ b/tools/build_rules/java_rules_skylark.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2014 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/py_rules.bzl
+++ b/tools/build_rules/py_rules.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2014 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/rust/rust.bzl
+++ b/tools/build_rules/rust/rust.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/rust/test/rust_rule_test.bzl
+++ b/tools/build_rules/rust/test/rust_rule_test.bzl
@@ -1,3 +1,5 @@
+# -*- mode: python; -*-
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/build_rules/test_rules.bzl
+++ b/tools/build_rules/test_rules.bzl
@@ -1,4 +1,4 @@
-"""Utilities for testing bazel."""
+# -*- mode: python; -*-
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Utilities for testing bazel."""
 
 ### First, trivial tests that either always pass, always fail,
 ### or sometimes pass depending on a trivial computation.


### PR DESCRIPTION
GitHub currently doesn't display any syntax highlighting for your `.bzl` files. So I fixed FTFY.

These comments tell GitHub what to do. They also instruct most editors, e.g. Emacs, on how to deal with these files. This saves people the trouble of having to configure them.