### PR TITLE
Fix bazel-j2objc repo name to use an underscore

### DIFF
--- a/third_party/java/j2objc/BUILD
+++ b/third_party/java/j2objc/BUILD
@@ -28,7 +28,7 @@ filegroup(
 
 java_library(
     name = "annotations",
-    srcs = ["@bazel-j2objc//:annotations"],
+    srcs = ["@bazel_j2objc//:annotations"],
 )
 
 objc_library(


### PR DESCRIPTION
I'm surprised your testing system didn't catch this.