### PR TITLE
Allow hyphen - in legal workspace names

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/WorkspaceFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/WorkspaceFactory.java
@@ -60,7 +60,7 @@ import javax.annotation.Nullable;
  */
 public class WorkspaceFactory {
   public static final String BIND = "bind";
-  private static final Pattern LEGAL_WORKSPACE_NAME = Pattern.compile("^\\p{Alpha}\\w*$");
+  private static final Pattern LEGAL_WORKSPACE_NAME = Pattern.compile("^\\p{Alpha}(\\w|-)*$");
 
   // List of static function added by #addWorkspaceFunctions. Used to trim them out from the
   // serialized list of variables bindings.


### PR DESCRIPTION
I don't see how directories with a hyphen aren't legal workspaces.  Please consider adding support for names with hyphen in them to master or provide a reason why hyphen can't be used.