### PR TITLE
Update go tools to release 1.6

### DIFF
--- a/tools/build_rules/go/def.bzl
+++ b/tools/build_rules/go/def.bzl
@@ -399,14 +399,14 @@ filegroup(
 def go_repositories():
   native.new_http_archive(
     name=  "golang_linux_amd64",
-    url = "https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz",
+    url = "https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz",
     build_file_content = GO_TOOLCHAIN_BUILD_FILE,
-    sha256 = "2593132ca490b9ee17509d65ee2cd078441ff544899f6afb97a03d08c25524e7"
+    sha256 = "5470eac05d273c74ff8bac7bef5bad0b5abbd1c4052efbdbc8db45332e836b0b"
   )
 
   native.new_http_archive(
     name=  "golang_darwin_amd64",
-    url = "https://storage.googleapis.com/golang/go1.5.1.darwin-amd64.tar.gz",
+    url = "https://storage.googleapis.com/golang/go1.6.darwin-amd64.tar.gz",
     build_file_content = GO_TOOLCHAIN_BUILD_FILE,
-    sha256 = "e94487b8cd2e0239f27dc51e6c6464383b10acb491f753584605e9b28abf48fb"
+    sha256 = "8b686ace24c0166738fd9f6003503f9d55ce03b7f24c963b043ba7bb56f43000"
   )


### PR DESCRIPTION
This updates the golang tools to release 1.6 from 1.5.1
