### PR TITLE
strip remote workspace path from java resources

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHelper.java
@@ -109,6 +109,12 @@ public abstract class JavaHelper {
   public static PathFragment getJavaResourcePath(
       JavaSemantics semantics, RuleContext ruleContext, Artifact resource) {
     PathFragment rootRelativePath = resource.getRootRelativePath();
+
+    if (!resource.getOwner().getWorkspaceRoot().isEmpty()) {
+      PathFragment workspace = new PathFragment(resource.getOwner().getWorkspaceRoot());
+      rootRelativePath = rootRelativePath.relativeTo(workspace);
+    }
+
     if (!ruleContext.attributes().has("resource_strip_prefix", Type.STRING)
         || !ruleContext.attributes().isAttributeValueExplicitlySpecified("resource_strip_prefix")) {
       return semantics.getDefaultJavaResourcePath(rootRelativePath);


### PR DESCRIPTION
Resources in `java_library`s get the external repo path added to them, e.g., `foo` becomes `external/git_remote_repo/foo`. It needs to be removed, though I'm not sure this is the right way to strip it ...