### PR TITLE
Fix mismatch between docs and backend/BUILD in master in examples/tutorial.

### DIFF
--- a/site/docs/tutorial/backend-server.md
+++ b/site/docs/tutorial/backend-server.md
@@ -109,7 +109,7 @@ java_binary(
     srcs = glob(["src/main/java/**/*.java"]),
     main_class = "does.not.exist",
     deps = [
-        "//external:javax/servlet/api",
+        "@io_bazel_rules_appengine//appengine:javax.servlet.api",
     ],
 )
 ```


### PR DESCRIPTION
The tutorial is broken when using the original BUILD source copied from the docs, and this change fixes it.