### PR TITLE
Fixes apple tests

### DIFF
--- a/src/test/shell/bazel/bazel_apple_test.sh
+++ b/src/test/shell/bazel/bazel_apple_test.sh
@@ -28,6 +28,7 @@ fi
 
 function set_up() {
   copy_examples
+  IOS_SDK_VERSION=$(xcrun --sdk iphoneos --show-sdk-version)
 }
 
 function test_swift_library() {
@@ -35,8 +36,10 @@ function test_swift_library() {
   ln -sv ${workspace_file} WORKSPACE
 
   local swift_lib_pkg=examples/swift
-  assert_build_output ./bazel-bin/${swift_lib_pkg}/swift_lib.a ${swift_lib_pkg}:swift_lib
-  assert_build_output ./bazel-bin/${swift_lib_pkg}/swift_lib.swiftmodule ${swift_lib_pkg}:swift_lib
+  assert_build_output ./bazel-bin/${swift_lib_pkg}/swift_lib.a \
+      ${swift_lib_pkg}:swift_lib --ios_sdk_version=$IOS_SDK_VERSION
+  assert_build_output ./bazel-bin/${swift_lib_pkg}/swift_lib.swiftmodule \
+      ${swift_lib_pkg}:swift_lib --ios_sdk_version=$IOS_SDK_VERSION
 }
 
 run_suite "apple_tests"


### PR DESCRIPTION
The previous version took the default value of ios_sdk_version which is 8.4 and really old. 

This change makes it so the current installed Xcode's SDK version is always used.