### PR TITLE
Fixes the bazel_apple_test

### DIFF
--- a/src/test/shell/bazel/bazel_apple_test.sh
+++ b/src/test/shell/bazel/bazel_apple_test.sh
@@ -28,6 +28,7 @@ fi
 
 function set_up() {
   copy_examples
+  IOS_SDK_VERSION=$(xcrun --sdk iphoneos --show-sdk-version)
 }
 
 function test_swift_library() {
@@ -35,8 +36,10 @@ function test_swift_library() {
   ln -sv ${workspace_file} WORKSPACE
 
   local swift_lib_pkg=examples/swift
-  assert_build_output ./bazel-bin/${swift_lib_pkg}/swift_lib.a ${swift_lib_pkg}:swift_lib
-  assert_build_output ./bazel-bin/${swift_lib_pkg}/swift_lib.swiftmodule ${swift_lib_pkg}:swift_lib
+  assert_build_output ./bazel-bin/${swift_lib_pkg}/swift_lib.a \
+      ${swift_lib_pkg}:swift_lib --ios_sdk_version=$IOS_SDK_VERSION
+  assert_build_output ./bazel-bin/${swift_lib_pkg}/swift_lib.swiftmodule \
+      ${swift_lib_pkg}:swift_lib --ios_sdk_version=$IOS_SDK_VERSION
 }
 
 run_suite "apple_tests"

--- a/src/test/shell/bazel/bazel_apple_test.sh
+++ b/src/test/shell/bazel/bazel_apple_test.sh
@@ -28,7 +28,7 @@ fi
 
 function set_up() {
   copy_examples
-  IOS_SDK_VERSION=$(xcrun --sdk iphoneos --show-sdk-version)
+  setup_objc_test_support
 }
 
 function test_swift_library() {


### PR DESCRIPTION
Instead of default SDK version, use currently installed one.