### PR TITLE
fix Docker rules link in a simple way

### DIFF
--- a/site/faq.md
+++ b/site/faq.md
@@ -264,7 +264,7 @@ Can I build Docker images with Bazel?
 -------------------------------------
 
 Yes, you can use our
-[Docker rules](https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/docker/#readme)
+[Docker rules](http://bazel.io/docs/be/docker.html)
 to build reproducible Docker images.
 
 Will Bazel make my builds reproducible automatically?

--- a/site/faq.md
+++ b/site/faq.md
@@ -264,7 +264,7 @@ Can I build Docker images with Bazel?
 -------------------------------------
 
 Yes, you can use our
-[Docker rules](https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/docker/README.md)
+[Docker rules](https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/docker/#readme)
 to build reproducible Docker images.
 
 Will Bazel make my builds reproducible automatically?


### PR DESCRIPTION
Updates #1236

This doesn't fix the real problem (`README.md` seems to be turning into `README.html` during the render process), but, depending on how much time others have to look at the document generator, this might be worth submitting.