### PR TITLE
Fix a casting error in unix_jni that caused 32 bit builds to break

### DIFF
--- a/src/main/native/unix_jni.cc
+++ b/src/main/native/unix_jni.cc
@@ -862,7 +862,7 @@ extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_devtools_build_lib_unix_NativePosixSystem_sysctlbynameGetLong(
     JNIEnv *env, jclass clazz, jstring name) {
   const char *name_chars = GetStringLatin1Chars(env, name);
-  jlong r;
+  long r;
   size_t len = sizeof(r);
   if (portable_sysctlbyname(name_chars, &r, &len) == -1) {
     ::PostSystemException(env, errno, "sysctlbyname", name_chars);


### PR DESCRIPTION
Fixes #1254

Change-Id: Ie6138ed96ae031d72033e32fa1557b1fe27978b9