### PR TITLE
DO NOT SUBMIT - TEST ONLY

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -126,7 +126,11 @@ genrule(
     srcs = [
         ":create_embedded_tools.sh",
         "//tools:embedded_tools_srcs",
-        "//third_party:embedded_tools_srcs",
+        "//third_party/iossim:srcs",
+        "//third_party/py/concurrent:srcs",
+        "//third_party/py/gflags:srcs",
+        "//third_party/java/jarjar:srcs",
+        "//third_party/java/jdk/langtools:srcs",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper:srcs",
         "//src/tools/android/java/com/google/devtools/build/android:embedded_tools",
         "//src/tools/android/java/com/google/devtools/build/android/ideinfo:embedded_tools",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -26,24 +26,6 @@ filegroup(
 )
 
 filegroup(
-    name = "embedded_tools_srcs",
-    srcs = glob(["**"]) + [
-        "//third_party/ijar:srcs",
-        "//third_party/iossim:srcs",
-        "//third_party/java/apkbuilder:srcs",
-        "//third_party/java/buck-ios-support:srcs",
-        "//third_party/java/dd_plist:srcs",
-        "//third_party/java/j2objc:srcs",
-        "//third_party/java/jarjar:srcs",
-        "//third_party/java/jdk/langtools:srcs",
-        "//third_party/py/concurrent:srcs",
-        "//third_party/py/gflags:srcs",
-        "//third_party/py/mock:srcs",
-        "//third_party/py/six:srcs",
-    ],
-)
-
-filegroup(
     name = "d3-js",
     srcs = glob(["javascript/d3/**/*.js"]),
 )

--- a/third_party/iossim/BUILD
+++ b/third_party/iossim/BUILD
@@ -3,7 +3,10 @@ licenses(["notice"])  # 3-clause BSD
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
-    visibility = ["//third_party:__pkg__"],
+    visibility = [
+        "//src:__pkg__",
+        "//third_party:__pkg__",
+    ],
 )
 
 exports_files(["iossim"])

--- a/third_party/java/jarjar/BUILD
+++ b/third_party/java/jarjar/BUILD
@@ -5,7 +5,6 @@ licenses(["notice"])  # Apache 2.0
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
-    visibility = ["//third_party:__pkg__"],
 )
 
 java_import(

--- a/third_party/py/concurrent/BUILD
+++ b/third_party/py/concurrent/BUILD
@@ -3,7 +3,7 @@ licenses(["notice"])
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
-    visibility = ["//third_party:__pkg__"],
+    visibility = ["//visibility:public"],
 )
 
 py_library(

--- a/third_party/py/gflags/BUILD
+++ b/third_party/py/gflags/BUILD
@@ -3,7 +3,7 @@ licenses(["notice"])
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
-    visibility = ["//third_party:__pkg__"],
+    visibility = ["//visibility:public"],
 )
 
 py_library(


### PR DESCRIPTION
Remove a bunch of unnecessary files from the Bazel binary.

This reduces the size of the Bazel binary by ~25%.