### PR TITLE
Make ASTNode visibility consistent.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/DictionaryLiteral.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/DictionaryLiteral.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class DictionaryLiteral extends Expression {
 
-  static final class DictionaryEntryLiteral extends ASTNode {
+  public static final class DictionaryEntryLiteral extends ASTNode {
 
     private final Expression key;
     private final Expression value;
@@ -43,11 +43,11 @@ public class DictionaryLiteral extends Expression {
       this.value = value;
     }
 
-    Expression getKey() {
+    public Expression getKey() {
       return key;
     }
 
-    Expression getValue() {
+    public Expression getValue() {
       return value;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/syntax/IfStatement.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/IfStatement.java
@@ -39,7 +39,7 @@ public final class IfStatement extends Statement {
   /**
    * Syntax node for an [el]if statement.
    */
-  static final class ConditionalStatements extends Statement {
+  public static final class ConditionalStatements extends Statement {
 
     private final Expression condition;
     private final ImmutableList<Statement> stmts;
@@ -66,11 +66,11 @@ public final class IfStatement extends Statement {
       visitor.visit(this);
     }
 
-    Expression getCondition() {
+    public Expression getCondition() {
       return condition;
     }
 
-    ImmutableList<Statement> getStmts() {
+    public ImmutableList<Statement> getStmts() {
       return stmts;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/syntax/NotExpression.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/NotExpression.java
@@ -31,7 +31,7 @@ public class NotExpression extends Expression {
     this.expression = expression;
   }
 
-  Expression getExpression() {
+  public Expression getExpression() {
     return expression;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/syntax/ReturnStatement.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/ReturnStatement.java
@@ -59,7 +59,7 @@ public class ReturnStatement extends Statement {
     throw new ReturnException(returnExpression.getLocation(), returnExpression.eval(env));
   }
 
-  Expression getReturnExpression() {
+  public Expression getReturnExpression() {
     return returnExpression;
   }
 


### PR DESCRIPTION
Change DicttionaryEntryLiteral and ConditionalStatements to public, along with their child node getter methods, and a few other similar child node getters.

I'm working on a BUILD file formatter written around the SyntaxTreeVisitor, and came across these inconsistencies that make writing a visitor a little difficult. They seem like oversights so I'm proposing this change to fix them.