### PR TITLE
Make LValue an ASTNode.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/LValue.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/LValue.java
@@ -27,7 +27,6 @@ import net.bytebuddy.implementation.bytecode.ByteCodeAppender;
 import net.bytebuddy.implementation.bytecode.Removal;
 import net.bytebuddy.implementation.bytecode.constant.IntegerConstant;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -41,7 +40,7 @@ import java.util.List;
  *    for lvalue in exp: pass
  * An LValue can be a simple variable or something more complex like a tuple.
  */
-public class LValue implements Serializable {
+public class LValue extends ASTNode {
   private final Expression expr;
 
   public LValue(Expression expr) {
@@ -137,6 +136,11 @@ public class LValue implements Serializable {
               ident.getName()));
     }
     env.update(ident.getName(), result);
+  }
+
+  @Override
+  public void accept(SyntaxTreeVisitor visitor) {
+    visitor.visit(this);
   }
 
   void validate(ValidationEnvironment env, Location loc) throws EvalException {


### PR DESCRIPTION
Make LValue extend ASTNode, adding an accept(visitor) method.

I'm working on a BUILD file formatter written around the SyntaxTreeVisitor and was surprised when LValue didn't extend ASTNode. It doesn't have much overall effect, but LValue seems like it *should* be an ASTNode.