### PR TITLE
Add support for Hazelcast configuration file

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/HazelcastCacheFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/HazelcastCacheFactory.java
@@ -17,10 +17,12 @@ package com.google.devtools.build.lib.remote;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 
+import java.io.IOException;
 import java.util.concurrent.ConcurrentMap;
 
 /**
@@ -33,7 +35,14 @@ public final class HazelcastCacheFactory {
 
   public static ConcurrentMap<String, byte[]> create(RemoteOptions options) {
     HazelcastInstance instance;
-    if (options.hazelcastNode != null) {
+    if (options.hazelcastClientConfig != null) {
+      try {
+        ClientConfig config = new XmlClientConfigBuilder(options.hazelcastClientConfig).build();
+        instance = HazelcastClient.newHazelcastClient(config);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    } else if (options.hazelcastNode != null) {
       // If --hazelcast_node is then create a client instance.
       ClientConfig config = new ClientConfig();
       ClientNetworkConfig net = config.getNetworkConfig();

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -63,7 +63,7 @@ public final class RemoteModule extends BlazeModule {
     RemoteOptions options = buildRequest.getOptions(RemoteOptions.class);
 
     // Don't provide the remote spawn unless at least action cache is initialized.
-    if (actionCache == null && options.hazelcastNode != null) {
+    if (actionCache == null && (options.hazelcastNode != null || options.hazelcastClientConfig != null)) {
       MemcacheActionCache cache =
           new MemcacheActionCache(
               this.env.getDirectories().getExecRoot(),

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
@@ -30,6 +30,14 @@ public final class RemoteOptions extends OptionsBase {
   public String hazelcastNode;
 
   @Option(
+          name = "hazelcast_client_config",
+          defaultValue = "null",
+          category = "remote",
+          help = "A file path to a hazelcast client config XML file. For client mode only."
+  )
+  public String hazelcastClientConfig;
+
+  @Option(
     name = "hazelcast_standalone_listen_port",
     defaultValue = "0",
     category = "build_worker",


### PR DESCRIPTION
Hazelcast has a zillion settings you can set. This commit adds a `--hazelcast_client_config` option to allow the user to pass in a Hazelcast configuration file.