### PR TITLE
Split and extract the SHA1 from Maven files that have extra paths in them

### DIFF
--- a/src/tools/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/Resolver.java
+++ b/src/tools/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/Resolver.java
@@ -272,11 +272,15 @@ public class Resolver {
       HttpURLConnection connection = (HttpURLConnection) new URL(sha1Url).openConnection();
       connection.setInstanceFollowRedirects(true);
       connection.connect();
-      return CharStreams.toString(
-          new InputStreamReader(connection.getInputStream(), Charset.defaultCharset())).trim();
+      return extractSha1(CharStreams.toString(
+          new InputStreamReader(connection.getInputStream(), Charset.defaultCharset())));
     } catch (IOException e) {
       handler.handle(Event.warn("Failed to download the sha1 at " + sha1Url));
     }
     return null;
+  }
+
+  static String extractSha1(String sha1Contents) {
+    return sha1Contents.split("\\s+")[0];
   }
 }

--- a/src/tools/generate_workspace/src/test/java/com/google/devtools/build/workspace/maven/ResolverTest.java
+++ b/src/tools/generate_workspace/src/test/java/com/google/devtools/build/workspace/maven/ResolverTest.java
@@ -55,4 +55,17 @@ public class ResolverTest {
     Rule rule = rules.iterator().next();
     assertThat(rule.name()).isEqualTo("x_y");
   }
+
+  @Test
+  public void testExtractSha1() {
+    assertThat(Resolver.extractSha1("5fe28b9518e58819180a43a850fbc0dd24b7c050"))
+        .isEqualTo("5fe28b9518e58819180a43a850fbc0dd24b7c050");
+
+    assertThat(Resolver.extractSha1("5fe28b9518e58819180a43a850fbc0dd24b7c050\n"))
+        .isEqualTo("5fe28b9518e58819180a43a850fbc0dd24b7c050");
+
+    assertThat(Resolver.extractSha1(
+        "83cd2cd674a217ade95a4bb83a8a14f351f48bd0  /home/maven/repository-staging/to-ibiblio/maven2/antlr/antlr/2.7.7/antlr-2.7.7.jar"))
+        .isEqualTo("83cd2cd674a217ade95a4bb83a8a14f351f48bd0");
+  }
 }


### PR DESCRIPTION
This fixes #1461, which leads to bad sha1 values for some maven jars.