### PR TITLE
clarified needing to run generate_workspace from bazel source folder

### DIFF
--- a/site/docs/external.md
+++ b/site/docs/external.md
@@ -62,6 +62,8 @@ following to build the tool and see usage:
 bazel run //src/tools/generate_workspace
 ```
 
+Note that you need run this from your Bazel source folder even if you build your binary from source.  
+
 You can specify directories containing Bazel projects (i.e., directories
 containing a `WORKSPACE` file), Maven projects (i.e., directories containing a
 `pom.xml` file), or Maven artifact coordinates directly. For example:


### PR DESCRIPTION
Hi,
If you feel this is unnecessary please feel free to close this PR but it took me some time and @lberki's help to understand that even though I built the binary from source and I have the source cloned then I still need to run the command from the source folder so I added that note in.