### PR TITLE
WIP: Added support for null terminated queries

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/output/GraphOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/output/GraphOutputFormatter.java
@@ -41,20 +41,10 @@ import java.util.Set;
 class GraphOutputFormatter extends OutputFormatter {
 
   private int graphNodeStringLimit;
-  private final String lineTerminator;
 
-  public GraphOutputFormatter(final String lineTerminator) {
-    this.lineTerminator = lineTerminator;
-  }
-  
   @Override
   public String getName() {
     return "graph";
-  }
-  
-  @Override
-  public String getLineTerminator() {
-    return lineTerminator;
   }
 
   @Override
@@ -66,18 +56,18 @@ class GraphOutputFormatter extends OutputFormatter {
     if (options.graphFactored) {
       outputFactored(result, new PrintWriter(out), sortLabels);
     } else {
-      outputUnfactored(result, new PrintWriter(out), sortLabels);
+      outputUnfactored(result, new PrintWriter(out), sortLabels, options);
     }
   }
 
-  private void outputUnfactored(Digraph<Target> result, PrintWriter out, boolean sortLabels) {
+  private void outputUnfactored(Digraph<Target> result, PrintWriter out, boolean sortLabels, final QueryOptions options) {
     result.visitNodesBeforeEdges(
         new DotOutputVisitor<Target>(out, LABEL_STRINGIFIER) {
           @Override
           public void beginVisit() {
             super.beginVisit();
             // TODO(bazel-team): (2009) make this the default in Digraph.
-            out.printf("  node [shape=box];%s", getLineTerminator());
+            out.printf("  node [shape=box];%s", options.getLineTerminator());
           }
         },
         sortLabels ? new TargetOrdering() : null);

--- a/src/main/java/com/google/devtools/build/lib/query2/output/GraphOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/output/GraphOutputFormatter.java
@@ -41,10 +41,20 @@ import java.util.Set;
 class GraphOutputFormatter extends OutputFormatter {
 
   private int graphNodeStringLimit;
+  private final String lineTerminator;
 
+  public GraphOutputFormatter(final String lineTerminator) {
+    this.lineTerminator = lineTerminator;
+  }
+  
   @Override
   public String getName() {
     return "graph";
+  }
+  
+  @Override
+  public String getLineTerminator() {
+    return lineTerminator;
   }
 
   @Override
@@ -67,7 +77,7 @@ class GraphOutputFormatter extends OutputFormatter {
           public void beginVisit() {
             super.beginVisit();
             // TODO(bazel-team): (2009) make this the default in Digraph.
-            out.println("  node [shape=box];");
+            out.printf("  node [shape=box];%s", getLineTerminator());
           }
         },
         sortLabels ? new TargetOrdering() : null);

--- a/src/main/java/com/google/devtools/build/lib/query2/output/OutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/output/OutputFormatter.java
@@ -103,13 +103,21 @@ public abstract class OutputFormatter implements Serializable {
   public static ImmutableList<OutputFormatter> getDefaultFormatters() {
     return ImmutableList.of(
         new LabelOutputFormatter(false, LINE_TERM),
+        new LabelOutputFormatter(false, "\0"),
         new LabelOutputFormatter(true, LINE_TERM),
+        new LabelOutputFormatter(true, "\0"),
         new BuildOutputFormatter(LINE_TERM),
+        new BuildOutputFormatter("\0"),
         new MinrankOutputFormatter(LINE_TERM),
+        new MinrankOutputFormatter("\0"),
         new MaxrankOutputFormatter(LINE_TERM),
+        new MaxrankOutputFormatter("\0"),
         new PackageOutputFormatter(LINE_TERM),
+        new PackageOutputFormatter("\0"),
         new LocationOutputFormatter(LINE_TERM),
+        new LocationOutputFormatter("\0"),
         new GraphOutputFormatter(LINE_TERM),
+        new GraphOutputFormatter("\0"),
         new XmlOutputFormatter(),
         new ProtoOutputFormatter());
   }
@@ -123,19 +131,37 @@ public abstract class OutputFormatter implements Serializable {
           }
     }));
   }
+  
+  public static String escapeTerminator(String value) {
+		return value
+			.replace("\t", "\\t")
+			.replace("\n", "\\n")
+			.replace("\0", "\\0");
+  }
+  
+  public static String formatterTerminators(Iterable<OutputFormatter> formatters) {
+    return Joiner.on(", ").join(Iterables.transform(formatters,
+      new Function<OutputFormatter, String>() {
+        @Override
+        public String apply(OutputFormatter input) {
+          return escapeTerminator(input.getLineTerminator());
+        }
+    }));
+  }
 
   /**
-   * Returns the output formatter for the specified command-line options.
+   * Returns the output formatters for the specified command-line options.
    */
-  public static OutputFormatter getFormatter(
-      Iterable<OutputFormatter> formatters, String type, final String terminator) {
+  public static Iterable<OutputFormatter> getFormatters(
+      Iterable<OutputFormatter> formatters, String type) {
+    List<OutputFormatter> result = new ArrayList<OutputFormatter>();
     for (OutputFormatter formatter : formatters) {
-      if (formatter.getName().equals(type) && formatter.getLineTerminator().equals(terminator)) {
-        return formatter;
+      if (formatter.getName().equals(type)) {
+        result.add(formatter);
       }
     }
 
-    return null;
+    return result;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/query2/output/ProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/output/ProtoOutputFormatter.java
@@ -63,6 +63,10 @@ import java.util.Set;
  */
 public class ProtoOutputFormatter extends AbstractUnorderedFormatter {
 
+  public ProtoOutputFormatter() {
+    super(System.lineSeparator());
+  }
+
   /**
    * A special attribute name for the rule implementation hash code.
    */

--- a/src/main/java/com/google/devtools/build/lib/query2/output/ProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/output/ProtoOutputFormatter.java
@@ -63,10 +63,6 @@ import java.util.Set;
  */
 public class ProtoOutputFormatter extends AbstractUnorderedFormatter {
 
-  public ProtoOutputFormatter() {
-    super(System.lineSeparator());
-  }
-
   /**
    * A special attribute name for the rule implementation hash code.
    */
@@ -92,7 +88,7 @@ public class ProtoOutputFormatter extends AbstractUnorderedFormatter {
   }
 
   @Override
-  public OutputFormatterCallback<Target> createStreamCallback(final PrintStream out) {
+  public OutputFormatterCallback<Target> createStreamCallback(final PrintStream out, final QueryOptions options) {
     return new OutputFormatterCallback<Target>() {
 
       private Builder queryResult;

--- a/src/main/java/com/google/devtools/build/lib/query2/output/QueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/output/QueryOptions.java
@@ -14,10 +14,12 @@
 package com.google.devtools.build.lib.query2.output;
 
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.Setting;
+import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionsBase;
+import com.google.devtools.common.options.OptionsParsingException;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -48,7 +50,18 @@ public class QueryOptions extends OptionsBase {
           + " Allowed values are: label, label_kind, minrank, maxrank, package, location, graph,"
           + " xml, proto, record.")
   public String outputFormat;
-  public String lineTerminator = System.lineSeparator();
+  @Option(name = "null",
+      defaultValue = "null",
+      category = "query",
+      expansion = {"--line_terminator=\0"},
+      help = "Whether each format is terminated with \0 instead of newline.")
+  public Void isNull;
+  
+  @Option(name = "line_terminator",
+	  defaultValue = "null",
+      category = "query",
+      help = "The line terminator for each line.")
+  public String lineTerminator;
 
   @Option(
     name = "order_results",
@@ -225,6 +238,16 @@ public class QueryOptions extends OptionsBase {
             + "command line. It is an error to specify a file here as well as a command-line query."
   )
   public String queryFile;
+  
+  /**
+   * Ugly workaround since line terminator option default has to be constant expression.
+   */
+  public String getLineTerminator() {
+	  if (lineTerminator == null)
+		  return System.lineSeparator();
+	  
+	  return lineTerminator;
+  }
 
   /**
    * Return the current options as a set of QueryEnvironment settings.

--- a/src/main/java/com/google/devtools/build/lib/query2/output/QueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/output/QueryOptions.java
@@ -48,6 +48,7 @@ public class QueryOptions extends OptionsBase {
           + " Allowed values are: label, label_kind, minrank, maxrank, package, location, graph,"
           + " xml, proto, record.")
   public String outputFormat;
+  public String lineTerminator = System.lineSeparator();
 
   @Option(
     name = "order_results",

--- a/src/main/java/com/google/devtools/build/lib/query2/output/QueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/output/QueryOptions.java
@@ -50,18 +50,19 @@ public class QueryOptions extends OptionsBase {
           + " Allowed values are: label, label_kind, minrank, maxrank, package, location, graph,"
           + " xml, proto, record.")
   public String outputFormat;
-  @Option(name = "null",
+  @Option(
+      name = "null",
       defaultValue = "null",
       category = "query",
-      expansion = {"--line_terminator=\0"},
+      expansion = {"--line_terminator_null=true"},
       help = "Whether each format is terminated with \0 instead of newline.")
   public Void isNull;
-  
-  @Option(name = "line_terminator",
-	  defaultValue = "null",
+
+  @Option(name = "line_terminator_null",
+	  defaultValue = "false",
       category = "query",
-      help = "The line terminator for each line.")
-  public String lineTerminator;
+      help = "Whether each format is terminated with \0 instead of newline.")
+  public boolean lineTerminatorNull;
 
   @Option(
     name = "order_results",
@@ -243,10 +244,10 @@ public class QueryOptions extends OptionsBase {
    * Ugly workaround since line terminator option default has to be constant expression.
    */
   public String getLineTerminator() {
-    if (lineTerminator == null)
-      return System.lineSeparator();
-    
-    return lineTerminator;
+    if (lineTerminatorNull)
+      return "\0";
+
+    return System.lineSeparator();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/query2/output/QueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/output/QueryOptions.java
@@ -243,10 +243,10 @@ public class QueryOptions extends OptionsBase {
    * Ugly workaround since line terminator option default has to be constant expression.
    */
   public String getLineTerminator() {
-	  if (lineTerminator == null)
-		  return System.lineSeparator();
-	  
-	  return lineTerminator;
+    if (lineTerminator == null)
+      return System.lineSeparator();
+    
+    return lineTerminator;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/query2/output/QueryOutputUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/output/QueryOutputUtils.java
@@ -52,7 +52,7 @@ public class QueryOutputUtils {
       StreamedFormatter streamedFormatter = (StreamedFormatter) formatter;
       streamedFormatter.setOptions(queryOptions, aspectResolver);
       OutputFormatterCallback.processAllTargets(
-          streamedFormatter.createStreamCallback(outputStream), targetsResult);
+          streamedFormatter.createStreamCallback(outputStream, queryOptions), targetsResult);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/output/XmlOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/output/XmlOutputFormatter.java
@@ -57,17 +57,13 @@ import javax.xml.transform.stream.StreamResult;
  * An output formatter that prints the result as XML.
  */
 class XmlOutputFormatter extends AbstractUnorderedFormatter {
-  public XmlOutputFormatter() {
-    super(System.lineSeparator());
-  }
-
   @Override
   public String getName() {
     return "xml";
   }
 
   @Override
-  public OutputFormatterCallback<Target> createStreamCallback(final PrintStream out) {
+  public OutputFormatterCallback<Target> createStreamCallback(final PrintStream out, final QueryOptions options) {
     return new OutputFormatterCallback<Target>() {
 
       private Document doc;

--- a/src/main/java/com/google/devtools/build/lib/query2/output/XmlOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/output/XmlOutputFormatter.java
@@ -57,6 +57,10 @@ import javax.xml.transform.stream.StreamResult;
  * An output formatter that prints the result as XML.
  */
 class XmlOutputFormatter extends AbstractUnorderedFormatter {
+  public XmlOutputFormatter() {
+    super(System.lineSeparator());
+  }
+
   @Override
   public String getName() {
     return "xml";

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
@@ -269,9 +269,18 @@ public class GenQuery implements RuleConfiguredTargetFactory {
           ruleContext.getAnalysisEnvironment().getSkyframeEnv());
       // This is a precomputed value so it should have been injected by the rules module by the
       // time we get there.
-      formatter =  OutputFormatter.getFormatter(
-          Preconditions.checkNotNull(outputFormatters), queryOptions.outputFormat, queryOptions.lineTerminator);
-
+      Iterable<OutputFormatter> filteredOutputFormatters = OutputFormatter.getFormatters(
+          Preconditions.checkNotNull(outputFormatters), queryOptions.outputFormat);
+      
+      final String lineTerm = queryOptions.getLineTerminator();
+      formatter = null;
+      for (OutputFormatter outputFormatter : filteredOutputFormatters) {
+    	  if (outputFormatter.getLineTerminator().equals(lineTerm)) {
+    		  formatter = outputFormatter;
+    		  break;
+    	  }
+      }
+      
       // All the packages are already loaded at this point, so there is no need
       // to start up many threads. 4 are started up to make good use of multiple
       // cores.

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
@@ -270,7 +270,7 @@ public class GenQuery implements RuleConfiguredTargetFactory {
       // This is a precomputed value so it should have been injected by the rules module by the
       // time we get there.
       formatter =  OutputFormatter.getFormatter(
-          Preconditions.checkNotNull(outputFormatters), queryOptions.outputFormat);
+          Preconditions.checkNotNull(outputFormatters), queryOptions.outputFormat, queryOptions.lineTerminator);
 
       // All the packages are already loaded at this point, so there is no need
       // to start up many threads. 4 are started up to make good use of multiple

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/GenQuery.java
@@ -269,18 +269,8 @@ public class GenQuery implements RuleConfiguredTargetFactory {
           ruleContext.getAnalysisEnvironment().getSkyframeEnv());
       // This is a precomputed value so it should have been injected by the rules module by the
       // time we get there.
-      Iterable<OutputFormatter> filteredOutputFormatters = OutputFormatter.getFormatters(
+      formatter =  OutputFormatter.getFormatter(
           Preconditions.checkNotNull(outputFormatters), queryOptions.outputFormat);
-      
-      final String lineTerm = queryOptions.getLineTerminator();
-      formatter = null;
-      for (OutputFormatter outputFormatter : filteredOutputFormatters) {
-    	  if (outputFormatter.getLineTerminator().equals(lineTerm)) {
-    		  formatter = outputFormatter;
-    		  break;
-    	  }
-      }
-      
       // All the packages are already loaded at this point, so there is no need
       // to start up many threads. 4 are started up to make good use of multiple
       // cores.

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/QueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/QueryCommand.java
@@ -123,7 +123,7 @@ public final class QueryCommand implements BlazeCommand {
 
     Iterable<OutputFormatter> formatters = runtime.getQueryOutputFormatters();
     OutputFormatter formatter =
-        OutputFormatter.getFormatter(formatters, queryOptions.outputFormat);
+        OutputFormatter.getFormatter(formatters, queryOptions.outputFormat, queryOptions.lineTerminator);
     if (formatter == null) {
       env.getReporter().handle(Event.error(
           String.format("Invalid output format '%s'. Valid values are: %s",

--- a/src/test/shell/integration/loading_phase_tests.sh
+++ b/src/test/shell/integration/loading_phase_tests.sh
@@ -55,6 +55,12 @@ function test_query_buildfiles_with_load() {
     expect_log //y:BUILD
     expect_log //y:rules.bzl
 
+    # null terminated:
+    bazel query --noshow_progress --null 'buildfiles(//x)' >null.log ||
+        fail "Expected null success"
+    printf '//y:rules.bzl\0//y:BUILD\0//x:BUILD\0' >null.ref.log
+    cmp null.ref.log null.log || fail "Expected match"
+
     # Missing skylark file:
     rm -f y/rules.bzl
     bazel query --noshow_progress 'buildfiles(//x)' 2>$TEST_log &&


### PR DESCRIPTION
This is the work in progress for implementing null terminated lines in `bazel query`.
Should be mostly done but is currently still missing tests.
Connected issue is #1486.

Looking for basic feedback whether it is ok like this.