### PR TITLE
Site footer: auto-generate year from system time

### DIFF
--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -2,7 +2,7 @@
       <div class="container">
         <div class="row">
           <div class="col-lg-12">
-            <p class="text-muted">&copy; 2015 Google</p>
+            <p class="text-muted">&copy; {{ 'now' | date: "%Y" }} Google</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The site footer currently shows 2015. This fix will set it to 2016, plus it will auto-update to the current year with every build. 

To the bazel maintainers  - it's worth pointing out that on January 1, 2017, this build may not be re-run due to caching. I'm not sure how to address this. 