### PR TITLE
ProxyHelper handles proxy URLs with trailing slash.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
@@ -75,7 +75,7 @@ public class ProxyHelper {
 
     // Here there be dragons.
     Pattern urlPattern =
-        Pattern.compile("^(https?)://(([^:@]+?)(?::([^@]+?))?@)?([^:]+)(?::(\\d+))?$");
+        Pattern.compile("^(https?)://(([^:@]+?)(?::([^@]+?))?@)?([^:]+)(?::(\\d+))?/?$");
     Matcher matcher = urlPattern.matcher(proxyAddress);
     if (!matcher.matches()) {
       throw new IOException("Proxy address " + proxyAddress + " is not a valid URL");

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
@@ -174,4 +174,24 @@ public class ProxyHelperTest {
       assertThat(e.getMessage()).contains("No password given for proxy");
     }
   }
+
+  @Test
+  public void testNoProxyAuth() throws Exception {
+    Proxy proxy = ProxyHelper.createProxy("http://127.0.0.1:3128/");
+    assertEquals(Proxy.Type.HTTP, proxy.type());
+    assertThat(proxy.toString()).endsWith(":3128");
+    assertEquals(System.getProperty("http.proxyHost"), "127.0.0.1");
+    assertEquals(System.getProperty("http.proxyPort"), "3128");
+  }
+
+  @Test
+  public void testTrailingSlash() throws Exception {
+    Proxy proxy = ProxyHelper.createProxy("http://foo:bar@example.com:8000/");
+    assertEquals(Proxy.Type.HTTP, proxy.type());
+    assertThat(proxy.toString()).endsWith(":8000");
+    assertEquals(System.getProperty("http.proxyHost"), "example.com");
+    assertEquals(System.getProperty("http.proxyPort"), "8000");
+    assertEquals(System.getProperty("http.proxyUser"), "foo");
+    assertEquals(System.getProperty("http.proxyPassword"), "bar");
+  }
 }


### PR DESCRIPTION
Having a proxy URL defined with a trailing slash caused an exception. `Proxy address ... is not a valid URL"` This pull request fixes this issue.

I also added two test cases for this issue. 1. Trailing slash in proxy URL. 2. No
user:password provided in proxy URL.

