### PR TITLE
Protobuf Python should run on both 2 and 3.

### DIFF
--- a/third_party/protobuf/BUILD
+++ b/third_party/protobuf/BUILD
@@ -52,6 +52,7 @@ py_library(
         ],
     ),
     imports = ["python"],
+    srcs_version = "PY2AND3",
 )
 
 py_proto_library(


### PR DESCRIPTION
No upconversion necessary (which does not work anyway).