### PR TITLE
Restore Objective-C rules in the Build Encyclopedia.

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/BUILD
+++ b/src/main/java/com/google/devtools/build/docgen/BUILD
@@ -17,6 +17,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib:skylarkinterface",
         "//src/main/java/com/google/devtools/build/lib/rules/apple",
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",
+        "//src/main/java/com/google/devtools/build/lib/rules/objc",
         "//third_party:apache_velocity",
         "//third_party:guava",
         "//third_party:jsr305",


### PR DESCRIPTION
Fixes #1615