### PR TITLE
Redirect http://bazel.io to https://bazel.io.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 /bazel-testlogs
 /bazel.iml
 /output/
+/.sass-cache/
+/production/

--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -8,7 +8,11 @@
       var current_url = window.location.href;
       var bad_url = new RegExp("^https?://bazelbuild.github.io/bazel/");
       if (bad_url.test(current_url)) {
-        window.location.replace(current_url.replace(bad_url, "http://bazel.io/"));
+        window.location.replace(current_url.replace(bad_url, "https://www.bazel.io/"));
+      }
+      var http_url = new RegExp("^http://(www\.)?bazel.io/");
+      if (http_url.test(current_url)) {
+        window.location.replace(current_url.replace(http_url, "https://www.bazel.io/"));
       }
     </script>
 


### PR DESCRIPTION
Fixes #1644