### PR TITLE
Use a protocol-relative URL for loading fonts on website.

### DIFF
--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -15,7 +15,7 @@
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site_root }}">
 
     <!-- Webfont -->
-    <link href="http://fonts.googleapis.com/css?family=RobotoDraft:300,400,500|Source+Code+Pro:400,500,700" rel="stylesheet">
+    <link href="//fonts.googleapis.com/css?family=RobotoDraft:300,400,500|Source+Code+Pro:400,500,700" rel="stylesheet">
 
     <link rel="shortcut icon" type="image/png" href="/images/favicon.ico">
 

--- a/site/_sass/style.scss
+++ b/site/_sass/style.scss
@@ -1,6 +1,6 @@
 $body-font-family: 'RobotoDraft', 'Helvetica Neue', Helvetica, Arial,
                    sans-serif;
-$code-font-family: 'Source Code Pro';
+$code-font-family: 'Source Code Pro', monospace;
 
 $link-color: #4caf50;
 $link-hover-color: darken($link-color, 10%);


### PR DESCRIPTION
If you visit the HTTPS version of the site, the custom fonts don't load because they are linked to with an `http://` URL. This makes all the code blocks difficult to read, since they default to a non-monospaced font.

This PR makes two changes:
1. It changes the webfont `<link>` URL to use a protocol-relative URL, so that it matches whichever protocol the user views the site with.
2. It explicitly names `monospace` as a fallback font for Source Code Pro.