### PR TITLE
Change HOST_CFG to "host".

### DIFF
--- a/third_party/protobuf/3.0.0/protobuf.bzl
+++ b/third_party/protobuf/3.0.0/protobuf.bzl
@@ -88,13 +88,13 @@ _proto_gen = rule(
         "deps": attr.label_list(providers = ["proto"]),
         "includes": attr.string_list(),
         "protoc": attr.label(
-            cfg = HOST_CFG,
+            cfg = "host",
             executable = True,
             single_file = True,
             mandatory = True,
         ),
         "grpc_cpp_plugin": attr.label(
-            cfg = HOST_CFG,
+            cfg = "host",
             executable = True,
             single_file = True,
         ),


### PR DESCRIPTION
See also commit c4ddf6f45a5a4d93098c521af391f4466b31a869 which says
"Deprecate DATA_CFG and HOST_CFG, use string 'data' and 'host' instead."