### PR TITLE
Use nanosleep(2) instead of poll(2) to sleep.

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -31,7 +31,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
-#include <poll.h>
 #include <sched.h>
 #include <signal.h>
 #include <stdarg.h>
@@ -1056,7 +1055,10 @@ static void StartServerAndConnect(BlazeServer *server) {
     }
     fputc('.', stderr);
     fflush(stderr);
-    poll(NULL, 0, 1000);  // sleep 100ms.  (usleep(3) is obsolete.)
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 100 * 1000 * 1000;
+    nanosleep(&ts, NULL);
     if (!server_startup->IsStillAlive()) {
       fprintf(stderr, "\nunexpected pipe read status: %s\n"
           "Server presumed dead. Now printing '%s':\n",
@@ -1080,7 +1082,10 @@ static bool WaitForServerDeath(pid_t pid, int wait_time_secs) {
       }
       pdie(blaze_exit_code::INTERNAL_ERROR, "could not be killed");
     }
-    poll(NULL, 0, 100);  // sleep 100ms.  (usleep(3) is obsolete.)
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 100 * 1000 * 1000;
+    nanosleep(&ts, NULL);
   }
   return false;
 }


### PR DESCRIPTION
Starting with macOS Sierra developer beta 4, the behavior of poll(2) was changed, such that poll(2) will return immediately regardless the timeout if there is no file descriptor.

This fixes #1767.
And, this should be a better solution for Homebrew/homebrew-core#5041.