### PR TITLE
Changes necessary for releasing 0.3.2 chocolatey package

### DIFF
--- a/scripts/packages/chocolatey/.gitignore
+++ b/scripts/packages/chocolatey/.gitignore
@@ -2,5 +2,6 @@
 *.zip
 bazel.nuspec
 chocolateyinstall.ps1
+chocolateyuninstall.ps1
 tools/*.exe
 tools/LICENSE.txt

--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -76,7 +76,7 @@ Supply like `--params="/option:value ..."` ([see docs for --params](https://gith
     </dependencies>-->
     <dependencies>
       <dependency id="jdk8" version="[8.0.102,)"/>
-      <dependency id="msys2" version="[20150916.0.1,)"/>
+      <dependency id="msys2" version="[20160205,)"/>
       <dependency id="python2" version="[2.7.11,3.0)"/>
     </dependencies>
     <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->

--- a/scripts/packages/chocolatey/chocolateyinstall.ps1.template
+++ b/scripts/packages/chocolatey/chocolateyinstall.ps1.template
@@ -54,11 +54,12 @@ if (ps_var_packageParameters)
 }
 Install-ChocolateyPath -PathToInstall "ps_var_msys2Path\usr\bin" -PathType "Machine"
 
+ps_var_addToMsysPath = (ps_var_packageDir -replace 'c:\\','/c/') -replace '\\','/'
 write-host @"
 bazel installed to ps_var_packageDir
 
 To use it in msys2, you should add that to your msys2 PATH:
-  export PATH=ps_var_(ps_var_packageDir):escape_charps_var_PATH
+  export PATH=ps_var_(ps_var_addToMsysPath):escape_charps_var_PATH
 
 You also need, in your msys2 environment:
   export JAVA_HOME="escape_charps_var_(ls -d C:/Program\ Files/Java/jdk* | sort | tail -n 1)escape_char"

--- a/scripts/packages/chocolatey/test.ps1
+++ b/scripts/packages/chocolatey/test.ps1
@@ -1,5 +1,5 @@
 param(
-  [string] $version = "0.3.1"
+  [string] $version = "0.3.2"
 )
 
 choco uninstall bazel --force -y


### PR DESCRIPTION
@damienmg @meteorcloudy @dslomov: I had to change the filename to match the convention that you used to publish with (not sure how I missed the differences in #1742!).

I have published to chocolatey (log below), and the package should be available from https://chocolatey.org/packages/bazel/0.3.2 as/when it passes the automated checks and is approved by a moderator there. That can take minutes to days, especially since it's a weekend now.

(Oh, also, my PR to update msys2's chocolatey package to pull the latest version was merged earlier today).

Once the package has been approved, I'd be grateful if you would try to install it yourselves (I'll do that too), via `choco install bazel -v 0.3.2`. It should
* download the zip from GH releases
* make bazel.exe available on PATH via chocolatey's shimgen
  * the shim will be at `C:\ProgramData\chocolatey\bin\bazel.exe`
  * the actual exe should be at `C:\ProgramData\chocolatey\lib\bazel\bazel.exe`
* put your msys2 DLL on PATH, so be runnable from cmd and powershell
* output some text (which, thinking about it, could be improved):
```
bazel installed to C:\ProgramData\chocolatey\lib\bazel

To use it in msys2, you should add that to your msys2 PATH:
  export PATH=C:\ProgramData\chocolatey\lib\bazel:$PATH

You also need, in your msys2 environment:
  export JAVA_HOME="$(ls -d C:/Program\ Files/Java/jdk* | sort | tail -n 1)"
  export BAZEL_SH=c:/tools/msys64/usr/bin/bash.exe
  export BAZEL_PYTHON=c:/tools/python2/python.exe

See also https://bazel.io/docs/windows.html
```

The chocolatey package can be improved separately from its payload, via [their package fix version notation](https://github.com/chocolatey/choco/wiki/CreatePackages#package-fix-version-notation).

If that all works, then I think #971 and #1453 can be shut.

Publishing console output:
```
C:\Users\Pete\bazel\scripts\packages\chocolatey [choco_0-3-2 ≡]
λ choco push .\bazel.0.3.2.nupkg
Chocolatey v0.10.2
Attempting to push bazel.0.3.2.nupkg to https://chocolatey.org/
bazel 0.3.2 was pushed successfully to https://chocolatey.org/


Your package may be subject to moderation. A moderator will review the
package prior to acceptance. You should have received an email. If you
don't hear back from moderators within 1-3 business days, please reply
to the email and ask for status or use contact site admins on the
package page to contact moderators.

Please ensure your registered email address is correct and emails from
chocolateywebadmin at googlegroups dot com are not being sent to your
spam/junk folder.
```