### PR TITLE
Declare all inputs of protoc action

### DIFF
--- a/third_party/protobuf/protobuf.bzl
+++ b/third_party/protobuf/protobuf.bzl
@@ -67,13 +67,15 @@ def _proto_gen_impl(ctx):
   if ctx.attr.gen_py:
     args += ["--python_out=" + ctx.var["GENDIR"] + "/" + gen_dir]
 
+  inputs = srcs + deps
   if ctx.executable.grpc_cpp_plugin:
+    inputs += [ctx.executable.grpc_cpp_plugin]
     args += ["--plugin=protoc-gen-grpc=" + ctx.executable.grpc_cpp_plugin.path]
     args += ["--grpc_out=" + ctx.var["GENDIR"] + "/" + gen_dir]
 
   if args:
     ctx.action(
-        inputs=srcs + deps,
+        inputs=inputs,
         outputs=ctx.outputs.outs,
         arguments=args + import_flags + [s.path for s in srcs],
         executable=ctx.executable.protoc,


### PR DESCRIPTION
grpc_cpp_plugin must be in the inputs of protoc's action when using --plugin=protoc-gen-grpc - otherwise the action will fail.

This bug has been hidden by another bug: for every ctx.action, Bazel used to automatically add the runfiles of all executable inputs of the RULE instead of using the inputs of the specific ACTION. Consequently, we could get away with underspecifying the inputs of an action.

Fixes #1929