### PR TITLE
Warn the user about required PATH entry ordering

### DIFF
--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -76,7 +76,7 @@ Supply like `--params="/option:value ..."` ([see docs for --params](https://gith
     </dependencies>-->
     <dependencies>
       <dependency id="jdk8" version="[8.0.102,)"/>
-      <dependency id="msys2" version="[20160205,)"/>
+      <dependency id="msys2" version="[20160719.1,)"/>
       <dependency id="python2" version="[2.7.11,3.0)"/>
     </dependencies>
     <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->

--- a/scripts/packages/chocolatey/chocolateyinstall.ps1.template
+++ b/scripts/packages/chocolatey/chocolateyinstall.ps1.template
@@ -58,6 +58,12 @@ ps_var_addToMsysPath = (ps_var_packageDir -replace 'c:\\','/c/') -replace '\\','
 write-host @"
 bazel installed to ps_var_packageDir
 
+To use it in powershell or cmd, you should ensure your PATH environment variable contains
+  ps_var_(ps_var_msys2Path)\usr\bin
+BEFORE both
+  c:\windows\system32 (because bash-on-windows' bash.exe will be found here, if it's installed)
+  any references to msysgit (like c:\program files (x86)\git\bin or c:\program files (x86)\git\cmd) (because git's vendored version of msys2 will interfere with the real msys2)
+
 To use it in msys2, you should add that to your msys2 PATH:
   export PATH=ps_var_(ps_var_addToMsysPath):escape_charps_var_PATH
 


### PR DESCRIPTION
As discovered within #1919, the order of entries in the `PATH` matters, and is hard to diagnose when it's wrong.

* [x] add the warning message
* [ ] try it out on clean windows box
* [ ] ❓ mention this in the windows.md doc? It's a pretty inscrutable environment error, and I'd assume most people installing bazel on windows will already have git, so would be affected right out of the gate.
* [ ] bump the package version number according to [chocolatey's package fix version notation](https://github.com/chocolatey/choco/wiki/CreatePackages#package-fix-version-notation)

Once I've done both of those, I'll publish the package _after_ this has been merged.