### PR TITLE
Mention PATH niggles in more detail

### DIFF
--- a/site/versions/master/docs/windows.md
+++ b/site/versions/master/docs/windows.md
@@ -40,7 +40,7 @@ If you run outside of `bash`, ensure that ``msys-2.0.dll`` is in your ``PATH``
 
 If you have another tool that vendors msys2 (such as msysgit), then ``c:\tools\msys64\usr\bin`` must appear in your ``PATH`` *before* entries for those tools.
 
-Similarly, if you have [bash on Ubuntu on Windows](https://msdn.microsoft.com/en-gb/commandline/wsl/about) installed, you should make sure ``c:\tools\msys64\usr\bin`` appears in ``PATH`` *before* ``c:\windows\system32``, because otherwise windows' ``bash.exe`` is used before msys2's.
+Similarly, if you have [bash on Ubuntu on Windows](https://msdn.microsoft.com/en-gb/commandline/wsl/about) installed, you should make sure ``c:\tools\msys64\usr\bin`` appears in ``PATH`` *before* ``c:\windows\system32``, because otherwise Windows' ``bash.exe`` is used before msys2's.
 
 
 Building Bazel on Windows

--- a/site/versions/master/docs/windows.md
+++ b/site/versions/master/docs/windows.md
@@ -38,9 +38,13 @@ If you run outside of `bash`, ensure that ``msys-2.0.dll`` is in your ``PATH``
 (if you install msys2 to ``c:\tools\msys64``, just add
 ``c:\tools\msys64\usr\bin`` to ``PATH``).
 
+### Issues/Troubleshooting
+
 If you have another tool that vendors msys2 (such as msysgit), then ``c:\tools\msys64\usr\bin`` must appear in your ``PATH`` *before* entries for those tools.
 
 Similarly, if you have [bash on Ubuntu on Windows](https://msdn.microsoft.com/en-gb/commandline/wsl/about) installed, you should make sure ``c:\tools\msys64\usr\bin`` appears in ``PATH`` *before* ``c:\windows\system32``, because otherwise Windows' ``bash.exe`` is used before msys2's.
+
+Use `where msys-2.0.dll` to ensure your ``PATH`` is set up correctly.
 
 
 Building Bazel on Windows

--- a/site/versions/master/docs/windows.md
+++ b/site/versions/master/docs/windows.md
@@ -38,6 +38,10 @@ If you run outside of `bash`, ensure that ``msys-2.0.dll`` is in your ``PATH``
 (if you install msys2 to ``c:\tools\msys64``, just add
 ``c:\tools\msys64\usr\bin`` to ``PATH``).
 
+If you have another tool that vendors msys2 (such as msysgit), then ``c:\tools\msys64\usr\bin`` must appear in your ``PATH`` *before* entries for those tools.
+
+Similarly, if you have [bash on Ubuntu on Windows](https://msdn.microsoft.com/en-gb/commandline/wsl/about) installed, you should make sure ``c:\tools\msys64\usr\bin`` appears in ``PATH`` *before* ``c:\windows\system32``, because otherwise windows' ``bash.exe`` is used before msys2's.
+
 
 Building Bazel on Windows
 =========================


### PR DESCRIPTION
When the chocolatey package passes moderation and your own qualification steps, I suggest we update the steps here to mention that the dependencies are fine (and more convenient) to install via chocolatey, and that the chocolatey bazel package does that automatically.