### PR TITLE
Update io_bazel_rules_appengine to use tag 0.0.3

### DIFF
--- a/site/versions/master/docs/tutorial/backend-server.md
+++ b/site/versions/master/docs/tutorial/backend-server.md
@@ -72,7 +72,7 @@ Add the following to your `WORKSPACE` file:
 git_repository(
     name = "io_bazel_rules_appengine",
     remote = "https://github.com/bazelbuild/rules_appengine.git",
-    tag = "0.0.2",
+    tag = "0.0.3",
 )
 load("@io_bazel_rules_appengine//appengine:appengine.bzl", "appengine_repositories")
 appengine_repositories()


### PR DESCRIPTION
Release 0.0.2 is too old and doesn't work any more.

I'll make the same change in the tutorial repo.