### PR TITLE
Add quotes around variables when running dirname

### DIFF
--- a/scripts/bootstrap/buildenv.sh
+++ b/scripts/bootstrap/buildenv.sh
@@ -32,7 +32,7 @@ fi
 
 # Set standard variables
 DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-WORKSPACE_DIR="$(dirname $(dirname ${DIR}))"
+WORKSPACE_DIR="$(dirname "$(dirname "${DIR}")")"
 
 JAVA_VERSION=${JAVA_VERSION:-1.8}
 BAZELRC=${BAZELRC:-"/dev/null"}


### PR DESCRIPTION
If a user happens to have spaces in the path name,
`scripts/bootstrap/buildenv.sh` will fail with the error `usage: dirname
path`. Quoting the argument to `dirname` when setting `WORKSPACE_DIR`
avoids this issue.