### PR TITLE
Add --async clean independent of expunge

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CleanCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CleanCommand.java
@@ -57,28 +57,39 @@ public final class CleanCommand implements BlazeCommand {
     @Option(name = "clean_style",
             defaultValue = "",
             category = "clean",
-            help = "Can be either 'expunge' or 'expunge_async'.")
+            help = "Can be 'expunge', 'expunge_async', or 'async'.")
     public String cleanStyle;
 
     @Option(name = "expunge",
             defaultValue = "false",
             category = "clean",
             expansion = "--clean_style=expunge",
-            help = "If specified, clean will remove the entire working tree for this %{product} "
+            help = "If specified, clean removes the entire working tree for this %{product} "
                  + "instance, which includes all %{product}-created temporary and build output "
-                 + "files, and it will stop the %{product} server if it is running.")
+                 + "files, and stops the %{product} server if it is running.")
     public boolean expunge;
 
     @Option(name = "expunge_async",
         defaultValue = "false",
         category = "clean",
         expansion = "--clean_style=expunge_async",
-        help = "If specified, clean will asynchronously remove the entire working tree for "
+        help = "If specified, clean asynchronously removes the entire working tree for "
              + "this %{product} instance, which includes all %{product}-created temporary and "
-             + "build output files, and it will stop the %{product} server if it is running. When "
+             + "build output files, and stops the %{product} server if it is running. When "
              + "this command completes, it will be safe to execute new commands in the same "
              + "client, even though the deletion may continue in the background.")
     public boolean expunge_async;
+
+    @Option(name = "async",
+        defaultValue = "false",
+        category = "clean",
+        expansion = "--clean_style=async",
+        help = "If specified, clean asynchronously removes the entire working tree for "
+             + "this %{product} instance, which includes all %{product}-created temporary and "
+             + "build output files. When this command completes, it will be safe to execute new "
+             + "commands in the same client, even though the deletion may continue in the "
+             + "background.")
+    public boolean async;
   }
 
   private static Logger LOG = Logger.getLogger(CleanCommand.class.getName());
@@ -89,30 +100,37 @@ public final class CleanCommand implements BlazeCommand {
     Options cleanOptions = options.getOptions(Options.class);
     cleanOptions.expunge_async = cleanOptions.cleanStyle.equals("expunge_async");
     cleanOptions.expunge = cleanOptions.cleanStyle.equals("expunge");
+    cleanOptions.async = cleanOptions.cleanStyle.equals("async");
 
     env.getEventBus().post(new NoBuildEvent());
 
-    if (!cleanOptions.expunge && !cleanOptions.expunge_async
+    if (!cleanOptions.expunge && !cleanOptions.expunge_async && !cleanOptions.async
         && !cleanOptions.cleanStyle.isEmpty()) {
       env.getReporter().handle(Event.error(
           null, "Invalid clean_style value '" + cleanOptions.cleanStyle + "'"));
       return ExitCode.COMMAND_LINE_ERROR;
     }
 
+    String asyncName = (cleanOptions.expunge || cleanOptions.expunge_async) ?
+        "--expunge_async" : "--async";
+
     // TODO(dmarting): Deactivate expunge_async on non-Linux platform until we completely fix it
     // for non-Linux platforms (https://github.com/bazelbuild/bazel/issues/1906).
-    if (cleanOptions.expunge_async && OS.getCurrent() != OS.LINUX) {
+    if ((cleanOptions.expunge_async || cleanOptions.async) && OS.getCurrent() != OS.LINUX) {
+      boolean expunge = cleanOptions.expunge_async;
+      String fallbackName = expunge ? "--expunge" : "synchronous clean";
       env.getReporter().handle(Event.info(null /*location*/,
-          "--expunge_async cannot be used on non-Linux platforms, falling back to --expunge"));
+          asyncName + " cannot be used on non-Linux platforms, falling back to " + fallbackName));
       cleanOptions.expunge_async = false;
-      cleanOptions.expunge = true;
-      cleanOptions.cleanStyle = "expunge";
+      cleanOptions.expunge = expunge;
+      cleanOptions.async = false;
+      cleanOptions.cleanStyle = expunge ? "expunge" : "";
     }
 
-    String cleanBanner = cleanOptions.expunge_async ?
+    String cleanBanner = (cleanOptions.expunge_async || cleanOptions.async) ?
         "Starting clean." :
         "Starting clean (this may take a while). " +
-            "Consider using --expunge_async if the clean takes more than several minutes.";
+            "Consider using " + asyncName + " if the clean takes more than several minutes.";
 
     env.getReporter().handle(Event.info(null/*location*/, cleanBanner));
     try {
@@ -132,6 +150,30 @@ public final class CleanCommand implements BlazeCommand {
     }
   }
 
+  private static void asyncClean(CommandEnvironment env,
+      Path path, String pathItemName) throws IOException, CommandException {
+    String tempBaseName = path.getBaseName() + "_tmp_" + ProcessUtils.getpid();
+
+    // Keeping tempOutputBase in the same directory ensures it remains in the
+    // same file system, and therefore the mv will be atomic and fast.
+    Path tempPath = path.getParentDirectory().getChild(tempBaseName);
+    path.renameTo(tempPath);
+    env.getReporter().handle(Event.info(
+        null, pathItemName + " moved to " + tempPath + " for deletion"));
+
+    // Daemonize the shell and use the double-fork idiom to ensure that the shell
+    // exits even while the "rm -rf" command continues.
+    String command = String.format("exec >&- 2>&- <&- && (/usr/bin/setsid /bin/rm -rf %s &)&",
+        ShellEscaper.escapeString(tempPath.getPathString()));
+
+    LOG.info("Executing shell commmand " + ShellEscaper.escapeString(command));
+
+    // Doesn't throw iff command exited and was successful.
+    new CommandBuilder().addArg(command).useShell(true)
+        .setWorkingDir(tempPath.getParentDirectory())
+        .build().execute();
+  }
+
   private void actuallyClean(CommandEnvironment env,
       Path outputBase, Options cleanOptions, String symlinkPrefix) throws IOException,
       ShutdownBlazeServerException, CommandException, ExecException, InterruptedException {
@@ -149,26 +191,7 @@ public final class CleanCommand implements BlazeCommand {
       FileSystemUtils.deleteTree(outputBase);
     } else if (cleanOptions.expunge_async) {
       LOG.info("Expunging asynchronously...");
-      String tempBaseName = outputBase.getBaseName() + "_tmp_" + ProcessUtils.getpid();
-
-      // Keeping tempOutputBase in the same directory ensures it remains in the
-      // same file system, and therefore the mv will be atomic and fast.
-      Path tempOutputBase = outputBase.getParentDirectory().getChild(tempBaseName);
-      outputBase.renameTo(tempOutputBase);
-      env.getReporter().handle(Event.info(
-          null, "Output base moved to " + tempOutputBase + " for deletion"));
-
-      // Daemonize the shell and use the double-fork idiom to ensure that the shell
-      // exits even while the "rm -rf" command continues.
-      String command = String.format("exec >&- 2>&- <&- && (/usr/bin/setsid /bin/rm -rf %s &)&",
-          ShellEscaper.escapeString(tempOutputBase.getPathString()));
-
-      LOG.info("Executing shell commmand " + ShellEscaper.escapeString(command));
-
-      // Doesn't throw iff command exited and was successful.
-      new CommandBuilder().addArg(command).useShell(true)
-        .setWorkingDir(tempOutputBase.getParentDirectory())
-        .build().execute();
+      asyncClean(env, outputBase, "Output base");
     } else {
       LOG.info("Output cleaning...");
       env.getBlazeWorkspace().clearCaches();
@@ -178,8 +201,12 @@ public final class CleanCommand implements BlazeCommand {
           env.getWorkspaceName(), "execroot/" + env.getWorkspaceName() }) {
         Path child = outputBase.getRelative(directory);
         if (child.exists()) {
-          LOG.finest("Cleaning " + child);
-          FileSystemUtils.deleteTreesBelow(child);
+          LOG.finest("Cleaning " + child + (cleanOptions.async ? " asynchronously..." : ""));
+          if (cleanOptions.async) {
+            asyncClean(env, child, "Output tree");
+          } else {
+            FileSystemUtils.deleteTreesBelow(child);
+          }
         }
       }
     }
@@ -191,6 +218,7 @@ public final class CleanCommand implements BlazeCommand {
     if (cleanOptions.expunge || cleanOptions.expunge_async) {
       throw new ShutdownBlazeServerException(0, ShutdownMethod.EXPUNGE);
     }
+    System.gc();
   }
 
   @Override


### PR DESCRIPTION
An asynchronous clean without a complete purge and daemon shutdown is
particularly useful when the daemon takes an inordinate amount of time
to read output files for md5sums.  Incurs a garbage collector invocation
after cache cleanup in the interest of correct usage reporting.