### PR TITLE
Improve windows docs around C++

### DIFF
--- a/site/versions/master/docs/windows.md
+++ b/site/versions/master/docs/windows.md
@@ -85,7 +85,8 @@ To build C++ targets, you will need:
 
 * [Visual Studio](https://www.visualstudio.com/)
 <br/>We are using MSVC as the native C++ toolchain, so please ensure you have Visual
-Studio installed with the Visual C++ components
+Studio installed with the `Visual C++ > Common Tools for Visual C++` and
+`Visual C++ > Microsoft Foundation Classes for C++` features.
 (which is NOT the default installation type of Visual Studio).
 You can set BAZEL\_VS environment variable to tell Bazel
 where Visual Studio is, otherwise Bazel will try to find the latest version installed.

--- a/site/versions/master/docs/windows.md
+++ b/site/versions/master/docs/windows.md
@@ -88,14 +88,14 @@ To build C++ targets, you will need:
 Studio installed with the `Visual C++ > Common Tools for Visual C++` and
 `Visual C++ > Microsoft Foundation Classes for C++` features.
 (which is NOT the default installation type of Visual Studio).
-You can set BAZEL\_VS environment variable to tell Bazel
+You can set `BAZEL_VS` environment variable to tell Bazel
 where Visual Studio is, otherwise Bazel will try to find the latest version installed.
 <br/>For example: `export BAZEL_VS="C:/Program Files (x86)/Microsoft Visual Studio 14.0"`
 
 * [Python 2.7](https://www.python.org/downloads/)
 <br/>Currently, we use python wrapper scripts to call the actual MSVC compiler, so
 please make sure Python is installed and its location is added into PATH.
-It's also a good idea to set BAZEL\_PYTHON environment variable to tell Bazel
+It's also a good idea to set `BAZEL_PYTHON` environment variable to tell Bazel
 where python is.
 <br/>For example: `export BAZEL_PYTHON=C:/Python27/python.exe`
 


### PR DESCRIPTION
These are the options that a colleague needed to install in their VS 2015 Community Edition install before it was possible to compile C++ with Bazel. I've reflected this in the doc (I thought I remembered an open issue for this, but couldn't find it just now when I looked).

(I elected to not change the markdown formatting because of the `<br/>` in play. I think it's possible to get the same hanging indent by indenting the text within a bullet by one indent-width, but I have no way of previewing the rendering to know whether that's true or not.)

![cpp options in vs 2015](https://cloud.githubusercontent.com/assets/69720/20141432/3cfe71e6-a688-11e6-83cd-070fa60a54f2.PNG)

(Specifically, in the screenshot, I'm referring to the C++ ones, not any of the others).