### PR TITLE
Correct maven_server rule docs to use valid workspace name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/MavenServerRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/MavenServerRule.java
@@ -78,18 +78,18 @@ public class MavenServerRule implements RuleDefinition {
 maven_jar(
     name = "junit",
     artifact = "junit:junit-dep:4.10",
-    server = "my-server",
+    server = "my_server",
 )
 
 maven_server(
-    name = "my-server",
+    name = "my_server",
     url = "http://intranet.mycorp.net",
 )
 </pre>
 
 This specifies that junit should be downloaded from http://intranet.mycorp.net using the
 authentication information found in ~/.m2/settings.xml (specifically, the settings
-for the server with the id <code>my-server</code>).
+for the server with the id <code>my_server</code>).
 
 <h4>Specifying a default server</h4>
 


### PR DESCRIPTION
The current documentation for maven_server uses a rule name of `my-server`,
which is not a legal rule name due to its use of a hyphen. This commit changes
the hyphen to an underscore and changes all instances of `my-server` to
`my_server`