### PR TITLE
fix typo in example in aspects docs

### DIFF
--- a/site/versions/master/docs/skylark/aspects.md
+++ b/site/versions/master/docs/skylark/aspects.md
@@ -113,7 +113,7 @@ Example:
 ```python
 def _metal_proto_aspect_impl(target, ctx):
     # For every `src` in proto_library, generate an output file
-    proto_sources = [f for src in ctx.rule.attr.src
+    proto_sources = [f for src in ctx.rule.attr.srcs
                        for f in src.files]
     outputs = [ctx.new_file(f.short_path + ".metal")
                for f in proto_sources]


### PR DESCRIPTION
The attribute for the source list is "srcs", not "src".