### PR TITLE
Make the python dependency more lenient

### DIFF
--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -77,7 +77,7 @@ Supply like `--params="/option:value ..."` ([see docs for --params](https://gith
     <dependencies>
       <dependency id="jdk8" version="[8.0.102,)"/>
       <dependency id="msys2" version="[20160719.1,)"/>
-      <dependency id="python2" version="[2.7.11,)"/>
+      <dependency id="python" version="[2.7.11,)"/>
     </dependencies>
     <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->
 

--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -77,7 +77,7 @@ Supply like `--params="/option:value ..."` ([see docs for --params](https://gith
     <dependencies>
       <dependency id="jdk8" version="[8.0.102,)"/>
       <dependency id="msys2" version="[20160719.1,)"/>
-      <dependency id="python2" version="[2.7.11,3.0)"/>
+      <dependency id="python2" version="[2.7.11,)"/>
     </dependencies>
     <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->
 

--- a/scripts/packages/chocolatey/build.ps1
+++ b/scripts/packages/chocolatey/build.ps1
@@ -11,6 +11,9 @@ if ($mode -eq "release") {
   $tvFilename = "bazel-$($tvVersion)-windows-x86_64.zip"
   $tvUri = "https://github.com/bazelbuild/bazel/releases/download/$($tvVersion)/$($tvFilename)"
 } elseif ($mode -eq "rc") {
+  if (($rc -eq $null) -or ($rc -lt 1)) {
+    throw "When mode is rc, Must supply rc parameter greater than 0"
+  }
   $tvVersion = "$($version)-rc$($rc)"
   $tvFilename = "bazel-$($version)rc$($rc)-windows-x86_64.zip"
   $tvUri = "https://storage.googleapis.com/bazel/$($version)/rc$($rc)/$($tvFilename)"

--- a/scripts/packages/chocolatey/build.ps1
+++ b/scripts/packages/chocolatey/build.ps1
@@ -32,21 +32,10 @@ if ($checksum -eq "") {
   rm -force -ErrorAction SilentlyContinue ./*.zip
 }
 
-if ($mode -eq "release") {
+if (($mode -eq "release") -or ($mode -eq "rc")) {
   Invoke-WebRequest "$($tvUri).sha256" -UseBasicParsing -passthru -outfile sha256.txt
   $tvChecksum = (gc sha256.txt).split(' ')[0]
   rm sha256.txt
-} elseif ($mode -eq "rc") {
-  if (-not(test-path $tvFilename)) {
-    Invoke-WebRequest "$($tvUri)" -UseBasicParsing -passthru -outfile $tvFilename
-  }
-  if ($checksum -eq "") {
-    write-host "calculating checksum"
-    $tvChecksum = (get-filehash $tvFilename -algorithm sha256).Hash
-  } else {
-    write-host "using passed checksum"
-    $tvChecksum = $checksum
-  }
 } elseif ($mode -eq "local") {
   Add-Type -A System.IO.Compression.FileSystem
   $outputDir = "$pwd/../../../output"

--- a/scripts/packages/chocolatey/test.ps1
+++ b/scripts/packages/chocolatey/test.ps1
@@ -19,6 +19,7 @@ It should not have had errors.
   exit 1
 }
 
+write-host "Trying out 'bazel version'"
 & bazel version
 if ($LASTEXITCODE -ne 0)
 {
@@ -30,6 +31,7 @@ It should have shown you bazel's version number.
   exit 1
 }
 
+write-host "Trying out 'bazel info'"
 & bazel info
 if ($LASTEXITCODE -ne 0)
 {


### PR DESCRIPTION
Based on [this comment](https://github.com/bazelbuild/bazel/issues/2027#issuecomment-262229811), allow python3 to be used. cc @meteorcloudy.