### PR TITLE
Add Oracle JDK 7/8 as optional dependencies.

### DIFF
--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -155,10 +155,10 @@ pkg_deb(
     data = ":debian-data",
     depends = select({
         "//tools/jdk:jdk7": [
-            "java7-jdk | java7-sdk",
+            "java7-jdk | java7-sdk | oracle-java7-installer",
         ],
         "//conditions:default": [
-            "google-jdk | java8-jdk | java8-sdk",
+            "google-jdk | java8-jdk | java8-sdk | oracle-java8-installer",
         ],
     }) + [
         "g++",

--- a/scripts/packages/debian/control
+++ b/scripts/packages/debian/control
@@ -9,7 +9,7 @@ Package: bazel
 Section: contrib/devel
 Priority: optional
 Architecture: amd64
-Depends: google-jdk | java8-jdk | java8-sdk, g++, zlib1g-dev, bash-completion
+Depends: google-jdk | java8-jdk | java8-sdk | oracle-java8-installer, g++, zlib1g-dev, bash-completion
 Conflicts: openjdk-9-jdk
 Description: Bazel is a tool that automates software builds and tests.
  Supported build tasks include running compilers and linkers to produce


### PR DESCRIPTION
With this change, `oracle-java7-installer` and `oracle-java8-installer` become
alternatives to satisfy the JDK dependency and thus can be implicitly installed
when someone just asks to install Bazel by itself.

Resolves issue #1821.