### PR TITLE
Improved support for /MD and /MT in MSVC [#2120]

### DIFF
--- a/tools/cpp/wrapper/bin/pydir/msvc_cl.py
+++ b/tools/cpp/wrapper/bin/pydir/msvc_cl.py
@@ -33,7 +33,7 @@ GCCPATTERNS = [
     ('-Os', ['/O1']),
     ('-O2', ['/O2']),
     ('-g0', []),
-    ('-g', ['/MTd']),
+    ('-g', ['$DEBUG_RT']),
     ('-fexceptions', ['/U_HAS_EXCEPTIONS', '/D_HAS_EXCEPTIONS=1', '/EHsc']),
     ('-fomit-frame-pointer', ['/Oy']),
     ('-fno-rtti', ['/GR-']),


### PR DESCRIPTION
msvc_tools.py now prefers the last /MT / /MD option given; if none,
/MD is preferred.

Additionally, the behaviour of the copt -g has been improved to enforce
the debug version of the user-selected runtime, not necessarily /MTd.

Issue: #2120 