### PR TITLE
Set User-Agent to "Bazel/{{Release Name}}" for http connections

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
@@ -20,6 +20,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Ordering;
+import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
 import com.google.devtools.build.lib.bazel.repository.downloader.RetryingInputStream.Reconnector;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.events.Event;
@@ -61,7 +62,9 @@ final class HttpConnectorMultiplexer {
   private static final int MAX_THREADS_PER_CONNECT = 2;
   private static final long FAILOVER_DELAY_MS = 2000;
   private static final ImmutableMap<String, String> REQUEST_HEADERS =
-      ImmutableMap.of("Accept-Encoding", "gzip");
+      ImmutableMap.of(
+          "Accept-Encoding", "gzip",
+          "User-Agent", "Bazel/" + BlazeVersionInfo.instance().getReleaseName());
 
   private final EventHandler eventHandler;
   private final HttpConnector connector;


### PR DESCRIPTION
Previously the java default was used, which was of the format "Java/x.x.x". This caused a problem fetching external dependencies for some websites that block user agents of that format.

I initially was going to include the bazel version in the user agent string, but it seems that a version number isn't always baked into the bazel binary.  When I compile bazel locally, no "Build label: x.x.x" shows up when I run `bazel version`.

Fixes #2131