### PR TITLE
correct the executable path in script_path docs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -91,7 +91,7 @@ public class RunCommand implements BlazeCommand  {
         converter = OptionsUtils.PathFragmentConverter.class,
         help = "If set, write a shell script to the given file which invokes the "
             + "target. If this option is set, the target is not run from %{product}. "
-            + "Use '%{product} run --script_path=foo //foo && foo' to invoke target '//foo' "
+            + "Use '%{product} run --script_path=foo //foo && ./foo' to invoke target '//foo' "
             + "This differs from '%{product} run //foo' in that the %{product} lock is released "
             + "and the executable is connected to the terminal's stdin.")
     public PathFragment scriptPath;


### PR DESCRIPTION
This confused me every time I looked it up. Thought that was working through some magic shell alias tricks until I found the files on my hard drive.