### PR TITLE
Extend attr with label_dict

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/skylark/SkylarkDoc.java
+++ b/src/main/java/com/google/devtools/build/docgen/skylark/SkylarkDoc.java
@@ -63,6 +63,10 @@ abstract class SkylarkDoc {
     return getTypeAnchor(returnType) + " of " + getTypeAnchor(generic1) + "s";
   }
 
+  protected String getTypeAnchor(Class<?> returnType, Class<?> generic1, Class<?> generic2) {
+    return getTypeAnchor(returnType) + " of " + getTypeAnchor(generic1) + " mapping to " + getTypeAnchor(generic2);
+  }
+
   protected String getTypeAnchor(Class<?> type) {
     if (type.equals(Boolean.class) || type.equals(boolean.class)) {
       return "<a class=\"anchor\" href=\"" + TOP_LEVEL_ID + ".html#bool\">bool</a>";

--- a/src/main/java/com/google/devtools/build/docgen/skylark/SkylarkParamDoc.java
+++ b/src/main/java/com/google/devtools/build/docgen/skylark/SkylarkParamDoc.java
@@ -55,8 +55,10 @@ public final class SkylarkParamDoc extends SkylarkDoc {
     }
     if (param.generic1().equals(Object.class)) {
       return getTypeAnchor(param.type());
-    } else {
+    } else if (param.generic2().equals(Object.class)) {
       return getTypeAnchor(param.type(), param.generic1());
+    } else {
+      return getTypeAnchor(param.type(), param.generic1(), param.generic2());
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -1065,7 +1065,8 @@ public final class RuleContext extends TargetContext
         + " attribute " + attributeName + " is not defined");
     }
     if (!(attributeDefinition.getType() == BuildType.LABEL
-        || attributeDefinition.getType() == BuildType.LABEL_LIST)) {
+        || attributeDefinition.getType() == BuildType.LABEL_LIST
+            || attributeDefinition.getType() == BuildType.LABEL_DICT_UNARY)) {
       throw new IllegalStateException(getRuleClassNameForLogging() + " attribute " + attributeName
         + " is not a label type attribute");
     }
@@ -1107,7 +1108,8 @@ public final class RuleContext extends TargetContext
         + " attribute " + attributeName + " is not defined");
     }
     if (!(attributeDefinition.getType() == BuildType.LABEL
-        || attributeDefinition.getType() == BuildType.LABEL_LIST)) {
+        || attributeDefinition.getType() == BuildType.LABEL_LIST
+    || attributeDefinition.getType() == BuildType.LABEL_DICT_UNARY)) {
       throw new IllegalStateException(getRuleClassNameForLogging() + " attribute " + attributeName
         + " is not a label type attribute");
     }

--- a/src/main/java/com/google/devtools/build/lib/packages/Attribute.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Attribute.java
@@ -511,7 +511,7 @@ public final class Attribute implements Comparable<Attribute> {
      * Makes the built attribute producing a single artifact.
      */
     public Builder<TYPE> singleArtifact() {
-      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST),
+      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST) || (type == BuildType.LABEL_DICT_UNARY),
           "attribute '%s' must be a label-valued type", name);
       return setPropertyFlag(PropertyFlag.SINGLE_ARTIFACT, "single_artifact");
     }
@@ -521,7 +521,7 @@ public final class Attribute implements Comparable<Attribute> {
      * This flag is introduced to handle plugins, do not use it in other cases.
      */
     public Builder<TYPE> silentRuleClassFilter() {
-      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST),
+      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST) || (type == BuildType.LABEL_DICT_UNARY),
           "must be a label-valued type");
       return setPropertyFlag(PropertyFlag.SILENT_RULECLASS_FILTER, "silent_ruleclass_filter");
     }
@@ -530,7 +530,7 @@ public final class Attribute implements Comparable<Attribute> {
      * Skip analysis time filetype check. Don't use it if avoidable.
      */
     public Builder<TYPE> skipAnalysisTimeFileTypeCheck() {
-      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST),
+      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST) || (type == BuildType.LABEL_DICT_UNARY),
           "must be a label-valued type");
       return setPropertyFlag(PropertyFlag.SKIP_ANALYSIS_TIME_FILETYPE_CHECK,
           "skip_analysis_time_filetype_check");
@@ -797,7 +797,7 @@ public final class Attribute implements Comparable<Attribute> {
      * other words, it works for 'deps' attributes, but not 'srcs' attributes.
      */
     public Builder<TYPE> allowedRuleClasses(Predicate<RuleClass> allowedRuleClasses) {
-      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST),
+      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST) || (type == BuildType.LABEL_DICT_UNARY),
           "must be a label-valued type");
       propertyFlags.add(PropertyFlag.STRICT_LABEL_CHECKING);
       allowedRuleClassesForLabels = allowedRuleClasses;
@@ -882,7 +882,7 @@ public final class Attribute implements Comparable<Attribute> {
      * other words, it works for 'deps' attributes, but not 'srcs' attributes.
      */
     public Builder<TYPE> allowedRuleClassesWithWarning(Predicate<RuleClass> allowedRuleClasses) {
-      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST),
+      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST) || (type == BuildType.LABEL_DICT_UNARY),
           "must be a label-valued type");
       propertyFlags.add(PropertyFlag.STRICT_LABEL_CHECKING);
       allowedRuleClassesForLabelsWarning = allowedRuleClasses;
@@ -910,7 +910,7 @@ public final class Attribute implements Comparable<Attribute> {
      */
     public final Builder<TYPE> mandatoryNativeProvidersList(
         Iterable<? extends Iterable<Class<? extends TransitiveInfoProvider>>> providersList) {
-      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST),
+      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST) || (type == BuildType.LABEL_DICT_UNARY),
           "must be a label-valued type");
       ImmutableList.Builder<ImmutableList<Class<? extends TransitiveInfoProvider>>> listBuilder
           = ImmutableList.builder();
@@ -937,7 +937,7 @@ public final class Attribute implements Comparable<Attribute> {
      */
     public Builder<TYPE> mandatoryProvidersList(
         Iterable<? extends Iterable<SkylarkProviderIdentifier>> providersList){
-      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST),
+      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST) || (type == BuildType.LABEL_DICT_UNARY),
           "must be a label-valued type");
       ImmutableList.Builder<ImmutableSet<SkylarkProviderIdentifier>> listBuilder
           = ImmutableList.builder();

--- a/src/main/java/com/google/devtools/build/lib/packages/Attribute.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Attribute.java
@@ -827,7 +827,7 @@ public final class Attribute implements Comparable<Attribute> {
      * other words, it works for 'deps' attributes, but not 'srcs' attributes.
      */
     public Builder<TYPE> allowedFileTypes(FileTypeSet allowedFileTypes) {
-      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST),
+      Preconditions.checkState((type == BuildType.LABEL) || (type == BuildType.LABEL_LIST) || (type == BuildType.LABEL_DICT_UNARY),
           "must be a label-valued type");
       propertyFlags.add(PropertyFlag.STRICT_LABEL_CHECKING);
       allowedFileTypesForLabels = Preconditions.checkNotNull(allowedFileTypes);

--- a/src/main/java/com/google/devtools/build/lib/packages/AttributeFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/AttributeFormatter.java
@@ -61,7 +61,7 @@ public class AttributeFormatter {
 
   private static final ImmutableSet<Type<?>> depTypes =
       ImmutableSet.<Type<?>>of(
-          STRING, LABEL, OUTPUT, STRING_LIST, LABEL_LIST, OUTPUT_LIST, DISTRIBUTIONS);
+          STRING, LABEL, OUTPUT, STRING_LIST, LABEL_LIST, LABEL_DICT_UNARY, OUTPUT_LIST, DISTRIBUTIONS);
 
   private static final ImmutableSet<Type<?>> noDepTypes =
       ImmutableSet.<Type<?>>of(NODEP_LABEL_LIST, NODEP_LABEL);

--- a/src/main/java/com/google/devtools/build/lib/rules/SkylarkAttr.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/SkylarkAttr.java
@@ -1040,7 +1040,6 @@ public final class SkylarkAttr {
                               flags,
                               MANDATORY_ARG,
                               mandatory,
-                              NON_EMPTY_ARG,
                               ALLOW_EMPTY_ARG,
                               allowEmpty,
                               CONFIGURATION_ARG,

--- a/src/main/java/com/google/devtools/build/lib/rules/SkylarkAttr.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/SkylarkAttr.java
@@ -916,6 +916,148 @@ public final class SkylarkAttr {
       };
 
   @SkylarkSignature(
+          name = "label_dict",
+          doc =
+                  "Creates an attribute of type <a href=\"dict.html\">dict</a>, mapping from <a href=\"string.html\">string</a> "
+                          + " to <a href=\"Target.html\">Target</a> which are specified by the labels in the list. "
+                          + "See <a href=\"attr.html#label\">label</a> for more information.",
+          objectType = SkylarkAttr.class,
+          returnType = Descriptor.class,
+          parameters = {
+                  @Param(
+                          name = DEFAULT_ARG,
+                          type = SkylarkDict.class,
+                          generic1 = String.class,
+                          generic2 = Label.class,
+                          callbackEnabled = true,
+                          defaultValue = "{}",
+                          named = true,
+                          positional = false,
+                          doc =
+                                  DEFAULT_DOC
+                                          + " Use the <a href=\"globals.html#Label\"><code>Label</code></a> function to "
+                                          + "specify default values ex:</p>"
+                                          + "<code>attr.label_dict(default = { \"foo\": Label(\"//a:b\") })</code>"
+                  ),
+                  @Param(
+                          name = ALLOW_FILES_ARG, // bool or FileType filter
+                          defaultValue = "None",
+                          named = true,
+                          positional = false,
+                          doc = ALLOW_FILES_DOC
+                  ),
+                  @Param(
+                          name = ALLOW_RULES_ARG,
+                          type = SkylarkList.class,
+                          generic1 = String.class,
+                          noneable = true,
+                          defaultValue = "None",
+                          named = true,
+                          positional = false,
+                          doc = ALLOW_RULES_DOC
+                  ),
+                  @Param(
+                          name = PROVIDERS_ARG,
+                          type = SkylarkList.class,
+                          defaultValue = "[]",
+                          named = true,
+                          positional = false,
+                          doc = PROVIDERS_DOC
+                  ),
+                  @Param(
+                          name = FLAGS_ARG,
+                          type = SkylarkList.class,
+                          generic1 = String.class,
+                          defaultValue = "[]",
+                          named = true,
+                          positional = false,
+                          doc = FLAGS_DOC
+                  ),
+                  @Param(
+                          name = MANDATORY_ARG,
+                          type = Boolean.class,
+                          defaultValue = "False",
+                          named = true,
+                          positional = false,
+                          doc = MANDATORY_DOC
+                  ),
+                  @Param(
+                          name = ALLOW_EMPTY_ARG,
+                          type = Boolean.class,
+                          defaultValue = "True",
+                          doc = ALLOW_EMPTY_DOC
+                  ),
+                  @Param(
+                          name = CONFIGURATION_ARG,
+                          type = Object.class,
+                          noneable = true,
+                          defaultValue = "None",
+                          named = true,
+                          positional = false,
+                          doc = CONFIGURATION_DOC
+                  ),
+                  @Param(
+                          name = ASPECTS_ARG,
+                          type = SkylarkList.class,
+                          generic1 = SkylarkAspect.class,
+                          defaultValue = "[]",
+                          named = true,
+                          positional = false,
+                          doc = ASPECTS_ARG_DOC
+                  )
+          },
+          useAst = true,
+          useEnvironment = true
+  )
+  private static BuiltinFunction labelDict =
+          new BuiltinFunction("label_dict") {
+            public Descriptor invoke(
+                    Object defaultDict,
+                    Object allowFiles,
+                    Object allowRules,
+                    SkylarkList<?> providers,
+                    SkylarkList<?> flags,
+                    Boolean mandatory,
+                    Boolean allowEmpty,
+                    Object cfg,
+                    SkylarkList<?> aspects,
+                    FuncallExpression ast,
+                    Environment env)
+                    throws EvalException {
+              env.checkLoadingOrWorkspacePhase("attr.label_dict", ast.getLocation());
+              SkylarkDict<String, Object> kwargs =
+                      EvalUtils.<String, Object>optionMap(
+                              env,
+                              DEFAULT_ARG,
+                              defaultDict,
+                              ALLOW_FILES_ARG,
+                              allowFiles,
+                              ALLOW_RULES_ARG,
+                              allowRules,
+                              PROVIDERS_ARG,
+                              providers,
+                              FLAGS_ARG,
+                              flags,
+                              MANDATORY_ARG,
+                              mandatory,
+                              NON_EMPTY_ARG,
+                              ALLOW_EMPTY_ARG,
+                              allowEmpty,
+                              CONFIGURATION_ARG,
+                              cfg);
+              try {
+                Attribute.Builder<?> attribute =
+                        createAttribute(BuildType.LABEL_DICT_UNARY, kwargs, ast, env, ast.getLocation());
+                ImmutableList<SkylarkAspect> skylarkAspects =
+                        ImmutableList.copyOf(aspects.getContents(SkylarkAspect.class, "aspects"));
+                return new Descriptor(attribute, skylarkAspects);
+              } catch (EvalException e) {
+                throw new EvalException(ast.getLocation(), e.getMessage(), e);
+              }
+            }
+          };
+
+  @SkylarkSignature(
     name = "bool",
     doc = "Creates an attribute of type bool.",
     objectType = SkylarkAttr.class,

--- a/src/main/java/com/google/devtools/build/lib/rules/SkylarkAttr.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/SkylarkAttr.java
@@ -236,7 +236,7 @@ public final class SkylarkAttr {
       Object fileTypesObj = arguments.get(ALLOW_SINGLE_FILE_ARG);
       setAllowedFileTypes(ALLOW_SINGLE_FILE_ARG, fileTypesObj, ast, builder);
       builder.setPropertyFlag("SINGLE_ARTIFACT");
-    } else if (type.equals(BuildType.LABEL) || type.equals(BuildType.LABEL_LIST)) {
+    } else if (type.equals(BuildType.LABEL) || type.equals(BuildType.LABEL_LIST) || type.equals(BuildType.LABEL_DICT_UNARY)) {
       builder.allowedFileTypes(FileTypeSet.NO_FILE);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/SkylarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/SkylarkRuleContext.java
@@ -276,7 +276,7 @@ public final class SkylarkRuleContext {
     for (Attribute a : attributes) {
       Type<?> type = a.getType();
       Object val = attributeValueExtractor.apply(a);
-      if (type != BuildType.LABEL && type != BuildType.LABEL_LIST) {
+      if (type != BuildType.LABEL && type != BuildType.LABEL_LIST && type != BuildType.LABEL_DICT_UNARY) {
         attrBuilder.put(a.getPublicName(), val == null ? Runtime.NONE
             // Attribute values should be type safe
             : SkylarkType.convertToSkylark(val, null));

--- a/src/main/java/com/google/devtools/build/lib/rules/SkylarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/SkylarkRuleContext.java
@@ -322,10 +322,13 @@ public final class SkylarkRuleContext {
           prereq = Runtime.NONE;
         }
         attrBuilder.put(skyname, prereq);
-      } else {
-        // Type.LABEL_LIST
+      } else if(type == BuildType.LABEL_LIST) {
         List<?> allPrereq = ruleContext.getPrerequisites(a.getName(), Mode.DONT_CHECK);
         attrBuilder.put(skyname, SkylarkList.createImmutable(allPrereq));
+      } else {
+        // type == BuildType.LABEL_DICT_UNARY
+        Map<?, ?> allPrereq = ruleContext.getPrerequisiteMap(a.getName());
+        attrBuilder.put(skyname, SkylarkDict.createImmutable(allPrereq));
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/skylarkinterface/Param.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkinterface/Param.java
@@ -59,6 +59,14 @@ public @interface Param {
   Class<?> generic1() default Object.class;
 
   /**
+   * When {@link #type()} is a generic type (e.g.,
+   * {@link com.google.devtools.build.lib.syntax.SkylarkDict}), specify the second type parameter (e.g.
+   * {@link String}.class} along with {@link com.google.devtools.build.lib.syntax.SkylarkDict} for
+   * {@link #type()} to specify a dict which maps to strings).
+   */
+  Class<?> generic2() default Object.class;
+
+  /**
    * Whether the name of a callback function can be given instead of a computed value. If a
    * callback function is used then the value of this parameter will be computed only when
    * actually requested. E.g., if a parameter {@code foo} of a function {@code bar} is passed a

--- a/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
@@ -403,11 +403,13 @@ public final class FuncallExpression extends Expression {
   }
 
   private static SkylarkType getType(Param param) {
-    SkylarkType type =
-        param.generic1() != Object.class
-            ? SkylarkType.of(param.type(), param.generic1())
-            : SkylarkType.of(param.type());
-    return type;
+    if (param.generic2() != Object.class) {
+      return SkylarkType.of(param.type(), param.generic1(), param.generic2());
+    } else if(param.generic1() != Object.class) {
+      return SkylarkType.of(param.type(), param.generic1());
+    } else {
+      return SkylarkType.of(param.type());
+    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/syntax/SkylarkDict.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/SkylarkDict.java
@@ -215,6 +215,14 @@ public final class SkylarkDict<K, V>
     return (SkylarkDict<KeyType, ValueType>) this;
   }
 
+  /**
+   * Creates immutable SkylarkDict with given elements.
+   */
+  public static <K, V> SkylarkDict<K, V> createImmutable(Map<? extends K, ? extends V> contents) {
+    // Without env, this implicitly gets to be immutable.
+    return SkylarkDict.copyOf(null, contents);
+  }
+
   @Override
   public final Object getIndex(Object key, Location loc) throws EvalException {
     if (!this.containsKey(key)) {

--- a/src/main/java/com/google/devtools/build/lib/syntax/SkylarkSignatureProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/SkylarkSignatureProcessor.java
@@ -125,7 +125,10 @@ public class SkylarkSignatureProcessor {
       return new Parameter.Star<>(null);
     }
     if (param.type() != Object.class) {
-      if (param.generic1() != Object.class) {
+      if (param.generic2() != Object.class) {
+        // Enforce the proper parametric type for Skylark dict objects
+        officialType = SkylarkType.of(param.type(), param.generic1(), param.generic2());
+      } else if (param.generic1() != Object.class) {
         // Enforce the proper parametric type for Skylark list and set objects
         officialType = SkylarkType.of(param.type(), param.generic1());
       } else {

--- a/src/main/java/com/google/devtools/build/lib/syntax/SkylarkSignatureProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/SkylarkSignatureProcessor.java
@@ -128,11 +128,11 @@ public class SkylarkSignatureProcessor {
       if (param.generic1() != Object.class) {
         // Enforce the proper parametric type for Skylark list and set objects
         officialType = SkylarkType.of(param.type(), param.generic1());
-        enforcedType = officialType;
       } else {
         officialType = SkylarkType.of(param.type());
-        enforcedType = officialType;
       }
+      enforcedType = officialType;
+
       if (param.callbackEnabled()) {
         officialType = SkylarkType.Union.of(
             officialType, SkylarkType.SkylarkFunctionType.of(name, officialType));

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/TestAspects.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/TestAspects.java
@@ -15,9 +15,7 @@ package com.google.devtools.build.lib.analysis.util;
 
 import static com.google.devtools.build.lib.packages.Attribute.ConfigurationTransition.HOST;
 import static com.google.devtools.build.lib.packages.Attribute.attr;
-import static com.google.devtools.build.lib.packages.BuildType.LABEL;
-import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
-import static com.google.devtools.build.lib.packages.BuildType.NODEP_LABEL_LIST;
+import static com.google.devtools.build.lib.packages.BuildType.*;
 import static com.google.devtools.build.lib.syntax.Type.BOOLEAN;
 import static com.google.devtools.build.lib.syntax.Type.STRING;
 import static com.google.devtools.build.lib.syntax.Type.STRING_LIST;
@@ -134,7 +132,7 @@ public class TestAspects {
     Iterable<String> attributeNames = ruleContext.attributes().getAttributeNames();
     for (String attributeName : attributeNames) {
       Type<?> attributeType = ruleContext.attributes().getAttributeType(attributeName);
-      if (!LABEL.equals(attributeType) && !LABEL_LIST.equals(attributeType)) {
+      if (!LABEL.equals(attributeType) && !LABEL_LIST.equals(attributeType) && !LABEL_DICT_UNARY.equals(attributeType)) {
         continue;
       }
       Iterable<AspectInfo> prerequisites = ruleContext


### PR DESCRIPTION
Started extending `attr` with an additional `label_dict`.

This requires a bit of groundwork in the Skylark type handling.
~~Currently most code should be in place but it still crashes so not finished.~~

@damienmg Can you perhaps point me to the place where I should add unit tests for this?