### PR TITLE
Adding verbatim cc_library parameter

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java
@@ -530,6 +530,11 @@ public class BazelCppRuleClasses {
               .legacyAllowAnyFileType())
           // TODO(bazel-team): document or remove.
           .add(attr("linkstamp", LABEL).allowedFileTypes(CPP_SOURCE, C_SOURCE))
+          /*<!-- #BLAZE_RULE($cc_library).ATTRIBUTE(verbatim) -->
+          If 1, the library file name generated will match the name exactly, without
+          a lib prefix added to it.
+          <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
+          .add(attr("verbatim", BOOLEAN).value(false))
           .build();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/ArtifactCategory.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/ArtifactCategory.java
@@ -18,11 +18,16 @@ package com.google.devtools.build.lib.rules.cpp;
  * select a single artifact.
  */
 public enum ArtifactCategory {
+  VERBATIM_STATIC_LIBRARY("%{base_name}.a"),
+  VERBATIM_PIC_STATIC_LIBRARY("%{base_name}.pic.a"),
+  VERBATIM_ALWAYSLINK_STATIC_LIBRARY("%{base_name}.lo"),
+  VERBATIM_DYNAMIC_LIBRARY("%{base_name}.so"),
   STATIC_LIBRARY("lib%{base_name}.a"),
   ALWAYSLINK_STATIC_LIBRARY("lib%{base_name}.lo"),
   DYNAMIC_LIBRARY("lib%{base_name}.so"),
   EXECUTABLE("%{base_name}"),
   INTERFACE_LIBRARY("lib%{base_name}.ifso"),
+  VERBATIM_INTERFACE_LIBRARY("%{base_name}.ifso"),
   PIC_FILE("%{output_name}.pic"),
   INCLUDED_FILE_LIST("%{output_name}.d"),
   OBJECT_FILE("%{output_name}.o"),

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -115,6 +115,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
       return;
     }
 
+    boolean verbatim = ruleContext.attributes().get("verbatim", Type.BOOLEAN);
     CcLibraryHelper helper =
         new CcLibraryHelper(ruleContext, semantics, featureConfiguration)
             .fromCommon(common)
@@ -131,7 +132,8 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
                 ruleContext.getRule().getImplicitOutputsFunction() != ImplicitOutputsFunction.NONE)
             .setLinkType(linkType)
             .setNeverLink(neverLink)
-            .addPrecompiledFiles(precompiledFiles);
+            .addPrecompiledFiles(precompiledFiles)
+            .setVerbatim(verbatim);
 
     if (collectLinkstamp) {
       helper.addLinkstamps(ruleContext.getPrerequisites("linkstamp", Mode.TARGET));
@@ -180,7 +182,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
     // which only happens when some rule explicitly depends on the dynamic library.
     if (!createDynamicLibrary && !supportsDynamicLinker) {
       Artifact solibArtifact =
-          CppHelper.getLinuxLinkedArtifact(ruleContext, LinkTargetType.DYNAMIC_LIBRARY);
+          CppHelper.getLinuxLinkedArtifact(ruleContext, LinkTargetType.DYNAMIC_LIBRARY, !verbatim);
       ruleContext.registerAction(new FailAction(ruleContext.getActionOwner(),
           ImmutableList.of(solibArtifact), "Toolchain does not support dynamic linking"));
     } else if (!createDynamicLibrary
@@ -191,7 +193,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
       // generate an .so with. If that's the case, register a fake generating action to prevent
       // a "no generating action for this artifact" error.
       Artifact solibArtifact =
-          CppHelper.getLinuxLinkedArtifact(ruleContext, LinkTargetType.DYNAMIC_LIBRARY);
+          CppHelper.getLinuxLinkedArtifact(ruleContext, LinkTargetType.DYNAMIC_LIBRARY, !verbatim);
       ruleContext.registerAction(new FailAction(ruleContext.getActionOwner(),
           ImmutableList.of(solibArtifact), "configurable \"srcs\" triggers an implicit .so output "
           + "even though there are no sources to compile in this configuration"));

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibraryHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibraryHelper.java
@@ -277,6 +277,7 @@ public final class CcLibraryHelper {
   private HeadersCheckingMode headersCheckingMode = HeadersCheckingMode.LOOSE;
   private boolean neverlink;
   private boolean fake;
+  private boolean verbatim;
 
   private final List<LibraryToLink> staticLibraries = new ArrayList<>();
   private final List<LibraryToLink> picStaticLibraries = new ArrayList<>();
@@ -793,6 +794,14 @@ public final class CcLibraryHelper {
   }
 
   /**
+   * Sets the model link action as verbatim, omitting the "lib" prefix
+   */
+  public CcLibraryHelper setVerbatim(boolean verbatim) {
+    this.verbatim = verbatim;
+    return this;
+  }
+
+  /**
    * This adds the {@link CcNativeLibraryProvider} to the providers created by this class.
    */
   public CcLibraryHelper enableCcNativeLibrariesProvider() {
@@ -1067,15 +1076,15 @@ public final class CcLibraryHelper {
     if (ruleContext.attributes().get("alwayslink", Type.BOOLEAN)) {
       archiveFile.add(
           CppHelper.getLinuxLinkedArtifact(
-              ruleContext, Link.LinkTargetType.ALWAYS_LINK_STATIC_LIBRARY));
+              ruleContext, Link.LinkTargetType.ALWAYS_LINK_STATIC_LIBRARY, !verbatim));
     } else {
       archiveFile.add(
-          CppHelper.getLinuxLinkedArtifact(ruleContext, Link.LinkTargetType.STATIC_LIBRARY));
+          CppHelper.getLinuxLinkedArtifact(ruleContext, Link.LinkTargetType.STATIC_LIBRARY, !verbatim));
     }
 
     if (CppRuleClasses.shouldCreateDynamicLibrary(ruleContext.attributes())) {
       dynamicLibrary.add(
-          CppHelper.getLinuxLinkedArtifact(ruleContext, Link.LinkTargetType.DYNAMIC_LIBRARY));
+          CppHelper.getLinuxLinkedArtifact(ruleContext, Link.LinkTargetType.DYNAMIC_LIBRARY, !verbatim));
     }
 
     outputGroups.put("archive", archiveFile.build());
@@ -1102,7 +1111,8 @@ public final class CcLibraryHelper {
         .setDynamicLibrary(dynamicLibrary)
         .addLinkopts(linkopts)
         .setFeatureConfiguration(featureConfiguration)
-        .addVariablesExtension(variablesExtensions);
+        .addVariablesExtension(variablesExtensions)
+        .setVerbatim(verbatim);
   }
 
   @Immutable

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -335,10 +335,15 @@ public class CppHelper {
   }
 
   /** Returns the linked artifact for linux. */
-  public static Artifact getLinuxLinkedArtifact(RuleContext ruleContext, LinkTargetType linkType) {
+  public static Artifact getLinuxLinkedArtifact(
+      RuleContext ruleContext, LinkTargetType linkType, boolean libPrefix) {
     PathFragment name = new PathFragment(ruleContext.getLabel().getName());
     if (linkType != LinkTargetType.EXECUTABLE) {
-      name = name.replaceName("lib" + name.getBaseName() + linkType.getExtension());
+      String baseName = name.getBaseName();
+      if (libPrefix) {
+        baseName = "lib" + baseName;
+      }
+      name = name.replaceName(baseName + linkType.getExtension());
     }
 
     return ruleContext.getBinArtifact(name);

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkAction.java
@@ -110,6 +110,7 @@ public final class CppLinkAction extends AbstractAction
 
   /** True for cc_fake_binary targets. */
   private final boolean fake;
+  private final boolean verbatim;
   private final boolean isLTOIndexing;
 
   // This is set for both LTO indexing and LTO linking.
@@ -150,6 +151,7 @@ public final class CppLinkAction extends AbstractAction
       Artifact linkOutput,
       LibraryToLink interfaceOutputLibrary,
       boolean fake,
+      boolean verbatim,
       boolean isLTOIndexing,
       Iterable<LTOBackendArtifacts> allLTOBackendArtifacts,
       LinkCommandLine linkCommandLine,
@@ -169,6 +171,7 @@ public final class CppLinkAction extends AbstractAction
     this.linkOutput = linkOutput;
     this.interfaceOutputLibrary = interfaceOutputLibrary;
     this.fake = fake;
+    this.verbatim = verbatim;
     this.isLTOIndexing = isLTOIndexing;
     this.allLTOBackendArtifacts = allLTOBackendArtifacts;
     this.linkCommandLine = linkCommandLine;
@@ -553,6 +556,7 @@ public final class CppLinkAction extends AbstractAction
     final LinkTargetType linkType;
     final LinkStaticness linkStaticness;
     final boolean fake;
+    final boolean verbatim;
     final boolean isNativeDeps;
     final boolean useTestOnlyFlags;
 
@@ -580,6 +584,7 @@ public final class CppLinkAction extends AbstractAction
       this.linkType = builder.getLinkType();
       this.linkStaticness = builder.getLinkStaticness();
       this.fake = builder.isFake();
+      this.verbatim = builder.isVerbatim();
       this.isNativeDeps = builder.isNativeDeps();
       this.useTestOnlyFlags = builder.useTestOnlyFlags();
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/Link.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/Link.java
@@ -123,6 +123,7 @@ public abstract class Link {
         "c++-link-static-library",
         Picness.NOPIC,
         ArtifactCategory.STATIC_LIBRARY,
+        ArtifactCategory.VERBATIM_STATIC_LIBRARY,
         Executable.NOT_EXECUTABLE),
     
     /** An objc static archive. */
@@ -132,6 +133,7 @@ public abstract class Link {
         "objc-archive", 
         Picness.NOPIC,
         ArtifactCategory.STATIC_LIBRARY,
+        ArtifactCategory.VERBATIM_STATIC_LIBRARY,
         Executable.NOT_EXECUTABLE),
     
     /** An objc fully linked static archive. */
@@ -141,6 +143,7 @@ public abstract class Link {
         "objc-fully-link",
         Picness.NOPIC,
         ArtifactCategory.STATIC_LIBRARY,
+        ArtifactCategory.VERBATIM_STATIC_LIBRARY,
         Executable.NOT_EXECUTABLE),
 
     /** An objc executable. */
@@ -149,6 +152,7 @@ public abstract class Link {
         Staticness.STATIC,
         "objc-executable",
         Picness.NOPIC,
+        ArtifactCategory.EXECUTABLE,
         ArtifactCategory.EXECUTABLE,
         Executable.EXECUTABLE),
 
@@ -159,6 +163,7 @@ public abstract class Link {
         "objc++-executable",
         Picness.NOPIC,
         ArtifactCategory.EXECUTABLE,
+        ArtifactCategory.EXECUTABLE,
         Executable.EXECUTABLE),
 
     /** A static archive with .pic.o object files (compiled with -fPIC). */
@@ -168,6 +173,7 @@ public abstract class Link {
         "c++-link-pic-static-library",
         Picness.PIC,
         ArtifactCategory.STATIC_LIBRARY,
+        ArtifactCategory.VERBATIM_STATIC_LIBRARY,
         Executable.NOT_EXECUTABLE),
 
     /** An interface dynamic library. */
@@ -177,6 +183,7 @@ public abstract class Link {
         "c++-link-interface-dynamic-library",
         Picness.NOPIC,  // Actually PIC but it's not indicated in the file name
         ArtifactCategory.INTERFACE_LIBRARY,
+        ArtifactCategory.VERBATIM_INTERFACE_LIBRARY,
         Executable.NOT_EXECUTABLE),
 
     /** A dynamic library. */
@@ -186,6 +193,7 @@ public abstract class Link {
         "c++-link-dynamic-library",
         Picness.NOPIC,  // Actually PIC but it's not indicated in the file name
         ArtifactCategory.DYNAMIC_LIBRARY,
+        ArtifactCategory.VERBATIM_DYNAMIC_LIBRARY,
         Executable.NOT_EXECUTABLE),
 
     /** A static archive without removal of unused object files. */
@@ -195,6 +203,7 @@ public abstract class Link {
         "c++-link-alwayslink-static-library",
         Picness.NOPIC,
         ArtifactCategory.ALWAYSLINK_STATIC_LIBRARY,
+        ArtifactCategory.VERBATIM_ALWAYSLINK_STATIC_LIBRARY,
         Executable.NOT_EXECUTABLE),
 
     /** A PIC static archive without removal of unused object files. */
@@ -204,6 +213,7 @@ public abstract class Link {
         "c++-link-alwayslink-pic-static-library",
         Picness.PIC,
         ArtifactCategory.ALWAYSLINK_STATIC_LIBRARY,
+        ArtifactCategory.VERBATIM_ALWAYSLINK_STATIC_LIBRARY,
         Executable.NOT_EXECUTABLE),
 
     /** An executable binary. */
@@ -213,12 +223,14 @@ public abstract class Link {
         "c++-link-executable",
         Picness.NOPIC,  // Picness is not indicate in the file name
         ArtifactCategory.EXECUTABLE,
+        ArtifactCategory.EXECUTABLE,
         Executable.EXECUTABLE);
 
     private final String extension;
     private final Staticness staticness;
     private final String actionName;
     private final ArtifactCategory linkerOutput;
+    private final ArtifactCategory verbatimLinkerOutput;
     private final Picness picness;
     private final Executable executable;
 
@@ -228,11 +240,13 @@ public abstract class Link {
         String actionName,
         Picness picness,
         ArtifactCategory linkerOutput,
+        ArtifactCategory verbatimLinkerOutput,
         Executable executable) {
       this.extension = extension;
       this.staticness = staticness;
       this.actionName = actionName;
       this.linkerOutput = linkerOutput;
+      this.verbatimLinkerOutput = verbatimLinkerOutput;
       this.picness = picness;
       this.executable = executable;
     }
@@ -253,8 +267,8 @@ public abstract class Link {
     }
     
     /** Returns an {@code ArtifactCategory} identifying the artifact type this link action emits. */
-    public ArtifactCategory getLinkerOutput() {
-      return linkerOutput;
+    public ArtifactCategory getLinkerOutput(boolean verbatim) {
+      return verbatim ? verbatimLinkerOutput : linkerOutput;
     }
 
     /**

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkerInput.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkerInput.java
@@ -54,4 +54,9 @@ public interface LinkerInput {
    * legal to call this only when {@link #containsObjectFiles()} returns true.
    */
   Iterable<Artifact> getObjectFiles();
+
+  /**
+   * Return whether this input artifact can be linked with -l
+   */
+  boolean isLibraryLinkable();
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkerInputs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkerInputs.java
@@ -88,6 +88,11 @@ public abstract class LinkerInputs {
     }
 
     @Override
+    public boolean isLibraryLinkable() {
+      return CppFileTypes.SHARED_LIBRARY.matches(getArtifact().getFilename());
+    }
+
+    @Override
     public boolean equals(Object that) {
       if (this == that) {
         return true;
@@ -153,14 +158,16 @@ public abstract class LinkerInputs {
     private final Artifact solibSymlinkArtifact;
     private final Artifact libraryArtifact;
     private final String libraryIdentifier;
+    private final boolean libraryLinkable;
 
     private SolibLibraryToLink(Artifact solibSymlinkArtifact, Artifact libraryArtifact,
-        String libraryIdentifier) {
+        String libraryIdentifier, boolean libraryLinkable) {
       Preconditions.checkArgument(
           Link.SHARED_LIBRARY_FILETYPES.matches(solibSymlinkArtifact.getFilename()));
       this.solibSymlinkArtifact = solibSymlinkArtifact;
       this.libraryArtifact = libraryArtifact;
       this.libraryIdentifier = libraryIdentifier;
+      this.libraryLinkable = libraryLinkable;
     }
 
     @Override
@@ -203,6 +210,11 @@ public abstract class LinkerInputs {
     public Iterable<Artifact> getObjectFiles() {
       throw new IllegalStateException(
           "LinkerInputs: does not support getObjectFiles: " + toString());
+    }
+
+    @Override
+    public boolean isLibraryLinkable() {
+      return libraryLinkable;
     }
 
     @Override
@@ -252,14 +264,17 @@ public abstract class LinkerInputs {
       String basename = libraryArtifact.getFilename();
       switch (category) {
         case ALWAYSLINK_STATIC_LIBRARY:
+        case VERBATIM_ALWAYSLINK_STATIC_LIBRARY:
           Preconditions.checkState(Link.LINK_LIBRARY_FILETYPES.matches(basename));
           break;
 
         case STATIC_LIBRARY:
+        case VERBATIM_STATIC_LIBRARY:
           Preconditions.checkState(Link.ARCHIVE_FILETYPES.matches(basename));
           break;
 
         case DYNAMIC_LIBRARY:
+        case VERBATIM_DYNAMIC_LIBRARY:
           Preconditions.checkState(Link.SHARED_LIBRARY_FILETYPES.matches(basename));
           break;
 
@@ -316,6 +331,11 @@ public abstract class LinkerInputs {
     public Iterable<Artifact> getObjectFiles() {
       Preconditions.checkNotNull(objectFiles);
       return objectFiles;
+    }
+
+    @Override
+    public boolean isLibraryLinkable() {
+      return false;
     }
 
     @Override
@@ -393,8 +413,21 @@ public abstract class LinkerInputs {
    * Creates a solib library symlink from the given artifact.
    */
   public static LibraryToLink solibLibraryToLink(
+      Artifact solibSymlink, Artifact original, String libraryIdentifier,
+      boolean libraryLinkable) {
+    return new SolibLibraryToLink(
+        solibSymlink, original, libraryIdentifier,
+        libraryLinkable && CppFileTypes.SHARED_LIBRARY.matches(solibSymlink.getFilename()));
+  }
+
+  /**
+   * Creates a solib library symlink from the given artifact.
+   */
+  public static LibraryToLink solibLibraryToLink(
       Artifact solibSymlink, Artifact original, String libraryIdentifier) {
-    return new SolibLibraryToLink(solibSymlink, original, libraryIdentifier);
+    return solibLibraryToLink(
+        solibSymlink, original, libraryIdentifier,
+        CppFileTypes.SHARED_LIBRARY.matches(solibSymlink.getFilename()));
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LibraryLinkingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LibraryLinkingTest.java
@@ -75,6 +75,24 @@ public final class LibraryLinkingTest extends BuildViewTestCase {
   }
 
   /**
+   * Tests that the shared library specified with verbatim produces static and dynamic
+   * libraries without 'lib' prefix
+   */
+  @Test
+  public void testVerbatimCcLibrary() throws Exception {
+    ConfiguredTarget verbatimlib =
+      scratchConfiguredTarget(
+          "verbatimrule",
+          "verbatim",
+          "cc_library(name = 'verbatim',",
+          "           verbatim = True)");
+    Artifact staticLibrary = getBinArtifact("verbatim.a", verbatimlib);
+    Artifact dynamicLibrary = getBinArtifact("verbatim.so", verbatimlib);
+    assertThat(staticLibrary).isNotNull();
+    assertThat(dynamicLibrary).isNotNull();
+  }
+
+  /**
    * Tests that the shared library version of a cc_library includes linkopts settings
    * in its link command line, but the archive library version doesn't.
    */


### PR DESCRIPTION
Specifying a cc_library as verbatim prevents a lib prefix from being
added.  This is specifically desireable in order to allow non-lib-
prefixed shared object output which can be used as dependencies for
other targets (versus using cc_binary output, giving us the verbatim
behavior, but is required to be a leaf node in cc_* subtree).  Linking
commandlines have been altered to provide the .so in the same manner as
interface shared objects (instead of -lfoo).

This was particularly useful when constructing graphs of python
extension libraries, where each component represents an importable
module, but depend upon one another for symbol resolution.