### PR TITLE
Fix formatting of README.md

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/README.md
+++ b/src/main/java/com/google/devtools/build/lib/remote/README.md
@@ -4,14 +4,18 @@
 configuration. If you already have a separate Hazelcast cluster you can skip
 this step.
 
+```
     java -cp third_party/hazelcast/hazelcast-3.6.4.jar \
         com.hazelcast.core.server.StartServer
+```
 
 - Then you run Bazel pointing to the Hazelcast server.
 
+```
     bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
         --hazelcast_node=localhost:5701 --spawn_strategy=remote \
         src/tools/generate_workspace:all
+```
 
 Above command will build generate_workspace with remote spawn strategy that uses
 Hazelcast as the distributed caching backend.
@@ -21,15 +25,19 @@ Hazelcast as the distributed caching backend.
 - First run the remote worker. This will start a standalone Hazelcast server
 with default configuration.
 
+```
     bazel-bin/src/tools/remote_worker/remote_worker \
         --work_path=/tmp/remote --listen_port 8080
+```
 
 - Then run Bazel pointing to the Hazelcast server and remote worker.
 
+```
         bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
             --hazelcast_node=localhost:5701 \
             --remote_worker=localhost:8080 \
             --spawn_strategy=remote src/tools/generate_workspace:all
+```
 
 # How to run a remote worker with a remote cache server.
 
@@ -37,22 +45,30 @@ with default configuration.
 configuration. If you already have a separate Hazelcast cluster you can skip
 this step.
 
+```
     java -cp third_party/hazelcast/hazelcast-3.6.4.jar \
         com.hazelcast.core.server.StartServer
+```
 
 - Then run the remote cache server:
 
+```
     bazel-bin/src/tools/remote_worker/remote_cache --listen_port 8081
+```
 
 - The run the remote worker:
 
+```
     bazel-bin/src/tools/remote_worker/remote_worker \
         --work_path=/tmp/remote --listen_port 8080
+```
 
 - Then run Bazel pointing to the cache server and remote worker.
 
+```
         bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
             --hazelcast_node=localhost:5701 \
             --remote_worker=localhost:8080 \
             --remote_cache=localhost:8081 \
             --spawn_strategy=remote src/tools/generate_workspace:all
+```


### PR DESCRIPTION
A number of the shorter commands were not displayed in a code block, making them trickier to copy and paste into a console.