### PR TITLE
Allowing objc_* rules to override clang module name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/BundleSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/BundleSupport.java
@@ -272,7 +272,7 @@ final class BundleSupport {
             .add("--minimum-deployment-target")
             .add(bundling.getMinimumOsVersion().toString())
             .add("--module")
-            .add(ruleContext.getLabel().getName());
+            .add(ObjcCommon.getClangModuleName(ruleContext));
 
     for (TargetDeviceFamily targetDeviceFamily : targetDeviceFamiliesForResources()) {
       commandLine.add("--target-device").add(targetDeviceFamily.name().toLowerCase(Locale.US));

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/IntermediateArtifacts.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/IntermediateArtifacts.java
@@ -432,14 +432,8 @@ public final class IntermediateArtifacts {
    * {@link CppModuleMap} that provides the clang module map for this target.
    */
   public CppModuleMap moduleMap() {
-    String moduleName =
-        ruleContext
-            .getLabel()
-            .toString()
-            .replace("//", "")
-            .replace("@", "")
-            .replace("/", "_")
-            .replace(":", "_");
+    String moduleName = ObjcCommon.getClangModuleName(ruleContext);
+
     // To get Swift to pick up module maps, we need to name them "module.modulemap" and have their
     // parent directory in the module map search paths.
     if (umbrellaHeaderStrategy == UmbrellaHeaderStrategy.GENERATE) {

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
@@ -371,7 +371,7 @@ public class ObjcRuleClasses {
    * Files that are already compiled.
    */
   static final FileTypeSet PRECOMPILED_SRCS_TYPE = FileTypeSet.of(OBJECT_FILE_SOURCES);
-  
+
   static final FileTypeSet NON_ARC_SRCS_TYPE = FileTypeSet.of(FileType.of(".m", ".mm"));
 
   static final FileTypeSet PLIST_TYPE = FileTypeSet.of(FileType.of(".plist"));
@@ -714,8 +714,13 @@ public class ObjcRuleClasses {
           Setting this to 1 will allow you to @import system headers and other targets:
           @import UIKit;
           @import path_to_package_target;
+          @import module_name;
           <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
           .add(attr("enable_modules", BOOLEAN))
+          /* <!-- #BLAZE_RULE($objc_compiling_rule).ATTRIBUTE(module_name) -->
+          Controls clang module name. The default for this is path_to_package_target
+          <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
+          .add(attr("module_name", STRING))
           /* Provides the label for header_scanner tool that is used to scan inclusions for ObjC
           sources and provide a list of required headers via a .header_list file.
 

--- a/src/test/shell/bazel/apple/bazel_apple_test.sh
+++ b/src/test/shell/bazel/apple/bazel_apple_test.sh
@@ -342,6 +342,60 @@ EOF
       //ios:swift_lib >$TEST_log 2>&1 || fail "should build"
 }
 
+function test_swift_imports_swift_custom_module_name() {
+  rm -rf ios
+  mkdir -p ios
+
+  cat >ios/main.swift <<EOF
+import Foundation
+import IosUtil
+
+public class SwiftClass {
+  public func bar() -> String {
+    return Utility().foo()
+  }
+}
+EOF
+
+  cat >ios/Utility.h <<EOF
+#import <Foundation/Foundation.h>
+
+@interface Utility : NSObject
+
+- (NSString * _Nonnull)foo;
+
+@end
+EOF
+  cat >ios/Utility.m <<EOF
+#import "Utility.h"
+
+@implementation Utility
+
+- (NSString *)foo;
+{
+    return @"Cheeseburger";
+}
+
+@end
+EOF
+
+  cat >ios/BUILD <<EOF
+load("//tools/build_defs/apple:swift.bzl", "swift_library")
+
+swift_library(name = "swift_lib",
+              srcs = ["main.swift"],
+              deps = [":util"])
+
+objc_library(name = "util",
+             module_name = "IosUtil",
+             srcs = ['Utility.m'],
+             hdrs = ['Utility.h'])
+EOF
+
+  bazel build --verbose_failures --xcode_version=$XCODE_VERSION \
+      //ios:swift_lib >$TEST_log 2>&1 || fail "should build"
+}
+
 function test_swift_tests() {
   make_app
 


### PR DESCRIPTION
This allows for easier integration with existing objective c and swift
projects.
It also allows for better interoperability with swift and objective-c.

This also includes a fix for how xibs are processed which were being set to the wrong clang module name already.

Depends on #2312 to avoid merge conflicts