### PR TITLE
Doc: section title should reflect the correct rule name

### DIFF
--- a/site/versions/master/docs/tutorial/backend-server.md
+++ b/site/versions/master/docs/tutorial/backend-server.md
@@ -56,7 +56,7 @@ file. For the backend server, these are references to the App Engine SDK,
 the Java Servlet SDK and other libraries needed to build the App Engine
 applications.
 
-### Add a new\_http\_archive rule
+### Add a git\_repository rule
 
 When you built the Android app, you added a reference to the location on your
 filesystem where you downloaded and installed the Android SDK. For the


### PR DESCRIPTION
The instructions are about adding a `git_repository` rule, not an `new_http_archive` rule, as it was written in the section title.