### PR TITLE
Fix ClassCastException for non-http pom urls

### DIFF
--- a/src/tools/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
+++ b/src/tools/generate_workspace/src/main/java/com/google/devtools/build/workspace/maven/DefaultModelResolver.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -134,7 +135,12 @@ public class DefaultModelResolver implements ModelResolver {
 
   private boolean pomFileExists(URL url) {
     try {
-      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+      URLConnection urlConnection = url.openConnection();
+      if (!(urlConnection instanceof HttpURLConnection)) {
+        return false;
+      }
+
+      HttpURLConnection connection = (HttpURLConnection) urlConnection;
       connection.setRequestMethod("HEAD");
       connection.setInstanceFollowRedirects(true);
       connection.connect();


### PR DESCRIPTION
For example for this library:
```
bazel run //src/tools/generate_workspace -- --artifact=com.wix:wix-embedded-mysql:2.1.3
```

I get this exception:
```
Exception in thread "main" java.lang.ClassCastException: sun.net.www.protocol.ftp.FtpURLConnection cannot be cast to java.net.HttpURLConnection
	at com.google.devtools.build.workspace.maven.DefaultModelResolver.pomFileExists(DefaultModelResolver.java:143)
	at com.google.devtools.build.workspace.maven.DefaultModelResolver.getModelSource(DefaultModelResolver.java:124)
	at com.google.devtools.build.workspace.maven.DefaultModelResolver.resolveModel(DefaultModelResolver.java:96)
	at com.google.devtools.build.workspace.maven.Resolver.resolveEffectiveModel(Resolver.java:172)
	at com.google.devtools.build.workspace.maven.Resolver.resolveArtifact(Resolver.java:137)
	at com.google.devtools.build.workspace.GenerateWorkspace.generateFromArtifacts(GenerateWorkspace.java:123)
	at com.google.devtools.build.workspace.GenerateWorkspace.main(GenerateWorkspace.java:64)
```

The cause is the dependency's pom is resolved as `file://${basedir}/src/test/lib/org/apache/httpcomponents/httpclient/4.2.5/httpclient-4.2.5.pom`, which can't be tested with HTTP HEAD request, obviously.

This patch is workaround, until there will be some better handling of such cases.