### PR TITLE
Make protobuf's BUILD file standlone

### DIFF
--- a/third_party/protobuf/3.0.0/BUILD
+++ b/third_party/protobuf/3.0.0/BUILD
@@ -2,7 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-load("//third_party/protobuf/3.0.0:protobuf.bzl", "py_proto_library")
+load(":protobuf.bzl", "py_proto_library")
 
 filegroup(
     name = "srcs",
@@ -95,12 +95,17 @@ COPTS = [
 ]
 
 LINK_OPTS = select({
-    "//src:freebsd": [
+    ":freebsd": [
         "-lpthread",
         "-lm",
     ],
     "//conditions:default": ["-lpthread"],
 })
+
+config_setting(
+    name = "freebsd",
+    values = {"cpu": "freebsd"},
+)
 
 cc_library(
     name = "protobuf_lite",


### PR DESCRIPTION
This is in preparation for placing it in a local repository of its own.

The goal is to make proto_library depend on @com_google_protobuf//:protoc by default instead of //third_party/protobuf:protoc.
This, in turn, will allow easier set-up for proto_library: just download a protobuf distro and point at it from their WORKSPACE.