### PR TITLE
Update _get_cpu_value() to fix issue #1264

### DIFF
--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -142,6 +142,8 @@ def _get_cpu_value(repository_ctx):
   result = repository_ctx.execute(["uname", "-m"])
   if result.stdout.strip() in ["power", "ppc64le", "ppc"]:
     return "ppc"
+  if result.stdout.strip() in ["arm", "armv7l", "aarch64"]:
+    return "arm"
   return "k8" if result.stdout.strip() in ["amd64", "x86_64", "x64"] else "piii"
 
 


### PR DESCRIPTION
I have tested on NVIDA Jetson TK1 and bazel was able to compile. 

I believe with this quick fix would make bazel installation on Linux ARM devices easier. I have been spending 5 hours to figure out a correct way to install bazel.