### PR TITLE
Fixes directory path computation in docker_build

### DIFF
--- a/tools/build_defs/docker/docker.bzl
+++ b/tools/build_defs/docker/docker.bzl
@@ -53,7 +53,11 @@ def _validate_command(name, argument):
 def _short_path_dirname(path):
   """Returns the directory's name of the short path of an artifact."""
   sp = path.short_path
-  return sp[:sp.rfind("/")]
+  last_sep = sp.rfind("/")
+  if last_sep == -1:
+    return "" # The artifact is at the top level.
+
+  return sp[:last_sep]
 
 def _dest_path(f, strip_prefix):
   """Returns the short path of f, stripped of strip_prefix."""


### PR DESCRIPTION
This fixes #1178.

When a docker_build rule has a `files` input that is at the root of the repository, it contains no / characters, and the current version of `_short_path_dirname` returns the last character of the name instead of an empty string.