### PR TITLE
Regression test for ActionCache shutdown roundtrip

### DIFF
--- a/src/test/shell/integration/cpp_test.sh
+++ b/src/test/shell/integration/cpp_test.sh
@@ -90,4 +90,30 @@ EOF
   bazel build //a || fail "build failled"
 }
 
+function test_no_recompile_on_shutdown() {
+  mkdir -p a
+  cat > a/BUILD <<EOF
+cc_binary(name="a", srcs=["a.cc"], deps=["b"])
+cc_inc_library(name="b", hdrs=["b.h"])
+EOF
+
+  cat > a/a.cc <<EOF
+#include <a/b.h>
+
+int main(void) {
+  return B_RETURN_VALUE;
+}
+EOF
+
+  cat > a/b.h <<EOF
+#define B_RETURN_VALUE 31
+EOF
+
+  bazel build -s //a >& $TEST_log || fail "build failed"
+  expect_log "Compiling a/a.cc"
+  bazel shutdown >& /dev/null || fail "query failed"
+  bazel build -s //a >& $TEST_log || fail "build failed"
+  expect_not_log "Compiling a/a.cc"
+}
+
 run_suite "Tests for Bazel's C++ rules"


### PR DESCRIPTION
Determines whether an action cache loaded after bazel daemon shutdown is
accurate to prevent C++ recompilation. Demonstrates the validity of
a28b540 and should prevent future regressions in the input discovery
space for C++.