### PR TITLE
Windows: Assist JNI builds with a target for jni_md.h.

### DIFF
--- a/src/main/tools/jdk.BUILD
+++ b/src/main/tools/jdk.BUILD
@@ -21,6 +21,11 @@ filegroup(
 )
 
 filegroup(
+    name = "jni_md_header-windows",
+    srcs = ["include/win32/jni_md.h"],
+)
+
+filegroup(
     name = "java",
     srcs = select({
        ":windows" : ["bin/java.exe"],


### PR DESCRIPTION
This rule can be used in building JNI shared libraries for Windows.
For example, see TensorFlow usage of these targets in jdk.BUILD:
https://github.com/tensorflow/tensorflow/blob/27a98083a6c16f263d668271889863596efbeb84/tensorflow/java/src/main/native/BUILD#L68