### PR TITLE
Detail support channels

### DIFF
--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -36,7 +36,8 @@
               <a href="/blog">Blog</a>
             </li>
             <li><a href="https://github.com/bazelbuild/bazel">GitHub</a></li>
-            <li><a href="https://groups.google.com/forum/#!forum/bazel-discuss">Mailing List</a></li>
+            <li><a href="http://stackoverflow.com/questions/tagged/bazel" class="nav-icon"><i class="fa fa-stack-overflow"></i></a></li>
+            <li><a href="https://groups.google.com/forum/#!forum/bazel-discuss" class="nav-icon"><i class="fa fa-envelope"></i></a></li>
             <li><a href="https://twitter.com/bazelbuild" class="nav-icon"><i class="fa fa-twitter"></i></a></li>
           </ul>
         </div><!-- /.navbar-collapse -->

--- a/site/contributing.md
+++ b/site/contributing.md
@@ -13,7 +13,8 @@ machine to develop Bazel and, when you've made a patch, how to submit it.</p>
 In general, we prefer contributions that fix bugs or add features (as opposed to
 stylistic, refactoring, or "cleanup" changes). Please check with us on the
 [dev list](https://groups.google.com/forum/#!forum/bazel-dev) before investing
-a lot of time in a patch.
+a lot of time in a patch. Meet other Bazel contributors on [IRC](http://webchat.freenode.net)
+(irc.freenode.net#bazel).
 
 ## Patch Acceptance Process
 

--- a/site/versions/master/docs/support.md
+++ b/site/versions/master/docs/support.md
@@ -5,10 +5,12 @@ title: Get Support
 
 # Get Support
 
-* [User mailing list](https://groups.google.com/forum/#!forum/bazel-discuss)
-* [Issue tracker](https://github.com/bazelbuild/bazel/issues)
-* [Twitter](http://www.twitter.com/bazelbuild)
-* [IRC](http://webchat.freenode.net) (irc.freenode.net#bazel)
+* Ask questions on [Stack Overflow](http://stackoverflow.com/questions/tagged/bazel) using the 
+`bazel` tag.
+* Discuss on the [User mailing list](https://groups.google.com/forum/#!forum/bazel-discuss).
+* Report bugs or feature requests in our [GitHub issue tracker](https://github.com/bazelbuild/bazel/issues).
+* Find other Bazel contributors on [IRC](http://webchat.freenode.net)
+(irc.freenode.net#bazel).
 
 # Support Policy
 


### PR DESCRIPTION
Put forward Stack Overflow as the main place for questions.