### PR TITLE
Update android tutorial to clarify android sdk path options

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -57,6 +57,7 @@ Kamal Marhubi <kamal@marhubi.com>
 Damien Martin-Guillerez <dmarting@google.com>
 Carl Mastrangelo <carl-mastrangelo@users.noreply.github.com>
 Michajlo Matijkiw <michajlo@google.com>
+Iain McGinniss <iainmcgin@google.com>
 Julio Merino <jmmv@google.com>
 Adam Michael <ajmichael@google.com>
 Liam Miller-Cushon <cushon@google.com>

--- a/site/versions/master/docs/tutorial/android-app.md
+++ b/site/versions/master/docs/tutorial/android-app.md
@@ -98,8 +98,6 @@ file:
 ```python
 android_ndk_repository(
     name = "androidndk",
-    # Replace with path to Android NDK on your system
-    path = "/Users/username/Library/Android/ndk",
     # Replace with the Android NDK API level
     api_level = 21
 )
@@ -110,6 +108,9 @@ android_ndk_repository(
 the API levels to the same value for the SDK and NDK.
 [This web page](https://developer.android.com/ndk/guides/stable_apis.html)
 contains a map from Android releases to NDK-supported API levels.
+
+Similar to `android_sdk_repository`, the path to the ndk can be explicitly
+specified with a `path` parameter.
 
 ## Create a BUILD file
 

--- a/site/versions/master/docs/tutorial/android-app.md
+++ b/site/versions/master/docs/tutorial/android-app.md
@@ -77,7 +77,7 @@ environment variable, and automatically detect the latest build tools
 version installed within that location.
 
 Alternatively, you can explicitly specify the location of the Android
-SDK and build tools version to use by including a `path` and
+SDK and build tools version to use by including the `path` and
 `build_tools_version` attributes:
 
 ```python
@@ -109,7 +109,7 @@ the API levels to the same value for the SDK and NDK.
 [This web page](https://developer.android.com/ndk/guides/stable_apis.html)
 contains a map from Android releases to NDK-supported API levels.
 
-Similar to `android_sdk_repository`, the path to the Android NDK if inferred from 
+Similar to `android_sdk_repository`, the path to the Android NDK is inferred from 
 the `ANDROID_NDK_HOME` environment variable by default. The path can also be 
 explicitly specified with a `path` attribute on `android_ndk_repository`.
 

--- a/site/versions/master/docs/tutorial/android-app.md
+++ b/site/versions/master/docs/tutorial/android-app.md
@@ -78,14 +78,14 @@ version installed within that location.
 
 Alternatively, you can explicitly specify the location of the Android
 SDK and build tools version to use by including a `path` and
-`build_tools_version` arguments:
+`build_tools_version` attributes:
 
 ```python
 android_sdk_repository(
     name = "androidsdk",
     path = "/path/to/Android/sdk",
     api_level = 25,
-    build_tools_version="25.0.1"
+    build_tools_version = "25.0.1"
 )
 ```
 
@@ -109,8 +109,9 @@ the API levels to the same value for the SDK and NDK.
 [This web page](https://developer.android.com/ndk/guides/stable_apis.html)
 contains a map from Android releases to NDK-supported API levels.
 
-Similar to `android_sdk_repository`, the path to the ndk can be explicitly
-specified with a `path` parameter.
+Similar to `android_sdk_repository`, the path to the Android NDK if inferred from 
+the `ANDROID_NDK_HOME` environment variable by default. The path can also be 
+explicitly specified with a `path` attribute on `android_ndk_repository`.
 
 ## Create a BUILD file
 

--- a/site/versions/master/docs/tutorial/android-app.md
+++ b/site/versions/master/docs/tutorial/android-app.md
@@ -67,12 +67,23 @@ Add the following lines to your `WORKSPACE` file:
 ```python
 android_sdk_repository(
     name = "androidsdk",
-    # Replace with path to Android SDK on your system
-    path = "/Users/username/Library/Android/sdk",
-    # Replace with the Android SDK API level
-    api_level = 23,
-    # Replace with the version in sdk/build-tools/
-    build_tools_version="23.0.0"
+    # Replace with your installed Android SDK API level
+    api_level = 25,
+    # Replace with your installed Android SDK build-tools version
+    build_tools_version="25.0.1"
+)
+```
+
+This will use the Android SDK specified referenced by the `ANDROID_HOME`
+environment variable. Alternatively, you can explicitly specify which Android
+SDK to use by including a `path` argument:
+
+```python
+android_sdk_repository(
+    name = "androidsdk",
+    path = "/path/to/Android/sdk",
+    api_level = 25,
+    build_tools_version="25.0.1"
 )
 ```
 

--- a/site/versions/master/docs/tutorial/android-app.md
+++ b/site/versions/master/docs/tutorial/android-app.md
@@ -68,15 +68,17 @@ Add the following lines to your `WORKSPACE` file:
 android_sdk_repository(
     name = "androidsdk",
     # Replace with your installed Android SDK API level
-    api_level = 25,
-    # Replace with your installed Android SDK build-tools version
-    build_tools_version="25.0.1"
+    api_level = 25
 )
 ```
 
 This will use the Android SDK specified referenced by the `ANDROID_HOME`
-environment variable. Alternatively, you can explicitly specify which Android
-SDK to use by including a `path` argument:
+environment variable, and automatically detect the latest build tools
+version installed within that location.
+
+Alternatively, you can explicitly specify the location of the Android
+SDK and build tools version to use by including a `path` and
+`build_tools_version` arguments:
 
 ```python
 android_sdk_repository(


### PR DESCRIPTION
The android_sdk_repository path parameter is now optional, and for most setups it is easier to omit it and rely on the `ANDROID_HOME` environment variable. Updated this part of the tutorial to clarify this.