### PR TITLE
Fix powershellv2

### DIFF
--- a/scripts/packages/chocolatey/build.ps1
+++ b/scripts/packages/chocolatey/build.ps1
@@ -27,7 +27,11 @@ if ($mode -eq "release") {
 }
 
 if ($fixPackage -eq $true) {
-  $tvPackageFixVersion = "-$((get-date).tostring("yyyyMMdd-hhmmss"))"
+  $prefix = "-"
+  if ($mode -eq "release") {
+    $prefix = "."
+  }
+  $tvPackageFixVersion = "$($prefix)$((get-date).tostring("yyyyMMdd"))"
 }
 rm -force -ErrorAction SilentlyContinue ./*.nupkg
 rm -force -ErrorAction SilentlyContinue ./bazel.nuspec

--- a/scripts/packages/chocolatey/build.ps1
+++ b/scripts/packages/chocolatey/build.ps1
@@ -32,8 +32,8 @@ if ($fixPackage -eq $true) {
 rm -force -ErrorAction SilentlyContinue ./*.nupkg
 rm -force -ErrorAction SilentlyContinue ./bazel.nuspec
 rm -force -ErrorAction SilentlyContinue ./tools/LICENSE
-rm -force -ErrorAction SilentlyContinue ./tools/params.json
 rm -force -ErrorAction SilentlyContinue ./tools/*.orig
+rm -force -ErrorAction SilentlyContinue "./tools/params.*"
 if ($checksum -eq "") {
   rm -force -ErrorAction SilentlyContinue ./*.zip
 }
@@ -63,13 +63,10 @@ From: https://github.com/bazelbuild/bazel/blob/master/LICENSE
 add-content -value $licenseHeader -path "./tools/LICENSE"
 add-content -value (get-content "../../../LICENSE") -path "./tools/LICENSE"
 
-$params = @{
-  package = @{
-    uri = $tvUri;
-    checksum = $tvChecksum;
-    checksumType = "sha256";
-  }
-}
-add-content -value (ConvertTo-Json $params) -path "./tools/params.json"
+$params = @"
+$tvUri
+$tvChecksum
+"@
+add-content -value $params -path "./tools/params.txt"
 
 choco pack ./bazel.nuspec

--- a/scripts/packages/chocolatey/test.ps1
+++ b/scripts/packages/chocolatey/test.ps1
@@ -1,12 +1,13 @@
 param(
-  [switch] $prerelease
+  [switch] $prerelease,
+  [string] $sources = "."
 )
 
 choco uninstall bazel --force -y
 if ($prerelease) {
-  choco install bazel --verbose --debug --prerelease --force -y -s ".;https://chocolatey.org/api/v2/"
+  choco install bazel --verbose --debug --prerelease --force -y -s $sources
 } else {
-  choco install bazel --verbose --debug --force -y -s ".;https://chocolatey.org/api/v2/"
+  choco install bazel --verbose --debug --force -y -s $sources
 }
 
 if ($LASTEXITCODE -ne 0)

--- a/scripts/packages/chocolatey/tools/chocolateyinstall.ps1
+++ b/scripts/packages/chocolatey/tools/chocolateyinstall.ps1
@@ -6,7 +6,6 @@ $paramsText = get-content "$($toolsDir)\params.txt"
 $p = $paramsText.Split("`n")
 
 $packageDir = Split-Path -parent $toolsDir
-$binRoot = (Get-ToolsLocation) -replace "\\", "/"
 
 write-host "Read params from text file"
 write-host $p

--- a/scripts/packages/chocolatey/tools/chocolateyinstall.ps1
+++ b/scripts/packages/chocolatey/tools/chocolateyinstall.ps1
@@ -2,22 +2,19 @@ $ErrorActionPreference = 'Stop'; # stop on all errors
 $packageName = 'bazel'
 
 $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
-$json = gc "$toolsDir\params.json"
-$p = (($json) -join "`n") | convertfrom-json
+$paramsText = get-content "$($toolsDir)\params.txt"
+$p = $paramsText.Split("`n")
 
 $packageDir = Split-Path -parent $toolsDir
 $binRoot = (Get-ToolsLocation) -replace "\\", "/"
 
-write-host "Read params from json"
-write-host (convertto-json $p)
+write-host "Read params from text file"
+write-host $p
 
 Install-ChocolateyZipPackage -PackageName "$packageName" `
-  -Url "$($p.package.uri)" `
-  -Checksum "$($p.package.checksum)" `
-  -ChecksumType "$($p.package.checksumType)" `
-  -Url64bit "$($p.package.uri)" `
-  -Checksum64 "$($p.package.checksum)" `
-  -Checksum64Type "$($p.package.checksumType)" `
+  -Url64bit "$($p[0])" `
+  -Checksum64 "$($p[1])" `
+  -Checksum64Type "sha256" `
   -UnzipLocation "$packageDir"
 
 write-host "Ensure that msys2 dll is present in PATH to allow bazel to be run from non-msys2 shells"


### PR DESCRIPTION
Powershell v2 (win7 vintage) doesn't have json cmdlets.

Got a report via chocolatey.org message that this doesn't work on win7. Cried. Replaced with simpler text file based approach for separating data from code.

Also fix package version fix notation bit of the automation to produce version numbers valid with chocolatey/nuspec.

I've already published a fixed 0.4.5-rc2 and 0.4.4 with this
* https://chocolatey.org/packages/bazel/0.4.4.20170306
* https://chocolatey.org/packages/bazel/0.4.5-rc2-20170306-124051