### PR TITLE
Initialize the mutex in JNIEventsDiffAwareness

### DIFF
--- a/src/main/native/fsevents.cc
+++ b/src/main/native/fsevents.cc
@@ -32,6 +32,14 @@ struct JNIEventsDiffAwareness {
   // The former is called inside the FsEvents run loop and the latter
   // from Java threads.
   pthread_mutex_t mutex;
+
+  JNIEventsDiffAwareness() {
+    pthread_mutex_init(&mutex, nullptr);
+  }
+
+  ~JNIEventsDiffAwareness() {
+    pthread_mutex_destroy(&mutex);
+  }
 };
 
 // Callback called when an event is reported by the FSEvents API
@@ -64,7 +72,7 @@ Java_com_google_devtools_build_lib_skyframe_MacOSXFsEventsDiffAwareness_create(
     JNIEnv *env, jobject fsEventsDiffAwareness, jobjectArray paths,
     jdouble latency) {
   // Create a FSEventStreamContext to pass around (env, fsEventsDiffAwareness)
-  JNIEventsDiffAwareness *info = new JNIEventsDiffAwareness;
+  JNIEventsDiffAwareness *info = new JNIEventsDiffAwareness();
 
   FSEventStreamContext context;
   context.version = 0;


### PR DESCRIPTION
pthread mutexes must be initialized with pthread_mutex_init and cleaned
up with pthread_mutex_destroy.

This seems to fix a race where poll() would access invalid array indexes
on an array constructed based on the size of a shared list protected by
the mutex.  This is understandable because the mutex may not have been
doing anything due to the lack of its proper initialization -- and, if
so, I'm surprised the consequences were not more catastrophic.

As with any race condition, it is hard to confirm that this fixes the
observed problem, but I could trivially reproduce this issue earlier
and now I cannot with this fix after tens of runs.  See reproduction
code in the referenced bug for details on how to expose the issue.

Fixes #1676.