### PR TITLE
fixed java tutorial in Docs

### DIFF
--- a/site/versions/master/docs/tutorial/java.md
+++ b/site/versions/master/docs/tutorial/java.md
@@ -56,7 +56,7 @@ directory.  Add the following lines to this BUILD file:
 java_binary(
     name = "my-runner",
     srcs = glob(["**/*.java"]),
-    main_class = "com.example.ProjectRunner",
+    main_class = "ProjectRunner",
 )
 {% endhighlight %}
 
@@ -64,7 +64,7 @@ java_binary(
 `glob(["**/*.java"])` is a handy shorthand for "recursively include every file
 that ends with .java" (see the
 [build encyclopedia](/docs/be/functions.html#glob) for more information about
-globbing). `com.example.ProjectRunner` specifies the class that contains the
+globbing). `ProjectRunner` specifies the class that contains the
 main method.
 
 Now you are ready to build your Java binary:
@@ -99,7 +99,7 @@ to the `BUILD` file:
 java_binary(
     name = "my-other-runner",
     srcs = ["src/main/java/com/example/ProjectRunner.java"],
-    main_class = "com.example.ProjectRunner",
+    main_class = "ProjectRunner",
     deps = [":greeter"],
 )
 


### PR DESCRIPTION
Change-Id: I674589adc74d1c266dec1f00255352cfaecf185e


Subrats-MacBook-Air:test subrat$ cat BUILD 
java_binary(
    name = "my-other-runner",
    srcs = ["src/main/java/com/example/ProjectRunner.java"],
    main_class = "com.example.ProjectRunner",
    deps = [":greeter"],
)

java_library(
    name = "greeter",
    srcs = ["src/main/java/com/example/Greeting.java"],
)
Subrats-MacBook-Air:test subrat$ bazel run //:my-other-runner
INFO: Found 1 target...
Target //:my-other-runner up-to-date:
  bazel-bin/my-other-runner.jar
  bazel-bin/my-other-runner
INFO: Elapsed time: 0.410s, Critical Path: 0.02s

INFO: Running command line: bazel-bin/my-other-runner
Error: Could not find or load main class com.example.ProjectRunner
ERROR: Non-zero return code '1' from command: Process exited with status 1.
Subrats-MacBook-Air:test subrat$ nano BUILD 
Subrats-MacBook-Air:test subrat$ cat BUILD 
java_binary(
    name = "my-other-runner",
    srcs = ["src/main/java/com/example/ProjectRunner.java"],
    main_class = "ProjectRunner",
    deps = [":greeter"],
)

java_library(
    name = "greeter",
    srcs = ["src/main/java/com/example/Greeting.java"],
)
Subrats-MacBook-Air:test subrat$ bazel run //:my-other-runner
INFO: Found 1 target...
Target //:my-other-runner up-to-date:
  bazel-bin/my-other-runner.jar
  bazel-bin/my-other-runner
INFO: Elapsed time: 0.286s, Critical Path: 0.01s

INFO: Running command line: bazel-bin/my-other-runner
Hi Bazel
Subrats-MacBook-Air:test subrat$ 