### PR TITLE
Parse params via a built-in, and lock msys2 version

### DIFF
--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -58,7 +58,7 @@ Bazel has built-in support for building both client and server software, includi
 
 ## Package parameters
 
-Supply like `--params="/option:value ..."` ([see docs for --params](https://github.com/chocolatey/choco/wiki/CommandsInstall#options-and-switches))
+Supply like `--params="/option:'value' ..."` ([see docs for --params](https://github.com/chocolatey/choco/wiki/CommandsInstall#options-and-switches))
 
 * `msys2Path` (optional, defaults to c:\tools\msys64) - override this if msys2 is installed elsewhere.
 </description>
@@ -75,6 +75,7 @@ Supply like `--params="/option:value ..."` ([see docs for --params](https://gith
       <dependency id="chocolatey-uninstall.extension" />
     </dependencies>-->
     <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.0.7"/>
       <dependency id="jdk8" version="[8.0.102,)"/>
       <dependency id="msys2" version="[20160719.1,)"/>
       <dependency id="python2" version="[2.7.11,3.0)"/>

--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -77,7 +77,7 @@ Supply like `--params="/option:'value' ..."` ([see docs for --params](https://gi
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.0.7"/>
       <dependency id="jdk8" version="[8.0.102,)"/>
-      <dependency id="msys2" version="[20160719.1.0]"/>
+      <dependency id="msys2" version="[20160719.1.0,20160719.1.1]"/>
       <dependency id="python2" version="[2.7.11,3.0)"/>
     </dependencies>
     <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->

--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -77,7 +77,7 @@ Supply like `--params="/option:'value' ..."` ([see docs for --params](https://gi
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.0.7"/>
       <dependency id="jdk8" version="[8.0.102,)"/>
-      <dependency id="msys2" version="[20160719.1]"/>
+      <dependency id="msys2" version="[20160719.1.0]"/>
       <dependency id="python2" version="[2.7.11,3.0)"/>
     </dependencies>
     <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->

--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -77,7 +77,7 @@ Supply like `--params="/option:'value' ..."` ([see docs for --params](https://gi
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.0.7"/>
       <dependency id="jdk8" version="[8.0.102,)"/>
-      <dependency id="msys2" version="[20160719.1,)"/>
+      <dependency id="msys2" version="[20160719.1]"/>
       <dependency id="python2" version="[2.7.11,3.0)"/>
     </dependencies>
     <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->


### PR DESCRIPTION
@laszlocsomor - This addresses https://github.com/bazelbuild/bazel/issues/2449#issuecomment-278059161.

Note - this is _not_ in the 0.4.5 package, since I was waiting for that release to go out prior to this.