### PR TITLE
Add "aarch64" to the set of ARM CPU archs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/util/CPU.java
+++ b/src/main/java/com/google/devtools/build/lib/util/CPU.java
@@ -25,7 +25,7 @@ public enum CPU {
   X86_32("x86_32", ImmutableSet.of("i386", "i486", "i586", "i686", "i786", "x86")),
   X86_64("x86_64", ImmutableSet.of("amd64", "x86_64", "x64")),
   PPC("ppc", ImmutableSet.of("ppc", "ppc64", "ppc64le")),
-  ARM("arm", ImmutableSet.of("arm", "armv7l")),
+  ARM("arm", ImmutableSet.of("aarch64", "arm", "armv7l")),
   S390X("s390x", ImmutableSet.of("s390x", "s390")),
   UNKNOWN("unknown", ImmutableSet.<String>of());
 


### PR DESCRIPTION
This change, suggested by @tylerfox at
https://github.com/tensorflow/tensorflow/issues/851#issuecomment-230810921
allows Bazel 0.4.5 to be built on a Jetson TX1 with JetPack 3.0.

The other of @tylerfox's suggested changes was made in 7c4afb6.

Refs #1264