### PR TITLE
Fix potential uninitialized variable usage in linux-sandbox-options.cc

### DIFF
--- a/src/main/tools/linux-sandbox-options.cc
+++ b/src/main/tools/linux-sandbox-options.cc
@@ -122,7 +122,7 @@ static void ParseCommandLine(unique_ptr<vector<char *>> args) {
   extern char *optarg;
   extern int optind, optopt;
   int c;
-  bool source_specified;
+  bool source_specified = false;
 
   while ((c = getopt(args->size(), args->data(),
                      ":CW:T:t:l:L:w:e:M:m:HNRUD")) != -1) {


### PR DESCRIPTION
INFO: From Compiling src/main/tools/linux-sandbox-options.cc [for host]:
src/main/tools/linux-sandbox-options.cc: In function 'void ParseOptions(int, char**)':                                                                                  src/main/tools/linux-sandbox-options.cc:203:9: warning: 'source_specified' may be used uninitialized in this function [-Wmaybe-uninitialized]
         if (!source_specified) {
         ^
src/main/tools/linux-sandbox-options.cc:126:8: note: 'source_specified' was declared here                                                                                  bool source_specified;
        ^