### PR TITLE
Use sha256 prefix when tagging docker images with full IDs

### DIFF
--- a/tools/build_defs/docker/incremental_load.sh.tpl
+++ b/tools/build_defs/docker/incremental_load.sh.tpl
@@ -68,7 +68,7 @@ function tag_layer() {
   if [ "$LEGACY_DOCKER" = true ]; then
     "${DOCKER}" tag -f ${name} ${TAG}
   else
-    "${DOCKER}" tag ${name} ${TAG}
+    "${DOCKER}" tag sha256:${name} ${TAG}
   fi
 }
 


### PR DESCRIPTION
Newer versions of docker require 'sha256' prefix with full IDs (see
https://github.com/docker/docker/issues/20972#issuecomment-193381422). Without
the prefix users get the following error with newer versions of docke, e.g. 17.04.0-ce-rc1:

    $ docker tag 7cd4bfeb6766d1c5e5d729b7444cba3d9f97dfddfbeab90ed2e3f7147804ee8f \
      	     docker.io/<user>/<image>:<tag>
    Error parsing reference:
    "7cd4bfeb6766d1c5e5d729b7444cba3d9f97dfddfbeab90ed2e3f7147804ee8f"
    is not a valid repository/tag: invalid repository name
    (7cd4bfeb6766d1c5e5d729b7444cba3d9f97dfddfbeab90ed2e3f7147804ee8f),
    cannot specify 64-byte hexadecimal strings

---
 I'm not sure if this is the proper solution, but it seems to fix the problem with docker version `17.04.0-ce-rc1` as well as older docker version (e.g. `1.12.0`). Alternative solutions welcome.