### PR TITLE
Provide more information regarding compiler

### DIFF
--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -387,18 +387,21 @@ def _get_system_root(repository_ctx):
 def _find_cc(repository_ctx):
   """Find the C++ compiler."""
   cc_name = "gcc"
-  if "CC" in repository_ctx.os.environ:
-    cc_name = repository_ctx.os.environ["CC"].strip()
-    if not cc_name:
-      cc_name = "gcc"
+  cc_environ = repository_ctx.os.environ.get("CC")
+  cc_paren = ""
+  if cc_environ != None:
+    cc_environ = cc_environ.strip()
+    if cc_environ:
+      cc_name = cc_environ
+      cc_paren = " (%s)" % cc_environ
   if cc_name.startswith("/"):
     # Absolute path, maybe we should make this suported by our which function.
     return cc_name
   cc = repository_ctx.which(cc_name)
   if cc == None:
     fail(
-        "Cannot find gcc, either correct your path or set the CC" +
-        " environment variable")
+        ("Cannot find gcc or CC%s, either correct your path or set the CC"
+        + " environment variable") % cc_paren)
   return cc
 
 


### PR DESCRIPTION
This addresses #2761, to provide a minor improvement if neither `gcc` or `CC` are found on the path.
Let me know if you would like anything changed!

Local qualification steps:
```
$ cd bazel
$ git rebase 0.4.5   # Did not want to spend too much time synchronizing derived stuff in master
$ ln -s ~/Downloads/bazel-0.4.5-dist/derived .
$ ./compile.sh
$ export PATH=~+/output/bazel;$PATH
$ cd .../someproject
$ CC=clang-9000 bazel build //package:test
Cannot find gcc or CC (clang-9000), either correct your path or set the CC environment variable.
```