### PR TITLE
MSVC: attempt to choose msvcrt.lib vs libcmt.lib correctly

### DIFF
--- a/tools/cpp/wrapper/bin/pydir/msvc_link.py
+++ b/tools/cpp/wrapper/bin/pydir/msvc_link.py
@@ -114,10 +114,13 @@ class MsvcLinker(msvc_tools.WindowsRunner):
             raise ValueError('Must specify compilation mode '
                              '(-Xcompilation-mode={dbg,fastbuild,opt})')
 
-          if parser.compilation_mode == 'dbg':
-            default_args.insert(0, 'libcmtd.lib')
-          else:
-            default_args.insert(0, 'libcmt.lib')
+          rtlib = "libcmt%s.lib"
+          # attempt to choose the right runtime library if we can
+          for opt in reversed(parser.options):
+            if opt in ['/MT', '/MTd']:
+              rtlib = "msvcrt%s.lib"
+              break
+          default_args.insert(0, rtlib % ('d' if parser.compilation_mode == 'dbg' else ''))
 
       return self.RunBinary(tool, default_args + parser.options,
                             parser.target_arch, parser)


### PR DESCRIPTION
See Issue #2120: if we specify /MD for copts, we should attempt to use
MSVCRTx.lib instead of LIBCMTx.lib.