### PR TITLE
Make tools/build_defs/pkg/archive.py py3 compatible

### DIFF
--- a/tools/build_defs/pkg/archive.py
+++ b/tools/build_defs/pkg/archive.py
@@ -14,7 +14,10 @@
 """Archive manipulation library for the Docker rules."""
 
 import os
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import subprocess
 import tarfile
 


### PR DESCRIPTION
Without this change, any build using python3 and involving this tool fails with:

    Traceback (most recent call last):
      File ".../bazel-out/host/bin/external/bazel_tools/tools/build_defs/pkg/build_tar.runfiles/__main__/../bazel_tools/tools/build_defs/pkg/build_tar.py", line 22, in <module>
        from tools.build_defs.pkg import archive
      File ".../bazel-out/host/bin/external/bazel_tools/tools/build_defs/pkg/build_tar.runfiles/bazel_tools/tools/build_defs/pkg/archive.py", line 17, in <module>
        from StringIO import StringIO
    ModuleNotFoundError: No module named 'StringIO'