### PR TITLE
Make tools/build_defs/hash/sha256.py py3 compatible

### DIFF
--- a/tools/build_defs/hash/sha256.py
+++ b/tools/build_defs/hash/sha256.py
@@ -20,7 +20,7 @@ import sys
 
 if __name__ == "__main__":
   if len(sys.argv) != 3:
-    print("Usage: %s input output" % (sys.argv[0],))
+    print("Usage: %s input output" % sys.argv[0])
     sys.exit(-1)
   with open(sys.argv[2], "w") as outputfile:
     with open(sys.argv[1], "rb") as inputfile:

--- a/tools/build_defs/hash/sha256.py
+++ b/tools/build_defs/hash/sha256.py
@@ -20,7 +20,7 @@ import sys
 
 if __name__ == "__main__":
   if len(sys.argv) != 3:
-    print "Usage: %s input output" % sys.argv[0]
+    print("Usage: %s input output" % (sys.argv[0],))
     sys.exit(-1)
   with open(sys.argv[2], "w") as outputfile:
     with open(sys.argv[1], "rb") as inputfile:


### PR DESCRIPTION
Without this change, any build using python3 and involving this tool fails with:

      File ".../bazel-out/host/bin/external/bazel_tools/tools/build_defs/docker/sha256.runfiles/__main__/../bazel_tools/tools/build_defs/docker/sha256.py", line 23
        print "Usage: %s input output" % sys.argv[0]