### PR TITLE
Confer outputs arity implicitly for list/singular

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.analysis;
 
+import static java.util.Collections.singleton;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -28,6 +30,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.actions.Action;
@@ -64,6 +67,7 @@ import com.google.devtools.build.lib.packages.ConfigurationFragmentPolicy;
 import com.google.devtools.build.lib.packages.FileTarget;
 import com.google.devtools.build.lib.packages.FilesetEntry;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction;
+import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.TemplateSubstitution;
 import com.google.devtools.build.lib.packages.InputFile;
 import com.google.devtools.build.lib.packages.OutputFile;
 import com.google.devtools.build.lib.packages.PackageSpecification;
@@ -1330,14 +1334,17 @@ public final class RuleContext extends TargetContext
    */
   public Artifact getImplicitOutputArtifact(ImplicitOutputsFunction function)
       throws InterruptedException {
-    Iterable<String> result;
+    TemplateSubstitution implicitOutputs;
     try {
-      result = function.getImplicitOutputs(RawAttributeMapper.of(rule));
+      implicitOutputs = function.getImplicitOutputs(RawAttributeMapper.of(rule));
+      if (implicitOutputs.isPlural()) {
+        throw new IllegalStateException("implicit output must be singular");
+      }
     } catch (EvalException e) {
       // It's ok as long as we don't use this method from Skylark.
       throw new IllegalStateException(e);
     }
-    return getImplicitOutputArtifact(Iterables.getOnlyElement(result));
+    return getImplicitOutputArtifact(implicitOutputs.singular());
   }
 
   /**
@@ -1345,6 +1352,21 @@ public final class RuleContext extends TargetContext
    */
   public Artifact getImplicitOutputArtifact(String path) {
     return getPackageRelativeArtifact(path, getBinOrGenfilesDirectory());
+  }
+
+  /**
+   * Only use from Skylark. Returns the implicit output artifacts for a given output paths list.
+   */
+  public Object getImplicitOutputArtifacts(TemplateSubstitution substitution) {
+    if (!substitution.isPlural()) {
+      return getPackageRelativeArtifact(substitution.singular(), getBinOrGenfilesDirectory());
+    }
+
+    List<Artifact> result = Lists.<Artifact>newArrayList();
+    for( String path : substitution.plural() ) {
+      result.add(getPackageRelativeArtifact(path, getBinOrGenfilesDirectory()));
+    }
+    return result;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/SkylarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/SkylarkRuleContext.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Root;
 import com.google.devtools.build.lib.analysis.ActionsProvider;
@@ -45,6 +46,7 @@ import com.google.devtools.build.lib.packages.Attribute.ConfigurationTransition;
 import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.ClassObjectConstructor;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction;
+import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.TemplateSubstitution;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.SkylarkImplicitOutputsFunction;
 import com.google.devtools.build.lib.packages.NativeClassObjectConstructor;
 import com.google.devtools.build.lib.packages.OutputFile;
@@ -211,12 +213,12 @@ public final class SkylarkRuleContext implements SkylarkValue {
       if (implicitOutputsFunction instanceof SkylarkImplicitOutputsFunction) {
         SkylarkImplicitOutputsFunction func =
             (SkylarkImplicitOutputsFunction) implicitOutputsFunction;
-        for (Map.Entry<String, String> entry :
+        for (Map.Entry<String, TemplateSubstitution> entry :
             func.calculateOutputs(RawAttributeMapper.of(ruleContext.getRule())).entrySet()) {
           addOutput(
               outputsBuilder,
               entry.getKey(),
-              ruleContext.getImplicitOutputArtifact(entry.getValue()));
+              ruleContext.getImplicitOutputArtifacts(entry.getValue()));
         }
       }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidRuleClasses.java
@@ -308,7 +308,7 @@ public final class AndroidRuleClasses {
       new SafeImplicitOutputsFunction() {
 
         @Override
-        public Iterable<String> getImplicitOutputs(AttributeMap rule) {
+        public TemplateSubstitution getImplicitOutputs(AttributeMap rule) {
           List<SafeImplicitOutputsFunction> functions = Lists.newArrayList();
           functions.add(AndroidRuleClasses.ANDROID_BINARY_APK);
           functions.add(AndroidRuleClasses.ANDROID_BINARY_UNSIGNED_APK);
@@ -328,7 +328,7 @@ public final class AndroidRuleClasses {
   public static final SafeImplicitOutputsFunction ANDROID_LIBRARY_IMPLICIT_OUTPUTS =
       new SafeImplicitOutputsFunction() {
         @Override
-        public Iterable<String> getImplicitOutputs(AttributeMap attributes) {
+        public TemplateSubstitution getImplicitOutputs(AttributeMap attributes) {
 
           ImmutableList.Builder<SafeImplicitOutputsFunction> implicitOutputs =
               ImmutableList.builder();

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
@@ -1880,7 +1880,7 @@ public abstract class BuildViewTestCase extends FoundationTestCase {
 
     RawAttributeMapper attr = RawAttributeMapper.of(associatedRule);
 
-    String path = Iterables.getOnlyElement(outputFunction.getImplicitOutputs(attr));
+    String path = outputFunction.getImplicitOutputs(attr).singular();
 
     return view.getArtifactFactory()
         .getDerivedArtifact(

--- a/src/test/java/com/google/devtools/build/lib/packages/ImplicitOutputsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/ImplicitOutputsFunctionTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.AttributeValueGetter;
+import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.TemplateSubstitution;
 import com.google.devtools.build.lib.testutil.Suite;
 import com.google.devtools.build.lib.testutil.TestSpec;
 import com.google.devtools.build.lib.util.Preconditions;
@@ -140,13 +141,15 @@ public final class ImplicitOutputsFunctionTest {
       String[] expectedFoundPlaceholders)
       throws Exception {
     List<String> foundAttributes = new ArrayList<>();
-    List<String> substitutions =
+    TemplateSubstitution substitutions =
         ImplicitOutputsFunction.substitutePlaceholderIntoTemplate(
             template, null, attrValues, foundAttributes);
     assertThat(foundAttributes)
         .containsExactlyElementsIn(Arrays.asList(expectedFoundPlaceholders))
         .inOrder();
-    assertThat(substitutions).containsExactlyElementsIn(Arrays.asList(expectedSubstitutions));
+    assertThat(substitutions.isPlural()).isTrue();
+    List<String> substitutionsList = substitutions.plural();
+    assertThat(substitutionsList).containsExactlyElementsIn(Arrays.asList(expectedSubstitutions));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -739,15 +739,15 @@ public class RuleClassTest extends PackageLoadingTestCase {
     AttributeMap rule = RawAttributeMapper.of(
         createRule(ruleClass, "testrule", attributeValues, testRuleLocation));
 
-    assertThat(substitutePlaceholderIntoTemplate("foo", rule)).containsExactly("foo");
-    assertThat(substitutePlaceholderIntoTemplate("foo-%{baz}-bar", rule)).containsExactly(
+    assertThat(substitutePlaceholderIntoTemplate("foo", rule).singular()).isEqualTo("foo");
+    assertThat(substitutePlaceholderIntoTemplate("foo-%{baz}-bar", rule).plural()).containsExactly(
         "foo-baz-bar", "foo-BAZ-bar").inOrder();
-    assertThat(substitutePlaceholderIntoTemplate("%{a}-%{b}-%{c}", rule)).containsExactly("a-b-c",
+    assertThat(substitutePlaceholderIntoTemplate("%{a}-%{b}-%{c}", rule).plural()).containsExactly("a-b-c",
         "a-b-C", "a-B-c", "a-B-C", "A-b-c", "A-b-C", "A-B-c", "A-B-C").inOrder();
-    assertThat(substitutePlaceholderIntoTemplate("%{a", rule)).containsExactly("%{a");
-    assertThat(substitutePlaceholderIntoTemplate("%{a}}", rule)).containsExactly("a}", "A}")
+    assertThat(substitutePlaceholderIntoTemplate("%{a", rule).singular()).isEqualTo("%{a");
+    assertThat(substitutePlaceholderIntoTemplate("%{a}}", rule).plural()).containsExactly("a}", "A}")
         .inOrder();
-    assertThat(substitutePlaceholderIntoTemplate("x%{a}y%{empty}", rule)).isEmpty();
+    assertThat(substitutePlaceholderIntoTemplate("x%{a}y%{empty}", rule).plural()).isEmpty();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/skylark/SkylarkIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skylark/SkylarkIntegrationTest.java
@@ -841,7 +841,8 @@ public class SkylarkIntegrationTest extends BuildViewTestCase {
     scratch.file(
         "test/skylark/extension.bzl",
         "def custom_rule_impl(ctx):",
-        "  files = [ctx.outputs.lbl, ctx.outputs.list, ctx.outputs.str]",
+        "  files = [ctx.outputs.lbl, ctx.outputs.str]",
+        "  files += ctx.outputs.list",
         "  print('==!=!=!=')",
         "  print(files)",
         "  ctx.action(",

--- a/src/test/java/com/google/devtools/build/lib/skylark/SkylarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skylark/SkylarkRuleClassFunctionsTest.java
@@ -608,7 +608,7 @@ public class SkylarkRuleClassFunctionsTest extends SkylarkTestCase {
         "r1 = rule(impl, outputs = {'a': 'a.txt'})");
     RuleClass c = ((RuleFunction) lookup("r1")).getRuleClass();
     ImplicitOutputsFunction function = c.getDefaultImplicitOutputsFunction();
-    assertEquals("a.txt", Iterables.getOnlyElement(function.getImplicitOutputs(null)));
+    assertEquals("a.txt", function.getImplicitOutputs(null).singular());
   }
 
   @Test


### PR DESCRIPTION
Multiple outputs, expanded through placeholder specification of list
attributes, should be conveyed to outputs struct definition unmodified.
Presumed singleton extraction from implicit outputs subsystem has been
reworked, and tests of singular/list behavior have been updated.