### PR TITLE
Fixing j2objc support by referencing an external `@bazel_j2objc` project

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/J2ObjcAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/J2ObjcAspect.java
@@ -97,10 +97,10 @@ public class J2ObjcAspect extends NativeAspectClass implements ConfiguredAspectF
           new Attribute("$protobuf_lib", Mode.TARGET), new Attribute("deps", Mode.TARGET));
 
   private static final Label JRE_CORE_LIB =
-      Label.parseAbsoluteUnchecked("//third_party/java/j2objc:jre_core_lib");
+      Label.parseAbsoluteUnchecked("@bazel_j2objc//:jre_core_lib");
 
   private static final Label JRE_EMUL_LIB =
-      Label.parseAbsoluteUnchecked("//third_party/java/j2objc:jre_emul_lib");
+      Label.parseAbsoluteUnchecked("@bazel_j2objc//:jre_emul_lib");
 
   private static final String PROTO_SOURCE_FILE_BLACKLIST_ATTR = "$j2objc_proto_blacklist";
 
@@ -133,7 +133,7 @@ public class J2ObjcAspect extends NativeAspectClass implements ConfiguredAspectF
             .exec()
             .value(
                 Label.parseAbsoluteUnchecked(
-                    toolsRepository + "//third_party/java/j2objc:proto_plugin")));
+                    "@bazel_j2objc//:proto_plugin")));
   }
 
   /** Returns whether this aspect should generate J2ObjC protos from this proto rule */
@@ -193,7 +193,7 @@ public class J2ObjcAspect extends NativeAspectClass implements ConfiguredAspectF
                 .cfg(HOST)
                 .value(
                     Label.parseAbsoluteUnchecked(
-                        toolsRepository + "//third_party/java/j2objc:jre_emul.jar")))
+                        "@bazel_j2objc//:jre_emul.jar")))
         .add(
             attr(":dead_code_report", LABEL)
                 .cfg(HOST)
@@ -201,7 +201,7 @@ public class J2ObjcAspect extends NativeAspectClass implements ConfiguredAspectF
         .add(attr(":jre_lib", LABEL).value(JRE_LIB))
         .add(
             attr("$protobuf_lib", LABEL)
-                .value(Label.parseAbsoluteUnchecked("//third_party/java/j2objc:proto_runtime")))
+                .value(Label.parseAbsoluteUnchecked("@bazel_j2objc//:proto_runtime")))
         .add(
             attr("$xcrunwrapper", LABEL)
                 .cfg(HOST)


### PR DESCRIPTION
This is instead of referencing `@bazel_tools//third_party/j2objc` etc
which wasn't compiled into bazel

Usage is adding something like this to your `WORKSPACE`

```
j2objc_version = "2.0"

new_http_archive(
  name = "bazel_j2objc",
  build_file = "BUILD.j2objc",
  strip_prefix = "j2objc-" + j2objc_version,
  url = "https://github.com/google/j2objc/releases/download/" + j2objc_version + "/j2objc-" + j2objc_version + ".zip",
)
```

And then `BUILD.j2objc` should be similar in contents to `third_party/java/j2objc/BUILD.remote` from the bazel repo.

Pretty sure `j2objc` is currently broken, so I think this would at least let people have an escape hatch to make it work in user land.