### PR TITLE
Add satisfaction survey script.

### DIFF
--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -112,6 +112,9 @@ version_prefix: /versions/master
       </div>
     </div>
 
+    <!-- satisfaction survey -->
+    <script async="" defer="" src="//survey.g.doubleclick.net/async_survey?site=oohdpic4fyfp3jcnym6aqkdf3e"></script>
+
     {% include footer.html %}
   </body>
 </html>


### PR DESCRIPTION
This script is from Google Survey.
The survey is configured remotely from Google survey. For the moment, it is disabled.
We will trigger the satisfaction survey only on documentation pages.