### PR TITLE
add an edit button on Documentation pages

### DIFF
--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -115,8 +115,15 @@ version_prefix: /versions/master
             if(editButton
               && window.location.pathname.split('docs/').length > 1
               && window.location.pathname.lastIndexOf('/be/') == -1) {
-              var mdFile = window.location.pathname.split('docs/')[1].replace('html', 'md');
-              editButton.href = ghDocsBazeURL + mdFile;
+              var docFile = window.location.pathname.split('docs/')[1];
+              // some pages are now using markdown :(
+              if( docFile !== 'bazel-user-manual.html'
+              && docFile !== 'build-ref.html'
+              && docFile !== 'query.html'
+              && docFile !== 'test-encyclopedia.html') {
+                docFile = docFile.replace('html', 'md');
+              }
+              editButton.href = ghDocsBazeURL + docFile;
               editButton.style.visibility = 'visible';
             }
           </script>

--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -107,6 +107,20 @@ version_prefix: /versions/master
           </nav>
         </div>
         <div class="col-lg-9">
+          <a id="gh-edit" style="visibility: hidden;"><i class="fa fa-pencil" aria-hidden="true"></i> Edit</a>
+          <script>
+            var ghDocsBazeURL = 'https://github.com/bazelbuild/bazel/tree/master/site/versions/master/docs/';
+            var editButton = document.getElementById('gh-edit');
+            // if there is an edit button and we are on a doc page but not in the Build Encyclopedia
+            if(editButton
+              && window.location.pathname.split('docs/').length > 1
+              && window.location.pathname.lastIndexOf('/be/') == -1) {
+              var mdFile = window.location.pathname.split('docs/')[1].replace('html', 'md');
+              editButton.href = ghDocsBazeURL + mdFile;
+              editButton.style.visibility = 'visible';
+            }
+          </script>
+
           {{ content }}
         </div>
       </div>

--- a/site/styles/main.css
+++ b/site/styles/main.css
@@ -100,6 +100,9 @@ body {
   text-align: right;
   color: #360;
 }
+#gh-edit {
+  float: right;
+}
 code, var, pre {
   font-size: 13px;
   color: #488f26;


### PR DESCRIPTION
I successfully tested the change by playing with Chrome DevTools on bazel.build, as I could not find instructions about how to run the site locally :(.