### PR TITLE
Make archive.py a bit more py3 compatible

### DIFF
--- a/tools/build_defs/pkg/archive.py
+++ b/tools/build_defs/pkg/archive.py
@@ -17,7 +17,7 @@
 import os
 try:
   from StringIO import StringIO
-except ImportError:
+except ImportError or ModuleNotFoundError:
   from io import StringIO
 import subprocess
 import tarfile


### PR DESCRIPTION
Python 3 will raise an ModuleNotFoundError, not an ImportError when told to import the StringIO module which was removed from the stdlib in Python 3.

This is a small part of #1580, there probably should be a bigger/more thorough rewrite in the future (e.g. just using io.StringIO which also exists on Python2 or compatibility libraries like six).