### PR TITLE
Update BUILD files

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,29 @@
+# Bazel - Google's Build System
+
 package(default_visibility = ["//scripts/release:__pkg__"])
 
 exports_files(["LICENSE"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(
+        ["*"],
+        exclude = [
+            "bazel-*",  # convenience symlinks
+            "out",  # IntelliJ with setup-intellij.sh
+            "output",  # output of compile.sh
+            ".*",  # mainly .git* files
+        ],
+    ) + [
+        "//examples:srcs",
+        "//scripts:srcs",
+        "//site:srcs",
+        "//src:srcs",
+        "//tools:srcs",
+        "//third_party:srcs",
+    ],
+    visibility = ["//visibility:private"],
+)
 
 filegroup(
     name = "git",
@@ -27,27 +50,6 @@ filegroup(
     visibility = [
         "//scripts/packages:__subpackages__",
     ],
-)
-
-filegroup(
-    name = "srcs",
-    srcs = glob(
-        ["*"],
-        exclude = [
-            "bazel-*",  # convenience symlinks
-            "out",  # IntelliJ with setup-intellij.sh
-            "output",  # output of compile.sh
-            ".*",  # mainly .git* files
-        ],
-    ) + [
-        "//examples:srcs",
-        "//scripts:srcs",
-        "//site:srcs",
-        "//src:srcs",
-        "//tools:srcs",
-        "//third_party:srcs",
-    ],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
@@ -26,16 +26,13 @@ java_library(
 java_library(
     name = "javac",
     srcs = glob(
-        [
-            "javac/*.java",
-        ],
+        ["javac/*.java"],
         exclude = [
             "javac/JavacOptions.java",
         ],
     ),
     deps = [
         ":invalid_command_line_exception",
-        ":javac_options",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins",
         "//third_party:auto_value",
         "//third_party:guava",

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/genclass/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/genclass/BUILD
@@ -1,11 +1,11 @@
+package(default_visibility = [":packages"])
+
 package_group(
     name = "packages",
     packages = [
         "//src/java_tools/buildjar/...",
     ],
 )
-
-package(default_visibility = [":packages"])
 
 java_binary(
     name = "GenClass",

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper/BUILD
@@ -1,11 +1,11 @@
+package(default_visibility = [":packages"])
+
 package_group(
     name = "packages",
     packages = [
         "//src/java_tools/buildjar/...",
     ],
 )
-
-package(default_visibility = [":packages"])
 
 JARHELPER_SRCS = [
     "JarHelper.java",

--- a/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/BUILD
@@ -1,15 +1,20 @@
+package(default_visibility = [":packages"])
+
 package_group(
     name = "packages",
     packages = ["//src/java_tools/buildjar/..."],
 )
 
-package(default_visibility = [":packages"])
-
 java_binary(
     name = "turbine",
-    srcs = ["Turbine.java"],
     main_class = "com.google.devtools.build.java.turbine.Turbine",
     visibility = ["//visibility:public"],
+    runtime_deps = [":turbine_main"],
+)
+
+java_library(
+    name = "turbine_main",
+    srcs = ["Turbine.java"],
     deps = [
         "//src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/javac:javac_turbine",
         "//third_party:guava",
@@ -19,6 +24,7 @@ java_binary(
 
 filegroup(
     name = "srcs",
-    srcs = glob(["**"]) + ["//src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/javac:srcs"],
-    visibility = ["//src/java_tools/buildjar:__pkg__"],
+    srcs = glob(["**"]) + [
+        "//src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/javac:srcs",
+    ],
 )

--- a/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/javac/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/javac/BUILD
@@ -1,9 +1,9 @@
+package(default_visibility = [":packages"])
+
 package_group(
     name = "packages",
     packages = ["//src/java_tools/buildjar/..."],
 )
-
-package(default_visibility = [":packages"])
 
 java_library(
     name = "javac_turbine",

--- a/src/java_tools/buildjar/javatests/com/google/devtools/build/java/bazel/BUILD
+++ b/src/java_tools/buildjar/javatests/com/google/devtools/build/java/bazel/BUILD
@@ -1,3 +1,7 @@
+# Description:
+#  Tests for tools for working with Java source code
+package(default_visibility = ["//src:__subpackages__"])
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),

--- a/src/java_tools/buildjar/javatests/com/google/devtools/build/java/turbine/BUILD
+++ b/src/java_tools/buildjar/javatests/com/google/devtools/build/java/turbine/BUILD
@@ -1,12 +1,13 @@
-filegroup(
-    name = "srcs",
-    srcs = glob(["**"]) + ["//src/java_tools/buildjar/javatests/com/google/devtools/build/java/turbine/javac:srcs"],
-    visibility = ["//src/java_tools/buildjar:__pkg__"],
-)
+package(default_visibility = [":packages"])
 
 package_group(
     name = "packages",
     packages = ["//src/java_tools/buildjar/..."],
 )
 
-package(default_visibility = [":packages"])
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]) + [
+        "//src/java_tools/buildjar/javatests/com/google/devtools/build/java/turbine/javac:srcs",
+    ],
+)

--- a/src/java_tools/buildjar/javatests/com/google/devtools/build/java/turbine/javac/BUILD
+++ b/src/java_tools/buildjar/javatests/com/google/devtools/build/java/turbine/javac/BUILD
@@ -16,7 +16,6 @@ java_test(
     ],
     tags = ["jdk8"],
     deps = [
-        "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar:JarOwner",
         "//src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/javac:javac_turbine",
         "//src/main/protobuf:deps_java_proto",
         "//third_party:asm",

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/BUILD
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/BUILD
@@ -2,8 +2,6 @@ DEFAULT_VISIBILITY = [
     "//src/java_tools/junitrunner:__subpackages__",
 ]
 
-licenses(["notice"])  # Apache 2.0
-
 # Libraries
 # =========================================================
 java_library(
@@ -46,6 +44,7 @@ java_binary(
 
 # Tests
 # =========================================================
+
 java_test(
     name = "AllTests",
     args = glob(["**/*Test.java"]),

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/testbed/BUILD
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/testbed/BUILD
@@ -4,8 +4,6 @@ DEFAULT_VISIBILITY = [
 
 package(default_visibility = DEFAULT_VISIBILITY)
 
-licenses(["notice"])  # Apache 2.0
-
 java_library(
     name = "testbed",
     testonly = 1,

--- a/src/java_tools/singlejar/BUILD
+++ b/src/java_tools/singlejar/BUILD
@@ -1,3 +1,6 @@
+# Description:
+#   SingleJar combines multiple zip files and additional files
+#   into a single zip file.
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(


### PR DESCRIPTION
We're currently maintaining two sets of BUILD files; one at Google, and one
in the Git repository. We'd like to not do that. This change makes some of
the Bazel BUILD files more closely match their counterparts, in preparation
for removing the internal ones.