### PR TITLE
Change help message for --batch

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
@@ -164,9 +164,8 @@ public class BlazeServerStartupOptions extends OptionsBase {
     defaultValue = "false", // NOTE: purely decorative!  See class docstring.
     category = "server startup",
     help =
-        "If set, Blaze will be run in batch mode, instead of the standard client/server mode. "
-            + "Running in batch mode prevents Blaze from caching data in memory, which makes it a "
-            + "lot slower. We recommend against using this flag."
+        "If set, Blaze will be run as just a client process without a server, instead of in "
+            + "the standard client/server mode."
   )
   public boolean batch;
 


### PR DESCRIPTION
The help message previously said that `--batch` is strongly discouraged, but in fact it's only discouraged when using bazel interactively.  Since the tradeoffs of `--batch` are fully explained in the online docs, this commit changes the help message to explain what the option does without getting into the tradeoffs.

Fixes #3051