### PR TITLE
Removed docs for nonexistent option

### DIFF
--- a/site/docs/bazel-user-manual.html
+++ b/site/docs/bazel-user-manual.html
@@ -1824,9 +1824,6 @@ The default is <code>armeabi-v7a</code>.
 
 </ul>
 
-<h4 id='flag--local_genrule_timeout_seconds'><code class='flag'>--local_genrule_timeout_seconds <var>seconds</var></code></h4>
-<p>Sets a timeout value for local genrules with the given number of seconds.</p>
-
 <h4 id='flag--jobs'><code class='flag'>--jobs <var>n</var></code> (-j)</h4>
 <p>
   This option, which takes an integer argument, specifies a limit on


### PR DESCRIPTION
Removed `--local_genrule_timeout_seconds` from the documentation. This option does not exist in the codebase, and is apparently a holdover from internal docs for blaze.

Fixes #3131 