### PR TITLE
Name generated BUILD files `BUILD.bazel` to avoid name conflicts.

### DIFF
--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -59,9 +59,9 @@ def _new_git_repository_implementation(ctx):
   _clone_or_update(ctx)
   ctx.file('WORKSPACE', "workspace(name = \"{name}\")\n".format(name=ctx.name))
   if ctx.attr.build_file:
-    ctx.symlink(ctx.attr.build_file, 'BUILD')
+    ctx.symlink(ctx.attr.build_file, 'BUILD.bazel')
   else:
-    ctx.file('BUILD', ctx.attr.build_file_content)
+    ctx.file('BUILD.bazel', ctx.attr.build_file_content)
 
 def _git_repository_implementation(ctx):
   _clone_or_update(ctx)


### PR DESCRIPTION
This allows `new_git_repository` to depend on codebases with
pre-existing `BUILD` files from other tools, or `build/` directories
in case-insensitive file systems.

Fixes #3127