### PR TITLE
Add :apache_commons_logging as the dependency of the remote worker.

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -131,6 +131,7 @@ java_import(
 java_import(
     name = "apache_httpclient",
     jars = ["apache_httpclient/httpclient-4.5.3.jar"],
+    deps = [":apache_commons_logging"],
 )
 
 java_import(


### PR DESCRIPTION
This fixes an exception being thrown and logged by the remote worker process
(//src/tools/remote_worker:remote_worker) every time the remote worker attempts
to access the remote REST cache.