### PR TITLE
Increase the WindowsFileSystem timeout for executing 'cygpath' for slow machines

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -504,8 +504,8 @@ public class WindowsFileSystem extends JavaIoFileSystem {
       try {
         process = Runtime.getRuntime().exec("cmd.exe /C " + bash + " -c \"/usr/bin/cygpath -m /\"");
 
-        // Wait 3 seconds max, that should be enough to run this command.
-        process.waitFor(3, TimeUnit.SECONDS);
+        // Wait 13 seconds max, that should be enough to run this command.
+        process.waitFor(13, TimeUnit.SECONDS);
 
         if (process.exitValue() == 0) {
           path = readAll(process.getInputStream());


### PR DESCRIPTION
Fixes #2983

Tested both by using a slow Windows 7 laptop (ugh) and by replacing `cygpath` with an executable that adds a delay before running.