### PR TITLE
Handle windows environment variables with spaces and backslashes during bootstrap build

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -332,17 +332,17 @@ function run_bazel_jar() {
         if (name == "_") continue;
         if (ENVIRON[name] ~ /^[[:space:]]*$/) continue;
         if (PLATFORM == "windows") {
-            if (tolower(name) ~ /path|tmp|temp|tempdir|systemroot|zzz/) {
+            if (tolower(name) ~ /^(path|tmp|temp|tempdir|systemroot)$/) {
                 value = ENVIRON[name]
                 delete ENVIRON[name]
                 name = toupper(name)
                 ENVIRON[name] = value
             }
         }
-        printf(" --client_env=%c%s=%s%c\n", 39, name, ENVIRON[name], 39);
+        gsub("\x27", "\\\x27", ENVIRON[name])
+        printf(" --client_env=%c%s=%s%c\n", 0x27, name, ENVIRON[name], 0x27);
     }
 }' "PLATFORM=${PLATFORM}" </dev/null)")
-
   "${JAVA_HOME}/bin/java" \
       -XX:+HeapDumpOnOutOfMemoryError -Xverify:none -Dfile.encoding=ISO-8859-1 \
       -XX:HeapDumpPath=${OUTPUT_DIR} \

--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -339,7 +339,7 @@ function run_bazel_jar() {
                 ENVIRON[name] = value
             }
         }
-        gsub("\x27", "\\\x27", ENVIRON[name])
+        gsub("\x27", "\\\x27", ENVIRON[name]) # 0x27 -> ASCII Apostrophe
         printf(" --client_env=%c%s=%s%c\n", 0x27, name, ENVIRON[name], 0x27);
     }
 }' "PLATFORM=${PLATFORM}" </dev/null)")


### PR DESCRIPTION
When compiling under Windows/MSYS2, [this line](https://github.com/bazelbuild/bazel/blob/master/scripts/bootstrap/compile.sh#L332) in `bootstrap/compile.sh` will fail if any environment variables have spaces or backslashes.

This is common on many MSYS2 installations, especially if you have the `MSYS2_PATH_TYPE=inherit` or `-use-full-path` settings enabled (as many do).

The attached patch does what is intended but is fully whitespace- and escape-character safe.

Tested by actually building (and examining the `arguments.residue` property) and manually checking the resultant command in the shell script.

(Note: it only uses POSIX awk commands, no GNU extensions!)