### PR TITLE
Expose test runner jar for other languages that use JUnit.

### DIFF
--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -94,6 +94,11 @@ filegroup(
     srcs = ["//tools/jdk:VanillaJavaBuilder_deploy.jar"],
 )
 
+filegroup(
+    name = "testrunner",
+    srcs = ["//tools/jdk:TestRunner_deploy.jar"],
+)
+
 BOOTCLASS_JARS = [
     "rt.jar",
     "resources.jar",


### PR DESCRIPTION
Context: https://github.com/bazelbuild/rules_scala/pull/220

Probably a `java_import` at the end instead?