### PR TITLE
use procstat_getpathname to get self path

### DIFF
--- a/src/main/cpp/blaze_util_freebsd.cc
+++ b/src/main/cpp/blaze_util_freebsd.cc
@@ -73,16 +73,23 @@ void WarnFilesystemType(const string &output_base) {
 
 string GetSelfPath() {
   char buffer[PATH_MAX] = {};
-  ssize_t bytes = readlink("/proc/curproc/file", buffer, sizeof(buffer));
-  if (bytes == sizeof(buffer)) {
-    // symlink contents truncated
-    bytes = -1;
-    errno = ENAMETOOLONG;
+  auto pid = getpid();
+  if (kill(pid, 0) < 0) return "";
+  auto procstat = procstat_open_sysctl();
+  unsigned int n;
+  auto p = procstat_getprocs(procstat, KERN_PROC_PID, pid, &n);
+  if (p) {
+    if (n != 1) {
+      pdie(blaze_exit_code::INTERNAL_ERROR,
+           "expected exactly one process from procstat_getprocs, got %d", n);
+    }
+    auto r = procstat_getpathname(procstat, p, buffer,PATH_MAX);
+    if (r != 0) {
+      pdie(blaze_exit_code::INTERNAL_ERROR, "error procstat_getpathname");
+    }
+    procstat_freeprocs(procstat, p);
   }
-  if (bytes == -1) {
-    pdie(blaze_exit_code::INTERNAL_ERROR, "error reading /proc/curproc/file");
-  }
-  buffer[bytes] = '\0';  // readlink does not NUL-terminate
+  procstat_close(procstat);
   return string(buffer);
 }
 


### PR DESCRIPTION
Use procstat_getpathname instead of /proc/curproc/file to get self path, as /proc do not always exists, and need root privilege to mount. procstat_getpathname is preferred on FreeBSD.