### PR TITLE
Safe-guard against broken client environments

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -103,6 +103,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
@@ -115,7 +116,7 @@ import javax.annotation.Nullable;
  */
 public final class BlazeRuntime {
   private static final Pattern suppressFromLog =
-      Pattern.compile("(auth|pass|cookie)", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("--client_env=([^=]*(?:auth|pass|cookie)[^=]*)=", Pattern.CASE_INSENSITIVE);
 
   private static final Logger LOG = Logger.getLogger(BlazeRuntime.class.getName());
 
@@ -593,23 +594,18 @@ public final class BlazeRuntime {
    * @return the filtered request to write to the log.
    */
   @VisibleForTesting
-  public static String getRequestLogString(List<String> requestStrings) {
+  static String getRequestLogString(List<String> requestStrings) {
     StringBuilder buf = new StringBuilder();
     buf.append('[');
     String sep = "";
+    Matcher m = suppressFromLog.matcher("");
     for (String s : requestStrings) {
       buf.append(sep);
-      if (s.startsWith("--client_env")) {
-        int varStart = "--client_env=".length();
-        int varEnd = s.indexOf('=', varStart);
-        String varName = s.substring(varStart, varEnd);
-        if (suppressFromLog.matcher(varName).find()) {
-          buf.append("--client_env=");
-          buf.append(varName);
-          buf.append("=__private_value_removed__");
-        } else {
-          buf.append(s);
-        }
+      m.reset(s);
+      if (m.lookingAt()) {
+        buf.append("--client_env=");
+        buf.append(m.group(1));
+        buf.append("=__private_value_removed__");
       } else {
         buf.append(s);
       }

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeRuntimeUnitTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeRuntimeUnitTest.java
@@ -1,0 +1,43 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.runtime;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link BlazeRuntime} static methods.
+ */
+@RunWith(JUnit4.class)
+public class BlazeRuntimeUnitTest {
+  @Test
+  public void requestLogStringParsing() {
+    assertThat(BlazeRuntime.getRequestLogString(ImmutableList.of("--client_env=A=B")))
+        .isEqualTo("[--client_env=A=B]");
+    assertThat(BlazeRuntime.getRequestLogString(ImmutableList.of("--client_env=BROKEN")))
+        .isEqualTo("[--client_env=BROKEN]");
+    assertThat(BlazeRuntime.getRequestLogString(ImmutableList.of("--client_env=auth=notprinted")))
+        .isEqualTo("[--client_env=auth=__private_value_removed__]");
+    assertThat(BlazeRuntime.getRequestLogString(ImmutableList.of("--client_env=MY_COOKIE=notprinted")))
+        .isEqualTo("[--client_env=MY_COOKIE=__private_value_removed__]");
+    assertThat(BlazeRuntime.getRequestLogString(ImmutableList.of("--client_env=dont_paSS_ME=notprinted")))
+        .isEqualTo("[--client_env=dont_paSS_ME=__private_value_removed__]");
+    assertThat(BlazeRuntime.getRequestLogString(ImmutableList.of("--client_env=ok=COOKIE")))
+        .isEqualTo("[--client_env=ok=COOKIE]");
+  }
+}


### PR DESCRIPTION
The code previously threw StringIndexOutOfBoundsException if the client
env contained just a variable name with no '=' or value.

Fixed #3196.

Change-Id: I5afcaa398ab2e8bacc709445f50ba363659cadbb