### PR TITLE
Include all directories in ij.bazelproject.

### DIFF
--- a/scripts/ij.bazelproject
+++ b/scripts/ij.bazelproject
@@ -1,8 +1,7 @@
 # Setup IntelliJ for Bazel development using the IntelliJ Bazel Plugin.
 # See https://github.com/bazelbuild/intellij for installation instructions.
 directories:
-  src/main
-  src/test
+  .
 
 test_sources:
   src/test/*

--- a/scripts/ij.bazelproject
+++ b/scripts/ij.bazelproject
@@ -8,6 +8,7 @@ test_sources:
 
 targets:
   //src:bazel
+  //src/tools/remote_worker
   //src/test/...
 
 # TODO: Remove this once Bazel can use Java 8.


### PR DESCRIPTION
Without this change you can't work on any code that's not in src/{main,test} in IntelliJ, e.g. tools like the remote_worker.