### PR TITLE
Create and example of how to change the default on inherited attributes

### DIFF
--- a/site/docs/skylark/rules.md
+++ b/site/docs/skylark/rules.md
@@ -591,6 +591,16 @@ the `implementation` function of the rule must generate the output file
 `ctx.outputs.executable`.
 
 Test rules inherit the following attributes: `args`, `flaky`, `local`,
-`shard_count`, `size`, `timeout`.
+`shard_count`, `size`, `timeout`. The defaults of inherited attributes can be
+changed by using default arguments of a skylark function.
+
+```python
+def example_test(size="small", **kwargs):
+  _example_test(size=size, **kwargs)
+
+_example_test = rule(
+ ...
+)
+```
 
 [1]: https://www.python.org/dev/peps/pep-0008/#id46


### PR DESCRIPTION
I found it confusing how to create a test rule with a different default size and had to dig through a lot of example code to figure this out. This pull request adds and example to the docs.