### PR TITLE
Expose wrapped_clang_pp in osx crosstool for ObjC++

### DIFF
--- a/tools/osx/crosstool/BUILD.tpl
+++ b/tools/osx/crosstool/BUILD.tpl
@@ -38,6 +38,7 @@ cc_toolchain_suite(
           ":libtool",
           ":make_hashed_objlist.py",
           ":wrapped_clang",
+          ":wrapped_clang_pp",
           ":wrapped_ar",
           ":xcrunwrapper.sh",
         ],


### PR DESCRIPTION
Problem: 
- When you're using the osx crosstool, compilation of ObjC++ does not work because `wrapped_clang_pp` is not exposed.

Solution:
- Expose `wrapped_clang_pp` in the osx toolchain.


