### PR TITLE
Resolve tool paths to allow CROSSTOOL without wrapper scripts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainFeatures.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
 import com.google.devtools.build.lib.analysis.config.InvalidConfigurationException;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.Variables.VariableValue;
@@ -659,7 +660,11 @@ public class CcToolchainFeatures implements Serializable {
      * Returns the path to this action's tool relative to the provided crosstool path.
      */
     PathFragment getToolPath(PathFragment crosstoolTopPathFragment) {
-      return crosstoolTopPathFragment.getRelative(toolPathString);
+      if (toolPathString.toString().startsWith(Label.EXTERNAL_PATH_PREFIX.getPathString())) {
+        return PathFragment.create(toolPathString);
+      } else {
+        return crosstoolTopPathFragment.getRelative(toolPathString);
+      }
     }
 
     /**

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -648,7 +648,8 @@ public class CppConfiguration extends BuildConfiguration.Fragment {
         String arToolPath = "DUMMY_AR_TOOL";
         for (ToolPath tool : toolchain.getToolPathList()) {
           if (tool.getName().equals(Tool.GCC.getNamePart())) {
-            gccToolPath = resolveIncludeDir(tool.getPath(), null, crosstoolTopPathFragment);
+            gccToolPath = resolveIncludeDir(tool.getPath(), null, crosstoolTopPathFragment)
+                .getPathString();
             linkerToolPath =
                 crosstoolTopPathFragment
                     .getRelative(gccToolPath)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -405,6 +405,8 @@ public class CppConfiguration extends BuildConfiguration.Fragment {
       }
       if (path.toString().startsWith(crosstoolTopPathFragment.getPathString())) {
         toolPaths.put(tool.getName(), path);
+      } else if (path.toString().startsWith(Label.EXTERNAL_PATH_PREFIX.getPathString())) {
+        toolPaths.put(tool.getName(), path);
       } else {
         toolPaths.put(tool.getName(), crosstoolTopPathFragment.getRelative(path));
       }
@@ -655,7 +657,7 @@ public class CppConfiguration extends BuildConfiguration.Fragment {
                     .getPathString();
           }
           if (tool.getName().equals(Tool.AR.getNamePart())) {
-            arToolPath = tool.getPath();
+            arToolPath = resolvePath(tool.getPath()).getPathString();
           }
         }
         TextFormat.merge(


### PR DESCRIPTION
These wrapper scripts do nothing but workaround bad path handling in the
CROSSTOOL proto reader:
https://github.com/bazelbuild/bazel/wiki/Building-with-a-custom-toolchain#writing-the-wrapper-scripts

With this change, %package(...) can be used inside of tool_path:

```protobuf
toolchain {
  ...
  tool_path { name: "ar" path: "%package(@linaroLinuxGcc49Repo//bin)%/arm-linux-gnueabihf-ar" }
  ...
}
```