### PR TITLE
Fix build failure with old OS X mktemp

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/BUILD
@@ -77,7 +77,7 @@ genrule(
     ],
     outs = ["JacocoCoverage_jarjar_deploy.jar"],
     cmd = "\n".join([
-        "JARJAR=\"$$(mktemp)\"",
+        "JARJAR=\"$$(mktemp -t bazel.XXXXXXXX)\"",
         "\"$(JAVA)\" -jar \"$(location //third_party/java/jarjar:jarjar_bin_deploy.jar)\" --rules \"$(location :JacocoCoverage.jarjar)\" --output \"$${JARJAR}\" \"$(location :JacocoCoverage_deploy.jar)\"",
         "\"$(JAVA)\" -jar \"$(location //src/java_tools/singlejar:SingleJar_deploy.jar)\" --normalize --sources \"$${JARJAR}\" --output \"$@\"",
         "rm -fr \"$${JARJAR}\"",


### PR DESCRIPTION
This fixes a minor regression introduced by bazelbuild/bazel@2c3c87fab48646167e4233f539540df6b5ed3d04.

mktemp's interface changed in OS X 10.11 to allow the prefix to be
unspecified, but not specifying the prefix will cause the command to
error out on OS X 10.10 and earlier.