### PR TITLE
Apply /U before passing arguments to cl.exe.

### DIFF
--- a/tools/cpp/wrapper/bin/pydir/msvc_cl.py
+++ b/tools/cpp/wrapper/bin/pydir/msvc_cl.py
@@ -94,6 +94,7 @@ class MsvcCompiler(msvc_tools.WindowsRunner):
       ValueError: if target architecture isn't specified
     """
     parser = msvc_tools.ArgParser(self, argv, GCCPATTERNS)
+    parser.ApplyUndefines()
 
     # Select runtime option
     # Find the last runtime option passed

--- a/tools/cpp/wrapper/bin/pydir/msvc_tools.py.tpl
+++ b/tools/cpp/wrapper/bin/pydir/msvc_tools.py.tpl
@@ -63,6 +63,21 @@ class ArgParser(object):
     self.enforce_debug_rt = False
     self._ParseArgs(argv)
 
+  def ApplyUndefines(self):
+    """Collapse paired /D and /U arguments.
+
+    cl.exe will emit warning D9025 whenever /U is used and it cannot be
+    silenced. This operation works around that by removing any define that is
+    also undefined in the same command line.
+    """
+    # Remove all /D's that have a matching /U.
+    self.options = [option for option in self.options
+                    if (option[0:2] != '/D' or
+                        '/U%s' % (option[2:]) not in self.options)]
+    # Remove the unneeded /Us.
+    self.options = [option for option in self.options
+                    if option[0:2] != '/U']
+
   def ReplaceLibrary(self, arg):
     """Do the actual replacement if necessary."""
     if arg == "/WHOLEARCHIVE":


### PR DESCRIPTION
This silences a warning that cl.exe emits whenever -U is used.
clang/gcc don't warn on -U either so this helps to normalize build logs.

Note that cl.exe treats -U as an override regardless of the number of -Ds or their order (so e.g. `cl.exe /DA /UA /DA` will have `A` undefined), so this code is similarly simplistic and blasts away any define that is ever undefined in the same command line.