### PR TITLE
Fixing docs of remote worker

### DIFF
--- a/src/tools/remote_worker/README.md
+++ b/src/tools/remote_worker/README.md
@@ -11,9 +11,13 @@ The simplest setup is as follows:
             --work_path=/tmp/test \
             --listen_port=8080
 
+- Make sure your `~/.bazelrc` file is settings your DigestFunction to SHA1:
+```
+        startup --host_jvm_args=-Dbazel.DigestFunction=SHA1
+```
 - Then you run Bazel pointing to the remote_worker instance.
 
-        bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
+        bazel build \
             --spawn_strategy=remote --remote_cache=localhost:8080 \
             --remote_executor=localhost:8080 src/tools/generate_workspace:all
 

--- a/src/tools/remote_worker/README.md
+++ b/src/tools/remote_worker/README.md
@@ -11,7 +11,7 @@ The simplest setup is as follows:
             --work_path=/tmp/test \
             --listen_port=8080
 
-- Make sure your `~/.bazelrc` file is settings your DigestFunction to SHA1:
+- Make sure you set the DigestFunction to SHA1 in your `~/.bazelrc` file:
 ```
         startup --host_jvm_args=-Dbazel.DigestFunction=SHA1
 ```


### PR DESCRIPTION
Seems like we cannot change the `DigestFunction` from command line and it must reside in your `.bazelrc` file.
I first opened #3294 but then realized my settings were wrong