### PR TITLE
blaze_util_freebsd.cc: gracefully handle server directory being NULL

### DIFF
--- a/src/main/cpp/blaze_util_freebsd.cc
+++ b/src/main/cpp/blaze_util_freebsd.cc
@@ -124,7 +124,11 @@ string GetProcessCWD(int pid) {
     filestat *entry;
     STAILQ_FOREACH(entry, files, next) {
       if (entry->fs_uflags & PS_FST_UFLAG_CDIR) {
-        cwd = entry->fs_path;
+        if (entry->fs_path) {
+          cwd = entry->fs_path;
+        } else {
+          cwd = "";
+        }
       }
     }
     procstat_freefiles(procstat, files);


### PR DESCRIPTION
Gracefully handle the case that the working directory of the server
process no longer exists in the file system. This happens if the
directory in which bazel was called gets removed and later a directory
with the same name is created; a particular such case is running
bazel in integration tests.