### PR TITLE
Add //third_party/py/six to embedded_tools.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -133,6 +133,7 @@ filegroup(
         "//third_party/java/jdk/langtools:test-srcs",
         "//third_party/py/concurrent:srcs",
         "//third_party/py/gflags:srcs",
+        "//third_party/py/six:srcs",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper:srcs",
         "//src/tools/android/java/com/google/devtools/build/android:embedded_tools",
         "//src/tools/android/java/com/google/devtools/build/android/ideinfo:embedded_tools",


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/pull/3363#issuecomment-314774384