### PR TITLE
Stops ARM from compiling 64-bit only C++ SingleJar

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -178,6 +178,9 @@ filegroup(
         ":windows_msvc": [
             "//src/java_tools/singlejar:SingleJar_deploy.jar",
         ],
+        ":arm": [
+            "//src/java_tools/singlejar:SingleJar_deploy.jar",
+         ],
         "//conditions:default": [
             "//src/tools/singlejar:singlejar",
         ],
@@ -330,6 +333,12 @@ config_setting(
 config_setting(
     name = "windows_msys",
     values = {"cpu": "x64_windows_msys"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "arm",
+    values = {"cpu": "arm"},
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
The C++ implementation of SingleJar only works for 64-bit platforms, as
it uses memory mapped files. Attempting to compile this on a 32-bit
platform gives the following error from [`src/tools/singlejar/mapped_file.h`](https://github.com/bazelbuild/bazel/blob/master/src/tools/singlejar/mapped_file.h#L38-L40):

```
src/tools/singlejar/mapped_file.h:40:2: error: #error This code for 64bit Unix.
#error This code for 64 bit Unix.
```

As ARM is usually 32-bit (and I believe even the aarch64 64-bit ARM is still using
the ARM 32-bit compiler when compiling bazel, see
[`src/main/java/com/google/devtools/build/lib/util/CPU.java`](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/util/CPU.java#L27) and
[`tools/cpp/lib_cc_configure.bzl`](https://github.com/bazelbuild/bazel/blob/master/tools/cpp/lib_cc_configure.bzl#L106-L107)), forcing bazel to use the `SingleJar_deploy.jar` java implementation of SingleJar fixes this issue.

I suspect 32-bit Unix has the same issue, which could be fixed by adding the same configuration for `piii`, but I don't have a 32-bit x86 system to test it on. But if anyone is here by Googling the above error code, try replacing all the `arm` references in this pull request with `piii`!