### PR TITLE
Fixed relative link in documentation to Provider

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/ClassObjectConstructor.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/ClassObjectConstructor.java
@@ -50,7 +50,7 @@ import javax.annotation.Nullable;
           + "     Note: Some providers, defined internally, do not allow instance creation"
           + "     </li>"
           + "     <li>It is a <i>key</i> to access a provider instance on a"
-          + "        <a href=\"lib/Target.html\">Target</a>"
+          + "        <a href=\"Target.html\">Target</a>"
           + "<pre class=\"language-python\">DataInfo = provider()\n"
           + "def _rule_impl(ctx)\n"
           + "  ... ctx.attr.dep[DataInfo]</pre>"


### PR DESCRIPTION
Please look to page:

Note "Target" link.

Actual: https://docs.bazel.build/versions/master/skylark/lib/lib/Target.html
`404 - Page not found
$ bazel build :what-you-were-looking-for
...............
ERROR: no such page ':what-you-were-looking-for': BUILD file not found on package path.
INFO: Elapsed time: 0.567s`

Expected: https://docs.bazel.build/versions/master/skylark/lib/Target.html