### PR TITLE
Confer outputs arity implicitly for list/singular

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.analysis;
 
+import static java.util.Collections.singleton;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -77,6 +79,7 @@ import com.google.devtools.build.lib.packages.FileTarget;
 import com.google.devtools.build.lib.packages.FilesetEntry;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction;
 import com.google.devtools.build.lib.packages.Info;
+import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.TemplateSubstitution;
 import com.google.devtools.build.lib.packages.InputFile;
 import com.google.devtools.build.lib.packages.NativeProvider;
 import com.google.devtools.build.lib.packages.OutputFile;
@@ -1254,16 +1257,19 @@ public final class RuleContext extends TargetContext
    */
   public Artifact getImplicitOutputArtifact(ImplicitOutputsFunction function)
       throws InterruptedException {
-    Iterable<String> result;
+    TemplateSubstitution result;
     try {
       result =
           function.getImplicitOutputs(
               getAnalysisEnvironment().getEventHandler(), RawAttributeMapper.of(rule));
+      if (result.isPlural()) {
+        throw new IllegalStateException("implicit output must be singular");
+      }
     } catch (EvalException e) {
       // It's ok as long as we don't use this method from Skylark.
       throw new IllegalStateException(e);
     }
-    return getImplicitOutputArtifact(Iterables.getOnlyElement(result));
+    return getImplicitOutputArtifact(result.singular());
   }
 
   /**
@@ -1271,6 +1277,21 @@ public final class RuleContext extends TargetContext
    */
   public Artifact getImplicitOutputArtifact(String path) {
     return getPackageRelativeArtifact(path, getBinOrGenfilesDirectory());
+  }
+
+  /**
+   * Only use from Skylark. Returns the implicit output artifacts for a given output paths list.
+   */
+  public Object getImplicitOutputArtifacts(TemplateSubstitution substitution) {
+    if (!substitution.isPlural()) {
+      return getPackageRelativeArtifact(substitution.singular(), getBinOrGenfilesDirectory());
+    }
+
+    List<Artifact> result = Lists.<Artifact>newArrayList();
+    for( String path : substitution.plural() ) {
+      result.add(getPackageRelativeArtifact(path, getBinOrGenfilesDirectory()));
+    }
+    return result;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleContext.java
@@ -49,6 +49,7 @@ import com.google.devtools.build.lib.packages.AspectDescriptor;
 import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction;
+import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.TemplateSubstitution;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.SkylarkImplicitOutputsFunction;
 import com.google.devtools.build.lib.packages.Info;
 import com.google.devtools.build.lib.packages.NativeProvider;
@@ -252,14 +253,14 @@ public final class SkylarkRuleContext implements SkylarkValue {
       if (implicitOutputsFunction instanceof SkylarkImplicitOutputsFunction) {
         SkylarkImplicitOutputsFunction func =
             (SkylarkImplicitOutputsFunction) implicitOutputsFunction;
-        for (Map.Entry<String, String> entry :
+        for (Map.Entry<String, TemplateSubstitution> entry :
             func.calculateOutputs(
                     ruleContext.getAnalysisEnvironment().getEventHandler(),
                     RawAttributeMapper.of(ruleContext.getRule()))
                 .entrySet()) {
           outputs.addOutput(
               entry.getKey(),
-              ruleContext.getImplicitOutputArtifact(entry.getValue()));
+              ruleContext.getImplicitOutputArtifacts(entry.getValue()));
         }
       }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidRuleClasses.java
@@ -343,7 +343,7 @@ public final class AndroidRuleClasses {
       new SafeImplicitOutputsFunction() {
 
         @Override
-        public Iterable<String> getImplicitOutputs(EventHandler eventHandler, AttributeMap rule) {
+        public TemplateSubstitution getImplicitOutputs(EventHandler eventHandler, AttributeMap rule) {
           List<SafeImplicitOutputsFunction> functions = Lists.newArrayList();
           functions.add(AndroidRuleClasses.ANDROID_BINARY_APK);
           functions.add(AndroidRuleClasses.ANDROID_BINARY_UNSIGNED_APK);
@@ -363,7 +363,7 @@ public final class AndroidRuleClasses {
   public static final SafeImplicitOutputsFunction ANDROID_LIBRARY_IMPLICIT_OUTPUTS =
       new SafeImplicitOutputsFunction() {
         @Override
-        public Iterable<String> getImplicitOutputs(
+        public TemplateSubstitution getImplicitOutputs(
             EventHandler eventHandler, AttributeMap attributes) {
 
           ImmutableList.Builder<SafeImplicitOutputsFunction> implicitOutputs =

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
@@ -2006,7 +2006,7 @@ public abstract class BuildViewTestCase extends FoundationTestCase {
 
     RawAttributeMapper attr = RawAttributeMapper.of(associatedRule);
 
-    String path = Iterables.getOnlyElement(outputFunction.getImplicitOutputs(eventCollector, attr));
+    String path = outputFunction.getImplicitOutputs(eventCollector, attr).singular();
 
     return view.getArtifactFactory()
         .getDerivedArtifact(target.getLabel().getPackageFragment().getRelative(path), root, owner);

--- a/src/test/java/com/google/devtools/build/lib/packages/ImplicitOutputsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/ImplicitOutputsFunctionTest.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.AttributeValueGetter;
+import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.TemplateSubstitution;
 import com.google.devtools.build.lib.testutil.Suite;
 import com.google.devtools.build.lib.testutil.TestSpec;
 import java.util.ArrayList;
@@ -145,9 +146,10 @@ public final class ImplicitOutputsFunctionTest {
         .inOrder();
 
     // Test the actual substitution code.
-    List<String> substitutions =
+    TemplateSubstitution substitution =
         ImplicitOutputsFunction.substitutePlaceholderIntoTemplate(template, null, attrValues);
-    assertThat(substitutions)
+    assertThat(substitution.isPlural()).isTrue();
+    assertThat(substitution.plural())
         .containsExactlyElementsIn(Arrays.asList(expectedSubstitutions));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -724,15 +724,15 @@ public class RuleClassTest extends PackageLoadingTestCase {
     AttributeMap rule = RawAttributeMapper.of(
         createRule(ruleClass, "testrule", attributeValues, testRuleLocation));
 
-    assertThat(substitutePlaceholderIntoTemplate("foo", rule)).containsExactly("foo");
-    assertThat(substitutePlaceholderIntoTemplate("foo-%{baz}-bar", rule)).containsExactly(
+    assertThat(substitutePlaceholderIntoTemplate("foo", rule).singular()).isEqualTo("foo");
+    assertThat(substitutePlaceholderIntoTemplate("foo-%{baz}-bar", rule).plural()).containsExactly(
         "foo-baz-bar", "foo-BAZ-bar").inOrder();
-    assertThat(substitutePlaceholderIntoTemplate("%{a}-%{b}-%{c}", rule)).containsExactly("a-b-c",
+    assertThat(substitutePlaceholderIntoTemplate("%{a}-%{b}-%{c}", rule).plural()).containsExactly("a-b-c",
         "a-b-C", "a-B-c", "a-B-C", "A-b-c", "A-b-C", "A-B-c", "A-B-C").inOrder();
-    assertThat(substitutePlaceholderIntoTemplate("%{a", rule)).containsExactly("%{a");
-    assertThat(substitutePlaceholderIntoTemplate("%{a}}", rule)).containsExactly("a}", "A}")
+    assertThat(substitutePlaceholderIntoTemplate("%{a", rule).singular()).isEqualTo("%{a");
+    assertThat(substitutePlaceholderIntoTemplate("%{a}}", rule).plural()).containsExactly("a}", "A}")
         .inOrder();
-    assertThat(substitutePlaceholderIntoTemplate("x%{a}y%{empty}", rule)).isEmpty();
+    assertThat(substitutePlaceholderIntoTemplate("x%{a}y%{empty}", rule).plural()).isEmpty();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/skylark/SkylarkIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skylark/SkylarkIntegrationTest.java
@@ -842,7 +842,8 @@ public class SkylarkIntegrationTest extends BuildViewTestCase {
     scratch.file(
         "test/skylark/extension.bzl",
         "def custom_rule_impl(ctx):",
-        "  files = [ctx.outputs.lbl, ctx.outputs.list, ctx.outputs.str]",
+        "  files = [ctx.outputs.lbl, ctx.outputs.str]",
+        "  files += ctx.outputs.list",
         "  print('==!=!=!=')",
         "  print(files)",
         "  ctx.actions.run_shell(",


### PR DESCRIPTION
Multiple outputs, expanded through placeholder specification of list
attributes, should be conveyed to outputs struct definition unmodified.
Presumed singleton extraction from implicit outputs subsystem has been
reworked, and tests of singular/list behavior have been updated.