### PR TITLE
Fix UNIX linker detection (was erroneously disabling ld.gold)

### DIFF
--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -353,6 +353,7 @@ def find_cc(repository_ctx):
 
 def configure_unix_toolchain(repository_ctx, cpu_value):
   """Configure C++ toolchain on Unix platforms."""
+  repository_ctx.file("tools/cpp/empty.cc", "int main() {}")
   darwin = cpu_value == "darwin"
   cc = find_cc(repository_ctx)
   tool_paths = _get_tool_paths(repository_ctx, darwin,


### PR DESCRIPTION
Adds back a compiler test empty .cc file. Seems to be an omission in https://github.com/bazelbuild/bazel/commit/65cda4f219e564ccb190b2992151658dfae9904

The _is_gold_supported check in unix_cc_configure.bzl always fails without this change, since the file it's checking with isn't created. Looks like there may be other effects through _add_option_if_supported, although I only noticed because apparently I have written linker-specific code.