### PR TITLE
Fix broken link to cc_binary

### DIFF
--- a/site/docs/tutorial/cpp.md
+++ b/site/docs/tutorial/cpp.md
@@ -114,7 +114,7 @@ cc_binary(
 ```
 
 In our example, the `hello-world` target instantiates Bazel's built-in
-[`cc_binary` rule](docs/be/c-cpp.html#cc_binary). The rule tells Bazel to build
+[`cc_binary` rule](be/c-cpp.html#cc_binary). The rule tells Bazel to build
 a self-contained executable binary from the `hello-world.cc` source file with no
 dependencies.
 

--- a/site/docs/tutorial/cpp.md
+++ b/site/docs/tutorial/cpp.md
@@ -114,7 +114,7 @@ cc_binary(
 ```
 
 In our example, the `hello-world` target instantiates Bazel's built-in
-[`cc_binary` rule](be/c-cpp.html#cc_binary). The rule tells Bazel to build
+[`cc_binary` rule](/be/c-cpp.html#cc_binary). The rule tells Bazel to build
 a self-contained executable binary from the `hello-world.cc` source file with no
 dependencies.
 


### PR DESCRIPTION
Invalid url https://docs.bazel.build/versions/master/tutorial/docs/be/c-cpp.html#cc_binary
Valid url: https://docs.bazel.build/versions/master/be/c-cpp.html#cc_binary

Hence changed relative path `docs/be/c-cpp.html#cc_binary` to abs path `/be/c-cpp.html#cc_binary`.
