### PR TITLE
Fix that the releases.bazel.build host doesn't resolve

### DIFF
--- a/scripts/packages/chocolatey/build.ps1
+++ b/scripts/packages/chocolatey/build.ps1
@@ -17,8 +17,8 @@ if ($mode -eq "release") {
 } elseif ($mode -eq "rc") {
   $tvVersion = "$($version)-rc$($rc)"
   $tvFilename = "bazel-$($version)rc$($rc)-windows-x86_64.zip"
-  $tvUri = "https://release.bazel.build/$($version)/rc$($rc)/$($tvFilename)"
-  $tvReleaseNotesUri = "https://release.bazel.build/$($version)/rc$($rc)/index.html"
+  $tvUri = "https://storage.googleapis.com/bazel/$($version)/rc$($rc)/$($tvFilename)"
+  $tvReleaseNotesUri = "https://storage.googleapis.com/bazel/$($version)/rc$($rc)/index.html"
 } elseif ($mode -eq "local") {
   $tvVersion = $version
   $tvFilename = "bazel-$($tvVersion)-windows-x86_64.zip"


### PR DESCRIPTION
The releases.bazel.build host does not resolve for me, and it's been a week or so.

This reverts that back to the GCS bucket, and it was how I published 0.5.4 RCs 1 and 2.