### PR TITLE
Added support for $(LD) for genrule() and ld_executable for Skylark

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -1291,6 +1291,16 @@ public class CppConfiguration extends BuildConfiguration.Fragment {
    * Returns the execution path to the linker binary to use for this build.
    * Relative paths are relative to the execution root.
    */
+  @SkylarkCallable(
+    name = "ld_executable",
+    structField = true,
+    doc = "Path to GNU binutils 'ld' binary."
+  )
+  public String getLdExecutableForSkylark() {
+    PathFragment ldExecutable = getLdExecutable();
+    return ldExecutable != null ? ldExecutable.getPathString() : "";
+  }
+
   public PathFragment getLdExecutable() {
     return ldExecutable;
   }
@@ -1821,6 +1831,7 @@ public class CppConfiguration extends BuildConfiguration.Fragment {
     // Make variables provided by crosstool/gcc compiler suite.
     globalMakeEnvBuilder.put("AR", getArExecutable().getPathString());
     globalMakeEnvBuilder.put("NM", getNmExecutable().getPathString());
+    globalMakeEnvBuilder.put("LD", getLdExecutable().getPathString());
     PathFragment objcopyTool = getObjCopyExecutable();
     if (objcopyTool != null) {
       // objcopy is optional in Crosstool


### PR DESCRIPTION
I added support for exposing the GNU linker (ld) for genrule() and Skylark.

For reference: https://stackoverflow.com/questions/45560314/building-kernel-module-with-bazel
