### PR TITLE
Propagate compiler arguments as they were given to wrapper scripts

### DIFF
--- a/tools/osx/crosstool/wrapped_clang.tpl
+++ b/tools/osx/crosstool/wrapped_clang.tpl
@@ -7,4 +7,4 @@ if [ -z ${MY_LOCATION+x} ]; then
   fi
 fi
 
-"${MY_LOCATION}"/xcrunwrapper.sh clang $@
+"${MY_LOCATION}"/xcrunwrapper.sh clang "$@"

--- a/tools/osx/crosstool/wrapped_clang_pp.tpl
+++ b/tools/osx/crosstool/wrapped_clang_pp.tpl
@@ -7,4 +7,4 @@ if [ -z ${MY_LOCATION+x} ]; then
   fi
 fi
 
-"${MY_LOCATION}"/xcrunwrapper.sh clang++ $@
+"${MY_LOCATION}"/xcrunwrapper.sh clang++ "$@"


### PR DESCRIPTION
Unquoted $@ parameter expansion was breaking up values containing spaces.
Fix #3541