### PR TITLE
Add the option to include sources in the native maven_jar rule

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorDescriptor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorDescriptor.java
@@ -31,17 +31,21 @@ public class DecompressorDescriptor {
   private final String targetKind;
   private final String targetName;
   private final Path archivePath;
+  private final Optional<Path> archiveSourcesPath;
   private final Path repositoryPath;
   private final Optional<String> prefix;
   private final boolean executable;
   private final Decompressor decompressor;
 
   private DecompressorDescriptor(
-      String targetKind, String targetName, Path archivePath, Path repositoryPath,
+      String targetKind, String targetName, Path archivePath,
+      @Nullable Path archiveSourcesPath,
+      Path repositoryPath,
       @Nullable String prefix, boolean executable, Decompressor decompressor) {
     this.targetKind = targetKind;
     this.targetName = targetName;
     this.archivePath = archivePath;
+    this.archiveSourcesPath = Optional.fromNullable(archiveSourcesPath);
     this.repositoryPath = repositoryPath;
     this.prefix = Optional.fromNullable(prefix);
     this.executable = executable;
@@ -58,6 +62,10 @@ public class DecompressorDescriptor {
 
   public Path archivePath() {
     return archivePath;
+  }
+
+  public Optional<Path> archiveSourcesPath() {
+    return archiveSourcesPath;
   }
 
   public Path repositoryPath() {
@@ -113,6 +121,7 @@ public class DecompressorDescriptor {
     private String targetKind;
     private String targetName;
     private Path archivePath;
+    private Path archiveSourcesPath;
     private Path repositoryPath;
     private String prefix;
     private boolean executable;
@@ -126,7 +135,7 @@ public class DecompressorDescriptor {
         decompressor = DecompressorValue.getDecompressor(archivePath);
       }
       return new DecompressorDescriptor(
-          targetKind, targetName, archivePath, repositoryPath, prefix, executable, decompressor);
+          targetKind, targetName, archivePath, archiveSourcesPath, repositoryPath, prefix, executable, decompressor);
     }
 
     public Builder setTargetKind(String targetKind) {
@@ -141,6 +150,11 @@ public class DecompressorDescriptor {
 
     public Builder setArchivePath(Path archivePath) {
       this.archivePath = archivePath;
+      return this;
+    }
+
+    public Builder setArchiveSourcesPath(Path archiveSourcesPath) {
+      this.archiveSourcesPath = archiveSourcesPath;
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/FileDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/FileDecompressor.java
@@ -15,7 +15,9 @@
 package com.google.devtools.build.lib.bazel.repository;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
+import com.google.devtools.build.lib.vfs.Path;
 
 /**
  * Creates a repository for a random file.
@@ -32,7 +34,7 @@ public class FileDecompressor extends JarDecompressor {
   }
 
   @Override
-  protected String createBuildFile(String baseName) {
+  protected String createBuildFile(String baseName, Optional<Path> sourcesJar) {
     return Joiner.on("\n")
         .join(
             "filegroup(",

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/MavenJarRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/MavenJarRule.java
@@ -65,6 +65,22 @@ public class MavenJarRule implements RuleDefinition {
          should be set before shipping.</p>
          <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("sha1", Type.STRING))
+        /* <!-- #BLAZE_RULE(maven_jar).ATTRIBUTE(attach_sources) -->
+         Set this to make Bazel also pull down the sources jar from the Maven repository.
+
+         <p>The sources jar will be located in the same package as the main jar with the label
+         :sources</p>
+         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(attr("attach_sources", Type.BOOLEAN))
+        /* <!-- #BLAZE_RULE(maven_jar).ATTRIBUTE(sources_sha1) -->
+         A SHA-1 hash of the desired sources jar.
+
+         <p>If the downloaded jar does not match this hash, Bazel will error out. <em>It is a
+         security risk to omit the SHA-1 as remote files can change.</em> At best omitting this
+         field will make your build non-hermetic. It is optional to make development easier but
+         should be set before shipping.</p>
+         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(attr("sources_sha1", Type.STRING))
         .setWorkspaceOnly()
         .build();
   }


### PR DESCRIPTION
This adds the option to download the sources jar (defined as the same maven artifact, but with classifier = "sources") along with the main jar. When doing so it will specify the `srcjar` attribute on the `java_import` rule generated by `maven_jar`.

The motivation behind this is improving IDE integration for third party dependencies, specifically allowing the IJ plugin to automatically attach sources to maven jars without having to use custom Skylark macros. 

This also adds in the option to specify a `sources_sha1`, though I'm not sure how useful that is. 

Example of generated BUILD file:

```
# DO NOT EDIT: automatically generated BUILD.bazel file for maven_jar rule com_google_guava_guava
java_import(
    name = 'jar',
    jars = ['guava-22.0.jar'],
    srcjar = ':sources',
    visibility = ['//visibility:public'],
)

filegroup(
    name = 'file',
    srcs = ['guava-22.0.jar'],
    visibility = ['//visibility:public']
)

filegroup(
    name = 'sources',
    srcs = ['guava-22.0-sources.jar'],
    visibility = ['//visibility:public']
)
```

Discussed in https://github.com/bazelbuild/bazel/issues/1410 & https://github.com/bazelbuild/bazel/issues/308