### PR TITLE
use SHA256 by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/README.md
+++ b/src/main/java/com/google/devtools/build/lib/remote/README.md
@@ -39,7 +39,7 @@ build --strategy=Closure=remote
 
 #### Customizing The Digest Function
 
-Bazel currently supports the following digest functions with the remote worker: SHA1, SHA256, and MD5. The digest function is passed via the `--host_jvm_args=-Dbazel.DigestFunction=###` startup option. In the example above, SHA256 is used, but you can use any one of SHA1, SHA256, and MD5, provided that your remote execution server supports it and is configured to use the same one. For example, the provided remote worker (`//src/tools/remote_worker`) is configured to use SHA257 by default in the binary build rule. You can customize it there by modifying the `jvm_flags` attribute to use, for example, `"-Dbazel.DigestFunction=SHA1"` instead.
+Bazel currently supports the following digest functions with the remote worker: SHA1, SHA256, and MD5. The digest function is passed via the `--host_jvm_args=-Dbazel.DigestFunction=###` startup option. In the example above, SHA256 is used, but you can use any one of SHA1, SHA256, and MD5, provided that your remote execution server supports it and is configured to use the same one. For example, the provided remote worker (`//src/tools/remote_worker`) is configured to use SHA256 by default in the binary build rule. You can customize it there by modifying the `jvm_flags` attribute to use, for example, `"-Dbazel.DigestFunction=SHA1"` instead.
 
 
 ### Hazelcast with REST interface

--- a/src/main/java/com/google/devtools/build/lib/remote/README.md
+++ b/src/main/java/com/google/devtools/build/lib/remote/README.md
@@ -26,7 +26,7 @@ For a quick setup, you can use Hazelcast's REST interface. Alternatively you can
 We recommend editing your `~/.bazelrc` to enable remote caching using the HTTP REST protocol. You will need to replace `http://server-address:port/cache` with the correct address for your HTTP REST server:
 
 ```
-startup --host_jvm_args=-Dbazel.DigestFunction=SHA1
+startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
 build --spawn_strategy=remote
 build --remote_rest_cache=REPLACE_THIS:http://server-address:port/cache
 # Bazel currently doesn't support remote caching in combination with workers.
@@ -39,7 +39,7 @@ build --strategy=Closure=remote
 
 #### Customizing The Digest Function
 
-Bazel currently supports the following digest functions with the remote worker: SHA1, SHA256, and MD5. The digest function is passed via the `--host_jvm_args=-Dbazel.DigestFunction=###` startup option. In the example above, SHA1 is used, but you can use any one of SHA1, SHA256, and MD5, provided that your remote execution server supports it and is configured to use the same one. For example, the provided remote worker (`//src/tools/remote_worker`) is configured to use SHA1 by default in the binary build rule. You can customize it there by modifying the `jvm_flags` attribute to use, for example, `"-Dbazel.DigestFunction=SHA256"` instead.
+Bazel currently supports the following digest functions with the remote worker: SHA1, SHA256, and MD5. The digest function is passed via the `--host_jvm_args=-Dbazel.DigestFunction=###` startup option. In the example above, SHA256 is used, but you can use any one of SHA1, SHA256, and MD5, provided that your remote execution server supports it and is configured to use the same one. For example, the provided remote worker (`//src/tools/remote_worker`) is configured to use SHA257 by default in the binary build rule. You can customize it there by modifying the `jvm_flags` attribute to use, for example, `"-Dbazel.DigestFunction=SHA1"` instead.
 
 
 ### Hazelcast with REST interface
@@ -114,7 +114,7 @@ that supports both remote caching and remote execution. As of this writing, ther
 We recommend editing your `~/.bazelrc` to enable remote caching using the gRPC protocol. Use the following build options to use the gRPC CAS endpoint for sharing build artifacts. Change `REPLACE_THIS:address:8080` to the correct server address and port number.
 
 ```
-startup --host_jvm_args=-Dbazel.DigestFunction=SHA1
+startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
 build --spawn_strategy=remote
 build --remote_cache=REPLACE_THIS:address:8080
 # Bazel currently doesn't support remote caching in combination with workers.

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -76,7 +76,7 @@ public abstract class FileSystem {
   static {
     try {
       digestFunction = new HashFunction.Converter().convert(
-          System.getProperty("bazel.DigestFunction", "MD5"));
+          System.getProperty("bazel.DigestFunction", "SHA256"));
     } catch (OptionsParsingException e) {
       throw new IllegalStateException(e);
     }

--- a/src/test/shell/bazel/remote_execution_sandboxing_test.sh
+++ b/src/test/shell/bazel/remote_execution_sandboxing_test.sh
@@ -83,7 +83,7 @@ function tear_down() {
 }
 
 function test_genrule() {
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 build \
       --spawn_strategy=remote \
       --remote_executor=localhost:${worker_port} \
       --remote_cache=localhost:${worker_port} \
@@ -92,7 +92,7 @@ function test_genrule() {
 }
 
 function test_genrule_can_write_to_path() {
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 build \
       --spawn_strategy=remote \
       --remote_executor=localhost:${worker_port} \
       --remote_cache=localhost:${worker_port} \
@@ -103,7 +103,7 @@ function test_genrule_can_write_to_path() {
 }
 
 function test_genrule_cannot_write_to_other_path() {
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 build \
       --spawn_strategy=remote \
       --remote_executor=localhost:${worker_port} \
       --remote_cache=localhost:${worker_port} \

--- a/src/test/shell/bazel/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote_execution_test.sh
@@ -83,7 +83,7 @@ EOF
   cp -f bazel-bin/a/test ${TEST_TMPDIR}/test_expected
 
   bazel clean --expunge >& $TEST_log
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 build \
       --spawn_strategy=remote \
       --remote_executor=localhost:${worker_port} \
       --remote_cache=localhost:${worker_port} \
@@ -106,7 +106,7 @@ EOF
 #include <iostream>
 int main() { std::cout << "Hello test!" << std::endl; return 0; }
 EOF
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 test \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 test \
       --spawn_strategy=remote \
       --remote_executor=localhost:${worker_port} \
       --remote_cache=localhost:${worker_port} \
@@ -133,7 +133,7 @@ EOF
   cp -f bazel-bin/a/test ${TEST_TMPDIR}/test_expected
 
   bazel clean --expunge >& $TEST_log
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 build \
       --spawn_strategy=remote \
       --remote_cache=localhost:${worker_port} \
       //a:test >& $TEST_log \
@@ -155,7 +155,7 @@ EOF
 #include <iostream>
 int main() { std::cout << "Fail me!" << std::endl; return 1; }
 EOF
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 test \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 test \
       --spawn_strategy=remote \
       --remote_executor=localhost:${worker_port} \
       --remote_cache=localhost:${worker_port} \
@@ -187,7 +187,7 @@ EOF
   cp -f bazel-genfiles/a/large_blob.txt ${TEST_TMPDIR}/large_blob_expected.txt
 
   bazel clean --expunge >& $TEST_log
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 build \
       --spawn_strategy=remote \
       --remote_executor=localhost:${worker_port} \
       --remote_cache=localhost:${worker_port} \
@@ -215,7 +215,7 @@ EOF
   cp -f bazel-bin/a/test ${TEST_TMPDIR}/test_expected
 
   bazel clean --expunge >& $TEST_log
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 build \
       --spawn_strategy=remote \
       --remote_rest_cache=http://localhost:${hazelcast_port}/hazelcast/rest/maps/cache \
       //a:test >& $TEST_log \
@@ -245,7 +245,7 @@ import sys
 if __name__ == "__main__":
     sys.exit(0)
 EOF
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 test \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 test \
       --spawn_strategy=remote \
       --remote_executor=localhost:${worker_port} \
       --remote_cache=localhost:${worker_port} \
@@ -278,7 +278,7 @@ if __name__ == "__main__":
 ''')
     sys.exit(0)
 EOF
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 test \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 test \
       --spawn_strategy=remote \
       --remote_executor=localhost:${worker_port} \
       --remote_cache=localhost:${worker_port} \
@@ -315,7 +315,7 @@ if __name__ == "__main__":
 ''')
     sys.exit(1)
 EOF
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 test \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 test \
       --spawn_strategy=remote \
       --remote_executor=localhost:${worker_port} \
       --remote_cache=localhost:${worker_port} \
@@ -347,7 +347,7 @@ load("//a:rule.bzl", "empty")
 package(default_visibility = ["//visibility:public"])
 empty(name = 'test')
 EOF
-  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
+  bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 build \
       --spawn_strategy=remote \
       --remote_cache=localhost:${worker_port} \
       --test_output=errors \

--- a/src/tools/remote_worker/BUILD
+++ b/src/tools/remote_worker/BUILD
@@ -10,7 +10,7 @@ java_binary(
         # Enables REST for Hazelcast server for testing.
         "-Dhazelcast.rest.enabled=true",
         # Set this to the same function that you run Bazel with.
-        "-Dbazel.DigestFunction=SHA1",
+        "-Dbazel.DigestFunction=SHA256",
     ],
     main_class = "com.google.devtools.build.remote.RemoteWorker",
     visibility = ["//visibility:public"],

--- a/src/tools/remote_worker/README.md
+++ b/src/tools/remote_worker/README.md
@@ -13,7 +13,7 @@ The simplest setup is as follows:
 
 - Then you run Bazel pointing to the remote_worker instance.
 
-        bazel --host_jvm_args=-Dbazel.DigestFunction=SHA1 build \
+        bazel --host_jvm_args=-Dbazel.DigestFunction=SHA256 build \
             --spawn_strategy=remote --remote_cache=localhost:8080 \
             --remote_executor=localhost:8080 src/tools/generate_workspace:all
 


### PR DESCRIPTION
SHA1 and MD5 have well-known security problems and SHA256 is now the industry
standard (e.g. in the web PKI ecosystem).

Fixes #3193