### PR TITLE
Install Bazel on CentOS

### DIFF
--- a/site/docs/install-compile-source.md
+++ b/site/docs/install-compile-source.md
@@ -7,27 +7,35 @@ title: Compile Bazel from Source
 
 ## <a name="unix"></a> On Linux or macOS
 
+Prerequisites:
+
 1. Ensure that you have OpenJDK 8 and python installed on your system.
    For a system based on debian packages (e.g. Debian, Ubuntu), install
    OpenJDK 8 and python by running the command `sudo apt-get install
    openjdk-8-jdk python`.
+   
+2. If installing on CentOS (Linux), install the `which` command.
 
-2. The standard way of compiling a release version of Bazel from source is to
-   use a distribution archive. Download `bazel-<VERSION>-dist.zip` from the
-   [release page](https://github.com/bazelbuild/bazel/releases) for the desired
-   version. We recommend to also verify the signature made by our
-   [release key](https://bazel.build/bazel-release.pub.gpg) 48457EE0.
+To compile Bazel on Linux or macOS:
+
+1. From the [release page](https://github.com/bazelbuild/bazel/releases),
+   download the distribution archive for the desired released version
+   and distrubution.
+   
    The distribution archive also contains generated files in addition to the
    versioned sources, so this step _cannot_ be short cut by using a checkout
    of the source tree.
-
-3. Unzip the archive and call `bash ./compile.sh`; this will create a bazel
+   
+2. Verify the signature made by the
+   [release key](https://bazel.build/bazel-release.pub.gpg) 48457EE0.
+   
+4. Unzip the archive and call `bash ./compile.sh`. This script will create a bazel
    binary in `output/bazel`. This binary is self-contained, so it can be copied
    to a directory on the PATH (such as `/usr/local/bin`) or used in-place.
 
 ## <a name="windows"></a> On Windows
 
-Windows support is in beta. Known issues are [marked with label
+Known issues with Bazel and Windows are [marked with label
 "Windows"](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+label%3A%22category%3A+multi-platform+%3E+windows%22)
 on github issues.
 

--- a/site/docs/install-ubuntu.md
+++ b/site/docs/install-ubuntu.md
@@ -3,28 +3,28 @@ layout: documentation
 title: Installing Bazel on Ubuntu
 ---
 
-# <a name="ubuntu"></a>Install Bazel on Ubuntu
+# <a name="ubuntu"></a>Install Bazel on Linux
 
-Supported Ubuntu Linux platforms:
+Supported Linux platforms:
 
-*   16.04 (LTS)
-*   14.04 (LTS)
+*  Ubuntu
+   *   16.04 (LTS)
+   *   14.04 (LTS)
+*  CentOS 6.7
 
-Install Bazel on Ubuntu using one of the following methods:
 
-*   [Use our custom APT repository (recommended)](#install-on-ubuntu)
-*   [Use the binary installer](#install-with-installer-ubuntu)
+Install Bazel on Linux using one of the following methods:
+
+*   [Use our custom APT repository (recommended)](#install-on-linux)
+*   [Use the binary installer](#install-with-installer-linux)
 *   [Compile Bazel from source](install-compile-source.md)
-
-To install Bazel on CentOS, you must install the `which` command. Then, follow
-the Ubuntu instructions below.
 
 Bazel comes with two completion scripts. After installing Bazel, you can:
 
 *   access the [bash completion script](install.md)
 *   install the [zsh completion script](install.md)
 
-## <a name="install-on-ubuntu"></a> Using Bazel custom APT repository (recommended)
+## <a name="install-on-linux"></a> Using Bazel custom APT repository (recommended)
 
 ### 1. Install JDK 8
 
@@ -63,7 +63,7 @@ Once installed, you can upgrade to a newer version of Bazel with:
 sudo apt-get upgrade bazel
 ```
 
-## <a name="install-with-installer-ubuntu"></a>Install using binary installer
+## <a name="install-with-installer-linux"></a>Install using binary installer
 
 The binary installers are on Bazel's [GitHub releases page](https://github.com/bazelbuild/bazel/releases).
 

--- a/site/docs/install-ubuntu.md
+++ b/site/docs/install-ubuntu.md
@@ -12,10 +12,9 @@ Supported Linux platforms:
    *   14.04 (LTS)
 *  CentOS 6.7
 
-
 Install Bazel on Linux using one of the following methods:
 
-*   [Use our custom APT repository (recommended)](#install-on-linux)
+*   [Use our custom APT repository (Ubuntu only)](#install-on-ubuntu)
 *   [Use the binary installer](#install-with-installer-linux)
 *   [Compile Bazel from source](install-compile-source.md)
 
@@ -24,7 +23,9 @@ Bazel comes with two completion scripts. After installing Bazel, you can:
 *   access the [bash completion script](install.md)
 *   install the [zsh completion script](install.md)
 
-## <a name="install-on-linux"></a> Using Bazel custom APT repository (recommended)
+## <a name="install-on-ubuntu"></a> Using Bazel custom APT repository
+
+The APT repository 
 
 ### 1. Install JDK 8
 

--- a/site/docs/install-ubuntu.md
+++ b/site/docs/install-ubuntu.md
@@ -16,6 +16,9 @@ Install Bazel on Ubuntu using one of the following methods:
 *   [Use the binary installer](#install-with-installer-ubuntu)
 *   [Compile Bazel from source](install-compile-source.md)
 
+To install Bazel on CentOS, you must install the `which` command. Then, follow
+the Ubuntu instructions below.
+
 Bazel comes with two completion scripts. After installing Bazel, you can:
 
 *   access the [bash completion script](install.md)

--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -7,7 +7,7 @@ title: Installing Bazel
 
 See the instructions for installing Bazel on:
 
-*   [Ubuntu Linux (16.04, 15.10, and 14.04)](install-ubuntu.md)
+*   [Linux](install-ubuntu.md)
 *   [Mac OS X](install-os-x.md)
 *   [Windows (experimental)](install-windows.md)
 *   [CentOS (experimental)](install-ubuntu.md)

--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -8,7 +8,7 @@ title: Installing Bazel
 See the instructions for installing Bazel on:
 
 *   [Linux](install-ubuntu.md)
-*   [Mac OS X](install-os-x.md)
+*   [macOS](install-os-x.md)
 *   [Windows](install-windows.md)
 
 For other platforms, you can try to [compile from source](install-compile-source.md).

--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -9,8 +9,7 @@ See the instructions for installing Bazel on:
 
 *   [Linux](install-ubuntu.md)
 *   [Mac OS X](install-os-x.md)
-*   [Windows (experimental)](install-windows.md)
-*   [CentOS (experimental)](install-ubuntu.md)
+*   [Windows](install-windows.md)
 
 For other platforms, you can try to [compile from source](install-compile-source.md).
 

--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -10,6 +10,7 @@ See the instructions for installing Bazel on:
 *   [Ubuntu Linux (16.04, 15.10, and 14.04)](install-ubuntu.md)
 *   [Mac OS X](install-os-x.md)
 *   [Windows (experimental)](install-windows.md)
+*   [CentOS (experimental)](install-ubuntu.md)
 
 For other platforms, you can try to [compile from source](install-compile-source.md).
 


### PR DESCRIPTION
Is the `which` command the only difference between the requirements and steps for Ubuntu and CentOS? I've told users to follow the Ubuntu steps - is this okay?

Is our support for CentOS considered "experimental" or "beta"? Which versions of this OS do we currently test?