### PR TITLE
drop apt upgrade from shell script install

### DIFF
--- a/site/docs/install-ubuntu.md
+++ b/site/docs/install-ubuntu.md
@@ -109,9 +109,3 @@ export PATH="$PATH:$HOME/bin"
 ```
 
 You can also add this command to your `~/.bashrc` file.
-
-Once installed, you can upgrade to a newer version of Bazel with:
-
-```bash
-sudo apt-get upgrade bazel
-```


### PR DESCRIPTION
I assume apt-get upgrade does _not_ upgrade the shell-script install, especially if you used `--user` but also in general.