### PR TITLE
Support BUILD.bazel in the autocomplete script

### DIFF
--- a/scripts/bazel-complete-template.bash
+++ b/scripts/bazel-complete-template.bash
@@ -229,7 +229,10 @@ _bazel__expand_rules_in_package() {
       cut -f2 -d: | "grep" "^$rule_prefix")
   else
     for root in $(_bazel__package_path "$workspace" "$displacement"); do
-      buildfile="$root/$package_name/BUILD"
+      buildfile="$root/$package_name/BUILD.bazel"
+      if [ ! -f "$buildfile" ]; then
+        buildfile="$root/$package_name/BUILD"
+      fi
       if [ -f "$buildfile" ]; then
         result=$(_bazel__matching_targets \
                    "$pattern" "$rule_prefix" <"$buildfile")
@@ -268,7 +271,7 @@ _bazel__expand_package_name() {
       [[ "$dir" =~ ^(.*/)?\.[^/]*$ ]] && continue  # skip dotted dir (e.g. .git)
       found=1
       echo "${dir#$root}/"
-      if [ -f $dir/BUILD ]; then
+      if [ -f $dir/BUILD.bazel -o -f $dir/BUILD ]; then
         if [ "${type}" = "label-package" ]; then
           echo "${dir#$root} "
         else


### PR DESCRIPTION
This adds support for BUILD.bazel in the bash auto completion script.
