### PR TITLE
Set correct PWD in coverage

### DIFF
--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -90,7 +90,7 @@ if [[ "$COVERAGE_LEGACY_MODE" ]]; then
   export GCOV_PREFIX="${COVERAGE_DIR}"
 fi
 
-cd "$TEST_SRCDIR"
+cd "$TEST_SRCDIR/$TEST_WORKSPACE"
 "$@"
 TEST_STATUS=$?
 


### PR DESCRIPTION
The [test encyclopedia](https://docs.bazel.build/versions/master/test-encyclopedia.html) mentioned that when running tests the `PWD` should be `$TEST_SRCDIR/workspace-name`