### PR TITLE
crosstool: fix typo

### DIFF
--- a/tools/osx/crosstool/CROSSTOOL.tpl
+++ b/tools/osx/crosstool/CROSSTOOL.tpl
@@ -1373,7 +1373,7 @@ toolchain {
       }
       flag_group {
         flag: "-weak_framework %{weak_framework_names}"
-        iterate_over: "weak_framwork_names"
+        iterate_over: "weak_framework_names"
       }
       flag_group {
         flag: "-l%{library_names}"
@@ -2876,7 +2876,7 @@ toolchain {
       }
       flag_group {
         flag: "-weak_framework %{weak_framework_names}"
-        iterate_over: "weak_framwork_names"
+        iterate_over: "weak_framework_names"
       }
       flag_group {
         flag: "-l%{library_names}"
@@ -4381,7 +4381,7 @@ toolchain {
       }
       flag_group {
         flag: "-weak_framework %{weak_framework_names}"
-        iterate_over: "weak_framwork_names"
+        iterate_over: "weak_framework_names"
       }
       flag_group {
         flag: "-l%{library_names}"
@@ -5915,7 +5915,7 @@ toolchain {
       }
       flag_group {
         flag: "-weak_framework %{weak_framework_names}"
-        iterate_over: "weak_framwork_names"
+        iterate_over: "weak_framework_names"
       }
       flag_group {
         flag: "-l%{library_names}"
@@ -7420,7 +7420,7 @@ toolchain {
       }
       flag_group {
         flag: "-weak_framework %{weak_framework_names}"
-        iterate_over: "weak_framwork_names"
+        iterate_over: "weak_framework_names"
       }
       flag_group {
         flag: "-l%{library_names}"
@@ -8911,7 +8911,7 @@ toolchain {
       }
       flag_group {
         flag: "-weak_framework %{weak_framework_names}"
-        iterate_over: "weak_framwork_names"
+        iterate_over: "weak_framework_names"
       }
       flag_group {
         flag: "-l%{library_names}"
@@ -10404,7 +10404,7 @@ toolchain {
       }
       flag_group {
         flag: "-weak_framework %{weak_framework_names}"
-        iterate_over: "weak_framwork_names"
+        iterate_over: "weak_framework_names"
       }
       flag_group {
         flag: "-l%{library_names}"
@@ -11926,7 +11926,7 @@ toolchain {
       }
       flag_group {
         flag: "-weak_framework %{weak_framework_names}"
-        iterate_over: "weak_framwork_names"
+        iterate_over: "weak_framework_names"
       }
       flag_group {
         flag: "-l%{library_names}"
@@ -13419,7 +13419,7 @@ toolchain {
       }
       flag_group {
         flag: "-weak_framework %{weak_framework_names}"
-        iterate_over: "weak_framwork_names"
+        iterate_over: "weak_framework_names"
       }
       flag_group {
         flag: "-l%{library_names}"
@@ -14916,7 +14916,7 @@ toolchain {
       }
       flag_group {
         flag: "-weak_framework %{weak_framework_names}"
-        iterate_over: "weak_framwork_names"
+        iterate_over: "weak_framework_names"
       }
       flag_group {
         flag: "-l%{library_names}"


### PR DESCRIPTION
This fixes what was probably a copy-paste typo: `weak_framwork_names => weak_framework_names`

```
java.lang.RuntimeException: Unrecoverable error while evaluating node 'ACTION_EXECUTION:ActionLookupData{actionLookupNode=CONFIGURED_TARGET://MYTARGET.apple_binary 837bb3c2542b6ed8706814666a339d17 (1696330961 1832440685), actionIndex=6}' (requested by nodes 'MYTARGET.apple_binary_bin //MYTARGET.apple_binary 837bb3c2542b6ed8706814666a339d17 (69526438 1832440685)')
	at com.google.devtools.build.skyframe.ParallelEvaluator$Evaluate.run(ParallelEvaluator.java:475)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:352)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)
Caused by: com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$ExpansionException: Invalid toolchain configuration: Cannot find variable named 'weak_framwork_names'.
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$Variables.lookupVariable(CcToolchainFeatures.java:1563)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$Variables.getVariable(CcToolchainFeatures.java:1543)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$Variables.getSequenceVariable(CcToolchainFeatures.java:1627)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$FlagGroup.expand(CcToolchainFeatures.java:411)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$FlagGroup.expandCommandLine(CcToolchainFeatures.java:472)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$FlagGroup.access$600(CcToolchainFeatures.java:361)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$FlagSet.expandCommandLine(CcToolchainFeatures.java:536)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$FlagSet.access$1100(CcToolchainFeatures.java:493)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$ActionConfig.expandCommandLine(CcToolchainFeatures.java:763)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$ActionConfig.access$2100(CcToolchainFeatures.java:694)
	at com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures$FeatureConfiguration.getCommandLine(CcToolchainFeatures.java:1714)
	at com.google.devtools.build.lib.rules.cpp.LinkCommandLine.getRawLinkArgv(LinkCommandLine.java:398)
	at com.google.devtools.build.lib.rules.cpp.LinkCommandLine.getCommandLine(LinkCommandLine.java:416)
	at com.google.devtools.build.lib.rules.cpp.CppLinkAction.getCommandLine(CppLinkAction.java:291)
	at com.google.devtools.build.lib.rules.cpp.CppLinkAction.execute(CppLinkAction.java:322)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor.executeActionTask(SkyframeActionExecutor.java:849)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor.prepareScheduleExecuteAndCompleteAction(SkyframeActionExecutor.java:792)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor.access$900(SkyframeActionExecutor.java:107)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$ActionRunner.call(SkyframeActionExecutor.java:660)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$ActionRunner.call(SkyframeActionExecutor.java:617)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor.executeAction(SkyframeActionExecutor.java:404)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.checkCacheAndExecuteIfNeeded(ActionExecutionFunction.java:440)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.compute(ActionExecutionFunction.java:201)
	at com.google.devtools.build.skyframe.ParallelEvaluator$Evaluate.run(ParallelEvaluator.java:400)
	... 4 more
```

@mhlopko @calpeyser @c-parsons 