### PR TITLE
Make original working directory available to commands that are run

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -73,7 +73,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Builds and run a target with the given command line arguments.
@@ -320,8 +322,11 @@ public class RunCommand implements BlazeCommand  {
     env.getReporter().handle(Event.info(
         null, "Running command line: " + ShellEscaper.escapeJoinAll(prettyCmdLine)));
 
+    Map<String, String> clientEnv = new HashMap<String, String>(env.getClientEnv());
+    clientEnv.put("BAZEL_PWD", env.getWorkingDirectory().getPathString());
+
     com.google.devtools.build.lib.shell.Command command = new CommandBuilder()
-        .addArgs(cmdLine).setEnv(env.getClientEnv()).setWorkingDir(workingDir).build();
+        .addArgs(cmdLine).setEnv(clientEnv).setWorkingDir(workingDir).build();
 
     try {
       // Restore a raw EventHandler if it is registered. This allows for blaze run to produce the


### PR DESCRIPTION
This adds the environment variable BAZEL_PWD for things invoked with `bazel run`
This allows programs that you run to access the original path it was run from.
It enables you to write rules to run code modification tools (refactoring, formatting, build file generation) without changing anything fundamental.
You can see an example of using it [here](https://github.com/ianthehat/rules_go/commit/06b235971f3c921c128842c9b7a8f52d9d181b74), to run the gazelle build file generator.

See #3325 for the discussion that led to this suggestion