### PR TITLE
Make bash completion zsh friendly

### DIFF
--- a/scripts/bazel-complete-template.bash
+++ b/scripts/bazel-complete-template.bash
@@ -128,7 +128,10 @@ _bazel__get_cword() {
   wordbreaks="${wordbreaks//\"/}"
   wordbreaks="${wordbreaks//:/}"
   wordbreaks="${wordbreaks//=/}"
-  local word_start=$(expr "$cur" : '.*[^\]['"${wordbreaks}"']')
+  local word_start=0
+  if [[ ! -z "$wordbreaks" ]]; then
+    word_start=$(expr "$cur" : '.*[^\]['"${wordbreaks}"']')
+  fi
   echo "${cur:$word_start}"
 }
 
@@ -319,7 +322,7 @@ _bazel__expand_target_pattern() {
 }
 
 _bazel__get_command() {
-  for word in "${COMP_WORDS[@]:1:COMP_CWORD-1}"; do
+  for word in "${COMP_WORDS[@]:1:$COMP_CWORD-1}"; do
     if echo "$BAZEL_COMMAND_LIST" | "grep" -wsq -e "$word"; then
       echo $word
       break


### PR DESCRIPTION
Currently if you source /etc/bash_completion.d/bazel using zsh and attempt to use tab completion for bazel commands you will receive the following errors:

```
expr: Unmatched [ or [^

_bazel__get_command:1: unrecognized modifier `C'
```

This pull request makes the completion script bash and zsh compatible and protects against the case that `$wordbreaks` is empty due to `$COMP_WORDBREAKS` only being defined with `:` which appears to be the case with zsh.