### PR TITLE
Add closing paren to documentation on workspace rules.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/NewGitRepositoryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/NewGitRepositoryRule.java
@@ -57,8 +57,8 @@ public class NewGitRepositoryRule implements RuleDefinition {
         <p>Either build_file or build_file_content must be specified.</p>
 
         <p>This attribute is a label relative to the main workspace. The file does not need to be
-        named BUILD, but can be (something like BUILD.new-repo-name may work well for
-        distinguishing it from the repository's actual BUILD files.</p>
+        named BUILD, but can be. (Something like BUILD.new-repo-name may work well for
+        distinguishing it from the repository's actual BUILD files.)</p>
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("build_file", STRING))
         /* <!-- #BLAZE_RULE(new_git_repository).ATTRIBUTE(build_file_content) -->
@@ -73,8 +73,8 @@ public class NewGitRepositoryRule implements RuleDefinition {
          <p>Either workspace_file or workspace_file_content can be specified, but not both.</p>
 
          <p>This attribute is a label relative to the main workspace. The file does not need to be
-        named WORKSPACE, but can be (something like WORKSPACE.new-repo-name may work well for
-        distinguishing it from the repository's actual WORKSPACE files.</p>
+        named WORKSPACE, but can be. (Something like WORKSPACE.new-repo-name may work well for
+        distinguishing it from the repository's actual WORKSPACE files.)</p>
          <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("workspace_file", STRING))
         /* <!-- #BLAZE_RULE(new_http_archive).ATTRIBUTE(workspace_file_content) -->

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/NewHttpArchiveRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/NewHttpArchiveRule.java
@@ -62,8 +62,8 @@ public class NewHttpArchiveRule implements RuleDefinition {
          <p>Either build_file or build_file_content must be specified.</p>
 
          <p>This attribute is a label relative to the main workspace. The file does not need to be
-        named BUILD, but can be (something like BUILD.new-repo-name may work well for
-        distinguishing it from the repository's actual BUILD files.</p>
+        named BUILD, but can be. (Something like BUILD.new-repo-name may work well for
+        distinguishing it from the repository's actual BUILD files.)</p>
          <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("build_file", STRING))
         /* <!-- #BLAZE_RULE(new_http_archive).ATTRIBUTE(build_file_content) -->
@@ -78,8 +78,8 @@ public class NewHttpArchiveRule implements RuleDefinition {
          <p>Either workspace_file or workspace_file_content can be specified, but not both.</p>
 
          <p>This attribute is a label relative to the main workspace. The file does not need to be
-        named WORKSPACE, but can be (something like WORKSPACE.new-repo-name may work well for
-        distinguishing it from the repository's actual WORKSPACE files.</p>
+        named WORKSPACE, but can be. (Something like WORKSPACE.new-repo-name may work well for
+        distinguishing it from the repository's actual WORKSPACE files.)</p>
          <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("workspace_file", STRING))
         /* <!-- #BLAZE_RULE(new_http_archive).ATTRIBUTE(workspace_file_content) -->

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryRule.java
@@ -44,8 +44,8 @@ public class NewLocalRepositoryRule implements RuleDefinition {
         <p>Either build_file or build_file_content must be specified.</p>
 
         <p>This attribute is a label relative to the main workspace. The file does not need to be
-        named BUILD, but can be (something like BUILD.new-repo-name may work well for
-        distinguishing it from the repository's actual BUILD files.</p>
+        named BUILD, but can be. (Something like BUILD.new-repo-name may work well for
+        distinguishing it from the repository's actual BUILD files.)</p>
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("build_file", STRING))
         /* <!-- #BLAZE_RULE(new_local_repository).ATTRIBUTE(build_file_content) -->
@@ -60,8 +60,8 @@ public class NewLocalRepositoryRule implements RuleDefinition {
          <p>Either workspace_file or workspace_file_content can be specified, but not both.</p>
 
          <p>This attribute is a label relative to the main workspace. The file does not need to be
-        named WORKSPACE, but can be (something like WORKSPACE.new-repo-name may work well for
-        distinguishing it from the repository's actual WORKSPACE files.</p>
+        named WORKSPACE, but can be. (Something like WORKSPACE.new-repo-name may work well for
+        distinguishing it from the repository's actual WORKSPACE files.)</p>
          <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("workspace_file", STRING))
         /* <!-- #BLAZE_RULE(new_http_archive).ATTRIBUTE(workspace_file_content) -->


### PR DESCRIPTION
Also moves parenthetical remark to a completely different sentence, as
it seemed off where it was.