### PR TITLE
"Blaze" -> "Bazel" in message visible on CLI

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -110,7 +110,7 @@ public class RunCommand implements BlazeCommand  {
   }
 
   @VisibleForTesting
-  public static final String SINGLE_TARGET_MESSAGE = "Blaze can only run a single target. "
+  public static final String SINGLE_TARGET_MESSAGE = "Bazel can only run a single target. "
       + "Do not use wildcards that match more than one target";
   @VisibleForTesting
   public static final String NO_TARGET_MESSAGE = "No targets found to run";


### PR DESCRIPTION
Example message containing "Blaze" - should be "Bazel":

    $ bazel run //...
    ERROR: Blaze can only run a single target. Do not use wildcards that match more than one target.
    INFO: Elapsed time: 0.092s
