### PR TITLE
Add -v, --version flag

### DIFF
--- a/src/main/cpp/blaze_util.cc
+++ b/src/main/cpp/blaze_util.cc
@@ -125,7 +125,8 @@ bool SearchNullaryOption(const vector<string>& args,
 
 bool IsArg(const string& arg) {
   return blaze_util::starts_with(arg, "-") && (arg != "--help")
-      && (arg != "-help") && (arg != "-h");
+      && (arg != "-help") && (arg != "-h") && (arg != "--version")
+      && (arg != "-v");
 }
 
 void LogWait(unsigned int elapsed_seconds, unsigned int wait_seconds) {

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -471,7 +471,7 @@ std::vector<std::string> OptionProcessor::GetBlazercAndEnvCommandArgs(
 std::vector<std::string> OptionProcessor::GetCommandArguments() const {
   assert(cmd_line_ != nullptr);
   // When the user didn't specify a command, the server expects the command
-  // arguments to be empty in order to display the help message.
+  // arguments to be empty in order to display the help or version message.
   if (cmd_line_->command.empty()) {
     return {};
   }

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -77,6 +77,9 @@ public class BlazeCommandDispatcher {
   private static final ImmutableSet<String> ALL_HELP_OPTIONS =
       ImmutableSet.of("--help", "-help", "-h");
 
+  private static final ImmutableSet<String> ALL_VERSION_OPTIONS =
+      ImmutableSet.of("--version", "-v");
+
   private final BlazeRuntime runtime;
   private final Object commandLock;
   private String currentClientDescription = null;
@@ -140,6 +143,11 @@ public class BlazeCommandDispatcher {
     // Be gentle to users who want to find out about Blaze invocation.
     if (ALL_HELP_OPTIONS.contains(commandName)) {
       commandName = "help";
+    }
+
+    // Be gentle to users who want to find out Blaze version information.
+    if (ALL_VERSION_OPTIONS.contains(commandName)) {
+      commandName = "version";
     }
 
     BlazeCommand command = runtime.getCommandMap().get(commandName);

--- a/src/test/cpp/option_processor_test.cc
+++ b/src/test/cpp/option_processor_test.cc
@@ -490,6 +490,14 @@ TEST_F(OptionProcessorTest, SplitCommandLineWithBlazeVersion) {
   SuccessfulSplitStartupOptionsTest(
       {"bazel", "version"},
       CommandLine("bazel", {}, "version", {}));
+
+  SuccessfulSplitStartupOptionsTest(
+      {"bazel", "-v"},
+      CommandLine("bazel", {}, "-v", {}));
+
+  SuccessfulSplitStartupOptionsTest(
+      {"bazel", "--version"},
+      CommandLine("bazel", {}, "--version", {}));
 }
 
 TEST_F(OptionProcessorTest, SplitCommandLineWithMultipleCommandArgs) {


### PR DESCRIPTION
Attempts to resolve issue #3599 by adding conventional `-v` and `--version` flags to the Bazel client, calling `bazel version` under the hood.