### PR TITLE
Implicit HeaderMaps

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -1058,25 +1058,27 @@ public final class CcCompilationHelper {
       ccCompilationInfoBuilder.addQuoteIncludeDir(internalHeaderMap.getExecPath());
       headerMapsBuilder.add(internalHeaderMap);
 
-      String namespace;
-      if (ruleContext.attributes().has("header_namespace")) {
-         namespace = ruleContext.attributes().get("header_namespace", Type.STRING);
+      String includePrefix;
+      if (ruleContext.attributes().has("include_prefix")) {
+         includePrefix = ruleContext.attributes().get("include_prefix", Type.STRING);
       } else {
-         namespace = ruleContext.getRule().getName();
+         includePrefix = ruleContext.getRule().getName();
       }
 
       // Construct the dep headermap.
-      // This header map additionally contains namespaced headers so that a user
+      // This header map additionally contains include prefixed headers so that a user
       // can import headers of the form Namespace/Header.h from headers within
       // the current target.
       HeaderMapInfo.Builder depHeaderMapInfo = new HeaderMapInfo.Builder();
-      depHeaderMapInfo.setNamespace(namespace);
-      depHeaderMapInfo.addNamespacedHeaders(publicHeaders.getHeaders());
-      depHeaderMapInfo.addHeaders(publicHeaders.getHeaders());
-      depHeaderMapInfo.addNamespacedHeaders(privateHeaders);
-      depHeaderMapInfo.addHeaders(privateHeaders);
-      depHeaderMapInfo.addNamespacedHeaders(publicTextualHeaders);
+      depHeaderMapInfo.setIncludePrefix(includePrefix);
+      depHeaderMapInfo.addIncludePrefixdHeaders(publicHeaders.getHeaders());
+      depHeaderMapInfo.addIncludePrefixdHeaders(privateHeaders);
+      depHeaderMapInfo.addIncludePrefixdHeaders(publicTextualHeaders);
+
+      // TODO flatten_virtual_headers
       depHeaderMapInfo.addHeaders(publicTextualHeaders);
+      depHeaderMapInfo.addHeaders(publicHeaders.getHeaders());
+      depHeaderMapInfo.addHeaders(privateHeaders);
 
       // Merge all of the header map info from deps. The headers within a given
       // target have precedence over over dep headers ( See

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/ClangHeaderMap.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/ClangHeaderMap.java
@@ -1,0 +1,325 @@
+package com.google.devtools.build.lib.rules.cpp;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.channels.FileChannel;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static java.lang.Math.max;
+
+public final class ClangHeaderMap {
+  // Logical representation of a bucket.
+  // The actual data is stored in the string pool.
+  private class HMapBucket {
+    String key;
+    String prefix;
+    String suffix;
+
+    HMapBucket(String key, String prefix, String suffix) {
+      this.key = key;
+      this.prefix = prefix;
+      this.suffix = suffix;
+    }
+  }
+
+  private static final int HEADER_MAGIC = ('h' << 24) | ('m' << 16) | ('a' << 8) | 'p';
+  private static final short HEADER_VERSION = 1;
+  private static final short HEADER_RESERVED = 0;
+  private static final int EMPTY_BUCKET_KEY = 0;
+
+  private static final int HEADER_SIZE = 24;
+  private static final int BUCKET_SIZE = 12;
+
+  private static final int INT_SIZE = Integer.SIZE/8;
+
+  // Data stored in accordance to Clang's lexer types
+  /**
+  enum {
+      HMAP_HeaderMagicNumber = ('h' << 24) | ('m' << 16) | ('a' << 8) | 'p',
+      HMAP_HeaderVersion = 1,
+      HMAP_EmptyBucketKey = 0
+    };
+
+    struct HMapBucket {
+      uint32_t Key;    // Offset (into strings) of key.
+      uint32_t Prefix; // Offset (into strings) of value prefix.
+      uint32_t Suffix; // Offset (into strings) of value suffix.
+    };
+
+    struct HMapHeader {
+      uint32_t Magic;      // Magic word, also indicates byte order.
+      uint16_t Version;      // Version number -- currently 1.
+      uint16_t Reserved;     // Reserved for future use - zero for now.
+      uint32_t StringsOffset;  // Offset to start of string pool.
+      uint32_t NumEntries;     // Number of entries in the string table.
+      uint32_t NumBuckets;     // Number of buckets (always a power of 2).
+      uint32_t MaxValueLength; // Length of longest result path (excluding nul).
+      // An array of 'NumBuckets' HMapBucket objects follows this header.
+      // Strings follow the buckets, at StringsOffset.
+    };
+  */
+  public ByteBuffer buff;
+
+  private int numBuckets;
+  private int numUsedBuckets;
+  private int stringsOffset;
+  private int stringsSize;
+  private int maxValueLength;
+  private int maxStringsSize;
+
+  // Used only for creation
+  private HMapBucket[] buckets;
+
+  // Create a headermap from a raw Map of keys to strings
+  // Usage:
+  // A given path to a header is keyed by that header.
+  // .e. Header.h -> Path/To/Header.h
+  //
+  // Additionally, it is possible to alias custom paths to headers.
+  // For example, it is possible to namespace a given target
+  // i.e. MyTarget/Header.h -> Path/To/Header.h
+  //
+  // The HeaderMap format is defined by the lexer of Clang
+  // https://clang.llvm.org/doxygen/HeaderMap_8cpp_source.html
+  ClangHeaderMap(Map<String, String> headerPathsByKeys) {
+    int dataOffset = 1;
+    setMap(headerPathsByKeys);
+
+    int endBuckets = HEADER_SIZE + numBuckets * BUCKET_SIZE;
+    stringsOffset = endBuckets - dataOffset;
+    int totalBufferSize = endBuckets + maxStringsSize;
+    buff = ByteBuffer.wrap(new byte[totalBufferSize]).order(ByteOrder.LITTLE_ENDIAN);
+
+    // Write out the header
+    buff.putInt(HEADER_MAGIC);
+    buff.putShort(HEADER_VERSION);
+    buff.putShort(HEADER_RESERVED);
+    buff.putInt(stringsOffset);
+
+    // For each entry, we write a key, suffix, and prefix
+    int stringPoolSize = headerPathsByKeys.size() * 3;
+    buff.putInt(stringPoolSize);
+    buff.putInt(numBuckets);
+    buff.putInt(maxValueLength);
+
+    // Write out buckets and compute string offsets
+    byte[] stringBytes = new byte[maxStringsSize];
+
+    // Used to compute the current offset
+    stringsSize = 0;
+    for (int i = 0; i < numBuckets; i++) {
+      HMapBucket bucket = buckets[i];
+      if (bucket == null) {
+        buff.putInt(EMPTY_BUCKET_KEY);
+        buff.putInt(0);
+        buff.putInt(0);
+      } else {
+        int keyOffset = stringsSize;
+        buff.putInt(keyOffset + dataOffset);
+        stringsSize = addString(bucket.key, stringsSize, stringBytes);
+
+        int prefixOffset = stringsSize;
+        stringsSize = addString(bucket.prefix, stringsSize, stringBytes);
+        buff.putInt(prefixOffset + dataOffset);
+
+        int suffixOffset = stringsSize;
+        stringsSize = addString(bucket.suffix, stringsSize, stringBytes);
+        buff.putInt(suffixOffset + dataOffset);
+      }
+    }
+    buff.put(stringBytes, 0, stringsSize);
+  }
+
+  // For testing purposes. Implement a similiar algorithm as the clang
+  // lexer.
+  public String get(String key) {
+    int bucketIdx = clangKeyHash(key) & (numBuckets - 1);
+    while (bucketIdx < numBuckets) {
+      // Buckets are right after the header
+      int bucketOffset = HEADER_SIZE + (BUCKET_SIZE * bucketIdx);
+      int keyOffset = buff.getInt(bucketOffset);
+
+      // Note: the lexer does a case insensitive compare here but
+      // it isn't necessary for test purposes
+      if (key.equals(getString(keyOffset)) == false) {
+        bucketIdx++;
+        continue;
+      }
+
+      // Start reading bytes from the prefix
+      int prefixOffset = buff.getInt(bucketOffset + INT_SIZE);
+      int suffixOffset = buff.getInt(bucketOffset + INT_SIZE * 2);
+      return getString(prefixOffset) + getString(suffixOffset);
+    }
+    return null;
+  }
+
+  // Return a string from an offset
+  // This method is used for testing only.
+  private String getString(int offset) {
+    int readOffset = stringsOffset + offset;
+    int endStringsOffset = stringsOffset + stringsSize;
+    int idx = readOffset;
+    byte[] stringBytes = new byte[2048];
+    while(idx < endStringsOffset) {
+      byte c = (byte)buff.getChar(idx);
+      if (c == 0) {
+        break;
+      }
+      stringBytes[idx] = c;
+      idx++;
+    }
+    try {
+      return new String(stringBytes).trim();
+    } catch(Exception e) {
+      return null;
+    }
+  }
+
+  private void addBucket(HMapBucket bucket, HMapBucket[] buckets, int numBuckets) {
+    // Use a load factor of 0.5
+    if (((numUsedBuckets + 1) / numBuckets) > 0.5 == false) {
+      int bucketIdx = clangKeyHash(bucket.key) & (numBuckets - 1);
+      // Base case, the bucket Idx is free
+      if (buckets[bucketIdx] == null) {
+        buckets[bucketIdx] = bucket;
+        this.numUsedBuckets++;
+        return;
+      }
+
+      // Handle collisions.
+      //
+      // The lexer does a linear scan of the hash table when keys do
+      // not match, starting at the bucket.
+      while(bucketIdx < numBuckets) {
+        bucketIdx = (bucketIdx + 1) & (numBuckets - 1);
+        if (buckets[bucketIdx] == null) {
+          buckets[bucketIdx] = bucket;
+          this.numUsedBuckets++;
+          return;
+        }
+      }
+    }
+
+    // If there are no more slots left, grow by a power of 2
+    int newNumBuckets = numBuckets * 2;
+    HMapBucket[] newBuckets = new HMapBucket[newNumBuckets];
+
+    HMapBucket[] oldBuckets = buckets;
+    this.buckets = newBuckets;
+    this.numBuckets = newNumBuckets;
+    this.numUsedBuckets = 0;
+    for(HMapBucket cpBucket: oldBuckets) {
+      if (cpBucket != null) {
+        addBucket(cpBucket, newBuckets, newNumBuckets);
+      }
+    }
+
+    // Start again
+    addBucket(bucket, newBuckets, newNumBuckets);
+  }
+
+  private void setMap(Map<String, String> headerPathsByKeys){
+    // Compute header metadata
+    maxValueLength = 1;
+    maxStringsSize = 0;
+    numUsedBuckets = 0;
+
+    // Per the format, buckets need to be powers of 2 in size
+    numBuckets = getNextPowerOf2(headerPathsByKeys.size() + 1);
+    buckets = new HMapBucket[numBuckets];
+
+    for(Map.Entry<String, String> entry: headerPathsByKeys.entrySet()){
+      String key = entry.getKey();
+      String path = entry.getValue();
+
+      // Get the prefix and suffix
+      String suffix;
+      String prefix;
+      Path pathValue = Paths.get(path);
+      if (pathValue.getNameCount() < 2) {
+        // The suffix is empty when the file path just a filename
+        prefix = "";
+        suffix = pathValue.getFileName().toString();
+      } else {
+        prefix = pathValue.getParent().toString() + "/";
+        suffix = pathValue.getFileName().toString();
+      }
+
+      HMapBucket bucket = new HMapBucket(key, prefix, suffix);
+      addBucket(bucket, buckets, numBuckets);
+      int prefixLen = prefix.getBytes().length + 1;
+      int suffixLen = suffix.getBytes().length + 1;
+      int keyLen = key.getBytes().length + 1;
+      maxStringsSize += prefixLen + suffixLen + keyLen;
+
+      maxValueLength = max(maxValueLength, keyLen);
+      maxValueLength = max(maxValueLength, suffixLen);
+      maxValueLength = max(maxValueLength, prefixLen);
+    }
+  }
+
+  // Utils
+
+  private static int addString(String str, int totalLength, byte[] stringBytes) {
+    for (byte b : str.getBytes(StandardCharsets.UTF_8)) {
+      stringBytes[totalLength] = b;
+      totalLength++;
+    }
+    stringBytes[totalLength] = (byte) 0;
+    totalLength++;
+    return totalLength;
+  }
+
+  private static int getNextPowerOf2(int a) {
+    int b = 1;
+    while (b < a) {
+      b = b << 1;
+    }
+    return b;
+  }
+
+  // The same hashing algorithm as the Lexer.
+  // Buckets must be inserted according to this.
+  private static int clangKeyHash(String key) {
+    // Keys are case insensitve.
+    String lowerCaseKey = toLowerCaseAscii(key);
+    int hash = 0;
+    for (byte c : lowerCaseKey.getBytes(StandardCharsets.UTF_8)) {
+      hash += c * 13;
+    }
+    return hash;
+  }
+
+  // Utils from Guava ( FIXME: use those utils )
+  public static String toLowerCaseAscii(String string) {
+    int length = string.length();
+    StringBuilder builder = new StringBuilder(length);
+    for (int i = 0; i < length; i++) {
+      builder.append(toLowerCaseAscii(string.charAt(i)));
+    }
+    return builder.toString();
+  }
+
+  public static char toLowerCaseAscii(char c) {
+    return isUpperCase(c) ? (char) (c ^ 0x20) : c;
+  }
+
+  public static boolean isUpperCase(char c) {
+    return (c >= 'A') && (c <= 'Z');
+  }
+}
+

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/ClangHeaderMap.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/ClangHeaderMap.java
@@ -304,7 +304,6 @@ public final class ClangHeaderMap {
     return hash;
   }
 
-  // Utils from Guava ( FIXME: use those utils )
   public static String toLowerCaseAscii(String string) {
     int length = string.length();
     StringBuilder builder = new StringBuilder(length);

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -1035,6 +1035,13 @@ public final class CppConfiguration extends BuildConfiguration.Fragment {
     return cppOptions.fissionModes.contains(compilationMode);
   }
 
+  /**
+   * Returns whether we are implicitly creating header maps.
+   */
+  public boolean experimentalEnableImplicitHeaderMaps() {
+    return cppOptions.experimentalEnableImplicitHeaderMaps;
+  }
+
   /** Returns true if --build_test_dwp is set on this build. */
   public boolean buildTestDwpIsActivated() {
     return cppOptions.buildTestDwp;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -316,6 +316,18 @@ public class CppOptions extends FragmentOptions {
   public boolean processHeadersInDependencies;
 
   @Option(
+    name = "experimental_enable_implicit_headermaps",
+    defaultValue = "false",
+    category = "semantics",
+    documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+    effectTags = {OptionEffectTag.UNKNOWN},
+    help =
+        "When building a target //a:a, generate a header map containing all of the headrs that //a:a depends "
+            + "on (if header processing is enabled for the toolchain)."
+  )
+  public boolean experimentalEnableImplicitHeaderMaps;
+
+  @Option(
     name = "copt",
     allowMultiple = true,
     defaultValue = "",

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -322,7 +322,7 @@ public class CppOptions extends FragmentOptions {
     documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
     effectTags = {OptionEffectTag.UNKNOWN},
     help =
-        "When building a target //a:a, generate a header map containing all of the headrs that //a:a depends "
+        "When building a target //a:a, generate a header map containing all of the headers that //a:a depends "
             + "on (if header processing is enabled for the toolchain)."
   )
   public boolean experimentalEnableImplicitHeaderMaps;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderMapAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderMapAction.java
@@ -1,0 +1,87 @@
+package com.google.devtools.build.lib.rules.cpp;
+
+//TODO: Cleanup Imports
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.devtools.build.lib.actions.ActionExecutionContext;
+import com.google.devtools.build.lib.actions.ActionKeyContext;
+import com.google.devtools.build.lib.actions.ActionOwner;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
+import com.google.devtools.build.lib.actions.CommandLine;
+import com.google.devtools.build.lib.actions.CommandLineExpansionException;
+import com.google.devtools.build.lib.analysis.actions.AbstractFileWriteAction;
+import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import com.google.devtools.build.lib.util.Fingerprint;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+import java.io.OutputStream;//?
+import java.io.DataOutputStream;//?
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.nio.channels.FileChannel;
+import java.io.FileOutputStream;
+
+@Immutable
+public final class HeaderMapAction extends AbstractFileWriteAction {
+
+  private static final String GUID = "4f407081-1951-40c1-befc-d6b4daff5de3";
+
+  // C++ header map of the current target
+  private final Map <String, String> headerMap;
+
+  public HeaderMapAction(
+      ActionOwner owner,
+      Map <String, String> headerMap,
+      Artifact output
+      ) {
+    super(
+        owner,
+        ImmutableList.<Artifact>builder().build(),
+        output,
+        /*makeExecutable=*/ false);
+    this.headerMap = headerMap;
+  }
+
+  @Override
+  public DeterministicWriter newDeterministicWriter(ActionExecutionContext ctx)  {
+    return new DeterministicWriter() {
+      @Override
+      public void writeOutputFile(OutputStream out) throws IOException {
+        ClangHeaderMap hmap = new ClangHeaderMap(headerMap);
+        ByteBuffer b = hmap.buff;
+        b.flip();
+        WritableByteChannel channel = Channels.newChannel(out);
+        channel.write(b);
+        out.flush();
+        out.close();
+      }
+    };
+  }
+
+  @Override
+  public String getMnemonic() {
+    return "CppHeaderMap";
+  }
+
+  @Override
+  protected void computeKey(ActionKeyContext actionKeyContext, Fingerprint f)
+      throws CommandLineExpansionException {
+    f.addString(GUID);
+    for(Map.Entry<String, String> entry: headerMap.entrySet()){
+      String key = entry.getKey();
+      String path = entry.getValue();
+      f.addString(key + path);
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderMapInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderMapInfo.java
@@ -1,0 +1,86 @@
+package com.google.devtools.build.lib.rules.cpp;
+
+import com.google.devtools.build.lib.vfs.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
+
+public class HeaderMapInfo {
+  private final ImmutableMap<String, String> sources;
+
+  public final static HeaderMapInfo EMPTY = new HeaderMapInfo(ImmutableMap.of());
+
+  private HeaderMapInfo(ImmutableMap<String, String> sources) {
+    this.sources = sources;
+  }
+
+  public ImmutableMap<String, String> getSources() {
+    return sources;
+  }
+
+  /** Builder for HeaderMapInfo */
+  public static class Builder {
+    private final ImmutableList.Builder<Artifact> basicHeaders = ImmutableList.builder();
+    private final ImmutableList.Builder<Artifact> namespacedHeaders = ImmutableList.builder();
+    private final ImmutableList.Builder<HeaderMapInfo> mergedHeaderMapInfos = ImmutableList.builder();
+    private String namespace = "";
+
+    /** Set the namespace. */
+    public Builder setNamespace(String namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+
+    /** Signals that the build uses headers. */
+    public Builder addHeaders(Iterable<Artifact> headers) {
+      this.basicHeaders.addAll(headers);
+      return this;
+    }
+
+    /** Signals that the build uses headers under the namespace. */
+    public Builder addNamespacedHeaders(Iterable<Artifact> headers) {
+      this.namespacedHeaders.addAll(headers);
+      return this;
+    }
+
+    /**
+     * Merge a header map info.
+     * Merged HeaderMapInfos are merged in reverse that they were added.
+     * Directly added headers take precedence over those that were merged.
+     */
+    public Builder mergeHeaderMapInfo(HeaderMapInfo info) {
+      this.mergedHeaderMapInfos.add(info);
+      return this;
+    }
+
+    public HeaderMapInfo build() {
+      Map inputMap = new HashMap();
+      for (HeaderMapInfo info: mergedHeaderMapInfos.build().reverse()){
+        for (Map.Entry<String, String> entry: info.getSources().entrySet()){
+          inputMap.put(entry.getKey(), entry.getValue());
+        }
+      }
+
+      for (Artifact hdr : basicHeaders.build()) {
+        inputMap.put(hdr.getPath().getBaseName(), hdr.getExecPath().getPathString());
+      }
+
+      // If there is no namespace, don't add a slash
+      if (namespace.equals("") == false) {
+        for (Artifact hdr : namespacedHeaders.build()) {
+          String namespacedKey = namespace + "/" + hdr.getPath().getBaseName();
+          inputMap.put(namespacedKey, hdr.getExecPath().getPathString());
+        }
+      } else {
+        for (Artifact hdr : namespacedHeaders.build()) {
+          inputMap.put(hdr.getPath().getBaseName(), hdr.getExecPath().getPathString());
+        }
+      }
+      return new HeaderMapInfo(ImmutableMap.copyOf(inputMap));
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderMapInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderMapInfo.java
@@ -38,8 +38,8 @@ public class HeaderMapInfo {
     /**
      * Signals that the build uses headers.
      *
-     * If `flatten_virtual_headers` is set, the headers will be mapped to
-     * "Header.h" -> path/to/Header.
+     * This is used when `flatten_virtual_headers` is set: these headers will be
+     * mapped to "Header.h" -> path/to/Header.
      */
     public Builder addHeaders(Iterable<Artifact> headers) {
       this.basicHeaders.addAll(headers);
@@ -77,12 +77,10 @@ public class HeaderMapInfo {
       // If there is no includePrefix, don't add a slash
       if (includePrefix.equals("") == false) {
         for (Artifact hdr : includePrefixdHeaders.build()) {
+          // Set the include prefix:
+          // IncludePrefix/Header.h -> Path/To/Header.h
           String includePrefixdKey = includePrefix + "/" + hdr.getPath().getBaseName();
           inputMap.put(includePrefixdKey, hdr.getExecPath().getPathString());
-        }
-      } else {
-        for (Artifact hdr : includePrefixdHeaders.build()) {
-          inputMap.put(hdr.getPath().getBaseName(), hdr.getExecPath().getPathString());
         }
       }
       return new HeaderMapInfo(ImmutableMap.copyOf(inputMap));

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderMapInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderMapInfo.java
@@ -25,25 +25,30 @@ public class HeaderMapInfo {
   /** Builder for HeaderMapInfo */
   public static class Builder {
     private final ImmutableList.Builder<Artifact> basicHeaders = ImmutableList.builder();
-    private final ImmutableList.Builder<Artifact> namespacedHeaders = ImmutableList.builder();
+    private final ImmutableList.Builder<Artifact> includePrefixdHeaders = ImmutableList.builder();
     private final ImmutableList.Builder<HeaderMapInfo> mergedHeaderMapInfos = ImmutableList.builder();
-    private String namespace = "";
+    private String includePrefix = "";
 
-    /** Set the namespace. */
-    public Builder setNamespace(String namespace) {
-      this.namespace = namespace;
+    /** Set include prefix. */
+    public Builder setIncludePrefix(String includePrefix) {
+      this.includePrefix = includePrefix;
       return this;
     }
 
-    /** Signals that the build uses headers. */
+    /**
+     * Signals that the build uses headers.
+     *
+     * If `flatten_virtual_headers` is set, the headers will be mapped to
+     * "Header.h" -> path/to/Header.
+     */
     public Builder addHeaders(Iterable<Artifact> headers) {
       this.basicHeaders.addAll(headers);
       return this;
     }
 
-    /** Signals that the build uses headers under the namespace. */
-    public Builder addNamespacedHeaders(Iterable<Artifact> headers) {
-      this.namespacedHeaders.addAll(headers);
+    /** Signals that the build uses headers under the includePrefix. */
+    public Builder addIncludePrefixdHeaders(Iterable<Artifact> headers) {
+      this.includePrefixdHeaders.addAll(headers);
       return this;
     }
 
@@ -69,14 +74,14 @@ public class HeaderMapInfo {
         inputMap.put(hdr.getPath().getBaseName(), hdr.getExecPath().getPathString());
       }
 
-      // If there is no namespace, don't add a slash
-      if (namespace.equals("") == false) {
-        for (Artifact hdr : namespacedHeaders.build()) {
-          String namespacedKey = namespace + "/" + hdr.getPath().getBaseName();
-          inputMap.put(namespacedKey, hdr.getExecPath().getPathString());
+      // If there is no includePrefix, don't add a slash
+      if (includePrefix.equals("") == false) {
+        for (Artifact hdr : includePrefixdHeaders.build()) {
+          String includePrefixdKey = includePrefix + "/" + hdr.getPath().getBaseName();
+          inputMap.put(includePrefixdKey, hdr.getExecPath().getPathString());
         }
       } else {
-        for (Artifact hdr : namespacedHeaders.build()) {
+        for (Artifact hdr : includePrefixdHeaders.build()) {
           inputMap.put(hdr.getPath().getBaseName(), hdr.getExecPath().getPathString());
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderMapInfoProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderMapInfoProvider.java
@@ -1,0 +1,33 @@
+package com.google.devtools.build.lib.rules.cpp;
+
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.analysis.TransitiveInfoProvider;
+import com.google.devtools.build.lib.util.FileTypeSet;
+
+public class HeaderMapInfoProvider implements TransitiveInfoProvider {
+  private HeaderMapInfo info;
+
+  public static HeaderMapInfoProvider EMPTY = new HeaderMapInfoProvider(HeaderMapInfo.EMPTY);
+
+  public HeaderMapInfo getInfo() {
+    return info;
+  }
+
+  private HeaderMapInfoProvider(HeaderMapInfo info) {
+    this.info = info;
+  }
+
+  /** Builder for HeaderMapInfoProvider */
+  public static class Builder {
+    private HeaderMapInfo info;
+
+    public Builder setHeaderMapInfo(HeaderMapInfo info) {
+      this.info = info;
+      return this;
+    }
+
+    public HeaderMapInfoProvider build() {
+      return new HeaderMapInfoProvider(this.info);
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommon.java
@@ -366,16 +366,18 @@ public final class ObjcCommon {
 
     public HeaderMapInfoProvider getHeaderMapInfoProvider(RuleContext ruleContext, ImmutableList<Artifact>hdrs){
       HeaderMapInfo.Builder headerMapInfo = new HeaderMapInfo.Builder();
-      String namespace;
-      if (ruleContext.attributes().has("header_namespace")) {
-         namespace = ruleContext.attributes().get("header_namespace", Type.STRING);
+      String includePrefix;
+      if (ruleContext.attributes().has("include_prefix")) {
+         includePrefix = ruleContext.attributes().get("include_prefix", Type.STRING);
       } else {
-         namespace = ruleContext.getRule().getName();
+         includePrefix = ruleContext.getRule().getName();
       }
 
-      headerMapInfo.setNamespace(namespace);
+      headerMapInfo.setIncludePrefix(includePrefix);
+      headerMapInfo.addIncludePrefixdHeaders(hdrs);
+
+      // TODO flatten_virtual_headers
       headerMapInfo.addHeaders(hdrs);
-      headerMapInfo.addNamespacedHeaders(hdrs);
 
       if (ruleContext.attributes().has("deps")){
         // Propagate all of the dep sources

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommon.java
@@ -68,34 +68,26 @@ import com.google.devtools.build.lib.packages.Info;
 import com.google.devtools.build.lib.packages.NativeProvider;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.rules.apple.AppleToolchain;
+import com.google.devtools.build.lib.rules.cpp.CppConfiguration;
 import com.google.devtools.build.lib.rules.cpp.CcCompilationInfo;
 import com.google.devtools.build.lib.rules.cpp.CcLinkParams;
 import com.google.devtools.build.lib.rules.cpp.CcLinkParamsInfo;
-
-import com.google.devtools.build.lib.rules.cpp.CppFileTypes;
-import com.google.devtools.build.lib.rules.cpp.CppModuleMap;
-import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
-
-import com.google.devtools.build.lib.rules.cpp.CppConfiguration;
 import com.google.devtools.build.lib.rules.cpp.CppFileTypes;
 import com.google.devtools.build.lib.rules.cpp.CppModuleMap;
 import com.google.devtools.build.lib.rules.cpp.HeaderMapAction;
 import com.google.devtools.build.lib.rules.cpp.HeaderMapInfo;
 import com.google.devtools.build.lib.rules.cpp.HeaderMapInfoProvider;
+import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
 import com.google.devtools.build.lib.syntax.Type;
-
 
 import com.google.devtools.build.lib.util.FileType;
 import com.google.devtools.build.lib.util.FileTypeSet;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.HashMap;
 import java.util.Map;
-/**
-import com.google.devtools.build.lib.actions.Root;
-*/
+import java.util.Set;
 
 /**
  * Contains information common to multiple objc_* rules, and provides a unified API for extracting
@@ -368,16 +360,19 @@ public final class ObjcCommon {
       HeaderMapInfo.Builder headerMapInfo = new HeaderMapInfo.Builder();
       String includePrefix;
       if (ruleContext.attributes().has("include_prefix")) {
-         includePrefix = ruleContext.attributes().get("include_prefix", Type.STRING);
+        includePrefix = ruleContext.attributes().get("include_prefix", Type.STRING);
       } else {
-         includePrefix = ruleContext.getRule().getName();
+        includePrefix = ruleContext.getRule().getName();
       }
 
       headerMapInfo.setIncludePrefix(includePrefix);
       headerMapInfo.addIncludePrefixdHeaders(hdrs);
 
-      // TODO flatten_virtual_headers
-      headerMapInfo.addHeaders(hdrs);
+      boolean flattenVirtualHeaders = ruleContext.attributes().has("flatten_virtual_headers") &&
+          ruleContext.attributes().get("flatten_virtual_headers", Type.BOOLEAN);
+      if (flattenVirtualHeaders) {
+        headerMapInfo.addHeaders(hdrs);
+      }
 
       if (ruleContext.attributes().has("deps")){
         // Propagate all of the dep sources

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcLibrary.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.rules.cpp.CcCompilationInfo;
 import com.google.devtools.build.lib.rules.cpp.CcLinkParamsInfo;
+import com.google.devtools.build.lib.rules.cpp.HeaderMapInfoProvider;
 import com.google.devtools.build.lib.rules.objc.ObjcCommon.ResourceAttributes;
 import com.google.devtools.build.lib.syntax.Type;
 import java.util.Map;
@@ -101,6 +102,7 @@ public class ObjcLibrary implements RuleConfiguredTargetFactory {
     return ObjcRuleClasses.ruleConfiguredTarget(ruleContext, filesToBuild.build())
         .addNativeDeclaredProvider(common.getObjcProvider())
         .addNativeDeclaredProvider(ccCompilationInfo)
+        .addProvider(common.getHeaderMapInfoProvider())
         .addProvider(J2ObjcEntryClassProvider.class, j2ObjcEntryClassProvider)
         .addProvider(J2ObjcMappingFileProvider.class, j2ObjcMappingFileProvider)
         .addProvider(

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
@@ -704,13 +704,16 @@ public class ObjcRuleClasses {
           <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
           .add(attr("module_map", LABEL).allowedFileTypes(FileType.of(".modulemap")))
 
-          /* <!--
-           * #BLAZE_RULE($objc_compiling_rule).ATTRIBUTE(include_prefix) -->
+          /* <!-- #BLAZE_RULE($objc_compiling_rule).ATTRIBUTE(include_prefix) -->
           <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
-          .add(attr("include_prefix", Type.STRING))
+          .add(attr("include_prefix", STRING))
 
-          /* <!--
-           * #BLAZE_RULE($objc_compiling_rule).ATTRIBUTE(flatten_virtual_headers) -->
+          /* <!-- #BLAZE_RULE($objc_compiling_rule).ATTRIBUTE(flatten_virtual_headers) -->
+           When flatten virtual headers is set, we add all headers to the headermap.
+
+           This allows a user to include a Header, "path/to/header" as "header.h"
+
+           Together with include_prefix, this allows bazel to support Xcode style includes.
           <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
           .add(attr("flatten_virtual_headers", BOOLEAN))
 

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
@@ -703,6 +703,14 @@ public class ObjcRuleClasses {
           provided module map to the compiler.
           <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
           .add(attr("module_map", LABEL).allowedFileTypes(FileType.of(".modulemap")))
+
+          /* <!--
+           * #BLAZE_RULE($objc_compiling_rule).ATTRIBUTE(header_namespace) -->
+          The namespace that headers in this rule may be imported as.
+          If not set, it defaults to the name of the target.
+          <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
+          .add(attr("header_namespace", Type.STRING))
+
           /* Provides the label for header_scanner tool that is used to scan inclusions for ObjC
           sources and provide a list of required headers via a .header_list file.
 

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
@@ -705,11 +705,14 @@ public class ObjcRuleClasses {
           .add(attr("module_map", LABEL).allowedFileTypes(FileType.of(".modulemap")))
 
           /* <!--
-           * #BLAZE_RULE($objc_compiling_rule).ATTRIBUTE(header_namespace) -->
-          The namespace that headers in this rule may be imported as.
-          If not set, it defaults to the name of the target.
+           * #BLAZE_RULE($objc_compiling_rule).ATTRIBUTE(include_prefix) -->
           <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
-          .add(attr("header_namespace", Type.STRING))
+          .add(attr("include_prefix", Type.STRING))
+
+          /* <!--
+           * #BLAZE_RULE($objc_compiling_rule).ATTRIBUTE(flatten_virtual_headers) -->
+          <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
+          .add(attr("flatten_virtual_headers", BOOLEAN))
 
           /* Provides the label for header_scanner tool that is used to scan inclusions for ObjC
           sources and provide a list of required headers via a .header_list file.

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/ClangHeaderMapTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/ClangHeaderMapTest.java
@@ -1,0 +1,41 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.rules.cpp;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.build.lib.testutil.FoundationTestCase;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+public class ClangHeaderMapTest extends FoundationTestCase {
+  @Test
+  public void testNamespacedHeaderMap() {
+    Map<String, String> paths = new HashMap();
+    paths.put("MyHeader.h", "include/MyHeader.h");
+    paths.put("X/MyHeader2.h", "include/MyHeader2.h");
+    paths.put("X/MyHeader3.h", "include/MyHeader3.h");
+
+    ClangHeaderMap hmap = new ClangHeaderMap(paths);
+    assertThat(hmap.get("MyHeader.h")).isEqualTo("include/MyHeader.h");
+    assertThat(hmap.get("X/MyHeader2.h")).isEqualTo("include/MyHeader2.h");
+    assertThat(hmap.get("X/MyHeader3.h")).isEqualTo("include/MyHeader3.h");
+  }
+}
+

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -1793,6 +1793,41 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   }
 
   @Test
+  public void testObjcNamespacedImports() throws Exception {
+    useConfiguration(
+        "--crosstool_top=" + MockObjcSupport.DEFAULT_OSX_CROSSTOOL,
+        "--experimental_objc_crosstool=all",
+        "--experimental_enable_implicit_headermaps=true");
+    scratch.file(
+        "x/importer.m",
+        // By default, we would be able to import this header
+        // under the namespace of dep_liba.
+        "#import \"dep_liba/header.h\"",
+        // This header has a custom namespace
+        "#import \"some/headerb.h\"");
+    scratch.file(
+        "x/headerb.h");
+    scratch.file(
+        "x/BUILD",
+        "objc_library(",
+        "   name = 'objc',",
+        "   srcs = ['importer.m'],",
+        "   deps = [':dep_liba', ':dep_libb'],",
+        ")",
+        "objc_library(",
+        "   name = 'dep_liba',",
+        "   hdrs = ['header.h'],",
+        ")",
+        "objc_library(",
+        "   name = 'dep_libb',",
+        "   header_namespace = 'some',",
+        "   hdrs = ['headerb.h'],",
+        ")");
+
+    assertThat(getConfiguredTarget("//x:objc")).isNotNull();
+  }
+
+  @Test
   public void testObjcImportDoesNotCrash() throws Exception {
     useConfiguration("--crosstool_top=" + MockObjcSupport.DEFAULT_OSX_CROSSTOOL);
     scratch.file(

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -1820,7 +1820,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
         ")",
         "objc_library(",
         "   name = 'dep_libb',",
-        "   header_namespace = 'some',",
+        "   include_prefix = 'some',",
         "   hdrs = ['headerb.h'],",
         ")");
 


### PR DESCRIPTION
Request for feedback on an implementation of C++ HeaderMaps in Bazel.

A HeaderMap is a data structure that allows the compiler to lookup included
headers in constant time.

Traditionally, the compiler has to parse a large string of `iquote` includes,
and then search these directories for a given header. This is slow for many
reasons.

The protocol of HeaderMap is implemented within compilers. Please find the
Lexer implementation in Clang.
https://clang.llvm.org/doxygen/HeaderMapTypes_8h.html
https://clang.llvm.org/doxygen/HeaderMap_8cpp_source.html

Use case:

I'm seeing a massive increase in build performance by using this. It cut my
clean build time in half.

Performance data:

Build time before HeaderMap:
```
Target //Pinterest/iOS/App:PinterestDevelopment up-to-date:
bazel-bin/Pinterest/iOS/App/PinterestDevelopment.ipa
____Elapsed time: 373.588s, Critical Path: 18.86s
```

Build time after header maps on the entire project:
```
Target //Pinterest/iOS/App:PinterestDevelopment up-to-date:
bazel-bin/Pinterest/iOS/App/PinterestDevelopment.ipa
____Elapsed time: 188.971s, Critical Path: 17.11s
```

Additionally, this solves the problem of having namespaced headers which is used
in CocoaPods all over. Using a namespace makes includes more clear since it is
easier for the user to distinguish where the header was derived.

Implementation:

At the ObjC level, headermaps are created with a namespace of the given target.
In `objc_library` it is possible for the user to override the value of the
namespace via the new attribute, `header_namespace`.

By using 2 headermaps the headersearchs are most efficient: a headermap for the
current target, and a header map with namespaced includes.

Users can include headers from ObjC targets in the convention of
`Namespace/Header.h`. Projects that don't use namespacing should see benefits as
well: includes of the form `Header.h` will be read from the headermap.

`HeaderMapInfo` contains all of the transitive info for dependent header maps,
and is merged together into a single map. This yields much better performance
than multiple headermaps.

This is my first PR to the Bazel repo, so any suggestions or feedback is greatly
appreciated!
