### PR TITLE
Show --experimental_repository_cache in Bazel options

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -36,9 +36,9 @@ public class RepositoryOptions extends OptionsBase {
   @Option(
     name = "experimental_repository_cache",
     defaultValue = "null",
-    documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-    effectTags = {OptionEffectTag.UNKNOWN},
-    metadataTags = {OptionMetadataTag.HIDDEN},
+    documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+    effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+    metadataTags = {OptionMetadataTag.EXPERIMENTAL},
     converter = OptionsUtils.PathFragmentConverter.class,
     help =
         "Specifies the cache location of the downloaded values obtained "


### PR DESCRIPTION
It's been some time since this feature was implemented and there are quite a number of users and discussions for it [1]. Tracker issue: #1752

This PR surfaces the flag in the help messages.

[1]: https://github.com/search?q=experimental_repository_cache&type=Issues&utf8=%E2%9C%93)