### PR TITLE
Change the default of `objc_enable_binary_stripping` to "true".

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
@@ -169,7 +169,7 @@ public class ObjcCommandLineOptions extends FragmentOptions {
 
   @Option(
     name = "objc_enable_binary_stripping",
-    defaultValue = "false",
+    defaultValue = "true",
     category = "flags",
     documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
     effectTags = {OptionEffectTag.ACTION_OPTIONS},


### PR DESCRIPTION
Enabling this flag greatly reduces the size of an iOS application and it is expected that release builds (compilation_mode opt) would have had this enabled by default.

In our experience we observed a 50% reduction in binary size and since this only takes effect when `--compilation_mode=opt` is enabled it should be harmless for debug / fastbuild configurations.