### PR TITLE
Provide installation instructions for CentOS

### DIFF
--- a/site/docs/install-centos.md
+++ b/site/docs/install-centos.md
@@ -1,0 +1,43 @@
+---
+layout: documentation
+title: Installing Bazel on CentOS
+---
+
+# <a name="centos"></a>Install Bazel on CentOS
+
+Supported CentOS Linux platforms:
+
+*   CentOS 7.3
+*   CentOS 7.4
+
+Install Bazel on CentOS using one of the following methods:
+
+*   [Use our custom Bazel COPR repository (experimental)](#install-on-centos)
+*   [Compile Bazel from source (experimental)](install-compile-source.md)
+
+Bazel comes with two completion scripts. After installing Bazel, you can:
+
+*   access the [bash completion script](install.md)
+*   install the [zsh completion script](install.md)
+
+## <a name="install-on-centos"></a> Using Bazel custom COPR repository (experimental)
+
+### 1. Install Bazel COPR repository (one time setup)
+
+```bash
+sudo curl -L https://copr.fedorainfracloud.org/coprs/sdake/bazel/repo/epel-7/sdake-bazel-epel-7.repo -o /etc/yum.repos.d/sdake-bazel-epel-7.repo
+```
+
+### 2. Install Bazel
+
+```bash
+sudo yum install bazel
+```
+
+### 3. Update Bazel
+
+Once installed, you can upgrade to a newer version of Bazel with:
+
+```bash
+sudo yum update bazel
+```

--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -10,6 +10,7 @@ See the instructions for installing Bazel on:
 *   [Ubuntu Linux (16.04, 15.10, and 14.04)](install-ubuntu.md)
 *   [Mac OS X](install-os-x.md)
 *   [Windows](install-windows.md)
+*   [CentOS 7.3, 7.4](install-centos.md)
 
 For other platforms, you can try to [compile from source](install-compile-source.md).
 


### PR DESCRIPTION
CentOS does not build from source particularly easily.  This
patch provides instructions to install via an RPM on COPR.
COPR is the "Cool Other Packages Repo" and is similar in
nature to Ubuntu's PPAs.

Fixes #2701
RELNOTES: None.