### PR TITLE
Update Appengine Rules Label

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/be/be-nav.vm
+++ b/src/main/java/com/google/devtools/build/docgen/templates/be/be-nav.vm
@@ -32,7 +32,7 @@
   #end
 #end
 
-  <li><a href="${bazelbuildGithub}/rules_appengine" target="_blank">Java AppEngine</a></li>
+  <li><a href="${bazelbuildGithub}/rules_appengine" target="_blank">AppEngine</a></li>
   <li><a href="${bazelbuildGithub}/rules_dotnet" target="_blank">C#</a></li>
   <li><a href="${bazelbuildGithub}/rules_d" target="_blank">D</a></li>
   <li><a href="${bazelbuildGithub}/rules_docker" target="_blank">Docker</a></li>


### PR DESCRIPTION
Minor change, but the Rules AppEngine now supports Python with Google App Engine, so it's more than just Java.