### PR TITLE
Proxy archive interfaces through buffered input

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarBz2Function.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarBz2Function.java
@@ -18,6 +18,7 @@ import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompre
 
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 
+import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,6 +28,7 @@ import java.io.InputStream;
  */
 public class TarBz2Function extends CompressedTarFunction {
   public static final Decompressor INSTANCE = new TarBz2Function();
+  private static final int BUFFER_SIZE = 32 * 1024;
 
   private TarBz2Function() {
   }
@@ -35,6 +37,6 @@ public class TarBz2Function extends CompressedTarFunction {
   protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
       throws IOException {
     return new BZip2CompressorInputStream(
-        new FileInputStream(descriptor.archivePath().getPathFile()));
+        new BufferedInputStream(new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarGzFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarGzFunction.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.bazel.repository;
 
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 
+import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,6 +27,7 @@ import java.util.zip.GZIPInputStream;
  */
 public class TarGzFunction extends CompressedTarFunction {
   public static final Decompressor INSTANCE = new TarGzFunction();
+  private static final int BUFFER_SIZE = 32 * 1024;
 
   private TarGzFunction() {
   }
@@ -33,6 +35,7 @@ public class TarGzFunction extends CompressedTarFunction {
   @Override
   protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
       throws IOException {
-    return new GZIPInputStream(new FileInputStream(descriptor.archivePath().getPathFile()));
+    return new GZIPInputStream(
+        new BufferedInputStream(new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarXzFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarXzFunction.java
@@ -18,6 +18,7 @@ import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompre
 
 import org.tukaani.xz.XZInputStream;
 
+import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,6 +28,7 @@ import java.io.InputStream;
  */
 class TarXzFunction extends CompressedTarFunction {
   public static final Decompressor INSTANCE = new TarXzFunction();
+  private static final int BUFFER_SIZE = 32 * 1024;
 
   private TarXzFunction() {
   }
@@ -34,6 +36,7 @@ class TarXzFunction extends CompressedTarFunction {
   @Override
   protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
       throws IOException {
-    return new XZInputStream(new FileInputStream(descriptor.archivePath().getPathFile()));
+    return new XZInputStream(
+        new BufferedInputStream(new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE));
   }
 }


### PR DESCRIPTION
Internal bazel use of compressed archives, exemplified through
repository inspection, is utilizing a single-byte read syscall over
all, possibly extremely large, archives, with substantial syscall
roundtrip penalties. Time spent fetching all archives for a workspace
was observed to be <50% of the time without the fix (performing single-
byte reads).

Fixes #3397