### PR TITLE
Add 'assemble' action_config for Windows.

### DIFF
--- a/src/test/py/bazel/bazel_windows_test.py
+++ b/src/test/py/bazel/bazel_windows_test.py
@@ -68,6 +68,50 @@ class BazelWindowsTest(test_base.TestBase):
                 execution_root,
                 'external/local_config_cc/wrapper/bin/pydir/msvc_tools.py')))
 
+  def testWindowsCompilesAssembly(self):
+    self.ScratchFile('WORKSPACE')
+    exit_code, stdout, stderr = self.RunBazel(['info', 'bazel-bin'])
+    self.AssertExitCode(exit_code, 0, stderr)
+    bazel_bin = stdout[0]
+    self.ScratchFile('BUILD', [
+        'cc_binary(',
+        '    name="x",',
+        '    srcs=['
+        '        "x.asm",',
+        '        "y.cc",',
+        '    ],',
+        ')',
+    ])
+    self.ScratchFile('x.asm', [
+        '.code',
+        'PUBLIC increment',
+        'increment PROC x:WORD',
+        '  xchg rcx,rax',
+        '  inc rax',
+        '  ret',
+        'increment EndP',
+        'END',
+    ])
+    self.ScratchFile('y.cc', [
+        '#include <stdio.h>',
+        'extern "C" int increment(int);',
+        'int main(int, char**) {'
+        '  int x = 5;',
+        '  x = increment(x);',
+        '  printf("%d\\n", x);',
+        '  return 0;',
+        '}',
+    ])
+
+    exit_code, _, stderr = self.RunBazel(
+        [
+            'build',
+            '//:x',
+        ])
+
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertTrue(os.path.exists(os.path.join(bazel_bin, 'x.exe')))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tools/cpp/CROSSTOOL.tpl
+++ b/tools/cpp/CROSSTOOL.tpl
@@ -133,6 +133,10 @@ toolchain {
     path: "%{msvc_lib_path}"
   }
   tool_path {
+    name: "ml"
+    path: "%{msvc_ml_path}"
+  }
+  tool_path {
     name: "cpp"
     path: "%{msvc_cl_path}"
   }
@@ -262,6 +266,26 @@ toolchain {
 
   feature {
     name: 'copy_dynamic_libraries_to_binary'
+  }
+
+  action_config {
+    config_name: 'assemble'
+    action_name: 'assemble'
+    tool {
+      tool_path: '%{msvc_ml_path}'
+    }
+    flag_set {
+      expand_if_all_available: 'output_object_file'
+      flag_group {
+        flag: '/Fo%{output_object_file}'
+        flag: '/Zi'
+        flag: '/c'
+        flag: '%{source_file}'
+      }
+    }
+    implies: 'nologo'
+    implies: 'msvc_env'
+    implies: 'sysroot'
   }
 
   action_config {
@@ -453,7 +477,6 @@ toolchain {
     name: 'legacy_compile_flags'
     flag_set {
       expand_if_all_available: 'legacy_compile_flags'
-      action: 'assemble'
       action: 'preprocess-assemble'
       action: 'c-compile'
       action: 'c++-compile'
@@ -523,6 +546,7 @@ toolchain {
   feature {
     name: 'include_paths'
     flag_set {
+      action: "assemble"
       action: 'preprocess-assemble'
       action: 'c-compile'
       action: 'c++-compile'
@@ -547,6 +571,7 @@ toolchain {
   feature {
     name: "preprocessor_defines"
     flag_set {
+      action: "assemble"
       action: "preprocess-assemble"
       action: "c-compile"
       action: "c++-compile"
@@ -564,7 +589,6 @@ toolchain {
   feature {
     name: 'parse_showincludes'
     flag_set {
-      action: 'assemble'
       action: 'preprocess-assemble'
       action: 'c-compile'
       action: 'c++-compile'
@@ -933,7 +957,6 @@ toolchain {
     name: 'user_compile_flags'
     flag_set {
       expand_if_all_available: 'user_compile_flags'
-      action: 'assemble'
       action: 'preprocess-assemble'
       action: 'c-compile'
       action: 'c++-compile'
@@ -973,7 +996,6 @@ toolchain {
     name: 'unfiltered_compile_flags'
     flag_set {
       expand_if_all_available: 'unfiltered_compile_flags'
-      action: 'assemble'
       action: 'preprocess-assemble'
       action: 'c-compile'
       action: 'c++-compile'

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -392,6 +392,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value):
       "%{msvc_env_include}": "",
       "%{msvc_env_lib}": "",
       "%{msvc_cl_path}": "",
+      "%{msvc_ml_path}": "",
       "%{msvc_link_path}": "",
       "%{msvc_lib_path}": "",
       "%{compilation_mode_content}": "",

--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -295,6 +295,7 @@ def configure_windows_toolchain(repository_ctx):
   escaped_tmp_dir = escape_string(
       get_env_var(repository_ctx, "TMP", "C:\\Windows\\Temp").replace("\\", "\\\\"))
   msvc_cl_path = _find_msvc_tool(repository_ctx, vc_path, "cl.exe").replace("\\", "/")
+  msvc_ml_path = _find_msvc_tool(repository_ctx, vc_path, "ml64.exe").replace("\\", "/")
   msvc_link_path = _find_msvc_tool(repository_ctx, vc_path, "link.exe").replace("\\", "/")
   msvc_lib_path = _find_msvc_tool(repository_ctx, vc_path, "lib.exe").replace("\\", "/")
   escaped_cxx_include_directories = []
@@ -346,6 +347,7 @@ def configure_windows_toolchain(repository_ctx):
       "%{msvc_env_include}": escaped_include_paths,
       "%{msvc_env_lib}": escaped_lib_paths,
       "%{msvc_cl_path}": msvc_cl_path,
+      "%{msvc_ml_path}": msvc_ml_path,
       "%{msvc_link_path}": msvc_link_path,
       "%{msvc_lib_path}": msvc_lib_path,
       "%{compilation_mode_content}": compilation_mode_content,


### PR DESCRIPTION
Allows .asm files to be included in srcs. ml64.exe is used to create .o files which can later be linked. However, this change will not allow custom flags to be passed to ml64.exe other than /I and /D.

Fixes #3648 