### PR TITLE
Handle spaces in absolute paths to tests.

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -112,7 +112,7 @@ else
     if is_absolute "$1" ; then
       echo "$1"
     else
-      echo $(grep "^$1 " $RUNFILES_MANIFEST_FILE | awk '{ print $2 }')
+      echo $(grep "^$1 " "${RUNFILES_MANIFEST_FILE}" | sed 's/[^ ]* //')
     fi
   }
 fi


### PR DESCRIPTION
This allows for output_base paths that contain spaces, fixing #3897 

The test path is set by grepping the MANIFEST, in which each line is a
space-separated 2-tuple of relative path and absolute path to the test.
Replace the awk command that extracts the second item in the
space-separated list with a sed command that extracts everything after the
first space. Also, quote the manifest path arg to the grep command.

There will still be problems if there are spaces in the relative path,
below the Bazel project root.

Test: Built and tested a test with an output_base containing a space.

Change-Id: I5dba285bb50c27eedace17a5e20efac7392a9a6e