### PR TITLE
Update install.md

### DIFF
--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -32,6 +32,9 @@ For more information on using Bazel, see
 
 ## <a name="bash"></a>Getting bash completion
 
+**Note:** If you installed Bazel using the custom APT repository, the bash completion script
+is already installed in `/etc/bash_completion.d`.
+
 Bazel comes with a bash completion script, which the installer copies into the
 `bin` directory. If you ran the installer with `--user`, this will be
 `$HOME/.bazel/bin`. If you ran the installer as root, this will be
@@ -42,9 +45,6 @@ Copy the `bazel-complete.bash` script to your completion folder
 completion folder, you can copy it wherever suits you and insert
 `source /path/to/bazel-complete.bash` in your `~/.bashrc` file (under OS X, put
 it in your `~/.bash_profile` file).
-
-If you installed Bazel using the custom APT repository, the bash completion script
-is already installed in `/etc/bash_completion.d`.
 
 If you built Bazel from source, the bash completion target is in the `//scripts`
 package:

--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -43,6 +43,9 @@ completion folder, you can copy it wherever suits you and insert
 `source /path/to/bazel-complete.bash` in your `~/.bashrc` file (under OS X, put
 it in your `~/.bash_profile` file).
 
+If you installed Bazel using the custom APT repository, the bash completion script
+is already installed in `/etc/bash_completion.d`.
+
 If you built Bazel from source, the bash completion target is in the `//scripts`
 package:
 


### PR DESCRIPTION
Clarify that bash_completion script is already installed when installing bazel from the custom APT repository.

https://github.com/bazelbuild/bazel/issues/1539