### PR TITLE
Add BAZEL_VC and JAVA_HOME to build_windows_jni.sh

### DIFF
--- a/src/main/native/windows/build_windows_jni.sh
+++ b/src/main/native/windows/build_windows_jni.sh
@@ -38,18 +38,29 @@ fi
 # as the temp directory for CL.EXE .
 VSTEMP=$(mktemp -d)
 trap "rm -fr \"$VSTEMP\"" EXIT
+VSVARS=""
 
-# Find Visual Studio. We don't have any regular environment variables available
-# so this is the best we can do.
-if [ -z "${BAZEL_VS+set}" ]; then
-  VSVERSION="$(ls "C:/Program Files (x86)" \
-      | grep -E "Microsoft Visual Studio [0-9]+" \
-      | sort --version-sort \
-      | tail -n 1)"
-  [[ -n "$VSVERSION" ]] || fail "Visual Studio not found"
-  BAZEL_VS="C:/Program Files (x86)/$VSVERSION"
+# Visual Studio or Visual C++ Build Tools might not be installed at default
+# location. Check BAZEL_VS and BAZEL_VC first.
+if [ -n "${BAZEL_VC+set}" ]; then
+  VSVARS="${BAZEL_VC}/VCVARSALL.BAT"
+  # Check if BAZEL_VC points to Visual C++ Build Tools 2017
+  if [ ! -f "${VSVARS}" ]; then
+    VSVARS="${BAZEL_VC}/Auxiliary/Build/VCVARSALL.BAT"
+  fi
+else
+  # Find Visual Studio. We don't have any regular environment variables
+  # available so this is the best we can do.
+  if [ -z "${BAZEL_VS+set}" ]; then
+    VSVERSION="$(ls "C:/Program Files (x86)" \
+        | grep -E "Microsoft Visual Studio [0-9]+" \
+        | sort --version-sort \
+        | tail -n 1)"
+    [[ -n "$VSVERSION" ]] || fail "Visual Studio not found"
+    BAZEL_VS="C:/Program Files (x86)/$VSVERSION"
+  fi
+  VSVARS="${BAZEL_VS}/VC/VCVARSALL.BAT"
 fi
-VSVARS="${BAZEL_VS}/VC/VCVARSALL.BAT"
 
 # Check if Visual Studio 2017 is installed. Look for it at the default
 # locations.
@@ -70,11 +81,16 @@ if [ ! -f "${VSVARS}" ]; then
   fail "VCVARSALL.bat not found, check your Visual Studio installation"
 fi
 
-# Find Java. $(JAVA) in the BUILD file points to external/local_jdk/..., which
-# is not very useful for anything not MSYS-based.
-JAVA=$(ls "C:/Program Files/java" | grep -E "^jdk" | sort | tail -n 1)
-[[ -n "$JAVA" ]] || fail "JDK not found"
-JAVAINCLUDES="C:/Program Files/java/$JAVA/include"
+JAVAINCLUDES=""
+if [ -n "${JAVA_HOME+set}" ]; then
+  JAVAINCLUDES="$JAVA_HOME/include"
+else
+  # Find Java. $(JAVA) in the BUILD file points to external/local_jdk/...,
+  # which is not very useful for anything not MSYS-based.
+  JAVA=$(ls "C:/Program Files/java" | grep -E "^jdk" | sort | tail -n 1)
+  [[ -n "$JAVA" ]] || fail "JDK not found"
+  JAVAINCLUDES="C:/Program Files/java/$JAVA/include"
+fi
 
 # Convert all compilation units to Windows paths.
 WINDOWS_SOURCES=()


### PR DESCRIPTION
User might have Visual C++ Build Tools and JDK installed at non-default location, but they are still usable for bootstrapping.

PS: I used Visual C++ 2017 15.3 for bootstrapping, there is a nice 1.5MB size reduction in final `bazel.exe` compared with `bazel-0.7.0-without-jdk-windows-x86_64.exe`.