### PR TITLE
Fix spelling errors in site docs

### DIFF
--- a/site/docs/best-practices.md
+++ b/site/docs/best-practices.md
@@ -156,7 +156,7 @@ A Skylark repository rule should generally be responsible for:
 -  Generating or symlinking BUILD files into the external repository directory.
 
 Avoid using `repository_ctx.execute` when possible.  For example, when using a non-Bazel C++
-library that has a build using Make, it is preferable to use `respository_ctx.download()` and then
+library that has a build using Make, it is preferable to use `repository_ctx.download()` and then
 write a BUILD file that builds it, instead of running `ctx.execute(["make"])`.
 
 

--- a/site/docs/generate-workspace.md
+++ b/site/docs/generate-workspace.md
@@ -8,7 +8,7 @@ title: Generate external dependencies for a Java project
 The tool `generate_workspace` helps automate the process of writing
 the WORKSPACE file for a Java project. This tool is
 helpful when the list of external dependencies is long, such as when working
-with [external transitive dependnecies](external.html#transitive-dependencies).
+with [external transitive dependencies](external.html#transitive-dependencies).
 
 The `generate_workspace` tool will generate a `generate_workspace.bzl` file
 which includes:

--- a/site/docs/migrate-maven.md
+++ b/site/docs/migrate-maven.md
@@ -266,7 +266,7 @@ granularity, allowing:
 
 Tips for adding more BUILD files:
 
-*  You can start by adding a BUILD file to each Java package. Start wtih
+*  You can start by adding a BUILD file to each Java package. Start with
    Java packages that have the fewest dependencies and work you way up
    to packages with the most dependencies.
 *  As you add BUILD files and specify targets, add these new targets to the

--- a/site/docs/query-how-to.md
+++ b/site/docs/query-how-to.md
@@ -83,7 +83,7 @@ To execute a query while ignoring errors such as missing targets, use the
             upon:](#Show_me_a_path_from_docker_updater)
         *   [Why does library `//photos/frontend:lib` depend on two variants of
             the same library `//third_party/jpeglib` and
-            `//third_party/jpeg`?](#Why_does_library_photos_fronten)
+            `//third_party/jpeg`?](#Why_does_library_photos_frontend)
     *   [What depends on ...](#What_depends_on_)
         *   [What rules under bar depend on Y?](#What_rules_under_bar_depend_o)
         *   [What targets directly depend on T, in T's
@@ -396,7 +396,7 @@ bazel query 'let cc = kind(cc_library, deps(docker/updater:updater_systest)) in
   somepath(docker/updater:updater_systest, $cc)'
 ```
 
-<a name="Why_does_library_photos_fronten"></a>
+<a name="Why_does_library_photos_frontend"></a>
 #### Why does library `//photos/frontend:lib` depend on two variants of the same library `//third_party/jpeglib` and `//third_party/jpeg`?
 
 This query boils down to: "show me the subgraph of `//photos/frontend:lib` that

--- a/site/docs/skylark/backward-compatibility.md
+++ b/site/docs/skylark/backward-compatibility.md
@@ -21,7 +21,7 @@ Backward incompatible changes are introduced gradually:
 To check if your code will be compatible with future releases you can:
 
 *   Build your code with the flag `--all_incompatible_changes`. This flag
-    enables all backward incomaptible changes, and so you can ensure your code
+    enables all backward incompatible changes, and so you can ensure your code
     is compatible with upcoming changes.
 *   Use boolean flags to enable/disable specific backward incompatible changes.
 


### PR DESCRIPTION
I used [GNU Aspell](http://aspell.net/) to quickly look through markdown files in `site/docs/` for typos. Still involved a bit of manual checking, but ultimately found a handful of spelling errors.