### PR TITLE
Open source Bazel Maven Config Generator website

### DIFF
--- a/tools/build_defs/repo/maven_config_generator/README.md
+++ b/tools/build_defs/repo/maven_config_generator/README.md
@@ -1,0 +1,175 @@
+# Bazel Maven Config Generator
+
+This directory contains the source code to a website that runs on
+[Google Apps Script](https://script.google.com). It crawls Maven POM metadata to
+generate `WORKSPACE` configs using [`java_import_external`](../java.bzl).
+
+Please watch the [demo video](https://www.youtube.com/watch?v=xdMDuhJTKMI) on
+YouTube.
+
+## Features
+
+- Defines all transitive relationships
+- Resolves diamond conflicts by bumping versions
+- Calculates SHA256 (slow due to Apps Script API issue)
+- Documents `licenses` heuristically categorizes
+- Heuristics for `neverlink` (provided) jars
+- Source jars and optional dependencies
+- Mirrors jars to Google Drive
+- Adds iBiblio URLs if 200 OK
+
+## Verbosity
+
+The huge config is good because it makes builds deterministic, highly available,
+minimal, scalable, and *fast* because Bazel won't need to BFS HTTP POMs each
+build. Even Java projects with hundreds of transitive dependencies can expect
+`bazel fetch //....` to take seconds.
+
+You'll also see all the mysterious code from the Internet that you're running on
+your machine. For example, you might discover Apache Commons Collections 3.2.1
+on the classpath, in which case it's game over if anything in the JVM is
+deserializing. So the verbosity might actually save you from ending up in the
+same boat as Equifax. See
+[Operation Rosehub](https://opensource.googleblog.com/2017/03/operation-rosehub.html)
+to learn more.
+
+## Imperfection
+
+Another reason why the generated config is huge is because it only gets you 90%
+there. You will need to make subtle adjustments after using the tool.
+
+### Optional Dependencies
+
+Optional dependencies require careful consideration while tuning. If you click
+the "Include optional dependencies" checkbox, you may quickly find yourself
+overwhelmed by just how many there are. However, if you turn it off, you may
+discover at runtime that some of those optional jars weren't so optional after
+all.
+
+Take for example Guava. The tool generates this:
+
+```py
+# Without optional dependencies
+java_import_external(
+    name = "com_google_guava",
+    licenses = ["notice"],  # The Apache Software License, Version 2.0
+    jar_sha256 = "36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8",
+    jar_urls = [
+        "http://maven.ibiblio.org/maven2/com/google/guava/guava/20.0/guava-20.0.jar",
+        "http://repo1.maven.org/maven2/com/google/guava/guava/20.0/guava-20.0.jar",
+    ],
+)
+
+# With optional dependencies
+java_import_external(
+    name = "com_google_guava",
+    licenses = ["notice"],  # The Apache Software License, Version 2.0
+    jar_sha256 = "36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8",
+    jar_urls = [
+        "http://maven.ibiblio.org/maven2/com/google/guava/guava/20.0/guava-20.0.jar",
+        "http://repo1.maven.org/maven2/com/google/guava/guava/20.0/guava-20.0.jar",
+    ],
+    deps = [
+        "@com_google_code_findbugs_jsr305",
+        "@com_google_errorprone_error_prone_annotations",
+        "@com_google_j2objc_annotations",
+        "@org_codehaus_mojo_animal_sniffer_annotations",
+    ],
+)
+```
+
+But experience on several teams has shown us the optimal config is this:
+
+```py
+java_import_external(
+    name = "com_google_guava",
+    licenses = ["notice"],  # The Apache Software License, Version 2.0
+    jar_sha256 = "36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8",
+    jar_urls = [
+        "http://maven.ibiblio.org/maven2/com/google/guava/guava/20.0/guava-20.0.jar",
+        "http://repo1.maven.org/maven2/com/google/guava/guava/20.0/guava-20.0.jar",
+    ],
+    exports = [
+        "@com_google_code_findbugs_jsr305",
+        "@com_google_errorprone_error_prone_annotations",
+    ],
+)
+```
+
+Not including optional dependencies is a good starting point, but in practice,
+your config is probably going to end up somewhere in-between.
+
+### Exports
+
+Tuning the output with the `exports` attribute can be very helpful when taken in
+moderation. It's good for Guava in the example above, because it's nonobvious
+when or why those annotations might be needed at runtime. However the canonical
+example would be a dependency injection library (e.g. Dagger, Guice) exporting
+`@javax_inject`, since nearly everything that depends on the DI library will
+statically reference those classes too.
+
+### Test Libraries
+
+It's strongly recommended that you add `testonly = 1` to testing libraries, so
+they'll be isolated from production code. The tool currently doesn't have this
+feature.
+
+### Licenses
+
+The tool only looks at pom.xml files to find the license(s). This includes both the
+artifact POM and any parents it might have. Every unique license it finds will
+be documented. Categories merge towards restrictiveness.
+
+If the tool can't figure out or categorize the license(s), it'll leave you a
+TODO. The [java.bzl](../java.bzl) file talks a little bit about what the license
+categories mean. You can also read the heuristics in [index.html](index.html).
+
+Please also note that package authors sometimes put third party classes in their
+jars without declaring those licenses. So it's a good idea to actually look at
+what's inside each jar.
+
+### Annotation Processors
+
+Significant adjustments will be need to made to annotation processing libraries.
+For example, here's how one would
+[configure Google Auto and Dagger](https://gist.github.com/jart/5333824b94cd706499a7bfa1e086ee00).
+
+### Never Link
+
+There are many subtleties to the appropriate use of `neverlink = 1`. For
+example, the App Engine jars required many such adjustments in the
+[Nomulus WORKSPACE](https://github.com/google/nomulus/blob/master/java/google/registry/repositories.bzl)
+configuration.
+
+One common pattern is to have a jar not linked by default, but you still want to
+be able to link it in certain situations. In that case, the
+`generated_linkable_rule_name` attribute is your friend. For example:
+
+```py
+java_import_external(
+    name = "com_google_appengine_remote_api",
+    jar_sha256 = "6ea6dc3b529038ea6b37e855cd1cd7612f6640feaeb0eec842d4e6d85e1fd052",
+    jar_urls = [
+        "http://domain-registry-maven.storage.googleapis.com/repo1.maven.org/maven2/com/google/appengine/appengine-remote-api/1.9.48/appengine-remote-api-1.9.48.jar",
+        "http://repo1.maven.org/maven2/com/google/appengine/appengine-remote-api/1.9.48/appengine-remote-api-1.9.48.jar",
+    ],
+    licenses = ["permissive"],  # Google App Engine Terms of Service: https://cloud.google.com/terms/
+    neverlink = True,
+    generated_linkable_rule_name = "link",
+)
+```
+
+In this case, `@com_google_appengine_remote_api` won't link and
+`@com_google_appengine_remote_api//:link` will link.
+
+### Jumbo Jars
+
+Avoid jumbo jars when possible. It's a good idea to actually look inside each
+one to make sure the author didn't shade or schlep in third party classes. That
+can be problematic with this tool, because then: a) builds can't be minimal; and
+b) difficult to troubleshoot classpath collisions might occur.
+
+The author of a jumbo jar will hopefully offer a nonobvious way to opt-out.  For
+example, `com.google.javascript:closure-compiler:v20170910` is a jumbo jar, but
+you can use `com.google.javascript:closure-compiler-unshaded:v20170910` instead
+which is minimal and fully specified.

--- a/tools/build_defs/repo/maven_config_generator/backend.gs
+++ b/tools/build_defs/repo/maven_config_generator/backend.gs
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Backend RPC functions and HTML serving.
+ * @author jart@google.com (Justine Tunney)
+ */
+
+
+/**
+ * Returns index web page for website.
+ * @return {!HtmlService.HtmlOutput}
+ */
+function doGet() {
+  return (HtmlService.createHtmlOutputFromFile('index')
+          .setTitle('Bazel Maven Config Generator')
+          .setFaviconUrl('https://i.imgur.com/Ute4LEE.png'));
+}
+
+
+/**
+ * Returns email address of logged in Google account.
+ * @return {string}
+ */
+function getUserEmail() {
+  return Session.getActiveUser().getEmail();
+}
+
+
+/**
+ * Fetches {@code url} as text/plain.
+ * @param {string} url
+ * @return {string}
+ */
+function fetchTextFromUrl(url) {
+  return UrlFetchApp.fetch(url).getAs('text/plain').getDataAsString();
+}
+
+
+/**
+ * Fetches {@code url} as binary and slowly calculates hex SHA256 checksum.
+ * @param {string} url
+ * @return {string}
+ */
+function getSha256ForUrl(url) {
+  var props = PropertiesService.getScriptProperties();
+  var key = 'sha256 ' + url;
+  var cached = props.getProperty(key);
+  if (cached !== null && cached.length == 64) {
+    return cached;
+  }
+  var result = Sha256.hash(UrlFetchApp.fetch(url).getContentText('ISO-8859-1'));
+  props.setProperty(key, result);
+  return result;
+}
+
+
+/**
+ * Stores {@code url} to Google Drive in bazel-mirror/ folder with public read
+ * permissions and returns direct URL to file.
+ * @param {string} url
+ * @return {string}
+ */
+function mirrorUrl(url) {
+  // Note: Drive allows filenames within a folder to contain slashes.
+  // Note: Drive allows multiple files within a folder with the same name.
+  var lock = LockService.getUserLock();
+  var path = 'bazel-mirror/' + url.replace(new RegExp('^https?://'), '');
+  var p = path.lastIndexOf('/');
+  var dir = path.substr(0, p);
+  var folder = DriveApp.getRootFolder();
+  var labels = dir.split('/');
+  for (var i = 0; i < labels.length; i++) {
+    folder = getFolder_(lock, folder, labels[i]);
+  }
+  var name = path.substr(p + 1);
+  var files = folder.getFilesByName(name);
+  var file = null;
+  while (files.hasNext()) {
+    file = files.next();
+    if (file.getSize() == 0) {
+      file = null;
+    }
+  }
+  // we don't need to lock this, assuming user isn't using multiple tabs
+  if (file == null) {
+    file = folder.createFile(UrlFetchApp.fetch(url).getBlob());
+    file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
+  }
+  return 'https://drive.google.com/uc?export=download&id=' + file.getId();
+}
+
+
+/**
+ * Returns {@code true} if HEAD request to {@code url} returns 200.
+ * @param {string} url
+ * @param {boolean}
+ */
+function doesUrlExist(url) {
+  var props = PropertiesService.getScriptProperties();
+  var key = 'exists ' + url;
+  var cached = props.getProperty(key);
+  if (cached !== null) {
+    return cached == 'true';
+  }
+  var status = UrlFetchApp.fetch(url, {'muteHttpExceptions': true}).getResponseCode();
+  var result = status == 200;
+  if (status == 200 || status == 404) {
+    props.setProperty(key, result.toString());
+  }
+  return result;
+}
+
+
+/**
+ * Returns subfolder, creating it if it doesn't exist.
+ * @param {!LockService.Lock} lock
+ * @param {!DriveApp.Folder} parent
+ * @param {string} name
+ * @return {!DriveApp.Folder}
+ */
+function getFolder_(lock, parent, name) {
+  if (name == '') {
+    return parent;
+  }
+  var folder = getLiteralFolder_(parent, name);
+  if (folder != null) {
+    return folder;
+  }
+  lock.waitLock(10000);
+  try {
+    folder = getLiteralFolder_(parent, name);
+    if (folder != null) {
+      return folder;
+    }
+    return parent.createFolder(name);
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+
+/**
+ * Returns subfolder or {@code null} if it doesn't exist.
+ * @param {!DriveApp.Folder} parent
+ * @param {string} name
+ * @return {?DriveApp.Folder}
+ */
+function getLiteralFolder_(parent, name) {
+  var folders = parent.getFoldersByName(name);
+  return folders.hasNext() ? folders.next() : null;
+}
+

--- a/tools/build_defs/repo/maven_config_generator/index.html
+++ b/tools/build_defs/repo/maven_config_generator/index.html
@@ -1,0 +1,1089 @@
+<!doctype html>
+<base target="_top">
+<meta charset="utf-8">
+<link href="https://fonts.googleapis.com/css?family=Inconsolata|Noto+Sans" rel="stylesheet">
+<style>
+body {
+  font: 16px 'Noto Sans', sans-serif;
+  color: #333;
+  margin: 0 auto 1em auto;
+  padding: 0 1em;
+  width: 960px;
+}
+
+pre {
+  font: 16px 'Inconsolata', monospace;
+}
+
+textarea {
+  font: 14px 'Inconsolata', monospace;
+}
+
+input {
+  font: 14px 'Noto Sans', sans-serif;
+}
+
+input[type=text] {
+  width: 300px;
+}
+
+label,
+.hint {
+  display: block;
+}
+
+label {
+  margin-bottom: 6px;
+}
+
+input[type=checkbox] {
+  vertical-align: middle;
+}
+
+textarea,
+input[type=text] {
+  border: 1px solid #d9d9d9;
+  border-top: 1px solid #c0c0c0;
+  line-height: 28px;
+  padding-left: 8px;
+}
+
+textarea:hover,
+input[type=text]:hover {
+  border: 1px solid #b9b9b9;
+  border-top: 1px solid #a0a0a0;
+  box-shadow: inset 0px 1px 2px rgba(0,0,0,0.1);
+}
+
+textarea:focus,
+input[type=text]:focus {
+  outline: none;
+  border: 1px solid #4d90fe;
+  box-shadow: inset 0px 1px 2px rgba(0,0,0,0.3);
+}
+
+input[type=submit] {
+  font-size: 16px;
+}
+
+.hint {
+  color: #777;
+  font-size: small;
+}
+
+#result {
+  overflow: scroll;
+}
+
+#errors {
+  color: #d00;
+}
+
+#progress {
+  font-size: small;
+  padding-left: 0.5em;
+}
+
+footer {
+  font-size: 14px;
+  font-style: italic;
+}
+</style>
+
+<header>
+  <img src="https://i.imgur.com/mzAGP7m.jpg" width="960" height="320"
+       alt="Beautiful people hanging out in antiquity as depicted by Sir Lawrence Alma-Tadema in his 1881 painting Sappho and Alcaeus">
+  <h1>Bazel Maven Config Generator</h1>
+  <p>
+    This tool is intended for Java projects using the <a href="https://bazel.build/">Bazel</a>
+    build system. Using this tool makes your Bazel builds unbelievably fast, reliable, and readable.
+    Give it the Maven artifacts you directly depend upon. It generates a Bazel configuration you can
+    copy into your <code>WORKSPACE</code> file. It resolves transitive and diamond dependencies
+    automatically. 
+</header>
+
+<form id="form">
+  <p>
+    <label for="artifacts">
+      Maven Artifacts
+      <span class="hint">Only those your code directly references, i.e. jars whose classes you import; separated by <code>[\s#]+</code></span>
+    </label>
+    <textarea id="artifacts" rows="4" cols="70" required autofocus>com.google.guava:guava:20.0</textarea>
+  <p>
+    <label for="calculateChecksum">
+      <input type="checkbox" id="calculateChecksum" checked>
+      Calculate SHA-256 checksums
+      <span class="hint">You always want this, but our backend might do it slowly due to an Apps Script bug</span>
+    </label>
+  <p>
+    <label for="includeOptional">
+      <input type="checkbox" id="includeOptional">
+      Include optional dependencies
+      <span class="hint">These may or may not be needed depending on what features of the artifacts you use</span>
+    </label>
+  <p>
+    <label for="includeSauce">
+      <input type="checkbox" id="includeSauce">
+      Include source jars
+      <span class="hint">Define the <code>srcjar</code> attribute if a -sources.jar exists</span>
+    </label>
+  <p>
+    <label for="mirror">
+      <input type="checkbox" id="mirror">
+      Mirror to my Google Drive
+      <span class="hint">Jars will be mirrored to <em>your</em> Google Drive account in the 'bazel-mirror/urlhost/urlpath' folder and made public</span>
+    </label>
+  <p>
+    <input type="submit" value="Generate Bazel Config">
+    <span id="progress"></span>
+</form>
+
+<pre id="errors"></pre>
+
+<h2>Generated Configuration</h2>
+<pre id="result">java_import_external(
+    name = "com_google_code_findbugs_jsr305",
+    licenses = ["notice"],  # The Apache Software License, Version 2.0
+    jar_sha256 = "905721a0eea90a81534abb7ee6ef4ea2e5e645fa1def0a5cd88402df1b46c9ed",
+    jar_urls = [
+        "http://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar",
+        "http://maven.ibiblio.org/maven2/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar",
+    ],
+)
+
+java_import_external(
+    name = "com_google_errorprone_error_prone_annotations",
+    licenses = ["notice"],  # Apache 2.0
+    jar_sha256 = "7e9c688f734ee5cf2386d3efc367d4a3e6d09130d2afeb52434e1cc2880820a4",
+    jar_urls = [
+        "http://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.0.12/error_prone_annotations-2.0.12.jar",
+        "http://maven.ibiblio.org/maven2/com/google/errorprone/error_prone_annotations/2.0.12/error_prone_annotations-2.0.12.jar",
+    ],
+)
+
+java_import_external(
+    name = "com_google_guava",
+    licenses = ["notice"],  # The Apache Software License, Version 2.0
+    jar_sha256 = "36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8",
+    jar_urls = [
+        "http://repo1.maven.org/maven2/com/google/guava/guava/20.0/guava-20.0.jar",
+        "http://maven.ibiblio.org/maven2/com/google/guava/guava/20.0/guava-20.0.jar",
+    ],
+    deps = [
+        "@com_google_code_findbugs_jsr305",
+        "@com_google_errorprone_error_prone_annotations",
+        "@com_google_j2objc_annotations",
+        "@org_codehaus_mojo_animal_sniffer_annotations",
+    ]
+)
+
+java_import_external(
+    name = "com_google_j2objc_annotations",
+    licenses = ["notice"],  # The Apache Software License, Version 2.0
+    jar_sha256 = "40ceb7157feb263949e0f503fe5f71689333a621021aa20ce0d0acee3badaa0f",
+    jar_urls = [
+        "http://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
+        "http://maven.ibiblio.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
+    ],
+)
+
+java_import_external(
+    name = "org_codehaus_mojo_animal_sniffer_annotations",
+    licenses = ["notice"],  # MIT license
+    jar_sha256 = "2068320bd6bad744c3673ab048f67e30bef8f518996fa380033556600669905d",
+    jar_urls = [
+        "http://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
+        "http://maven.ibiblio.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
+    ],
+)</pre>
+
+<script>
+/**
+ * @license
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @fileoverview Frontend application for generating Bazel Maven configs.
+ * @author jart@google.com (Justine Tunney)
+ */
+
+var ELEMENT_NODE = 1;
+var COMMENT_NODE = 8;
+var ARTIFACT_PATTERN = new RegExp('^([-._0-9A-Za-z]*):([-._0-9A-Za-z]*):([-._0-9A-Za-z]+)$');
+var WHITESPACE_PATTERN = new RegExp('[ \t\r\n#]+');
+var CLEANSE_CHARS = new RegExp('[^_0-9A-Za-z]', 'g');
+var VERSION_RANGE_PATTERN = /^([\[(])([^,)\]]*),([^)\]]*)([\])])$/;
+
+var LICENSE_ZEAL = {
+    '': -1,
+    'unencumbered': 0,
+    'permissive': 1,
+    'notice': 2,
+    'reciprocal': 3,
+    'restricted': 4,
+    'by_exception_only': 5,
+    'TODO': 6,
+};
+
+var rpc;
+var formElement;
+var artifactsElement;
+var mirrorElement;
+var includeOptionalElement;
+var includeSauceElement;
+var resultElement;
+var errorsElement;
+var progressElement;
+var calculateChecksumElement;
+
+var xmlCache = {};
+var xmlFetching = {};
+var checksums = {};
+var mirrors = {};
+var hasSauce = {};
+var userEmail = 'unknown@gmail.com';
+
+var count = 0;
+var total = 0;
+var edges = {};
+var edgesBackwards = {};
+var discovered = {};
+var neverlink = {};
+var diamonds = [];
+
+function isString(x) {
+  return typeof x === 'string' || x instanceof String;
+}
+
+function forEach(items, callback) {
+  if (!items) {
+    return;
+  }
+  for (var i = 0; i < items.length; i++) {
+    if (callback(items[i], i) === false) {
+      break;
+    }
+  }
+}
+
+function arrayContains(array, item) {
+  for (var i = 0; i < array.length; i++) {
+    if (array[i] == item) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function preventDefault(callback) {
+  return function(ev) {
+    ev.preventDefault();
+    callback();
+    return false;
+  };
+}
+
+function isDigit(c) {
+  return '0' <= c && c <= '9';
+}
+
+function isSeparator(c) {
+  return c == '-' || c == '_' || c == ' ' || c == '.';
+}
+
+function isBreak(c) {
+  return isSeparator(c) || isDigit(c);
+}
+
+function ifElement(callback) {
+  return function(element) {
+    if (element.nodeType == ELEMENT_NODE) {
+      callback(element);
+    }
+  };
+}
+
+function consumeInt(s, i) {
+  for (; i < s.length; i++) {
+    if (!isDigit(s[i])) {
+      break;
+    }
+  }
+  return i;
+}
+
+// https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning
+function compareVersions(a, b) {
+  var ai = 0;
+  var bi = 0;
+  while (true) {
+    if (ai == a.length) {
+      if (bi == b.length) {
+        return 0;
+      }
+      if (isSeparator(b[bi])) {
+        return compareVersions('0', b.slice(bi + 1, b.length));
+      }
+      return -1;
+    }
+    if (bi == b.length) {
+      return -compareVersions(b, a);
+    }
+    if (isDigit(a[ai]) && isDigit(b[bi])) {
+      var ais = ai;
+      var bis = bi;
+      ai = consumeInt(a, ai + 1);
+      bi = consumeInt(b, bi + 1);
+      var an = parseInt(a.slice(ais, ai));
+      var bn = parseInt(b.slice(bis, bi));
+      if (an < bn) {
+        return -1;
+      }
+      if (an > bn) {
+        return 1;
+      }
+      continue;
+    } else if (isDigit(a[ai])) {
+      return 1;
+    } else if (isDigit(b[bi])) {
+      return -1;
+    }
+    if (isBreak(a[ai])) {
+      if (!isBreak(b[bi])) {
+        return -1;
+      }
+    } else if (isBreak(b[bi])) {
+      return 1;
+    } else if (a[ai] < b[bi]) {
+      return -1;
+    } else if (a[ai] > b[bi]) {
+      return 1;
+    }
+    ai++;
+    bi++;
+  }
+}
+
+function testCompareVersions(want, a, b) {
+  var go = function(want, a, b) {
+    var res = compareVersions(a, b);
+    if (res != want) {
+      console.error('TEST', 'compareVersions', a, b,
+                    'wanted', want,
+                    'got', res);
+    }
+    return res == want;
+  };
+  if (go(want, a, b)) {
+    go(-want, b, a);
+  }
+}
+
+testCompareVersions( 0, '1', '1');
+testCompareVersions(-1, '1', '2');
+testCompareVersions( 0, '1.9', '1.9.0');
+testCompareVersions(-1, '1.9', '1.9.15');
+testCompareVersions(-1, '1.9.0', '1.9.15');
+testCompareVersions(-1, '1.1', '1.2.0');
+testCompareVersions(-1, '1.0.0', '1.1');
+testCompareVersions(-1, '1.0-alpha-1', '1.0');
+testCompareVersions(-1, '1.0-alpha-1', '1.0-alpha-2');
+testCompareVersions(-1, '1.0-alpha-1', '1.0-beta-1');
+testCompareVersions( 0, '2.0-0', '2.0');
+testCompareVersions(-1, '2.0', '2.0-1');
+testCompareVersions( 0, '1-SNAPSHOT', '1-SNAPSHOT');
+testCompareVersions(-1, '2.0.1', '2.0.1-123');
+testCompareVersions(-1, '2.0.1-xyz', '2.0.1');
+testCompareVersions(-1, '2.0.1-xyz', '2.0.1-123');
+
+function showProgress(message) {
+  console.log(message);
+  progressElement.innerText = '' + count + '/' + total + ': ' + message;
+}
+
+function addError(message) {
+  message = 'ERROR: ' + message;
+  console.log(message);
+  errorsElement.innerText += '\n' + message;
+}
+
+function addDiamond(message) {
+  if (!arrayContains(diamonds, message)) {
+    diamonds.push(message);
+    diamonds.sort(compareVersions);
+  }
+}
+
+function getName(pom) {
+  var left = pom['group'].replace(CLEANSE_CHARS, '_');
+  var right = pom['artifact'].replace(CLEANSE_CHARS, '_');
+  // turn names like com_google_guava_guava into com_google_guava
+  var p = -1;
+  while (p < right.length) {
+    p = right.indexOf('_', p + 1);
+    if (p == -1) {
+      p = right.length;
+    }
+    var chunk = right.slice(0, p);
+    if (left == chunk) {
+      return right;
+    }
+    chunk = '_' + chunk;
+    if (left.slice(-chunk.length) == chunk) {
+      left = left.slice(0, -chunk.length);
+      break;
+    }
+  }
+  return left + '_' + right;
+}
+
+function getXmlValue(parent, key) {
+  var nodes = parent.getElementsByTagName(key);
+  if (nodes.length == 0) {
+    return '';
+  }
+  return nodes[0].textContent.trim();
+}
+
+function extractDep(element) {
+  return {
+    'group': getXmlValue(element, 'groupId'),
+    'artifact': getXmlValue(element, 'artifactId'),
+    'version': getXmlValue(element, 'version'),
+    'scope': getXmlValue(element, 'scope'),
+    'optional': getXmlValue(element, 'optional'),
+    'classifier': getXmlValue(element, 'classifier'),
+  };
+}
+
+function extractLicense(element) {
+  return {
+    'name': getXmlValue(element, 'name'),
+    'url': getXmlValue(element, 'url'),
+  };
+}
+
+function mergeParentIntoPom(pom, parent) {
+  forEach(parent['licenses'], function(plicense) {
+    var found = false;
+    forEach(pom['licenses'], function(license) {
+      if (license['name'] == plicense['name'] || license['url'] == plicense['url']) {
+        found = true;
+        return false;
+      }
+    });
+    if (!found) {
+      pom['licenses'].push(plicense);
+    }
+  });
+  forEach(pom['deps'], function(dep) {
+    forEach(parent['deps'], function(pdep) {
+      if (dep['group'] == pdep['group'] && dep['artifact'] == pdep['artifact']) {
+        if (dep['version'] == '') {
+          dep['version'] = pdep['version'];
+        }
+        if (dep['scope'] == '') {
+          dep['scope'] = pdep['scope'];
+        }
+      }
+    });
+  });
+  for (var k in parent['props']) {
+    if (!(k in pom['props'])) {
+      pom['props'][k] = parent['props'][k];
+    }
+  }
+}
+
+function substituteProps(pom) {
+  var go = function(map) {
+    for (var k in map) {
+      var v = map[k];
+      if (!isString(v)) {
+        continue;
+      }
+      if (v.indexOf('${') != -1) {
+        for (var pk in pom['props']) {
+          var pv = pom['props'][pk];
+          v = v.replace('${' + pk + '}', pv);
+        }
+        map[k] = v;
+      }
+    }
+  };
+  go(pom['props']);
+  go(pom);
+  for (var i = 0; i < pom['deps'].length; i++) {
+    go(pom['deps'][i]);
+  }
+}
+
+function getMavenUrl(ext, server, info) {
+  return ('http://' + server + '/maven2/' +
+          info['group'].replace(new RegExp('\\.', 'g'), '/') + '/' +
+          info['artifact'] + '/' +
+          info['version'] + '/' +
+          info['artifact'] + '-' +
+          info['version'] +
+          ext);
+}
+
+function getMavenMetadataUrl(info) {
+  return ('http://repo1.maven.org/maven2/' +
+          info['group'].replace(new RegExp('\\.', 'g'), '/') + '/' +
+          info['artifact'] + '/maven-metadata.xml');
+}
+
+function parseXml(xmlText) {
+  return new DOMParser().parseFromString(xmlText, 'text/xml');
+}
+
+function fetchXml(url, callback) {
+  if (url.match(/\$\{/)) {
+    throw Error('bad url: ' + url);
+  }
+  if (url in xmlCache) {
+    callback(parseXml(xmlCache[url]));
+    return;
+  }
+  if (xmlFetching[url]) {
+    setTimeout(function() {
+      fetchXml(url, callback);
+    }, 500);
+    return;
+  }
+  total++;
+  xmlFetching[url] = true;
+  showProgress('Fetching ' + url);
+  rpc.withSuccessHandler(function(xmlText) {
+    count++;
+    xmlCache[url] = xmlText;
+    xmlFetching[url] = false;
+    callback(parseXml(xmlText));
+  }).fetchTextFromUrl(url);
+}
+
+function parseVersionRange(spec) {
+  var match = spec.match(VERSION_RANGE_PATTERN);
+  if (!match) {
+    return null;
+  }
+  return {
+    'leftInclusive': match[1] == '[',
+    'left': match[2],
+    'right': match[3],
+    'rightInclusive': match[4] == ']',
+  };
+}
+
+function isVersionInRange(range, version) {
+  var lcomp = compareVersions(range['left'], version);
+  if (lcomp < 0 || (range['leftInclusive'] && lcomp == 0)) {
+    var rcomp = compareVersions(version, range['right']);
+    if (rcomp < 0 || (range['rightInclusive'] && rcomp == 0)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resolveVersion_(info, callback) {
+  var range = parseVersionRange(info['version']);
+  if (!range) {
+    callback(info);
+    return;
+  }
+  var url = getMavenMetadataUrl(info);
+  fetchXml(url, function(xmlDocument) {
+    var result = '';
+    var onElement = ifElement(function(child) {
+      if (child.tagName == 'metadata' ||
+          child.tagName == 'versioning' ||
+          child.tagName == 'versions') {
+        forEach(child.childNodes, onElement);
+      } else if (child.tagName == 'version') {
+        var version = child.textContent.trim();
+        if (isVersionInRange(range, version)) {
+          result = version;
+        }
+      }
+    });
+    forEach(xmlDocument.childNodes, onElement);
+    if (result == '') {
+      addError('Could not resolve version: ' + info['group'] + ':' +
+               info['artifact'] + ':' + info['version']);
+      return;
+    }
+    callback({
+      'group': info['group'],
+      'artifact': info['artifact'],
+      'version': result,
+    });
+  });
+}
+
+function getLiteralPom_(info, callback) {
+  var url = getMavenUrl('.pom', 'repo1.maven.org', info);
+  fetchXml(url, function(xmlDocument) {
+    var parent = null;
+    var pom = {
+      'group': info['group'],
+      'artifact': info['artifact'],
+      'version': info['version'],
+      'deps': [],
+      'licenses': [],
+      'props': {
+        'project.groupId': info['group'],
+        'project.version': info['version'],
+      },
+    };
+    var onElement = ifElement(function(element) {
+      if (element.tagName == 'parent') {
+        parent = extractDep(element);
+      } else if (element.tagName == 'dependencyManagement') {
+        forEach(element.childNodes, onElement);
+      } else if (element.tagName == 'dependencies') {
+        forEach(element.childNodes, ifElement(function(child) {
+          if (child.tagName == 'dependency') {
+            var dep = extractDep(child);
+            if (dep['group'] == 'jdk') {
+              return;
+            }
+            pom['deps'].push(dep);
+          }
+        }));
+      } else if (element.tagName == 'licenses') {
+        forEach(element.childNodes, ifElement(function(child) {
+          if (child.tagName == 'license') {
+            pom['licenses'].push(extractLicense(child));
+          }
+        }));
+      } else if (element.tagName == 'properties') {
+        forEach(element.childNodes, ifElement(function(child) {
+          pom['props'][child.tagName] = child.textContent.trim();
+        }));
+      }
+    });
+    forEach(xmlDocument.childNodes, ifElement(function(child) {
+      if (child.tagName == 'project') {
+        forEach(child.childNodes, onElement);
+      }
+    }));
+    if (parent != null) {
+      if (parent['group'] == '') {
+        parent['group'] = pom['group'];
+      }
+      if (parent['version'] == '') {
+        parent['version'] = pom['version'];
+      }
+      getLiteralPom_(parent, function(parentPom) {
+        mergeParentIntoPom(pom, parentPom);
+        substituteProps(pom);
+        callback(pom);
+      });
+    } else {
+      substituteProps(pom);
+      callback(pom);
+    }
+  });
+}
+
+function getPom(info, callback) {
+  resolveVersion_(info, function(resolvedInfo) {
+    getLiteralPom_(resolvedInfo, function(pom) {
+      forEach(pom['deps'], function(dep, i) {
+        if (dep['version'] == '') { 
+          addError(getName(pom) + ' missing version for dep ' + getName(dep));
+          pom['deps'].splice(i, 1);
+        }
+      });
+      callback(pom);
+    });
+  });
+}
+
+function getChecksum(ext, pom) {
+  if (!calculateChecksumElement.checked) {
+    return;
+  }
+  var url = getMavenUrl(ext, 'repo1.maven.org', pom);
+  if (url in checksums) {
+    return;
+  }
+  total++;
+  checksums[url] = 'TODO';
+  rpc.withSuccessHandler(function(checksum) {
+    count++;
+    showProgress('Got checksum for ' + getName(pom) + ext);
+    checksums[url] = checksum;
+    printDiscovered();
+  }).getSha256ForUrl(url);
+}
+
+function mirror(ext, pom) {
+  var url = getMavenUrl(ext, 'repo1.maven.org', pom);
+  if (url in mirrors) {
+    return;
+  }
+  total++;
+  rpc.withSuccessHandler(function(mirroredUrl) {
+    count++;
+    showProgress('Mirrored ' + getName(pom) + ext);
+    mirrors[url] = mirroredUrl;
+    printDiscovered();
+  }).mirrorUrl(url);
+}
+
+function getSauce(pom) {
+  var url = getMavenUrl('-sources.jar', 'repo1.maven.org', pom);
+  var name = getName(pom);
+  if (name in hasSauce) {
+    return;
+  }
+  total++;
+  rpc.withSuccessHandler(function(exists) {
+    count++;
+    hasSauce[name] = exists;
+    showProgress((exists ? 'Found' : 'No') + ' srcjar for ' + getName(pom));
+    printDiscovered();
+    if (exists) {
+      if (mirrorElement.checked) {
+        mirror('-sources.jar', pom);
+      }
+      getChecksum('-sources.jar', pom);
+    }
+  }).doesUrlExist(url);
+}
+
+// https://bazel.build/versions/master/docs/be/functions.html#licenses_args
+function guessLicenseType(license) {
+  if (license['url'].indexOf('gnu.org/licenses/agpl') != -1 ||
+      license['url'].indexOf('wtfpl.net') != -1 ||
+      license['name'].indexOf('WTFPL') != -1 ||
+      license['name'].indexOf('AGPL') != -1 ||
+      license['name'].indexOf('Affero') != -1 ||
+      license['name'].indexOf('affero') != -1 ||
+      license['name'].indexOf('Fuck') != -1 ||
+      license['name'].indexOf('fuck') != -1) {
+    return 'by_exception_only';
+  }
+  if (license['url'].indexOf('apache.org/licenses/LICENSE-2.0') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/mit') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/bsd') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/BSD') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/ISC') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/zpl') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/zlib') != -1 ||
+      license['url'].indexOf('unicode.org/copyright') != -1 ||
+      license['url'].indexOf('json.org/license') != -1 ||
+      license['url'].indexOf('gwtproject.org/terms') != -1) {
+    return 'notice';
+  }
+  if (license['url'].indexOf('www.gnu.org') != -1 ||
+      license['url'].indexOf('www.oracle.com/technetwork/java/javase/terms/license/index.html') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/sleepycat.php') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/osl') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/qtpl') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/sleepycat') != -1 ||
+      license['url'].indexOf('cr.yp.to/qmail') != -1 ||
+      license['url'].indexOf('MPL/NPL/') != -1) {
+    return 'restricted';
+  }
+  if (license['url'].indexOf('opensource.org/licenses/cpl') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/eclipse') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/apsl') != -1 ||
+      license['url'].indexOf('opensource.org/licenses/ibmpl') != -1 ||
+      license['url'].indexOf('eclipse.org/org/documents/epl') != -1 ||
+      license['url'].indexOf('eclipse.org/legal/epl') != -1) {
+    return 'reciprocal';
+  }
+  if (license['url'].indexOf('creativecommons.org/licenses/publicdomain') != -1 ||
+      license['url'].indexOf('unlicense.org') != -1) {
+    return 'unencumbered';
+  }
+  if (license['name'] == 'gpl' ||
+      license['name'] == 'lgpl' ||
+      license['name'].indexOf('GPL') != -1 ||
+      license['name'].indexOf('BCL') != -1 ||
+      license['name'].indexOf('Oracle Binary Code License') != -1 ||
+      license['name'].indexOf('Attribution-ShareAlike') != -1 ||
+      license['name'].indexOf('CC BY-SA') != -1 ||
+      license['name'].indexOf('Attribution-NoDerivs') != -1 ||
+      license['name'].indexOf('CC BY-ND') != -1 ||
+      license['name'].indexOf('Sleepycat') != -1) {
+    return 'restricted';
+  }
+  if (license['name'].indexOf('MPL') != -1 ||
+      license['name'].indexOf('Mozilla Public License') != -1 ||
+      license['name'].indexOf('Common Public License') != -1 ||
+      license['name'].indexOf('CDDL') != -1 ||
+      license['name'].indexOf('Common Development and Distribution License') != -1 ||
+      license['name'].indexOf('EPL') != -1 ||
+      license['name'].indexOf('Eclipse Public License') != -1 ||
+      license['name'].indexOf('APSL') != -1 ||
+      license['name'].indexOf('Apple Public Source License') != -1) {
+    return 'reciprocal';
+  }
+  if (license['name'].indexOf('BSD') != -1 ||
+      license['name'].indexOf('MIT') != -1 ||
+      license['name'].indexOf('X11') != -1 ||
+      license['name'].indexOf('Apache') != -1 ||
+      license['name'].indexOf('Artistic') != -1 ||
+      license['name'].indexOf('ISC') != -1 ||
+      license['name'].indexOf('ICU') != -1 ||
+      license['name'].indexOf('JSON License') != -1) {
+    return 'notice';
+  }
+  if (license['name'].indexOf('Beerware') != -1 ||
+      license['name'].indexOf('beerware') != -1 ||
+      license['name'].indexOf('Google App Engine Terms of Service') != -1) {
+    return 'permissive';
+  }
+  if (license['name'] == 'Public Domain' && license['url'] == '') {
+    return 'unencumbered';  // e.g. aopalliance
+  }
+  return 'TODO';
+}
+
+function mixLicenseTypes(current, other) {
+  return LICENSE_ZEAL[other] > LICENSE_ZEAL[current] ? other : current;
+}
+
+function printDiscovered() {
+  var c = '';
+  c += '################################################################################\n'
+  c += '# BEGIN BAZEL MAVEN CONFIG GENERATOR\n';
+  c += '#\n';
+  var artifacts = artifactsElement.value.split(WHITESPACE_PATTERN);
+  for (var i = 0; i < artifacts.length; i++) {
+    var artifact = artifacts[i];
+    if (artifact == '') {
+      continue;
+    }
+    c += '#   ' + artifact + '\n';
+  }
+  c += '#\n';
+  c += '# Include optional dependencies: ' + includeOptionalElement.checked + '\n';
+  c += '# Include source jars: ' + includeSauceElement.checked + '\n';
+  c += '# Run by: ' + userEmail + '\n';
+  c += '# Run on: ' + new Date().toISOString() + '\n';
+  for (var i = 0; i < diamonds.length; i++) {
+    c += '# Note: ' + diamonds[i] + '\n';
+  }
+  var rules = [c];
+  var names = Object.keys(discovered);
+  names.sort();
+  for (var k = 0; k < names.length; k++) {
+    var pom = discovered[names[k]];
+    var depNames = [];
+    for (var i = 0; i < pom['deps'].length; i++) {
+      var dep = pom['deps'][i];
+      if (dep['scope'] == 'test') {
+        continue;
+      }
+      if (dep['classifier'] == 'sources') {
+        continue;
+      }
+      if (dep['optional'] == 'true' && !includeOptionalElement.checked) {
+        continue;
+      }
+      var depKey = getName(dep);
+      if (depKey in discovered) {
+        var depPom = discovered[depKey];
+        depNames.push(getName(depPom));
+      }
+    }
+    var name = getName(pom);
+    var s = '';
+    s += 'java_import_external(\n';
+    s += '    name = "' + name + '",\n';
+    if (neverlink[name]) {
+      s += '    neverlink = 1,\n';
+    }
+    if (pom['licenses'].length == 0) {
+      s += '    licenses = ["TODO"],  # NO LICENSE DECLARED\n';
+    } else if (pom['licenses'].length == 1) {
+      var license = pom['licenses'][0];
+      var type = guessLicenseType(license);
+      if (type == 'TODO') {
+        s += '    # ' + license['name'].replace(/\r?\n/g, ' ') + '\n';
+        s += '    # ' + license['url'] + '\n';
+        s += '    licenses = ["' + type + '"],\n';
+      } else {
+        s += '    licenses = ["' + type + '"],  # ' + license['name'].replace(/\r?\n/g, ' ') + '\n';
+      }
+    } else {
+      var type = '';
+      for (var i = 0; i < pom['licenses'].length; i++) {
+        var license = pom['licenses'][i];
+        type = mixLicenseTypes(type, guessLicenseType(license));
+        s += '    # ' + license['name'].replace(/\r?\n/g, ' ') + '\n';
+        s += '    # ' + license['url'] + '\n';
+      }
+      s += '    licenses = ["' + type + '"],\n';
+    }
+    var url = getMavenUrl('.jar', 'repo1.maven.org', pom);
+    var url2 = getMavenUrl('.jar', 'maven.ibiblio.org', pom);
+    var checksum = url in checksums ? checksums[url] : 'TODO';
+    s += '    jar_sha256 = "' + checksum + '",\n',
+    s += '    jar_urls = [\n';
+    if (Math.random() > 0.5) {
+      s += '        "' + url + '",\n';
+      s += '        "' + url2 + '",\n';
+    } else {
+      s += '        "' + url2 + '",\n';
+      s += '        "' + url + '",\n';
+    }
+    if (url in mirrors && mirrorElement.checked) {
+      s += '        "' + mirrors[url] + '",\n';
+    }
+    s += '    ],\n';
+    if (name in hasSauce && hasSauce[name] && includeSauceElement.checked) {
+      url = getMavenUrl('-sources.jar', 'repo1.maven.org', pom);
+      url2 = getMavenUrl('-sources.jar', 'maven.ibiblio.org', pom);
+      checksum = url in checksums ? checksums[url] : 'TODO';
+      s += '    srcjar_sha256 = "' + checksum + '",\n',
+      s += '    srcjar_urls = [\n';
+      if (Math.random() > 0.5) {
+        s += '        "' + url + '",\n';
+        s += '        "' + url2 + '",\n';
+      } else {
+        s += '        "' + url2 + '",\n';
+        s += '        "' + url + '",\n';
+      }
+      if (url in mirrors && mirrorElement.checked) {
+        s += '        "' + mirrors[url] + '",\n';
+      }
+      s += '    ],\n';
+    }
+    if (depNames.length == 1) {
+      s += '    deps = ["@' + depNames[0] + '"],\n';
+    } else if (depNames.length > 0) {
+      s += '    deps = [\n';
+      for (var i = 0; i < depNames.length; i++) {
+        s += '        "@' + depNames[i] + '",\n';
+      }
+      s += '    ],\n';
+    }
+    s += ')\n';
+    rules.push(s);
+  }
+  rules.push('# END BAZEL MAVEN CONFIG GENERATOR\n' +
+             '################################################################################\n');
+  resultElement.innerText = rules.join('\n');
+}
+
+function addLiteralEdge_(map, from, to) {
+  if (!(from in map)) {
+    map[from] = [to];
+  } else {
+    if (!arrayContains(map[from], to)) {
+      map[from].push(to);
+    }
+  }
+}
+
+function addEdge(from, to) {
+  addLiteralEdge_(edges, from, to);
+  addLiteralEdge_(edgesBackwards, to, from);
+}
+
+function onPom(pom) {
+  if (includeSauceElement.checked) {
+    getSauce(pom);
+  }
+  if (mirrorElement.checked) {
+    mirror('.jar', pom);
+  }
+  getChecksum('.jar', pom);
+  var name = getName(pom);
+  showProgress('Got ' + name);
+  if (name in discovered) {
+    var old = discovered[name];
+    var cr = compareVersions(old['version'], pom['version']);
+    if (cr == 0) {
+      return;
+    } else if (cr > 0) {
+      addDiamond('Evicted ' + name + ' ' + pom['version'] + ' in favor of ' + old['version']);
+      return;
+    }
+    addDiamond('Evicted ' + name + ' ' + old['version'] + ' in favor of ' + pom['version']);
+  }
+  discovered[name] = pom;
+  printDiscovered();
+  for (var i = 0; i < pom['deps'].length; i++) {
+    var dep = pom['deps'][i];
+    if (dep['scope'] == 'test') {
+      continue;
+    }
+    if (dep['optional'] == 'true' && !includeOptionalElement.checked) {
+      continue;
+    }
+    var depName = getName(dep);
+    neverlink[depName] = (dep['scope'] == 'provided' &&
+                          (!(depName in neverlink) || neverlink[depName]));
+    addEdge(name, depName);
+    getPom(dep, onPom);
+  }
+}
+
+function onSubmit() {
+  count = 0;
+  total = 0;
+  edges = {};
+  edgesBackwards = {};
+  discovered = {};
+  neverlink = {};
+  diamonds = [];
+  errorsElement.innerText = '';
+  resultElement.innerText = '';
+  var artifacts = artifactsElement.value.split(WHITESPACE_PATTERN);
+  for (var i = 0; i < artifacts.length; i++) {
+    var artifact = artifacts[i];
+    if (artifact == '') {
+      continue;
+    }
+    var matches = ARTIFACT_PATTERN.exec(artifact);
+    if (matches == null) {
+      alert('Bad artifact string: ' + artifact);
+      continue;
+    }
+    var dep = {
+      'group': matches[1],
+      'artifact': matches[2],
+      'version': matches[3],
+    };
+    addEdge('', getName(dep));
+    getPom(dep, onPom);
+  }
+}
+
+rpc = google.script.run.withFailureHandler(addError);
+
+rpc.withSuccessHandler(function(email) {
+  userEmail = email;
+}).getUserEmail();
+
+formElement = document.getElementById('form');
+artifactsElement = document.getElementById('artifacts');
+mirrorElement = document.getElementById('mirror');
+includeOptionalElement = document.getElementById('includeOptional');
+includeSauceElement = document.getElementById('includeSauce');
+resultElement = document.getElementById('result');
+errorsElement = document.getElementById('errors');
+progressElement = document.getElementById('progress');
+calculateChecksumElement = document.getElementById('calculateChecksum');
+formElement.addEventListener('submit', preventDefault(onSubmit));
+</script>
+

--- a/tools/build_defs/repo/maven_config_generator/sha256.gs
+++ b/tools/build_defs/repo/maven_config_generator/sha256.gs
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * SHA-256 (FIPS 180-4) implementation in JavaScript
+ * (c) Chris Veness 2002-2016
+ * MIT License
+ * www.movable-type.co.uk/scripts/sha256.html
+ *
+ * @fileoverview Pure JavaScript SHA-256 implementation for backend.
+ *
+ * The Google Apps Script API has a SHA-256 hasher which plugs into Guava's
+ * implementation. But it was not designed to take binary data as input. So
+ * we must use a very slow hasher until we can get the API fixed. It takes
+ * a few minutes to hash a 3MB jar. But it eventually completes and the result
+ * is cached in the PropertyService.
+ *
+ * Retrieved from web page above on 2016-12-09.
+ *
+ * Google modifications:
+ *
+ *   - Removed options parameter because input will always be an ISO-8859-1
+ *     string which is identical to binary.
+ */
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  */
+/* SHA-256 (FIPS 180-4) implementation in JavaScript                  (c) Chris Veness 2002-2016  */
+/*                                                                                   MIT Licence  */
+/* www.movable-type.co.uk/scripts/sha256.html                                                     */
+/*                                                                                                */
+/*  - see http://csrc.nist.gov/groups/ST/toolkit/secure_hashing.html                              */
+/*        http://csrc.nist.gov/groups/ST/toolkit/examples.html                                    */
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  */
+
+/**
+ * SHA-256 hash function reference implementation.
+ *
+ * This is a direct implementation of FIPS 180-4, without any optimisations. It is intended to aid
+ * understanding of the algorithm rather than for production use, though it could be used where
+ * performance is not critical.
+ *
+ * @namespace
+ */
+var Sha256 = {};
+
+
+/**
+ * Generates SHA-256 hash of string.
+ *
+ * @param   {string} msg - (Unicode) string to be hashed.
+ * @returns {string} Hash of msg as hex character string.
+ */
+Sha256.hash = function(msg) {
+    // note use throughout this routine of 'n >>> 0' to coerce Number 'n' to unsigned 32-bit integer
+
+    // constants [§4.2.2]
+    var K = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2 ];
+
+    // initial hash value [§5.3.3]
+    var H = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19 ];
+
+    // PREPROCESSING [§6.2.1]
+
+    msg += String.fromCharCode(0x80);  // add trailing '1' bit (+ 0's padding) to string [§5.1.1]
+
+    // convert string msg into 512-bit blocks (array of 16 32-bit integers) [§5.2.1]
+    var l = msg.length/4 + 2; // length (in 32-bit integers) of msg + ‘1’ + appended length
+    var N = Math.ceil(l/16);  // number of 16-integer (512-bit) blocks required to hold 'l' ints
+    var M = new Array(N);     // message M is N×16 array of 32-bit integers
+
+    for (var i=0; i<N; i++) {
+        M[i] = new Array(16);
+        for (var j=0; j<16; j++) { // encode 4 chars per integer (64 per block), big-endian encoding
+            M[i][j] = (msg.charCodeAt(i*64+j*4)<<24) | (msg.charCodeAt(i*64+j*4+1)<<16) |
+                      (msg.charCodeAt(i*64+j*4+2)<<8) | (msg.charCodeAt(i*64+j*4+3));
+        } // note running off the end of msg is ok 'cos bitwise ops on NaN return 0
+    }
+    // add length (in bits) into final pair of 32-bit integers (big-endian) [§5.1.1]
+    // note: most significant word would be (len-1)*8 >>> 32, but since JS converts
+    // bitwise-op args to 32 bits, we need to simulate this by arithmetic operators
+    var lenHi = ((msg.length-1)*8) / Math.pow(2, 32);
+    var lenLo = ((msg.length-1)*8) >>> 0;
+    M[N-1][14] = Math.floor(lenHi);
+    M[N-1][15] = lenLo;
+
+
+    // HASH COMPUTATION [§6.2.2]
+
+    for (var i=0; i<N; i++) {
+        var W = new Array(64);
+
+        // 1 - prepare message schedule 'W'
+        for (var t=0;  t<16; t++) W[t] = M[i][t];
+        for (var t=16; t<64; t++) {
+            W[t] = (Sha256.σ1(W[t-2]) + W[t-7] + Sha256.σ0(W[t-15]) + W[t-16]) >>> 0;
+        }
+
+        // 2 - initialise working variables a, b, c, d, e, f, g, h with previous hash value
+        var a = H[0], b = H[1], c = H[2], d = H[3], e = H[4], f = H[5], g = H[6], h = H[7];
+
+        // 3 - main loop (note 'addition modulo 2^32')
+        for (var t=0; t<64; t++) {
+            var T1 = h + Sha256.Σ1(e) + Sha256.Ch(e, f, g) + K[t] + W[t];
+            var T2 =     Sha256.Σ0(a) + Sha256.Maj(a, b, c);
+            h = g;
+            g = f;
+            f = e;
+            e = (d + T1) >>> 0;
+            d = c;
+            c = b;
+            b = a;
+            a = (T1 + T2) >>> 0;
+        }
+
+        // 4 - compute the new intermediate hash value (note '>>> 0' for 'addition modulo 2^32')
+        H[0] = (H[0]+a) >>> 0;
+        H[1] = (H[1]+b) >>> 0;
+        H[2] = (H[2]+c) >>> 0;
+        H[3] = (H[3]+d) >>> 0;
+        H[4] = (H[4]+e) >>> 0;
+        H[5] = (H[5]+f) >>> 0;
+        H[6] = (H[6]+g) >>> 0;
+        H[7] = (H[7]+h) >>> 0;
+    }
+
+    // convert H0..H7 to hex strings (with leading zeros)
+    for (var h=0; h<H.length; h++) H[h] = ('00000000'+H[h].toString(16)).slice(-8);
+
+    return H.join('');
+};
+
+
+/**
+ * Rotates right (circular right shift) value x by n positions [§3.2.4].
+ * @private
+ */
+Sha256.ROTR = function(n, x) {
+    return (x >>> n) | (x << (32-n));
+};
+
+/**
+ * Logical functions [§4.1.2].
+ * @private
+ */
+Sha256.Σ0  = function(x) { return Sha256.ROTR(2,  x) ^ Sha256.ROTR(13, x) ^ Sha256.ROTR(22, x); };
+Sha256.Σ1  = function(x) { return Sha256.ROTR(6,  x) ^ Sha256.ROTR(11, x) ^ Sha256.ROTR(25, x); };
+Sha256.σ0  = function(x) { return Sha256.ROTR(7,  x) ^ Sha256.ROTR(18, x) ^ (x>>>3);  };
+Sha256.σ1  = function(x) { return Sha256.ROTR(17, x) ^ Sha256.ROTR(19, x) ^ (x>>>10); };
+Sha256.Ch  = function(x, y, z) { return (x & y) ^ (~x & z); };          // 'choice'
+Sha256.Maj = function(x, y, z) { return (x & y) ^ (x & z) ^ (y & z); }; // 'majority'
+


### PR DESCRIPTION
This directory contains the source code to a website that runs on [Google Apps Script](https://script.google.com). It crawls Maven POM metadata to generate `WORKSPACE` configs using [`java_import_external`](https://github.com/bazelbuild/bazel/blob/062fe70189fc622285833311d241021be313680b/tools/build_defs/repo/java.bzl).

Please watch the [demo video](https://www.youtube.com/watch?v=xdMDuhJTKMI) on YouTube.

### Features

- Defines all transitive relationships
- Resolves diamond conflicts by bumping versions
- Calculates SHA256 (slow due to Apps Script API issue)
- Documents `licenses` and heuristically categorizes them
- Heuristics for `neverlink` (provided) jars
- Source jars and optional dependencies
- Mirrors jars to Google Drive
- Adds iBiblio URLs if 200 OK

### Verbosity

The huge config is good because it makes builds deterministic, highly available, and fast because Bazel won't need to BFS HTTP POMs each build. Even Java projects with hundreds of transitive dependencies can expect `bazel fetch //....` to take seconds.

You'll also see all the mysterious code from the Internet that you're running on your machine. For example, you might discover Apache Commons Collections 3.2.1 on the classpath, in which case it's game over if anything in the JVM is deserializing. So the verbosity might actually save you from ending up in the same boat as Equifax. See [Operation Rosehub](https://opensource.googleblog.com/2017/03/operation-rosehub.html) to learn more.

### Imperfection

Another reason why the generated config is huge is because it only gets you 90% there. You will need to make subtle adjustments after using the tool. See the README in the PR to learn more.