### PR TITLE
[Trivial] Add a designated method for retrieving java.nio.file.Path

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -24,6 +24,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -64,6 +65,17 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
     return new File(path.toString());
   }
 
+  /**
+   * Returns a {@link java.nio.file.Path} representing the same path as provided {@code path}.
+   *
+   * <p>Note: while it's possible to use {@link #getIoFile(Path)} in combination with {@link File#toPath()} to achieve
+   * essentially the same, using this method is preferable because it avoids extra allocations and does not lose track
+   * of the underlying Java filesystem, which is useful for some in-memory filesystem implementations like JimFS.
+   */
+  protected java.nio.file.Path getNioPath(Path path) {
+    return Paths.get(path.toString());
+  }
+
   private LinkOption[] linkOpts(boolean followSymlinks) {
     return followSymlinks ? NO_LINK_OPTION : NOFOLLOW_LINKS_OPTION;
   }
@@ -96,10 +108,10 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
 
   @Override
   protected boolean exists(Path path, boolean followSymlinks) {
-    File file = getIoFile(path);
+    java.nio.file.Path nioPath = getNioPath(path);
     long startTime = Profiler.nanoTimeMaybe();
     try {
-      return Files.exists(file.toPath(), linkOpts(followSymlinks));
+      return Files.exists(nioPath, linkOpts(followSymlinks));
     } finally {
       profiler.logSimpleTask(startTime, ProfilerTask.VFS_STAT, path.toString());
     }
@@ -242,9 +254,9 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
   @Override
   protected void createSymbolicLink(Path linkPath, PathFragment targetFragment)
       throws IOException {
-    File file = getIoFile(linkPath);
+    java.nio.file.Path nioPath = getNioPath(linkPath);
     try {
-      Files.createSymbolicLink(file.toPath(), new File(targetFragment.getPathString()).toPath());
+      Files.createSymbolicLink(nioPath, Paths.get(targetFragment.getPathString()));
     } catch (java.nio.file.FileAlreadyExistsException e) {
       throw new IOException(linkPath + ERR_FILE_EXISTS);
     } catch (java.nio.file.AccessDeniedException e) {
@@ -256,17 +268,17 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
 
   @Override
   protected PathFragment readSymbolicLink(Path path) throws IOException {
-    File file = getIoFile(path);
+    java.nio.file.Path nioPath = getNioPath(path);
     long startTime = Profiler.nanoTimeMaybe();
     try {
-      String link = Files.readSymbolicLink(file.toPath()).toString();
+      String link = Files.readSymbolicLink(nioPath).toString();
       return PathFragment.create(link);
     } catch (java.nio.file.NotLinkException e) {
       throw new NotASymlinkException(path);
     } catch (java.nio.file.NoSuchFileException e) {
       throw new FileNotFoundException(path + ERR_NO_SUCH_FILE_OR_DIR);
     } finally {
-      profiler.logSimpleTask(startTime, ProfilerTask.VFS_READLINK, file.getPath());
+      profiler.logSimpleTask(startTime, ProfilerTask.VFS_READLINK, nioPath);
     }
   }
 
@@ -377,11 +389,11 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
    */
   @Override
   protected FileStatus stat(final Path path, final boolean followSymlinks) throws IOException {
-    File file = getIoFile(path);
+    java.nio.file.Path nioPath = getNioPath(path);
     final BasicFileAttributes attributes;
     try {
       attributes = Files.readAttributes(
-          file.toPath(), BasicFileAttributes.class, linkOpts(followSymlinks));
+          nioPath, BasicFileAttributes.class, linkOpts(followSymlinks));
     } catch (java.nio.file.FileSystemException e) {
       throw new FileNotFoundException(path + ERR_NO_SUCH_FILE_OR_DIR);
     }


### PR DESCRIPTION
As explained in the javadoc this avoids unnecessary allocations and
preserves underlying Java filesystem information.

This partially addresses #3952.