### PR TITLE
Update ios-app.md

### DIFF
--- a/site/docs/tutorial/ios-app.md
+++ b/site/docs/tutorial/ios-app.md
@@ -40,9 +40,9 @@ its dependencies.
 
 ### Install Xcode
 
-Download and install [Xcode](https://developer.apple.com/xcode/downloads/). The
-Xcode download contains the iOS libraries, the Objective-C compiler, and other
-tools required by Bazel to build iOS apps.
+Download and install [Xcode](https://developer.apple.com/xcode/downloads/).
+Xcode contains the compilers, SDKs, and other tools required by Bazel to build 
+apps for all of Apples platforms (including iOS).
 
 ### Get the sample project
 
@@ -104,23 +104,35 @@ Enter the following at the command line:
 
 ```bash
 touch $WORKSPACE/WORKSPACE
+open -a Xcode $WORKSPACE/WORKSPACE
 ```
 
-This creates the empty `WORKSPACE` file.
+This creates and open the empty `WORKSPACE` file.
 
 ### Update the WORKSPACE file
 
 To build applications for Apple devices, Bazel needs to pull the latest
 [Apple build rules](https://github.com/bazelbuild/rules_apple) from its GitHub
-repository. To enable this, add the following to your `WORKSPACE` file:
+repository. To enable this, add the following 
+[`http_archive`](../be/workspace.html#http_archive) rule to your `WORKSPACE` 
+file:
 
 ```
-git_repository(
+http_archive(
     name = "build_bazel_rules_apple",
-    remote = "https://github.com/bazelbuild/rules_apple.git",
-    commit = "7ea0557",
+    strip_prefix = "rules_apple-0.1.0",
+    urls = ["https://github.com/bazelbuild/rules_apple/archive/0.1.0.tar.gz"],
 )
 ```
+
+**NOTE:** Please check the 
+[Apple build rules releases](https://github.com/bazelbuild/rules_apple/releases)
+and use the URL of the latest release available in the `urls` parameter of
+your `git_repository` rule. You will need to update the `strip_prefix` parameter
+accordingly as well.
+
+**NOTE2:** The `name` parameter of the `git_repository` rule *must* be
+`build_bazel_rules_apple`. The Apple rules depend on this name internally.
 
 ## Review the source files
 
@@ -131,10 +143,11 @@ source files to complete this tutorial.
 
 ## Create a BUILD file
 
-At a command-line prompt, open your new `BUILD` file for editing:
+At a command-line prompt, open a new `BUILD` file for editing:
 
 ```bash
-vi $WORKSPACE/ios-app/BUILD
+touch $WORKSPACE/ios-app/BUILD
+open -a Xcode $WORKSPACE/ios-app/BUILD
 ```
 
 ### Add the rule load statement
@@ -146,6 +159,10 @@ following load statement to the beginning of your `BUILD` file:
 ```
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 ```
+
+We only need to load the `ios_application` rule because currently the 
+`objc_library` rule is built into the bazel package. Eventually the
+`objc_library` rule will need to be loaded as well.
 
 ### Add an objc_library rule
 
@@ -192,11 +209,14 @@ ios_application(
         "iphone",
         "ipad",
     ],
+    minimum_os_version = "9.0"
     infoplists = [":UrlGet/UrlGet-Info.plist"],
     visibility = ["//visibility:public"],
     deps = [":UrlGetClasses"],
 )
 ```
+**NOTE:** Please update the `minimum_os_version` parameter to the minimum version
+of iOS that you plan to support.
 
 Note how the `deps` attribute references the output of the `UrlGetClasses` rule
 you added to the `BUILD` file above.
@@ -246,6 +266,9 @@ The `.ipa` file and other outputs are located in the
 ### Run and debug the app in the simulator
 
 You can now run the app from Xcode using the iOS Simulator. First, [generate an Xcode project using Tulsi](http://tulsi.bazel.io/).
+
+**TODO:** Better documentation on using Tulsi
+
 Then, open the project in Xcode, choose an iOS Simulator as the runtime scheme,
 and click **Run**.
 

--- a/site/docs/tutorial/ios-app.md
+++ b/site/docs/tutorial/ios-app.md
@@ -42,7 +42,7 @@ its dependencies.
 
 Download and install [Xcode](https://developer.apple.com/xcode/downloads/).
 Xcode contains the compilers, SDKs, and other tools required by Bazel to build 
-apps for all of Apples platforms (including iOS).
+Apple applications.
 
 ### Get the sample project
 
@@ -107,7 +107,7 @@ touch $WORKSPACE/WORKSPACE
 open -a Xcode $WORKSPACE/WORKSPACE
 ```
 
-This creates and open the empty `WORKSPACE` file.
+This creates and opens the empty `WORKSPACE` file.
 
 ### Update the WORKSPACE file
 
@@ -127,11 +127,11 @@ http_archive(
 
 **NOTE:** Please check the 
 [Apple build rules releases](https://github.com/bazelbuild/rules_apple/releases)
-and use the URL of the latest release available in the `urls` parameter of
-your `git_repository` rule. You will need to update the `strip_prefix` parameter
+and use the URL of the latest release available in the `urls` attribute of
+your `http_archive` rule. You will need to update the `strip_prefix` attribute
 accordingly as well.
 
-**NOTE2:** The `name` parameter of the `git_repository` rule *must* be
+**NOTE2:** The `name` attribute of the `http_archive` rule *must* be
 `build_bazel_rules_apple`. The Apple rules depend on this name internally.
 
 ## Review the source files
@@ -161,8 +161,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 ```
 
 We only need to load the `ios_application` rule because currently the 
-`objc_library` rule is built into the bazel package. Eventually the
-`objc_library` rule will need to be loaded as well.
+`objc_library` rule is built into the bazel package.
 
 ### Add an objc_library rule
 
@@ -215,8 +214,9 @@ ios_application(
     deps = [":UrlGetClasses"],
 )
 ```
-**NOTE:** Please update the `minimum_os_version` parameter to the minimum version
-of iOS that you plan to support.
+
+**NOTE:** Please update the `minimum_os_version` attribute to the minimum
+version of iOS that you plan to support.
 
 Note how the `deps` attribute references the output of the `UrlGetClasses` rule
 you added to the `BUILD` file above.
@@ -266,8 +266,6 @@ The `.ipa` file and other outputs are located in the
 ### Run and debug the app in the simulator
 
 You can now run the app from Xcode using the iOS Simulator. First, [generate an Xcode project using Tulsi](http://tulsi.bazel.io/).
-
-**TODO:** Better documentation on using Tulsi
 
 Then, open the project in Xcode, choose an iOS Simulator as the runtime scheme,
 and click **Run**.

--- a/site/docs/tutorial/ios-app.md
+++ b/site/docs/tutorial/ios-app.md
@@ -125,13 +125,11 @@ http_archive(
 )
 ```
 
-**NOTE:** Please check the 
-[Apple build rules releases](https://github.com/bazelbuild/rules_apple/releases)
-and use the URL of the latest release available in the `urls` attribute of
-your `http_archive` rule. You will need to update the `strip_prefix` attribute
-accordingly as well.
+**NOTE:** "Always use the 
+[latest version of the build_apple rules](https://github.com/bazelbuild/rules_apple/releases)
+in the `urls` and `strip_prefix` attributes."
 
-**NOTE2:** The `name` attribute of the `http_archive` rule *must* be
+**NOTE 2:** The `name` attribute of the `http_archive` rule *must* be
 `build_bazel_rules_apple`. The Apple rules depend on this name internally.
 
 ## Review the source files


### PR DESCRIPTION
Move from git_repository to http_archive and add more details to the documentation.

Will update bazelbuild/examples with https://github.com/bazelbuild/examples/pull/44