### PR TITLE
Document parameter of repository_ctx.path

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -142,7 +142,17 @@ public class SkylarkRepositoryContext {
             + "relative to the repository directory. If the path is a label, it will resolve to "
             + "the path of the corresponding file. Note that remote repositories are executed "
             + "during the analysis phase and thus cannot depends on a target result (the "
-            + "label should point to a non-generated file)."
+            + "label should point to a non-generated file).",
+    parameters = {
+      @Param(
+        name = "path",
+        allowedTypes = {
+          @ParamType(type = String.class),
+          @ParamType(type = Label.class),
+        },
+        doc = "string or label from which to create a path from"
+      )
+    }
   )
   public SkylarkPath path(Object path) throws EvalException, InterruptedException {
     return getPath("path()", path);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -138,19 +138,21 @@ public class SkylarkRepositoryContext {
   @SkylarkCallable(
     name = "path",
     doc =
-        "Returns a path from a string or a label. If the path is relative, it will resolve "
+        "Returns a path from a string, label or path. If the path is relative, it will resolve "
             + "relative to the repository directory. If the path is a label, it will resolve to "
             + "the path of the corresponding file. Note that remote repositories are executed "
             + "during the analysis phase and thus cannot depends on a target result (the "
-            + "label should point to a non-generated file).",
+            + "label should point to a non-generated file). If path is a path, it will return "
+            + "that path as is.",
     parameters = {
       @Param(
         name = "path",
         allowedTypes = {
           @ParamType(type = String.class),
           @ParamType(type = Label.class),
+          @ParamType(type = SkylarkPath.class)
         },
-        doc = "string or label from which to create a path from"
+        doc = "string, label or path from which to create a path from"
       )
     }
   )


### PR DESCRIPTION
Current documentation is pretty confusing without this. Looking at the implementation this could technically also accept a `SkylarkPath`, but I'm not sure if we'd want to expose that in the documentation? 