### PR TITLE
Change error on adding a directory to the remote cache to be non-fatal

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
@@ -197,7 +197,7 @@ public final class SimpleBlobStoreActionCache implements RemoteActionCache {
       if (file.isDirectory()) {
         // TODO(olaola): to implement this for a directory, will need to create or pass a
         // TreeNodeRepository to call uploadTree.
-        throw new UnsupportedOperationException("Storing a directory is not yet supported.");
+        throw new IOException("Storing a directory is not yet supported.");
       }
       // TODO(olaola): inline small file contents here.
       // First put the file content to cache.


### PR DESCRIPTION
While this doesn't implement directory support requested in #3891 it does allow the build to continue and succeed by skipping cache checks for directories.