### PR TITLE
Use macOS as the new name for Mac OS X

### DIFF
--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -9,7 +9,7 @@ See the instructions for installing Bazel on:
 
 *   [Ubuntu Linux (16.04, 15.10, and 14.04)](install-ubuntu.md)
 *   [Fedora 25, 26, and CentOS 7](install-redhat.md)
-*   [Mac OS X](install-os-x.md)
+*   [macOS](install-os-x.md)
 *   [Windows](install-windows.md)
 
 For other platforms, you can try to [compile from source](install-compile-source.md).


### PR DESCRIPTION
Mac OS X is the name of operating systems released by Apple, Inc between years 2001 and 2015. macOS is the name of operating systems released by Apple, Inc starting in 2016 and continuing until current times.

Documentation of the change in product name:

https://en.wikipedia.org/wiki/MacOS#macOS_10.12_Sierra
http://www.businessinsider.com/wwdc-2016-os-x-becomes-macos-2016-6