### PR TITLE
Export hash.bzl.

### DIFF
--- a/tools/build_defs/hash/BUILD
+++ b/tools/build_defs/hash/BUILD
@@ -16,3 +16,7 @@ py_binary(
     srcs = ["sha256.py"],
     visibility = ["//visibility:public"],
 )
+
+exports_files([
+    "hash.bzl",
+])


### PR DESCRIPTION
This allows Skylib `skylark_library` users to use `hash.bzl` as a file dependency without the base Bazel rules having to import the actual `skylark_library` rule from Skylib.