### PR TITLE
Make bazel work with java9

### DIFF
--- a/scripts/bootstrap/buildenv.sh
+++ b/scripts/bootstrap/buildenv.sh
@@ -287,8 +287,8 @@ function get_java_version() {
     || fail "JAVA_HOME ($JAVA_HOME) is not a path to a working JDK."
 
   JAVAC_VERSION=$("${JAVAC}" -version 2>&1)
-  if [[ "$JAVAC_VERSION" =~ javac\ (1\.([789]|[1-9][0-9])).*$ ]]; then
-    JAVAC_VERSION=${BASH_REMATCH[1]}
+  if [[ "$JAVAC_VERSION" =~ javac\ ((1\.)?([789]|[1-9][0-9])).*$ ]]; then
+    JAVAC_VERSION=1.${BASH_REMATCH[3]}
   else
     fail \
       "Cannot determine JDK version, please set \$JAVA_HOME.\n" \


### PR DESCRIPTION
unlike earlier versions,
openjdk9 returns "javac 9" when asked for its version