### PR TITLE
Allow Bazel's Debian package to install with headless JDK.

### DIFF
--- a/scripts/packages/debian/control
+++ b/scripts/packages/debian/control
@@ -9,7 +9,7 @@ Package: bazel
 Section: contrib/devel
 Priority: optional
 Architecture: amd64
-Depends: google-jdk | java8-jdk | java8-sdk | oracle-java8-installer, g++, zlib1g-dev, bash-completion
+Depends: google-jdk | java8-sdk-headless | java8-jdk | java8-sdk | oracle-java8-installer, g++, zlib1g-dev, bash-completion
 Description: Bazel is a tool that automates software builds and tests.
  Supported build tasks include running compilers and linkers to produce
  executable programs and libraries, and assembling deployable packages


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/3761