### PR TITLE
Consistent use of SOURCE_DATE_EPOCH in Bazel.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfiguration.java
@@ -1321,6 +1321,13 @@ public class BuildConfiguration implements BuildEvent {
     for (Map.Entry<String, String> entry : options.actionEnvironment) {
       actionEnv.put(entry.getKey(), entry.getValue());
     }
+    // If we have not specified SOURCE_DATE_EPOCH yet, we will define it there.
+    if (!actionEnv.containsKey("SOURCE_DATE_EPOCH")) {
+      // We overwrite by default SOURCE_DATE_EPOCH unless --action_env SOURCE_DATE_EPOCH is defined
+      // (https://reproducible-builds.org/specs/source-date-epoch/)
+      // to 1 so program that understand it will get a constant value and will strip timestamps.
+      actionEnv.put("SOURCE_DATE_EPOCH", "1");
+    }
     return ActionEnvironment.split(actionEnv);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -1876,6 +1876,12 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
       for (Entry<String, String> v : opt.actionEnvironment) {
         actionEnvironment.put(v.getKey(), v.getValue());
       }
+      if (!actionEnvironment.containsKey("SOURCE_DATE_EPOCH")) {
+        // We overwrite by default SOURCE_DATE_EPOCH
+        // (https://reproducible-builds.org/specs/source-date-epoch/)
+        // to 1 so program that understand it will get a constant value and will strip timestamps.
+        actionEnvironment.put("SOURCE_DATE_EPOCH", "1");
+      }
     }
     preparePackageLoading(
         createPackageLocator(

--- a/src/test/shell/integration/action_env_test.sh
+++ b/src/test/shell/integration/action_env_test.sh
@@ -218,4 +218,22 @@ function test_action_env_changes_honored {
 
 }
 
+function assert_source_date_epoch {
+  local expected="$1"
+  shift 1
+  bazel build //pkg:showenv "$@" || fail "//pkg:showenv failed to build"
+  cat `bazel info ${PRODUCT_NAME}-genfiles`/pkg/env.txt > $TEST_log
+  expect_log "SOURCE_DATE_EPOCH=$expected"
+}
+
+function test_source_date_epoch_propagation {
+  bazel clean --expunge
+  assert_source_date_epoch 1
+  SOURCE_DATE_EPOCH=2 assert_source_date_epoch 2 --action_env SOURCE_DATE_EPOCH
+  assert_source_date_epoch 1
+
+  bazel clean --expunge
+  SOURCE_DATE_EPOCH=2 assert_source_date_epoch 1
+}
+
 run_suite "Tests for bazel's handling of environment variables in actions"


### PR DESCRIPTION
Hello there,

There is 2 changes in this PR (that I will import in 2 change in final, would have been easier on gerrit, but this is easier to pull in @infinity0 here). These changes implement the [SOURCE_DATE_EPOCH specification](https://reproducible-builds.org/specs/source-date-epoch/) at its yet to come version 1.1.
  - First change overwrites SOURCE_DATE_EPOCH to 1 for every downstream action, except if `--action_env SOURCE_DATE_EPOCH` is specified
  - Second change overwrite BUILD_TIMESTAMP by SOURCE_DATE_EPOCH when provided. It also make sure we use it rather than getSystemTimeInMillis()

In review:
  - @aehlig because previous work on action_env and his participation in the SOURCE_DATE_EPOCH discussions
  - @ulfjack to double check that this is ok for Google; although I don't expect any issue there.
  - @infinity0 for SOURCE_DATE_EPOCH