### PR TITLE
Expressly fetch remote and ref when using git_repository

### DIFF
--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -32,7 +32,7 @@ set -ex
       git clone '{remote}' '{dir}'
     fi
     cd '{dir}'
-    git reset --hard {ref} || (git fetch && git reset --hard {ref})
+    git reset --hard {ref} || (git fetch origin {ref}:{ref} && git reset --hard {ref})
     git clean -xdf )
   """.format(
       working_dir=ctx.path('.').dirname,


### PR DESCRIPTION
When I clone from a git repo that doesn't have the default branch the same as the branch that I want ; it doesn't seem to fetch the appropriate branch. I am using a name rather than explicit sha. 

What happens is:
```
+ git reset --hard build-with-bazel
fatal: ambiguous argument 'build-with-bazel': unknown revision or path not in the working tree.
```

because it hasn't fetched that ref.