### PR TITLE
Allow @Ignore to be used on test classes without BUILD file change

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4TestModelBuilder.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4TestModelBuilder.java
@@ -50,8 +50,9 @@ class JUnit4TestModelBuilder implements Supplier<TestSuiteModel> {
   public TestSuiteModel get() {
     Description root = request.getRunner().getDescription();
     if (!root.isSuite()) {
-      throw new IllegalArgumentException("Top test must be a suite");
+      return builder.build(suiteName);
+    } else {
+      return builder.build(suiteName, root);
     }
-    return builder.build(suiteName, root);
   }
 }

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/junit4/JUnit4TestModelBuilderTest.java
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/junit4/JUnit4TestModelBuilderTest.java
@@ -32,6 +32,7 @@ import com.google.testing.junit.runner.sharding.testing.StubShardingEnvironment;
 import com.google.testing.junit.runner.util.FakeTicker;
 import com.google.testing.junit.runner.util.Ticker;
 import java.util.List;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runner.Request;
@@ -92,6 +93,18 @@ public class JUnit4TestModelBuilderTest {
   }
 
   @Test
+  public void testCreateModel_topLevelIgnore() throws Exception {
+    Class<?> testClass = SampleTestCaseWithTopLevelIgnore.class;
+    Request request = Request.classWithoutSuiteMethod(testClass);
+    String testClassName = testClass.getCanonicalName();
+    JUnit4TestModelBuilder modelBuilder =
+        builder(request, testClassName, stubShardingEnvironment, null, xmlResultWriter);
+
+    TestSuiteModel testSuiteModel = modelBuilder.get();
+    assertThat(testSuiteModel.getNumTestCases()).isEqualTo(0);
+  }
+
+  @Test
   public void testCreateModel_singleTestClass() throws Exception {
     Class<?> testClass = SampleTestCaseWithTwoTests.class;
     Request request = Request.classWithoutSuiteMethod(testClass);
@@ -140,7 +153,6 @@ public class JUnit4TestModelBuilderTest {
     assertThat(model.getNumTestCases()).isEqualTo(1);
   }
 
-
   /** Sample test case with two tests. */
   @RunWith(JUnit4.class)
   public static class SampleTestCaseWithTwoTests {
@@ -153,6 +165,18 @@ public class JUnit4TestModelBuilderTest {
     }
   }
 
+  /** Sample test case with top level @Ignore */
+  @Ignore
+  @RunWith(JUnit4.class)
+  public static class SampleTestCaseWithTopLevelIgnore {
+    @Test
+    public void testOne() {
+    }
+
+    @Test
+    public void testTwo() {
+    }
+  }
 
   /** Sample test case with one test. */
   @RunWith(JUnit4.class)
@@ -161,7 +185,6 @@ public class JUnit4TestModelBuilderTest {
     public void testOne() {
     }
   }
-
 
   /** Sample suite with one test. */
   @RunWith(Suite.class)


### PR DESCRIPTION
Currently a test class annotated with `@Ignore` will cause the test runner to fail with

```
    Exception in thread "main" java.lang.IllegalArgumentException: Top test must be a suite
        at com.google.testing.junit.runner.junit4.JUnit4TestModelBuilder.get(JUnit4TestModelBuilder.java:53)
```

This happens because a test class with `@Ignore` will have 0 tests in the `Request` created from the test class.

This change treats classes with no tests (e.g. no `@Test` annotations or `@Ignore` at class level) as an empty test suite. The main motivation behind this is allowing an entire test class to be ignored (e.g. to quickly deal with a flaky test) without having to modify the BUILD file. This is desirable in order to reduce the likelihood that a developer forgets to update the BUILD file when removing the `@Ignore` annotation.

Not sure if this should be flagged off or not? I don't imagine anyone relying on the check that I'm removing, but I am making it a bit more permissive so might be a good idea?