### PR TITLE
Improve Windows error when arg list is too long 

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -102,3 +102,4 @@ Peter Mounce <pete@neverrunwithscissors.com>
 Yue Gan <yueg@google.com>
 Yun Peng <pcloudy@google.com>
 Dmitry Babkin <dbabkin@google.com>
+Jacob Parker <jacob@solidangle.ca>


### PR DESCRIPTION
CreateProcess has a limit of 32768 for its lpCommandLine argument.
Currently Bazel will emit an error about a parameter to CreateProcess
being incorrect if we exceed that. This change makes it print a more
informative error message (but still fail.)

---

This "fixes" #4083. I don't think there is anything more Bazel could do here (creating Windows-compatible build rules is just going to be a bit tough in general, I think.)

---

I'm not super happy about this: the error message is a little weird because this may not be the result of an action. It's easiest to put the check here because 1) it's platform specific 2) the length calculation depends on things like quoting which are done in here.

I opted to keep this `IOException` because it's not something I expect is a common scenario and this involves the least plumbing. Objections? (I'm not a Java person myself, not familiar with the idioms.)

---

I haven't tested this at all. I haven't got Bazel building on Windows yet (this builds on Linux though, heh.) I'm not sure this is even the right spot for the change :) **I'll confirm, though**. In particular I need to check that the arithmetic is correct.