### PR TITLE
Minor fixes to spacing in help messages

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelStrategyModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelStrategyModule.java
@@ -56,8 +56,8 @@ public class BazelStrategyModule extends BlazeModule {
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
-          "Specify how to execute genrules."
-              + "'standalone' means run all of them locally."
+          "Specify how to execute genrules. "
+              + "'standalone' means run all of them locally. "
               + "'sandboxed' means run them in namespaces based sandbox (available only on Linux)"
     )
     public String genruleStrategy;

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequestOptions.java
@@ -244,7 +244,7 @@ public class BuildRequestOptions extends OptionsBase {
     defaultValue = "",
     help =
         "Specifies which output groups of the top-level targets to build. If omitted, a default "
-            + "set of output groups are built. When specified the default set is overridden."
+            + "set of output groups are built. When specified the default set is overridden. "
             + "However you may use --output_groups=+<output_group> or "
             + "--output_groups=-<output_group> to instead modify the set of output groups."
   )

--- a/src/main/java/com/google/devtools/build/lib/pkgcache/LoadingOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/pkgcache/LoadingOptions.java
@@ -130,7 +130,7 @@ public class LoadingOptions extends OptionsBase {
             + "optionally preceded with '-' to specify excluded languages. Only those "
             + "test targets will be found that are written in the specified languages. "
             + "The name used for each language should be the same as the language prefix in the "
-            + "*_test rule, e.g. one of 'cc', 'java', 'py', etc."
+            + "*_test rule, e.g. one of 'cc', 'java', 'py', etc. "
             + "This option affects --build_tests_only behavior and the test command."
   )
   public List<String> testLangFilterList;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
@@ -33,7 +33,7 @@ public final class RemoteOptions extends OptionsBase {
     documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
     effectTags = {OptionEffectTag.UNKNOWN},
     help =
-        "A base URL for a RESTful cache server for storing build artifacts."
+        "A base URL for a RESTful cache server for storing build artifacts. "
             + "It has to support PUT, GET, and HEAD requests."
   )
   public String remoteRestCache;


### PR DESCRIPTION
A few help messages were missing a space after the period at the end of a sentence.