### PR TITLE
RestBlobStore: add missing CAS_PREFIX

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/RestBlobStore.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/RestBlobStore.java
@@ -79,7 +79,7 @@ public final class RestBlobStore implements SimpleBlobStore {
   @Override
   public boolean containsKey(String key) throws IOException {
     HttpClient client = clientFactory.build();
-    HttpHead head = new HttpHead(baseUrl + "/" + key);
+    HttpHead head = new HttpHead(baseUrl + "/" + CAS_PREFIX + "/" + key);
     return client.execute(
         head,
         response -> {


### PR DESCRIPTION
According to the [SimpleBlobStore interface](https://github.com/bazelbuild/bazel/blob/0.7.0/src/main/java/com/google/devtools/build/lib/remote/blobstore/SimpleBlobStore.java), `containsKey` should look up blobs in the CAS. However, the URL it requests is missing `CAS_PREFIX`, so it will never find anything.

AFAICT, `containsKey` is only used in the demo worker, which is probably the reason it was overlooked when the CAS/AC prefixes were added.