### PR TITLE
Enable internal C++ compiler path

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -25,8 +25,8 @@ load(
     "@bazel_tools//tools/cpp:unix_cc_configure.bzl",
     "get_escaped_cxx_inc_directories",
     "tpl",
+    "get_cc",
     "get_env",
-    "find_cc",
     "configure_unix_toolchain"
 )
 
@@ -57,7 +57,7 @@ def configure_osx_toolchain(repository_ctx):
       repository_ctx,
       Label("@bazel_tools//tools/osx:xcode_locator.m"))
   if xcode_toolchains:
-    cc = find_cc(repository_ctx)
+    cc = get_cc(repository_ctx)
     tpl(repository_ctx, "osx_cc_wrapper.sh", {
         "%{cc}": escape_string(str(cc)),
         "%{env}": escape_string(get_env(repository_ctx))

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -330,24 +330,20 @@ def _coverage_feature(darwin):
   """
 
 
-def find_cc(repository_ctx):
-  """Find the C++ compiler. Doesn't %-escape the result."""
+def get_cc(repository_ctx):
+  """Gets the C++ compiler. Doesn't %-escape the result."""
   cc_name = "gcc"
   cc_environ = repository_ctx.os.environ.get("CC")
-  cc_paren = ""
   if cc_environ != None:
     cc_environ = cc_environ.strip()
     if cc_environ:
-      cc_name = cc_environ
-      cc_paren = " (%s)" % cc_environ
-  if cc_name.startswith("/"):
-    # Absolute path, maybe we should make this suported by our which function.
-    return cc_name
+      return cc_environ
+
   cc = repository_ctx.which(cc_name)
   if cc == None:
     fail(
-        ("Cannot find gcc or CC%s, either correct your path or set the CC"
-         + " environment variable") % cc_paren)
+        ("Cannot find gcc. Either check that a `%s` file is available via PATH"
+         + " or set the CC environment variable") % cc_name)
   return cc
 
 
@@ -355,7 +351,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value):
   """Configure C++ toolchain on Unix platforms."""
   repository_ctx.file("tools/cpp/empty.cc", "int main() {}")
   darwin = cpu_value == "darwin"
-  cc = find_cc(repository_ctx)
+  cc = get_cc(repository_ctx)
   tool_paths = _get_tool_paths(repository_ctx, darwin,
                                "cc_wrapper.sh" if darwin else str(cc))
   crosstool_content = _crosstool_content(repository_ctx, cc, cpu_value, darwin)


### PR DESCRIPTION
Enable overriding path to C++ compiler without having to go through `which` validation.
Introduces a new `BAZEL_CC` environment variable, which gets evaluated before `CC`.