### PR TITLE
Fix broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ Build and test software of any size, quickly and reliably.
 
     - [Build C++](https://docs.bazel.build/tutorial/cpp.html)
     - [Build Java](https://docs.bazel.build/tutorial/java.html)
-    - [Android and iOS](https://docs.bazel.build/tutorial/app.html)
+    - [Android](https://docs.bazel.build/tutorial/android-app.html) and [iOS](https://docs.bazel.build/tutorial/ios-app.html)
 
 ## Documentation
 
   * [Bazel command line](https://docs.bazel.build/user-manual.html)
   * [Rule reference](https://docs.bazel.build/be/overview.html)
   * [Use the query command](https://docs.bazel.build/query.html)
-  * [Extend Bazel](https://docs.bazel.build/skylark/index.html)
+  * [Extend Bazel](https://docs.bazel.build/skylark/concepts.html)
   * [Write tests](https://docs.bazel.build/test-encyclopedia.html)
   * [Roadmap](https://bazel.build/roadmap.html)
   * [Who is using Bazel?](https://github.com/bazelbuild/bazel/wiki/Bazel-Users)


### PR DESCRIPTION
This does not remove the "Who is using Bazel?" link, which isn't a 404 but leads to an empty GitHub page.