### PR TITLE
Enable using workspace_name in CROSSTOOL template

### DIFF
--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -396,4 +396,5 @@ def configure_unix_toolchain(repository_ctx, cpu_value):
       "%{msvc_link_path}": "",
       "%{msvc_lib_path}": "",
       "%{compilation_mode_content}": "",
+      "%{workspace_name}": repository_ctx.name,
   })


### PR DESCRIPTION
This way we can reference hermetic libraries.