### PR TITLE
Docs: (minor) Change "chaiscript" to "mockascript"

### DIFF
--- a/site/docs/skylark/deploying.md
+++ b/site/docs/skylark/deploying.md
@@ -39,24 +39,24 @@ Every rule repository should have a certain layout so that users can quickly
 understand new rules.
 
 For example, suppose we are writing new Skylark rules for the (make-believe)
-chaiscript language. We would have the following structure:
+mockascript language. We would have the following structure:
 
 ```
 .travis.yml
 README.md
 WORKSPACE
-chaiscript/
+mockascript/
   BUILD
-  chaiscript.bzl
+  mockascript.bzl
 tests/
   BUILD
   some_test.sh
   another_test.py
 examples/
   BUILD
-  bin.chai
-  lib.chai
-  test.chai
+  bin.mocs
+  lib.mocs
+  test.mocs
 ```
 
 ### README.md


### PR DESCRIPTION
Avoids ambiguity; "chaiscript" is a real language. (See http://chaiscript.com )

Satisfies (unreported issue): https://twitter.com/lefticus/status/932423849928519681
Resolves #4133.