### PR TITLE
Avoid a race condition in the remote upload

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/cache/DigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/DigestUtils.java
@@ -174,6 +174,12 @@ public class DigestUtils {
     return mtimeBeforeFirstDigest.getOrDefault(resolvedPath, -1L);
   }
 
+  public static void init() {
+    // It's important to clear the cache of timestamps when a new build is started, so that we
+    // don't keep stale timestamps from previous builds.
+    mtimeBeforeFirstDigest.clear();
+  }
+
   /**
    * Obtain file's MD5 metadata using synchronized method, ensuring that system
    * is not overloaded in case when multiple threads are requesting MD5
@@ -190,8 +196,6 @@ public class DigestUtils {
   }
 
   private static byte[] getDigestInternal(Path path) throws IOException {
-    cacheMtimeBeforeFirstDigest(path);
-
     long startTime = BlazeClock.nanoTime();
     byte[] digest = path.getDigest();
 

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/DigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/DigestUtils.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
@@ -128,8 +130,49 @@ public class DigestUtils {
    */
   private static volatile Cache<CacheKey, byte[]> globalCache = null;
 
+  /**
+   * Map from a path to the last-modified time of that file before the first time that its digest
+   * was computed.
+   *
+   * <p>The paths stored here must already have all symbolic links resolved.
+   */
+  private static volatile ConcurrentMap<Path, Long> mtimeBeforeFirstDigest =
+      new ConcurrentHashMap<>();
+
   /** Private constructor to prevent instantiation of utility class. */
   private DigestUtils() {}
+
+  /**
+   * Caches the last-modified time of a file before the first time that its digest is computed.
+   *
+   * <p>This must be called *before* the file's digest has been computed, because the purpose of
+   * this cache is to detect whether a file was modified after the digest was computed, and we need
+   * to make sure we correctly handle the case that the file was modified *while* its digest was
+   * being computed.
+   *
+   * <p>If the cache already contains an entry for this file, the cache is not changed.
+   *
+   * @param path Path of the file.
+   * @throws IOException if reading the file status data fails
+   */
+  private static void cacheMtimeBeforeFirstDigest(Path path) throws IOException {
+    Path resolvedPath = path.resolveSymbolicLinks();
+    long mtime = path.stat().getLastModifiedTime();
+    mtimeBeforeFirstDigest.putIfAbsent(resolvedPath, mtime);
+  }
+
+  /**
+   * Gets the last-modified time that a file had before the first time its digest was computed.
+   *
+   * @param path Path of the file.
+   * @return the last-modified time that the file had before the first time its digest was computed,
+   * or -1 if none was recorded.
+   * @throws IOException if resolving the file's symbolic links fails
+   */
+  public static long getMtimeBeforeFirstDigest(Path path) throws IOException {
+    Path resolvedPath = path.resolveSymbolicLinks();
+    return mtimeBeforeFirstDigest.getOrDefault(resolvedPath, -1L);
+  }
 
   /**
    * Obtain file's MD5 metadata using synchronized method, ensuring that system
@@ -147,6 +190,8 @@ public class DigestUtils {
   }
 
   private static byte[] getDigestInternal(Path path) throws IOException {
+    cacheMtimeBeforeFirstDigest(path);
+
     long startTime = BlazeClock.nanoTime();
     byte[] digest = path.getDigest();
 
@@ -205,6 +250,8 @@ public class DigestUtils {
    */
   public static byte[] getDigestOrFail(Path path, long fileSize)
       throws IOException {
+    cacheMtimeBeforeFirstDigest(path);
+
     byte[] digest = path.getFastDigest();
 
     if (digest != null && !path.isValidDigest(digest)) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
 import com.google.devtools.build.lib.actions.Spawns;
+import com.google.devtools.build.lib.actions.cache.DigestUtils;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.events.Event;
@@ -283,8 +284,14 @@ class RemoteSpawnRunner implements SpawnRunner {
     return command.build();
   }
 
-  private Map<Path, Long> getInputCtimes(SortedMap<PathFragment, ActionInput> inputMap) {
-    HashMap<Path, Long>  ctimes = new HashMap<>();
+  private interface Mtime {
+    long get(Path path) throws IOException;
+  }
+
+  private Map<Path, Long> getInputMtimes(
+      SortedMap<PathFragment, ActionInput> inputMap,
+      Mtime mtime) {
+    HashMap<Path, Long> mtimes = new HashMap<>();
     for (Map.Entry<PathFragment, ActionInput> e : inputMap.entrySet()) {
       ActionInput input = e.getValue();
       if (input == SpawnInputExpander.EMPTY_FILE || input instanceof VirtualActionInput) {
@@ -292,15 +299,15 @@ class RemoteSpawnRunner implements SpawnRunner {
       }
       Path path = execRoot.getRelative(input.getExecPathString());
       try {
-        ctimes.put(path, path.stat().getLastChangeTime());
+        mtimes.put(path, mtime.get(path));
       } catch (IOException ex) {
         // Put a token value indicating an exception; this is used so that if the exception
         // is raised both before and after the execution, it is ignored, but if it is raised only
         // one of the times, it triggers a remote cache upload skip.
-        ctimes.put(path, -1L);
+        mtimes.put(path, -1L);
       }
     }
-    return ctimes;
+    return mtimes;
   }
 
   /**
@@ -330,12 +337,15 @@ class RemoteSpawnRunner implements SpawnRunner {
       RemoteActionCache remoteCache,
       ActionKey actionKey)
       throws ExecException, IOException, InterruptedException {
-    Map<Path, Long> ctimesBefore = getInputCtimes(inputMap);
     SpawnResult result = fallbackRunner.exec(spawn, policy);
-    Map<Path, Long> ctimesAfter = getInputCtimes(inputMap);
-    for (Map.Entry<Path, Long> e : ctimesBefore.entrySet()) {
-      // Skip uploading to remote cache, because an input was modified during execution.
-      if (!ctimesAfter.get(e.getKey()).equals(e.getValue())) {
+    Map<Path, Long> mtimesBefore = getInputMtimes(inputMap,
+        path -> DigestUtils.getMtimeBeforeFirstDigest(path));
+    Map<Path, Long> mtimesAfter = getInputMtimes(inputMap,
+        path -> path.stat().getLastModifiedTime());
+    for (Map.Entry<Path, Long> e : mtimesBefore.entrySet()) {
+      // Skip uploading to remote cache, because an input was modified after its digest was
+      // computed.
+      if (!mtimesAfter.get(e.getKey()).equals(e.getValue())) {
         return result;
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/runtime/CacheFileDigestsModule.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CacheFileDigestsModule.java
@@ -61,6 +61,8 @@ public class CacheFileDigestsModule extends BlazeModule {
   public void executorInit(CommandEnvironment env, BuildRequest request, ExecutorBuilder builder) {
     super.executorInit(env, request, builder);
 
+    DigestUtils.init();
+
     ExecutionOptions options = request.getOptions(ExecutionOptions.class);
     if (lastKnownCacheSize == null
         || options.cacheSizeForComputedFileDigests != lastKnownCacheSize) {


### PR DESCRIPTION
Avoid triggering #3360. Immediately before a file's digest is computed for the first time, cache its last-modified time (mtime). Later, before uploading output artifacts, check if any of the inputs' mtimes have changed since their digest was computed, and if so, don't upload the outputs to the remote cache.

We need to use mtime, not ctime (last-change time), because some files (e.g. genrule-setup.sh) have their metadata changed after their digest is computed.

Also, the cache needs to resolve symbolic links, because some files are accessed from multiple paths that all resolve to the same file.