### PR TITLE
Fix broken link for "C++ common use cases"

### DIFF
--- a/site/docs/bazel-and-cpp.md
+++ b/site/docs/bazel-and-cpp.md
@@ -21,7 +21,7 @@ projects with Bazel.
 The following resources will help you work with Bazel on C++ projects:
 
 *  [Tutorial: Building a C++ project](tutorial/cpp.html)
-*  [C++ common use cases](tutorial/cpp-use-cases.html)
+*  [C++ common use cases](cpp-use-cases.html)
 *  [C/C++ rules](https://docs.bazel.build/versions/master/be/c-cpp.html)
 
 ## Best practices


### PR DESCRIPTION
Links to cpp use cases outside of tutorial directory.

Fixes #4174  (I think?)