### PR TITLE
Apply % encoding to CPLUS_INCLUDE_PATH.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -362,6 +362,7 @@ filegroup(
         "//src/test/java/com/google/devtools/build/docgen:srcs",
         "//src/test/java/com/google/devtools/build/lib:srcs",
         "//src/test/java/com/google/devtools/build/skyframe:srcs",
+        "//src/test/java/com/google/devtools/build/lib/skylark/cpp:srcs",
         "//src/test/java/com/google/devtools/common/options:srcs",
         "//src/test/py/bazel:srcs",
         "//src/test/shell:srcs",

--- a/src/test/java/com/google/devtools/build/lib/skylark/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skylark/cpp/BUILD
@@ -1,0 +1,51 @@
+java_test(
+    name = "SkylarkTests",
+    srcs = glob([
+        "*.java",
+    ]),
+    size = "small",
+    test_class = "com.google.devtools.build.lib.AllTests",
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib:bazel-main",
+        "//src/main/java/com/google/devtools/build/lib:bazel-rules",
+        "//src/main/java/com/google/devtools/build/lib:build-base",
+        "//src/main/java/com/google/devtools/build/lib:events",
+        "//src/main/java/com/google/devtools/build/lib:java-compilation",
+        "//src/main/java/com/google/devtools/build/lib:java-rules",
+        "//src/main/java/com/google/devtools/build/lib:packages",
+        "//src/main/java/com/google/devtools/build/lib:python-rules",
+        "//src/main/java/com/google/devtools/build/lib:skylarkinterface",
+        "//src/main/java/com/google/devtools/build/lib:util",
+        "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/collect",
+        "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
+        "//src/main/java/com/google/devtools/build/lib/concurrent",
+        "//src/main/java/com/google/devtools/build/lib/rules/cpp",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/skyframe",
+        "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
+        "//src/test/java/com/google/devtools/build/lib:actions_testutil",
+        "//src/test/java/com/google/devtools/build/lib:analysis_testutil",
+        "//src/test/java/com/google/devtools/build/lib:foundations_testutil",
+        "//src/test/java/com/google/devtools/build/lib:packages_testutil",
+        "//src/test/java/com/google/devtools/build/lib:test_runner",
+        "//src/test/java/com/google/devtools/build/lib:testutil",
+        "//third_party:guava",
+        "//third_party:guava-testlib",
+        "//third_party:jsr305",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+    data = [
+        "//tools/cpp:lib_cc_configure.bzl",
+    ],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = [
+        "BUILD",
+        "SkylarkToolchainTest.java",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/src/test/java/com/google/devtools/build/lib/skylark/cpp/SkylarkToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skylark/cpp/SkylarkToolchainTest.java
@@ -1,0 +1,208 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.skylark.cpp;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static com.google.devtools.build.lib.analysis.OutputGroupProvider.INTERNAL_SUFFIX;
+import static org.junit.Assert.fail;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.FileProvider;
+import com.google.devtools.build.lib.analysis.FilesToRunProvider;
+import com.google.devtools.build.lib.analysis.OutputGroupProvider;
+import com.google.devtools.build.lib.analysis.RunfilesProvider;
+import com.google.devtools.build.lib.analysis.configuredtargets.FileConfiguredTarget;
+import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
+import com.google.devtools.build.lib.analysis.test.InstrumentedFilesProvider;
+import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.events.EventHandler;
+import com.google.devtools.build.lib.events.EventKind;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.packages.AttributeContainer;
+import com.google.devtools.build.lib.packages.BuildFileContainsErrorsException;
+import com.google.devtools.build.lib.packages.Info;
+import com.google.devtools.build.lib.packages.Provider;
+import com.google.devtools.build.lib.packages.SkylarkProvider;
+import com.google.devtools.build.lib.packages.SkylarkProvider.SkylarkKey;
+import com.google.devtools.build.lib.skyframe.PackageFunction;
+import com.google.devtools.build.lib.skyframe.SkyFunctions;
+import com.google.devtools.build.lib.skyframe.SkylarkImportLookupFunction;
+import com.google.devtools.build.lib.syntax.Runtime;
+import com.google.devtools.build.lib.syntax.SkylarkList;
+import com.google.devtools.build.lib.syntax.SkylarkList.MutableList;
+import com.google.devtools.build.lib.syntax.SkylarkNestedSet;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.skyframe.InMemoryMemoizingEvaluator;
+import com.google.devtools.build.skyframe.SkyFunction;
+import com.google.devtools.build.skyframe.SkyFunctionName;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Integration tests for Skylark CPP.
+ */
+@RunWith(JUnit4.class)
+public class SkylarkToolchainTest extends BuildViewTestCase {
+
+  @Before
+  public void createLib() throws Exception {
+    Path path = FileSystems.getDefault().getPath("tools/cpp/lib_cc_configure.bzl");
+    List<String> lineList = Files.readAllLines(path, StandardCharsets.UTF_8);
+    String[] lines = new String[lineList.size()];
+    lineList.toArray(lines);
+    scratch.file(
+        "tools/cpp/lib_cc_configure.bzl",
+        lines);
+    scratch.file(
+        "tools/cpp/BUILD",
+        "");
+  }
+
+  @Before
+  public void createEmptyRule() throws Exception {
+    scratch.file(
+        "test/skylark/empty.bzl",
+        "def _empty(ctx):",
+        "  pass",
+        "empty = rule(implementation = _empty)");
+  }
+
+  @Before
+  public void createAssertions() throws Exception {
+    scratch.file(
+      "test/skylark/assert.bzl",
+      "def assertIsNone(arg):",
+      "  if arg != None:",
+      "    fail('Value is %s. Expected None.' % arg)",
+      "def assertListEqual(list1, list2):",
+      "  eq = len(list1) == len(list2)",
+      "  if eq:",
+      "    for i, l in enumerate(list1):",
+      "      r = list2[i]",
+      "      if l != r:",
+      "        eq = False",
+      "        break",
+      "  if eq:",
+      "    return",
+      "  fail('Lists do not match {} <> {}'.format(list1, list2))",
+      "def assertTrue(arg):",
+      "  if not bool(arg):",
+      "    fail('Value is %s. Expected convertible to True.' % arg)");
+  }
+
+  @Test
+  public void testEscaping() throws Exception {
+    scratch.file(
+        "test/skylark/extension.bzl",
+        "load('//tools/cpp:lib_cc_configure.bzl', 'escape_string', 'unescape_string')",
+        "load('//test/skylark:empty.bzl', 'empty')",
+        "def test(arg, **kwargs):",
+        "  escaped = escape_string(arg)",
+        "  result = unescape_string(escaped)",
+        "  if result != arg:",
+        "    fail('Could not reverse escaping {} -escape> {} -unescape> {}'.format(arg, escaped, result))",
+        "  return empty(**kwargs)");
+
+    scratch.file(
+        "test/skylark/BUILD",
+        "load('//test/skylark:extension.bzl', 'test')",
+        "test('\\my%simple;%%test!%%%for?%%escaping:%works/', name = 'test_target')");
+
+    getTarget("//test/skylark:test_target");
+  }
+
+  @Test
+  public void testError() throws Exception {
+    scratch.file(
+        "test/skylark/extension.bzl",
+        "load('//tools/cpp:lib_cc_configure.bzl', 'get_escaping_error')",
+        "load('//test/skylark:assert.bzl', 'assertIsNone', 'assertTrue')",
+        "load('//test/skylark:empty.bzl', 'empty')",
+        "def test(**kwargs):",
+        "  error = get_escaping_error('foo')",
+        "  assertIsNone(error)",
+        "  error = get_escaping_error('foo;', additionals = ';')",
+        "  assertTrue(error)",
+        "  error = get_escaping_error('foo%a')",
+        "  assertTrue(error)",
+        "  error = get_escaping_error('foo%')",
+        "  assertTrue(error)",
+        "  error = get_escaping_error('foo%;bar', additionals = ';')",
+        "  assertIsNone(error)",
+        "  empty(**kwargs)");
+
+    scratch.file(
+        "test/skylark/BUILD",
+        "load('//test/skylark:extension.bzl', 'test')",
+        "test(name = 'test_target')");
+
+    getTarget("//test/skylark:test_target");
+  }
+
+  @Test
+  public void testErrorFail() throws Exception {
+
+    scratch.file(
+      "test/skylark/extension.bzl",
+      "load('//tools/cpp:lib_cc_configure.bzl', 'get_escaping_error')",
+      "load('//test/skylark:empty.bzl', 'empty')",
+      "def test(**kwargs):",
+      "  get_escaping_error('foo', additionals = '%')",
+      "  empty(**kwargs)");
+
+    scratch.file(
+        "test/skylark/BUILD",
+        "load('//test/skylark/extension.bzl', 'test')",
+        "test(name = 'test_target')");
+    
+    ConfiguredTarget target = getConfiguredTarget("//test/skylark:test_target");
+    assertThat(target).isNull();
+    assertThat(view.hasErrors(target)).isTrue();
+  }
+
+  @Test
+  public void testEscapedSplit() throws Exception {
+    scratch.file(
+      "test/skylark/extension.bzl",
+      "load('//tools/cpp:lib_cc_configure.bzl', 'split_escaped_by_sep')",
+      "load('//test/skylark:assert.bzl', 'assertListEqual')",
+      "load('//test/skylark:empty.bzl', 'empty')",
+      "def test(**kwargs):",
+      "  result = split_escaped_by_sep('test:file', sep = ':')",
+      "  assertListEqual(result, ['test', 'file'])",
+      "  empty(**kwargs)");
+
+    scratch.file(
+        "test/skylark/BUILD",
+        "load('//test/skylark:extension.bzl', 'test')",
+        "test(name = 'test_target')");
+
+    getTarget("//test/skylark:test_target");
+  }
+}

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -19,6 +19,8 @@ load(
     "@bazel_tools//tools/cpp:lib_cc_configure.bzl",
     "escape_string",
     "get_env_var",
+    "split_escaped_by_sep",
+    "unescape_string",
     "which",
     "tpl",
 )
@@ -98,14 +100,15 @@ def _get_tool_paths(repository_ctx, darwin, cc):
 
 def _escaped_cplus_include_paths(repository_ctx):
   """Use ${CPLUS_INCLUDE_PATH} to compute the %-escaped list of flags for cxxflag."""
-  if "CPLUS_INCLUDE_PATH" in repository_ctx.os.environ:
-    result = []
-    for p in repository_ctx.os.environ["CPLUS_INCLUDE_PATH"].split(":"):
-      p = escape_string(str(repository_ctx.path(p)))  # Normalize the path
-      result.append("-I" + p)
-    return result
-  else:
-    return []
+  result = []
+  include_paths = repository_ctx.os.environ.get("CPLUS_INCLUDE_PATH", default = [])
+  for escaped in split_escaped_by_sep(include_paths, ":"):
+    # Have to remove escaping to be able to use path call
+    unescaped = unescape_string(escaped.replace("%:", ":"))
+    p = str(repository_ctx.path(unescaped))  # Normalize the path
+    escaped = escape_string(p)
+    result.append("-I" + escaped)
+  return result
 
 
 _INC_DIR_MARKER_BEGIN = "#include <...>"


### PR DESCRIPTION
As a result, `%` and `:` from now on need to be escaped.
Errors will be shown when unescaped characters are detected.
It silently breaks if there is a `%:` anywhere in CPLUS_INCLUDE_PATH.
With proper encoding this needs to be `%%:` now.

Changes:
- Reverse `escape_string` with `unescape_string`
- Proper escaping can be checked with `get_escaping_error` (with returned error being None)
- Split of encoded string with `split_escaped_by_sep`
- Add tests for all latest macros