### PR TITLE
Add . to the bootstrap protoc include paths

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -189,7 +189,9 @@ if [ -z "${BAZEL_SKIP_JAVA_COMPILATION}" ]; then
 
         log "Compiling Java stubs for protocol buffers..."
         for f in $PROTO_FILES ; do
-            run "${PROTOC}" -Isrc/main/protobuf/ \
+            run "${PROTOC}" \
+                -I. \
+                -Isrc/main/protobuf/ \
                 -Isrc/main/java/com/google/devtools/build/lib/buildeventstream/proto/ \
                 --java_out=${OUTPUT_DIR}/src \
                 --plugin=protoc-gen-grpc="${GRPC_JAVA_PLUGIN-}" \


### PR DESCRIPTION
This fixes the following error I got when building from scratch on Raspbian:

```
src/main/protobuf/invocation_policy.proto: File not found.
src/main/protobuf/command_line.proto: File not found.
```

Note:
```
protoc --version
libprotoc 3.0.0
```