### PR TITLE
Change error on adding a directory to the remote cache to be non-fatal

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
@@ -197,7 +197,7 @@ public final class SimpleBlobStoreActionCache implements RemoteActionCache {
       if (file.isDirectory()) {
         // TODO(olaola): to implement this for a directory, will need to create or pass a
         // TreeNodeRepository to call uploadTree.
-        throw new UnsupportedOperationException("Storing a directory is not yet supported.");
+        throw new IOException("Storing a directory is not yet supported.");
       }
       // TODO(olaola): inline small file contents here.
       // First put the file content to cache.


### PR DESCRIPTION
@ulfjack @buchgr  - I'm resubmitting https://github.com/bazelbuild/bazel/pull/3984 on behalf of @mterring to get past CLA issues that are holding it up from merging.

This is a temporary fix for the issue https://github.com/bazelbuild/bazel/issues/3891 while we wait for https://github.com/bazelbuild/bazel/pull/4011 to be reviewed and tested

