### PR TITLE
add option cores for jobs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/LocalHostCapacity.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/LocalHostCapacity.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.util.OS;
  */
 @ThreadCompatible
 public final class LocalHostCapacity {
+  private static final double EFFECTIVE_CPUS_PER_HYPERTHREADED_CPU = 0.6;
 
   private static final OS currentOS = OS.getCurrent();
   private static ResourceSet localHostCapacity;
@@ -30,20 +31,24 @@ public final class LocalHostCapacity {
   private LocalHostCapacity() {}
 
   public static ResourceSet getLocalHostCapacity() {
+    return getLocalHostCapacity(EFFECTIVE_CPUS_PER_HYPERTHREADED_CPU);
+  }
+
+  public static ResourceSet getLocalHostCapacity(double cpusPerHyperthreadedCpuFactor) {
     if (localHostCapacity == null) {
-      localHostCapacity = getNewLocalHostCapacity();
+      localHostCapacity = getNewLocalHostCapacity(cpusPerHyperthreadedCpuFactor);
     }
     return localHostCapacity;
   }
 
-  private static ResourceSet getNewLocalHostCapacity() {
+  private static ResourceSet getNewLocalHostCapacity(double cpusPerHyperthreadedCpuFactor) {
     ResourceSet localResources = null;
     switch (currentOS) {
       case DARWIN:
-        localResources = LocalHostResourceManagerDarwin.getLocalHostResources();
+        localResources = LocalHostResourceManagerDarwin.getLocalHostResources(cpusPerHyperthreadedCpuFactor);
         break;
       case LINUX:
-        localResources = LocalHostResourceManagerLinux.getLocalHostResources();
+        localResources = LocalHostResourceManagerLinux.getLocalHostResources(cpusPerHyperthreadedCpuFactor);
         break;
       default:
         break;

--- a/src/main/java/com/google/devtools/build/lib/actions/LocalHostResourceManagerDarwin.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/LocalHostResourceManagerDarwin.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 public class LocalHostResourceManagerDarwin {
   private static final Boolean JNI_UNAVAILABLE =
       "0".equals(System.getProperty("io.bazel.EnableJni"));
-  private static final double EFFECTIVE_CPUS_PER_HYPERTHREADED_CPU = 0.6;
 
   private static int getLogicalCpuCount() throws IOException {
     return (int) NativePosixSystem.sysctlbynameGetLong("hw.logicalcpu");
@@ -38,7 +37,7 @@ public class LocalHostResourceManagerDarwin {
     return NativePosixSystem.sysctlbynameGetLong("hw.memsize") / 1E6;
   }
 
-  public static ResourceSet getLocalHostResources() {
+  public static ResourceSet getLocalHostResources(double cpusPerHyperthreadedCpuFactor) {
     if (JNI_UNAVAILABLE) {
       return null;
     }
@@ -50,7 +49,7 @@ public class LocalHostResourceManagerDarwin {
 
       return ResourceSet.create(
           ramMb,
-          logicalCpuCount * (hyperthreading ? EFFECTIVE_CPUS_PER_HYPERTHREADED_CPU : 1.0),
+          logicalCpuCount * (hyperthreading ? cpusPerHyperthreadedCpuFactor : 1.0),
           1.0,
           Integer.MAX_VALUE);
     } catch (IOException e) {

--- a/src/main/java/com/google/devtools/build/lib/actions/LocalHostResourceManagerLinux.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/LocalHostResourceManagerLinux.java
@@ -48,17 +48,16 @@ public class LocalHostResourceManagerLinux {
     return getMemoryInMbHelper(MEM_INFO_FILE);
   }
 
-  public static ResourceSet getLocalHostResources() {
+  public static ResourceSet getLocalHostResources(double cpusPerHyperthreadedCpuFactor) {
     try {
       int logicalCpuCount = getLogicalCpuCount();
       int physicalCpuCount = getPhysicalCpuCount(logicalCpuCount);
       double ramMb = getMemoryInMb();
 
       boolean hyperthreading = (logicalCpuCount != physicalCpuCount);
-      final double EFFECTIVE_CPUS_PER_HYPERTHREADED_CPU = 0.6;
       return ResourceSet.create(
           ramMb,
-          logicalCpuCount * (hyperthreading ? EFFECTIVE_CPUS_PER_HYPERTHREADED_CPU : 1.0),
+          logicalCpuCount * (hyperthreading ? cpusPerHyperthreadedCpuFactor : 1.0),
           1.0,
           Integer.MAX_VALUE);
     } catch (IOException | ProcMeminfoParser.KeywordNotFoundException e) {

--- a/src/tools/remote_worker/src/main/java/com/google/devtools/build/remote/RemoteWorkerOptions.java
+++ b/src/tools/remote_worker/src/main/java/com/google/devtools/build/remote/RemoteWorkerOptions.java
@@ -130,6 +130,7 @@ public class RemoteWorkerOptions extends OptionsBase {
     help =
         "The maximum number of concurrent jobs to run. \"auto\" means to use a reasonable value"
             + " derived from the machine's hardware profile (e.g. the number of processors)."
+            + " \"cores\" means using number of available cpu cores."
             + " Values above " + MAX_JOBS + " are not allowed."
   )
   public int jobs;
@@ -156,8 +157,14 @@ public class RemoteWorkerOptions extends OptionsBase {
 
     @Override
     public Integer convert(String input) throws OptionsParsingException {
-      if (input.equals("auto")) {
-        int autoJobs = (int) Math.ceil(LocalHostCapacity.getLocalHostCapacity().getCpuUsage());
+      if (input.equals("auto") || input.equals("cores")) {
+        double cpuUsage;
+        if (input.equals("auto")) {
+          cpuUsage = LocalHostCapacity.getLocalHostCapacity().getCpuUsage();
+        } else {
+          cpuUsage = LocalHostCapacity.getLocalHostCapacity(1.0).getCpuUsage();
+        }
+        int autoJobs = (int) Math.ceil(cpuUsage);
         return Math.min(autoJobs, MAX_JOBS);
       } else {
         return super.convert(input);


### PR DESCRIPTION
As in #3814 shown a higher number of jobs could decrease build time. the option "--jobs=cores" uses the `cores*1.0` instead of `cores*0.6` for "auto".