### PR TITLE
Fix Bazel's compilation from scratch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+services:
+- docker
+script:
+# Ideally we'd just run compile.sh here:
+#
+# - VERBOSE=yes bash ./compile.sh
+#
+# Unfortunately bazel workers seem to hang in Travis right now so we test the
+# build from scratch in a controlled Docker container (that's... a docker
+# inside a docker inside a VM). This also helps test which packages are actually
+# required for a successful build from scratch (Travis otherwise has tons of
+# installed installed by default).
+#
+# Note: Verbosity is to avoid being killed by Travis after 10min w/o output.
+- echo "set -ex" > docker-test.sh
+- echo "apt-get update" >> docker-test.sh
+- echo "apt-get install -y automake g++ libtool make curl default-jdk git python unzip wget zip" >> docker-test.sh
+- echo "VERBOSE=yes bash ./compile.sh" >> docker-test.sh
+- docker run --rm -v `pwd`:`pwd` -w `pwd` -it debian:stable bash docker-test.sh

--- a/compile.sh
+++ b/compile.sh
@@ -80,6 +80,8 @@ fi
 
 source scripts/bootstrap/bootstrap.sh
 
+cp -r ${OUTPUT_DIR}/src derived
+
 new_step 'Building Bazel with Bazel'
 display "."
 log "Building output/bazel"

--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -128,7 +128,9 @@ function java_compilation() {
 
   run "${JAVAC}" -classpath "${classpath}" -sourcepath "${sourcepath}" \
       -d "${output}/classes" -source "$JAVA_VERSION" -target "$JAVA_VERSION" \
-      -encoding UTF-8 "@${paramfile}"
+      -J-Xmx800M \
+      -encoding UTF-8 \
+      "@${paramfile}"
 
   log "Extracting helper classes for $name..."
   for f in ${library_jars} ; do

--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -16,7 +16,19 @@
 
 # Script for building bazel from scratch without bazel
 
-PROTO_FILES=$(ls src/main/protobuf/*.proto src/main/java/com/google/devtools/build/lib/buildeventstream/proto/*.proto)
+PROTO_FILES=$(ls \
+  src/main/protobuf/*.proto \
+  src/main/java/com/google/devtools/build/lib/buildeventstream/proto/*.proto \
+  third_party/pprof/*.proto \
+  third_party/googleapis/google/devtools/remoteexecution/v1test/*.proto \
+  third_party/googleapis/google/devtools/build/v1/*.proto \
+  third_party/googleapis/google/api/*.proto \
+  third_party/googleapis/google/api/experimental/*.proto \
+  third_party/googleapis/google/rpc/*.proto \
+  third_party/googleapis/google/longrunning/*.proto \
+  third_party/googleapis/google/bytestream/*.proto \
+  third_party/googleapis/google/watcher/v1/*.proto \
+)
 LIBRARY_JARS=$(find third_party -name '*.jar' | grep -Fv /javac-9-dev-r3297-4.jar | grep -Fv /javac-9-dev-4023-3.jar | grep -Fv /javac7.jar | grep -Fv JavaBuilder | grep -Fv third_party/guava | grep -Fv third_party/guava | grep -ve third_party/grpc/grpc.*jar | tr "\n" " ")
 GRPC_JAVA_VERSION=1.7.0
 GRPC_LIBRARY_JARS=$(find third_party/grpc -name '*.jar' | grep -e .*${GRPC_JAVA_VERSION}.*jar | tr "\n" " ")
@@ -193,6 +205,7 @@ if [ -z "${BAZEL_SKIP_JAVA_COMPILATION}" ]; then
                 -I. \
                 -Isrc/main/protobuf/ \
                 -Isrc/main/java/com/google/devtools/build/lib/buildeventstream/proto/ \
+                -Ithird_party/googleapis \
                 --java_out=${OUTPUT_DIR}/src \
                 --plugin=protoc-gen-grpc="${GRPC_JAVA_PLUGIN-}" \
                 --grpc_out=${OUTPUT_DIR}/src "$f"

--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -30,6 +30,7 @@ PROTO_FILES=$(ls \
   third_party/googleapis/google/watcher/v1/*.proto \
 )
 LIBRARY_JARS=$(find third_party -name '*.jar' | grep -Fv /javac-9-dev-r3297-4.jar | grep -Fv /javac-9-dev-4023-3.jar | grep -Fv /javac7.jar | grep -Fv JavaBuilder | grep -Fv third_party/guava | grep -Fv third_party/guava | grep -ve third_party/grpc/grpc.*jar | tr "\n" " ")
+PROTOBUF_VERSION=3.4.0
 GRPC_JAVA_VERSION=1.7.0
 GRPC_LIBRARY_JARS=$(find third_party/grpc -name '*.jar' | grep -e .*${GRPC_JAVA_VERSION}.*jar | tr "\n" " ")
 GUAVA_VERSION=23.1
@@ -61,6 +62,7 @@ EXCLUDE_FILES="src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl
 
 mkdir -p "${OUTPUT_DIR}/classes"
 mkdir -p "${OUTPUT_DIR}/src"
+mkdir -p "${OUTPUT_DIR}/bootstrap"
 
 # May be passed in from outside.
 ZIPOPTS="$ZIPOPTS"
@@ -189,11 +191,37 @@ if [ -z "${BAZEL_SKIP_JAVA_COMPILATION}" ]; then
         cp -r derived/src/java/* "${OUTPUT_DIR}/src"
     else
 
-        [ -n "${PROTOC}" ] \
-            || fail "Must specify PROTOC if not bootstrapping from the distribution artifact${HOW_TO_BOOTSTRAP}"
+        if [ -z "${PROTOC}" ] || [ -z "${GRPC_JAVA_PLUGIN}" ]
+        then
+          log "Compiling protoc"
+          export PROTOBUF_PREFIX="${OUTPUT_DIR}/bootstrap/protobuf/usr/local"
+          mkdir -p "${PROTOBUF_PREFIX}"
+          
+          pushd "third_party/protobuf/${PROTOBUF_VERSION}" >/dev/null
+          run ./autogen.sh
+          run ./configure "--prefix=${PROTOBUF_PREFIX}"
+          run make install
+          export PROTOC="${PROTOBUF_PREFIX}/bin/protoc"
+          popd >/dev/null
+        fi
 
-        [ -n "${GRPC_JAVA_PLUGIN}" ] \
-            || fail "Must specify GRPC_JAVA_PLUGIN if not bootstrapping from the distribution artifact${HOW_TO_BOOTSTRAP}"
+        if [ -z "${GRPC_JAVA_PLUGIN}" ]
+        then
+          log "Compiling GRPC_JAVA_PLUGIN"
+          GRPC_JAVA_OUTPUT_DIR="${OUTPUT_DIR}/bootstrap/grpc-java"
+          mkdir -p "${GRPC_JAVA_OUTPUT_DIR}"
+
+          export GRPC_JAVA_PLUGIN="${GRPC_JAVA_OUTPUT_DIR}/protoc-gen-grpc-java"
+          pushd third_party/grpc/compiler/src/java_plugin/cpp >/dev/null
+          run g++ -std=c++11 \
+            "-I${PROTOBUF_PREFIX}/include" \
+            -w -O2 -export-dynamic \
+            *.cpp \
+            "${PROTOBUF_PREFIX}/lib/libprotobuf.a" \
+            "${PROTOBUF_PREFIX}/lib/libprotoc.a" \
+            -o "${GRPC_JAVA_PLUGIN}"
+          popd >/dev/null
+        fi
 
         [[ -x "${PROTOC-}" ]] \
             || fail "Protobuf compiler not found in ${PROTOC-}"

--- a/third_party/protobuf/3.4.0/BUILD
+++ b/third_party/protobuf/3.4.0/BUILD
@@ -260,7 +260,7 @@ cc_library(
         "src/google/protobuf/stubs/time.cc",
         "src/google/protobuf/wire_format_lite.cc",
     ],
-    hdrs = glob(["src/google/protobuf/**/*.h"]),
+    hdrs = [":headers"],
     copts = select({
         ":ios_armv7": IOS_ARM_COPTS,
         ":ios_armv7s": IOS_ARM_COPTS,
@@ -332,7 +332,7 @@ cc_library(
         "src/google/protobuf/wire_format.cc",
         "src/google/protobuf/wrappers.pb.cc",
     ],
-    hdrs = glob(["src/**/*.h"]),
+    hdrs = [":headers"],
     copts = select({
         ":ios_armv7": IOS_ARM_COPTS,
         ":ios_armv7s": IOS_ARM_COPTS,
@@ -345,13 +345,28 @@ cc_library(
     deps = [":protobuf_lite"],
 )
 
+filegroup(
+    name = "headers",
+    srcs = glob(
+      ["src/**/*.h"],
+      exclude = [
+        "**/testdata/**/*.h",
+        "**/*unittest*.h",
+        # cpp_test_large_enum_value.pb.h, 
+        "**/*_test*.h",
+        # imports unittest, oops.
+        "**/json_format_proto3.pb.h",
+      ]
+    )
+)
+
 # This provides just the header files for use in projects that need to build
 # shared libraries for dynamic loading. This target is available until Bazel
 # adds native support for such use cases.
 # TODO(keveman): Remove this target once the support gets added to Bazel.
 cc_library(
     name = "protobuf_headers",
-    hdrs = glob(["src/**/*.h"]),
+    hdrs = [":headers"],
     includes = ["src/"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This makes it possible to build Bazel from sources without bazel, protoc or the grpc-java plugin.

For instance Bazel now builds well in Raspbian (either on a Raspbery Pi 3 or in a Docker container, see [this repo](https://github.com/ochafik/rpi-raspbian-bazel)).

Notes: not sure if Travis is enabled yet for the bazelbuild organization?
