### PR TITLE
Spoof gflags pseudo-package __name__ for backwards compatibility.

### DIFF
--- a/third_party/py/gflags/__init__.py
+++ b/third_party/py/gflags/__init__.py
@@ -1,1 +1,6 @@
+# gflags raises DuplicateFlagError when defining default flags from packages
+# with different names, so this pseudo-package must mimic the core gflags
+# package name.
+__name__ += ".gflags"  # i.e. "third_party.py.gflags.gflags"
+
 from gflags import *


### PR DESCRIPTION
The core gflags package is `third_party.py.gflags.gflags`, but many downstream
projects and tools use the pseudo-package `third_party.py.gflags`. gflags raises
DuplicateFlagError when defining default flags from packages with different
names, so this fix adjusts the pseudo-package's `__name__` attribute to match that
of the core package.

As discussed in #3855, gflags should probably be deprecated in favor of abseil's flag package (absl.flags) in the long run, but this PR fixes immediate breakage:

* Fixes #4206 
* Fixes #4208

The DuplicateFlagError fixed by this PR looks something like:
```
  File "/home/akira/.cache/bazel/_bazel_akira/e36bf307e80952c206a5da49e956330b/bazel-sandbox/8019243632335963150/execroot/io_bazel/bazel-out/host/bin/tools/build_defs/pkg/build_tar.runfiles/io_bazel/tools/build_defs/pkg/build_tar.py", line 23, in <module>
    from third_party.py import gflags
  File "/home/akira/.cache/bazel/_bazel_akira/e36bf307e80952c206a5da49e956330b/bazel-sandbox/8019243632335963150/execroot/io_bazel/bazel-out/host/bin/tools/build_defs/pkg/build_tar.runfiles/io_bazel/third_party/py/gflags/__init__.py", line 1, in <module>
    from gflags import *
  File "/home/akira/.cache/bazel/_bazel_akira/e36bf307e80952c206a5da49e956330b/bazel-sandbox/8019243632335963150/execroot/io_bazel/bazel-out/host/bin/tools/build_defs/pkg/build_tar.runfiles/io_bazel/third_party/py/gflags/gflags/__init__.py", line 871, in <module>
    _helpers.SPECIAL_FLAGS)
  File "/home/akira/.cache/bazel/_bazel_akira/e36bf307e80952c206a5da49e956330b/bazel-sandbox/8019243632335963150/execroot/io_bazel/bazel-out/host/bin/tools/build_defs/pkg/build_tar.runfiles/io_bazel/third_party/py/gflags/gflags/__init__.py", line 560, in DEFINE_string
    DEFINE(parser, name, default, help, flag_values, serializer, **args)
  File "/home/akira/.cache/bazel/_bazel_akira/e36bf307e80952c206a5da49e956330b/bazel-sandbox/8019243632335963150/execroot/io_bazel/bazel-out/host/bin/tools/build_defs/pkg/build_tar.runfiles/io_bazel/third_party/py/gflags/gflags/__init__.py", line 392, in DEFINE
    flag_values, module_name)
  File "/home/akira/.cache/bazel/_bazel_akira/e36bf307e80952c206a5da49e956330b/bazel-sandbox/8019243632335963150/execroot/io_bazel/bazel-out/host/bin/tools/build_defs/pkg/build_tar.runfiles/io_bazel/third_party/py/gflags/gflags/__init__.py", line 413, in DEFINE_flag
    fv[flag.name] = flag
  File "/home/akira/.cache/bazel/_bazel_akira/e36bf307e80952c206a5da49e956330b/bazel-sandbox/8019243632335963150/execroot/io_bazel/bazel-out/host/bin/tools/build_defs/pkg/build_tar.runfiles/io_bazel/third_party/py/gflags/gflags/flagvalues.py", line 442, in __setitem__
    raise exceptions.DuplicateFlagError.from_flag(name, self)
gflags.exceptions.DuplicateFlagError: The flag 'flagfile' is defined twice. First from third_party.py.gflags.gflags, Second from third_party.py.gflags.  Description from first occurrence: Insert flag definitions from the given file into the command line.
```