### PR TITLE
Fix link to Skylark Linter docs from main docs navigation

### DIFF
--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -161,7 +161,7 @@ nav: docs
               </li>
 
               <li><a href="/versions/{{ site.version }}/skylark/deploying.html">Packaging rules</a></li>
-              <li><a href="/versions/{{ site.version }}/skylark/lib/skylint.html">Linter</a></li>
+              <li><a href="/versions/{{ site.version }}/skylark/skylint.html">Linter</a></li>
               <li><a href="https://skydoc.bazel.build" target="_blank">Documenting rules</a></li>
               <li><a href="/versions/{{ site.version }}/skylark/performance.html">Performance</a></li>
               <li><a href="/versions/{{ site.version }}/skylark/build-style.html">Style guide for BUILD files</a></li>


### PR DESCRIPTION
Fixes #4202 