### PR TITLE
Fix excessive warnings created by #4212

### DIFF
--- a/third_party/py/gflags/__init__.py
+++ b/third_party/py/gflags/__init__.py
@@ -1,6 +1,2 @@
-# gflags raises DuplicateFlagError when defining default flags from packages
-# with different names, so this pseudo-package must mimic the core gflags
-# package name.
-__name__ += ".gflags"  # i.e. "third_party.py.gflags.gflags"
-
+from __future__ import absolute_import
 from gflags import *


### PR DESCRIPTION
Use PEP 328 absolute import for third_party python gflags.

Commit d926bc40260549b997a6a5a1e82d9e7999dbb65e fixed a bug (#4206, #4208) in the third_party python gflags pseudo-package but added excessive runtime warnings (see #4212). Using the python PEP 328 (absolute import) implementation eliminates these warnings while properly addressing the original bug.
