### PR TITLE
Fixed documentation navigation bar/content layout awkwardness.

### DIFF
--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -16,7 +16,7 @@ nav: docs
 
     <div class="container vpad">
       <div class="row">
-        <div class="col-lg-3">
+        <div class="col-md-3">
           <a class="btn btn-default btn-lg btn-block sidebar-toggle"
               data-toggle="collapse" href="#sidebar-nav" aria-expanded="false"
               aria-controls="sidebar-nav">
@@ -200,7 +200,7 @@ nav: docs
           </nav>
         </div>
 
-        <div class="col-lg-9">
+        <div class="col-md-9">
           <a id="gh-edit" class="gh-edit default-hidden"><i class="fa fa-pencil" aria-hidden="true"></i> Edit</a>
           <script>
             var versionDocsURLRegex = /\/versions\/[\w\.]+\/(.*)/;


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/4262

A specific browser view width range causes the navigation bar to be stacked on top of the documentation content, therefore requiring a bit of scrolling to get to it. 

This fix changes col-lg-* to col-md-*, which reduces the view width threshold at which the columns  are restyled using `@media queries`.

Tested locally on Chrome & Safari. This is also testable by going to the production site and changing the CSS classes in the inspector.