### PR TITLE
Don't output duplicate srcs when jar and sourcejar are the same

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/JarDecompressor.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/JarDecompressor.java
@@ -134,6 +134,7 @@ public class JarDecompressor implements Decompressor {
 
   protected String createBuildFileWithSrcjar(String baseName, String srcjarBaseName) {
     return Joiner.on("\n")
+        .skipNulls()
         .join(
             "java_import(",
             "    name = 'jar',",
@@ -146,7 +147,7 @@ public class JarDecompressor implements Decompressor {
             "    name = 'file',",
             "    srcs = [",
             "        '" + baseName + "',",
-            "        '" + srcjarBaseName + "',",
+            baseName.equals(srcjarBaseName) ? null : "        '" + srcjarBaseName + "',",
             "    ],",
             "    visibility = ['//visibility:public']",
             ")");

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/JarDecompressorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/JarDecompressorTest.java
@@ -91,6 +91,22 @@ public class JarDecompressorTest {
   }
 
   @Test
+  public void testTargetIsSource() throws Exception {
+    Path outputDir =
+        decompressor.decompressWithSrcjar(
+            srcjarDescriptorBuilder.build(), Optional.fromNullable(srcjarDescriptorBuilder.build()));
+    assertThat(outputDir.exists()).isTrue();
+    assertThat(outputDir.getRelative("jar/foo.jar").exists()).isFalse();
+    assertThat(outputDir.getRelative("jar/foo-sources.jar").exists()).isTrue();
+    String buildContent =
+        new String(FileSystemUtils.readContentAsLatin1(outputDir.getRelative("jar/BUILD.bazel")));
+    assertThat(buildContent).contains("java_import");
+    assertThat(buildContent).contains("srcjar = 'foo-sources.jar'");
+    assertThat(buildContent).contains("filegroup");
+    assertThat(buildContent).contains("srcs = [\n        'foo-sources.jar',\n    ],");
+  }
+
+  @Test
   // Note: WORKSPACE gen is not affected by presence or absence of Optional arg to
   // decompressWithSrcjar
   public void testWorkspaceGen() throws Exception {


### PR DESCRIPTION
When a source jar is used as maven_jar the filegroup in the generated BUILD.bazel contains duplicate entries. This results in an error when the jar is used as a dependency (... is duplicated in the 'srcs' attribute of rule 'file').

This change simply doesn't write the duplicate entry to the BUILD.bazel file when  the filenames are equal.