### PR TITLE
Use --depth=1 on git clone for git_repository skylark rules

### DIFF
--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -29,10 +29,10 @@ set -ex
 ( cd {working_dir} &&
     if ! ( cd '{dir}' && git rev-parse --git-dir ) >/dev/null 2>&1; then
       rm -rf '{dir}'
-      git clone '{remote}' '{dir}'
+      git clone --depth=1 '{remote}' '{dir}'
     fi
     cd '{dir}'
-    git reset --hard {ref} || (git fetch origin {ref}:{ref} && git reset --hard {ref})
+    git reset --hard {ref} || (git fetch --depth=1 origin {ref}:{ref} && git reset --hard {ref})
     git clean -xdf )
   """.format(
       working_dir=ctx.path('.').dirname,


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/4359