### PR TITLE
Concatenate reference config files in singlejar

### DIFF
--- a/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/DefaultJarEntryFilter.java
+++ b/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/DefaultJarEntryFilter.java
@@ -66,6 +66,9 @@ public class DefaultJarEntryFilter implements ZipEntryFilter {
   // Merge all protobuf extension registries.
   private static final String PROTOBUF_META = "protobuf.meta";
 
+  // Merge all reference config files.
+  private static final String REFERENCE_CONF = "reference.conf";
+
   protected final Date date;
   protected final Date classDate;
   protected PathFilter allowedPaths;
@@ -91,6 +94,8 @@ public class DefaultJarEntryFilter implements ZipEntryFilter {
     } else if (filename.equals(SPRING_HANDLERS)) {
       callback.customMerge(date, new ConcatenateStrategy());
     } else if (filename.equals(SPRING_SCHEMAS)) {
+      callback.customMerge(date, new ConcatenateStrategy());
+    } else if (filename.equals(REFERENCE_CONF)) {
       callback.customMerge(date, new ConcatenateStrategy());
     } else if (filename.startsWith(SERVICES_DIR)) {
       // Merge all services files.

--- a/src/java_tools/singlejar/javatests/com/google/devtools/build/singlejar/DefaultJarEntryFilterTest.java
+++ b/src/java_tools/singlejar/javatests/com/google/devtools/build/singlejar/DefaultJarEntryFilterTest.java
@@ -80,6 +80,14 @@ public class DefaultJarEntryFilterTest {
   }
 
   @Test
+  public void testReferenceConfigs() throws IOException {
+    RecordingCallback callback = new RecordingCallback();
+    new DefaultJarEntryFilter().accept("reference.conf", callback);
+    assertThat(callback.calls).isEqualTo(Arrays.asList("customMerge"));
+    assertThat(callback.dates).isEqualTo(Arrays.asList(DOS_EPOCH));
+  }
+
+  @Test
   public void testClassInput() throws IOException {
     RecordingCallback callback = new RecordingCallback();
     new DefaultJarEntryFilter().accept("a.class", callback);

--- a/src/tools/singlejar/singlejar_main.cc
+++ b/src/tools/singlejar/singlejar_main.cc
@@ -28,5 +28,7 @@ int main(int argc, char *argv[]) {
   } else {
     output_jar.ExtraCombiner("META-INF/desugar_deps", new NullCombiner());
   }
+  output_jar.ExtraCombiner("reference.conf",
+                           new Concatenator("reference.conf"));
   return output_jar.Doit(&options);
 }


### PR DESCRIPTION
Merge reference.conf files in single jar since [akka will break](https://doc.akka.io/docs/akka/current/general/configuration.html#when-using-jarjar-onejar-assembly-or-any-jar-bundler) if reference.conf files are overwritten.
The feature is added to both java and cpp implementations of singlejar to concatenate reference.conf files to keep behaviors consistent. For the cpp implementation, using `OutputJar.ExtraCombiner` in singlejar_main.cc feels less intrusive than adding a new `Concatenator` in the output_jar code.

Bazel-dev discussion on the issue is [here](https://groups.google.com/forum/#!topic/bazel-dev/C30dwAPL708).