### PR TITLE
Always use the JavaIO VFS implementation in the remote worker.

### DIFF
--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
@@ -17,7 +17,6 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib:process_util",
         "//src/main/java/com/google/devtools/build/lib:runtime",
         "//src/main/java/com/google/devtools/build/lib:single-line-formatter",
-        "//src/main/java/com/google/devtools/build/lib:unix",
         "//src/main/java/com/google/devtools/build/lib:util",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/remote",

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
@@ -36,7 +36,6 @@ import com.google.devtools.build.lib.runtime.LinuxSandboxUtil;
 import com.google.devtools.build.lib.shell.Command;
 import com.google.devtools.build.lib.shell.CommandException;
 import com.google.devtools.build.lib.shell.CommandResult;
-import com.google.devtools.build.lib.unix.UnixFileSystem;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.ProcessUtils;
 import com.google.devtools.build.lib.util.SingleLineFormatter;
@@ -97,9 +96,7 @@ public final class RemoteWorker {
     } catch (OptionsParsingException e) {
       throw new Error("The specified hash function '" + value + "' is not supported.");
     }
-    return OS.getCurrent() == OS.WINDOWS
-        ? new JavaIoFileSystem(hashFunction)
-        : new UnixFileSystem(hashFunction);
+    return new JavaIoFileSystem(hashFunction);
   }
 
   public RemoteWorker(


### PR DESCRIPTION
The JNI implementation doesn't work from a deployable jar.

Fixes https://github.com/bazelbuild/bazel/issues/3249

cc @ulfjack 