### PR TITLE
Minor changes to vendored protobuf/grpc libraries to match upstreams

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,6 +27,12 @@ bind(
     actual = "//third_party:guava",
 )
 
+# Used by //third_party/protobuf:protobuf_java_util
+bind(
+    name = "gson",
+    actual = "//third_party:gson",
+)
+
 # Used by //third_party/protobuf:protobuf_python
 bind(
     name = "six",

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BUILD
@@ -29,7 +29,7 @@ java_library(
         "//third_party/grpc:grpc-jar",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
-        "@com_google_protobuf//:well_known_types_any_proto",
+        "@com_google_protobuf//:any_proto",
         "@googleapis//:google_devtools_build_v1_build_events_java_proto",
         "@googleapis//:google_devtools_build_v1_build_status_java_proto",
         "@googleapis//:google_devtools_build_v1_publish_build_event_java_proto",

--- a/third_party/googleapis/BUILD
+++ b/third_party/googleapis/BUILD
@@ -146,8 +146,8 @@ proto_library(
         ":google_api_annotations_proto",
         ":google_longrunning_operations_proto",
         ":google_rpc_status_proto",
-        "@com_google_protobuf//:well_known_types_any_proto",
-        "@com_google_protobuf//:well_known_types_duration_proto",
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
     ],
 )
 
@@ -160,8 +160,8 @@ proto_library(
     name = "google_rpc_error_details_proto",
     srcs = ["google/rpc/error_details.proto"],
     deps = [
-        "@com_google_protobuf//:well_known_types_any_proto",
-        "@com_google_protobuf//:well_known_types_duration_proto",
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
     ],
 )
 
@@ -170,8 +170,8 @@ proto_library(
     srcs = ["google/watcher/v1/watch.proto"],
     deps = [
         ":google_api_annotations_proto",
-        "@com_google_protobuf//:well_known_types_any_proto",
-        "@com_google_protobuf//:well_known_types_empty_proto",
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:empty_proto",
     ],
 )
 
@@ -180,7 +180,7 @@ proto_library(
     srcs = ["google/bytestream/bytestream.proto"],
     deps = [
         ":google_api_annotations_proto",
-        "@com_google_protobuf//:well_known_types_wrappers_proto",
+        "@com_google_protobuf//:wrappers_proto",
     ],
 )
 
@@ -191,8 +191,8 @@ proto_library(
         ":google_api_annotations_proto",
         ":google_api_http_proto",
         ":google_rpc_status_proto",
-        "@com_google_protobuf//:well_known_types_any_proto",
-        "@com_google_protobuf//:well_known_types_empty_proto",
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:empty_proto",
     ],
 )
 
@@ -201,7 +201,7 @@ proto_library(
     srcs = ["google/devtools/build/v1/build_status.proto"],
     deps = [
         ":google_api_annotations_proto",
-        "@com_google_protobuf//:well_known_types_any_proto",
+        "@com_google_protobuf//:any_proto",
     ],
 )
 
@@ -212,9 +212,9 @@ proto_library(
         ":google_api_annotations_proto",
         ":google_devtools_build_v1_build_status_proto",
         ":google_rpc_status_proto",
-        "@com_google_protobuf//:well_known_types_any_proto",
-        "@com_google_protobuf//:well_known_types_timestamp_proto",
-        "@com_google_protobuf//:well_known_types_wrappers_proto",
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:wrappers_proto",
     ],
 )
 
@@ -225,9 +225,9 @@ proto_library(
         ":google_api_annotations_proto",
         ":google_api_auth_proto",
         ":google_devtools_build_v1_build_events_proto",
-        "@com_google_protobuf//:well_known_types_any_proto",
-        "@com_google_protobuf//:well_known_types_duration_proto",
-        "@com_google_protobuf//:well_known_types_empty_proto",
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:empty_proto",
     ],
 )
 
@@ -236,7 +236,7 @@ proto_library(
     srcs = ["google/api/annotations.proto"],
     deps = [
         ":google_api_http_proto",
-        "@com_google_protobuf//:well_known_types_descriptor_proto",
+        "@com_google_protobuf//:descriptor_proto",
     ],
 )
 
@@ -248,7 +248,7 @@ proto_library(
 proto_library(
     name = "google_rpc_status_proto",
     srcs = ["google/rpc/status.proto"],
-    deps = ["@com_google_protobuf//:well_known_types_any_proto"],
+    deps = ["@com_google_protobuf//:any_proto"],
 )
 
 proto_library(

--- a/third_party/grpc/build_defs.bzl
+++ b/third_party/grpc/build_defs.bzl
@@ -5,7 +5,7 @@ load("//third_party/grpc:build_defs.bzl", "java_grpc_library")
 def _path_ignoring_repository(f):
   if (len(f.owner.workspace_root) == 0):
     return f.short_path
-  return f.path[len(f.owner.workspace_root)+1:]
+  return f.path[f.path.find(f.owner.workspace_root)+len(f.owner.workspace_root)+1:]
 
 def _gensource_impl(ctx):
   if len(ctx.attr.srcs) > 1:

--- a/third_party/protobuf/3.4.0/BUILD
+++ b/third_party/protobuf/3.4.0/BUILD
@@ -50,88 +50,88 @@ filegroup(
 # Well Known Types
 
 proto_library(
-    name = "well_known_types_any_proto",
+    name = "any_proto",
     srcs = ["google/protobuf/any.proto"],
     visibility = ["//visibility:public"],
 )
 
 proto_library(
-    name = "well_known_types_timestamp_proto",
+    name = "timestamp_proto",
     srcs = ["google/protobuf/timestamp.proto"],
     visibility = ["//visibility:public"],
 )
 
 proto_library(
-    name = "well_known_types_api_proto",
+    name = "api_proto",
     srcs = ["google/protobuf/api.proto"],
     visibility = ["//visibility:public"],
     deps = [
-        ":well_known_types_source_context_proto",
-        ":well_known_types_type_proto",
+        ":source_context_proto",
+        ":type_proto",
     ],
 )
 
 proto_library(
-    name = "well_known_types_type_proto",
+    name = "type_proto",
     srcs = ["google/protobuf/type.proto"],
     visibility = ["//visibility:public"],
     deps = [
-        ":well_known_types_any_proto",
-        ":well_known_types_source_context_proto",
+        ":any_proto",
+        ":source_context_proto",
     ],
 )
 
 proto_library(
-    name = "well_known_types_source_context_proto",
+    name = "source_context_proto",
     srcs = ["google/protobuf/source_context.proto"],
     visibility = ["//visibility:public"],
 )
 
 proto_library(
-    name = "well_known_types_compiler_plugin_proto",
+    name = "compiler_plugin_proto",
     srcs = ["google/protobuf/compiler/plugin.proto"],
     visibility = ["//visibility:public"],
-    deps = [":well_known_types_descriptor_proto"],
+    deps = [":descriptor_proto"],
 )
 
 proto_library(
-    name = "well_known_types_descriptor_proto",
+    name = "descriptor_proto",
     srcs = ["google/protobuf/descriptor.proto"],
     visibility = ["//visibility:public"],
 )
 
 proto_library(
-    name = "well_known_types_duration_proto",
+    name = "duration_proto",
     srcs = ["google/protobuf/duration.proto"],
     visibility = ["//visibility:public"],
 )
 
 proto_library(
-    name = "well_known_types_empty_proto",
+    name = "empty_proto",
     srcs = ["google/protobuf/empty.proto"],
     visibility = ["//visibility:public"],
 )
 
 proto_library(
-    name = "well_known_types_field_mask_proto",
+    name = "field_mask_proto",
     srcs = ["google/protobuf/field_mask.proto"],
     visibility = ["//visibility:public"],
 )
 
 proto_library(
-    name = "well_known_types_struct_proto",
+    name = "struct_proto",
     srcs = ["google/protobuf/struct.proto"],
     visibility = ["//visibility:public"],
 )
 
 proto_library(
-    name = "well_known_types_wrappers_proto",
+    name = "wrappers_proto",
     srcs = ["google/protobuf/wrappers.proto"],
     visibility = ["//visibility:public"],
 )
 
 proto_library(
-    name = "well_known_types_compiler_profile_proto",
+    name = "compiler_profile_proto",
     srcs = ["google/protobuf/compiler/profile.proto"],
     visibility = ["//visibility:public"],
 )

--- a/third_party/protobuf/3.4.0/BUILD
+++ b/third_party/protobuf/3.4.0/BUILD
@@ -30,7 +30,7 @@ java_import(
     jars = ["libprotobuf_java_util.jar"],
     visibility = ["//visibility:public"],
     exports = [
-        "@io_bazel//third_party:gson",
+        "//external:gson",
     ],
 )
 


### PR DESCRIPTION
With these changes, Bazel's vendored copy of protobuf can be swapped out with the main protobuf library in a workspace. This is useful when building Bazel or its helper binaries (e.g. remote builder) as part of a larger project.

Tested by building //src:bazel-bin with both the vendored copy, and a `http_archive` of protobuf 3.5.1 (unmodified upstream). I don't have enough deps on my local workstation to run the full Bazel test suite, so I'm hoping the Bazel CI can run the full tests.