### PR TITLE
Provide a bit more information on the expected location of bazelrc files.

### DIFF
--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -165,10 +165,12 @@ title: User Manual
 
 <p>
   Aside from the optional configuration file described above, Bazel also looks
-  for a master rc file next to the binary, in the workspace at
-  <code>tools/bazel.rc</code> or system-wide at <code>/etc/bazel.bazelrc</code>.
-  These files are here to support installation-wide options or options shared
-  between users. Reading of this file can be disabled using the
+  for a master rc file named <code>bazel.bazelrc</code> next to the binary, in
+  the workspace at <code>tools/bazel.rc</code> or system-wide at
+  <code>/etc/bazel.bazelrc</code>. These files are here to support
+  installation-wide options or options shared between users. These files do not
+  override one another; if all of these files exist, all of them will be loaded.
+  Reading of these files can be disabled using the
   <code class='flag'>--nomaster_bazelrc</code> option.
 </p>
 <h4><code>.bazelrc</code> syntax and semantics</h4>


### PR DESCRIPTION
The docs failed to mention the expected name of the file next to the binary. Also missing was the information that these files do not override each other; they are always loaded if present.