### PR TITLE
Create ndk wrong path in TMPDIR, not SRCDIR

### DIFF
--- a/src/test/shell/bazel/android/android_ndk_integration_test.sh
+++ b/src/test/shell/bazel/android/android_ndk_integration_test.sh
@@ -291,16 +291,16 @@ EOF
 
 function test_android_ndk_repository_wrong_path() {
   create_new_workspace
-  mkdir "$TEST_SRCDIR/some_dir"
+  mkdir "$TEST_TMPDIR/some_dir"
   cat > WORKSPACE <<EOF
 android_ndk_repository(
     name = "androidndk",
     api_level = 25,
-    path = "$TEST_SRCDIR/some_dir",
+    path = "$TEST_TMPDIR/some_dir",
 )
 EOF
   bazel build @androidndk//:files >& $TEST_log && fail "Should have failed"
-  expect_log "Unable to read the Android NDK at $TEST_SRCDIR/some_dir, the path may be invalid." \
+  expect_log "Unable to read the Android NDK at $TEST_TMPDIR/some_dir, the path may be invalid." \
     " Is the path in android_ndk_repository() or \$ANDROID_NDK_HOME set correctly?"
 }
 


### PR DESCRIPTION
test_android_ndk_repository_wrong_path presumes the wrong ndk path
'some_dir' to not exist. This test will work initially, but break if run
incrementally, because of the some_dir remaining in the TEST_SRCDIR (the
runfiles root for this test). Switching this over to use the ephemeral
TEST_TMPDIR instead.