### PR TITLE
Update java_import_external best practices

### DIFF
--- a/tools/build_defs/repo/java.bzl
+++ b/tools/build_defs/repo/java.bzl
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE: Maintainers of this file are strongly advised to never rename
+# it, or making breaking changes to this API. Doing so will break the
+# builds at all historical revisions of Bazel projects that depend on
+# this file, because @bazel_tools is unabled to pinned at a version.
+
 """Rules for defining external Java dependencies.
 
 java_import_external() replaces `maven_jar` and `http_jar`. It is the
@@ -107,12 +112,11 @@ java_import_external(
     name = "com_google_guava",
     licenses = ["notice"],  # Apache 2.0
     jar_urls = [
-        "http://bazel-mirror.storage.googleapis.com/repo1.maven.org/maven2/com/google/guava/guava/20.0/guava-20.0.jar",
-        "http://repo1.maven.org/maven2/com/google/guava/guava/20.0/guava-20.0.jar",
-        "http://maven.ibiblio.org/maven2/com/google/guava/guava/20.0/guava-20.0.jar",
+        "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/guava/guava/21.0/guava-21.0.jar",
+        "https://repo1.maven.org/maven2/com/google/guava/guava/21.0/guava-21.0.jar",
     ],
-    jar_sha256 = "36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8",
-    deps = [
+    jar_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
+    exports = [
         "@com_google_code_findbugs_jsr305",
         "@com_google_errorprone_error_prone_annotations",
     ],
@@ -122,21 +126,20 @@ java_import_external(
     name = "com_google_code_findbugs_jsr305",
     licenses = ["notice"],  # BSD 3-clause
     jar_urls = [
-        "http://bazel-mirror.storage.googleapis.com/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar",
-        "http://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar",
-        "http://maven.ibiblio.org/maven2/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar",
+        "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/code/findbugs/jsr305/2.0.3/jsr305-2.0.3.jar",
+        "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/2.0.3/jsr305-2.0.3.jar",
+        "http://maven.ibiblio.org/maven2/com/google/code/findbugs/jsr305/2.0.3/jsr305-2.0.3.jar",
     ],
-    jar_sha256 = "905721a0eea90a81534abb7ee6ef4ea2e5e645fa1def0a5cd88402df1b46c9ed",
+    jar_sha256 = "bec0b24dcb23f9670172724826584802b80ae6cbdaba03bdebdef9327b962f6a",
 )
 
 java_import_external(
     name = "com_google_errorprone_error_prone_annotations",
     licenses = ["notice"],  # Apache 2.0
-    jar_sha256 = "e7749ffdf03fb8ebe08a727ea205acb301c8791da837fee211b99b04f9d79c46",
+    jar_sha256 = "cde78ace21e46398299d0d9c6be9f47b7f971c7f045d40c78f95be9a638cbf7e",
     jar_urls = [
-        "http://bazel-mirror.storage.googleapis.com/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.0.15/error_prone_annotations-2.0.15.jar",
-        "http://maven.ibiblio.org/maven2/com/google/errorprone/error_prone_annotations/2.0.15/error_prone_annotations-2.0.15.jar",
-        "http://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.0.15/error_prone_annotations-2.0.15.jar",
+        "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.0.19/error_prone_annotations-2.0.19.jar",
+        "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.0.19/error_prone_annotations-2.0.19.jar",
     ],
 )
 ```


### PR DESCRIPTION
Our best practices have evolved to recommend HTTP. There's also now a
note that should help maintainers do the right thing.

https://github.com/bazelbuild/bazel/issues/4425#issuecomment-358230243