### PR TITLE
Propagate remote_upload_local_results to remote ex

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -124,6 +124,7 @@ class RemoteSpawnRunner implements SpawnRunner {
     TreeNode inputRoot = repository.buildFromActionInputs(inputMap);
     repository.computeMerkleDigests(inputRoot);
     Command command = buildCommand(spawn.getArguments(), spawn.getEnvironment());
+    boolean uploadLocalResults = options.remoteUploadLocalResults;
     Action action =
         buildAction(
             execRoot,
@@ -141,7 +142,6 @@ class RemoteSpawnRunner implements SpawnRunner {
     Context previous = withMetadata.attach();
     try {
       boolean acceptCachedResult = options.remoteAcceptCached && Spawns.mayBeCached(spawn);
-      boolean uploadLocalResults = options.remoteUploadLocalResults;
 
       try {
         // Try to lookup the action in the action cache.
@@ -177,6 +177,12 @@ class RemoteSpawnRunner implements SpawnRunner {
         remoteCache.ensureInputsPresent(repository, execRoot, inputRoot, command);
       } catch (IOException e) {
         return execLocallyOrFail(spawn, policy, inputMap, actionKey, uploadLocalResults, e);
+      }
+
+      if (!uploadLocalResults) {
+        action = action.toBuilder()
+            .setDoNotCache(true)
+            .build();
       }
 
       final ActionResult result;

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -225,6 +225,54 @@ public class RemoteSpawnRunnerTest {
 
   @Test
   @SuppressWarnings("unchecked")
+  public void noRemoteUploadResultsShouldNotBeCached() throws Exception {
+    // Test that if remoteUploadLocalResults is false, an action can miss cache with a
+    // cacheable action key, but be executed remotely with an action definition with
+    // do_not_cache=true, so that the action result is not saved in the remote cache.
+
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteAcceptCached = true;
+    options.remoteLocalFallback = false;
+    options.remoteUploadLocalResults = false;
+
+    RemoteSpawnRunner runner =
+        new RemoteSpawnRunner(
+            execRoot,
+            options,
+            localRunner,
+            true,
+            /*cmdlineReporter=*/ null,
+            "build-req-id",
+            "command-id",
+            cache,
+            executor,
+            digestUtil);
+
+    ExecuteResponse succeeded = ExecuteResponse.newBuilder().setResult(
+        ActionResult.newBuilder().setExitCode(0).build()).build();
+    when(executor.executeRemotely(any(ExecuteRequest.class))).thenReturn(succeeded);
+
+    Spawn spawn = newSimpleSpawn();
+    SpawnExecutionPolicy policy = new FakeSpawnExecutionPolicy(spawn);
+
+    runner.exec(spawn, policy);
+
+    ArgumentCaptor<ExecuteRequest> requestCaptor = ArgumentCaptor.forClass(ExecuteRequest.class);
+    verify(executor).executeRemotely(requestCaptor.capture());
+    assertThat(requestCaptor.getValue().getAction().getDoNotCache()).isTrue();
+
+    verify(cache, never())
+        .upload(
+            any(ActionKey.class),
+            any(Path.class),
+            any(Collection.class),
+            any(FileOutErr.class),
+            any(Boolean.class));
+    verifyZeroInteractions(localRunner);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
   public void failedActionShouldOnlyUploadOutputs() throws Exception {
     // Test that the outputs of a failed locally executed action are uploaded to a remote cache,
     // but the action result itself is not.


### PR DESCRIPTION
Translated a false 'remote_upload_local_results' into a desire to not
cache action outputs if a miss was encountered; the actionKey continues
to be based on an action for which do_not_cache is false, while the exec
can have this value flipped after an action cache miss.

This is currently the only way to have bazel alter the do_not_cache for
remotely executed actions after a cache miss (because do_not_cache must
be false to perform a cache check).