### PR TITLE
Use linear search when there are < 20 items to match

### DIFF
--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -459,8 +459,8 @@ static bool IsValidEnvName(const char* p) {
 
 #if defined(COMPILER_MSVC)
 static void PreprocessEnvString(string* env_str) {
-  static std::set<string> vars_to_uppercase = {"PATH", "TMP", "TEMP", "TEMPDIR",
-                                               "SYSTEMROOT"};
+  static const string vars_to_uppercase[] = {"PATH", "SYSTEMROOT", "TEMP",
+                                             "TEMPDIR", "TMP"};
 
   int pos = env_str->find_first_of('=');
   if (pos == string::npos) return;
@@ -468,7 +468,8 @@ static void PreprocessEnvString(string* env_str) {
   string name = env_str->substr(0, pos);
   // We do not care about locale. All variable names are ASCII.
   std::transform(name.begin(), name.end(), name.begin(), ::toupper);
-  if (vars_to_uppercase.find(name) != vars_to_uppercase.end()) {
+  if (std::find(std::begin(vars_to_uppercase), std::end(vars_to_uppercase),
+                name) != std::end(vars_to_uppercase)) {
     env_str->assign(name + "=" + env_str->substr(pos + 1));
   }
 }


### PR DESCRIPTION
Better performance and smaller binary size than `std::set`. We can easily change to `std::binary_search` if the list grows > 20.