### PR TITLE
[MSVC] Don't declare environ when it is already defined as macro

### DIFF
--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -30,7 +30,9 @@
 #include "src/main/cpp/workspace_layout.h"
 
 // On OSX, there apparently is no header that defines this.
+#ifndef environ
 extern char **environ;
+#endif
 
 namespace blaze {
 


### PR DESCRIPTION
In MSVC, `environ` is a macro (from `stdlib.h`):

```cpp
extern char***               __p__environ(void);
#define _environ           (*__p__environ())
#define environ _environ
```

So `extern char **environ;` will be expanded as `extern char **(*__p_environ());` which is invalid. This causes compile warning on MSVC.