### PR TITLE
Use std::to_string for non-mingw/cygwin

### DIFF
--- a/src/main/cpp/blaze_util.h
+++ b/src/main/cpp/blaze_util.h
@@ -107,9 +107,13 @@ extern const unsigned int kPostKillGracePeriodSeconds;
 // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52015.
 template <typename T>
 std::string ToString(const T &value) {
+#if defined(__CYGWIN__) || defined(__MINGW32__)
   std::ostringstream oss;
   oss << value;
   return oss.str();
+#else
+  return std::to_string(value);
+#endif
 }
 
 // Control the output of debug information by debug_log.


### PR DESCRIPTION
`std::to_string` is faster than `std::stringstream`.

This issue only presents in older versions of Mingw/Cygwin. My Mingw64 GCC 7.1.0 has `std::to_string`. I can't determine the exact version of GCC that fixed the issue.