### PR TITLE
remote: output stats on each run

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -37,16 +37,19 @@ final class RemoteActionContextProvider extends ActionContextProvider {
   private final AbstractRemoteActionCache cache;
   private final GrpcRemoteExecutor executor;
   private final DigestUtil digestUtil;
+  private final RemoteStats stats;
 
   RemoteActionContextProvider(
       CommandEnvironment env,
       @Nullable AbstractRemoteActionCache cache,
       @Nullable GrpcRemoteExecutor executor,
-      DigestUtil digestUtil) {
+      DigestUtil digestUtil,
+      @Nullable RemoteStats stats) {
     this.env = env;
     this.executor = executor;
     this.cache = cache;
     this.digestUtil = digestUtil;
+    this.stats = stats;
   }
 
   @Override
@@ -81,7 +84,8 @@ final class RemoteActionContextProvider extends ActionContextProvider {
               commandId,
               cache,
               executor,
-              digestUtil);
+              digestUtil,
+              stats);
       return ImmutableList.of(new RemoteSpawnStrategy(env.getExecRoot(), spawnRunner));
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteStats.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteStats.java
@@ -1,0 +1,49 @@
+package com.google.devtools.build.lib.remote;
+
+import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Collecting always-on stats on a remote run */
+@ThreadSafe
+public class RemoteStats {
+  AtomicInteger total_spawns;
+  AtomicInteger remote_cache_hit;
+  AtomicInteger remote_exec;
+  AtomicInteger local;
+
+  public RemoteStats() {
+    total_spawns = new AtomicInteger();
+    remote_cache_hit = new AtomicInteger();
+    remote_exec = new AtomicInteger();
+    local = new AtomicInteger();
+  }
+
+  public void addSpawn() {
+    total_spawns.incrementAndGet();
+  }
+
+  public void addRemoteCacheHit() { remote_cache_hit.incrementAndGet(); };
+
+  // Spawns remotely executed
+  public void addRemoteExec() { remote_exec.incrementAndGet(); }
+
+  // Spawns that are intentionally executed locally (as opposed to fall back mechanism)
+  public void addLocal() { local.incrementAndGet(); }
+
+  public String Summary() {
+    // We are assuming this is called after all the increments. Calling it at concurrently
+    // might produce inconsistent stats.
+    int remote = remote_exec.get() + remote_cache_hit.get();
+
+    // Actions that were attempted, but were neither successful remote nor local had to be
+    // fallbacks to local from remote.
+    int fallback = total_spawns.get() - remote - local.get();
+
+    String result = String.format("Remote stats: %d/%d remote actions cached, %d local",
+        remote_cache_hit.get(), remote, local.get());
+    if(fallback > 0) {
+      result += String.format(" (%d fallback)", fallback);
+    }
+    return result;
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
@@ -252,7 +252,8 @@ public class GrpcRemoteExecutionClientTest {
             "command-id",
             remoteCache,
             executor,
-            DIGEST_UTIL);
+            DIGEST_UTIL,
+            null);
     inputDigest = fakeFileCache.createScratchInput(simpleSpawn.getInputFiles().get(0), "xyz");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -134,7 +134,8 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             executor,
-            digestUtil);
+            digestUtil,
+            null);
 
     ExecuteResponse succeeded = ExecuteResponse.newBuilder().setResult(
         ActionResult.newBuilder().setExitCode(0).build()).build();
@@ -192,7 +193,8 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             null,
-            digestUtil);
+            digestUtil,
+            null);
 
     // Throw an IOException to trigger the local fallback.
     when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(IOException.class);
@@ -244,7 +246,8 @@ public class RemoteSpawnRunnerTest {
                 "command-id",
                 cache,
                 null,
-                digestUtil));
+                digestUtil,
+                null));
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionPolicy policy = new FakeSpawnExecutionPolicy(spawn);
@@ -292,7 +295,8 @@ public class RemoteSpawnRunnerTest {
                 "command-id",
                 cache,
                 null,
-                digestUtil));
+                digestUtil,
+                null));
 
     try {
       runner.exec(spawn, policy);
@@ -326,7 +330,8 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             null,
-            digestUtil);
+            digestUtil,
+            null);
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionPolicy policy = new FakeSpawnExecutionPolicy(spawn);
@@ -377,7 +382,8 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             null,
-            digestUtil);
+            digestUtil,
+            null);
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionPolicy policy = new FakeSpawnExecutionPolicy(spawn);
@@ -416,7 +422,8 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             null,
-            digestUtil);
+            digestUtil,
+            null);
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionPolicy policy = new FakeSpawnExecutionPolicy(spawn);
@@ -452,7 +459,8 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             executor,
-            digestUtil);
+            digestUtil,
+            null);
 
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
     when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(new IOException());
@@ -490,7 +498,8 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             executor,
-            digestUtil);
+            digestUtil,
+            null);
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(cachedResult);
@@ -531,7 +540,8 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             executor,
-            digestUtil);
+            digestUtil,
+            null);
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
@@ -567,7 +577,8 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             executor,
-            digestUtil);
+            digestUtil,
+            null);
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
@@ -601,7 +612,8 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             executor,
-            digestUtil);
+            digestUtil,
+            null);
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
@@ -641,7 +653,8 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             executor,
-            digestUtil);
+            digestUtil,
+            null);
 
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
     when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(new IOException());
@@ -677,7 +690,8 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             executor,
-            digestUtil);
+            digestUtil,
+            null);
 
     when(cache.getCachedActionResult(any(ActionKey.class))).thenThrow(new IOException());
 

--- a/src/test/shell/bazel/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote_execution_test.sh
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
@@ -505,6 +506,90 @@ EOF
       && fail "Test failure expected" || true
   expect_not_log "test.log"
   expect_log "Remote connection/protocol failed"
+}
+
+
+# Bazel corrects outputs remote statistics
+function test_remote_stats() {
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = "foo",
+  srcs = [],
+  outs = ["foo.txt"],
+  cmd = "echo \"hello world\" > \"$@\"",
+)
+
+genrule(
+  name = "foo2",
+  srcs = ["foo.txt"],
+  outs = ["foo2.txt"],
+  cmd = "cat $(location foo.txt) > $@",
+)
+EOF
+  bazel build \
+      --spawn_strategy=remote \
+      --remote_executor=localhost:${worker_port} \
+      --remote_cache=localhost:${worker_port} \
+      //a:foo >& $TEST_log \
+      || fail "Failed to build //a:foo with remote execution"
+  expect_log "Remote stats" "Expected remote stats message"
+  # This is a clean build. We expect no cache hits and some remote executions.
+  expect_log " 0/[1-9][0-9]* remote actions cached"
+  expect_not_log "fallback"
+  
+
+  bazel clean --expunge >& $TEST_log
+  bazel build \
+      --spawn_strategy=remote \
+      --remote_executor=localhost:${worker_port} \
+      --remote_cache=localhost:${worker_port} \
+      //a:foo >& $TEST_log \
+      || fail "Failed to rebuild //a:foo with remote execution"
+  expect_not_log " 0/[1-9][0-9]* remote actions cached"
+  # Should get no remote execution since everything is cached.
+  # So, should have the same number cached as uncached.
+  expect_log " \([1-9][0-9]*\)/\1 remote actions cached"
+  expect_not_log "fallback"
+
+  bazel clean --expunge >& $TEST_log
+  bazel build \
+      --spawn_strategy=remote \
+      --remote_executor=localhost:${worker_port} \
+      --remote_cache=localhost:${worker_port} \
+      //a:foo2 >& $TEST_log \
+      || fail "Failed to build //a:foo2 with remote execution"
+  # foo2 depends on foo which is cached, but also adds new work.
+  # Expect a mixture of cached and remote actions: both numbers should be non-zero
+  # and they should not be the same.
+  expect_log " [1-9][0-9]*/[1-9][0-9]* remote actions cached"
+  expect_not_log " \([1-9][0-9]*\)/\1 remote actions cached"
+  expect_not_log "fallback"
+}
+
+# Bazel corrects outputs remote statistics
+function test_remote_stats() {
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = "foo",
+  srcs = [],
+  outs = ["foo.txt"],
+  cmd = "echo \"hello world\" > \"$@\"",
+)
+EOF
+  bazel build \
+      --spawn_strategy=remote \
+      --remote_executor=bazel-test-does-not-exist \
+      --remote_cache=bazel-test-does-not-exist \
+      --remote_local_fallback=true \
+      //a:foo >& $TEST_log \
+      || fail "Failed to build //a:foo with fallback"
+  expect_log "Remote stats" "Expected remote stats message"
+  # Could not reach remote worker. Expect no remote actions or cache hits. Expect non-zero
+  # fallback actions
+  expect_log " 0/0 remote actions cached"
+  expect_log " ([1-9][0-9]* fallback)"
 }
 
 # TODO(alpha): Add a test that fails remote execution when remote worker


### PR DESCRIPTION
Initial implementation for outputting a summary of actions ran
when using RemoteSpawnRunner. Breaks down by cached/uncached and
local vs non-local.

Currently it surfaces a number of local steps that are for Bazel's
bookkeeping: I've seen CreateRunfiles, though there could be more
in that category. As a follow up, we need to decide what to do about
those: users would expect to see 100% remote execution if everything
is working properly.

RELNOTES: Bazel now adds action summary statistics when using remote execution.
FIXES: #2846