### PR TITLE
docs : add `touch WORKSPACE`

### DIFF
--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -424,6 +424,7 @@ Package path elements may be specified in three formats:
 <pre>
   % mkdir -p foo/bazel
   % cd foo/bazel
+  % touch WORKSPACE
   % bazel build --package_path /some/other/path //foo
 </pre>
 <h3 id='target-patterns'>Specifying targets to build</h3>


### PR DESCRIPTION
It seems that we still need to touch a file named `WORKSPACE`
```
ERROR: The 'build' command is only supported from within a workspace.
```