### PR TITLE
Use `@loader_path` instead of `$ORIGIN` in rpath on macos. Issue #4480.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
@@ -57,6 +57,14 @@ public class CppActionConfigs {
               + "  }"
               + "}";
     }
+    String originLinkerVariableName = "";
+    if (platform == CppPlatform.MAC) {
+        originLinkerVariableName = "@loader_path";
+    }
+    if (platform == CppPlatform.LINUX) {
+        originLinkerVariableName = "$ORIGIN";
+    }
+
     return Joiner.on("\n")
         .join(
             ImmutableList.of(
@@ -574,7 +582,8 @@ public class CppActionConfigs {
                         "  }",
                         "  flag_group {",
                         "    expand_if_all_available: 'is_not_cc_test_link_action'"),
-                    "        flag: '-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}'",
+                    "        flag: '-Wl,-rpath," + originLinkerVariableName
+                        + "/%{runtime_library_search_directories}'",
                     "      }",
                     "    }",
                     "  }",


### PR DESCRIPTION
This patch fixes the issue with `$ORIGIN` in rpath on macos #4480. I'm not sure whether it is the best way to solve the issue, but it works :) I have a superficial knowledge about bazel's code, so feel free to correct me if I'm wrong in some way.
 
There a still several open questions:

1. I'm not use should we use `@loader_path` or `@executable_path`. As I understand, it is the same for plain executables, and only makes a difference for mac's frameworks or 'app' directories. But description in `man dyld` is pretty crypric to me.
2. There is a file `tools/osx/crosstool/CROSSTOOL.tpl`, that conains `"-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}"`. I have tried to change it too, but it have not affected my test project. I'm not sure should I change this file too.
3. I tested as described [here](https://bazel.build/contributing.html). If there is another way, say me.

    ```
    bazel build //:bazel-distfile
    #unzip to a tmp directory
    bazel test //src/... //third_party/ijar/...
    ```

I tested using [this](https://github.com/alexanderlobov/try-bazel/tree/master/linking-with-dynamic-lib) project.



