### PR TITLE
Let ijar handle jars with incorrect class files

### DIFF
--- a/third_party/ijar/classfile.cc
+++ b/third_party/ijar/classfile.cc
@@ -1547,8 +1547,9 @@ static ClassFile *ReadClass(const void *classdata, size_t length) {
 
   clazz->magic = get_u4be(p);
   if (clazz->magic != 0xCAFEBABE) {
-    fprintf(stderr, "Bad magic %" PRIx32 "\n", clazz->magic);
-    abort();
+    fprintf(stderr, "Bad magic %" PRIx32 ". Passing class through.\n", clazz->magic);
+    delete clazz;
+    return NULL;
   }
   clazz->major = get_u2be(p);
   clazz->minor = get_u2be(p);


### PR DESCRIPTION
Some jars in Maven Central (e.g. aspectjtools-1.8.13.jar) contain
invalid class files. When such a jar is used in a Bazel project the ijar
utility returns with an error, which makes it impossible to use the jar
(see #4597).

By continuing on an invalid class file after emitting an error message
those jars can be used in a Bazel project.