### PR TITLE
Increase font-weight for h1-h6 elements in docs for better contrast

### DIFF
--- a/site/_sass/style.scss
+++ b/site/_sass/style.scss
@@ -48,7 +48,7 @@ h4,
 h5,
 h6 {
   color: $text-color;
-  font-weight: 300;
+  font-weight: 400;
   margin-top: 30px;
   margin-bottom: 15px;
 }


### PR DESCRIPTION
See also https://github.com/bazelbuild/bazel-website/pull/97

The header elements are too thin, and difficult for the eyes to identify the start of a new section.

Before:

![image](https://user-images.githubusercontent.com/347918/36271696-64e594d2-124d-11e8-8c72-8642f9272b39.png)

After:

![image](https://user-images.githubusercontent.com/347918/36271689-5b5e4576-124d-11e8-8db7-6b22b3da872f.png)