### PR TITLE
Fix ci.sh's file concatenation.

### DIFF
--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -50,7 +50,7 @@ cd "$(git rev-parse --show-toplevel)"
 # Get a list of the current files in package form by querying Bazel.
 files=()
 for file in $(git diff --name-only ${COMMIT_RANGE} ); do
-  IFS=$'\n' read -r -a files <<< "$(bazel query $file)"
+  mapfile -O ${#files[@]} -t files <<< "$(bazel query $file)"
   bazel query $file
 done
 


### PR DESCRIPTION
This was broken by #3162--rather than appending to the array, 'read' overwrites the array in each loop iteration, so the later queries will only use the last file listed in the git diff.