### PR TITLE
Fixed broken links to user manual in docs

### DIFF
--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -224,7 +224,7 @@ nav: docs
                 && window.location.pathname.lastIndexOf('/skylark/lib/') == -1) {
               var docFile = window.location.pathname.match(versionDocsURLRegex)[1];
               // some pages are not using markdown :(
-              if (docFile !== 'bazel-user-manual.html'
+              if (docFile !== 'user-manual.html'
                   && docFile !== 'build-ref.html'
                   && docFile !== 'query.html'
                   && docFile !== 'test-encyclopedia.html') {

--- a/site/docs/bazel-overview.md
+++ b/site/docs/bazel-overview.md
@@ -99,15 +99,15 @@ When running a build or a test, Bazel does the following:
 
 Since all previous build work is cached, Bazel can identify and reuse cached
 artifacts and only rebuild or retest what's changed. To further enforce
-correctness, you can set up Bazel to run builds and tests [hermetically](https://docs.bazel.build/versions/master/bazel-user-manual.html#sandboxing)
-through sandboxing, minimizing skew and maximizing [reproducibility](https://docs.bazel.build/versions/master/bazel-user-manual.html#correctness).
+correctness, you can set up Bazel to run builds and tests [hermetically](https://docs.bazel.build/versions/master/user-manual.html#sandboxing)
+through sandboxing, minimizing skew and maximizing [reproducibility](https://docs.bazel.build/versions/master/user-manual.html#correctness).
 
 
 ## What is the action graph?
 
 The action graph represents the build artifacts, the relationships between them,
 and the build actions that Bazel will perform. Thanks to this graph, Bazel can
-[track](https://docs.bazel.build/versions/master/bazel-user-manual.html#build-consistency-and-incremental-builds)
+[track](https://docs.bazel.build/versions/master/user-manual.html#build-consistency-and-incremental-builds)
 changes to file content as well as changes to actions, such as build or test
 commands, and know what build work has previously been done. The graph also
 enables you to easily [trace dependencies](https://docs.bazel.build/versions/master/query-how-to.html)

--- a/site/docs/best-practices.md
+++ b/site/docs/best-practices.md
@@ -87,7 +87,7 @@ misleading alias to point both targets to one guava library, then the BUILD file
 ## `.bazelrc`
 
 For project-specific options, use the configuration file `_your-workspace_/tools/bazel.rc` (see
-[bazelrc format](https://docs.bazel.build/bazel-user-manual.html#bazelrc)).
+[bazelrc format](https://docs.bazel.build/user-manual.html#bazelrc)).
 
 For options that you **do not** want to check into source control, create the configuration file
 `_your-workspace_/.bazelrc` and add `.bazelrc` to your `.gitignore`.  Note that this file has a

--- a/site/docs/query.html
+++ b/site/docs/query.html
@@ -323,7 +323,7 @@ title: Query Language
 <p>
   <code>bazel query</code> target patterns work the same as
   <code>bazel build</code> build targets do;
-  refer to <a href='bazel-user-manual.html#target-patterns'>Target Patterns</a>
+  refer to <a href='user-manual.html#target-patterns'>Target Patterns</a>
   in the Bazel User Manual for further details, or type <code>bazel
   help target-syntax</code>.
 

--- a/site/docs/test-encyclopedia.html
+++ b/site/docs/test-encyclopedia.html
@@ -11,7 +11,7 @@ title: Test Encyclopedia
 <p>The Bazel BUILD language includes rules which can be used to define
 automated test programs in many languages.</p>
 
-<p>Tests are run using <code><a href="bazel-user-manual.html#test">bazel test</a></code>.
+<p>Tests are run using <code><a href="user-manual.html#test">bazel test</a></code>.
 
 Users may also execute test binaries directly. This is allowed but not endorsed, as such
 an invocation will not adhere to the mandates described below.</p>

--- a/site/docs/tutorial/android-app.md
+++ b/site/docs/tutorial/android-app.md
@@ -315,7 +315,7 @@ Now, enter the following to build the sample app:
 bazel build //android:android
 ```
 
-The [`build`](../bazel-user-manual.html#build) subcommand instructs Bazel to
+The [`build`](../user-manual.html#build) subcommand instructs Bazel to
 build the target that follows. The target is specified as the name of a build
 rule inside a `BUILD` file, with along with the package path relative to
 your workspace directory. Note that you can sometimes omit the package path
@@ -367,7 +367,7 @@ how to build the backend server.
 
 You can now deploy the app to a connected Android device or emulator from the
 command line using the
-[`bazel mobile-install`](../bazel-user-manual.html#mobile-install)
+[`bazel mobile-install`](../user-manual.html#mobile-install)
 command. This command uses the Android Debug Bridge (`adb`) to communicate with
 the device. You must set up your device to use `adb` following the instructions
 in
@@ -383,7 +383,7 @@ bazel mobile-install //android:android
 ```
 
 Note that the `mobile-install` subcommand also supports the
-[`--incremental`](../bazel-user-manual.html#mobile-install)
+[`--incremental`](../user-manual.html#mobile-install)
 flag that can be used to deploy only those parts of the app that have changed
 since the last deployment.
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaSkylarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaSkylarkCommon.java
@@ -278,7 +278,7 @@ public class JavaSkylarkCommon {
         type = String.class,
         doc = "A string that specifies how to handle strict deps. Possible values: 'OFF', 'ERROR',"
           + "'WARN' and 'DEFAULT'. For more details see "
-          + "https://docs.bazel.build/versions/master/bazel-user-manual.html#flag--strict_java_deps"
+          + "https://docs.bazel.build/versions/master/user-manual.html#flag--strict_java_deps"
           + ". By default 'ERROR'."
       ),
       @Param(


### PR DESCRIPTION
The user manual filename has been renamed from `bazel-user-manual.html` to `user-manual.html`.