### PR TITLE
Sync Debian package deps, and add a comment to prevent future desync.

### DIFF
--- a/scripts/packages/debian/BUILD
+++ b/scripts/packages/debian/BUILD
@@ -72,7 +72,8 @@ pkg_deb(
     built_using = "bazel (HEAD)",
     data = ":debian-data",
     depends = [
-        "google-jdk | java8-jdk | java8-sdk | oracle-java8-installer",
+        # Keep in sync with Depends section in ./control
+        "google-jdk | java8-sdk-headless | java8-jdk | java8-sdk | oracle-java8-installer",
         "g++",
         "zlib1g-dev",
         "bash-completion",

--- a/scripts/packages/debian/control
+++ b/scripts/packages/debian/control
@@ -9,6 +9,7 @@ Package: bazel
 Section: contrib/devel
 Priority: optional
 Architecture: amd64
+# Keep in sync with :bazel-debian in ./BUILD
 Depends: google-jdk | java8-sdk-headless | java8-jdk | java8-sdk | oracle-java8-installer, g++, zlib1g-dev, bash-completion
 Description: Bazel is a tool that automates software builds and tests.
  Supported build tasks include running compilers and linkers to produce


### PR DESCRIPTION
Commit c8be465869fbcfaa00b75d241c67279324976e0b added the headless JDK
to `debian/control`, but this isn't propagating to published packages
because those use the deps list in `debian/BUILD`.

This commit adds the headless JDK to `debian/BUILD`, with comments so
future changes won't hit the same problem.