### PR TITLE
Genericize closed-source .bzl file references in examples

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/be/functions.vm
+++ b/src/main/java/com/google/devtools/build/docgen/templates/be/functions.vm
@@ -39,20 +39,20 @@ title: Functions
 </p>
 
 <pre class="code">
-load("//tools/build_rules:build_test.bzl", "build_test")
+load("//path/to/rules:my_rules.bzl", "my_rules")
 
 build_test(name = ...)
 </pre>
 
 <p>This will execute the
   <a href="{{ page.version_prefix }}/docs/skylark/index.html">Skylark</a>
-  module <code>tools/build_rules/build_test.bzl</code> and import the symbol
-  <code>build_test</code> in the local environment. This is useful for
+  module <code>//path/to/rules:my_rules.bzl</code> and import the symbol
+  <code>my_rules</code> in the local environment. This is useful for
   using macros or for sharing values between multiple BUILD files. By
   using more arguments, you can load more symbols at once.</p>
 
 <pre class="code">
-load("//tools/build_rules:build_defs.bzl", "COMPILER_FLAGS", "LINKER_FLAGS")
+load("//path/to/rules:my_defs.bzl", "COMPILER_FLAGS", "LINKER_FLAGS")
 </pre>
 
 <p>
@@ -62,11 +62,11 @@ load("//tools/build_rules:build_defs.bzl", "COMPILER_FLAGS", "LINKER_FLAGS")
 </p>
 
 <pre class="code">
-load("//tools/build_rules:build_defs.bzl", BUILD_DEF_COMPILER_FLAGS="COMPILER_FLAGS", "LINKER_FLAGS")
+load("//path/to/rules:my_defs.bzl", BUILD_DEF_COMPILER_FLAGS="COMPILER_FLAGS", "LINKER_FLAGS")
 </pre>
 <p>
 This will make <code>COMPILER_FLAGS</code> exported from
-<code>build_defs.bzl</code> available under the name
+<code>my_defs.bzl</code> available under the name
 <code>BUILD_DEF_COMPILER_FLAGS</code> in the current file.
 </p>
 


### PR DESCRIPTION
Replace references to closed-source .bzl files in examples with generic ones. Addresses issue [4321](https://github.com/bazelbuild/bazel/issues/4321).