### PR TITLE
Update cpp-use-cases.md

### DIFF
--- a/site/docs/cpp-use-cases.md
+++ b/site/docs/cpp-use-cases.md
@@ -80,7 +80,7 @@ directory structure:
 
 ```
 └── my-project
-    ├── third_party
+    ├── legacy
     │   └── some_lib
     │       ├── BUILD
     │       ├── include
@@ -90,17 +90,17 @@ directory structure:
 ```
 
 Bazel will expect `some_lib.h` to be included as
-`third_party/some_lib/include/some_lib.h`, but suppose `some_lib.cc` includes
+`legacy/some_lib/include/some_lib.h`, but suppose `some_lib.cc` includes
 `"include/some_lib.h"`.  To make that include path valid,
-`third_party/some_lib/BUILD` will need to specify that the `some_lib/`
+`legacy/some_lib/BUILD` will need to specify that the `some_lib/`
 directory is an include directory:
 
 ```python
 cc_library(
     name = "some_lib",
     srcs = ["some_lib.cc"],
-    hdrs = ["some_lib.h"],
-    copts = ["-Ithird_party/some_lib"],
+    hdrs = ["include/some_lib.h"],
+    copts = ["-Ilegacy/some_lib/include"],
 )
 ```
 


### PR DESCRIPTION
I wasn't able to build a simple 'hello-world' example with an identical structure.  I encountered several problems:
1) bazel forces to declare a license for code within the 'third_party' sub-directory.  This not at all obvious to noobs.
2) bazel complains about a missing input file 'some_lib.h' without the leading 'include' in hdrs and the build fails.
3) compilation throws "No such file or directory" when trying to include 'some_lib.h' with the trailing 'include' in copts.

I think this is particularly important for converting legacy projects (not necessarily third party) that use cmake, autoconf, etc...