### PR TITLE
bazel_workspace_status_test: don't assume order

### DIFF
--- a/src/test/shell/bazel/bazel_workspace_status_test.sh
+++ b/src/test/shell/bazel/bazel_workspace_status_test.sh
@@ -127,9 +127,9 @@ genrule(
 )
 EOF
 
-  bazel build --workspace_status_command=$TEST_TMPDIR/wsc.sh --stamp //:a &> $TEST_log \
+  bazel build --workspace_status_command=$TEST_TMPDIR/wscmissing.sh --stamp //:a &> $TEST_log \
     && fail "build succeeded"
-  expect_log "wsc.sh: No such file or directory\|wsc.sh: not found"
+  expect_log "wscmissing.sh: No such file or directory\|wscmissing.sh: not found"
 }
 
 


### PR DESCRIPTION
The test_errmsg test tested the behaviour when workspace_status_command
was set to a file that did not exist, but other tests created a file
with that name.  If test_errmsg did not run first, the
workspace_status_command would be valid and the test would fail.