### PR TITLE
Remove unnecessary copy of source SPEC file to temporary destination

### DIFF
--- a/tools/build_defs/pkg/make_rpm.py
+++ b/tools/build_defs/pkg/make_rpm.py
@@ -180,8 +180,6 @@ class RpmBuilder(object):
       if not os.path.exists(name):
         os.makedirs(name, 0o777)
 
-    shutil.copy(os.path.join(original_dir, spec_file), os.getcwd())
-
     # Copy the files.
     for f in self.files:
       shutil.copy(os.path.join(original_dir, f), RpmBuilder.BUILD_DIR)

--- a/tools/build_defs/pkg/pkg.bzl
+++ b/tools/build_defs/pkg/pkg.bzl
@@ -66,7 +66,6 @@ def _pkg_tar_impl(ctx):
       use_default_shell_env = True,
       )
 
-
 def _pkg_deb_impl(ctx):
   """The implementation for the pkg_deb rule."""
   files = [ctx.file.data]


### PR DESCRIPTION
Previous behaviour:
* The CopyAndRewrite function would raise a write permission denied error on the output file, which had permissions 0555, when the input SPEC file was auto-generated.

Current behaviour:
* Do not copy the input SPEC file (auto-generated or otherwise) to the destination in the temporary working directory since the CopyAndRewrite function will generate the output file regardless. This allows the package to support static or auto-generated SPEC files.