### PR TITLE
expose getTransitiveProtoPathFlags to skylark

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoSourcesProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoSourcesProvider.java
@@ -136,6 +136,13 @@ public abstract class ProtoSourcesProvider implements TransitiveInfoProvider {
    * Directories of .proto sources collected from the transitive closure, each prefixed with
    * {@code --proto_path}. These flags will be passed to {@code protoc} in the specified oreder.
    */
+  @SkylarkCallable(
+    name = "transitive_proto_path_flags",
+    doc =
+        "Directories of .proto sources collected from the transitive closure, each prefixed with"
+            + "--proto_path. These flags will be passed to protoc in the specified oreder."
+    structField = true
+  )
   public abstract NestedSet<String> getTransitiveProtoPathFlags();
 
   ProtoSourcesProvider() {}


### PR DESCRIPTION
as transitive_proto_path_flags
this is to fix #4544 