### PR TITLE
Add execution platform information to the action key.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
@@ -317,7 +317,11 @@ public abstract class AbstractAction implements Action, SkylarkValue {
 
         // Always add the execution platform.
         if (getExecutionPlatform() != null) {
+          fp.addBoolean(true);
           getExecutionPlatform().addTo(fp);
+        } else {
+          // Ensure we can distinguish keys for actions with no execution platform.
+          fp.addBoolean(false);
         }
 
         // Compute the actual key and store it.

--- a/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
@@ -314,6 +314,13 @@ public abstract class AbstractAction implements Action, SkylarkValue {
       try {
         Fingerprint fp = new Fingerprint();
         computeKey(actionKeyContext, fp);
+
+        // Always add the execution platform.
+        if (getExecutionPlatform() != null) {
+          getExecutionPlatform().addTo(fp);
+        }
+
+        // Compute the actual key and store it.
         cachedKey = fp.hexDigestAndReset();
       } catch (CommandLineExpansionException e) {
         cachedKey = KEY_ERROR;

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintSettingInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintSettingInfo.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.skylarkinterface.SkylarkModuleCategory;
 import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.FunctionSignature;
 import com.google.devtools.build.lib.syntax.SkylarkType;
+import com.google.devtools.build.lib.util.Fingerprint;
 
 /** Provider for a platform constraint setting that is available to be fulfilled. */
 @SkylarkModule(
@@ -96,5 +97,12 @@ public class ConstraintSettingInfo extends NativeInfo {
   /** Returns a new {@link ConstraintSettingInfo} with the given data. */
   public static ConstraintSettingInfo create(Label constraintSetting, Location location) {
     return new ConstraintSettingInfo(constraintSetting, location);
+  }
+
+  /**
+   * Add this constraint setting to the given fingerprint.
+   */
+  public void addTo(Fingerprint fp) {
+    fp.addString(label.getCanonicalForm());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfo.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.skylarkinterface.SkylarkModuleCategory;
 import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.FunctionSignature;
 import com.google.devtools.build.lib.syntax.SkylarkType;
+import com.google.devtools.build.lib.util.Fingerprint;
 
 /** Provider for a platform constraint value that fulfills a {@link ConstraintSettingInfo}. */
 @SkylarkModule(
@@ -113,5 +114,13 @@ public class ConstraintValueInfo extends NativeInfo {
   public static ConstraintValueInfo create(
       ConstraintSettingInfo constraint, Label value, Location location) {
     return new ConstraintValueInfo(constraint, value, location);
+  }
+
+  /**
+   * Add this constraint value to the given fingerprint.
+   */
+  public void addTo(Fingerprint fp) {
+    this.constraint.addTo(fp);
+    fp.addString(label.getCanonicalForm());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
@@ -39,10 +39,12 @@ import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.FunctionSignature;
 import com.google.devtools.build.lib.syntax.SkylarkList;
 import com.google.devtools.build.lib.syntax.SkylarkType;
+import com.google.devtools.build.lib.util.Fingerprint;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /** Provider for a platform, which is a group of constraints and values. */
@@ -174,6 +176,15 @@ public class PlatformInfo extends NativeInfo {
   /** Returns a new {@link Builder} for creating a fresh {@link PlatformInfo} instance. */
   public static Builder builder() {
     return new Builder();
+  }
+
+  /**
+   * Add this platform to the given fingerprint.
+   */
+  public void addTo(Fingerprint f) {
+    f.addString(label.toString());
+    f.addNullableString(remoteExecutionProperties);
+    f.addInt(constraints.size());
   }
 
   /** Builder class to facilitate creating valid {@link PlatformInfo} instances. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
@@ -182,14 +182,12 @@ public class PlatformInfo extends NativeInfo {
   /**
    * Add this platform to the given fingerprint.
    */
-  public void addTo(Fingerprint f) {
-    f.addString(label.toString());
-    f.addNullableString(remoteExecutionProperties);
-    f.addInt(constraints.size());
-    f.addStrings(constraints.values().stream()
-        .map(ConstraintValueInfo::label)
-        .map(Label::getCanonicalForm)
-        .collect(toImmutableList()));
+  public void addTo(Fingerprint fp) {
+    fp.addString(label.toString());
+    fp.addNullableString(remoteExecutionProperties);
+    fp.addInt(constraints.size());
+    constraints.values().forEach(
+        constraintValue -> constraintValue.addTo(fp));
   }
 
   /** Builder class to facilitate creating valid {@link PlatformInfo} instances. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.analysis.platform;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableListMultimap.flatteningToImmutableListMultimap;
 import static com.google.common.collect.ImmutableListMultimap.toImmutableListMultimap;
 import static java.util.stream.Collectors.joining;
@@ -185,6 +186,10 @@ public class PlatformInfo extends NativeInfo {
     f.addString(label.toString());
     f.addNullableString(remoteExecutionProperties);
     f.addInt(constraints.size());
+    f.addStrings(constraints.values().stream()
+        .map(ConstraintValueInfo::label)
+        .map(Label::getCanonicalForm)
+        .collect(toImmutableList()));
   }
 
   /** Builder class to facilitate creating valid {@link PlatformInfo} instances. */

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
@@ -116,6 +116,14 @@ public class PlatformInfoTest extends BuildViewTestCase {
                 .setLabel(makeLabel("//platform/plat1"))
                 .addConstraint(value1)
                 .build())
+        .addEqualityGroup(
+            // Different remote exec properties.
+            PlatformInfo.builder()
+                .setLabel(makeLabel("//platform/plat1"))
+                .addConstraint(value1)
+                .addConstraint(value2)
+                .setRemoteExecutionProperties("foo")
+                .build())
         .testEquals();
   }
 


### PR DESCRIPTION
Needed so that actions are properly invalidated and re-run when the platform's remote execution properties change.
 See 
Change-Id: I603d78efb0953b89682cc32226e246ed94af2e44