### PR TITLE
CROSSTOOLS: Fix comment for /EHsc compiler flag

### DIFF
--- a/tools/cpp/CROSSTOOL.tpl
+++ b/tools/cpp/CROSSTOOL.tpl
@@ -249,7 +249,8 @@ toolchain {
   compiler_flag: "/Gy"
   # Use string pooling.
   compiler_flag: "/GF"
-  # Catch both asynchronous (structured) and synchronous (C++) exceptions.
+  # Catch C++ exceptions only and tell the compiler to assume that functions declared
+  # as extern "C" never throw a C++ exception.
   compiler_flag: "/EHsc"
 
   # Globally disabled warnings.


### PR DESCRIPTION
The previous comment referred to the option `/EHa`, but `/EHsc` is the option to only catch C++ standards (which seems to be what we want, according to this doc: https://msdn.microsoft.com/en-us/library/1deeycx5.aspx)