### PR TITLE
docs,windows: update bootstrap & install docs

### DIFF
--- a/site/docs/install-compile-source.md
+++ b/site/docs/install-compile-source.md
@@ -47,34 +47,3 @@ You can build Bazel from source following these steps:
     and `output/bazel.exe` on Windows. This is a self-contained Bazel binary.
     You can copy it to a directory on the `PATH` (such as `/usr/local/bin` on
     Linux) or use it in-place.
-
-## Note to Windows users
-
-Make sure your machine meets the [requirements](windows.html) and that you use
-the latest version of the sources (`bazel-0.X.Y-dist.zip`).
-
-There's a bug in the compilation scripts in `bazel-0.6.0-dist.zip` and in
-`bazel-0.6.1-dist.zip`:
-
-To fix it:
-
-*   either apply the changes in
-    [e79a110](https://github.com/bazelbuild/bazel/commit/e79a1107d90380501102990d82cbfaa8f51a1778)
-    to the source tree,
-
-*   or just replace the following line in
-    `src/main/native/windows/build_windows_jni.sh`:
-
-     ```sh
-     @CL /O2 /EHsc /LD /Fe:"$(cygpath -a -w ${DLL})" /I "${VSTEMP}" /I . ${WINDOWS_SOURCES[*]}
-     ```
-
-     with this line:
-
-     ```sh
-     @CL /O2 /EHsc /LD /Fe:"$(cygpath -a -w ${DLL})" /I "%TMP%" /I . ${WINDOWS_SOURCES[*]}
-     ```
-
-It suffices to do one of these to bootstrap Bazel. We however recommend
-applying the full commit (e79a110) because it also adds extra environment
-checks to `./compile.sh`.

--- a/site/docs/install-compile-source.md
+++ b/site/docs/install-compile-source.md
@@ -3,11 +3,12 @@ layout: documentation
 title: Compiling Bazel from Source
 ---
 
-# <a name="compiling-from-source"></a>Compiling Bazel from Source
+# <a name="compiling-from-source"></a>Compiling Bazel from Source (bootstrapping)
 
-You can build Bazel from source following these steps:
+You can build Bazel from source without using an existing Bazel binary by
+doing the following:
 
-1.  Ensure that JDK 8, Python, bash, zip, and the usual C build toolchain
+1.  Ensure that JDK 8, Python, Bash, zip, and the usual C++ build toolchain
     are installed on your system.
     *   On systems based on Debian packages (Debian, Ubuntu): you can install
         OpenJDK 8 and Python by running the following command in a terminal:
@@ -15,16 +16,17 @@ You can build Bazel from source following these steps:
         ```sh
         sudo apt-get install build-essential openjdk-8-jdk python zip
         ```
-    *   On Windows: you need additional software. See the [requirements
-        page](windows.html#requirements).
+    *   On Windows: you need additional software and the right OS version.
+        See the [Windows page](windows.html).
 
 2.  Download and unpack Bazel's distribution archive.
 
     Download `bazel-<version>-dist.zip` from the [release
     page](https://github.com/bazelbuild/bazel/releases).
 
-    **Note:** There is a **single architecture independent** distribution
-    archive. There are no architecture-specific distribution archives.
+    **Note:** There is a **single, architecture independent** distribution
+    archive. There are no architecture-specific or OS-specific distribution
+    archives.
 
     We recommend to also
     verify the signature made by our [release
@@ -39,9 +41,12 @@ You can build Bazel from source following these steps:
         shell session:
         1.  `cd` into the directory where you unpacked the distribution archive
         2.  run `bash ./compile.sh`
-    *   On Windows, do following steps in the msys2 shell:
+    *   On Windows, do following steps in the MSYS2 shell:
         1.  `cd` into the directory where you unpacked the distribution archive
         2.  run `./compile.sh`
+
+        Once you have a Bazel binary, you no longer need to use the MSYS2 shell.
+        You can run Bazel from the Command Prompt (`cmd.exe`) or PowerShell.
 
     The output will be `output/bazel` on Unix-like systems (e.g. Ubuntu, macOS)
     and `output/bazel.exe` on Windows. This is a self-contained Bazel binary.

--- a/site/docs/install-windows.md
+++ b/site/docs/install-windows.md
@@ -7,13 +7,14 @@ title: Installing Bazel on Windows
 
 Supported Windows platforms:
 
-*   64 bit Windows 7 or higher
+*   64 bit Windows 7 or higher, or equivalent Windows Server versions.
 
-Before installing Bazel, make sure your system meets the
-[Windows requirements](windows.html#requirements) to run Bazel.
+Check
+<a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx">Microsoft's
+Operating System Version table</a> to see if your OS is supported.
 
-After installing Bazel on Windows, see
-[Using Bazel on Windows](windows.html#using).
+Before installing Bazel, make sure your system meets the system and software
+requirements. See the page about [using Bazel on Windows](windows.html).
 
 Install Bazel on Windows using one of the following methods:
 
@@ -24,16 +25,17 @@ Install Bazel on Windows using one of the following methods:
 ## Download the binary (recommended)
 
 Go to Bazel's [GitHub releases page](https://github.com/bazelbuild/bazel/releases)
-and download the Windows binary. We recommend putting the binary in a directory
-that's on your `%PATH%`. You can, however, put the binary anywhere on your
-filesystem.
+and download the Windows binary.
+
+For convenience, move the binary to a directory that's on your `%PATH%`. This
+way you can run Bazel by typing `bazel` in any directory, without typing out the
+full path. That said, you may put the binary anywhere on your filesystem.
 
 After you download the binary, you'll need additional
 software and some setup in your environment to run Bazel. For details, see the
 [Windows requirements](windows.html).
 
 ## Install using Chocolatey
-
 
 You can install the Bazel package using the [Chocolatey](https://chocolatey.org)
 package manager:
@@ -43,7 +45,7 @@ choco install bazel
 ```
 
 This command will install the latest available version of Bazel and most of
-its dependencies, such as the msys2 shell. This will not install Visual C++
+its dependencies, such as the MSYS2 shell. This will not install Visual C++
 though.
 
 See [Chocolatey installation and package maintenance

--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -5,28 +5,51 @@ title: Windows
 
 # Using Bazel on Windows
 
-Bazel runs on 64 bit Windows 7 or higher. Known issues are [marked with label
-"Windows"](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+label%3A%22category%3A+multi-platform+%3E+windows%22)
-on GitHub issues.
+## Windows version requirements
 
-Bazel is a native Windows binary. Run it from the Windows Command Prompt
-(`cmd.exe`) or from PowerShell.
+Bazel is a native Windows binary.
 
-## <a name="requirements"></a>Requirements
+Bazel runs on 64 bit Windows 7 or higher, and on equivalent Windows Server
+versions. Check
+<a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx">Microsoft's
+Operating System Version table</a> to see if your OS is supported.
+
+## Known issues
+
+We mark Windows-related Bazel issues on GitHub with the "multi-platform >
+windows" label. [You can see the open issues here.](https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+label%3A%22category%3A+multi-platform+%3E+windows%22)
+
+## Running Bazel: MSYS2 shell vs. Command Prompt vs. PowerShell
+
+It's best to run Bazel from the Command Prompt (`cmd.exe`) or from PowerShell.
+
+You can also run Bazel from the MSYS2 shell, but you need to disable MSYS2's
+automatic path converion. See [this StackOverflow
+answer](https://stackoverflow.com/a/49004265/7778502) for details.
+
+## <a name="requirements"></a>Software requirements
 
 *   Python 2.7 or later.
-*   [msys2 shell](https://msys2.github.io/).
+
+    Use the Windows-native Python version. Do not use Python that comes with the
+    MSYS2 shell or that you installed in MSYS using Pacman, because it doesn't
+    work with Bazel.
+
+*   [MSYS2 shell](https://msys2.github.io/).
 
     You also need to set the `BAZEL_SH` environment variable to point to
     `bash.exe`. For example in the Windows Command Prompt (`cmd.exe`):
 
     ```
-    set BAZEL_SH=C:\msys64\usr\bin\bash.exe
+    set BAZEL_SH=C:\tools\msys64\usr\bin\bash.exe
     ```
 
-*   Several msys2 packages.
+    **Note**: do not use quotes (") around the path like you would on Unixes.
+    Windows doesn't need them and it may confuse Bazel.
 
-    Run the following command in the msys2 shell to install them:
+*   Several MSYS2 packages.
+
+    Run the following command in the MSYS2 shell to install them:
 
     ```bash
     pacman -Syuu git curl zip unzip
@@ -36,8 +59,8 @@ Bazel is a native Windows binary. Run it from the Windows Command Prompt
 
     JDK 7 and 9 are not supported.
 
-    If you downloaded a binary distribution of Bazel (see [installing Bazel on
-    Windows](install-windows.html)), the binary has JDK 8 embedded by default.
+    This step is not required if you downloaded a binary distribution of Bazel,
+    because it has JDK 8 embedded.
 
 *   If you built Bazel from source: set the `JAVA_HOME` environment variable to
     the JDK's directory.
@@ -48,9 +71,14 @@ Bazel is a native Windows binary. Run it from the Windows Command Prompt
     set JAVA_HOME=C:\Program Files\Java\jdk1.8.0_112
     ```
 
+    **Note**: do not use quotes (") around the path like you would on Unixes.
+    Windows doesn't need them and it may confuse Bazel.
+
     This step is not required if you downloaded a binary distribution of Bazel
     or installed Bazel using Chocolatey. See [installing Bazel on
     Windows](install-windows.html).
+
+## Setting environment variables
 
 Environment variables you set in the Windows Command Prompt (`cmd.exe`) are only
 set in that command prompt session. If you start a new `cmd.exe`, you need to
@@ -69,7 +97,12 @@ The first time you build any target, Bazel auto-configures the location of
 Python and the Visual C++ compiler. If you need to auto-configure again, run
 `bazel clean` then build a target.
 
-### Build C++
+You can also tell Bazel where to find the Python binary and the C++ compiler:
+- use the [`--python_path=c:\path\to\python.exe`](command-line-reference.html#flag--python_path) flag for Python
+- use the `BAZEL_VC` or `BAZEL_VS` environment variable. See the [Build
+  C++ section](#build_cpp) below.
+
+### <a name="build_cpp"></a>Build C++
 
 To build C++ targets, you need:
 


### PR DESCRIPTION
Update the documentation about:
- compiling Bazel from source (without an existing Bazel binary) on Windows
- OS and software requirements on Windows