### PR TITLE
Do not allow platform-related providers to be constructed from Skylark.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintSettingInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintSettingInfo.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.analysis.platform;
 
-import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.events.Location;
@@ -25,9 +24,6 @@ import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec.
 import com.google.devtools.build.lib.skylarkinterface.SkylarkCallable;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkModule;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkModuleCategory;
-import com.google.devtools.build.lib.syntax.EvalException;
-import com.google.devtools.build.lib.syntax.FunctionSignature;
-import com.google.devtools.build.lib.syntax.SkylarkType;
 
 /** Provider for a platform constraint setting that is available to be fulfilled. */
 @SkylarkModule(
@@ -41,30 +37,9 @@ public class ConstraintSettingInfo extends NativeInfo {
   /** Name used in Skylark for accessing this provider. */
   public static final String SKYLARK_NAME = "ConstraintSettingInfo";
 
-  private static final FunctionSignature.WithValues<Object, SkylarkType> SIGNATURE =
-      FunctionSignature.WithValues.create(
-          FunctionSignature.of(
-              /*numMandatoryPositionals=*/ 1,
-              /*numOptionalPositionals=*/ 0,
-              /*numMandatoryNamedOnly*/ 0,
-              /*starArg=*/ false,
-              /*kwArg=*/ false,
-              /*names=*/ "label"),
-          /*defaultValues=*/ null,
-          /*types=*/ ImmutableList.<SkylarkType>of(SkylarkType.of(Label.class)));
-
   /** Skylark constructor and identifier for this provider. */
   public static final NativeProvider<ConstraintSettingInfo> PROVIDER =
-      new NativeProvider<ConstraintSettingInfo>(
-          ConstraintSettingInfo.class, SKYLARK_NAME, SIGNATURE) {
-        @Override
-        protected ConstraintSettingInfo createInstanceFromSkylark(Object[] args, Location loc)
-            throws EvalException {
-          // Based on SIGNATURE above, the args are label.
-          Label label = (Label) args[0];
-          return ConstraintSettingInfo.create(label, loc);
-        }
-      };
+      new NativeProvider<ConstraintSettingInfo>(ConstraintSettingInfo.class, SKYLARK_NAME) {};
 
   private final Label label;
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfo.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.analysis.platform;
 
-import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.events.Location;
@@ -25,9 +24,6 @@ import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec.
 import com.google.devtools.build.lib.skylarkinterface.SkylarkCallable;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkModule;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkModuleCategory;
-import com.google.devtools.build.lib.syntax.EvalException;
-import com.google.devtools.build.lib.syntax.FunctionSignature;
-import com.google.devtools.build.lib.syntax.SkylarkType;
 
 /** Provider for a platform constraint value that fulfills a {@link ConstraintSettingInfo}. */
 @SkylarkModule(
@@ -41,32 +37,9 @@ public class ConstraintValueInfo extends NativeInfo {
   /** Name used in Skylark for accessing this provider. */
   public static final String SKYLARK_NAME = "ConstraintValueInfo";
 
-  private static final FunctionSignature.WithValues<Object, SkylarkType> SIGNATURE =
-      FunctionSignature.WithValues.create(
-          FunctionSignature.of(
-              /*numMandatoryPositionals=*/ 2,
-              /*numOptionalPositionals=*/ 0,
-              /*numMandatoryNamedOnly*/ 0,
-              /*starArg=*/ false,
-              /*kwArg=*/ false,
-              /*names=*/ "label",
-              "constraint_setting"),
-          /*defaultValues=*/ null,
-          /*types=*/ ImmutableList.<SkylarkType>of(
-              SkylarkType.of(Label.class), SkylarkType.of(ConstraintSettingInfo.class)));
-
   /** Skylark constructor and identifier for this provider. */
   public static final NativeProvider<ConstraintValueInfo> SKYLARK_CONSTRUCTOR =
-      new NativeProvider<ConstraintValueInfo>(ConstraintValueInfo.class, SKYLARK_NAME, SIGNATURE) {
-        @Override
-        protected ConstraintValueInfo createInstanceFromSkylark(Object[] args, Location loc)
-            throws EvalException {
-          // Based on SIGNATURE above, the args are label, constraint_setting.
-          Label label = (Label) args[0];
-          ConstraintSettingInfo constraint = (ConstraintSettingInfo) args[1];
-          return ConstraintValueInfo.create(constraint, label, loc);
-        }
-      };
+      new NativeProvider<ConstraintValueInfo>(ConstraintValueInfo.class, SKYLARK_NAME) {};
 
   private final ConstraintSettingInfo constraint;
   private final Label label;

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfo.java
@@ -21,7 +21,7 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 
 /**
- * Provider for a toolchain declaration, which assosiates a toolchain type, the execution and target
+ * Provider for a toolchain declaration, which associates a toolchain type, the execution and target
  * constraints, and the actual toolchain label. The toolchain is then available for use but will be
  * lazily resolved only when it is actually needed for toolchain-aware rules. Toolchain definitions
  * are exposed to Skylark and Bazel via {@link ToolchainInfo} providers.

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformInfo.java
@@ -34,10 +34,6 @@ import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec.
 import com.google.devtools.build.lib.skylarkinterface.SkylarkCallable;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkModule;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkModuleCategory;
-import com.google.devtools.build.lib.syntax.EvalException;
-import com.google.devtools.build.lib.syntax.FunctionSignature;
-import com.google.devtools.build.lib.syntax.SkylarkList;
-import com.google.devtools.build.lib.syntax.SkylarkType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -56,46 +52,9 @@ public class PlatformInfo extends NativeInfo {
   /** Name used in Skylark for accessing this provider. */
   public static final String SKYLARK_NAME = "PlatformInfo";
 
-  private static final FunctionSignature.WithValues<Object, SkylarkType> SIGNATURE =
-      FunctionSignature.WithValues.create(
-          FunctionSignature.of(
-              /*numMandatoryPositionals=*/ 2,
-              /*numOptionalPositionals=*/ 0,
-              /*numMandatoryNamedOnly*/ 0,
-              /*starArg=*/ false,
-              /*kwArg=*/ false,
-              /*names=*/ "label",
-              "constraint_values"),
-          /*defaultValues=*/ null,
-          /*types=*/ ImmutableList.<SkylarkType>of(
-              SkylarkType.of(Label.class),
-              SkylarkType.Combination.of(
-                  SkylarkType.LIST, SkylarkType.of(ConstraintValueInfo.class))));
-
   /** Skylark constructor and identifier for this provider. */
   public static final NativeProvider<PlatformInfo> SKYLARK_CONSTRUCTOR =
-      new NativeProvider<PlatformInfo>(PlatformInfo.class, SKYLARK_NAME, SIGNATURE) {
-        @Override
-        protected PlatformInfo createInstanceFromSkylark(Object[] args, Location loc)
-            throws EvalException {
-          // Based on SIGNATURE above, the args are label, constraint_values.
-
-          Label label = (Label) args[0];
-          List<ConstraintValueInfo> constraintValues =
-              SkylarkList.castSkylarkListOrNoneToList(
-                  args[1], ConstraintValueInfo.class, "constraint_values");
-          try {
-            return builder()
-                .setLabel(label)
-                .addConstraints(constraintValues)
-                .setLocation(loc)
-                .build();
-          } catch (DuplicateConstraintException dce) {
-            throw new EvalException(
-                loc, String.format("Cannot create PlatformInfo: %s", dce.getMessage()));
-          }
-        }
-      };
+      new NativeProvider<PlatformInfo>(PlatformInfo.class, SKYLARK_NAME) {};
 
   private final Label label;
   private final ImmutableMap<ConstraintSettingInfo, ConstraintValueInfo> constraints;

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/ConstraintSettingInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/ConstraintSettingInfoTest.java
@@ -37,28 +37,4 @@ public class ConstraintSettingInfoTest extends BuildViewTestCase {
         .addEqualityGroup(ConstraintSettingInfo.create(makeLabel("//constraint:other")))
         .testEquals();
   }
-
-  @Test
-  public void constraintSettingInfoConstructor() throws Exception {
-    scratch.file(
-        "test/platform/my_constraint_setting.bzl",
-        "def _impl(ctx):",
-        "  constraint_setting = platform_common.ConstraintSettingInfo(label = ctx.label)",
-        "  return [constraint_setting]",
-        "my_constraint_setting = rule(",
-        "  implementation = _impl,",
-        "  attrs = {",
-        "  }",
-        ")");
-    scratch.file(
-        "test/platform/BUILD",
-        "load('//test/platform:my_constraint_setting.bzl', 'my_constraint_setting')",
-        "my_constraint_setting(name = 'custom')");
-
-    ConfiguredTarget setting = getConfiguredTarget("//test/platform:custom");
-    assertThat(setting).isNotNull();
-    assertThat(PlatformProviderUtils.constraintSetting(setting)).isNotNull();
-    assertThat(PlatformProviderUtils.constraintSetting(setting).label())
-        .isEqualTo(Label.parseAbsolute("//test/platform:custom"));
-  }
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfoTest.java
@@ -45,37 +45,4 @@ public class ConstraintValueInfoTest extends BuildViewTestCase {
             ConstraintValueInfo.create(setting2, makeLabel("//constraint:otherValue")))
         .testEquals();
   }
-
-  @Test
-  public void constraintValueInfoConstructor() throws Exception {
-    scratch.file(
-        "test/platform/my_constraint_value.bzl",
-        "def _impl(ctx):",
-        "  setting = ctx.attr.setting[platform_common.ConstraintSettingInfo]",
-        "  constraint_value = platform_common.ConstraintValueInfo(",
-        "    label = ctx.label, constraint_setting = setting)",
-        "  return [constraint_value]",
-        "my_constraint_value = rule(",
-        "  implementation = _impl,",
-        "  attrs = {",
-        "    'setting': attr.label(providers = [platform_common.ConstraintSettingInfo]),",
-        "  }",
-        ")");
-    scratch.file(
-        "test/platform/BUILD",
-        "load('//test/platform:my_constraint_value.bzl', 'my_constraint_value')",
-        "constraint_setting(name = 'basic')",
-        "my_constraint_value(",
-        "  name = 'custom',",
-        "  setting = ':basic',",
-        ")");
-
-    ConfiguredTarget value = getConfiguredTarget("//test/platform:custom");
-    assertThat(value).isNotNull();
-    assertThat(PlatformProviderUtils.constraintValue(value)).isNotNull();
-    assertThat(PlatformProviderUtils.constraintValue(value).constraint().label())
-        .isEqualTo(Label.parseAbsolute("//test/platform:basic"));
-    assertThat(PlatformProviderUtils.constraintValue(value).label())
-        .isEqualTo(Label.parseAbsolute("//test/platform:custom"));
-  }
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
@@ -120,45 +120,6 @@ public class PlatformInfoTest extends BuildViewTestCase {
   }
 
   @Test
-  public void platformInfoConstructor() throws Exception {
-    scratch.file(
-        "test/platform/my_platform.bzl",
-        "def _impl(ctx):",
-        "  constraints = [val[platform_common.ConstraintValueInfo] "
-            + "for val in ctx.attr.constraints]",
-        "  platform = platform_common.PlatformInfo(",
-        "      label = ctx.label, constraint_values = constraints)",
-        "  return [platform]",
-        "my_platform = rule(",
-        "  implementation = _impl,",
-        "  attrs = {",
-        "    'constraints': attr.label_list(providers = [platform_common.ConstraintValueInfo])",
-        "  }",
-        ")");
-    scratch.file(
-        "test/platform/BUILD",
-        "load('//test/platform:my_platform.bzl', 'my_platform')",
-        "my_platform(name = 'custom',",
-        "    constraints = [",
-        "       '//constraint:foo',",
-        "    ])");
-
-    ConfiguredTarget platform = getConfiguredTarget("//test/platform:custom");
-    assertThat(platform).isNotNull();
-
-    PlatformInfo provider = PlatformProviderUtils.platform(platform);
-    assertThat(provider).isNotNull();
-    assertThat(provider.label()).isEqualTo(makeLabel("//test/platform:custom"));
-    assertThat(provider.constraints()).hasSize(1);
-    ConstraintSettingInfo constraintSetting =
-        ConstraintSettingInfo.create(makeLabel("//constraint:basic"));
-    ConstraintValueInfo constraintValue =
-        ConstraintValueInfo.create(constraintSetting, makeLabel("//constraint:foo"));
-    assertThat(provider.constraints()).containsExactly(constraintValue);
-    assertThat(provider.remoteExecutionProperties()).isNull();
-  }
-
-  @Test
   public void platformInfoConstructor_error_duplicateConstraints() throws Exception {
     scratch.file(
         "test/platform/my_platform.bzl",


### PR DESCRIPTION
This is needed so we can load platforms directly from platform-rule
targets without needing a full configured target, and to effiently
distinguish platform providers from non-platform providers.

Change-Id: I6b61f9ee7518d5e9311232908a922596e18fe32f