### PR TITLE
cc_library for ext build rule example to fit '.so'

### DIFF
--- a/site/docs/external.md
+++ b/site/docs/external.md
@@ -107,7 +107,7 @@ new_local_repository(
 example:
 
 ```python
-java_library(
+cc_library(
     name = "some-lib",
     srcs = glob(["**"]),
     visibility = ["//visibility:public"],


### PR DESCRIPTION
The example for Depending on non-Bazel projects describes depending on a .so file. java_library builds .jar files, so is inconsistent.This PR switches the example to use cc_library, which actually builds a .so file so matches the description.