### PR TITLE
ci,windows: fix "bazel-rules-tests"

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/android/ndkcrosstools/AndroidNdkCrosstoolsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/android/ndkcrosstools/AndroidNdkCrosstoolsTest.java
@@ -85,7 +85,7 @@ public class AndroidNdkCrosstoolsTest {
         // The contents of the NDK are placed at "external/%repositoryName%/ndk".
         // The "external/%repositoryName%" part is removed using NdkPaths.stripRepositoryPrefix,
         // but to make it easier the "ndk/" part is added here.
-        ndkFiles.add("ndk/" + line);
+        ndkFiles.add("ndk/" + line.trim());
       }
       return ndkFiles.build();
     }
@@ -95,7 +95,7 @@ public class AndroidNdkCrosstoolsTest {
           ResourceFileLoader.loadResource(AndroidNdkCrosstoolsTest.class, ndkDirectoriesFilename);
       ImmutableSet.Builder<String> ndkDirectories = ImmutableSet.builder();
       for (String line : ndkFilesFileContent.split("\n")) {
-        ndkDirectories.add("ndk/" + line);
+        ndkDirectories.add("ndk/" + line.trim());
       }
       return ndkDirectories.build();
     }


### PR DESCRIPTION
Fix the failing test in
//src/test/java/com/google/devtools/build/lib:bazel-rules-tests
on Windows.

The problem was that the test setup read a
resource file and assumed line endings to be "\n",
but on Windows this resource file was generated
with "\r\n" endings.

The test setup code then put those strings into a
set.

Finally, the test tried to match a string in this
set, but because the entries had an invisible "\r"
at the end, the matching failed.

This commit trims the entries before putting them
in the set.

Fixes https://github.com/bazelbuild/bazel/issues/4752