### PR TITLE
Revert "Preserve the source directory tree in the RPM BUILD directory"

### DIFF
--- a/tools/build_defs/pkg/make_rpm.py
+++ b/tools/build_defs/pkg/make_rpm.py
@@ -182,10 +182,7 @@ class RpmBuilder(object):
 
     # Copy the files.
     for f in self.files:
-      dst_dir = os.path.join(RpmBuilder.BUILD_DIR, os.path.dirname(f))
-      if not os.path.exists(dst_dir):
-        os.makedirs(dst_dir, 0o777)
-      shutil.copy(os.path.join(original_dir, f), dst_dir)
+      shutil.copy(os.path.join(original_dir, f), RpmBuilder.BUILD_DIR)
 
     # Copy the spec file, updating with the correct version.
     spec_origin = os.path.join(original_dir, spec_file)


### PR DESCRIPTION
This breaks building the bazel RPM output: built artifacts are under
bazel-out, but the spec file assumes they are at the top level.

This reverts commit 2afed516f4d5d46ba1664dc0eeb8121f60e8088f.
Re-open #4747.