### PR TITLE
tests: fix flaky SkyframeAwareActionTest

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/util/io/TimestampGranularityMonitor.java
+++ b/src/main/java/com/google/devtools/build/lib/util/io/TimestampGranularityMonitor.java
@@ -203,7 +203,7 @@ public class TimestampGranularityMonitor {
   public void waitForTimestampGranularity(long ctimeMillis, OutErr outErr) {
     setCommandStartTime();
     notifyDependenceOnFileTime(null, ctimeMillis);
-    tsgm.waitForTimestampGranularity(outErr);
+    waitForTimestampGranularity(outErr);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/util/io/TimestampGranularityMonitor.java
+++ b/src/main/java/com/google/devtools/build/lib/util/io/TimestampGranularityMonitor.java
@@ -127,11 +127,15 @@ public class TimestampGranularityMonitor {
   @ThreadSafe
   public void notifyDependenceOnFileTime(PathFragment path, long ctimeMillis) {
     if (!this.waitAMillisecond && ctimeMillis == this.commandStartTimeMillis) {
-      logger.info("Will have to wait for a millisecond on completion because of " + path);
+      if (path != null) {
+        logger.info("Will have to wait for a millisecond on completion because of " + path);
+      }
       this.waitAMillisecond = true;
     }
     if (!this.waitASecond && ctimeMillis == this.commandStartTimeMillisRounded) {
-      logger.info("Will have to wait for a second on completion because of " + path);
+      if (path != null) {
+        logger.info("Will have to wait for a second on completion because of " + path);
+      }
       this.waitASecond = true;
     }
   }
@@ -193,6 +197,13 @@ public class TimestampGranularityMonitor {
               + "ms for file system"
               + " to catch up");
     }
+  }
+
+  /** Wait enough such that changes to a file with the given ctime will have observable effects. */
+  public void waitForTimestampGranularity(long ctimeMillis, OutErr outErr) {
+    setCommandStartTime();
+    notifyDependenceOnFileTime(null, ctimeMillis);
+    tsgm.waitForTimestampGranularity(outErr);
   }
 
   /**


### PR DESCRIPTION
Fix testCacheBypassingActionWithMtimeChangingInput
in SkyframeAwareActionTest by ensuring that enough
time elapses between file updates so their effects
are observable on the file's ctime.

Fixes https://github.com/bazelbuild/bazel/issues/4755