### PR TITLE
tests: fix flaky RecursiveFSTraversalFunctionTest

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/util/io/TimestampGranularityMonitor.java
+++ b/src/main/java/com/google/devtools/build/lib/util/io/TimestampGranularityMonitor.java
@@ -203,7 +203,7 @@ public class TimestampGranularityMonitor {
   public void waitForTimestampGranularity(long ctimeMillis, OutErr outErr) {
     setCommandStartTime();
     notifyDependenceOnFileTime(null, ctimeMillis);
-    tsgm.waitForTimestampGranularity(outErr);
+    waitForTimestampGranularity(outErr);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/util/io/TimestampGranularityMonitor.java
+++ b/src/main/java/com/google/devtools/build/lib/util/io/TimestampGranularityMonitor.java
@@ -206,6 +206,11 @@ public class TimestampGranularityMonitor {
     waitForTimestampGranularity(outErr);
   }
 
+  /** Wait enough such that changes to a file with the given ctime will have observable effects. */
+  public static void waitForTimestampGranularity(long ctimeMillis, Clock clock, OutErr outErr) {
+    new TimestampGranularityMonitor(clock).waitForTimestampGranularity(ctimeMillis, outErr);
+  }
+
   /**
    * Rounds the specified time, in milliseconds, down to the nearest second,
    * and returns the result in milliseconds.

--- a/src/main/java/com/google/devtools/build/lib/util/io/TimestampGranularityMonitor.java
+++ b/src/main/java/com/google/devtools/build/lib/util/io/TimestampGranularityMonitor.java
@@ -127,11 +127,15 @@ public class TimestampGranularityMonitor {
   @ThreadSafe
   public void notifyDependenceOnFileTime(PathFragment path, long ctimeMillis) {
     if (!this.waitAMillisecond && ctimeMillis == this.commandStartTimeMillis) {
-      logger.info("Will have to wait for a millisecond on completion because of " + path);
+      if (path != null) {
+        logger.info("Will have to wait for a millisecond on completion because of " + path);
+      }
       this.waitAMillisecond = true;
     }
     if (!this.waitASecond && ctimeMillis == this.commandStartTimeMillisRounded) {
-      logger.info("Will have to wait for a second on completion because of " + path);
+      if (path != null) {
+        logger.info("Will have to wait for a second on completion because of " + path);
+      }
       this.waitASecond = true;
     }
   }
@@ -193,6 +197,13 @@ public class TimestampGranularityMonitor {
               + "ms for file system"
               + " to catch up");
     }
+  }
+
+  /** Wait enough such that changes to a file with the given ctime will have observable effects. */
+  public void waitForTimestampGranularity(long ctimeMillis, OutErr outErr) {
+    setCommandStartTime();
+    notifyDependenceOnFileTime(null, ctimeMillis);
+    tsgm.waitForTimestampGranularity(outErr);
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/RecursiveFilesystemTraversalFunctionTest.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
+import com.google.devtools.build.lib.clock.BlazeClock;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
@@ -44,6 +45,8 @@ import com.google.devtools.build.lib.skyframe.RecursiveFilesystemTraversalFuncti
 import com.google.devtools.build.lib.skyframe.RecursiveFilesystemTraversalValue.ResolvedFile;
 import com.google.devtools.build.lib.skyframe.RecursiveFilesystemTraversalValue.TraversalRequest;
 import com.google.devtools.build.lib.testutil.FoundationTestCase;
+import com.google.devtools.build.lib.util.io.OutErr;
+import com.google.devtools.build.lib.util.io.TimestampGranularityMonitor;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
@@ -277,8 +280,6 @@ public final class RecursiveFilesystemTraversalFunctionTest extends FoundationTe
       // Strip metadata so only the type and path of the objects are compared.
       actual.add(act.stripMetadataForTesting());
     }
-    // First just assert equality of the keys, so in case of a mismatch the error message is easier
-    // to read.
     assertThat(actual).containsExactly((Object[]) expectedFilesIgnoringMetadata);
 
     // The returned object still has the unstripped metadata.
@@ -480,6 +481,10 @@ public final class RecursiveFilesystemTraversalFunctionTest extends FoundationTe
     progressReceiver.clear();
 
     // Add a new file to the directory and see that the value is rebuilt.
+    TimestampGranularityMonitor.waitForTimestampGranularity(
+        directoryArtifact.getPath().stat().getLastChangeTime(),
+        BlazeClock.instance(),
+        OutErr.SYSTEM_OUT_ERR);
     RootedPath file3 = createFile(childOf(directoryArtifact, "foo.txt"));
     if (directoryArtifact.isSourceArtifact()) {
       invalidateDirectory(directoryArtifact);
@@ -827,9 +832,9 @@ public final class RecursiveFilesystemTraversalFunctionTest extends FoundationTe
     progressReceiver.clear();
 
     // Change the mtime of the file but not the digest. See that the value is *not* rebuilt.
-    long mtime = path.asPath().getLastModifiedTime();
-    mtime += 1000000L; // more than the timestamp granularity of any filesystem
-    path.asPath().setLastModifiedTime(mtime);
+    TimestampGranularityMonitor.waitForTimestampGranularity(
+        path.asPath().stat().getLastChangeTime(), BlazeClock.instance(), OutErr.SYSTEM_OUT_ERR);
+    path.asPath().setLastModifiedTime(System.currentTimeMillis());
     RecursiveFilesystemTraversalValue v2 = traverseAndAssertFiles(params, expected);
     assertThat(v2).isEqualTo(v1);
     assertTraversalRootHashesAreEqual(v1, v2);


### PR DESCRIPTION
Fix the testTraversalOfGeneratedDirectory method
in RecursiveFilesystemTraversalFunctionTest that
was flaky on Windows.

The fix is to wait so that changes to files in the
InMemoryFileSystem will have observable effects on
the file ctimes.

Depends on https://github.com/bazelbuild/bazel/pull/4787

Fixes https://github.com/bazelbuild/bazel/issues/4755