### PR TITLE
Fixing issue with external j2objc protos (reattempt at #4058)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/J2ObjcAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/J2ObjcAspect.java
@@ -630,11 +630,15 @@ public class J2ObjcAspect extends NativeAspectClass implements ConfiguredAspectF
             .addAll(outputClassMappingFiles)
             .build();
 
+    String genfilesPath =
+        getProtoOutputRoot(ruleContext)
+            .getPathString();
+
     String langPluginParameter =
         String.format(
             "%s:%s",
             Joiner.on(',').join(J2OBJC_PLUGIN_PARAMS),
-            ruleContext.getConfiguration().getGenfilesFragment().getPathString());
+            genfilesPath);
 
     SupportData supportData = base.getProvider(ProtoSupportDataProvider.class).getSupportData();
 
@@ -745,10 +749,8 @@ public class J2ObjcAspect extends NativeAspectClass implements ConfiguredAspectF
   private static J2ObjcSource protoJ2ObjcSource(
       RuleContext ruleContext, ImmutableList<Artifact> protoSources) {
     PathFragment objcFileRootExecPath =
-        ruleContext
-            .getConfiguration()
-            .getGenfilesDirectory(ruleContext.getRule().getRepository())
-            .getExecPath();
+        getProtoOutputRoot(ruleContext);
+
     Iterable<PathFragment> headerSearchPaths =
         J2ObjcLibrary.j2objcSourceHeaderSearchPaths(
             ruleContext, objcFileRootExecPath, protoSources);
@@ -760,6 +762,18 @@ public class J2ObjcAspect extends NativeAspectClass implements ConfiguredAspectF
         objcFileRootExecPath,
         SourceType.PROTO,
         headerSearchPaths);
+  }
+
+  private static PathFragment getProtoOutputRoot(RuleContext ruleContext) {
+    return ruleContext
+        .getConfiguration()
+        .getGenfilesFragment()
+        .getRelative(
+            ruleContext
+                .getLabel()
+                .getPackageIdentifier()
+                .getRepository()
+                .getPathUnderExecRoot());
   }
 
   private static boolean isProtoRule(ConfiguredTarget base) {

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoLibraryTest.java
@@ -21,6 +21,7 @@ import static com.google.devtools.build.lib.actions.util.ActionsTestUtil.prettyA
 import com.google.common.collect.ImmutableList;
 import com.google.common.eventbus.EventBus;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.actions.SpawnAction;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.rules.cpp.CcCompilationInfo;
@@ -161,9 +162,10 @@ public class CcProtoLibraryTest extends BuildViewTestCase {
         "WORKSPACE", "local_repository(name = 'bla', path = '/bla/')", existingWorkspace);
     invalidatePackages(); // A dash of magic to re-evaluate the WORKSPACE file.
 
+    ConfiguredTarget target = getConfiguredTarget("//x:foo_cc_proto");
     Artifact hFile =
         getFirstArtifactEndingWith(
-            getFilesToBuild(getConfiguredTarget("//x:foo_cc_proto")), "bar.pb.h");
+            getFilesToBuild(target), "bar.pb.h");
     SpawnAction protoCompileAction = getGeneratingSpawnAction(hFile);
 
     assertThat(protoCompileAction.getArguments())
@@ -171,6 +173,12 @@ public class CcProtoLibraryTest extends BuildViewTestCase {
             String.format(
                 "--cpp_out=%s/external/bla",
                 getTargetConfiguration().getGenfilesFragment().toString()));
+
+    Artifact headerFile = getGenfilesArtifactWithNoOwner("external/bla/foo/bar.pb.h");
+    CcCompilationInfo ccCompilationInfo =
+        target.get(CcCompilationInfo.PROVIDER);
+    assertThat(ccCompilationInfo.getDeclaredIncludeSrcs())
+        .containsExactly(headerFile);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/BazelJ2ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/BazelJ2ObjcLibraryTest.java
@@ -47,6 +47,7 @@ import com.google.devtools.build.lib.rules.cpp.CppCompileActionTemplate;
 import com.google.devtools.build.lib.rules.cpp.CppModuleMapAction;
 import com.google.devtools.build.lib.rules.cpp.UmbrellaHeaderAction;
 import com.google.devtools.build.lib.testutil.TestConstants;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.ByteArrayOutputStream;
 import java.util.List;
@@ -274,6 +275,51 @@ public class BazelJ2ObjcLibraryTest extends J2ObjcLibraryTest {
     Artifact sourceFile = getGenfilesArtifact("test.j2objc.pb.m", test);
     assertThat(objcProvider.get(ObjcProvider.HEADER)).contains(headerFile);
     assertThat(objcProvider.get(ObjcProvider.SOURCE)).contains(sourceFile);
+  }
+
+  @Test
+  public void testJavaProtoLibraryWithProtoLibrary_external() throws Exception {
+    scratch.file("/bla/WORKSPACE");
+    // Create the rule '@bla//foo:test_proto'.
+    scratch.file(
+        "/bla/foo/BUILD",
+        "package(default_visibility=['//visibility:public'])",
+        j2ObjcCompatibleProtoLibrary("    name = 'test_proto',", "    srcs = ['test.proto'],"),
+        "java_proto_library(",
+        "    name = 'test_java_proto',",
+        "    deps = [':test_proto'])",
+        "");
+
+    String existingWorkspace =
+        new String(FileSystemUtils.readContentAsLatin1(rootDirectory.getRelative("WORKSPACE")));
+    scratch.overwriteFile(
+        "WORKSPACE", "local_repository(name = 'bla', path = '/bla/')", existingWorkspace);
+    invalidatePackages(); // A dash of magic to re-evaluate the WORKSPACE file.
+
+    scratch.file(
+        "x/BUILD",
+        "",
+        "java_library(",
+        "    name = 'test',",
+        "    srcs = ['test.java'],",
+        "    deps = ['@bla//foo:test_java_proto'])");
+
+    ConfiguredTarget target = getJ2ObjCAspectConfiguredTarget("//x:test");
+    ConfiguredTarget test =
+        getConfiguredTarget("@bla//foo:test_proto", getAppleCrosstoolConfiguration());
+
+    J2ObjcMappingFileProvider provider = target.getProvider(J2ObjcMappingFileProvider.class);
+
+    Artifact classMappingFile = getGenfilesArtifact("../external/bla/foo/test.clsmap.properties", test);
+    assertThat(provider.getClassMappingFiles()).containsExactly(classMappingFile);
+
+    ObjcProvider objcProvider = target.get(ObjcProvider.SKYLARK_CONSTRUCTOR);
+
+    Artifact headerFile = getGenfilesArtifact("../external/bla/foo/test.j2objc.pb.h", test);
+    Artifact sourceFile = getGenfilesArtifact("../external/bla/foo/test.j2objc.pb.m", test);
+    assertThat(objcProvider.get(ObjcProvider.HEADER)).contains(headerFile);
+    assertThat(objcProvider.get(ObjcProvider.SOURCE)).contains(sourceFile);
+    assertThat(objcProvider.get(ObjcProvider.INCLUDE)).contains(test.getConfiguration().getGenfilesFragment().getRelative("external/bla"));
   }
 
   @Test


### PR DESCRIPTION
This is a re-attempt at https://github.com/bazelbuild/bazel/pull/4058 which got reverted via https://github.com/bazelbuild/bazel/issues/4780

#4780 was being caused because cc plugin and j2objc plugin used different paths for outputs. I also manually verified that this works for both external cc_proto_librarys and external j2objc java_proto_libraries.

The output files are created without a repository, but the expected
filenames have them

This resolves issues when having a proto_library from an external build
file.

cc @c-parsons @pmbethe09 