### PR TITLE
tests,windows: enable android.desugar.runtime

### DIFF
--- a/src/test/java/com/google/devtools/build/android/desugar/runtime/BUILD
+++ b/src/test/java/com/google/devtools/build/android/desugar/runtime/BUILD
@@ -28,9 +28,8 @@ java_test(
     srcs = ["ThrowableExtensionTest.java"],
     jvm_flags = [
         "-Dfortest.simulated.android.sdk_int=18",
-        "'-Dexpected.strategy=com.google.devtools.build.android.desugar.runtime.ThrowableExtension$$MimicDesugaringStrategy'",
+        "-Dexpected.strategy='com.google.devtools.build.android.desugar.runtime.ThrowableExtension$$MimicDesugaringStrategy'",
     ],
-    tags = ["no_windows"],
     test_class = "com.google.devtools.build.android.desugar.runtime.ThrowableExtensionTest",
     deps = [
         ":throwable_extension_test_utility",
@@ -50,9 +49,8 @@ java_test(
     jvm_flags = [
         "-Dfortest.simulated.android.sdk_int=18",
         "-Dcom.google.devtools.build.android.desugar.runtime.twr_disable_mimic=true",
-        "'-Dexpected.strategy=com.google.devtools.build.android.desugar.runtime.ThrowableExtension$$NullDesugaringStrategy'",
+        "-Dexpected.strategy='com.google.devtools.build.android.desugar.runtime.ThrowableExtension$$NullDesugaringStrategy'",
     ],
-    tags = ["no_windows"],
     test_class = "com.google.devtools.build.android.desugar.runtime.ThrowableExtensionTest",
     deps = [
         ":throwable_extension_test_utility",
@@ -71,9 +69,8 @@ java_test(
     srcs = ["ThrowableExtensionTest.java"],
     jvm_flags = [
         "-Dfortest.simulated.android.sdk_int=19",
-        "'-Dexpected.strategy=com.google.devtools.build.android.desugar.runtime.ThrowableExtension$$ReuseDesugaringStrategy'",
+        "-Dexpected.strategy='com.google.devtools.build.android.desugar.runtime.ThrowableExtension$$ReuseDesugaringStrategy'",
     ],
-    tags = ["no_windows"],
     test_class = "com.google.devtools.build.android.desugar.runtime.ThrowableExtensionTest",
     deps = [
         ":throwable_extension_test_utility",

--- a/src/test/java/com/google/devtools/build/android/desugar/runtime/ThrowableExtensionTestUtility.java
+++ b/src/test/java/com/google/devtools/build/android/desugar/runtime/ThrowableExtensionTestUtility.java
@@ -27,7 +27,7 @@ public class ThrowableExtensionTestUtility {
   private static final String SYSTEM_PROPERTY_EXPECTED_STRATEGY = "expected.strategy";
 
   public static String getTwrStrategyClassNameSpecifiedInSystemProperty() {
-    String className = System.getProperty(SYSTEM_PROPERTY_EXPECTED_STRATEGY);
+    String className = unquote(System.getProperty(SYSTEM_PROPERTY_EXPECTED_STRATEGY));
     assertThat(className).isNotEmpty();
     return className;
   }
@@ -60,5 +60,14 @@ public class ThrowableExtensionTestUtility {
 
   public static boolean isReuseStrategy() {
     return isStrategyOfClass(THROWABLE_EXTENSION_CLASS_NAME + "$ReuseDesugaringStrategy");
+  }
+
+  private static String unquote(String s) {
+    if (s.startsWith("'") || s.startsWith("\"")) {
+      assertThat(s).endsWith(s.substring(0, 1));
+      return s.substring(1, s.length() - 1);
+    } else {
+      return s;
+    }
   }
 }


### PR DESCRIPTION
Add the c.g.d.build.android.desugar.runtime
tests to the transitive closure of
//src:all_windows_tests, thus running them on CI.

See https://github.com/bazelbuild/bazel/issues/4292