### PR TITLE
tests,windows: enable repository tests

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
@@ -27,7 +27,6 @@ java_test(
     ]),
     data = [":empty-tarball"],
     tags = [
-        "no_windows",  # Runfiles aren't supported.
         "rules",
     ],
     test_class = "com.google.devtools.build.lib.AllTests",
@@ -60,6 +59,7 @@ java_test(
         "//third_party:maven",
         "//third_party:mockito",
         "//third_party:truth",
+        "@bazel_tools//tools/runfiles:java-runfiles",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/GitClonerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/GitClonerTest.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.rules.repository.RepositoryFunction.Reposit
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.util.FileSystems;
+import com.google.devtools.build.runfiles.Runfiles;
 import java.net.URL;
 import java.util.Map;
 import org.junit.Before;
@@ -49,7 +50,6 @@ import org.mockito.Mockito;
  */
 @RunWith(JUnit4.class)
 public class GitClonerTest extends BuildViewTestCase {
-  private FileSystem diskFs = FileSystems.getNativeFileSystem();
   private Path diskTarball;
   private Path outputDirectory;
   private StoredEventHandler eventHandler = new StoredEventHandler();
@@ -60,11 +60,16 @@ public class GitClonerTest extends BuildViewTestCase {
 
   @Before
   public void initialize() throws Exception {
+    FileSystem diskFs = FileSystems.getNativeFileSystem();
     outputDirectory = diskFs.getPath(System.getenv("TEST_TMPDIR"))
         .getRelative("output-dir");
-    diskTarball = diskFs.getPath(System.getenv("TEST_SRCDIR"))
-        .getRelative(
+    Runfiles runfiles = Runfiles.create();
+    String emptyTarGz =
+        runfiles.rlocation(
             "io_bazel/src/test/java/com/google/devtools/build/lib/bazel/repository/empty.tar.gz");
+    assertThat(emptyTarGz).isNotEmpty();
+    diskTarball = diskFs.getPath(emptyTarGz);
+    assertThat(diskTarball.exists()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Add the c.g.d.build.lib.bazel.repository:*
tests to the transitive closure of
//src:all_windows_tests, thus running them on CI.

As part of that, use the Java runfiles library in
@bazel_tools that was introduced in Bazel 0.11.0
to retrieve the test's data-dependency in a
platform-independent way.

See https://github.com/bazelbuild/bazel/issues/4292

Change-Id: I70ed7e04283fdfd898670a36a9eec01024788153