### PR TITLE
tests,windows: enable skylarkinterface/processor:*

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -1541,6 +1541,7 @@ test_suite(
         "//src/test/java/com/google/devtools/build/lib/shell:all_windows_tests",
         "//src/test/java/com/google/devtools/build/lib/skyframe:all_windows_tests",
         "//src/test/java/com/google/devtools/build/lib/skylark:all_windows_tests",
+        "//src/test/java/com/google/devtools/build/lib/skylarkinterface/processor:all_windows_tests",
     ],
     visibility = ["//src:__pkg__"],
 )

--- a/src/test/java/com/google/devtools/build/lib/skylarkinterface/processor/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skylarkinterface/processor/BUILD
@@ -29,3 +29,20 @@ filegroup(
     name = "ProcessorTestFiles",
     srcs = glob(["testsources/*.java"]),
 )
+
+test_suite(
+    name = "windows_tests",
+    tags = [
+        "-no_windows",
+        "-slow",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+test_suite(
+    name = "all_windows_tests",
+    tests = [
+        ":windows_tests",
+    ],
+    visibility = ["//src/test/java/com/google/devtools/build/lib:__pkg__"],
+)


### PR DESCRIPTION
Add these tests to the transitive closure of
//src:all_windows_tests thus run them on CI.

See https://github.com/bazelbuild/bazel/issues/4292

Change-Id: Iae0bd925bdde2921fb0b2d4222b81fcecb28dea3