### PR TITLE
runfiles,py,java: rlocation accepts absolute path

### DIFF
--- a/src/tools/runfiles/java/com/google/devtools/build/runfiles/Runfiles.java
+++ b/src/tools/runfiles/java/com/google/devtools/build/runfiles/Runfiles.java
@@ -95,7 +95,8 @@ public abstract class Runfiles {
     Util.checkArgument(path != null);
     Util.checkArgument(!path.isEmpty());
     Util.checkArgument(!path.contains(".."), "path contains uplevel references: \"%s\"", path);
-    if (new File(path).isAbsolute() || path.charAt(0) == File.separatorChar) {
+    Util.checkArgument(!path.startsWith("\\"), "path is absolute without a drive letter: \"%s\"", path);
+    if (new File(path).isAbsolute()) {
       return path;
     }
     return rlocationChecked(path);

--- a/src/tools/runfiles/java/com/google/devtools/build/runfiles/RunfilesTest.java
+++ b/src/tools/runfiles/java/com/google/devtools/build/runfiles/RunfilesTest.java
@@ -52,6 +52,7 @@ public final class RunfilesTest {
     assertRlocationArg(r, null, null);
     assertRlocationArg(r, "", null);
     assertRlocationArg(r, "foo/..", "contains uplevel");
+    assertRlocationArg(r, "\\foo", "path is absolute without a drive letter");
   }
 
   @Test
@@ -69,7 +70,6 @@ public final class RunfilesTest {
       assertThat(r.rlocation("foo")).isNull();
 
       if (isWindows()) {
-        assertThat(r.rlocation("\\foo")).isEqualTo("\\foo");
         assertThat(r.rlocation("c:/foo")).isEqualTo("c:/foo");
         assertThat(r.rlocation("c:\\foo")).isEqualTo("c:\\foo");
       } else {

--- a/src/tools/runfiles/runfiles.py
+++ b/src/tools/runfiles/runfiles.py
@@ -128,8 +128,10 @@ class _Runfiles(object):
       raise TypeError()
     if ".." in path:
       raise ValueError("path contains uplevel references: \"%s\"" % path)
-    if os.path.isabs(path) or path[0] == os.sep:
-      raise ValueError("path is absolute: \"%s\"" % path)
+    if path[0] == "\\":
+      raise ValueError("path is absolute without a drive letter: \"%s\"" % path)
+    if os.path.isabs(path):
+      return path
     return self._strategy.RlocationChecked(path)
 
   def EnvVars(self):

--- a/src/tools/runfiles/runfiles_test.py
+++ b/src/tools/runfiles/runfiles_test.py
@@ -30,16 +30,8 @@ class RunfilesTest(unittest.TestCase):
     self.assertRaises(TypeError, lambda: r.Rlocation(1))
     self.assertRaisesRegexp(ValueError, "contains uplevel",
                             lambda: r.Rlocation("foo/.."))
-    if RunfilesTest.IsWindows():
-      self.assertRaisesRegexp(ValueError, "is absolute",
-                              lambda: r.Rlocation("\\foo"))
-      self.assertRaisesRegexp(ValueError, "is absolute",
-                              lambda: r.Rlocation("c:/foo"))
-      self.assertRaisesRegexp(ValueError, "is absolute",
-                              lambda: r.Rlocation("c:\\foo"))
-    else:
-      self.assertRaisesRegexp(ValueError, "is absolute",
-                              lambda: r.Rlocation("/foo"))
+    self.assertRaisesRegexp(ValueError, "is absolute without a drive letter",
+                            lambda: r.Rlocation("\\foo"))
 
   def testCreatesManifestBasedRunfiles(self):
     with _MockFile(contents=["a/b c/d"]) as mf:
@@ -141,6 +133,11 @@ class RunfilesTest(unittest.TestCase):
       self.assertEqual(
           r.Rlocation("Foo/Bar/runfile3"), "D:\\the path\\run file 3.txt")
       self.assertIsNone(r.Rlocation("unknown"))
+      if RunfilesTest.IsWindows():
+        self.assertEqual(r.Rlocation("c:/foo"), "c:/foo")
+        self.assertEqual(r.Rlocation("c:\\foo"), "c:\\foo")
+      else:
+        self.assertEqual(r.Rlocation("/foo"), "/foo")
 
   def testDirectoryBasedRlocation(self):
     # The _DirectoryBased strategy simply joins the runfiles directory and the
@@ -148,6 +145,11 @@ class RunfilesTest(unittest.TestCase):
     # nor does it check that the path exists.
     r = runfiles.CreateDirectoryBased("foo/bar baz//qux/")
     self.assertEqual(r.Rlocation("arg"), "foo/bar baz//qux/arg")
+    if RunfilesTest.IsWindows():
+      self.assertEqual(r.Rlocation("c:/foo"), "c:/foo")
+      self.assertEqual(r.Rlocation("c:\\foo"), "c:\\foo")
+    else:
+      self.assertEqual(r.Rlocation("/foo"), "/foo")
 
   @staticmethod
   def IsWindows():


### PR DESCRIPTION
The rlocation functions in the Python and Java
runfiles libraries (under
@bazel_tools//tools/runfiles) now consistently
return the argument itself if it is an absolute
path.

If the argument is a driveless absolute Windows
path (e.g. "\\windows\\system32") then rlocation
reports an error.

See https://github.com/bazelbuild/bazel/issues/4460

Change-Id: I80474f7cc4736a571bf113438a916f71c36a344d