### PR TITLE
Android tools: remove mtime-modifications

### DIFF
--- a/src/tools/android/java/com/google/devtools/build/android/AndroidResourceOutputs.java
+++ b/src/tools/android/java/com/google/devtools/build/android/AndroidResourceOutputs.java
@@ -32,6 +32,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -56,7 +57,7 @@ public class AndroidResourceOutputs {
 
     // The earliest date representable in a zip file, 1-1-1980 (the DOS epoch).
     private static final long ZIP_EPOCH =
-        new GregorianCalendar(1980, 01, 01, 0, 0).getTimeInMillis();
+        new GregorianCalendar(1980, Calendar.JANUARY, 01, 0, 0).getTimeInMillis();
 
     private final ZipOutputStream zip;
 

--- a/src/tools/android/java/com/google/devtools/build/android/AndroidResourceOutputs.java
+++ b/src/tools/android/java/com/google/devtools/build/android/AndroidResourceOutputs.java
@@ -299,8 +299,6 @@ public class AndroidResourceOutputs {
     try {
       Files.createDirectories(manifestOut.getParent());
       Files.copy(provider.getManifest(), manifestOut);
-      // Set to the epoch for caching purposes.
-      Files.setLastModifiedTime(manifestOut, FileTime.fromMillis(0L));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -332,8 +330,6 @@ public class AndroidResourceOutputs {
         // outputs. This state occurs when there are no resource directories.
         Files.createFile(rOutput);
       }
-      // Set to the epoch for caching purposes.
-      Files.setLastModifiedTime(rOutput, FileTime.fromMillis(0L));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -349,8 +345,6 @@ public class AndroidResourceOutputs {
         visitor.writeEntries();
         visitor.writeManifestContent();
       }
-      // Set to the epoch for caching purposes.
-      Files.setLastModifiedTime(classJar, FileTime.fromMillis(0L));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -366,8 +360,6 @@ public class AndroidResourceOutputs {
         Files.walkFileTree(root, visitor);
         visitor.writeEntries();
       }
-      // Set to the epoch for caching purposes.
-      Files.setLastModifiedTime(archive, FileTime.fromMillis(0L));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -383,8 +375,6 @@ public class AndroidResourceOutputs {
         Files.walkFileTree(generatedSourcesRoot, visitor);
         visitor.writeEntries();
       }
-      // Set to the epoch for caching purposes.
-      Files.setLastModifiedTime(srcJar, FileTime.fromMillis(0L));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/tools/android/java/com/google/devtools/build/android/AndroidResourceProcessor.java
+++ b/src/tools/android/java/com/google/devtools/build/android/AndroidResourceProcessor.java
@@ -343,23 +343,16 @@ public class AndroidResourceProcessor {
           dependencyData, customPackageForR, androidManifest, sourceOut);
     }
     // Reset the output date stamps.
-    if (proguardOut != null) {
-      Files.setLastModifiedTime(proguardOut, FileTime.fromMillis(0L));
-    }
-    if (mainDexProguardOut != null) {
-      Files.setLastModifiedTime(mainDexProguardOut, FileTime.fromMillis(0L));
-    }
     if (packageOut != null) {
-      Files.setLastModifiedTime(packageOut, FileTime.fromMillis(0L));
       if (!splits.isEmpty()) {
         Iterable<Path> splitFilenames = findAndRenameSplitPackages(packageOut, splits);
         for (Path splitFilename : splitFilenames) {
-          Files.setLastModifiedTime(splitFilename, FileTime.fromMillis(0L));
+          // Iterate over the elements to get the side-effects of findAndRenameSplitPackages.
+          // TODO(ajmichael): find out if findAndRenameSplitPackages's side-effects are actually
+          // needed for anything, and turn the function into an eager one if so or delete it
+          // otherwise.
         }
       }
-    }
-    if (publicResourcesOut != null && Files.exists(publicResourcesOut)) {
-      Files.setLastModifiedTime(publicResourcesOut, FileTime.fromMillis(0L));
     }
     return new MergedAndroidData(resourceDir, assetsDir, androidManifest);
   }

--- a/src/tools/android/java/com/google/devtools/build/android/AndroidResourceProcessor.java
+++ b/src/tools/android/java/com/google/devtools/build/android/AndroidResourceProcessor.java
@@ -345,13 +345,7 @@ public class AndroidResourceProcessor {
     // Reset the output date stamps.
     if (packageOut != null) {
       if (!splits.isEmpty()) {
-        Iterable<Path> splitFilenames = findAndRenameSplitPackages(packageOut, splits);
-        for (Path splitFilename : splitFilenames) {
-          // Iterate over the elements to get the side-effects of findAndRenameSplitPackages.
-          // TODO(ajmichael): find out if findAndRenameSplitPackages's side-effects are actually
-          // needed for anything, and turn the function into an eager one if so or delete it
-          // otherwise.
-        }
+        renameSplitPackages(packageOut, splits);
       }
     }
     return new MergedAndroidData(resourceDir, assetsDir, androidManifest);
@@ -616,8 +610,8 @@ public class AndroidResourceProcessor {
     }
   }
 
-  /** Finds aapt's split outputs and renames them according to the input flags. */
-  private Iterable<Path> findAndRenameSplitPackages(Path packageOut, Iterable<String> splits)
+  /** Renames aapt's split outputs according to the input flags. */
+  private void renameSplitPackages(Path packageOut, Iterable<String> splits)
       throws UnrecognizedSplitsException, IOException {
     String prefix = packageOut.getFileName().toString() + "_";
     // The regex java string literal below is received as [\\{}\[\]*?] by the regex engine,
@@ -634,16 +628,13 @@ public class AndroidResourceProcessor {
     }
     Map<String, String> outputs =
         SplitConfigurationFilter.mapFilenamesToSplitFlags(filenameSuffixes.build(), splits);
-    ImmutableList.Builder<Path> outputPaths = new ImmutableList.Builder<>();
     for (Map.Entry<String, String> splitMapping : outputs.entrySet()) {
       Path resultPath = packageOut.resolveSibling(prefix + splitMapping.getValue());
-      outputPaths.add(resultPath);
       if (!splitMapping.getKey().equals(splitMapping.getValue())) {
         Path sourcePath = packageOut.resolveSibling(prefix + splitMapping.getKey());
         Files.move(sourcePath, resultPath);
       }
     }
-    return outputPaths.build();
   }
 
   /** A logger that will print messages to a target OutputStream. */

--- a/src/tools/android/java/com/google/devtools/build/android/ManifestMergerAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/ManifestMergerAction.java
@@ -217,9 +217,6 @@ public class ManifestMergerAction {
       if (!mergedManifest.equals(options.manifestOutput)) {
         Files.copy(options.manifest, options.manifestOutput, StandardCopyOption.REPLACE_EXISTING);
       }
-
-      // Set to the epoch for caching purposes.
-      Files.setLastModifiedTime(options.manifestOutput, FileTime.fromMillis(0L));
     } catch (AndroidManifestProcessor.ManifestProcessingException e) {
       System.exit(1);
     } catch (Exception e) {

--- a/src/tools/android/java/com/google/devtools/build/android/dexer/DexBuilder.java
+++ b/src/tools/android/java/com/google/devtools/build/android/dexer/DexBuilder.java
@@ -138,8 +138,6 @@ class DexBuilder {
         executor.shutdown();
       }
     }
-    // Use input's timestamp for output file so the output file is stable.
-    Files.setLastModifiedTime(options.outputZip, Files.getLastModifiedTime(options.inputJar));
   }
 
   /**
@@ -225,8 +223,6 @@ class DexBuilder {
           new Dexing(context, optionsParser.getOptions(DexingOptions.class)),
           dexCache);
     }
-    // Use input's timestamp for output file so the output file is stable.
-    Files.setLastModifiedTime(options.outputZip, Files.getLastModifiedTime(options.inputJar));
   }
 
   private static ZipOutputStream createZipOutputStream(Path path) throws IOException {


### PR DESCRIPTION
The Android tools no longer modify output file
mtimes in hopes of achievening better action
cache hits.

Modifying the mtimes was confusing Bazel and
causing correctness bugs.

Modifying the mtimes is unnecessary because Bazel
is smart about picking up filesystem changes and
observes more signals than just the mtime, though
as the corresponding bug shows it's sadly not
bullet-proof.

Fixes https://github.com/bazelbuild/bazel/issues/4734

Change-Id: I4aa8abf29486841ba8133f927e2816d7f85881fe