### PR TITLE
Allow path options to use user specific paths

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/util/OptionsUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/util/OptionsUtils.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.util;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.Converter;
@@ -103,7 +104,11 @@ public final class OptionsUtils {
 
     @Override
     public PathFragment convert(String input) {
-      return PathFragment.create(input);
+      String path = Preconditions.checkNotNull(input);
+      if (!path.isEmpty() && path.startsWith("~/")) {
+        path = path.replace("~", System.getProperty("user.home"));
+      }
+      return PathFragment.create(path);
     }
 
     @Override
@@ -123,6 +128,9 @@ public final class OptionsUtils {
       List<PathFragment> list = new ArrayList<>();
       for (String piece : input.split(":")) {
         if (!piece.isEmpty()) {
+          if (piece.startsWith("~/")) {
+            piece = piece.replace("~", System.getProperty("user.home"));
+          }
           list.add(PathFragment.create(piece));
         }
       }

--- a/src/test/java/com/google/devtools/build/lib/util/OptionsUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/OptionsUtilsTest.java
@@ -17,6 +17,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
+import com.google.devtools.build.lib.util.OptionsUtils.PathFragmentConverter;
 import com.google.devtools.build.lib.util.OptionsUtils.PathFragmentListConverter;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.Option;
@@ -166,6 +167,10 @@ public class OptionsUtilsTest {
     return new PathFragmentListConverter().convert(input);
   }
 
+  private PathFragment convertOne(String input) throws Exception {
+    return new PathFragmentConverter().convert(input);
+  }
+
   @Test
   public void emptyStringYieldsEmptyList() throws Exception {
     assertThat(convert("")).isEqualTo(list());
@@ -183,10 +188,21 @@ public class OptionsUtilsTest {
 
   @Test
   public void multiplePaths() throws Exception {
-    assertThat(convert("foo:/bar/baz:.:/tmp/bang"))
+    assertThat(convert("~/foo:foo:/bar/baz:.:/tmp/bang"))
         .containsExactly(
-            fragment("foo"), fragment("/bar/baz"), fragment("."), fragment("/tmp/bang"))
+            fragment(System.getProperty("user.home") + "/foo"),
+            fragment("foo"),
+            fragment("/bar/baz"),
+            fragment("."),
+            fragment("/tmp/bang"))
         .inOrder();
+  }
+
+  @Test
+  public void singlePath() throws Exception {
+    assertThat(convertOne("foo")).isEqualTo(fragment("foo"));
+    assertThat(convertOne("foo/bar/baz")).isEqualTo(fragment("foo/bar/baz"));
+    assertThat(convertOne("~/foo")).isEqualTo(fragment(System.getProperty("user.home") + "/foo"));
   }
 
   @Test


### PR DESCRIPTION
Fixes #2054.

Allow users to be able to specify user specific paths. With this option
we can now commit bazel configuration file and force local action cache
activation per default:

  $ cat tools/bazel.rc
  build --experimental_local_disk_cache_path=~/.gerrit/bazel-cache/cas
  build --experimental_local_disk_cache
  build --experimental_strict_action_env

Test Plan:

  $ bazel test //src/test/java/com/google/devtools/build/lib:util_test