### PR TITLE
Remove current contents of the default global bazelrc.

### DIFF
--- a/scripts/packages/bazel.bazelrc
+++ b/scripts/packages/bazel.bazelrc
@@ -1,5 +1,0 @@
-build --action_env=PATH
-build --action_env=LD_LIBRARY_PATH
-build --action_env=TMPDIR
-build --test_env=PATH
-build --test_env=LD_LIBRARY_PATH


### PR DESCRIPTION
The file is left as an empty file, so make upgrades easier. Site administrators can add their own content as needed, still.

Fixes #4850.

TESTED: Created a Debian VM and tested installing the new version as an upgrade and as the first Bazel, observed that the global bazelrc had the expected content.

Change-Id: I5f285f0c59d18179005ffe5bfc35931299635bbb
