### PR TITLE
NDK cc_toolchains: include bundled runtime libraries in cc_toolchain.all_files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_cc_toolchain_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_cc_toolchain_template.txt
@@ -22,6 +22,9 @@ filegroup(
     name = "%toolchainName%-all_files",
     srcs = glob(["ndk/toolchains/%toolchainDirectory%/**"]) + glob([
         %toolchainFileGlobs%
-    ]),
+    ]) + [
+      ":%dynamicRuntimeLibs%",
+      ":%staticRuntimeLibs%",
+    ],
 )
 


### PR DESCRIPTION
Currently, generated NDK `cc_toolchain.all_files` filegroups do not glob the STL's static and dynamic runtime libraries, which includes important files like `libandroid_support.a` and `libc++.{so, a}`. This introduces sandboxed link time errors as @steeve discovered at https://github.com/bazelbuild/bazel/issues/3923#issuecomment-372750002

This PR adds the two filegroups to the respective toolchain's `all-files` filegroup to make them part of the toolchain's output in the sandbox. This generates a BUILD.bazel file like this: https://gist.github.com/jin/7d9fcf924fa33ab8fbc4c43c97676ab3

Fixes https://github.com/bazelbuild/bazel/issues/4864
