### PR TITLE
runfiles,Bash: add a package for runfiles library

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -409,6 +409,7 @@ test_suite(
         "//src/tools/launcher:all_windows_tests",
         "//src/tools/runfiles:all_windows_tests",
         "//third_party/def_parser:all_windows_tests",
+        "//tools/bash/runfiles:all_windows_tests",
     ],
 )
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -8,6 +8,7 @@ filegroup(
     name = "srcs",
     srcs = glob(["**"]) + [
         "//tools/android:srcs",
+        "//tools/bash:srcs",
         "//tools/buildstamp:srcs",
         "//tools/build_defs/apple:srcs",
         "//tools/build_defs/apple/test:srcs",
@@ -39,6 +40,7 @@ filegroup(
     name = "embedded_tools_srcs",
     srcs = glob(["**"]) + [
         "//tools/android:embedded_tools",
+        "//tools/bash:embedded_tools",
         "//tools/build_defs/apple:srcs",
         "//tools/build_defs/hash:srcs",
         "//tools/build_defs/pkg:srcs",

--- a/tools/bash/BUILD
+++ b/tools/bash/BUILD
@@ -1,0 +1,21 @@
+package(default_visibility = ["//visibility:private"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(
+        ["**"],
+        exclude = [
+            "*~",
+            ".*",
+        ],
+    ) + [
+        "//tools/bash/runfiles:srcs",
+    ],
+    visibility = ["//tools:__pkg__"],
+)
+
+filegroup(
+    name = "embedded_tools",
+    srcs = ["//tools/bash/runfiles:embedded_tools"],
+    visibility = ["//tools:__pkg__"],
+)

--- a/tools/bash/runfiles/BUILD
+++ b/tools/bash/runfiles/BUILD
@@ -1,0 +1,49 @@
+package(default_visibility = ["//visibility:private"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(
+        ["**"],
+        exclude = [
+            "*~",
+            ".*",
+        ],
+    ),
+    visibility = ["//tools/bash:__pkg__"],
+)
+
+filegroup(
+    name = "embedded_tools",
+    srcs = [
+        "BUILD.tools",
+        "runfiles.sh",
+    ],
+    visibility = ["//tools/bash:__pkg__"],
+)
+
+sh_library(
+    name = "runfiles_sh_lib",
+    srcs = ["runfiles.sh"],
+)
+
+sh_test(
+    name = "runfiles_sh_test",
+    srcs = ["runfiles_sh_test.sh"],
+    deps = [":runfiles_sh_lib"],
+)
+
+test_suite(
+    name = "windows_tests",
+    tags = [
+        "-no_windows",
+        "-slow",
+    ],
+)
+
+test_suite(
+    name = "all_windows_tests",
+    tests = [
+        ":windows_tests",
+    ],
+    visibility = ["//src:__pkg__"],
+)

--- a/tools/bash/runfiles/BUILD.tools
+++ b/tools/bash/runfiles/BUILD.tools
@@ -1,0 +1,2 @@
+# This package will host the Bash runfiles library.
+# See https://github.com/bazelbuild/bazel/issues/4460


### PR DESCRIPTION
Add a new package that'll host the Bash runfiles
library.

See https://github.com/bazelbuild/bazel/issues/4460