### PR TITLE
Fix visibility of def_parser for remote builds

### DIFF
--- a/third_party/def_parser/BUILD
+++ b/third_party/def_parser/BUILD
@@ -1,5 +1,12 @@
 licenses(["notice"])  # 3-clause BSD
 
+package(
+    default_visibility = [
+        "//src:__subpackages__",
+        "//tools/def_parser:__subpackages__",
+    ],
+)
+
 cc_library(
     name = "def_parser_lib",
     srcs = ["def_parser.cc"],


### PR DESCRIPTION
Fix https://github.com/bazelbuild/bazel/issues/4883

