### PR TITLE
Local Disk Cache: Only write to disk if target hash doesn't already exist.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -103,3 +103,4 @@ Yue Gan <yueg@google.com>
 Yun Peng <pcloudy@google.com>
 Dmitry Babkin <dbabkin@google.com>
 Klaus Aehlig <aehlig@google.com>
+Robin Nabel <rnabel@ucdavis.edu>

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/OnDiskBlobStore.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/OnDiskBlobStore.java
@@ -54,6 +54,11 @@ public final class OnDiskBlobStore implements SimpleBlobStore {
 
   @Override
   public void put(String key, long length, InputStream in) throws IOException {
+    Path target = toPath(key);
+    if (target.exists()) {
+      return;
+    }
+
     // Write a temporary file first, and then rename, to avoid data corruption in case of a crash.
     Path temp = toPath(UUID.randomUUID().toString());
     try (OutputStream out = temp.getOutputStream()) {
@@ -61,8 +66,7 @@ public final class OnDiskBlobStore implements SimpleBlobStore {
     }
     // TODO(ulfjack): Fsync temp here before we rename it to avoid data loss in the case of machine
     // crashes (the OS may reorder the writes and the rename).
-    Path f = toPath(key);
-    temp.renameTo(f);
+    temp.renameTo(target);
   }
 
   @Override


### PR DESCRIPTION
Under Windows, the default permissions used when writing to the local disk cache prevent the files from being overwritten. 

This CR adds a check: if the target file already exists, return early. This is a performance improvement and will fix the error described above as existing files will no longer need to be overwritten. Similar features have been implemented on the remote gRPC cache implementations, see bazel issue #4789.