### PR TITLE
Remove stale cc_library nonconfigurables

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcLibraryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcLibraryRule.java
@@ -43,12 +43,10 @@ public final class BazelCcLibraryRule implements RuleDefinition {
         provided by some service.
         <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
         .add(
-            attr("alwayslink", BOOLEAN)
-                .nonconfigurable("value is referenced in an ImplicitOutputsFunction"))
+            attr("alwayslink", BOOLEAN))
         .override(
             attr("linkstatic", BOOLEAN)
-                .value(false)
-                .nonconfigurable("value is referenced in an ImplicitOutputsFunction"))
+                .value(false))
         .build();
   }
 


### PR DESCRIPTION
Specifications of cc_library attribute nonconfigurability for linkstatic
and alwayslink were introduced in d08b27f and have been stale since the
ImplicitOutputsFunction specification was removed in 8a995b4. These
attributes should have no problem interpreting configured specifications
for their values.