### PR TITLE
Add is_empty skylark method to depset

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/BazelLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BazelLibrary.java
@@ -172,6 +172,23 @@ public class BazelLibrary {
   }
 
   @SkylarkSignature(
+    name = "is_empty",
+    objectType = SkylarkNestedSet.class,
+    returnType = Boolean.class,
+    doc = "Returns if a depset is empty without traversing it in O(1) time",
+    parameters = {@Param(name = "input", type = SkylarkNestedSet.class, doc = "The input depset.")},
+    useLocation = false,
+    useEnvironment = false
+  )
+  private static final BuiltinFunction isEmpty =
+      new BuiltinFunction("is_empty") {
+        @SuppressWarnings("unused")
+        public Boolean invoke(SkylarkNestedSet input) throws EvalException {
+          return input.isEmpty();
+        }
+      };
+
+  @SkylarkSignature(
     name = "union",
     objectType = SkylarkNestedSet.class,
     returnType = SkylarkNestedSet.class,


### PR DESCRIPTION
Change-Id: I93ee07fb7543d0e800e986da2b34f6dd25989574

Problem: currently to see if a depset is empty you have to call `len(ds.to_list()) == 0` which is expensive if the depset is not empty. If it is empty, we should be able to quickly see.

This adds is_empty to depset.

TODO: It is not yet tested. I didn't yet find the best place to add a test. I would appreciate guidance on which file would be the appropriate place to add the test.

