### PR TITLE
Fix typo in user manual

### DIFF
--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -1382,7 +1382,7 @@ $ bazel fetch //...
 <p>
   This option only has an effect when FDO is also enabled (see the
   <a href="#flag--fdo_instrument">--fdo_instrument</a> and
-  <a href="#flag--fdo_optimize">--fdo_options</a>).
+  <a href="#flag--fdo_optimize">--fdo_optimize</a>).
   Currently LIPO is only supported when building a single <code>cc_binary</code> rule.
 </p>
 <p>Setting <code>--lipo=binary</code> implicitly sets


### PR DESCRIPTION
Fix a typo in option name