### PR TITLE
Fix crosstool target cpu to match local

### DIFF
--- a/tools/cpp/CROSSTOOL.tpl
+++ b/tools/cpp/CROSSTOOL.tpl
@@ -22,7 +22,7 @@ default_toolchain {
 }
 
 default_toolchain {
-  cpu: "armeabi-v7a"
+  cpu: "local"
   toolchain_identifier: "stub_armeabi-v7a"
 }
 
@@ -47,7 +47,7 @@ default_toolchain {
 }
 
 default_toolchain {
-  cpu: "ios_x86_64"
+  cpu: "local"
   toolchain_identifier: "ios_x86_64"
 }
 

--- a/tools/cpp/CROSSTOOL.tpl
+++ b/tools/cpp/CROSSTOOL.tpl
@@ -27,6 +27,11 @@ default_toolchain {
 }
 
 default_toolchain {
+  cpu: "armeabi-v7a"
+  toolchain_identifier: "stub_armeabi-v7a"
+}
+
+default_toolchain {
   cpu: "x64_windows"
   toolchain_identifier: "msvc_x64"
 }
@@ -48,6 +53,11 @@ default_toolchain {
 
 default_toolchain {
   cpu: "local"
+  toolchain_identifier: "ios_x86_64"
+}
+
+default_toolchain {
+  cpu: "ios_x86_64"
   toolchain_identifier: "ios_x86_64"
 }
 


### PR DESCRIPTION
The entries in BUILD.tpl specify cpu "local", so CROSSTOOL.tpl needs to match.