### PR TITLE
Made 'build-runfiles.cc' POSIX compatible.

### DIFF
--- a/src/main/tools/build-runfiles.cc
+++ b/src/main/tools/build-runfiles.cc
@@ -246,7 +246,7 @@ class RunfilesCreator {
 
       std::string entry_path = prefix + entry->d_name;
       FileInfo actual_info;
-      actual_info.type = DentryToFileType(entry_path, entry->d_type);
+      actual_info.type = DentryToFileType(entry_path, entry);
 
       if (actual_info.type == FILE_TYPE_SYMLINK) {
         ReadLinkOrDie(entry_path, &actual_info.symlink_target);
@@ -310,9 +310,20 @@ class RunfilesCreator {
     }
   }
 
-  FileType DentryToFileType(const std::string &path, char d_type) {
-    if (d_type == DT_UNKNOWN) {
-      struct stat st;
+  FileType DentryToFileType(const std::string &path, struct dirent *ent) {
+    #ifdef _DIRENT_HAVE_D_TYPE
+    if (ent->d_type != DT_UNKNOWN) {
+      if (ent->d_type == DT_DIR) {
+        return FILE_TYPE_DIRECTORY;
+      } else if (ent->d_type == DT_LNK) {
+        return FILE_TYPE_SYMLINK;
+      } else {
+        return FILE_TYPE_REGULAR;
+      }
+    } else
+    #endif
+    {
+     struct stat st;
       LStatOrDie(path, &st);
       if (S_ISDIR(st.st_mode)) {
         return FILE_TYPE_DIRECTORY;
@@ -321,12 +332,6 @@ class RunfilesCreator {
       } else {
         return FILE_TYPE_REGULAR;
       }
-    } else if (d_type == DT_DIR) {
-      return FILE_TYPE_DIRECTORY;
-    } else if (d_type == DT_LNK) {
-      return FILE_TYPE_SYMLINK;
-    } else {
-      return FILE_TYPE_REGULAR;
     }
   }
 
@@ -386,7 +391,7 @@ class RunfilesCreator {
     while ((entry = readdir(dh)) != nullptr) {
       if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..")) continue;
       const std::string entry_path = path + '/' + entry->d_name;
-      FileType entry_file_type = DentryToFileType(entry_path, entry->d_type);
+      FileType entry_file_type = DentryToFileType(entry_path, entry);
       DelTree(entry_path, entry_file_type);
       errno = 0;
     }


### PR DESCRIPTION
The 'd_type' field is not part of the POSIX specification. Added a compile time check to see if we can use it. When not present fallback to a (slightly more expensive) call to 'stat'.

This PR is similar to my other PR #4967. It's part of an effort to port Bazel to an POSIX compliant platform. Even though my porting effort may fail I think POSIX compliance could be beneficiary to Bazel either way.