### PR TITLE
analyze-profile: prevent bazel from crashing outside a workspace

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/ProfileCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/ProfileCommand.java
@@ -290,7 +290,7 @@ public final class ProfileCommand implements BlazeCommand {
                       phase,
                       info,
                       (workspace == null
-                          ? new String("<workspace>")
+                          ? "<workspace>"
                           : workspace.getBaseName()),
                       opts.vfsStatsLimit > 0));
             }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/ProfileCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/ProfileCommand.java
@@ -281,11 +281,18 @@ public final class ProfileCommand implements BlazeCommand {
             PhaseSummaryStatistics phaseSummaryStatistics = new PhaseSummaryStatistics(info);
             EnumMap<ProfilePhase, PhaseStatistics> phaseStatistics =
                 new EnumMap<>(ProfilePhase.class);
+
+            Path workspace = env.getWorkspace();
             for (ProfilePhase phase : ProfilePhase.values()) {
               phaseStatistics.put(
                   phase,
                   new PhaseStatistics(
-                      phase, info, env.getWorkspace().getBaseName(), opts.vfsStatsLimit > 0));
+                      phase,
+                      info,
+                      (workspace == null
+                          ? new String("<workspace>")
+                          : workspace.getBaseName()),
+                      opts.vfsStatsLimit > 0));
             }
 
             CriticalPathStatistics critPathStats = new CriticalPathStatistics(info);


### PR DESCRIPTION
This commit closes #3256.