### PR TITLE
Allow user-provided arguments to patch, including a verbose mode for debugging

### DIFF
--- a/src/test/shell/bazel/external_patching_test.sh
+++ b/src/test/shell/bazel/external_patching_test.sh
@@ -62,6 +62,8 @@ http_archive(
   urls=["file://${EXTREPODIR}/ext.zip"],
   build_file_content="exports_files([\"foo.sh\"])",
   patches = ["//:patch_foo.sh"],
+  patch_verbose = True,
+  patch_arguments = ["--verbose", "-p0"],
   patch_cmds = ["find . -name '*.sh' -exec sed -i.orig '1s|#!/usr/bin/env sh\$|/bin/sh\$|' {} +"],
 )
 EOF
@@ -89,7 +91,7 @@ EOF
 -echo Here be dragons...
 +echo completely differently patched
 EOF
-  bazel build :foo.sh
+  bazel build :foo.sh | grep -q 'Hunk' || fail "expected verbose patch output"
   foopath=`bazel info bazel-genfiles`/foo.sh
   grep -q 'differently patched' $foopath \
       || fail "expected the new patch to be applied"

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -88,6 +88,8 @@ _http_archive_attrs = {
     "build_file_content": attr.string(),
     "patches": attr.label_list(default=[]),
     "patch_tool": attr.string(default="patch"),
+    "patch_arguments": attr.string_list(default=["-p0"]),
+    "patch_verbose": attr.bool(default=False),
     "patch_cmds": attr.string_list(default=[]),
 }
 

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -54,10 +54,13 @@ def patch(ctx):
   """Implementation of patching an already extracted repository"""
   bash_exe = ctx.os.environ["BAZEL_SH"] if "BAZEL_SH" in ctx.os.environ else "bash"
   for patchfile in ctx.attr.patches:
-    command = "{patchtool} -p0 < {patchfile}".format(
+    command = "{patchtool} {patchargs} < {patchfile}".format(
       patchtool=ctx.attr.patch_tool,
+      patchargs=" ".join(ctx.attr.patch_arguments),
       patchfile=ctx.path(patchfile))
     st = ctx.execute([bash_exe, "-c", command])
+    if ctx.attr.patch_verbose:
+      print(st.stdout)
     if st.return_code:
       fail("Error applying patch %s:\n%s" % (str(patchfile), st.stderr))
   for cmd in ctx.attr.patch_cmds:


### PR DESCRIPTION
I have my own version of the patch behavior added to http_archive that passes different arguments to patch. This generalization should make the patch feature more generally usable. 