### PR TITLE
Add JavaInfo.transitive_full_compile_time_jars.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfo.java
@@ -463,12 +463,27 @@ public final class JavaInfo extends NativeInfo {
 
   @SkylarkCallable(
       name = "transitive_compile_time_jars",
-      doc = "Depset of compile time jars recusrively required by this target. See `compile_jars` "
+      doc = "Depset of compile time jars recursively required by this target. See `compile_jars` "
           + "for more details.",
       structField = true
   )
   public SkylarkNestedSet getTransitiveCompileTimeJars() {
     return SkylarkNestedSet.of(Artifact.class, getTransitiveDeps());
+  }
+
+  @SkylarkCallable(
+      name = "transitive_full_compile_time_jars",
+      doc = "Depset of full compile time jars recursively required by this target. See "
+          + "`full_compile_jars` for more details.",
+      structField = true
+  )
+  public SkylarkNestedSet getTransitiveFullCompileTimeJars() {
+    NestedSet<Artifact> transitiveFullCompileTimeJars =
+        getProviderAsNestedSet(
+            JavaCompilationArgsProvider.class,
+            JavaCompilationArgsProvider::getRecursiveJavaCompilationArgs,
+            JavaCompilationArgs::getFullCompileTimeJars);
+    return SkylarkNestedSet.of(Artifact.class, transitiveFullCompileTimeJars);
   }
 
   @SkylarkCallable(
@@ -703,4 +718,3 @@ public final class JavaInfo extends NativeInfo {
     }
   }
 }
-

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaSkylarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaSkylarkApiTest.java
@@ -189,6 +189,7 @@ public class JavaSkylarkApiTest extends BuildViewTestCase {
         "   return [result(",
         "             transitive_runtime_jars = depj.transitive_runtime_jars,",
         "             transitive_compile_time_jars = depj.transitive_compile_time_jars,",
+        "             transitive_full_compile_time_jars = depj.transitive_full_compile_time_jars,",
         "             compile_jars = depj.compile_jars,",
         "             full_compile_jars = depj.full_compile_jars,",
         "             source_jars = depj.source_jars,",
@@ -205,6 +206,8 @@ public class JavaSkylarkApiTest extends BuildViewTestCase {
         ((SkylarkNestedSet) info.getValue("transitive_runtime_jars"));
     SkylarkNestedSet transitiveCompileTimeJars =
         ((SkylarkNestedSet) info.getValue("transitive_compile_time_jars"));
+    SkylarkNestedSet transitiveFullCompileTimeJars =
+        ((SkylarkNestedSet) info.getValue("transitive_full_compile_time_jars"));
     SkylarkNestedSet compileJars = ((SkylarkNestedSet) info.getValue("compile_jars"));
     SkylarkNestedSet fullCompileJars = ((SkylarkNestedSet) info.getValue("full_compile_jars"));
     SkylarkList<Artifact> sourceJars = ((SkylarkList<Artifact>) info.getValue("source_jars"));
@@ -214,6 +217,8 @@ public class JavaSkylarkApiTest extends BuildViewTestCase {
         .containsExactly("libdep.jar");
     assertThat(artifactFilesNames(transitiveCompileTimeJars.toCollection(Artifact.class)))
         .containsExactly("libdep-hjar.jar");
+    assertThat(artifactFilesNames(transitiveFullCompileTimeJars.toCollection(Artifact.class)))
+        .containsExactly("libdep.jar");
     assertThat(transitiveCompileTimeJars.toCollection()).isEqualTo(compileJars.toCollection());
     assertThat(artifactFilesNames(fullCompileJars.toCollection(Artifact.class)))
         .containsExactly("libdep.jar");
@@ -254,6 +259,7 @@ public class JavaSkylarkApiTest extends BuildViewTestCase {
         "             transitive_compile_time_jars = depj.transitive_compile_time_jars,",
         "             compile_jars = depj.compile_jars,",
         "             full_compile_jars = depj.full_compile_jars,",
+        "             transitive_full_compile_time_jars = depj.transitive_full_compile_time_jars,",
         "             source_jars = depj.source_jars,",
         "             outputs = depj.outputs,",
         "          )]",
@@ -1592,4 +1598,3 @@ public class JavaSkylarkApiTest extends BuildViewTestCase {
     return true;
   }
 }
-


### PR DESCRIPTION
Inspired by https://github.com/bazelbuild/bazel/commit/655a529db693e0d3c89a68ca81fc4858147b90f0.

Fixes #4297.