### PR TITLE
Fix signedness warnings in cpp tests.

### DIFF
--- a/src/test/cpp/option_processor_test.cc
+++ b/src/test/cpp/option_processor_test.cc
@@ -95,7 +95,7 @@ TEST_F(OptionProcessorTest, CanParseOptions) {
                 << error;
 
   ASSERT_EQ("", error);
-  ASSERT_EQ(1,
+  ASSERT_EQ(size_t(1),
             option_processor_->GetParsedStartupOptions()->host_jvm_args.size());
   EXPECT_EQ("MyParam",
             option_processor_->GetParsedStartupOptions()->host_jvm_args[0]);
@@ -119,7 +119,7 @@ TEST_F(OptionProcessorTest, CanParseHelpArgs) {
                 << error;
 
   ASSERT_EQ("", error);
-  ASSERT_EQ(1,
+  ASSERT_EQ(size_t(1),
             option_processor_->GetParsedStartupOptions()->host_jvm_args.size());
   EXPECT_EQ("MyParam",
             option_processor_->GetParsedStartupOptions()->host_jvm_args[0]);
@@ -155,7 +155,7 @@ TEST_F(OptionProcessorTest, CanParseDifferentStartupArgs) {
                 << error;
   ASSERT_EQ("", error);
 
-  ASSERT_EQ(2,
+  ASSERT_EQ(size_t(2),
             option_processor_->GetParsedStartupOptions()->host_jvm_args.size());
   EXPECT_EQ("MyParam",
             option_processor_->GetParsedStartupOptions()->host_jvm_args[0]);

--- a/src/test/cpp/util/file_posix_test.cc
+++ b/src/test/cpp/util/file_posix_test.cc
@@ -159,7 +159,7 @@ TEST(FilePosixTest, MakeDirectories) {
   ASSERT_TRUE(ok);
   struct stat filestat = {};
   ASSERT_EQ(0, stat(dir.c_str(), &filestat));
-  ASSERT_EQ(0750, filestat.st_mode & 0777);
+  ASSERT_EQ(mode_t(0750), filestat.st_mode & 0777);
 
   // srcdir shouldn't be writable.
   // TODO(ulfjack): Fix this!
@@ -361,7 +361,7 @@ TEST(FilePosixTest, ForEachDirectoryEntry) {
   // Actual test: list the directory.
   MockDirectoryEntryConsumer consumer;
   ForEachDirectoryEntry(root, &consumer);
-  ASSERT_EQ(4, consumer.entries.size());
+  ASSERT_EQ(size_t(4), consumer.entries.size());
 
   // Sort the collected directory entries.
   struct {
@@ -387,7 +387,7 @@ TEST(FilePosixTest, ForEachDirectoryEntry) {
   // Actual test: list a directory symlink.
   consumer.entries.clear();
   ForEachDirectoryEntry(dir_sym, &consumer);
-  ASSERT_EQ(1, consumer.entries.size());
+  ASSERT_EQ(size_t(1), consumer.entries.size());
   expected = pair<string, bool>(subfile_through_sym, false);
   ASSERT_EQ(expected, consumer.entries[0]);
 

--- a/src/test/cpp/util/file_test.cc
+++ b/src/test/cpp/util/file_test.cc
@@ -71,7 +71,7 @@ TEST(FileTest, TestReadFileIntoString) {
   std::string filename(JoinPath(tempdir, "test.readfile"));
   AutoFileStream fh(fopen(filename.c_str(), "wt"));
   EXPECT_TRUE(fh.IsOpen());
-  ASSERT_EQ(11, fwrite("hello world", 1, 11, fh));
+  ASSERT_EQ(size_t(11), fwrite("hello world", 1, 11, fh));
   fh.Close();
 
   std::string actual;
@@ -93,7 +93,7 @@ TEST(FileTest, TestReadFileIntoBuffer) {
   std::string filename(JoinPath(tempdir, "test.readfile"));
   AutoFileStream fh(fopen(filename.c_str(), "wt"));
   EXPECT_TRUE(fh.IsOpen());
-  EXPECT_EQ(11, fwrite("hello world", 1, 11, fh));
+  EXPECT_EQ(size_t(11), fwrite("hello world", 1, 11, fh));
   fh.Close();
 
   char buffer[30];
@@ -123,7 +123,7 @@ TEST(FileTest, TestWriteFile) {
   AutoFileStream fh(fopen(filename.c_str(), "rt"));
   EXPECT_TRUE(fh.IsOpen());
   fflush(fh);
-  ASSERT_EQ(3, fread(buf, 1, 5, fh));
+  ASSERT_EQ(size_t(3), fread(buf, 1, 5, fh));
   fh.Close();
   ASSERT_EQ(std::string(buf), std::string("hel"));
 
@@ -131,7 +131,7 @@ TEST(FileTest, TestWriteFile) {
   fh = fopen(filename.c_str(), "rt");
   EXPECT_TRUE(fh.IsOpen());
   memset(buf, 0, 6);
-  ASSERT_EQ(5, fread(buf, 1, 5, fh));
+  ASSERT_EQ(size_t(5), fread(buf, 1, 5, fh));
   fh.Close();
   ASSERT_EQ(std::string(buf), std::string("hello"));
 

--- a/src/test/cpp/util/strings_test.cc
+++ b/src/test/cpp/util/strings_test.cc
@@ -49,42 +49,42 @@ TEST(BlazeUtil, JoinStrings) {
 TEST(BlazeUtil, Split) {
   string lines = "";
   vector<string> pieces = Split(lines, '\n');
-  ASSERT_EQ(0, pieces.size());
+  ASSERT_EQ(size_t(0), pieces.size());
 
   lines = "foo";
   pieces = Split(lines, '\n');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
 
   lines = "\nfoo";
   pieces = Split(lines, '\n');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
 
   lines = "\n\n\nfoo";
   pieces = Split(lines, '\n');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
 
   lines = "foo\n";
   pieces = Split(lines, '\n');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
 
   lines = "foo\n\n\n";
   pieces = Split(lines, '\n');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
 
   lines = "foo\nbar";
   pieces = Split(lines, '\n');
-  ASSERT_EQ(2, pieces.size());
+  ASSERT_EQ(size_t(2), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
   ASSERT_EQ("bar", pieces[1]);
 
   lines = "foo\n\nbar";
   pieces = Split(lines, '\n');
-  ASSERT_EQ(2, pieces.size());
+  ASSERT_EQ(size_t(2), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
   ASSERT_EQ("bar", pieces[1]);
 }
@@ -135,91 +135,91 @@ TEST(BlazeUtil, Tokenize) {
   vector<string> result;
   string str = "a b c";
   Tokenize(str, '#', &result);
-  ASSERT_EQ(3, result.size());
+  ASSERT_EQ(size_t(3), result.size());
   EXPECT_EQ("a", result[0]);
   EXPECT_EQ("b", result[1]);
   EXPECT_EQ("c", result[2]);
 
   str = "a 'b c'";
   Tokenize(str, '#', &result);
-  ASSERT_EQ(2, result.size());
+  ASSERT_EQ(size_t(2), result.size());
   EXPECT_EQ("a", result[0]);
   EXPECT_EQ("b c", result[1]);
 
   str = "foo# bar baz";
   Tokenize(str, '#', &result);
-  ASSERT_EQ(1, result.size());
+  ASSERT_EQ(size_t(1), result.size());
   EXPECT_EQ("foo", result[0]);
 
   str = "foo # bar baz";
   Tokenize(str, '#', &result);
-  ASSERT_EQ(1, result.size());
+  ASSERT_EQ(size_t(1), result.size());
   EXPECT_EQ("foo", result[0]);
 
   str = "#bar baz";
   Tokenize(str, '#', &result);
-  ASSERT_EQ(0, result.size());
+  ASSERT_EQ(size_t(0), result.size());
 
   str = "#";
   Tokenize(str, '#', &result);
-  ASSERT_EQ(0, result.size());
+  ASSERT_EQ(size_t(0), result.size());
 
   str = " \tfirst second /    ";
   Tokenize(str, 0, &result);
-  ASSERT_EQ(3, result.size());
+  ASSERT_EQ(size_t(3), result.size());
   EXPECT_EQ("first", result[0]);
   EXPECT_EQ("second", result[1]);
   EXPECT_EQ("/", result[2]);
 
   str = " \tfirst second /    ";
   Tokenize(str, '/', &result);
-  ASSERT_EQ(2, result.size());
+  ASSERT_EQ(size_t(2), result.size());
   EXPECT_EQ("first", result[0]);
   EXPECT_EQ("second", result[1]);
 
   str = "first \"second' third\" fourth";
   Tokenize(str, '/', &result);
-  ASSERT_EQ(3, result.size());
+  ASSERT_EQ(size_t(3), result.size());
   EXPECT_EQ("first", result[0]);
   EXPECT_EQ("second' third", result[1]);
   EXPECT_EQ("fourth", result[2]);
 
   str = "first 'second\" third' fourth";
   Tokenize(str, '/', &result);
-  ASSERT_EQ(3, result.size());
+  ASSERT_EQ(size_t(3), result.size());
   EXPECT_EQ("first", result[0]);
   EXPECT_EQ("second\" third", result[1]);
   EXPECT_EQ("fourth", result[2]);
 
   str = "\\ this\\ is\\ one\\'\\ token";
   Tokenize(str, 0, &result);
-  ASSERT_EQ(1, result.size());
+  ASSERT_EQ(size_t(1), result.size());
   EXPECT_EQ(" this is one' token", result[0]);
 
   str = "\\ this\\ is\\ one\\'\\ token\\";
   Tokenize(str, 0, &result);
-  ASSERT_EQ(1, result.size());
+  ASSERT_EQ(size_t(1), result.size());
   EXPECT_EQ(" this is one' token", result[0]);
 
   str = "unterminated \" runs to end of line";
   Tokenize(str, 0, &result);
-  ASSERT_EQ(2, result.size());
+  ASSERT_EQ(size_t(2), result.size());
   EXPECT_EQ("unterminated", result[0]);
   EXPECT_EQ(" runs to end of line", result[1]);
 
   str = "";
   Tokenize(str, 0, &result);
-  ASSERT_EQ(0, result.size());
+  ASSERT_EQ(size_t(0), result.size());
 
   str = "one two\'s three";
   Tokenize(str, 0, &result);
-  ASSERT_EQ(2, result.size());
+  ASSERT_EQ(size_t(2), result.size());
   EXPECT_EQ("one", result[0]);
   EXPECT_EQ("twos three", result[1]);
 
   str = "one \'two three";
   Tokenize(str, 0, &result);
-  ASSERT_EQ(2, result.size());
+  ASSERT_EQ(size_t(2), result.size());
   EXPECT_EQ("one", result[0]);
   EXPECT_EQ("two three", result[1]);
 }
@@ -234,66 +234,66 @@ static vector<string> SplitQuoted(const string &contents,
 TEST(BlazeUtil, SplitQuoted) {
   string lines = "";
   vector<string> pieces = SplitQuoted(lines, '\n');
-  ASSERT_EQ(0, pieces.size());
+  ASSERT_EQ(size_t(0), pieces.size());
 
   // Same behaviour without quotes as Split
   lines = "foo";
   pieces = SplitQuoted(lines, ' ');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
 
   lines = " foo";
   pieces = SplitQuoted(lines, ' ');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
 
   lines = "   foo";
   pieces = SplitQuoted(lines, ' ');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
 
   lines = "foo ";
   pieces = SplitQuoted(lines, ' ');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
 
   lines = "foo   ";
   pieces = SplitQuoted(lines, ' ');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
 
   lines = "foo bar";
   pieces = SplitQuoted(lines, ' ');
-  ASSERT_EQ(2, pieces.size());
+  ASSERT_EQ(size_t(2), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
   ASSERT_EQ("bar", pieces[1]);
 
   lines = "foo  bar";
   pieces = SplitQuoted(lines, ' ');
-  ASSERT_EQ(2, pieces.size());
+  ASSERT_EQ(size_t(2), pieces.size());
   ASSERT_EQ("foo", pieces[0]);
   ASSERT_EQ("bar", pieces[1]);
 
   // Test with quotes
   lines = "' 'foo";
   pieces = SplitQuoted(lines, ' ');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("' 'foo", pieces[0]);
 
   lines = " ' ' foo";
   pieces = SplitQuoted(lines, ' ');
-  ASSERT_EQ(2, pieces.size());
+  ASSERT_EQ(size_t(2), pieces.size());
   ASSERT_EQ("' '", pieces[0]);
   ASSERT_EQ("foo", pieces[1]);
 
   lines = "foo' \\' ' ";
   pieces = SplitQuoted(lines, ' ');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("foo' \\' '", pieces[0]);
 
   lines = "foo'\\'\" ' ";
   pieces = SplitQuoted(lines, ' ');
-  ASSERT_EQ(1, pieces.size());
+  ASSERT_EQ(size_t(1), pieces.size());
   ASSERT_EQ("foo'\\'\" '", pieces[0]);
 }
 


### PR DESCRIPTION
The compiler infers the type of unsuffixed literals as signed. That causes GCC
warnings like this with gtest's ASSERT_EQ if one side is a literal and other is
an unsigned type:
```
In file included from src/test/cpp/option_processor_test.cc:23:0:
external/com_google_googletest/googletest/include/gtest/gtest.h: In instantiation of 'testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = long unsigned int]':
external/com_google_googletest/googletest/include/gtest/gtest.h:1449:23:   required from 'static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = long unsigned int; bool lhs_is_null_literal = false]'
src/test/cpp/option_processor_test.cc:98:3:   required from here
external/com_google_googletest/googletest/include/gtest/gtest.h:1421:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
```