### PR TITLE
Remove cc_inc_library in ObjcRuleClasses

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
@@ -611,8 +611,7 @@ public class ObjcRuleClasses {
      * Rule class names for cc rules which are allowed as targets of the 'deps' attribute of this
      * rule.
      */
-    static final ImmutableSet<String> ALLOWED_CC_DEPS_RULE_CLASSES =
-        ImmutableSet.of("cc_library", "cc_inc_library");
+    static final String[] ALLOWED_CC_DEPS_RULE_CLASSES = new String[] {"cc_library"};
 
     @Override
     public RuleClass build(Builder builder, RuleDefinitionEnvironment env) {
@@ -946,8 +945,7 @@ public class ObjcRuleClasses {
      * Rule class names for cc rules which are allowed as targets of the 'deps' attribute of this
      * rule.
      */
-    static final ImmutableSet<String> ALLOWED_CC_DEPS_RULE_CLASSES =
-        ImmutableSet.of("cc_library", "cc_inc_library");
+    static final String[] ALLOWED_CC_DEPS_RULE_CLASSES = new String[] {"cc_library"};
 
     @Override
     public RuleClass build(Builder builder, RuleDefinitionEnvironment env) {

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
@@ -25,7 +25,6 @@ import static com.google.devtools.build.lib.syntax.Type.STRING_LIST;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.analysis.BaseRuleClasses;


### PR DESCRIPTION
Split from https://bazel-review.googlesource.com/c/bazel/+/50050

/cc @mhlopko

Change-Id: Ie8a6d9256f65ed81b2b7006a9d19065eaf199f32