### PR TITLE
Java,runfiles: add Runfiles.getEnvVars()

### DIFF
--- a/src/test/py/bazel/testdata/runfiles_test/foo/BUILD.mock
+++ b/src/test/py/bazel/testdata/runfiles_test/foo/BUILD.mock
@@ -15,6 +15,8 @@ java_binary(
     srcs = ["Foo.java"],
     data = [
         "datadep/hello.txt",
+        "//bar:bar-py",
+        "//bar:bar-java",
     ],
     main_class = "Foo",
     deps = ["@bazel_tools//tools/runfiles:java-runfiles"],

--- a/src/test/py/bazel/testdata/runfiles_test/foo/Foo.java
+++ b/src/test/py/bazel/testdata/runfiles_test/foo/Foo.java
@@ -13,13 +13,68 @@
 // limitations under the License.
 
 import com.google.devtools.build.runfiles.Runfiles;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /** A mock Java binary only used in tests, to exercise the Java Runfiles library. */
 public class Foo {
-  public static void main(String[] args) throws IOException {
+  public static void main(String[] args) throws IOException, InterruptedException {
     System.out.println("Hello Java Foo!");
     Runfiles r = Runfiles.create();
     System.out.println("rloc=" + r.rlocation("foo_ws/foo/datadep/hello.txt"));
+
+    for (String lang : new String[] {"py", "java"}) {
+      String path = r.rlocation(childBinaryName(lang));
+      if (path == null || path.isEmpty()) {
+        throw new IOException("cannot find child binary for " + lang);
+      }
+
+      ProcessBuilder pb = new ProcessBuilder(path);
+      pb.environment().putAll(r.getEnvVars());
+      if (isWindows()) {
+        pb.environment().put("SYSTEMROOT", System.getenv("SYSTEMROOT"));
+      }
+      Process p = pb.start();
+      if (!p.waitFor(3, TimeUnit.SECONDS)) {
+        throw new IOException("child process for " + lang + " timed out");
+      }
+      if (p.exitValue() != 0) {
+        throw new IOException(
+            "child process for " + lang + " failed: " + readStream(p.getErrorStream()));
+      }
+      System.out.printf(readStream(p.getInputStream()));
+    }
+  }
+
+  private static boolean isWindows() {
+    return File.separatorChar == '\\';
+  }
+
+  private static String childBinaryName(String lang) {
+    if (isWindows()) {
+      return "foo_ws/bar/bar-" + lang + ".exe";
+    } else {
+      return "foo_ws/bar/bar-" + lang;
+    }
+  }
+
+  private static String readStream(InputStream stm) throws IOException {
+    StringBuilder result = new StringBuilder();
+    try (BufferedReader r =
+        new BufferedReader(new InputStreamReader(stm, StandardCharsets.UTF_8))) {
+      String line = null;
+      while ((line = r.readLine()) != null) {
+        line = line.trim();  // trim CRLF on Windows, LF on Linux
+        result.append(line).append("\n");  // ensure uniform line ending
+      }
+    }
+    return result.toString();
   }
 }

--- a/src/tools/runfiles/java/com/google/devtools/build/runfiles/DirectoryBased.java
+++ b/src/tools/runfiles/java/com/google/devtools/build/runfiles/DirectoryBased.java
@@ -14,18 +14,32 @@
 
 package com.google.devtools.build.runfiles;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 /** {@link Runfiles} implementation that appends runfiles paths to the runfiles root. */
-class DirectoryBased extends Runfiles {
+final class DirectoryBased extends Runfiles {
   private final String runfilesRoot;
 
-  DirectoryBased(String runfilesDir) {
-    Util.checkArgument(runfilesDir != null);
-    Util.checkArgument(!runfilesDir.isEmpty());
+  DirectoryBased(String runfilesDir) throws IOException {
+    Util.checkArgument(!Util.isNullOrEmpty(runfilesDir));
+    Util.checkArgument(new File(runfilesDir).isDirectory());
     this.runfilesRoot = runfilesDir;
   }
 
   @Override
   String rlocationChecked(String path) {
     return runfilesRoot + "/" + path;
+  }
+
+  @Override
+  public Map<String, String> getEnvVars() {
+    HashMap<String, String> result = new HashMap<>(2);
+    result.put("RUNFILES_DIR", runfilesRoot);
+    // TODO(laszlocsomor): remove JAVA_RUNFILES once the Java launcher can pick up RUNFILES_DIR.
+    result.put("JAVA_RUNFILES", runfilesRoot);
+    return result;
   }
 }

--- a/src/tools/runfiles/java/com/google/devtools/build/runfiles/DirectoryBasedTest.java
+++ b/src/tools/runfiles/java/com/google/devtools/build/runfiles/DirectoryBasedTest.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.runfiles;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,8 +31,10 @@ public final class DirectoryBasedTest {
     // The DirectoryBased implementation simply joins the runfiles directory and the runfile's path
     // on a "/". DirectoryBased does not perform any normalization, nor does it check that the path
     // exists.
-    DirectoryBased r = new DirectoryBased("foo/bar baz//qux/");
-    assertThat(r.rlocation("arg")).isEqualTo("foo/bar baz//qux//arg");
+    File dir = new File(System.getenv("TEST_TMPDIR"), "mock/runfiles");
+    assertThat(dir.mkdirs()).isTrue();
+    DirectoryBased r = new DirectoryBased(dir.toString());
+    assertThat(r.rlocation("arg")).endsWith("/mock/runfiles/arg");
   }
 
   @Test
@@ -50,6 +53,13 @@ public final class DirectoryBasedTest {
       // expected
     }
 
-    new DirectoryBased("non-empty value is fine");
+    try {
+      new DirectoryBased("non-existent directory is bad");
+      fail();
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    new DirectoryBased(System.getenv("TEST_TMPDIR"));
   }
 }

--- a/src/tools/runfiles/java/com/google/devtools/build/runfiles/DirectoryBasedTest.java
+++ b/src/tools/runfiles/java/com/google/devtools/build/runfiles/DirectoryBasedTest.java
@@ -34,7 +34,8 @@ public final class DirectoryBasedTest {
     File dir = new File(System.getenv("TEST_TMPDIR"), "mock/runfiles");
     assertThat(dir.mkdirs()).isTrue();
     DirectoryBased r = new DirectoryBased(dir.toString());
-    assertThat(r.rlocation("arg")).endsWith("/mock/runfiles/arg");
+    // Escaping for "\": once for string and once for regex.
+    assertThat(r.rlocation("arg")).matches(".*[/\\\\]mock[/\\\\]runfiles[/\\\\]arg");
   }
 
   @Test

--- a/src/tools/runfiles/java/com/google/devtools/build/runfiles/ManifestBased.java
+++ b/src/tools/runfiles/java/com/google/devtools/build/runfiles/ManifestBased.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.runfiles;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -24,12 +25,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 /** {@link Runfiles} implementation that parses a runfiles-manifest file to look up runfiles. */
-class ManifestBased extends Runfiles {
+final class ManifestBased extends Runfiles {
   private final Map<String, String> runfiles;
+  private final String manifestPath;
 
   ManifestBased(String manifestPath) throws IOException {
     Util.checkArgument(manifestPath != null);
     Util.checkArgument(!manifestPath.isEmpty());
+    this.manifestPath = manifestPath;
     this.runfiles = loadRunfiles(manifestPath);
   }
 
@@ -49,8 +52,31 @@ class ManifestBased extends Runfiles {
     return Collections.unmodifiableMap(result);
   }
 
+  private static String findRunfilesDir(String manifest) {
+    if (manifest.endsWith("/MANIFEST") || manifest.endsWith("\\MANIFEST")
+        || manifest.endsWith(".runfiles_manifest")) {
+      String path = manifest.substring(0, manifest.length() - 9);
+      if (new File(path).isDirectory()) {
+        return path;
+      }
+    }
+    return "";
+  }
+
   @Override
   public String rlocationChecked(String path) {
     return runfiles.get(path);
+  }
+
+  @Override
+  public Map<String, String> getEnvVars() {
+    HashMap<String, String> result = new HashMap<>(4);
+    result.put("RUNFILES_MANIFEST_ONLY", "1");
+    result.put("RUNFILES_MANIFEST_FILE", manifestPath);
+    String runfilesDir = findRunfilesDir(manifestPath);
+    result.put("RUNFILES_DIR", runfilesDir);
+    // TODO(laszlocsomor): remove JAVA_RUNFILES once the Java launcher can pick up RUNFILES_DIR.
+    result.put("JAVA_RUNFILES", runfilesDir);
+    return result;
   }
 }

--- a/src/tools/runfiles/java/com/google/devtools/build/runfiles/Runfiles.java
+++ b/src/tools/runfiles/java/com/google/devtools/build/runfiles/Runfiles.java
@@ -27,6 +27,17 @@ import java.util.Map;
  *   Runfiles runfiles = Runfiles.create();
  *   File p = new File(runfiles.rlocation("io_bazel/src/bazel"));
  * </pre>
+ *
+ * <p>If you want to start subprocesses that also need runfiles, you need to set the right
+ * environment variables for them:
+ *
+ * <pre>
+ *   String path = r.rlocation("path/to/binary");
+ *   ProcessBuilder pb = new ProcessBuilder(path);
+ *   pb.environment().putAll(r.getEnvVars());
+ *   ...
+ *   Process p = pb.start();
+ * </pre>
  */
 public abstract class Runfiles {
 
@@ -102,6 +113,14 @@ public abstract class Runfiles {
     }
     return rlocationChecked(path);
   }
+
+  /**
+   * Returns environment variables for subprocesses.
+   *
+   * <p>The caller should add the returned key-value pairs to the environment of subprocesses in
+   * case those subprocesses are also Bazel-built binaries that need to use runfiles.
+   */
+  public abstract Map<String, String> getEnvVars();
 
   /** Returns true if the platform supports runfiles only via manifests. */
   private static boolean isManifestOnly(Map<String, String> env) {

--- a/src/tools/runfiles/java/com/google/devtools/build/runfiles/RunfilesTest.java
+++ b/src/tools/runfiles/java/com/google/devtools/build/runfiles/RunfilesTest.java
@@ -21,6 +21,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,7 +54,10 @@ public final class RunfilesTest {
 
   @Test
   public void testRlocationArgumentValidation() throws Exception {
-    Runfiles r = Runfiles.create(ImmutableMap.of("RUNFILES_DIR", "whatever"));
+    Path dir = Files.createTempDirectory(
+        FileSystems.getDefault().getPath(System.getenv("TEST_TMPDIR")), null);
+
+    Runfiles r = Runfiles.create(ImmutableMap.of("RUNFILES_DIR", dir.toString()));
     assertRlocationArg(r, null, null);
     assertRlocationArg(r, "", null);
     assertRlocationArg(r, "foo/..", "contains uplevel");
@@ -80,38 +89,44 @@ public final class RunfilesTest {
 
   @Test
   public void testCreatesDirectoryBasedRunfiles() throws Exception {
+    Path dir = Files.createTempDirectory(
+        FileSystems.getDefault().getPath(System.getenv("TEST_TMPDIR")), null);
+
     Runfiles r =
         Runfiles.create(
             ImmutableMap.of(
                 "RUNFILES_MANIFEST_FILE", "ignored when RUNFILES_MANIFEST_ONLY is not set to 1",
-                "RUNFILES_DIR", "runfiles/dir",
+                "RUNFILES_DIR", dir.toString(),
                 "JAVA_RUNFILES", "ignored when RUNFILES_DIR has a value",
                 "TEST_SRCDIR", "should always be ignored"));
-    assertThat(r.rlocation("a/b")).isEqualTo("runfiles/dir/a/b");
-    assertThat(r.rlocation("foo")).isEqualTo("runfiles/dir/foo");
+    assertThat(r.rlocation("a/b")).endsWith("/a/b");
+    assertThat(r.rlocation("foo")).endsWith("/foo");
 
     r =
         Runfiles.create(
             ImmutableMap.of(
                 "RUNFILES_MANIFEST_FILE", "ignored when RUNFILES_MANIFEST_ONLY is not set to 1",
                 "RUNFILES_DIR", "",
-                "JAVA_RUNFILES", "runfiles/dir",
+                "JAVA_RUNFILES", dir.toString(),
                 "TEST_SRCDIR", "should always be ignored"));
-    assertThat(r.rlocation("a/b")).isEqualTo("runfiles/dir/a/b");
-    assertThat(r.rlocation("foo")).isEqualTo("runfiles/dir/foo");
+    assertThat(r.rlocation("a/b")).endsWith("/a/b");
+    assertThat(r.rlocation("foo")).endsWith("/foo");
   }
 
   @Test
   public void testIgnoresTestSrcdirWhenJavaRunfilesIsUndefinedAndJustFails() throws Exception {
+    Path dir = Files.createTempDirectory(
+        FileSystems.getDefault().getPath(System.getenv("TEST_TMPDIR")), null);
+
     Runfiles.create(
         ImmutableMap.of(
-            "RUNFILES_DIR", "non-empty",
+            "RUNFILES_DIR", dir.toString(),
             "RUNFILES_MANIFEST_FILE", "ignored when RUNFILES_MANIFEST_ONLY is not set to 1",
             "TEST_SRCDIR", "should always be ignored"));
 
     Runfiles.create(
         ImmutableMap.of(
-            "JAVA_RUNFILES", "non-empty",
+            "JAVA_RUNFILES", dir.toString(),
             "RUNFILES_MANIFEST_FILE", "ignored when RUNFILES_MANIFEST_ONLY is not set to 1",
             "TEST_SRCDIR", "should always be ignored"));
 
@@ -142,5 +157,58 @@ public final class RunfilesTest {
     } catch (IOException e) {
       assertThat(e).hasMessageThat().contains("non-existing path");
     }
+  }
+
+  @Test
+  public void testManifestBasedEnvVars() throws Exception {
+    Path dir = Files.createTempDirectory(
+        FileSystems.getDefault().getPath(System.getenv("TEST_TMPDIR")), null);
+
+    Path mf = dir.resolve("MANIFEST");
+    Files.write(mf, Collections.emptyList(), StandardCharsets.UTF_8);
+    Map<String, String> envvars = Runfiles.create(
+        ImmutableMap.of(
+            "RUNFILES_MANIFEST_ONLY", "1",
+            "RUNFILES_MANIFEST_FILE", mf.toString(),
+            "RUNFILES_DIR", "ignored when RUNFILES_MANIFEST_ONLY=1",
+            "JAVA_RUNFILES", "ignored when RUNFILES_DIR has a value",
+            "TEST_SRCDIR", "should always be ignored")).getEnvVars();
+    assertThat(envvars.keySet()).containsExactly("RUNFILES_MANIFEST_ONLY", "RUNFILES_MANIFEST_FILE", "RUNFILES_DIR", "JAVA_RUNFILES");
+    assertThat(envvars.get("RUNFILES_MANIFEST_ONLY")).isEqualTo("1");
+    assertThat(envvars.get("RUNFILES_MANIFEST_FILE")).isEqualTo(mf.toString());
+    assertThat(envvars.get("RUNFILES_DIR")).isEqualTo(dir.toString());
+    assertThat(envvars.get("JAVA_RUNFILES")).isEqualTo(dir.toString());
+
+    Path rfDir = dir.resolve("foo.runfiles");
+    Files.createDirectories(rfDir);
+    mf = dir.resolve("foo.runfiles_manifest");
+    Files.write(mf, Collections.emptyList(), StandardCharsets.UTF_8);
+    envvars = Runfiles.create(
+        ImmutableMap.of(
+            "RUNFILES_MANIFEST_ONLY", "1",
+            "RUNFILES_MANIFEST_FILE", mf.toString(),
+            "RUNFILES_DIR", "ignored when RUNFILES_MANIFEST_ONLY=1",
+            "JAVA_RUNFILES", "ignored when RUNFILES_DIR has a value",
+            "TEST_SRCDIR", "should always be ignored")).getEnvVars();
+    assertThat(envvars.get("RUNFILES_MANIFEST_ONLY")).isEqualTo("1");
+    assertThat(envvars.get("RUNFILES_MANIFEST_FILE")).isEqualTo(mf.toString());
+    assertThat(envvars.get("RUNFILES_DIR")).isEqualTo(rfDir.toString());
+    assertThat(envvars.get("JAVA_RUNFILES")).isEqualTo(rfDir.toString());
+  }
+
+  @Test
+  public void testDirectoryBasedEnvVars() throws Exception {
+    Path dir = Files.createTempDirectory(
+        FileSystems.getDefault().getPath(System.getenv("TEST_TMPDIR")), null);
+
+    Map<String, String> envvars = Runfiles.create(
+        ImmutableMap.of(
+                "RUNFILES_MANIFEST_FILE", "ignored when RUNFILES_MANIFEST_ONLY is not set to 1",
+            "RUNFILES_DIR", dir.toString(),
+            "JAVA_RUNFILES", "ignored when RUNFILES_DIR has a value",
+            "TEST_SRCDIR", "should always be ignored")).getEnvVars();
+    assertThat(envvars.keySet()).containsExactly("RUNFILES_DIR", "JAVA_RUNFILES");
+    assertThat(envvars.get("RUNFILES_DIR")).isEqualTo(dir.toString());
+    assertThat(envvars.get("JAVA_RUNFILES")).isEqualTo(dir.toString());
   }
 }


### PR DESCRIPTION
The new method lets Java programs export the
RUNFILES_* environment variables for subprocesses,
in case those subprocesses are other Bazel-built
binaries that also need runfiles.

See https://github.com/bazelbuild/bazel/issues/4460

Change-Id: I05c0b84db357128bc15f21a167a0d92e8d17599c