### PR TITLE
Add a workaround for gcov-based coverage with clang

### DIFF
--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -61,6 +61,7 @@ cc_autoconf = repository_rule(
         "CPLUS_INCLUDE_PATH",
         "CUDA_COMPUTE_CAPABILITIES",
         "CUDA_PATH",
+        "GCOV",
         "HOMEBREW_RUBY_PATH",
         "NO_WHOLE_ARCHIVE_OPTION",
         "USE_DYNAMIC_CRT",

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -414,15 +414,16 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
   repository_ctx.file("tools/cpp/empty.cc", "int main() {}")
   darwin = cpu_value == "darwin"
 
+  cc = _find_generic(repository_ctx, "gcc", "CC", overriden_tools)
   overriden_tools = dict(overriden_tools)
-  overriden_tools["gcc"] = _find_generic(repository_ctx, "gcc", "CC", overriden_tools)
+  overriden_tools["gcc"] = cc
   overriden_tools["gcov"] = _find_generic(repository_ctx, "gcov", "GCOV", overriden_tools)
   if darwin:
     overriden_tools["ar"] = "/usr/bin/libtool"
     overriden_tools["gcc"] = "cc_wrapper.sh"
 
   tool_paths = _get_tool_paths(repository_ctx, darwin, overriden_tools)
-  crosstool_content = _crosstool_content(repository_ctx, overriden_tools["gcc"], cpu_value, darwin)
+  crosstool_content = _crosstool_content(repository_ctx, str(cc), cpu_value, darwin)
   opt_content = _opt_content(darwin)
   dbg_content = _dbg_content()
   tpl(repository_ctx, "BUILD", {
@@ -433,7 +434,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
   })
   tpl(repository_ctx,
       "osx_cc_wrapper.sh" if darwin else "linux_cc_wrapper.sh",
-      {"%{cc}": escape_string(overriden_tools["gcc"]),
+      {"%{cc}": escape_string(str(cc)),
        "%{env}": escape_string(get_env(repository_ctx))},
       "cc_wrapper.sh")
   tpl(repository_ctx, "CROSSTOOL", {

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -423,7 +423,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
     overriden_tools["gcc"] = "cc_wrapper.sh"
 
   tool_paths = _get_tool_paths(repository_ctx, darwin, overriden_tools)
-  crosstool_content = _crosstool_content(repository_ctx, str(cc), cpu_value, darwin)
+  crosstool_content = _crosstool_content(repository_ctx, cc, cpu_value, darwin)
   opt_content = _opt_content(darwin)
   dbg_content = _dbg_content()
   tpl(repository_ctx, "BUILD", {

--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -126,13 +126,21 @@ if [[ "$COVERAGE_LEGACY_MODE" ]]; then
     touch "${COVERAGE_DIR}/${path}"
   done
 
+  # Symlink the gcov tool such with a link called gcov. Clang comes with a tool
+  # called llvm-cov, which behaves like gcov if symlinked in this way (otherwise
+  # we would need to invoke it with "llvm-cov gcov").
+  GCOV="${COVERAGE_DIR}/gcov"
+  ln -s "${COVERAGE_GCOV_PATH}" "${GCOV}"
+
   # Run lcov over the .gcno and .gcda files to generate the lcov tracefile.
   # -c - Collect coverage data
   # --no-external - Do not collect coverage data for system files
   # --ignore-errors graph - Ignore missing .gcno files; Bazel only instruments some files
+  # --gcov-tool "${GCOV}" - Pass the local symlink to be uses as gcov by lcov
   # -d "${COVERAGE_DIR}" - Directory to search for .gcda files
   # -o "${COVERAGE_OUTPUT_FILE}" - Output file
   /usr/bin/lcov -c --no-external --ignore-errors graph \
+      --gcov-tool "${GCOV}" \
       -d "${COVERAGE_DIR}" -o "${COVERAGE_OUTPUT_FILE}"
 
   # The paths are all wrong, because they point to /tmp. Fix up the paths to


### PR DESCRIPTION
- Allow overriding the gcov tool with the GCOV env variable in cc_configure
- Symlink the GCOV tool in collect-coverage.sh to a temporary location with
  the name "gcov"

This allows the user to specify GCOV=llvm-cov in the environment of a bazel
build, which then leads to cc_configure picking up llvm-cov in the crosstool,
which the collect-coverage.sh script then uses as "gcov".

On linux distributions, the gcov tool does not generally work with clang
coverage output, so this provides at least a workaround for running coverage
with clang (by setting the GCOV env variable).