### PR TITLE
Proof of concept: Versioned documentation for docs.bazel.build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -165,3 +165,11 @@ http_file(
   name = 'mount_path_toolchain',
   url = 'https://asci-toolchain.appspot.com.storage.googleapis.com/toolchain-testing/mount_path_toolchain.tar.gz',
 )
+
+load("//scripts/docs:versions.bzl", "DOCS_VERSIONS")
+
+[http_file(
+    name = "bazel_docs_%s" % DOC_VERSION["version"].replace(".", "_"),
+    url = "https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-%s.tar" % DOC_VERSION["version"],
+    sha256 = DOC_VERSION["sha256"],
+) for DOC_VERSION in DOCS_VERSIONS]

--- a/scripts/docs/BUILD
+++ b/scripts/docs/BUILD
@@ -16,4 +16,7 @@ py_binary(
     deps = [":dot-converter"],
 )
 
-exports_files(["jekyll_build.sh.tpl"])
+exports_files([
+    "jekyll_build.sh.tpl",
+    "versions.bzl",
+])

--- a/scripts/docs/generate_versioned_docs.sh
+++ b/scripts/docs/generate_versioned_docs.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Usage: 
+# $BAZEL_ROOT/scripts/docs/generate_versioned_docs.sh 0.8.0 0.9.0 ..
+
+set -eu
+
+ORIGINAL_GIT_REF=$(git symbolic-ref --quiet --short HEAD || git rev-parse --short HEAD)
+
+readonly RELEASES=$@; shift
+
+main() {
+  for release in $RELEASES; do
+    git checkout $release
+    bazel build //site:jekyll-tree.tar --action_env=BAZEL_RELEASE=$release
+    gsutil cp -n -a public-read bazel-genfiles/site/jekyll-tree.tar gs://bazel-mirror/bazel_versioned_docs/jekyll-tree-$release.tar
+  done
+}
+
+cleanup() {
+  git checkout $ORIGINAL_GIT_REF
+}
+
+trap cleanup EXIT
+
+if [ -e WORKSPACE ]
+then
+  main
+else
+  echo "Please run this from the root of the Bazel workspace."
+fi

--- a/scripts/docs/versions.bzl
+++ b/scripts/docs/versions.bzl
@@ -1,0 +1,8 @@
+DOCS_VERSIONS = [
+    { "version": "0.12.0", "sha256": "cfd921d86c4f94a1273e49da6c4cba3e8a6a08f16a0a499f046dfaf967fce9ed" },
+    { "version": "0.11.1", "sha256": "cebf174a322d001f11da4ef99b6a38a56d98528b4bbdc72329e0f6100d77a0ba" },
+    { "version": "0.11.0", "sha256": "59c2289cd58090fc99d40fa091d149b0e101698cff1e3da6c639da5993a7e4e1" },
+    { "version": "0.10.1", "sha256": "445bd36a015b1a2a0f0d0ddf012a86cb1d0bd72b307403376fbfa7679c2d9efa" },
+    { "version": "0.10.0", "sha256": "0764d21af77462435f00f76e24c862e17e85c8e2de2e34f0fc24508902c5d9f5" },
+    { "version": "0.9.0",  "sha256": "4ab91b2cb952de4781b2d9dc38683aeb7931229cdc60ac4dcc48d3ae0bb1cd16" },
+]

--- a/site/BUILD
+++ b/site/BUILD
@@ -147,8 +147,12 @@ genrule(
     ],
 )
 
+load("//scripts/docs:versions.bzl", "DOCS_VERSIONS")
+
 jekyll_build(
     name = "site",
-    srcs = [":jekyll-tree"],
+    srcs = [
+        ":jekyll-tree",
+    ] + ["@bazel_docs_%s//file" % DOC_VERSION["version"].replace(".", "_") for DOC_VERSION in DOCS_VERSIONS],
     bucket = "docs.bazel.build",
 )

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect: bazel-overview.html
+redirect: /versions/master/bazel-overview.html
 ---

--- a/site/jekyll-tree.sh
+++ b/site/jekyll-tree.sh
@@ -40,10 +40,8 @@ readonly TMP=$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")
 readonly OUT_DIR="$TMP/out"
 trap "rm -rf ${TMP}" EXIT
 
-# TODO: Create a variant of this script for cutting versions of documentation
-# for Bazel releases. For that case, consider extracting the Git branch or tag
-# name to be used as the versioned directory name.
-readonly VERSION="master"
+# Use scripts/generate_versioned_docs.sh to generate versioned documentation
+readonly VERSION="${BAZEL_RELEASE:-master}"
 readonly VERSION_DIR="$OUT_DIR/versions/$VERSION"
 
 # Unpacks the base Jekyll tree, Build Encyclopedia, Skylark Library, and


### PR DESCRIPTION
As requested in bazelbuild#579, this PR adds a new script to generate 
versioned documentation for docs.bazel.build. The script accepts an argv 
of release versions, does git checkouts for each release and builds the 
jekyll-tree tarball for that checkout.

The jekyll-tree.sh script is modified to set the version component of the URL
based on an env var `BAZEL_RELEASE`, which is passed in via the documentation
generate script using `--action_env`.

The URLs now look like these:

docs.bazel.build/versions/master/remote-caching.html # Exists
docs.bazel.build/versions/0.10.0/remote-caching.html # Does not exist

docs.bazel.build/versions/master/be/android.html # has Android test rules
docs.bazel.build/versions/0.9.0/be/android.html # no Android test rules

For demo purposes, I've hosted the tarballs from 0.9.0 to 0.12.0 on the
Bazel mirror, which are fetched with `http_file`.

To test this out: checkout this PR and run `bazel run //site`. Then, open
`http://localhost:12345`.

Fixes bazelbuild#579
Also see bazelbuild#1788
Also see bazelbuild#3537