### PR TITLE
test-setup: remove leading "./" from test name

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -201,10 +201,10 @@ EOF
 PATH=".:$PATH"
 
 if [ -z "$COVERAGE_DIR" ]; then
-  EXE="$1"
+  EXE="${1#./}"
   shift
 else
-  EXE="$2"
+  EXE="${2#./}"
 fi
 
 if is_absolute "$EXE"; then


### PR DESCRIPTION
Fixes release-blocking regression https://github.com/bazelbuild/bazel/issues/5079

Change-Id: I26202d571d53cd843d559b86d849d29173df4015