### PR TITLE
AddFiles will recursively add files when a directory is encountered

### DIFF
--- a/tools/build_defs/pkg/make_rpm.py
+++ b/tools/build_defs/pkg/make_rpm.py
@@ -173,9 +173,16 @@ class RpmBuilder(object):
     self.rpmbuild_path = FindRpmbuild()
     self.rpm_path = None
 
-  def AddFiles(self, files):
-    """Add a set of files to the current RPM."""
-    self.files += files
+  def AddFiles(self, paths, root=""):
+    """Add a set of files to the current RPM.
+    If an item in paths is a directory, its files are recursively added.
+    """
+    for path in paths:
+        full_path = os.path.join(root, path)
+        if os.path.isdir(full_path):
+            self.AddFiles(os.listdir(full_path), full_path)
+        else:
+            self.files.append(full_path)
 
   def SetupWorkdir(self, spec_file, original_dir):
     """Create the needed structure in the workdir."""


### PR DESCRIPTION
This PR provides support for directories as inputs to pkg_rpm, which is useful for RPMs that contain a lot of files, and one doesn't want to exceed the shell argument buffer size. Files are recursively added from the top-level parent directory.