### PR TITLE
remote/http: fully read http content on error status

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpDownloadHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpDownloadHandlerTest.java
@@ -19,9 +19,11 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.net.HttpHeaders;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -99,8 +101,45 @@ public class HttpDownloadHandlerTest extends AbstractHttpHandlerTest {
 
     HttpResponse response =
         new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
-    response.headers().set(HttpHeaders.CONNECTION, HttpHeaderValues.CLOSE);
+    response.headers().set(HttpHeaders.HOST, "localhost");
+    response.headers().set(HttpHeaders.CONTENT_LENGTH, 0);
+    response.headers().set(HttpHeaders.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
     ch.writeInbound(response);
+    assertThat(writePromise.isDone()).isTrue();
+    assertThat(writePromise.cause()).isInstanceOf(HttpException.class);
+    assertThat(((HttpException) writePromise.cause()).response().status())
+        .isEqualTo(HttpResponseStatus.NOT_FOUND);
+    // No data should have been written to the OutputStream and it should have been closed.
+    assertThat(out.size()).isEqualTo(0);
+    // The caller is responsible for closing the stream.
+    verify(out, never()).close();
+    assertThat(ch.isOpen()).isTrue();
+  }
+
+  /**
+   * Test that the handler correctly supports http error codes i.e. 404 (NOT FOUND)
+   * with a Content-Length header.
+   * */
+  @Test
+  public void httpErrorsWithContentAreSupported() throws IOException {
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null));
+    ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
+    DownloadCommand cmd = new DownloadCommand(CACHE_URI, true, "abcdef", out);
+    ChannelPromise writePromise = ch.newPromise();
+    ch.writeOneOutbound(cmd, writePromise);
+
+    HttpResponse response =
+        new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
+    ByteBuf errorMessage = ByteBufUtil.writeAscii(ch.alloc(), "Error message");
+    response.headers().set(HttpHeaders.HOST, "localhost");
+    response.headers().set(HttpHeaders.CONTENT_LENGTH, String.valueOf(errorMessage.readableBytes()));
+    response.headers().set(HttpHeaders.CONNECTION, HttpHeaderValues.CLOSE);
+
+    ch.writeInbound(response);
+    // The promise must not be done because we haven't received the error message yet.
+    assertThat(writePromise.isDone()).isFalse();
+
+    ch.writeInbound(new DefaultHttpContent(errorMessage));
     assertThat(writePromise.isDone()).isTrue();
     assertThat(writePromise.cause()).isInstanceOf(HttpException.class);
     assertThat(((HttpException) writePromise.cause()).response().status())

--- a/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpUploadHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpUploadHandlerTest.java
@@ -17,7 +17,9 @@ package com.google.devtools.build.lib.remote.blobstore.http;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.net.HttpHeaders;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -83,7 +85,7 @@ public class HttpUploadHandlerTest extends AbstractHttpHandlerTest {
 
   /** Test that the handler correctly supports http error codes i.e. 404 (NOT FOUND). */
   @Test
-  public void httpErrorsAreSupported() throws Exception {
+  public void httpErrorsAreSupported() {
     EmbeddedChannel ch = new EmbeddedChannel(new HttpUploadHandler(null));
     ByteArrayInputStream data = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5});
     ChannelPromise writePromise = ch.newPromise();
@@ -105,5 +107,35 @@ public class HttpUploadHandlerTest extends AbstractHttpHandlerTest {
     assertThat(((HttpException) writePromise.cause()).response().status())
         .isEqualTo(HttpResponseStatus.FORBIDDEN);
     assertThat(ch.isOpen()).isFalse();
+  }
+
+  /**
+   * Test that the handler correctly supports http error codes i.e. 404 (NOT FOUND)
+   * with a Content-Length header.
+   * */
+  @Test
+  public void httpErrorsWithContentAreSupported() {
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpUploadHandler(null));
+    ByteArrayInputStream data = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5});
+    ChannelPromise writePromise = ch.newPromise();
+    ch.writeOneOutbound(new UploadCommand(CACHE_URI, true, "abcdef", data, 5), writePromise);
+
+    HttpRequest request = ch.readOutbound();
+    assertThat(request).isInstanceOf(HttpRequest.class);
+    HttpChunkedInput content = ch.readOutbound();
+    assertThat(content).isInstanceOf(HttpChunkedInput.class);
+
+    ByteBuf errorMsg = ByteBufUtil.writeAscii(ch.alloc(), "error message");
+    FullHttpResponse response =
+        new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND, errorMsg);
+    response.headers().set(HttpHeaders.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+
+    ch.writeInbound(response);
+
+    assertThat(writePromise.isDone()).isTrue();
+    assertThat(writePromise.cause()).isInstanceOf(HttpException.class);
+    assertThat(((HttpException) writePromise.cause()).response().status())
+        .isEqualTo(HttpResponseStatus.NOT_FOUND);
+    assertThat(ch.isOpen()).isTrue();
   }
 }


### PR DESCRIPTION
When the http response has a status other than 200 and
also has a Content-Length header set, then wait until
all content has been received before completing the user
promise.

In case of any errors, close the channel in order to make
sure it's not reused as we don't know what data is left
on the wire.