### PR TITLE
Explicitly assign --buildroot in the rpmbuild invocation

### DIFF
--- a/tools/build_defs/pkg/make_rpm.py
+++ b/tools/build_defs/pkg/make_rpm.py
@@ -212,6 +212,8 @@ class RpmBuilder(object):
         '--define',
         '_tmppath %s/TMP' % dirname,
         '--bb',
+        '--buildroot',
+        os.path.join(dirname, 'BUILDROOT'),
         self.spec_file,
     ]
     p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
Occasionally, I see the following error messages when running a pkg_rpm target:
`
INFO: Analysed target //foo/deploy:pkgs (1 packages loaded).
INFO: Found 1 target...
INFO: From Executing genrule //foo/deploy:pkgs:
error: cannot open Packages database in /home/mmikitka/.rpmdb
`
This PR explicitly sets the --buildroot to address this error message.