### PR TITLE
c++,runfiles: move runfiles library

### DIFF
--- a/src/main/cpp/util/BUILD
+++ b/src/main/cpp/util/BUILD
@@ -47,9 +47,9 @@ cc_library(
         ":ijar",
         "//src/test/cpp/util:__pkg__",
         "//src/tools/launcher:__subpackages__",
-        "//src/tools/runfiles:__pkg__",
         "//src/tools/singlejar:__pkg__",
         "//third_party/def_parser:__pkg__",
+        "//tools/cpp/runfiles:__pkg__",
     ],
     deps = [
         ":blaze_exit_code",

--- a/src/tools/runfiles/BUILD
+++ b/src/tools/runfiles/BUILD
@@ -20,40 +20,9 @@ filegroup(
     name = "embedded_tools",
     srcs = [
         "BUILD.tools",
-        "runfiles.cc",
-        "runfiles.h",
         "//src/tools/runfiles/java/com/google/devtools/build/runfiles:embedded_tools",
     ],
     visibility = ["//src:__pkg__"],
-)
-
-cc_library(
-    name = "cc-runfiles",
-    srcs = ["runfiles.cc"],
-    hdrs = ["runfiles.h"],
-    # This library is available to clients under
-    # @bazel_tools//tools/runfiles:cc-runfiles, with the same source files.
-    # The include statement in runfiles.cc that includes runfiles.h must work
-    # both here in the //src/tools/runfiles package, and in the
-    # @bazel_tools//tools/runfiles package.
-    # runfiles.cc includes "tools/runfiles/runfiles.h" so we need to tell the
-    # compiler to prepend "src" to it so the include path is valid.
-    # Alternatively we could omit this "copts" attribute here and add some
-    # include path manipulating attributes to
-    # @bazel_tools//tools/runfiles:cc-runfiles instead -- that would work too,
-    # but I (laszlocsomor@) find this solution (i.e. the "copts" attribute on
-    # this rule) to be simpler.
-    copts = ["-Isrc"],
-)
-
-cc_test(
-    name = "cc-runfiles-test",
-    srcs = ["runfiles_test.cc"],
-    deps = [
-        ":cc-runfiles",
-        "//src/main/cpp/util:file",
-        "@com_google_googletest//:gtest_main",
-    ],
 )
 
 test_suite(

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -49,7 +49,7 @@ filegroup(
         "//tools/build_rules:embedded_tools_srcs",
         "//tools/buildstamp:srcs",
         "//tools/coverage:srcs",
-        "//tools/cpp:srcs",
+        "//tools/cpp:embedded_tools",
         "//tools/genrule:srcs",
         "//tools/j2objc:srcs",
         "//tools/jdk:package-srcs",

--- a/tools/cpp/BUILD
+++ b/tools/cpp/BUILD
@@ -360,7 +360,17 @@ filegroup(
 
 filegroup(
     name = "srcs",
-    srcs = glob(["**"]),
+    srcs = glob(["**"]) + [
+        "//tools/cpp/runfiles:srcs",
+    ],
+)
+
+filegroup(
+    name = "embedded_tools",
+    srcs = glob(["**"]) + [
+        "//tools/cpp/runfiles:embedded_tools",
+    ],
+    visibility = ["//tools:__pkg__"],
 )
 
 filegroup(

--- a/tools/cpp/runfiles/BUILD
+++ b/tools/cpp/runfiles/BUILD
@@ -1,0 +1,40 @@
+package(default_visibility = ["//visibility:private"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(
+        ["**"],
+        exclude = [
+            ".*",
+            "*~",
+        ],
+    ),
+    visibility = ["//tools/cpp:__pkg__"],
+)
+
+filegroup(
+    name = "embedded_tools",
+    srcs = [
+        "BUILD.tools",
+        "runfiles.cc",
+    ],
+    visibility = ["//tools/cpp:__pkg__"],
+)
+
+cc_library(
+    name = "runfiles",
+    testonly = 1,
+    srcs = ["runfiles.cc"],
+    hdrs = ["runfiles.h"],
+)
+
+cc_test(
+    name = "runfiles_test",
+    srcs = ["runfiles_test.cc"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":runfiles",
+        "//src/main/cpp/util:file",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/tools/cpp/runfiles/BUILD.tools
+++ b/tools/cpp/runfiles/BUILD.tools
@@ -1,0 +1,10 @@
+# This package will host the C++ runfiles library when it's finally released.
+
+# TODO(laszlocsomor): uncomment the cc_library below when the C++ runfiles library is ready to be
+# released.
+# cc_library(
+#     name = "runfiles",
+#     srcs = ["runfiles.cc"],
+#     hdrs = ["runfiles.h"],
+#     visibility = ["//visibility:public"],
+# )

--- a/tools/cpp/runfiles/runfiles.cc
+++ b/tools/cpp/runfiles/runfiles.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "tools/runfiles/runfiles.h"
+#include "tools/cpp/runfiles/runfiles.h"
 
 #ifdef COMPILER_MSVC
 #include <windows.h>
@@ -32,6 +32,8 @@
 #endif  // COMPILER_MSVC
 
 namespace bazel {
+namespace tools {
+namespace cpp {
 namespace runfiles {
 
 using std::function;
@@ -347,4 +349,6 @@ Runfiles* Runfiles::CreateDirectoryBased(const string& directory_path,
 }
 
 }  // namespace runfiles
+}  // namespace cpp
+}  // namespace tools
 }  // namespace bazel

--- a/tools/cpp/runfiles/runfiles.h
+++ b/tools/cpp/runfiles/runfiles.h
@@ -16,13 +16,13 @@
 //
 // Usage:
 //
-//   #include "tools/runfiles/runfiles.h"
-//   ...
+//   #include "tools/cpp/runfiles/runfiles.h"
+//
+//   using bazel::tools::cpp::runfiles::Runfiles;
 //
 //   int main(int argc, char** argv) {
 //     std::string error;
-//     std::unique_ptr<bazel::runfiles::Runfiles> runfiles(
-//         bazel::runfiles::Runfiles::Create(argv[0], &error));
+//     std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0], &error));
 //     if (runfiles == nullptr) {
 //       ...  // error handling
 //     }
@@ -39,19 +39,16 @@
 // If you want to explicitly create a manifest- or directory-based
 // implementation, you can do so as follows:
 //
-//   std::unique_ptr<bazel::runfiles::Runfiles> runfiles1(
-//       bazel::runfiles::Runfiles::CreateManifestBased(
-//           "path/to/foo.runfiles/MANIFEST", &error));
+//   std::unique_ptr<Runfiles> runfiles1(
+//       Runfiles::CreateManifestBased(path/to/foo.runfiles/MANIFEST", &error));
 //
-//   std::unique_ptr<bazel::runfiles::Runfiles> runfiles2(
-//       bazel::runfiles::Runfiles::CreateDirectoryBased(
-//           "path/to/foo.runfiles", &error));
+//   std::unique_ptr<Runfiles> runfiles2(
+//       Runfiles::CreateDirectoryBased(path/to/foo.runfiles", &error));
 //
 // If you want to start child processes that also need runfiles, you need to set
 // the right environment variables for them:
 //
-//   std::unique_ptr<bazel::runfiles::Runfiles> runfiles(
-//       bazel::runfiles::Runfiles::Create(argv[0], &error));
+//   std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0], &error));
 //
 //   for (const auto i : runfiles->EnvVars()) {
 //     setenv(i.first, i.second, 1);
@@ -61,8 +58,8 @@
 //     pid_t child = fork();
 //     ...
 
-#ifndef BAZEL_SRC_TOOLS_RUNFILES_RUNFILES_H_
-#define BAZEL_SRC_TOOLS_RUNFILES_RUNFILES_H_ 1
+#ifndef TOOLS_CPP_RUNFILES_RUNFILES_H_
+#define TOOLS_CPP_RUNFILES_RUNFILES_H_ 1
 
 #include <functional>
 #include <memory>
@@ -70,6 +67,8 @@
 #include <vector>
 
 namespace bazel {
+namespace tools {
+namespace cpp {
 namespace runfiles {
 
 class Runfiles {
@@ -179,6 +178,8 @@ bool TestOnly_IsAbsolute(const std::string& path);
 
 }  // namespace testing
 }  // namespace runfiles
+}  // namespace cpp
+}  // namespace tools
 }  // namespace bazel
 
-#endif  // BAZEL_SRC_TOOLS_RUNFILES_RUNFILES_H_
+#endif  // TOOLS_CPP_RUNFILES_RUNFILES_H_

--- a/tools/cpp/runfiles/runfiles_test.cc
+++ b/tools/cpp/runfiles/runfiles_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "src/tools/runfiles/runfiles.h"
+#include "tools/cpp/runfiles/runfiles.h"
 
 #ifdef COMPILER_MSVC
 #include <windows.h>
@@ -31,11 +31,13 @@
 #define LINE() T(__LINE__)
 
 namespace bazel {
+namespace tools {
+namespace cpp {
 namespace runfiles {
 namespace {
 
-using bazel::runfiles::testing::TestOnly_CreateRunfiles;
-using bazel::runfiles::testing::TestOnly_IsAbsolute;
+using bazel::tools::cpp::runfiles::testing::TestOnly_CreateRunfiles;
+using bazel::tools::cpp::runfiles::testing::TestOnly_IsAbsolute;
 using std::cerr;
 using std::endl;
 using std::function;
@@ -486,4 +488,6 @@ TEST_F(RunfilesTest, IsAbsolute) {
 
 }  // namespace
 }  // namespace runfiles
+}  // namespace cpp
+}  // namespace tools
 }  // namespace bazel


### PR DESCRIPTION
Move the half-done C++ runfiles library to
`//tools/cpp/runfiles`. (The Python and
Bash runfiles libraries are already under
`//tools/<language>/runfiles`.)

See https://github.com/bazelbuild/bazel/issues/4460

Change-Id: I1006f7f81462ea0e4b1de1adcdba89e386d4f9e7