### PR TITLE
Add //examples/... to postsubmit CI pipeline

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -82,8 +82,8 @@ platforms:
     - "-//src/test/shell/bazel:bazel_determinism_test"
   windows:
     shell_commands:
-    - echo android_sdk_repository(name = "androidsdk") >> WORKSPACE
-    - echo android_ndk_repository(name = "androidndk") >> WORKSPACE
+    - powershell -Command \"(gc WORKSPACE) -replace '# android_sdk_repository', 'android_sdk_repository' | Out-File WORKSPACE\"
+    - powershell -Command \"(gc WORKSPACE) -replace '# android_ndk_repository', 'android_ndk_repository' | Out-File WORKSPACE\"
     build_flags:
     - "--copt=-w"
     - "--host_copt=-w"

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -6,7 +6,13 @@ platforms:
       android_ndk_repository/android_ndk_repository/' WORKSPACE
     - rm -f WORKSPACE.bak
     build_targets:
+    - "--"
     - "//src:bazel"
+    - "//examples/..."
+    - "-//examples/android/java/bazel:jni"
+    - "-//examples/android/java/bazel:jni_dep"
+    - "-//examples/windows/..."
+    - "-//examples/java-native/src/main/java/com/example/myproject:hello-error-prone"
     test_flags:
     - "--test_timeout=1200"
     test_targets:
@@ -21,7 +27,13 @@ platforms:
       android_ndk_repository/android_ndk_repository/' WORKSPACE
     - rm -f WORKSPACE.bak
     build_targets:
+    - "--"
     - "//src:bazel"
+    - "//examples/..."
+    - "-//examples/android/java/bazel:jni"
+    - "-//examples/android/java/bazel:jni_dep"
+    - "-//examples/windows/..."
+    - "-//examples/java-native/src/main/java/com/example/myproject:hello-error-prone"
     test_flags:
     - "--test_timeout=1200"
     test_targets:
@@ -51,7 +63,13 @@ platforms:
       android_ndk_repository/android_ndk_repository/' WORKSPACE
     - rm -f WORKSPACE.bak
     build_targets:
+    - "--"
     - "//src:bazel"
+    - "//examples/..."
+    - "-//examples/android/java/bazel:jni"
+    - "-//examples/android/java/bazel:jni_dep"
+    - "-//examples/windows/..."
+    - "-//examples/java-native/src/main/java/com/example/myproject:hello-error-prone"
     test_flags:
     - "--test_timeout=1200"
     test_targets:
@@ -67,7 +85,12 @@ platforms:
     - "--copt=-w"
     - "--host_copt=-w"
     build_targets:
+    - "--"
     - "//src:bazel"
+    - "//examples/..."
+    - "-//examples/android/java/bazel:jni"
+    - "-//examples/android/java/bazel:jni_dep"
+    - "-//examples/java-native/src/main/java/com/example/myproject:hello-error-prone"
     test_flags:
     - "--copt=-w"
     - "--host_copt=-w"

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -81,6 +81,9 @@ platforms:
     # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/4663
     - "-//src/test/shell/bazel:bazel_determinism_test"
   windows:
+    shell_commands:
+    - echo android_sdk_repository(name = "androidsdk") >> WORKSPACE
+    - echo android_ndk_repository(name = "androidndk") >> WORKSPACE
     build_flags:
     - "--copt=-w"
     - "--host_copt=-w"


### PR DESCRIPTION
While fixing https://github.com/bazelbuild/bazel/issues/3663, I figured that it'll be great to build_test all of the targets in //examples/..., on top of the Android ones.

Tested manually on Ubuntu, macOS and Windows machines.

Fixes https://github.com/bazelbuild/bazel/issues/3663