### PR TITLE
remote/caching: improve error messages for remote caching

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -72,7 +72,6 @@ final class RemoteActionContextProvider extends ActionContextProvider {
               cache,
               buildRequestId,
               commandId,
-              executionOptions.verboseFailures,
               env.getReporter(),
               digestUtil);
       return ImmutableList.of(spawnCache);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -41,19 +41,17 @@ import com.google.devtools.remoteexecution.v1test.Command;
 import io.grpc.Context;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.SortedMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
-/**
- * A remote {@link SpawnCache} implementation.
- */
+/** A remote {@link SpawnCache} implementation. */
 @ThreadSafe // If the RemoteActionCache implementation is thread-safe.
 @ExecutionStrategy(
-  name = {"remote-cache"},
-  contextType = SpawnCache.class
-)
+    name = {"remote-cache"},
+    contextType = SpawnCache.class)
 final class RemoteSpawnCache implements SpawnCache {
   private final Path execRoot;
   private final RemoteOptions options;
@@ -61,12 +59,10 @@ final class RemoteSpawnCache implements SpawnCache {
   private final AbstractRemoteActionCache remoteCache;
   private final String buildRequestId;
   private final String commandId;
-  private final boolean verboseFailures;
 
   @Nullable private final Reporter cmdlineReporter;
 
-  // Used to ensure that a warning is reported only once.
-  private final AtomicBoolean warningReported = new AtomicBoolean();
+  private final Set<String> reportedErrors = new HashSet<>();
 
   private final DigestUtil digestUtil;
 
@@ -76,13 +72,11 @@ final class RemoteSpawnCache implements SpawnCache {
       AbstractRemoteActionCache remoteCache,
       String buildRequestId,
       String commandId,
-      boolean verboseFailures,
       @Nullable Reporter cmdlineReporter,
       DigestUtil digestUtil) {
     this.execRoot = execRoot;
     this.options = options;
     this.remoteCache = remoteCache;
-    this.verboseFailures = verboseFailures;
     this.cmdlineReporter = cmdlineReporter;
     this.buildRequestId = buildRequestId;
     this.commandId = commandId;
@@ -142,10 +136,12 @@ final class RemoteSpawnCache implements SpawnCache {
       } catch (CacheNotFoundException e) {
         // There's a cache miss. Fall back to local execution.
       } catch (IOException e) {
-        // There's an IO error. Fall back to local execution.
-        reportOnce(
-            Event.warn(
-                "Some artifacts failed to be downloaded from the remote cache: " + e.getMessage()));
+        String errorMsg = e.getMessage();
+        if (errorMsg == null || errorMsg.isEmpty()) {
+          errorMsg = e.getClass().getSimpleName();
+        }
+        errorMsg = "Error reading from the remote cache:\n" + errorMsg;
+        report(Event.warn(errorMsg));
       } finally {
         withMetadata.detach(previous);
       }
@@ -188,13 +184,12 @@ final class RemoteSpawnCache implements SpawnCache {
           try {
             remoteCache.upload(actionKey, execRoot, files, context.getFileOutErr(), uploadAction);
           } catch (IOException e) {
-            if (verboseFailures) {
-              report(Event.debug("Upload to remote cache failed: " + e.getMessage()));
-            } else {
-              reportOnce(
-                  Event.warn(
-                      "Some artifacts failed be uploaded to the remote cache: " + e.getMessage()));
+            String errorMsg = e.getMessage();
+            if (errorMsg == null || errorMsg.isEmpty()) {
+              errorMsg = e.getClass().getSimpleName();
             }
+            errorMsg = "Error writing to the remote cache:\n" + errorMsg;
+            report(Event.warn(errorMsg));
           } finally {
             withMetadata.detach(previous);
           }
@@ -224,14 +219,16 @@ final class RemoteSpawnCache implements SpawnCache {
     }
   }
 
-  private void reportOnce(Event evt) {
-    if (warningReported.compareAndSet(false, true)) {
-      report(evt);
-    }
-  }
-
   private void report(Event evt) {
-    if (cmdlineReporter != null) {
+    if (cmdlineReporter == null) {
+      return;
+    }
+
+    synchronized (this) {
+      if (reportedErrors.contains(evt.getMessage())) {
+        return;
+      }
+      reportedErrors.add(evt.getMessage());
       cmdlineReporter.handle(evt);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpDownloadHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpDownloadHandler.java
@@ -32,6 +32,7 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.internal.StringUtil;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -81,6 +82,9 @@ final class HttpDownloadHandler extends AbstractHttpHandler<HttpObject> {
         return;
       }
       downloadSucceeded = response.status().equals(HttpResponseStatus.OK);
+      if (!downloadSucceeded) {
+        out = new ByteArrayOutputStream();
+      }
       keepAlive = HttpUtil.isKeepAlive((HttpResponse) msg);
       if (HttpUtil.isContentLengthSet(response)) {
         contentLength = HttpUtil.getContentLength(response);
@@ -89,7 +93,7 @@ final class HttpDownloadHandler extends AbstractHttpHandler<HttpObject> {
       if (!downloadSucceeded
           && (contentLength == 0 || HttpUtil.isTransferEncodingChunked(response))) {
         HttpException error =
-            new HttpException(response, "Download failed with status: " + response, null);
+            new HttpException(response, response.status().toString(), null);
         failAndReset(error, ctx);
         return;
       }
@@ -100,16 +104,16 @@ final class HttpDownloadHandler extends AbstractHttpHandler<HttpObject> {
 
       ByteBuf content = ((HttpContent) msg).content();
       bytesReceived += content.readableBytes();
-      if (downloadSucceeded) {
-        content.readBytes(out, content.readableBytes());
-      }
+      content.readBytes(out, content.readableBytes());
       if (bytesReceived == contentLength || msg instanceof LastHttpContent) {
         if (downloadSucceeded) {
           succeedAndReset(ctx);
         } else {
-          HttpException error =
-              new HttpException(
-                  response, "Download failed with status: " + response.status(), null);
+          String errorMsg = response.status() + "\n";
+          errorMsg += new String(((ByteArrayOutputStream) out).toByteArray(),
+              HttpUtil.getCharset(response));
+          out.close();
+          HttpException error = new HttpException(response, errorMsg, null);
           failAndReset(error, ctx);
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpUploadHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpUploadHandler.java
@@ -30,6 +30,7 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.stream.ChunkedStream;
 import io.netty.util.internal.StringUtil;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 /** ChannelHandler for uploads. */
@@ -53,8 +54,13 @@ final class HttpUploadHandler extends AbstractHttpHandler<FullHttpResponse> {
           && !response.status().equals(HttpResponseStatus.CREATED)
           && !response.status().equals(HttpResponseStatus.NO_CONTENT)) {
         // Supporting more than OK status to be compatible with nginx webdav.
-        failAndResetUserPromise(
-            new HttpException(response, "Upload failed with status: " + response.status(), null));
+        String errorMsg = response.status().toString();
+        if (response.content().readableBytes() > 0) {
+          byte[] data = new byte[response.content().readableBytes()];
+          response.content().readBytes(data);
+          errorMsg += "\n" + new String(data, HttpUtil.getCharset(response));
+        }
+        failAndResetUserPromise(new HttpException(response, errorMsg, null));
       } else {
         succeedAndResetUserPromise();
       }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -354,8 +354,9 @@ public class RemoteSpawnCacheTest {
     assertThat(eventHandler.getEvents()).hasSize(1);
     Event evt = eventHandler.getEvents().get(0);
     assertThat(evt.getKind()).isEqualTo(EventKind.WARNING);
-    assertThat(evt.getMessage()).contains("fail");
-    assertThat(evt.getMessage()).contains("upload");
+    assertThat(evt.getMessage()).contains("Error");
+    assertThat(evt.getMessage()).contains("writing");
+    assertThat(evt.getMessage()).contains("cache down");
     assertThat(progressUpdates)
         .containsExactly(Pair.of(ProgressStatus.CHECKING_CACHE, "remote-cache"));
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -188,7 +188,6 @@ public class RemoteSpawnCacheTest {
             remoteCache,
             "build-req-id",
             "command-id",
-            false,
             reporter,
             digestUtil);
     fakeFileCache.createScratchInput(simpleSpawn.getInputFiles().get(0), "xyz");


### PR DESCRIPTION
Only the last commit needs to be reviewed, as it's rebased on https://github.com/bazelbuild/bazel/pull/5101