### PR TITLE
remote: introduce --disk_cache_flag

### DIFF
--- a/site/docs/remote-caching.md
+++ b/site/docs/remote-caching.md
@@ -28,6 +28,7 @@ make builds significantly faster.
     * [Delete content from the remote cache](#delete-content-from-the-remote-cache)
 * [Known Issues](#known-issues)
 * [External Links](#external-links)
+* [Disk cache](#disk-cache)
 * [Bazel remote execution (in development)](#bazel-remote-execution-in-development)
 
 ## Remote caching overview
@@ -305,6 +306,30 @@ You may want to delete content from the cache to:
 
 * Create a clean cache after a cache was poisoned
 * Reduce the amount of storage used by deleting old outputs
+
+## Disk cache
+
+Bazel can use a directory on the filesystem as a remote cache. This is
+useful for sharing build artifacts when switching branches and/or working
+on multiple workspaces of the same project i.e. multiple checkouts. Bazel
+does not garbage collect the directory and thus one might want to set up a
+cron job or similar to periodically clean up the directory. The disk cache
+can be enabled with the following flags.
+
+```
+build --disk_cache=/path/to/build/cache
+```
+
+Additionally, one can pass a user specific path to the `--disk_cache` flag
+via the `~` character. Bazel will replace this with the current user's home
+directory. This comes in handy when one wants to enable the disk cache for
+all developers of a project via the project's checked in `.bazelrc` file.
+
+To have cache hits across different workspaces, the flag should be used:
+
+```
+build --experimental_strict_action_env
+```
 
 ## Known issues
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -64,7 +64,7 @@ final class RemoteActionContextProvider extends ActionContextProvider {
     String buildRequestId = env.getBuildRequestId().toString();
     String commandId = env.getCommandId().toString();
 
-    if (remoteOptions.experimentalRemoteSpawnCache || remoteOptions.experimentalLocalDiskCache) {
+    if (remoteOptions.experimentalRemoteSpawnCache || remoteOptions.diskCache != null) {
       RemoteSpawnCache spawnCache =
           new RemoteSpawnCache(
               env.getExecRoot(),

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
@@ -175,25 +175,16 @@ public final class RemoteOptions extends OptionsBase {
   )
   public boolean experimentalRemoteSpawnCache;
 
-  // TODO(davido): Find a better place for this and the next option.
   @Option(
-    name = "experimental_local_disk_cache",
-    defaultValue = "false",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-    effectTags = {OptionEffectTag.UNKNOWN},
-    help = "Whether to use the experimental local disk cache."
-  )
-  public boolean experimentalLocalDiskCache;
-
-  @Option(
-    name = "experimental_local_disk_cache_path",
+    name = "disk_cache",
     defaultValue = "null",
     documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
     effectTags = {OptionEffectTag.UNKNOWN},
     converter = OptionsUtils.PathFragmentConverter.class,
-    help = "A file path to a local disk cache."
+    help = "A path to a directory where Bazel can read and write actions and action outputs. "
+        + "If the directory does not exist, it will be created."
   )
-  public PathFragment experimentalLocalDiskCachePath;
+  public PathFragment diskCache;
 
   @Option(
     name = "experimental_guard_against_concurrent_changes",

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -332,9 +332,9 @@ sh_test(
 )
 
 sh_test(
-    name = "local_action_cache_test",
+    name = "disk_cache_test",
     size = "small",
-    srcs = ["local_action_cache_test.sh"],
+    srcs = ["disk_cache_test.sh"],
     data = [":test-deps"],
 )
 

--- a/src/test/shell/bazel/disk_cache_test.sh
+++ b/src/test/shell/bazel/disk_cache_test.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Test the local action cache
+# Test the local disk cache
 #
 
 # Load the test setup defined in the parent directory
@@ -27,7 +27,7 @@ function test_local_action_cache() {
   local execution_file="${TEST_TMPDIR}/run.log"
   local input_file="foo.in"
   local output_file="bazel-genfiles/foo.txt"
-  local flags="--experimental_local_disk_cache_path=$cache --experimental_local_disk_cache"
+  local flags="--disk_cache=$cache"
 
   rm -rf $cache
   mkdir $cache


### PR DESCRIPTION
Consolidate the --experimental_local_disk_cache and --experimental_local_disk_cache_path
flags into a single --disk_cache= flag. Also, create the cache directory
if it doesn't exist.

RELNOTES: We replaced the --experimental_local_disk_cache and
--experimental_local_disk_cache_path flags into a single --disk_cache
flag. Additionally, Bazel now tries to create the disk cache directory
if it doesn't exist.