### PR TITLE
Remove unsafe use of state in MavenDownloader

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenDownloader.java
@@ -48,27 +48,8 @@ import org.eclipse.aether.resolution.ArtifactResult;
  */
 public class MavenDownloader extends HttpDownloader {
 
-  @Nullable
-  private String name;
-  @Nullable
-  private Path outputDirectory;
-
   public MavenDownloader(RepositoryCache repositoryCache) {
     super(repositoryCache);
-  }
-
-  /**
-   * Returns the name for this artifact-fetching rule.
-   */
-  public String getName() {
-    return name;
-  }
-
-  /**
-   * Returns the directory that this artifact will be downloaded to.
-   */
-  public Path getOutputDirectory() {
-    return outputDirectory;
   }
 
   /**
@@ -77,8 +58,6 @@ public class MavenDownloader extends HttpDownloader {
    */
   public JarPaths download(String name, WorkspaceAttributeMapper mapper, Path outputDirectory,
       MavenServerValue serverValue) throws IOException, EvalException {
-    this.name = name;
-    this.outputDirectory = outputDirectory;
 
     String url = serverValue.getUrl();
     Server server = serverValue.getServer();
@@ -101,7 +80,7 @@ public class MavenDownloader extends HttpDownloader {
     boolean isCaching = repositoryCache.isEnabled() && KeyType.SHA1.isValid(sha1);
 
     if (isCaching) {
-      Path downloadPath = getDownloadDestination(artifact);
+      Path downloadPath = getDownloadDestination(outputDirectory, artifact);
       Path cachedDestination = repositoryCache.get(sha1, downloadPath, KeyType.SHA1);
       if (cachedDestination != null) {
         return new JarPaths(cachedDestination, Optional.absent());
@@ -152,7 +131,7 @@ public class MavenDownloader extends HttpDownloader {
     }
   }
 
-  private Path getDownloadDestination(Artifact artifact) {
+  private Path getDownloadDestination(Path outputDirectory, Artifact artifact) {
     String groupIdPath = artifact.getGroupId().replace('.', '/');
     String artifactId = artifact.getArtifactId();
     String version = artifact.getVersion();


### PR DESCRIPTION
Looks like migration from standalone MavenDownloader to one based on HttpDownloader kept state-setting, but made MavenDownloader a singleton, creating a race.

I'm about 99% sure this fixes #5103. The bug is in the right place, and running the test case described in that issue 25 times in a loop produced no errors.

