### PR TITLE
Don't convert InterruptException to EvalException in struct field call expressions.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/BuiltinFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BuiltinFunction.java
@@ -179,10 +179,8 @@ public class BuiltinFunction extends BaseFunction {
       } else if (e instanceof IllegalArgumentException) {
         throw new EvalException(loc, "illegal argument in call to " + getName(), e);
       }
-      // TODO(bazel-team): replace with Throwables.throwIfInstanceOf once Guava 20 is released.
-      Throwables.propagateIfInstanceOf(e, InterruptedException.class);
-      // TODO(bazel-team): replace with Throwables.throwIfUnchecked once Guava 20 is released.
-      Throwables.propagateIfPossible(e);
+      Throwables.throwIfInstanceOf(e, InterruptedException.class);
+      Throwables.throwIfUnchecked(e);
       throw badCallException(loc, e, args);
     } catch (IllegalArgumentException e) {
       // Either this was thrown by Java itself, or it's a bug

--- a/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.syntax;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;

--- a/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
@@ -764,20 +764,23 @@ public final class FuncallExpression extends Expression {
           call.findJavaMethod(objClass, method, positionalArgs, keyWordArgs, env);
       if (javaMethod.first.isStructField()) {
         // Not a method but a callable attribute
+        Object func;
         try {
-          return callFunction(javaMethod.first.invoke(obj), env);
+          func = javaMethod.first.invoke(obj);
         } catch (IllegalAccessException e) {
           throw new EvalException(getLocation(), "method invocation failed: " + e);
         } catch (InvocationTargetException e) {
           if (e.getCause() instanceof FuncallException) {
             throw new EvalException(getLocation(), e.getCause().getMessage());
           } else if (e.getCause() != null) {
+            Throwables.throwIfInstanceOf(e.getCause(), InterruptedException.class);
             throw new EvalExceptionWithJavaCause(getLocation(), e.getCause());
           } else {
             // This is unlikely to happen
             throw new EvalException(getLocation(), "method invocation failed: " + e);
           }
         }
+        return callFunction(func, env);
       }
       return javaMethod.first.call(obj, javaMethod.second.toArray(), location, env);
     }

--- a/src/test/java/com/google/devtools/build/lib/syntax/SkylarkEvaluationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/SkylarkEvaluationTest.java
@@ -74,6 +74,17 @@ public class SkylarkEvaluationTest extends EvaluationTest {
     }
   };
 
+  @SkylarkSignature(
+      name = "interrupted_function",
+      returnType = Runtime.NoneType.class,
+      documented = false
+  )
+  static BuiltinFunction interruptedFunction = new BuiltinFunction("interrupted_function") {
+    public Runtime.NoneType invoke() throws InterruptedException {
+      throw new InterruptedException();
+    }
+  };
+
   @SkylarkModule(name = "Mock", doc = "")
   static class NativeInfoMock extends NativeInfo {
 
@@ -1270,10 +1281,19 @@ public class SkylarkEvaluationTest extends EvaluationTest {
   }
 
   @Test
-  public void testCallingInterruptingStructField() throws Exception {
+  public void testCallingInterruptedStructField() throws Exception {
     update("mock", new Mock());
     assertThrows(
         InterruptedException.class, () -> eval("mock.interrupted_struct_field()"));
+  }
+
+  @Test
+  public void testCallingInterruptedFunction() throws Exception {
+    interruptedFunction.configure(
+        getClass().getDeclaredField("interruptedFunction").getAnnotation(SkylarkSignature.class));
+    update("interrupted_function", interruptedFunction);
+    assertThrows(
+        InterruptedException.class, () -> eval("interrupted_function()"));
   }
 
   @Test


### PR DESCRIPTION
This is probably only a theoretical problem, since a blocking struct field is probably a very bad idea.