### PR TITLE
tests: use rlocation in one shell test

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/HttpFileRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/HttpFileRule.java
@@ -96,4 +96,7 @@ public class HttpFileRule implements RuleDefinition {
 
  <p>Targets would specify <code>@my_deb//file</code> as a dependency to depend on this file.</p>
 
+ <p>You may also reference files on the localhost, using "file:///path/to/file" (on Unixes) or
+ "file:///c:/path/to/file" (on Windows; mind the 3 "/" characters!).</p>
+
  <!-- #END_BLAZE_RULE -->*/

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -108,8 +108,10 @@ sh_test(
     name = "bazel_random_characters_test",
     size = "large",
     srcs = ["bazel_random_characters_test.sh"],
-    data = [":test-deps"],
-    tags = ["no_windows"],
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )
 
 sh_test(
@@ -133,8 +135,10 @@ sh_test(
     name = "bazel_experimental_ui_test",
     size = "medium",
     srcs = ["bazel_experimental_ui_test.sh"],
-    data = [":test-deps"],
-    tags = ["no_windows"],
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )
 
 sh_test(

--- a/src/test/shell/bazel/bazel_random_characters_test.sh
+++ b/src/test/shell/bazel/bazel_random_characters_test.sh
@@ -17,9 +17,29 @@
 # Tests the examples provided in Bazel
 #
 
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../integration_test_setup.sh" \
+set -euo pipefail
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+    if [[ -f "$0.runfiles_manifest" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+      export RUNFILES_DIR="$0.runfiles"
+    fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 function basic_glob_scenario_test_template() {

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -57,6 +57,9 @@ if is_windows; then
 
   export JAVA_HOME="${JAVA_HOME:-$(ls -d C:/Program\ Files/Java/jdk* | sort | tail -n 1)}"
   export BAZEL_SH="$(cygpath -m /usr/bin/bash)"
+
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
 fi
 
 # Make the command "bazel" available for tests.

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -316,6 +316,9 @@ Examples:
 
   Targets would specify <code>@my_ssl//jar</code> as a dependency to depend on this jar.
 
+  You may also reference files on the localhost, using "file:///path/to/file" (on Unixes) or
+  "file:///c:/path/to/file" (on Windows; mind the 3 "/" characters!).
+
 
 Args:
   name: A unique name for this rule.


### PR DESCRIPTION
Use the new Bash runfiles library (for now from
//tools/bash/runfiles, later from
@bazel_tools//tools/bash/runfiles) in:
- //src/test/shell:testenv.sh
- //src/test/shell:integration_test_setup.sh
- //src/test/shell/bazel:location_test.sh

Also enable this test on Windows.

Add missing runfiles that tests were using, such
as //:WORKSPACE.

See https://github.com/bazelbuild/bazel/issues/4930
See https://github.com/bazelbuild/bazel/issues/4292

Change-Id: Ib66e96fe73281deabafa6578fb8681d70cd8665b