### PR TITLE
Use BUILD.bazel instead of BUILD for external projects

### DIFF
--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -44,11 +44,11 @@ def workspace_and_buildfile(ctx):
   if ctx.attr.build_file:
     bash_exe = ctx.os.environ["BAZEL_SH"] if "BAZEL_SH" in ctx.os.environ else "bash"
     ctx.execute([bash_exe, "-c", "rm -f BUILD BUILD.bazel"])
-    ctx.symlink(ctx.attr.build_file, "BUILD")
+    ctx.symlink(ctx.attr.build_file, "BUILD.bazel")
   elif ctx.attr.build_file_content:
     bash_exe = ctx.os.environ["BAZEL_SH"] if "BAZEL_SH" in ctx.os.environ else "bash"
     ctx.execute([bash_exe, "-c", "rm -f BUILD.bazel"])
-    ctx.file("BUILD", ctx.attr.build_file_content)
+    ctx.file("BUILD.bazel", ctx.attr.build_file_content)
 
 def patch(ctx):
   """Implementation of patching an already extracted repository"""


### PR DESCRIPTION
While upgrading an internal project from 0.10 to 0.13 we have found that we no longer were able to build one of external non-basel dependencies that already has a lowercase `build` directory in their repo.

As the name `BUILD` is much more common than `BUILD.bazel`, in particular on file systems that are case-insensitive, I propose to generate the latter by default.