### PR TITLE
[DO NOT MERGE] Test for Windows, Java launcher: Support jar files under different drives

### DIFF
--- a/src/main/cpp/util/file_windows.cc
+++ b/src/main/cpp/util/file_windows.cc
@@ -1218,7 +1218,8 @@ void ForEachDirectoryEntry(const string &path,
     if (kDot != metadata.cFileName && kDotDot != metadata.cFileName) {
       wstring wname = wpath + metadata.cFileName;
       string name(WstringToCstring(/* omit prefix */ 4 + wname.c_str()).get());
-      bool is_dir = (metadata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+      bool is_dir = ((metadata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+                 && !(metadata.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)) != 0;
       consume->Consume(name, is_dir);
     }
   } while (::FindNextFileW(handle, &metadata));

--- a/src/tools/launcher/java_launcher.h
+++ b/src/tools/launcher/java_launcher.h
@@ -90,6 +90,13 @@ class JavaBinaryLauncher : public BinaryLauncherBase {
   //
   // Return the path of the classpath jar created.
   std::string CreateClasspathJar(const std::string& classpath);
+
+  // Creat a directory based on the binary path, all the junctions will be generated under this
+  // directory.
+  std::string GetJunctionBaseDir();
+
+  // Delete all the junction directory and all the junctions under it.
+  void DeleteJunctionBaseDir();
 };
 
 }  // namespace launcher

--- a/src/tools/launcher/util/launcher_util.cc
+++ b/src/tools/launcher/util/launcher_util.cc
@@ -100,6 +100,10 @@ bool DeleteFileByPath(const char* path) {
   return DeleteFileW(AsAbsoluteWindowsPath(path).c_str());
 }
 
+bool DeleteDirectoryByPath(const char* path) {
+  return RemoveDirectoryW(AsAbsoluteWindowsPath(path).c_str());
+}
+
 string GetBinaryPathWithoutExtension(const string& binary) {
   if (binary.find(".exe", binary.size() - 4) != string::npos) {
     return binary.substr(0, binary.length() - 4);
@@ -182,6 +186,14 @@ bool NormalizePath(const string& path, string* result) {
   }
   std::transform(result->begin(), result->end(), result->begin(), ::tolower);
   return true;
+}
+
+string GetBaseNameFromPath(const string& path) {
+  return path.substr(path.find_last_of("\\/") + 1);
+}
+
+string GetParentDirFromPath(const string& path) {
+  return path.substr(0, path.find_last_of("\\/"));
 }
 
 bool RelativeTo(const string& path, const string& base, string* result) {

--- a/src/tools/launcher/util/launcher_util.h
+++ b/src/tools/launcher/util/launcher_util.h
@@ -61,6 +61,12 @@ bool DoesDirectoryPathExist(const char* path);
 // Delete a file at a given path.
 bool DeleteFileByPath(const char* path);
 
+// Delete a directory at a given path,.
+// If it's a real directory, it must be empty
+// If it's a junction, the target directory it points to doesn't have to be empty,
+// the junction will be deleted regardless of the state of the target.
+bool DeleteDirectoryByPath(const char* path);
+
 // Get the value of a specific environment variable
 //
 // Return true if succeeded and the result is stored in buffer.
@@ -78,6 +84,12 @@ std::string GetRandomStr(size_t len);
 
 // Normalize a path to a Windows path in lower case
 bool NormalizePath(const std::string& path, std::string* result);
+
+// Get the base name from a normalized absoulute path
+std::string GetBaseNameFromPath(const std::string& path);
+
+// Get parent directory from a normalized absoulute path
+std::string GetParentDirFromPath(const std::string& path);
 
 // Calculate a relative path from `path` to `base`.
 // This function expects normalized Windows path in lower case.


### PR DESCRIPTION
Create junctions to jar's directory when java launcher and its jar are under different drives

Fixed https://github.com/bazelbuild/bazel/issues/5135

Change-Id: I21c5b28f5f36c1fe234f8b781fe40d526db846cc