### PR TITLE
Portability with BSD stat in collect_coverage.sh

### DIFF
--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -109,7 +109,7 @@ fi
 cd $ROOT
 
 USES_LLVM_COV=
-if stat --printf='' "${COVERAGE_DIR}"/*.profraw 2>/dev/null; then
+if stat "${COVERAGE_DIR}"/*.profraw >/dev/null 2>&1; then
   USES_LLVM_COV=1
 fi
 


### PR DESCRIPTION
BSD stat does not have --printf option.