### PR TITLE
uid related fixes in docker sandbox

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
@@ -292,6 +292,12 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
       return baseImage;
     }
 
+    // We only need to create a customized image, if we're running on Linux, as Docker on macOS
+    // and Windows doesn't map users from the host into the container anyway.
+    if (OS.getCurrent() != OS.LINUX) {
+      return baseImage;
+    }
+
     return imageMap.computeIfAbsent(
         baseImage,
         (image) -> {


### PR DESCRIPTION
uid and gid of -1 (set when not linux) can not really be used anywhere.