### PR TITLE
Shallow since tests and doc improvements

### DIFF
--- a/src/test/shell/bazel/skylark_git_repository_test.sh
+++ b/src/test/shell/bazel/skylark_git_repository_test.sh
@@ -81,7 +81,9 @@ function do_git_repository_test() {
   # Commit corresponds to tag 1-build. See testdata/pluto.git_log.
   local commit_hash="$1"
   local strip_prefix=""
+  local shallow_since=""
   [ $# -eq 2 ] && strip_prefix="strip_prefix=\"$2\","
+  [ $# -eq 3 ] && shallow_since="shallow_since=\"$3\","
   # Create a workspace that clones the repository at the first commit.
   cd $WORKSPACE_DIR
   cat > WORKSPACE <<EOF
@@ -91,6 +93,7 @@ git_repository(
     remote = "$pluto_repo_dir",
     commit = "$commit_hash",
     $strip_prefix
+    $shallow_since
 )
 EOF
   mkdir -p planets
@@ -123,6 +126,10 @@ function test_git_repository_strip_prefix() {
   do_git_repository_test "dbf9236251a9ea01b7a2eb563ca8e911060fc97c" "pluto"
 }
 
+function test_git_repository_shallow_since() {
+    # This date is the day the commit was made.
+    do_git_repository_test "52f9a3f87a2dd17ae0e5847bbae9734f09354afd" "" "2016-07-16"
+}
 function test_new_git_repository_with_build_file() {
   do_new_git_repository_test "0-initial" "build_file"
 }
@@ -544,6 +551,29 @@ EOF
   bazel fetch //planets:planet-info >& $TEST_log \
     || echo "Expect run to fail."
   expect_log "strip_prefix at dir_does_not_exist does not exist in repo"
+}
+
+
+# Verifies that rule fails if tag and shallow_since are set
+#
+function test_git_repository_shallow_since_with_tag_error() {
+  setup_error_test
+  local pluto_repo_dir=$TEST_TMPDIR/pluto
+
+  cd $WORKSPACE_DIR
+  cat > WORKSPACE <<EOF
+load('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+git_repository(
+    name = "pluto",
+    remote = "$pluto_repo_dir",
+    tag = "1-build",
+    shallow_since = "2018-01-01"
+)
+EOF
+
+  bazel fetch //planets:planet-info >& $TEST_log \
+    || echo "Expect run to fail."
+  expect_log "shallow_since not allowed if a tag is specified; --depth=1 will be used for tags"
 }
 
 run_suite "skylark git_repository tests"

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -35,7 +35,7 @@ def _clone_or_update(ctx):
     shallow='--shallow-since=%s' % ctx.attr.shallow_since
 
   if (ctx.attr.verbose):
-    print('git.bzl: Cloning or updating%s repository %s using strip_prefix of [%s]' %
+    print('git.bzl: Cloning or updating %s repository %s using strip_prefix of [%s]' %
     (' (%s)' % shallow if shallow else '',
      ctx.name,
      ctx.attr.strip_prefix if ctx.attr.strip_prefix else 'None',
@@ -178,11 +178,11 @@ Args:
   commit: specific commit to be checked out
     Either tag or commit must be specified.
 
-  shallow_since: an optional date, not after the specified commit; the
-    argument is not allowed if a tag is specified (which allows cloning
-    with depth 1). Setting such a date close to the specified commit
-    allows for a more shallow clone of the repository, saving bandwith and
-    wall-clock time.
+  shallow_since: an optional date in the form YYYY-MM-DD, not after
+    the specified commit; the argument is not allowed if a tag is specified
+    (which allows cloning with depth 1). Setting such a date close to the
+    specified commit allows for a more shallow clone of the repository, saving
+    bandwith and wall-clock time.
 
   strip_prefix: A directory prefix to strip from the extracted files.
 


### PR DESCRIPTION
This changeset introduces tests for the `shallow_since` functionality that was introduced in 6496b1d1d25025f33406b1eaf9949cab126f08bd.

We test that if the user specifies a tag as well as a `shallow_since` that it fails since they are incompatible. We also verify that specifying a commit before the `shallow_since` date causes the clone to fail (albeit currently with a non-useful error message; perhaps that could be improved at a later date).

It also documents more clearly how to use the feature by explaining the format of the 'since' string.