### PR TITLE
Set Locale to English when uppercasing strings to match Enums

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/sharding/ShardingFilters.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/sharding/ShardingFilters.java
@@ -20,6 +20,7 @@ import org.junit.runner.Description;
 import org.junit.runner.manipulation.Filter;
 
 import java.util.Collection;
+import java.util.Locale;
 
 import javax.inject.Inject;
 
@@ -97,7 +98,7 @@ public class ShardingFilters {
     }
     ShardingFilterFactory shardingFilterFactory;
     try {
-      shardingFilterFactory = ShardingStrategy.valueOf(strategy.toUpperCase());
+      shardingFilterFactory = ShardingStrategy.valueOf(strategy.toUpperCase(Locale.ENGLISH));
     } catch (IllegalArgumentException e) {
       try {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();

--- a/src/main/java/com/google/devtools/build/lib/packages/FilesetEntry.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/FilesetEntry.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -98,7 +99,7 @@ public final class FilesetEntry implements SkylarkValue {
     DEREFERENCE;
 
     public static SymlinkBehavior parse(String value) throws IllegalArgumentException {
-      return valueOf(value.toUpperCase());
+      return valueOf(value.toUpperCase(Locale.ENGLISH));
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/packages/License.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/License.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /** Support for license and distribution checking. */
@@ -124,7 +125,7 @@ public final class License {
       Set<DistributionType> result = EnumSet.noneOf(DistributionType.class);
       for (String distStr : distStrings) {
         try {
-          DistributionType dist = DistributionType.valueOf(distStr.toUpperCase());
+          DistributionType dist = DistributionType.valueOf(distStr.toUpperCase(Locale.ENGLISH));
           result.add(dist);
         } catch (IllegalArgumentException e) {
           throw new LicenseParsingException("Invalid distribution type '" + distStr + "'");
@@ -216,7 +217,7 @@ public final class License {
         }
       } else {
         try {
-          licenseTypes.add(LicenseType.valueOf(str.toUpperCase()));
+          licenseTypes.add(LicenseType.valueOf(str.toUpperCase(Locale.ENGLISH)));
         } catch (IllegalArgumentException e) {
           throw new LicenseParsingException("invalid license type: '" + str + "'");
         }

--- a/src/main/java/com/google/devtools/build/lib/packages/TestTimeout.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TestTimeout.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -123,7 +124,7 @@ public enum TestTimeout {
       return null;
     }
     try {
-      return TestTimeout.valueOf(attr.toUpperCase());
+      return TestTimeout.valueOf(attr.toUpperCase(Locale.ENGLISH));
     } catch (IllegalArgumentException e) {
       return null;
     }
@@ -181,7 +182,7 @@ public enum TestTimeout {
       return null;  // attribute values must be lowercase
     }
     try {
-      return TestTimeout.valueOf(attr.toUpperCase());
+      return TestTimeout.valueOf(attr.toUpperCase(Locale.ENGLISH));
     } catch (IllegalArgumentException e) {
       return null;
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppToolchainInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppToolchainInfo.java
@@ -45,6 +45,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -335,7 +336,8 @@ public final class CppToolchainInfo {
     Set<ArtifactCategory> definedCategories = new HashSet<>();
     for (ArtifactNamePattern pattern : toolchainBuilder.getArtifactNamePatternList()) {
       try {
-        definedCategories.add(ArtifactCategory.valueOf(pattern.getCategoryName().toUpperCase()));
+        definedCategories.add(
+                ArtifactCategory.valueOf(pattern.getCategoryName().toUpperCase(Locale.ENGLISH)));
       } catch (IllegalArgumentException e) {
         // Invalid category name, will be detected later.
         continue;

--- a/src/tools/android/java/com/google/devtools/build/android/xml/SimpleXmlResourceValue.java
+++ b/src/tools/android/java/com/google/devtools/build/android/xml/SimpleXmlResourceValue.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.android.proto.SerializeFormat.DataValueXml;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -283,7 +284,7 @@ public class SimpleXmlResourceValue implements XmlResourceValue {
     }
 
     return of(
-        Type.valueOf(resourceType.toString().toUpperCase()),
+        Type.valueOf(resourceType.toString().toUpperCase(Locale.ENGLISH)),
         ImmutableMap.of(),
         stringValue);
   }


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/5157

If a user's default system locale is not `en`, `en_US` or `en_UK`, there may be a chance that `String#toUpperCase` will result in a string that does not exist in the Enum declaration. This is the case in #5157.

To fix this, it's either 

1) setting the Locale in the individual `toUpperCase` calls or 
2) set Locale to English by default from `Bazel.java`. 

I chose the first because it seemed less intrusive, but I'm open to suggestions.
