### PR TITLE
remote/exec: always mark files executable.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/TreeNodeRepository.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/TreeNodeRepository.java
@@ -362,23 +362,21 @@ public final class TreeNodeRepository {
         TreeNode child = entry.getChild();
         if (child.isLeaf()) {
           ActionInput input = child.getActionInput();
+          final Digest digest;
           if (input instanceof VirtualActionInput) {
             VirtualActionInput virtualInput = (VirtualActionInput) input;
-            Digest digest = digestUtil.compute(virtualInput);
+            digest = digestUtil.compute(virtualInput);
             virtualInputDigestCache.put(virtualInput, digest);
             // There may be multiple inputs with the same digest. In that case, we don't care which
             // one we get back from the digestVirtualInputCache later.
             digestVirtualInputCache.put(digest, virtualInput);
-            b.addFilesBuilder()
-                .setName(entry.getSegment())
-                .setDigest(digest)
-                .setIsExecutable(false);
           } else {
-            b.addFilesBuilder()
-                .setName(entry.getSegment())
-                .setDigest(DigestUtil.getFromInputCache(input, inputFileCache))
-                .setIsExecutable(execRoot.getRelative(input.getExecPathString()).isExecutable());
+            digest = DigestUtil.getFromInputCache(input, inputFileCache);
           }
+          b.addFilesBuilder()
+              .setName(entry.getSegment())
+              .setDigest(digest)
+              .setIsExecutable(true);
         } else {
           Digest childDigest = Preconditions.checkNotNull(treeNodeDigestCache.get(child));
           if (child.getActionInput() != null) {


### PR DESCRIPTION
The main motivation for this change is to act as a workaround for #4751. Additionally,
this reduces the number of stat() system calls significantly e.g. by 50% when building Bazel
(600K vs 1.2M).

cc: @werkt @ola-rozenfeld 