### PR TITLE
test failure: print stacktrace on I/O error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -181,7 +181,14 @@ public class StandaloneTestStrategy extends TestStrategy {
       // returning the last list?
       return standaloneTestResult.spawnResults();
     } catch (IOException e) {
-      actionExecutionContext.getEventHandler().handle(Event.error("Caught I/O exception: " + e));
+      // Print the stack trace, otherwise the unexpected I/O error is hard to diagnose.
+      // A stack trace could help with bugs like https://github.com/bazelbuild/bazel/issues/4924
+      StringBuilder sb = new StringBuilder();
+      sb.append("Caught I/O exception:");
+      for (Object s : e.getStackTrace()) {
+        sb.append("\n\t").append(s);
+      }
+      actionExecutionContext.getEventHandler().handle(Event.error(sb.toString()));
       throw new EnvironmentalExecException("unexpected I/O exception", e);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -184,7 +184,7 @@ public class StandaloneTestStrategy extends TestStrategy {
       // Print the stack trace, otherwise the unexpected I/O error is hard to diagnose.
       // A stack trace could help with bugs like https://github.com/bazelbuild/bazel/issues/4924
       StringBuilder sb = new StringBuilder();
-      sb.append("Caught I/O exception:");
+      sb.append("Caught I/O exception: ").append(e.getMessage());
       for (Object s : e.getStackTrace()) {
         sb.append("\n\t").append(s);
       }


### PR DESCRIPTION
Print the stacktrace of unexpected I/O errors in
StandaloneTestStrategy, to ease diagnosing the
root cause of the exception.

See https://github.com/bazelbuild/bazel/issues/4924

Without the stacktrace, all we see in BuildKite
is, for example:

```
ERROR: Caught I/O exception: java.io.IOException: C:/users/b/_bazel_b/bnp8s_vg/execroot/io_bazel/_tmp/b6bda2f0385d1152d3a7f550c6cc1938/_bazel_b/install/23a47abea50baae4d7e032437c1cecc9/_embedded_binaries/embedded_tools/jdk/bin/java.exe (Permission denied)
ERROR: C:/build/buildkite-worker-windows-java8-lfl8-1/bazel/google-bazel-presubmit/src/test/py/bazel/BUILD:71:1: Couldn't build file src/test/py/bazel/bazel_windows_test/test.log:  failed: unexpected I/O exception: C:/users/b/_bazel_b/bnp8s_vg/execroot/io_bazel/_tmp/b6bda2f0385d1152d3a7f550c6cc1938/_bazel_b/install/23a47abea50baae4d7e032437c1cecc9/_embedded_binaries/embedded_tools/jdk/bin/java.exe (Permission denied)
```

The above log contains no information on what
exactly tried accessing java.exe and how, and why
it failed. With a stacktrace I'm hoping to shed
light on the culprit.

Change-Id: I4f3851cd1bc1b2b348217de5b41069591a8f4446