### PR TITLE
Allow rules and targets to specify extra execution platform constraints.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformSemantics.java
@@ -40,19 +40,15 @@ public class PlatformSemantics {
   }
 
   /**
-   * Return the target-specific execution platform constraints, based on the rule definition and any
-   * constraints added by the target.
+   * Returns the target-specific execution platform constraints, based on the rule definition and
+   * any constraints added by the target.
    */
   public static ImmutableSet<Label> getExecutionPlatformConstraints(Rule rule) {
     NonconfigurableAttributeMapper mapper = NonconfigurableAttributeMapper.of(rule);
     ImmutableSet.Builder<Label> execConstraintLabels = new ImmutableSet.Builder<>();
 
-    if (rule.getRuleClassObject().executionPlatformConstraintsAllowed().allowsRule()) {
-      // Add any default rule-level constraints.
-      execConstraintLabels.addAll(rule.getRuleClassObject().getExecutionPlatformConstraints());
-    }
+    execConstraintLabels.addAll(rule.getRuleClassObject().getExecutionPlatformConstraints());
 
-    // Add any target-level constraints, if allowed.
     if (rule.getRuleClassObject().executionPlatformConstraintsAllowed().allowsTarget()
         && mapper.has(PlatformSemantics.EXEC_COMPATIBLE_WITH_ATTR)) {
       execConstraintLabels.addAll(

--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformSemantics.java
@@ -24,8 +24,6 @@ import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.NonconfigurableAttributeMapper;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.RuleClass;
-import java.util.HashSet;
-import java.util.Set;
 
 /** Helper class to manage rules' use of platforms. */
 public class PlatformSemantics {
@@ -47,7 +45,7 @@ public class PlatformSemantics {
    */
   public static ImmutableSet<Label> getExecutionPlatformConstraints(Rule rule) {
     NonconfigurableAttributeMapper mapper = NonconfigurableAttributeMapper.of(rule);
-    Set<Label> execConstraintLabels = new HashSet<>();
+    ImmutableSet.Builder<Label> execConstraintLabels = new ImmutableSet.Builder<>();
 
     if (rule.getRuleClassObject().executionPlatformConstraintsAllowed().allowsRule()) {
       // Add any default rule-level constraints.
@@ -61,6 +59,6 @@ public class PlatformSemantics {
           mapper.get(PlatformSemantics.EXEC_COMPATIBLE_WITH_ATTR, BuildType.LABEL_LIST));
     }
 
-    return ImmutableSet.copyOf(execConstraintLabels);
+    return execConstraintLabels.build();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformSemantics.java
@@ -18,11 +18,6 @@ import static com.google.devtools.build.lib.packages.Attribute.attr;
 import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.devtools.build.lib.cmdline.Label;
-import com.google.devtools.build.lib.packages.BuildType;
-import com.google.devtools.build.lib.packages.NonconfigurableAttributeMapper;
-import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.RuleClass;
 
 /** Helper class to manage rules' use of platforms. */
@@ -37,24 +32,5 @@ public class PlatformSemantics {
             attr(TOOLCHAINS_ATTR, LABEL_LIST)
                 .nonconfigurable("Used in toolchain resolution")
                 .value(ImmutableList.of()));
-  }
-
-  /**
-   * Returns the target-specific execution platform constraints, based on the rule definition and
-   * any constraints added by the target.
-   */
-  public static ImmutableSet<Label> getExecutionPlatformConstraints(Rule rule) {
-    NonconfigurableAttributeMapper mapper = NonconfigurableAttributeMapper.of(rule);
-    ImmutableSet.Builder<Label> execConstraintLabels = new ImmutableSet.Builder<>();
-
-    execConstraintLabels.addAll(rule.getRuleClassObject().getExecutionPlatformConstraints());
-
-    if (rule.getRuleClassObject().executionPlatformConstraintsAllowed().allowsTarget()
-        && mapper.has(PlatformSemantics.EXEC_COMPATIBLE_WITH_ATTR)) {
-      execConstraintLabels.addAll(
-          mapper.get(PlatformSemantics.EXEC_COMPATIBLE_WITH_ATTR, BuildType.LABEL_LIST));
-    }
-
-    return execConstraintLabels.build();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -211,7 +211,8 @@ public class RuleClass {
     PER_RULE(true, false),
     /**
      * Users are allowed to specify additional execution platform constraints for each target, using
-     * the 'exec_compatible_with' attribute.
+     * the 'exec_compatible_with' attribute. This also allows setting constraints in the rule
+     * definition, like PER_RULE.
      */
     PER_TARGET(true, true);
 
@@ -647,7 +648,7 @@ public class RuleClass {
     private final Set<Label> requiredToolchains = new HashSet<>();
     private boolean supportsPlatforms = true;
     private ExecutionPlatformConstraintsAllowed executionPlatformConstraintsAllowed =
-        ExecutionPlatformConstraintsAllowed.NONE;
+        ExecutionPlatformConstraintsAllowed.PER_RULE;
     private Set<Label> executionPlatformConstraints = new HashSet<>();
 
     /**
@@ -681,8 +682,8 @@ public class RuleClass {
 
         addRequiredToolchains(parent.getRequiredToolchains());
         supportsPlatforms = parent.supportsPlatforms;
-        executionPlatformConstraintsAllowed = parent.executionPlatformConstraintsAllowed;
-        addExecutionPlatformConstraint(parent.getExecutionPlatformConstraints());
+        // executionPlatformConstraintsAllowed is not inherited and takes the default.
+        addExecutionPlatformConstraints(parent.getExecutionPlatformConstraints());
 
         for (Attribute attribute : parent.getAttributes()) {
           String attrName = attribute.getName();
@@ -1224,10 +1225,10 @@ public class RuleClass {
     }
 
     public Builder addExecutionPlatformConstraints(Label... constraints) {
-      return this.addExecutionPlatformConstraint(Lists.newArrayList(constraints));
+      return this.addExecutionPlatformConstraints(Lists.newArrayList(constraints));
     }
 
-    public Builder addExecutionPlatformConstraint(Iterable<Label> constraints) {
+    public Builder addExecutionPlatformConstraints(Iterable<Label> constraints) {
       Iterables.addAll(this.executionPlatformConstraints, constraints);
       return this;
     }

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -200,6 +200,38 @@ public class RuleClass {
     public static final class RuleErrorException extends Exception {}
   }
 
+  /** Describes whether a rule implementation allows additional execution platform constraints. */
+  public enum ExecutionPlatformConstraintsAllowed {
+    /** The rule implementation does not allow any additional execution platform constraints. */
+    NONE(false, false),
+    /**
+     * The rule allows additional execution platform constraints to be added at the rule level,
+     * which apply to all targets of that rule.
+     */
+    PER_RULE(true, false),
+    /**
+     * Users are allowed to specify additional execution platform constraints for each target, using
+     * the 'exec_compatible_with' attribute.
+     */
+    PER_TARGET(true, true);
+
+    private final boolean allowsRule;
+    private final boolean allowsTarget;
+
+    ExecutionPlatformConstraintsAllowed(boolean allowsRule, boolean allowsTarget) {
+      this.allowsRule = allowsRule;
+      this.allowsTarget = allowsTarget;
+    }
+
+    public boolean allowsRule() {
+      return allowsRule;
+    }
+
+    public boolean allowsTarget() {
+      return allowsTarget;
+    }
+  }
+
   /**
    * For Bazel's constraint system: the attribute that declares the set of environments a rule
    * supports, overriding the defaults for their respective groups.
@@ -614,6 +646,9 @@ public class RuleClass {
     private final Map<String, Attribute> attributes = new LinkedHashMap<>();
     private final Set<Label> requiredToolchains = new HashSet<>();
     private boolean supportsPlatforms = true;
+    private ExecutionPlatformConstraintsAllowed executionPlatformConstraintsAllowed =
+        ExecutionPlatformConstraintsAllowed.NONE;
+    private Set<Label> executionPlatformConstraints = new HashSet<>();
 
     /**
      * Constructs a new {@code RuleClassBuilder} using all attributes from all
@@ -646,6 +681,8 @@ public class RuleClass {
 
         addRequiredToolchains(parent.getRequiredToolchains());
         supportsPlatforms = parent.supportsPlatforms;
+        executionPlatformConstraintsAllowed = parent.executionPlatformConstraintsAllowed;
+        addExecutionPlatformConstraint(parent.getExecutionPlatformConstraints());
 
         for (Attribute attribute : parent.getAttributes()) {
           String attrName = attribute.getName();
@@ -706,6 +743,21 @@ public class RuleClass {
       if (type == RuleClassType.PLACEHOLDER) {
         Preconditions.checkNotNull(ruleDefinitionEnvironmentHashCode, this.name);
       }
+      if (executionPlatformConstraintsAllowed == ExecutionPlatformConstraintsAllowed.NONE) {
+        Preconditions.checkArgument(
+            executionPlatformConstraints.isEmpty(),
+            "Rule %s does not allow setting execution platform constraints",
+            name);
+      } else if (executionPlatformConstraintsAllowed
+          == ExecutionPlatformConstraintsAllowed.PER_TARGET) {
+        // Only rules that allow per target execution constraints need this attribute.
+        this.add(
+            attr("exec_compatible_with", BuildType.LABEL_LIST)
+                .allowedFileTypes()
+                .nonconfigurable("Used in toolchain resolution")
+                .value(ImmutableList.of()));
+      }
+
       return new RuleClass(
           name,
           key,
@@ -733,6 +785,8 @@ public class RuleClass {
           supportsConstraintChecking,
           requiredToolchains,
           supportsPlatforms,
+          executionPlatformConstraintsAllowed,
+          executionPlatformConstraints,
           attributes.values());
     }
 
@@ -911,8 +965,8 @@ public class RuleClass {
     /**
      * Applies the given transition factory to all incoming edges for this rule class.
      *
-     * <p>Unlike{@link #cfg(ConfigurationTransition)}, the factory can examine the rule when
-     * deciding what transition to use.
+     * <p>Unlike{@link #cfg(PatchTransition)}, the factory can examine the rule when deciding what
+     * transition to use.
      */
     public Builder cfg(RuleTransitionFactory transitionFactory) {
       Preconditions.checkState(type != RuleClassType.ABSTRACT,
@@ -1154,12 +1208,25 @@ public class RuleClass {
     }
 
     public Builder addRequiredToolchains(Label... toolchainLabels) {
-      Iterables.addAll(this.requiredToolchains, Lists.newArrayList(toolchainLabels));
-      return this;
+      return this.addRequiredToolchains(Lists.newArrayList(toolchainLabels));
     }
 
     public Builder supportsPlatforms(boolean flag) {
       this.supportsPlatforms = flag;
+      return this;
+    }
+
+    public Builder executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed value) {
+      this.executionPlatformConstraintsAllowed = value;
+      return this;
+    }
+
+    public Builder addExecutionPlatformConstraints(Label... constraints) {
+      return this.addExecutionPlatformConstraint(Lists.newArrayList(constraints));
+    }
+
+    public Builder addExecutionPlatformConstraint(Iterable<Label> constraints) {
+      Iterables.addAll(this.executionPlatformConstraints, constraints);
       return this;
     }
 
@@ -1280,6 +1347,8 @@ public class RuleClass {
 
   private final ImmutableSet<Label> requiredToolchains;
   private final boolean supportsPlatforms;
+  private final ExecutionPlatformConstraintsAllowed executionPlatformConstraintsAllowed;
+  private final ImmutableSet<Label> executionPlatformConstraints;
 
   /**
    * Constructs an instance of RuleClass whose name is 'name', attributes are 'attributes'. The
@@ -1329,6 +1398,8 @@ public class RuleClass {
       boolean supportsConstraintChecking,
       Set<Label> requiredToolchains,
       boolean supportsPlatforms,
+      ExecutionPlatformConstraintsAllowed executionPlatformConstraintsAllowed,
+      Set<Label> executionPlatformConstraints,
       Collection<Attribute> attributes) {
     this.name = name;
     this.key = key;
@@ -1359,6 +1430,8 @@ public class RuleClass {
     this.supportsConstraintChecking = supportsConstraintChecking;
     this.requiredToolchains = ImmutableSet.copyOf(requiredToolchains);
     this.supportsPlatforms = supportsPlatforms;
+    this.executionPlatformConstraintsAllowed = executionPlatformConstraintsAllowed;
+    this.executionPlatformConstraints = ImmutableSet.copyOf(executionPlatformConstraints);
 
     // Create the index and collect non-configurable attributes.
     int index = 0;
@@ -2173,6 +2246,14 @@ public class RuleClass {
 
   public boolean supportsPlatforms() {
     return supportsPlatforms;
+  }
+
+  public ExecutionPlatformConstraintsAllowed executionPlatformConstraintsAllowed() {
+    return executionPlatformConstraintsAllowed;
+  }
+
+  public ImmutableSet<Label> getExecutionPlatformConstraints() {
+    return executionPlatformConstraints;
   }
 
   public static boolean isThirdPartyPackage(PackageIdentifier packageIdentifier) {

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -205,7 +205,7 @@ public class RuleClass {
     /** The rule implementation does not allow any additional execution platform constraints. */
     NONE(false, false),
     /**
-     * The rule allows additional execution platform constraints to be added at the rule level,
+     * Allows additional execution platform constraints to be added in the rule definition,
      * which apply to all targets of that rule.
      */
     PER_RULE(true, false),
@@ -751,11 +751,13 @@ public class RuleClass {
       } else if (executionPlatformConstraintsAllowed
           == ExecutionPlatformConstraintsAllowed.PER_TARGET) {
         // Only rules that allow per target execution constraints need this attribute.
-        this.add(
-            attr("exec_compatible_with", BuildType.LABEL_LIST)
-                .allowedFileTypes()
-                .nonconfigurable("Used in toolchain resolution")
-                .value(ImmutableList.of()));
+        if (!this.attributes.containsKey("exec_compatible_with")) {
+          this.add(
+              attr("exec_compatible_with", BuildType.LABEL_LIST)
+                  .allowedFileTypes()
+                  .nonconfigurable("Used in toolchain resolution")
+                  .value(ImmutableList.of()));
+        }
       }
 
       return new RuleClass(
@@ -965,7 +967,7 @@ public class RuleClass {
     /**
      * Applies the given transition factory to all incoming edges for this rule class.
      *
-     * <p>Unlike{@link #cfg(PatchTransition)}, the factory can examine the rule when deciding what
+     * <p>Unlike {@link #cfg(PatchTransition)}, the factory can examine the rule when deciding what
      * transition to use.
      */
     public Builder cfg(RuleTransitionFactory transitionFactory) {

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -202,8 +202,6 @@ public class RuleClass {
 
   /** Describes whether a rule implementation allows additional execution platform constraints. */
   public enum ExecutionPlatformConstraintsAllowed {
-    /** The rule implementation does not allow any additional execution platform constraints. */
-    NONE,
     /**
      * Allows additional execution platform constraints to be added in the rule definition,
      * which apply to all targets of that rule.

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -674,6 +674,10 @@ public class RuleClass {
               "Attribute %s is inherited multiple times in %s ruleclass",
               attrName,
               name);
+          if (attrName.equals("exec_compatible_with") && parent.executionPlatformConstraintsAllowed == ExecutionPlatformConstraintsAllowed.PER_TARGET) {
+            // This attribute should not be inherited because executionPlatformConstraintsAllowed is not inherited.
+            continue;
+          }
           attributes.put(attrName, attribute);
         }
 
@@ -1181,29 +1185,60 @@ public class RuleClass {
       return this;
     }
 
+    /**
+     * Causes rules of this type to require the specified toolchains be available via toolchain
+     * resolution when a target is configured.
+     */
     public Builder addRequiredToolchains(Iterable<Label> toolchainLabels) {
       Iterables.addAll(this.requiredToolchains, toolchainLabels);
       return this;
     }
 
+    /**
+     * Causes rules of this type to require the specified toolchains be available via toolchain
+     * resolution when a target is configured.
+     */
     public Builder addRequiredToolchains(Label... toolchainLabels) {
       return this.addRequiredToolchains(Lists.newArrayList(toolchainLabels));
     }
 
+    /**
+     * Rules that support platforms can use toolchains and execution platforms. Rules that are part
+     * of configuring toolchains and platforms should set this to {@code false}.
+     */
     public Builder supportsPlatforms(boolean flag) {
       this.supportsPlatforms = flag;
       return this;
     }
 
+    /**
+     * Specifies whether targets of this rule can add additional constraints on the execution
+     * platform selected. If this is {@link ExecutionPlatformConstraintsAllowed#PER_TARGET}, there
+     * will be an attribute named {@code exec_compatible_with} that can be used to add these
+     * constraints.
+     *
+     * <p> Please note that this value is not inherited by child rules, and must be re-set on
+     * them if the same behavior is required.
+     */
     public Builder executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed value) {
       this.executionPlatformConstraintsAllowed = value;
       return this;
     }
 
+    /**
+     * Adds additional execution platform constraints that apply for all targets from this rule.
+     *
+     * <p> Please note that this value is inherited by child rules.
+     */
     public Builder addExecutionPlatformConstraints(Label... constraints) {
       return this.addExecutionPlatformConstraints(Lists.newArrayList(constraints));
     }
 
+    /**
+     * Adds additional execution platform constraints that apply for all targets from this rule.
+     *
+     * <p> Please note that this value is inherited by child rules.
+     */
     public Builder addExecutionPlatformConstraints(Iterable<Label> constraints) {
       Iterables.addAll(this.executionPlatformConstraints, constraints);
       return this;

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -203,34 +203,18 @@ public class RuleClass {
   /** Describes whether a rule implementation allows additional execution platform constraints. */
   public enum ExecutionPlatformConstraintsAllowed {
     /** The rule implementation does not allow any additional execution platform constraints. */
-    NONE(false, false),
+    NONE,
     /**
      * Allows additional execution platform constraints to be added in the rule definition,
      * which apply to all targets of that rule.
      */
-    PER_RULE(true, false),
+    PER_RULE,
     /**
      * Users are allowed to specify additional execution platform constraints for each target, using
      * the 'exec_compatible_with' attribute. This also allows setting constraints in the rule
      * definition, like PER_RULE.
      */
-    PER_TARGET(true, true);
-
-    private final boolean allowsRule;
-    private final boolean allowsTarget;
-
-    ExecutionPlatformConstraintsAllowed(boolean allowsRule, boolean allowsTarget) {
-      this.allowsRule = allowsRule;
-      this.allowsTarget = allowsTarget;
-    }
-
-    public boolean allowsRule() {
-      return allowsRule;
-    }
-
-    public boolean allowsTarget() {
-      return allowsTarget;
-    }
+    PER_TARGET;
   }
 
   /**
@@ -744,13 +728,7 @@ public class RuleClass {
       if (type == RuleClassType.PLACEHOLDER) {
         Preconditions.checkNotNull(ruleDefinitionEnvironmentHashCode, this.name);
       }
-      if (executionPlatformConstraintsAllowed == ExecutionPlatformConstraintsAllowed.NONE) {
-        Preconditions.checkArgument(
-            executionPlatformConstraints.isEmpty(),
-            "Rule %s does not allow setting execution platform constraints",
-            name);
-      } else if (executionPlatformConstraintsAllowed
-          == ExecutionPlatformConstraintsAllowed.PER_TARGET) {
+      if (executionPlatformConstraintsAllowed == ExecutionPlatformConstraintsAllowed.PER_TARGET) {
         // Only rules that allow per target execution constraints need this attribute.
         if (!this.attributes.containsKey("exec_compatible_with")) {
           this.add(

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -674,8 +674,11 @@ public class RuleClass {
               "Attribute %s is inherited multiple times in %s ruleclass",
               attrName,
               name);
-          if (attrName.equals("exec_compatible_with") && parent.executionPlatformConstraintsAllowed == ExecutionPlatformConstraintsAllowed.PER_TARGET) {
-            // This attribute should not be inherited because executionPlatformConstraintsAllowed is not inherited.
+          if (attrName.equals("exec_compatible_with")
+              && parent.executionPlatformConstraintsAllowed
+                  == ExecutionPlatformConstraintsAllowed.PER_TARGET) {
+            // This attribute should not be inherited because executionPlatformConstraintsAllowed is
+            // not inherited.
             continue;
           }
           attributes.put(attrName, attribute);
@@ -1217,8 +1220,8 @@ public class RuleClass {
      * will be an attribute named {@code exec_compatible_with} that can be used to add these
      * constraints.
      *
-     * <p> Please note that this value is not inherited by child rules, and must be re-set on
-     * them if the same behavior is required.
+     * <p>Please note that this value is not inherited by child rules, and must be re-set on them if
+     * the same behavior is required.
      */
     public Builder executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed value) {
       this.executionPlatformConstraintsAllowed = value;
@@ -1228,7 +1231,7 @@ public class RuleClass {
     /**
      * Adds additional execution platform constraints that apply for all targets from this rule.
      *
-     * <p> Please note that this value is inherited by child rules.
+     * <p>Please note that this value is inherited by child rules.
      */
     public Builder addExecutionPlatformConstraints(Label... constraints) {
       return this.addExecutionPlatformConstraints(Lists.newArrayList(constraints));
@@ -1237,7 +1240,7 @@ public class RuleClass {
     /**
      * Adds additional execution platform constraints that apply for all targets from this rule.
      *
-     * <p> Please note that this value is inherited by child rules.
+     * <p>Please note that this value is inherited by child rules.
      */
     public Builder addExecutionPlatformConstraints(Iterable<Label> constraints) {
       Iterables.addAll(this.executionPlatformConstraints, constraints);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
@@ -413,6 +413,7 @@ public final class AspectFunction implements SkyFunction {
                     aspect.getDescriptor().getDescription(),
                     associatedConfiguredTargetAndData.getTarget().toString()),
                 requiredToolchains,
+                /* execConstraintLabels= */ ImmutableSet.of(),
                 key.getAspectConfigurationKey());
       } catch (ToolchainContextException e) {
         // TODO(katre): better error handling

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
@@ -57,6 +57,7 @@ import com.google.devtools.build.lib.packages.NonconfigurableAttributeMapper;
 import com.google.devtools.build.lib.packages.Package;
 import com.google.devtools.build.lib.packages.RawAttributeMapper;
 import com.google.devtools.build.lib.packages.Rule;
+import com.google.devtools.build.lib.packages.RuleClass.ExecutionPlatformConstraintsAllowed;
 import com.google.devtools.build.lib.packages.RuleClassProvider;
 import com.google.devtools.build.lib.packages.RuleTransitionFactory;
 import com.google.devtools.build.lib.packages.Target;
@@ -398,7 +399,7 @@ public final class ConfiguredTargetFunction implements SkyFunction {
 
     execConstraintLabels.addAll(rule.getRuleClassObject().getExecutionPlatformConstraints());
 
-    if (rule.getRuleClassObject().executionPlatformConstraintsAllowed().allowsTarget()
+    if (rule.getRuleClassObject().executionPlatformConstraintsAllowed() == ExecutionPlatformConstraintsAllowed.PER_TARGET
         && mapper.has(PlatformSemantics.EXEC_COMPATIBLE_WITH_ATTR)) {
       execConstraintLabels.addAll(
           mapper.get(PlatformSemantics.EXEC_COMPATIBLE_WITH_ATTR, BuildType.LABEL_LIST));

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.ConfiguredTargetFactory;
 import com.google.devtools.build.lib.analysis.Dependency;
 import com.google.devtools.build.lib.analysis.DependencyResolver.InconsistentAspectOrderException;
+import com.google.devtools.build.lib.analysis.PlatformSemantics;
 import com.google.devtools.build.lib.analysis.TargetAndConfiguration;
 import com.google.devtools.build.lib.analysis.ToolchainContext;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
@@ -264,11 +265,16 @@ public final class ConfiguredTargetFunction implements SkyFunction {
         if (rule.getRuleClassObject().supportsPlatforms()) {
           ImmutableSet<Label> requiredToolchains =
               rule.getRuleClassObject().getRequiredToolchains();
+
+          // Collect local (target, rule) constraints for filtering out execution platforms.
+          ImmutableSet<Label> execConstraintLabels =
+              PlatformSemantics.getExecutionPlatformConstraints(rule);
           toolchainContext =
               ToolchainUtil.createToolchainContext(
                   env,
                   rule.toString(),
                   requiredToolchains,
+                  execConstraintLabels,
                   configuredTargetKey.getConfigurationKey());
           if (env.valuesMissing()) {
             return null;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
@@ -399,7 +399,8 @@ public final class ConfiguredTargetFunction implements SkyFunction {
 
     execConstraintLabels.addAll(rule.getRuleClassObject().getExecutionPlatformConstraints());
 
-    if (rule.getRuleClassObject().executionPlatformConstraintsAllowed() == ExecutionPlatformConstraintsAllowed.PER_TARGET
+    if (rule.getRuleClassObject().executionPlatformConstraintsAllowed()
+            == ExecutionPlatformConstraintsAllowed.PER_TARGET
         && mapper.has(PlatformSemantics.EXEC_COMPATIBLE_WITH_ATTR)) {
       execConstraintLabels.addAll(
           mapper.get(PlatformSemantics.EXEC_COMPATIBLE_WITH_ATTR, BuildType.LABEL_LIST));

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -967,7 +967,11 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     SkyFunctionEnvironmentForTesting env =
         new SkyFunctionEnvironmentForTesting(buildDriver, eventHandler, this);
     return ToolchainUtil.createToolchainContext(
-        env, "", requiredToolchains, config == null ? null : BuildConfigurationValue.key(config));
+        env,
+        "",
+        requiredToolchains,
+        /* execConstraintLabels= */ ImmutableSet.of(),
+        config == null ? null : BuildConfigurationValue.key(config));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainUtil.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.skyframe;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.stream.Collectors.joining;
 
 import com.google.auto.value.AutoValue;
@@ -28,6 +29,7 @@ import com.google.devtools.build.lib.analysis.PlatformConfiguration;
 import com.google.devtools.build.lib.analysis.PlatformOptions;
 import com.google.devtools.build.lib.analysis.ToolchainContext;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
+import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformProviderUtils;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -63,6 +65,7 @@ public class ToolchainUtil {
       Environment env,
       String targetDescription,
       Set<Label> requiredToolchains,
+      Set<Label> execConstraintLabels,
       @Nullable BuildConfigurationValue.Key configurationKey)
       throws ToolchainContextException, InterruptedException {
 
@@ -91,6 +94,11 @@ public class ToolchainUtil {
     ConfiguredTargetKey hostPlatformKey = ConfiguredTargetKey.of(hostPlatformLabel, configuration);
     ConfiguredTargetKey targetPlatformKey =
         ConfiguredTargetKey.of(targetPlatformLabel, configuration);
+    ImmutableList<ConfiguredTargetKey> execConstraintKeys =
+        execConstraintLabels
+            .stream()
+            .map(label -> ConfiguredTargetKey.of(label, configuration))
+            .collect(toImmutableList());
 
     // Load the host and target platforms early, to check for errors.
     getPlatformInfo(ImmutableList.of(hostPlatformKey, targetPlatformKey), env);
@@ -108,6 +116,14 @@ public class ToolchainUtil {
             .addAll(registeredExecutionPlatforms.registeredExecutionPlatformKeys())
             .add(hostPlatformKey)
             .build();
+
+    // Filter out execution platforms that don't satisfy the extra constraints.
+    availableExecutionPlatformKeys =
+        filterPlatforms(availableExecutionPlatformKeys, execConstraintKeys, env);
+    if (availableExecutionPlatformKeys == null) {
+      return null;
+    }
+
     Optional<ResolvedToolchains> resolvedToolchains =
         resolveToolchainLabels(
             env,
@@ -421,6 +437,93 @@ public class ToolchainUtil {
     return labels.build();
   }
 
+  @Nullable
+  private static ImmutableList<ConfiguredTargetKey> filterPlatforms(
+      ImmutableList<ConfiguredTargetKey> platformKeys,
+      ImmutableList<ConfiguredTargetKey> constraintKeys,
+      Environment env)
+      throws ToolchainContextException, InterruptedException {
+
+    // Short circuit if not needed.
+    if (constraintKeys.isEmpty()) {
+      return platformKeys;
+    }
+
+    Map<ConfiguredTargetKey, PlatformInfo> platformInfoMap = getPlatformInfo(platformKeys, env);
+    if (platformInfoMap == null) {
+      return null;
+    }
+    List<ConstraintValueInfo> constraints = getConstraintValueInfo(constraintKeys, env);
+    if (constraints == null) {
+      return null;
+    }
+
+    return platformKeys
+        .stream()
+        .filter(key -> filterPlatform(platformInfoMap.get(key), constraints))
+        .collect(toImmutableList());
+  }
+
+  @Nullable
+  private static List<ConstraintValueInfo> getConstraintValueInfo(
+      ImmutableList<ConfiguredTargetKey> constraintKeys, Environment env)
+      throws InterruptedException, ToolchainContextException {
+
+    Map<SkyKey, ValueOrException<ConfiguredValueCreationException>> values =
+        env.getValuesOrThrow(constraintKeys, ConfiguredValueCreationException.class);
+    boolean valuesMissing = env.valuesMissing();
+    List<ConstraintValueInfo> constraintValues = valuesMissing ? null : new ArrayList<>();
+    try {
+      for (ConfiguredTargetKey key : constraintKeys) {
+        ConstraintValueInfo constraintValueInfo = findConstraintValueInfo(values.get(key));
+        if (!valuesMissing && constraintValueInfo != null) {
+          constraintValues.add(constraintValueInfo);
+        }
+      }
+    } catch (ConfiguredValueCreationException e) {
+      throw new ToolchainContextException(e);
+    }
+    if (valuesMissing) {
+      return null;
+    }
+    return constraintValues;
+  }
+
+  @Nullable
+  private static ConstraintValueInfo findConstraintValueInfo(
+      ValueOrException<ConfiguredValueCreationException> valueOrException)
+      throws ConfiguredValueCreationException, ToolchainContextException {
+
+    ConfiguredTargetValue ctv = (ConfiguredTargetValue) valueOrException.get();
+    if (ctv == null) {
+      return null;
+    }
+
+    ConfiguredTarget configuredTarget = ctv.getConfiguredTarget();
+    ConstraintValueInfo constraintValueInfo =
+        PlatformProviderUtils.constraintValue(configuredTarget);
+    if (constraintValueInfo == null) {
+      throw new ToolchainContextException(
+          new InvalidConstraintValueException(configuredTarget.getLabel()));
+    }
+
+    return constraintValueInfo;
+  }
+
+  private static boolean filterPlatform(
+      PlatformInfo platformInfo, List<ConstraintValueInfo> constraints) {
+    for (ConstraintValueInfo constraint : constraints) {
+      ConstraintValueInfo fromPlatform = platformInfo.getConstraint(constraint.constraint());
+      if (fromPlatform == null || !fromPlatform.equals(constraint)) {
+        // The value for this setting is not present in the platform, or doesn't match the expected
+        // value.
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   /**
    * Exception used when an error occurs in {@link #expandTargetPatterns(Environment, List,
    * FilteringPolicy)}.
@@ -460,6 +563,23 @@ public class ToolchainUtil {
     }
   }
 
+  /** Exception used when a constraint value label is not a valid constraint value. */
+  static final class InvalidConstraintValueException extends Exception {
+    InvalidConstraintValueException(Label label) {
+      super(formatError(label));
+    }
+
+    InvalidConstraintValueException(Label label, ConfiguredValueCreationException e) {
+      super(formatError(label), e);
+    }
+
+    private static String formatError(Label label) {
+      return String.format(
+          "Target %s was referenced as a constraint_value, but does not provide ConstraintValueInfo",
+          label);
+    }
+  }
+
   /** Exception used when a toolchain type is required but no matching toolchain is found. */
   public static final class UnresolvedToolchainsException extends Exception {
     private final ImmutableList<Label> missingToolchainTypes;
@@ -480,6 +600,10 @@ public class ToolchainUtil {
   /** Exception used to wrap exceptions during toolchain resolution. */
   public static class ToolchainContextException extends Exception {
     public ToolchainContextException(InvalidPlatformException e) {
+      super(e);
+    }
+
+    public ToolchainContextException(InvalidConstraintValueException e) {
       super(e);
     }
 

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -896,7 +896,7 @@ public class RuleClassTest extends PackageLoadingTestCase {
         supportsConstraintChecking,
         /*requiredToolchains=*/ ImmutableSet.of(),
         /*supportsPlatforms=*/ true,
-        ExecutionPlatformConstraintsAllowed.NONE,
+        ExecutionPlatformConstraintsAllowed.PER_RULE,
         /* executionPlatformConstraints= */ ImmutableSet.of(),
         ImmutableList.copyOf(attributes));
   }
@@ -1046,32 +1046,6 @@ public class RuleClassTest extends PackageLoadingTestCase {
     assertThat(ruleClass.getRequiredToolchains())
         .containsExactly(
             Label.parseAbsolute("//toolchain:tc1"), Label.parseAbsolute("//toolchain:tc2"));
-  }
-
-  @Test
-  public void testExecutionPlatformConstraints_none() {
-    RuleClass.Builder ruleClassBuilder =
-        new RuleClass.Builder("ruleClass", RuleClassType.NORMAL, false)
-            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
-            .add(attr("tags", STRING_LIST))
-            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.NONE);
-
-    RuleClass ruleClass = ruleClassBuilder.build();
-    assertThat(ruleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isFalse();
-  }
-
-  @Test
-  public void testExecutionPlatformConstraints_none_constraintsCauseError() throws Exception {
-    RuleClass.Builder ruleClassBuilder =
-        new RuleClass.Builder("ruleClass", RuleClassType.NORMAL, false)
-            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
-            .add(attr("tags", STRING_LIST))
-            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.NONE);
-
-    ruleClassBuilder.addExecutionPlatformConstraints(
-        Label.parseAbsolute("//constraints:cv1"), Label.parseAbsolute("//constraints:cv2"));
-
-    assertThrows(IllegalArgumentException.class, () -> ruleClassBuilder.build());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -25,6 +25,7 @@ import static com.google.devtools.build.lib.syntax.Type.BOOLEAN;
 import static com.google.devtools.build.lib.syntax.Type.INTEGER;
 import static com.google.devtools.build.lib.syntax.Type.STRING;
 import static com.google.devtools.build.lib.syntax.Type.STRING_LIST;
+import static com.google.devtools.build.lib.testutil.MoreAsserts.assertThrows;
 import static org.junit.Assert.fail;
 
 import com.google.common.base.Function;
@@ -50,6 +51,7 @@ import com.google.devtools.build.lib.packages.Attribute.ValidityPredicate;
 import com.google.devtools.build.lib.packages.ConfigurationFragmentPolicy.MissingFragmentPolicy;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory;
+import com.google.devtools.build.lib.packages.RuleClass.ExecutionPlatformConstraintsAllowed;
 import com.google.devtools.build.lib.packages.RuleFactory.BuildLangTypedAttributeValuesMap;
 import com.google.devtools.build.lib.packages.util.PackageLoadingTestCase;
 import com.google.devtools.build.lib.syntax.BaseFunction;
@@ -892,8 +894,10 @@ public class RuleClassTest extends PackageLoadingTestCase {
             .setMissingFragmentPolicy(missingFragmentPolicy)
             .build(),
         supportsConstraintChecking,
-        /*requiredToolchains=*/ ImmutableSet.<Label>of(),
+        /*requiredToolchains=*/ ImmutableSet.of(),
         /*supportsPlatforms=*/ true,
+        ExecutionPlatformConstraintsAllowed.NONE,
+        /* executionPlatformConstraints= */ ImmutableSet.of(),
         ImmutableList.copyOf(attributes));
   }
 
@@ -1035,13 +1039,74 @@ public class RuleClassTest extends PackageLoadingTestCase {
             .add(attr("tags", STRING_LIST));
 
     ruleClassBuilder.addRequiredToolchains(
-        ImmutableList.of(
-            Label.parseAbsolute("//toolchain:tc1"), Label.parseAbsolute("//toolchain:tc2")));
+        Label.parseAbsolute("//toolchain:tc1"), Label.parseAbsolute("//toolchain:tc2"));
 
     RuleClass ruleClass = ruleClassBuilder.build();
 
     assertThat(ruleClass.getRequiredToolchains())
         .containsExactly(
             Label.parseAbsolute("//toolchain:tc1"), Label.parseAbsolute("//toolchain:tc2"));
+  }
+
+  @Test
+  public void testExecutionPlatformConstraints_none() {
+    RuleClass.Builder ruleClassBuilder =
+        new RuleClass.Builder("ruleClass", RuleClassType.NORMAL, false)
+            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
+            .add(attr("tags", STRING_LIST))
+            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.NONE);
+
+    RuleClass ruleClass = ruleClassBuilder.build();
+    assertThat(ruleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isFalse();
+  }
+
+  @Test
+  public void testExecutionPlatformConstraints_none_constraintsCauseError() throws Exception {
+    RuleClass.Builder ruleClassBuilder =
+        new RuleClass.Builder("ruleClass", RuleClassType.NORMAL, false)
+            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
+            .add(attr("tags", STRING_LIST))
+            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.NONE);
+
+    ruleClassBuilder.addExecutionPlatformConstraints(
+        Label.parseAbsolute("//constraints:cv1"), Label.parseAbsolute("//constraints:cv2"));
+
+    assertThrows(IllegalArgumentException.class, () -> ruleClassBuilder.build());
+  }
+
+  @Test
+  public void testExecutionPlatformConstraints_perRule() throws Exception {
+    RuleClass.Builder ruleClassBuilder =
+        new RuleClass.Builder("ruleClass", RuleClassType.NORMAL, false)
+            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
+            .add(attr("tags", STRING_LIST))
+            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_RULE);
+
+    ruleClassBuilder.addExecutionPlatformConstraints(
+        Label.parseAbsolute("//constraints:cv1"), Label.parseAbsolute("//constraints:cv2"));
+
+    RuleClass ruleClass = ruleClassBuilder.build();
+
+    assertThat(ruleClass.getExecutionPlatformConstraints())
+        .containsExactly(
+            Label.parseAbsolute("//constraints:cv1"), Label.parseAbsolute("//constraints:cv2"));
+    assertThat(ruleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isFalse();
+  }
+
+  @Test
+  public void testExecutionPlatformConstraints_perTarget() throws Exception {
+    RuleClass.Builder ruleClassBuilder =
+        new RuleClass.Builder("ruleClass", RuleClassType.NORMAL, false)
+            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
+            .add(attr("tags", STRING_LIST));
+
+    ruleClassBuilder.executionPlatformConstraintsAllowed(
+        ExecutionPlatformConstraintsAllowed.PER_TARGET);
+
+    RuleClass ruleClass = ruleClassBuilder.build();
+
+    assertThat(ruleClass.executionPlatformConstraintsAllowed())
+        .isEqualTo(ExecutionPlatformConstraintsAllowed.PER_TARGET);
+    assertThat(ruleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isTrue();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -1094,11 +1094,10 @@ public class RuleClassTest extends PackageLoadingTestCase {
                 Label.parseAbsolute("//constraints:cv1"), Label.parseAbsolute("//constraints:cv2"))
             .build();
 
-    RuleClass.Builder childRuleClassBuilder =
+    RuleClass childRuleClass =
         new RuleClass.Builder("childRuleClass", RuleClassType.NORMAL, false, parentRuleClass)
-            .factory(DUMMY_CONFIGURED_TARGET_FACTORY);
-
-    RuleClass childRuleClass = childRuleClassBuilder.build();
+            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
+            .build();
 
     assertThat(childRuleClass.getExecutionPlatformConstraints())
         .containsExactly(
@@ -1126,5 +1125,42 @@ public class RuleClassTest extends PackageLoadingTestCase {
         .containsExactly(
             Label.parseAbsolute("//constraints:cv1"), Label.parseAbsolute("//constraints:cv2"));
     assertThat(childRuleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isFalse();
+  }
+
+  @Test
+  public void testExecutionPlatformConstraints_inherit_parentAllowsPerTarget() {
+    RuleClass parentRuleClass =
+        new RuleClass.Builder("parentRuleClass", RuleClassType.NORMAL, false)
+            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
+            .add(attr("tags", STRING_LIST))
+            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET)
+            .build();
+
+    RuleClass.Builder childRuleClassBuilder =
+        new RuleClass.Builder("childRuleClass", RuleClassType.NORMAL, false, parentRuleClass)
+            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
+            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_RULE);
+
+    RuleClass childRuleClass = childRuleClassBuilder.build();
+
+    assertThat(childRuleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isFalse();
+  }
+
+  @Test
+  public void testExecutionPlatformConstraints_inherit_childAllowsPerTarget() {
+    RuleClass parentRuleClass =
+        new RuleClass.Builder("$parentRuleClass", RuleClassType.ABSTRACT, false)
+            .add(attr("tags", STRING_LIST))
+            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_RULE)
+            .build();
+
+    RuleClass.Builder childRuleClassBuilder =
+        new RuleClass.Builder("childRuleClass", RuleClassType.NORMAL, false, parentRuleClass)
+            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
+            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET);
+
+    RuleClass childRuleClass = childRuleClassBuilder.build();
+
+    assertThat(childRuleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isTrue();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -25,7 +25,6 @@ import static com.google.devtools.build.lib.syntax.Type.BOOLEAN;
 import static com.google.devtools.build.lib.syntax.Type.INTEGER;
 import static com.google.devtools.build.lib.syntax.Type.STRING;
 import static com.google.devtools.build.lib.syntax.Type.STRING_LIST;
-import static com.google.devtools.build.lib.testutil.MoreAsserts.assertThrows;
 import static org.junit.Assert.fail;
 
 import com.google.common.base.Function;

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainUtilTest.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.analysis.ToolchainContext;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.rules.platform.ToolchainTestCase;
+import com.google.devtools.build.lib.skyframe.ToolchainUtil.InvalidConstraintValueException;
 import com.google.devtools.build.lib.skyframe.ToolchainUtil.InvalidPlatformException;
 import com.google.devtools.build.lib.skyframe.ToolchainUtil.ToolchainContextException;
 import com.google.devtools.build.lib.skyframe.ToolchainUtil.UnresolvedToolchainsException;
@@ -258,6 +259,82 @@ public class ToolchainUtilTest extends ToolchainTestCase {
         .contains("//invalid:not_a_platform");
   }
 
+  @Test
+  public void createToolchainContext_execConstraints() throws Exception {
+    // This should select platform linux, toolchain extra_toolchain_linux, due to extra constraints,
+    // even though platform mac is registered first.
+    addToolchain(
+        "extra",
+        "extra_toolchain_linux",
+        ImmutableList.of("//constraints:linux"),
+        ImmutableList.of("//constraints:linux"),
+        "baz");
+    addToolchain(
+        "extra",
+        "extra_toolchain_mac",
+        ImmutableList.of("//constraints:mac"),
+        ImmutableList.of("//constraints:linux"),
+        "baz");
+    rewriteWorkspace(
+        "register_toolchains('//extra:extra_toolchain_linux', '//extra:extra_toolchain_mac')",
+        "register_execution_platforms('//platforms:mac', '//platforms:linux')");
+
+    useConfiguration("--platforms=//platforms:linux");
+    CreateToolchainContextKey key =
+        CreateToolchainContextKey.create(
+            "test",
+            ImmutableSet.of(testToolchainType),
+            ImmutableSet.of(Label.parseAbsoluteUnchecked("//constraints:linux")),
+            targetConfigKey);
+
+    EvaluationResult<CreateToolchainContextValue> result = createToolchainContext(key);
+
+    assertThatEvaluationResult(result).hasNoError();
+    ToolchainContext toolchainContext = result.get(key).toolchainContext();
+    assertThat(toolchainContext).isNotNull();
+
+    assertThat(toolchainContext.getRequiredToolchains()).containsExactly(testToolchainType);
+    assertThat(toolchainContext.getResolvedToolchainLabels())
+        .containsExactly(Label.parseAbsoluteUnchecked("//extra:extra_toolchain_linux_impl"));
+
+    assertThat(toolchainContext.getExecutionPlatform()).isNotNull();
+    assertThat(toolchainContext.getExecutionPlatform().label())
+        .isEqualTo(Label.parseAbsoluteUnchecked("//platforms:linux"));
+
+    assertThat(toolchainContext.getTargetPlatform()).isNotNull();
+    assertThat(toolchainContext.getTargetPlatform().label())
+        .isEqualTo(Label.parseAbsoluteUnchecked("//platforms:linux"));
+  }
+
+  @Test
+  public void createToolchainContext_execConstraints_invalid() throws Exception {
+    CreateToolchainContextKey key =
+        CreateToolchainContextKey.create(
+            "test",
+            ImmutableSet.of(testToolchainType),
+            ImmutableSet.of(Label.parseAbsoluteUnchecked("//platforms:linux")),
+            targetConfigKey);
+
+    EvaluationResult<CreateToolchainContextValue> result = createToolchainContext(key);
+
+    assertThatEvaluationResult(result).hasError();
+    assertThatEvaluationResult(result)
+        .hasErrorEntryForKeyThat(key)
+        .hasExceptionThat()
+        .isInstanceOf(ToolchainContextException.class);
+    assertThatEvaluationResult(result)
+        .hasErrorEntryForKeyThat(key)
+        .hasExceptionThat()
+        .hasCauseThat()
+        .isInstanceOf(InvalidConstraintValueException.class);
+    assertThatEvaluationResult(result)
+        .hasErrorEntryForKeyThat(key)
+        .hasExceptionThat()
+        .hasCauseThat()
+        .hasMessageThat()
+        .contains("//platforms:linux");
+  }
+
   // Calls ToolchainUtil.createToolchainContext.
   private static final SkyFunctionName CREATE_TOOLCHAIN_CONTEXT_FUNCTION =
       SkyFunctionName.create("CREATE_TOOLCHAIN_CONTEXT_FUNCTION");
@@ -271,7 +348,9 @@ public class ToolchainUtilTest extends ToolchainTestCase {
 
     abstract String targetDescription();
 
-    abstract Set<Label> requiredToolchains();
+    abstract ImmutableSet<Label> requiredToolchains();
+
+    abstract ImmutableSet<Label> execConstraintLabels();
 
     abstract BuildConfigurationValue.Key configurationKey();
 
@@ -279,8 +358,23 @@ public class ToolchainUtilTest extends ToolchainTestCase {
         String targetDescription,
         Set<Label> requiredToolchains,
         BuildConfigurationValue.Key configurationKey) {
+      return create(
+          targetDescription,
+          requiredToolchains,
+          /* execConstraintLabels= */ ImmutableSet.of(),
+          configurationKey);
+    }
+
+    public static CreateToolchainContextKey create(
+        String targetDescription,
+        Set<Label> requiredToolchains,
+        Set<Label> execConstraintLabels,
+        BuildConfigurationValue.Key configurationKey) {
       return new AutoValue_ToolchainUtilTest_CreateToolchainContextKey(
-          targetDescription, requiredToolchains, configurationKey);
+          targetDescription,
+          ImmutableSet.copyOf(requiredToolchains),
+          ImmutableSet.copyOf(execConstraintLabels),
+          configurationKey);
     }
   }
 
@@ -325,7 +419,11 @@ public class ToolchainUtilTest extends ToolchainTestCase {
       try {
         toolchainContext =
             ToolchainUtil.createToolchainContext(
-                env, key.targetDescription(), key.requiredToolchains(), key.configurationKey());
+                env,
+                key.targetDescription(),
+                key.requiredToolchains(),
+                key.execConstraintLabels(),
+                key.configurationKey());
         if (toolchainContext == null) {
           return null;
         }


### PR DESCRIPTION
RuleClass.Builder now allows authors to specify whether a rule's targets
can add additional constraints on the execution platform, and to declare
additional constraints for all targets of that rule.

Targets which support this now have an attribute,
"exec_compatible_with", which supports specifying additional constraints
that the execution platform used must match.

This attribute is non-configurable. It will only affect execution
platforms used during toolchain resolution.

Part of #5217.

Change-Id: Id2400dbf869a00aa2be3e3d2f085c2850cd6dc00