### PR TITLE
runfiles,python: add a method to discover runfiles

### DIFF
--- a/tools/python/runfiles/runfiles.py
+++ b/tools/python/runfiles/runfiles.py
@@ -219,3 +219,34 @@ class _DirectoryBased(object):
         # pick up RUNFILES_DIR.
         "JAVA_RUNFILES": self._runfiles_root,
     }
+
+
+def _PathsFrom(argv0, runfiles_mf, runfiles_dir, is_runfiles_manifest,
+               is_runfiles_directory):
+  mfValid = is_runfiles_manifest(runfiles_mf)
+  dirValid = is_runfiles_directory(runfiles_dir)
+
+  if not mfValid and not dirValid:
+    runfiles_mf = argv0 + ".runfiles/MANIFEST"
+    runfiles_dir = argv0 + ".runfiles"
+    mfValid = is_runfiles_manifest(runfiles_mf)
+    dirValid = is_runfiles_directory(runfiles_dir)
+    if not mfValid:
+      runfiles_mf = argv0 + ".runfiles_manifest"
+      mfValid = is_runfiles_manifest(runfiles_mf)
+
+  if not mfValid and not dirValid:
+    return ("", "")
+
+  if not mfValid:
+    runfiles_mf = runfiles_dir + "/MANIFEST"
+    mfValid = is_runfiles_manifest(runfiles_mf)
+    if not mfValid:
+      runfiles_mf = runfiles_dir + "_manifest"
+      mfValid = is_runfiles_manifest(runfiles_mf)
+
+  if not dirValid:
+    runfiles_dir = runfiles_mf[:-9]  # "_manifest" or "/MANIFEST"
+    dirValid = is_runfiles_directory(runfiles_dir)
+
+  return (runfiles_mf if mfValid else "", runfiles_dir if dirValid else "")

--- a/tools/python/runfiles/runfiles_test.py
+++ b/tools/python/runfiles/runfiles_test.py
@@ -167,6 +167,96 @@ class RunfilesTest(unittest.TestCase):
     else:
       self.assertEqual(r.Rlocation("/foo"), "/foo")
 
+  def testPathsFromEnvvars(self):
+    # Both envvars have a valid value.
+    mf, dr = runfiles._PathsFrom(
+        "argv0", "mock1/MANIFEST", "mock2",
+        lambda path: path == "mock1/MANIFEST", lambda path: path == "mock2")
+    self.assertEqual(mf, "mock1/MANIFEST")
+    self.assertEqual(dr, "mock2")
+
+    # RUNFILES_MANIFEST_FILE is invalid but RUNFILES_DIR is good and there's a
+    # runfiles manifest in the runfiles directory.
+    mf, dr = runfiles._PathsFrom(
+        "argv0", "mock1/MANIFEST", "mock2",
+        lambda path: path == "mock2/MANIFEST", lambda path: path == "mock2")
+    self.assertEqual(mf, "mock2/MANIFEST")
+    self.assertEqual(dr, "mock2")
+
+    # RUNFILES_MANIFEST_FILE is invalid but RUNFILES_DIR is good, but there's no
+    # runfiles manifest in the runfiles directory.
+    mf, dr = runfiles._PathsFrom(
+        "argv0", "mock1/MANIFEST", "mock2",
+        lambda path: False, lambda path: path == "mock2")
+    self.assertEqual(mf, "")
+    self.assertEqual(dr, "mock2")
+
+    # RUNFILES_DIR is invalid but RUNFILES_MANIFEST_FILE is good, and it is in
+    # a valid-looking runfiles directory.
+    mf, dr = runfiles._PathsFrom(
+        "argv0", "mock1/MANIFEST", "mock2",
+        lambda path: path == "mock1/MANIFEST", lambda path: path == "mock1")
+    self.assertEqual(mf, "mock1/MANIFEST")
+    self.assertEqual(dr, "mock1")
+
+    # RUNFILES_DIR is invalid but RUNFILES_MANIFEST_FILE is good, but it is not
+    # in any valid-looking runfiles directory.
+    mf, dr = runfiles._PathsFrom(
+        "argv0", "mock1/MANIFEST", "mock2",
+        lambda path: path == "mock1/MANIFEST", lambda path: False)
+    self.assertEqual(mf, "mock1/MANIFEST")
+    self.assertEqual(dr, "")
+
+    # Both envvars are invalid, but there's a manifest in a runfiles directory
+    # next to argv0, however there's no other content in the runfiles directory.
+    mf, dr = runfiles._PathsFrom(
+        "argv0", "mock1/MANIFEST", "mock2",
+        lambda path: path == "argv0.runfiles/MANIFEST", lambda path: False)
+    self.assertEqual(mf, "argv0.runfiles/MANIFEST")
+    self.assertEqual(dr, "")
+
+    # Both envvars are invalid, but there's a manifest next to argv0. There's
+    # no runfiles tree anywhere.
+    mf, dr = runfiles._PathsFrom(
+        "argv0", "mock1/MANIFEST", "mock2",
+        lambda path: path == "argv0.runfiles_manifest", lambda path: False)
+    self.assertEqual(mf, "argv0.runfiles_manifest")
+    self.assertEqual(dr, "")
+
+    # Both envvars are invalid, but there's a valid manifest next to argv0, and
+    # a valid runfiles directory (without a manifest in it).
+    mf, dr = runfiles._PathsFrom(
+        "argv0", "mock1/MANIFEST", "mock2",
+        lambda path: path == "argv0.runfiles_manifest",
+        lambda path: path == "argv0.runfiles")
+    self.assertEqual(mf, "argv0.runfiles_manifest")
+    self.assertEqual(dr, "argv0.runfiles")
+
+    # Both envvars are invalid, but there's a valid runfiles directory next to
+    # argv0, though no manifest in it.
+    mf, dr = runfiles._PathsFrom(
+        "argv0", "mock1/MANIFEST", "mock2",
+        lambda path: False, lambda path: path == "argv0.runfiles")
+    self.assertEqual(mf, "")
+    self.assertEqual(dr, "argv0.runfiles")
+
+    # Both envvars are invalid, but there's a valid runfiles directory next to
+    # argv0 with a valid manifest in it.
+    mf, dr = runfiles._PathsFrom(
+        "argv0", "mock1/MANIFEST", "mock2",
+        lambda path: path == "argv0.runfiles/MANIFEST",
+        lambda path: path == "argv0.runfiles")
+    self.assertEqual(mf, "argv0.runfiles/MANIFEST")
+    self.assertEqual(dr, "argv0.runfiles")
+
+    # Both envvars are invalid and there's no runfiles directory or manifest
+    # next to the argv0.
+    mf, dr = runfiles._PathsFrom(
+        "argv0", "mock1/MANIFEST", "mock2",
+        lambda path: False, lambda path: False)
+    self.assertEqual(mf, "")
+    self.assertEqual(dr, "")
+
   @staticmethod
   def IsWindows():
     return os.name == "nt"


### PR DESCRIPTION
The new method discovers the runfiles manifest and
runfiles directory using the values of the
RUNFILES_MANIFEST_FILE and RUNFILES_DIR envvars
(if specified), and if needed, also looks for them
next to sys.argv[0].

This commit is a copy of https://github.com/bazelbuild/bazel/commit/9f2b052d93bfd188687f28fe6771f390d3626936
ported from C++ to Python.

See https://github.com/bazelbuild/bazel/issues/4460

Change-Id: I6916366ca73575703fe39ce69020eec3b54457bf