### PR TITLE
Make //src:derived_java_srcs RBE ready

### DIFF
--- a/src/combine_derived_java_srcs.sh
+++ b/src/combine_derived_java_srcs.sh
@@ -18,18 +18,14 @@ set -eu
 
 # Combine src jars to a single archive containing all the source files.
 
-
 if [[ "$1" = /* ]]; then
     JAVABASE="$1"
-    shift
-    OUTPUT="$1"
-    shift
 else
     JAVABASE="${PWD}/$1"
-    shift
-    OUTPUT="${PWD}/$1"
-    shift
 fi
+shift
+OUTPUT="${PWD}/$1"
+shift
 
 TMP_DIR=${TMPDIR:-/tmp}
 PACKAGE_DIR="$(mktemp -d ${TMP_DIR%%/}/bazel.XXXXXXXX)"

--- a/src/combine_derived_java_srcs.sh
+++ b/src/combine_derived_java_srcs.sh
@@ -18,11 +18,11 @@ set -eu
 
 # Combine src jars to a single archive containing all the source files.
 
-if [[ "$1" = /* ]]; then
-    JAVABASE="$1"
-else
-    JAVABASE="${PWD}/$1"
-fi
+
+case $1 in
+  "/"*) JAVABASE="$1" ;;
+  *) JAVABASE="${PWD}/$1" ;;
+esac
 shift
 OUTPUT="${PWD}/$1"
 shift

--- a/src/combine_derived_java_srcs.sh
+++ b/src/combine_derived_java_srcs.sh
@@ -18,10 +18,18 @@ set -eu
 
 # Combine src jars to a single archive containing all the source files.
 
-JAVABASE="${PWD}/$1"
-shift
-OUTPUT="${PWD}/$1"
-shift
+
+if [[ "$1" = /* ]]; then
+    JAVABASE="$1"
+    shift
+    OUTPUT="$1"
+    shift
+else
+    JAVABASE="${PWD}/$1"
+    shift
+    OUTPUT="${PWD}/$1"
+    shift
+fi
 
 TMP_DIR=${TMPDIR:-/tmp}
 PACKAGE_DIR="$(mktemp -d ${TMP_DIR%%/}/bazel.XXXXXXXX)"


### PR DESCRIPTION
If ${JAVABASE} is a relative path prefix it with ${PWD}
but if it's an absolute path just use that i.e. when
specified via --javabase.