### PR TITLE
[Skylark] Size newly created arrays to avoid unnecessary re-allocations.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/SkylarkList.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/SkylarkList.java
@@ -714,7 +714,7 @@ public abstract class SkylarkList<E> extends BaseMutableList<E>
     public static <T> Tuple<T> concat(Tuple<? extends T> left, Tuple<? extends T> right) {
       // Build the ImmutableList directly rather than use Iterables.concat, to avoid unnecessary
       // array resizing.
-      return create(ImmutableList.<T>builder()
+      return create(ImmutableList.<T>builderWithExpectedSize(left.size() + right.size())
           .addAll(left)
           .addAll(right)
           .build());
@@ -725,7 +725,7 @@ public abstract class SkylarkList<E> extends BaseMutableList<E>
         Object start, Object end, Object step, Location loc, Mutability mutability)
         throws EvalException {
       List<Integer> sliceIndices = EvalUtils.getSliceIndices(start, end, step, this.size(), loc);
-      ImmutableList.Builder<E> builder = ImmutableList.builder();
+      ImmutableList.Builder<E> builder = ImmutableList.builderWithExpectedSize(sliceIndices.size());
       for (int pos : sliceIndices) {
         builder.add(this.get(pos));
       }
@@ -734,7 +734,11 @@ public abstract class SkylarkList<E> extends BaseMutableList<E>
 
     @Override
     public Tuple<E> repeat(int times, Mutability mutability) {
-      ImmutableList.Builder<E> builder = ImmutableList.builder();
+      if (times <= 0) {
+        return empty();
+      }
+
+      ImmutableList.Builder<E> builder = ImmutableList.builderWithExpectedSize(this.size() * times);
       for (int i = 0; i < times; i++) {
         builder.addAll(this);
       }

--- a/src/test/java/com/google/devtools/build/lib/syntax/SkylarkListTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/SkylarkListTest.java
@@ -210,6 +210,22 @@ public class SkylarkListTest extends EvaluationTestCase {
   }
 
   @Test
+  public void testListRepeat() throws Exception {
+    assertThat(listEval("[1, 2] * -1")).isEmpty();
+    assertThat(listEval("[1, 2] * 0")).isEmpty();
+    assertThat(listEval("[1, 2] * 1")).containsExactly(1, 2).inOrder();
+    assertThat(listEval("[1, 2] * 2")).containsExactly(1, 2, 1, 2).inOrder();
+  }
+
+  @Test
+  public void testTupleRepeat() throws Exception {
+    assertThat(listEval("(1, 2) * -1")).isEmpty();
+    assertThat(listEval("(1, 2) * 0")).isEmpty();
+    assertThat(listEval("(1, 2) * 1")).containsExactly(1, 2).inOrder();
+    assertThat(listEval("(1, 2) * 2")).containsExactly(1, 2, 1, 2).inOrder();
+  }
+
+  @Test
   public void testConcatListToString() throws Exception {
     eval("l = [1, 2] + [3, 4]",
          "s = str(l)");


### PR DESCRIPTION
It's more efficient to use properly sized array builders to avoid having
a need to dynamically adjust the size of the underlying array. The result
is improved performance (no need to copy elements to newly created array)
and better memory efficiency - no need to re-allocate and no extra space
is wasted.