### PR TITLE
Add integration tests for singlejar APK builds

### DIFF
--- a/src/test/shell/bazel/android/BUILD
+++ b/src/test/shell/bazel/android/BUILD
@@ -35,6 +35,17 @@ sh_test(
 )
 
 sh_test(
+    name = "apk_integration_test",
+    size = "large",
+    srcs = ["apk_integration_test.sh"],
+    data = [
+        ":android_helper",
+        "//external:android_sdk_for_testing",
+        "//src/test/shell/bazel:test-deps",
+    ],
+)
+
+sh_test(
     name = "aar_integration_test",
     size = "large",
     srcs = ["aar_integration_test.sh"],

--- a/src/test/shell/bazel/android/apk_integration_test.sh
+++ b/src/test/shell/bazel/android/apk_integration_test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For these tests to run do the following:
+#
+#   1. Install an Android SDK from https://developer.android.com
+#   2. Set the $ANDROID_HOME environment variable
+#   3. Uncomment the line in WORKSPACE containing android_sdk_repository
+#
+# Note that if the environment is not set up as above android_integration_test
+# will silently be ignored and will be shown as passing.
+
+# Load the test setup defined in the parent directory
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${CURRENT_DIR}/android_helper.sh" \
+  || { echo "android_helper.sh not found!" >&2; exit 1; }
+fail_if_no_android_sdk
+
+source "${CURRENT_DIR}/../../integration_test_setup.sh" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+function test_build_with_singlejar() {
+  create_new_workspace
+  setup_android_sdk_support
+  create_android_binary
+
+  assert_build //java/bazel:bin --use_singlejar_apkbuilder
+}
+
+function test_build_with_legacy_apkbuilder() {
+  create_new_workspace
+  setup_android_sdk_support
+  create_android_binary
+
+  assert_build //java/bazel:bin --nouse_singlejar_apkbuilder
+}
+
+run_suite "Android integration tests"

--- a/src/test/shell/bazel/android/apk_integration_test.sh
+++ b/src/test/shell/bazel/android/apk_integration_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2015 The Bazel Authors. All rights reserved.
+# Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,4 +49,4 @@ function test_build_with_legacy_apkbuilder() {
   assert_build //java/bazel:bin --nouse_singlejar_apkbuilder
 }
 
-run_suite "Android integration tests"
+run_suite "Android APK building integration tests"


### PR DESCRIPTION
The test with `--nouse_singlejar_apkbuilder` is expected to fail.

TODO:

- [ ] fix legacy apkbuilder or deprecate/remove it from Bazel