### PR TITLE
CommandHelper: do not look up shell's path

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/CommandHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/CommandHelper.java
@@ -259,8 +259,8 @@ public final class CommandHelper {
    * Fixes up the input artifact list with the created bash script when required.
    */
   public List<String> buildCommandLine(
-      String command, NestedSetBuilder<Artifact> inputs, String scriptPostFix) {
-    return buildCommandLine(command, inputs, scriptPostFix, ImmutableMap.<String, String>of());
+      PathFragment shExecutable, String command, NestedSetBuilder<Artifact> inputs, String scriptPostFix) {
+    return buildCommandLine(shExecutable, command, inputs, scriptPostFix, ImmutableMap.<String, String>of());
   }
 
   /**
@@ -272,11 +272,11 @@ public final class CommandHelper {
    *     built.
    */
   public List<String> buildCommandLine(
-      String command, NestedSetBuilder<Artifact> inputs, String scriptPostFix,
+      PathFragment shExecutable, String command, NestedSetBuilder<Artifact> inputs, String scriptPostFix,
       Map<String, String> executionInfo) {
     Pair<List<String>, Artifact> argvAndScriptFile =
         buildCommandLineMaybeWithScriptFile(ruleContext, command, scriptPostFix,
-            shellPath(executionInfo));
+            shellPath(executionInfo, shExecutable));
     if (argvAndScriptFile.second != null) {
       inputs.add(argvAndScriptFile.second);
     }
@@ -289,10 +289,10 @@ public final class CommandHelper {
    * Fixes up the input artifact list with the created bash script when required.
    */
   public List<String> buildCommandLine(
-      String command, List<Artifact> inputs, String scriptPostFix,
+      PathFragment shExecutable, String command, List<Artifact> inputs, String scriptPostFix,
       Map<String, String> executionInfo) {
     Pair<List<String>, Artifact> argvAndScriptFile = buildCommandLineMaybeWithScriptFile(
-        ruleContext, command, scriptPostFix, shellPath(executionInfo));
+        ruleContext, command, scriptPostFix, shellPath(executionInfo, shExecutable));
     if (argvAndScriptFile.second != null) {
       inputs.add(argvAndScriptFile.second);
     }
@@ -302,10 +302,10 @@ public final class CommandHelper {
   /**
    * Returns the path to the shell for an action with the given execution requirements.
    */
-  private PathFragment shellPath(Map<String, String> executionInfo) {
+  private PathFragment shellPath(Map<String, String> executionInfo, PathFragment shExecutable) {
     // Use vanilla /bin/bash for actions running on mac machines.
     return executionInfo.containsKey(ExecutionRequirements.REQUIRES_DARWIN)
         ? PathFragment.create("/bin/bash")
-        : ShToolchain.getPathOrError(ruleContext);
+        : shExecutable;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraActionSpec.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraActionSpec.java
@@ -44,6 +44,7 @@ import java.util.Map;
  */
 @Immutable
 public final class ExtraActionSpec implements TransitiveInfoProvider {
+  private final PathFragment shExecutable;
   private final ImmutableList<Artifact> resolvedTools;
   private final RunfilesSupplier runfilesSupplier;
   private final ImmutableList<Artifact> resolvedData;
@@ -54,6 +55,7 @@ public final class ExtraActionSpec implements TransitiveInfoProvider {
   private final Label label;
 
   public ExtraActionSpec(
+      PathFragment shExecutable,
       Iterable<Artifact> resolvedTools,
       RunfilesSupplier runfilesSupplier,
       Iterable<Artifact> resolvedData,
@@ -62,6 +64,7 @@ public final class ExtraActionSpec implements TransitiveInfoProvider {
       Label label,
       Map<String, String> executionInfo,
       boolean requiresActionOutput) {
+    this.shExecutable = shExecutable;
     this.resolvedTools = ImmutableList.copyOf(resolvedTools);
     this.runfilesSupplier = runfilesSupplier;
     this.resolvedData = ImmutableList.copyOf(resolvedData);
@@ -132,7 +135,7 @@ public final class ExtraActionSpec implements TransitiveInfoProvider {
         actionToShadow.getPrimaryOutput().getExecPath().getBaseName()
             + "."
             + actionToShadow.getKey(owningRule.getActionKeyContext());
-    List<String> argv = commandHelper.buildCommandLine(command, extraActionInputs,
+    List<String> argv = commandHelper.buildCommandLine(shExecutable, command, extraActionInputs,
         "." + actionUniquifier + ".extra_action_script.sh", executionInfo);
 
     String commandMessage = String.format("Executing extra_action %s on %s", label, ownerLabel);

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleContext.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.analysis.LocationExpander;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.analysis.RunfilesProvider;
+import com.google.devtools.build.lib.analysis.ShToolchain;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.analysis.config.FragmentCollection;
@@ -1002,8 +1003,9 @@ public final class SkylarkRuleContext implements SkylarkRuleContextApi {
                 String.class,
                 String.class,
                 "execution_requirements"));
+    PathFragment shExecutable = ShToolchain.getPathOrError(ruleContext);
     List<String> argv =
-        helper.buildCommandLine(command, inputs, SCRIPT_SUFFIX, executionRequirements);
+        helper.buildCommandLine(shExecutable, command, inputs, SCRIPT_SUFFIX, executionRequirements);
     return Tuple.<Object>of(
         MutableList.copyOf(env, inputs),
         MutableList.copyOf(env, argv),

--- a/src/main/java/com/google/devtools/build/lib/rules/extra/ExtraActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/extra/ExtraActionFactory.java
@@ -27,10 +27,12 @@ import com.google.devtools.build.lib.analysis.RuleConfiguredTargetFactory;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.analysis.RunfilesProvider;
+import com.google.devtools.build.lib.analysis.ShToolchain;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget.Mode;
 import com.google.devtools.build.lib.analysis.extra.ExtraActionSpec;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.syntax.Type;
 import java.util.List;
@@ -76,7 +78,12 @@ public final class ExtraActionFactory implements RuleConfiguredTargetFactory {
     boolean requiresActionOutput =
         context.attributes().get("requires_action_output", Type.BOOLEAN);
 
+    PathFragment shExecutable = ShToolchain.getPathOrError(context);
+    if (context.hasErrors()) {
+      return null;
+    }
     ExtraActionSpec spec = new ExtraActionSpec(
+        shExecutable,
         commandHelper.getResolvedTools(),
         new CompositeRunfilesSupplier(commandHelper.getToolsRunfilesSuppliers()),
         resolvedData,

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.analysis.RuleConfiguredTargetFactory;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.analysis.RunfilesProvider;
+import com.google.devtools.build.lib.analysis.ShToolchain;
 import com.google.devtools.build.lib.analysis.TemplateVariableInfo;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget.Mode;
@@ -195,7 +196,11 @@ public abstract class GenRuleBase implements RuleConfiguredTargetFactory {
     FilesToRunProvider genruleSetup =
         ruleContext.getPrerequisite("$genrule_setup", Mode.HOST, FilesToRunProvider.class);
     inputs.addTransitive(genruleSetup.getFilesToRun());
-    List<String> argv = commandHelper.buildCommandLine(command, inputs, ".genrule_script.sh",
+    PathFragment shExecutable = ShToolchain.getPathOrError(ruleContext);
+    if (ruleContext.hasErrors()) {
+      return null;
+    }
+    List<String> argv = commandHelper.buildCommandLine(shExecutable, command, inputs, ".genrule_script.sh",
           ImmutableMap.copyOf(executionInfo));
 
     // TODO(bazel-team): Make the make variable expander pass back a list of these.


### PR DESCRIPTION
The CommandHelper no longer looks up the shell
interpreter's path itself. Instead its ctor takes
the path as an argument.

This change will allow incrementally migrating
rules that use CommandHelper to start depending on
the shell toolchain.

Shell-using rules today only use the
ShellConfiguration config fragment to look up the
shell's path. In the future, more and more rules
will also retrieve the active shell toolchain, and
be able to:

1. use the auto-detected local shell interpreter's
   location, especially when it's not the default
   /bin/bash

2. use define different shell toolchains
  (different interpreter paths) for remote builds

3. gracefully fail the build if the machine has no
   shell installed but the action graph included a
   shell action

See https://github.com/bazelbuild/bazel/issues/4319

Change-Id: I4da4e77e7d1fe57e8e4f5eb8820d03a840915e20