### PR TITLE
docs, website: remove bad `sh` from command

### DIFF
--- a/site/docs/install-compile-source.md
+++ b/site/docs/install-compile-source.md
@@ -38,7 +38,8 @@ Ensure you have installed:
 
 *   **The required MSYS2 packages.** Run the following command in the MSYS2
     shell:
-    ```sh
+
+    ```
     pacman -Syu zip unzip
     ```
 


### PR DESCRIPTION
The MarkDown engine we use for the Bazel website
renders the following MarkDown block:

  foo:
  ```sh
  bar
  ```

to HTML as:

  foo: <code>sh bar</code>

when in fact it should render it as:

  foo: <code class="sh">bar</code>

This resulted in a bad command that the users
couldn't run as it was on the website.

Change-Id: If127ca83375b4d1f8c6403fdec16bbd79498cb5d