### PR TITLE
 docs(tutorial/cpp): fix link to other tutorials

### DIFF
--- a/site/docs/tutorial/cpp.md
+++ b/site/docs/tutorial/cpp.md
@@ -408,7 +408,10 @@ Then, check out the following:
 *  The [Java build tutorial](java.md) to get started with
    building Java applications with Bazel.
 
-*  The [mobile application tutorial](app.md) to get started with
-   building mobile applications for Android and iOS with Bazel.
+*  The [android application tutorial](android-app.md) to get started with
+   building mobile applications for Android with Bazel.
+
+*  The [iOS application tutorial](ios-app.md) to get started with
+   building mobile applications for iOS with Bazel.
 
 Happy building!

--- a/site/docs/tutorial/cpp.md
+++ b/site/docs/tutorial/cpp.md
@@ -408,7 +408,7 @@ Then, check out the following:
 *  The [Java build tutorial](java.md) to get started with
    building Java applications with Bazel.
 
-*  The [android application tutorial](android-app.md) to get started with
+*  The [Android application tutorial](android-app.md) to get started with
    building mobile applications for Android with Bazel.
 
 *  The [iOS application tutorial](ios-app.md) to get started with


### PR DESCRIPTION
iOS and android now have separated tutorials, fix a dead-link in the documentation