### PR TITLE
Carry tree artifacts' self data through aggregating middlemen.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
@@ -282,13 +282,15 @@ class ArtifactFunction implements SkyFunction {
       Artifact input = ArtifactSkyKey.artifact(entry.getKey());
       SkyValue inputValue = entry.getValue();
       Preconditions.checkNotNull(inputValue, "%s has null dep %s", artifact, input);
-      if (!(inputValue instanceof FileArtifactValue)) {
+      if (inputValue instanceof FileArtifactValue) {
+        inputs.add(Pair.of(input, (FileArtifactValue) inputValue));
+      } else if (inputValue instanceof TreeArtifactValue) {
+        inputs.add(Pair.of(input, ((TreeArtifactValue) inputValue).getSelfData()));
+      } else {
         // We do not recurse in aggregating middleman artifacts.
         Preconditions.checkState(!(inputValue instanceof AggregatingArtifactValue),
             "%s %s %s", artifact, action, inputValue);
-        continue;
       }
-      inputs.add(Pair.of(input, (FileArtifactValue) inputValue));
     }
     return (action.getActionType() == MiddlemanType.AGGREGATING_MIDDLEMAN)
         ? new AggregatingArtifactValue(inputs.build(), value)

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTest.java
@@ -139,18 +139,25 @@ public class ArtifactFunctionTest extends ArtifactFunctionTestCase {
     Artifact output = createMiddlemanArtifact("output");
     Artifact input1 = createSourceArtifact("input1");
     Artifact input2 = createDerivedArtifact("input2");
+    SpecialArtifact tree = createDerivedTreeArtifactWithAction("treeArtifact");
+    file(createFakeTreeFileArtifact(tree, "child1", "hello1").getPath(), "src1");
+    file(createFakeTreeFileArtifact(tree, "child2", "hello2").getPath(), "src2");
     Action action =
         new DummyAction(
-            ImmutableList.of(input1, input2), output, MiddlemanType.AGGREGATING_MIDDLEMAN);
+            ImmutableList.of(input1, input2, tree), output, MiddlemanType.AGGREGATING_MIDDLEMAN);
     actions.add(action);
     file(input2.getPath(), "contents");
     file(input1.getPath(), "source contents");
     evaluate(
         Iterables.toArray(
-            ArtifactSkyKey.mandatoryKeys(ImmutableSet.of(input2, input1, input2)), SkyKey.class));
+            ArtifactSkyKey.mandatoryKeys(
+                ImmutableSet.of(input2, input1, input2, tree)), SkyKey.class));
     SkyValue value = evaluateArtifactValue(output);
     assertThat(((AggregatingArtifactValue) value).getInputs())
-        .containsExactly(Pair.of(input1, create(input1)), Pair.of(input2, create(input2)));
+        .containsExactly(
+            Pair.of(input1, create(input1)),
+            Pair.of(input2, create(input2)),
+            Pair.of(tree, ((TreeArtifactValue) evaluateArtifactValue(tree)).getSelfData()));
   }
 
   /**


### PR DESCRIPTION
This CL is a followup to c868c47. It is
intended to fix #5296. The immediate
problem in that issue is that remote caching finds a tree artifact in an input
runfiles tree without metadata in the cache. The metadata isn't there because
the runfiles artifacts are now all behind a middleman action, and
ArtifactFunction didn't propagate tree artifact values through middlemen. This
change fixes the problem by adding a tree artifact's self data value to the
values carried through to dependent actions.

Remote caching with tree artifact inputs seems to have been working mostly by
accident. (Evidence: it wasn't tested, and remote execution of actions with tree
artifact inputs results a Java traceback before and after
c868c47.) This CL is only really a bandaid to
return to the old "working" state. If remote execution wants to start supporting
tree artifacts properly in the future, we'll likely need to carry the tree
artifact child data through middleman actions, too.