### PR TITLE
Add flag to skip early base extraction

### DIFF
--- a/scripts/packages/template_bin.sh
+++ b/scripts/packages/template_bin.sh
@@ -43,12 +43,15 @@ usage() {
   echo "  --base= set the base install path (default=%prefix%/lib/bazel)." >&2
   echo "  --user configure for user install, expands to:" >&2
   echo '      --bin=$HOME/bin --base=$HOME/.bazel' >&2
+  echo "  --skip-uncompress skip uncompressing the base image until the" >&2
+  echo "      first bazel invocation" >&2
   exit 1
 }
 
 prefix="/usr/local"
 bin="%prefix%/bin"
 base="%prefix%/lib/bazel"
+should_uncompress=true
 
 for opt in "${@}"; do
   case $opt in
@@ -64,6 +67,9 @@ for opt in "${@}"; do
     --user)
       bin="$HOME/bin"
       base="$HOME/.bazel"
+      ;;
+    --skip-uncompress)
+      should_uncompress=false
       ;;
     *)
       usage
@@ -158,7 +164,7 @@ echo -n .
 ln -s "${base}/bin/bazel" "${bin}/bazel"
 echo -n .
 
-if [ "${UID}" -ne 0 ]; then
+if [ "$should_uncompress" = true ] && [ "${UID}" -ne 0 ]; then
   # Uncompress the bazel base install for faster startup time
   "${bin}/bazel" help >/dev/null
 fi


### PR DESCRIPTION
This adds a flag to the installer to skip uncompressing the base image during installation.

Uncompressing the base image during installation can be problematic:
1. If you configure the startup option `output_user_root` you'll wind up extracting the image twice. Once during installation and a second time during the first bazel invocation in your project.
2. If you're bootstrapping Bazel in a controlled environment (in my case via Nix) then you can get permission errors if Bazel defaults to extracting to the home directory. There's no way to skip this extraction and for the time being I have resorted to seting `HOME` to a throw away directory during install.