### PR TITLE
Replace varnames with Identifiers.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkModules.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkModules.java
@@ -20,6 +20,7 @@ import com.google.devtools.build.lib.packages.BazelLibrary;
 import com.google.devtools.build.lib.packages.SkylarkNativeModule;
 import com.google.devtools.build.lib.packages.StructProvider;
 import com.google.devtools.build.lib.skylarkbuildapi.TopLevelBootstrap;
+import com.google.devtools.build.lib.syntax.Identifier;
 
 /**
  * The basis for a Skylark Environment with all build-related modules registered.
@@ -43,7 +44,7 @@ public final class SkylarkModules {
    * Adds bindings for skylark built-ins and non-rules-specific globals of the build API to
    * the given environment map builder.
    */
-  public static void addSkylarkGlobalsToBuilder(ImmutableMap.Builder<String, Object> envBuilder) {
+  public static void addSkylarkGlobalsToBuilder(ImmutableMap.Builder<Identifier, Object> envBuilder) {
     BazelLibrary.addSkylarkGlobalsToBuilder(envBuilder);
     topLevelBootstrap.addBindingsToBuilder(envBuilder);
   }

--- a/src/main/java/com/google/devtools/build/lib/packages/BazelLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BazelLibrary.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.syntax.BuiltinFunction;
 import com.google.devtools.build.lib.syntax.Environment.GlobalFrame;
 import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.EvalUtils;
+import com.google.devtools.build.lib.syntax.Identifier;
 import com.google.devtools.build.lib.syntax.MethodLibrary;
 import com.google.devtools.build.lib.syntax.Runtime;
 import com.google.devtools.build.lib.syntax.SelectorList;
@@ -221,9 +222,9 @@ public class BazelLibrary {
       };
 
   /** Adds bindings for all the builtin functions of this class to the given map builder. */
-  public static void addBindingsToBuilder(ImmutableMap.Builder<String, Object> builder) {
+  public static void addBindingsToBuilder(ImmutableMap.Builder<Identifier, Object> builder) {
     for (BaseFunction function : allFunctions) {
-      builder.put(function.getName(), function);
+      builder.put(Identifier.of(function.getName()), function);
     }
   }
 
@@ -234,7 +235,7 @@ public class BazelLibrary {
   public static final GlobalFrame GLOBALS = createGlobals();
 
   private static GlobalFrame createGlobals() {
-    ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+    ImmutableMap.Builder<Identifier, Object> builder = ImmutableMap.builder();
     addSkylarkGlobalsToBuilder(builder);
     return GlobalFrame.createForBuiltins(builder.build());
   }
@@ -242,7 +243,7 @@ public class BazelLibrary {
   /**
    * Adds bindings for skylark built-ins to the given environment map builder.
    */
-  public static void addSkylarkGlobalsToBuilder(ImmutableMap.Builder<String, Object> envBuilder) {
+  public static void addSkylarkGlobalsToBuilder(ImmutableMap.Builder<Identifier, Object> envBuilder) {
     Runtime.addConstantsToBuilder(envBuilder);
     MethodLibrary.addBindingsToBuilder(envBuilder);
     BazelLibrary.addBindingsToBuilder(envBuilder);

--- a/src/main/java/com/google/devtools/build/lib/packages/PackageFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/PackageFactory.java
@@ -49,6 +49,7 @@ import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.EvalUtils;
 import com.google.devtools.build.lib.syntax.FuncallExpression;
 import com.google.devtools.build.lib.syntax.FunctionSignature;
+import com.google.devtools.build.lib.syntax.Identifier;
 import com.google.devtools.build.lib.syntax.Mutability;
 import com.google.devtools.build.lib.syntax.ParserInputSource;
 import com.google.devtools.build.lib.syntax.Runtime;
@@ -260,7 +261,7 @@ public final class PackageFactory {
     }
   }
 
-  public static final String PKG_CONTEXT = "$pkg_context";
+  public static final Identifier PKG_CONTEXT = Identifier.of("$pkg_context");
 
   // Used outside of Bazel!
   /** {@link Globber} that uses the legacy GlobCache. */
@@ -1541,19 +1542,19 @@ public final class PackageFactory {
           exception);
     }
     pkgEnv
-        .setup("native", nativeModule)
-        .setup("distribs", newDistribsFunction.apply(context))
-        .setup("glob", newGlobFunction.apply(context))
-        .setup("licenses", newLicensesFunction.apply(context))
-        .setup("exports_files", newExportsFilesFunction.apply())
-        .setup("package_group", newPackageGroupFunction.apply())
-        .setup("package", newPackageFunction(packageArguments))
-        .setup("package_name", packageNameFunction)
-        .setup("repository_name", repositoryNameFunction)
-        .setup("environment_group", newEnvironmentGroupFunction.apply(context));
+        .setup(Identifier.of("native"), nativeModule)
+        .setup(Identifier.of("distribs"), newDistribsFunction.apply(context))
+        .setup(Identifier.of("glob"), newGlobFunction.apply(context))
+        .setup(Identifier.of("licenses"), newLicensesFunction.apply(context))
+        .setup(Identifier.of("exports_files"), newExportsFilesFunction.apply())
+        .setup(Identifier.of("package_group"), newPackageGroupFunction.apply())
+        .setup(Identifier.of("package"), newPackageFunction(packageArguments))
+        .setup(Identifier.of("package_name"), packageNameFunction)
+        .setup(Identifier.of("repository_name"), repositoryNameFunction)
+        .setup(Identifier.of("environment_group"), newEnvironmentGroupFunction.apply(context));
 
     for (Map.Entry<String, BuiltinRuleFunction> entry : ruleFunctions.entrySet()) {
-      pkgEnv.setup(entry.getKey(), entry.getValue());
+      pkgEnv.setup(Identifier.of(entry.getKey()), entry.getValue());
     }
 
     for (EnvironmentExtension extension : environmentExtensions) {

--- a/src/main/java/com/google/devtools/build/lib/packages/WorkspaceFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/WorkspaceFactory.java
@@ -44,6 +44,7 @@ import com.google.devtools.build.lib.syntax.Environment.Phase;
 import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.FuncallExpression;
 import com.google.devtools.build.lib.syntax.FunctionSignature;
+import com.google.devtools.build.lib.syntax.Identifier;
 import com.google.devtools.build.lib.syntax.Mutability;
 import com.google.devtools.build.lib.syntax.ParserInputSource;
 import com.google.devtools.build.lib.syntax.Runtime.NoneType;
@@ -74,7 +75,7 @@ public class WorkspaceFactory {
           "__workspace_dir__", // serializable so optional
           "DEFAULT_SERVER_JAVABASE", // serializable so optional
           "DEFAULT_SYSTEM_JAVABASE", // serializable so optional
-          PackageFactory.PKG_CONTEXT);
+          PackageFactory.PKG_CONTEXT.getName());
 
   private final Package.Builder builder;
 
@@ -233,10 +234,10 @@ public class WorkspaceFactory {
     // each workspace file.
     ImmutableMap.Builder<String, Object> bindingsBuilder = ImmutableMap.builder();
     GlobalFrame globals = workspaceEnv.getGlobals();
-    for (String s : globals.getBindings().keySet()) {
+    for (Identifier s : globals.getBindings().keySet()) {
       Object o = globals.get(s);
-      if (!isAWorkspaceFunction(s, o)) {
-        bindingsBuilder.put(s, o);
+      if (!isAWorkspaceFunction(s.getName(), o)) {
+        bindingsBuilder.put(s.getName(), o);
       }
     }
     variableBindings = bindingsBuilder.build();
@@ -554,7 +555,7 @@ public class WorkspaceFactory {
 
   private void addWorkspaceFunctions(Environment workspaceEnv, StoredEventHandler localReporter) {
     try {
-      workspaceEnv.setup("workspace", newWorkspaceFunction.apply(allowOverride, ruleFactory));
+      workspaceEnv.setup(Identifier.of("workspace"), newWorkspaceFunction.apply(allowOverride, ruleFactory));
       for (Map.Entry<String, BaseFunction> function : workspaceFunctions.entrySet()) {
         workspaceEnv.update(function.getKey(), function.getValue());
       }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
@@ -69,6 +69,7 @@ import com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.Dependenc
 import com.google.devtools.build.lib.skyframe.SkyframeExecutor.BuildViewProvider;
 import com.google.devtools.build.lib.skyframe.SkylarkImportLookupFunction.SkylarkImportFailedException;
 import com.google.devtools.build.lib.skyframe.ToolchainUtil.ToolchainContextException;
+import com.google.devtools.build.lib.syntax.Identifier;
 import com.google.devtools.build.lib.syntax.Type.ConversionException;
 import com.google.devtools.build.lib.util.OrderedSetMultimap;
 import com.google.devtools.build.skyframe.SkyFunction;
@@ -191,7 +192,7 @@ public final class AspectFunction implements SkyFunction {
       }
 
       Object skylarkValue = skylarkImportLookupValue.getEnvironmentExtension().getBindings()
-          .get(skylarkValueName);
+          .get(Identifier.of(skylarkValueName));
       if (skylarkValue == null) {
         throw new ConversionException(
             String.format(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkylarkImportLookupFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkylarkImportLookupFunction.java
@@ -476,7 +476,7 @@ public class SkylarkImportLookupFunction implements SkyFunction {
               .createSkylarkRuleClassEnvironment(
                   extensionLabel, mutability, skylarkSemantics,
                   eventHandler, ast.getContentHashCode(), importMap);
-      extensionEnv.setupOverride("native", packageFactory.getNativeModule(inWorkspace));
+      extensionEnv.setupOverride(Identifier.of("native"), packageFactory.getNativeModule(inWorkspace));
       execAndExport(ast, extensionLabel, eventHandler, extensionEnv);
 
       Event.replayEventsOn(env.getListener(), eventHandler.getEvents());
@@ -509,7 +509,7 @@ public class SkylarkImportLookupFunction implements SkyFunction {
     AssignmentStatement assignmentStatement = (AssignmentStatement) statement;
     ImmutableSet<Identifier> boundIdentifiers = assignmentStatement.getLValue().boundIdentifiers();
     for (Identifier ident : boundIdentifiers) {
-      Object lookup = extensionEnv.lookup(ident.getName());
+      Object lookup = extensionEnv.lookup(ident);
       if (lookup instanceof SkylarkExportable) {
         try {
           SkylarkExportable exportable = (SkylarkExportable) lookup;

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/Bootstrap.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/Bootstrap.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.skylarkbuildapi;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.syntax.Identifier;
 
 /**
  * A helper for registering a portion of the build API to skylark environment globals.
@@ -27,5 +28,5 @@ public interface Bootstrap {
   /**
    * Adds this bootstrap's bindings to the given environment map builder.
    */
-  public void addBindingsToBuilder(ImmutableMap.Builder<String, Object> builder);
+  public void addBindingsToBuilder(ImmutableMap.Builder<Identifier, Object> builder);
 }

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/TopLevelBootstrap.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/TopLevelBootstrap.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.skylarkbuildapi;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.skylarkbuildapi.OutputGroupInfoApi.OutputGroupInfoApiProvider;
+import com.google.devtools.build.lib.syntax.Identifier;
 import com.google.devtools.build.lib.syntax.Runtime;
 
 /**
@@ -48,13 +49,13 @@ public class TopLevelBootstrap implements Bootstrap {
   }
 
   @Override
-  public void addBindingsToBuilder(ImmutableMap.Builder<String, Object> builder) {
+  public void addBindingsToBuilder(ImmutableMap.Builder<Identifier, Object> builder) {
     Runtime.setupModuleGlobals(builder, skylarkAttrApi);
     Runtime.setupModuleGlobals(builder, skylarkBuildApiGlobals);
     Runtime.setupModuleGlobals(builder, skylarkCommandLineApi);
     Runtime.setupModuleGlobals(builder, skylarkNativeModuleApi);
     Runtime.setupModuleGlobals(builder, skylarkRuleFunctionsApi);
-    builder.put("struct", structProvider);
-    builder.put("OutputGroupInfo", outputGroupInfoProvider);
+    builder.put(Identifier.of("struct"), structProvider);
+    builder.put(Identifier.of("OutputGroupInfo"), outputGroupInfoProvider);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/config/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/config/BUILD
@@ -20,6 +20,7 @@ java_library(
     srcs = glob(["*.java"]),
     deps = [
         "//src/main/java/com/google/devtools/build/lib:skylarkinterface",
+        "//src/main/java/com/google/devtools/build/lib:syntax",
         "//src/main/java/com/google/devtools/build/lib/skylarkbuildapi",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/config/ConfigBootstrap.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/config/ConfigBootstrap.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.skylarkbuildapi.config;
 
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.devtools.build.lib.skylarkbuildapi.Bootstrap;
+import com.google.devtools.build.lib.syntax.Identifier;
 
 /**
  * A {@link Bootstrap} for config-related libraries of the build API.
@@ -29,7 +30,7 @@ public class ConfigBootstrap implements Bootstrap {
   }
 
   @Override
-  public void addBindingsToBuilder(Builder<String, Object> builder) {
-    builder.put("config_common", configSkylarkCommonApi);
+  public void addBindingsToBuilder(Builder<Identifier, Object> builder) {
+    builder.put(Identifier.of("config_common"), configSkylarkCommonApi);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebugEventHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebugEventHelper.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.skylarkdebugging.SkylarkDebuggingProtos.Thr
 import com.google.devtools.build.lib.skylarkdebugging.SkylarkDebuggingProtos.Value;
 import com.google.devtools.build.lib.syntax.DebugFrame;
 import com.google.devtools.build.lib.syntax.Debuggable.Stepping;
+import com.google.devtools.build.lib.syntax.Identifier;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -167,18 +168,18 @@ final class DebugEventHelper {
   }
 
   private static ImmutableList<Scope> getScopes(DebugFrame frame) {
-    ImmutableMap<String, Object> localVars = frame.lexicalFrameBindings();
+    ImmutableMap<Identifier, Object> localVars = frame.lexicalFrameBindings();
     if (localVars.isEmpty()) {
       return ImmutableList.of(getScope("global", frame.globalBindings()));
     }
-    Map<String, Object> globalVars = new LinkedHashMap<>(frame.globalBindings());
+    Map<Identifier, Object> globalVars = new LinkedHashMap<>(frame.globalBindings());
     // remove shadowed bindings
     localVars.keySet().forEach(globalVars::remove);
 
     return ImmutableList.of(getScope("local", localVars), getScope("global", globalVars));
   }
 
-  private static SkylarkDebuggingProtos.Scope getScope(String name, Map<String, Object> bindings) {
+  private static SkylarkDebuggingProtos.Scope getScope(String name, Map<Identifier, Object> bindings) {
     SkylarkDebuggingProtos.Scope.Builder builder =
         SkylarkDebuggingProtos.Scope.newBuilder().setName(name);
     bindings.forEach((s, o) -> builder.addBinding(DebuggerSerialization.getValueProto(s, o)));

--- a/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebuggerSerialization.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebuggerSerialization.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.skylarkdebugging.SkylarkDebuggingProtos.Val
 import com.google.devtools.build.lib.syntax.ClassObject;
 import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.EvalUtils;
+import com.google.devtools.build.lib.syntax.Identifier;
 import com.google.devtools.build.lib.syntax.Printer;
 import com.google.devtools.build.lib.syntax.SkylarkNestedSet;
 import java.lang.reflect.Array;
@@ -30,6 +31,12 @@ import java.util.Map;
 /** Helper class for creating {@link SkylarkDebuggingProtos.Value} from skylark objects. */
 final class DebuggerSerialization {
 
+  static Value getValueProto(Identifier identifier, Object value) {
+    return getValueProto(identifier.getName(), value);
+  }
+
+  /** @deprecated Use {@link #getValueProto(Identifier, Object)} instead. */
+  @Deprecated
   static Value getValueProto(String label, Object value) {
     // TODO(bazel-team): prune cycles, and provide a way to limit breadth/depth of children reported
     return Value.newBuilder()

--- a/src/main/java/com/google/devtools/build/lib/syntax/AbstractComprehension.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/AbstractComprehension.java
@@ -287,7 +287,7 @@ public abstract class AbstractComprehension extends Expression {
       LValue lvalue = clause.getLValue();
       if (lvalue != null) {
         for (Identifier ident : lvalue.boundIdentifiers()) {
-          env.removeLocalBinding(ident.getName());
+          env.removeLocalBinding(ident);
         }
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/syntax/DebugFrame.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/DebugFrame.java
@@ -33,10 +33,10 @@ public abstract class DebugFrame {
    * The local bindings associated with the current lexical frame. For the outer-most scope this
    * will be empty.
    */
-  public abstract ImmutableMap<String, Object> lexicalFrameBindings();
+  public abstract ImmutableMap<Identifier, Object> lexicalFrameBindings();
 
   /** The global vars and builtins for this frame. May be shadowed by the lexical frame bindings. */
-  public abstract ImmutableMap<String, Object> globalBindings();
+  public abstract ImmutableMap<Identifier, Object> globalBindings();
 
   public static Builder builder() {
     return new AutoValue_DebugFrame.Builder().setLexicalFrameBindings(ImmutableMap.of());
@@ -49,9 +49,9 @@ public abstract class DebugFrame {
 
     public abstract Builder setFunctionName(String functionName);
 
-    public abstract Builder setLexicalFrameBindings(ImmutableMap<String, Object> bindings);
+    public abstract Builder setLexicalFrameBindings(ImmutableMap<Identifier, Object> bindings);
 
-    public abstract Builder setGlobalBindings(ImmutableMap<String, Object> bindings);
+    public abstract Builder setGlobalBindings(ImmutableMap<Identifier, Object> bindings);
 
     public abstract DebugFrame build();
   }

--- a/src/main/java/com/google/devtools/build/lib/syntax/Eval.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Eval.java
@@ -157,7 +157,7 @@ public class Eval {
         }
         // The key is the original name that was used to define the symbol
         // in the loaded bzl file.
-        env.importSymbol(node.getImport().getValue(), name, declared.getName());
+        env.importSymbol(node.getImport().getValue(), name, declared);
       } catch (Environment.LoadFailedException e) {
         throw new EvalException(node.getLocation(), e.getMessage());
       }

--- a/src/main/java/com/google/devtools/build/lib/syntax/Identifier.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Identifier.java
@@ -73,7 +73,7 @@ public final class Identifier extends Expression {
 
   @Override
   Object doEval(Environment env) throws EvalException {
-    Object value = env.lookup(name);
+    Object value = env.lookup(this);
     if (value == null) {
       throw createInvalidIdentifierException(env.getVariableNames());
     }

--- a/src/main/java/com/google/devtools/build/lib/syntax/LValue.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/LValue.java
@@ -98,7 +98,7 @@ public final class LValue extends ASTNode {
       throws EvalException {
     Preconditions.checkNotNull(value, "trying to assign null to %s", ident);
 
-    if (env.isKnownGlobalVariable(ident.getName())) {
+    if (env.isKnownGlobalVariable(ident)) {
       throw new EvalException(
           loc,
           String.format(

--- a/src/main/java/com/google/devtools/build/lib/syntax/MethodLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/MethodLibrary.java
@@ -939,9 +939,9 @@ public class MethodLibrary {
   public static final class BoolModule {}
 
   /** Adds bindings for all the builtin functions of this class to the given map builder. */
-  public static void addBindingsToBuilder(ImmutableMap.Builder<String, Object> builder) {
+  public static void addBindingsToBuilder(ImmutableMap.Builder<Identifier, Object> builder) {
     for (BaseFunction function : allFunctions) {
-      builder.put(function.getName(), function);
+      builder.put(Identifier.of(function.getName()), function);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/syntax/SkylarkUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/SkylarkUtils.java
@@ -26,7 +26,7 @@ public final class SkylarkUtils {
     Object lipoDataTransition;
   }
 
-  private static final String BAZEL_INFO_KEY = "$bazel";
+  private static final Identifier BAZEL_INFO_KEY = Identifier.of("$bazel");
 
   private static BazelInfo getInfo(Environment env) {
     Object info = env.lookup(BAZEL_INFO_KEY);

--- a/src/test/java/com/google/devtools/build/lib/skylark/util/SkylarkTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/skylark/util/SkylarkTestCase.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.syntax.Environment;
 import com.google.devtools.build.lib.syntax.Environment.GlobalFrame;
 import com.google.devtools.build.lib.syntax.Environment.Phase;
 import com.google.devtools.build.lib.syntax.EvalException;
+import com.google.devtools.build.lib.syntax.Identifier;
 import com.google.devtools.build.lib.syntax.Runtime;
 import com.google.devtools.build.lib.syntax.SkylarkSemantics;
 import com.google.devtools.build.lib.syntax.SkylarkUtils;
@@ -55,7 +56,7 @@ public abstract class SkylarkTestCase extends BuildViewTestCase {
   }
 
   private static final Environment.GlobalFrame getSkylarkGlobals() {
-    ImmutableMap.Builder<String, Object> envBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<Identifier, Object> envBuilder = ImmutableMap.builder();
 
     SkylarkModules.addSkylarkGlobalsToBuilder(envBuilder);
     Runtime.setupModuleGlobals(envBuilder, PlatformCommon.class);

--- a/src/test/java/com/google/devtools/build/lib/syntax/BuildFileASTTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/BuildFileASTTest.java
@@ -64,7 +64,7 @@ public class BuildFileASTTest extends EvaluationTestCase {
     //
     // input1.BUILD contains:
     // x = [1,2,'foo',4] + [1,2, "%s%d" % ('foo', 1)]
-    assertThat(env.lookup("x"))
+    assertThat(env.lookup(Identifier.of("x")))
         .isEqualTo(SkylarkList.createImmutable(Tuple.of(1, 2, "foo", 4, 1, 2, "foo1")));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/syntax/EnvironmentDebuggingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/EnvironmentDebuggingTest.java
@@ -64,7 +64,11 @@ public class EnvironmentDebuggingTest {
             DebugFrame.builder()
                 .setFunctionName("<top level>")
                 .setLocation(Location.BUILTIN)
-                .setGlobalBindings(ImmutableMap.of("a", 1, "b", 2, "c", 3))
+                .setGlobalBindings(
+                    ImmutableMap.of(
+                        Identifier.of("a"), 1,
+                        Identifier.of("b"), 2,
+                        Identifier.of("c"), 3))
                 .build());
   }
 
@@ -90,15 +94,19 @@ public class EnvironmentDebuggingTest {
             DebugFrame.builder()
                 .setFunctionName("function")
                 .setLocation(Location.BUILTIN)
-                .setLexicalFrameBindings(ImmutableMap.of("a", 4, "y", 5, "z", 6))
-                .setGlobalBindings(ImmutableMap.of("a", 1, "b", 2, "c", 3))
+                .setLexicalFrameBindings(ImmutableMap.of(Identifier.of("a"), 4, Identifier.of("y"), 5, Identifier.of("z"), 6))
+                .setGlobalBindings(
+                    ImmutableMap.of(
+                        Identifier.of("a"), 1, Identifier.of("b"), 2, Identifier.of("c"), 3))
                 .build());
     assertThat(frames.get(1))
         .isEqualTo(
             DebugFrame.builder()
                 .setFunctionName("<top level>")
                 .setLocation(funcallLocation)
-                .setGlobalBindings(ImmutableMap.of("a", 1, "b", 2, "c", 3))
+                .setGlobalBindings(
+                    ImmutableMap.of(
+                        Identifier.of("a"), 1, Identifier.of("b"), 2, Identifier.of("c"), 3))
                 .build());
   }
 

--- a/src/test/java/com/google/devtools/build/lib/syntax/EnvironmentTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/EnvironmentTest.java
@@ -47,9 +47,9 @@ public class EnvironmentTest extends EvaluationTestCase {
 
   @Test
   public void testHasVariable() throws Exception {
-    assertThat(getEnvironment().hasVariable("VERSION")).isFalse();
+    assertThat(getEnvironment().hasVariable(Identifier.of("VERSION"))).isFalse();
     update("VERSION", 42);
-    assertThat(getEnvironment().hasVariable("VERSION")).isTrue();
+    assertThat(getEnvironment().hasVariable(Identifier.of("VERSION"))).isTrue();
   }
 
   @Test
@@ -221,12 +221,12 @@ public class EnvironmentTest extends EvaluationTestCase {
               .setEventHandler(Environment.FAIL_FAST_HANDLER)
               .build();
       env.update("x", 1);
-      assertThat(env.lookup("x")).isEqualTo(1);
-      env.update("y", 2);
-      assertThat(env.lookup("y")).isEqualTo(2);
-      assertThat(env.lookup("x")).isEqualTo(1);
-      env.update("x", 3);
-      assertThat(env.lookup("x")).isEqualTo(3);
+      assertThat(env.lookup(Identifier.of("x"))).isEqualTo(1);
+      env.update(Identifier.of("y"), 2);
+      assertThat(env.lookup(Identifier.of("y"))).isEqualTo(2);
+      assertThat(env.lookup(Identifier.of("x"))).isEqualTo(1);
+      env.update(Identifier.of("x"), 3);
+      assertThat(env.lookup(Identifier.of("x"))).isEqualTo(3);
     }
     try {
       // This update to an existing variable should fail because the environment was frozen.
@@ -247,8 +247,8 @@ public class EnvironmentTest extends EvaluationTestCase {
   @Test
   public void testReadOnly() throws Exception {
     Environment env = newSkylarkEnvironment()
-        .setup("special_var", 42)
-        .update("global_var", 666);
+        .setup(Identifier.of("special_var"), 42)
+        .update(Identifier.of("global_var"), 666);
 
     // We don't even get a runtime exception trying to modify these,
     // because we get compile-time exceptions even before we reach runtime!
@@ -296,7 +296,14 @@ public class EnvironmentTest extends EvaluationTestCase {
     assertThat(env.getVariableNames())
         .containsExactly("a", "c", "b", "x", "z", "y").inOrder();
     assertThat(env.getGlobals().getTransitiveBindings())
-        .containsExactly("a", 1, "c", 2, "b", 3, "x", 4, "z", 5, "y", 6).inOrder();
+        .containsExactly(
+            Identifier.of("a"), 1,
+            Identifier.of("c"), 2,
+            Identifier.of("b"), 3,
+            Identifier.of("x"), 4,
+            Identifier.of("z"), 5,
+            Identifier.of("y"), 6)
+        .inOrder();
   }
 
   @Test
@@ -338,16 +345,26 @@ public class EnvironmentTest extends EvaluationTestCase {
   @Test
   public void testExtensionEqualityDebugging_DifferentBindings() {
     assertCheckStateFailsWithMessage(
-        new Extension(ImmutableMap.of("w", 1, "x", 2, "y", 3), "abc"),
-        new Extension(ImmutableMap.of("y", 3, "z", 4), "abc"),
+        new Extension(ImmutableMap.of(Identifier.of("w"), 1, Identifier.of("x"), 2, Identifier.of("y"), 3), "abc"),
+        new Extension(ImmutableMap.of(Identifier.of("y"), 3, Identifier.of("z"), 4), "abc"),
         "in this one but not given one: [w, x]; in given one but not this one: [z]");
   }
 
   @Test
   public void testExtensionEqualityDebugging_DifferentValues() {
     assertCheckStateFailsWithMessage(
-        new Extension(ImmutableMap.of("x", 1, "y", "foo", "z", true), "abc"),
-        new Extension(ImmutableMap.of("x", 2.0, "y", "foo", "z", false), "abc"),
+        new Extension(
+            ImmutableMap.of(
+                Identifier.of("x"), 1,
+                Identifier.of("y"), "foo",
+                Identifier.of("z"), true),
+            "abc"),
+        new Extension(
+            ImmutableMap.of(
+                Identifier.of("x"), 2.0,
+                Identifier.of("y"), "foo",
+                Identifier.of("z"), false),
+            "abc"),
         "bindings are unequal: x: this one has 1 (class java.lang.Integer, 1), but given one has "
             + "2.0 (class java.lang.Double, 2.0); z: this one has True (class java.lang.Boolean, "
             + "true), but given one has False (class java.lang.Boolean, false)");

--- a/src/test/java/com/google/devtools/build/lib/syntax/util/EvaluationTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/util/EvaluationTestCase.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.syntax.Environment.FailFastException;
 import com.google.devtools.build.lib.syntax.Environment.Phase;
 import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.Expression;
+import com.google.devtools.build.lib.syntax.Identifier;
 import com.google.devtools.build.lib.syntax.Mutability;
 import com.google.devtools.build.lib.syntax.Parser;
 import com.google.devtools.build.lib.syntax.ParserInputSource;
@@ -166,8 +167,12 @@ public class EvaluationTestCase {
     return this;
   }
 
-  public Object lookup(String varname) throws Exception {
-    return env.lookup(varname);
+  public Object lookup(Identifier identifier) {
+    return env.lookup(identifier);
+  }
+
+  public Object lookup(String varname) {
+    return env.lookup(Identifier.of(varname));
   }
 
   public Object eval(String... input) throws Exception {


### PR DESCRIPTION
This builds on top of #5304 and replaces varnames with `Identifier` instances to
make the API cleaner, but more importantly open up new possibilities for optimizations
around ways to perform lookups.