### PR TITLE
Fix dependencies of //src/tools/singlejar:desugar_checking.

### DIFF
--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -334,6 +334,7 @@ cc_library(
     srcs = ["desugar_checking.cc"],
     hdrs = ["desugar_checking.h"],
     deps = [
+        "//src/main/protobuf:desugar_deps_cc_proto",
         ":combiners",
     ],
 )


### PR DESCRIPTION
This fixes the following compilation error:
```
ERROR: src/tools/singlejar/BUILD:332:1: C++ compilation of rule '//src/tools/singlejar:desugar_checking' failed (Exit 1)
src/tools/singlejar/desugar_checking.cc:17:10: fatal error: src/main/protobuf/desugar_deps.pb.h: No such file or directory
 #include "src/main/protobuf/desugar_deps.pb.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated
```