### PR TITLE
update bazel's embedded jdk to jdk9

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,31 +117,31 @@ distdir_tar(
 # OpenJDK distributions used to create a version of Bazel bundled with the OpenJDK.
 http_file(
     name = "openjdk_linux",
-    sha256 = "85b81652b3fe8cfb0a2cfb835988672bde7844f613dae5b9487b5b44921a1afd",
+    sha256 = "45f2dfbee93b91b1468cf81d843fc6d9a47fef1f831c0b7ceff4f1eb6e6851c8",
     urls = [
-        "https://mirror.bazel.build/openjdk/azul-zulu-8.28.0.1-jdk8.0.163/zulu8.28.0.1-jdk8.0.163-linux_x64.tar.gz",
-        "https://bazel-mirror.storage.googleapis.com/openjdk/azul-zulu-8.28.0.1-jdk8.0.163/zulu8.28.0.1-jdk8.0.163-linux_x64.tar.gz",
-        "https://cdn.azul.com/zulu/bin/zulu8.28.0.1-jdk8.0.163-linux_x64.tar.gz",
+        "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64.tar.gz",
+        "https://bazel-mirror.storage.googleapis.com/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu9.0.7.1-jdk9.0.7-linux_x64.tar.gz",
     ],
 )
 
 http_file(
     name = "openjdk_macos",
-    sha256 = "292a44695e708a8822b3d0a462faf32887ddb80b56aa91e7598fd4b6f6341f69",
+    sha256 = "5a5b3225b86d3fdb51e9add5335f43cc19c6b2d9b8b5558e72b52d7b2ce9162e",
     urls = [
-        "https://mirror.bazel.build/openjdk/azul-zulu-8.28.0.1-jdk8.0.163/zulu8.28.0.1-jdk8.0.163-macosx_x64.tar.gz",
-        "https://bazel-mirror.storage.googleapis.com/openjdk/azul-zulu-8.28.0.1-jdk8.0.163/zulu8.28.0.1-jdk8.0.163-macosx_x64.tar.gz",
-        "https://cdn.azul.com/zulu/bin/zulu8.28.0.1-jdk8.0.163-macosx_x64.tar.gz",
+        "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-macosx_x64.tar.gz",
+        "https://bazel-mirror.storage.googleapis.com/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-macosx_x64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu9.0.7.1-jdk9.0.7-macosx_x64.tar.gz",
     ],
 )
 
 http_file(
     name = "openjdk_win",
-    sha256 = "0c5ea3634ae7d7851630cf61fdd6344cce110cf9246593345e49fc430bb39442",
+    sha256 = "75f76c53c6a1f12b1a571b86bd9708ab75adf582d689dddc94fdd77dcc0f3f5c",
     urls = [
-        "https://mirror.bazel.build/openjdk/azul-zulu-8.28.0.1-jdk8.0.163/zulu8.28.0.1-jdk8.0.163-win_x64.zip",
-        "https://bazel-mirror.storage.googleapis.com/openjdk/azul-zulu-8.28.0.1-jdk8.0.163/zulu8.28.0.1-jdk8.0.163-win_x64.zip",
-        "https://cdn.azul.com/zulu/bin/zulu8.28.0.1-jdk8.0.163-win_x64.zip",
+        "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-win_x64.zip",
+        "https://bazel-mirror.storage.googleapis.com/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-win_x64.zip",
+        "https://cdn.azul.com/zulu/bin/zulu9.0.7.1-jdk9.0.7-win_x64.zip",
     ],
 )
 

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -414,6 +414,10 @@ static vector<string> GetArgumentArray(
   string heap_crash_path = globals->options->output_base;
   result.push_back("-XX:HeapDumpPath=" + blaze::PathAsJvmFlag(heap_crash_path));
 
+  // quiet warnings from com.google.protobuf.UnsafeUtil,
+  // see: https://github.com/google/protobuf/issues/3781
+  result.push_back("--add-opens=java.base/java.nio=ALL-UNNAMED");
+
   result.push_back("-Xverify:none");
 
   vector<string> user_options;

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -27,7 +27,7 @@ filegroup(
         "testing_server.py",
         ":langtools-copy",
         "//examples:srcs",
-        "//src:bazel",
+        "//src:bazel_with_jdk",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/genclass:GenClass_deploy.jar",
         "//src/java_tools/junitrunner/java/com/google/testing/junit/runner:Runner_deploy.jar",
         "//src/main/tools:linux-sandbox",

--- a/src/test/shell/bazel/bazel_determinism_test.sh
+++ b/src/test/shell/bazel/bazel_determinism_test.sh
@@ -56,11 +56,11 @@ function test_determinism()  {
     unzip -q "${DISTFILE}"
 
     # Build Bazel once.
-    bazel --output_base="${TEST_TMPDIR}/out1" build --nostamp //src:bazel
+    bazel --output_base="${TEST_TMPDIR}/out1" build --nostamp //src:bazel_with_jdk
     hash_outputs >"${TEST_TMPDIR}/sum1"
 
     # Build Bazel twice.
-    bazel-bin/src/bazel --output_base="${TEST_TMPDIR}/out2" build --nostamp //src:bazel
+    bazel-bin/src/bazel_with_jdk --output_base="${TEST_TMPDIR}/out2" build --nostamp //src:bazel_with_jdk
     hash_outputs >"${TEST_TMPDIR}/sum2"
 
     if ! diff -U0 "${TEST_TMPDIR}/sum1" "${TEST_TMPDIR}/sum2" >$TEST_log; then

--- a/src/test/shell/bin/bazel
+++ b/src/test/shell/bin/bazel
@@ -17,4 +17,4 @@
 # Wrapper script to run bazel in the tests. Any change to this file will
 # affect all our integration tests.
 #
-exec $(rlocation io_bazel/src/bazel) --bazelrc=$TEST_TMPDIR/bazelrc "$@"
+exec $(rlocation io_bazel/src/bazel_with_jdk) --bazelrc=$TEST_TMPDIR/bazelrc "$@"

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -60,7 +60,7 @@ if is_windows; then
 fi
 
 # Make the command "bazel" available for tests.
-PATH_TO_BAZEL_BIN=$(rlocation io_bazel/src/bazel)
+PATH_TO_BAZEL_BIN=$(rlocation io_bazel/src/bazel_with_jdk)
 PATH_TO_BAZEL_WRAPPER="$(dirname $(rlocation io_bazel/src/test/shell/bin/bazel))"
 # Convert PATH_TO_BAZEL_WRAPPER to Unix path style on Windows, because it will be
 # added into PATH. There's problem if PATH=C:/msys64/usr/bin:/usr/local,
@@ -266,8 +266,6 @@ function setup_bazelrc() {
   cat >$TEST_TMPDIR/bazelrc <<EOF
 # Set the user root properly for this test invocation.
 startup --output_user_root=${bazel_root}
-# Set the correct javabase from the outer bazel invocation.
-startup --host_javabase=${bazel_javabase}
 
 # Print all progress messages because we regularly grep the output in tests.
 common --show_progress_rate_limit=-1


### PR DESCRIPTION
- Updates the embedded JDK to Azul Zulu 9.0.7
- All integration tests use Bazel with the embedded JDK

Also updated: http://storage.googleapis.com/bazel-mirror/openjdk/index.html