### PR TITLE
Fix xdot command example in cpp tutorial

### DIFF
--- a/site/docs/tutorial/cpp.md
+++ b/site/docs/tutorial/cpp.md
@@ -203,8 +203,8 @@ Then you can generate and view the graph by piping the text output above
 straight to xdot:
 
 ```
-bazel query --nohost_deps --noimplicit_deps 'deps(//main:hello-world)' \
-  --output graph | xdot
+xdot <(bazel query --nohost_deps --noimplicit_deps 'deps(//main:hello-world)' \
+  --output graph)
 ```
 
 As you can see, the first stage of the sample project has a single target


### PR DESCRIPTION
[Documentation fix]

In recent versions of xdot, piping the output of `bazel query` no
longer displays the visualization due to an unrelated change in xdot.
So, use redirection instead of pipe.