### PR TITLE
Add support for aar_import_external and aar_maven_import_external

### DIFF
--- a/tools/build_defs/repo/android.bzl
+++ b/tools/build_defs/repo/android.bzl
@@ -19,17 +19,17 @@
 #
 #     # Specify the URL directly:
 #     aar_import_external(
-#         name = 'com_android_support_preference_v14_25_1_0',                              # required
-#         licenses = ['notice'],                                                           # required
+#         name = "com_android_support_preference_v14_25_1_0",                              # required
+#         licenses = ["notice"],                                                           # required
 #         aar_urls = [                                                                     # required
-#             'https://dl.google.com/dl/android/maven2/com/android/support/preference-v14/25.1.0/preference-v14-25.1.0.aar'
+#             "https://dl.google.com/dl/android/maven2/com/android/support/preference-v14/25.1.0/preference-v14-25.1.0.aar"
 #         ],
-#         aar_sha256 = '442473fe5c395ebef26c14eb01d17ceda33ad207a4cc23a32a2ad95b87edfabb', # optional or empty string
+#         aar_sha256 = "442473fe5c395ebef26c14eb01d17ceda33ad207a4cc23a32a2ad95b87edfabb", # optional or empty string
 #         deps = [                                                                         # optional or empty list
-#             '@com_android_support_recyclerview_v7_25_1_0//aar',
-#             '@com_android_support_appcompat_v7_25_1_0//aar',
-#             '@com_android_support_preference_v7_25_1_0//aar',
-#             '@com_android_support_support_v4_25_1_0//aar',
+#             "@com_android_support_recyclerview_v7_25_1_0//aar",
+#             "@com_android_support_appcompat_v7_25_1_0//aar",
+#             "@com_android_support_preference_v7_25_1_0//aar",
+#             "@com_android_support_support_v4_25_1_0//aar",
 #         ],
 #     )
 #
@@ -41,10 +41,10 @@
 #         licenses = ["notice"],                                                      # required
 #         server_urls = ["https://maven.google.com"],                                 # required
 #         deps = [                                                                    # optional or empty list
-#             '@com_android_support_recyclerview_v7_25_1_0//aar',
-#             '@com_android_support_appcompat_v7_25_1_0//aar',
-#             '@com_android_support_preference_v7_25_1_0//aar',
-#             '@com_android_support_support_v4_25_1_0//aar',
+#             "@com_android_support_recyclerview_v7_25_1_0//aar",
+#             "@com_android_support_appcompat_v7_25_1_0//aar",
+#             "@com_android_support_preference_v7_25_1_0//aar",
+#             "@com_android_support_support_v4_25_1_0//aar",
 #         ],
 #     )
 #
@@ -72,7 +72,7 @@ def aar_import_external(aar_sha256, aar_urls, **kwargs):
         **kwargs
     )
 
-def aar_maven_import_external(artifact, server_urls, aar_sha256 = '', **kwargs):
+def aar_maven_import_external(artifact, server_urls, aar_sha256 = "", **kwargs):
     aar_import_external(
         aar_sha256 = aar_sha256,
         aar_urls = convert_artifact_coordinate_to_urls(

--- a/tools/build_defs/repo/android.bzl
+++ b/tools/build_defs/repo/android.bzl
@@ -15,7 +15,7 @@
 # Usage:
 #
 #     # In WORKSPACE
-#     load("@bazel_tools//tools/build_defs/repo:android.bzl", "aar_import_external)
+#     load("@bazel_tools//tools/build_defs/repo:android.bzl", "aar_import_external", "aar_maven_import_external")
 #
 #     # Specify the URL directly:
 #     aar_import_external(

--- a/tools/build_defs/repo/android.bzl
+++ b/tools/build_defs/repo/android.bzl
@@ -1,0 +1,84 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Usage:
+#
+#     # In WORKSPACE
+#     load("@bazel_tools//tools/build_defs/repo:android.bzl", "aar_import_external)
+#
+#     # Specify the URL directly:
+#     aar_import_external(
+#         name = 'com_android_support_preference_v14_25_1_0',                              # required
+#         licenses = ['notice'],                                                           # required
+#         aar_urls = [                                                                     # required
+#             'https://dl.google.com/dl/android/maven2/com/android/support/preference-v14/25.1.0/preference-v14-25.1.0.aar'
+#         ],
+#         aar_sha256 = '442473fe5c395ebef26c14eb01d17ceda33ad207a4cc23a32a2ad95b87edfabb', # optional or empty string
+#         deps = [                                                                         # optional or empty list
+#             '@com_android_support_recyclerview_v7_25_1_0//aar',
+#             '@com_android_support_appcompat_v7_25_1_0//aar',
+#             '@com_android_support_preference_v7_25_1_0//aar',
+#             '@com_android_support_support_v4_25_1_0//aar',
+#         ],
+#     )
+#
+#     # Or, specify the artifact coordinate:
+#     aar_maven_import_external(
+#         name = "com_android_support_preference_v14_25_1_0",                         # required
+#         artifact = "com.android.support.test:preference-v14:25.1.0",                # required
+#         sha256 = "442473fe5c395ebef26c14eb01d17ceda33ad207a4cc23a32a2ad95b87edfabb" # optional or empty string
+#         licenses = ["notice"],                                                      # required
+#         server_urls = ["https://maven.google.com"],                                 # required
+#         deps = [                                                                    # optional or empty list
+#             '@com_android_support_recyclerview_v7_25_1_0//aar',
+#             '@com_android_support_appcompat_v7_25_1_0//aar',
+#             '@com_android_support_preference_v7_25_1_0//aar',
+#             '@com_android_support_support_v4_25_1_0//aar',
+#         ],
+#     )
+#
+#     # In BUILD.bazel
+#     android_library(
+#         name = "foo",
+#         srcs = [...],
+#         deps = [
+#             "@com_android_support_preference_v14_25_1_0//aar",
+#         ],
+#     )
+
+
+load(":jvm.bzl", "jvm_import_external", "convert_artifact_coordinate_to_urls")
+
+def aar_import_external(aar_sha256, aar_urls, **kwargs):
+    jvm_import_external(
+        rule_name = "aar_import",
+        rule_metadata = {
+            "extension": "aar",
+            "import_attr": "aar = %s"
+        },
+        artifact_sha256 = aar_sha256,
+        artifact_urls = aar_urls,
+        **kwargs
+    )
+
+def aar_maven_import_external(artifact, server_urls, aar_sha256 = '', **kwargs):
+    aar_import_external(
+        aar_sha256 = aar_sha256,
+        aar_urls = convert_artifact_coordinate_to_urls(
+            artifact,
+            server_urls,
+            "aar"
+        ),
+        **kwargs
+    )

--- a/tools/build_defs/repo/java.bzl
+++ b/tools/build_defs/repo/java.bzl
@@ -176,15 +176,17 @@ def java_import_external(jar_sha256, jar_urls, **kwargs):
         rule_name = "java_import",
         artifact_sha256 = jar_sha256,
         artifact_urls = jar_urls,
-        packaging = "jar",
         **kwargs
     )
 
-def aar_import_external(aar_urls, aar_sha256, **kwargs):
+def aar_import_external(aar_sha256, aar_urls, **kwargs):
     jvm_import_external(
         rule_name = "aar_import",
+        rule_metadata = {
+            "extension": "aar",
+            "import_attr": "aar = %s"
+        },
         artifact_sha256 = aar_sha256,
         artifact_urls = aar_urls,
-        packaging = "aar",
         **kwargs
     )

--- a/tools/build_defs/repo/java.bzl
+++ b/tools/build_defs/repo/java.bzl
@@ -178,15 +178,3 @@ def java_import_external(jar_sha256, jar_urls, **kwargs):
         artifact_urls = jar_urls,
         **kwargs
     )
-
-def aar_import_external(aar_sha256, aar_urls, **kwargs):
-    jvm_import_external(
-        rule_name = "aar_import",
-        rule_metadata = {
-            "extension": "aar",
-            "import_attr": "aar = %s"
-        },
-        artifact_sha256 = aar_sha256,
-        artifact_urls = aar_urls,
-        **kwargs
-    )

--- a/tools/build_defs/repo/java.bzl
+++ b/tools/build_defs/repo/java.bzl
@@ -171,18 +171,20 @@ reasonably expected to already be provided.
 
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_import_external")
 
-def java_import_external(jar_sha256, **kwargs):
+def java_import_external(jar_sha256, jar_urls, **kwargs):
     jvm_import_external(
         rule_name = "java_import",
-        jar_sha256 = jar_sha256,
+        artifact_sha256 = jar_sha256,
+        artifact_urls = jar_urls,
+        packaging = "jar",
         **kwargs
     )
 
 def aar_import_external(aar_urls, aar_sha256, **kwargs):
     jvm_import_external(
         rule_name = "aar_import",
-        jar_sha256 = aar_sha256,
-        jar_urls = aar_urls,
+        artifact_sha256 = aar_sha256,
+        artifact_urls = aar_urls,
         packaging = "aar",
         **kwargs
     )

--- a/tools/build_defs/repo/java.bzl
+++ b/tools/build_defs/repo/java.bzl
@@ -177,3 +177,12 @@ def java_import_external(jar_sha256, **kwargs):
         jar_sha256 = jar_sha256,
         **kwargs
     )
+
+def aar_import_external(aar_urls, aar_sha256, **kwargs):
+    jvm_import_external(
+        rule_name = "aar_import",
+        jar_sha256 = aar_sha256,
+        jar_urls = aar_urls,
+        packaging = "aar",
+        **kwargs
+    )

--- a/tools/build_defs/repo/jvm.bzl
+++ b/tools/build_defs/repo/jvm.bzl
@@ -198,30 +198,16 @@ jvm_import_external = repository_rule(
     },
 )
 
-def jvm_maven_import_external(
-    artifact,
-    server_urls,
-    **kwargs):
+def jvm_maven_import_external(artifact, server_urls, **kwargs):
   jvm_import_external(
-      artifact_urls = _convert_to_url(
-          artifact,
-          server_urls,
-          "jar",
-      ),
+      artifact_urls = _convert_to_url(artifact, server_urls, "jar"),
       **kwargs
   )
 
-def aar_maven_import_external(
-    artifact,
-    server_urls,
-    **kwargs):
+def aar_maven_import_external(artifact, server_urls, **kwargs):
   jvm_import_external(
-      artifact_urls = _convert_to_url(
-          artifact,
-          server_urls,
-          "aar",
-      ),
-      rule_name = "aar_import",
+      artifact_urls = _convert_to_url(artifact, server_urls, "aar"),
+      rule_name = "aar_import"
       rule_metadata = {
           "extension": "aar",
           "import_attr": "aar = %s",

--- a/tools/build_defs/repo/jvm.bzl
+++ b/tools/build_defs/repo/jvm.bzl
@@ -122,7 +122,8 @@ def _jvm_import_external(repository_ctx):
         "",
     ]))
 
-def _convert_to_url(artifact, server_urls, packaging):
+# This method is public for usage in android.bzl macros
+def convert_artifact_coordinate_to_urls(artifact, server_urls, packaging):
     parts = artifact.split(":")
     group_id_part = parts[0].replace(".", "/")
     artifact_id = parts[1]
@@ -199,19 +200,13 @@ jvm_import_external = repository_rule(
     },
 )
 
+
 def jvm_maven_import_external(artifact, server_urls, **kwargs):
     jvm_import_external(
-        artifact_urls = _convert_to_url(artifact, server_urls, "jar"),
-        **kwargs
-    )
-
-def aar_maven_import_external(artifact, server_urls, **kwargs):
-    jvm_import_external(
-        artifact_urls = _convert_to_url(artifact, server_urls, "aar"),
-        rule_name = "aar_import",
-        rule_metadata = {
-            "extension": "aar",
-            "import_attr": "aar = %s",
-        },
+        artifact_urls = convert_artifact_coordinate_to_urls(
+            artifact,
+            server_urls,
+            "jar"
+        ),
         **kwargs
     )

--- a/tools/build_defs/repo/jvm.bzl
+++ b/tools/build_defs/repo/jvm.bzl
@@ -127,7 +127,6 @@ def _convert_to_url(artifact, server_urls, packaging):
     group_id_part = parts[0].replace(".", "/")
     artifact_id = parts[1]
     version = parts[2]
-    packaging = packaging
     classifier_part = ""
     if len(parts) == 4:
         packaging = parts[2]

--- a/tools/build_defs/repo/jvm.bzl
+++ b/tools/build_defs/repo/jvm.bzl
@@ -201,18 +201,13 @@ jvm_import_external = repository_rule(
 def jvm_maven_import_external(
     artifact,
     server_urls,
-    rule_metadata = {
-        "extension": "jar",
-        "import_attr": "jars = [%s]",
-    },
     **kwargs):
   jvm_import_external(
       artifact_urls = _convert_to_url(
           artifact,
           server_urls,
-          rule_metadata["extension"]
+          "jar",
       ),
-      rule_metadata = rule_metadata,
       **kwargs
   )
 
@@ -220,13 +215,16 @@ def aar_maven_import_external(
     artifact,
     server_urls,
     **kwargs):
-  jvm_maven_import_external(
-      artifact = artifact,
-      server_urls = server_urls,
+  jvm_import_external(
+      artifact_urls = _convert_to_url(
+          artifact,
+          server_urls,
+          "aar",
+      ),
+      rule_name = "aar_import",
       rule_metadata = {
           "extension": "aar",
           "import_attr": "aar = %s",
       },
-      rule_name = "aar_import",
       **kwargs
   )


### PR DESCRIPTION
Usage example:

```python
# In WORKSPACE
load("@bazel_tools//tools/build_defs/repo:android.bzl", "aar_import_external", "aar_maven_import_external")

# Specify the URL directly:
aar_import_external(
    name = "com_android_support_preference_v14_25_1_0",                              # required
    licenses = ["notice"],                                                           # required
    aar_urls = [                                                                     # required
        "https://dl.google.com/dl/android/maven2/com/android/support/preference-v14/25.1.0/preference-v14-25.1.0.aar"
    ],
    aar_sha256 = "442473fe5c395ebef26c14eb01d17ceda33ad207a4cc23a32a2ad95b87edfabb", # optional or empty string
    deps = [                                                                         # optional or empty list
        "@com_android_support_recyclerview_v7_25_1_0//aar",
        "@com_android_support_appcompat_v7_25_1_0//aar",
        "@com_android_support_preference_v7_25_1_0//aar",
        "@com_android_support_support_v4_25_1_0//aar",
    ],
)

# Or, specify the artifact coordinate:
aar_maven_import_external(
    name = "com_android_support_preference_v14_25_1_0",                         # required
    artifact = "com.android.support.test:preference-v14:25.1.0",                # required
    sha256 = "442473fe5c395ebef26c14eb01d17ceda33ad207a4cc23a32a2ad95b87edfabb" # optional or empty string
    licenses = ["notice"],                                                      # required
    server_urls = ["https://maven.google.com"],                                 # required
    deps = [                                                                    # optional or empty list
        "@com_android_support_recyclerview_v7_25_1_0//aar",
        "@com_android_support_appcompat_v7_25_1_0//aar",
        "@com_android_support_preference_v7_25_1_0//aar",
        "@com_android_support_support_v4_25_1_0//aar",
    ],
)

# In BUILD.bazel
android_library(
    name = "foo",
    srcs = [...],
    deps = [
        "@com_android_support_preference_v14_25_1_0//aar",
    ],
)
```

To test this out with gmaven_rules, change the `load` statement in https://github.com/bazelbuild/gmaven_rules/blob/master/gmaven.bzl to 

```
load('@bazel_tools//tools/build_defs/repo:android.bzl', 'aar_import_external')
load('@bazel_tools//tools/build_defs/repo:java.bzl', 'java_import_external')
```

Fixes https://github.com/bazelbuild/bazel/issues/4654

RELNOTES: New rules for importing Android dependencies: `aar_import_external` and `aar_maven_import_external`. `aar_import_external` enables specifying external AAR dependencies using a list of HTTP URLs for the artifact. `aar_maven_import_external` enables specifying external AAR dependencies using the artifact coordinate and a list of server URLs. 