### PR TITLE
Add a new flag to specify the default execution platform

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformConfiguration.java
@@ -34,6 +34,7 @@ import java.util.List;
 )
 public class PlatformConfiguration extends BuildConfiguration.Fragment {
   private final Label hostPlatform;
+  private final Label legacyFallbackExecutionPlatform;
   private final ImmutableList<String> extraExecutionPlatforms;
   private final ImmutableList<Label> targetPlatforms;
   private final ImmutableList<String> extraToolchains;
@@ -42,11 +43,13 @@ public class PlatformConfiguration extends BuildConfiguration.Fragment {
   @AutoCodec.Instantiator
   PlatformConfiguration(
       Label hostPlatform,
+      Label legacyFallbackExecutionPlatform,
       ImmutableList<String> extraExecutionPlatforms,
       ImmutableList<Label> targetPlatforms,
       ImmutableList<String> extraToolchains,
       ImmutableList<Label> enabledToolchainTypes) {
     this.hostPlatform = hostPlatform;
+    this.legacyFallbackExecutionPlatform = legacyFallbackExecutionPlatform;
     this.extraExecutionPlatforms = extraExecutionPlatforms;
     this.targetPlatforms = targetPlatforms;
     this.extraToolchains = extraToolchains;
@@ -56,6 +59,10 @@ public class PlatformConfiguration extends BuildConfiguration.Fragment {
   @SkylarkCallable(name = "host_platform", structField = true, doc = "The current host platform")
   public Label getHostPlatform() {
     return hostPlatform;
+  }
+
+  public Label getLegacyFallbackExecutionPlatform() {
+    return legacyFallbackExecutionPlatform;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformConfigurationLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformConfigurationLoader.java
@@ -46,6 +46,7 @@ public class PlatformConfigurationLoader implements ConfigurationFragmentFactory
       throws InvalidConfigurationException {
     return new PlatformConfiguration(
         options.hostPlatform,
+        options.legacyFallbackExecutionPlatform,
         ImmutableList.copyOf(options.extraExecutionPlatforms),
         ImmutableList.copyOf(options.platforms),
         ImmutableList.copyOf(options.extraToolchains),

--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
@@ -57,6 +57,21 @@ public class PlatformOptions extends FragmentOptions {
   public String hostPlatformRemotePropertiesOverride;
 
   @Option(
+      name = "legacy_fallback_execution_platform",
+      converter = BuildConfiguration.EmptyToNullLabelConverter.class,
+      defaultValue = "",
+      documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
+      effectTags = {
+        OptionEffectTag.AFFECTS_OUTPUTS,
+        OptionEffectTag.CHANGES_INPUTS,
+        OptionEffectTag.LOADING_AND_ANALYSIS
+      },
+      help =
+          "The label of a platform rule to use as the execution platform for rules that do not"
+              + " participate in toolchain resolution.")
+  public Label legacyFallbackExecutionPlatform;
+
+  @Option(
     name = "extra_execution_platforms",
     converter = CommaSeparatedOptionListConverter.class,
     defaultValue = "",
@@ -151,6 +166,7 @@ public class PlatformOptions extends FragmentOptions {
     host.platforms =
         this.hostPlatform == null ? ImmutableList.of() : ImmutableList.of(this.hostPlatform);
     host.hostPlatform = this.hostPlatform;
+    host.legacyFallbackExecutionPlatform = this.legacyFallbackExecutionPlatform;
     host.extraExecutionPlatforms = this.extraExecutionPlatforms;
     host.extraToolchains = this.extraToolchains;
     host.enabledToolchainTypes = this.enabledToolchainTypes;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainUtil.java
@@ -129,11 +129,19 @@ public class ToolchainUtil {
           requiredToolchains,
           resolvedToolchains.get().toolchains());
     } else {
-      // No toolchain could be resolved, but no error happened, so fall back to host platform.
+      // No toolchain could be resolved, but no error happened, so fall back to a default platform.
+      ConfiguredTargetKey fallbackExecutionPlatformKey;
+      if (platformConfiguration.getLegacyFallbackExecutionPlatform() != null) {
+        fallbackExecutionPlatformKey =
+            ConfiguredTargetKey.of(
+                platformConfiguration.getLegacyFallbackExecutionPlatform(), configuration);
+      } else {
+        fallbackExecutionPlatformKey = hostPlatformKey;
+      }
       return createContext(
           env,
           targetDescription,
-          hostPlatformKey,
+          fallbackExecutionPlatformKey,
           targetPlatformKey,
           requiredToolchains,
           ImmutableBiMap.of());

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainUtilTest.java
@@ -258,6 +258,42 @@ public class ToolchainUtilTest extends ToolchainTestCase {
         .contains("//invalid:not_a_platform");
   }
 
+  @Test
+  public void createToolchainContext_executionPlatformFallback_host() throws Exception {
+    useConfiguration("--host_platform=//platforms:mac");
+    CreateToolchainContextKey key =
+        CreateToolchainContextKey.create("test", ImmutableSet.of(), targetConfigKey);
+
+    EvaluationResult<CreateToolchainContextValue> result = createToolchainContext(key);
+
+    assertThatEvaluationResult(result).hasNoError();
+    ToolchainContext toolchainContext = result.get(key).toolchainContext();
+    assertThat(toolchainContext).isNotNull();
+
+    assertThat(toolchainContext.getExecutionPlatform()).isNotNull();
+    assertThat(toolchainContext.getExecutionPlatform().label())
+        .isEqualTo(Label.parseAbsoluteUnchecked("//platforms:mac"));
+  }
+
+  @Test
+  public void createToolchainContext_executionPlatformFallback_flag() throws Exception {
+    useConfiguration(
+        "--host_platform=//platforms:mac",
+        "--legacy_fallback_execution_platform=//platforms:linux");
+    CreateToolchainContextKey key =
+        CreateToolchainContextKey.create("test", ImmutableSet.of(), targetConfigKey);
+
+    EvaluationResult<CreateToolchainContextValue> result = createToolchainContext(key);
+
+    assertThatEvaluationResult(result).hasNoError();
+    ToolchainContext toolchainContext = result.get(key).toolchainContext();
+    assertThat(toolchainContext).isNotNull();
+
+    assertThat(toolchainContext.getExecutionPlatform()).isNotNull();
+    assertThat(toolchainContext.getExecutionPlatform().label())
+        .isEqualTo(Label.parseAbsoluteUnchecked("//platforms:linux"));
+  }
+
   // Calls ToolchainUtil.createToolchainContext.
   private static final SkyFunctionName CREATE_TOOLCHAIN_CONTEXT_FUNCTION =
       SkyFunctionName.create("CREATE_TOOLCHAIN_CONTEXT_FUNCTION");


### PR DESCRIPTION
Add a new flag to specify the execution platform to use when toolchain resolution is not used.

If the flag is not set, the execution platform will be the host
platform.

Fixes #5309.

RELNOTES: Adds the --legacy_fallback_execution_platform flag to specify
a fallback execution platform whentoolchain resolution is not used.

Change-Id: I5e91c209cf5f043e29fb512c0ef81385a44d4817