### PR TITLE
Consider runfiles symlinks when computing Runfiles.getEmptyFilenames().

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java
@@ -18,7 +18,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget.Mode;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -81,22 +83,6 @@ public final class Runfiles implements RunfilesApi {
 
   @AutoCodec @AutoCodec.VisibleForSerialization
   static final EmptyFilesSupplier DUMMY_EMPTY_FILES_SUPPLIER = new DummyEmptyFilesSupplier();
-
-  private static final Function<Artifact, PathFragment> GET_ROOT_RELATIVE_PATH =
-      new Function<Artifact, PathFragment>() {
-        @Override
-        public PathFragment apply(Artifact input) {
-          return input.getRootRelativePath();
-        }
-      };
-
-  private static final Function<PathFragment, String> PATH_FRAGMENT_TO_STRING =
-      new Function<PathFragment, String>() {
-        @Override
-        public String apply(PathFragment input) {
-          return input.toString();
-        }
-      };
 
   /**
    * An entry in the runfiles map.
@@ -360,12 +346,19 @@ public final class Runfiles implements RunfilesApi {
 
   @Override
   public NestedSet<String> getEmptyFilenames() {
-    Set<PathFragment> manifest = new TreeSet<>();
-    Iterables.addAll(
-        manifest, Iterables.transform(getArtifacts().toCollection(), GET_ROOT_RELATIVE_PATH));
-    return NestedSetBuilder.wrap(
-        Order.STABLE_ORDER,
-        Iterables.transform(emptyFilesSupplier.getExtraPaths(manifest), PATH_FRAGMENT_TO_STRING));
+    Set<PathFragment> manifestKeys =
+        Streams.concat(
+            Streams.stream(symlinks).map(SymlinkEntry::getPath),
+            Streams.stream(getArtifacts()).map(Artifact::getRootRelativePath))
+        .collect(ImmutableSet.toImmutableSet());
+    Iterable<PathFragment> emptyKeys = emptyFilesSupplier.getExtraPaths(manifestKeys);
+    return NestedSetBuilder.<String>stableOrder()
+        .addAll(
+            Streams
+                .stream(emptyKeys)
+                .map(PathFragment::toString)
+                .collect(ImmutableList.toImmutableList()))
+        .build();
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/analysis/RunfilesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/RunfilesTest.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.vfs.Root;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -431,5 +432,23 @@ public class RunfilesTest extends FoundationTestCase {
         new Runfiles.Builder("TESTING").merge(runfiles1).merge(runfiles2).build();
     assertThat(runfilesMerged.getExtraMiddlemen())
         .containsExactlyElementsIn(ImmutableList.of(mm1, mm2));
+  }
+
+  @Test
+  public void testGetEmptyFilenames() {
+    ArtifactRoot root = ArtifactRoot.asSourceRoot(Root.fromPath(scratch.resolve("/workspace")));
+    Artifact artifact = new Artifact(PathFragment.create("my-artifact"), root);
+    Runfiles runfiles = new Runfiles.Builder("TESTING")
+        .addArtifact(artifact)
+        .addSymlink(PathFragment.create("my-symlink"), artifact)
+        .addRootSymlink(PathFragment.create("my-root-symlink"), artifact)
+        .setEmptyFilesSupplier((manifestPaths) ->
+            manifestPaths
+                .stream()
+                .map((f) -> f.replaceName(f.getBaseName() + "-empty"))
+                .collect(ImmutableList.toImmutableList()))
+        .build();
+    assertThat(runfiles.getEmptyFilenames())
+        .containsExactly("my-artifact-empty", "my-symlink-empty");
   }
 }


### PR DESCRIPTION
Runfiles.getEmptyFilenames() only considered the unconditional and
pruning manifest artifacts for empty-file insertion. Actual manifest
creation asks the empty files supplier for empty files over symlinks
(but not root symlinks!), too.

Change-Id: Ice69bbaa9e6169bff7ec5833ee7ef1b73049a4a7