### PR TITLE
Fix a few generated docs.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/CommandLineArgsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/CommandLineArgsApi.java
@@ -510,9 +510,10 @@ public interface CommandLineArgsApi extends SkylarkValue {
           type = String.class,
           named = true,
           doc =
-              "The format of the param file. Must be one of:<br>"
-                  + "\"shell\": All arguments are shell quoted and separated by whitespace<br>"
+              "The format of the param file. Must be one of:<ul><li>"
+                  + "\"shell\": All arguments are shell quoted and separated by whitespace</li><li>"
                   + "\"multiline\": All arguments are unquoted and separated by newline characters"
+                  + "</li></ul>"
                   + "The format defaults to \"shell\" if not called.")
     }
   )

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkActionFactoryApi.java
@@ -41,8 +41,8 @@ public interface SkylarkActionFactoryApi extends SkylarkValue {
     name = "declare_file",
     doc =
         "Declares that the rule or aspect creates a file with the given filename. "
-            + "If <code>sibling</code> is not specified, the file name is relative to the package"
-            + "directory, otherwise the file is in the same directory as <code>sibling</code>."
+            + "If <code>sibling</code> is not specified, the file name is relative to the package "
+            + "directory, otherwise the file is in the same directory as <code>sibling</code>. "
             + "Files cannot be created outside of the current package."
             + "<p>Remember that in addition to declaring a file, you must separately create an "
             + "action that emits the file. Creating that action will require passing the returned "
@@ -52,7 +52,7 @@ public interface SkylarkActionFactoryApi extends SkylarkValue {
             + "<code>File</code> objects from <a href=\"ctx.html#outputs\"><code>ctx.outputs</code>"
             + "</a> instead. "
             + "<a href=\"https://github.com/bazelbuild/examples/tree/master/rules/"
-            + "computed_dependencies/hash.bzl\">See example of use</a>",
+            + "computed_dependencies/hash.bzl\">See example of use</a>.",
     parameters = {
       @Param(
         name = "filename",
@@ -165,7 +165,7 @@ public interface SkylarkActionFactoryApi extends SkylarkValue {
     doc =
         "Creates an action that runs an executable. "
             + "<a href=\"https://github.com/bazelbuild/examples/tree/master/rules/"
-            + "actions_run/execute.bzl\">See example of use</a>",
+            + "actions_run/execute.bzl\">See example of use</a>.",
     parameters = {
       @Param(
         name = "outputs",
@@ -312,7 +312,7 @@ public interface SkylarkActionFactoryApi extends SkylarkValue {
     doc =
         "Creates an action that runs a shell command. "
             + "<a href=\"https://github.com/bazelbuild/examples/tree/master/rules/"
-            + "shell_command/size.bzl\">See example of use</a>",
+            + "shell_command/size.bzl\">See example of use</a>.",
     parameters = {
       @Param(
         name = "outputs",
@@ -474,7 +474,7 @@ public interface SkylarkActionFactoryApi extends SkylarkValue {
             + "There is no special syntax for the keys. You may, for example, use curly braces "
             + "to avoid conflicts (for example, <code>{KEY}</code>). "
             + "<a href=\"https://github.com/bazelbuild/examples/blob/master/rules/expand_template/hello.bzl\">"
-            + "See example of use</a>",
+            + "See example of use</a>.",
     parameters = {
       @Param(
         name = "template",

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleContextApi.java
@@ -371,10 +371,10 @@ public interface SkylarkRuleContextApi extends SkylarkValue {
       throws EvalException;
 
   @SkylarkCallable(
-    doc = "<b>Deprecated.</b> Use <code>ctx.var</code> to access the variables instead.<br>"
-        + "Returns a string after expanding all references to \"Make variables\". The variables "
-        + "must have the following format: <code>$(VAR_NAME)</code>. Also, <code>$$VAR_NAME"
-        + "</code> expands to <code>$VAR_NAME</code>. Parameters:"
+    doc = "<b>Deprecated.</b> Use <a href=\"ctx.html#var\">ctx.var</a> to access the variables "
+        + "instead.<br>Returns a string after expanding all references to \"Make variables\". The "
+        + "variables must have the following format: <code>$(VAR_NAME)</code>. Also, "
+        + "<code>$$VAR_NAME</code> expands to <code>$VAR_NAME</code>. Parameters:"
         + "<ul><li>The name of the attribute (<code>string</code>). It's only used for error "
         + "reporting.</li>\n"
         + "<li>The expression to expand (<code>string</code>). It can contain references to "
@@ -488,8 +488,8 @@ public interface SkylarkRuleContextApi extends SkylarkValue {
         named = true,
         positional = false,
         doc =
-            "Command line arguments of the action."
-                + "Must be a list of strings or actions.args() objects."
+            "Command line arguments of the action. Must be a list of strings or actions.args() "
+                + "objects."
       ),
       @Param(
         name = "mnemonic",
@@ -760,7 +760,7 @@ public interface SkylarkRuleContextApi extends SkylarkValue {
         named = true,
         doc =
             "The (transitive) set of files to be added to the runfiles. The depset should "
-                + "use the `default` order (which, as the name implies, is the default)."
+                + "use the <code>default</code> order (which, as the name implies, is the default)."
       ),
       @Param(
         name = "collect_data",

--- a/src/main/java/com/google/devtools/build/lib/syntax/Runtime.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Runtime.java
@@ -134,7 +134,7 @@ public final class Runtime {
             + "<code>@local</code>. In packages in the main repository, it will be set to "
             + "<code>@</code>. It can only be accessed in functions (transitively) called from "
             + "BUILD files, i.e. it follows the same restrictions as "
-            + "<a href=\"#PACKAGE_NAME\">PACKAGE_NAME</a>"
+            + "<a href=\"#PACKAGE_NAME\">PACKAGE_NAME</a>."
   )
   public static final String REPOSITORY_NAME = "REPOSITORY_NAME";
 


### PR DESCRIPTION
In particular,

* fix sentences with no space after the period, like [here](https://g3doc.corp.google.com/devtools/blaze/rules/g3doc/lib/ctx.html#action)
* switch backticks to `<code>`, like [here](https://g3doc.corp.google.com/devtools/blaze/rules/g3doc/lib/ctx.html#parameters_9)
* link `ctx.var` [here](https://g3doc.corp.google.com/devtools/blaze/rules/g3doc/lib/ctx.html#expand_make_variables)
* Add periods to the end of paragraphs, like [here](https://g3doc.corp.google.com/devtools/blaze/rules/g3doc/lib/actions.html#declare_file)
* Format a list [here](https://g3doc.corp.google.com/devtools/blaze/rules/g3doc/lib/Args.html#set_param_file_format).
