### PR TITLE
Allow disabling the simple blob caches via CLI flag overrides.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
@@ -75,7 +75,7 @@ public final class SimpleBlobStoreFactory {
   }
 
   public static boolean isDiskCache(RemoteOptions options) {
-    return options.diskCache != null;
+    return options.diskCache != null && !options.diskCache.isEmpty();
   }
 
   static boolean isRestUrlOptions(RemoteOptions options) {


### PR DESCRIPTION
This fixes a regression from v0.13. When the local disk cache flags were
unified into `--disk_cache`, it became impossible to override a default
cache location such that the cache became disabled. This prevents
canarying of remote execution in the presence of a default bazelrc that
enables the disk cache.

Fixes #5308