### PR TITLE
[launcher] Don't pass std::string to C varargs function

### DIFF
--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -114,7 +114,7 @@ vector<string> JavaBinaryLauncher::ProcessesCommandLine() {
     // launcher.
     if (GetFlagValue(arg, "--wrapper_script_flag=", &flag_value)) {
       if (!ProcessWrapperArgument(flag_value)) {
-        die("invalid wrapper argument '%s'", arg);
+        die("invalid wrapper argument '%s'", arg.c_str());
       }
     } else if (!args.empty() || !ProcessWrapperArgument(arg)) {
       args.push_back(arg);


### PR DESCRIPTION
`die` passes parameters to `vfprintf`. Passing `std::string` to this function might crash the program.

Found by Clang on Windows.

/cc @meteorcloudy