### PR TITLE
Delete RunfilesSupport.getExecutable.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
@@ -165,13 +165,6 @@ public final class RunfilesSupport {
   }
 
   /**
-   * Returns the executable owning this RunfilesSupport. Only use from Skylark.
-   */
-  public Artifact getExecutable() {
-    return owningExecutable;
-  }
-
-  /**
    * Returns the exec path of the directory where the runfiles contained in this
    * RunfilesSupport are generated. When the owning rule has no executable,
    * returns null.


### PR DESCRIPTION
Despite the javadoc, this method is not exposed to Skylark. Nor does it appear to have usage in the Java codebase.