### PR TITLE
Remove usage of COMPILER_MSVC in Bazel and ijar

### DIFF
--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -128,7 +128,7 @@ extern const char kListSeparator;
 bool SymlinkDirectories(const std::string& target, const std::string& link);
 
 struct BlazeLock {
-#if defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
   /* HANDLE */ void* handle;
 #else
   int lockfd;

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -387,7 +387,7 @@ blaze_exit_code::ExitCode OptionProcessor::ParseStartupOptions(
 }
 
 static bool IsValidEnvName(const char* p) {
-#if defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
   for (; *p && *p != '='; ++p) {
     if (!((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
           (*p >= '0' && *p <= '9') || *p == '_')) {
@@ -398,7 +398,7 @@ static bool IsValidEnvName(const char* p) {
   return true;
 }
 
-#if defined(COMPILER_MSVC)
+#if defined(_WIN32)
 static void PreprocessEnvString(string* env_str) {
   static constexpr const char* vars_to_uppercase[] = {"PATH", "SYSTEMROOT",
                                                       "TEMP", "TEMPDIR", "TMP"};
@@ -415,7 +415,7 @@ static void PreprocessEnvString(string* env_str) {
   }
 }
 
-#elif defined(__CYGWIN__)  // not defined(COMPILER_MSVC)
+#elif defined(__CYGWIN__)  // not defined(_WIN32)
 
 static void PreprocessEnvString(string* env_str) {
   int pos = env_str->find_first_of('=');
@@ -435,7 +435,7 @@ static void PreprocessEnvString(string* env_str) {
 static void PreprocessEnvString(const string* env_str) {
   // do nothing.
 }
-#endif  // defined(COMPILER_MSVC)
+#endif  // defined(_WIN32)
 
 static std::vector<std::string> GetProcessedEnv() {
   std::vector<std::string> processed_env;

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -108,13 +108,13 @@ StartupOptions::StartupOptions(const string &product_name,
                     << "'.";
   }
 
-#if defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
   string windows_unix_root = WindowsUnixRoot(blaze::GetEnv("BAZEL_SH"));
   if (!windows_unix_root.empty()) {
     host_jvm_args.push_back(string("-Dbazel.windows_unix_root=") +
                             windows_unix_root);
   }
-#endif  // defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
 
   const string product_name_lower = GetLowercaseProductName();
   output_user_root = blaze_util::JoinPath(
@@ -528,7 +528,7 @@ blaze_exit_code::ExitCode StartupOptions::AddJVMMemoryArguments(
   return blaze_exit_code::SUCCESS;
 }
 
-#if defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
 // Extract the Windows path of "/" from $BAZEL_SH.
 // $BAZEL_SH usually has the form `<prefix>/usr/bin/bash.exe` or
 // `<prefix>/bin/bash.exe`, and this method returns that `<prefix>` part.
@@ -554,6 +554,6 @@ string StartupOptions::WindowsUnixRoot(const string &bazel_sh) {
     return split.first;
   }
 }
-#endif  // defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
 
 }  // namespace blaze

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -312,7 +312,7 @@ class StartupOptions {
   // Contains the collection of startup flags that Bazel accepts.
   std::set<std::unique_ptr<StartupFlag>> valid_startup_flags;
 
-#if defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
   static std::string WindowsUnixRoot(const std::string &bazel_sh);
 #endif
 };

--- a/src/main/cpp/util/file_platform.h
+++ b/src/main/cpp/util/file_platform.h
@@ -50,7 +50,7 @@ class IFileMtime {
 // Creates a platform-specific implementation of `IFileMtime`.
 IFileMtime *CreateFileMtime();
 
-#if defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
 // We cannot include <windows.h> because it #defines many symbols that conflict
 // with our function names, e.g. GetUserName, SendMessage.
 // Instead of typedef'ing HANDLE, let's use the actual type, void*. If that ever
@@ -58,9 +58,9 @@ IFileMtime *CreateFileMtime();
 // (very unlikely, given how fundamental this type is in Windows), then we'd get
 // a compilation error.
 typedef /* HANDLE */ void *file_handle_type;
-#else   // !(defined(COMPILER_MSVC) || defined(__CYGWIN__))
+#else   // !(defined(_WIN32) || defined(__CYGWIN__))
 typedef int file_handle_type;
-#endif  // defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
 
 // Result of a `ReadFromHandle` operation.
 //
@@ -199,9 +199,9 @@ class DirectoryEntryConsumer {
 void ForEachDirectoryEntry(const std::string &path,
                            DirectoryEntryConsumer *consume);
 
-#if defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
 std::wstring GetCwdW();
-#endif  // defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
 
 }  // namespace blaze_util
 

--- a/src/main/cpp/util/md5.h
+++ b/src/main/cpp/util/md5.h
@@ -20,9 +20,9 @@
 
 #include <string>
 
-#if defined(COMPILER_MSVC) && !defined(__alignof__)
+#if defined(_MSC_VER) && !defined(__alignof__)
 #define __alignof__ __alignof
-#endif  // COMPILER_MSVC && !__alignof__
+#endif  // _MSC_VER && !__alignof__
 
 namespace blaze_util {
 

--- a/src/main/cpp/util/path_platform.h
+++ b/src/main/cpp/util/path_platform.h
@@ -59,7 +59,7 @@ std::string MakeAbsolute(const std::string &path);
 // are included by an import statement. The downside to this gain in clarity
 // is that this would add more complexity to the implementation file(s)? of
 // path.h, which would have to have the platform-specific implementations.
-#if defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
 const wchar_t *RemoveUncPrefixMaybe(const wchar_t *ptr);
 void AddUncPrefixMaybe(std::wstring *path);
 
@@ -122,7 +122,7 @@ bool IsPathSeparator(char_type ch);
 template <typename char_type>
 bool HasDriveSpecifierPrefix(const char_type *ch);
 
-#endif  // defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
 }  // namespace blaze_util
 
 #endif  // BAZEL_SRC_MAIN_CPP_UTIL_PATH_PLATFORM_H_

--- a/src/main/cpp/util/port.h
+++ b/src/main/cpp/util/port.h
@@ -135,12 +135,12 @@ char (&ArraySizeHelper(const T (&array)[N]))[N];
 
 #define arraysize(array) (sizeof(ArraySizeHelper(array)))
 
-#ifdef COMPILER_MSVC
+#ifdef _WIN32
 // TODO(laszlocsomor) 2016-11-28: move pid_t usage out of global_variables.h and
 // whereever else it appears. Find some way to not have to declare a pid_t here,
 // either by making PID handling platform-independent or some other idea; remove
 // the following typedef afterwards.
 typedef int pid_t;
-#endif  // COMPILER_MSVC
+#endif  // _WIN32
 
 #endif  // BAZEL_SRC_MAIN_CPP_UTIL_PORT_H_

--- a/src/test/cpp/option_processor_test.cc
+++ b/src/test/cpp/option_processor_test.cc
@@ -319,7 +319,7 @@ TEST_F(OptionProcessorTest, TestDedupePathsWithRelativePath) {
   ASSERT_EQ(expected, internal::DedupeBlazercPaths(input));
 }
 
-#if !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 static bool Symlink(const std::string& old_path, const std::string& new_path) {
   return symlink(old_path.c_str(), new_path.c_str()) == 0;
 }
@@ -334,6 +334,6 @@ TEST_F(OptionProcessorTest, TestDedupePathsWithSymbolicLink) {
   std::vector<std::string> expected = {foo_path};
   ASSERT_EQ(expected, internal::DedupeBlazercPaths(input));
 }
-#endif  // !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#endif  // !defined(_WIN32) && !defined(__CYGWIN__)
 
 }  // namespace blaze

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -30,7 +30,7 @@ namespace blaze {
 using ::testing::HasSubstr;
 using ::testing::MatchesRegex;
 
-#if defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
 constexpr const char* kNullDevice = "nul";
 #else  // Assume POSIX if not Windows.
 constexpr const char* kNullDevice = "/dev/null";

--- a/src/test/cpp/util/file_windows_test.cc
+++ b/src/test/cpp/util/file_windows_test.cc
@@ -30,9 +30,9 @@
 #include "src/test/cpp/util/test_util.h"
 #include "src/test/cpp/util/windows_test_util.h"
 
-#if !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 #error("This test should only be run on Windows")
-#endif  // !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#endif  // !defined(_WIN32) && !defined(__CYGWIN__)
 
 namespace blaze_util {
 

--- a/src/test/cpp/util/path_windows_test.cc
+++ b/src/test/cpp/util/path_windows_test.cc
@@ -29,9 +29,9 @@
 #include "src/test/cpp/util/test_util.h"
 #include "src/test/cpp/util/windows_test_util.h"
 
-#if !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 #error("This test should only be run on Windows")
-#endif  // !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#endif  // !defined(_WIN32) && !defined(__CYGWIN__)
 
 namespace blaze_util {
 

--- a/src/test/cpp/util/test_util.h
+++ b/src/test/cpp/util/test_util.h
@@ -16,9 +16,9 @@
 
 #include <stdio.h>
 
-#if !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 #include <unistd.h>
-#endif  // not COMPILER_MSVC and not __CYGWIN__
+#endif  // not _WIN32 and not __CYGWIN__
 
 namespace blaze_util {
 
@@ -51,9 +51,9 @@ struct AutoFileHandle {
   handle_type fd;
 };
 
-#if !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 typedef struct AutoFileHandle<int, -1, close> AutoFd;
-#endif  // not COMPILER_MSVC and not __CYGWIN__
+#endif  // not _WIN32 and not __CYGWIN__
 
 typedef struct AutoFileHandle<FILE*, nullptr, fclose> AutoFileStream;
 

--- a/src/test/cpp/util/windows_test_util.cc
+++ b/src/test/cpp/util/windows_test_util.cc
@@ -19,9 +19,9 @@
 
 #include "src/test/cpp/util/windows_test_util.h"
 
-#if !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 #error("This test should only be run on Windows")
-#endif  // !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#endif  // !defined(_WIN32) && !defined(__CYGWIN__)
 
 namespace blaze_util {
 

--- a/src/test/cpp/util/windows_test_util_test.cc
+++ b/src/test/cpp/util/windows_test_util_test.cc
@@ -18,9 +18,9 @@
 #include "googletest/include/gtest/gtest.h"
 #include "src/test/cpp/util/windows_test_util.h"
 
-#if !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 #error("This test should only be run on Windows")
-#endif  // !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#endif  // !defined(_WIN32) && !defined(__CYGWIN__)
 
 namespace blaze_util {
 

--- a/src/test/native/windows/file_test.cc
+++ b/src/test/native/windows/file_test.cc
@@ -23,9 +23,9 @@
 #include "src/main/native/windows/file.h"
 #include "src/test/cpp/util/windows_test_util.h"
 
-#if !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 #error("This test should only be run on Windows")
-#endif  // !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#endif  // !defined(_WIN32) && !defined(__CYGWIN__)
 
 namespace bazel {
 namespace windows {

--- a/src/test/native/windows/util_test.cc
+++ b/src/test/native/windows/util_test.cc
@@ -23,9 +23,9 @@
 #include "gtest/gtest.h"
 #include "src/main/native/windows/util.h"
 
-#if !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 #error("This test should only be run on Windows")
-#endif  // !defined(COMPILER_MSVC) && !defined(__CYGWIN__)
+#endif  // !defined(_WIN32) && !defined(__CYGWIN__)
 
 namespace bazel {
 namespace windows {

--- a/src/test/py/bazel/cc_import_test.py
+++ b/src/test/py/bazel/cc_import_test.py
@@ -79,7 +79,7 @@ class CcImportTest(test_base.TestBase):
     self.ScratchFile('lib/a.cc', [
         '#include <stdio.h>',
         '',
-        '#ifdef COMPILER_MSVC',
+        '#ifdef _WIN32',
         '  #define DLLEXPORT __declspec(dllexport)',
         '#else',
         '  #define DLLEXPORT',

--- a/src/tools/singlejar/diag.h
+++ b/src/tools/singlejar/diag.h
@@ -27,7 +27,7 @@
 #define diag_warn(...) warn(__VA_ARGS__)
 #define diag_warnx(...) warnx(__VA_ARGS__)
 
-#elif defined(COMPILER_MSVC)
+#elif defined(_WIN32)
 
 #include <stdio.h>
 #include <string.h>

--- a/src/tools/singlejar/mapped_file.h
+++ b/src/tools/singlejar/mapped_file.h
@@ -28,11 +28,11 @@
  */
 class MappedFile {
  public:
-#ifdef COMPILER_MSVC
+#ifdef _WIN32
   typedef /* HANDLE = void* */ void *FileHandleType;
-#else  // not COMPILER_MSVC
+#else  // not _WIN32
   typedef int FileHandleType;
-#endif  // COMPILER_MSVC
+#endif  // _WIN32
 
   MappedFile();
 
@@ -64,10 +64,10 @@ class MappedFile {
   FileHandleType fd_;
 };
 
-#ifdef COMPILER_MSVC
+#ifdef _WIN32
 #include "src/tools/singlejar/mapped_file_windows.inc"
-#else  // not COMPILER_MSVC
+#else  // not _WIN32
 #include "src/tools/singlejar/mapped_file_posix.inc"
-#endif  // COMPILER_MSVC
+#endif  // _WIN32
 
 #endif  //  BAZEL_SRC_TOOLS_SINGLEJAR_MAPPED_FILE_H_

--- a/src/tools/singlejar/mapped_file_windows.inc
+++ b/src/tools/singlejar/mapped_file_windows.inc
@@ -15,7 +15,7 @@
 #ifndef BAZEL_SRC_TOOLS_SINGLEJAR_MAPPED_FILE_WINDOWS_H_
 #define BAZEL_SRC_TOOLS_SINGLEJAR_MAPPED_FILE_WINDOWS_H_ 1
 
-#if !defined(COMPILER_MSVC) || !defined(_WIN64)
+#if !defined(_WIN64)
 #error This code is for 64 bit Windows.
 #endif
 

--- a/src/tools/singlejar/zip_headers.h
+++ b/src/tools/singlejar/zip_headers.h
@@ -29,7 +29,7 @@
 #include <endian.h>
 #elif defined(__FreeBSD__)
 #include <sys/endian.h>
-#elif defined(__APPLE__) || defined(COMPILER_MSVC)
+#elif defined(__APPLE__) || defined(_WIN32)
 // Hopefully OSX and Windows will keep running solely on little endian CPUs, so:
 #define le16toh(x) (x)
 #define le32toh(x) (x)
@@ -44,7 +44,7 @@
 #include <string>
 #include <type_traits>
 
-#ifdef COMPILER_MSVC
+#ifdef _MSC_VER
 #pragma pack(push, 1)
 #define attr_packed
 #else
@@ -653,7 +653,7 @@ class ECD64 {
 } attr_packed;
 static_assert(56 == sizeof(ECD64), "ECD64 class fields layout is incorrect.");
 
-#ifdef COMPILER_MSVC
+#ifdef _MSC_VER
 #pragma pack(pop)
 #endif
 

--- a/third_party/ijar/common.h
+++ b/third_party/ijar/common.h
@@ -22,10 +22,10 @@
 #include <stdint.h>
 #include <string.h>
 
-#ifdef COMPILER_MSVC
+#ifdef _WIN32
 #define PATH_MAX 4096
 typedef int mode_t;
-#endif  // COMPILER_MSVC
+#endif  // _WIN32
 
 namespace devtools_ijar {
 

--- a/third_party/ijar/platform_utils.cc
+++ b/third_party/ijar/platform_utils.cc
@@ -17,13 +17,13 @@
 #include <limits.h>
 #include <stdio.h>
 
-#if defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
-#else  // !(defined(COMPILER_MSVC) || defined(__CYGWIN__))
+#else  // !(defined(_WIN32) || defined(__CYGWIN__))
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#endif  // defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
 
 #include <string>
 
@@ -39,7 +39,7 @@ namespace devtools_ijar {
 using std::string;
 
 bool stat_file(const char* path, Stat* result) {
-#if defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
   std::wstring wpath;
   std::string error;
   if (!blaze_util::AsAbsoluteWindowsPath(path, &wpath, &error)) {
@@ -69,7 +69,7 @@ bool stat_file(const char* path, Stat* result) {
   }
   ::CloseHandle(handle);
   return success;
-#else   // !(defined(COMPILER_MSVC) || defined(__CYGWIN__))
+#else   // !(defined(_WIN32) || defined(__CYGWIN__))
   struct stat statst;
   if (stat(path, &statst) < 0) {
     return false;
@@ -78,7 +78,7 @@ bool stat_file(const char* path, Stat* result) {
   result->file_mode = statst.st_mode;
   result->is_directory = (statst.st_mode & S_IFDIR) != 0;
   return true;
-#endif  // defined(COMPILER_MSVC) || defined(__CYGWIN__)
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
 }
 
 bool write_file(const char* path, unsigned int perm, const void* data,
@@ -93,10 +93,10 @@ bool read_file(const char* path, void* buffer, size_t size) {
 string get_cwd() { return blaze_util::GetCwd(); }
 
 bool make_dirs(const char* path, unsigned int mode) {
-#ifndef COMPILER_MSVC
+#ifndef _WIN32
   // TODO(laszlocsomor): respect `mode` on Windows/MSVC.
   mode |= S_IWUSR | S_IXUSR;
-#endif  // not COMPILER_MSVC
+#endif  // not _WIN32
   string spath(path);
   if (spath.empty()) {
     return true;

--- a/tools/cpp/runfiles/runfiles.cc
+++ b/tools/cpp/runfiles/runfiles.cc
@@ -13,23 +13,23 @@
 // limitations under the License.
 #include "tools/cpp/runfiles/runfiles.h"
 
-#ifdef COMPILER_MSVC
+#ifdef _WIN32
 #include <windows.h>
-#else  // not COMPILER_MSVC
+#else  // not _WIN32
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#endif  // COMPILER_MSVC
+#endif  // _WIN32
 
 #include <fstream>
 #include <map>
 #include <sstream>
 #include <vector>
 
-#ifdef COMPILER_MSVC
+#ifdef _WIN32
 #include <memory>
-#endif  // COMPILER_MSVC
+#endif  // _WIN32
 
 namespace bazel {
 namespace tools {
@@ -79,7 +79,7 @@ bool IsReadableFile(const string& path) {
 }
 
 bool IsDirectory(const string& path) {
-#ifdef COMPILER_MSVC
+#ifdef _WIN32
   DWORD attrs = GetFileAttributesA(path.c_str());
   return (attrs != INVALID_FILE_ATTRIBUTES) &&
          (attrs & FILE_ATTRIBUTE_DIRECTORY);
@@ -153,7 +153,7 @@ bool IsAbsolute(const string& path) {
 }
 
 string GetEnv(const string& key) {
-#ifdef COMPILER_MSVC
+#ifdef _WIN32
   DWORD size = ::GetEnvironmentVariableA(key.c_str(), NULL, 0);
   if (size == 0) {
     return std::move(string());  // unset or empty envvar

--- a/tools/cpp/runfiles/runfiles_test.cc
+++ b/tools/cpp/runfiles/runfiles_test.cc
@@ -14,9 +14,9 @@
 
 #include "tools/cpp/runfiles/runfiles.h"
 
-#ifdef COMPILER_MSVC
+#ifdef _WIN32
 #include <windows.h>
-#endif  // COMPILER_MSVC
+#endif  // _WIN32
 
 #include <fstream>
 #include <memory>
@@ -95,7 +95,7 @@ void RunfilesTest::AssertEnvvars(const Runfiles& runfiles,
 }
 
 string RunfilesTest::GetTemp() {
-#ifdef COMPILER_MSVC
+#ifdef _WIN32
   DWORD size = ::GetEnvironmentVariableA("TEST_TMPDIR", NULL, 0);
   if (size == 0) {
     return std::move(string());  // unset or empty envvar


### PR DESCRIPTION
Convert most `COMPILER_MSVC` to `_WIN32` (as they apply to Windows platform, not MSVC compiler). Only `src/tools/singlejar/zip_headers.h` and `src/main/cpp/util/md5.h` actually need `_MSC_VER`.

`COMPILER_MSVC` in `third_party/protobuf` are not removed. They can be fixed by updating dependency to newer version.

/cc @meteorcloudy