### PR TITLE
docs: fix broken link on tutorial/java.html

### DIFF
--- a/site/docs/tutorial/java.md
+++ b/site/docs/tutorial/java.md
@@ -412,7 +412,8 @@ dependencies.
 *  The [C++ build tutorial](../tutorial/cpp.md) to get started with building
    C++ projects with Bazel.
 
-*  The [mobile application tutorial](../tutorial/app.md) to get started with
+*  The [Android application tutorial](../tutorial/android-app.md) and
+   [iOS application tutorial](../tutorial/ios-app.md) to get started with
    building mobile applications for Android and iOS with Bazel.
 
 Happy building!


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/5358

Change-Id: I0c9eca59349069a41e3613600df25ed2b678b34c