### PR TITLE
docs: don't list all attribute types in build-ref

### DIFF
--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -358,7 +358,7 @@ testdata/input.txt
   the <a href='be/overview.html'>Build
   Encyclopedia</a> for the full list of supported rules and their
   corresponding attributes.  Each attribute has a name and a
-  type.  The full set of types that an attribute can have is: integer,
+  type.  Some of the common types an attribute can have are integer,
   label, list of labels, string, list of strings, output label,
   list of output labels.  Not all attributes need to be specified in
   every rule.  Attributes thus form a dictionary from keys (names) to


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/5362

Change-Id: I41d7b78e8d31d4a08ba0aba35c81723cbb315c40