### PR TITLE
Clean up uses of SkylarkList<String> and ast in toolchains parameters.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
@@ -313,7 +313,7 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
       SkylarkList<?> fragments,
       SkylarkList<?> hostFragments,
       Boolean skylarkTestable,
-      SkylarkList<String> toolchains,
+      SkylarkList<?> toolchains,
       String doc,
       SkylarkList<?> providesArg,
       FuncallExpression ast,
@@ -380,7 +380,9 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
     builder.setRuleDefinitionEnvironmentLabelAndHashCode(
         funcallEnv.getGlobals().getTransitiveLabel(),
         funcallEnv.getTransitiveContentHashCode());
-    builder.addRequiredToolchains(collectToolchainLabels(toolchains, ast));
+    builder.addRequiredToolchains(
+        collectToolchainLabels(
+            toolchains.getContents(String.class, "toolchains"), ast.getLocation()));
 
     for (Object o : providesArg) {
       if (!SkylarkAttr.isProvider(o)) {
@@ -426,7 +428,7 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
   }
 
   private static ImmutableList<Label> collectToolchainLabels(
-      Iterable<String> rawLabels, FuncallExpression ast) throws EvalException {
+      Iterable<String> rawLabels, Location loc) throws EvalException {
     ImmutableList.Builder<Label> requiredToolchains = new ImmutableList.Builder<>();
     for (String rawLabel : rawLabels) {
       try {
@@ -434,9 +436,7 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
         requiredToolchains.add(toolchainLabel);
       } catch (LabelSyntaxException e) {
         throw new EvalException(
-            ast.getLocation(),
-            String.format("Unable to parse toolchain %s: %s", rawLabel, e.getMessage()),
-            e);
+            loc, String.format("Unable to parse toolchain %s: %s", rawLabel, e.getMessage()), e);
       }
     }
 
@@ -452,7 +452,7 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
       SkylarkList providesArg,
       SkylarkList fragments,
       SkylarkList hostFragments,
-      SkylarkList<String> toolchains,
+      SkylarkList<?> toolchains,
       String doc,
       FuncallExpression ast,
       Environment funcallEnv)
@@ -543,7 +543,8 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
         ImmutableSet.copyOf(fragments.getContents(String.class, "fragments")),
         HostTransition.INSTANCE,
         ImmutableSet.copyOf(hostFragments.getContents(String.class, "host_fragments")),
-        collectToolchainLabels(toolchains, ast));
+        collectToolchainLabels(
+            toolchains.getContents(String.class, "toolchains"), ast.getLocation()));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleFunctionsApi.java
@@ -280,7 +280,7 @@ public interface SkylarkRuleFunctionsApi<FileApiT extends FileApi> {
       SkylarkList<?> fragments,
       SkylarkList<?> hostFragments,
       Boolean skylarkTestable,
-      SkylarkList<String> toolchains,
+      SkylarkList<?> toolchains,
       String doc,
       SkylarkList<?> providesArg,
       FuncallExpression ast,
@@ -409,7 +409,7 @@ public interface SkylarkRuleFunctionsApi<FileApiT extends FileApi> {
       SkylarkList providesArg,
       SkylarkList fragments,
       SkylarkList hostFragments,
-      SkylarkList<String> toolchains,
+      SkylarkList<?> toolchains,
       String doc,
       FuncallExpression ast,
       Environment funcallEnv)


### PR DESCRIPTION
Change-Id: I3655868d34dd98f5cde084a61995dfae8e4b94c0