### PR TITLE
Optionize input creation time check

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
@@ -228,4 +228,14 @@ public final class RemoteOptions extends OptionsBase {
             + "otherwise cachable actions that output symlinks will fail."
   )
   public boolean allowSymlinkUpload;
+
+  @Option(
+    name = "remote_cache_validate_input_ctimes",
+    defaultValue = "true",
+    category = "remote",
+    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    effectTags = {OptionEffectTag.UNKNOWN},
+    help = "Whether to validate ctimes after local execution before uploading results."
+  )
+  public boolean remoteCacheValidateInputCtimes;
 }


### PR DESCRIPTION
Make the inputCtime validation (pre- and post-local-execution scan of
inputs with stats for cache populators) optional.

Option is --[no]remote_cache_validate_input_ctimes