### PR TITLE
Suppress RepositoryCache IOException on download

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunction.java
@@ -20,6 +20,7 @@ import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.bazel.repository.MavenDownloader.JarPaths;
 import com.google.devtools.build.lib.bazel.rules.workspace.MavenJarRule;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue;
 import com.google.devtools.build.lib.rules.repository.WorkspaceAttributeMapper;
@@ -101,11 +102,11 @@ public class MavenJarFunction extends HttpArchiveFunction {
     }
 
     Path outputDir = getExternalRepositoryDirectory(directories).getRelative(rule.getName());
-    return createOutputTree(rule, outputDir, serverValue);
+    return createOutputTree(rule, outputDir, serverValue, env.getListener());
   }
 
   private RepositoryDirectoryValue.Builder createOutputTree(Rule rule, Path outputDirectory,
-      MavenServerValue serverValue) throws RepositoryFunctionException {
+      MavenServerValue serverValue, ExtendedEventHandler eventHandler) throws RepositoryFunctionException {
     Preconditions.checkState(downloader instanceof MavenDownloader);
     MavenDownloader mavenDownloader = (MavenDownloader) downloader;
 
@@ -115,7 +116,7 @@ public class MavenJarFunction extends HttpArchiveFunction {
     try {
       repositoryJars =
           mavenDownloader.download(
-              name, WorkspaceAttributeMapper.of(rule), outputDirectory, serverValue);
+              name, WorkspaceAttributeMapper.of(rule), outputDirectory, serverValue, eventHandler);
     } catch (IOException e) {
       throw new RepositoryFunctionException(e, Transience.TRANSIENT);
     } catch (EvalException e) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -183,10 +183,14 @@ public class HttpDownloader {
       if (repositoryCache.isEnabled()) {
         isCachingByProvidedSha256 = true;
 
-        Path cachedDestination = repositoryCache.get(sha256, destination, KeyType.SHA256);
-        if (cachedDestination != null) {
-          // Cache hit!
-          return cachedDestination;
+        try {
+          Path cachedDestination = repositoryCache.get(sha256, destination, KeyType.SHA256);
+          if (cachedDestination != null) {
+            // Cache hit!
+            return cachedDestination;
+          }
+        } catch (IOException e) {
+          // Ignore error trying to get. We'll just download again.
         }
       }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunctionTest.java
@@ -16,9 +16,14 @@ package com.google.devtools.build.lib.bazel.repository;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
+import com.google.common.eventbus.EventBus;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
+import com.google.devtools.build.lib.events.EventHandler;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.packages.Rule;
 
 import com.google.devtools.build.lib.rules.repository.WorkspaceAttributeMapper;
@@ -37,6 +42,9 @@ import java.io.IOException;
 public class MavenJarFunctionTest extends BuildViewTestCase {
   private static final MavenServerValue TEST_SERVER = new MavenServerValue(
       "server", "http://example.com", new Server(), new byte[]{});
+  private final EventHandler eventHandler = mock(EventHandler.class);
+  private final ExtendedEventHandler extendedEventHandler =
+      new Reporter(new EventBus(), eventHandler);
 
   @Test
   public void testInvalidSha1() throws Exception {
@@ -49,7 +57,7 @@ public class MavenJarFunctionTest extends BuildViewTestCase {
     MavenDownloader downloader = new MavenDownloader(Mockito.mock(RepositoryCache.class));
     try {
       downloader.download(
-          "foo", WorkspaceAttributeMapper.of(rule), scratch.dir("/whatever"), TEST_SERVER);
+          "foo", WorkspaceAttributeMapper.of(rule), scratch.dir("/whatever"), TEST_SERVER, extendedEventHandler);
       fail("Invalid sha1 should have thrown.");
     } catch (IOException expected) {
       assertThat(expected.getMessage()).contains("Invalid SHA-1 for maven_jar foo");
@@ -68,7 +76,7 @@ public class MavenJarFunctionTest extends BuildViewTestCase {
     MavenDownloader downloader = new MavenDownloader(Mockito.mock(RepositoryCache.class));
     try {
       downloader.download(
-          "foo", WorkspaceAttributeMapper.of(rule), scratch.dir("/whatever"), TEST_SERVER);
+          "foo", WorkspaceAttributeMapper.of(rule), scratch.dir("/whatever"), TEST_SERVER, extendedEventHandler);
       fail("Expected failure to fetch artifact because of nonexistent server and not due to "
           + "the existence of a valid SHA");
     } catch (IOException expected) {
@@ -86,7 +94,7 @@ public class MavenJarFunctionTest extends BuildViewTestCase {
     MavenDownloader downloader = new MavenDownloader(Mockito.mock(RepositoryCache.class));
     try {
       downloader.download(
-          "foo", WorkspaceAttributeMapper.of(rule), scratch.dir("/whatever"), TEST_SERVER);
+          "foo", WorkspaceAttributeMapper.of(rule), scratch.dir("/whatever"), TEST_SERVER, extendedEventHandler);
       fail("Expected failure to fetch artifact because of nonexistent server and not due to "
           + "lack of SHA.");
     } catch (IOException expected) {
@@ -106,7 +114,7 @@ public class MavenJarFunctionTest extends BuildViewTestCase {
     MavenDownloader downloader = new MavenDownloader(cache);
     try {
       downloader.download(
-          "foo", WorkspaceAttributeMapper.of(rule), scratch.dir("/whatever"), TEST_SERVER);
+          "foo", WorkspaceAttributeMapper.of(rule), scratch.dir("/whatever"), TEST_SERVER, extendedEventHandler);
       fail("Expected failure to fetch artifact because of nonexistent server.");
     } catch (IOException expected) {
       assertThat(expected.getMessage()).contains("Failed to fetch Maven dependency:");


### PR DESCRIPTION
With invalid contents in the repository cache, silence the IOException
on RepositoryCache::get and re-download an artifact when attempting to
short-circuit that operation. The repository cache can easily get into
this state when a build is interrupted while downloading into the non-
atomic repository cache destination.

Possible solution to #5390