### PR TITLE
Add Missing RobotoDraft-700 font to docs

### DIFF
--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -7,7 +7,7 @@
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site_root }}">
 
     <!-- Webfont -->
-    <link href="//fonts.googleapis.com/css?family=RobotoDraft:300,400,500|Source+Code+Pro:400,500,700" rel="stylesheet">
+    <link href="//fonts.googleapis.com/css?family=RobotoDraft:300,400,500,700|Source+Code+Pro:400,500,700" rel="stylesheet">
 
     <link rel="shortcut icon" type="image/png" href="/images/favicon.ico">
 


### PR DESCRIPTION
Fixed bug where \<strong\> tags were being improperly rendered