### PR TITLE
Add option --android_compress_apk_with_singlejar to toggle compression of the APK at the generation step

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidBinary.java
@@ -533,7 +533,7 @@ public abstract class AndroidBinary implements RuleConfiguredTargetFactory {
       finalClassesDex = dexPostprocessingOutput.classesDexZip();
     }
 
-    ApkActionsBuilder.create("apk")
+    ApkActionsBuilder.create("apk for " + ruleContext.getLabel())
         .setClassesDex(finalClassesDex)
         .addInputZip(resourceApk.getArtifact())
         .setJavaResourceZip(dexingOutput.javaResourceJar, resourceExtractor)

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -712,9 +712,22 @@ public class AndroidConfiguration extends BuildConfiguration.Fragment
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
       effectTags = OptionEffectTag.LOADING_AND_ANALYSIS,
-      help = "Build Android APKs with SingleJar."
+      help = "Build Android APKs with SingleJar. SingleJar is a bundled tool in Bazel for building "
+          + "and compressing JARs and APKs."
     )
     public boolean useSingleJarApkBuilder;
+
+    @Option(
+        name = "android_compress_apk_with_singlejar",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,
+        effectTags = {
+            OptionEffectTag.AFFECTS_OUTPUTS
+        },
+        help =
+            "If enabled, the final APK will be compressed using SingleJar."
+    )
+    public boolean compressApkWithSinglejar;
 
     @Option(
       name = "experimental_android_compress_java_resources",
@@ -923,6 +936,7 @@ public class AndroidConfiguration extends BuildConfiguration.Fragment
   private final boolean decoupleDataProcessing;
   private final boolean checkForMigrationTag;
   private final boolean oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest;
+  private final boolean compressApkWithSinglejar;
 
   AndroidConfiguration(Options options) throws InvalidConfigurationException {
     this.sdk = options.sdk;
@@ -964,6 +978,7 @@ public class AndroidConfiguration extends BuildConfiguration.Fragment
     this.checkForMigrationTag = options.checkForMigrationTag;
     this.oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest =
         options.oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest;
+    this.compressApkWithSinglejar = options.compressApkWithSinglejar;
 
     if (incrementalDexingShardsAfterProguard < 0) {
       throw new InvalidConfigurationException(
@@ -1016,7 +1031,8 @@ public class AndroidConfiguration extends BuildConfiguration.Fragment
       AndroidRobolectricTestDeprecationLevel robolectricTestDeprecationLevel,
       boolean decoupleDataProcessing,
       boolean checkForMigrationTag,
-      boolean oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest) {
+      boolean oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest,
+      boolean compressApkWithSinglejar) {
     this.sdk = sdk;
     this.cpu = cpu;
     this.useIncrementalNativeLibs = useIncrementalNativeLibs;
@@ -1053,6 +1069,7 @@ public class AndroidConfiguration extends BuildConfiguration.Fragment
     this.checkForMigrationTag = checkForMigrationTag;
     this.oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest =
         oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest;
+    this.compressApkWithSinglejar = compressApkWithSinglejar;
   }
 
   public String getCpu() {
@@ -1209,6 +1226,10 @@ public class AndroidConfiguration extends BuildConfiguration.Fragment
 
   public boolean getOneVersionEnforcementUseTransitiveJarsForBinaryUnderTest() {
     return oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest;
+  }
+
+  public boolean getCompressApkWithSinglejar() {
+    return compressApkWithSinglejar;
   }
 
   @Override


### PR DESCRIPTION
For debug builds, there's little to no need to generate the compression action for the APK at the end of the build. This removes a "Generating unsigned APK" action from the critical path when using `--noandroid_compress_apk_with_singlejar`, which saves a round trip when using RBE.