### PR TITLE
On type errors for select()s, show which branch is responsible.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
@@ -578,7 +578,8 @@ public final class BuildType {
           defaultValuesBuilder.add(key);
         } else {
           String selectBranch = what == null ? null :
-              String.format("%s over select() branch '%s'", what.toString(), key.toString());
+              String.format("each branch in select expression of %s (including '%s')",
+                  what.toString(), key.toString());
           result.put(key, originalType.convert(entry.getValue(), selectBranch, context));
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
@@ -559,6 +559,23 @@ public final class BuildType {
     }
 
     /**
+     * This class provides more precise error messaging for type failures on select()s by
+     * highlighting which select() branch has the failure.
+     */
+    private static class CustomToString {
+      private final String str;
+
+      CustomToString(String str) {
+        this.str = str;
+      }
+
+      @Override
+      public String toString() {
+        return str;
+      }
+    }
+
+    /**
      * Creates a new Selector with a custom error message for when no conditions match.
      */
     Selector(ImmutableMap<?, ?> x, Object what, @Nullable Label context, Type<T> originalType,
@@ -577,7 +594,9 @@ public final class BuildType {
           result.put(key, originalType.getDefaultValue());
           defaultValuesBuilder.add(key);
         } else {
-          result.put(key, originalType.convert(entry.getValue(), what, context));
+          CustomToString selectBranch = what == null ? null : new CustomToString(
+              String.format("%s over select() branch '%s'", what.toString(), key.toString()));
+          result.put(key, originalType.convert(entry.getValue(), selectBranch, context));
         }
       }
       this.map = Collections.unmodifiableMap(result);

--- a/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
@@ -578,7 +578,7 @@ public final class BuildType {
           defaultValuesBuilder.add(key);
         } else {
           String selectBranch = what == null ? null :
-              String.format("%s over select() branch '%s'", what.toString(), key.toString()));
+              String.format("%s over select() branch '%s'", what.toString(), key.toString());
           result.put(key, originalType.convert(entry.getValue(), selectBranch, context));
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
@@ -594,7 +594,11 @@ public final class BuildType {
           result.put(key, originalType.getDefaultValue());
           defaultValuesBuilder.add(key);
         } else {
+<<<<<<< HEAD
+          String selectBranch = what == null ? null :
+=======
           CustomToString selectBranch = what == null ? null : new CustomToString(
+>>>>>>> 61a4a88f83f614e21a2bf8c14043c0def97ad2f9
               String.format("%s over select() branch '%s'", what.toString(), key.toString()));
           result.put(key, originalType.convert(entry.getValue(), selectBranch, context));
         }

--- a/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
@@ -559,23 +559,6 @@ public final class BuildType {
     }
 
     /**
-     * This class provides more precise error messaging for type failures on select()s by
-     * highlighting which select() branch has the failure.
-     */
-    private static class CustomToString {
-      private final String str;
-
-      CustomToString(String str) {
-        this.str = str;
-      }
-
-      @Override
-      public String toString() {
-        return str;
-      }
-    }
-
-    /**
      * Creates a new Selector with a custom error message for when no conditions match.
      */
     Selector(ImmutableMap<?, ?> x, Object what, @Nullable Label context, Type<T> originalType,
@@ -594,11 +577,7 @@ public final class BuildType {
           result.put(key, originalType.getDefaultValue());
           defaultValuesBuilder.add(key);
         } else {
-<<<<<<< HEAD
           String selectBranch = what == null ? null :
-=======
-          CustomToString selectBranch = what == null ? null : new CustomToString(
->>>>>>> 61a4a88f83f614e21a2bf8c14043c0def97ad2f9
               String.format("%s over select() branch '%s'", what.toString(), key.toString()));
           result.put(key, originalType.convert(entry.getValue(), selectBranch, context));
         }


### PR DESCRIPTION
From https://groups.google.com/forum/#!topic/bazel-discuss/UqEmIjv5J-0

FYI quoting the value, i.e. turning:

  but got ["BROKEN"] (list)
to:

  but got '["BROKEN"]' (list)
is unfortunately not as straightforward to pipe through the type validation logic. So that's not included here.