### PR TITLE
[Windows] Fix kOneYear initialization

### DIFF
--- a/src/main/cpp/util/file_windows.cc
+++ b/src/main/cpp/util/file_windows.cc
@@ -114,58 +114,15 @@ class WindowsFileMtime : public IFileMtime {
   bool SetToDistantFuture(const string& path) override;
 
  private:
-  // 1 year in FILETIME.
-  static const ULARGE_INTEGER kOneYear;
   // 9 years in the future.
   const FILETIME near_future_;
   // 10 years in the future.
   const FILETIME distant_future_;
 
-  static ULARGE_INTEGER&& OneYearDelay();
-  static const FILETIME GetNow();
-  static const FILETIME GetFuture(WORD years);
-  static bool Set(const string& path, const FILETIME& time);
+  static FILETIME GetNow();
+  static FILETIME GetFuture(WORD years);
+  static bool Set(const string& path, FILETIME time);
 };
-
-const ULARGE_INTEGER WindowsFileMtime::kOneYear =
-    std::move(WindowsFileMtime::OneYearDelay());
-
-ULARGE_INTEGER&& WindowsFileMtime::OneYearDelay() {
-  SYSTEMTIME now;
-  GetSystemTime(&now);
-  now.wMonth = 1;
-  now.wDayOfWeek = 0;
-  now.wDay = 1;
-  now.wHour = 0;
-  now.wMinute = 0;
-  now.wSecond = 0;
-  now.wMilliseconds = 0;
-
-  FILETIME now_ft;
-  if (!::SystemTimeToFileTime(&now, &now_ft)) {
-    string err = GetLastErrorString();
-    BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "WindowsFileMtime::OneYearDelay: SystemTimeToFileTime 1 failed: "
-        << err;
-  }
-  ULARGE_INTEGER t1;
-  t1.LowPart = now_ft.dwLowDateTime;
-  t1.HighPart = now_ft.dwHighDateTime;
-
-  now.wYear++;
-  if (!::SystemTimeToFileTime(&now, &now_ft)) {
-    string err = GetLastErrorString();
-    BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "WindowsFileMtime::OneYearDelay: SystemTimeToFileTime 2 failed: "
-        << err;
-  }
-  ULARGE_INTEGER t2;
-  t2.LowPart = now_ft.dwLowDateTime;
-  t2.HighPart = now_ft.dwHighDateTime;
-
-  t2.QuadPart -= t1.QuadPart;
-  return std::move(t2);
-}
 
 bool WindowsFileMtime::GetIfInDistantFuture(const string& path, bool* result) {
   if (path.empty()) {
@@ -224,7 +181,7 @@ bool WindowsFileMtime::SetToDistantFuture(const string& path) {
   return Set(path, distant_future_);
 }
 
-bool WindowsFileMtime::Set(const string& path, const FILETIME& time) {
+bool WindowsFileMtime::Set(const string& path, FILETIME time) {
   if (path.empty()) {
     return false;
   }
@@ -258,20 +215,23 @@ bool WindowsFileMtime::Set(const string& path, const FILETIME& time) {
              /* lpLastWriteTime */ &time) == TRUE;
 }
 
-const FILETIME WindowsFileMtime::GetNow() {
+FILETIME WindowsFileMtime::GetNow() {
   FILETIME now;
   GetSystemTimeAsFileTime(&now);
   return now;
 }
 
-const FILETIME WindowsFileMtime::GetFuture(WORD years) {
+FILETIME WindowsFileMtime::GetFuture(WORD years) {
   FILETIME result;
   GetSystemTimeAsFileTime(&result);
+
+  // 1 year in FILETIME.
+  constexpr ULONGLONG kOneYear = 365ULL * 24 * 60 * 60 * 10'000'000;
 
   ULARGE_INTEGER result_value;
   result_value.LowPart = result.dwLowDateTime;
   result_value.HighPart = result.dwHighDateTime;
-  result_value.QuadPart += kOneYear.QuadPart * years;
+  result_value.QuadPart += kOneYear * years;
   result.dwLowDateTime = result_value.LowPart;
   result.dwHighDateTime = result_value.HighPart;
   return result;


### PR DESCRIPTION
Fix breakage introduced in #5385 due to incorrect use of `std::move` on local temporary variable after function returns (found by Clang on Windows).

Since `OneYearDelay` function will return the same value and `kOneYear` is only used in one place, remove unused `OneYearDelay` function and move `kOneYear` to `GetFuture` as a `constexpr` constant.

Drive-by improvement: remove some const reference in function signatures. `FILETIME` is a plain C struct with size of 64-bit, so it is trivially-copyable and can easily fit into a 64-bit register. It is more efficient to pass `FILETIME` by value (smaller code size).

/cc @laszlocsomor 