### PR TITLE
add helper JUnit TestWrapper class to do some action on test timeout

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -62,6 +62,7 @@ filegroup(
         "//src/test/java/com/google/devtools/build/lib/skylarkdebug/server:srcs",
         "//src/test/java/com/google/devtools/build/lib/skylarkinterface/processor:srcs",
         "//src/test/java/com/google/devtools/build/lib/unsafe:srcs",
+        "//src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit:srcs",
     ],
     visibility = ["//src:__pkg__"],
 )

--- a/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/BUILD
@@ -1,0 +1,21 @@
+java_test(
+    name = "TimeoutTestWatcherTest",
+    srcs = [
+        "TimeoutTestWatcher.java",
+        "TimeoutTestWatcherBaseTest.java",
+        "TimeoutTestWatcherTest.java",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//third_party:junit4",
+    ],
+)
+
+java_library(
+    name = "timeout_watcher",
+    srcs = ["TimeoutTestWatcher.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//third_party:junit4",
+    ],
+)

--- a/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/BUILD
@@ -11,6 +11,12 @@ java_test(
     ],
 )
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**/*"]),
+    visibility = ["//src/test/java/com/google/devtools/build/lib:__pkg__"],
+)
+
 java_library(
     name = "timeout_watcher",
     srcs = ["TimeoutTestWatcher.java"],

--- a/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/TimeoutTestWatcher.java
+++ b/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/TimeoutTestWatcher.java
@@ -1,3 +1,19 @@
+/*
+ * // Copyright 2018 The Bazel Authors. All rights reserved.
+ * //
+ * // Licensed under the Apache License, Version 2.0 (the "License");
+ * // you may not use this file except in compliance with the License.
+ * // You may obtain a copy of the License at
+ * //
+ * // http://www.apache.org/licenses/LICENSE-2.0
+ * //
+ * // Unless required by applicable law or agreed to in writing, software
+ * // distributed under the License is distributed on an "AS IS" BASIS,
+ * // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * // See the License for the specific language governing permissions and
+ * // limitations under the License.
+ */
+
 package com.google.devtools.build.lib.integration.blackbox.framework.junit;
 
 import java.util.concurrent.TimeoutException;

--- a/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/TimeoutTestWatcher.java
+++ b/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/TimeoutTestWatcher.java
@@ -1,0 +1,67 @@
+package com.google.devtools.build.lib.integration.blackbox.framework.junit;
+
+import java.util.concurrent.TimeoutException;
+import org.junit.rules.TestWatcher;
+import org.junit.rules.Timeout;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public abstract class TimeoutTestWatcher extends TestWatcher {
+  private String name;
+
+  protected abstract long getTimeoutMillis();
+  protected abstract boolean onTimeout();
+
+  @Override
+  protected void starting(Description description) {
+    name = description.getMethodName();
+  }
+
+  @Override
+  protected void finished(Description description) {
+    name = null;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    // we are using exception wrapping, because unfortunately JUnit's Timeout throws
+    // java.util.Exception on timeout, which is hard to distinguish from other cases
+    Statement wrapper = new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        try {
+          base.evaluate();
+        } catch (Throwable th) {
+          throw new ExceptionWrapper(th);
+        }
+      }
+    };
+
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        try {
+          new Timeout((int) getTimeoutMillis()).apply(wrapper, description).evaluate();
+        } catch (ExceptionWrapper wrapper) {
+          // original test exception
+          throw wrapper.getCause();
+        } catch (Exception e) {
+          // timeout exception
+          if (!onTimeout()) {
+            throw new TimeoutException(e.getMessage());
+          }
+        }
+      }
+    };
+  }
+
+  private static class ExceptionWrapper extends Throwable {
+    ExceptionWrapper(Throwable cause) {
+      super(cause);
+    }
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/TimeoutTestWatcherBaseTest.java
+++ b/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/TimeoutTestWatcherBaseTest.java
@@ -1,3 +1,19 @@
+/*
+ * // Copyright 2018 The Bazel Authors. All rights reserved.
+ * //
+ * // Licensed under the Apache License, Version 2.0 (the "License");
+ * // you may not use this file except in compliance with the License.
+ * // You may obtain a copy of the License at
+ * //
+ * // http://www.apache.org/licenses/LICENSE-2.0
+ * //
+ * // Unless required by applicable law or agreed to in writing, software
+ * // distributed under the License is distributed on an "AS IS" BASIS,
+ * // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * // See the License for the specific language governing permissions and
+ * // limitations under the License.
+ */
+
 package com.google.devtools.build.lib.integration.blackbox.framework.junit;
 
 import org.junit.Rule;

--- a/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/TimeoutTestWatcherBaseTest.java
+++ b/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/TimeoutTestWatcherBaseTest.java
@@ -1,0 +1,24 @@
+package com.google.devtools.build.lib.integration.blackbox.framework.junit;
+
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TimeoutTestWatcherBaseTest {
+  boolean timeoutCaught = false;
+
+  @Rule
+  public TimeoutTestWatcher testWatcher =
+      new TimeoutTestWatcher() {
+        @Override
+        protected long getTimeoutMillis() {
+          return 100;
+        }
+
+        @Override
+        protected boolean onTimeout() {
+          return timeoutCaught = true;
+        }
+      };
+}

--- a/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/TimeoutTestWatcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/TimeoutTestWatcherTest.java
@@ -1,0 +1,35 @@
+package com.google.devtools.build.lib.integration.blackbox.framework.junit;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TimeoutTestWatcherTest extends TimeoutTestWatcherBaseTest {
+  @After
+  public void tearDown() {
+    if ("testTimeoutCaught".equals(testWatcher.getName())) {
+      Assert.assertTrue(timeoutCaught);
+    }
+  }
+
+  /**
+   * Test that timeout handler is called
+   */
+  @Test
+  public void testTimeoutCaught() throws Exception {
+    for (int i = 0; i < 10; i++) {
+      Thread.sleep(500);
+    }
+  }
+
+  /**
+   * Test that normal test failures are not blocked
+   */
+  @Test(expected = AssertionError.class)
+  public void testFailure()  {
+    Assert.assertTrue(false);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/TimeoutTestWatcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/integration/blackbox/framework/junit/TimeoutTestWatcherTest.java
@@ -1,3 +1,19 @@
+/*
+ * // Copyright 2018 The Bazel Authors. All rights reserved.
+ * //
+ * // Licensed under the Apache License, Version 2.0 (the "License");
+ * // you may not use this file except in compliance with the License.
+ * // You may obtain a copy of the License at
+ * //
+ * // http://www.apache.org/licenses/LICENSE-2.0
+ * //
+ * // Unless required by applicable law or agreed to in writing, software
+ * // distributed under the License is distributed on an "AS IS" BASIS,
+ * // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * // See the License for the specific language governing permissions and
+ * // limitations under the License.
+ */
+
 package com.google.devtools.build.lib.integration.blackbox.framework.junit;
 
 import org.junit.After;


### PR DESCRIPTION
add helper JUnit TestWrapper class to do some action on test timeout

i.e. we want to dump the current state of the test on timeout before
exit
for the new junit integration test framework