### PR TITLE
Windows,Bazel client: check embedded tools faster

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1064,12 +1064,6 @@ static void ExtractData(const string &self_path) {
       string path = blaze_util::JoinPath(real_install_dir, it);
       if (!mtime.get()->IsValidEmbeddedBinary(path)) {
         BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-            << "corrupt installation: failed to check '" << path
-            << "'. Please remove '" << globals->options->install_base
-            << "' and try again.";
-      }
-      if (!is_good) {
-        BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
             << "Error: corrupt installation: file '" << path
             << "' modified.  Please remove '" << globals->options->install_base
             << "' and try again.";

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1062,27 +1062,14 @@ static void ExtractData(const string &self_path) {
         globals->options->install_base, "_embedded_binaries");
     for (const auto &it : globals->extracted_binaries) {
       string path = blaze_util::JoinPath(real_install_dir, it);
-      // Check that the file exists and is readable.
-      if (blaze_util::IsDirectory(path)) {
-        continue;
-      }
-      if (!blaze_util::CanReadFile(path)) {
+      bool is_good = false;
+      if (!mtime.get()->CheckExtractedBinary(path, &is_good)) {
         BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
             << "corrupt installation: file '" << path
             << "' missing. Please remove '" << globals->options->install_base
             << "' and try again.";
       }
-      // Check that the timestamp is in the future. A past timestamp would
-      // indicate that the file has been tampered with.
-      // See ActuallyExtractData().
-      bool is_in_future = false;
-      if (!mtime.get()->GetIfInDistantFuture(path, &is_in_future)) {
-        BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-            << "Error: could not retrieve mtime of file '" << path
-            << "'. Please remove '" << globals->options->install_base
-            << "' and try again.";
-      }
-      if (!is_in_future) {
+      if (!is_good) {
         BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
             << "Error: corrupt installation: file '" << path
             << "' modified.  Please remove '" << globals->options->install_base

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1065,8 +1065,8 @@ static void ExtractData(const string &self_path) {
       bool is_good = false;
       if (!mtime.get()->CheckExtractedBinary(path, &is_good)) {
         BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-            << "corrupt installation: file '" << path
-            << "' missing. Please remove '" << globals->options->install_base
+            << "corrupt installation: failed to check '" << path
+            << "'. Please remove '" << globals->options->install_base
             << "' and try again.";
       }
       if (!is_good) {

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1062,7 +1062,7 @@ static void ExtractData(const string &self_path) {
         globals->options->install_base, "_embedded_binaries");
     for (const auto &it : globals->extracted_binaries) {
       string path = blaze_util::JoinPath(real_install_dir, it);
-      if (!mtime.get()->IsValidEmbeddedBinary(path)) {
+      if (!mtime.get()->IsUntampered(path)) {
         BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
             << "Error: corrupt installation: file '" << path
             << "' modified.  Please remove '" << globals->options->install_base

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1062,8 +1062,7 @@ static void ExtractData(const string &self_path) {
         globals->options->install_base, "_embedded_binaries");
     for (const auto &it : globals->extracted_binaries) {
       string path = blaze_util::JoinPath(real_install_dir, it);
-      bool is_good = false;
-      if (!mtime.get()->CheckExtractedBinary(path, &is_good)) {
+      if (!mtime.get()->IsValidEmbeddedBinary(path)) {
         BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
             << "corrupt installation: failed to check '" << path
             << "'. Please remove '" << globals->options->install_base

--- a/src/main/cpp/util/file_platform.h
+++ b/src/main/cpp/util/file_platform.h
@@ -34,7 +34,7 @@ class IFileMtime {
   // Queries the mtime of `path` to see whether it's in the distant future.
   // Returns true if querying succeeded and stores the result in `result`.
   // Returns false if querying failed.
-  virtual bool GetIfInDistantFuture(const std::string &path, bool *result) = 0;
+  virtual bool CheckExtractedBinary(const std::string &path, bool *result) = 0;
 
   // Sets the mtime of file under `path` to the current time.
   // Returns true if the mtime was changed successfully.

--- a/src/main/cpp/util/file_platform.h
+++ b/src/main/cpp/util/file_platform.h
@@ -31,11 +31,15 @@ class IFileMtime {
  public:
   virtual ~IFileMtime() {}
 
-  // Checks if `path` is a valid embedded binary, i.e. it is either an
-  // embedded binary that Bazel extracted from a previous run and it hasn't
-  // been tampered with (its mtime is unchanged), or it's a directory.
+  // Checks if `path` is a file/directory in the embedded tools directory that
+  // was not tampered with.
+  // Returns true if `path` is a directory or directory symlink, or if `path` is
+  // a file with an mtime in the distant future.
   // Returns false otherwise, or if querying the information failed.
-  virtual bool IsValidEmbeddedBinary(const std::string &path) = 0;
+  // TODO(laszlocsomor): move this function, and with it the whole IFileMtime
+  // class into blaze_util_<platform>.cc, because it is Bazel-specific logic,
+  // not generic file-handling logic.
+  virtual bool IsUntampered(const std::string &path) = 0;
 
   // Sets the mtime of file under `path` to the current time.
   // Returns true if the mtime was changed successfully.

--- a/src/main/cpp/util/file_platform.h
+++ b/src/main/cpp/util/file_platform.h
@@ -31,9 +31,11 @@ class IFileMtime {
  public:
   virtual ~IFileMtime() {}
 
-  // Queries the mtime of `path` to see whether it's in the distant future.
-  // Returns true if querying succeeded and stores the result in `result`.
-  // Returns false if querying failed.
+  // Checks if `path` is a good "extracted binary", i.e. it is either an
+  // embedded binary that Bazel extracted from a previous run, and it hasn't
+  // been tampered with (its mtime is unchanged), or it's a directory.
+  // Returns false if querying the information failed, either due to I/O error
+  // or due to the `path` missing or it being a broken symlink.
   virtual bool CheckExtractedBinary(const std::string &path, bool *result) = 0;
 
   // Sets the mtime of file under `path` to the current time.

--- a/src/main/cpp/util/file_platform.h
+++ b/src/main/cpp/util/file_platform.h
@@ -31,12 +31,11 @@ class IFileMtime {
  public:
   virtual ~IFileMtime() {}
 
-  // Checks if `path` is a good "extracted binary", i.e. it is either an
-  // embedded binary that Bazel extracted from a previous run, and it hasn't
+  // Checks if `path` is a valid embedded binary, i.e. it is either an
+  // embedded binary that Bazel extracted from a previous run and it hasn't
   // been tampered with (its mtime is unchanged), or it's a directory.
-  // Returns false if querying the information failed, either due to I/O error
-  // or due to the `path` missing or it being a broken symlink.
-  virtual bool CheckExtractedBinary(const std::string &path, bool *result) = 0;
+  // Returns false otherwise, or if querying the information failed.
+  virtual bool IsValidEmbeddedBinary(const std::string &path) = 0;
 
   // Sets the mtime of file under `path` to the current time.
   // Returns true if the mtime was changed successfully.

--- a/src/main/cpp/util/file_posix.cc
+++ b/src/main/cpp/util/file_posix.cc
@@ -329,7 +329,7 @@ class PosixFileMtime : public IFileMtime {
       : near_future_(GetFuture(9)),
         distant_future_({GetFuture(10), GetFuture(10)}) {}
 
-  bool GetIfInDistantFuture(const string &path, bool *result) override;
+  bool CheckExtractedBinary(const string &path, bool *result) override;
   bool SetToNow(const string &path) override;
   bool SetToDistantFuture(const string &path) override;
 
@@ -344,17 +344,19 @@ class PosixFileMtime : public IFileMtime {
   static time_t GetFuture(unsigned int years);
 };
 
-bool PosixFileMtime::GetIfInDistantFuture(const string &path, bool *result) {
+bool PosixFileMtime::CheckExtractedBinary(
+    const string &path, bool *result) {
   struct stat buf;
   if (stat(path.c_str(), &buf)) {
     return false;
   }
+
   // Compare the mtime with `near_future_`, not with `GetNow()` or
   // `distant_future_`.
   // This way we don't need to call GetNow() every time we want to compare and
   // we also don't need to worry about potentially unreliable time equality
   // check (in case it uses floats or something crazy).
-  *result = (buf.st_mtime > near_future_);
+  *result = S_ISDIR(buf.st_mode) || (buf.st_mtime > near_future_);
   return true;
 }
 

--- a/src/main/cpp/util/file_posix.cc
+++ b/src/main/cpp/util/file_posix.cc
@@ -329,7 +329,7 @@ class PosixFileMtime : public IFileMtime {
       : near_future_(GetFuture(9)),
         distant_future_({GetFuture(10), GetFuture(10)}) {}
 
-  bool IsValidEmbeddedBinary(const string &path) override;
+  bool IsUntampered(const string &path) override;
   bool SetToNow(const string &path) override;
   bool SetToDistantFuture(const string &path) override;
 
@@ -344,7 +344,7 @@ class PosixFileMtime : public IFileMtime {
   static time_t GetFuture(unsigned int years);
 };
 
-bool PosixFileMtime::IsValidEmbeddedBinary(const string &path) {
+bool PosixFileMtime::IsUntampered(const string &path) {
   struct stat buf;
   if (stat(path.c_str(), &buf)) {
     return false;

--- a/src/main/cpp/util/file_posix.cc
+++ b/src/main/cpp/util/file_posix.cc
@@ -329,7 +329,7 @@ class PosixFileMtime : public IFileMtime {
       : near_future_(GetFuture(9)),
         distant_future_({GetFuture(10), GetFuture(10)}) {}
 
-  bool CheckExtractedBinary(const string &path, bool *result) override;
+  bool IsValidEmbeddedBinary(const string &path) override;
   bool SetToNow(const string &path) override;
   bool SetToDistantFuture(const string &path) override;
 
@@ -344,8 +344,7 @@ class PosixFileMtime : public IFileMtime {
   static time_t GetFuture(unsigned int years);
 };
 
-bool PosixFileMtime::CheckExtractedBinary(
-    const string &path, bool *result) {
+bool PosixFileMtime::IsValidEmbeddedBinary(const string &path) {
   struct stat buf;
   if (stat(path.c_str(), &buf)) {
     return false;
@@ -356,8 +355,7 @@ bool PosixFileMtime::CheckExtractedBinary(
   // This way we don't need to call GetNow() every time we want to compare and
   // we also don't need to worry about potentially unreliable time equality
   // check (in case it uses floats or something crazy).
-  *result = S_ISDIR(buf.st_mode) || (buf.st_mtime > near_future_);
-  return true;
+  return S_ISDIR(buf.st_mode) || (buf.st_mtime > near_future_);
 }
 
 bool PosixFileMtime::SetToNow(const string &path) {

--- a/src/main/cpp/util/file_windows.cc
+++ b/src/main/cpp/util/file_windows.cc
@@ -126,8 +126,7 @@ class WindowsFileMtime : public IFileMtime {
 
 bool WindowsFileMtime::CheckExtractedBinary(const string& path, bool* result) {
   if (path.empty() || IsDevNull(path.c_str())) {
-    *result = false;
-    return true;
+    return false;
   }
 
   wstring wpath;

--- a/src/main/cpp/util/file_windows.cc
+++ b/src/main/cpp/util/file_windows.cc
@@ -109,7 +109,7 @@ class WindowsFileMtime : public IFileMtime {
   WindowsFileMtime()
       : near_future_(GetFuture(9)), distant_future_(GetFuture(10)) {}
 
-  bool IsValidEmbeddedBinary(const string& path) override;
+  bool IsUntampered(const string& path) override;
   bool SetToNow(const string& path) override;
   bool SetToDistantFuture(const string& path) override;
 
@@ -124,7 +124,7 @@ class WindowsFileMtime : public IFileMtime {
   static bool Set(const string& path, FILETIME time);
 };
 
-bool WindowsFileMtime::IsValidEmbeddedBinary(const string& path) {
+bool WindowsFileMtime::IsUntampered(const string& path) {
   if (path.empty() || IsDevNull(path.c_str())) {
     return false;
   }
@@ -133,7 +133,7 @@ bool WindowsFileMtime::IsValidEmbeddedBinary(const string& path) {
   string error;
   if (!AsAbsoluteWindowsPath(path, &wpath, &error)) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "WindowsFileMtime::IsValidEmbeddedBinary(" << path
+        << "WindowsFileMtime::IsUntampered(" << path
         << "): AsAbsoluteWindowsPath failed: " << error;
   }
 

--- a/src/test/cpp/util/file_test.cc
+++ b/src/test/cpp/util/file_test.cc
@@ -148,31 +148,31 @@ TEST(FileTest, TestMtimeHandling) {
   string tempdir(tempdir_cstr);
 
   std::unique_ptr<IFileMtime> mtime(CreateFileMtime());
-  // Assert that a directory is always a good embedded embedded binary. (We do
+  // Assert that a directory is always untampered with. (We do
   // not care about directories' mtimes.)
-  ASSERT_TRUE(mtime.get()->IsValidEmbeddedBinary(tempdir));
+  ASSERT_TRUE(mtime.get()->IsUntampered(tempdir));
   // Create a new file, assert its mtime is not in the future.
   string file(JoinPath(tempdir, "foo.txt"));
   ASSERT_TRUE(WriteFile("hello", 5, file));
-  ASSERT_FALSE(mtime.get()->IsValidEmbeddedBinary(file));
+  ASSERT_FALSE(mtime.get()->IsUntampered(file));
   // Set the file's mtime to the future, assert that it's so.
   ASSERT_TRUE(mtime.get()->SetToDistantFuture(file));
-  ASSERT_TRUE(mtime.get()->IsValidEmbeddedBinary(file));
+  ASSERT_TRUE(mtime.get()->IsUntampered(file));
   // Overwrite the file, resetting its mtime, assert that
-  // IsValidEmbeddedBinary notices.
+  // IsUntampered notices.
   ASSERT_TRUE(WriteFile("world", 5, file));
-  ASSERT_FALSE(mtime.get()->IsValidEmbeddedBinary(file));
+  ASSERT_FALSE(mtime.get()->IsUntampered(file));
   // Set it to the future again so we can reset it using SetToNow.
   ASSERT_TRUE(mtime.get()->SetToDistantFuture(file));
-  ASSERT_TRUE(mtime.get()->IsValidEmbeddedBinary(file));
+  ASSERT_TRUE(mtime.get()->IsUntampered(file));
   // Assert that SetToNow resets the timestamp.
   ASSERT_TRUE(mtime.get()->SetToNow(file));
-  ASSERT_FALSE(mtime.get()->IsValidEmbeddedBinary(file));
+  ASSERT_FALSE(mtime.get()->IsUntampered(file));
   // Delete the file and assert that we can no longer set or query its mtime.
   ASSERT_TRUE(UnlinkPath(file));
   ASSERT_FALSE(mtime.get()->SetToNow(file));
   ASSERT_FALSE(mtime.get()->SetToDistantFuture(file));
-  ASSERT_FALSE(mtime.get()->IsValidEmbeddedBinary(file));
+  ASSERT_FALSE(mtime.get()->IsUntampered(file));
 }
 
 TEST(FileTest, TestRenameDirectory) {

--- a/src/test/cpp/util/file_test.cc
+++ b/src/test/cpp/util/file_test.cc
@@ -148,38 +148,31 @@ TEST(FileTest, TestMtimeHandling) {
   string tempdir(tempdir_cstr);
 
   std::unique_ptr<IFileMtime> mtime(CreateFileMtime());
-  bool actual = false;
   // Assert that a directory is always a good embedded embedded binary. (We do
   // not care about directories' mtimes.)
-  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(tempdir, &actual));
-  ASSERT_TRUE(actual);
+  ASSERT_TRUE(mtime.get()->IsValidEmbeddedBinary(tempdir));
   // Create a new file, assert its mtime is not in the future.
   string file(JoinPath(tempdir, "foo.txt"));
   ASSERT_TRUE(WriteFile("hello", 5, file));
-  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(file, &actual));
-  ASSERT_FALSE(actual);
+  ASSERT_FALSE(mtime.get()->IsValidEmbeddedBinary(file));
   // Set the file's mtime to the future, assert that it's so.
   ASSERT_TRUE(mtime.get()->SetToDistantFuture(file));
-  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(file, &actual));
-  ASSERT_TRUE(actual);
+  ASSERT_TRUE(mtime.get()->IsValidEmbeddedBinary(file));
   // Overwrite the file, resetting its mtime, assert that
-  // CheckExtractedBinary notices.
+  // IsValidEmbeddedBinary notices.
   ASSERT_TRUE(WriteFile("world", 5, file));
-  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(file, &actual));
-  ASSERT_FALSE(actual);
+  ASSERT_FALSE(mtime.get()->IsValidEmbeddedBinary(file));
   // Set it to the future again so we can reset it using SetToNow.
   ASSERT_TRUE(mtime.get()->SetToDistantFuture(file));
-  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(file, &actual));
-  ASSERT_TRUE(actual);
+  ASSERT_TRUE(mtime.get()->IsValidEmbeddedBinary(file));
   // Assert that SetToNow resets the timestamp.
   ASSERT_TRUE(mtime.get()->SetToNow(file));
-  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(file, &actual));
-  ASSERT_FALSE(actual);
+  ASSERT_FALSE(mtime.get()->IsValidEmbeddedBinary(file));
   // Delete the file and assert that we can no longer set or query its mtime.
   ASSERT_TRUE(UnlinkPath(file));
   ASSERT_FALSE(mtime.get()->SetToNow(file));
   ASSERT_FALSE(mtime.get()->SetToDistantFuture(file));
-  ASSERT_FALSE(mtime.get()->CheckExtractedBinary(file, &actual));
+  ASSERT_FALSE(mtime.get()->IsValidEmbeddedBinary(file));
 }
 
 TEST(FileTest, TestRenameDirectory) {

--- a/src/test/cpp/util/file_test.cc
+++ b/src/test/cpp/util/file_test.cc
@@ -149,36 +149,37 @@ TEST(FileTest, TestMtimeHandling) {
 
   std::unique_ptr<IFileMtime> mtime(CreateFileMtime());
   bool actual = false;
-  ASSERT_TRUE(mtime.get()->GetIfInDistantFuture(tempdir, &actual));
-  ASSERT_FALSE(actual);
-
+  // Assert that a directory is always a good embedded embedded binary. (We do
+  // not care about directories' mtimes.)
+  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(tempdir, &actual));
+  ASSERT_TRUE(actual);
   // Create a new file, assert its mtime is not in the future.
   string file(JoinPath(tempdir, "foo.txt"));
   ASSERT_TRUE(WriteFile("hello", 5, file));
-  ASSERT_TRUE(mtime.get()->GetIfInDistantFuture(file, &actual));
+  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(file, &actual));
   ASSERT_FALSE(actual);
   // Set the file's mtime to the future, assert that it's so.
   ASSERT_TRUE(mtime.get()->SetToDistantFuture(file));
-  ASSERT_TRUE(mtime.get()->GetIfInDistantFuture(file, &actual));
+  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(file, &actual));
   ASSERT_TRUE(actual);
-  // Overwrite the file, resetting its mtime, assert that GetIfInDistantFuture
-  // notices.
+  // Overwrite the file, resetting its mtime, assert that
+  // CheckExtractedBinary notices.
   ASSERT_TRUE(WriteFile("world", 5, file));
-  ASSERT_TRUE(mtime.get()->GetIfInDistantFuture(file, &actual));
+  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(file, &actual));
   ASSERT_FALSE(actual);
   // Set it to the future again so we can reset it using SetToNow.
   ASSERT_TRUE(mtime.get()->SetToDistantFuture(file));
-  ASSERT_TRUE(mtime.get()->GetIfInDistantFuture(file, &actual));
+  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(file, &actual));
   ASSERT_TRUE(actual);
   // Assert that SetToNow resets the timestamp.
   ASSERT_TRUE(mtime.get()->SetToNow(file));
-  ASSERT_TRUE(mtime.get()->GetIfInDistantFuture(file, &actual));
+  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(file, &actual));
   ASSERT_FALSE(actual);
   // Delete the file and assert that we can no longer set or query its mtime.
   ASSERT_TRUE(UnlinkPath(file));
   ASSERT_FALSE(mtime.get()->SetToNow(file));
   ASSERT_FALSE(mtime.get()->SetToDistantFuture(file));
-  ASSERT_FALSE(mtime.get()->GetIfInDistantFuture(file, &actual));
+  ASSERT_FALSE(mtime.get()->CheckExtractedBinary(file, &actual));
 }
 
 TEST(FileTest, TestRenameDirectory) {

--- a/src/test/cpp/util/file_windows_test.cc
+++ b/src/test/cpp/util/file_windows_test.cc
@@ -312,21 +312,18 @@ TEST_F(FileWindowsTest, TestMtimeHandling) {
   EXPECT_TRUE(CreateDirectoryW(wtarget.c_str(), NULL));
 
   std::unique_ptr<IFileMtime> mtime(CreateFileMtime());
-  bool actual = false;
   // Assert that a directory is always a good embedded binary. (We do not care
   // about directories' mtimes.)
-  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(target, &actual));
-  ASSERT_TRUE(actual);
+  ASSERT_TRUE(mtime.get()->IsValidEmbeddedBinary(target));
   // Assert that junctions whose target exists are "good" embedded binaries.
   string sym(JoinPath(tempdir, "junc" T(__LINE__)));
   CREATE_JUNCTION(sym, target);
-  ASSERT_TRUE(mtime.get()->CheckExtractedBinary(sym, &actual));
-  ASSERT_TRUE(actual);
+  ASSERT_TRUE(mtime.get()->IsValidEmbeddedBinary(sym));
   // Assert that checking fails for non-existent directories and dangling
   // junctions.
   EXPECT_TRUE(RemoveDirectoryW(wtarget.c_str()));
-  ASSERT_FALSE(mtime.get()->CheckExtractedBinary(target, &actual));
-  ASSERT_FALSE(mtime.get()->CheckExtractedBinary(sym, &actual));
+  ASSERT_FALSE(mtime.get()->IsValidEmbeddedBinary(target));
+  ASSERT_FALSE(mtime.get()->IsValidEmbeddedBinary(sym));
 }
 
 }  // namespace blaze_util

--- a/src/test/cpp/util/file_windows_test.cc
+++ b/src/test/cpp/util/file_windows_test.cc
@@ -34,8 +34,7 @@
 #error("This test should only be run on Windows")
 #endif  // !defined(_WIN32) && !defined(__CYGWIN__)
 
-#define _T(x) #x
-#define T(x) _T(x)
+#define TOSTRING(x) #x
 
 namespace blaze_util {
 
@@ -306,7 +305,7 @@ TEST_F(FileWindowsTest, TestMtimeHandling) {
   ASSERT_NE(tempdir_cstr[0], 0);
   string tempdir(tempdir_cstr);
 
-  string target(JoinPath(tempdir, "target" T(__LINE__)));
+  string target(JoinPath(tempdir, "target" TOSTRING(__LINE__)));
   wstring wtarget;
   EXPECT_TRUE(AsWindowsPath(target, &wtarget, nullptr));
   EXPECT_TRUE(CreateDirectoryW(wtarget.c_str(), NULL));
@@ -314,16 +313,16 @@ TEST_F(FileWindowsTest, TestMtimeHandling) {
   std::unique_ptr<IFileMtime> mtime(CreateFileMtime());
   // Assert that a directory is always a good embedded binary. (We do not care
   // about directories' mtimes.)
-  ASSERT_TRUE(mtime.get()->IsValidEmbeddedBinary(target));
+  ASSERT_TRUE(mtime.get()->IsUntampered(target));
   // Assert that junctions whose target exists are "good" embedded binaries.
-  string sym(JoinPath(tempdir, "junc" T(__LINE__)));
+  string sym(JoinPath(tempdir, "junc" TOSTRING(__LINE__)));
   CREATE_JUNCTION(sym, target);
-  ASSERT_TRUE(mtime.get()->IsValidEmbeddedBinary(sym));
+  ASSERT_TRUE(mtime.get()->IsUntampered(sym));
   // Assert that checking fails for non-existent directories and dangling
   // junctions.
   EXPECT_TRUE(RemoveDirectoryW(wtarget.c_str()));
-  ASSERT_FALSE(mtime.get()->IsValidEmbeddedBinary(target));
-  ASSERT_FALSE(mtime.get()->IsValidEmbeddedBinary(sym));
+  ASSERT_FALSE(mtime.get()->IsUntampered(target));
+  ASSERT_FALSE(mtime.get()->IsUntampered(sym));
 }
 
 }  // namespace blaze_util


### PR DESCRIPTION
The Bazel client on Windows is now 50% faster to
check the embedded tools than it was before.

Results:
- Linux: 20 ms -> 6 ms
- Windows: 294 ms -> 133 ms

Measurements were done with n=10 runs and a hot
server, using blaze::GetMillisecondsMonotonic().

Previously the client performed the same tasks
multiple times while trying to determine if a path
was a good extracted binary. (E.g. converted the
path to Windows format multiple times, checked if
it was a directory twice, opened the path twice.)

Now the client performes these tasks only once,
e.g. it converts path once and stats only once.

See https://github.com/bazelbuild/bazel/issues/5444