### PR TITLE
http_archive: remove noisy debug prints

### DIFF
--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -39,12 +39,6 @@ def _http_archive_impl(ctx):
     if ctx.attr.build_file and ctx.attr.build_file_content:
         ctx.fail("Only one of build_file and build_file_content can be provided.")
 
-    if ctx.attr.build_file:
-        print("ctx.attr.build_file %s, path %s" %
-              (str(ctx.attr.build_file), ctx.path(ctx.attr.build_file)))
-    for patchfile in ctx.attr.patches:
-        print("patch file %s, path %s" % (patchfile, ctx.path(patchfile)))
-
     all_urls = []
     if ctx.attr.urls:
         all_urls = ctx.attr.urls


### PR DESCRIPTION
Commit bd16ab9454e624a26c53a0f3fb892e20fb1c36e6 documents that these statements are no longer required to achieve prefetching (as of commit cdc99afc1a03ff8fbbbae088d358b7c029e0d232).  Given that many `http_archive` calls will need at least a `build_file`, these debugging prints generate an incredible amount of spam in projects with many external archives.

I looked over the rest of the `build_defs/repo` files and none of them have any tracing debug prints, except for `git.bzl` which guards it with an `attr.verbose`.  I could rework this to add a verbosity flag if you wish, but it doesn't seem merited for http fetching (unlike git, which is relatively more expensive and can be flaky).

Relates to #2700.