### PR TITLE
Adding --repositories to generate_workspace docs

### DIFF
--- a/site/docs/generate-workspace.md
+++ b/site/docs/generate-workspace.md
@@ -47,7 +47,8 @@ use this tool:
     $ bazel run //generate_workspace -- \
     >    --maven_project=/path/to/my/project \
     >    --artifact=groupId:artifactId:version \
-    >    --artifact=groupId:artifactId:version
+    >    --artifact=groupId:artifactId:version \
+    >    --repositories=https://jcenter.bintray.com
     Wrote
     /usr/local/.../generate_workspace.runfiles/__main__/generate_workspace.bzl
     ```


### PR DESCRIPTION
Without this parameter, I was getting the same error that others reported at https://github.com/bazelbuild/migration-tooling/issues/86