### PR TITLE
Suppress all C++ warning when compiling generated protobuf code.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
@@ -223,6 +223,7 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
     private FeatureConfiguration getFeatureConfiguration(SupportData supportData) {
       ImmutableSet.Builder<String> requestedFeatures = new ImmutableSet.Builder<>();
       requestedFeatures.addAll(ruleContext.getFeatures());
+      requestedFeatures.add("disable_errors");
       ImmutableSet.Builder<String> unsupportedFeatures = new ImmutableSet.Builder<>();
       unsupportedFeatures.addAll(ruleContext.getDisabledFeatures());
       unsupportedFeatures.add(CppRuleClasses.PARSE_HEADERS);

--- a/tools/cpp/CROSSTOOL.tpl
+++ b/tools/cpp/CROSSTOOL.tpl
@@ -155,6 +155,16 @@ toolchain {
       }
     }
   }
+  feature {
+    name: "disable_errors"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      flag_group {
+        flag: "-w"
+      }
+    }
+  }
 }
 
 toolchain {

--- a/tools/osx/crosstool/CROSSTOOL.tpl
+++ b/tools/osx/crosstool/CROSSTOOL.tpl
@@ -202,6 +202,16 @@ toolchain {
     }
   }
   feature {
+    name: "disable_errors"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      flag_group {
+        flag: "-w"
+      }
+    }
+  }
+  feature {
     name: "generate_dsym_file"
     flag_set {
       action: "c-compile"


### PR DESCRIPTION
This PR is a suggested fix for #5466. 

As long as a) one cannot specify `copt`s for the compilation of generated C++ code, and b) protobuf generated code is warning-generating, we should suppress _at least_ the errors protobuf code is known to generate (from my experience at least `unused-parameter` (as seen here: https://github.com/google/protobuf/issues/4628) and `invalid-offset` and `zero-as-null-pointer-constant`). 

a) is fixable, but has no timeline, b) will not be fixed.

## Option 1: Suppress all warnings (currently chosen)
Since protobuf code is already assumed to be correct, suppressing all warnings both reduces log message spam and solves the `-Werror` problem.
**Advantages**: Will compile with any CROSSTOOL copts.
**Disadvantages**: Could suppress warnings of a broken C++ protobuf `plugin`.

## Option 2: Suppress specific known errors 
It is theoretically possible to suppress only the known errors, but I'm not a C++ expert so don't know how compatible these flags are between OSs.
**Risks**: Windows, different protobuf versions could have different errors.

## Option 3: Pass `-Wno-error`
Warnings would still be shown but at least the compilation would succeed.
**Advantages**: least intrusive, builds complete.
**Disadvantages**: many un-actionable log messages.


I hope this is the correct format for this kind of discussion. Many thanks in advance for any comments :)