### PR TITLE
Add virtual destructor and override to BinaryLauncherBase and subclasses

### DIFF
--- a/src/tools/launcher/bash_launcher.h
+++ b/src/tools/launcher/bash_launcher.h
@@ -25,7 +25,8 @@ class BashBinaryLauncher : public BinaryLauncherBase {
   BashBinaryLauncher(const LaunchDataParser::LaunchInfo& launch_info, int argc,
                      wchar_t* argv[])
       : BinaryLauncherBase(launch_info, argc, argv) {}
-  ExitCode Launch();
+  ~BashBinaryLauncher() override = default;
+  ExitCode Launch() override;
 };
 
 }  // namespace launcher

--- a/src/tools/launcher/java_launcher.h
+++ b/src/tools/launcher/java_launcher.h
@@ -35,7 +35,8 @@ class JavaBinaryLauncher : public BinaryLauncherBase {
         singlejar(false),
         print_javabin(false),
         classpath_limit(MAX_ARG_STRLEN) {}
-  ExitCode Launch();
+  ~JavaBinaryLauncher() override = default;
+  ExitCode Launch() override;
 
  private:
   // If present, these flags should either be at the beginning of the command

--- a/src/tools/launcher/launcher.h
+++ b/src/tools/launcher/launcher.h
@@ -42,6 +42,8 @@ class BinaryLauncherBase {
   BinaryLauncherBase(const LaunchDataParser::LaunchInfo& launch_info, int argc,
                      wchar_t* argv[]);
 
+  virtual ~BinaryLauncherBase() = default;
+
   // Get launch information based on a launch info key.
   std::wstring GetLaunchInfoByKey(const std::string& key);
 

--- a/src/tools/launcher/python_launcher.h
+++ b/src/tools/launcher/python_launcher.h
@@ -25,7 +25,8 @@ class PythonBinaryLauncher : public BinaryLauncherBase {
   PythonBinaryLauncher(const LaunchDataParser::LaunchInfo& launch_info,
                        int argc, wchar_t* argv[])
       : BinaryLauncherBase(launch_info, argc, argv) {}
-  ExitCode Launch();
+  ~PythonBinaryLauncher() override = default;
+  ExitCode Launch() override;
 };
 
 }  // namespace launcher


### PR DESCRIPTION
Class with virtual functions must have virtual destructor. Subclasses should annotate overriden functions as `override`.

Found by Clang's `-Winconsistent-missing-override`.