### PR TITLE
Add parentheses to bool expr with && and ||

### DIFF
--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -126,7 +126,7 @@ static bool NestedJobsSupported() {
   }
 
   return version_info.dwMajorVersion > 6 ||
-         version_info.dwMajorVersion == 6 && version_info.dwMinorVersion >= 2;
+         (version_info.dwMajorVersion == 6 && version_info.dwMinorVersion >= 2);
 }
 
 // Ensure we can safely cast jlong to void*.


### PR DESCRIPTION
Boolean expression with *both* `&&` and `||` must use parentheses to prevent ambiguity.