### PR TITLE
Fix UnionFileSystem symlink following.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/UnionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/UnionFileSystem.java
@@ -506,7 +506,7 @@ public final class UnionFileSystem extends FileSystem {
   private Path internalResolveSymlink(Path path) throws IOException {
     while (isSymbolicLink(path)) {
       PathFragment pathFragment = resolveOneLink(path);
-      path = path.getRelative(pathFragment);
+      path = path.getParentDirectory().getRelative(pathFragment);
     }
     return path;
   }

--- a/src/test/java/com/google/devtools/build/lib/vfs/UnionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/UnionFileSystemTest.java
@@ -192,8 +192,6 @@ public class UnionFileSystemTest extends SymlinkAwareFileSystemTest {
     assertThat(unionfs.getDelegate(unionfs.getPath("/in/./foo.txt"))).isSameAs(inDelegate);
   }
 
-  // Basic *explicit* cross-filesystem symlink check.
-  // Note: This does not work implicitly yet, as the next test illustrates.
   @Test
   public void testCrossDeviceSymlinks() throws Exception {
     assertThat(unionfs.createDirectory(unionfs.getPath("/out"))).isTrue();
@@ -209,12 +207,7 @@ public class UnionFileSystemTest extends SymlinkAwareFileSystemTest {
     unionfs.createSymbolicLink(outFoo, PathFragment.create("../in/bar.txt"));
     assertThat(unionfs.stat(outFoo, false).isSymbolicLink()).isTrue();
 
-    try {
-      unionfs.stat(outFoo, true).isFile();
-      fail("Stat on cross-device symlink succeeded!");
-    } catch (FileNotFoundException expected) {
-      // OK
-    }
+    assertThat(unionfs.stat(outFoo, true).isFile()).isTrue();
 
     Path resolved = unionfs.resolveSymbolicLinks(outFoo);
     assertThat(resolved.getFileSystem()).isSameAs(unionfs);


### PR DESCRIPTION
UnionFileSystem was resolving a symlink relative to the symlink itself rather than the symlink's parent directory.

Fixes https://github.com/bazelbuild/bazel/issues/5464.