### PR TITLE
Bazel client: implement a simple ThreadPool

### DIFF
--- a/src/main/cpp/util/BUILD
+++ b/src/main/cpp/util/BUILD
@@ -175,6 +175,11 @@ cc_library(
         "//src/main/cpp:__pkg__",
         "//src/test/cpp/util:__pkg__",
     ],
+    deps = [
+        ":blaze_exit_code",
+        ":errors",
+        ":logging",
+    ],
 )
 
 cc_library(

--- a/src/main/cpp/util/BUILD
+++ b/src/main/cpp/util/BUILD
@@ -168,6 +168,16 @@ cc_library(
 )
 
 cc_library(
+    name = "threadpool",
+    hdrs = ["thrdpool.h"],
+    srcs = ["thrdpool.cc"],
+    visibility = [
+        "//src/main/cpp:__pkg__",
+        "//src/test/cpp/util:__pkg__",
+    ],
+)
+
+cc_library(
     name = "blaze_exit_code",
     hdrs = ["exit_code.h"],
     visibility = ["//visibility:public"],

--- a/src/main/cpp/util/thrdpool.cc
+++ b/src/main/cpp/util/thrdpool.cc
@@ -1,0 +1,88 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/main/cpp/util/thrdpool.h"
+
+namespace blaze_util {
+namespace threads {
+
+// Tries removing the item from the front of `queue`, returns true upon success.
+// The queue is guarded by `queue_mutex`. If the function returns true, the
+// popped iteam is stored in `result`.
+static bool Pop(std::queue<std::function<void()> >* queue,
+                std::mutex* queue_mutex, std::function<void()>* result) {
+  std::lock_guard<std::mutex> guard(*queue_mutex);
+  if (queue->empty()) {
+    return false;
+  }
+  *result = queue->front();
+  queue->pop();
+  return true;
+}
+
+static void ThreadFunc(std::queue<std::function<void()> >* queue,
+                       std::mutex* queue_mutex, std::atomic_bool* pushing) {
+  std::function<void()> func;
+  bool running = true;
+  while (true) {
+    if (!*pushing) {
+      // Do not return yet: the pushing thread may just have finished pushing
+      // the queue but there may be still unprocessed work items. Let the drain
+      // cycle run one last time.
+      running = false;
+    }
+    while (Pop(queue, queue_mutex, &func)) {
+      // Drain as many work items as possible.
+      func();
+    }
+    if (running) {
+      // Temporarily drained the queue. Let the pushing thread push more work
+      // items.
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    } else {
+      // Fully drained the queue, return.
+      break;
+    }
+  }
+}
+
+ThreadPool::ThreadPool(const size_t size)
+    : size_(size), pushing_(true), threads_(new std::thread[size]) {
+  for (size_t i = 0; i < size_; i++) {
+    threads_[i] = std::thread(ThreadFunc, &queue_, &queue_mutex_, &pushing_);
+  }
+}
+
+ThreadPool::~ThreadPool() { Join(); }
+
+bool ThreadPool::Push(std::function<void()> func) {
+  if (!pushing_) {
+    return false;
+  }
+  std::lock_guard<std::mutex> guard(queue_mutex_);
+  queue_.push(func);
+  return true;
+}
+
+void ThreadPool::Join() {
+  if (pushing_) {
+    pushing_ = false;
+    for (size_t i = 0; i < size_; i++) {
+      threads_[i].join();
+    }
+  }
+}
+
+}  // namespace threads
+}  // namespace blaze_util

--- a/src/main/cpp/util/thrdpool.cc
+++ b/src/main/cpp/util/thrdpool.cc
@@ -14,45 +14,42 @@
 
 #include "src/main/cpp/util/thrdpool.h"
 
+#include "src/main/cpp/util/errors.h"
+#include "src/main/cpp/util/exit_code.h"
+#include "src/main/cpp/util/logging.h"
+
 namespace blaze_util {
 namespace threads {
 
-// Tries removing the item from the front of `queue`, returns true upon success.
-// The queue is guarded by `queue_mutex`. If the function returns true, the
-// popped iteam is stored in `result`.
-static bool Pop(std::queue<std::function<void()> >* queue,
-                std::mutex* queue_mutex, std::function<void()>* result) {
-  std::lock_guard<std::mutex> guard(*queue_mutex);
-  if (queue->empty()) {
-    return false;
-  }
-  *result = queue->front();
-  queue->pop();
-  return true;
-}
-
+// Main function of worker threads: it pops items from the `queue` as long as
+// `pushing` is true. Once `pushing` is false, the function drains the remaining
+// elements from `queue` then returns.
 static void ThreadFunc(std::queue<std::function<void()> >* queue,
-                       std::mutex* queue_mutex, std::atomic_bool* pushing) {
-  std::function<void()> func;
-  bool running = true;
+                       std::mutex* queue_mutex,
+                       std::condition_variable* queue_filled,
+                       std::atomic_bool* pushing) {
+  bool terminate = false;
   while (true) {
-    if (!*pushing) {
-      // Do not return yet: the pushing thread may just have finished pushing
-      // the queue but there may be still unprocessed work items. Let the drain
-      // cycle run one last time.
-      running = false;
+    std::unique_lock<std::mutex> lock(*queue_mutex);
+    // Drain cycle: pop tasks from the queue as long as the queue is filled.
+    while (!queue->empty()) {
+      std::function<void()> task = queue->front();
+      queue->pop();
+      lock.unlock();  // let other threads pop tasks or Push() or Join()
+      task();
+      lock.lock();  // lock again to check `queue` or to start waiting
     }
-    while (Pop(queue, queue_mutex, &func)) {
-      // Drain as many work items as possible.
-      func();
-    }
-    if (running) {
-      // Temporarily drained the queue. Let the pushing thread push more work
-      // items.
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    if (terminate) {
+      // Drained the queue and `pushing` was false before the last drain cycle
+      // so no more tasks could have arrived.
+      return;
+    } else if (*pushing) {
+      // Temporarily drained the queue. Wait for more tasks or for Join().
+      queue_filled->wait(lock);
     } else {
-      // Fully drained the queue, return.
-      break;
+      // No more tasks can be pushed. Don't return yet, let the drain cycle run
+      // once more, in case Push() raced with Join().
+      terminate = true;
     }
   }
 }
@@ -60,28 +57,48 @@ static void ThreadFunc(std::queue<std::function<void()> >* queue,
 ThreadPool::ThreadPool(const size_t size)
     : size_(size), pushing_(true), threads_(new std::thread[size]) {
   for (size_t i = 0; i < size_; i++) {
-    threads_[i] = std::thread(ThreadFunc, &queue_, &queue_mutex_, &pushing_);
+    threads_[i] = std::thread(ThreadFunc, &queue_, &queue_mutex_,
+                              &queue_filled_, &pushing_);
   }
 }
 
 ThreadPool::~ThreadPool() { Join(); }
 
-bool ThreadPool::Push(std::function<void()> func) {
+bool ThreadPool::Push(const std::function<void()>& task) {
+  // Acquire the lock to avoid racing with Join() and to mutate the queue.
+  std::unique_lock<std::mutex> lock(queue_mutex_);
   if (!pushing_) {
-    return false;
+    return false;  // unique_lock destructor unlocks the lock
   }
-  std::lock_guard<std::mutex> guard(queue_mutex_);
-  queue_.push(func);
+  queue_.push(task);
+  lock.unlock();
+  // Benign race condition: another thread may call Join() now, but the task is
+  // already on the queue and worker threads drain the queue once more after
+  // `pushing_` became false.
+  queue_filled_.notify_one();
   return true;
 }
 
-void ThreadPool::Join() {
-  if (pushing_) {
-    pushing_ = false;
-    for (size_t i = 0; i < size_; i++) {
-      threads_[i].join();
-    }
+bool ThreadPool::Join() {
+  // Acquire the lock to avoid racing with Push().
+  std::unique_lock<std::mutex> lock(queue_mutex_);
+  if (!pushing_.exchange(false)) {
+    return false;  // unique_lock destructor unlocks the lock
   }
+  lock.unlock();  // let worker threads pop tasks from the queue
+  // Benign race condition: another thread may call Push() now, but `pushing_`
+  // is false so Push() will fail.
+  queue_filled_.notify_all();
+  for (size_t i = 0; i < size_; i++) {
+    threads_[i].join();
+  }
+  if (!queue_.empty()) {
+    // This is a bug: the worker threads should have drained the queue.
+    BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
+        << "ThreadPool error: " << queue_.size()
+        << " task(s) remained in queue after Join()";
+  }
+  return true;
 }
 
 }  // namespace threads

--- a/src/main/cpp/util/thrdpool.h
+++ b/src/main/cpp/util/thrdpool.h
@@ -17,26 +17,43 @@
 #include <stddef.h>  // size_t
 
 #include <atomic>
+#include <condition_variable>  // NOLINT
 #include <functional>
 #include <memory>
-#include <mutex>
+#include <mutex>  // NOLINT
 #include <queue>
-#include <thread>
+#include <thread>  // NOLINT
 
 namespace blaze_util {
 namespace threads {
 
+// Fixed-size thread pool.
+// Completes each Push()'d task on an async thread.
 class ThreadPool {
  public:
+  // Creates this ThreadPool, allocating `size` many threads.
   ThreadPool(const size_t size);
+
+  // Destructor. Also Join()'s the pool.
   ~ThreadPool();
-  bool Push(std::function<void()> func);
-  void Join();
+
+  // Pushes a task to the work queue.
+  // One of the async threads will complete the task.
+  // Returns true if the task was pushed to the queue.
+  // Has no effect and returns false if the pool is Join()'ing or already has.
+  bool Push(const std::function<void()>& task);
+
+  // Blocks until worker threads complete all tasks in the queue and terminate.
+  // Returns true once all threads are joined. No more tasks may be Push()'d to
+  // the queue afterwards. Subsequent calls to Join() have no effect and return
+  // false.
+  bool Join();
 
  private:
   const size_t size_;
   std::queue<std::function<void()> > queue_;
   std::mutex queue_mutex_;
+  std::condition_variable queue_filled_;
   std::atomic_bool pushing_;
   std::unique_ptr<std::thread[]> threads_;
 };

--- a/src/main/cpp/util/thrdpool.h
+++ b/src/main/cpp/util/thrdpool.h
@@ -1,0 +1,47 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef BAZEL_SRC_MAIN_CPP_UTIL_THRDPOOL_H_
+#define BAZEL_SRC_MAIN_CPP_UTIL_THRDPOOL_H_
+
+#include <stddef.h>  // size_t
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+namespace blaze_util {
+namespace threads {
+
+class ThreadPool {
+ public:
+  ThreadPool(const size_t size);
+  ~ThreadPool();
+  bool Push(std::function<void()> func);
+  void Join();
+
+ private:
+  const size_t size_;
+  std::queue<std::function<void()> > queue_;
+  std::mutex queue_mutex_;
+  std::atomic_bool pushing_;
+  std::unique_ptr<std::thread[]> threads_;
+};
+
+}  // namespace threads
+}  // namespace blaze_util
+
+#endif  // BAZEL_SRC_MAIN_CPP_UTIL_THRDPOOL_H_

--- a/src/test/cpp/util/BUILD
+++ b/src/test/cpp/util/BUILD
@@ -140,6 +140,16 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "threadpool_test",
+    srcs = ["thrdpool_test.cc"],
+    deps = [
+        "//src/main/cpp/util:profiler",
+        "//src/main/cpp/util:threadpool",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "test_util",
     testonly = 1,

--- a/src/test/cpp/util/thrdpool_test.cc
+++ b/src/test/cpp/util/thrdpool_test.cc
@@ -1,0 +1,119 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/main/cpp/util/thrdpool.h"
+
+#include <atomic>
+#include <thread>  // NOLINT
+
+#include "googletest/include/gtest/gtest.h"
+#include "src/main/cpp/util/profiler.h"
+
+namespace blaze_util {
+namespace threads {
+
+using blaze_util::profiler::ScopedTask;
+using blaze_util::profiler::Task;
+using std::atomic_bool;
+
+static void SleepMeasurably(size_t units) {
+  // 20ms is long enough for the OS scheduler to preempt the thread.
+  std::this_thread::sleep_for(std::chrono::milliseconds(units * 20));
+}
+
+TEST(ThreadPoolTest, TestFewerThreadsThanWorkItemsCanCompleteTheWork) {
+  ThreadPool pool(2);
+
+  atomic_bool flag1(false);
+  atomic_bool flag2(false);
+  atomic_bool flag3(false);
+  atomic_bool flag4(false);
+  atomic_bool* pflag1 = &flag1;
+  atomic_bool* pflag2 = &flag2;
+  atomic_bool* pflag3 = &flag3;
+  atomic_bool* pflag4 = &flag4;
+  EXPECT_TRUE(pool.Push([pflag1]() { *pflag1 = true; }));
+  EXPECT_TRUE(pool.Push([pflag2]() { *pflag2 = true; }));
+  EXPECT_TRUE(pool.Push([pflag3]() { *pflag3 = true; }));
+  EXPECT_TRUE(pool.Push([pflag4]() { *pflag4 = true; }));
+  pool.Join();
+
+  EXPECT_TRUE(flag1);
+  EXPECT_TRUE(flag2);
+  EXPECT_TRUE(flag3);
+  EXPECT_TRUE(flag4);
+}
+
+TEST(ThreadPoolTest, TestThreadsWorkInParallel) {
+  ThreadPool pool(3);
+
+  Task total("total");
+  Task task1("t1");
+  Task task2("t2");
+  Task task3("t3");
+  Task* ptask1 = &task1;
+  Task* ptask2 = &task2;
+  Task* ptask3 = &task3;
+
+  {
+    ScopedTask prof(&total);
+    EXPECT_TRUE(pool.Push([ptask1]() {
+      ScopedTask prof(ptask1);
+      SleepMeasurably(1);
+    }));
+    EXPECT_TRUE(pool.Push([ptask2]() {
+      ScopedTask prof(ptask2);
+      SleepMeasurably(2);
+    }));
+    EXPECT_TRUE(pool.Push([ptask3]() {
+      ScopedTask prof(ptask3);
+      SleepMeasurably(3);
+    }));
+    pool.Join();
+  }
+
+  // Sleep does not guarantee to terminate in a timely manner, so do not assert
+  // concrete sleep lengths, nor hard relations -- allow for equality (even if
+  // that's very unlikely with a high-precision clock).
+  EXPECT_LE(task1.GetDuration().micros_, task2.GetDuration().micros_);
+  EXPECT_LE(task2.GetDuration().micros_, task3.GetDuration().micros_);
+  EXPECT_LE(task3.GetDuration().micros_, total.GetDuration().micros_);
+  EXPECT_LE(total.GetDuration().micros_,
+            task3.GetDuration().micros_ + task2.GetDuration().micros_);
+}
+
+TEST(ThreadPoolTest, TestCannotPushAfterWorkerThreadsJoined) {
+  ThreadPool pool(2);
+
+  atomic_bool flag1(false);
+  atomic_bool flag2(false);
+  atomic_bool flag3(false);
+  atomic_bool* pflag1 = &flag1;
+  atomic_bool* pflag2 = &flag2;
+  atomic_bool* pflag3 = &flag3;
+  EXPECT_TRUE(pool.Push([pflag1]() { *pflag1 = true; }));
+  EXPECT_TRUE(pool.Push([pflag2]() { *pflag2 = true; }));
+
+  pool.Join();
+  EXPECT_TRUE(flag1);
+  EXPECT_TRUE(flag2);
+  EXPECT_FALSE(pool.Push([pflag3]() { *pflag3 = true; }));
+
+  // Join() again has no effect.
+  pool.Join();
+  EXPECT_FALSE(flag3);
+}
+
+}  // namespace threads
+}  // namespace blaze_util

--- a/src/test/cpp/util/thrdpool_test.cc
+++ b/src/test/cpp/util/thrdpool_test.cc
@@ -26,10 +26,17 @@ namespace threads {
 using blaze_util::profiler::ScopedTask;
 using blaze_util::profiler::Task;
 using std::atomic_bool;
+using std::thread;
 
 static void SleepMeasurably(size_t units) {
   // 20ms is long enough for the OS scheduler to preempt the thread.
   std::this_thread::sleep_for(std::chrono::milliseconds(units * 20));
+}
+
+TEST(ThreadPoolTest, TestPoolThatNeverGotWorkPushed) {
+  ThreadPool pool(2);
+  SleepMeasurably(1);
+  EXPECT_TRUE(pool.Join());
 }
 
 TEST(ThreadPoolTest, TestFewerThreadsThanWorkItemsCanCompleteTheWork) {
@@ -39,14 +46,10 @@ TEST(ThreadPoolTest, TestFewerThreadsThanWorkItemsCanCompleteTheWork) {
   atomic_bool flag2(false);
   atomic_bool flag3(false);
   atomic_bool flag4(false);
-  atomic_bool* pflag1 = &flag1;
-  atomic_bool* pflag2 = &flag2;
-  atomic_bool* pflag3 = &flag3;
-  atomic_bool* pflag4 = &flag4;
-  EXPECT_TRUE(pool.Push([pflag1]() { *pflag1 = true; }));
-  EXPECT_TRUE(pool.Push([pflag2]() { *pflag2 = true; }));
-  EXPECT_TRUE(pool.Push([pflag3]() { *pflag3 = true; }));
-  EXPECT_TRUE(pool.Push([pflag4]() { *pflag4 = true; }));
+  EXPECT_TRUE(pool.Push([&flag1]() { flag1 = true; }));
+  EXPECT_TRUE(pool.Push([&flag2]() { flag2 = true; }));
+  EXPECT_TRUE(pool.Push([&flag3]() { flag3 = true; }));
+  EXPECT_TRUE(pool.Push([&flag4]() { flag4 = true; }));
   pool.Join();
 
   EXPECT_TRUE(flag1);
@@ -62,26 +65,28 @@ TEST(ThreadPoolTest, TestThreadsWorkInParallel) {
   Task task1("t1");
   Task task2("t2");
   Task task3("t3");
-  Task* ptask1 = &task1;
-  Task* ptask2 = &task2;
-  Task* ptask3 = &task3;
 
   {
     ScopedTask prof(&total);
-    EXPECT_TRUE(pool.Push([ptask1]() {
-      ScopedTask prof(ptask1);
+    EXPECT_TRUE(pool.Push([&task1]() {
+      ScopedTask prof(&task1);
       SleepMeasurably(1);
     }));
-    EXPECT_TRUE(pool.Push([ptask2]() {
-      ScopedTask prof(ptask2);
+    EXPECT_TRUE(pool.Push([&task2]() {
+      ScopedTask prof(&task2);
       SleepMeasurably(2);
     }));
-    EXPECT_TRUE(pool.Push([ptask3]() {
-      ScopedTask prof(ptask3);
+    EXPECT_TRUE(pool.Push([&task3]() {
+      ScopedTask prof(&task3);
       SleepMeasurably(3);
     }));
     pool.Join();
   }
+
+  EXPECT_EQ(task1.GetCalls(), 1u);
+  EXPECT_EQ(task2.GetCalls(), 1u);
+  EXPECT_EQ(task3.GetCalls(), 1u);
+  EXPECT_EQ(total.GetCalls(), 1u);
 
   // Sleep does not guarantee to terminate in a timely manner, so do not assert
   // concrete sleep lengths, nor hard relations -- allow for equality (even if
@@ -93,26 +98,106 @@ TEST(ThreadPoolTest, TestThreadsWorkInParallel) {
             task3.GetDuration().micros_ + task2.GetDuration().micros_);
 }
 
+TEST(ThreadPoolTest, TestSlowPushFastPop) {
+  ThreadPool pool(2);
+
+  atomic_bool flag1(false);
+  atomic_bool flag2(false);
+  atomic_bool flag3(false);
+  atomic_bool flag4(false);
+  EXPECT_TRUE(pool.Push([&flag1]() { flag1 = true; }));
+  SleepMeasurably(1);
+  EXPECT_TRUE(pool.Push([&flag2]() { flag2 = true; }));
+  SleepMeasurably(1);
+  EXPECT_TRUE(pool.Push([&flag3]() { flag3 = true; }));
+  SleepMeasurably(1);
+  EXPECT_TRUE(pool.Push([&flag4]() { flag4 = true; }));
+  SleepMeasurably(1);
+  pool.Join();
+
+  EXPECT_TRUE(flag1);
+  EXPECT_TRUE(flag2);
+  EXPECT_TRUE(flag3);
+  EXPECT_TRUE(flag4);
+}
+
+TEST(ThreadPoolTest, TestFastPushSlowPop) {
+  ThreadPool pool(2);
+
+  atomic_bool flag1(false);
+  atomic_bool flag2(false);
+  atomic_bool flag3(false);
+  atomic_bool flag4(false);
+  EXPECT_TRUE(pool.Push([&flag1]() {
+    SleepMeasurably(1);
+    flag1 = true;
+  }));
+  EXPECT_TRUE(pool.Push([&flag2]() {
+    SleepMeasurably(1);
+    flag2 = true;
+  }));
+  EXPECT_TRUE(pool.Push([&flag3]() {
+    SleepMeasurably(1);
+    flag3 = true;
+  }));
+  EXPECT_TRUE(pool.Push([&flag4]() {
+    SleepMeasurably(1);
+    flag4 = true;
+  }));
+  pool.Join();
+
+  EXPECT_TRUE(flag1);
+  EXPECT_TRUE(flag2);
+  EXPECT_TRUE(flag3);
+  EXPECT_TRUE(flag4);
+}
+
 TEST(ThreadPoolTest, TestCannotPushAfterWorkerThreadsJoined) {
   ThreadPool pool(2);
 
   atomic_bool flag1(false);
   atomic_bool flag2(false);
   atomic_bool flag3(false);
-  atomic_bool* pflag1 = &flag1;
-  atomic_bool* pflag2 = &flag2;
-  atomic_bool* pflag3 = &flag3;
-  EXPECT_TRUE(pool.Push([pflag1]() { *pflag1 = true; }));
-  EXPECT_TRUE(pool.Push([pflag2]() { *pflag2 = true; }));
+  EXPECT_TRUE(pool.Push([&flag1]() { flag1 = true; }));
+  EXPECT_TRUE(pool.Push([&flag2]() { flag2 = true; }));
 
   pool.Join();
   EXPECT_TRUE(flag1);
   EXPECT_TRUE(flag2);
-  EXPECT_FALSE(pool.Push([pflag3]() { *pflag3 = true; }));
+  EXPECT_FALSE(pool.Push([&flag3]() { flag3 = true; }));
 
   // Join() again has no effect.
   pool.Join();
   EXPECT_FALSE(flag3);
+}
+
+TEST(ThreadPoolTest, TestMultipleThreadsPushingAndJoining) {
+  ThreadPool pool(2);
+
+  atomic_bool flag1(false);
+  atomic_bool flag2(false);
+
+  // Main thread may Push().
+  EXPECT_TRUE(pool.Push([&flag1]() { flag1 = true; }));
+
+  // Another thread may Push().
+  atomic_bool success(false);
+  thread t1([&pool, &success, &flag2]() {
+    success = pool.Push([&flag2]() { flag2 = true; });
+  });
+  t1.join();
+  EXPECT_TRUE(success);
+
+  // Another thread may Join().
+  success = false;
+  thread t2([&pool, &success]() { success = pool.Join(); });
+  t2.join();
+  EXPECT_TRUE(success);
+  EXPECT_TRUE(flag1);
+  EXPECT_TRUE(flag2);
+
+  // Cannot Join() again from main thread.
+  EXPECT_FALSE(pool.Join());
 }
 
 }  // namespace threads


### PR DESCRIPTION
Add a ThreadPool implementation to the Bazel
client.

The ThreadPool has a fixed number of std::thread
objects that each execute tasks from a shared
queue. Tasks are std::function objects.

The ThreadPool will be used in
blaze.cc::ActuallyExtractData, specifically
in ExtractBlazeZipProcessor::Process, to
parallelize I/O work.

Writing extracted binaries to disk from multiple
worker threads instead of from a single thread
shows a significant speedup when using a HDD
instead of a SSD.

See https://github.com/bazelbuild/bazel/issues/5444

Change-Id: If0971f10abff8195d269074a1dd4be6f0f454576