### PR TITLE
Windows,tests: port bazel_example_test

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -61,9 +61,23 @@ sh_test(
     data = [
         ":test-deps",
         "//src/test/shell/bazel/apple:objc-deps",
+        "@bazel_tools//tools/bash/runfiles",
     ],
-    shard_count = 3,
-    tags = ["no_windows"],
+    shard_count = 5,
+)
+
+sh_test(
+    name = "bazel_example_skylark_test",
+    size = "large",
+    srcs = ["bazel_example_skylark_test.sh"],
+    data = [
+        ":test-deps",
+        "//src/test/shell/bazel/apple:objc-deps",
+    ],
+    shard_count = 2,
+    tags = [
+        "no_windows",  # The Skylark examples don't work on Windows yet.
+    ],
 )
 
 sh_test(
@@ -73,6 +87,7 @@ sh_test(
     data = [
         ":test-deps",
     ],
+    shard_count = 3,
 )
 
 sh_test(

--- a/src/test/shell/bazel/bazel_example_skylark_test.sh
+++ b/src/test/shell/bazel/bazel_example_skylark_test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Tests the examples provided in Bazel
+#
+
+# Load the test setup defined in the parent directory
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CURRENT_DIR}/../integration_test_setup.sh" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+function set_up() {
+  copy_examples
+  cat > WORKSPACE <<EOF
+workspace(name = "io_bazel")
+EOF
+}
+
+function test_java_skylark() {
+  # Must be ported to Windows. Currently fails because:
+  # - Greeter.java uses runfiles, so it must depend on
+  #   @bazel_tools//tools/runfiles:java-runfiles and use Runfiles::rlocation
+  # - The Skylark implementation of the java_* rules does not use JavaInfo and
+  #   therefore cannot depend on native java rules.
+  local java_pkg=examples/java-skylark/src/main/java/com/example/myproject
+  assert_build_output ./bazel-bin/${java_pkg}/libhello-lib.jar ${java_pkg}:hello-lib
+  assert_build_output ./bazel-bin/${java_pkg}/hello-data ${java_pkg}:hello-data
+  assert_build_output ./bazel-bin/${java_pkg}/hello-world ${java_pkg}:hello-world
+  # we built hello-world but hello-data is still there.
+  want=./bazel-bin/${java_pkg}/hello-data
+  test -x $want || fail "executable $want not found"
+  assert_binary_run_from_subdir "bazel-bin/${java_pkg}/hello-data foo" "Heyo foo"
+}
+
+function test_java_test_skylark() {
+  # Must be ported to Windows. Currently fails because:
+  # - The Skylark implementation of the java_test creates a stub script without
+  #   Windows path support
+  setup_skylark_javatest_support
+  javatests=examples/java-skylark/src/test/java/com/example/myproject
+  assert_build //${javatests}:pass
+  assert_test_ok //${javatests}:pass
+  assert_test_fails //${javatests}:fail
+}
+
+run_suite "examples"

--- a/src/test/shell/bazel/bazel_windows_example_test.sh
+++ b/src/test/shell/bazel/bazel_windows_example_test.sh
@@ -120,16 +120,6 @@ EOF
   expect_log "global : 2"
 }
 
-function test_java() {
-  local java_pkg=examples/java-native/src/main/java/com/example/myproject
-
-  assert_build_output ./bazel-bin/${java_pkg}/libhello-lib.jar ${java_pkg}:hello-lib
-  assert_build_output ./bazel-bin/${java_pkg}/libcustom-greeting.jar ${java_pkg}:custom-greeting
-  assert_build_output ./bazel-bin/${java_pkg}/hello-world ${java_pkg}:hello-world
-  assert_build_output ./bazel-bin/${java_pkg}/hello-resources ${java_pkg}:hello-resources
-  assert_binary_run_from_subdir "bazel-bin/${java_pkg}/hello-world foo" "Hello foo"
-}
-
 function create_tmp_drive() {
   mkdir "$TEST_TMPDIR/tmp_drive"
 
@@ -165,20 +155,6 @@ function test_java_with_jar_under_different_drive() {
   bazel --output_user_root=${TMP_DRIVE}:/tmp build ${java_pkg}:hello-world
 
   assert_binary_run_from_subdir "bazel-bin/${java_pkg}/hello-world --classpath_limit=0" "Hello world"
-}
-
-function test_java_test() {
-  setup_javatest_support
-  local java_native_tests=//examples/java-native/src/test/java/com/example/myproject
-  local java_native_main=//examples/java-native/src/main/java/com/example/myproject
-
-  assert_build "-- //examples/java-native/... -${java_native_main}:hello-error-prone"
-  assert_build_fails "${java_native_main}:hello-error-prone" \
-      "Did you mean 'result = b == -1;'?"
-  assert_test_ok "${java_native_tests}:hello"
-  assert_test_ok "${java_native_tests}:custom"
-  assert_test_fails "${java_native_tests}:fail"
-  assert_test_fails "${java_native_tests}:resource-fail"
 }
 
 function test_native_python() {


### PR DESCRIPTION
Port //src/test/shell/bazel:bazel_example_test to
Windows:

- Use the Bash runfiles library (in @bazel_tools)

- Split off bazel_example_skylark_test.sh to
encapsulate test methods that cannot run on
Windows yet

- Deduplicate some test methods between
bazel_example_test.sh and
bazel_windows_example_test.sh

See https://github.com/bazelbuild/bazel/issues/4292

Change-Id: I6a7687d15ae3af2ca605149fa75ff48bf2fb89c8