### PR TITLE
Windows,tests: port rule_test_test

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -573,9 +573,11 @@ sh_test(
     name = "rule_test_test",
     size = "medium",
     srcs = ["rule_test_test.sh"],
-    data = [":test-deps"],
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
     shard_count = 2,
-    tags = ["no_windows"],
 )
 
 sh_test(

--- a/src/test/shell/bazel/rule_test_test.sh
+++ b/src/test/shell/bazel/rule_test_test.sh
@@ -17,10 +17,35 @@
 # Test rule_test usage.
 #
 
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../integration_test_setup.sh" \
+set -euo pipefail
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+function set_up() {
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+}
 
 function test_local_rule_test_in_root() {
   create_new_workspace

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -258,6 +258,25 @@ log_info "bazel binary is at $PATH_TO_BAZEL_WRAPPER"
 # Here we unset variable that were set by the invoking Blaze instance
 unset JAVA_RUNFILES
 
+# Runs a command, retrying if needed for a fixed timeout.
+#
+# Necessary to use it on Windows, typically when deleting directory trees,
+# because the OS cannot delete open files, which we attempt to do when deleting
+# workspaces where a Bazel server is still in the middle of shutting down.
+# (Because "bazel shutdown" returns sooner than the server actually shuts down.)
+function try_with_timeout() {
+  for i in {1..120}; do
+    if $* ; then
+      break
+    fi
+    if (( i == 10 )) || (( i == 30 )) || (( i == 60 )) ; then
+      log_info "try_with_timeout($*): no success after $i seconds" \
+               "(timeout in $((120-i)) seconds)"
+    fi
+    sleep 1
+  done
+}
+
 function setup_bazelrc() {
   cat >$TEST_TMPDIR/bazelrc <<EOF
 # Set the user root properly for this test invocation.
@@ -357,7 +376,7 @@ workspaces=()
 # Set-up a new, clean workspace with only the tools installed.
 function create_new_workspace() {
   new_workspace_dir=${1:-$(mktemp -d ${TEST_TMPDIR}/workspace.XXXXXXXX)}
-  rm -fr ${new_workspace_dir}
+  try_with_timeout rm -fr ${new_workspace_dir}
   mkdir -p ${new_workspace_dir}
   workspaces+=(${new_workspace_dir})
   cd ${new_workspace_dir}
@@ -376,7 +395,7 @@ function create_new_workspace() {
 function setup_clean_workspace() {
   export WORKSPACE_DIR=${TEST_TMPDIR}/workspace
   log_info "setting up client in ${WORKSPACE_DIR}" >> $TEST_log
-  rm -fr ${WORKSPACE_DIR}
+  try_with_timeout rm -fr ${WORKSPACE_DIR}
   create_new_workspace ${WORKSPACE_DIR}
   [ "${new_workspace_dir}" = "${WORKSPACE_DIR}" ] \
     || log_fatal "Failed to create workspace"
@@ -399,8 +418,8 @@ function setup_clean_workspace() {
   # Shut down this server in case the tests will run Bazel in a different output
   # root, otherwise we could not clean up $WORKSPACE_DIR (under $TEST_TMPDIR)
   # once the test is finished.
-  bazel shutdown
-  rm -f "$bazel_stdout" "$bazel_stderr"
+  bazel shutdown >&/dev/null
+  try_with_timeout rm -f "$bazel_stdout" "$bazel_stderr"
 
   if is_windows; then
     export BAZEL_SH="$(cygpath --windows /bin/bash)"
@@ -415,18 +434,18 @@ function cleanup_workspace() {
     cd ${WORKSPACE_DIR}
     bazel clean >> $TEST_log 2>&1 # Clean up the output base
     # Shut down this server to allow any cleanup code to delete its output_root.
-    bazel shutdown
+    bazel shutdown >&/dev/null
 
     for i in *; do
       if ! is_tools_directory "$i"; then
-        rm -fr "$i"
+        try_with_timeout rm -fr "$i"
       fi
     done
     touch WORKSPACE
   fi
   for i in "${workspaces[@]}"; do
     if [ "$i" != "${WORKSPACE_DIR:-}" ]; then
-      rm -fr $i
+      try_with_timeout rm -fr $i
     fi
   done
   workspaces=()
@@ -438,16 +457,7 @@ function cleanup() {
     log_info "Cleaning up BAZEL_INSTALL_BASE under $BAZEL_INSTALL_BASE"
     # Windows takes its time to shut down Bazel and we can't delete A-server.jar
     # until then, so just give it time and keep trying for 2 minutes.
-    for i in {1..120}; do
-      if rm -fr "${BAZEL_INSTALL_BASE}" >&/dev/null ; then
-        break
-      fi
-      if (( i == 10 )) || (( i == 30 )) || (( i == 60 )) ; then
-        log_info "Test cleanup: couldn't delete ${BAZEL_INSTALL_BASE} after $i seconds" \
-                 "(Timeout in $((120-i)) seconds.)"
-      fi
-      sleep 1
-    done
+    try_with_timeout rm -fr "${BAZEL_INSTALL_BASE}" >&/dev/null
   fi
 }
 


### PR DESCRIPTION
Port //src/test/shell/bazel:rule_test_test to
Windows:

- Use the Bash runfiles library (in @bazel_tools)

- Update testenv.sh to retry failed "rm" commands
  because often they attempt to delete a Bazel's
  output directory that is still in the middle of
  shutting down, and just needs a bit of time to
  finish doing so.

See https://github.com/bazelbuild/bazel/issues/4292

Change-Id: I6a7687d15ae3af2ca605149fa75ff48bf2fb89c8