### PR TITLE
[singlejar] Various portability fixes for MSVC

### DIFF
--- a/src/tools/singlejar/combiners.cc
+++ b/src/tools/singlejar/combiners.cc
@@ -15,6 +15,8 @@
 #include "src/tools/singlejar/combiners.h"
 #include "src/tools/singlejar/diag.h"
 
+#include <cctype>
+
 Combiner::~Combiner() {}
 
 Concatenator::~Concatenator() {}
@@ -33,7 +35,7 @@ bool Concatenator::Merge(const CDH *cdh, const LH *lh) {
     }
     buffer_->DecompressEntryContents(cdh, lh, inflater_.get());
   } else {
-    errx(2, "%s is neither stored nor deflated", filename_.c_str());
+    diag_errx(2, "%s is neither stored nor deflated", filename_.c_str());
   }
   return true;
 }
@@ -138,7 +140,7 @@ bool XmlCombiner::Merge(const CDH *cdh, const LH *lh) {
     }
     bytes_.DecompressEntryContents(cdh, lh, inflater_.get());
   } else {
-    errx(2, "%s is neither stored nor deflated", filename_.c_str());
+    diag_errx(2, "%s is neither stored nor deflated", filename_.c_str());
   }
   uint32_t checksum;
   char *buf = reinterpret_cast<char *>(malloc(bytes_.data_size()));

--- a/src/tools/singlejar/desugar_checking.cc
+++ b/src/tools/singlejar/desugar_checking.cc
@@ -27,7 +27,7 @@ bool Java8DesugarDepsChecker::Merge(const CDH *cdh, const LH *lh) {
     }
     buffer_->DecompressEntryContents(cdh, lh, inflater_.get());
   } else {
-    errx(2, "META-INF/desugar_deps is neither stored nor deflated");
+    diag_errx(2, "META-INF/desugar_deps is neither stored nor deflated");
   }
 
   // TODO(kmb): Wrap buffer_ as ZeroCopyInputStream to avoid copying out.
@@ -41,10 +41,10 @@ bool Java8DesugarDepsChecker::Merge(const CDH *cdh, const LH *lh) {
   bazel::tools::desugar::DesugarDepsInfo deps_info;
   google::protobuf::io::CodedInputStream content(buf, data_size);
   if (!deps_info.ParseFromCodedStream(&content)) {
-    errx(2, "META-INF/desugar_deps: unable to parse");
+    diag_errx(2, "META-INF/desugar_deps: unable to parse");
   }
   if (!content.ConsumedEntireMessage()) {
-    errx(2, "META-INF/desugar_deps: unexpected trailing content");
+    diag_errx(2, "META-INF/desugar_deps: unexpected trailing content");
   }
   free(buf);
 
@@ -91,10 +91,10 @@ bool Java8DesugarDepsChecker::Merge(const CDH *cdh, const LH *lh) {
 
 void *Java8DesugarDepsChecker::OutputEntry(bool compress) {
   if (verbose_) {
-    fprintf(stderr, "Needed deps: %lu\n", needed_deps_.size());
-    fprintf(stderr, "Interfaces to check: %lu\n", missing_interfaces_.size());
-    fprintf(stderr, "Sub-interfaces: %lu\n", extended_interfaces_.size());
-    fprintf(stderr, "Interfaces w/ default methods: %lu\n",
+    fprintf(stderr, "Needed deps: %zu\n", needed_deps_.size());
+    fprintf(stderr, "Interfaces to check: %zu\n", missing_interfaces_.size());
+    fprintf(stderr, "Sub-interfaces: %zu\n", extended_interfaces_.size());
+    fprintf(stderr, "Interfaces w/ default methods: %zu\n",
             has_default_methods_.size());
   }
   for (auto needed : needed_deps_) {
@@ -103,8 +103,8 @@ void *Java8DesugarDepsChecker::OutputEntry(bool compress) {
     }
     if (!known_member_(needed.first)) {
       if (fail_on_error_) {
-        errx(2, "%s referenced by %s but not found.  Is the former defined in "
-                "a neverlink library?",
+        diag_errx(2, "%s referenced by %s but not found.  Is the former defined"
+                " in a neverlink library?",
                 needed.first.c_str(), needed.second.c_str());
       } else {
         error_ = true;
@@ -118,8 +118,8 @@ void *Java8DesugarDepsChecker::OutputEntry(bool compress) {
     }
     if (HasDefaultMethods(missing.first)) {
       if (fail_on_error_) {
-        errx(2, "%s needed on the classpath for desugaring %s.  Please add the "
-                "missing dependency to the target containing the latter.",
+        diag_errx(2, "%s needed on the classpath for desugaring %s.  Please add"
+                " the missing dependency to the target containing the latter.",
                 missing.first.c_str(), missing.second.c_str());
       } else {
         error_ = true;

--- a/src/tools/singlejar/input_jar.cc
+++ b/src/tools/singlejar/input_jar.cc
@@ -27,8 +27,8 @@ bool InputJar::Open(const std::string &path) {
   }
   if (mapped_file_.size() < sizeof(ECD)) {
     diag_warnx(
-        "%s:%d: %s is only 0x%lx"
-        " bytes long, should be at least 0x%lx bytes long",
+        "%s:%d: %s is only 0x%zx"
+        " bytes long, should be at least 0x%zx bytes long",
         __FILE__, __LINE__, path.c_str(), mapped_file_.size(), sizeof(ECD));
     mapped_file_.Close();
     return false;

--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -120,7 +120,7 @@ int OutputJar::Doit(Options *options) {
     // TODO(asmundak):  Consider going back to sendfile() or reflink
     // (BTRFS_IOC_CLONE/XFS_IOC_CLONE) here.  The launcher preamble can
     // be very large for targets with many native deps.
-    ptrdiff_t byte_count = AppendFile(in_fd, 0, statbuf.st_size);
+    ssize_t byte_count = AppendFile(in_fd, 0, statbuf.st_size);
     if (byte_count < 0) {
       diag_err(1, "%s:%d: Cannot copy %s to %s", __FILE__, __LINE__,
                launcher_path, options_->output_jar.c_str());

--- a/src/tools/singlejar/output_jar.h
+++ b/src/tools/singlejar/output_jar.h
@@ -18,6 +18,7 @@
 #include <stdio.h>
 
 #include <cinttypes>
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/tools/singlejar/output_jar.h
+++ b/src/tools/singlejar/output_jar.h
@@ -18,7 +18,6 @@
 #include <stdio.h>
 
 #include <cinttypes>
-#include <cstddef>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/tools/singlejar/transient_bytes.h
+++ b/src/tools/singlejar/transient_bytes.h
@@ -276,7 +276,7 @@ class TransientBytes {
   // Returns the old write position.
   uint8_t *advance(size_t amount) {
     if (amount > free_size()) {
-      diag_errx(2, "%s: %d: Cannot advance %ld bytes, only %" PRIu64
+      diag_errx(2, "%s: %d: Cannot advance %zu bytes, only %" PRIu64
                    " is available",
                 __FILE__, __LINE__, amount, free_size());
     }


### PR DESCRIPTION
- MSVC does not have `errx` functions, so use `diag_errx` etc. instead.
- Fix format when trying to print `size_t`, use `%zu` so that the function will handle 32/64-bit `size_t` according to target system automatically.
- Adding/guarding a few includes for MSVC.
- MSVC does not have `ssize_t`, so replace it with `ptrdiff_t`

#2241 

/cc @laszlocsomor 