### PR TITLE
[singlejar] Replace setbuffer with setvbuf

### DIFF
--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -275,7 +275,7 @@ bool OutputJar::Open() {
   }
   outpos_ = 0;
   buffer_.reset(new char[kBufferSize]);
-  setbuffer(file_, buffer_.get(), kBufferSize);
+  setvbuf(file_, buffer_.get(), _IOFBF, kBufferSize);
   if (options_->verbose) {
     fprintf(stderr, "Writing to %s\n", path());
   }


### PR DESCRIPTION
`setbuffer` is not available on MSVC, use C-standard `setvbuf` from `stdio.h` instead.

`setbuffer` was introduced in https://github.com/bazelbuild/bazel/commit/b4cf5e32a94024c1bfdc6ca432677c31306a3fb5.

#2241 /cc @laszlocsomor 