### PR TITLE
remote: support directory inputs in runfiles

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnInputExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnInputExpander.java
@@ -20,6 +20,8 @@ import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
+import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FilesetOutputSymlink;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.actions.RunfilesSupplier;
@@ -29,6 +31,7 @@ import com.google.devtools.build.lib.exec.FilesetManifest.RelativeSymlinkBehavio
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -40,8 +43,7 @@ import java.util.TreeMap;
  * laid out.
  */
 public class SpawnInputExpander {
-  @VisibleForTesting
-  static final ActionInput EMPTY_FILE = new EmptyActionInput("/dev/null");
+  @VisibleForTesting static final ActionInput EMPTY_FILE = new EmptyActionInput("/dev/null");
 
   private final Path execRoot;
   private final boolean strict;
@@ -103,10 +105,11 @@ public class SpawnInputExpander {
   void addRunfilesToInputs(
       Map<PathFragment, ActionInput> inputMap,
       RunfilesSupplier runfilesSupplier,
-      MetadataProvider actionFileCache)
+      MetadataProvider actionFileCache,
+      ArtifactExpander artifactExpander)
       throws IOException {
-    Map<PathFragment, Map<PathFragment, Artifact>> rootsAndMappings = null;
-    rootsAndMappings = runfilesSupplier.getMappings();
+    Map<PathFragment, Map<PathFragment, Artifact>> rootsAndMappings =
+        runfilesSupplier.getMappings();
 
     for (Map.Entry<PathFragment, Map<PathFragment, Artifact>> rootAndMappings :
         rootsAndMappings.entrySet()) {
@@ -116,14 +119,38 @@ public class SpawnInputExpander {
         PathFragment location = root.getRelative(mapping.getKey());
         Artifact localArtifact = mapping.getValue();
         if (localArtifact != null) {
-          if (strict && !actionFileCache.getMetadata(localArtifact).getType().isFile()) {
-            throw new IOException("Not a file: " + localArtifact.getPath().getPathString());
+          Preconditions.checkState(!localArtifact.isMiddlemanArtifact());
+          if (localArtifact.isTreeArtifact()) {
+            List<ActionInput> expandedInputs =
+                ActionInputHelper.expandArtifacts(
+                    Collections.singletonList(localArtifact), artifactExpander);
+            for (ActionInput input : expandedInputs) {
+              if (strict) {
+                failIfDirectory(actionFileCache, input);
+              }
+              addMapping(
+                  inputMap,
+                  location.getRelative(((TreeFileArtifact) input).getParentRelativePath()),
+                  input);
+            }
+          } else {
+            if (strict) {
+              failIfDirectory(actionFileCache, localArtifact);
+            }
+            addMapping(inputMap, location, localArtifact);
           }
-          addMapping(inputMap, location, localArtifact);
         } else {
           addMapping(inputMap, location, EMPTY_FILE);
         }
       }
+    }
+  }
+
+  private static void failIfDirectory(MetadataProvider actionFileCache, ActionInput input)
+      throws IOException {
+    FileArtifactValue metadata = actionFileCache.getMetadata(input);
+    if (metadata != null && !metadata.getType().isFile()) {
+      throw new IOException("Not a file: " + input.getExecPathString());
     }
   }
 
@@ -186,7 +213,7 @@ public class SpawnInputExpander {
     TreeMap<PathFragment, ActionInput> inputMap = new TreeMap<>();
     addInputs(inputMap, spawn, artifactExpander);
     addRunfilesToInputs(
-        inputMap, spawn.getRunfilesSupplier(), actionInputFileCache);
+        inputMap, spawn.getRunfilesSupplier(), actionInputFileCache, artifactExpander);
     addFilesetManifests(spawn.getFilesetMappings(), inputMap);
     return inputMap;
   }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/AggregatingArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AggregatingArtifactValue.java
@@ -23,17 +23,24 @@ import java.util.Collection;
 /** Value for aggregating artifacts, which must be expanded to a set of other artifacts. */
 class AggregatingArtifactValue implements SkyValue {
   private final FileArtifactValue selfData;
-  private final ImmutableList<Pair<Artifact, FileArtifactValue>> inputs;
+  private final ImmutableList<Pair<Artifact, FileArtifactValue>> fileInputs;
+  private final ImmutableList<Pair<Artifact, TreeArtifactValue>> directoryInputs;
 
-  AggregatingArtifactValue(ImmutableList<Pair<Artifact, FileArtifactValue>> inputs,
+  AggregatingArtifactValue(ImmutableList<Pair<Artifact, FileArtifactValue>> fileInputs,
+      ImmutableList<Pair<Artifact, TreeArtifactValue>> directoryInputs,
       FileArtifactValue selfData) {
-    this.inputs = inputs;
+    this.fileInputs = fileInputs;
+    this.directoryInputs = directoryInputs;
     this.selfData = selfData;
   }
 
   /** Returns the artifacts that this artifact expands to, together with their data. */
-  Collection<Pair<Artifact, FileArtifactValue>> getInputs() {
-    return inputs;
+  Collection<Pair<Artifact, FileArtifactValue>> getFileInputs() {
+    return fileInputs;
+  }
+
+  Collection<Pair<Artifact, TreeArtifactValue>> getDirectoryInputs() {
+    return directoryInputs;
   }
 
   /** Returns the data of the artifact for this value, as computed by the action cache checker. */

--- a/src/main/java/com/google/devtools/build/lib/skyframe/RunfilesArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/RunfilesArtifactValue.java
@@ -20,8 +20,8 @@ import com.google.devtools.build.lib.util.Pair;
 
 /** The artifacts behind a runfiles middleman. */
 class RunfilesArtifactValue extends AggregatingArtifactValue {
-  RunfilesArtifactValue(
-      ImmutableList<Pair<Artifact, FileArtifactValue>> inputs, FileArtifactValue selfData) {
-    super(inputs, selfData);
+  RunfilesArtifactValue(ImmutableList<Pair<Artifact, FileArtifactValue>> fileInputs,
+      ImmutableList<Pair<Artifact, TreeArtifactValue>> directoryInputs, FileArtifactValue selfData) {
+    super(fileInputs, directoryInputs, selfData);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -507,16 +507,6 @@ public final class SkyframeActionExecutor {
       Preconditions.checkState(artifact.isMiddlemanArtifact() || artifact.isTreeArtifact(),
           artifact);
       Collection<Artifact> result = expandedInputs.get(artifact);
-
-      // Note that the result can be empty but not null for TreeArtifacts. And it may be null for
-      // non-aggregating middlemen.
-      if (artifact.isTreeArtifact()) {
-        Preconditions.checkNotNull(
-            result,
-            "TreeArtifact %s cannot be expanded because it is not an input for the action",
-            artifact);
-      }
-
       if (result != null) {
         output.addAll(result);
       }

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnInputExpanderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnInputExpanderTest.java
@@ -25,14 +25,21 @@ import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
+import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
+import com.google.devtools.build.lib.actions.Artifact.SpecialArtifactType;
+import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
+import com.google.devtools.build.lib.actions.ArtifactOwner;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.EmptyRunfilesSupplier;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FilesetOutputSymlink;
 import com.google.devtools.build.lib.actions.RunfilesSupplier;
+import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.analysis.RunfilesSupplierImpl;
 import com.google.devtools.build.lib.exec.util.FakeActionInputFileCache;
+import com.google.devtools.build.lib.exec.util.SpawnBuilder;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
@@ -41,6 +48,8 @@ import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
@@ -48,12 +57,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Tests for {@link SpawnInputExpander}.
- */
+/** Tests for {@link SpawnInputExpander}. */
 @RunWith(JUnit4.class)
 public class SpawnInputExpanderTest {
   private static final byte[] FAKE_DIGEST = new byte[] {1, 2, 3, 4};
+
+  private static ArtifactExpander NO_ARTIFACT_EXPANDER = (a, b) -> fail("expected no interactions");
 
   private FileSystem fs;
   private Path execRoot;
@@ -61,7 +70,7 @@ public class SpawnInputExpanderTest {
   private Map<PathFragment, ActionInput> inputMappings;
 
   @Before
-  public final void createSpawnInputExpander() throws Exception  {
+  public final void createSpawnInputExpander() {
     fs = new InMemoryFileSystem();
     execRoot = fs.getPath("/root");
     expander = new SpawnInputExpander(execRoot, /*strict=*/ true);
@@ -70,14 +79,15 @@ public class SpawnInputExpanderTest {
 
   private void scratchFile(String file, String... lines) throws Exception {
     Path path = fs.getPath(file);
-    FileSystemUtils.createDirectoryAndParents(path.getParentDirectory());
+    path.getParentDirectory().createDirectoryAndParents();
     FileSystemUtils.writeLinesAs(path, StandardCharsets.UTF_8, lines);
   }
 
   @Test
   public void testEmptyRunfiles() throws Exception {
     RunfilesSupplier supplier = EmptyRunfilesSupplier.INSTANCE;
-    expander.addRunfilesToInputs(inputMappings, supplier, null);
+    FakeActionInputFileCache mockCache = new FakeActionInputFileCache();
+    expander.addRunfilesToInputs(inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER);
     assertThat(inputMappings).isEmpty();
   }
 
@@ -92,14 +102,14 @@ public class SpawnInputExpanderTest {
     FakeActionInputFileCache mockCache = new FakeActionInputFileCache();
     mockCache.put(artifact, FileArtifactValue.createNormalFile(FAKE_DIGEST, 0));
 
-    expander.addRunfilesToInputs(inputMappings, supplier, mockCache);
+    expander.addRunfilesToInputs(inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER);
     assertThat(inputMappings).hasSize(1);
     assertThat(inputMappings)
         .containsEntry(PathFragment.create("runfiles/workspace/dir/file"), artifact);
   }
 
   @Test
-  public void testRunfilesDirectoryStrict() throws Exception {
+  public void testRunfilesDirectoryStrict() {
     Artifact artifact =
         new Artifact(
             fs.getPath("/root/dir/file"),
@@ -110,10 +120,10 @@ public class SpawnInputExpanderTest {
     mockCache.put(artifact, FileArtifactValue.createDirectory(-1));
 
     try {
-      expander.addRunfilesToInputs(inputMappings, supplier, mockCache);
+      expander.addRunfilesToInputs(inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER);
       fail();
     } catch (IOException expected) {
-      assertThat(expected.getMessage().contains("Not a file: /root/dir/file")).isTrue();
+      assertThat(expected).hasMessageThat().isEqualTo("Not a file: dir/file");
     }
   }
 
@@ -129,7 +139,7 @@ public class SpawnInputExpanderTest {
     mockCache.put(artifact, FileArtifactValue.createDirectory(-1));
 
     expander = new SpawnInputExpander(execRoot, /*strict=*/ false);
-    expander.addRunfilesToInputs(inputMappings, supplier, mockCache);
+    expander.addRunfilesToInputs(inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER);
     assertThat(inputMappings).hasSize(1);
     assertThat(inputMappings)
         .containsEntry(PathFragment.create("runfiles/workspace/dir/file"), artifact);
@@ -145,16 +155,14 @@ public class SpawnInputExpanderTest {
         new Artifact(
             fs.getPath("/root/dir/baz"),
             ArtifactRoot.asSourceRoot(Root.fromPath(fs.getPath("/root"))));
-    Runfiles runfiles = new Runfiles.Builder("workspace")
-        .addArtifact(artifact1)
-        .addArtifact(artifact2)
-        .build();
+    Runfiles runfiles =
+        new Runfiles.Builder("workspace").addArtifact(artifact1).addArtifact(artifact2).build();
     RunfilesSupplier supplier = new RunfilesSupplierImpl(PathFragment.create("runfiles"), runfiles);
     FakeActionInputFileCache mockCache = new FakeActionInputFileCache();
     mockCache.put(artifact1, FileArtifactValue.createNormalFile(FAKE_DIGEST, 1));
     mockCache.put(artifact2, FileArtifactValue.createNormalFile(FAKE_DIGEST, 2));
 
-    expander.addRunfilesToInputs(inputMappings, supplier, mockCache);
+    expander.addRunfilesToInputs(inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER);
     assertThat(inputMappings).hasSize(2);
     assertThat(inputMappings)
         .containsEntry(PathFragment.create("runfiles/workspace/dir/file"), artifact1);
@@ -168,13 +176,15 @@ public class SpawnInputExpanderTest {
         new Artifact(
             fs.getPath("/root/dir/file"),
             ArtifactRoot.asSourceRoot(Root.fromPath(fs.getPath("/root"))));
-    Runfiles runfiles = new Runfiles.Builder("workspace")
-        .addSymlink(PathFragment.create("symlink"), artifact).build();
+    Runfiles runfiles =
+        new Runfiles.Builder("workspace")
+            .addSymlink(PathFragment.create("symlink"), artifact)
+            .build();
     RunfilesSupplier supplier = new RunfilesSupplierImpl(PathFragment.create("runfiles"), runfiles);
     FakeActionInputFileCache mockCache = new FakeActionInputFileCache();
     mockCache.put(artifact, FileArtifactValue.createNormalFile(FAKE_DIGEST, 1));
 
-    expander.addRunfilesToInputs(inputMappings, supplier, mockCache);
+    expander.addRunfilesToInputs(inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER);
     assertThat(inputMappings).hasSize(1);
     assertThat(inputMappings)
         .containsEntry(PathFragment.create("runfiles/workspace/symlink"), artifact);
@@ -186,13 +196,15 @@ public class SpawnInputExpanderTest {
         new Artifact(
             fs.getPath("/root/dir/file"),
             ArtifactRoot.asSourceRoot(Root.fromPath(fs.getPath("/root"))));
-    Runfiles runfiles = new Runfiles.Builder("workspace")
-        .addRootSymlink(PathFragment.create("symlink"), artifact).build();
+    Runfiles runfiles =
+        new Runfiles.Builder("workspace")
+            .addRootSymlink(PathFragment.create("symlink"), artifact)
+            .build();
     RunfilesSupplier supplier = new RunfilesSupplierImpl(PathFragment.create("runfiles"), runfiles);
     FakeActionInputFileCache mockCache = new FakeActionInputFileCache();
     mockCache.put(artifact, FileArtifactValue.createNormalFile(FAKE_DIGEST, 1));
 
-    expander.addRunfilesToInputs(inputMappings, supplier, mockCache);
+    expander.addRunfilesToInputs(inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER);
     assertThat(inputMappings).hasSize(2);
     assertThat(inputMappings).containsEntry(PathFragment.create("runfiles/symlink"), artifact);
     // If there's no other entry, Runfiles adds an empty file in the workspace to make sure the
@@ -200,6 +212,105 @@ public class SpawnInputExpanderTest {
     assertThat(inputMappings)
         .containsEntry(
             PathFragment.create("runfiles/workspace/.runfile"), SpawnInputExpander.EMPTY_FILE);
+  }
+
+  @Test
+  public void testRunfilesWithTreeArtifacts() throws Exception {
+    SpecialArtifact treeArtifact = createTreeArtifact("treeArtifact");
+    assertThat(treeArtifact.isTreeArtifact()).isTrue();
+    TreeFileArtifact file1 = ActionInputHelper.treeFileArtifact(treeArtifact, "file1");
+    TreeFileArtifact file2 = ActionInputHelper.treeFileArtifact(treeArtifact, "file2");
+    FileSystemUtils.writeContentAsLatin1(file1.getPath(), "foo");
+    FileSystemUtils.writeContentAsLatin1(file2.getPath(), "bar");
+
+    Runfiles runfiles = new Runfiles.Builder("workspace").addArtifact(treeArtifact).build();
+    ArtifactExpander artifactExpander =
+        (Artifact artifact, Collection<? super Artifact> output) -> {
+          if (artifact.equals(treeArtifact)) {
+            output.addAll(Arrays.asList(file1, file2));
+          }
+        };
+    RunfilesSupplier supplier = new RunfilesSupplierImpl(PathFragment.create("runfiles"), runfiles);
+    FakeActionInputFileCache fakeCache = new FakeActionInputFileCache();
+    fakeCache.put(file1, FileArtifactValue.create(file1));
+    fakeCache.put(file2, FileArtifactValue.create(file2));
+
+    expander.addRunfilesToInputs(inputMappings, supplier, fakeCache, artifactExpander);
+    assertThat(inputMappings).hasSize(2);
+    assertThat(inputMappings)
+        .containsEntry(PathFragment.create("runfiles/workspace/treeArtifact/file1"), file1);
+    assertThat(inputMappings)
+        .containsEntry(PathFragment.create("runfiles/workspace/treeArtifact/file2"), file2);
+  }
+
+  @Test
+  public void testRunfilesWithTreeArtifactsInSymlinks() throws Exception {
+    SpecialArtifact treeArtifact = createTreeArtifact("treeArtifact");
+    assertThat(treeArtifact.isTreeArtifact()).isTrue();
+    TreeFileArtifact file1 = ActionInputHelper.treeFileArtifact(treeArtifact, "file1");
+    TreeFileArtifact file2 = ActionInputHelper.treeFileArtifact(treeArtifact, "file2");
+    FileSystemUtils.writeContentAsLatin1(file1.getPath(), "foo");
+    FileSystemUtils.writeContentAsLatin1(file2.getPath(), "bar");
+    Runfiles runfiles =
+        new Runfiles.Builder("workspace")
+            .addSymlink(PathFragment.create("symlink"), treeArtifact)
+            .build();
+
+    ArtifactExpander artifactExpander =
+        (Artifact artifact, Collection<? super Artifact> output) -> {
+          if (artifact.equals(treeArtifact)) {
+            output.addAll(Arrays.asList(file1, file2));
+          }
+        };
+    RunfilesSupplier supplier = new RunfilesSupplierImpl(PathFragment.create("runfiles"), runfiles);
+    FakeActionInputFileCache fakeCache = new FakeActionInputFileCache();
+    fakeCache.put(file1, FileArtifactValue.create(file1));
+    fakeCache.put(file2, FileArtifactValue.create(file2));
+
+    expander.addRunfilesToInputs(inputMappings, supplier, fakeCache, artifactExpander);
+    assertThat(inputMappings).hasSize(2);
+    assertThat(inputMappings)
+        .containsEntry(PathFragment.create("runfiles/workspace/symlink/file1"), file1);
+    assertThat(inputMappings)
+        .containsEntry(PathFragment.create("runfiles/workspace/symlink/file2"), file2);
+  }
+
+  @Test
+  public void testTreeArtifactsInInputs() throws Exception {
+    SpecialArtifact treeArtifact = createTreeArtifact("treeArtifact");
+    assertThat(treeArtifact.isTreeArtifact()).isTrue();
+    TreeFileArtifact file1 = ActionInputHelper.treeFileArtifact(treeArtifact, "file1");
+    TreeFileArtifact file2 = ActionInputHelper.treeFileArtifact(treeArtifact, "file2");
+    FileSystemUtils.writeContentAsLatin1(file1.getPath(), "foo");
+    FileSystemUtils.writeContentAsLatin1(file2.getPath(), "bar");
+
+    ArtifactExpander artifactExpander =
+        (Artifact artifact, Collection<? super Artifact> output) -> {
+          if (artifact.equals(treeArtifact)) {
+            output.addAll(Arrays.asList(file1, file2));
+          }
+        };
+    FakeActionInputFileCache fakeCache = new FakeActionInputFileCache();
+    fakeCache.put(file1, FileArtifactValue.create(file1));
+    fakeCache.put(file2, FileArtifactValue.create(file2));
+
+    Spawn spawn = new SpawnBuilder("/bin/echo", "Hello World").withInput(treeArtifact).build();
+    inputMappings = expander.getInputMapping(spawn, artifactExpander, fakeCache);
+    assertThat(inputMappings).hasSize(2);
+    assertThat(inputMappings).containsEntry(PathFragment.create("treeArtifact/file1"), file1);
+    assertThat(inputMappings).containsEntry(PathFragment.create("treeArtifact/file2"), file2);
+  }
+
+  private SpecialArtifact createTreeArtifact(String relPath) throws IOException {
+    Path outputDir = fs.getPath("/root");
+    Path outputPath = execRoot.getRelative(relPath);
+    outputPath.createDirectoryAndParents();
+    ArtifactRoot derivedRoot = ArtifactRoot.asSourceRoot(Root.fromPath(outputDir));
+    return new SpecialArtifact(
+        derivedRoot,
+        derivedRoot.getExecPath().getRelative(derivedRoot.getRoot().relativize(outputPath)),
+        ArtifactOwner.NullArtifactOwner.INSTANCE,
+        SpecialArtifactType.TREE);
   }
 
   @Test
@@ -217,10 +328,7 @@ public class SpawnInputExpanderTest {
   @Test
   public void testManifestWithSingleFile() throws Exception {
     // See AnalysisUtils for the mapping from "foo" to "_foo/MANIFEST".
-    scratchFile(
-        "/root/out/_foo/MANIFEST",
-        "workspace/bar /dir/file",
-        "<some digest>");
+    scratchFile("/root/out/_foo/MANIFEST", "workspace/bar /dir/file", "<some digest>");
 
     ArtifactRoot outputRoot =
         ArtifactRoot.asDerivedRoot(fs.getPath("/root"), fs.getPath("/root/out"));
@@ -255,10 +363,7 @@ public class SpawnInputExpanderTest {
   @Test
   public void testManifestWithDirectory() throws Exception {
     // See AnalysisUtils for the mapping from "foo" to "_foo/MANIFEST".
-    scratchFile(
-        "/root/out/_foo/MANIFEST",
-        "workspace/bar /some",
-        "<some digest>");
+    scratchFile("/root/out/_foo/MANIFEST", "workspace/bar /some", "<some digest>");
 
     ArtifactRoot outputRoot =
         ArtifactRoot.asDerivedRoot(fs.getPath("/root"), fs.getPath("/root/out"));
@@ -266,8 +371,7 @@ public class SpawnInputExpanderTest {
     expander.parseFilesetManifest(inputMappings, artifact, "workspace");
     assertThat(inputMappings).hasSize(1);
     assertThat(inputMappings)
-        .containsEntry(
-            PathFragment.create("out/foo/bar"), ActionInputHelper.fromPath("/some"));
+        .containsEntry(PathFragment.create("out/foo/bar"), ActionInputHelper.fromPath("/some"));
   }
 
   private FilesetOutputSymlink filesetSymlink(String from, String to) {
@@ -279,8 +383,7 @@ public class SpawnInputExpanderTest {
     return ImmutableMap.of(
         PathFragment.create("out"),
         ImmutableList.of(
-            filesetSymlink("workspace/bar", "foo"),
-            filesetSymlink("workspace/foo", "/foo/bar")));
+            filesetSymlink("workspace/bar", "foo"), filesetSymlink("workspace/foo", "/foo/bar")));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTest.java
@@ -55,6 +55,7 @@ import com.google.devtools.build.skyframe.SkyValue;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -142,8 +143,10 @@ public class ArtifactFunctionTest extends ArtifactFunctionTestCase {
     Artifact input1 = createSourceArtifact("input1");
     Artifact input2 = createDerivedArtifact("input2");
     SpecialArtifact tree = createDerivedTreeArtifactWithAction("treeArtifact");
-    file(createFakeTreeFileArtifact(tree, "child1", "hello1").getPath(), "src1");
-    file(createFakeTreeFileArtifact(tree, "child2", "hello2").getPath(), "src2");
+    TreeFileArtifact treeFile1 = createFakeTreeFileArtifact(tree, "child1", "hello1");
+    TreeFileArtifact treeFile2 = createFakeTreeFileArtifact(tree, "child2", "hello2");
+    file(treeFile1.getPath(), "src1");
+    file(treeFile2.getPath(), "src2");
     Action action =
         new DummyAction(
             ImmutableList.of(input1, input2, tree), output, MiddlemanType.AGGREGATING_MIDDLEMAN);
@@ -152,11 +155,14 @@ public class ArtifactFunctionTest extends ArtifactFunctionTestCase {
     file(input1.getPath(), "source contents");
     evaluate(Iterables.toArray(ImmutableSet.of(input2, input1, input2, tree), SkyKey.class));
     SkyValue value = evaluateArtifactValue(output);
-    assertThat(((AggregatingArtifactValue) value).getInputs())
+    ArrayList<Pair<Artifact, ?>> inputs = new ArrayList<>();
+    inputs.addAll(((AggregatingArtifactValue) value).getFileInputs());
+    inputs.addAll(((AggregatingArtifactValue) value).getDirectoryInputs());
+    assertThat(inputs)
         .containsExactly(
             Pair.of(input1, create(input1)),
             Pair.of(input2, create(input2)),
-            Pair.of(tree, ((TreeArtifactValue) evaluateArtifactValue(tree)).getSelfData()));
+            Pair.of(tree, ((TreeArtifactValue) evaluateArtifactValue(tree))));
   }
 
   /**

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -528,6 +528,71 @@ EOF
     expect_log "/l is a symbolic link"
 }
 
+function test_treeartifact_in_runfiles() {
+     mkdir -p a
+    cat > a/BUILD <<'EOF'
+load(":output_directory.bzl", "gen_output_dir", "gen_output_dir_test")
+
+gen_output_dir(
+    name = "skylark_output_dir",
+    outdir = "dir",
+)
+
+gen_output_dir_test(
+    name = "skylark_output_dir_test",
+    dir = ":skylark_output_dir",
+)
+EOF
+     cat > a/output_directory.bzl <<'EOF'
+def _gen_output_dir_impl(ctx):
+  output_dir = ctx.actions.declare_directory(ctx.attr.outdir)
+  ctx.actions.run_shell(
+      outputs = [output_dir],
+      inputs = [],
+      command = """
+        mkdir -p $1/sub; \
+        echo "foo" > $1/foo; \
+        echo "bar" > $1/sub/bar
+      """,
+      arguments = [output_dir.path],
+  )
+  return [
+      DefaultInfo(files=depset(direct=[output_dir]),
+                  runfiles = ctx.runfiles(files = [output_dir]))
+  ]
+gen_output_dir = rule(
+    implementation = _gen_output_dir_impl,
+    attrs = {
+        "outdir": attr.string(mandatory = True),
+    },
+)
+def _gen_output_dir_test_impl(ctx):
+    test = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(test, "echo hello world")
+    myrunfiles = ctx.runfiles(files=ctx.attr.dir.default_runfiles.files.to_list())
+    return [
+        DefaultInfo(
+            executable = test,
+            runfiles = myrunfiles,
+        ),
+    ]
+gen_output_dir_test = rule(
+    implementation = _gen_output_dir_test_impl,
+    test = True,
+    attrs = {
+        "dir":  attr.label(mandatory = True),
+    },
+)
+EOF
+
+     bazel test \
+           --spawn_strategy=remote \
+           --remote_executor=localhost:${worker_port} \
+           //a:skylark_output_dir_test \
+           || fail "Failed to run //a:skylark_output_dir_test with remote execution"
+}
+
+
 # TODO(alpha): Add a test that fails remote execution when remote worker
 # supports sandbox.
 


### PR DESCRIPTION
This change adds support for tree artifacts (directories) in runfiles in remote execution.