### PR TITLE
Improve MSVC Crosstool

### DIFF
--- a/tools/cpp/CROSSTOOL.tpl
+++ b/tools/cpp/CROSSTOOL.tpl
@@ -217,6 +217,9 @@ toolchain {
   compiler_flag: "/bigobj"
   # Allocate 500MB for precomputed headers.
   compiler_flag: "/Zm500"
+  # Catch C++ exceptions only and tell the compiler to assume that functions declared
+  # as extern "C" never throw a C++ exception.
+  compiler_flag: "/EHsc"
 
   # Globally disabled warnings.
   # Don't warn about elements of array being be default initialized.
@@ -974,73 +977,6 @@ toolchain {
       action: 'c++-compile'
       flag_group {
         flag: "/WX"
-      }
-    }
-  }
-
-  ##
-  # C++ exceptions
-  #
-  # 'default_exceptions' is in effect automatically when user does not choose
-  # between 'use_exceptions' and 'no_exceptions'. It will enable C++ exceptions,
-  # which is the default behaviour for most C++ compilers. Do not enable/disable
-  # this feature directly.
-  #
-  # If you enable 'use_exceptions' or 'no_exceptions' globally and need to switch
-  # to the opposite feature for one target, you need to first disable the
-  # original feature due to limitation of CROSSTOOL.
-  #
-  # E.g. cc_library(... features = ["-no_exceptions", "use_exceptions"])
-  #
-  # These two features are marked with "provides: 'cpp_exceptions'" to make sure
-  # that user can never enable both of them at once for any target.
-
-  feature {
-    name: 'default_exceptions'
-    enabled: true
-    flag_set {
-      action: 'c-compile'
-      action: 'c++-compile'
-      with_feature: {
-        not_feature: 'no_exceptions'
-        not_feature: 'use_exceptions'
-      }
-      flag_group {
-        flag: "/D_HAS_EXCEPTIONS=1"
-        flag: "/EHsc"
-      }
-    }
-  }
-
-  feature {
-    name: 'use_exceptions'
-    provides: 'cpp_exceptions'
-    flag_set {
-      action: 'c-compile'
-      action: 'c++-compile'
-      with_feature: {
-        not_feature: 'no_exceptions'
-      }
-      flag_group {
-        flag: "/D_HAS_EXCEPTIONS=1"
-        flag: "/EHsc"
-      }
-    }
-  }
-
-  feature {
-    name: 'no_exceptions'
-    provides: 'cpp_exceptions'
-    flag_set {
-      action: 'c-compile'
-      action: 'c++-compile'
-      with_feature: {
-        not_feature: 'use_exceptions'
-      }
-      flag_group {
-        flag: "/D_HAS_EXCEPTIONS=0"
-        flag: "/EHs-c-"
-        flag: "/wd4577" # Suppress 'noexcept used with no exception handling mode specified'
       }
     }
   }


### PR DESCRIPTION
- Remove `/D_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS`: it disables warnings for deprecated C++ headers (`<stdext/*>`, `<hash_map>` etc.). Only useful for legacy codebase.
- Remove `/J`: `char` is signed according to ISO C++. There is no reason to make `char` unsigned by default.
- Remove default `/Gy`: moved to feature (`smaller_binary`).
- Remove default `/GF`: string pooling, enabled by default with `/O2`.
- Remove `/DDEBUG` in `dbg` mode: conflict with macros defined in some OSS projects such as LLVM. User should use standard `NDEBUG` to detect debug mode.

Implements a few general `feature` to abstract away details about the compiler:
- `treat_warnings_as_errors`: aka `-Werror`.
- `frame_pointer`: aka `-fno-omit-frame-pointer'.
- `determinism`: redact `__TIME__` macros etc.
- `disable_assertions`: allow user to have `assert/DCHECK` back even in `opt` mode.
- `smaller_binary`: common optimization enabled in `opt` mode. Still allow user to disable it in `opt` (such as when using ASAN).
- `ignore_noisy_warnings`: suppress a bunch of warnings most people don't care. If users want to be pedantic, they can still get those warnings back with `--features=-ignore_noisy_warnings`.