### PR TITLE
[Skylint] Fix a crash on analyzing augmented assignment to IndexExpre…

### DIFF
--- a/src/tools/skylark/java/com/google/devtools/skylark/skylint/BadOperationChecker.java
+++ b/src/tools/skylark/java/com/google/devtools/skylark/skylint/BadOperationChecker.java
@@ -137,7 +137,13 @@ public class BadOperationChecker extends AstVisitorWithNameResolution {
   @Override
   public void visit(AugmentedAssignmentStatement node) {
     super.visit(node);
-    Identifier ident = Iterables.getOnlyElement(node.getLValue().boundIdentifiers());
+    ImmutableSet<Identifier> lvalues = node.getLValue().boundIdentifiers();
+    if (lvalues.size() != 1) {
+      // assignment visitor does not track information about assignments to IndexExpressions like
+      // kwargs["name"] += "foo" so nothing to do here until that changes
+      return;
+    }
+    Identifier ident = Iterables.getOnlyElement(lvalues);
     NodeType identType = getInferredTypeOrNull(ident);
     NodeType expressionType = getInferredTypeOrNull(node.getExpression());
     if (identType == NodeType.DICT || expressionType == NodeType.DICT) {

--- a/src/tools/skylark/javatests/com/google/devtools/skylark/skylint/BadOperationCheckerTest.java
+++ b/src/tools/skylark/javatests/com/google/devtools/skylark/skylint/BadOperationCheckerTest.java
@@ -152,4 +152,9 @@ public class BadOperationCheckerTest {
         .contains("1:1-1:5: '/' operator is deprecated");
     Truth.assertThat(findIssues("5 // 2")).isEmpty();
   }
+
+  @Test
+  public void augmentedAssignmentOperator() {
+    Truth.assertThat(findIssues("kwargs['name'] += 'foo'")).isEmpty();
+  }
 }


### PR DESCRIPTION
…ssion.

Fixes #5534.
Skylint was operating under assumption that all lvalues have a single
bound identifier, which is not true for `IndexExpression`s like
```
d["foo"] += "bar"
```
As a result, Skylint would crash. This change makes it handle cases without
bound identifiers gracefully.

Ideally `IndexExpression` assigments should be analyzed too, but it's a more
involved change.