### PR TITLE
[singlejar] Change off_t and ssize_t to C standard ptrdiff_t

### DIFF
--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -117,7 +117,7 @@ int OutputJar::Doit(Options *options) {
     // TODO(asmundak):  Consider going back to sendfile() or reflink
     // (BTRFS_IOC_CLONE/XFS_IOC_CLONE) here.  The launcher preamble can
     // be very large for targets with many native deps.
-    ptrdiff_t byte_count = AppendFile(in_fd, 0, statbuf.st_size);
+    ssize_t byte_count = AppendFile(in_fd, 0, statbuf.st_size);
     if (byte_count < 0) {
       diag_err(1, "%s:%d: Cannot copy %s to %s", __FILE__, __LINE__,
                launcher_path, options_->output_jar.c_str());
@@ -890,7 +890,7 @@ void OutputJar::ClasspathResource(const std::string &resource_name,
   }
 }
 
-ptrdiff_t OutputJar::AppendFile(int in_fd, off64_t offset, size_t count) {
+ssize_t OutputJar::AppendFile(int in_fd, off64_t offset, size_t count) {
   if (count == 0) {
     return 0;
   }
@@ -898,11 +898,11 @@ ptrdiff_t OutputJar::AppendFile(int in_fd, off64_t offset, size_t count) {
   if (buffer == nullptr) {
     diag_err(1, "%s:%d: malloc", __FILE__, __LINE__);
   }
-  ptrdiff_t total_written = 0;
+  ssize_t total_written = 0;
 
   while (static_cast<size_t>(total_written) < count) {
     size_t len = std::min(kBufferSize, count - total_written);
-    ptrdiff_t n_read = pread(in_fd, buffer.get(), len, offset + total_written);
+    ssize_t n_read = pread(in_fd, buffer.get(), len, offset + total_written);
     if (n_read > 0) {
       if (!WriteBytes(buffer.get(), n_read)) {
         return -1;

--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -117,7 +117,7 @@ int OutputJar::Doit(Options *options) {
     // TODO(asmundak):  Consider going back to sendfile() or reflink
     // (BTRFS_IOC_CLONE/XFS_IOC_CLONE) here.  The launcher preamble can
     // be very large for targets with many native deps.
-    ssize_t byte_count = AppendFile(in_fd, 0, statbuf.st_size);
+    ptrdiff_t byte_count = AppendFile(in_fd, 0, statbuf.st_size);
     if (byte_count < 0) {
       diag_err(1, "%s:%d: Cannot copy %s to %s", __FILE__, __LINE__,
                launcher_path, options_->output_jar.c_str());
@@ -416,7 +416,7 @@ bool OutputJar::AddJar(int jar_path_index) {
     //  local header
     //  file data
     //  data descriptor, if present.
-    off_t copy_from = jar_entry->local_header_offset();
+    ptrdiff_t copy_from = jar_entry->local_header_offset();
     size_t num_bytes = lh->size();
     if (jar_entry->no_size_in_local_header()) {
       const DDR *ddr = reinterpret_cast<const DDR *>(
@@ -429,7 +429,7 @@ bool OutputJar::AddJar(int jar_path_index) {
     } else {
       num_bytes += lh->compressed_file_size();
     }
-    off_t local_header_offset = Position();
+    ptrdiff_t local_header_offset = Position();
 
     // When normalize_timestamps is set, entry's timestamp is to be set to
     // 01/01/1980 00:00:00 (or to 01/01/1980 00:00:02, if an entry is a .class
@@ -499,7 +499,7 @@ bool OutputJar::AddJar(int jar_path_index) {
   return input_jar.Close();
 }
 
-off_t OutputJar::Position() {
+ptrdiff_t OutputJar::Position() {
   if (file_ == nullptr) {
     diag_err(1, "%s:%d: output file is not open", __FILE__, __LINE__);
   }
@@ -551,7 +551,7 @@ void OutputJar::WriteEntry(void *buffer) {
   }
 
   uint8_t *data = reinterpret_cast<uint8_t *>(entry);
-  off_t output_position = Position();
+  ptrdiff_t output_position = Position();
   if (!WriteBytes(data, entry->data() + entry->in_zip_size() - data)) {
     diag_err(1, "%s:%d: write", __FILE__, __LINE__);
   }
@@ -636,7 +636,7 @@ void OutputJar::WriteDirEntry(const std::string &name,
 }
 
 // Create output Central Directory entry for the input jar entry.
-void OutputJar::AppendToDirectoryBuffer(const CDH *cdh, off_t lh_pos,
+void OutputJar::AppendToDirectoryBuffer(const CDH *cdh, ptrdiff_t lh_pos,
                                         uint16_t normalized_time,
                                         bool fix_timestamp) {
   // While copying from the input CDH pointed to by 'cdh', we may need to drop
@@ -777,7 +777,7 @@ bool OutputJar::Close() {
   WriteEntry(spring_schemas_.OutputEntry(options_->force_compression));
   WriteEntry(protobuf_meta_handler_.OutputEntry(options_->force_compression));
   // TODO(asmundak): handle manifest;
-  off_t output_position = Position();
+  ptrdiff_t output_position = Position();
   bool write_zip64_ecd = output_position >= 0xFFFFFFFF || entries_ >= 0xFFFF ||
                          cen_size_ >= 0xFFFFFFFF;
 
@@ -814,7 +814,7 @@ bool OutputJar::Close() {
       // affects javac and javah only, 'jar' experiences no problems.
       ecd->cen_size32(std::min(cen_size, static_cast<size_t>(0xFFFFFFFFUL)));
       ecd->cen_offset32(
-          std::min(output_position, static_cast<off_t>(0x0FFFFFFFFL)));
+          std::min(output_position, static_cast<ptrdiff_t>(0x0FFFFFFFFL)));
     }
   } else {
     ECD *ecd = reinterpret_cast<ECD *>(ReserveCdh(sizeof(ECD)));
@@ -855,7 +855,7 @@ bool IsDir(const std::string &path) {
     diag_warn("%s:%d: stat %s:", __FILE__, __LINE__, path.c_str());
     return false;
   }
-  return S_ISDIR(st.st_mode);
+  return (st.st_mode & S_IFDIR) == S_IFDIR;
 }
 
 void OutputJar::ClasspathResource(const std::string &resource_name,
@@ -890,7 +890,7 @@ void OutputJar::ClasspathResource(const std::string &resource_name,
   }
 }
 
-ssize_t OutputJar::AppendFile(int in_fd, off_t offset, size_t count) {
+ptrdiff_t OutputJar::AppendFile(int in_fd, ptrdiff_t offset, size_t count) {
   if (count == 0) {
     return 0;
   }
@@ -898,11 +898,11 @@ ssize_t OutputJar::AppendFile(int in_fd, off_t offset, size_t count) {
   if (buffer == nullptr) {
     diag_err(1, "%s:%d: malloc", __FILE__, __LINE__);
   }
-  ssize_t total_written = 0;
+  ptrdiff_t total_written = 0;
 
   while (static_cast<size_t>(total_written) < count) {
     size_t len = std::min(kBufferSize, count - total_written);
-    ssize_t n_read = pread(in_fd, buffer.get(), len, offset + total_written);
+    ptrdiff_t n_read = pread(in_fd, buffer.get(), len, offset + total_written);
     if (n_read > 0) {
       if (!WriteBytes(buffer.get(), n_read)) {
         return -1;

--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -416,7 +416,7 @@ bool OutputJar::AddJar(int jar_path_index) {
     //  local header
     //  file data
     //  data descriptor, if present.
-    ptrdiff_t copy_from = jar_entry->local_header_offset();
+    off64_t copy_from = jar_entry->local_header_offset();
     size_t num_bytes = lh->size();
     if (jar_entry->no_size_in_local_header()) {
       const DDR *ddr = reinterpret_cast<const DDR *>(
@@ -429,7 +429,7 @@ bool OutputJar::AddJar(int jar_path_index) {
     } else {
       num_bytes += lh->compressed_file_size();
     }
-    ptrdiff_t local_header_offset = Position();
+    off64_t local_header_offset = Position();
 
     // When normalize_timestamps is set, entry's timestamp is to be set to
     // 01/01/1980 00:00:00 (or to 01/01/1980 00:00:02, if an entry is a .class
@@ -499,7 +499,7 @@ bool OutputJar::AddJar(int jar_path_index) {
   return input_jar.Close();
 }
 
-ptrdiff_t OutputJar::Position() {
+off64_t OutputJar::Position() {
   if (file_ == nullptr) {
     diag_err(1, "%s:%d: output file is not open", __FILE__, __LINE__);
   }
@@ -551,7 +551,7 @@ void OutputJar::WriteEntry(void *buffer) {
   }
 
   uint8_t *data = reinterpret_cast<uint8_t *>(entry);
-  ptrdiff_t output_position = Position();
+  off64_t output_position = Position();
   if (!WriteBytes(data, entry->data() + entry->in_zip_size() - data)) {
     diag_err(1, "%s:%d: write", __FILE__, __LINE__);
   }
@@ -636,7 +636,7 @@ void OutputJar::WriteDirEntry(const std::string &name,
 }
 
 // Create output Central Directory entry for the input jar entry.
-void OutputJar::AppendToDirectoryBuffer(const CDH *cdh, ptrdiff_t lh_pos,
+void OutputJar::AppendToDirectoryBuffer(const CDH *cdh, off64_t lh_pos,
                                         uint16_t normalized_time,
                                         bool fix_timestamp) {
   // While copying from the input CDH pointed to by 'cdh', we may need to drop
@@ -777,7 +777,7 @@ bool OutputJar::Close() {
   WriteEntry(spring_schemas_.OutputEntry(options_->force_compression));
   WriteEntry(protobuf_meta_handler_.OutputEntry(options_->force_compression));
   // TODO(asmundak): handle manifest;
-  ptrdiff_t output_position = Position();
+  off64_t output_position = Position();
   bool write_zip64_ecd = output_position >= 0xFFFFFFFF || entries_ >= 0xFFFF ||
                          cen_size_ >= 0xFFFFFFFF;
 
@@ -814,7 +814,7 @@ bool OutputJar::Close() {
       // affects javac and javah only, 'jar' experiences no problems.
       ecd->cen_size32(std::min(cen_size, static_cast<size_t>(0xFFFFFFFFUL)));
       ecd->cen_offset32(
-          std::min(output_position, static_cast<ptrdiff_t>(0x0FFFFFFFFL)));
+          std::min(output_position, static_cast<off64_t>(0x0FFFFFFFFL)));
     }
   } else {
     ECD *ecd = reinterpret_cast<ECD *>(ReserveCdh(sizeof(ECD)));
@@ -890,7 +890,7 @@ void OutputJar::ClasspathResource(const std::string &resource_name,
   }
 }
 
-ptrdiff_t OutputJar::AppendFile(int in_fd, ptrdiff_t offset, size_t count) {
+ptrdiff_t OutputJar::AppendFile(int in_fd, off64_t offset, size_t count) {
   if (count == 0) {
     return 0;
   }

--- a/src/tools/singlejar/output_jar.h
+++ b/src/tools/singlejar/output_jar.h
@@ -71,7 +71,7 @@ class OutputJar {
   // Add the contents of the given input jar.
   bool AddJar(int jar_path_index);
   // Returns the current output position.
-  ptrdiff_t Position();
+  off64_t Position();
   // Write Jar entry.
   void WriteEntry(void *local_header_and_payload);
   // Write META_INF/ entry (the first entry on output).
@@ -82,7 +82,7 @@ class OutputJar {
   // Create output Central Directory Header for the given input entry and
   // append it to CEN (Central Directory) buffer.
   void AppendToDirectoryBuffer(const CDH* cdh,
-                               ptrdiff_t local_header_offset,
+                               off64_t local_header_offset,
                                uint16_t normalized_time,
                                bool fix_timestamp);
   // Reserve space in CEN buffer.
@@ -95,7 +95,7 @@ class OutputJar {
   void ClasspathResource(const std::string& resource_name,
                          const std::string& resource_path);
   // Copy 'count' bytes starting at 'offset' from the given file.
-  ptrdiff_t AppendFile(int in_fd, ptrdiff_t offset, size_t count);
+  ptrdiff_t AppendFile(int in_fd, off64_t offset, size_t count);
   // Write bytes to the output file, return true on success.
   bool WriteBytes(const void *buffer, size_t count);
 
@@ -110,7 +110,7 @@ class OutputJar {
 
   std::unordered_map<std::string, struct EntryInfo> known_members_;
   FILE *file_;
-  ptrdiff_t outpos_;
+  off64_t outpos_;
   std::unique_ptr<char[]> buffer_;
   int entries_;
   int duplicate_entries_;

--- a/src/tools/singlejar/output_jar.h
+++ b/src/tools/singlejar/output_jar.h
@@ -18,6 +18,7 @@
 #include <stdio.h>
 
 #include <cinttypes>
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/tools/singlejar/output_jar.h
+++ b/src/tools/singlejar/output_jar.h
@@ -70,7 +70,7 @@ class OutputJar {
   // Add the contents of the given input jar.
   bool AddJar(int jar_path_index);
   // Returns the current output position.
-  off_t Position();
+  ptrdiff_t Position();
   // Write Jar entry.
   void WriteEntry(void *local_header_and_payload);
   // Write META_INF/ entry (the first entry on output).
@@ -80,8 +80,10 @@ class OutputJar {
                      const uint16_t n_extra_fields);
   // Create output Central Directory Header for the given input entry and
   // append it to CEN (Central Directory) buffer.
-  void AppendToDirectoryBuffer(const CDH *cdh, off_t local_header_offset,
-                               uint16_t normalized_time, bool fix_timestamp);
+  void AppendToDirectoryBuffer(const CDH* cdh,
+                               ptrdiff_t local_header_offset,
+                               uint16_t normalized_time,
+                               bool fix_timestamp);
   // Reserve space in CEN buffer.
   uint8_t *ReserveCdr(size_t chunk_size);
   // Reserve space for the Central Directory Header in CEN buffer.
@@ -92,7 +94,7 @@ class OutputJar {
   void ClasspathResource(const std::string& resource_name,
                          const std::string& resource_path);
   // Copy 'count' bytes starting at 'offset' from the given file.
-  ssize_t AppendFile(int in_fd, off_t offset, size_t count);
+  ptrdiff_t AppendFile(int in_fd, ptrdiff_t offset, size_t count);
   // Write bytes to the output file, return true on success.
   bool WriteBytes(const void *buffer, size_t count);
 
@@ -107,7 +109,7 @@ class OutputJar {
 
   std::unordered_map<std::string, struct EntryInfo> known_members_;
   FILE *file_;
-  off_t outpos_;
+  ptrdiff_t outpos_;
   std::unique_ptr<char[]> buffer_;
   int entries_;
   int duplicate_entries_;

--- a/src/tools/singlejar/output_jar.h
+++ b/src/tools/singlejar/output_jar.h
@@ -15,6 +15,9 @@
 #ifndef SRC_TOOLS_SINGLEJAR_COMBINED_JAR_H_
 #define SRC_TOOLS_SINGLEJAR_COMBINED_JAR_H_
 
+// Some platform (such as MacOS) needs this macro to get off64_t.
+#define _LARGEFILE64_SOURCE 1
+
 #include <stdio.h>
 
 #include <cinttypes>

--- a/src/tools/singlejar/output_jar.h
+++ b/src/tools/singlejar/output_jar.h
@@ -101,7 +101,7 @@ class OutputJar {
   void ClasspathResource(const std::string& resource_name,
                          const std::string& resource_path);
   // Copy 'count' bytes starting at 'offset' from the given file.
-  ptrdiff_t AppendFile(int in_fd, off64_t offset, size_t count);
+  ssize_t AppendFile(int in_fd, off64_t offset, size_t count);
   // Write bytes to the output file, return true on success.
   bool WriteBytes(const void *buffer, size_t count);
 

--- a/src/tools/singlejar/output_jar.h
+++ b/src/tools/singlejar/output_jar.h
@@ -15,9 +15,6 @@
 #ifndef SRC_TOOLS_SINGLEJAR_COMBINED_JAR_H_
 #define SRC_TOOLS_SINGLEJAR_COMBINED_JAR_H_
 
-// Some platform (such as MacOS) needs this macro to get off64_t.
-#define _LARGEFILE64_SOURCE 1
-
 #include <stdio.h>
 
 #include <cinttypes>
@@ -29,6 +26,12 @@
 
 #include "src/tools/singlejar/combiners.h"
 #include "src/tools/singlejar/options.h"
+
+#if defined(__APPLE__)
+typedef off_t off64_t;
+#elif defined(_WIN32)
+typedef __int64 off64_t;
+#endif
 
 /*
  * Jar file we are writing.


### PR DESCRIPTION
MSVC does not have `ssize_t` type. MSVC does have `off_t`, but is defined as 32-bit `long` due to legacy reason, this will prevent us from handling large file.

Changing `off_t` and `ssize_t` to C standard `ptrdiff_t` for portability and consistency.

Changing one instance of `S_ISDIR(st.st_mode)` to `(st.st_mode & S_IFDIR) == S_IFDIR` as MSVC does not have `S_ISDIR` macro.

/cc @laszlocsomor 