### PR TITLE
NDK cpusupport: link against dl

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_misc_libraries_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_misc_libraries_template.txt
@@ -2,4 +2,5 @@ cc_library(
     name = 'cpufeatures',
     srcs = glob(['ndk/sources/android/cpufeatures/*.c']),
     hdrs = glob(['ndk/sources/android/cpufeatures/*.h']),
+    linkopts = ['-ldl'],
 )


### PR DESCRIPTION
The cpusupport code uses functions like dlopen, dlclose that
require linking with libdl.  Adding that library to the
linkopts makes cpusupport self-contained.