### PR TITLE
http.bzl: Use allow_single_file for labels

### DIFF
--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -109,13 +109,13 @@ _http_archive_attrs = {
     "sha256": attr.string(),
     "strip_prefix": attr.string(),
     "type": attr.string(),
-    "build_file": attr.label(),
+    "build_file": attr.label(allow_single_file = True),
     "build_file_content": attr.string(),
     "patches": attr.label_list(default = []),
     "patch_tool": attr.string(default = "patch"),
     "patch_args": attr.string_list(default = ["-p0"]),
     "patch_cmds": attr.string_list(default = []),
-    "workspace_file": attr.label(),
+    "workspace_file": attr.label(allow_single_file = True),
     "workspace_file_content": attr.string(),
 }
 


### PR DESCRIPTION
To match the label declarations in git.bzl, use `allow_single_file` for
workspace and build file labels.

Per https://docs.bazel.build/versions/master/skylark/lib/attr.html#label this restricts the labels to specify only a single file.