### PR TITLE
[CROSSTOOL] Implement disable_rtti for MSVC

### DIFF
--- a/tools/cpp/CROSSTOOL.tpl
+++ b/tools/cpp/CROSSTOOL.tpl
@@ -932,6 +932,17 @@ toolchain {
   }
 
   feature {
+    name: 'disable_rtti'
+    flag_set {
+      action: 'c-compile'
+      action: 'c++-compile'
+      flag_group {
+        flag: "/GR-"
+      }
+    }
+  }
+
+  feature {
     name: 'user_compile_flags'
     flag_set {
       expand_if_all_available: 'user_compile_flags'


### PR DESCRIPTION
Example:
```
# lib\BUILD
cc_library(name = "a", features = ["-disable_rtti"]) # I absolutely need RTTI
cc_library(name = "b")
```

Run `bazel build --features=disable_rtti //lib:all`

`//lib:b` will be built without RTTI.
`//lib:a` will be built with RTTI.

/cc @mhlopko @meteorcloudy 