### PR TITLE
Add RemoteCooldown circuit breaker

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -43,6 +43,7 @@ final class RemoteActionContextProvider extends ActionContextProvider {
   @Nullable private final AbstractRemoteActionCache cache;
   @Nullable private final GrpcRemoteExecutor executor;
   private final RemoteRetrier retrier;
+  private final RemoteCooldown remoteCooldown;
   private final DigestUtil digestUtil;
   private final Path logDir;
   private final AtomicReference<SpawnRunner> fallbackRunner = new AtomicReference<>();
@@ -52,12 +53,14 @@ final class RemoteActionContextProvider extends ActionContextProvider {
       @Nullable AbstractRemoteActionCache cache,
       @Nullable GrpcRemoteExecutor executor,
       RemoteRetrier retrier,
+      RemoteCooldown remoteCooldown,
       DigestUtil digestUtil,
       Path logDir) {
     this.env = env;
     this.executor = executor;
     this.cache = cache;
     this.retrier = retrier;
+    this.remoteCooldown = remoteCooldown;
     this.digestUtil = digestUtil;
     this.logDir = logDir;
   }
@@ -95,6 +98,7 @@ final class RemoteActionContextProvider extends ActionContextProvider {
               cache,
               executor,
               retrier,
+              remoteCooldown,
               digestUtil,
               logDir);
       return ImmutableList.of(new RemoteSpawnStrategy(env.getExecRoot(), spawnRunner));

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCooldown.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCooldown.java
@@ -1,0 +1,56 @@
+package com.google.devtools.build.lib.remote;
+
+import static com.google.devtools.build.lib.remote.Retrier.CircuitBreaker.State.*;
+
+import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
+class RemoteCooldown implements CircuitBreaker {
+  private final int delay; // seconds
+  private final int minAcceptSuccess;
+
+  private Instant offUntil = Instant.MIN;
+  private int successSinceOff;
+
+  RemoteCooldown(int delay, int minAcceptSuccess) {
+    this.delay = delay;
+    this.minAcceptSuccess = minAcceptSuccess;
+
+    successSinceOff = minAcceptSuccess; // start off optimistic
+  }
+
+  @Override
+  public synchronized State state() {
+    if (isOff(Instant.now())) {
+      return REJECT_CALLS;
+    }
+    return successSinceOff >= minAcceptSuccess ? ACCEPT_CALLS : TRIAL_CALL;
+  }
+
+  @Override
+  public void recordFailure() {
+    // no failure based reaction
+  }
+
+  @Override
+  public synchronized void recordSuccess() {
+    if (successSinceOff < minAcceptSuccess) {
+      successSinceOff++;
+    }
+  }
+
+  private boolean isOff(Instant at) {
+    return at.compareTo(offUntil) < 0;
+  }
+
+  synchronized void start() {
+    Instant now = Instant.now();
+    if (!isOff(now)) {
+      offUntil = now.plus(delay, ChronoUnit.SECONDS);
+    }
+    successSinceOff = 0;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
@@ -248,4 +248,26 @@ public final class RemoteOptions extends OptionsBase {
             + "otherwise cachable actions that output symlinks will fail."
   )
   public boolean allowSymlinkUpload;
+
+  @Option(
+    name = "remote_cooldown_delay",
+    defaultValue = "0",
+    category = "remote",
+    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    effectTags = {OptionEffectTag.UNKNOWN},
+    help = "Specify a delay in seconds after a fallback to local execution to avoid"
+        + " remote cache or remote executor procedure calls."
+  )
+  public int remoteCooldownDelay;
+
+  @Option(
+    name = "remote_cooldown_success_accept_after_off",
+    defaultValue = "0",
+    category = "remote",
+    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    effectTags = {OptionEffectTag.UNKNOWN},
+    help = "A number of successful responses which must be received in order to allow"
+        + " remote procedure retries."
+  )
+  public int remoteCooldownSuccessAcceptAfterOff;
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -90,6 +90,7 @@ class RemoteSpawnRunner implements SpawnRunner {
   @Nullable private final AbstractRemoteActionCache remoteCache;
   @Nullable private final GrpcRemoteExecutor remoteExecutor;
   @Nullable private final RemoteRetrier retrier;
+  @Nullable private final RemoteCooldown remoteCooldown;
   private final String buildRequestId;
   private final String commandId;
   private final DigestUtil digestUtil;
@@ -110,6 +111,7 @@ class RemoteSpawnRunner implements SpawnRunner {
       @Nullable AbstractRemoteActionCache remoteCache,
       @Nullable GrpcRemoteExecutor remoteExecutor,
       @Nullable RemoteRetrier retrier,
+      @Nullable RemoteCooldown remoteCooldown,
       DigestUtil digestUtil,
       Path logDir) {
     this.execRoot = execRoot;
@@ -123,6 +125,7 @@ class RemoteSpawnRunner implements SpawnRunner {
     this.buildRequestId = buildRequestId;
     this.commandId = commandId;
     this.retrier = retrier;
+    this.remoteCooldown = remoteCooldown;
     this.digestUtil = digestUtil;
     this.logDir = logDir;
   }
@@ -296,6 +299,9 @@ class RemoteSpawnRunner implements SpawnRunner {
     if (remoteOptions.remoteLocalFallback
         && !(cause instanceof RetryException
             && RemoteRetrierUtils.causedByExecTimeout((RetryException) cause))) {
+      if (remoteCooldown != null) {
+        remoteCooldown.start();
+      }
       return execLocally(spawn, context, inputMap, uploadLocalResults, remoteCache, actionKey);
     }
     return handleError(cause, context.getFileOutErr(), actionKey);

--- a/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
@@ -386,4 +386,8 @@ public class Retrier {
   public boolean isRetriable(Exception e) {
     return shouldRetry.test(e);
   }
+
+  public CircuitBreaker getCircuitBreaker() {
+    return circuitBreaker;
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
@@ -281,6 +281,7 @@ public class GrpcRemoteExecutionClientTest {
             remoteCache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             DIGEST_UTIL,
             logDir);
     inputDigest = fakeFileCache.createScratchInput(simpleSpawn.getInputFiles().get(0), "xyz");

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -145,7 +146,7 @@ public class RemoteSpawnRunnerTest {
     outErr = new FileOutErr(stdout, stderr);
 
     options = Options.getDefaults(RemoteOptions.class);
-    retrier = RemoteModule.createExecuteRetrier(options, retryService);
+    retrier = RemoteModule.createExecuteRetrier(options, retryService, Retrier.ALLOW_ALL_CALLS);
   }
 
   @AfterClass
@@ -177,6 +178,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -237,6 +239,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             null,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -291,6 +294,7 @@ public class RemoteSpawnRunnerTest {
                 cache,
                 null,
                 retrier,
+                /*remoteCooldown=*/ null,
                 digestUtil,
                 logDir));
 
@@ -342,6 +346,7 @@ public class RemoteSpawnRunnerTest {
                 cache,
                 null,
                 retrier,
+                /*remoteCooldown=*/ null,
                 digestUtil,
                 logDir));
 
@@ -355,8 +360,8 @@ public class RemoteSpawnRunnerTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void printWarningIfCacheIsDown() throws Exception {
-    // If we try to upload to a local cache, that is down a warning should be printed.
+  public void fallbackIfCacheIsDown() throws Exception {
+    // If we try to upload to an unavailable cache, we should fallback
 
     options.remoteUploadLocalResults = true;
     options.remoteLocalFallback = true;
@@ -365,6 +370,7 @@ public class RemoteSpawnRunnerTest {
     StoredEventHandler eventHandler = new StoredEventHandler();
     reporter.addHandler(eventHandler);
 
+    RemoteCooldown remoteCooldown = Mockito.mock(RemoteCooldown.class);
     RemoteSpawnRunner runner =
         new RemoteSpawnRunner(
             execRoot,
@@ -378,6 +384,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             null,
             retrier,
+            remoteCooldown,
             digestUtil,
             logDir);
 
@@ -408,12 +415,7 @@ public class RemoteSpawnRunnerTest {
 
     verify(localRunner).exec(eq(spawn), eq(policy));
 
-    assertThat(eventHandler.getEvents()).hasSize(1);
-
-    Event evt = eventHandler.getEvents().get(0);
-    assertThat(evt.getKind()).isEqualTo(EventKind.WARNING);
-    assertThat(evt.getMessage()).contains("fail");
-    assertThat(evt.getMessage()).contains("upload");
+    verify(remoteCooldown, times(1)).start();
   }
 
   @Test
@@ -436,6 +438,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             null,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -477,6 +480,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             null,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -515,6 +519,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -552,6 +557,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -594,6 +600,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -639,6 +646,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -679,6 +687,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -721,6 +730,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -764,6 +774,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -813,6 +824,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -860,6 +872,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -902,6 +915,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -940,6 +954,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 
@@ -975,6 +990,7 @@ public class RemoteSpawnRunnerTest {
             cache,
             executor,
             retrier,
+            /*remoteCooldown=*/ null,
             digestUtil,
             logDir);
 


### PR DESCRIPTION
Prevent stuttering remote retries through the use of a cooldown circuit
breaker that triggers on a fallback to local execution.