### PR TITLE
Windows,JNI: graceful error-handling

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
@@ -61,10 +61,10 @@ public class WindowsFileOperations {
 
   // Keep DELETE_PATH_* values in sync with src/main/native/windows/file.cc.
   private static final int DELETE_PATH_SUCCESS = 0;
-  private static final int DELETE_PATH_DOES_NOT_EXIST = 1;
-  private static final int DELETE_PATH_DIRECTORY_NOT_EMPTY = 2;
-  private static final int DELETE_PATH_ACCESS_DENIED = 3;
-  private static final int DELETE_PATH_ERROR = 4;
+  private static final int DELETE_PATH_ERROR = 1;
+  private static final int DELETE_PATH_DOES_NOT_EXIST = 2;
+  private static final int DELETE_PATH_DIRECTORY_NOT_EMPTY = 3;
+  private static final int DELETE_PATH_ACCESS_DENIED = 4;
 
   private static native int nativeIsJunction(String path, String[] error);
 

--- a/src/main/native/windows/file-jni.cc
+++ b/src/main/native/windows/file-jni.cc
@@ -98,7 +98,7 @@ Java_com_google_devtools_build_lib_windows_jni_WindowsFileOperations_nativeDelet
   std::wstring wpath(bazel::windows::GetJavaWstring(env, path));
   std::wstring error;
   int result = bazel::windows::DeletePath(wpath, &error);
-  if (result != bazel::windows::DELETE_PATH_SUCCESS && !error.empty() &&
+  if (result != bazel::windows::DeletePathResult::kSuccess && !error.empty() &&
       CanReportError(env, error_msg_holder)) {
     ReportLastError(
         bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,

--- a/src/main/native/windows/file.h
+++ b/src/main/native/windows/file.h
@@ -42,12 +42,14 @@ enum {
 };
 
 // Keep in sync with j.c.g.devtools.build.lib.windows.WindowsFileOperations
-enum {
-  DELETE_PATH_SUCCESS = 0,
-  DELETE_PATH_DOES_NOT_EXIST = 1,
-  DELETE_PATH_DIRECTORY_NOT_EMPTY = 2,
-  DELETE_PATH_ACCESS_DENIED = 3,
-  DELETE_PATH_ERROR = 4,
+struct DeletePathResult {
+  enum {
+    kSuccess = 0,
+    kError = 1,
+    kDoesNotExist = 2,
+    kDirectoryNotEmpty = 3,
+    kAccessDenied = 4,
+  };
 };
 
 struct CreateJunctionResult {

--- a/src/test/native/windows/file_test.cc
+++ b/src/test/native/windows/file_test.cc
@@ -177,7 +177,7 @@ TEST_F(WindowsFileOperationsTest, TestCannotCreateJunctionFromExistingFile) {
             CreateJunctionResult::kAlreadyExistsButNotJunction);
 }
 
-TEST_F(WindowsFileOperationsTest, TestCannotCreateJunctionIfNameIsBusy) {
+TEST_F(WindowsFileOperationsTest, TestCannotCreateButCanCheckIfNameIsBusy) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring name = tmp + L"\\junc" WLINE;
   wstring target = tmp + L"\\target" WLINE;
@@ -188,7 +188,7 @@ TEST_F(WindowsFileOperationsTest, TestCannotCreateJunctionIfNameIsBusy) {
   EXPECT_NE(h, INVALID_HANDLE_VALUE);
   int actual = CreateJunction(name, target, nullptr);
   CloseHandle(h);
-  ASSERT_EQ(actual, CreateJunctionResult::kAccessDenied);
+  ASSERT_EQ(actual, CreateJunctionResult::kAlreadyExistsButNotJunction);
 }
 
 TEST_F(WindowsFileOperationsTest, TestCanCreateJunctionIfTargetIsBusy) {
@@ -208,14 +208,14 @@ TEST_F(WindowsFileOperationsTest, TestCanDeleteExistingFile) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring path = tmp + L"\\file" WLINE;
   EXPECT_TRUE(blaze_util::CreateDummyFile(path));
-  ASSERT_EQ(DeletePath(path.c_str(), nullptr), DELETE_PATH_SUCCESS);
+  ASSERT_EQ(DeletePath(path.c_str(), nullptr), DeletePathResult::kSuccess);
 }
 
 TEST_F(WindowsFileOperationsTest, TestCanDeleteExistingDirectory) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring path = tmp + L"\\dir" WLINE;
   EXPECT_TRUE(CreateDirectoryW(path.c_str(), NULL));
-  ASSERT_EQ(DeletePath(path.c_str(), nullptr), DELETE_PATH_SUCCESS);
+  ASSERT_EQ(DeletePath(path.c_str(), nullptr), DeletePathResult::kSuccess);
 }
 
 TEST_F(WindowsFileOperationsTest, TestCanDeleteExistingJunction) {
@@ -225,7 +225,7 @@ TEST_F(WindowsFileOperationsTest, TestCanDeleteExistingJunction) {
   EXPECT_TRUE(CreateDirectoryW(target.c_str(), NULL));
   EXPECT_EQ(CreateJunction(name, target, nullptr),
             CreateJunctionResult::kSuccess);
-  ASSERT_EQ(DeletePath(name.c_str(), nullptr), DELETE_PATH_SUCCESS);
+  ASSERT_EQ(DeletePath(name.c_str(), nullptr), DeletePathResult::kSuccess);
 }
 
 TEST_F(WindowsFileOperationsTest, TestCanDeleteExistingJunctionWithoutTarget) {
@@ -240,14 +240,14 @@ TEST_F(WindowsFileOperationsTest, TestCanDeleteExistingJunctionWithoutTarget) {
   EXPECT_NE(GetFileAttributesW(name.c_str()), INVALID_FILE_ATTRIBUTES);
   EXPECT_EQ(GetFileAttributesW(target.c_str()), INVALID_FILE_ATTRIBUTES);
   // We can delete the dangling junction.
-  ASSERT_EQ(DeletePath(name.c_str(), nullptr), DELETE_PATH_SUCCESS);
+  ASSERT_EQ(DeletePath(name.c_str(), nullptr), DeletePathResult::kSuccess);
 }
 
 TEST_F(WindowsFileOperationsTest, TestCannotDeleteNonExistentPath) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring path = tmp + L"\\dummy" WLINE;
   EXPECT_EQ(GetFileAttributesW(path.c_str()), INVALID_FILE_ATTRIBUTES);
-  ASSERT_EQ(DeletePath(path.c_str(), nullptr), DELETE_PATH_DOES_NOT_EXIST);
+  ASSERT_EQ(DeletePath(path.c_str(), nullptr), DeletePathResult::kDoesNotExist);
 }
 
 TEST_F(WindowsFileOperationsTest, TestCannotDeletePathWhereParentIsFile) {
@@ -255,7 +255,7 @@ TEST_F(WindowsFileOperationsTest, TestCannotDeletePathWhereParentIsFile) {
   wstring parent = tmp + L"\\file" WLINE;
   wstring child = parent + L"\\file" WLINE;
   EXPECT_TRUE(blaze_util::CreateDummyFile(parent));
-  ASSERT_EQ(DeletePath(child.c_str(), nullptr), DELETE_PATH_DOES_NOT_EXIST);
+  ASSERT_EQ(DeletePath(child.c_str(), nullptr), DeletePathResult::kDoesNotExist);
 }
 
 TEST_F(WindowsFileOperationsTest, TestCannotDeleteNonEmptyDirectory) {
@@ -265,7 +265,7 @@ TEST_F(WindowsFileOperationsTest, TestCannotDeleteNonEmptyDirectory) {
   EXPECT_TRUE(CreateDirectoryW(parent.c_str(), NULL));
   EXPECT_TRUE(blaze_util::CreateDummyFile(child));
   ASSERT_EQ(DeletePath(parent.c_str(), nullptr),
-            DELETE_PATH_DIRECTORY_NOT_EMPTY);
+            DeletePathResult::kDirectoryNotEmpty);
 }
 
 TEST_F(WindowsFileOperationsTest, TestCannotDeleteBusyFile) {
@@ -277,7 +277,7 @@ TEST_F(WindowsFileOperationsTest, TestCannotDeleteBusyFile) {
   EXPECT_NE(h, INVALID_HANDLE_VALUE);
   int actual = DeletePath(path.c_str(), nullptr);
   CloseHandle(h);
-  ASSERT_EQ(actual, DELETE_PATH_ACCESS_DENIED);
+  ASSERT_EQ(actual, DeletePathResult::kAccessDenied);
 }
 
 TEST_F(WindowsFileOperationsTest, TestCannotDeleteBusyDirectory) {
@@ -289,7 +289,7 @@ TEST_F(WindowsFileOperationsTest, TestCannotDeleteBusyDirectory) {
   EXPECT_NE(h, INVALID_HANDLE_VALUE);
   int actual = DeletePath(path.c_str(), nullptr);
   CloseHandle(h);
-  ASSERT_EQ(actual, DELETE_PATH_ACCESS_DENIED);
+  ASSERT_EQ(actual, DeletePathResult::kAccessDenied);
 }
 
 TEST_F(WindowsFileOperationsTest, TestCannotDeleteBusyJunction) {
@@ -306,7 +306,7 @@ TEST_F(WindowsFileOperationsTest, TestCannotDeleteBusyJunction) {
   EXPECT_NE(h, INVALID_HANDLE_VALUE);
   int actual = DeletePath(name.c_str(), nullptr);
   CloseHandle(h);
-  ASSERT_EQ(actual, DELETE_PATH_ACCESS_DENIED);
+  ASSERT_EQ(actual, DeletePathResult::kAccessDenied);
 }
 
 TEST_F(WindowsFileOperationsTest, TestCanDeleteJunctionWhoseTargetIsBusy) {
@@ -322,7 +322,7 @@ TEST_F(WindowsFileOperationsTest, TestCanDeleteJunctionWhoseTargetIsBusy) {
   EXPECT_NE(h, INVALID_HANDLE_VALUE);
   int actual = DeletePath(name.c_str(), nullptr);
   CloseHandle(h);
-  ASSERT_EQ(actual, DELETE_PATH_SUCCESS);
+  ASSERT_EQ(actual, DeletePathResult::kSuccess);
 }
 
 #undef TOSTRING1


### PR DESCRIPTION
CreateJunction and DeletePath are now more
resilient to errors:

- CreateJunction opens the junction path to check
  its target requesting fewer rights and with
  greater sharing permission. This way it can
  check junction targets even if the junction name
  is opened by another process with no sharing.

- DeletePath attempts to call FindFirstFileW if
  GetFileAttributesW fails with
  ERROR_ACCESS_DENIED. There's hardly any info
  about this error mode online, except for a code
  comment in the .NET CoreFX library. (See new
  code comments in this commit.)

Also:

- Change the error codes for DeletePath.

- Wrap the DeletPath error codes in a struct for
  better readability.

Fixes https://github.com/bazelbuild/bazel/issues/5433

Change-Id: I5b6e0f27b5b22c1cf00da90104495eda84178283