### PR TITLE
Windows,Bazel client: multithreaded file writing

### DIFF
--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -33,13 +33,14 @@ class Dumper {
  public:
   // Requests to write the `data` of `size` bytes to disk under `path`.
   // The actual writing may happen asynchronously.
-  // All parent directories of `path` will be created.
+  // `path` must be an absolute path. All of its parent directories be created.
   // The caller retains ownership of `data` and may release it immediately after
   // this method returns.
   // Callers may call this method repeatedly, but only from the same thread
   // (this method is not thread-safe).
   // If writing fails, this method sets a flag in the `Dumper`, and `Finish`
   // will return false. Subsequent `Dump` calls will have no effect.
+  // Args:
   virtual void Dump(const void* data, const size_t size,
                     const std::string& path) = 0;
 
@@ -47,6 +48,7 @@ class Dumper {
   //
   // This method may block in case the Dumper is asynchronous and some async
   // writes are still in progress.
+  // Subsequent `Dump` calls after this method have no effect.
   //
   // Returns true if there were no errors in any of the `Dump` calls.
   // Returns false if any of the `Dump` calls failed, and if `error` is not

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -33,14 +33,14 @@ class Dumper {
  public:
   // Requests to write the `data` of `size` bytes to disk under `path`.
   // The actual writing may happen asynchronously.
-  // `path` must be an absolute path. All of its parent directories be created.
+  // `path` must be an absolute path. All of its parent directories will be
+  // created.
   // The caller retains ownership of `data` and may release it immediately after
   // this method returns.
   // Callers may call this method repeatedly, but only from the same thread
   // (this method is not thread-safe).
   // If writing fails, this method sets a flag in the `Dumper`, and `Finish`
   // will return false. Subsequent `Dump` calls will have no effect.
-  // Args:
   virtual void Dump(const void* data, const size_t size,
                     const std::string& path) = 0;
 

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -25,6 +25,48 @@
 
 namespace blaze {
 
+namespace embedded_binaries {
+
+// Dumps embedded binaries that were extracted from the Bazel zip to disk.
+// The platform-specific implementations may use multi-threaded I/O.
+class Dumper {
+ public:
+  // Requests to write the `data` of `size` bytes to disk under `path`.
+  // The actual writing may happen asynchronously.
+  // All parent directories of `path` will be created.
+  // The caller retains ownership of `data` and may release it immediately after
+  // this method returns.
+  // Callers may call this method repeatedly, but only from the same thread
+  // (this method is not thread-safe).
+  // If writing fails, this method sets a flag in the `Dumper`, and `Finish`
+  // will return false. Subsequent `Dump` calls will have no effect.
+  virtual void Dump(const void* data, const size_t size,
+                    const std::string& path) = 0;
+
+  // Finishes dumping data.
+  //
+  // This method may block in case the Dumper is asynchronous and some async
+  // writes are still in progress.
+  //
+  // Returns true if there were no errors in any of the `Dump` calls.
+  // Returns false if any of the `Dump` calls failed, and if `error` is not
+  // null then puts an error message in `error`.
+  virtual bool Finish(std::string* error) = 0;
+
+  // Destructor. Subclasses should make sure it calls `Finish(nullptr)`.
+  virtual ~Dumper() {}
+
+ protected:
+  Dumper() {}
+};
+
+// Creates a new Dumper. The caller takes ownership of the returned object.
+// Returns nullptr upon failure and puts an error message in `error` (if `error`
+// is not nullptr).
+Dumper* Create(std::string* error = nullptr);
+
+}  // namespace embedded_binaries
+
 struct GlobalVariables;
 
 class SignalHandler {

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -95,8 +95,7 @@ void PosixDumper::Dump(const void* data, const size_t size,
   string dirname = blaze_util::Dirname(path);
   // Performance optimization: memoize the paths we already created a
   // directory for, to spare a stat in attempting to recreate an already
-  // existing directory. This optimization alone shaves off seconds from the
-  // extraction time on Windows.
+  // existing directory.
   if (dir_cache_.insert(dirname).second) {
     if (!blaze_util::MakeDirectories(dirname, 0777)) {
       was_error_ = true;

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -36,6 +36,8 @@
 
 #include <cassert>
 #include <cinttypes>
+#include <set>
+#include <string>
 
 #include "src/main/cpp/blaze_util.h"
 #include "src/main/cpp/global_variables.h"
@@ -54,8 +56,74 @@ namespace blaze {
 using blaze_exit_code::INTERNAL_ERROR;
 using blaze_util::GetLastErrorString;
 
+using std::set;
 using std::string;
 using std::vector;
+
+namespace embedded_binaries {
+
+class PosixDumper : public Dumper {
+ public:
+  static PosixDumper* Create(string* error);
+  ~PosixDumper() { Finish(nullptr); }
+  virtual void Dump(const void* data, const size_t size, const string& path)
+      override;
+  virtual bool Finish(string* error) override;
+
+ private:
+  PosixDumper() : was_error_(false) {}
+
+  set<string> dir_cache_;
+  string error_msg_;
+  bool was_error_;
+};
+
+Dumper* Create(string* error) {
+  return PosixDumper::Create(error);
+}
+
+PosixDumper* PosixDumper::Create(string* error) {
+  return new PosixDumper();
+}
+
+void PosixDumper::Dump(const void* data, const size_t size,
+                       const string& path) {
+  if (was_error_) {
+    return;
+  }
+
+  string dirname = blaze_util::Dirname(path);
+  // Performance optimization: memoize the paths we already created a
+  // directory for, to spare a stat in attempting to recreate an already
+  // existing directory. This optimization alone shaves off seconds from the
+  // extraction time on Windows.
+  if (dir_cache_.insert(dirname).second) {
+    if (!blaze_util::MakeDirectories(dirname, 0777)) {
+      was_error_ = true;
+      string msg = GetLastErrorString();
+      error_msg_ = string("couldn't create '") + path + "': " + msg;
+    }
+  }
+
+  if (was_error_) {
+    return;
+  }
+
+  if (!blaze_util::WriteFile(data, size, path, 0755)) {
+    was_error_ = true;
+    string msg = GetLastErrorString();
+    error_msg_ = string("Failed to write zipped file '") + path + "': " + msg;
+  }
+}
+
+bool PosixDumper::Finish(string* error) {
+  if (was_error_ && error) {
+    *error = error_msg_;
+  }
+  return !was_error_;
+}
+
+}  // namespace embedded_binaries
 
 SignalHandler SignalHandler::INSTANCE;
 


### PR DESCRIPTION
The Bazel client on Windows now writes extracted
binaries to disk in parallel. On all other systems
it writes them serially (as before).

This change makes blaze.cc:ActuallyExtractData()
about 3x faster when using a HDD. (In previous
experiments I saw no speedup with multi-threaded
writing on machines with an SSD.)

The Windows-specific code uses the native
Threadpool API of Windows, creating a pool of at
least 8 and at most 16 threads. (This seems to be
a good balance between speed and thread count.)

The OS manages everything about the pool; Bazel
submits callbacks and the pool executes them
asynchronously.

blaze.cc:ActuallyExtractData() speed, before:
- Windows: 6.48s (avg) / 6.38s (median)
- Linux (Debian): 4.78s (avg) / 4.79s (median)

blaze.cc:ActuallyExtractData() speed, after:
- Windows (8-16 threads): 2.05s (avg) / 2.01s (md)
- Windows (1 thread): 5.77s (avg) / 5.74s (median)

See https://github.com/bazelbuild/bazel/issues/5444

Change-Id: I7211f3d28eb8b9837352c16ff8df0411d5a9ebe1