### PR TITLE
Experimental CL to split generating the test.xml into a separate Spawn

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
@@ -45,7 +45,7 @@ public final class SimpleSpawn implements Spawn {
       ImmutableList<String> arguments,
       ImmutableMap<String, String> environment,
       ImmutableMap<String, String> executionInfo,
-      RunfilesSupplier runfilesSupplier,
+      @Nullable RunfilesSupplier runfilesSupplier,
       Map<PathFragment, ImmutableList<FilesetOutputSymlink>> filesetMappings,
       ImmutableList<? extends ActionInput> inputs,
       ImmutableList<? extends ActionInput> tools,

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -4,7 +4,10 @@ package(default_visibility = ["//visibility:public"])
 # TestRunnerAction#getRuntimeArtifact() will get confused.
 filegroup(
     name = "runtime",
-    srcs = ["test-setup.sh"],
+    srcs = [
+        "test-setup.sh",
+        "generate-xml.sh",
+    ],
 )
 
 filegroup(

--- a/tools/test/generate-xml.sh
+++ b/tools/test/generate-xml.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+function encode_output_file {
+  if [ -f "$1" ]; then
+    # Replace invalid XML characters and invalid sequence in CDATA
+    # cf. https://stackoverflow.com/a/7774512/4717701
+    perl -CSDA -pe's/[^\x9\xA\xD\x20-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+/?/g;' "$1" \
+      | sed 's|]]>|]]>]]<![CDATA[>|g'
+  fi
+}
+
+function write_xml_output_file {
+  local duration=$(expr $(date +%s) - $start)
+  local errors=0
+  local error_msg=
+  local signal="${1-}"
+  local test_name=
+  if [ -n "${XML_OUTPUT_FILE-}" -a ! -f "${XML_OUTPUT_FILE-}" ]; then
+    # Create a default XML output file if the test runner hasn't generated it
+    if [ -n "${signal}" ]; then
+      errors=1
+      if [ "${signal}" = "SIGTERM" ]; then
+        error_msg="<error message=\"Timed out\"></error>"
+      else
+        error_msg="<error message=\"Terminated by signal ${signal}\"></error>"
+      fi
+    elif (( $exitCode != 0 )); then
+      errors=1
+      error_msg="<error message=\"exited with error code $exitCode\"></error>"
+    fi
+    test_name="${TEST_BINARY#./}"
+    # Ensure that test shards have unique names in the xml output.
+    if [[ -n "${TEST_TOTAL_SHARDS+x}" ]] && ((TEST_TOTAL_SHARDS != 0)); then
+      ((shard_num=TEST_SHARD_INDEX+1))
+      test_name="${test_name}"_shard_"$shard_num"/"$TEST_TOTAL_SHARDS"
+    fi
+    cat <<EOF >${XML_OUTPUT_FILE}
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="$test_name" tests="1" failures="0" errors="${errors}">
+    <testcase name="$test_name" status="run" duration="${duration}" time="${duration}">${error_msg}</testcase>
+    <system-out><![CDATA[$(encode_output_file "${XML_OUTPUT_FILE}.log")]]></system-out>
+  </testsuite>
+</testsuites>
+EOF
+  fi
+  rm -f "${XML_OUTPUT_FILE}.log"
+}
+
+TEST_LOG="$1"
+XML_OUTPUT_FILE="$2"
+DURATION_IN_SECONDS="$3"
+EXIT_CODE="$4"
+
+write_xml_output_file

--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -152,53 +152,6 @@ if [[ -z "$no_echo" ]]; then
   echo "-----------------------------------------------------------------------------"
 fi
 
-function encode_output_file {
-  if [ -f "$1" ]; then
-    # Replace invalid XML characters and invalid sequence in CDATA
-    # cf. https://stackoverflow.com/a/7774512/4717701
-    perl -CSDA -pe's/[^\x9\xA\xD\x20-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+/?/g;' "$1" \
-      | sed 's|]]>|]]>]]<![CDATA[>|g'
-  fi
-}
-
-function write_xml_output_file {
-  local duration=$(expr $(date +%s) - $start)
-  local errors=0
-  local error_msg=
-  local signal="${1-}"
-  local test_name=
-  if [ -n "${XML_OUTPUT_FILE-}" -a ! -f "${XML_OUTPUT_FILE-}" ]; then
-    # Create a default XML output file if the test runner hasn't generated it
-    if [ -n "${signal}" ]; then
-      errors=1
-      if [ "${signal}" = "SIGTERM" ]; then
-        error_msg="<error message=\"Timed out\"></error>"
-      else
-        error_msg="<error message=\"Terminated by signal ${signal}\"></error>"
-      fi
-    elif (( $exitCode != 0 )); then
-      errors=1
-      error_msg="<error message=\"exited with error code $exitCode\"></error>"
-    fi
-    test_name="${TEST_BINARY#./}"
-    # Ensure that test shards have unique names in the xml output.
-    if [[ -n "${TEST_TOTAL_SHARDS+x}" ]] && ((TEST_TOTAL_SHARDS != 0)); then
-      ((shard_num=TEST_SHARD_INDEX+1))
-      test_name="${test_name}"_shard_"$shard_num"/"$TEST_TOTAL_SHARDS"
-    fi
-    cat <<EOF >${XML_OUTPUT_FILE}
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
-  <testsuite name="$test_name" tests="1" failures="0" errors="${errors}">
-    <testcase name="$test_name" status="run" duration="${duration}" time="${duration}">${error_msg}</testcase>
-    <system-out><![CDATA[$(encode_output_file "${XML_OUTPUT_FILE}.log")]]></system-out>
-  </testsuite>
-</testsuites>
-EOF
-  fi
-  rm -f "${XML_OUTPUT_FILE}.log"
-}
-
 # The path of this command-line is usually relative to the exec-root,
 # but when using --run_under it can be a "/bin/bash -c" command-line.
 
@@ -269,16 +222,15 @@ if [ "$has_tail" == true ] && [  -z "$no_echo" ]; then
   exitCode=$?
 else
   if [ -z "$COVERAGE_DIR" ]; then
-    "${TEST_PATH}" "$@" 2> >(tee -a "${XML_OUTPUT_FILE}.log" >&2) 1> >(tee -a "${XML_OUTPUT_FILE}.log") 2>&1 || exitCode=$?
+    "${TEST_PATH}" "$@" 2>&1 || exitCode=$?
   else
-    "$1" "$TEST_PATH" "${@:3}" 2> >(tee -a "${XML_OUTPUT_FILE}.log" >&2) 1> >(tee -a "${XML_OUTPUT_FILE}.log") 2>&1 || exitCode=$?
+    "$1" "$TEST_PATH" "${@:3}" 2>&1 || exitCode=$?
   fi
 fi
 
 for signal in $signals; do
   trap - ${signal}
 done
-write_xml_output_file
 
 # Add all of the files from the undeclared outputs directory to the manifest.
 if [[ -n "$TEST_UNDECLARED_OUTPUTS_DIR" && -n "$TEST_UNDECLARED_OUTPUTS_MANIFEST" ]]; then


### PR DESCRIPTION
This crashes when the remote spawn cache is enabled:
Caused by: java.lang.IllegalStateException: null for File:[[/usr/local/google/home/ulfjack/.cache/bazel/_bazel_ulfjack/14840415760c7e7b12619af029e4e276/execroot/io_bazel]bazel-out/k8-fastbuild/testlogs]foo/foo/test.log
	at com.google.common.base.Preconditions.checkState(Preconditions.java:582)
	at com.google.devtools.build.lib.skyframe.PerActionFileCache.getMetadata(PerActionFileCache.java:60)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor$DelegatingPairFileCache.getMetadata(SkyframeActionExecutor.java:1201)
	at com.google.devtools.build.lib.remote.DigestUtil.getFromInputCache(DigestUtil.java:109)
	at com.google.devtools.build.lib.remote.TreeNodeRepository.getOrComputeDirectory(TreeNodeRepository.java:363)
	at com.google.devtools.build.lib.remote.TreeNodeRepository.computeMerkleDigests(TreeNodeRepository.java:396)
	at com.google.devtools.build.lib.remote.TreeNodeRepository.computeMerkleDigests(TreeNodeRepository.java:394)
	at com.google.devtools.build.lib.remote.TreeNodeRepository.computeMerkleDigests(TreeNodeRepository.java:394)
	at com.google.devtools.build.lib.remote.TreeNodeRepository.computeMerkleDigests(TreeNodeRepository.java:394)
	at com.google.devtools.build.lib.remote.TreeNodeRepository.computeMerkleDigests(TreeNodeRepository.java:394)
	at com.google.devtools.build.lib.remote.TreeNodeRepository.computeMerkleDigests(TreeNodeRepository.java:394)
	at com.google.devtools.build.lib.remote.RemoteSpawnCache.lookup(RemoteSpawnCache.java:96)