### PR TITLE
bazel,tests: allow empty TMPDIR in test

### DIFF
--- a/src/test/shell/bazel/bazel_rules_test.sh
+++ b/src/test/shell/bazel/bazel_rules_test.sh
@@ -289,10 +289,10 @@ EOF
     fail "Could not create new temporary directory ${new_tmpdir}"
   export PATH="$PATH_TO_BAZEL_WRAPPER:/bin:/usr/bin:/random/path"
   if is_windows; then
-    local old_tmpdir="$TMP"
+    local old_tmpdir="${TMP:-}"
     export TMP="${new_tmpdir}"
   else
-    local old_tmpdir="$TMPDIR"
+    local old_tmpdir="${TMPDIR:-}"
     export TMPDIR="${new_tmpdir}"
   fi
   # shut down to force reload of the environment


### PR DESCRIPTION
Allow the `$TMPDIR` to be empty in
//src/test/shell/bazel:bazel_rules_test.

This used to be the case before commit
https://github.com/bazelbuild/bazel/commit/f814454ff5477418ca44696efb5c71339368efa4

Bazel only guarantees to set TMPDIR for locally
executed tests, but not (to my knowledge) for
remote execution.

Fixes https://github.com/bazelbuild/bazel/issues/5607

Change-Id: I2e97c13d137f94c7f668b7a6c7fc5020a19e4a0b