### PR TITLE
Disable the correct warning

### DIFF
--- a/tools/cpp/CROSSTOOL.tpl
+++ b/tools/cpp/CROSSTOOL.tpl
@@ -962,7 +962,7 @@ toolchain {
         # Make C++ compilation deterministic. Use linkstamping instead of these
         # compiler symbols.
         # TODO: detect clang on Windows and use "-Wno-builtin-macro-redefined"
-        flag: "/wd4177" # Trying to define or undefine a predefined macro
+        flag: "/wd4117" # Trying to define or undefine a predefined macro
         flag: "-D__DATE__=\"redacted\""
         flag: "-D__TIMESTAMP__=\"redacted\""
         flag: "-D__TIME__=\"redacted\""


### PR DESCRIPTION
I realized that I wrote the wrong warning code when I use Bazel from master branch and build something with MSVC.

For the curious:

- C4117: https://msdn.microsoft.com/en-us/library/9d2szxf8.aspx
- C4177: https://msdn.microsoft.com/en-us/library/s4becxs9.aspx

/cc @meteorcloudy 