### PR TITLE
Always set --direct_dependencies in Java header actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileAction.java
@@ -612,6 +612,12 @@ public class JavaHeaderCompileAction extends SpawnAction {
         result.add("--injecting_rule_kind", injectingRuleKind);
       }
       result.addExecPaths("--classpath", classpathEntries);
+      if (strictJavaDeps != BuildConfiguration.StrictDepsMode.OFF) {
+        result.addExecPaths("--direct_dependencies", directJars);
+        if (!compileTimeDependencyArtifacts.isEmpty()) {
+          result.addExecPaths("--deps_artifacts", compileTimeDependencyArtifacts);
+        }
+      }
       return result;
     }
 


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_scala/pull/559 for more details 