### PR TITLE
vfs: do not close streams twice

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystemUtils.java
@@ -698,14 +698,7 @@ public class FileSystemUtils {
    */
   public static void writeContent(Path outputFile, Charset charset, String content)
       throws IOException {
-    try (OutputStream out = outputFile.getOutputStream()) {
-      new ByteSink() {
-        @Override
-        public OutputStream openStream() throws IOException {
-          return out;
-        }
-      }.asCharSink(charset).write(content);
-    }
+    asByteSink(outputFile).asCharSink(charset).write(content);
   }
 
   /**
@@ -736,14 +729,7 @@ public class FileSystemUtils {
   public static void writeLinesAs(Path file, Charset charset, Iterable<String> lines)
       throws IOException {
     createDirectoryAndParents(file.getParentDirectory());
-    try (OutputStream out = file.getOutputStream()) {
-      new ByteSink() {
-        @Override
-        public OutputStream openStream() throws IOException {
-          return out;
-        }
-      }.asCharSink(charset).writeLines(lines);
-    }
+    asByteSink(file).asCharSink(charset).writeLines(lines);
   }
 
   /**
@@ -754,14 +740,7 @@ public class FileSystemUtils {
   public static void appendLinesAs(Path file, Charset charset, Iterable<String> lines)
       throws IOException {
     createDirectoryAndParents(file.getParentDirectory());
-    try (OutputStream out = file.getOutputStream(true)) {
-      new ByteSink() {
-        @Override
-        public OutputStream openStream() throws IOException {
-          return out;
-        }
-      }.asCharSink(charset).writeLines(lines);
-    }
+    asByteSink(file, true).asCharSink(charset).writeLines(lines);
   }
 
   /**
@@ -770,15 +749,7 @@ public class FileSystemUtils {
    * @throws IOException if there was an error
    */
   public static void writeContent(Path outputFile, byte[] content) throws IOException {
-    try (OutputStream out = outputFile.getOutputStream()) {
-      new ByteSink() {
-        @Override
-        public OutputStream openStream() throws IOException {
-          return out;
-        }
-      }.write(content);
-      ;
-    }
+    asByteSink(outputFile).write(content);
   }
 
   /**


### PR DESCRIPTION
ByteStream's functions already close the
underlying stream.

See https://github.com/bazelbuild/bazel/commit/09d20311d982606093ed881d779bb05a5ee70ed3

Change-Id: Id389ef594946bfebb90ca66d97ea96f271b20331