### PR TITLE
jdk: use parallel old gc and disable compact strings

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -422,6 +422,7 @@ static vector<string> GetArgumentArray(
   if (!globals->options->GetEmbeddedJavabase().empty()) {
     // quiet warnings from com.google.protobuf.UnsafeUtil,
     // see: https://github.com/google/protobuf/issues/3781
+    result.push_back("-XX:+UseParallelOldGC");
     result.push_back("--add-opens=java.base/java.nio=ALL-UNNAMED");
   }
 

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -19,6 +19,8 @@ JDK8_JVM_OPTS = [
 ]
 
 JDK9_JVM_OPTS = [
+    "-XX:+UseParallelOldGC",
+    "-XX:-CompactStrings",
     # Allow JavaBuilder to access internal javac APIs.
     "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
     "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
@@ -36,6 +38,7 @@ JDK9_JVM_OPTS = [
     # quiet warnings from com.google.protobuf.UnsafeUtil,
     # see: https://github.com/google/protobuf/issues/3781
     "--add-opens=java.base/java.nio=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
 ]
 
 DEFAULT_JAVACOPTS = [


### PR DESCRIPTION
When switching to JDK9 we regressed on java build
performance by about ~30%. We found that when
using parallel gc instead of G1 and disabling
compact strings for JavaBuilder then java
build performance is "only" 10% slower.