### PR TITLE
Load toolchains with the target configuration

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/DependencyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/DependencyResolver.java
@@ -236,7 +236,8 @@ public abstract class DependencyResolver {
 
     Attribute toolchainsAttribute =
         attributeMap.getAttributeDefinition(PlatformSemantics.RESOLVED_TOOLCHAINS_ATTR);
-    resolveToolchainDependencies(outgoingEdges.get(toolchainsAttribute), toolchainLabels);
+    resolveToolchainDependencies(
+        outgoingEdges.get(toolchainsAttribute), toolchainLabels, ruleConfig);
   }
 
   /**
@@ -447,11 +448,10 @@ public abstract class DependencyResolver {
   }
 
   private void resolveToolchainDependencies(
-      Set<Dependency> dependencies, ImmutableSet<Label> toolchainLabels) {
+      Set<Dependency> dependencies, ImmutableSet<Label> toolchainLabels,
+      BuildConfiguration ruleConfig) {
     for (Label label : toolchainLabels) {
-      Dependency dependency =
-          Dependency.withTransitionAndAspects(
-              label, HostTransition.INSTANCE, AspectCollection.EMPTY);
+      Dependency dependency = Dependency.withConfiguration(label, ruleConfig);
       dependencies.add(dependency);
     }
   }

--- a/src/test/shell/bazel/toolchain_test.sh
+++ b/src/test/shell/bazel/toolchain_test.sh
@@ -168,6 +168,25 @@ EOF
   expect_log 'extra_str = "bar"'
 }
 
+function test_toolchain_build_with_target_configuration {
+  write_test_toolchain
+  write_test_rule
+  write_register_toolchain
+
+  mkdir -p demo
+  cat >> demo/BUILD <<EOF
+load('//toolchain:rule_use_toolchain.bzl', 'use_toolchain')
+# Use the toolchain.
+use_toolchain(
+    name = 'use',
+    message = 'this is the rule')
+EOF
+
+  bazel cquery 'kind("test_toolchain", deps(//demo:use))' | grep -Fv HOST \
+    &> $TEST_log || fail "cquery failed"
+  expect_log "//:test_toolchain_impl_1"
+}
+
 function test_toolchain_use_in_rule {
   write_test_toolchain
   write_test_rule


### PR DESCRIPTION
A toolchain might specify core libraries to be compiled
in the target configuration (e.g. libc or for my precise
case Rust' libprotobuf). With the current code, the compilation
would fail despite the toolchain specifying 'target' as the
transition configuration for those dependencies.

This was detected when trying to rebase the protobuf PR for
rules_rust and examples where failing because protobufs where
compiled with the host libprotobuf but the target example was
compiled with the target libprotobuf. Rustc detected a version.

/review @katre