### PR TITLE
Write print(x) instead of print x for python3 compatibility

### DIFF
--- a/src/test/shell/unittest.bash
+++ b/src/test/shell/unittest.bash
@@ -717,7 +717,7 @@ if [ "$UNAME" = "linux" ] || [[ "$UNAME" =~ msys_nt* ]]; then
 else
     function timestamp() {
       # OS X and FreeBSD do not have %N so python is the best we can do
-      python -c 'import time; print int(round(time.time() * 1000))'
+      python -c 'import time; print(int(round(time.time() * 1000)))'
     }
 fi
 


### PR DESCRIPTION
There is only one argument, so this shouldn't affect Python 2.