### PR TITLE
update to embedded jdk to jdk10

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,25 +117,25 @@ distdir_tar(
 # OpenJDK distributions used to create a version of Bazel bundled with the OpenJDK.
 http_file(
     name = "openjdk_linux",
-    sha256 = "f27cb933de4f9e7fe9a703486cf44c84bc8e9f138be0c270c9e5716a32367e87",
+    sha256 = "57fad3602e74c79587901d6966d3b54ef32cb811829a2552163185d5064fe9b5",
     urls = [
-        "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz",
+        "https://mirror.bazel.build/openjdk/azul-zulu10.2%2B3-jdk10.0.1/zulu10.2%2B3-jdk10.0.1-linux_x64-allmodules.tar.gz",
     ],
 )
 
 http_file(
     name = "openjdk_macos",
-    sha256 = "404e7058ff91f956612f47705efbee8e175a38b505fb1b52d8c1ea98718683de",
+    sha256 = "e669c9a897413d855b550b4e39d79614392e6fb96f494e8ef99a34297d9d85d3",
     urls = [
-        "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-macosx_x64-allmodules.tar.gz",
+        "https://mirror.bazel.build/openjdk/azul-zulu10.2%2B3-jdk10.0.1/zulu10.2%2B3-jdk10.0.1-macosx_x64-allmodules.tar.gz",
     ],
 )
 
 http_file(
     name = "openjdk_win",
-    sha256 = "e738829017f107e7a7cd5069db979398ec3c3f03ef56122f89ba38e7374f63ed",
+    sha256 = "c39e7700a8d41794d60985df5a20352435196e78ecbc6a2b30df7be8637bffd5",
     urls = [
-        "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-win_x64-allmodules.zip",
+        "https://mirror.bazel.build/openjdk/azul-zulu10.2%2B3-jdk10.0.1/zulu10.2%2B3-jdk10.0.1-win_x64-allmodules.zip",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/GenericRules.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/GenericRules.java
@@ -54,7 +54,7 @@ public class GenericRules implements RuleSet {
                   "%java_toolchain%",
                   isJdk8OrEarlier()
                       ? "@bazel_tools//tools/jdk:toolchain_hostjdk8"
-                      : "@bazel_tools//tools/jdk:toolchain_hostjdk9"));
+                      : "@bazel_tools//tools/jdk:toolchain_hostjdk10"));
 
     } catch (IOException e) {
       throw new IllegalStateException(e);

--- a/third_party/protobuf/3.6.0/BUILD
+++ b/third_party/protobuf/3.6.0/BUILD
@@ -9,9 +9,9 @@ exports_files(["LICENSE"])
 ################################################################################
 
 config_setting(
-    name = "jdk9",
+    name = "jdk10",
     values = {
-        "java_toolchain": "@bazel_tools//tools/jdk:toolchain_jdk9",
+        "java_toolchain": "@bazel_tools//tools/jdk:toolchain_jdk10",
     },
 )
 

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -4,7 +4,7 @@ load(
     "//tools/jdk:default_java_toolchain.bzl",
     "default_java_toolchain",
     "JDK8_JVM_OPTS",
-    "JDK9_JVM_OPTS",
+    "JDK10_JVM_OPTS",
     "DEFAULT_JAVACOPTS",
 )
 
@@ -219,20 +219,20 @@ default_java_toolchain(
 )
 
 default_java_toolchain(
-    name = "toolchain_hostjdk9",
+    name = "toolchain_hostjdk10",
     bootclasspath = [":bootclasspath"],
     extclasspath = [":extclasspath"],
-    jvm_opts = JDK9_JVM_OPTS,
+    jvm_opts = JDK10_JVM_OPTS,
     source_version = "8",
     target_version = "8",
 )
 
 default_java_toolchain(
     name = "toolchain_java9",
-    jvm_opts = JDK9_JVM_OPTS,
+    jvm_opts = JDK10_JVM_OPTS,
     misc = DEFAULT_JAVACOPTS + [
         "--release",
-        "9",
+        "10",
     ],
 )
 

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -18,7 +18,7 @@ JDK8_JVM_OPTS = [
     "-Xbootclasspath/p:$(location @bazel_tools//third_party/java/jdk/langtools:javac_jar)",
 ]
 
-JDK9_JVM_OPTS = [
+JDK10_JVM_OPTS = [
     # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
     # G1 collector and having compact strings enabled.
     "-XX:+UseParallelOldGC",


### PR DESCRIPTION
RELNOTES: The JDK shipped with Bazel was updated to JDK10.