### PR TITLE
Create the native headers jar in java_common.compile.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaLibraryHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaLibraryHelper.java
@@ -254,13 +254,16 @@ public final class JavaLibraryHelper {
       helper.createGenJarAction(output, manifestProtoOutput, genClassJar, hostJavabase);
     }
 
+    Artifact nativeHeaderOutput = helper.createNativeHeaderJar(output);
+
+
     helper.createCompileAction(
         output,
         manifestProtoOutput,
         genSourceJar,
         outputDepsProto,
         /* instrumentationMetadataJar= */ null,
-        /* nativeHeaderOutput= */ null);
+        nativeHeaderOutput);
 
     artifactsBuilder.addRuntimeJar(output);
     Artifact iJar = helper.createCompileTimeJarAction(output, artifactsBuilder);
@@ -273,7 +276,8 @@ public final class JavaLibraryHelper {
         outputSourceJar == null ? ImmutableList.of() : ImmutableList.of(outputSourceJar);
     outputJarsBuilder
         .addOutputJar(new OutputJar(output, iJar, outputSourceJars))
-        .setJdeps(outputDepsProto);
+        .setJdeps(outputDepsProto)
+        .setNativeHeaders(nativeHeaderOutput);
 
     JavaCompilationArtifacts javaArtifacts = artifactsBuilder.build();
     if (javaInfoBuilder != null) {

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaSkylarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaSkylarkApiTest.java
@@ -306,6 +306,7 @@ public class JavaSkylarkApiTest extends BuildViewTestCase {
     assertThat(prettyArtifactNames(outputJar.getSrcJars()))
         .containsExactly("java/test/libdep-src.jar");
     assertThat(outputs.getJdeps().getFilename()).isEqualTo("libdep.jdeps");
+    assertThat(outputs.getNativeHeaders().getFilename()).isEqualTo("libdep-native-header.jar");
   }
 
   /**


### PR DESCRIPTION
RELNOTES: java_common.compile creates the native headers jar accesible via JavaInfo.outputs.native_headers.