### PR TITLE
Check that LHS --host_javabase is not provided by user before adding JDK9+ opts to it.

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -419,7 +419,8 @@ static vector<string> GetArgumentArray(
                    blaze_util::PathAsJvmFlag(heap_crash_path));
 
   // TODO(b/109998449): only assume JDK >= 9 for embedded JDKs
-  if (!globals->options->GetEmbeddedJavabase().empty()) {
+  if (!globals->options->GetEmbeddedJavabase().empty() &&
+      globals->options->GetExplicitHostJavabase().empty()) {
     // In JDK9 we have seen a slow down when using the default G1 collector
     // and thus switch back to parallel gc.
     result.push_back("-XX:+UseParallelOldGC");


### PR DESCRIPTION
If user provided LHS `--host_javabase`, we cannot assume that it is JDK9 or above. Check that there is no user-provided host JDK before adding mandatory JDK9 opts to it.

I'm sure that we want to develop against the latest embedded JDK [(now 10)](https://github.com/bazelbuild/bazel/commit/4c9149d558161e7d3e363fb697f5852bc5742a36), but we should maintain backwards compatibility as much as possible. If users try to specify a custom LHS `--host_javabase`, we shouldn't break them if possible.
