### PR TITLE
Replace cd with git -C during in git skylark rules

### DIFF
--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -52,9 +52,10 @@ set -ex
       rm -rf '{directory}' '{dir_link}'
       git clone {shallow} '{remote}' '{directory}' || git clone '{remote}' '{directory}'
     fi
-    cd '{directory}'
-    git reset --hard {ref} || ((git fetch {shallow} origin {ref}:{ref} || git fetch origin {ref}:{ref}) && git reset --hard {ref})
-    git clean -xdf )
+    git -C '{directory}' reset --hard {ref} || \
+    ((git -C '{directory}' fetch {shallow} origin {ref}:{ref} || \
+      git -C '{directory}' fetch origin {ref}:{ref}) && git -C '{directory}' reset --hard {ref})
+      git -C '{directory}' clean -xdf )
   """.format(
         working_dir = ctx.path(".").dirname,
         dir_link = ctx.path("."),
@@ -76,8 +77,7 @@ set -ex
     if ctx.attr.init_submodules:
         st = ctx.execute([bash_exe, "-c", """
 set -ex
-(   cd '{directory}'
-    git submodule update --init --checkout --force )
+(   git -C '{directory}' submodule update --init --checkout --force )
   """.format(
             directory = ctx.path("."),
         )])
@@ -88,14 +88,14 @@ set -ex
     actual_commit = ctx.execute([
         bash_exe,
         "-c",
-        "(cd '{directory}' && git log -n 1 --pretty='format:%H')".format(
+        "(git -C '{directory}' log -n 1 --pretty='format:%H')".format(
             directory = ctx.path("."),
         ),
     ]).stdout
     shallow_date = ctx.execute([
         bash_exe,
         "-c",
-        "(cd '{directory}' && git log -n 1 --pretty='format:%cd' --date='format:%Y-%d-%m')".format(
+        "(git -C '{directory}' log -n 1 --pretty='format:%cd' --date='format:%Y-%d-%m')".format(
             directory = ctx.path("."),
         ),
     ]).stdout


### PR DESCRIPTION
Use `git -C` instead of `cd` in git skylark rules to be more concise. I think it's probably better to use the built-in changedir functionality of git rather than `cd`ing around manually. Happy to be overruled however if it makes readability better.