### PR TITLE
Store SkylarkType in a ParamDescriptor.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/NativeInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/NativeInfo.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.events.Location;
 import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.FuncallExpression;
-import com.google.devtools.build.lib.syntax.FuncallExpression.MethodDescriptor;
+import com.google.devtools.build.lib.syntax.MethodDescriptor;
 import java.util.Map;
 
 /** Base class for native implementations of {@link Info}. */

--- a/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebuggerSerialization.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebuggerSerialization.java
@@ -24,8 +24,10 @@ import com.google.devtools.build.lib.syntax.ClassObject;
 import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.EvalUtils;
 import com.google.devtools.build.lib.syntax.FuncallExpression;
+import com.google.devtools.build.lib.syntax.MethodDescriptor;
 import com.google.devtools.build.lib.syntax.Printer;
 import com.google.devtools.build.lib.syntax.SkylarkNestedSet;
+
 import java.lang.reflect.Array;
 import java.util.Map;
 import java.util.Set;
@@ -146,7 +148,7 @@ final class DebuggerSerialization {
     }
     ImmutableList.Builder<Value> children = ImmutableList.builder();
     for (String fieldName : fieldNames) {
-      FuncallExpression.MethodDescriptor method =
+      MethodDescriptor method =
           FuncallExpression.getStructField(skylarkValue.getClass(), fieldName);
       try {
         children.add(

--- a/src/main/java/com/google/devtools/build/lib/syntax/BuiltinCallable.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BuiltinCallable.java
@@ -21,7 +21,7 @@ import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkCallable;
 import com.google.devtools.build.lib.syntax.Environment.LexicalFrame;
-import com.google.devtools.build.lib.syntax.FuncallExpression.MethodDescriptor;
+
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -53,7 +53,7 @@ public class BuiltinCallable extends BaseFunction {
     super(name);
     this.obj = obj;
     this.descriptor = descriptor;
-    this.extraArgs = getExtraArgs(descriptor.getAnnotation());
+    this.extraArgs = getExtraArgs(descriptor);
     configure(obj, descriptor);
   }
 
@@ -62,18 +62,18 @@ public class BuiltinCallable extends BaseFunction {
     return innerArgumentCount;
   }
 
-  private static List<ExtraArgKind> getExtraArgs(SkylarkCallable annotation) {
+  private static List<ExtraArgKind> getExtraArgs(MethodDescriptor method) {
     ImmutableList.Builder<ExtraArgKind> extraArgs = ImmutableList.builder();
-    if (annotation.useLocation()) {
+    if (method.isUseLocation()) {
       extraArgs.add(ExtraArgKind.LOCATION);
     }
-    if (annotation.useAst()) {
+    if (method.isUseAst()) {
       extraArgs.add(ExtraArgKind.SYNTAX_TREE);
     }
-    if (annotation.useEnvironment()) {
+    if (method.isUseEnvironment()) {
       extraArgs.add(ExtraArgKind.ENVIRONMENT);
     }
-    if (annotation.useSkylarkSemantics()) {
+    if (method.isUseSkylarkSemantics()) {
       extraArgs.add(ExtraArgKind.SEMANTICS);
     }
     return extraArgs.build();

--- a/src/main/java/com/google/devtools/build/lib/syntax/DotExpression.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/DotExpression.java
@@ -15,7 +15,6 @@ package com.google.devtools.build.lib.syntax;
 
 import com.google.common.collect.Streams;
 import com.google.devtools.build.lib.events.Location;
-import com.google.devtools.build.lib.syntax.FuncallExpression.MethodDescriptor;
 import com.google.devtools.build.lib.util.SpellChecker;
 import java.io.IOException;
 import java.util.Optional;
@@ -127,15 +126,15 @@ public final class DotExpression extends Expression {
     if (methods != null) {
       Optional<MethodDescriptor> method =
           Streams.stream(methods)
-              .filter(methodDescriptor -> methodDescriptor.getAnnotation().structField())
+              .filter(MethodDescriptor::isStructField)
               .findFirst();
-      if (method.isPresent() && method.get().getAnnotation().structField()) {
+      if (method.isPresent() && method.get().isStructField()) {
         return FuncallExpression.callMethod(
             method.get(),
             name,
             objValue,
             FuncallExpression.extraInterpreterArgs(
-                method.get().getAnnotation(),
+                method.get(),
                 /* ast = */ null,
                 loc,
                 env).toArray(),

--- a/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
@@ -512,30 +512,6 @@ public final class FuncallExpression extends Expression {
     return matchingMethod;
   }
 
-  private static SkylarkType getType(ParamDescriptor param) {
-    SkylarkType result = SkylarkType.BOTTOM;
-    if (!param.getAllowedTypes().isEmpty()) {
-      Preconditions.checkState(Object.class.equals(param.getType()));
-      for (ParamTypeDescriptor paramType : param.getAllowedTypes()) {
-        SkylarkType t =
-            paramType.getGeneric1() != Object.class
-                ? SkylarkType.of(paramType.getType(), paramType.getGeneric1())
-                : SkylarkType.of(paramType.getType());
-        result = SkylarkType.Union.of(result, t);
-      }
-    } else {
-      result =
-          param.getGeneric1() != Object.class
-              ? SkylarkType.of(param.getType(), param.getGeneric1())
-              : SkylarkType.of(param.getType());
-    }
-
-    if (param.isNoneable()) {
-      result = SkylarkType.Union.of(result, SkylarkType.NONE);
-    }
-    return result;
-  }
-
   private static boolean isParamNamed(ParamDescriptor param) {
     return param.isNamed() || param.isLegacyNamed();
   }
@@ -593,7 +569,7 @@ public final class FuncallExpression extends Expression {
     // And default-valued positional parameters are always enumerated after other positional
     // parameters. These invariants are validated by the SkylarkCallable annotation processor.
     for (ParamDescriptor param : method.getParameters()) {
-      SkylarkType type = getType(param);
+      SkylarkType type = param.getSkylarkType();
       Object value = null;
 
       if (argIndex < args.size() && param.isPositional()) { // Positional args and params remain.

--- a/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
@@ -27,8 +27,6 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.events.Location;
-import com.google.devtools.build.lib.skylarkinterface.Param;
-import com.google.devtools.build.lib.skylarkinterface.ParamType;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkCallable;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkInterfaceUtils;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkModule;
@@ -57,31 +55,6 @@ import javax.annotation.Nullable;
 /** Syntax node for a function call expression. */
 public final class FuncallExpression extends Expression {
 
-  /**
-   * A value class to store Methods with their corresponding SkylarkCallable annotations.
-   * This is needed because the annotation is sometimes in a superclass.
-   */
-  public static final class MethodDescriptor {
-    private final Method method;
-    private final SkylarkCallable annotation;
-
-    private MethodDescriptor(Method method, SkylarkCallable annotation) {
-      this.method = method;
-      this.annotation = annotation;
-    }
-
-    Method getMethod() {
-      return method;
-    }
-
-    /**
-     * Returns the SkylarkCallable annotation corresponding to this method.
-     */
-    public SkylarkCallable getAnnotation() {
-      return annotation;
-    }
-  }
-
   private static final LoadingCache<Class<?>, Optional<MethodDescriptor>> selfCallCache =
       CacheBuilder.newBuilder()
           .build(
@@ -102,7 +75,7 @@ public final class FuncallExpression extends Expression {
                               "Class %s has two selfCall methods defined",
                               key.getName()));
                       }
-                      returnValue = new MethodDescriptor(method, callable);
+                      returnValue = MethodDescriptor.of(method, callable);
                     }
                   }
                   return Optional.ofNullable(returnValue);
@@ -132,10 +105,10 @@ public final class FuncallExpression extends Expression {
                     }
                     String name = callable.name();
                     if (methodMap.containsKey(name)) {
-                      methodMap.get(name).add(new MethodDescriptor(method, callable));
+                      methodMap.get(name).add(MethodDescriptor.of(method, callable));
                     } else {
                       methodMap.put(
-                          name, Lists.newArrayList(new MethodDescriptor(method, callable)));
+                          name, Lists.newArrayList(MethodDescriptor.of(method, callable)));
                     }
                   }
                   return ImmutableMap.copyOf(methodMap);
@@ -157,13 +130,11 @@ public final class FuncallExpression extends Expression {
                           .values()
                           .stream()
                           .flatMap(List::stream)
-                          .filter(
-                              methodDescriptor -> methodDescriptor.getAnnotation().structField())
+                          .filter(MethodDescriptor::isStructField)
                           .collect(Collectors.toList());
 
                   for (MethodDescriptor fieldMethod : fieldMethods) {
-                    SkylarkCallable callable = fieldMethod.getAnnotation();
-                    String name = callable.name();
+                    String name = fieldMethod.getName();
                     // TODO(b/72113542): Validate with annotation processor instead of at runtime.
                     if (!fieldNamesForCollisions.add(name)) {
                       throw new IllegalArgumentException(
@@ -378,7 +349,7 @@ public final class FuncallExpression extends Expression {
         throw new IllegalStateException("Class " + obj.getClass() + " has no selfCall method");
       }
       MethodDescriptor descriptor = selfCallDescriptor.get();
-      return new BuiltinCallable(descriptor.getAnnotation().name(), obj, descriptor);
+      return new BuiltinCallable(descriptor.getName(), obj, descriptor);
     } catch (ExecutionException e) {
       throw new IllegalStateException("Method loading failed: " + e);
     }
@@ -414,11 +385,12 @@ public final class FuncallExpression extends Expression {
   public static Object invokeStructField(
       MethodDescriptor methodDescriptor, String fieldName, Object obj)
       throws EvalException, InterruptedException {
-    Preconditions.checkArgument(methodDescriptor.getAnnotation().structField(),
-        "Can only be invoked on structField callables");
-    Preconditions.checkArgument(!methodDescriptor.getAnnotation().useEnvironment()
-        || !methodDescriptor.getAnnotation().useSkylarkSemantics()
-        || !methodDescriptor.getAnnotation().useLocation(),
+    Preconditions.checkArgument(
+        methodDescriptor.isStructField(), "Can only be invoked on structField callables");
+    Preconditions.checkArgument(
+        !methodDescriptor.isUseEnvironment()
+            || !methodDescriptor.isUseSkylarkSemantics()
+            || !methodDescriptor.isUseLocation(),
         "Cannot be invoked on structField callables with extra interpreter params");
     return callMethod(methodDescriptor, fieldName, obj, new Object[0], Location.BUILTIN, null);
   }
@@ -438,7 +410,7 @@ public final class FuncallExpression extends Expression {
         return Runtime.NONE;
       }
       if (result == null) {
-        if (methodDescriptor.getAnnotation().allowReturnNones()) {
+        if (methodDescriptor.isAllowReturnNones()) {
           return Runtime.NONE;
         } else {
           throw new EvalException(
@@ -492,13 +464,12 @@ public final class FuncallExpression extends Expression {
     ArgumentListConversionResult argumentListConversionResult = null;
     if (methods != null) {
       for (MethodDescriptor method : methods) {
-        if (method.getAnnotation().structField()) {
+        if (method.isStructField()) {
           // This indicates a built-in structField which returns a function which may have
           // one or more arguments itself. For example, foo.bar('baz'), where foo.bar is a
           // structField returning a function. Calling the "bar" callable of foo should
           // not have 'baz' propagated, though extra interpreter arguments should be supplied.
-          return new Pair<>(method,
-              extraInterpreterArgs(method.getAnnotation(), null, getLocation(), environment));
+          return new Pair<>(method, extraInterpreterArgs(method, null, getLocation(), environment));
         } else {
           argumentListConversionResult = convertArgumentList(args, kwargs, method, environment);
           if (argumentListConversionResult.getArguments() != null) {
@@ -541,32 +512,32 @@ public final class FuncallExpression extends Expression {
     return matchingMethod;
   }
 
-  private static SkylarkType getType(Param param) {
+  private static SkylarkType getType(ParamDescriptor param) {
     SkylarkType result = SkylarkType.BOTTOM;
-    if (param.allowedTypes().length > 0) {
-      Preconditions.checkState(Object.class.equals(param.type()));
-      for (ParamType paramType : param.allowedTypes()) {
+    if (!param.getAllowedTypes().isEmpty()) {
+      Preconditions.checkState(Object.class.equals(param.getType()));
+      for (ParamTypeDescriptor paramType : param.getAllowedTypes()) {
         SkylarkType t =
-            paramType.generic1() != Object.class
-                ? SkylarkType.of(paramType.type(), paramType.generic1())
-                : SkylarkType.of(paramType.type());
+            paramType.getGeneric1() != Object.class
+                ? SkylarkType.of(paramType.getType(), paramType.getGeneric1())
+                : SkylarkType.of(paramType.getType());
         result = SkylarkType.Union.of(result, t);
       }
     } else {
       result =
-          param.generic1() != Object.class
-              ? SkylarkType.of(param.type(), param.generic1())
-              : SkylarkType.of(param.type());
+          param.getGeneric1() != Object.class
+              ? SkylarkType.of(param.getType(), param.getGeneric1())
+              : SkylarkType.of(param.getType());
     }
 
-    if (param.noneable()) {
+    if (param.isNoneable()) {
       result = SkylarkType.Union.of(result, SkylarkType.NONE);
     }
     return result;
   }
 
-  private static boolean isParamNamed(Param param) {
-    return param.named() || param.legacyNamed();
+  private static boolean isParamNamed(ParamDescriptor param) {
+    return param.isNamed() || param.isLegacyNamed();
   }
 
   /**
@@ -576,24 +547,24 @@ public final class FuncallExpression extends Expression {
    * <p>This method accepts null {@code ast} only if {@code callable.useAst()} is false. It is
    * up to the caller to validate this invariant.</p>
    */
-  public static List<Object> extraInterpreterArgs(SkylarkCallable callable,
-      @Nullable FuncallExpression ast, Location loc, Environment env) {
+  public static List<Object> extraInterpreterArgs(
+      MethodDescriptor method, @Nullable FuncallExpression ast, Location loc, Environment env) {
 
     ImmutableList.Builder<Object> builder = ImmutableList.builder();
 
-    if (callable.useLocation()) {
+    if (method.isUseLocation()) {
       builder.add(loc);
     }
-    if (callable.useAst()) {
+    if (method.isUseAst()) {
       if (ast == null) {
-        throw new IllegalArgumentException("Callable expects to receive ast: " + callable.name());
+        throw new IllegalArgumentException("Callable expects to receive ast: " + method.getName());
       }
       builder.add(ast);
     }
-    if (callable.useEnvironment()) {
+    if (method.isUseEnvironment()) {
       builder.add(env);
     }
-    if (callable.useSkylarkSemantics()) {
+    if (method.isUseSkylarkSemantics()) {
       builder.add(env.getSemantics());
     }
     return builder.build();
@@ -608,12 +579,11 @@ public final class FuncallExpression extends Expression {
       Map<String, Object> kwargs,
       MethodDescriptor method,
       Environment environment) {
-    SkylarkCallable callable = method.getAnnotation();
     ImmutableList.Builder<Object> builder = ImmutableList.builder();
     ImmutableList.Builder<Object> extraArgsBuilder = ImmutableList.builder();
     ImmutableMap.Builder<String, Object> extraKwargsBuilder = ImmutableMap.builder();
-    boolean acceptsExtraArgs = !callable.extraPositionals().name().isEmpty();
-    boolean acceptsExtraKwargs = !callable.extraKeywords().name().isEmpty();
+    boolean acceptsExtraArgs = method.isAcceptsExtraArgs();
+    boolean acceptsExtraKwargs = method.isAcceptsExtraKwargs();
 
     int argIndex = 0;
 
@@ -622,44 +592,46 @@ public final class FuncallExpression extends Expression {
     // Positional parameters are always enumerated before non-positional parameters,
     // And default-valued positional parameters are always enumerated after other positional
     // parameters. These invariants are validated by the SkylarkCallable annotation processor.
-    for (Param param : callable.parameters()) {
+    for (ParamDescriptor param : method.getParameters()) {
       SkylarkType type = getType(param);
       Object value = null;
 
-      if (argIndex < args.size() && param.positional()) { // Positional args and params remain.
+      if (argIndex < args.size() && param.isPositional()) { // Positional args and params remain.
         value = args.get(argIndex);
         if (!type.contains(value)) {
           return ArgumentListConversionResult.fromError(
               String.format(
                   "expected value of type '%s' for parameter '%s'",
-                  type.toString(), param.name()));
+                  type.toString(), param.getName()));
         }
-        if (isParamNamed(param) && keys.contains(param.name())) {
+        if (isParamNamed(param) && keys.contains(param.getName())) {
           return ArgumentListConversionResult.fromError(
-              String.format("got multiple values for keyword argument '%s'", param.name()));
+              String.format("got multiple values for keyword argument '%s'", param.getName()));
         }
         argIndex++;
       } else { // No more positional arguments, or no more positional parameters.
-        if (isParamNamed(param) && keys.remove(param.name())) {
+        if (isParamNamed(param) && keys.remove(param.getName())) {
           // Param specified by keyword argument.
-          value = kwargs.get(param.name());
+          value = kwargs.get(param.getName());
           if (!type.contains(value)) {
             return ArgumentListConversionResult.fromError(
                 String.format(
                     "expected value of type '%s' for parameter '%s'",
-                    type.toString(), param.name()));
+                    type.toString(), param.getName()));
           }
         } else { // Param not specified by user. Use default value.
-          if (param.defaultValue().isEmpty()) {
+          if (param.getDefaultValue().isEmpty()) {
             return ArgumentListConversionResult.fromError(
-                String.format("parameter '%s' has no default value", param.name()));
+                String.format("parameter '%s' has no default value", param.getName()));
           }
-          value = SkylarkSignatureProcessor.getDefaultValue(param, null);
+          value =
+              SkylarkSignatureProcessor.getDefaultValue(
+                  param.getName(), param.getDefaultValue(), null);
         }
       }
-      if (!param.noneable() && value instanceof NoneType) {
+      if (!param.isNoneable() && value instanceof NoneType) {
         return ArgumentListConversionResult.fromError(
-            String.format("parameter '%s' cannot be None", param.name()));
+            String.format("parameter '%s' cannot be None", param.getName()));
       }
       builder.add(value);
     }
@@ -697,7 +669,7 @@ public final class FuncallExpression extends Expression {
     if (acceptsExtraKwargs) {
       builder.add(SkylarkDict.copyOf(environment, extraKwargsBuilder.build()));
     }
-    builder.addAll(extraInterpreterArgs(callable, this, getLocation(), environment));
+    builder.addAll(extraInterpreterArgs(method, this, getLocation(), environment));
 
     return ArgumentListConversionResult.fromArgumentList(builder.build());
   }
@@ -866,7 +838,7 @@ public final class FuncallExpression extends Expression {
       }
       Pair<MethodDescriptor, List<Object>> javaMethod =
           call.findJavaMethod(objClass, method, positionalArgs, keyWordArgs, env);
-      if (javaMethod.first.getAnnotation().structField()) {
+      if (javaMethod.first.isStructField()) {
         // Not a method but a callable attribute
         try {
           return callFunction(javaMethod.first.getMethod().invoke(obj), env);
@@ -904,14 +876,14 @@ public final class FuncallExpression extends Expression {
       Object value = arg.getValue().eval(env);
       if (arg.isPositional()) {
         posargs.add(value);
-      } else if (arg.isStar()) {  // expand the starArg
+      } else if (arg.isStar()) { // expand the starArg
         if (!(value instanceof Iterable)) {
           throw new EvalException(
               getLocation(),
               "argument after * must be an iterable, not " + EvalUtils.getDataTypeName(value));
         }
         posargs.addAll((Iterable<Object>) value);
-      } else if (arg.isStarStar()) {  // expand the kwargs
+      } else if (arg.isStarStar()) { // expand the kwargs
         ImmutableList<String> duplicates =
             addKeywordArgsAndReturnDuplicates(kwargs, value, getLocation());
         if (duplicates != null) {

--- a/src/main/java/com/google/devtools/build/lib/syntax/MethodDescriptor.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/MethodDescriptor.java
@@ -1,0 +1,170 @@
+package com.google.devtools.build.lib.syntax;
+
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.skylarkinterface.SkylarkCallable;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+/**
+ * A value class to store Methods with their corresponding {@link SkylarkCallable} annotation
+ * metadata. This is needed because the annotation is sometimes in a superclass.
+ *
+ * <p>The annotation metadata is duplicated in this class to avoid usage of Java dynamic proxies
+ * which are ~7X slower
+ */
+public final class MethodDescriptor {
+  private final Method method;
+  private final SkylarkCallable annotation;
+
+  private final String name;
+  private final String doc;
+  private final boolean documented;
+  private final boolean structField;
+  private final ImmutableList<ParamDescriptor> parameters;
+  private final ParamDescriptor extraPositionals;
+  private final ParamDescriptor extraKeywords;
+  private final boolean selfCall;
+  private final boolean allowReturnNones;
+  private final boolean useLocation;
+  private final boolean useAst;
+  private final boolean useEnvironment;
+  private final boolean useSkylarkSemantics;
+
+  private MethodDescriptor(
+      Method method,
+      SkylarkCallable annotation,
+      String name,
+      String doc,
+      boolean documented,
+      boolean structField,
+      ImmutableList<ParamDescriptor> parameters,
+      ParamDescriptor extraPositionals,
+      ParamDescriptor extraKeywords,
+      boolean selfCall,
+      boolean allowReturnNones,
+      boolean useLocation,
+      boolean useAst,
+      boolean useEnvironment,
+      boolean useSkylarkSemantics) {
+    this.method = method;
+    this.annotation = annotation;
+    this.name = name;
+    this.doc = doc;
+    this.documented = documented;
+    this.structField = structField;
+    this.parameters = parameters;
+    this.extraPositionals = extraPositionals;
+    this.extraKeywords = extraKeywords;
+    this.selfCall = selfCall;
+    this.allowReturnNones = allowReturnNones;
+    this.useLocation = useLocation;
+    this.useAst = useAst;
+    this.useEnvironment = useEnvironment;
+    this.useSkylarkSemantics = useSkylarkSemantics;
+  }
+
+  Method getMethod() {
+    return method;
+  }
+
+  /** Returns the SkylarkCallable annotation corresponding to this method. */
+  public SkylarkCallable getAnnotation() {
+    return annotation;
+  }
+
+  /** @return Skylark method descriptor for provided Java method and signature annotation. */
+  public static MethodDescriptor of(Method method, SkylarkCallable annotation) {
+    return new MethodDescriptor(
+        method,
+        annotation,
+        annotation.name(),
+        annotation.doc(),
+        annotation.documented(),
+        annotation.structField(),
+        Arrays.stream(annotation.parameters())
+            .map(ParamDescriptor::of)
+            .collect(ImmutableList.toImmutableList()),
+        ParamDescriptor.of(annotation.extraPositionals()),
+        ParamDescriptor.of(annotation.extraKeywords()),
+        annotation.selfCall(),
+        annotation.allowReturnNones(),
+        annotation.useLocation(),
+        annotation.useAst(),
+        annotation.useEnvironment(),
+        annotation.useSkylarkSemantics());
+  }
+
+  /** @see SkylarkCallable#name() */
+  public String getName() {
+    return name;
+  }
+
+  /** @see SkylarkCallable#structField() */
+  public boolean isStructField() {
+    return structField;
+  }
+
+  /** @see SkylarkCallable#useEnvironment() */
+  public boolean isUseEnvironment() {
+    return useEnvironment;
+  }
+
+  /** @see SkylarkCallable#useSkylarkSemantics() */
+  public boolean isUseSkylarkSemantics() {
+    return useSkylarkSemantics;
+  }
+
+  /** @see SkylarkCallable#useLocation() */
+  public boolean isUseLocation() {
+    return useLocation;
+  }
+
+  /** @see SkylarkCallable#allowReturnNones() */
+  public boolean isAllowReturnNones() {
+    return allowReturnNones;
+  }
+
+  /** @see SkylarkCallable#useAst() */
+  public boolean isUseAst() {
+    return useAst;
+  }
+
+  /** @see SkylarkCallable#extraPositionals() */
+  public ParamDescriptor getExtraPositionals() {
+    return extraPositionals;
+  }
+
+  public ParamDescriptor getExtraKeywords() {
+    return extraKeywords;
+  }
+
+  /** @return {@code true} if this method accepts extra arguments ({@code *args}) */
+  public boolean isAcceptsExtraArgs() {
+    return !getExtraPositionals().getName().isEmpty();
+  }
+
+  /** @see SkylarkCallable#extraKeywords() */
+  public boolean isAcceptsExtraKwargs() {
+    return !getExtraKeywords().getName().isEmpty();
+  }
+
+  /** @see SkylarkCallable#parameters() */
+  public ImmutableList<ParamDescriptor> getParameters() {
+    return parameters;
+  }
+
+  /** @see SkylarkCallable#documented() */
+  public boolean isDocumented() {
+    return documented;
+  }
+
+  /** @see SkylarkCallable#doc() */
+  public String getDoc() {
+    return doc;
+  }
+
+  /** @see SkylarkCallable#selfCall() */
+  public boolean isSelfCall() {
+    return selfCall;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/syntax/ParamDescriptor.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/ParamDescriptor.java
@@ -1,0 +1,108 @@
+package com.google.devtools.build.lib.syntax;
+
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.skylarkinterface.Param;
+import java.util.Arrays;
+
+/** A value class for storing {@link Param} metadata to avoid using Java proxies. */
+public final class ParamDescriptor {
+
+  private String name;
+  private final String doc;
+  private final String defaultValue;
+  private final Class<?> type;
+  private final ImmutableList<ParamTypeDescriptor> allowedTypes;
+  private final Class<?> generic1;
+  private final boolean callbackEnabled;
+  private final boolean noneable;
+  private final boolean named;
+  private final boolean legacyNamed;
+  private final boolean positional;
+
+  private ParamDescriptor(
+      String name,
+      String doc,
+      String defaultValue,
+      Class<?> type,
+      ImmutableList<ParamTypeDescriptor> allowedTypes,
+      Class<?> generic1,
+      boolean callbackEnabled,
+      boolean noneable,
+      boolean named,
+      boolean legacyNamed,
+      boolean positional) {
+    this.name = name;
+    this.doc = doc;
+    this.defaultValue = defaultValue;
+    this.type = type;
+    this.allowedTypes = allowedTypes;
+    this.generic1 = generic1;
+    this.callbackEnabled = callbackEnabled;
+    this.noneable = noneable;
+    this.named = named;
+    this.legacyNamed = legacyNamed;
+    this.positional = positional;
+  }
+
+  static ParamDescriptor of(Param param) {
+    return new ParamDescriptor(
+        param.name(),
+        param.doc(),
+        param.defaultValue(),
+        param.type(),
+        Arrays.stream(param.allowedTypes())
+            .map(ParamTypeDescriptor::of)
+            .collect(ImmutableList.toImmutableList()),
+        param.generic1(),
+        param.callbackEnabled(),
+        param.noneable(),
+        param.named(),
+        param.legacyNamed(),
+        param.positional());
+  }
+
+  /** @see Param#name() */
+  public String getName() {
+    return name;
+  }
+
+  /** @see Param#allowedTypes() */
+  public ImmutableList<ParamTypeDescriptor> getAllowedTypes() {
+    return allowedTypes;
+  }
+
+  /** @see Param#type() */
+  public Class<?> getType() {
+    return type;
+  }
+
+  /** @see Param#generic1() */
+  public Class<?> getGeneric1() {
+    return generic1;
+  }
+
+  /** @see Param#noneable() */
+  public boolean isNoneable() {
+    return noneable;
+  }
+
+  /** @see Param#positional() */
+  public boolean isPositional() {
+    return positional;
+  }
+
+  /** @see Param#named() */
+  public boolean isNamed() {
+    return named;
+  }
+
+  /** @see Param#legacyNamed() */
+  public boolean isLegacyNamed() {
+    return legacyNamed;
+  }
+
+  /** @see Param#defaultValue() */
+  public String getDefaultValue() {
+    return defaultValue;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/syntax/ParamTypeDescriptor.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/ParamTypeDescriptor.java
@@ -1,0 +1,29 @@
+package com.google.devtools.build.lib.syntax;
+
+import com.google.devtools.build.lib.skylarkinterface.ParamType;
+
+/** A value class to store {@link ParamType} metadata to avoid using Java proxies. */
+public final class ParamTypeDescriptor {
+
+  private final Class<?> type;
+  private final Class<?> generic1;
+
+  private ParamTypeDescriptor(Class<?> type, Class<?> generic1) {
+    this.type = type;
+    this.generic1 = generic1;
+  }
+
+  /** @see ParamType#type() */
+  public Class<?> getType() {
+    return type;
+  }
+
+  /** @see ParamType#generic1() */
+  public Class<?> getGeneric1() {
+    return generic1;
+  }
+
+  static ParamTypeDescriptor of(ParamType paramType) {
+    return new ParamTypeDescriptor(paramType.type(), paramType.generic1());
+  }
+}


### PR DESCRIPTION
This saves extra overhead for creating SkylarkType for every param for each function invocation.
SkylarkType has a built-in `LoadingCache` but it's overhead is very significant.
This change brings down the Buck parse time of internal android apps from 78s to 68s