### PR TITLE
git_repository could use HTTP_PROXY to clone repository

### DIFF
--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -62,7 +62,7 @@ set -ex
         remote = ctx.attr.remote,
         ref = ref,
         shallow = shallow,
-    )])
+    )], environment = ctx.os.environ)
 
     if st.return_code:
         fail("error cloning %s:\n%s" % (ctx.name, st.stderr))
@@ -80,7 +80,7 @@ set -ex
     git submodule update --init --checkout --force )
   """.format(
             directory = ctx.path("."),
-        )])
+        )], environment = ctx.os.environ)
     if st.return_code:
         fail("error updating submodules %s:\n%s" % (ctx.name, st.stderr))
 


### PR DESCRIPTION
git_repository could use HTTP_PROXY to clone repository

Fixes #3893.