### PR TITLE
Windows,tests: port python_test

### DIFF
--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -30,6 +30,7 @@ sh_test(
     data = [":test-deps"],
     tags = [
         "local",
+        # no_windows: this test exercises the symlink-based runfiles tree.
         "no_windows",
     ],
 )
@@ -38,8 +39,10 @@ sh_test(
     name = "python_test",
     size = "medium",
     srcs = ["python_test.sh"],
-    data = [":test-deps"],
-    tags = ["no_windows"],
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )
 
 sh_test(

--- a/src/test/shell/integration/python_test.sh
+++ b/src/test/shell/integration/python_test.sh
@@ -49,7 +49,7 @@ msys*|mingw*|cygwin*)
   ;;
 esac
 
-if is_windows; then
+if "$is_windows"; then
   export MSYS_NO_PATHCONV=1
   export MSYS2_ARG_CONV_EXCL="*"
   declare -r EXE_EXT=".exe"

--- a/src/test/shell/integration/python_test.sh
+++ b/src/test/shell/integration/python_test.sh
@@ -15,12 +15,47 @@
 # limitations under the License.
 #
 
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../integration_test_setup.sh" \
+set -euo pipefail
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-set -eu
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*|mingw*|cygwin*)
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if is_windows; then
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+  declare -r EXE_EXT=".exe"
+else
+  declare -r EXE_EXT=""
+fi
 
 function test_python_binary_empty_files_in_runfiles_are_regular_files() {
   mkdir -p test/mypackage
@@ -81,10 +116,10 @@ sh_binary(
 )
 EOF
     bazel build --experimental_build_transitive_python_runfiles :sh-tool
-    [ -d 'bazel-bin/py-tool.runfiles' ] || fail "py_binary runfiles tree not built"
+    [ -d "bazel-bin/py-tool${EXE_EXT}.runfiles" ] || fail "py_binary runfiles tree not built"
     bazel clean
     bazel build --noexperimental_build_transitive_python_runfiles :sh-tool
-    [ ! -e 'bazel-bin/py-tool.runfiles' ] || fail "py_binary runfiles tree built"
+    [ ! -e "bazel-bin/py-tool${EXE_EXT}.runfiles" ] || fail "py_binary runfiles tree built"
 }
 
 run_suite "Tests for the Python rules"


### PR DESCRIPTION
//src/test/shell/integration:python_test now runs
on Windows.

See https://github.com/bazelbuild/bazel/issues/4292

Change-Id: Ie408ea55973a32fc5ee6e74f9bed5e3fa9f818b1