### PR TITLE
Order input files from TreeArtifacts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionMetadataHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionMetadataHandler.java
@@ -47,6 +47,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -390,8 +391,7 @@ public class ActionMetadataHandler implements MetadataHandler {
 
   private TreeArtifactValue constructTreeArtifactValue(Collection<TreeFileArtifact> contents)
       throws IOException {
-    Map<TreeFileArtifact, FileArtifactValue> values =
-        Maps.newHashMapWithExpectedSize(contents.size());
+    SortedMap<TreeFileArtifact, FileArtifactValue> values = Maps.newTreeMap();
 
     for (TreeFileArtifact treeFileArtifact : contents) {
       FileArtifactValue cachedValue = additionalOutputData.get(treeFileArtifact);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ArtifactFunction.java
@@ -17,7 +17,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionAnalysisMetadata;
@@ -159,7 +159,7 @@ class ArtifactFunction implements SkyFunction {
 
     // Aggregate the ArtifactValues for individual TreeFileArtifacts into a TreeArtifactValue for
     // the parent TreeArtifact.
-    ImmutableMap.Builder<TreeFileArtifact, FileArtifactValue> map = ImmutableMap.builder();
+    ImmutableSortedMap.Builder<TreeFileArtifact, FileArtifactValue> map = ImmutableSortedMap.naturalOrder();
     for (int i = 0; i < expansionValue.getNumActions(); i++) {
       final ActionExecutionValue actionExecutionValue =
           (ActionExecutionValue)

--- a/src/main/java/com/google/devtools/build/lib/skyframe/TreeArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TreeArtifactValue.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import javax.annotation.Nullable;
 
 /**
@@ -60,7 +61,7 @@ class TreeArtifactValue implements SkyValue {
    * Returns a TreeArtifactValue out of the given Artifact-relative path fragments
    * and their corresponding FileArtifactValues.
    */
-  static TreeArtifactValue create(Map<TreeFileArtifact, FileArtifactValue> childFileValues) {
+  static TreeArtifactValue create(SortedMap<TreeFileArtifact, FileArtifactValue> childFileValues) {
     Map<String, FileArtifactValue> digestBuilder =
         Maps.newHashMapWithExpectedSize(childFileValues.size());
     for (Map.Entry<TreeFileArtifact, FileArtifactValue> e : childFileValues.entrySet()) {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ActionTemplateExpansionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ActionTemplateExpansionFunctionTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.fail;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
@@ -62,6 +63,8 @@ import com.google.devtools.build.skyframe.SkyValue;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
@@ -237,7 +240,7 @@ public final class ActionTemplateExpansionFunctionTest extends FoundationTestCas
   private SpecialArtifact createAndPopulateTreeArtifact(String path, String... childRelativePaths)
       throws Exception {
     SpecialArtifact treeArtifact = createTreeArtifact(path);
-    Map<TreeFileArtifact, FileArtifactValue> treeFileArtifactMap = new LinkedHashMap<>();
+    SortedMap<TreeFileArtifact, FileArtifactValue> treeFileArtifactMap = new TreeMap<>();
 
     for (String childRelativePath : childRelativePaths) {
       TreeFileArtifact treeFileArtifact = ActionInputHelper.treeFileArtifact(
@@ -248,7 +251,7 @@ public final class ActionTemplateExpansionFunctionTest extends FoundationTestCas
     }
 
     artifactValueMap.put(
-        treeArtifact, TreeArtifactValue.create(ImmutableMap.copyOf(treeFileArtifactMap)));
+        treeArtifact, TreeArtifactValue.create(ImmutableSortedMap.copyOf(treeFileArtifactMap)));
 
     return treeArtifact;
   }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ArtifactFunctionTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionAnalysisMetadata.MiddlemanType;
@@ -413,7 +414,7 @@ public class ArtifactFunctionTest extends ArtifactFunctionTestCase {
               (SpecialArtifact) output, PathFragment.create("child1"));
           TreeFileArtifact treeFileArtifact2 = ActionInputHelper.treeFileArtifact(
               (SpecialArtifact) output, PathFragment.create("child2"));
-          TreeArtifactValue treeArtifactValue = TreeArtifactValue.create(ImmutableMap.of(
+          TreeArtifactValue treeArtifactValue = TreeArtifactValue.create(ImmutableSortedMap.of(
               treeFileArtifact1, FileArtifactValue.create(treeFileArtifact1),
               treeFileArtifact2, FileArtifactValue.create(treeFileArtifact2)));
           treeArtifactData.put(output, treeArtifactValue);

--- a/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/FilesystemValueCheckerTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.util.concurrent.Runnables;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionLookupValue.ActionLookupKey;
@@ -78,6 +79,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import org.junit.Before;
@@ -756,7 +759,7 @@ public class FilesystemValueCheckerTest {
 
   private ActionExecutionValue actionValueWithEmptyDirectory(Artifact emptyDir) {
     TreeArtifactValue emptyValue = TreeArtifactValue.create
-        (ImmutableMap.<TreeFileArtifact, FileArtifactValue>of());
+        (ImmutableSortedMap.of());
 
     return ActionExecutionValue.create(
         ImmutableMap.<Artifact, FileValue>of(),
@@ -769,14 +772,14 @@ public class FilesystemValueCheckerTest {
 
   private ActionExecutionValue actionValueWithTreeArtifacts(List<TreeFileArtifact> contents) {
     Map<Artifact, FileValue> fileData = new HashMap<>();
-    Map<Artifact, Map<TreeFileArtifact, FileArtifactValue>> directoryData = new HashMap<>();
+    Map<Artifact, SortedMap<TreeFileArtifact, FileArtifactValue>> directoryData = new TreeMap<>();
 
     for (TreeFileArtifact output : contents) {
       try {
-        Map<TreeFileArtifact, FileArtifactValue> dirDatum =
+        SortedMap<TreeFileArtifact, FileArtifactValue> dirDatum =
             directoryData.get(output.getParent());
         if (dirDatum == null) {
-          dirDatum = new HashMap<>();
+          dirDatum = new TreeMap<>();
           directoryData.put(output.getParent(), dirDatum);
         }
         FileValue fileValue = ActionMetadataHandler.fileValueFromArtifact(output, null, null);
@@ -787,8 +790,8 @@ public class FilesystemValueCheckerTest {
       }
     }
 
-    Map<Artifact, TreeArtifactValue> treeArtifactData = new HashMap<>();
-    for (Map.Entry<Artifact, Map<TreeFileArtifact, FileArtifactValue>> dirDatum :
+    SortedMap<Artifact, TreeArtifactValue> treeArtifactData = new TreeMap<>();
+    for (Map.Entry<Artifact, SortedMap<TreeFileArtifact, FileArtifactValue>> dirDatum :
         directoryData.entrySet()) {
       treeArtifactData.put(dirDatum.getKey(), TreeArtifactValue.create(dirDatum.getValue()));
     }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactMetadataTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactMetadataTest.java
@@ -56,8 +56,11 @@ import com.google.devtools.build.skyframe.SkyValue;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -198,6 +201,21 @@ public class TreeArtifactMetadataTest extends ArtifactFunctionTestCase {
     }
   }
 
+  @Test
+  public void testTreeArtifactOrder() throws Exception {
+    Artifact treeArtifact = createTreeArtifact("out");
+    ImmutableList<PathFragment> children =
+            ImmutableList.of(PathFragment.create("one"), PathFragment.create("two"), PathFragment.create("three"));
+    TreeArtifactValue value = evaluateTreeArtifact(treeArtifact, children);
+
+    Iterator<TreeFileArtifact> evaluated_children = value.getChildren().iterator();
+
+    // Check if TreeArtifacts are sorted in alphabetical order
+    assertThat(evaluated_children.next().getFilename()).isEqualTo("one");
+    assertThat(evaluated_children.next().getFilename()).isEqualTo("three");
+    assertThat(evaluated_children.next().getFilename()).isEqualTo("two");
+  }
+
   private void file(Path path, String contents) throws Exception {
     FileSystemUtils.createDirectoryAndParents(path.getParentDirectory());
     writeFile(path, contents);
@@ -252,7 +270,7 @@ public class TreeArtifactMetadataTest extends ArtifactFunctionTestCase {
     public SkyValue compute(SkyKey skyKey, Environment env)
         throws SkyFunctionException, InterruptedException {
       Map<Artifact, FileValue> fileData = new HashMap<>();
-      Map<TreeFileArtifact, FileArtifactValue> treeArtifactData = new HashMap<>();
+      SortedMap<TreeFileArtifact, FileArtifactValue> treeArtifactData = new TreeMap<>();
       ActionLookupData actionLookupData = (ActionLookupData) skyKey.argument();
       ActionLookupValue actionLookupValue =
           (ActionLookupValue) env.getValue(actionLookupData.getActionLookupKey());


### PR DESCRIPTION
This commit fixes non-deterministic behaviour when it comes to the usage
of C++ TreeArtifacts for compilation / linkage.

If a folder is passed to a cc_library rule, the source / header files
are discovered at execution phases. The order of which those files
are served by the OS is not be deterministic. This might lead to
non reproducable builds, meaning the order of each object file inside
the created library might differ.
This can be fixed by sorting the input into respective rule.

This commit might have side-effects to other rules that also utilize
TreeArtifacts, such that the inputs will be sorted here also.

I'm not sure if there is a `better` place to do the sorting with less impact. Maybe where the `SkyValue` is set, but this is what I did not found. Sorry.

This should fix: https://github.com/bazelbuild/bazel/issues/5686