### PR TITLE
Make sure the --host_platform_remote_properties_override flags is

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/platform/Platform.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/Platform.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.rules.platform;
 
+import com.google.common.base.Strings;
 import com.google.devtools.build.lib.actions.MutableActionGraph.ActionConflictException;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.FileProvider;
@@ -69,7 +70,7 @@ public class Platform implements RuleConfiguredTargetFactory {
 
     String remoteExecutionProperties =
         ruleContext.attributes().get(PlatformRule.REMOTE_EXECUTION_PROPS_ATTR, Type.STRING);
-    if (platformBuilder.getRemoteExecutionProperties() == null && isHostPlatform) {
+    if (Strings.isNullOrEmpty(platformBuilder.getRemoteExecutionProperties()) && isHostPlatform) {
       // Use the default override.
       PlatformOptions platformOptions =
           ruleContext.getConfiguration().getOptions().get(PlatformOptions.class);

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/PlatformTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/PlatformTest.java
@@ -120,6 +120,25 @@ public class PlatformTest extends BuildViewTestCase {
   }
 
   @Test
+  public void hostPlatformRemoteProperties_fromFlag() throws Exception {
+    useConfiguration("--host_platform_remote_properties_override='flag properties'");
+
+    scratch.file(
+        "autoconfig/BUILD",
+        "platform(name = 'host_platform',",
+        "    host_platform = True,",
+        ")");
+
+    // Check the host platform.
+    ConfiguredTarget hostPlatform = getConfiguredTarget("//autoconfig:host_platform");
+    assertThat(hostPlatform).isNotNull();
+
+    PlatformInfo hostPlatformProvider = PlatformProviderUtils.platform(hostPlatform);
+    assertThat(hostPlatformProvider).isNotNull();
+    assertThat(hostPlatformProvider.remoteExecutionProperties()).isEqualTo("'flag properties'");
+  }
+
+  @Test
   public void testPlatform_overlappingConstraintValueError() throws Exception {
     checkError(
         "constraint/overlap",


### PR DESCRIPTION
honored when creating the host platform.

Fixes #5695.

Change-Id: Iaa99c8189421893440e5e5140450c70de69d7b86