### PR TITLE
[Skylark] Avoid unnecessary copyOf invocations.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebuggerSerialization.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebuggerSerialization.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.syntax.FuncallExpression;
 import com.google.devtools.build.lib.syntax.MethodDescriptor;
 import com.google.devtools.build.lib.syntax.Printer;
 import com.google.devtools.build.lib.syntax.SkylarkNestedSet;
+
 import java.lang.reflect.Array;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebuggerSerialization.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebuggerSerialization.java
@@ -27,7 +27,6 @@ import com.google.devtools.build.lib.syntax.FuncallExpression;
 import com.google.devtools.build.lib.syntax.MethodDescriptor;
 import com.google.devtools.build.lib.syntax.Printer;
 import com.google.devtools.build.lib.syntax.SkylarkNestedSet;
-
 import java.lang.reflect.Array;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/com/google/devtools/build/lib/syntax/EvalUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/EvalUtils.java
@@ -319,7 +319,7 @@ public final class EvalUtils {
         for (Map.Entry<?, ?> entries : dict.entrySet()) {
           list.add(entries.getKey());
         }
-        return  ImmutableList.copyOf(list);
+        return ImmutableList.copyOf(list);
       }
       // For determinism, we sort the keys.
       try {
@@ -512,7 +512,10 @@ public final class EvalUtils {
     }
     start = clampRangeEndpoint(start, length, step < 0);
     end = clampRangeEndpoint(end, length, step < 0);
-    ImmutableList.Builder<Integer> indices = ImmutableList.builder();
+    // precise computation is slightly more involved, but since it can overshoot only by a single
+    // element it's fine
+    final int expectedMaxSize = Math.abs(start - end) / Math.abs(step) + 1;
+    ImmutableList.Builder<Integer> indices = ImmutableList.builderWithExpectedSize(expectedMaxSize);
     for (int current = start; step > 0 ? current < end : current > end; current += step) {
       indices.add(current);
     }

--- a/src/main/java/com/google/devtools/build/lib/syntax/SkylarkList.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/SkylarkList.java
@@ -627,6 +627,16 @@ public abstract class SkylarkList<E> extends BaseMutableList<E>
       return create(ImmutableList.<T>copyOf(contents));
     }
 
+    /**
+     * Returns a {@code Tuple} whose items are given by an immutable list.
+     *
+     * <p>This method is a specialization of a {@link #copyOf(Iterable)} that avoids an unnecessary
+     * {@code copyOf} invocation.
+     */
+    public static <T> Tuple<T> copyOf(ImmutableList<T> contents) {
+      return create(contents);
+    }
+
     /** Returns a {@code Tuple} with the given items. */
     public static <T> Tuple<T> of(T... elements) {
       return Tuple.create(ImmutableList.copyOf(elements));


### PR DESCRIPTION
According to async-profiler, about 50% of `Tuple.getSlice` method invocation is spent in `ImmutableList.copyOf` which is completely unnecessary for cases when an `ImmutableList` instance is passed.