### PR TITLE
[Skylark] Cache isParamNamed computation.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebuggerSerialization.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebuggerSerialization.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.syntax.FuncallExpression;
 import com.google.devtools.build.lib.syntax.MethodDescriptor;
 import com.google.devtools.build.lib.syntax.Printer;
 import com.google.devtools.build.lib.syntax.SkylarkNestedSet;
+
 import java.lang.reflect.Array;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebuggerSerialization.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/DebuggerSerialization.java
@@ -27,7 +27,6 @@ import com.google.devtools.build.lib.syntax.FuncallExpression;
 import com.google.devtools.build.lib.syntax.MethodDescriptor;
 import com.google.devtools.build.lib.syntax.Printer;
 import com.google.devtools.build.lib.syntax.SkylarkNestedSet;
-
 import java.lang.reflect.Array;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/com/google/devtools/build/lib/syntax/EvalUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/EvalUtils.java
@@ -319,7 +319,7 @@ public final class EvalUtils {
         for (Map.Entry<?, ?> entries : dict.entrySet()) {
           list.add(entries.getKey());
         }
-        return  ImmutableList.copyOf(list);
+        return ImmutableList.copyOf(list);
       }
       // For determinism, we sort the keys.
       try {
@@ -512,7 +512,10 @@ public final class EvalUtils {
     }
     start = clampRangeEndpoint(start, length, step < 0);
     end = clampRangeEndpoint(end, length, step < 0);
-    ImmutableList.Builder<Integer> indices = ImmutableList.builder();
+    // precise computation is slightly more involved, but since it can overshoot only by a single
+    // element it's fine
+    final int expectedMaxSize = Math.abs(start - end) / Math.abs(step) + 1;
+    ImmutableList.Builder<Integer> indices = ImmutableList.builderWithExpectedSize(expectedMaxSize);
     for (int current = start; step > 0 ? current < end : current > end; current += step) {
       indices.add(current);
     }

--- a/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
@@ -514,10 +514,6 @@ public final class FuncallExpression extends Expression {
     return matchingMethod;
   }
 
-  private static boolean isParamNamed(ParamDescriptor param) {
-    return param.isNamed() || param.isLegacyNamed();
-  }
-
   /**
    * Returns the extra interpreter arguments for the given {@link SkylarkCallable}, to be added at
    * the end of the argument list for the callable.
@@ -581,13 +577,13 @@ public final class FuncallExpression extends Expression {
                   "expected value of type '%s' for parameter '%s'",
                   type.toString(), param.getName()));
         }
-        if (isParamNamed(param) && keys.contains(param.getName())) {
+        if (param.isNamed() && keys.contains(param.getName())) {
           return ArgumentListConversionResult.fromError(
               String.format("got multiple values for keyword argument '%s'", param.getName()));
         }
         argIndex++;
       } else { // No more positional arguments, or no more positional parameters.
-        if (isParamNamed(param) && keys.remove(param.getName())) {
+        if (param.isNamed() && keys.remove(param.getName())) {
           // Param specified by keyword argument.
           value = kwargs.get(param.getName());
           if (!type.contains(value)) {

--- a/src/main/java/com/google/devtools/build/lib/syntax/ParamDescriptor.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/ParamDescriptor.java
@@ -29,7 +29,6 @@ public final class ParamDescriptor {
   private final Class<?> generic1;
   private final boolean noneable;
   private final boolean named;
-  private final boolean legacyNamed;
   private final boolean positional;
   // While the type can be inferred completely by the Param annotation, this tuple allows for the
   // type of a given parameter to be determined only once, as it is an expensive operation.
@@ -54,8 +53,7 @@ public final class ParamDescriptor {
     this.allowedTypes = allowedTypes;
     this.generic1 = generic1;
     this.noneable = noneable;
-    this.named = named;
-    this.legacyNamed = legacyNamed;
+    this.named = named || legacyNamed;
     this.positional = positional;
     this.skylarkType = skylarkType;
   }
@@ -141,11 +139,6 @@ public final class ParamDescriptor {
   /** @see Param#named() */
   public boolean isNamed() {
     return named;
-  }
-
-  /** @see Param#legacyNamed() */
-  public boolean isLegacyNamed() {
-    return legacyNamed;
   }
 
   /** @see Param#defaultValue() */

--- a/src/main/java/com/google/devtools/build/lib/syntax/SkylarkList.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/SkylarkList.java
@@ -627,6 +627,16 @@ public abstract class SkylarkList<E> extends BaseMutableList<E>
       return create(ImmutableList.<T>copyOf(contents));
     }
 
+    /**
+     * Returns a {@code Tuple} whose items are given by an immutable list.
+     *
+     * <p>This method is a specialization of a {@link #copyOf(Iterable)} that avoids an unnecessary
+     * {@code copyOf} invocation.
+     */
+    public static <T> Tuple<T> copyOf(ImmutableList<T> contents) {
+      return create(contents);
+    }
+
     /** Returns a {@code Tuple} with the given items. */
     public static <T> Tuple<T> of(T... elements) {
       return Tuple.create(ImmutableList.copyOf(elements));


### PR DESCRIPTION
When `isLegacyNamed` is `true`, `named` is considered to be `true` as well,
so instead of going through an extra indirection and computation, just use
`named` field to store combined result.