### PR TITLE
Build bazel as @io_bazel//src:bazel-bin

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -7,6 +7,7 @@ platforms:
     - rm -f WORKSPACE.bak
     build_targets:
     - "//src:bazel"
+    - "@io_bazel//src:bazel"
     test_flags:
     - "--test_timeout=1200"
     test_targets:
@@ -22,6 +23,7 @@ platforms:
     - rm -f WORKSPACE.bak
     build_targets:
     - "//src:bazel"
+    - "@io_bazel//src:bazel"
     test_flags:
     - "--test_timeout=1200"
     test_targets:
@@ -37,6 +39,7 @@ platforms:
     - rm -f WORKSPACE.bak
     build_targets:
     - "//src:bazel"
+    - "@io_bazel//src:bazel"
     test_flags:
     - "--test_timeout=1200"
     test_targets:
@@ -52,6 +55,7 @@ platforms:
     - rm -f WORKSPACE.bak
     build_targets:
     - "//src:bazel"
+    - "@io_bazel//src:bazel"
     test_flags:
     - "--test_timeout=1200"
     test_targets:
@@ -66,6 +70,7 @@ platforms:
     - "--host_copt=-w"
     build_targets:
     - "//src:bazel"
+    - "@io_bazel//src:bazel"
     test_flags:
     - "--copt=-w"
     - "--host_copt=-w"

--- a/src/create_embedded_tools.py
+++ b/src/create_embedded_tools.py
@@ -68,8 +68,13 @@ output_paths = [
 
 
 def get_output_path(path):
+  unixpath = path.replace('\\', '/')
+  if fnmatch.fnmatch(unixpath, 'external/io_bazel/*'):
+    l = len('external/io_bazel/')
+    path = path[l:]
+    unixpath = unixpath[l:]
   for pattern, transformer in output_paths:
-    if fnmatch.fnmatch(path.replace('\\', '/'), pattern):
+    if fnmatch.fnmatch(unixpath, pattern):
       # BUILD.tools are stored as BUILD files.
       return transformer(path).replace('/BUILD.tools', '/BUILD')
 

--- a/src/test/java/com/google/devtools/build/lib/packages/BazelDocumentationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/BazelDocumentationTest.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.packages.util.DocumentationTestUtil;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.windows.util.WindowsTestUtil;
 import java.io.File;
+import java.io.FileNotFoundException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -42,10 +43,18 @@ public class BazelDocumentationTest {
     if (OS.getCurrent() == OS.WINDOWS) {
       documentationFilePath = WindowsTestUtil.getRunfile("io_bazel/" + documentationFilePath);
     }
-    final File documentationFile = new File(documentationFilePath);
-    DocumentationTestUtil.validateUserManual(
-        Bazel.BAZEL_MODULES,
-        BazelRuleClassProvider.create(),
-        Files.asCharSource(documentationFile, UTF_8).read());
+    try {
+      final File documentationFile = new File(documentationFilePath);
+      DocumentationTestUtil.validateUserManual(
+          Bazel.BAZEL_MODULES,
+          BazelRuleClassProvider.create(),
+          Files.asCharSource(documentationFile, UTF_8).read());
+    } catch (FileNotFoundException e) {
+      final File documentationFile = new File("external/io_bazel/" + documentationFilePath);
+      DocumentationTestUtil.validateUserManual(
+          Bazel.BAZEL_MODULES,
+          BazelRuleClassProvider.create(),
+          Files.asCharSource(documentationFile, UTF_8).read());
+    }
   }
 }

--- a/third_party/grpc/BUILD
+++ b/third_party/grpc/BUILD
@@ -61,6 +61,8 @@ cc_binary(
     copts = [
         "-Ithird_party/grpc/include",
         "-Ithird_party/grpc",
+        "-Iexternal/io_bazel/third_party/grpc/include",
+        "-Iexternal/io_bazel/third_party/grpc",
     ],
     linkopts = [
         "-lm",

--- a/tools/build_rules/genproto.bzl
+++ b/tools/build_rules/genproto.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This is a quick and dirty rule to make Bazel compile itself.  It
-# only supports Java.
+# only supports C++.
 
 proto_filetype = [".proto"]
 
@@ -30,7 +30,10 @@ def cc_grpc_library(name, src):
             "    --plugin=protoc-gen-grpc=$(location " + cpp_plugin_label + ")",
             "    --cpp_out=$(GENDIR)",
             "    --grpc_out=$(GENDIR)",
-            "    $(location " + src + ")",
+            "    $(location " + src + ") &&",
+            "sed -i -e ",
+            "    's/^#include \"external\\/io_bazel\\//#include \"/'",
+            "    $(OUTS)",
         ]),
         outs = [basename + ".grpc.pb.h", basename + ".grpc.pb.cc", basename + ".pb.cc", basename + ".pb.h"],
     )


### PR DESCRIPTION
This patch makes it possible to build bazel as `@io_bazel//src:bazel-bin` (for example when imported into another repository, see #4435 #4285).

cc @dslomov @jmillikin-stripe 

This is WIP, will add some documentation why these changes are necessary later. It may also not work on Windows yet.