### PR TITLE
Add Locale.US to String.format

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
@@ -327,6 +327,7 @@ public interface SpawnResult {
       if (status() == Status.TIMEOUT) {
         if (getWallTime().isPresent()) {
           explanation += String.format(
+              Locale.US,
               " (failed due to timeout after %.2f seconds.)",
               getWallTime().get().toMillis() / 1000.0);
         } else {

--- a/src/main/java/com/google/devtools/build/lib/runtime/TestSummaryPrinter.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/TestSummaryPrinter.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.view.test.TestStatus.TestCase;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
@@ -204,7 +205,7 @@ public class TestSummaryPrinter {
    */
   static String timeInSec(long time, TimeUnit unit) {
     double ms = TimeUnit.MILLISECONDS.convert(time, unit);
-    return String.format("%.1fs", ms / 1000.0);
+    return String.format(Locale.US, "%.1fs", ms / 1000.0);
   }
 
   static String getAttemptSummary(TestSummary summary) {
@@ -228,7 +229,8 @@ public class TestSummaryPrinter {
     } else if (summary.getNumCached() == summary.totalRuns()) {
       return "(cached) ";
     } else {
-      return String.format("(%d/%d cached) ", summary.getNumCached(), summary.totalRuns());
+      return String.format(
+          Locale.US, "(%d/%d cached) ", summary.getNumCached(), summary.totalRuns());
     }
   }
 
@@ -258,6 +260,7 @@ public class TestSummaryPrinter {
       // distribution of times on the next line.
       String maxTime = timeInSec(max, TimeUnit.MILLISECONDS);
       return String.format(
+          Locale.US,
           " in %s\n  Stats over %d runs: max = %s, min = %s, avg = %s, dev = %s",
           maxTime,
           summary.getTestTimes().size(),


### PR DESCRIPTION
Not having Locale.US set caused some tests to fail because strings were
different (i.e. `5,00s` insteadbof `5.00s`).