### PR TITLE
Windows,tests: port startup_options_tests

### DIFF
--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -110,8 +110,10 @@ sh_test(
     name = "startup_options_test",
     size = "medium",
     srcs = ["startup_options_test.sh"],
-    data = [":test-deps"],
-    tags = ["no_windows"],
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )
 
 sh_test(

--- a/src/test/shell/integration/startup_options_test.sh
+++ b/src/test/shell/integration/startup_options_test.sh
@@ -56,9 +56,9 @@ if "$is_windows"; then
 fi
 
 function test_different_startup_options() {
-  pid=$(bazel --host_jvm_args=-Xmx1400m info server_pid 2> $TEST_log)
+  pid=$(bazel --nobatch info server_pid 2> $TEST_log)
   [[ -n $pid ]] || fail "Couldn't run ${PRODUCT_NAME}"
-  newpid=$(bazel --host_jvm_args=-Xmx1300m info server_pid 2> $TEST_log)
+  newpid=$(bazel --batch info server_pid 2> $TEST_log)
   expect_log "WARNING: Running B\\(azel\\|laze\\) server needs to be killed, because the startup options are different."
   [[ "$newpid" != "$pid" ]] || fail "pid $pid was the same!"
   if ! "$is_windows"; then

--- a/src/test/shell/integration/startup_options_test.sh
+++ b/src/test/shell/integration/startup_options_test.sh
@@ -16,20 +16,56 @@
 #
 # Test of Bazel's startup option handling.
 
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../integration_test_setup.sh" \
+# --- begin runfiles.bash initialization ---
+set -euo pipefail
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*|mingw*|cygwin*)
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+fi
+
 function test_different_startup_options() {
-  pid=$(bazel info server_pid 2> $TEST_log)
+  pid=$(bazel --host_jvm_args=-Xmx1400m info server_pid 2> $TEST_log)
   [[ -n $pid ]] || fail "Couldn't run ${PRODUCT_NAME}"
-  newpid=$(bazel --batch info server_pid 2> $TEST_log)
+  newpid=$(bazel --host_jvm_args=-Xmx1300m info server_pid 2> $TEST_log)
   expect_log "WARNING: Running B\\(azel\\|laze\\) server needs to be killed, because the startup options are different."
   [[ "$newpid" != "$pid" ]] || fail "pid $pid was the same!"
-  kill -0 $pid 2> /dev/null && fail "$pid not dead"
-  kill -0 $newpid 2> /dev/null && fail "$newpid not dead"
-  true
+  if ! "$is_windows"; then
+    # On Windows: the kill command of MSYS doesn't work for Windows PIDs.
+    kill -0 $pid 2> /dev/null && fail "$pid not dead" || true
+    kill -0 $newpid 2> /dev/null && fail "$newpid not dead" || true
+  fi
 }
 
 # Regression test for Issue #1659


### PR DESCRIPTION
//src/test/shell/integration:startup_options_tests
now runs on Windows.

See https://github.com/bazelbuild/bazel/issues/4292

Change-Id: I255b227f7b6b788f21b45b743e7065a646252a36