### PR TITLE
testenv.sh: do not run "bazel info" unnecessarily

### DIFF
--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -27,9 +27,6 @@ source ${CURRENT_DIR}/../sandboxing_test_utils.sh \
 source ${CURRENT_DIR}/remote_helpers.sh \
   || { echo "remote_helpers.sh not found!" >&2; exit 1; }
 
-BAZEL_GENFILES_DIR=$(bazel info bazel-genfiles 2>/dev/null)
-BAZEL_BIN_DIR=$(bazel info bazel-bin 2>/dev/null)
-
 cat >>$TEST_TMPDIR/bazelrc <<'EOF'
 # Testing the sandboxed strategy requires using the sandboxed strategy. While it is the default,
 # we want to make sure that this explicitly fails when the strategy is not available on the system
@@ -38,6 +35,9 @@ build --spawn_strategy=sandboxed --genrule_strategy=sandboxed
 EOF
 
 function set_up {
+  export BAZEL_GENFILES_DIR=$(bazel info bazel-genfiles 2>/dev/null)
+  export BAZEL_BIN_DIR=$(bazel info bazel-bin 2>/dev/null)
+
   mkdir -p examples/genrule
   cat << 'EOF' > examples/genrule/a.txt
 foo bar bz

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -27,6 +27,9 @@ source ${CURRENT_DIR}/../sandboxing_test_utils.sh \
 source ${CURRENT_DIR}/remote_helpers.sh \
   || { echo "remote_helpers.sh not found!" >&2; exit 1; }
 
+BAZEL_GENFILES_DIR=$(bazel info bazel-genfiles 2>/dev/null)
+BAZEL_BIN_DIR=$(bazel info bazel-bin 2>/dev/null)
+
 cat >>$TEST_TMPDIR/bazelrc <<'EOF'
 # Testing the sandboxed strategy requires using the sandboxed strategy. While it is the default,
 # we want to make sure that this explicitly fails when the strategy is not available on the system

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -400,14 +400,11 @@ function setup_clean_workspace() {
 
   # On macOS, mktemp expects the template to have the Xs at the end.
   # On Linux, the Xs may be anywhere.
-  local -r bazel_stdout="$(mktemp "${TEST_TMPDIR}/XXXXXXXX")"
-  local -r bazel_stderr="${bazel_stdout}.err"
   _BAZEL_INSTALL_BASE=$(bazel info install_base 2>/dev/null)
   # Shut down this server in case the tests will run Bazel in a different output
   # root, otherwise we could not clean up $WORKSPACE_DIR (under $TEST_TMPDIR)
   # once the test is finished.
   bazel shutdown >&/dev/null
-  try_with_timeout rm -f "$bazel_stdout" "$bazel_stderr"
 
   if is_windows; then
     export BAZEL_SH="$(cygpath --windows /bin/bash)"

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -400,7 +400,7 @@ function setup_clean_workspace() {
 
   # On macOS, mktemp expects the template to have the Xs at the end.
   # On Linux, the Xs may be anywhere.
-  _BAZEL_INSTALL_BASE=$(bazel info install_base 2>/dev/null)
+  export _BAZEL_INSTALL_BASE=$(bazel info install_base 2>/dev/null)
   # Shut down this server in case the tests will run Bazel in a different output
   # root, otherwise we could not clean up $WORKSPACE_DIR (under $TEST_TMPDIR)
   # once the test is finished.

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -402,17 +402,7 @@ function setup_clean_workspace() {
   # On Linux, the Xs may be anywhere.
   local -r bazel_stdout="$(mktemp "${TEST_TMPDIR}/XXXXXXXX")"
   local -r bazel_stderr="${bazel_stdout}.err"
-  # On Windows, we mustn't run Bazel in a subshell because of
-  # https://github.com/bazelbuild/bazel/issues/3148.
-  bazel info install_base >"$bazel_stdout" 2>"$bazel_stderr" \
-    && export BAZEL_INSTALL_BASE=$(cat "$bazel_stdout") \
-    || log_fatal "'bazel info install_base' failed, stderr: $(cat "$bazel_stderr")"
-  bazel info bazel-genfiles >"$bazel_stdout" 2>"$bazel_stderr" \
-    && export BAZEL_GENFILES_DIR=$(cat "$bazel_stdout") \
-    || log_fatal "'bazel info bazel-genfiles' failed, stderr: $(cat "$bazel_stderr")"
-  bazel info bazel-bin >"$bazel_stdout" 2>"$bazel_stderr" \
-    && export BAZEL_BIN_DIR=$(cat "$bazel_stdout") \
-    || log_fatal "'bazel info bazel-bin' failed, stderr: $(cat "$bazel_stderr")"
+  _BAZEL_INSTALL_BASE=$(bazel info install_base 2>/dev/null)
   # Shut down this server in case the tests will run Bazel in a different output
   # root, otherwise we could not clean up $WORKSPACE_DIR (under $TEST_TMPDIR)
   # once the test is finished.
@@ -451,11 +441,11 @@ function cleanup_workspace() {
 
 # Clean-up the bazel install base
 function cleanup() {
-  if [ -d "${BAZEL_INSTALL_BASE:-__does_not_exists__}" ]; then
-    log_info "Cleaning up BAZEL_INSTALL_BASE under $BAZEL_INSTALL_BASE"
+  if [ -d "${_BAZEL_INSTALL_BASE:-/dev/null}" ]; then
+    log_info "Cleaning up _BAZEL_INSTALL_BASE under $_BAZEL_INSTALL_BASE"
     # Windows takes its time to shut down Bazel and we can't delete A-server.jar
     # until then, so just give it time and keep trying for 2 minutes.
-    try_with_timeout rm -fr "${BAZEL_INSTALL_BASE}" >&/dev/null
+    try_with_timeout rm -fr "${_BAZEL_INSTALL_BASE}" >&/dev/null
   fi
 }
 


### PR DESCRIPTION
testenv.sh no longer runs "bazel info bazel-bin"
and "bazel info bazel-genfiles", because the only
test that needs this information is
bazel_sandboxing_test.sh

This saves 1-2 seconds on Windows in every shell
test setup.

Also, on Windows we can safely run Bazel in a
subshell since https://github.com/bazelbuild/bazel/issues/3148 is fixed.

Change-Id: If9873221d536f1acfd4849afbfc83b94311de2bd