### PR TITLE
Docker sandbox: Pass client environment to "docker" when calling it.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.sandbox;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MoreCollectors;
 import com.google.common.eventbus.Subscribe;
@@ -110,7 +109,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     Command cmd =
         new Command(
             new String[] {dockerClient.getPathString(), "info"},
-            ImmutableMap.of(),
+            cmdEnv.getClientEnv(),
             cmdEnv.getExecRoot().getPathFile());
     try {
       cmd.execute(ByteStreams.nullOutputStream(), ByteStreams.nullOutputStream());
@@ -149,6 +148,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
   private final int uid;
   private final int gid;
   private final List<UUID> containersToCleanup;
+  private final CommandEnvironment cmdEnv;
 
   /**
    * Creates a sandboxed spawn runner that uses the {@code linux-sandbox} tool.
@@ -179,6 +179,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     this.commandId = cmdEnv.getCommandId().toString();
     this.reporter = cmdEnv.getReporter();
     this.useCustomizedImages = useCustomizedImages;
+    this.cmdEnv = cmdEnv;
     if (OS.getCurrent() == OS.LINUX) {
       this.uid = ProcessUtils.getuid();
       this.gid = ProcessUtils.getgid();
@@ -259,7 +260,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
             sandboxPath,
             sandboxExecRoot,
             cmdLine.build(),
-            environment,
+            cmdEnv.getClientEnv(),
             SandboxHelpers.processInputFiles(spawn, context, execRoot),
             outputs,
             ImmutableSet.of());
@@ -347,8 +348,11 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
   private String executeCommand(List<String> cmdLine, InputStream stdIn) throws UserExecException {
     ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
     ByteArrayOutputStream stdErr = new ByteArrayOutputStream();
+
+    // Docker might need the $HOME and $PATH variables in order to be able to use advanced
+    // authentication mechanisms (e.g. for Google Cloud), thus we pass in the client env.
     Command cmd =
-        new Command(cmdLine.toArray(new String[0]), ImmutableMap.of(), execRoot.getPathFile());
+        new Command(cmdLine.toArray(new String[0]), cmdEnv.getClientEnv(), execRoot.getPathFile());
     try {
       cmd.executeAsync(stdIn, stdOut, stdErr, Command.KILL_SUBPROCESS_ON_INTERRUPT).get();
     } catch (CommandException e) {
@@ -412,7 +416,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     }
 
     Command cmd =
-        new Command(cmdLine.toArray(new String[0]), ImmutableMap.of(), execRoot.getPathFile());
+        new Command(cmdLine.toArray(new String[0]), cmdEnv.getClientEnv(), execRoot.getPathFile());
 
     try {
       cmd.execute();

--- a/src/test/shell/bazel/bazel_docker_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_docker_sandboxing_test.sh
@@ -23,6 +23,10 @@ source $(rlocation io_bazel/src/test/shell/integration_test_setup.sh) \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 # Test that Bazel can be build itself with Docker sandboxing.
+#
+# This test has to be run with "bazel test --action_env=PATH --action_env=HOME", because the inner
+# Bazel needs to be able to pass $HOME and $PATH to "docker" so that it can download the container
+# from gcr.io.
 function test_build_bazel_using_docker()  {
     unzip -qo "${DISTFILE}" &> $TEST_log || fail "Could not unzip Bazel's distfile"
 


### PR DESCRIPTION
Otherwise Docker will not be able to read the configuration of the current user and might fail to download containers from registries that require authentication.