### PR TITLE
Fix the ordering of month and day.

### DIFF
--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -95,7 +95,7 @@ set -ex
     shallow_date = ctx.execute([
         bash_exe,
         "-c",
-        "(cd '{directory}' && git log -n 1 --pretty='format:%cd' --date='format:%Y-%d-%m')".format(
+        "(cd '{directory}' && git log -n 1 --pretty='format:%cd' --date='format:%Y-%m-%d')".format(
             directory = ctx.path("."),
         ),
     ]).stdout


### PR DESCRIPTION
I got an INFO message from Bazel containing the following date string:

    "shallow_since": "2018-31-07"

The code seems to reveal that the date is intended to be YYYY-MM-DD, so
change the requested format passed to Git.