### PR TITLE
[Skylark] Speed up string.partition function.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/EvalUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/EvalUtils.java
@@ -413,7 +413,7 @@ public final class EvalUtils {
               + "--incompatible_string_is_not_iterable=false to temporarily disable this check.");
     }
 
-    ImmutableList.Builder<String> builder = new ImmutableList.Builder<>();
+    ImmutableList.Builder<String> builder = ImmutableList.builderWithExpectedSize(value.length());
     for (char c : value.toCharArray()) {
       builder.add(String.valueOf(c));
     }

--- a/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
@@ -512,8 +512,9 @@ public final class FuncallExpression extends Expression {
       Map<String, Object> kwargs,
       MethodDescriptor method,
       Environment environment) {
+    ImmutableList<ParamDescriptor> parameters = method.getParameters();
     ImmutableList.Builder<Object> builder =
-        ImmutableList.builderWithExpectedSize(method.getParameters().size() + EXTRA_ARGS_COUNT);
+        ImmutableList.builderWithExpectedSize(parameters.size() + EXTRA_ARGS_COUNT);
     boolean acceptsExtraArgs = method.isAcceptsExtraArgs();
     boolean acceptsExtraKwargs = method.isAcceptsExtraKwargs();
 
@@ -524,9 +525,11 @@ public final class FuncallExpression extends Expression {
     // Positional parameters are always enumerated before non-positional parameters,
     // And default-valued positional parameters are always enumerated after other positional
     // parameters. These invariants are validated by the SkylarkCallable annotation processor.
-    for (ParamDescriptor param : method.getParameters()) {
+    // Index is used deliberately, since usage of iterators adds a significant overhead
+    for (int i = 0; i < parameters.size(); ++i) {
+      ParamDescriptor param = parameters.get(i);
       SkylarkType type = param.getSkylarkType();
-      Object value = null;
+      Object value;
 
       if (argIndex < args.size() && param.isPositional()) { // Positional args and params remain.
         value = args.get(argIndex);

--- a/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
@@ -454,36 +454,29 @@ public final class StringModule {
    * @return A three-tuple (List) of the form [part_before_separator, separator,
    *     part_after_separator].
    */
-  private static List<String> stringPartition(String input, String separator, boolean forward) {
+  private static ImmutableList<String> stringPartition(
+      String input, String separator, boolean forward) {
     if (separator.isEmpty()) {
       throw new IllegalArgumentException("Empty separator");
     }
 
-    int partitionSize = 3;
-    ArrayList<String> result = new ArrayList<>(partitionSize);
     int pos = forward ? input.indexOf(separator) : input.lastIndexOf(separator);
 
     if (pos < 0) {
-      for (int i = 0; i < partitionSize; ++i) {
-        result.add("");
-      }
-
       // Following Python's implementation of str.partition() and str.rpartition(),
       // the input string is copied to either the first or the last position in the
       // list, depending on the value of the forward flag.
-      result.set(forward ? 0 : partitionSize - 1, input);
+      return forward ? ImmutableList.of(input, "", "") : ImmutableList.of("", "", input);
     } else {
-      result.add(input.substring(0, pos));
-      result.add(separator);
-
-      // pos + sep.length() is at most equal to input.length(). This worst-case
-      // happens when the separator is at the end of the input string. However,
-      // substring() will return an empty string in this scenario, thus making
-      // any additional safety checks obsolete.
-      result.add(input.substring(pos + separator.length()));
+      return ImmutableList.of(
+          input.substring(0, pos),
+          separator,
+          // pos + sep.length() is at most equal to input.length(). This worst-case
+          // happens when the separator is at the end of the input string. However,
+          // substring() will return an empty string in this scenario, thus making
+          // any additional safety checks obsolete.
+          input.substring(pos + separator.length()));
     }
-
-    return result;
   }
 
   @SkylarkCallable(


### PR DESCRIPTION
According to JMH using `ImmutableList.of` or `Arrays.asList` is ~2X faster
than using existing approach of creating an empty `ArrayList` with expected
size and populating it using `add` method. This is most likely due to extra
range and capacity checks.

Returning `ImmutableList` instead of `ArrayList` avoids the need to copy it
again in order to create a `SkylarkTuple`.

These changes speed up the function by ~3X.