### PR TITLE
Tree node repository scope

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -94,7 +94,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
    * documented that it cannot be used for remote execution.
    */
   public abstract void ensureInputsPresent(
-      TreeNodeRepository repository, Path execRoot, TreeNode root, Action action, Command command)
+      TreeNodeRepositoryVisitor repositoryVisitor, Path execRoot, TreeNode root, Action action, Command command)
       throws IOException, InterruptedException;
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -45,6 +45,7 @@ final class RemoteActionContextProvider extends ActionContextProvider {
   private final RemoteRetrier retrier;
   private final DigestUtil digestUtil;
   private final Path logDir;
+  private final TreeNodeRepository repository;
   private final AtomicReference<SpawnRunner> fallbackRunner = new AtomicReference<>();
 
   RemoteActionContextProvider(
@@ -53,13 +54,15 @@ final class RemoteActionContextProvider extends ActionContextProvider {
       @Nullable GrpcRemoteExecutor executor,
       RemoteRetrier retrier,
       DigestUtil digestUtil,
-      Path logDir) {
+      Path logDir,
+      TreeNodeRepository repository) {
     this.env = env;
     this.executor = executor;
     this.cache = cache;
     this.retrier = retrier;
     this.digestUtil = digestUtil;
     this.logDir = logDir;
+    this.repository = repository;
   }
 
   @Override
@@ -79,7 +82,8 @@ final class RemoteActionContextProvider extends ActionContextProvider {
               buildRequestId,
               commandId,
               env.getReporter(),
-              digestUtil);
+              digestUtil,
+              repository);
       return ImmutableList.of(spawnCache);
     } else {
       RemoteSpawnRunner spawnRunner =
@@ -96,7 +100,8 @@ final class RemoteActionContextProvider extends ActionContextProvider {
               executor,
               retrier,
               digestUtil,
-              logDir);
+              logDir,
+              repository);
       return ImmutableList.of(new RemoteSpawnStrategy(env.getExecRoot(), spawnRunner));
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -244,8 +244,11 @@ public final class RemoteModule extends BlazeModule {
       } else {
         executor = null;
       }
+
+      // is there a better place for this storage?
+      TreeNodeRepository repository = new TreeNodeRepository();
       actionContextProvider =
-          new RemoteActionContextProvider(env, cache, executor, executeRetrier, digestUtil, logDir);
+          new RemoteActionContextProvider(env, cache, executor, executeRetrier, digestUtil, logDir, repository);
     } catch (IOException e) {
       env.getReporter().handle(Event.error(e.getMessage()));
       env.getBlazeModuleEnvironment()

--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
@@ -69,17 +69,18 @@ public final class SimpleBlobStoreActionCache extends AbstractRemoteActionCache 
 
   @Override
   public void ensureInputsPresent(
-      TreeNodeRepository repository, Path execRoot, TreeNode root, Action action, Command command)
+      TreeNodeRepositoryVisitor repositoryVisitor, Path execRoot, TreeNode root, Action action, Command command)
           throws IOException, InterruptedException {
-    repository.computeMerkleDigests(root);
+    repositoryVisitor.computeMerkleDigests(root);
     uploadBlob(action.toByteArray());
+    TreeNodeRepository repository = repositoryVisitor.getRepository();
     uploadBlob(command.toByteArray());
     for (Directory directory : repository.treeToDirectories(root)) {
       uploadBlob(directory.toByteArray());
     }
     // TODO(ulfjack): Only upload files that aren't in the CAS yet?
     for (TreeNode leaf : repository.leaves(root)) {
-      uploadFileContents(leaf.getActionInput(), execRoot, repository.getInputFileCache());
+      uploadFileContents(leaf.getActionInput(), execRoot, repositoryVisitor.getInputFileCache());
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/TreeNodeRepositoryVisitor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/TreeNodeRepositoryVisitor.java
@@ -1,0 +1,85 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote;
+
+import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.Directory;
+import com.google.common.collect.ImmutableCollection;
+import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.MetadataProvider;
+import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
+import com.google.devtools.build.lib.remote.TreeNodeRepository.TreeNode;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+import java.util.Map;
+import java.util.SortedMap;
+
+/**
+ * A visitor for {@link TreeNodeRepository} objects. Provides a context for
+ * computing and caching Merkle hashes via the repository on all objects with
+ * a single inputFileCache.
+ */
+@ThreadSafe
+public final class TreeNodeRepositoryVisitor {
+  private final Path execRoot;
+  private final DigestUtil digestUtil;
+  private final TreeNodeRepository repository;
+  private final MetadataProvider inputFileCache;
+
+  public TreeNodeRepositoryVisitor(
+      Path execRoot,
+      DigestUtil digestUtil,
+      TreeNodeRepository repository,
+      MetadataProvider inputFileCache) {
+    this.execRoot = execRoot;
+    this.digestUtil = digestUtil;
+    this.repository = repository;
+    this.inputFileCache = inputFileCache;
+  }
+
+  public TreeNodeRepository getRepository() {
+    return repository;
+  }
+
+  public MetadataProvider getInputFileCache() {
+    return inputFileCache;
+  }
+
+  public TreeNode buildFromActionInputs(SortedMap<PathFragment, ActionInput> sortedMap)
+      throws IOException {
+    return repository.buildFromActionInputs(sortedMap, execRoot, inputFileCache);
+  }
+
+  public void computeMerkleDigests(TreeNode root) throws IOException {
+    repository.computeMerkleDigests(root, digestUtil, inputFileCache);
+  }
+
+  public Digest getMerkleDigest(TreeNode node) throws IOException {
+    return repository.getMerkleDigest(node, inputFileCache);
+  }
+
+  public ImmutableCollection<Digest> getAllDigests(TreeNode root) throws IOException {
+    return repository.getAllDigests(root, inputFileCache);
+  }
+
+  public void getDataFromDigests(
+      Iterable<Digest> digests,
+      Map<Digest, ActionInput> actionInputs,
+      Map<Digest, Directory> nodes) {
+    repository.getDataFromDigests(digests, actionInputs, nodes, inputFileCache);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -31,6 +31,7 @@ import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.actions.ExecException;
+import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.AbstractRemoteActionCache.UploadManifest;
 import com.google.devtools.build.lib.remote.TreeNodeRepository.TreeNode;
@@ -219,8 +220,11 @@ public class AbstractRemoteActionCacheTests {
 
     @Override
     public void ensureInputsPresent(
-        TreeNodeRepository repository, Path execRoot, TreeNode root, Action action, Command command)
-        throws IOException, InterruptedException {
+        TreeNodeRepositoryVisitor repositoryVisitor,
+        Path execRoot,
+        TreeNode root,
+        Action action,
+        Command command) throws IOException, InterruptedException {
       throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
@@ -244,13 +244,16 @@ public class GrpcRemoteCacheTest {
   @Test
   public void testVirtualActionInputSupport() throws Exception {
     GrpcRemoteCache client = newClient();
-    TreeNodeRepository treeNodeRepository =
-        new TreeNodeRepository(execRoot, fakeFileCache, DIGEST_UTIL);
+    TreeNodeRepositoryVisitor repositoryVisitor = new TreeNodeRepositoryVisitor(
+        execRoot,
+        DIGEST_UTIL,
+        new TreeNodeRepository(),
+        fakeFileCache);
     PathFragment execPath = PathFragment.create("my/exec/path");
     VirtualActionInput virtualActionInput = new StringVirtualActionInput("hello", execPath);
     Digest digest = DIGEST_UTIL.compute(virtualActionInput.getBytes().toByteArray());
     TreeNode root =
-        treeNodeRepository.buildFromActionInputs(
+        repositoryVisitor.buildFromActionInputs(
             ImmutableSortedMap.of(execPath, virtualActionInput));
 
     // Add a fake CAS that responds saying that the above virtual action input is missing
@@ -298,7 +301,7 @@ public class GrpcRemoteCacheTest {
 
     // Upload all missing inputs (that is, the virtual action input from above)
     client.ensureInputsPresent(
-        treeNodeRepository,
+        repositoryVisitor,
         execRoot,
         root,
         Action.getDefaultInstance(),

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
@@ -124,6 +124,7 @@ public class GrpcRemoteExecutionClientTest {
   private FileSystem fs;
   private Path execRoot;
   private Path logDir;
+  private TreeNodeRepository repository;
   private SimpleSpawn simpleSpawn;
   private FakeActionInputFileCache fakeFileCache;
   private Digest inputDigest;
@@ -211,6 +212,7 @@ public class GrpcRemoteExecutionClientTest {
     fs = new InMemoryFileSystem(new JavaClock(), DigestHashFunction.SHA256);
     execRoot = fs.getPath("/exec/root");
     logDir = fs.getPath("/server-logs");
+    repository = new TreeNodeRepository();
     FileSystemUtils.createDirectoryAndParents(execRoot);
     fakeFileCache = new FakeActionInputFileCache(execRoot);
     simpleSpawn =
@@ -282,7 +284,8 @@ public class GrpcRemoteExecutionClientTest {
             executor,
             retrier,
             DIGEST_UTIL,
-            logDir);
+            logDir,
+            repository);
     inputDigest = fakeFileCache.createScratchInput(simpleSpawn.getInputFiles().get(0), "xyz");
     command =
         Command.newBuilder()

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -43,6 +43,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventKind;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.events.StoredEventHandler;
+import com.google.devtools.build.lib.exec.SingleBuildFileCache;
 import com.google.devtools.build.lib.exec.SpawnCache.CacheHandle;
 import com.google.devtools.build.lib.exec.SpawnInputExpander;
 import com.google.devtools.build.lib.exec.SpawnRunner.ProgressStatus;
@@ -91,6 +92,7 @@ public class RemoteSpawnCacheTest {
   private FileSystem fs;
   private DigestUtil digestUtil;
   private Path execRoot;
+  private TreeNodeRepository repository;
   private SimpleSpawn simpleSpawn;
   private FakeActionInputFileCache fakeFileCache;
   @Mock private AbstractRemoteActionCache remoteCache;
@@ -161,6 +163,7 @@ public class RemoteSpawnCacheTest {
     fs = new InMemoryFileSystem(new JavaClock(), DigestHashFunction.SHA256);
     digestUtil = new DigestUtil(DigestHashFunction.SHA256);
     execRoot = fs.getPath("/exec/root");
+    repository = new TreeNodeRepository();
     FileSystemUtils.createDirectoryAndParents(execRoot);
     fakeFileCache = new FakeActionInputFileCache(execRoot);
     simpleSpawn =
@@ -190,7 +193,8 @@ public class RemoteSpawnCacheTest {
             "build-req-id",
             "command-id",
             reporter,
-            digestUtil);
+            digestUtil,
+            repository);
     fakeFileCache.createScratchInput(simpleSpawn.getInputFiles().get(0), "xyz");
   }
 
@@ -229,7 +233,7 @@ public class RemoteSpawnCacheTest {
     verify(remoteCache).download(actionResult, execRoot, outErr);
     verify(remoteCache, never())
         .ensureInputsPresent(
-            any(TreeNodeRepository.class),
+            any(TreeNodeRepositoryVisitor.class),
             any(Path.class),
             any(TreeNode.class),
             any(Action.class),

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -105,6 +105,7 @@ public class RemoteSpawnRunnerTest {
 
   private Path execRoot;
   private Path logDir;
+  private TreeNodeRepository repository;
   private DigestUtil digestUtil;
   private FakeActionInputFileCache fakeFileCache;
   private FileOutErr outErr;
@@ -136,6 +137,7 @@ public class RemoteSpawnRunnerTest {
     FileSystem fs = new InMemoryFileSystem(new JavaClock(), DigestHashFunction.SHA256);
     execRoot = fs.getPath("/exec/root");
     logDir = fs.getPath("/server-logs");
+    repository = new TreeNodeRepository();
     FileSystemUtils.createDirectoryAndParents(execRoot);
     fakeFileCache = new FakeActionInputFileCache(execRoot);
 
@@ -179,7 +181,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     ExecuteResponse succeeded = ExecuteResponse.newBuilder().setResult(
         ActionResult.newBuilder().setExitCode(0).build()).build();
@@ -241,7 +244,8 @@ public class RemoteSpawnRunnerTest {
             null,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     // Throw an IOException to trigger the local fallback.
     when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(IOException.class);
@@ -297,7 +301,8 @@ public class RemoteSpawnRunnerTest {
                 null,
                 retrier,
                 digestUtil,
-                logDir));
+                logDir,
+                repository));
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
@@ -358,7 +363,8 @@ public class RemoteSpawnRunnerTest {
                 null,
                 retrier,
                 digestUtil,
-                logDir));
+                logDir,
+                repository));
 
     try {
       runner.exec(spawn, policy);
@@ -394,7 +400,8 @@ public class RemoteSpawnRunnerTest {
             null,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
@@ -454,7 +461,8 @@ public class RemoteSpawnRunnerTest {
             null,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
@@ -495,7 +503,8 @@ public class RemoteSpawnRunnerTest {
             null,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
@@ -533,7 +542,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
     when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(new IOException());
@@ -570,7 +580,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     Digest logDigest = digestUtil.computeAsUtf8("bla");
     Path logPath = logDir.getRelative(simpleActionId).getRelative("logname");
@@ -612,7 +623,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     Digest logDigest = digestUtil.computeAsUtf8("bla");
     Path logPath = logDir.getRelative(simpleActionId).getRelative("logname");
@@ -657,7 +669,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     Digest logDigest = digestUtil.computeAsUtf8("bla");
     ActionResult result = ActionResult.newBuilder().setExitCode(31).build();
@@ -697,7 +710,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     Digest logDigest = digestUtil.computeAsUtf8("bla");
     ActionResult result = ActionResult.newBuilder().setExitCode(0).build();
@@ -739,7 +753,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(cachedResult);
@@ -782,7 +797,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
@@ -831,7 +847,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
@@ -878,7 +895,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
@@ -920,7 +938,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
     when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(new IOException());
@@ -958,7 +977,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     when(cache.getCachedActionResult(any(ActionKey.class))).thenThrow(new IOException());
 
@@ -993,7 +1013,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            repository);
 
     ExecuteResponse succeeded =
         ExecuteResponse.newBuilder()


### PR DESCRIPTION
Scope a single TreeNodeRepository per command invocation, and present a visitor to the repository with a reference MetadataProvider to perform actions requested. This reduces the number of stats substantially for a single build.