### PR TITLE
[Skylark] Avoid iterator overhead when creating slices.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/SkylarkList.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/SkylarkList.java
@@ -373,8 +373,9 @@ public abstract class SkylarkList<E> extends BaseMutableList<E>
         throws EvalException {
       List<Integer> sliceIndices = EvalUtils.getSliceIndices(start, end, step, this.size(), loc);
       ArrayList<E> list = new ArrayList<>(sliceIndices.size());
-      for (int pos : sliceIndices) {
-        list.add(this.get(pos));
+      // foreach is not used to avoid iterator overhead
+      for (int i = 0; i < sliceIndices.size(); ++i) {
+        list.add(this.get(sliceIndices.get(i)));
       }
       return MutableList.wrapUnsafe(mutability, list);
     }
@@ -691,8 +692,9 @@ public abstract class SkylarkList<E> extends BaseMutableList<E>
         throws EvalException {
       List<Integer> sliceIndices = EvalUtils.getSliceIndices(start, end, step, this.size(), loc);
       ImmutableList.Builder<E> builder = ImmutableList.builderWithExpectedSize(sliceIndices.size());
-      for (int pos : sliceIndices) {
-        builder.add(this.get(pos));
+      // foreach is not used to avoid iterator overhead
+      for (int i = 0; i < sliceIndices.size(); ++i) {
+        builder.add(this.get(sliceIndices.get(i)));
       }
       return copyOf(builder.build());
     }


### PR DESCRIPTION
According to async-profiler ~22% of the time spent in `getSlice` method as an iterator overhead.