### PR TITLE
[singlejar] Remove redundant test_util deps

### DIFF
--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -201,7 +201,6 @@ cc_test(
     ],
     deps = [
         ":options",
-        ":test_util",
         ":token_stream",
         "//src/main/cpp/util",
         "@com_google_googletest//:gtest_main",
@@ -293,7 +292,6 @@ cc_test(
         ":zlib_interface",
     ],
     deps = [
-        ":test_util",
         "//third_party/zlib",
         "@com_google_googletest//:gtest_main",
     ],

--- a/src/tools/singlejar/options_test.cc
+++ b/src/tools/singlejar/options_test.cc
@@ -15,7 +15,6 @@
 #include <memory>
 
 #include "src/tools/singlejar/options.h"
-#include "src/tools/singlejar/test_util.h"
 
 #include "src/main/cpp/util/port.h"
 #include "googletest/include/gtest/gtest.h"


### PR DESCRIPTION
Side-note: `options_test`, `zip_headers_test` and `zlib_interface_test` now pass on Windows.

/cc @laszlocsomor 