### PR TITLE
Windows: add skeleton for Bash-less test wrapper

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -166,6 +166,11 @@ public class BaseRuleClasses {
           .add(attr("args", STRING_LIST))
           // Input files for every test action
           .add(
+              attr("$test_wrapper", LABEL)
+                  .cfg(HostTransition.INSTANCE)
+                  .singleArtifact()
+                  .value(env.getToolsLabel("//tools/test:test_wrapper")))
+          .add(
               attr("$test_runtime", LABEL_LIST)
                   .cfg(HostTransition.INSTANCE)
                   .value(ImmutableList.of(env.getToolsLabel("//tools/test:runtime"))))

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
@@ -166,6 +166,12 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
         .add(attr("args", STRING_LIST))
         // Input files for every test action
         .add(
+            attr("$test_wrapper", LABEL)
+                .cfg(HostTransition.INSTANCE)
+                .singleArtifact()
+                .value(
+                    labelCache.getUnchecked(toolsRepository + "//tools/test:test_wrapper")))
+        .add(
             attr("$test_runtime", LABEL_LIST)
                 .cfg(HostTransition.INSTANCE)
                 .value(

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -216,6 +216,22 @@ public class TestConfiguration extends Fragment {
     )
     public Label coverageReportGenerator;
 
+    @Option(
+      name = "windows_native_test_wrapper",
+      // Undocumented: this features is under development and not yet ready for production use.
+      // We define the flag only in order to be able to test the feature.
+      // Design: https://github.com/laszlocsomor/proposals/blob/win-test-runner/designs/2018-07-18-windows-native-test-runner.md
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      // Affects loading and analysis: this flag affects which target Bazel loads and creates test
+      // actions with on Windows.
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+      defaultValue = "false",
+      help =
+          "On Windows: if true, uses the C++ test wrapper to run tests, otherwise uses "
+              + "tools/test/test-setup.sh as on other platforms. On other platforms: no-op."
+    )
+    public boolean windowsNativeTestWrapper;
+
     @Override
     public Map<String, Set<Label>> getDefaultsLabels() {
       return ImmutableMap.<String, Set<Label>>of(
@@ -230,6 +246,7 @@ public class TestConfiguration extends Fragment {
       // configuration.
       hostOptions.coverageSupport = this.coverageSupport;
       hostOptions.coverageReportGenerator = this.coverageReportGenerator;
+      hostOptions.windowsNativeTestWrapper = this.windowsNativeTestWrapper;
       return hostOptions;
     }
   }
@@ -296,6 +313,10 @@ public class TestConfiguration extends Fragment {
 
   public Label getCoverageReportGenerator(){
     return options.coverageReportGenerator;
+  }
+
+  public boolean getWindowsNativeTestWrapper() {
+    return options.windowsNativeTestWrapper;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -72,7 +72,7 @@ public class TestRunnerAction extends AbstractAction implements NotifyOnActionCa
 
   private static final String GUID = "cc41f9d0-47a6-11e7-8726-eb6ce83a8cc8";
 
-  private final Artifact testSetupScript;
+  private final Artifact testWrapper;
   private final Artifact testXmlGeneratorScript;
   private final Artifact collectCoverageScript;
   private final BuildConfiguration configuration;
@@ -101,6 +101,9 @@ public class TestRunnerAction extends AbstractAction implements NotifyOnActionCa
   private final int shardNum;
   private final int runNumber;
   private final String workspaceName;
+
+  // Takes the value of the `--windows_native_test_wrapper` flag.
+  private final boolean useWindowsNativeTestWrapper;
 
   // Mutable state related to test caching. Lazily initialized: null indicates unknown.
   private Boolean unconditionalExecution;
@@ -135,7 +138,8 @@ public class TestRunnerAction extends AbstractAction implements NotifyOnActionCa
   TestRunnerAction(
       ActionOwner owner,
       Iterable<Artifact> inputs,
-      Artifact testSetupScript, // Must be in inputs
+      Artifact testWrapper, // Must be in inputs
+      boolean useWindowsNativeTestWrapper,
       Artifact testXmlGeneratorScript, // Must be in inputs
       @Nullable Artifact collectCoverageScript, // Must be in inputs, if not null
       Artifact testLog,
@@ -158,7 +162,8 @@ public class TestRunnerAction extends AbstractAction implements NotifyOnActionCa
         list(testLog, cacheStatus, coverageArtifact),
         configuration.getActionEnvironment());
     Preconditions.checkState((collectCoverageScript == null) == (coverageArtifact == null));
-    this.testSetupScript = testSetupScript;
+    this.testWrapper = testWrapper;
+    this.useWindowsNativeTestWrapper = useWindowsNativeTestWrapper;
     this.testXmlGeneratorScript = testXmlGeneratorScript;
     this.collectCoverageScript = collectCoverageScript;
     this.configuration = Preconditions.checkNotNull(configuration);
@@ -740,8 +745,12 @@ public class TestRunnerAction extends AbstractAction implements NotifyOnActionCa
     return getOutputs();
   }
 
-  public Artifact getTestSetupScript() {
-    return testSetupScript;
+  public Artifact getTestWrapper() {
+    return testWrapper;
+  }
+
+  public boolean isUsingWindowsNativeTestWrapper() {
+    return useWindowsNativeTestWrapper;
   }
 
   public Artifact getTestXmlGeneratorScript() {

--- a/src/test/java/com/google/devtools/build/lib/exec/StandaloneTestStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/StandaloneTestStrategyTest.java
@@ -72,7 +72,7 @@ public final class StandaloneTestStrategyTest extends BuildViewTestCase {
 
     public TestedStandaloneTestStrategy(
         ExecutionOptions executionOptions, BinTools binTools, Path tmpDirRoot) {
-      super(executionOptions, binTools, tmpDirRoot);
+      super(executionOptions, binTools, tmpDirRoot, false);
     }
 
     @Override

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -139,6 +139,18 @@ py_test(
 )
 
 py_test(
+    name = "test_wrapper_test",
+    srcs = select({
+        "//src/conditions:windows": ["test_wrapper_test.py"],
+        "//conditions:default": ["empty_test.py"],
+    }),
+    deps = select({
+        "//src/conditions:windows": [":test_base"],
+        "//conditions:default": [],
+    }),
+)
+
+py_test(
     name = "query_test",
     size = "medium",
     srcs = ["query_test.py"],

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -140,6 +140,10 @@ py_test(
 
 py_test(
     name = "test_wrapper_test",
+    main = select({
+        "//src/conditions:windows": "test_wrapper_test.py",
+        "//conditions:default": "empty_test.py",
+    }),
     srcs = select({
         "//src/conditions:windows": ["test_wrapper_test.py"],
         "//conditions:default": ["empty_test.py"],

--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -1,0 +1,64 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from src.test.py.bazel import test_base
+
+
+class BazelCleanTest(test_base.TestBase):
+
+  def testTestExecutionWithTestSetupShAndWithTestWrapperExe(self):
+    self.ScratchFile('WORKSPACE')
+    self.ScratchFile('foo/BUILD', [
+        'py_test(',
+        '    name = "x_test",',
+        '    srcs = ["x_test.py"],',
+        ')',
+    ])
+    self.ScratchFile('foo/x_test.py', [
+        'from __future__ import print_function',
+        'import unittest',
+        '',
+        'class XTest(unittest.TestCase):',
+        '    def testFoo(self):',
+        '        print("lorem ipsum")',
+        '',
+        'if __name__ == "__main__":',
+        '  unittest.main()',
+    ], executable = True)
+
+    # Run test with test-setup.sh
+    exit_code, stdout, stderr = self.RunBazel([
+        'test', '//foo:x_test', '--test_output=streamed', '-t-',
+        '--nowindows_native_test_wrapper'])
+    self.AssertExitCode(exit_code, 0, stderr)
+    found = False
+    for line in stdout + stderr:
+        if 'lorem ipsum' in line:
+            found = True
+    if not found:
+        self.fail('FAIL: output:\n%s\n---' % '\n'.join(stderr + stdout))
+
+    # Run test with test_wrapper.exe
+    exit_code, _, stderr = self.RunBazel([
+        'test', '//foo:x_test', '--test_output=streamed', '-t-',
+        '--windows_native_test_wrapper'])
+
+    # As of 2018-08-07, test_wrapper.exe cannot yet run tests.
+    self.AssertExitCode(exit_code, 3, stderr)
+
+if __name__ == '__main__':
+  unittest.main()
+

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -66,7 +66,7 @@ filegroup(
         "//tools/objc:srcs",
         "//tools/python:embedded_tools",
         "//tools/runfiles:embedded_tools",
-        "//tools/test:srcs",
+        "//tools/test:embedded_tools",
         "//tools/test/LcovMerger/java/com/google/devtools/lcovmerger:embedded_tools",
         "//tools/osx/crosstool:srcs",
         "//tools/osx:srcs",

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -33,7 +33,33 @@ filegroup(
     srcs = ["@bazel_tools//tools/test/LcovMerger/java/com/google/devtools/lcovmerger:Main"],
 )
 
+cc_binary(
+    name = "test_wrapper",
+    srcs = select({
+        "@bazel_tools//src/conditions:windows": ["windows/test_wrapper.cc"],
+
+        # Dummy source file, so this rule can be built on non-Windows platforms
+        # (when building all targets in this package).
+        "//conditions:default": ["windows/dummy.cc"],
+    }),
+    visibility = ["//visibility:private"],
+)
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
+)
+
+filegroup(
+    name = "embedded_tools",
+    srcs = [
+        "BUILD.tools",
+        "test-setup.sh",
+        "generate-xml.sh",
+        "collect_coverage.sh",
+    ] + glob(["LcovMerger/**"]) + select({
+        "@bazel_tools//src/conditions:windows": ["test_wrapper"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//tools:__pkg__"],
 )

--- a/tools/test/BUILD.tools
+++ b/tools/test/BUILD.tools
@@ -1,0 +1,42 @@
+package(default_visibility = ["//visibility:public"])
+
+# Members of this filegroup shouldn't have duplicate basenames, otherwise
+# TestRunnerAction#getRuntimeArtifact() will get confused.
+# Deprecated, do not use.
+filegroup(
+    name = "runtime",
+    srcs = ["test-setup.sh"],
+)
+
+filegroup(
+    name = "test_setup",
+    srcs = ["test-setup.sh"],
+)
+
+filegroup(
+    name = "test_xml_generator",
+    srcs = ["generate-xml.sh"],
+)
+
+filegroup(
+    name = "collect_coverage",
+    srcs = ["collect_coverage.sh"],
+)
+
+filegroup(
+    name = "coverage_support",
+    srcs = ["collect_coverage.sh"],
+)
+
+filegroup(
+    name = "coverage_report_generator",
+    srcs = ["@bazel_tools//tools/test/LcovMerger/java/com/google/devtools/lcovmerger:Main"],
+)
+
+filegroup(
+    name = "test_wrapper",
+    srcs = select({
+        "@bazel_tools//src/conditions:windows": ["test_wrapper.exe"],
+        "//conditions:default": ["test_wrapper"],
+    }),
+)

--- a/tools/test/windows/dummy.cc
+++ b/tools/test/windows/dummy.cc
@@ -1,0 +1,27 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Empty implementation of the test wrapper.
+//
+// As of 2018-08-06, every platform uses //tools/test:test-setup.sh as the test
+// wrapper, and we are working on introducing a C++ test wrapper for Windows.
+// See https://github.com/laszlocsomor/proposals/blob/win-test-runner/designs/2018-07-18-windows-native-test-runner.md
+
+#include <stdio.h>
+
+int main(int, char**) {
+  fprintf(stderr,
+          __FILE__ ": The C++ test wrapper is not used on this platform.\n");
+  return 1;
+}

--- a/tools/test/windows/test_wrapper.cc
+++ b/tools/test/windows/test_wrapper.cc
@@ -1,0 +1,22 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test wrapper implementation for Windows.
+// Design: https://github.com/laszlocsomor/proposals/blob/win-test-runner/designs/2018-07-18-windows-native-test-runner.md
+
+int main(int argc, char** argv) {
+  // TODO(laszlocsomor): Implement the functionality described in
+  // https://github.com/laszlocsomor/proposals/blob/win-test-runner/designs/2018-07-18-windows-native-test-runner.md
+  return 0;
+}


### PR DESCRIPTION
In this commit:

- Add the not-yet-documented
  `--windows_native_test_wrapper` flag. This flag
  will guard the new feature and allow the Bazel
  team to roll out the feature gradually, as well
  as to deprecate the old test execution mechanism
  gradually.

- Add a target for the native implementation of
  the test wrapper.

- Hook up the test action creator logic to use the
  new binary, and add a test to assert this.

See https://github.com/bazelbuild/bazel/issues/5508

Change-Id: I980a1a88cfabd04ddcf8a5b26620f8f3255f77ef