### PR TITLE
Create BUILD.tools for //tools/test package.

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -66,7 +66,7 @@ filegroup(
         "//tools/objc:srcs",
         "//tools/python:embedded_tools",
         "//tools/runfiles:embedded_tools",
-        "//tools/test:srcs",
+        "//tools/test:embedded_tools",
         "//tools/test/LcovMerger/java/com/google/devtools/lcovmerger:embedded_tools",
         "//tools/osx/crosstool:srcs",
         "//tools/osx:srcs",

--- a/tools/test/BUILD.tools
+++ b/tools/test/BUILD.tools
@@ -32,19 +32,3 @@ filegroup(
     name = "coverage_report_generator",
     srcs = ["@bazel_tools//tools/test/LcovMerger/java/com/google/devtools/lcovmerger:Main"],
 )
-
-filegroup(
-    name = "srcs",
-    srcs = glob(["**"]),
-)
-
-filegroup(
-    name = "embedded_tools",
-    srcs = [
-        "BUILD.tools",
-        "test-setup.sh",
-        "generate-xml.sh",
-        "collect_coverage.sh",
-    ] + glob(["LcovMerger/**"]),
-    visibility = ["//tools:__pkg__"],
-)


### PR DESCRIPTION
Motivation: as part of fixing issue #5508, I'll
add a cc_binary to this package. The binary will
be embedded in Bazel as a prebuilt binary (to
avoid requiring a C++ compiler to use it).
Therefore //tools/test/BUILD and
@bazel_tools//tools/test/BUILD will contain
different rules, mandating the BUILD file split.

See https://github.com/bazelbuild/bazel/issues/5508

Change-Id: If21bafbc3d83d59e52de498cf3efd2b1b79fa7b6