### PR TITLE
Windows,tests: run //s/t/shell/integration:* tests

### DIFF
--- a/src/test/shell/BUILD
+++ b/src/test/shell/BUILD
@@ -81,6 +81,7 @@ test_suite(
     tests = [
         ":windows_tests",
         "//src/test/shell/bazel:all_windows_tests",
+        "//src/test/shell/integration:all_windows_tests",
     ],
     visibility = ["//src:__pkg__"],
 )

--- a/src/test/shell/integration/experimental_ui_test.sh
+++ b/src/test/shell/integration/experimental_ui_test.sh
@@ -226,10 +226,11 @@ function test_query_spacing() {
   # other tools, i.e., contains only result lines, separated only by newlines.
   BAZEL_QUERY_OUTPUT=`bazel query --experimental_ui 'deps(//pkg:true)'`
   echo "$BAZEL_QUERY_OUTPUT" | grep -q -v '^[@/]' \
-   && fail "bazel query output is >$BAZEL_QUERY_OUTPUT<"
-  echo "$BAZEL_QUERY_OUTPUT" | grep -q $'\r' \
-   && fail "bazel query output is >$BAZEL_QUERY_OUTPUT<"
-  true
+   && fail "bazel query output is >$BAZEL_QUERY_OUTPUT<" || true
+  if ! is_windows; then
+    echo "$BAZEL_QUERY_OUTPUT" | grep -q $'\r' \
+     && fail "bazel query output is >$BAZEL_QUERY_OUTPUT<" || true
+  fi
 }
 
 function test_clean_nobuild {

--- a/src/test/shell/integration/progress_reporting_test.sh
+++ b/src/test/shell/integration/progress_reporting_test.sh
@@ -218,12 +218,12 @@ EOF
   # It may happen that Skyframe does not discover (enque) the workspace status
   # writer action immediately, so the counter may initially report 3 total
   # actions instead of 4.
-  expect_log "\[0 / [34]\] Executing genrule //${pkg}:z$"
-  expect_log "\[1 / [34]\] Executing genrule //${pkg}:z DONE$"
-  expect_log "\[1 / [34]\] Executing genrule //${pkg}:y$"
-  expect_log "\[2 / [34]\] Executing genrule //${pkg}:y DONE$"
-  expect_log "\[2 / 4\] Executing genrule //${pkg}:x$"
-  expect_log "\[3 / 4\] Executing genrule //${pkg}:x DONE$"
+  expect_log "\[0 / [34]\] Executing genrule //${pkg}:z\s*$"
+  expect_log "\[1 / [34]\] Executing genrule //${pkg}:z DONE\s*$"
+  expect_log "\[1 / [34]\] Executing genrule //${pkg}:y\s*$"
+  expect_log "\[2 / [34]\] Executing genrule //${pkg}:y DONE\s*$"
+  expect_log "\[2 / 4\] Executing genrule //${pkg}:x\s*$"
+  expect_log "\[3 / 4\] Executing genrule //${pkg}:x DONE\s*$"
   expect_log "\[3 / 4\] Still waiting for 1 job to complete:"
 
   # Open-source Bazel calls this file stable-status.txt, Google internal version

--- a/src/test/shell/integration/python_test.sh
+++ b/src/test/shell/integration/python_test.sh
@@ -70,29 +70,30 @@ py_test(
 )
 EOF
   cat >test/a.py <<'EOF'
+from __future__ import print_function
 import os.path
 import sys
 
-print "This is my name: %s" % __file__
-print "This is my working directory: %s" % os.getcwd()
+print("This is my name: %s" % __file__)
+print("This is my working directory: %s" % os.getcwd())
 os.chdir(os.path.dirname(__file__))
-print "This is my new working directory: %s" % os.getcwd()
+print("This is my new working directory: %s" % os.getcwd())
 
 file_to_check = "mypackage/__init__.py"
 
 if not os.path.exists(file_to_check):
-  print "mypackage/__init__.py does not exist"
+  print("mypackage/__init__.py does not exist")
   sys.exit(1)
 
 if os.path.islink(file_to_check):
-  print "mypackage/__init__.py is a symlink, expected a regular file"
+  print("mypackage/__init__.py is a symlink, expected a regular file")
   sys.exit(1)
 
 if not os.path.isfile(file_to_check):
-  print "mypackage/__init__.py is not a regular file"
+  print("mypackage/__init__.py is not a regular file")
   sys.exit(1)
 
-print "OK"
+print("OK")
 EOF
   touch test/mypackage/b.py
 


### PR DESCRIPTION
Enable the tests in //src/test/shell/integration:*
to run on CI, and fix them all.

See See https://github.com/bazelbuild/bazel/issues/4292

Change-Id: I6a811d8045d85237a7df4024f893f3ca1b25177a