### PR TITLE
Remove an unnecessary addInput call in ctx.actions.run().

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkActionFactory.java
@@ -199,7 +199,6 @@ public class SkylarkActionFactory implements SkylarkActionFactoryApi {
     buildCommandLine(builder, argumentsList);
     if (executableUnchecked instanceof Artifact) {
       Artifact executable = (Artifact) executableUnchecked;
-      builder.addInput(executable);
       FilesToRunProvider provider = context.getExecutableRunfiles(executable);
       if (provider == null) {
         builder.setExecutable(executable);


### PR DESCRIPTION
SpawnAction.Builder.setExecutable adds the executable to the inputs for you.