### PR TITLE
Remove extra word from option documentation.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
@@ -245,7 +245,7 @@ public final class RemoteOptions extends OptionsBase {
             + "The remote cache currently doesn't support symlinks, "
             + "so symlink outputs are converted into regular files. "
             + "If this option is not enabled, "
-            + "otherwise cachable actions that output symlinks will fail."
+            + "cachable actions that output symlinks will fail."
   )
   public boolean allowSymlinkUpload;
 }


### PR DESCRIPTION
The sentence makes more sense without "otherwise" in it.