### PR TITLE
Allow tool_path to be unnormalized.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppToolchainInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppToolchainInfo.java
@@ -787,12 +787,9 @@ public final class CppToolchainInfo {
       CcToolchainConfigInfo ccToolchainConfigInfo, PathFragment crosstoolTopPathFragment) {
     Map<String, PathFragment> toolPathsCollector = Maps.newHashMap();
     for (Pair<String, String> tool : ccToolchainConfigInfo.getToolPaths()) {
-      String pathStr = tool.getSecond();
-      if (!PathFragment.isNormalized(pathStr)) {
-        throw new IllegalArgumentException("The include path '" + pathStr + "' is not normalized.");
-      }
-      PathFragment path = PathFragment.create(pathStr);
-      toolPathsCollector.put(tool.getFirst(), crosstoolTopPathFragment.getRelative(path));
+      toolPathsCollector.put(
+          tool.getFirst(),
+          crosstoolTopPathFragment.getRelative(tool.getSecond()));
     }
 
     if (toolPathsCollector.isEmpty()) {


### PR DESCRIPTION
1. It's sometimes useful to use relative paths for crosstool tools. For example, one can share common wrapper scripts between crosstools.

2. The ActionConfig.Tool.tool_path field is allowed to contain unnormalized paths.

3. This fixes an ugly skyframe traceback that you used to get by trying to use an unnormalized path:
```
java.lang.IllegalStateException: java.lang.RuntimeException: Unrecoverable error while evaluating node 'ConfigurationFragmentKey(class=com.google.devtools.build.lib.rules.cpp.CppConfiguration, checksum=ee0f8e363e5740c160cf05602b0ed15f)' (requested by nodes 'f65da6650cd83ab54356239a660f2d61')
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.evaluateSkyKeys(SkyframeExecutor.java:1762)
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.getConfigurations(SkyframeExecutor.java:1594)
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.createConfigurations(SkyframeExecutor.java:1203)
	at com.google.devtools.build.lib.buildtool.BuildTool.buildTargets(BuildTool.java:201)
	at com.google.devtools.build.lib.buildtool.BuildTool.processRequest(BuildTool.java:350)
	at com.google.devtools.build.lib.runtime.commands.BuildCommand.exec(BuildCommand.java:75)
	at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.execExclusively(BlazeCommandDispatcher.java:472)
	at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.exec(BlazeCommandDispatcher.java:199)
	at com.google.devtools.build.lib.server.GrpcServerImpl.executeCommand(GrpcServerImpl.java:855)
	at com.google.devtools.build.lib.server.GrpcServerImpl.access$2100(GrpcServerImpl.java:111)
	at com.google.devtools.build.lib.server.GrpcServerImpl$2.lambda$run$0(GrpcServerImpl.java:924)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.RuntimeException: Unrecoverable error while evaluating node 'ConfigurationFragmentKey(class=com.google.devtools.build.lib.rules.cpp.CppConfiguration, checksum=ee0f8e363e5740c160cf05602b0ed15f)' (requested by nodes 'f65da6650cd83ab54356239a660f2d61')
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:441)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:355)
	... 3 more
Caused by: java.lang.IllegalArgumentException: The include path '../external/root/bin/gcc' is not normalized.
	at com.google.devtools.build.lib.rules.cpp.CppToolchainInfo.computeToolPaths(CppToolchainInfo.java:805)
	at com.google.devtools.build.lib.rules.cpp.CppToolchainInfo.create(CppToolchainInfo.java:120)
	at com.google.devtools.build.lib.rules.cpp.CppConfiguration.create(CppConfiguration.java:214)
	at com.google.devtools.build.lib.rules.cpp.CppConfigurationLoader.create(CppConfigurationLoader.java:70)
	at com.google.devtools.build.lib.rules.cpp.CppConfigurationLoader.create(CppConfigurationLoader.java:42)
	at com.google.devtools.build.lib.skyframe.ConfigurationFragmentFunction.compute(ConfigurationFragmentFunction.java:64)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:363)
	... 4 more
java.lang.IllegalStateException: java.lang.RuntimeException: Unrecoverable error while evaluating node 'ConfigurationFragmentKey(class=com.google.devtools.build.lib.rules.cpp.CppConfiguration, checksum=ee0f8e363e5740c160cf05602b0ed15f)' (requested by nodes 'f65da6650cd83ab54356239a660f2d61')
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.evaluateSkyKeys(SkyframeExecutor.java:1762)
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.getConfigurations(SkyframeExecutor.java:1594)
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.createConfigurations(SkyframeExecutor.java:1203)
	at com.google.devtools.build.lib.buildtool.BuildTool.buildTargets(BuildTool.java:201)
	at com.google.devtools.build.lib.buildtool.BuildTool.processRequest(BuildTool.java:350)
	at com.google.devtools.build.lib.runtime.commands.BuildCommand.exec(BuildCommand.java:75)
	at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.execExclusively(BlazeCommandDispatcher.java:472)
	at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.exec(BlazeCommandDispatcher.java:199)
	at com.google.devtools.build.lib.server.GrpcServerImpl.executeCommand(GrpcServerImpl.java:855)
	at com.google.devtools.build.lib.server.GrpcServerImpl.access$2100(GrpcServerImpl.java:111)
	at com.google.devtools.build.lib.server.GrpcServerImpl$2.lambda$run$0(GrpcServerImpl.java:924)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.RuntimeException: Unrecoverable error while evaluating node 'ConfigurationFragmentKey(class=com.google.devtools.build.lib.rules.cpp.CppConfiguration, checksum=ee0f8e363e5740c160cf05602b0ed15f)' (requested by nodes 'f65da6650cd83ab54356239a660f2d61')
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:441)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:355)
	... 3 more
Caused by: java.lang.IllegalArgumentException: The include path '../external/root/bin/gcc' is not normalized.
	at com.google.devtools.build.lib.rules.cpp.CppToolchainInfo.computeToolPaths(CppToolchainInfo.java:805)
	at com.google.devtools.build.lib.rules.cpp.CppToolchainInfo.create(CppToolchainInfo.java:120)
	at com.google.devtools.build.lib.rules.cpp.CppConfiguration.create(CppConfiguration.java:214)
	at com.google.devtools.build.lib.rules.cpp.CppConfigurationLoader.create(CppConfigurationLoader.java:70)
	at com.google.devtools.build.lib.rules.cpp.CppConfigurationLoader.create(CppConfigurationLoader.java:42)
	at com.google.devtools.build.lib.skyframe.ConfigurationFragmentFunction.compute(ConfigurationFragmentFunction.java:64)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:363)
```