### PR TITLE
NDK API_LEVEL < 21 build failed as include error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/ndkcrosstools/NdkPaths.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/ndkcrosstools/NdkPaths.java
@@ -235,9 +235,7 @@ public class NdkPaths {
         "external/%repositoryName%/ndk/sources/".replace("%repositoryName%", repositoryName);
 
     ImmutableList.Builder<String> includePaths = ImmutableList.builder();
-
-    includePaths.add(prefix + "android/support/include");
-
+    
     if (majorRevision <= 12) {
       includePaths.add(prefix + "cxx-stl/llvm-libc++/libcxx/include");
       includePaths.add(prefix + "cxx-stl/llvm-libc++abi/libcxxabi/include");
@@ -247,6 +245,8 @@ public class NdkPaths {
       includePaths.add(prefix + "cxx-stl/llvm-libc++/include");
       includePaths.add(prefix + "cxx-stl/llvm-libc++abi/include");
     }
+    
+    includePaths.add(prefix + "android/support/include");
 
     return includePaths.build();
   }


### PR DESCRIPTION
```
In file included from external/basic/src/djinni/jni/djinni_support.cpp:19:
In file included from bazel-out/android-armeabi-v7a-fastbuild/bin/external/basic/_virtual_includes/djinni_jni/djinni/proxy_cache_impl.hpp:22:
In file included from external/androidndk/ndk/sources/cxx-stl/llvm-libc++/include/unordered_map:369:
In file included from external/androidndk/ndk/sources/cxx-stl/llvm-libc++/include/__hash_table:19:
In file included from external/androidndk/ndk/sources/cxx-stl/llvm-libc++/include/cmath:305:
In file included from external/androidndk/ndk/sources/android/support/include/math.h:32:
external/androidndk/ndk/sources/cxx-stl/llvm-libc++/include/math.h:1302:93: error: no member named 'log2f' in the global namespace
inline _LIBCPP_INLINE_VISIBILITY float       log2(float __lcpp_x) _NOEXCEPT       {return ::log2f(__lcpp_x);}
                                                                                          ~~^
external/androidndk/ndk/sources/cxx-stl/llvm-libc++/include/math.h:1303:93: error: no member named 'log2l' in the global namespace
```

i got failed message above when i build android ndk. 
```
env
     ndk: r16b
     api_level: 17
     toolchain:@androidndk//:toolchain-libcpp

```
then i found if ndk api level < 21 those methods define in ”android/support/include/math.h“

**android/support/include/math.h**  

```
#include_next <math.h>
...
__BEGIN_DECLS

#if __ANDROID_API__ < __ANDROID_API_J_MR2__
double        log2(double);
float         log2f(float);
long double   log2l(long double);
long double   logbl(long double);
float         tgammaf(float);
#endif
...
```

“cxx-stl/llvm-libc++/include/math.h” will compile first as  "#include_next <math.h>"  when add "android/support/include" before "cxx-stl/llvm-libc++/include", that cause failed above when build ndk with "libcpp toolchain" , "api level < 21"