### PR TITLE
Add --filter_sources flag to LcovMerger.

### DIFF
--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/BUILD
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/BUILD
@@ -104,12 +104,23 @@ java_library(
 )
 
 java_library(
+    name = "LcovMergerFlags",
+    srcs = ["LcovMergerFlags.java"],
+    deps = [
+        "//third_party:auto_value",
+        "//third_party:guava",
+        "//third_party:jsr305",
+    ],
+)
+
+java_library(
     name = "MainLibrary",
     srcs = ["Main.java"],
     deps = [
         ":Constants",
         ":Coverage",
         ":GcovParser",
+        ":LcovMergerFlags",
         ":LcovParser",
         ":LcovPrinter",
         ":SourceFileCoverage",

--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/Coverage.java
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/Coverage.java
@@ -47,25 +47,25 @@ class Coverage {
   }
 
   static Coverage filterOutMatchingSources(
-      Coverage coverage, List<String> regex) throws IllegalArgumentException {
-    if (coverage == null || regex == null) {
+      Coverage coverage, List<String> regexes) throws IllegalArgumentException {
+    if (coverage == null || regexes == null) {
       throw new IllegalArgumentException("Coverage and regex should not be null.");
     }
-    if (regex.isEmpty()) {
+    if (regexes.isEmpty()) {
       return coverage;
     }
     Coverage filteredCoverage = new Coverage();
     for (SourceFileCoverage source : coverage.getAllSourceFiles()) {
-      if (!matchesAnyRegex(source.sourceFileName(), regex)) {
+      if (!matchesAnyRegex(source.sourceFileName(), regexes)) {
         filteredCoverage.add(source);
       }
     }
     return filteredCoverage;
   }
 
-  private static boolean matchesAnyRegex(String input, List<String> regex) {
-    for (String currRegex : regex) {
-      if (input.matches(currRegex)) {
+  private static boolean matchesAnyRegex(String input, List<String> regexes) {
+    for (String regex : regexes) {
+      if (input.matches(regex)) {
         return true;
       }
     }

--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/Coverage.java
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/Coverage.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.lcovmerger;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.TreeMap;
 
@@ -43,6 +44,25 @@ class Coverage {
       merged.add(sourceFile);
     }
     return merged;
+  }
+
+  static Coverage filterOutMatchingSources(
+      Coverage coverage, String[] regex) throws IllegalArgumentException {
+    if (coverage == null || regex == null) {
+      throw new IllegalArgumentException("Coverage and regex should not be null.");
+    }
+    if (regex.length == 0) {
+      return coverage;
+    }
+    Coverage filteredCoverage = new Coverage();
+    coverage.getAllSourceFiles().stream()
+            .filter(s -> !matchesAnyRegex(s.sourceFileName(), regex))
+            .forEach(s -> filteredCoverage.add(s));
+    return filteredCoverage;
+  }
+
+  private static boolean matchesAnyRegex(String input, String[] regex) {
+    return Arrays.stream(regex).anyMatch(r -> input.matches(r));
   }
 
   boolean isEmpty() {

--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/Coverage.java
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/Coverage.java
@@ -14,8 +14,8 @@
 
 package com.google.devtools.lcovmerger;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.TreeMap;
 
 class Coverage {
@@ -47,22 +47,29 @@ class Coverage {
   }
 
   static Coverage filterOutMatchingSources(
-      Coverage coverage, String[] regex) throws IllegalArgumentException {
+      Coverage coverage, List<String> regex) throws IllegalArgumentException {
     if (coverage == null || regex == null) {
       throw new IllegalArgumentException("Coverage and regex should not be null.");
     }
-    if (regex.length == 0) {
+    if (regex.isEmpty()) {
       return coverage;
     }
     Coverage filteredCoverage = new Coverage();
-    coverage.getAllSourceFiles().stream()
-            .filter(s -> !matchesAnyRegex(s.sourceFileName(), regex))
-            .forEach(s -> filteredCoverage.add(s));
+    for (SourceFileCoverage source : coverage.getAllSourceFiles()) {
+      if (!matchesAnyRegex(source.sourceFileName(), regex)) {
+        filteredCoverage.add(source);
+      }
+    }
     return filteredCoverage;
   }
 
-  private static boolean matchesAnyRegex(String input, String[] regex) {
-    return Arrays.stream(regex).anyMatch(r -> input.matches(r));
+  private static boolean matchesAnyRegex(String input, List<String> regex) {
+    for (String currRegex : regex) {
+      if (input.matches(currRegex)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   boolean isEmpty() {

--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/LcovMergerFlags.java
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/LcovMergerFlags.java
@@ -1,3 +1,17 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.devtools.lcovmerger;
 
 import com.google.auto.value.AutoValue;

--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/LcovMergerFlags.java
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/LcovMergerFlags.java
@@ -62,7 +62,7 @@ abstract class LcovMergerFlags {
               filterSources.add(parts[1]);
             break;
           default:
-            throw new IllegalArgumentException("Unknown flag --" + parts[0]);
+            throw new IllegalArgumentException("Unknown flag " + arg);
         }
       }
 
@@ -75,8 +75,7 @@ abstract class LcovMergerFlags {
             "Only one of --coverage_dir or --reports_file must be specified.");
       }
       if (outputFile == null) {
-        // Different from blaze, this should be mandatory
-        throw new IllegalArgumentException("--output_file was not specified");
+        throw new IllegalArgumentException("--output_file was not specified.");
       }
       return new AutoValue_LcovMergerFlags(
               coverageDir, reportsFile, outputFile, filterSources.build());

--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/LcovMergerFlags.java
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/LcovMergerFlags.java
@@ -16,7 +16,6 @@ package com.google.devtools.lcovmerger;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -29,7 +28,6 @@ abstract class LcovMergerFlags {
     abstract String reportsFile();
     abstract String outputFile();
     abstract List<String> filterSources();
-
 
     /**
      * Parse flags in the form of "--coverage_dir=... -output_file=..."

--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/LcovMergerFlags.java
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/LcovMergerFlags.java
@@ -1,0 +1,70 @@
+package com.google.devtools.lcovmerger;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@AutoValue
+abstract class LcovMergerFlags {
+
+    @Nullable
+    abstract String coverageDir();
+    @Nullable
+    abstract String reportsFile();
+    abstract String outputFile();
+    abstract List<String> filterSources();
+
+
+    /**
+     * Parse flags in the form of "--coverage_dir=... -output_file=..."
+     */
+    static LcovMergerFlags parseFlags(String[] args) {
+      ImmutableList.Builder<String> filterSources = new ImmutableList.Builder<>();
+      String coverageDir = null;
+      String reportsFile = null;
+      String outputFile = null;
+
+      for (String arg : args) {
+        if (!arg.startsWith("--")) {
+          throw new IllegalArgumentException("Argument (" + arg + ") should start with --");
+        }
+        String[] parts = arg.substring(2).split("=", 2);
+        if (parts.length != 2) {
+           throw new IllegalArgumentException("There should be = in argument (" + arg + ")");
+        }
+        switch (parts[0]) {
+          case "coverage_dir":
+            coverageDir = parts[1];
+            break;
+          case "reports_file":
+            reportsFile = parts[1];
+            break;
+          case "output_file":
+            outputFile = parts[1];
+            break;
+          case "filter_sources":
+              filterSources.add(parts[1]);
+            break;
+          default:
+            throw new IllegalArgumentException("Unknown flag --" + parts[0]);
+        }
+      }
+
+      if (coverageDir == null && reportsFile == null) {
+        throw new IllegalArgumentException(
+            "At least one of --coverage_dir or --reports_file should be specified.");
+      }
+      if (coverageDir != null && reportsFile != null) {
+        throw new IllegalArgumentException(
+            "Only one of --coverage_dir or --reports_file must be specified.");
+      }
+      if (outputFile == null) {
+        // Different from blaze, this should be mandatory
+        throw new IllegalArgumentException("--output_file was not specified");
+      }
+      return new AutoValue_LcovMergerFlags(
+              coverageDir, reportsFile, outputFile, filterSources.build());
+    }
+}

--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/Main.java
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/Main.java
@@ -67,6 +67,11 @@ public class Main {
       System.exit(1);
     }
 
+    if (flags.containsKey("filter_sources")) {
+      String[] regex = flags.get("filter_sources").split(",");
+      coverage = Coverage.filterOutMatchingSources(coverage, regex);
+    }
+
     int exitStatus = 0;
     String outputFile = flags.get("output_file");
     try {
@@ -194,6 +199,7 @@ public class Main {
         case "coverage_dir":
         case "reports_file":
         case "output_file":
+        case "filter_sources":
           continue;
         default:
           throw new IllegalArgumentException("Unknown flag --" + flag);

--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/Main.java
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/Main.java
@@ -19,7 +19,6 @@ import static com.google.devtools.lcovmerger.Constants.TRACEFILE_EXTENSION;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -32,9 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -49,7 +46,7 @@ public class Main {
   public static void main(String[] args) {
     LcovMergerFlags flags = null;
     try {
-       flags = LcovMergerFlags.parseFlags(args);
+      flags = LcovMergerFlags.parseFlags(args);
     } catch (IllegalArgumentException e) {
       logger.log(Level.SEVERE, e.getMessage());
       System.exit(1);
@@ -96,7 +93,7 @@ public class Main {
   }
 
   private static List<File> getTracefiles(
-      LcovMergerFlags flags, List<File> filesInCoverageDir) {
+          LcovMergerFlags flags, List<File> filesInCoverageDir) {
     List<File> lcovTracefiles = new ArrayList<>();
     if (flags.coverageDir() != null) {
       lcovTracefiles = getFilesWithExtension(filesInCoverageDir, TRACEFILE_EXTENSION);

--- a/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/BUILD
+++ b/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/BUILD
@@ -103,6 +103,16 @@ java_test(
 )
 
 java_test(
+    name = "LcovMergerFlagsTest",
+    srcs = ["LcovMergerFlagsTest.java"],
+    deps = [
+        "//third_party:junit4",
+        "//third_party:truth",
+        "//tools/test/LcovMerger/java/com/google/devtools/lcovmerger:LcovMergerFlags",
+    ],
+)
+
+java_test(
     name = "MainTest",
     srcs = ["MainTest.java"],
     deps = [

--- a/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/CoverageTest.java
+++ b/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/CoverageTest.java
@@ -22,11 +22,14 @@ import static com.google.devtools.lcovmerger.LcovMergerTestUtils.createLinesExec
 import static com.google.devtools.lcovmerger.LcovMergerTestUtils.createSourceFile1;
 import static com.google.devtools.lcovmerger.LcovMergerTestUtils.createSourceFile2;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.util.Collection;
 
 /**
  * Test for LcovMerger.
@@ -77,5 +80,92 @@ public class CoverageTest {
     assertThat(coverage.getAllSourceFiles()).hasSize(2);
     assertTracefile1(Iterables.get(coverage.getAllSourceFiles(), 0));
     assertTracefile1(Iterables.get(coverage.getAllSourceFiles(), 1));
+  }
+
+  @Test
+  public void testFilterSources() {
+    Coverage coverage = new Coverage();
+
+    coverage.add(new SourceFileCoverage("/x/y/a.c"));
+    coverage.add(new SourceFileCoverage("/x/y/b.c"));
+    SourceFileCoverage validSource1 = new SourceFileCoverage("/z/c.c");
+    coverage.add(validSource1);
+    SourceFileCoverage validSource2 = new SourceFileCoverage("/z/d.c");
+    coverage.add(validSource2);
+    Collection<SourceFileCoverage> filteredSources =
+            Coverage.filterOutMatchingSources(coverage, new String[] {"/x/y/.+"})
+                .getAllSourceFiles();
+
+    assertThat(filteredSources).containsExactly(validSource1, validSource2);
+  }
+
+  @Test
+  public void testFilterSourcesEmptyResult() {
+    Coverage coverage = new Coverage();
+
+    coverage.add(new SourceFileCoverage("/x/y/a.c"));
+    coverage.add(new SourceFileCoverage("/x/y/b.c"));
+    Collection<SourceFileCoverage> filteredSources =
+            Coverage.filterOutMatchingSources(coverage, new String[] {"/x/y/.+"})
+                    .getAllSourceFiles();
+
+    assertThat(filteredSources).isEmpty();
+  }
+
+  @Test
+  public void testFilterSourcesNoMatches() {
+    Coverage coverage = new Coverage();
+
+    SourceFileCoverage validSource1 = new SourceFileCoverage("/z/c.c");
+    coverage.add(validSource1);
+    SourceFileCoverage validSource2 = new SourceFileCoverage("/z/d.c");
+    coverage.add(validSource2);
+    Collection<SourceFileCoverage> filteredSources =
+            Coverage.filterOutMatchingSources(coverage, new String[] {"/something/else/.+"})
+                    .getAllSourceFiles();
+
+    assertThat(filteredSources).containsExactly(validSource1, validSource2);
+  }
+
+  @Test
+  public void testFilterSourcesMultipleRegex() {
+    Coverage coverage = new Coverage();
+
+    coverage.add(new SourceFileCoverage("/x/y/a.c"));
+    coverage.add(new SourceFileCoverage("/x/y/b.c"));
+    coverage.add(new SourceFileCoverage("/repo/external/p.c"));
+    SourceFileCoverage validSource1 = new SourceFileCoverage("/z/c.c");
+    coverage.add(validSource1);
+    SourceFileCoverage validSource2 = new SourceFileCoverage("/z/d.c");
+    coverage.add(validSource2);
+    Collection<SourceFileCoverage> filteredSources =
+            Coverage.filterOutMatchingSources(coverage, new String[] {"/x/y/.+", ".+external.+"})
+                    .getAllSourceFiles();
+
+    assertThat(filteredSources).containsExactly(validSource1, validSource2);
+  }
+
+  @Test
+  public void testFilterSourcesNoFilter() {
+    Coverage coverage = new Coverage();
+
+    SourceFileCoverage validSource1 = new SourceFileCoverage("/z/c.c");
+    coverage.add(validSource1);
+    SourceFileCoverage validSource2 = new SourceFileCoverage("/z/d.c");
+    coverage.add(validSource2);
+    Collection<SourceFileCoverage> filteredSources =
+            Coverage.filterOutMatchingSources(coverage, new String[] {}).getAllSourceFiles();
+
+    assertThat(filteredSources).containsExactly(validSource1, validSource2);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFilterSourcesNullCoverage() {
+    Coverage.filterOutMatchingSources(null, new String[] {});
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFilterSourcesNullRegex() {
+    Coverage.filterOutMatchingSources(new Coverage(), null);
   }
 }

--- a/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/CoverageTest.java
+++ b/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/CoverageTest.java
@@ -93,7 +93,7 @@ public class CoverageTest {
     SourceFileCoverage validSource2 = new SourceFileCoverage("/z/d.c");
     coverage.add(validSource2);
     Collection<SourceFileCoverage> filteredSources =
-            Coverage.filterOutMatchingSources(coverage, new String[] {"/x/y/.+"})
+            Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/x/y/.+"))
                 .getAllSourceFiles();
 
     assertThat(filteredSources).containsExactly(validSource1, validSource2);
@@ -106,7 +106,7 @@ public class CoverageTest {
     coverage.add(new SourceFileCoverage("/x/y/a.c"));
     coverage.add(new SourceFileCoverage("/x/y/b.c"));
     Collection<SourceFileCoverage> filteredSources =
-            Coverage.filterOutMatchingSources(coverage, new String[] {"/x/y/.+"})
+            Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/x/y/.+"))
                     .getAllSourceFiles();
 
     assertThat(filteredSources).isEmpty();
@@ -121,7 +121,7 @@ public class CoverageTest {
     SourceFileCoverage validSource2 = new SourceFileCoverage("/z/d.c");
     coverage.add(validSource2);
     Collection<SourceFileCoverage> filteredSources =
-            Coverage.filterOutMatchingSources(coverage, new String[] {"/something/else/.+"})
+            Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/something/else/.+"))
                     .getAllSourceFiles();
 
     assertThat(filteredSources).containsExactly(validSource1, validSource2);
@@ -139,7 +139,7 @@ public class CoverageTest {
     SourceFileCoverage validSource2 = new SourceFileCoverage("/z/d.c");
     coverage.add(validSource2);
     Collection<SourceFileCoverage> filteredSources =
-            Coverage.filterOutMatchingSources(coverage, new String[] {"/x/y/.+", ".+external.+"})
+            Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/x/y/.+", ".+external.+"))
                     .getAllSourceFiles();
 
     assertThat(filteredSources).containsExactly(validSource1, validSource2);
@@ -154,14 +154,14 @@ public class CoverageTest {
     SourceFileCoverage validSource2 = new SourceFileCoverage("/z/d.c");
     coverage.add(validSource2);
     Collection<SourceFileCoverage> filteredSources =
-            Coverage.filterOutMatchingSources(coverage, new String[] {}).getAllSourceFiles();
+            Coverage.filterOutMatchingSources(coverage, ImmutableList.of()).getAllSourceFiles();
 
     assertThat(filteredSources).containsExactly(validSource1, validSource2);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testFilterSourcesNullCoverage() {
-    Coverage.filterOutMatchingSources(null, new String[] {});
+    Coverage.filterOutMatchingSources(null, ImmutableList.of());
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/CoverageTest.java
+++ b/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/CoverageTest.java
@@ -86,14 +86,14 @@ public class CoverageTest {
   public void testFilterSources() {
     Coverage coverage = new Coverage();
 
-    coverage.add(new SourceFileCoverage("/x/y/a.c"));
-    coverage.add(new SourceFileCoverage("/x/y/b.c"));
-    SourceFileCoverage validSource1 = new SourceFileCoverage("/z/c.c");
+    coverage.add(new SourceFileCoverage("/filterOut/package/file1.c"));
+    coverage.add(new SourceFileCoverage("/filterOut/package/file2.c"));
+    SourceFileCoverage validSource1 = new SourceFileCoverage("/valid/package/file3.c");
     coverage.add(validSource1);
-    SourceFileCoverage validSource2 = new SourceFileCoverage("/z/d.c");
+    SourceFileCoverage validSource2 = new SourceFileCoverage("/valid/package/file4.c");
     coverage.add(validSource2);
     Collection<SourceFileCoverage> filteredSources =
-            Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/x/y/.+"))
+            Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/filterOut/package/.+"))
                 .getAllSourceFiles();
 
     assertThat(filteredSources).containsExactly(validSource1, validSource2);
@@ -103,10 +103,10 @@ public class CoverageTest {
   public void testFilterSourcesEmptyResult() {
     Coverage coverage = new Coverage();
 
-    coverage.add(new SourceFileCoverage("/x/y/a.c"));
-    coverage.add(new SourceFileCoverage("/x/y/b.c"));
+    coverage.add(new SourceFileCoverage("/filterOut/package/file1.c"));
+    coverage.add(new SourceFileCoverage("/filterOut/package/file2.c"));
     Collection<SourceFileCoverage> filteredSources =
-            Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/x/y/.+"))
+            Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/filterOut/package/.+"))
                     .getAllSourceFiles();
 
     assertThat(filteredSources).isEmpty();
@@ -116,9 +116,9 @@ public class CoverageTest {
   public void testFilterSourcesNoMatches() {
     Coverage coverage = new Coverage();
 
-    SourceFileCoverage validSource1 = new SourceFileCoverage("/z/c.c");
+    SourceFileCoverage validSource1 = new SourceFileCoverage("/valid/package/file3.c");
     coverage.add(validSource1);
-    SourceFileCoverage validSource2 = new SourceFileCoverage("/z/d.c");
+    SourceFileCoverage validSource2 = new SourceFileCoverage("/valid/package/file4.c");
     coverage.add(validSource2);
     Collection<SourceFileCoverage> filteredSources =
             Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/something/else/.+"))
@@ -131,15 +131,16 @@ public class CoverageTest {
   public void testFilterSourcesMultipleRegex() {
     Coverage coverage = new Coverage();
 
-    coverage.add(new SourceFileCoverage("/x/y/a.c"));
-    coverage.add(new SourceFileCoverage("/x/y/b.c"));
+    coverage.add(new SourceFileCoverage("/filterOut/package/file1.c"));
+    coverage.add(new SourceFileCoverage("/filterOut/package/file2.c"));
     coverage.add(new SourceFileCoverage("/repo/external/p.c"));
-    SourceFileCoverage validSource1 = new SourceFileCoverage("/z/c.c");
+    SourceFileCoverage validSource1 = new SourceFileCoverage("/valid/package/file3.c");
     coverage.add(validSource1);
-    SourceFileCoverage validSource2 = new SourceFileCoverage("/z/d.c");
+    SourceFileCoverage validSource2 = new SourceFileCoverage("/valid/package/file4.c");
     coverage.add(validSource2);
     Collection<SourceFileCoverage> filteredSources =
-            Coverage.filterOutMatchingSources(coverage, ImmutableList.of("/x/y/.+", ".+external.+"))
+            Coverage.filterOutMatchingSources(
+                    coverage, ImmutableList.of("/filterOut/package/.+", ".+external.+"))
                     .getAllSourceFiles();
 
     assertThat(filteredSources).containsExactly(validSource1, validSource2);
@@ -149,9 +150,9 @@ public class CoverageTest {
   public void testFilterSourcesNoFilter() {
     Coverage coverage = new Coverage();
 
-    SourceFileCoverage validSource1 = new SourceFileCoverage("/z/c.c");
+    SourceFileCoverage validSource1 = new SourceFileCoverage("/valid/package/file3.c");
     coverage.add(validSource1);
-    SourceFileCoverage validSource2 = new SourceFileCoverage("/z/d.c");
+    SourceFileCoverage validSource2 = new SourceFileCoverage("/valid/package/file4.c");
     coverage.add(validSource2);
     Collection<SourceFileCoverage> filteredSources =
             Coverage.filterOutMatchingSources(coverage, ImmutableList.of()).getAllSourceFiles();

--- a/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/LcovMergerFlagsTest.java
+++ b/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/LcovMergerFlagsTest.java
@@ -1,0 +1,102 @@
+package com.google.devtools.lcovmerger;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class LcovMergerFlagsTest {
+    @Test
+    public void parseFlagsTestCoverageDirOutputFile() {
+        LcovMergerFlags flags = LcovMergerFlags.parseFlags(new String[] {
+            "--coverage_dir=my_dir",
+            "--output_file=my_file",
+        });
+        assertThat(flags.coverageDir()).isEqualTo("my_dir");
+        assertThat(flags.outputFile()).isEqualTo("my_file");
+        assertThat(flags.reportsFile()).isNull();
+        assertThat(flags.filterSources()).isEmpty();
+    }
+
+    @Test
+    public void parseFlagsTestReportsFileOutputFile() {
+        LcovMergerFlags flags = LcovMergerFlags.parseFlags(new String[] {
+            "--reports_file=my_reports_file",
+            "--output_file=my_file",
+        });
+        assertThat(flags.reportsFile()).isEqualTo("my_reports_file");
+        assertThat(flags.outputFile()).isEqualTo("my_file");
+        assertThat(flags.coverageDir()).isNull();
+        assertThat(flags.filterSources()).isEmpty();
+    }
+
+    @Test
+    public void parseFlagsTestReportsFileOutputFileFilterSources() {
+        LcovMergerFlags flags = LcovMergerFlags.parseFlags(new String[] {
+            "--reports_file=my_reports_file",
+            "--output_file=my_file",
+            "--filter_sources=first_filter"
+        });
+        assertThat(flags.reportsFile()).isEqualTo("my_reports_file");
+        assertThat(flags.outputFile()).isEqualTo("my_file");
+        assertThat(flags.coverageDir()).isNull();
+        assertThat(flags.filterSources()).containsExactly("first_filter");
+    }
+
+    @Test
+    public void parseFlagsTestReportsFileOutputFileMultipleFilterSources() {
+        LcovMergerFlags flags = LcovMergerFlags.parseFlags(new String[] {
+            "--reports_file=my_reports_file",
+            "--output_file=my_file",
+            "--filter_sources=first_filter",
+            "--filter_sources=second_filter"
+        });
+        assertThat(flags.reportsFile()).isEqualTo("my_reports_file");
+        assertThat(flags.outputFile()).isEqualTo("my_file");
+        assertThat(flags.coverageDir()).isNull();
+        assertThat(flags.filterSources()).containsExactly("first_filter", "second_filter");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseFlagsTestCoverageDirAndReportsFile() {
+        LcovMergerFlags.parseFlags(new String[] {
+            "--reports_file=my_reports_file",
+            "--coverage_dir=my_coverage_dir"
+        });
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseFlagsTestEmptyFlags() {
+        LcovMergerFlags.parseFlags(new String[] {});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseFlagsTestNoOutputFile() {
+        LcovMergerFlags.parseFlags(new String[] {
+            "--reports_file=my_reports_file",
+        });
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseFlagsTestUnknownFlag() {
+        LcovMergerFlags.parseFlags(new String[] {
+            "--fake_flag=my_reports_file",
+        });
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseFlagsTestInvalidFlagValue() {
+        LcovMergerFlags.parseFlags(new String[] {
+            "--reports_file",
+            "--output_file=my_file",
+        });
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseFlagsTestInvalidFlagValueWithoutDashes() {
+        LcovMergerFlags.parseFlags(new String[] {
+            "reports_file",
+            "--output_file=my_file",
+        });
+    }
+}


### PR DESCRIPTION
When the `--filter_sources` flag is used `LcovMerger`  excludes from the merged coverage the sources whose names match any of the regex in the flag. 

The value of `--filter_sources` is a list of regex separated by `,`.

This flag comes as a preparation for using `gcov` instead of `lcov` for collecting coverage data for C++. The flag was not needed before because `lcov` has some functionality for excluding some files (e.g. `--no-external` to ignore coverage data for system files).

Progress on #5880