### PR TITLE
query test: fix symlink creation

### DIFF
--- a/src/test/shell/integration/bazel_query_test.sh
+++ b/src/test/shell/integration/bazel_query_test.sh
@@ -247,7 +247,7 @@ function test_skylark_symlink_source_not_included_in_rbuildfiles() {
   rm -rf foo
   mkdir -p foo || fail "Couldn't make directories"
   echo "moo" > "foo/moo" || fail "Couldn't create moo"
-  ln -s "foo/moo" "foo/baz.bzl" || fail "Couldn't create baz.bzl symlink"
+  ln -s "$PWD/foo/moo" "foo/baz.bzl" && [[ -f foo/baz.bzl ]] || fail "Couldn't create baz.bzl symlink"
   echo 'sh_library(name = "foo", srcs = ["baz.bzl"])' > foo/BUILD
   bazel query --universe_scope=//...:* --order_output=no \
     'rbuildfiles(foo/baz.bzl)' >& $TEST_log || fail "Expected success"
@@ -261,7 +261,7 @@ function test_skylark_symlink_target_not_included_in_rbuildfiles() {
   rm -rf foo
   mkdir -p foo || fail "Couldn't make directories"
   echo "baz" > "foo/baz.bzl" || fail "Couldn't create baz.bzl"
-  ln -s "foo/baz.bzl" "foo/Moo.java" || fail "Couldn't create Moo.java symlink"
+  ln -s "$PWD/foo/baz.bzl" "foo/Moo.java" && [[ -f foo/Moo.java ]] || fail "Couldn't create Moo.java symlink"
   echo 'sh_library(name = "foo", srcs = ["Moo.java"])' > foo/BUILD
   bazel query --universe_scope=//...:* --order_output=no \
     'rbuildfiles(foo/baz.bzl)' >& $TEST_log || fail "Expected success"
@@ -288,7 +288,7 @@ function test_skylark_glob_symlink_source_not_included_in_rbuildfiles() {
   rm -rf foo
   mkdir -p foo || fail "Couldn't make directories"
   echo "moo" > "foo/moo" || fail "Couldn't create moo"
-  ln -s "foo/moo" "foo/baz.bzl" || fail "Couldn't create baz.bzl symlink"
+  ln -s "$PWD/foo/moo" "foo/baz.bzl" && [[ -f foo/baz.bzl ]] || fail "Couldn't create baz.bzl symlink"
   echo 'sh_library(name = "foo", srcs = glob(["*.bzl"]))' > foo/BUILD
   bazel query --universe_scope=//...:* --order_output=no \
     'rbuildfiles(foo/baz.bzl)' >& $TEST_log || fail "Expected success"
@@ -302,7 +302,7 @@ function test_skylark_glob_symlink_target_not_included_in_rbuildfiles() {
   rm -rf foo
   mkdir -p foo || fail "Couldn't make directories"
   echo "baz" > "foo/baz.bzl" || fail "Couldn't create baz.bzl"
-  ln -s "foo/baz.bzl" "foo/Moo.java" || fail "Couldn't create Moo.java symlink"
+  ln -s "$PWD/foo/baz.bzl" "foo/Moo.java" && [[ -f foo/Moo.java ]] || fail "Couldn't create Moo.java symlink"
   echo 'sh_library(name = "foo", srcs = glob(["*.java"]))' > foo/BUILD
   bazel query --universe_scope=//...:* --order_output=no \
     'rbuildfiles(foo/baz.bzl)' >& $TEST_log || fail "Expected success"
@@ -329,7 +329,7 @@ function test_skylark_recursive_glob_symlink_source_not_included_in_rbuildfiles(
   rm -rf foo
   mkdir -p foo/bar || fail "Couldn't make directories"
   echo "moo" > "foo/moo" || fail "Couldn't create moo"
-  ln -s "foo/moo" "foo/bar/baz.bzl" || fail "Couldn't create baz.bzl symlink"
+  ln -s "$PWD/foo/moo" "foo/bar/baz.bzl" && [[ -f foo/bar/baz.bzl ]] || fail "Couldn't create baz.bzl symlink"
   echo 'sh_library(name = "foo", srcs = glob(["**/*.bzl"]))' > foo/BUILD
   bazel query --universe_scope=//...:* --order_output=no \
     'rbuildfiles(foo/bar/baz.bzl)' >& $TEST_log || fail "Expected success"
@@ -343,7 +343,7 @@ function test_skylark_recursive_glob_symlink_target_not_included_in_rbuildfiles(
   rm -rf foo
   mkdir -p foo/bar || fail "Couldn't make directories"
   echo "baz" > "foo/bar/baz.bzl" || fail "Couldn't create baz.bzl"
-  ln -s "foo/bar/baz.bzl" "foo/Moo.java" || fail "Couldn't create Moo.java symlink"
+  ln -s "$PWD/foo/bar/baz.bzl" "foo/Moo.java" && [[ -f foo/Moo.java ]] || fail "Couldn't create Moo.java symlink"
   echo 'sh_library(name = "foo", srcs = glob(["**/*.java"]))' > foo/BUILD
   bazel query --universe_scope=//...:* --order_output=no \
     'rbuildfiles(foo/bar/baz.bzl)' >& $TEST_log || fail "Expected success"


### PR DESCRIPTION
Symlink targets are now absolute. Previously they
were relative, not to the symlink (as they should
have been) but to the workspace, so the symlinks
were in fact dangling.
 
Change-Id: I06e503168318bc76f0fa847d8f0937311deb9b81