### PR TITLE
Flag if networking is allowed or denied by default

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
@@ -42,6 +42,11 @@
     attribute has the same effect.
   </li>
 
+  <li><code>requires-network</code> keyword allows access to the external
+    network from inside the sandbox.  This tag only has an effect if sandboxing
+    is enabled.
+  </li>
+
   <li><code>block-network</code> keyword blocks access to the external
     network from inside the sandbox. In this case, only communication
     with localhost is allowed. This tag only has an effect if sandboxing is

--- a/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
@@ -174,6 +174,12 @@ public class ExecutionRequirements {
   public static final String NO_REMOTE = "no-remote";
 
   /**
+   * Enables networking for a spawn if possible (only if sandboxing is enabled and if the sandbox
+   * supports it).
+   */
+  public static final String REQUIRES_NETWORK = "requires-network";
+
+  /**
    * Disables networking for a spawn if possible (only if sandboxing is enabled and if the sandbox
    * supports it).
    */

--- a/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
@@ -38,8 +38,16 @@ public final class Spawns {
         && !spawn.getExecutionInfo().containsKey(ExecutionRequirements.LOCAL);
   }
 
-  public static boolean requiresNetwork(Spawn spawn) {
-    return !spawn.getExecutionInfo().containsKey(ExecutionRequirements.BLOCK_NETWORK);
+  public static boolean requiresNetwork(
+      Spawn spawn, boolean defaultSandboxDisallowNetwork) {
+    if (spawn.getExecutionInfo().containsKey(ExecutionRequirements.BLOCK_NETWORK)) {
+      return false;
+    }
+    if (spawn.getExecutionInfo().containsKey(ExecutionRequirements.REQUIRES_NETWORK)) {
+      return true;
+    }
+
+    return defaultSandboxDisallowNetwork;
   }
 
   public static boolean mayBeExecutedRemotely(Spawn spawn) {

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
@@ -255,7 +255,9 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
             .addAll(processWrapperCommandLineBuilder.build())
             .build();
 
-    boolean allowNetworkForThisSpawn = allowNetwork || Spawns.requiresNetwork(spawn);
+    boolean allowNetworkForThisSpawn =
+        allowNetwork
+            || Spawns.requiresNetwork(spawn, getSandboxOptions().defaultSandboxAllowNetwork);
 
     Map<PathFragment, Path> inputs = SandboxHelpers.processInputFiles(spawn, context, execRoot);
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
@@ -240,7 +240,9 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
         .setPrivileged(getSandboxOptions().dockerPrivileged)
         .setEnvironmentVariables(environment)
         .setKillDelay(timeoutKillDelay)
-        .setCreateNetworkNamespace(!(allowNetwork || Spawns.requiresNetwork(spawn)))
+        .setCreateNetworkNamespace(
+            !(allowNetwork
+                || Spawns.requiresNetwork(spawn, getSandboxOptions().defaultSandboxAllowNetwork)))
         .setCommandId(commandId)
         .setUuid(uuid);
     // If uid / gid are -1, we are on an operating system that doesn't require us to set them on the

--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -159,7 +159,10 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
             .setTmpfsDirectories(getTmpfsPaths())
             .setBindMounts(getReadOnlyBindMounts(blazeDirs, sandboxExecRoot))
             .setUseFakeHostname(getSandboxOptions().sandboxFakeHostname)
-            .setCreateNetworkNamespace(!(allowNetwork || Spawns.requiresNetwork(spawn)))
+            .setCreateNetworkNamespace(
+                !(allowNetwork
+                    || Spawns.requiresNetwork(
+                        spawn, getSandboxOptions().defaultSandboxAllowNetwork)))
             .setUseDebugMode(getSandboxOptions().sandboxDebug)
             .setKillDelay(timeoutKillDelay);
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
@@ -273,4 +273,13 @@ public class SandboxOptions extends OptionsBase {
               + "This might be required by your build, but it might also result in reduced "
               + "hermeticity.")
   public boolean dockerPrivileged;
+
+  @Option(
+    name = "experimental_sandbox_default_allow_network",
+    defaultValue = "true",
+    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    effectTags = {OptionEffectTag.UNKNOWN},
+    help = "Allow network access by default for actions."
+  )
+  public boolean defaultSandboxAllowNetwork;
 }


### PR DESCRIPTION
This patch adds --experimental_sandbox_default_allow_network.  By
default, it is true, ie network access is allowed unless a rule is
tagged with 'block-network'.  If a rule is marked with
'requires-network', networking will be enabled regardless.  Otherwise,
the default is controlled by the new
--experimental_sandbox_default_allow_network flag.