### PR TITLE
Use target bootclasspath for the default java toolchain.

### DIFF
--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -184,6 +184,21 @@ rm -rf $$TMPDIR
     tools = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
 )
 
+genrule(
+    name = "target_platformclasspath",
+    srcs = ["DumpPlatformClassPath.java"],
+    outs = ["platformclasspath.jar"],
+    cmd = """
+set -eu
+TMPDIR=$$(mktemp -d -t tmp.XXXXXXXX)
+$(JAVABASE)/bin/javac $< -d $$TMPDIR
+$(JAVA) -cp $$TMPDIR DumpPlatformClassPath $@
+rm -rf $$TMPDIR
+""",
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+    tools = ["@bazel_tools//tools/jdk:current_java_runtime"],
+)
+
 default_java_toolchain(
     name = "toolchain_hostjdk8",
     bootclasspath = [":platformclasspath"],
@@ -196,7 +211,7 @@ default_java_toolchain(
 
 default_java_toolchain(
     name = "toolchain",
-    bootclasspath = [":platformclasspath"],
+    bootclasspath = [":target_platformclasspath"],
     source_version = "8",
     target_version = "8",
 )


### PR DESCRIPTION
Fixes #5888