### PR TITLE
Use a JDK 8 bootclasspath by default

### DIFF
--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -176,8 +176,12 @@ genrule(
     cmd = """
 set -eu
 TMPDIR=$$(mktemp -d -t tmp.XXXXXXXX)
-$(JAVABASE)/bin/javac $< -d $$TMPDIR
-$(JAVA) -cp $$TMPDIR DumpPlatformClassPath $@
+$(JAVABASE)/bin/javac -source 8 -target 8 \
+    -cp $(JAVABASE)/lib/tools.jar \
+    -d $$TMPDIR $<
+$(JAVA) -XX:+IgnoreUnrecognizedVMOptions \
+    --add-exports=jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED \
+    -cp $$TMPDIR DumpPlatformClassPath $@
 rm -rf $$TMPDIR
 """,
     toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],

--- a/tools/jdk/DumpPlatformClassPath.java
+++ b/tools/jdk/DumpPlatformClassPath.java
@@ -12,11 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import static java.util.Comparator.comparing;
+
+import com.sun.tools.javac.api.JavacTool;
+import com.sun.tools.javac.util.Context;
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
-import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -24,11 +30,20 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.StandardLocation;
 
 /**
  * Output a jar file containing all classes on the platform classpath of the current JDK.
@@ -37,42 +52,93 @@ import java.util.zip.ZipEntry;
  */
 public class DumpPlatformClassPath {
 
-  public static void main(String[] args) throws IOException {
+  public static void main(String[] args) throws Exception {
     if (args.length != 1) {
       System.err.println("usage: DumpPlatformClassPath <output jar>");
       System.exit(1);
     }
     Path output = Paths.get(args[0]);
-    Path path = Paths.get(System.getProperty("java.home"));
-    if (path.endsWith("jre")) {
-      path = path.getParent();
+
+    Map<String, byte[]> entries = new HashMap<>();
+
+    // JDK 8 bootclasspath handling
+    Path javaHome = Paths.get(System.getProperty("java.home"));
+    if (javaHome.endsWith("jre")) {
+      javaHome = javaHome.getParent();
     }
-    Path rtJar = path.resolve("jre/lib/rt.jar");
-    if (Files.exists(rtJar)) {
-      Files.copy(rtJar, output);
-      return;
+    for (String jar :
+        Arrays.asList("rt.jar", "resources.jar", "jsse.jar", "jce.jar", "charsets.jar")) {
+      Path path = javaHome.resolve("jre/lib").resolve(jar);
+      if (!Files.exists(path)) {
+        continue;
+      }
+      try (JarFile jf = new JarFile(path.toFile())) {
+        jf.stream()
+            .forEachOrdered(
+                entry -> {
+                  try {
+                    entries.put(entry.getName(), toByteArray(jf.getInputStream(entry)));
+                  } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                  }
+                });
+      }
     }
-    Path modules = FileSystems.getFileSystem(URI.create("jrt:/")).getPath("modules");
+
+    if (entries.isEmpty()) {
+      // JDK > 8 bootclasspath handling
+
+      // Set up a compilation with --release 8 to initialize a filemanager
+      Context context = new Context();
+      JavacTool.create()
+          .getTask(null, null, null, Arrays.asList("--release", "8"), null, null, context);
+      JavaFileManager fileManager = context.get(JavaFileManager.class);
+
+      for (JavaFileObject fileObject :
+          fileManager.list(
+              StandardLocation.PLATFORM_CLASS_PATH,
+              "",
+              EnumSet.of(Kind.CLASS),
+              /* recurse= */ true)) {
+        String binaryName =
+            fileManager.inferBinaryName(StandardLocation.PLATFORM_CLASS_PATH, fileObject);
+        entries.put(
+            binaryName.replace('.', '/') + ".class", toByteArray(fileObject.openInputStream()));
+      }
+
+      // Include the jdk.unsupported module for compatibility with JDK 8.
+      // (see: https://bugs.openjdk.java.net/browse/JDK-8206937)
+      // `--release 8` only provides access to supported APIs, which excludes e.g. sun.misc.Unsafe.
+      Path module =
+          FileSystems.getFileSystem(URI.create("jrt:/")).getPath("modules/jdk.unsupported");
+      Files.walkFileTree(
+          module,
+          new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path path, BasicFileAttributes attrs)
+                throws IOException {
+              String name = path.getFileName().toString();
+              if (name.endsWith(".class") && !name.equals("module-info.class")) {
+                entries.put(module.relativize(path).toString(), Files.readAllBytes(path));
+              }
+              return super.visitFile(path, attrs);
+            }
+          });
+    }
+
     try (OutputStream os = Files.newOutputStream(output);
         BufferedOutputStream bos = new BufferedOutputStream(os, 65536);
         JarOutputStream jos = new JarOutputStream(bos)) {
-      try (DirectoryStream<Path> modulePaths = Files.newDirectoryStream(modules)) {
-        for (Path modulePath : modulePaths) {
-          Files.walkFileTree(
-              modulePath,
-              new SimpleFileVisitor<Path>() {
-                @Override
-                public FileVisitResult visitFile(Path path, BasicFileAttributes attrs)
-                    throws IOException {
-                  String name = path.getFileName().toString();
-                  if (name.endsWith(".class") && !name.equals("module-info.class")) {
-                    addEntry(jos, modulePath.relativize(path).toString(), Files.readAllBytes(path));
-                  }
-                  return super.visitFile(path, attrs);
+      entries.entrySet().stream()
+          .sorted(comparing(Map.Entry::getKey))
+          .forEachOrdered(
+              entry -> {
+                try {
+                  addEntry(jos, entry.getKey(), entry.getValue());
+                } catch (IOException e) {
+                  throw new UncheckedIOException(e);
                 }
               });
-        }
-      }
     }
   }
 
@@ -90,5 +156,18 @@ public class DumpPlatformClassPath {
     je.setCrc(crc.getValue());
     jos.putNextEntry(je);
     jos.write(bytes);
+  }
+
+  private static byte[] toByteArray(InputStream is) throws IOException {
+    byte[] buffer = new byte[8192];
+    ByteArrayOutputStream boas = new ByteArrayOutputStream();
+    while (true) {
+      int r = is.read(buffer);
+      if (r == -1) {
+        break;
+      }
+      boas.write(buffer, 0, r);
+    }
+    return boas.toByteArray();
   }
 }


### PR DESCRIPTION
for consistency with the default language level.

Include the jdk.unsupported module when running on a JDK 9 host_javabase
to work around JDK-6788376.

Also include the full bootclasspath when running on a JDK 8
host_javabase, not just rt.jar.

See #5888