### PR TITLE
[Coverage] Exit on errors in case lcov is not installed

### DIFF
--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -25,6 +25,9 @@
 # Script expects that it will be started in the execution root directory and
 # not in the test's runfiles directory.
 
+# Exit on errors (ex: lcov is not installed).
+set -e
+
 if [[ -z "$LCOV_MERGER" ]]; then
   echo --
   echo "Coverage collection running in legacy mode."


### PR DESCRIPTION
If `lcov` is not installed, `bazel coverage` will currently silently succeed but not generate any coverage reports. cc @iirina 