### PR TITLE
Unwrap CacheNotFound for RemoteActionCache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.hash.HashingOutputStream;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -189,6 +190,9 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
 
   @Override
   protected ListenableFuture<Void> downloadBlob(Digest digest, OutputStream out) {
+    if (digest.getSizeBytes() == 0) {
+      return Futures.immediateFuture(null);
+    }
     String resourceName = "";
     if (!options.remoteInstanceName.isEmpty()) {
       resourceName += options.remoteInstanceName + "/";

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
@@ -1048,10 +1048,10 @@ public class GrpcRemoteExecutionClientTest {
 
           @Override
           public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
-            // First read is a retriable error, next read succeeds.
+            // First read is a cache miss, next read succeeds.
             if (first) {
               first = false;
-              responseObserver.onError(Status.UNAVAILABLE.asRuntimeException());
+              responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
             } else {
               responseObserver.onNext(
                   ReadResponse.newBuilder().setData(ByteString.copyFromUtf8("stdout")).build());
@@ -1107,7 +1107,7 @@ public class GrpcRemoteExecutionClientTest {
     SpawnResult result = client.exec(simpleSpawn, simplePolicy);
     assertThat(result.setupSuccess()).isTrue();
     assertThat(result.exitCode()).isEqualTo(0);
-    assertThat(result.isCacheHit()).isTrue();
+    assertThat(result.isCacheHit()).isFalse();
     assertThat(outErr.outAsLatin1()).isEqualTo("stdout");
   }
 }


### PR DESCRIPTION
Using retrier causes CacheNotFoundException to be wrapped in a
RetryException, which is handled through undesirable means by the users
of RemoteActionCache#download via IOException. This must be unwrapped
and thrown directly as a part of the download interface for users, so
that users can distinguish these degraded cache entries specifically.

Reverting the behavior of remotelyReExecuteOrphanedCachedActions, which
was adapted to verify download retries, and should be separated into its
own test.