### PR TITLE
Updates the JDK to JDK 10 for aarch64

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -153,13 +153,13 @@ http_file(
 )
 
 # The source-code for this OpenJDK can be found at:
-# https://openjdk.linaro.org/releases/jdk9-src-1708.tar.xz
+# https://openjdk.linaro.org/releases/jdk10-src-1804.tar.xz
 http_file(
     name = "openjdk_linux_aarch64",
-    sha256 = "72e7843902b0395e2d30e1e9ad2a5f05f36a4bc62529828bcbc698d54aec6022",
+    sha256 = "b7098b7aaf6ee1ffd4a2d0371a0be26c5a5c87f6aebbe46fe9a92c90583a84be",
     urls = [
         # When you update this, also update the link to the source-code above.
-        "http://openjdk.linaro.org/releases/jdk9-server-release-1708.tar.xz",
+       "http://openjdk.linaro.org/releases/jdk10-server-release-1804.tar.xz",
     ],
 )
 


### PR DESCRIPTION
This pull request updates the JDK version from 9 to 10 to align aarch64 with the other architectures.