### PR TITLE
Windows,tests: port more shell tests

### DIFF
--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -379,8 +379,10 @@ sh_test(
     name = "server_logging_test",
     size = "medium",
     srcs = ["server_logging_test.sh"],
-    data = [":test-deps"],
-    tags = ["no_windows"],
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )
 
 sh_test(
@@ -394,16 +396,20 @@ sh_test(
 sh_test(
     name = "test_test",
     srcs = ["test_test.sh"],
-    data = [":test-deps"],
-    tags = ["no_windows"],
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )
 
 sh_test(
     name = "outputs_test",
     size = "medium",
     srcs = ["outputs_test.sh"],
-    data = [":test-deps"],
-    tags = ["no_windows"],
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )
 
 sh_test(

--- a/src/test/shell/integration/server_logging_test.sh
+++ b/src/test/shell/integration/server_logging_test.sh
@@ -16,12 +16,55 @@
 #
 # Test of Bazel's java logging.
 
-set -e
+# --- begin runfiles.bash initialization ---
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
+set -euo pipefail
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
 
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../integration_test_setup.sh" \
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+# `uname` returns the current platform, e.g "MSYS_NT-10.0" or "Linux".
+# `tr` converts all upper case letters to lower case.
+# `case` matches the result if the `uname | tr` expression to string prefixes
+# that use the same wildcards as names do in Bash, i.e. "msys*" matches strings
+# starting with "msys", and "*" matches everything (it's the default case).
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*)
+  # As of 2018-08-14, Bazel on Windows only supports MSYS Bash.
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  # Disable MSYS path conversion that converts path-looking command arguments to
+  # Windows paths (even if they arguments are not in fact paths).
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+fi
+
+#### TESTS #############################################################
 
 function test_log_file_uses_single_line_formatter() {
   local client_log="$(bazel info output_base)/java.log"

--- a/src/test/shell/integration/test_test.sh
+++ b/src/test/shell/integration/test_test.sh
@@ -14,63 +14,108 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+# --- begin runfiles.bash initialization ---
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
+set -euo pipefail
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
 
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../integration_test_setup.sh" \
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
+# `uname` returns the current platform, e.g "MSYS_NT-10.0" or "Linux".
+# `tr` converts all upper case letters to lower case.
+# `case` matches the result if the `uname | tr` expression to string prefixes
+# that use the same wildcards as names do in Bash, i.e. "msys*" matches strings
+# starting with "msys", and "*" matches everything (it's the default case).
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*)
+  # As of 2018-08-14, Bazel on Windows only supports MSYS Bash.
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  # Disable MSYS path conversion that converts path-looking command arguments to
+  # Windows paths (even if they arguments are not in fact paths).
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+fi
+
+#### TESTS #############################################################
 
 function test_passing_test_is_reported_correctly() {
-  mkdir -p tests
-  cat >tests/BUILD <<'EOF'
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg || fail "mkdir -p $pkg failed"
+  cat >$pkg/BUILD <<'EOF'
 sh_test(
     name = "success",
     size = "small",
     srcs = ["success.sh"],
 )
 EOF
-  cat >tests/success.sh <<'EOF'
+  cat >$pkg/success.sh <<'EOF'
 #!/bin/sh
 
 echo "success.sh is successful"
 exit 0
 EOF
-  chmod +x tests/success.sh
+  chmod +x $pkg/success.sh
 
-  bazel test --nocache_test_results //tests:success &>$TEST_log \
+  bazel test --nocache_test_results //$pkg:success &>$TEST_log \
       || fail "expected success"
   expect_not_log "success.sh is successful"
   expect_log "^Executed 1 out of 1 test: 1 test passes."
 }
 
 function test_failing_test_is_reported_correctly() {
-  mkdir -p tests
-  cat >tests/BUILD <<'EOF'
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg || fail "mkdir -p $pkg failed"
+  cat >$pkg/BUILD <<'EOF'
 sh_test(
     name = "fail",
     size = "small",
     srcs = ["fail.sh"],
 )
 EOF
-  cat >tests/fail.sh <<'EOF'
+  cat >$pkg/fail.sh <<'EOF'
 #!/bin/sh
 
 echo "fail.sh is failing"
 exit 42
 EOF
-  chmod +x tests/fail.sh
+  chmod +x $pkg/fail.sh
 
-  bazel test --nocache_test_results //tests:fail &>$TEST_log \
+  bazel test --nocache_test_results //$pkg:fail &>$TEST_log \
       && fail "expected failure" || true
-  expect_log "^//tests:fail[[:space:]]\+FAILED in [[:digit:]]\+[\.,][[:digit:]]\+s"
+  expect_log "^//$pkg:fail[[:space:]]\+FAILED in [[:digit:]]\+[\.,][[:digit:]]\+s"
   expect_log "^Executed 1 out of 1 test: 1 fails"
 }
 
 function test_build_fail_terse_summary() {
-    mkdir -p tests
-    cat > tests/BUILD <<'EOF'
+    local -r pkg=$FUNCNAME
+    mkdir -p $pkg || fail "mkdir -p $pkg failed"
+    cat > $pkg/BUILD <<'EOF'
 genrule(
   name = "testsrc",
   outs = ["test.sh"],
@@ -94,7 +139,7 @@ sh_test(
   srcs = ["slowtest.sh"],
 )
 EOF
-    bazel test --test_summary=terse //tests/... &>$TEST_log \
+    bazel test --test_summary=terse //$pkg/... &>$TEST_log \
       && fail "expected failure" || :
     expect_not_log 'NO STATUS'
     expect_log 'testsrc'
@@ -106,9 +151,10 @@ EOF
 # test is timing out, it means that Bazel is waiting for the "sleep" to finish,
 # which it shouldn't.
 function test_process_spawned_by_test_doesnt_block_test_from_completing() {
-  mkdir -p dir
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg || fail "mkdir -p $pkg failed"
 
-  cat > dir/BUILD <<'EOF'
+  cat > $pkg/BUILD <<'EOF'
 java_test(
     name = "my_test",
     main_class = "MyTest",
@@ -117,7 +163,7 @@ java_test(
     use_testrunner = 0,
 )
 EOF
-  cat > dir/MyTest.java <<'EOF'
+  cat > $pkg/MyTest.java <<'EOF'
 public class MyTest {
   public static void main(String[] args) throws Exception {
     new ProcessBuilder("sleep", "300").inheritIO().start();
@@ -125,12 +171,13 @@ public class MyTest {
 }
 EOF
 
-  bazel test //dir:my_test &> $TEST_log || fail "expected test to pass"
+  bazel test //$pkg:my_test &> $TEST_log || fail "expected test to pass"
 }
 
 function test_test_suite_non_expansion() {
-  mkdir -p dir
-  cat > dir/BUILD <<'EOF'
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg || fail "mkdir -p $pkg failed"
+  cat > $pkg/BUILD <<'EOF'
 sh_test(name = 'test_a',
         srcs = [':a.sh'],
 )
@@ -142,18 +189,19 @@ sh_test(name = 'test_b',
 test_suite(name = 'suite',
 )
 EOF
-  cat > dir/a.sh <<'EOF'
+  cat > $pkg/a.sh <<'EOF'
 #!/bin/sh
 exit 0
 EOF
 
-  cat > dir/b.sh <<'EOF'
+  cat > $pkg/b.sh <<'EOF'
 #!/bin/sh
 exit 0
 EOF
-  chmod +x dir/a.sh dir/b.sh
-  bazel test --noexpand_test_suites //dir:suite &> $TEST_log || fail "expected test to pass"
-  expect_log '//dir:test_a'
-  expect_log '//dir:test_b'
+  chmod +x $pkg/a.sh $pkg/b.sh
+  bazel test --noexpand_test_suites //$pkg:suite &> $TEST_log || fail "expected test to pass"
+  expect_log "//$pkg:test_a"
+  expect_log "//$pkg:test_b"
 }
+
 run_suite "test tests"


### PR DESCRIPTION
//src/test/shell/integration:outputs_test
//src/test/shell/integration:server_logging_test
//src/test/shell/integration:test_test
now run on Windows.

See https://github.com/bazelbuild/bazel/issues/4292

Change-Id: Ic2e8f8a705ff8e8bcd2bbc73c9798761e2402096