### PR TITLE
[WIP] Git repository rule cache

### DIFF
--- a/src/test/shell/bazel/skylark_git_repository_test.sh
+++ b/src/test/shell/bazel/skylark_git_repository_test.sh
@@ -41,6 +41,11 @@ function set_up() {
   tar zxf outer-planets-repo.tar.gz
   tar zxf refetch-repo.tar.gz
 
+  # TODO - get from argument or ENV
+  local cache_dir=/tmp/bazel_cache
+  rm -rf $cache_dir/pluto
+  rm -rf $cache_dir/outer_planets
+
   # Fix environment variables for a hermetic use of git.
   export GIT_CONFIG_NOSYSTEM=1
   export GIT_CONFIG_NOGLOBAL=1


### PR DESCRIPTION
fixes #5116 still WIP
Main open question which we'd love @aehlig's thoughts about is how to decide where to clone this?
Ideally it should be controlled by `--repository_cache`'s value and just add a new key type (`git`?) which this code clones under it. WDYT?
If this sounds like a good idea we'd really appreciate pointers on how to access the command line flag's value from the repository rule.

thank you @aoded and @eyalmalron for your work on this