### PR TITLE
Update Bazel Query docs about deprecated feature

### DIFF
--- a/site/docs/query-how-to.html
+++ b/site/docs/query-how-to.html
@@ -218,7 +218,7 @@ universe of the build.
 
 <h4>What's the set of BUILD files needed to build <code>//foo</code>?</h4>
 
-<pre>bazel query 'buildfiles(deps(//foo))' --output location | cut -f1 -d:</pre>
+<pre>bazel query 'buildfiles(deps(//foo))' | cut -f1 -d:</pre>
 
 <p><a name="What_are_the_individual_tests_th"></a></p>
 

--- a/site/docs/query.html
+++ b/site/docs/query.html
@@ -335,7 +335,7 @@ title: Query Language
 <p>
   <code>bazel query</code> target patterns work the same as
   <code>bazel build</code> build targets do;
-  refer to <a href='bazel-user-manual.html#target-patterns'>Target Patterns</a>
+  refer to <a href='user-manual.html#target-patterns'>Target Patterns</a>
   in the Bazel User Manual for further details, or type <code>bazel
   help target-syntax</code>.
 


### PR DESCRIPTION
After #4835, query expressions involving 'buildfiles' or 'loadfiles' cannot be used with --output=location.
Docs still suggest using location. The location is not necessarily critical for identifying all of the BUILD files one needs.