### PR TITLE
windows_cc_configure.bzl: Add VS2017 Professional install location

### DIFF
--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -153,6 +153,7 @@ def find_vc_path(repository_ctx):
     for path in [
         "Microsoft Visual Studio\\2017\\BuildTools\\VC",
         "Microsoft Visual Studio\\2017\\Community\\VC",
+        "Microsoft Visual Studio\\2017\\Professional\\VC",
         "Microsoft Visual Studio\\2017\\Enterprise\\VC",
         "Microsoft Visual Studio 14.0\\VC",
     ]:


### PR DESCRIPTION
Commit df42789d3e71a97a6ad0fbccb4ea9db4f05e2c7c added possible install locations for Visual Studio 2017. The professional edition seems to be missing.