### PR TITLE
Fix race condition with releaseUploadChannel().

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStore.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStore.java
@@ -100,7 +100,6 @@ import javax.net.ssl.SSLEngine;
  * <p>The implementation currently does not support transfer encoding chunked.
  */
 public final class HttpBlobStore implements SimpleBlobStore {
-
   private static final Pattern INVALID_TOKEN_ERROR =
       Pattern.compile("\\s*error\\s*=\\s*\"?invalid_token\"?");
 
@@ -239,12 +238,6 @@ public final class HttpBlobStore implements SimpleBlobStore {
                 Channel ch = channelAcquired.getNow();
                 ChannelPipeline p = ch.pipeline();
 
-                // Ensure the channel pipeline is empty.
-                if (!isChannelPipelineEmpty(p)) {
-                  channelReady.setFailure(new IllegalStateException("Channel pipeline is not empty."));
-                  return;
-                }
-
                 p.addLast(new HttpResponseDecoder());
                 // The 10KiB limit was chosen at random. We only expect HTTP servers to respond with
                 // an error message in the body and that should always be less than 10KiB.
@@ -304,12 +297,6 @@ public final class HttpBlobStore implements SimpleBlobStore {
                 Channel ch = channelAcquired.getNow();
                 ChannelPipeline p = ch.pipeline();
 
-                // Ensure the channel pipeline is empty.
-                if (!isChannelPipelineEmpty(p)) {
-                  channelReady.setFailure(new IllegalStateException("Channel pipeline is not empty."));
-                  return;
-                }
-
                 ch.pipeline()
                     .addFirst("read-timeout-handler", new ReadTimeoutHandler(timeoutMillis));
                 p.addLast(new HttpClientCodec());
@@ -343,10 +330,6 @@ public final class HttpBlobStore implements SimpleBlobStore {
       }
     }
     channelPool.release(ch);
-  }
-
-  private boolean isChannelPipelineEmpty(ChannelPipeline pipeline) {
-    return (pipeline.first() == null);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStore.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStore.java
@@ -487,7 +487,6 @@ public final class HttpBlobStore implements SimpleBlobStore {
     } finally {
       in.close();
       if (ch != null) {
-        ch.close().sync();
         releaseUploadChannel(ch);
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpUploadHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpUploadHandler.java
@@ -39,6 +39,9 @@ final class HttpUploadHandler extends AbstractHttpHandler<FullHttpResponse> {
     super(credentials);
   }
 
+  private boolean keepAlive = false;
+  public boolean keepAlive() { return keepAlive; }
+
   @SuppressWarnings("FutureReturnValueIgnored")
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse response) {
@@ -64,7 +67,8 @@ final class HttpUploadHandler extends AbstractHttpHandler<FullHttpResponse> {
         succeedAndResetUserPromise();
       }
     } finally {
-      if (!HttpUtil.isKeepAlive(response)) {
+      keepAlive = HttpUtil.isKeepAlive(response);
+      if (!keepAlive) {
         ctx.close();
       }
     }
@@ -112,6 +116,8 @@ final class HttpUploadHandler extends AbstractHttpHandler<FullHttpResponse> {
     request.headers().set(HttpHeaderNames.ACCEPT, "*/*");
     request.headers().set(HttpHeaderNames.CONTENT_LENGTH, msg.contentLength());
     request.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+
+    keepAlive = false;
     return request;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpUploadHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpUploadHandler.java
@@ -39,9 +39,6 @@ final class HttpUploadHandler extends AbstractHttpHandler<FullHttpResponse> {
     super(credentials);
   }
 
-  private boolean keepAlive = false;
-  public boolean keepAlive() { return keepAlive; }
-
   @SuppressWarnings("FutureReturnValueIgnored")
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse response) {
@@ -67,8 +64,7 @@ final class HttpUploadHandler extends AbstractHttpHandler<FullHttpResponse> {
         succeedAndResetUserPromise();
       }
     } finally {
-      keepAlive = HttpUtil.isKeepAlive(response);
-      if (!keepAlive) {
+      if (!HttpUtil.isKeepAlive(response)) {
         ctx.close();
       }
     }
@@ -116,8 +112,6 @@ final class HttpUploadHandler extends AbstractHttpHandler<FullHttpResponse> {
     request.headers().set(HttpHeaderNames.ACCEPT, "*/*");
     request.headers().set(HttpHeaderNames.CONTENT_LENGTH, msg.contentLength());
     request.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
-
-    keepAlive = false;
     return request;
   }
 


### PR DESCRIPTION
A race condition can occur in `HttpBlobStore.releaseUploadChannel()` when `ChannelHandlerContext` is closed by `HttpUploadHandler.channelRead0`. Because `ChannelHandlerContext.close` runs asynchronously and closes all pipelines in reverse order (before the channel is marked as closed), `HttpBlobStore.releaseUploadChannel()` can be executed while channel is still open and handlers are being removed, causing an exception to be thrown by the `ch.pipeline().remove(X)` calls. This fix saves the status of the keepAlive response from the `HttpUploadHandler` so that the channel can be fully closed before releasing.

Resolves #5952