### PR TITLE
docs: update homebrew install instructions

### DIFF
--- a/site/docs/install-os-x.md
+++ b/site/docs/install-os-x.md
@@ -76,11 +76,7 @@ To update to a newer release of Bazel, download and install the desired version.
 
 ## <a name="install-on-mac-os-x-homebrew"></a>Installing using Homebrew
 
-### Step 1: Install the JDK
-
-Download the JDK from [Oracle's JDK Page](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html). Look for "macOS" under "Java SE Development Kit" and download JDK version 8.
-
-### Step 2: Install Homebrew on macOS
+### Step 1: Install Homebrew on macOS
 
 Install Homebrew (a one-time step):
 
@@ -89,11 +85,13 @@ Install Homebrew (a one-time step):
 https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
 
-### Step 3: Install the Bazel Homebrew package
+### Step 2: Install the Bazel Homebrew package
 
 Install the Bazel package via Homebrew as follows:
 
 ```bash
+brew tap bazelbuild/tap
+brew tap-pin bazelbuild/tap
 brew install bazel
 ```
 

--- a/site/docs/install-os-x.md
+++ b/site/docs/install-os-x.md
@@ -87,6 +87,9 @@ https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
 ### Step 2: Install the Bazel Homebrew package
 
+_Please note that if your system has the Bazel package from homebrew core installed you first
+need to uninstall it by typing `brew uninstall bazel`_
+
 Install the Bazel package via Homebrew as follows:
 
 ```bash
@@ -106,3 +109,5 @@ Once installed, you can upgrade to a newer version of Bazel using the following 
 ```bash
 brew upgrade bazel
 ```
+
+


### PR DESCRIPTION
As of Bazel version 0.16.1 we are moving to our own
homebrew tap https://github.com/bazelbuild/homebrew-tap/.