### PR TITLE
/bin/bash does not exist on certain systems

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -1,4 +1,4 @@
-#!/bin/bash --posix
+#!/usr/bin/env bash
 # Copyright 2014 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,6 +43,8 @@
 #                       line flag, otherwise it creates a classpath jar.
 #
 # The remainder of the command line is passed to the program.
+
+set -o posix
 
 # Make it easy to insert 'set -x' or similar commands when debugging problems with this script.
 eval "$JAVA_STUB_DEBUG"


### PR DESCRIPTION
Bazel and rules_scala refer to `/bin/bash` which does not exist on certain systems. In particular on [NixOS](https://nixos.org/) where the issue was discovered. Replacing `/bin/bash` by `/usr/bin/env bash` resolves the issue.

On NixOS this problem is usually circumvented by the corresponding package description for bazel patching these paths. However, rules_scala downloads the `java_stub_template` directly from the GitHub repository. See the corresponding [issue on rules_scala][rules_scala_issue] for more information.

This PR replaces `/bin/bash` by `/usr/bin/env bash` in `java_stub_template`.

[rules_scala_issue]: https://github.com/bazelbuild/rules_scala/issues/595
