### PR TITLE
Stop using --release in versioned java_toolchains

### DIFF
--- a/src/java_tools/buildjar/BUILD
+++ b/src/java_tools/buildjar/BUILD
@@ -77,7 +77,7 @@ java_toolchain(
     # class path after -bootclasspath. For convenience, we currently have a
     # single jar that contains the contents of both the bootclasspath and
     # extdirs.
-    bootclasspath = ["//tools/jdk:platformclasspath.jar"],
+    bootclasspath = ["//tools/jdk:platformclasspath8.jar"],
     extclasspath = [],
     genclass = ["bootstrap_genclass_deploy.jar"],
     ijar = ["//third_party/ijar"],

--- a/tools/android/BUILD.tools
+++ b/tools/android/BUILD.tools
@@ -100,7 +100,7 @@ gen_java_lang_extras_jar_cmd = """
     $(location %s) \
         --exclude_build_data \
         --dont_change_compression \
-        --sources  $(location @bazel_tools//tools/jdk:platformclasspath) \
+        --sources  $(location @bazel_tools//tools/jdk:platformclasspath8) \
         --include_prefixes "java/lang/invoke/" \
         --include_prefixes "java/lang/annotation/" \
         --output $@
@@ -111,7 +111,7 @@ gen_java_lang_extras_jar_cmd = """
 genrule(
     name = "gen_java_lang_extras_jar",
     srcs = [
-        "@bazel_tools//tools/jdk:platformclasspath"
+        "@bazel_tools//tools/jdk:platformclasspath8"
     ],
     tools = select({
         "//src/conditions:windows": [":singlejar_javabin"],
@@ -176,7 +176,7 @@ genrule(
     $(location :desugar_java8) \
         --input $< \
         --output $@ \
-        --classpath_entry "$(location @bazel_tools//tools/jdk:platformclasspath)" \
+        --classpath_entry "$(location @bazel_tools//tools/jdk:platformclasspath8)" \
         --core_library --allow_empty_bootclasspath \
         --nobest_effort_tolerate_missing_deps \
         --noemit_dependency_metadata_as_needed \
@@ -213,7 +213,7 @@ genrule(
         --dont_rewrite_core_library_invocation "java/util/Iterator#remove" """,
     tools = [
         ":desugar_java8",
-        "@bazel_tools//tools/jdk:platformclasspath",
+        "@bazel_tools//tools/jdk:platformclasspath8",
     ],
     visibility = ["//visibility:private"],
 )

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -181,11 +181,14 @@ alias(
     actual = "@embedded_jdk//:jdk",
 )
 
-genrule(
-    name = "platformclasspath",
-    srcs = ["DumpPlatformClassPath.java"],
-    outs = ["platformclasspath.jar"],
-    cmd = """
+RELEASES = (8, 9, 10)
+
+[
+    genrule(
+        name = "platformclasspath%d" % release,
+        srcs = ["DumpPlatformClassPath.java"],
+        outs = ["platformclasspath%d.jar" % release],
+        cmd = """
 set -eu
 TMPDIR=$$(mktemp -d -t tmp.XXXXXXXX)
 $(JAVABASE)/bin/javac -source 8 -target 8 \
@@ -193,16 +196,18 @@ $(JAVABASE)/bin/javac -source 8 -target 8 \
     -d $$TMPDIR $<
 $(JAVA) -XX:+IgnoreUnrecognizedVMOptions \
     --add-exports=jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED \
-    -cp $$TMPDIR DumpPlatformClassPath $@
+    -cp $$TMPDIR DumpPlatformClassPath %d $@
 rm -rf $$TMPDIR
-""",
-    toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
-    tools = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
-)
+""" % release,
+        toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
+        tools = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
+    )
+    for release in RELEASES
+]
 
 default_java_toolchain(
     name = "toolchain_hostjdk8",
-    bootclasspath = [":platformclasspath"],
+    bootclasspath = [":platformclasspath8"],
     forcibly_disable_header_compilation = True,
     javabuilder = [":vanillajavabuilder"],
     jvm_opts = [],
@@ -210,28 +215,20 @@ default_java_toolchain(
     target_version = "8",
 )
 
-default_java_toolchain(
+alias(
     name = "toolchain",
-    bootclasspath = [":platformclasspath"],
-    source_version = "8",
-    target_version = "8",
+    actual = "toolchain_java8",
 )
 
-default_java_toolchain(
-    name = "toolchain_java9",
-    misc = DEFAULT_JAVACOPTS + [
-        "--release",
-        "9",
-    ],
-)
-
-default_java_toolchain(
-    name = "toolchain_java10",
-    misc = DEFAULT_JAVACOPTS + [
-        "--release",
-        "10",
-    ],
-)
+[
+    default_java_toolchain(
+        name = "toolchain_java%d" % release,
+        bootclasspath = [":platformclasspath%d" % release],
+        source_version = "%s" % release,
+        target_version = "%s" % release,
+    )
+    for release in RELEASES
+]
 
 filegroup(
     name = "srcs",


### PR DESCRIPTION
Using --release to target versions that support modules and are not the
latest supported version (e.g. --release 9 on JDK 10) doesn't work:
https://bugs.openjdk.java.net/browse/JDK-8209865

Related: #5723