### PR TITLE
Expose vanilla java toolchain

### DIFF
--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -201,6 +201,13 @@ rm -rf $$TMPDIR
 )
 
 default_java_toolchain(
+    name = "toolchain_vanilla",
+    forcibly_disable_header_compilation = True,
+    javabuilder = [":vanillajavabuilder"],
+    jvm_opts = [],
+)
+
+default_java_toolchain(
     name = "toolchain_hostjdk8",
     bootclasspath = [":platformclasspath"],
     forcibly_disable_header_compilation = True,


### PR DESCRIPTION
To use the latest supported language level from the --host_javabase, use
VanillaJavaBuilder (which should work with most host JDKs) and leave the
source/target/bootclasspath unset so they default to the latest
supported versions.

With this in place, new java_runtime can be used, e.g.:

  java_runtime(
      name = "jdk11",
      java_home = "/usr/lib64/jvm/java-11",
      visibility = ["//visibility:public"],
  )

Now the JDK11 can be used with the language level 11:

  $ bazel build --host_javabase=:jdk11 \
    --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla \
    --java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla \
    :a

Related: #5723