### PR TITLE
hide warning on macOS if no JDK is installed

### DIFF
--- a/src/main/cpp/blaze_util_darwin.cc
+++ b/src/main/cpp/blaze_util_darwin.cc
@@ -165,7 +165,8 @@ string GetSystemJavabase() {
     return java_home;
   }
 
-  FILE *output = popen("/usr/libexec/java_home -v 1.7+", "r");
+  // java_home will print a warning if no JDK could be found
+  FILE *output = popen("/usr/libexec/java_home -v 1.8+ 2> /dev/null", "r");
   if (output == NULL) {
     return "";
   }


### PR DESCRIPTION
On macOS Bazel calls /usr/libexec/java_home to detect the
system jdk (if any). This tool prints a warning if no system
jdk is installed:

> Unable to find any JVMs matching version "1.7+".
> No Java runtime present, try --request to install.

This patch hides this warning as Bazel ships with an embedded
JDK and does not require a system JDK installed. Additionally,
pump the version requirement to 1.8+ as this is the oldest JDK
version that Bazel can build for.