### PR TITLE
Delete duplicate "Build strategy options" header.

### DIFF
--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -1532,13 +1532,6 @@ the compilation of binaries during the build.
   --experimental_extra_action_filter=.*/bar/.*
 </pre>
 
-<h3 id='strategy-options'>Build strategy options</h3>
-<p>
-  Note that a particular combination of crosstool version, compiler version,
-  and target CPU is allowed only if it has been specified in the currently
-  used CROSSTOOL file.
-</p>
-
 <h4 id='flag--host_cpu'><code class='flag'>--host_cpu <var>cpu</var></code></h4>
 <p>
   This option specifies the name of the CPU architecture that should be


### PR DESCRIPTION
Also remove note about crosstool/compiler/cpu combinations, which seems to be duplicated with a note by the docs for the --compiler option.