### PR TITLE
Issue #3709: Better Invalid SHA256 checksum message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -121,7 +121,8 @@ public class HttpDownloader {
       }
       sha256 = Strings.nullToEmpty(mapper.get("sha256", Type.STRING));
       if (!sha256.isEmpty() && !RepositoryCache.KeyType.SHA256.isValid(sha256)) {
-        throw new EvalException(rule.getAttributeLocation("sha256"), "Invalid SHA256 checksum");
+        throw new EvalException(rule.getAttributeLocation("sha256"),
+                getChecksumErrorMessage(mapper.get("url", Type.STRING), sha256).toString());
       }
       type = Strings.nullToEmpty(mapper.get("type", Type.STRING));
     } catch (EvalException e) {
@@ -261,5 +262,17 @@ public class HttpDownloader {
       }
     }
     return output.getRelative(basename);
+  }
+
+  public static StringBuilder getChecksumErrorMessage(String url, String actualChecksum) {
+    StringBuilder message = new StringBuilder();
+    message.append("The SHA256 checksum specified in the WORKSPACE file does not match the SHA256\n"
+            + "checksum of the downloaded file. The checksum exists to ensure a secure build,\n"
+            + "since remote files can change. If the file is correct, update the SHA256 checksum.\n"
+            + "(\"sha256 = \") in your WORKSPACE file. Otherwise, this could be a security compromise.\n");
+    message.append("\nURL:\n" + url);
+    message.append("\nActual SHA26 (from WORKSPACE):\n" + actualChecksum + "\n is not valid\n");
+    return message;
+
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -327,7 +327,7 @@ public class SkylarkRepositoryContext
   public void download(
       Object url, Object output, String sha256, Boolean executable, Location location)
       throws RepositoryFunctionException, EvalException, InterruptedException {
-    validateSha256(sha256);
+    validateSha256(url.toString(), sha256);
     List<URL> urls = getUrls(url);
     SkylarkPath outputPath = getPath("download()", output);
     WorkspaceRuleEvent w =
@@ -359,7 +359,7 @@ public class SkylarkRepositoryContext
   public void downloadAndExtract(
       Object url, Object output, String sha256, String type, String stripPrefix, Location location)
       throws RepositoryFunctionException, InterruptedException, EvalException {
-    validateSha256(sha256);
+    validateSha256(url.toString(), sha256);
     List<URL> urls = getUrls(url);
 
     WorkspaceRuleEvent w =
@@ -414,10 +414,10 @@ public class SkylarkRepositoryContext
     }
   }
 
-  private static void validateSha256(String sha256) throws RepositoryFunctionException {
+  private static void validateSha256(String url, String sha256) throws RepositoryFunctionException {
     if (!sha256.isEmpty() && !KeyType.SHA256.isValid(sha256)) {
       throw new RepositoryFunctionException(
-          new IOException("Invalid SHA256 checksum"), Transience.TRANSIENT);
+          new IOException(HttpDownloader.getChecksumErrorMessage(url, sha256).toString()), Transience.TRANSIENT);
     }
   }
 

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -880,6 +880,14 @@ EOF
 }
 
 function test_sha256_weird() {
+  LOG='The SHA256 checksum specified in the WORKSPACE file does not match the SHA256
+checksum of the downloaded file. The checksum exists to ensure a secure build,
+since remote files can change. If the file is correct, update the SHA256 checksum.
+("sha256 = ") in your WORKSPACE file. Otherwise, this could be a security compromise.
+ URL:
+http://127.0.0.1:$fileserver_port/repo.zip
+ Actual SHA26 (from WORKSPACE):
+a random string is not valid'
   REPO_PATH=$TEST_TMPDIR/repo
   mkdir -p "$REPO_PATH"
   cd "$REPO_PATH"
@@ -897,7 +905,7 @@ http_archive(
 )
 EOF
   bazel build @repo//... &> $TEST_log && fail "Expected to fail"
-  expect_log "Invalid SHA256 checksum"
+  expect_log $LOG
   shutdown_server
 }
 


### PR DESCRIPTION
This is related to issue: #3709
I have updated the error message from "Invalid 256 checksum" to
"The SHA256 checksum specified in the WORKSPACE file does not match the SHA256
checksum of the downloaded file. The checksum exists to ensure a secure build,
since remote files can change. If the file is correct, update the SHA256 checksum.
("sha256 = ") in your WORKSPACE file. Otherwise, this could be a security compromise.

URL:
http://127.0.0.1:$fileserver_port/repo.zip

Actual SHA26 (from WORKSPACE):
a random string is not valid"

Updated the test case as well.