### PR TITLE
Support deploy_env in java_binary rule

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaBinaryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaBinaryRule.java
@@ -78,6 +78,16 @@ public final class BazelJavaBinaryRule implements RuleDefinition {
         </ul>
         <!-- #END_BLAZE_RULE.IMPLICIT_OUTPUTS --> */
         .setImplicitOutputsFunction(BazelJavaRuleClasses.JAVA_BINARY_IMPLICIT_OUTPUTS)
+        /* <!-- #BLAZE_RULE(java_binary).ATTRIBUTE(deploy_env) -->
+        A list of other <code>java_binary</code> targets which represent the deployment
+        environment for this binary.
+        Set this attribute when building a plugin which will be loaded by another
+        <code>java_binary</code>.<br/> Setting this attribute excludes all dependencies from
+        the runtime classpath (and the deploy jar) of this binary that are shared between this
+        binary and the targets specified in <code>deploy_env</code>.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(attr("deploy_env", LABEL_LIST).allowedRuleClasses("java_binary")
+            .allowedFileTypes(FileTypeSet.NO_FILE))
         .override(attr("$is_executable", BOOLEAN).nonconfigurable("automatic").value(
             new Attribute.ComputedDefault() {
               @Override


### PR DESCRIPTION
This adds support for `deploy_env`, an internal feature that supports transitive classpath subtraction to create deployable jars suited for different environments.
This PR cherrypicks @ulfjack's commit, as described in #1402, and will help with scenarios describe there, as well as #5856.
