### PR TITLE
[singlejar] Use Win32 API directly in OutputJar::AppendFile

### DIFF
--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -923,12 +923,15 @@ ssize_t OutputJar::AppendFile(int in_fd, off64_t offset, size_t count) {
   while (static_cast<size_t>(total_written) < count) {
     ssize_t len = std::min(kBufferSize, count - total_written);
     DWORD n_read;
-    if (!::ReadFile(hFile, buffer.get(), len, &n_read, NULL))
+    if (!::ReadFile(hFile, buffer.get(), len, &n_read, NULL)) {
       return -1;
-    if (n_read == 0)
+    }
+    if (n_read == 0) {
       break;
-    if (!WriteBytes(buffer.get(), n_read))
+    }
+    if (!WriteBytes(buffer.get(), n_read)) {
       return -1;
+    }
     total_written += n_read;
   }
 #else

--- a/src/tools/singlejar/port.cc
+++ b/src/tools/singlejar/port.cc
@@ -12,29 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef _WIN32
-
-#include "src/tools/singlejar/port.h"
-
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif  // WIN32_LEAN_AND_MEAN
-#include <windows.h>
-
-ssize_t pread(int fd, void *buf, size_t count, off64_t offset) {
-  DWORD ret = -1;
-  HANDLE hFile = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
-  if (hFile) {
-    OVERLAPPED overlap;
-    memset(&overlap, 0, sizeof(OVERLAPPED));
-    overlap.Offset = offset;
-    if (!::ReadFile(hFile, buf, count, &ret, &overlap)) {
-      // For this simple implementation, we don't update errno.
-      // Just return -1 as error.
-      return -1;
-    }
-  }
-  return ret;
-}
-
-#endif  // _WIN32
+// TODO(rongjiecomputer) Remove this file if it is still unused when the
+// porting work completes.

--- a/src/tools/singlejar/port.h
+++ b/src/tools/singlejar/port.h
@@ -59,10 +59,6 @@ inline tm* localtime_r(const time_t* tin, tm* tout) {
   return nullptr;
 }
 
-// Make sure that the file HANDLE associated with |fd| is created by CreateFile
-// with FILE_FLAG_OVERLAPPED flag for this function to work.
-ssize_t pread(int fd, void* buf, size_t count, off64_t offset);
-
 #endif  // _WIN32
 
 #endif  // BAZEL_SRC_TOOLS_SINGLEJAR_PORT_H_


### PR DESCRIPTION
`pread` is only used by `OutputJar::AppendFile`. Implementing `OutputJar::AppendFile` directly with Win32 API means better performance and no worry about whether `pread` polyfill follows POSIX spec correctly. 

Also remove unused `pread` polyfill.

See #2241