### PR TITLE
make_deb: Add new empty line in the end of conffiles file

### DIFF
--- a/tools/build_defs/pkg/make_deb.py
+++ b/tools/build_defs/pkg/make_deb.py
@@ -170,7 +170,7 @@ def CreateDeb(output,
   if postrm:
     extrafiles['postrm'] = (postrm, 0o755)
   if conffiles:
-    extrafiles['conffiles'] = ('\n'.join(conffiles), 0o644)
+    extrafiles['conffiles'] = ('\n'.join(conffiles) + '\n', 0o644)
   control = CreateDebControl(extrafiles=extrafiles, **kwargs)
 
   # Write the final AR archive (the deb package)


### PR DESCRIPTION
When generating the conffiles file, the trailing newline is forgotten. 

Update #6028 