### PR TITLE
[singlejar] WIP: Porting tests for Windows

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -160,13 +160,12 @@ py_binary(
             ":dummy_darwin_tools",
         ],
     }) + select({
-        # TODO(bazel-team): Once https://github.com/bazelbuild/bazel/issues/2241
-        # is resolved, use cc implementation of singlejar on windows
         "//src/conditions:windows": [
-            "//src/java_tools/singlejar:SingleJar_deploy.jar",
             "//src/tools/launcher:launcher",
             "//third_party/def_parser:def_parser",
         ],
+        "//conditions:default": [],
+    }) + select({
         "//src/conditions:arm": [
             "//src/java_tools/singlejar:SingleJar_deploy.jar",
         ],

--- a/src/create_embedded_tools.py
+++ b/src/create_embedded_tools.py
@@ -45,6 +45,7 @@ output_paths = [
     ('*ExperimentalRunner_deploy.jar',
      lambda x: 'tools/jdk/ExperimentalTestRunner_deploy.jar'),
     ('*Runner_deploy.jar', lambda x: 'tools/jdk/TestRunner_deploy.jar'),
+    ('*singlejar_local.exe', lambda x: 'tools/jdk/singlejar/singlejar.exe'),
     ('*singlejar_local', lambda x: 'tools/jdk/singlejar/singlejar'),
     ('*launcher.exe', lambda x: 'tools/launcher/launcher.exe'),
     ('*def_parser.exe', lambda x: 'tools/def_parser/def_parser.exe'),

--- a/src/test/java/com/google/devtools/build/lib/blackbox/bazel/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/bazel/BUILD
@@ -78,15 +78,11 @@ java_library(
     data = [
         ":langtools-copy",
         "//src/java_tools/junitrunner/java/com/google/testing/junit/runner:Runner_deploy.jar",
+        "//src/tools/singlejar:singlejar",
         "//third_party/ijar",
         "//third_party/java/jdk/langtools:test-srcs",
         "@bazel_tools//tools/jdk:current_java_runtime",
-    ] + select({
-        # TODO(bazel-team): Once https://github.com/bazelbuild/bazel/issues/2241
-        # is resolved, use cc implementation of singlejar on windows
-        "//src/conditions:windows": ["//src/java_tools/singlejar:SingleJar_deploy.jar"],
-        "//conditions:default": ["//src/tools/singlejar:singlejar"],
-    }),
+    ],
     visibility = [":tests"],
     deps = [
         ":common_tools_deps",

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -36,18 +36,14 @@ filegroup(
         "//src/test/shell:bin/bazel",
         "//src/test/shell:integration_test_setup.sh",
         "//src/test/shell:testenv.sh",
+        "//src/tools/singlejar:singlejar",
         "//third_party:srcs",
         "//third_party/ijar",
         "//third_party/java/jdk/langtools:test-srcs",
         "//tools:srcs",
         "@bazel_skylib//:test_deps",
         "@bazel_tools//tools/jdk:current_java_runtime",
-    ] + select({
-        # TODO(bazel-team): Once https://github.com/bazelbuild/bazel/issues/2241
-        # is resolved, use cc implementation of singlejar on windows
-        "//src/conditions:windows": ["//src/java_tools/singlejar:SingleJar_deploy.jar"],
-        "//conditions:default": ["//src/tools/singlejar:singlejar"],
-    }),
+    ],
     visibility = [
         "//src/test/shell:__subpackages__",
         "//src/tools/package_printer/java/com/google/devtools/build/packageprinter:__pkg__",

--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -2,13 +2,6 @@
 #   singlejar C++ implementation.
 package(default_visibility = ["//src:__subpackages__"])
 
-JAR_TOOL_PATH_COPT_TPL = "-DJAR_TOOL_PATH=\\\"external/local_jdk/bin/jar%s\\\""
-
-JAR_TOOL_PATH_COPTS = select({
-    "//src/conditions:windows": [JAR_TOOL_PATH_COPT_TPL % ".exe"],
-    "//conditions:default": [JAR_TOOL_PATH_COPT_TPL % ""],
-})
-
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
@@ -131,6 +124,7 @@ cc_test(
 
 cc_test(
     name = "input_jar_preambled_test",
+    size = "large",
     srcs = [
         "input_jar_preambled_test.cc",
     ],
@@ -152,7 +146,6 @@ cc_test(
         "input_jar_scan_entries_test.h",
         "input_jar_scan_jartool_test.cc",
     ],
-    copts = JAR_TOOL_PATH_COPTS,
     data = [
         "@local_jdk//:jar",
         "@local_jdk//:jdk",
@@ -224,7 +217,6 @@ cc_test(
     srcs = [
         "output_jar_simple_test.cc",
     ],
-    copts = JAR_TOOL_PATH_COPTS,
     data = [
         ":data1",
         ":data2",
@@ -232,12 +224,13 @@ cc_test(
         ":test1",
         ":test2",
         "@local_jdk//:jar",
-        "@local_jdk//:jdk-default",
+        "@local_jdk//:jdk",
     ],
     deps = [
         ":input_jar",
         ":options",
         ":output_jar",
+        ":port",
         ":test_util",
         "//src/main/cpp/util",
         "@com_google_googletest//:gtest_main",
@@ -413,8 +406,11 @@ cc_library(
     name = "test_util",
     srcs = ["test_util.cc"],
     hdrs = ["test_util.h"],
+    testonly = 1,
     deps = [
         "//src/main/cpp/util",
+        # TODO(laszlocsomor) Use @bazel_tools//tools/cpp/runfiles
+        "//tools/cpp/runfiles",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/tools/singlejar/combiners_test.cc
+++ b/src/tools/singlejar/combiners_test.cc
@@ -39,7 +39,9 @@ class CombinersTest : public ::testing::Test {
     ASSERT_EQ(0, system("zip -qm combiners.zip tag1.xml tag2.xml"));
   }
 
-  static void TearDownTestCase() { system("rm -f xmls.zip"); }
+  static void TearDownTestCase() {
+    remove("xmls.zip");
+  }
 
   static bool CreateFile(const char *filename, const char *contents) {
     FILE *fp = fopen(filename, "wb");

--- a/src/tools/singlejar/input_jar_empty_jar_test.cc
+++ b/src/tools/singlejar/input_jar_empty_jar_test.cc
@@ -25,7 +25,9 @@
  */
 
 #include <errno.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <memory>
 #include <string>
 
@@ -36,17 +38,14 @@
 #include "src/tools/singlejar/test_util.h"
 #include "googletest/include/gtest/gtest.h"
 
+using bazel::tools::cpp::runfiles::Runfiles;
 using singlejar_test_util::OutputFilePath;
 using singlejar_test_util::AllocateFile;
 using singlejar_test_util::RunCommand;
 
 namespace {
 
-#if !defined(DATA_DIR_TOP)
-#define DATA_DIR_TOP
-#endif
-
-const char kEmptyJar[] = DATA_DIR_TOP "src/tools/singlejar/data/empty.zip";
+const char kEmptyJar[] = "io_bazel/src/tools/singlejar/data/empty.zip";
 
 void VerifyEmpty(const std::string &jar_path) {
   InputJar input_jar;
@@ -61,14 +60,19 @@ void VerifyEmpty(const std::string &jar_path) {
 
 // Check that empty zip file (i.e., a valid zip file with no entries) is
 // handled correctly.
-TEST(InputJarBadjarTest, EmptyZipFile) { VerifyEmpty(kEmptyJar); }
+TEST(InputJarBadjarTest, EmptyZipFile) {
+  std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest());
+  VerifyEmpty(runfiles->Rlocation(kEmptyJar).c_str());
+}
 
 // Preambled empty zip.
 TEST(InputJarPreambledTest, Empty) {
+  std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest());
   std::string out_path = OutputFilePath("empty.jwp");
   std::string exe_path = OutputFilePath("exe");
   ASSERT_TRUE(AllocateFile(exe_path, 100));
-  ASSERT_EQ(0, RunCommand("cat", exe_path.c_str(), kEmptyJar, ">",
+  ASSERT_EQ(0, RunCommand("cat", exe_path.c_str(),
+                          runfiles->Rlocation(kEmptyJar).c_str(), ">",
                           out_path.c_str(), nullptr));
   VerifyEmpty(out_path);
 }

--- a/src/tools/singlejar/input_jar_preambled_test.cc
+++ b/src/tools/singlejar/input_jar_preambled_test.cc
@@ -25,7 +25,9 @@
  */
 
 #include <errno.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <memory>
 #include <string>
 
@@ -38,9 +40,7 @@
 
 namespace {
 
-#if !defined(DATA_DIR_TOP)
-#define DATA_DIR_TOP
-#endif
+using bazel::tools::cpp::runfiles::Runfiles;
 
 void Verify(const std::string &path) {
   InputJar input_jar;
@@ -65,29 +65,31 @@ void Verify(const std::string &path) {
 
 // Archive not containing 64-bit End of Central Directory/Locator with preamble.
 TEST(InputJarPreambledTest, Small) {
+  std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest());
   std::string out_path = singlejar_test_util::OutputFilePath("out.jwp");
   std::string exe_path = singlejar_test_util::OutputFilePath("exe");
   ASSERT_TRUE(singlejar_test_util::AllocateFile(exe_path, 100));
-  ASSERT_EQ(
-      0,
-      singlejar_test_util::RunCommand(
-          "cat", exe_path.c_str(),
-          DATA_DIR_TOP "src/tools/singlejar/libtest1.jar",
-          ">", out_path.c_str(), nullptr));
+  ASSERT_EQ(0,
+            singlejar_test_util::RunCommand(
+                "cat", exe_path.c_str(),
+                runfiles->Rlocation("io_bazel/src/tools/singlejar/libtest1.jar")
+                    .c_str(),
+                ">", out_path.c_str(), nullptr));
   Verify(out_path);
 }
 
 // Same as above with zip -A applied to the file.
 TEST(InputJarPreambledTest, SmallAdjusted) {
+  std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest());
   std::string out_path = singlejar_test_util::OutputFilePath("out.jwp");
   std::string exe_path = singlejar_test_util::OutputFilePath("exe");
   ASSERT_TRUE(singlejar_test_util::AllocateFile(exe_path, 100));
-  ASSERT_EQ(
-      0,
-      singlejar_test_util::RunCommand(
-          "cat", exe_path.c_str(),
-          DATA_DIR_TOP "src/tools/singlejar/libtest1.jar",
-          ">", out_path.c_str(), nullptr));
+  ASSERT_EQ(0,
+            singlejar_test_util::RunCommand(
+                "cat", exe_path.c_str(),
+                runfiles->Rlocation("io_bazel/src/tools/singlejar/libtest1.jar")
+                    .c_str(),
+                ">", out_path.c_str(), nullptr));
   ASSERT_EQ(0, singlejar_test_util::RunCommand("zip", "-A", out_path.c_str(),
                                                nullptr));
   Verify(out_path);

--- a/src/tools/singlejar/input_jar_scan_jartool_test.cc
+++ b/src/tools/singlejar/input_jar_scan_jartool_test.cc
@@ -14,29 +14,37 @@
 
 /* Verify that InputJar can scan zip/jar files created by JDK's jar tool.  */
 
+#include "src/tools/singlejar/port.h"
+
 #include <stdarg.h>
 #include <stdlib.h>
 
 #include "src/tools/singlejar/input_jar_scan_entries_test.h"
 
-#if !defined(JAR_TOOL_PATH)
-#error "The path to jar tool has to be defined via -DJAR_TOOL_PATH="
+#ifdef _WIN32
+const char JAR_TOOL_PATH[] = "local_jdk/bin/jar.exe";
+#else
+const char JAR_TOOL_PATH[] = "local_jdk/bin/jar";
 #endif
+
+using bazel::tools::cpp::runfiles::Runfiles;
 
 class JartoolCreator {
  public:
   static void SetUpTestCase() {
-    jar_path_ = realpath(JAR_TOOL_PATH, nullptr);
+    std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest());
+    static std::string jar_path_str = runfiles->Rlocation(JAR_TOOL_PATH);
+    jar_path_ = jar_path_str.c_str();
     if (!jar_path_) {
       // At least show what's available.
+#ifndef _WIN32
       system("ls -1R");
+#endif
     }
     ASSERT_NE(nullptr, jar_path_);
   }
 
-  static void TearDownTestCase() {
-    free(jar_path_);
-  }
+  static void TearDownTestCase() {}
 
   static int Jar(bool compress, const char *output_jar, ...) {
     std::string command(jar_path_);
@@ -55,10 +63,10 @@ class JartoolCreator {
     }
     return system(command.c_str());
   }
-  static char * jar_path_;
+  static const char* jar_path_;
 };
 
-char *JartoolCreator::jar_path_;
+const char* JartoolCreator::jar_path_ = nullptr;
 
 typedef testing::Types<JartoolCreator> Creators;
 INSTANTIATE_TYPED_TEST_CASE_P(Jartool, InputJarScanEntries, Creators);

--- a/src/tools/singlejar/output_huge_jar_test.cc
+++ b/src/tools/singlejar/output_huge_jar_test.cc
@@ -26,18 +26,19 @@
 
 namespace {
 
+using bazel::tools::cpp::runfiles::Runfiles;
 using singlejar_test_util::AllocateFile;
 using singlejar_test_util::OutputFilePath;
 using singlejar_test_util::VerifyZip;
 
 using std::string;
 
-#if !defined(DATA_DIR_TOP)
-#define DATA_DIR_TOP
-#endif
-
 class OutputHugeJarTest : public ::testing::Test {
  protected:
+  void SetUp() override {
+    runfiles.reset(Runfiles::CreateForTest());
+  }
+
   void CreateOutput(const string &out_path, const std::vector<string> &args) {
     const char *option_list[100] = {"--output", out_path.c_str()};
     int nargs = 2;
@@ -60,6 +61,7 @@ class OutputHugeJarTest : public ::testing::Test {
 
   OutputJar output_jar_;
   Options options_;
+  std::unique_ptr<Runfiles> runfiles;
 };
 
 TEST_F(OutputHugeJarTest, EntryAbove4G) {
@@ -70,8 +72,10 @@ TEST_F(OutputHugeJarTest, EntryAbove4G) {
   ASSERT_TRUE(AllocateFile(launcher_path, 0x100000010));
 
   string out_path = OutputFilePath("out.jar");
-  CreateOutput(out_path, {"--java_launcher", launcher_path, "--sources",
-                          DATA_DIR_TOP "src/tools/singlejar/libtest1.jar"});
+  CreateOutput(out_path,
+               {"--java_launcher", launcher_path, "--sources",
+                runfiles->Rlocation("io_bazel/src/tools/singlejar/libtest1.jar")
+                    .c_str()});
 }
 
 }  // namespace

--- a/src/tools/singlejar/output_jar_simple_test.cc
+++ b/src/tools/singlejar/output_jar_simple_test.cc
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 #include <stdlib.h>
+#include <stdio.h>
+
+// Must be included before anything else.
+#include "src/tools/singlejar/port.h"
 
 #include "src/main/cpp/util/file.h"
 #include "src/main/cpp/util/port.h"
@@ -23,12 +27,16 @@
 #include "src/tools/singlejar/test_util.h"
 #include "googletest/include/gtest/gtest.h"
 
-#if !defined(JAR_TOOL_PATH)
-#error "The path to jar tool has to be defined via -DJAR_TOOL_PATH="
+#ifdef _WIN32
+const char JAR_TOOL_PATH[] = "local_jdk/bin/jar.exe";
+#define unlink _unlink
+#else
+const char JAR_TOOL_PATH[] = "local_jdk/bin/jar";
 #endif
 
 namespace {
 
+using bazel::tools::cpp::runfiles::Runfiles;
 using singlejar_test_util::CreateTextFile;
 using singlejar_test_util::GetEntryContents;
 using singlejar_test_util::GetEntryContents;
@@ -38,12 +46,8 @@ using singlejar_test_util::VerifyZip;
 
 using std::string;
 
-#if !defined(DATA_DIR_TOP)
-#define DATA_DIR_TOP
-#endif
-
-const char kPathLibData1[] = DATA_DIR_TOP "src/tools/singlejar/libdata1.jar";
-const char kPathLibData2[] = DATA_DIR_TOP "src/tools/singlejar/libdata2.jar";
+const char kPathLibData1[] = "io_bazel/src/tools/singlejar/libdata1.jar";
+const char kPathLibData2[] = "io_bazel/src/tools/singlejar/libdata2.jar";
 
 static bool HasSubstr(const string &s, const string &what) {
   return string::npos != s.find(what);
@@ -72,6 +76,10 @@ class CustomOutputJar : public OutputJar {
 
 class OutputJarSimpleTest : public ::testing::Test {
  protected:
+  void SetUp() override {
+    runfiles.reset(Runfiles::CreateForTest());
+  }
+
   void CreateOutput(const string &out_path, const std::vector<string> &args) {
     const char *option_list[100] = {"--output", out_path.c_str()};
     int nargs = 2;
@@ -96,17 +104,20 @@ class OutputJarSimpleTest : public ::testing::Test {
     string cp_res_path =
         CreateTextFile("cp_res", "line1\nline2\nline3\nline4\n");
     string out_path = OutputFilePath("out.jar");
-    CreateOutput(out_path,
-                 {compression_option, "--sources",
-                  DATA_DIR_TOP "src/tools/singlejar/libtest1.jar",
-                  DATA_DIR_TOP "src/tools/singlejar/stored.jar", "--resources",
-                  cp_res_path, "--deploy_manifest_lines", "property1: value1",
-                  "property2: value2"});
+    CreateOutput(
+        out_path,
+        {compression_option, "--sources",
+         runfiles->Rlocation("io_bazel/src/tools/singlejar/libtest1.jar")
+             .c_str(),
+         runfiles->Rlocation("io_bazel/src/tools/singlejar/stored.jar").c_str(),
+         "--resources", cp_res_path, "--deploy_manifest_lines",
+         "property1: value1", "property2: value2"});
     return out_path;
   }
 
   OutputJar output_jar_;
   Options options_;
+  std::unique_ptr<Runfiles> runfiles;
 };
 
 // No inputs at all.
@@ -194,9 +205,12 @@ TEST_F(OutputJarSimpleTest, Empty) {
 // Source jars.
 TEST_F(OutputJarSimpleTest, Source) {
   string out_path = OutputFilePath("out.jar");
-  CreateOutput(out_path,
-               {"--sources", DATA_DIR_TOP "src/tools/singlejar/libtest1.jar",
-                DATA_DIR_TOP "src/tools/singlejar/libtest2.jar"});
+  CreateOutput(
+      out_path,
+      {"--sources",
+       runfiles->Rlocation("io_bazel/src/tools/singlejar/libtest1.jar").c_str(),
+       runfiles->Rlocation("io_bazel/src/tools/singlejar/libtest2.jar")
+           .c_str()});
   InputJar input_jar;
   ASSERT_TRUE(input_jar.Open(out_path));
   const LH *lh;
@@ -224,7 +238,8 @@ TEST_F(OutputJarSimpleTest, Source) {
 // Verify --java_launcher argument
 TEST_F(OutputJarSimpleTest, JavaLauncher) {
   string out_path = OutputFilePath("out.jar");
-  const char *launcher_path = DATA_DIR_TOP "src/tools/singlejar/libtest1.jar";
+  std::string launcher_path =
+      runfiles->Rlocation("io_bazel/src/tools/singlejar/libtest1.jar");
   CreateOutput(out_path, {"--java_launcher", launcher_path});
   // check that the offset of the first entry equals launcher size.
   InputJar input_jar;
@@ -234,7 +249,7 @@ TEST_F(OutputJarSimpleTest, JavaLauncher) {
   cdh = input_jar.NextEntry(&lh);
   ASSERT_NE(nullptr, cdh);
   struct stat statbuf;
-  ASSERT_EQ(0, stat(launcher_path, &statbuf));
+  ASSERT_EQ(0, stat(launcher_path.c_str(), &statbuf));
   EXPECT_TRUE(cdh->is());
   EXPECT_TRUE(lh->is());
   EXPECT_EQ(statbuf.st_size, cdh->local_header_offset());
@@ -438,9 +453,11 @@ TEST_F(OutputJarSimpleTest, ExtraHandler) {
 // --include_headers
 TEST_F(OutputJarSimpleTest, IncludeHeaders) {
   string out_path = OutputFilePath("out.jar");
-  CreateOutput(out_path,
-               {"--sources", DATA_DIR_TOP "src/tools/singlejar/libtest1.jar",
-                kPathLibData1, "--include_prefixes", "tools/singlejar/data"});
+  CreateOutput(
+      out_path,
+      {"--sources",
+       runfiles->Rlocation("io_bazel/src/tools/singlejar/libtest1.jar").c_str(),
+       kPathLibData1, "--include_prefixes", "tools/singlejar/data"});
   std::vector<string> expected_entries(
       {"META-INF/", "META-INF/MANIFEST.MF", "build-data.properties",
        "tools/singlejar/data/", "tools/singlejar/data/extra_file1",
@@ -467,14 +484,13 @@ TEST_F(OutputJarSimpleTest, Normalize) {
   string out_path = OutputFilePath("out.jar");
   string testjar_path = OutputFilePath("testinput.jar");
   {
-    char *jar_tool_path = realpath(JAR_TOOL_PATH, nullptr);
+    std::string jar_tool_path = runfiles->Rlocation(JAR_TOOL_PATH);
     string textfile_path = CreateTextFile("jar_testinput.txt", "jar_inputtext");
     string classfile_path = CreateTextFile("JarTestInput.class", "Dummy");
     unlink(testjar_path.c_str());
     ASSERT_EQ(
-        0, RunCommand(jar_tool_path, "-cf", testjar_path.c_str(),
+        0, RunCommand(jar_tool_path.c_str(), "-cf", testjar_path.c_str(),
                       textfile_path.c_str(), classfile_path.c_str(), nullptr));
-    free(jar_tool_path);
   }
 
   string testzip_path = OutputFilePath("testinput.zip");
@@ -497,11 +513,12 @@ TEST_F(OutputJarSimpleTest, Normalize) {
   //  * protobuf.meta
   //  * extra combiner
 
-  CreateOutput(out_path,
-               {"--normalize", "--sources",
-                DATA_DIR_TOP "src/tools/singlejar/libtest1.jar", testjar_path,
-                testzip_path, "--resources", resource_path,
-                "--classpath_resources", cp_resource_path});
+  CreateOutput(
+      out_path,
+      {"--normalize", "--sources",
+       runfiles->Rlocation("io_bazel/src/tools/singlejar/libtest1.jar").c_str(),
+       testjar_path, testzip_path, "--resources", resource_path,
+       "--classpath_resources", cp_resource_path});
 
   // Scan all entries, verify that *.class entries have timestamp
   // 01/01/2010 00:00:02 and the rest have the timestamp of 01/01/2010 00:00:00.
@@ -640,8 +657,8 @@ TEST_F(OutputJarSimpleTest, DontChangeCompressionOption) {
   ASSERT_TRUE(input_jar.Open(out_path));
   const LH *lh;
   const CDH *cdh;
-  const char kStoredEntry[] =
-      DATA_DIR_TOP "src/tools/singlejar/output_jar.cc";
+  std::string kStoredEntry =
+      runfiles->Rlocation("io_bazel/src/tools/singlejar/output_jar.cc");
 
   while ((cdh = input_jar.NextEntry(&lh))) {
     string entry_name = lh->file_name_string();
@@ -707,10 +724,12 @@ TEST_F(OutputJarSimpleTest, Nocompress) {
   string res2_path =
       CreateTextFile("resource.bar", "line1\nline2\nline3\nline4\n");
   string out_path = OutputFilePath("out.jar");
-  CreateOutput(out_path,
-               {"--compression", "--sources",
-                DATA_DIR_TOP "src/tools/singlejar/libtest1.jar", "--resources",
-                res1_path, res2_path, "--nocompress_suffixes", ".foo", ".h"});
+  CreateOutput(
+      out_path,
+      {"--compression", "--sources",
+       runfiles->Rlocation("io_bazel/src/tools/singlejar/libtest1.jar").c_str(),
+       "--resources", res1_path, res2_path, "--nocompress_suffixes", ".foo",
+       ".h"});
   InputJar input_jar;
   ASSERT_TRUE(input_jar.Open(out_path));
   const LH *lh;

--- a/src/tools/singlejar/test_util.h
+++ b/src/tools/singlejar/test_util.h
@@ -14,8 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <unistd.h>
 #include <string>
+
+#include "tools/cpp/runfiles/runfiles_src.h"
 
 namespace singlejar_test_util {
   using std::string;

--- a/src/tools/singlejar/transient_bytes.h
+++ b/src/tools/singlejar/transient_bytes.h
@@ -129,6 +129,13 @@ class TransientBytes {
     }
 
     // Smog check
+    // This check is disabled on Windows because z_stream::total_out is of type
+    // of uLong (unsigned long), which is 64-bit for most 64-bit Unix platforms,
+    // but it is 32-bit even for Win64. This means even though zlib is capable
+    // of compressing data >4GB as long as it is processed by chunks, zlib
+    // cannot report the correct total number of processed bytes >4GB through
+    // z_stream::total_out on Windows.
+#ifndef _WIN32
     if (inflater->total_out() - old_total_out != out_bytes) {
       diag_errx(2,
                 "%s:%d: Internal error inflating %.*s: inflater wrote %" PRIu64
@@ -137,6 +144,7 @@ class TransientBytes {
                 __FILE__, __LINE__, lh->file_name_length(), lh->file_name(),
                 inflater->total_out() - old_total_out, out_bytes);
     }
+#endif
     inflater->reset();
   }
 

--- a/src/tools/singlejar/transient_bytes_test.cc
+++ b/src/tools/singlejar/transient_bytes_test.cc
@@ -24,6 +24,12 @@
 #include "src/tools/singlejar/transient_bytes.h"
 #include "googletest/include/gtest/gtest.h"
 
+#ifdef _MSC_VER
+#define SINGLEJAR_ALYWAYS_INLINE __forceinline
+#else
+#define SINGLEJAR_ALYWAYS_INLINE __attribute__((always_inline))
+#endif
+
 namespace {
 const char kStoredJar[] = "stored.zip";
 const char kCompressedJar[] = "compressed.zip";
@@ -65,7 +71,7 @@ class TransientBytesTest : public ::testing::Test {
 
   // The value of the byte at a given position in a file created by the
   // CreateFile method below.
-  static __attribute__((always_inline)) uint8_t file_byte_at(uint64_t offset) {
+  static SINGLEJAR_ALYWAYS_INLINE uint8_t file_byte_at(uint64_t offset) {
     // return offset >> (8 * (offset & 7));
     return offset & 255;
   }

--- a/tools/android/BUILD.tools
+++ b/tools/android/BUILD.tools
@@ -77,35 +77,6 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-java_import(
-    name = "singlejar_deploy",
-    jars = select({
-        "//src/conditions:windows": ["@bazel_tools//tools/jdk:singlejar"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:private"],
-)
-
-java_binary(
-    name = "singlejar_javabin",
-    main_class = "com.google.devtools.build.singlejar.SingleJar",
-    runtime_deps = select({
-        "//src/conditions:windows": [":singlejar_deploy"],
-        "//conditions:default": [],
-    }),
-    visibility = ["//visibility:private"],
-)
-
-gen_java_lang_extras_jar_cmd = """
-    $(location %s) \
-        --exclude_build_data \
-        --dont_change_compression \
-        --sources  $(location @bazel_tools//tools/jdk:platformclasspath) \
-        --include_prefixes "java/lang/invoke/" \
-        --include_prefixes "java/lang/annotation/" \
-        --output $@
-    """
-
 # javac needs this Jar to compile lambdas, method references, and type annotations.
 # These classes are not part of the android.jar.
 genrule(
@@ -113,15 +84,16 @@ genrule(
     srcs = [
         "@bazel_tools//tools/jdk:platformclasspath"
     ],
-    tools = select({
-        "//src/conditions:windows": [":singlejar_javabin"],
-        "//conditions:default": ["@bazel_tools//tools/jdk:singlejar"],
-    }),
+    tools = ["@bazel_tools//tools/jdk:singlejar"],
     outs = ["java_lang_extras.jar"],
-    cmd = select({
-        "//src/conditions:windows": gen_java_lang_extras_jar_cmd % ":singlejar_javabin",
-        "//conditions:default": gen_java_lang_extras_jar_cmd % "@bazel_tools//tools/jdk:singlejar",
-    }),
+    cmd = """
+    $(location @bazel_tools//tools/jdk:singlejar) \
+        --exclude_build_data \
+        --dont_change_compression \
+        --sources  $(location @bazel_tools//tools/jdk:platformclasspath) \
+        --include_prefixes "java/lang/invoke/" \
+        --include_prefixes "java/lang/annotation/" \
+        --output $@""",
     visibility = ["//visibility:private"],
 )
 

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -106,20 +106,8 @@ filegroup(
 filegroup(
     name = "singlejar",
     srcs = select({
-        "//src/conditions:remote": [":singlejar_remote"],
+        "//src/conditions:remote": ["//src/tools/singlejar:singlejar"],
         "//conditions:default": glob(["singlejar/*"]),
-    }),
-)
-
-# This is a separate filegroup from :singlejar above since Bazel doesn't
-# support nested selects (we need a logical "remote AND windows" condition).
-filegroup(
-    name = "singlejar_remote",
-    srcs = select({
-        # TODO(jsharpe): Switch to //src/tools/singlejar:singlejar once
-        # native singlejar works on Windows.
-        "//src/conditions:windows": glob(["singlejar/*"]),
-        "//conditions:default": ["//src/tools/singlejar:singlejar"],
     }),
 )
 


### PR DESCRIPTION
This is to facilitate some discussion only. It is not yet ready for viewing.

How to navigate through this PR: starts from `src/tools/singlejar/test_util.h`, then `src/tools/singlejar/test_util.cc`, then the rest of the test files.

Summary:

1. Add new util function `singlejar_test_util::JoinFile`.

Many `singlejar_test_util::RunCommand` calls simply invoke `cat` to concatenate a few files into one. `singlejar_test_util::JoinFile` is 

2. Many tests rely on `zip` and `unzip` to be present.

Currently `cc_test` runs in bash, so many calls of `singlejar_test_util::RunCommand` and `system(cmd)` that uses `zip` and `unzip` actually just work even on Windows. However, these tests will break when tests no longer run in bash environment on Windows.

3. Use Bazel C++ Runfiles library.

Original tests use `DATA_DIR_TOP "hard/coded/path"` to figure out where are the data files. They are migrated to use Bazel C++ Runfiles object to do that. Tests will access the Runfiles object through a pointer `singlejar_test_util::Runfiles* runfiles` in global scope. It is initialized in `int main` before setting out gtest and test running.