### PR TITLE
test execution: close before attempting to delete

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -299,19 +299,19 @@ public class StandaloneTestStrategy extends TestStrategy {
       throws IOException, ExecException, InterruptedException {
     prepareFileSystem(action, tmpDir, coverageDir, workingDirectory);
 
-    try (FileOutErr fileOutErr =
-        new FileOutErr(
-            actionExecutionContext.getInputPath(action.getTestLog()),
-            action.resolve(execRoot).getTestStderr())) {
-      StandaloneTestResult standaloneTestResult =
+    Path out = actionExecutionContext.getInputPath(action.getTestLog());
+    Path err = action.resolve(execRoot).getTestStderr();
+    StandaloneTestResult standaloneTestResult = null;
+    try (FileOutErr fileOutErr = new FileOutErr(out, err)) {
+      standaloneTestResult =
           executeTest(action, spawn, actionExecutionContext.withFileOutErr(fileOutErr));
-      appendStderr(fileOutErr.getOutputPath(), fileOutErr.getErrorPath());
       if (!fileOutErr.hasRecordedOutput()) {
         // Touch the output file so that test.log can get created.
         FileSystemUtils.touchFile(fileOutErr.getOutputPath());
       }
-      return standaloneTestResult;
     }
+    appendStderr(out, err);
+    return standaloneTestResult;
   }
 
   private Map<String, String> setupEnvironment(


### PR DESCRIPTION
On Windows, attempting do delete open files will
fail with ERROR_ACCESS_DENIED.

This commit fixes one location where the code
attempted to delete (in appendStderr) a file that
had an open stream (in fileOutErr).

I found this bug while experimenting with the
Windows-native test wrapper, see https://github.com/bazelbuild/bazel/issues/5508

Change-Id: I91937847a06a6fa59202f59decbd587a242c94b1