### PR TITLE
C++,runfiles: avoid collision with @bazel_tools

### DIFF
--- a/src/create_embedded_tools.py
+++ b/src/create_embedded_tools.py
@@ -32,7 +32,7 @@ output_paths = [
     ('*tools/platforms/platforms.BUILD', lambda x: 'platforms/BUILD'),
     ('*tools/platforms/*', lambda x: 'platforms/' + os.path.basename(x)),
     ('*tools/cpp/runfiles/*',
-     lambda x: 'tools/cpp/runfiles/' + os.path.basename(x)),
+     lambda x: 'tools/cpp/runfiles/' + os.path.basename(x)[len('generated_'):]),
     ('*JavaBuilder*_deploy.jar', lambda x: 'tools/jdk/' + os.path.basename(x)),
     ('*JacocoCoverage*_deploy.jar',
      lambda x: 'tools/jdk/JacocoCoverage_deploy.jar'),

--- a/src/create_embedded_tools.py
+++ b/src/create_embedded_tools.py
@@ -31,7 +31,7 @@ output_paths = [
     ('*tools/jdk/BUILD*', lambda x: 'tools/jdk/BUILD'),
     ('*tools/platforms/platforms.BUILD', lambda x: 'platforms/BUILD'),
     ('*tools/platforms/*', lambda x: 'platforms/' + os.path.basename(x)),
-    ('*tools/cpp/runfiles/*',
+    ('*tools/cpp/runfiles/generated_*',
      lambda x: 'tools/cpp/runfiles/' + os.path.basename(x)[len('generated_'):]),
     ('*JavaBuilder*_deploy.jar', lambda x: 'tools/jdk/' + os.path.basename(x)),
     ('*JacocoCoverage*_deploy.jar',

--- a/tools/cpp/runfiles/BUILD
+++ b/tools/cpp/runfiles/BUILD
@@ -28,13 +28,13 @@ genrule(
         "runfiles_src.h",
     ],
     outs = [
-        "runfiles.cc",
-        "runfiles.h",
+        "generated_runfiles.cc",
+        "generated_runfiles.h",
     ],
     cmd = ("sed " +
            "  's|^#include.*/runfiles_src.h.*|#include \"tools/cpp/runfiles/runfiles.h\"|' " +
-           "  $(location runfiles_src.cc) > $(location runfiles.cc) && " +
-           "cp $(location runfiles_src.h) $(location runfiles.h)"),
+           "  $(location runfiles_src.cc) > $(location generated_runfiles.cc) && " +
+           "cp $(location runfiles_src.h) $(location generated_runfiles.h)"),
 )
 
 cc_library(


### PR DESCRIPTION
Rename outputs of
//tools/cpp/runfiles:srcs_for_embedded_tools so
that none of the targets in //tools/cpp/runfiles
package are called runfiles.cc or runfiles.h .

This is necessary to avoid the C++ compiler
picking up the wrong header file when a target
depends on @bazel_tools//tools/cpp/runfiles and
its source file includes
"tools/cpp/runfiles/runfiles.h", but the same file
is also available under bazel-genfiles (from a
past build of :srcs_for_embedded_tools).