### PR TITLE
Make system bazelrc configurable

### DIFF
--- a/src/main/cpp/option_processor.h
+++ b/src/main/cpp/option_processor.h
@@ -56,6 +56,10 @@ class OptionProcessor {
   OptionProcessor(const WorkspaceLayout* workspace_layout,
                   std::unique_ptr<StartupOptions> default_startup_options);
 
+  OptionProcessor(const WorkspaceLayout* workspace_layout,
+                  std::unique_ptr<StartupOptions> default_startup_options,
+                  const std::string& system_bazelrc_path);
+
   virtual ~OptionProcessor() {}
 
   // Splits the arguments of a command line invocation.
@@ -144,6 +148,8 @@ class OptionProcessor {
   // The startup options parsed from args, this field is initialized by
   // ParseOptions.
   std::unique_ptr<StartupOptions> parsed_startup_options_;
+
+  const std::string system_bazelrc_path_;
 };
 
 // Parses and returns the contents of the rc file.

--- a/src/main/cpp/option_processor.h
+++ b/src/main/cpp/option_processor.h
@@ -149,6 +149,8 @@ class OptionProcessor {
   // ParseOptions.
   std::unique_ptr<StartupOptions> parsed_startup_options_;
 
+  // Path to the system-wide bazelrc configuration file.
+  // This is configurable for testing purposes only.
   const std::string system_bazelrc_path_;
 };
 


### PR DESCRIPTION
The master bazelrc is now a member of OptionProcessor and is
configurable by the constructor. This fixes a heap-use-after-free,
introduced in bccf9c63ff0863e3ffb4fb24085a37a03db10aaa. Fixes #6054.

TESTED: bazel test //src/test/cpp:rc_file_test \
            --copt="-fsanitize=address" \
            --linkopt="-fsanitize=address"