### PR TITLE
Windows, launcher: Make launcher aware of if runfiles tree is enabled

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaSemantics.java
@@ -421,6 +421,8 @@ public class BazelJavaSemantics implements JavaSemantics {
         LaunchInfo.builder()
             .addKeyValuePair("binary_type", "Java")
             .addKeyValuePair("workspace_name", ruleContext.getWorkspaceName())
+            .addKeyValuePair("symlink_runfiles_enabled",
+                ruleContext.getConfiguration().runfilesEnabled() ? "1" : "0")
             .addKeyValuePair("java_bin_path", javaExecutable)
             .addKeyValuePair(
                 "jar_bin_path",

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
@@ -227,6 +227,8 @@ public class BazelPythonSemantics implements PythonSemantics {
         LaunchInfo.builder()
             .addKeyValuePair("binary_type", "Python")
             .addKeyValuePair("workspace_name", ruleContext.getWorkspaceName())
+            .addKeyValuePair("symlink_runfiles_enabled",
+                ruleContext.getConfiguration().runfilesEnabled() ? "1" : "0")
             .addKeyValuePair("python_bin_path", pythonBinary)
             .addKeyValuePair("use_zip_file", useZipFile ? "1" : "0")
             .build();

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/ShBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/ShBinary.java
@@ -122,6 +122,8 @@ public class ShBinary implements RuleConfiguredTargetFactory {
         LaunchInfo.builder()
             .addKeyValuePair("binary_type", "Bash")
             .addKeyValuePair("workspace_name", ruleContext.getWorkspaceName())
+            .addKeyValuePair("symlink_runfiles_enabled",
+                ruleContext.getConfiguration().runfilesEnabled() ? "1" : "0")
             .addKeyValuePair("bash_bin_path", shExecutable.getPathString())
             .build();
 

--- a/src/tools/launcher/launcher.cc
+++ b/src/tools/launcher/launcher.cc
@@ -53,7 +53,8 @@ BinaryLauncherBase::BinaryLauncherBase(
     : launch_info(_launch_info),
       manifest_file(FindManifestFile(argv[0])),
       runfiles_dir(GetRunfilesDir(argv[0])),
-      workspace_name(GetLaunchInfoByKey(WORKSPACE_NAME)) {
+      workspace_name(GetLaunchInfoByKey(WORKSPACE_NAME)),
+      symlink_runfiles_enabled(GetLaunchInfoByKey(SYMLINK_RUNFILES_ENABLED) == L"1") {
   for (int i = 0; i < argc; i++) {
     commandline_arguments.push_back(argv[i]);
   }
@@ -226,11 +227,15 @@ ExitCode BinaryLauncherBase::LaunchProcess(const wstring& executable,
   if (PrintLauncherCommandLine(executable, arguments)) {
     return 0;
   }
-  if (!manifest_file.empty()) {
+  // Set RUNFILES_DIR if:
+  //   1. Symlink runfiles tree is enabled, or
+  //   2. We couldn't find manifest file (which probably means we are running remotely).
+  // Otherwise, set RUNFILES_MANIFEST_ONLY and RUNFILES_MANIFEST_FILE
+  if (symlink_runfiles_enabled || manifest_file.empty()) {
+    SetEnv(L"RUNFILES_DIR", runfiles_dir);
+  } else {
     SetEnv(L"RUNFILES_MANIFEST_ONLY", L"1");
     SetEnv(L"RUNFILES_MANIFEST_FILE", manifest_file);
-  } else {
-    SetEnv(L"RUNFILES_DIR", runfiles_dir);
   }
   CmdLine cmdline;
   CreateCommandLine(&cmdline, executable, arguments);

--- a/src/tools/launcher/launcher.h
+++ b/src/tools/launcher/launcher.h
@@ -26,6 +26,7 @@ namespace launcher {
 
 typedef int32_t ExitCode;
 static constexpr const char* WORKSPACE_NAME = "workspace_name";
+static constexpr const char* SYMLINK_RUNFILES_ENABLED = "symlink_runfiles_enabled";
 
 // The maximum length of lpCommandLine is 32768 characters.
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx
@@ -101,6 +102,9 @@ class BinaryLauncherBase {
 
   // A map to store all entries of the manifest file.
   ManifestFileMap manifest_file_map;
+
+  // If symlink runfiles tree is enabled, this value is true.
+  const bool symlink_runfiles_enabled;
 
   // If --print_launcher_command is presented in arguments,
   // then print the command line.


### PR DESCRIPTION
The Windows launcher will no longer set `RUNFILES_MANIFEST_ONLY` to `1` when symlink runfiles tree is enabled.
@laszlocsomor 