### PR TITLE
client: implement path normalization for POSIX

### DIFF
--- a/src/main/cpp/util/path.h
+++ b/src/main/cpp/util/path.h
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include "src/main/cpp/util/path_platform.h"
+
 namespace blaze_util {
 
 // Returns the part of the path before the final "/".  If there is a single

--- a/src/main/cpp/util/path_platform.h
+++ b/src/main/cpp/util/path_platform.h
@@ -168,4 +168,31 @@ bool HasDriveSpecifierPrefix(const char_type *ch);
 #endif  // defined(_WIN32) || defined(__CYGWIN__)
 }  // namespace blaze_util
 
+namespace path {
+
+// Abstraction for a path on the host operating system.
+//
+// TODO(laszlocsomor): implement this class to resolve
+// https://github.com/bazelbuild/bazel/issues/6071. The class should wrap a
+// Path::string_type, holding a normalized path that follows the host OS' path
+// semantics.
+struct Path {
+ public:
+#if defined(_WIN32) || defined(__CYGWIN__)
+  typedef wchar_t char_type;
+#else
+  typedef char char_type;
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
+
+  typedef std::basic_string<char_type> string_type;
+};
+
+namespace testing {
+
+bool TestOnly_IsNormalized(const Path::string_type& path);
+Path::string_type TestOnly_Normalize(const Path::string_type& path);
+
+}  // namespace testing
+}  // namespace path
+
 #endif  // BAZEL_SRC_MAIN_CPP_UTIL_PATH_PLATFORM_H_

--- a/src/test/cpp/util/path_posix_test.cc
+++ b/src/test/cpp/util/path_posix_test.cc
@@ -19,13 +19,91 @@
 
 #include "src/main/cpp/util/file_platform.h"
 #include "src/main/cpp/util/path.h"
-#include "src/main/cpp/util/path_platform.h"
 #include "src/test/cpp/util/test_util.h"
 #include "googletest/include/gtest/gtest.h"
 
 namespace blaze_util {
 
+using path::testing::TestOnly_IsNormalized;
+using path::testing::TestOnly_Normalize;
 using std::string;
+
+TEST(PathPosixTest, TestIsNormalized) {
+  ASSERT_TRUE(TestOnly_IsNormalized(""));
+  ASSERT_TRUE(TestOnly_IsNormalized(" "));
+  ASSERT_TRUE(TestOnly_IsNormalized("/"));
+  ASSERT_FALSE(TestOnly_IsNormalized("//"));
+  ASSERT_TRUE(TestOnly_IsNormalized("a"));
+  ASSERT_TRUE(TestOnly_IsNormalized("/a"));
+  ASSERT_FALSE(TestOnly_IsNormalized("a/"));
+  ASSERT_FALSE(TestOnly_IsNormalized("/a/"));
+  ASSERT_TRUE(TestOnly_IsNormalized("a/b"));
+  ASSERT_FALSE(TestOnly_IsNormalized("a//b"));
+  ASSERT_FALSE(TestOnly_IsNormalized("."));
+  ASSERT_FALSE(TestOnly_IsNormalized(".."));
+  ASSERT_TRUE(TestOnly_IsNormalized("..."));
+  ASSERT_FALSE(TestOnly_IsNormalized("/."));
+  ASSERT_FALSE(TestOnly_IsNormalized("/.."));
+  ASSERT_TRUE(TestOnly_IsNormalized("/..."));
+  ASSERT_FALSE(TestOnly_IsNormalized("./a"));
+  ASSERT_FALSE(TestOnly_IsNormalized("../a"));
+  ASSERT_TRUE(TestOnly_IsNormalized(".../a"));
+  ASSERT_TRUE(TestOnly_IsNormalized(".../.a"));
+  ASSERT_TRUE(TestOnly_IsNormalized(".../..a"));
+  ASSERT_FALSE(TestOnly_IsNormalized("a/."));
+  ASSERT_FALSE(TestOnly_IsNormalized("a/.."));
+  ASSERT_TRUE(TestOnly_IsNormalized("a/..."));
+  ASSERT_TRUE(TestOnly_IsNormalized("a/..."));
+  ASSERT_FALSE(TestOnly_IsNormalized("a/./b"));
+  ASSERT_FALSE(TestOnly_IsNormalized("a/../b"));
+  ASSERT_TRUE(TestOnly_IsNormalized("a/.../b"));
+  ASSERT_TRUE(TestOnly_IsNormalized(".a"));
+  ASSERT_TRUE(TestOnly_IsNormalized("..a"));
+  ASSERT_TRUE(TestOnly_IsNormalized("a."));
+  ASSERT_TRUE(TestOnly_IsNormalized("a.."));
+  ASSERT_TRUE(TestOnly_IsNormalized("a./b"));
+  ASSERT_TRUE(TestOnly_IsNormalized("a../b"));
+  ASSERT_TRUE(TestOnly_IsNormalized("a/.b"));
+  ASSERT_TRUE(TestOnly_IsNormalized("a/..b"));
+}
+
+TEST(PathPosixTest, TestNormalizePath) {
+  ASSERT_EQ(TestOnly_Normalize(""), "");
+  ASSERT_EQ(TestOnly_Normalize(" "), " ");
+  ASSERT_EQ(TestOnly_Normalize("/"), "/");
+  ASSERT_EQ(TestOnly_Normalize("//"), "/");
+  ASSERT_EQ(TestOnly_Normalize("a"), "a");
+  ASSERT_EQ(TestOnly_Normalize("/a"), "/a");
+  ASSERT_EQ(TestOnly_Normalize("a/"), "a");
+  ASSERT_EQ(TestOnly_Normalize("/a/"), "/a");
+  ASSERT_EQ(TestOnly_Normalize("a/b"), "a/b");
+  ASSERT_EQ(TestOnly_Normalize("a//b"), "a/b");
+  ASSERT_EQ(TestOnly_Normalize("."), "");
+  ASSERT_EQ(TestOnly_Normalize(".."), "");
+  ASSERT_EQ(TestOnly_Normalize("..."), "...");
+  ASSERT_EQ(TestOnly_Normalize(".a"), ".a");
+  ASSERT_EQ(TestOnly_Normalize("..a"), "..a");
+  ASSERT_EQ(TestOnly_Normalize("/."), "/");
+  ASSERT_EQ(TestOnly_Normalize("/.."), "/");
+  ASSERT_EQ(TestOnly_Normalize("/..."), "/...");
+  ASSERT_EQ(TestOnly_Normalize("./a"), "a");
+  ASSERT_EQ(TestOnly_Normalize("../a"), "a");
+  ASSERT_EQ(TestOnly_Normalize(".../a"), ".../a");
+  ASSERT_EQ(TestOnly_Normalize("a/."), "a");
+  ASSERT_EQ(TestOnly_Normalize("a/.."), "");
+  ASSERT_EQ(TestOnly_Normalize("a/..."), "a/...");
+  ASSERT_EQ(TestOnly_Normalize("a/./b"), "a/b");
+  ASSERT_EQ(TestOnly_Normalize("a/../b"), "b");
+  ASSERT_EQ(TestOnly_Normalize("a/.../b"), "a/.../b");
+  ASSERT_EQ(TestOnly_Normalize(".a"), ".a");
+  ASSERT_EQ(TestOnly_Normalize("..a"), "..a");
+  ASSERT_EQ(TestOnly_Normalize("a."), "a.");
+  ASSERT_EQ(TestOnly_Normalize("a.."), "a..");
+  ASSERT_EQ(TestOnly_Normalize("a./b"), "a./b");
+  ASSERT_EQ(TestOnly_Normalize("a../b"), "a../b");
+  ASSERT_EQ(TestOnly_Normalize("a/.b"), "a/.b");
+  ASSERT_EQ(TestOnly_Normalize("a/..b"), "a/..b");
+}
 
 TEST(PathPosixTest, TestDirname) {
   // The Posix version of SplitPath (thus Dirname too, which is implemented on


### PR DESCRIPTION
I will use this method in the upcoming Path
abstraction, to ensure the internal path string is
always normalized.

See https://github.com/bazelbuild/bazel/issues/6071

Change-Id: Iee326763293f700eeb9b156c8b8ee9efbd321f2e