### PR TITLE
Remove the "discarding analysis cache" message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeBuildView.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeBuildView.java
@@ -220,7 +220,6 @@ public final class SkyframeBuildView {
     } else if (this.areConfigurationsDifferent(configurations)) {
       // Clearing cached ConfiguredTargets when the configuration changes is not required for
       // correctness, but prevents unbounded memory usage.
-      eventHandler.handle(Event.info("Build options have changed, discarding analysis cache."));
       skyframeExecutor.handleConfiguredTargetChange();
     }
     skyframeAnalysisWasDiscarded = false;


### PR DESCRIPTION
It doesn't seem to be providing any value for a user, who generally doesn't even know what an analysis cache is.