### PR TITLE
Windows,client: implement principled string conv.

### DIFF
--- a/src/main/cpp/util/strings.cc
+++ b/src/main/cpp/util/strings.cc
@@ -13,6 +13,10 @@
 // limitations under the License.
 #include "src/main/cpp/util/strings.h"
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+#include <windows.h>
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -311,5 +315,82 @@ unique_ptr<wchar_t[]> CstringToWstring(const char *input) {
 std::wstring CstringToWstring(const std::string &input) {
   return wstring(CstringToWstring(input.c_str()).get());
 }
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+template <typename U, typename V>
+static bool UStrToVStr(
+    const std::basic_string<U>& input,
+    std::basic_string<V>* output,
+    const bool use_utf8,
+    int (*Convert)(
+      const bool _utf8,
+      const std::basic_string<U>& _in,
+      V* _out,
+      const size_t _size),
+    uint32_t *win32_error) {
+  int buf_size = input.size() + 1;
+  std::unique_ptr<V[]> buf(new V[buf_size]);
+  // Attempt to convert, optimistically using the estimated output buffer size.
+  int res = Convert(use_utf8, input, buf.get(), buf_size);
+  if (res > 0) {
+    *output = buf.get();
+    return true;
+  }
+
+  DWORD err = GetLastError();
+  if (err != ERROR_INSUFFICIENT_BUFFER) {
+    *win32_error = static_cast<uint32_t>(err);
+    return false;
+  }
+
+  // The output buffer was too small. Get required buffer size.
+  res = Convert(use_utf8, input, NULL, 0);
+  if (res > 0) {
+    buf_size = res;
+    buf.reset(new V[buf_size]);
+    res = Convert(use_utf8, input, buf.get(), buf_size);
+    if (res > 0) {
+      *output = buf.get();
+      return true;
+    }
+  }
+  *win32_error = static_cast<uint32_t>(GetLastError());
+  return false;
+}
+
+static int ConvertWcsToMbs(const bool use_utf8, const std::wstring& input,
+                           char* output, const size_t output_size) {
+  return WideCharToMultiByte(use_utf8 ? CP_UTF8 : CP_ACP, 0, input.c_str(), -1,
+                             output, output_size, NULL, NULL);
+}
+
+static int ConvertMbsToWcs(const bool use_utf8, const std::string& input,
+                           wchar_t* output, const size_t output_size) {
+  return MultiByteToWideChar(use_utf8 ? CP_UTF8 : CP_ACP, 0, input.c_str(), -1,
+                             output, output_size);
+}
+
+bool WcsToAcp(const std::wstring& input, std::string* output,
+              uint32_t *win32_error) {
+  return UStrToVStr(input, output, false, ConvertWcsToMbs, win32_error);
+}
+
+bool WcsToUtf8(const std::wstring& input, std::string* output,
+               uint32_t *win32_error) {
+  return UStrToVStr(input, output, true, ConvertWcsToMbs, win32_error);
+}
+
+bool AcpToWcs(const std::string& input, std::wstring* output,
+              uint32_t *win32_error) {
+  return UStrToVStr(input, output, false, ConvertMbsToWcs, win32_error);
+}
+
+bool Utf8ToWcs(const std::string& input, std::wstring* output,
+               uint32_t *win32_error) {
+  return UStrToVStr(input, output, true, ConvertMbsToWcs, win32_error);
+}
+
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
 
 }  // namespace blaze_util

--- a/src/main/cpp/util/strings.h
+++ b/src/main/cpp/util/strings.h
@@ -109,13 +109,41 @@ std::string AsLower(const std::string &str);
 
 // Convert a wchar_t string to a char string. Useful when consuming results of
 // widechar Windows API functions.
+// TODO(laszlocsomor): audit usages of WstringToCstring and replace with
+// WcsToAcp or WcsToUtf8 appropriately. WstringToCstring does not specify the
+// output encoding.
+//
+// Deprecated. Use WcsToAcp or WcsToUtf8.
 std::unique_ptr<char[]> WstringToCstring(const wchar_t *input);
+
+// Deprecated. Use WcsToAcp or WcsToUtf8.
 std::string WstringToString(const std::wstring &input);
 
 // Convert a char string to a wchar_t string. Useful when passing arguments to
 // widechar Windows API functions.
+// TODO(laszlocsomor): audit usages of CstringToWstring and replace with
+// AcpToWcs or Utf8ToWcs appropriately. CstringToWstring does not specify the
+// input encoding.
+//
+// Deprecated. Use AcpToWcs or Utf8ToWcs.
 std::unique_ptr<wchar_t[]> CstringToWstring(const char *input);
+
+// Deprecated. Use AcpToWcs or Utf8ToWcs.
 std::wstring CstringToWstring(const std::string &input);
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+// Convert UTF-16 string to ASCII (using the Active Code Page).
+bool WcsToAcp(const std::wstring& input, std::string* output, uint32_t* error);
+
+// Convert UTF-16 string to UTF-8.
+bool WcsToUtf8(const std::wstring& input, std::string* output, uint32_t* error);
+
+// Convert ASCII string (using the Active Code Page) to UTF-16 string.
+bool AcpToWcs(const std::string& input, std::wstring* output, uint32_t* error);
+
+// Convert UTF-8 string to UTF-16.
+bool Utf8ToWcs(const std::string& input, std::wstring* output, uint32_t* error);
+#endif  // defined(_WIN32) || defined(__CYGWIN__)
 
 }  // namespace blaze_util
 

--- a/src/test/cpp/util/BUILD
+++ b/src/test/cpp/util/BUILD
@@ -90,7 +90,10 @@ cc_test(
 
 cc_test(
     name = "strings_test",
-    srcs = ["strings_test.cc"],
+    srcs = ["strings_test.cc"] + select({
+        "//src/conditions:windows": ["strings_windows_test.cc"],
+        "//conditions:default": [],
+    }),
     shard_count = 2,
     deps = [
         "//src/main/cpp/util:strings",

--- a/src/test/cpp/util/strings_windows_test.cc
+++ b/src/test/cpp/util/strings_windows_test.cc
@@ -1,0 +1,88 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "src/main/cpp/util/strings.h"
+
+#include <wchar.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "googletest/include/gtest/gtest.h"
+
+namespace blaze_util {
+
+static const char kAsciiLatin[] = {'A', 'b', 'c', '\0'};
+static const wchar_t kUtf16Latin[] = {L'A', L'b', L'c', L'\0'};
+static const char kUtf8Cyrillic[] = {
+  'H',
+  'e',
+  'y',
+  '=',
+  0xd0, 0x9f, // Cyrillic Capital Letter Pe
+  0xd1, 0x80, // Cyrillic Small Letter Er
+  0xd0, 0xb8, // Cyrillic Small Letter I
+  0xd0, 0xb2, // Cyrillic Small Letter Ve
+  0xd0, 0xb5, // Cyrillic Small Letter Ie
+  0xd1, 0x82, // Cyrillic Small Letter Te
+  0,
+};
+static const wchar_t kUtf16Cyrillic[] = {
+  L'H',
+  L'e',
+  L'y',
+  L'=',
+  0x41F, // Cyrillic Capital Letter Pe
+  0x440, // Cyrillic Small Letter Er
+  0x438, // Cyrillic Small Letter I
+  0x432, // Cyrillic Small Letter Ve
+  0x435, // Cyrillic Small Letter Ie
+  0x442, // Cyrillic Small Letter Te
+  0x0,
+};
+
+TEST(BlazeUtil, WcsToAcpTest) {
+  std::string actual;
+  uint32_t win32_err;
+  ASSERT_TRUE(WcsToAcp(kUtf16Latin, &actual, &win32_err));
+  ASSERT_TRUE(actual == kAsciiLatin);
+}
+
+TEST(BlazeUtil, WcsToUtf8Test) {
+  std::string actual;
+  uint32_t win32_err;
+  ASSERT_TRUE(WcsToUtf8(kUtf16Latin, &actual, &win32_err));
+  ASSERT_TRUE(actual == kAsciiLatin);
+  ASSERT_TRUE(WcsToUtf8(kUtf16Cyrillic, &actual, &win32_err));
+  ASSERT_TRUE(actual == kUtf8Cyrillic);
+}
+
+TEST(BlazeUtil, AcpToWcsTest) {
+  std::wstring actual;
+  uint32_t win32_err;
+  ASSERT_TRUE(AcpToWcs(kAsciiLatin, &actual, &win32_err));
+  ASSERT_TRUE(actual == kUtf16Latin);
+}
+
+TEST(BlazeUtil, Utf8ToWcsTest) {
+  std::wstring actual;
+  uint32_t win32_err;
+  ASSERT_TRUE(Utf8ToWcs(kAsciiLatin, &actual, &win32_err));
+  ASSERT_TRUE(actual == kUtf16Latin);
+  ASSERT_TRUE(Utf8ToWcs(kUtf8Cyrillic, &actual, &win32_err));
+  ASSERT_TRUE(actual == kUtf16Cyrillic);
+}
+
+}  // namespace blaze_util
+


### PR DESCRIPTION
Implement conversions between UTF-16, UTF-8, and
ASCII with the Active Code Page (ACP).

The existing CstringToWstring and WstringToCstring
methods do not declare the encoding of their
multi-byte string argument but just use whatever
msbtowcs or wcstombs uses.

Change-Id: Id03778eff7bcd055233ab697596ce9d002ca0bd6