### PR TITLE
Support aapt2 compilation for value xmls with multiple periods in the filename

### DIFF
--- a/src/tools/android/java/com/google/devtools/build/android/aapt2/ResourceCompiler.java
+++ b/src/tools/android/java/com/google/devtools/build/android/aapt2/ResourceCompiler.java
@@ -177,6 +177,10 @@ public class ResourceCompiler {
       // 2) res/values/foo.xml -> foo.asrc
       // 3) res/values/foo.bar.xml -> foo.bar.arsc
 
+      // This is consistent with aapt2 compilation:
+      // $ aapt2 compile -v --legacy -o $(pwd) <path>/res/values/Style.Cell.xml
+      // # produces `values_Style.Cell.arsc.flat`
+
       // For non-values, return the filename as it is:
       // 1) res/<not values>/foo.bar.baz -> foo.bar.baz
 

--- a/src/tools/android/java/com/google/devtools/build/android/aapt2/ResourceCompiler.java
+++ b/src/tools/android/java/com/google/devtools/build/android/aapt2/ResourceCompiler.java
@@ -172,8 +172,16 @@ public class ResourceCompiler {
     }
 
     static String interpolateAapt2Filename(Qualifiers qualifiers, String filename) {
+      // For values, extract the filename by looking for the last index of '.', so:
+      // 1) res/values/foo -> foo.arsc
+      // 2) res/values/foo.xml -> foo.src
+      // 3) res/values/foo.bar.xml -> foo.bar.arsc
+
+      // For non-values, return the filename as it is:
+      // 1) res/<not values>/foo.bar.baz -> foo.bar.baz
+
       return qualifiers.asFolderType().equals(ResourceFolderType.VALUES)
-          ? (filename.indexOf('.') != -1 ? filename.substring(0, filename.indexOf('.')) : filename)
+          ? (filename.lastIndexOf('.') != -1 ? filename.substring(0, filename.lastIndexOf('.')) : filename)
               + ".arsc"
           : filename;
     }

--- a/src/tools/android/java/com/google/devtools/build/android/aapt2/ResourceCompiler.java
+++ b/src/tools/android/java/com/google/devtools/build/android/aapt2/ResourceCompiler.java
@@ -174,7 +174,7 @@ public class ResourceCompiler {
     static String interpolateAapt2Filename(Qualifiers qualifiers, String filename) {
       // For values, extract the filename by looking for the last index of '.', so:
       // 1) res/values/foo -> foo.arsc
-      // 2) res/values/foo.xml -> foo.src
+      // 2) res/values/foo.xml -> foo.asrc
       // 3) res/values/foo.bar.xml -> foo.bar.arsc
 
       // For non-values, return the filename as it is:


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/6042