### PR TITLE
Never use @embedded_jdk for --javabase

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -520,7 +520,13 @@ static vector<string> GetArgumentArray(
                    blaze_util::ConvertPath(globals->options->output_base));
   result.push_back("--workspace_directory=" +
                    blaze_util::ConvertPath(globals->workspace));
-  result.push_back("--default_system_javabase=" + GetSystemJavabase());
+  std::string default_system_javabase = GetSystemJavabase();
+  if (globals->options->incompatible_never_use_embedded_jdk_for_javabase) {
+    result.push_back("--incompatible_never_use_embedded_jdk_for_javabase");
+  } else if (default_system_javabase.empty()) {
+    default_system_javabase = globals->options->GetServerJavabase();
+  }
+  result.push_back("--default_system_javabase=" + default_system_javabase);
 
   if (!globals->options->server_jvm_out.empty()) {
     result.push_back("--server_jvm_out=" + globals->options->server_jvm_out);

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -95,7 +95,8 @@ StartupOptions::StartupOptions(const string &product_name,
       digest_function(),
       idle_server_tasks(true),
       original_startup_options_(std::vector<RcStartupFlag>()),
-      unlimit_coredumps(false) {
+      unlimit_coredumps(false),
+      incompatible_never_use_embedded_jdk_for_javabase(false) {
   bool testing = !blaze::GetEnv("TEST_TMPDIR").empty();
   if (testing) {
     output_root = blaze_util::MakeAbsolute(blaze::GetEnv("TEST_TMPDIR"));
@@ -145,6 +146,7 @@ StartupOptions::StartupOptions(const string &product_name,
   RegisterUnaryStartupFlag("digest_function");
   RegisterUnaryStartupFlag("experimental_oom_more_eagerly_threshold");
   RegisterUnaryStartupFlag("server_javabase");
+  RegisterNullaryStartupFlag("incompatible_never_use_embedded_jdk_for_javabase");
   RegisterUnaryStartupFlag("host_jvm_args");
   RegisterUnaryStartupFlag("host_jvm_profile");
   RegisterUnaryStartupFlag("invocation_policy");
@@ -234,6 +236,9 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
     // of architecture mismatch.
     server_javabase_ = blaze::AbsolutePathFromFlag(value);
     option_sources["server_javabase"] = rcfile;
+  } else if (GetNullaryOption(arg, "--incompatible_never_use_embedded_jdk_for_javabase")) {
+    incompatible_never_use_embedded_jdk_for_javabase = true;
+    option_sources["incompatible_never_use_embedded_jdk_for_javabase"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--host_jvm_args")) !=
              NULL) {
     host_jvm_args.push_back(value);

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -201,6 +201,8 @@ class StartupOptions {
   // Otherwise a default path in the output base is used.
   std::string server_jvm_out;
 
+  bool incompatible_never_use_embedded_jdk_for_javabase;
+
   // Blaze's output base.  Everything is relative to this.  See
   // the BlazeDirectories Java class for details.
   std::string output_base;

--- a/src/main/java/com/google/devtools/build/lib/packages/WorkspaceFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/WorkspaceFactory.java
@@ -598,9 +598,7 @@ public class WorkspaceFactory {
       workspaceEnv.update("DEFAULT_SERVER_JAVABASE", javaHome.toString());
       workspaceEnv.update(
           "DEFAULT_SYSTEM_JAVABASE",
-          defaultSystemJavabaseDir != null
-              ? defaultSystemJavabaseDir.toString()
-              : javaHome.toString());
+          defaultSystemJavabaseDir != null ? defaultSystemJavabaseDir.toString() : "");
 
       for (EnvironmentExtension extension : environmentExtensions) {
         extension.updateWorkspace(workspaceEnv);

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
@@ -188,6 +188,19 @@ public class BlazeServerStartupOptions extends OptionsBase {
   public PathFragment defaultSystemJavabase;
 
   @Option(
+      name = "incompatible_never_use_embedded_jdk_for_javabase",
+      defaultValue = "false", // NOTE: only for documentation, value is always passed by the client.
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      metadataTags = {
+        OptionMetadataTag.DEPRECATED,
+        OptionMetadataTag.INCOMPATIBLE_CHANGE,
+        OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+      },
+      help = "")
+  public boolean incompatibleKittenPaws;
+
+  @Option(
     name = "max_idle_secs",
     // NOTE: default value only used for documentation, value is always passed by the client when
     // not in --batch mode.


### PR DESCRIPTION
Fixes #6105

RELNOTES: Future versions of Bazel will require a locally installed JDK
for Java development. Previously Bazel would fall back to using the
embedded --server_javabase if no JDK as available. Pass
--incompatible_never_use_embedded_jdk_for_javabase to disable the legacy
behaviour.