### PR TITLE
Avoid an unnecessary copy in Args.add_all.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkCustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkCustomCommandLine.java
@@ -150,7 +150,7 @@ public class SkylarkCustomCommandLine extends CommandLine {
       if (arg.nestedSet != null) {
         arguments.add(arg.nestedSet);
       } else {
-        ImmutableList<?> list = arg.list.getImmutableList();
+        List<?> list = arg.list;
         int count = list.size();
         arguments.add(count);
         for (int i = 0; i < count; ++i) {


### PR DESCRIPTION
getImmutableList() on a Starlark list will copy the contents. Here, we're copying the list into the command line, so let's avoid copying twice.