### PR TITLE
Windows: set correct RUNFILES_MANIFEST_ONLY value for test

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -531,6 +531,11 @@ public class TestRunnerAction extends AbstractAction
     }
     env.put("XML_OUTPUT_FILE", getXmlOutputPath().getPathString());
 
+    if (!isEnableRunfiles()) {
+      // If runfiles are disabled, tell remote-runtest.sh/local-runtest.sh about that.
+      env.put("RUNFILES_MANIFEST_ONLY", "1");
+    }
+
     if (isCoverageMode()) {
       // Instruct remote-runtest.sh/local-runtest.sh not to cd into the runfiles directory.
       // TODO(ulfjack): Find a way to avoid setting this variable.

--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -126,11 +126,11 @@ function rlocation() {
 
 export -f rlocation
 export -f is_absolute
-# If the runfiles manifest exists, then test programs should use it to find
+# If RUNFILES_MANIFEST_ONLY is set to 1, then test programs should use manifest file to find
 # runfiles.
-if [[ -e "$RUNFILES_MANIFEST_FILE" ]]; then
+if [[ "${RUNFILES_MANIFEST_ONLY:-}" == "1" ]]; then
   export RUNFILES_MANIFEST_FILE
-  export RUNFILES_MANIFEST_ONLY=1
+  export RUNFILES_MANIFEST_ONLY
 fi
 
 DIR="$TEST_SRCDIR"


### PR DESCRIPTION
RUNFILES_MANIFEST_ONLY should not depend on whether manifest file
exist or not. Bazel should tell test-setup.sh if runfiles tree is
enabled.

Related issues:
https://github.com/bazelbuild/bazel/issues/5926
https://github.com/bazelbuild/bazel/issues/6019