### PR TITLE
Windows: open file streams with deletion sharing

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper/JarCreator.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper/JarCreator.java
@@ -17,7 +17,7 @@ package com.google.devtools.build.buildjar.jarhelper;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -201,7 +201,7 @@ public class JarCreator extends JarHelper {
 
   private byte[] manifestContent() throws IOException {
     if (manifestFile != null) {
-      try (FileInputStream in = new FileInputStream(manifestFile)) {
+      try (InputStream in = Files.newInputStream(Paths.get(manifestFile))) {
         return manifestContentImpl(new Manifest(in));
       }
     } else {

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4Runner.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4Runner.java
@@ -22,9 +22,10 @@ import com.google.testing.junit.runner.model.TestSuiteModel;
 import com.google.testing.junit.runner.util.GoogleTestSecurityManager;
 import com.google.testing.junit.runner.util.Supplier;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -127,7 +128,7 @@ public class JUnit4Runner {
 
   private static void exitFileActive(@Nullable File file) {
     if (file != null) {
-      try (FileOutputStream outputStream = new FileOutputStream(file, false)) {
+      try (OutputStream outputStream = Files.newOutputStream(file.toPath())) {
         // Overwrite file content.
         outputStream.write(new byte[0]);
         outputStream.close();

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4RunnerModule.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4RunnerModule.java
@@ -22,9 +22,10 @@ import com.google.testing.junit.runner.internal.junit4.JUnit4TestXmlListener;
 import com.google.testing.junit.runner.internal.junit4.SettableCurrentRunningTest;
 import com.google.testing.junit.runner.util.TestNameProvider;
 import com.google.testing.junit.runner.util.Ticker;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import javax.annotation.Nullable;
 import javax.inject.Singleton;
@@ -62,8 +63,8 @@ public final class JUnit4RunnerModule {
     if (path != null) {
       try {
         // TODO(bazel-team): Change the provider method to return ByteSink or CharSink
-        return new FileOutputStream(path.toFile());
-      } catch (FileNotFoundException e) {
+        return Files.newOutputStream(path);
+      } catch (IOException e) {
         /*
          * We try to avoid throwing exceptions in the runner code. There is no
          * way to induce a test failure here, so the only thing we can do is

--- a/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/JavaIoFileSystem.java
+++ b/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/JavaIoFileSystem.java
@@ -20,6 +20,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 /**
  * An implementation based on java.io.
@@ -28,12 +30,12 @@ public final class JavaIoFileSystem implements SimpleFileSystem {
 
   @Override
   public InputStream getInputStream(String filename) throws IOException {
-    return new FileInputStream(filename);
+    return Files.newInputStream(Paths.get(filename));
   }
 
   @Override
   public OutputStream getOutputStream(String filename) throws IOException {
-    return new FileOutputStream(filename);
+    return Files.newOutputStream(Paths.get(filename));
   }
 
   @Override

--- a/src/java_tools/singlejar/javatests/com/google/devtools/build/zip/ZipWriterTest.java
+++ b/src/java_tools/singlejar/javatests/com/google/devtools/build/zip/ZipWriterTest.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.zip.ZipFileEntry.Compression;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Calendar;
 import java.util.Random;
 import java.util.zip.CRC32;
@@ -66,7 +67,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testEmpty() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
     }
 
     try (ZipFile zipFile = new ZipFile(test)) {
@@ -75,7 +76,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testComment() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       writer.setComment("test comment");
     }
 
@@ -86,7 +87,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testFileDataBeforeEntry() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       writer.write(new byte[] { 0xf, 0xa, 0xb });
       fail("Expected ZipException");
     } catch (ZipException e) {
@@ -104,7 +105,7 @@ public class ZipWriterTest {
 
   @Test public void testSingleEntry() throws IOException {
     byte[] content = "content".getBytes(UTF_8);
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       crc.update(content);
       ZipFileEntry entry = new ZipFileEntry("foo");
       entry.setSize(content.length);
@@ -136,7 +137,7 @@ public class ZipWriterTest {
     long fooCrc = -1;
     long barCrc = -1;
     int deflatedSize = -1;
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       writer.setComment("file comment");
 
       crc.update(fooContent);
@@ -198,7 +199,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testWrongSizeContent() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       byte[] content = "content".getBytes(UTF_8);
       crc.update(content);
       ZipFileEntry entry = new ZipFileEntry("foo");
@@ -217,7 +218,7 @@ public class ZipWriterTest {
 
   @Test public void testRawZipEntry() throws IOException {
     byte[] content = "content".getBytes(UTF_8);
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       crc.update(content);
       ZipFileEntry entry = new ZipFileEntry("foo");
       entry.setVersion((short) 1);
@@ -261,7 +262,7 @@ public class ZipWriterTest {
 
   @Test public void testPrefixFile() throws IOException, InterruptedException {
     byte[] content = "content".getBytes(UTF_8);
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       writer.startPrefixFile();
       writer.write("#!/bin/bash\necho 'hello world'\n".getBytes(UTF_8));
       writer.endPrefixFile();
@@ -299,7 +300,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testPrefixFileAfterZip() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       byte[] content = "content".getBytes(UTF_8);
       crc.update(content);
       ZipFileEntry entry = new ZipFileEntry("foo");
@@ -318,7 +319,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testPrefixAfterFinish() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       writer.finish();
       thrown.expect(IllegalStateException.class);
       writer.startPrefixFile();
@@ -328,7 +329,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testPutEntryAfterFinish() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       writer.finish();
       thrown.expect(IllegalStateException.class);
       writer.putNextEntry(new ZipFileEntry("foo"));
@@ -336,7 +337,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testCloseEntryAfterFinish() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       byte[] content = "content".getBytes(UTF_8);
       crc.update(content);
       ZipFileEntry entry = new ZipFileEntry("foo");
@@ -354,7 +355,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testFinishAfterFinish() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       writer.finish();
       thrown.expect(IllegalStateException.class);
       writer.finish();
@@ -362,7 +363,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testWriteAfterFinish() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8)) {
       writer.finish();
       thrown.expect(IllegalStateException.class);
       writer.write("content".getBytes(UTF_8));
@@ -370,7 +371,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testZip64_FileCount_32BitMax() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8, true)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8, true)) {
       ZipFileEntry template = new ZipFileEntry("template");
       template.setSize(0);
       template.setCompressedSize(0);
@@ -391,7 +392,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testZip64_FileCount_Zip64Range() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8, true)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8, true)) {
       ZipFileEntry template = new ZipFileEntry("template");
       template.setSize(0);
       template.setCompressedSize(0);
@@ -412,7 +413,7 @@ public class ZipWriterTest {
   }
 
   @Test public void testZip64_FileCount_Zip64Range_ForceZip32() throws IOException {
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8, false)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8, false)) {
       ZipFileEntry template = new ZipFileEntry("template");
       template.setSize(0);
       template.setCompressedSize(0);
@@ -434,7 +435,7 @@ public class ZipWriterTest {
 
   @Test public void testZip64_FileSize_32BitMax() throws IOException {
     long size = 0xffffffffL;
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8, true)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8, true)) {
       ZipFileEntry entry = new ZipFileEntry("big");
       entry.setCompressedSize(size);
       entry.setSize(size);
@@ -457,7 +458,7 @@ public class ZipWriterTest {
 
   @Test public void testZip64_FileSize_Zip64Range() throws IOException {
     long size = 0x1000000ffL;
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8, true)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8, true)) {
       ZipFileEntry entry = new ZipFileEntry("big");
       entry.setCompressedSize(size);
       entry.setSize(size);
@@ -480,7 +481,7 @@ public class ZipWriterTest {
 
   @Test public void testZip64_FileSize_Zip64Range_ForceZip32() throws IOException {
     long size = 0x1000000ffL;
-    try (ZipWriter writer = new ZipWriter(new FileOutputStream(test), UTF_8, false)) {
+    try (ZipWriter writer = new ZipWriter(Files.newOutputStream(test.toPath()), UTF_8, false)) {
       ZipFileEntry entry = new ZipFileEntry("big");
       entry.setCompressedSize(size);
       entry.setSize(size);

--- a/src/main/java/com/google/devtools/build/docgen/ApiExporter.java
+++ b/src/main/java/com/google/devtools/build/docgen/ApiExporter.java
@@ -33,6 +33,8 @@ import com.google.devtools.common.options.OptionsParser;
 import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -189,7 +191,8 @@ public class ApiExporter {
   }
 
   private static void writeBuiltins(String filename, Builtins.Builder builtins) throws IOException {
-    try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(filename))) {
+    try (BufferedOutputStream out =
+        new BufferedOutputStream(Files.newOutputStream(Paths.get(filename)))) {
       Builtins build = builtins.build();
       build.writeTo(out);
     }

--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -32,6 +32,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -127,7 +129,7 @@ public final class GoogleAuthUtils {
       return null;
     } else if (options.googleCredentials != null) {
       // Credentials from file
-      try (InputStream authFile = new FileInputStream(options.googleCredentials)) {
+      try (InputStream authFile = Files.newInputStream(Paths.get(options.googleCredentials))) {
         return newCredentials(authFile, options.googleAuthScopes);
       } catch (FileNotFoundException e) {
         String message =

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarBz2Function.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarBz2Function.java
@@ -19,6 +19,7 @@ import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 
 /**
@@ -36,6 +37,6 @@ public class TarBz2Function extends CompressedTarFunction {
       throws IOException {
     return new BZip2CompressorInputStream(
         new BufferedInputStream(
-            new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE));
+            Files.newInputStream(descriptor.archivePath().getPathFile().toPath()), BUFFER_SIZE));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarFunction.java
@@ -19,6 +19,7 @@ import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 /** Creates a repository by unarchiving a plain .tar file. */
 public class TarFunction extends CompressedTarFunction {
@@ -31,6 +32,6 @@ public class TarFunction extends CompressedTarFunction {
   protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
       throws IOException {
     return new BufferedInputStream(
-        new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE);
+        Files.newInputStream(descriptor.archivePath().getPathFile().toPath()), BUFFER_SIZE);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarGzFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarGzFunction.java
@@ -19,6 +19,7 @@ import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -36,6 +37,6 @@ public class TarGzFunction extends CompressedTarFunction {
       throws IOException {
     return new GZIPInputStream(
         new BufferedInputStream(
-            new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE));
+            Files.newInputStream(descriptor.archivePath().getPathFile().toPath()), BUFFER_SIZE));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/TarXzFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/TarXzFunction.java
@@ -19,6 +19,7 @@ import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import org.tukaani.xz.XZInputStream;
 
 /**
@@ -36,6 +37,6 @@ class TarXzFunction extends CompressedTarFunction {
       throws IOException {
     return new XZInputStream(
         new BufferedInputStream(
-            new FileInputStream(descriptor.archivePath().getPathFile()), BUFFER_SIZE));
+            Files.newInputStream(descriptor.archivePath().getPathFile().toPath()), BUFFER_SIZE));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/FileTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/FileTransport.java
@@ -40,10 +40,11 @@ import com.google.devtools.build.lib.util.io.AsynchronousFileOutputStream;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -109,8 +110,8 @@ abstract class FileTransport implements BuildEventTransport {
         Consumer<AbruptExitException> exitFunc,
         BuildEventArtifactUploader uploader) {
       try {
-        this.out = new BufferedOutputStream(new FileOutputStream(path));
-      } catch (FileNotFoundException e) {
+        this.out = new BufferedOutputStream(Files.newOutputStream(Paths.get(path)));
+      } catch (IOException e) {
         this.out = new ByteArrayOutputStream(0);
         closeNow();
         exitFunc.accept(

--- a/src/main/java/com/google/devtools/build/lib/profiler/callcounts/Callcounts.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/callcounts/Callcounts.java
@@ -24,6 +24,8 @@ import com.google.perftools.profiles.ProfileProto.Sample;
 import com.google.perftools.profiles.ProfileProto.ValueType;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -140,7 +142,8 @@ public class Callcounts {
 
   static void dump(String path) throws IOException {
     Profile profile = createProfile();
-    try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(new FileOutputStream(path))) {
+    try (GZIPOutputStream gzipOutputStream =
+        new GZIPOutputStream(Files.newOutputStream(Paths.get(path)))) {
       profile.writeTo(gzipOutputStream);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/profiler/grapher/ProfileGrapher.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/grapher/ProfileGrapher.java
@@ -20,6 +20,8 @@ import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -67,7 +69,8 @@ public class ProfileGrapher {
     try (JsonReader reader =
         new JsonReader(
             new BufferedReader(
-                new InputStreamReader(new FileInputStream(filename), StandardCharsets.UTF_8)))) {
+                new InputStreamReader(
+                    Files.newInputStream(Paths.get(filename)), StandardCharsets.UTF_8)))) {
       reader.beginArray();
       while (reader.hasNext()) {
         reader.beginObject();

--- a/src/main/java/com/google/devtools/build/lib/profiler/memory/AllocationTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/memory/AllocationTracker.java
@@ -36,6 +36,8 @@ import com.google.perftools.profiles.ProfileProto.Sample;
 import com.google.perftools.profiles.ProfileProto.ValueType;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -225,7 +227,8 @@ public class AllocationTracker implements Sampler {
     enabled = false;
     System.gc();
     Profile profile = buildMemoryProfile();
-    try (GZIPOutputStream outputStream = new GZIPOutputStream(new FileOutputStream(path))) {
+    try (GZIPOutputStream outputStream =
+        new GZIPOutputStream(Files.newOutputStream(Paths.get(path)))) {
       profile.writeTo(outputStream);
       outputStream.finish();
     }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/DumpCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/DumpCommand.java
@@ -43,9 +43,11 @@ import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingResult;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -303,9 +305,9 @@ public class DumpCommand implements BlazeCommand {
     out.println("Dumping action graph to '" + path + "'");
     ActionGraphContainer actionGraphContainer =
         executor.getActionGraphContainer(actionGraphTargets, includeActionCmdLine);
-    FileOutputStream protoOutputStream = new FileOutputStream(path);
-    actionGraphContainer.writeTo(protoOutputStream);
-    protoOutputStream.close();
+    try (OutputStream protoOutputStream = Files.newOutputStream(Paths.get(path))) {
+      actionGraphContainer.writeTo(protoOutputStream);
+    }
     return true;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/util/SimpleLogHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/util/SimpleLogHandler.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.file.Files;
 import java.lang.management.ManagementFactory;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -651,7 +652,7 @@ public final class SimpleLogHandler extends Handler {
       try {
         close();
         file = new File(path);
-        stream = new CountingOutputStream(new FileOutputStream(file, true));
+        stream = new CountingOutputStream(Files.newOutputStream(file.toPath(), true));
         writer = new OutputStreamWriter(stream, UTF_8);
       } catch (IOException e) {
         close();

--- a/src/main/java/com/google/devtools/build/lib/util/SimpleLogHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/util/SimpleLogHandler.java
@@ -28,6 +28,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.lang.management.ManagementFactory;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -652,7 +653,8 @@ public final class SimpleLogHandler extends Handler {
       try {
         close();
         file = new File(path);
-        stream = new CountingOutputStream(Files.newOutputStream(file.toPath(), true));
+        stream = new CountingOutputStream(
+            Files.newOutputStream(file.toPath(), StandardOpenOption.APPEND));
         writer = new OutputStreamWriter(stream, UTF_8);
       } catch (IOException e) {
         close();

--- a/src/main/java/com/google/devtools/build/lib/util/SimpleLogHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/util/SimpleLogHandler.java
@@ -27,8 +27,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
 import java.lang.management.ManagementFactory;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -653,8 +651,7 @@ public final class SimpleLogHandler extends Handler {
       try {
         close();
         file = new File(path);
-        stream = new CountingOutputStream(
-            Files.newOutputStream(file.toPath(), StandardOpenOption.APPEND));
+        stream = new CountingOutputStream(new FileOutputStream(file, true));
         writer = new OutputStreamWriter(stream, UTF_8);
       } catch (IOException e) {
         close();

--- a/src/main/java/com/google/devtools/build/lib/util/io/AsynchronousFileOutputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/util/io/AsynchronousFileOutputStream.java
@@ -28,9 +28,10 @@ import com.google.protobuf.MessageLite;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -54,7 +55,7 @@ public class AsynchronousFileOutputStream extends OutputStream implements Messag
     this(
         filename,
         new BufferedOutputStream( // Use a buffer of 100 kByte, scientifically chosen at random.
-            new FileOutputStream(new File(filename), /*append=*/ false), 100000));
+            Files.newOutputStream(Paths.get(filename)), 100000));
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/devtools/build/lib/windows/runfiles/WindowsRunfiles.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/runfiles/WindowsRunfiles.java
@@ -17,9 +17,10 @@ package com.google.devtools.build.lib.windows.runfiles;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,9 +45,12 @@ public final class WindowsRunfiles {
     }
 
     runfiles = new HashMap<>();
-    InputStream fis = new FileInputStream(System.getenv("RUNFILES_MANIFEST_FILE"));
-    InputStreamReader isr = new InputStreamReader(fis, Charset.forName("UTF-8"));
-    try (BufferedReader br = new BufferedReader(isr)) {
+    try (BufferedReader br =
+        new BufferedReader(
+            new InputStreamReader(
+                Files.newInputStream(Paths.get(System.getenv("RUNFILES_MANIFEST_FILE"))),
+                // TODO(laszlocsomor): Fix charset: Bazel writes a Latin-1 manifest file, not UTF-8.
+                StandardCharsets.UTF_8))) {
       String line;
       while ((line = br.readLine()) != null) {
         line = line.trim();

--- a/src/test/java/com/google/devtools/build/android/AarGeneratorActionTest.java
+++ b/src/test/java/com/google/devtools/build/android/AarGeneratorActionTest.java
@@ -199,16 +199,14 @@ public class AarGeneratorActionTest {
       }
 
       private void writeClassesJar() throws IOException {
-        final ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(classes.toFile()));
-
-        for (Map.Entry<String, String> file : classesToWrite.entrySet()) {
-          ZipEntry entry = new ZipEntry(file.getKey());
-          zout.putNextEntry(entry);
-          zout.write(file.getValue().getBytes(UTF_8));
-          zout.closeEntry();
+        try (ZipOutputStream zout = new ZipOutputStream(Files.newOutputStream(classes))) {
+          for (Map.Entry<String, String> file : classesToWrite.entrySet()) {
+            ZipEntry entry = new ZipEntry(file.getKey());
+            zout.putNextEntry(entry);
+            zout.write(file.getValue().getBytes(UTF_8));
+            zout.closeEntry();
+          }
         }
-
-        zout.close();
 
         classes.toFile().setLastModified(AarGeneratorAction.DEFAULT_TIMESTAMP);
       }

--- a/src/test/java/com/google/devtools/build/android/ZipFilterActionTest.java
+++ b/src/test/java/com/google/devtools/build/android/ZipFilterActionTest.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.singlejar.ZipEntryFilter.StrategyCallback;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
@@ -119,7 +120,7 @@ public class ZipFilterActionTest {
 
   private Path createZip(Entry... entries) throws IOException {
     File zip = tmp.newFile();
-    try (ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(zip))) {
+    try (ZipOutputStream zout = new ZipOutputStream(Files.newOutputStream(zip.toPath()))) {
       for (Entry entry : entries) {
         ZipEntry e = new ZipEntry(entry.getName());
         zout.putNextEntry(e);

--- a/src/test/java/com/google/devtools/build/android/desugar/io/IndexedInputsTest.java
+++ b/src/test/java/com/google/devtools/build/android/desugar/io/IndexedInputsTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.junit.After;
@@ -50,7 +51,7 @@ public final class IndexedInputsTest {
   public static void setUpClass() throws Exception {
     lib1 = File.createTempFile("lib1", ".jar");
     lib1Name = lib1.getName();
-    try (ZipOutputStream zos1 = new ZipOutputStream(new FileOutputStream(lib1))) {
+    try (ZipOutputStream zos1 = new ZipOutputStream(Files.newOutputStream(lib1.toPath()))) {
       zos1.putNextEntry(new ZipEntry("a/b/C.class"));
       zos1.putNextEntry(new ZipEntry("a/b/D.class"));
       zos1.closeEntry();
@@ -58,7 +59,7 @@ public final class IndexedInputsTest {
 
     lib2 = File.createTempFile("lib2", ".jar");
     lib2Name = lib2.getName();
-    try (ZipOutputStream zos2 = new ZipOutputStream(new FileOutputStream(lib2))) {
+    try (ZipOutputStream zos2 = new ZipOutputStream(Files.newOutputStream(lib2.toPath()))) {
       zos2.putNextEntry(new ZipEntry("a/b/C.class"));
       zos2.putNextEntry(new ZipEntry("a/b/E.class"));
       zos2.closeEntry();

--- a/src/test/java/com/google/devtools/build/android/idlclass/IdlClassTest.java
+++ b/src/test/java/com/google/devtools/build/android/idlclass/IdlClassTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -97,8 +98,7 @@ public class IdlClassTest {
             "c/g/Bar$Inner.class",
             "c/g/Bar2$Inner.class");
 
-    try (OutputStream os = new FileOutputStream(classJar);
-        ZipOutputStream zos = new ZipOutputStream(os)) {
+    try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(classJar.toPath()))) {
       for (String path : classes) {
         zos.putNextEntry(new ZipEntry(path));
       }
@@ -113,7 +113,7 @@ public class IdlClassTest {
       tempFolder.newFile(file);
     }
 
-    try (OutputStream os = new FileOutputStream(manifestProto)) {
+    try (OutputStream os = Files.newOutputStream(manifestProto.toPath())) {
       MANIFEST.writeTo(os);
     }
 

--- a/src/test/java/com/google/devtools/build/android/ziputils/FileSystem.java
+++ b/src/test/java/com/google/devtools/build/android/ziputils/FileSystem.java
@@ -19,6 +19,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 /**
  * A simple file system abstraction, for testing. This library doesn't itself open files.
@@ -50,7 +52,7 @@ class FileSystem  {
    * @throws java.io.IOException
    */
   public FileChannel getInputChannel(String filename) throws IOException {
-    return new FileInputStream(filename).getChannel();
+    return Files.newInputStream(Paths.get(filename)).getChannel();
   }
 
   /**
@@ -62,7 +64,7 @@ class FileSystem  {
    * @throws java.io.IOException
    */
   public FileChannel getOutputChannel(String filename, boolean append) throws IOException {
-    return new FileOutputStream(filename, append).getChannel();
+    return Files.newOutputStream(Paths.get(filename), append).getChannel();
   }
 
   /**
@@ -73,6 +75,6 @@ class FileSystem  {
    * @throws java.io.IOException
    */
   public InputStream getInputStream(String filename) throws IOException {
-    return new FileInputStream(filename);
+    return Files.newInputStream(Paths.get(filename));
   }
 }

--- a/src/test/java/com/google/devtools/build/android/ziputils/SplitZipFiltersTest.java
+++ b/src/test/java/com/google/devtools/build/android/ziputils/SplitZipFiltersTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -51,7 +52,7 @@ public class SplitZipFiltersTest {
   private File createZip(String... entries) throws FileNotFoundException, IOException {
     File zip = tmp.newFile();
     int count = 0;
-    try (ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(zip))) {
+    try (ZipOutputStream zout = new ZipOutputStream(Files.newOutputStream(zip.toPath()))) {
       for (String entry : entries) {
         zout.putNextEntry(new ZipEntry(entry));
         zout.write(("contents" + count++).getBytes(UTF_8)); // unique content

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.nio.file.Files;
 import java.net.InetAddress;
 import java.net.Proxy;
 import java.net.ServerSocket;

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorTest.java
@@ -32,10 +32,10 @@ import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.testutil.ManualSleeper;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.Reader;
 import java.net.InetAddress;
 import java.net.Proxy;
@@ -490,7 +490,7 @@ public class HttpConnectorTest {
 
   private File createTempFile(byte[] fileContents) throws IOException {
     File temp = testFolder.newFile();
-    try (FileOutputStream outputStream = new FileOutputStream(temp)) {
+    try (OutputStream outputStream = Files.newOutputStream(temp.toPath())) {
       outputStream.write(fileContents);
     }
     return temp;

--- a/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/BinaryFormatFileTransportTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/BinaryFormatFileTransportTest.java
@@ -44,6 +44,7 @@ import com.google.devtools.common.options.Options;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -110,7 +111,7 @@ public class BinaryFormatFileTransportTest {
     transport.sendBuildEvent(buildEvent, artifactGroupNamer);
 
     transport.close().get();
-    try (InputStream in = new FileInputStream(output)) {
+    try (InputStream in = Files.newInputStream(output.toPath())) {
       assertThat(BuildEventStreamProtos.BuildEvent.parseDelimitedFrom(in)).isEqualTo(started);
       assertThat(BuildEventStreamProtos.BuildEvent.parseDelimitedFrom(in)).isEqualTo(progress);
       assertThat(BuildEventStreamProtos.BuildEvent.parseDelimitedFrom(in)).isEqualTo(completed);
@@ -135,7 +136,7 @@ public class BinaryFormatFileTransportTest {
     transport.sendBuildEvent(buildEvent, artifactGroupNamer);
 
     transport.close().get();
-    try (InputStream in = new FileInputStream(output)) {
+    try (InputStream in = Files.newInputStream(output.toPath())) {
       assertThat(BuildEventStreamProtos.BuildEvent.parseDelimitedFrom(in)).isEqualTo(started);
       assertThat(in.available()).isEqualTo(0);
     }
@@ -164,7 +165,7 @@ public class BinaryFormatFileTransportTest {
     transport.close().get();
 
     // Also, nothing should have been written to the file
-    try (InputStream in = new FileInputStream(output)) {
+    try (InputStream in = Files.newInputStream(output.toPath())) {
       assertThat(in.available()).isEqualTo(0);
     }
   }
@@ -192,7 +193,7 @@ public class BinaryFormatFileTransportTest {
     assertThat(transport.writer.pendingWrites.isEmpty()).isTrue();
 
     // There should have only been one write.
-    try (InputStream in = new FileInputStream(output)) {
+    try (InputStream in = Files.newInputStream(output.toPath())) {
       assertThat(BuildEventStreamProtos.BuildEvent.parseDelimitedFrom(in)).isEqualTo(started);
       assertThat(in.available()).isEqualTo(0);
     }
@@ -233,7 +234,7 @@ public class BinaryFormatFileTransportTest {
 
     assertThat(transport.writer.pendingWrites.isEmpty()).isTrue();
 
-    try (InputStream in = new FileInputStream(output)) {
+    try (InputStream in = Files.newInputStream(output.toPath())) {
       assertThat(BuildEventStreamProtos.BuildEvent.parseDelimitedFrom(in))
           .isEqualTo(event1.asStreamProto(null));
       assertThat(BuildEventStreamProtos.BuildEvent.parseDelimitedFrom(in))
@@ -271,7 +272,7 @@ public class BinaryFormatFileTransportTest {
     transport.close().get();
 
     assertThat(transport.writer.pendingWrites).isEmpty();
-    try (InputStream in = new FileInputStream(output)) {
+    try (InputStream in = Files.newInputStream(output.toPath())) {
       assertThat(BuildEventStreamProtos.BuildEvent.parseDelimitedFrom(in))
           .isEqualTo(event1.asStreamProto(null));
       assertThat(in.available()).isEqualTo(0);
@@ -309,7 +310,7 @@ public class BinaryFormatFileTransportTest {
 
     closeFuture.get();
 
-    try (InputStream in = new FileInputStream(output)) {
+    try (InputStream in = Files.newInputStream(output.toPath())) {
       assertThat(BuildEventStreamProtos.BuildEvent.parseDelimitedFrom(in))
           .isEqualTo(event.asStreamProto(null));
       assertThat(in.available()).isEqualTo(0);

--- a/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/JsonFormatFileTransportTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/JsonFormatFileTransportTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.nio.file.Files;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -83,7 +84,7 @@ public class JsonFormatFileTransportTest {
     transport.sendBuildEvent(buildEvent, artifactGroupNamer);
 
     transport.close().get();
-    try (Reader reader = new InputStreamReader(new FileInputStream(output))) {
+    try (Reader reader = new InputStreamReader(Files.newInputStream(output.toPath()))) {
       JsonFormat.Parser parser = JsonFormat.parser();
       BuildEventStreamProtos.BuildEvent.Builder builder =
           BuildEventStreamProtos.BuildEvent.newBuilder();

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/CompressedTarFunctionTest.java
@@ -117,7 +117,8 @@ public class CompressedTarFunctionTest {
           @Override
           protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
               throws IOException {
-            return new GZIPInputStream(new FileInputStream(descriptor.archivePath().getPathFile()));
+            return new GZIPInputStream(
+                Files.newInputStream(descriptor.archivePath().getPathFile().toPath()));
           }
         }.decompress(descriptorBuilder.build());
 
@@ -140,7 +141,8 @@ public class CompressedTarFunctionTest {
           @Override
           protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
               throws IOException {
-            return new GZIPInputStream(new FileInputStream(descriptor.archivePath().getPathFile()));
+            return new GZIPInputStream(
+                Files.newInputStream(descriptor.archivePath().getPathFile().toFile()));
           }
         }.decompress(descriptorBuilder.build());
 

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/CompressedTarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/CompressedTarFunctionTest.java
@@ -142,7 +142,7 @@ public class CompressedTarFunctionTest {
           protected InputStream getDecompressorStream(DecompressorDescriptor descriptor)
               throws IOException {
             return new GZIPInputStream(
-                Files.newInputStream(descriptor.archivePath().getPathFile().toFile()));
+                Files.newInputStream(descriptor.archivePath().getPathFile().toPath()));
           }
         }.decompress(descriptorBuilder.build());
 

--- a/src/test/java/com/google/devtools/build/lib/util/SimpleLogHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/SimpleLogHandlerTest.java
@@ -324,7 +324,7 @@ public final class SimpleLogHandlerTest {
   private Path newFileWithContent(String name, String content) throws IOException {
     File file = tmp.newFile(name);
     try (OutputStreamWriter writer =
-        new OutputStreamWriter(new FileOutputStream(file.getPath()), UTF_8)) {
+        new OutputStreamWriter(Files.newOutputStream(file.toPath()), UTF_8)) {
       writer.write(content);
     }
     return file.toPath();
@@ -353,7 +353,7 @@ public final class SimpleLogHandlerTest {
     assertThat(handler.getCurrentLogFilePath().get().toString()).isEqualTo(logPath.toString());
     handler.close();
     try (BufferedReader logReader =
-        new BufferedReader(new InputStreamReader(new FileInputStream(logPath.toFile()), UTF_8))) {
+        new BufferedReader(new InputStreamReader(Files.newInputStream(logPath.toFile()), UTF_8))) {
       assertThat(logReader.readLine()).isEqualTo("Previous logs");
       assertThat(logReader.readLine()).isEqualTo("New logs");
     }

--- a/src/test/java/com/google/devtools/build/lib/util/SimpleLogHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/SimpleLogHandlerTest.java
@@ -324,7 +324,7 @@ public final class SimpleLogHandlerTest {
   private Path newFileWithContent(String name, String content) throws IOException {
     File file = tmp.newFile(name);
     try (OutputStreamWriter writer =
-        new OutputStreamWriter(Files.newOutputStream(file.toPath()), UTF_8)) {
+        new OutputStreamWriter(new FileOutputStream(file.getPath()), UTF_8)) {
       writer.write(content);
     }
     return file.toPath();
@@ -353,7 +353,7 @@ public final class SimpleLogHandlerTest {
     assertThat(handler.getCurrentLogFilePath().get().toString()).isEqualTo(logPath.toString());
     handler.close();
     try (BufferedReader logReader =
-        new BufferedReader(new InputStreamReader(Files.newInputStream(logPath), UTF_8))) {
+        new BufferedReader(new InputStreamReader(new FileInputStream(logPath.toFile()), UTF_8))) {
       assertThat(logReader.readLine()).isEqualTo("Previous logs");
       assertThat(logReader.readLine()).isEqualTo("New logs");
     }

--- a/src/test/java/com/google/devtools/build/lib/util/SimpleLogHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/SimpleLogHandlerTest.java
@@ -353,7 +353,7 @@ public final class SimpleLogHandlerTest {
     assertThat(handler.getCurrentLogFilePath().get().toString()).isEqualTo(logPath.toString());
     handler.close();
     try (BufferedReader logReader =
-        new BufferedReader(new InputStreamReader(Files.newInputStream(logPath.toFile()), UTF_8))) {
+        new BufferedReader(new InputStreamReader(Files.newInputStream(logPath), UTF_8))) {
       assertThat(logReader.readLine()).isEqualTo("Previous logs");
       assertThat(logReader.readLine()).isEqualTo("New logs");
     }

--- a/src/tools/android/java/com/google/devtools/build/android/ResourceShrinkerAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/ResourceShrinkerAction.java
@@ -35,8 +35,8 @@ import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.ShellQuotedParamsFilePreProcessor;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -255,14 +255,13 @@ public class ResourceShrinkerAction {
       resourcePackages.addAll(options.resourcePackages);
 
       // Expand resource files zip into working directory.
-      try (ZipInputStream zin =
-          new ZipInputStream(new FileInputStream(options.resourcesZip.toFile()))) {
+      try (ZipInputStream zin = new ZipInputStream(Files.newInputStream(options.resourcesZip))) {
         ZipEntry entry;
         while ((entry = zin.getNextEntry()) != null) {
           if (!entry.isDirectory()) {
             Path output = resourceFiles.resolve(entry.getName());
             Files.createDirectories(output.getParent());
-            try (FileOutputStream fos = new FileOutputStream(output.toFile())) {
+            try (OutputStream fos = Files.newOutputStream(output)) {
               ByteStreams.copy(zin, fos);
             }
           }

--- a/src/tools/android/java/com/google/devtools/build/android/ResourcesZip.java
+++ b/src/tools/android/java/com/google/devtools/build/android/ResourcesZip.java
@@ -31,8 +31,8 @@ import com.google.devtools.build.android.aapt2.ResourceCompiler;
 import com.google.devtools.build.android.aapt2.ResourceLinker;
 import com.google.devtools.build.android.proto.SerializeFormat.ToolAttributes;
 import java.io.Closeable;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -152,7 +152,7 @@ public class ResourcesZip {
               Path output = workingDirectory.resolve(entry.getName());
               try {
                 Files.createDirectories(output.getParent());
-                try (FileOutputStream fos = new FileOutputStream(output.toFile())) {
+                try (OutputStream fos = Files.newOutputStream(output)) {
                   ByteStreams.copy(zipFile.getInputStream(entry), fos);
                 }
               } catch (IOException e) {

--- a/src/tools/android/java/com/google/devtools/build/android/aapt2/ResourceCompiler.java
+++ b/src/tools/android/java/com/google/devtools/build/android/aapt2/ResourceCompiler.java
@@ -238,8 +238,7 @@ public class ResourceCompiler {
         // aapt2 compile strips out namespaces and attributes from the resources tag.
         // Read them here separately and package them with the other flat files.
         xmlEventReader =
-            XMLInputFactory.newInstance()
-                .createXMLEventReader(new FileInputStream(file.toString()));
+            XMLInputFactory.newInstance().createXMLEventReader(Files.newInputStream(file));
 
         // Iterate through the XML until we find a start element.
         // This should mimic xmlEventReader.nextTag() except that it also skips DTD elements.

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/io/DirectoryInputFileProvider.java
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/io/DirectoryInputFileProvider.java
@@ -43,7 +43,7 @@ class DirectoryInputFileProvider implements InputFileProvider {
 
   @Override
   public InputStream getInputStream(String filename) throws IOException {
-    return new FileInputStream(root.resolve(filename).toFile());
+    return Files.newInputStream(root.resolve(filename));
   }
 
   @Override

--- a/src/tools/android/java/com/google/devtools/build/android/incrementaldeployment/StubApplication.java
+++ b/src/tools/android/java/com/google/devtools/build/android/incrementaldeployment/StubApplication.java
@@ -31,6 +31,8 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -452,25 +454,13 @@ public class StubApplication extends Application {
 
   private static void copy(File src, File dst) throws IOException {
     Log.v("StubApplication", "Copying " + src + " -> " + dst);
-    InputStream in = null;
-    OutputStream out = null;
-    try {
-      in = new FileInputStream(src);
-      out = new FileOutputStream(dst);
-
+    try (InputStream in = Files.newInputStream(src.toPath());
+      OutputStream out = Files.newOutputStream(dst.toPath())) {
       // Transfer bytes from in to out
       byte[] buf = new byte[1048576];
       int len;
       while ((len = in.read(buf)) > 0) {
         out.write(buf, 0, len);
-      }
-    } finally {
-      if (in != null) {
-        in.close();
-      }
-
-      if (out != null) {
-        out.close();
       }
     }
   }

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogParser.java
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogParser.java
@@ -26,6 +26,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.List;
@@ -218,21 +220,21 @@ final class ExecLogParser {
       golden = new ReorderingParser.Golden();
     }
 
-    try (InputStream input = new FileInputStream(logPath)) {
+    try (InputStream input = Files.newInputStream(Paths.get(logPath))) {
       Parser parser = new FilteringLogParser(input, options.restrictToRunner);
 
       if (output1 == null) {
         output(parser, System.out, golden);
       } else {
-        try (OutputStream output = new FileOutputStream(output1)) {
+        try (OutputStream output = Files.newOutputStream(Paths.get(output1))) {
           output(parser, output, golden);
         }
       }
     }
 
     if (secondPath != null) {
-      try (InputStream file2 = new FileInputStream(secondPath);
-          OutputStream output = new FileOutputStream(output2)) {
+      try (InputStream file2 = Files.newInputStream(Paths.get(secondPath));
+          OutputStream output = Files.newOutputStream(Paths.get(output2))) {
         Parser parser = new FilteringLogParser(file2, options.restrictToRunner);
         // ReorderingParser will read the whole golden on initialization,
         // so it is safe to close after.

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
@@ -67,11 +67,12 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.file.Files;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -330,7 +331,7 @@ public final class RemoteWorker {
     Path sandboxPath = null;
     try {
       sandboxPath = fs.getPath(remoteWorkerOptions.workPath).getChild("linux-sandbox");
-      try (FileOutputStream fos = new FileOutputStream(sandboxPath.getPathString())) {
+      try (OutputStream fos = Files.newOutputStream(sandboxPath.getPathFile().toPath())) {
         ByteStreams.copy(sandbox, fos);
       }
       sandboxPath.setExecutable(true);

--- a/src/tools/workspacelog/src/main/java/com/google/devtools/build/workspacelog/WorkspaceLogParser.java
+++ b/src/tools/workspacelog/src/main/java/com/google/devtools/build/workspacelog/WorkspaceLogParser.java
@@ -26,6 +26,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -91,7 +93,7 @@ final class WorkspaceLogParser {
       System.exit(1);
     }
 
-    try (InputStream input = new FileInputStream(options.logPath)) {
+    try (InputStream input = Files.newInputStream(Paths.get(options.logPath))) {
       ExcludingLogParser parser;
       if (options.excludeRule == null) {
         parser = new ExcludingLogParser(input, null);
@@ -102,7 +104,7 @@ final class WorkspaceLogParser {
       if (options.outputPath == null) {
         output(parser, System.out);
       } else {
-        try (OutputStream output = new FileOutputStream(options.outputPath)) {
+        try (OutputStream output = Files.newOutputStream(Paths.get(options.outputPath))) {
           output(parser, output);
         }
       }


### PR DESCRIPTION
Use `java.nio.file.Files.newInputStream` instead
of `new java.io.FileInputStream`. Same for output
streams.

Reason: the nio methods open files with deletion
sharing on Windows, while the io methods don't.
See e.g.  https://github.com/bazelbuild/bazel/commit/1a955020ff7a27b9d49c83aef89e0991380daa5e

Change-Id: I8144e6934cca597f8e4d403885a2d1508a8a2a0a