### PR TITLE
test wrapper: introduce a simple Path abstraction

### DIFF
--- a/tools/test/windows/test_wrapper.cc
+++ b/tools/test/windows/test_wrapper.cc
@@ -55,7 +55,7 @@ class Path {
   Path(const Path& other) = delete;
   Path& operator=(const Path& other) = delete;
   Path(const wchar_t* value);
-  Path& operator=(std::wstring&& value);
+  Path& operator=(const std::wstring& value);
   const std::wstring& Get() const { return path_; }
 
  private:
@@ -175,7 +175,7 @@ bool FindTestBinary(const Path& argv0, std::wstring test_path, Path* result) {
     LogError(__LINE__, error.c_str());
     return false;
   }
-  *result = std::move(wpath);
+  *result = wpath;
   return true;
 }
 
@@ -228,8 +228,8 @@ Path::Path(const wchar_t* value) {
   AsWindowsPath(&path_);
 }
 
-Path& Path::operator=(std::wstring&& value) {
-  path_ == std::move(value);
+Path& Path::operator=(const std::wstring& value) {
+  path_ = value;
   return *this;
 }
 


### PR DESCRIPTION
The class allows extracting the underlying path as
a (immutable) string so it's easy to pass the path
to WinAPI functions, but the class does not allow
mutating the unterlying path so it's safe to pass
around Path objects.

Change-Id: I8bb3c96d816a505513ecc4953fed53ed144a32b2