### PR TITLE
Handle virtual include names in the code coverage report

### DIFF
--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/SourceFileCoverage.java
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/SourceFileCoverage.java
@@ -76,16 +76,16 @@ class SourceFileCoverage {
   static TreeMap<String, Integer> mergeFunctionsExecution(
       SourceFileCoverage s1, SourceFileCoverage s2) {
     return Stream.of(
-        s1.functionsExecution, s2.functionsExecution)
-        .map(Map::entrySet)
-        .flatMap(Collection::stream)
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                Map.Entry::getValue,
-                Integer::sum,
-                TreeMap::new
-            ));
+          s1.functionsExecution, s2.functionsExecution)
+          .map(Map::entrySet)
+          .flatMap(Collection::stream)
+          .collect(
+              Collectors.toMap(
+                  Map.Entry::getKey,
+                  Map.Entry::getValue,
+                  Integer::sum,
+                  TreeMap::new
+              ));
   }
 
   /*
@@ -99,12 +99,12 @@ class SourceFileCoverage {
         .map(Map::entrySet)
         .flatMap(Collection::stream)
         .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                Map.Entry::getValue,
-                BranchCoverage::merge,
-                TreeMap::new
-            )
+              Collectors.toMap(
+                  Map.Entry::getKey,
+                  Map.Entry::getValue,
+                  BranchCoverage::merge,
+                  TreeMap::new
+              )
         );
   }
 

--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/SourceFileCoverage.java
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/SourceFileCoverage.java
@@ -76,16 +76,16 @@ class SourceFileCoverage {
   static TreeMap<String, Integer> mergeFunctionsExecution(
       SourceFileCoverage s1, SourceFileCoverage s2) {
     return Stream.of(
-          s1.functionsExecution, s2.functionsExecution)
-          .map(Map::entrySet)
-          .flatMap(Collection::stream)
-          .collect(
-              Collectors.toMap(
-                  Map.Entry::getKey,
-                  Map.Entry::getValue,
-                  Integer::sum,
-                  TreeMap::new
-              ));
+            s1.functionsExecution, s2.functionsExecution)
+            .map(Map::entrySet)
+            .flatMap(Collection::stream)
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    Map.Entry::getValue,
+                    Integer::sum,
+                    TreeMap::new
+                ));
   }
 
   /*
@@ -121,16 +121,16 @@ class SourceFileCoverage {
   static TreeMap<Integer, LineCoverage> mergeLines(
       SourceFileCoverage s1, SourceFileCoverage s2) {
     return Stream.of(s1.lines, s2.lines)
-        .map(Map::entrySet)
-        .flatMap(Collection::stream)
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                Map.Entry::getValue,
-                LineCoverage::merge,
-                TreeMap::new
-            )
-        );
+            .map(Map::entrySet)
+            .flatMap(Collection::stream)
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    Map.Entry::getValue,
+                    LineCoverage::merge,
+                    TreeMap::new
+                )
+            );
   }
 
   private static int getNumberOfExecutedLines(SourceFileCoverage sourceFileCoverage) {

--- a/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/SourceFileCoverage.java
+++ b/tools/test/LcovMerger/java/com/google/devtools/lcovmerger/SourceFileCoverage.java
@@ -99,12 +99,12 @@ class SourceFileCoverage {
         .map(Map::entrySet)
         .flatMap(Collection::stream)
         .collect(
-              Collectors.toMap(
-                  Map.Entry::getKey,
-                  Map.Entry::getValue,
-                  BranchCoverage::merge,
-                  TreeMap::new
-              )
+            Collectors.toMap(
+              Map.Entry::getKey,
+              Map.Entry::getValue,
+              BranchCoverage::merge,
+              TreeMap::new
+            )
         );
   }
 

--- a/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/SourceFileCoverageTest.java
+++ b/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/SourceFileCoverageTest.java
@@ -84,4 +84,10 @@ public class SourceFileCoverageTest {
         "bazel-out/k8-fastbuild/bin/include/common/_virtual_includes/strategy/strategy.h")
         .sourceFileName()).isEqualTo("include/common/strategy.h");
   }
+
+  @Test
+  public void testConstructorWithoutVirtualIncludeFile() {
+    assertThat(new SourceFileCoverage("include/common/strategy.h")
+        .sourceFileName()).isEqualTo("include/common/strategy.h");
+  }
 }

--- a/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/SourceFileCoverageTest.java
+++ b/tools/test/LcovMerger/javatests/com/google/devtools/lcovmerger/SourceFileCoverageTest.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.lcovmerger;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.lcovmerger.LcovMergerTestUtils.assertMergedFunctionsExecution;
 import static com.google.devtools.lcovmerger.LcovMergerTestUtils.assertMergedLineNumbers;
 import static com.google.devtools.lcovmerger.LcovMergerTestUtils.assertMergedLines;
@@ -77,4 +78,10 @@ public class SourceFileCoverageTest {
         SourceFileCoverage.merge(sourceFile1, sourceFile2), linesExecution1, linesExecution2);
   }
 
+  @Test
+  public void testConstructorWithVirtualIncludeFile() {
+    assertThat(new SourceFileCoverage(
+        "bazel-out/k8-fastbuild/bin/include/common/_virtual_includes/strategy/strategy.h")
+        .sourceFileName()).isEqualTo("include/common/strategy.h");
+  }
 }


### PR DESCRIPTION
Reverse engineer the actual name of virtual includes in the code coverage report generated by LcovMerger.

RELNOTES: The code coverage report includes the actual paths to header files instead of the ugly, 
Bazel generated, virtual includes path. For example, the `SF:` (source file) lines in the coverage report are now like this:
```
SF:include/common/strategy.h
```
instead of
```
SF:bazel-out/k8-fastbuild/bin/include/common/_virtual_includes/strategy/strategy.h
```