### PR TITLE
Collect template variable providers from toolchain targets.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfigurationMakeVariableContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfigurationMakeVariableContext.java
@@ -26,7 +26,9 @@ import com.google.devtools.build.lib.analysis.stringtemplate.TemplateContext;
 import com.google.devtools.build.lib.packages.Package;
 import com.google.devtools.build.lib.syntax.SkylarkDict;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Implements make variable expansion for make variables that depend on the configuration and the
@@ -38,16 +40,28 @@ public class ConfigurationMakeVariableContext implements TemplateContext {
   private static ImmutableList<TemplateVariableInfo> getRuleTemplateVariableProviders(
       RuleContext ruleContext, Iterable<String> attributeNames) {
 
-    return Streams.stream(attributeNames)
-        // Only process this attribute it if is present in the rule.
-        .filter(attrName -> ruleContext.attributes().has(attrName))
-        // Get the TemplateVariableInfo providers from this attribute.
-        .flatMap(
-            attrName ->
-                Streams.stream(
-                    ruleContext.getPrerequisites(
-                        attrName, Mode.DONT_CHECK, TemplateVariableInfo.PROVIDER)))
-        .collect(ImmutableList.toImmutableList());
+    ImmutableList.Builder<TemplateVariableInfo> providers = new ImmutableList.Builder<>();
+
+    // Get template variable providers from the attributes.
+    List<TemplateVariableInfo> fromAttributes =
+        Streams.stream(attributeNames)
+            // Only process this attribute it if is present in the rule.
+            .filter(attrName -> ruleContext.attributes().has(attrName))
+            // Get the TemplateVariableInfo providers from this attribute.
+            .flatMap(
+                attrName ->
+                    Streams.stream(
+                        ruleContext.getPrerequisites(
+                            attrName, Mode.DONT_CHECK, TemplateVariableInfo.PROVIDER)))
+            .collect(Collectors.toList());
+    providers.addAll(fromAttributes);
+
+    // Also collect template variable providers from any resolved toolchains.
+    if (ruleContext.getToolchainContext() != null) {
+      providers.addAll(ruleContext.getToolchainContext().templateVariableProviders());
+    }
+
+    return providers.build();
   }
 
   private final ImmutableList<? extends MakeVariableSupplier> allMakeVariableSuppliers;
@@ -86,7 +100,7 @@ public class ConfigurationMakeVariableContext implements TemplateContext {
             // 1) extra suppliers passed in (assume the caller knows what they are doing)
             // 2) variables from the command-line
             // 3) package-level overrides (ie, vardef)
-            // 4) variables from the rule (and thus the toolchains)
+            // 4) variables from the rule (including from resolved toolchains)
             // 5) variables from the global configuration
             .addAll(Preconditions.checkNotNull(extraMakeVariableSuppliers))
             .add(new MapBackedMakeVariableSupplier(configuration.getCommandLineBuildVariables()))

--- a/src/main/java/com/google/devtools/build/lib/analysis/ToolchainContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ToolchainContext.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.analysis;
 import static java.util.stream.Collectors.joining;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
@@ -61,6 +62,9 @@ public abstract class ToolchainContext implements ToolchainContextApi {
     /** Sets the map from toolchain type to toolchain provider. */
     Builder setToolchains(ImmutableMap<Label, ToolchainInfo> toolchains);
 
+    /** Sets the template variables that these toolchains provide. */
+    Builder setTemplateVariableProviders(ImmutableList<TemplateVariableInfo> providers);
+
     /** Sets the labels of the specific toolchains being used. */
     Builder setResolvedToolchainLabels(ImmutableSet<Label> resolvedToolchainLabels);
 
@@ -81,6 +85,9 @@ public abstract class ToolchainContext implements ToolchainContextApi {
   public abstract ImmutableSet<Label> requiredToolchainTypes();
 
   abstract ImmutableMap<Label, ToolchainInfo> toolchains();
+
+  /** Returns the template variables that these toolchains provide. */
+  public abstract ImmutableList<TemplateVariableInfo> templateVariableProviders();
 
   /** Returns the labels of the specific toolchains being used. */
   public abstract ImmutableSet<Label> resolvedToolchainLabels();

--- a/src/main/java/com/google/devtools/build/lib/analysis/ToolchainResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ToolchainResolver.java
@@ -518,6 +518,7 @@ public class ToolchainResolver {
                       attribute.getName().equals(PlatformSemantics.RESOLVED_TOOLCHAINS_ATTR))
               .findFirst();
       ImmutableMap.Builder<Label, ToolchainInfo> toolchains = new ImmutableMap.Builder<>();
+      ImmutableList.Builder<TemplateVariableInfo> templateVariableProviders = new ImmutableList.Builder<>();
       if (toolchainAttribute.isPresent()) {
         for (ConfiguredTargetAndData target : prerequisiteMap.get(toolchainAttribute.get())) {
           Label discoveredLabel = target.getTarget().getLabel();
@@ -532,11 +533,18 @@ public class ToolchainResolver {
           }
 
           // Find any template variables present for this toolchain.
-          // TODO(jcater): save this somewhere.
+          TemplateVariableInfo templateVariableInfo = target.getConfiguredTarget()
+              .get(TemplateVariableInfo.PROVIDER);
+          if (templateVariableInfo != null) {
+            templateVariableProviders.add(templateVariableInfo);
+          }
         }
       }
 
-      return toolchainContext.setToolchains(toolchains.build()).build();
+      return toolchainContext
+          .setToolchains(toolchains.build())
+          .setTemplateVariableProviders(templateVariableProviders.build())
+          .build();
     }
   }
 


### PR DESCRIPTION
They can then be used by rules directly.

Note: genrule does not support per-target toolchains and so this is not
compatible with genrule.

Fixes #5223.

Change-Id: Idf673284a6c91d506e7ed48106050eb10b69f1b6