### PR TITLE
WIP -- Shell tests: call original set_up and tear_down

### DIFF
--- a/src/test/shell/BUILD
+++ b/src/test/shell/BUILD
@@ -67,6 +67,16 @@ sh_test(
     ],
 )
 
+sh_test(
+    name = "foo_test",
+    srcs = ["foo.sh"],
+    shard_count = 2,
+    data = [
+        ":bashunit",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
 test_suite(
     name = "windows_tests",
     tags = [

--- a/src/test/shell/bazel/apple/bazel_apple_test.sh
+++ b/src/test/shell/bazel/apple/bazel_apple_test.sh
@@ -28,6 +28,7 @@ if [ "${PLATFORM}" != "darwin" ]; then
 fi
 
 function set_up() {
+  testenv_set_up
   copy_examples
   setup_objc_test_support
 

--- a/src/test/shell/bazel/bazel_build_event_stream_test.sh
+++ b/src/test/shell/bazel/bazel_build_event_stream_test.sh
@@ -47,6 +47,8 @@ export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL="*"
 
 function set_up() {
+  testenv_set_up
+
   mkdir -p pkg
   touch remote_file
   if is_windows; then

--- a/src/test/shell/bazel/bazel_cc_code_coverage_test.sh
+++ b/src/test/shell/bazel/bazel_cc_code_coverage_test.sh
@@ -57,6 +57,7 @@ function get_file_id() {
 
 # Setup to be run for every test.
 function set_up() {
+   testenv_set_up
    mkdir -p "${COVERAGE_DIR_VAR}"
 
   # COVERAGE_DIR has to be different than ROOT and PWD for the test to be
@@ -158,6 +159,7 @@ function tear_down() {
   rm -f "$COVERAGE_OUTPUT_FILE_VAR"
   rm -rf "$COVERAGE_DIR_VAR"
   rm -rf coverage_srcs/
+  testenv_tear_down
 }
 
 # Runs the script that computes the code coverage report for CC code.

--- a/src/test/shell/bazel/bazel_example_test.sh
+++ b/src/test/shell/bazel/bazel_example_test.sh
@@ -23,6 +23,7 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 function set_up() {
+  testenv_set_up
   copy_examples
   cat > WORKSPACE <<EOF
 workspace(name = "io_bazel")

--- a/src/test/shell/bazel/bazel_experimental_ui_test.sh
+++ b/src/test/shell/bazel/bazel_experimental_ui_test.sh
@@ -41,6 +41,28 @@ fi
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
+# `uname` returns the current platform, e.g "MSYS_NT-10.0" or "Linux".
+# `tr` converts all upper case letters to lower case.
+# `case` matches the result if the `uname | tr` expression to string prefixes
+# that use the same wildcards as names do in Bash, i.e. "msys*" matches strings
+# starting with "msys", and "*" matches everything (it's the default case).
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*)
+  # As of 2018-08-14, Bazel on Windows only supports MSYS Bash.
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  # Disable MSYS path conversion that converts path-looking command arguments to
+  # Windows paths (even if they arguments are not in fact paths).
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+fi
+
 #### SETUP #############################################################
 
 set -e
@@ -49,9 +71,10 @@ add_to_bazelrc "build --genrule_strategy=local"
 add_to_bazelrc "test --test_strategy=standalone"
 
 function set_up() {
+  testenv_set_up
   mkdir -p pkg
   touch remote_file
-  if is_windows; then
+  if $is_windows; then
     # The correct syntax for http_file on Windows is "file:///c:/foo/bar.txt"
     local -r cwd="/$(cygpath -m "$PWD")"
   else

--- a/src/test/shell/bazel/bazel_repository_cache_test.sh
+++ b/src/test/shell/bazel/bazel_repository_cache_test.sh
@@ -24,6 +24,7 @@ source "${CURRENT_DIR}/remote_helpers.sh" \
   || { echo "remote_helpers.sh not found!" >&2; exit 1; }
 
 function set_up() {
+  testenv_set_up
   bazel clean --expunge >& $TEST_log
   repo_cache_dir=$TEST_TMPDIR/repository_cache
   # TODO(b/37617303): make test UI-independent
@@ -34,6 +35,7 @@ function set_up() {
 function tear_down() {
   shutdown_server
   rm -rf "$repo_cache_dir"
+  testenv_tear_down
 }
 
 function setup_repository() {

--- a/src/test/shell/bazel/bazel_sandboxing_cpp_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_cpp_test.sh
@@ -25,6 +25,7 @@ source ${CURRENT_DIR}/../sandboxing_test_utils.sh \
   || { echo "sandboxing_test_utils.sh not found!" >&2; exit 1; }
 
 function set_up {
+  testenv_set_up
   mkdir -p examples/cpp/{bin,lib}
   cat << 'EOF' > examples/cpp/BUILD
 cc_library(

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -35,6 +35,7 @@ build --spawn_strategy=sandboxed --genrule_strategy=sandboxed
 EOF
 
 function set_up {
+  testenv_set_up
   export BAZEL_GENFILES_DIR=$(bazel info bazel-genfiles 2>/dev/null)
   export BAZEL_BIN_DIR=$(bazel info bazel-bin 2>/dev/null)
 

--- a/src/test/shell/bazel/bazel_spawnstats_test.sh
+++ b/src/test/shell/bazel/bazel_spawnstats_test.sh
@@ -25,6 +25,7 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 function set_up() {
+  testenv_set_up
   cat > BUILD <<EOF
 genrule(
     name = "foo",

--- a/src/test/shell/bazel/bazel_strategy_test.sh
+++ b/src/test/shell/bazel/bazel_strategy_test.sh
@@ -22,7 +22,7 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 function set_up() {
-  create_new_workspace
+  testenv_set_up
   mkdir -p foo
 
   cat > foo/BUILD <<EOF

--- a/src/test/shell/bazel/bazel_windows_example_test.sh
+++ b/src/test/shell/bazel/bazel_windows_example_test.sh
@@ -32,6 +32,7 @@ if ! is_windows; then
 fi
 
 function set_up() {
+  testenv_set_up
   copy_examples
   setup_bazelrc
   cat >>"$TEST_TMPDIR/bazelrc" <<EOF

--- a/src/test/shell/bazel/bazel_with_jdk_test.sh
+++ b/src/test/shell/bazel/bazel_with_jdk_test.sh
@@ -27,6 +27,7 @@ function bazel() {
 }
 
 function set_up() {
+  testenv_set_up
   # TODO(philwo) remove this when the testenv improvement change is in
   if is_windows; then
     export PATH=/c/python_27_amd64/files:$PATH

--- a/src/test/shell/bazel/bazel_workspaces_test.sh
+++ b/src/test/shell/bazel/bazel_workspaces_test.sh
@@ -313,7 +313,7 @@ function tear_down() {
   if [ -d "${TEST_TMPDIR}/server_dir" ]; then
     rm -fr "${TEST_TMPDIR}/server_dir"
   fi
-  true
+  testenv_tear_down
 }
 
 run_suite "workspaces_tests"

--- a/src/test/shell/bazel/external_correctness_test.sh
+++ b/src/test/shell/bazel/external_correctness_test.sh
@@ -20,6 +20,7 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 function set_up() {
+  testenv_set_up
   LOCAL=$(pwd)
   REMOTE=$TEST_TMPDIR/remote
 

--- a/src/test/shell/bazel/git_repository_test.sh
+++ b/src/test/shell/bazel/git_repository_test.sh
@@ -26,6 +26,7 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
 #
 # Unpacks the test Git repositories in the test temporary directory.
 function set_up() {
+  testenv_set_up
   bazel clean --expunge
   local repos_dir=$TEST_TMPDIR/repos
   if [ -e "$repos_dir" ]; then

--- a/src/test/shell/bazel/maven_skylark_test.sh
+++ b/src/test/shell/bazel/maven_skylark_test.sh
@@ -78,6 +78,7 @@ EOF
 
 function tear_down() {
   shutdown_server
+  testenv_tear_down
 }
 
 function test_maven_jar_skylark() {

--- a/src/test/shell/bazel/maven_test.sh
+++ b/src/test/shell/bazel/maven_test.sh
@@ -50,6 +50,7 @@ EOF
 
 function tear_down() {
   shutdown_server
+  testenv_tear_down
 }
 
 function test_maven_jar() {

--- a/src/test/shell/bazel/remote/remote_execution_http_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_http_test.sh
@@ -23,6 +23,7 @@ source "${CURRENT_DIR}/../../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 function set_up() {
+  testenv_set_up
   work_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
   pid_file=$(mktemp -u "${TEST_TMPDIR}/remote.XXXXXXXX")
   attempts=1
@@ -57,6 +58,7 @@ function tear_down() {
   fi
   rm -rf "${pid_file}"
   rm -rf "${work_path}"
+  testenv_tear_down
 }
 
 function test_cc_binary_http_cache() {

--- a/src/test/shell/bazel/remote/remote_execution_sandboxing_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_sandboxing_test.sh
@@ -25,6 +25,7 @@ source "${CURRENT_DIR}/../../sandboxing_test_utils.sh" \
   || { echo "sandboxing_test_utils.sh not found!" >&2; exit 1; }
 
 function set_up() {
+  testenv_set_up
   work_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
   writable_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
   readonly_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
@@ -80,6 +81,7 @@ function tear_down() {
   fi
   rm -rf "${pid_file}"
   rm -rf "${work_path}"
+  testenv_tear_down
 }
 
 function test_genrule() {

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -23,6 +23,7 @@ source "${CURRENT_DIR}/../../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 function set_up() {
+  testenv_set_up
   work_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
   cas_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
   pid_file=$(mktemp -u "${TEST_TMPDIR}/remote.XXXXXXXX")
@@ -59,6 +60,7 @@ function tear_down() {
   rm -rf "${pid_file}"
   rm -rf "${work_path}"
   rm -rf "${cas_path}"
+  testenv_tear_down
 }
 
 function test_cc_binary() {

--- a/src/test/shell/bazel/rule_test_test.sh
+++ b/src/test/shell/bazel/rule_test_test.sh
@@ -42,13 +42,29 @@ fi
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-function set_up() {
+# `uname` returns the current platform, e.g "MSYS_NT-10.0" or "Linux".
+# `tr` converts all upper case letters to lower case.
+# `case` matches the result if the `uname | tr` expression to string prefixes
+# that use the same wildcards as names do in Bash, i.e. "msys*" matches strings
+# starting with "msys", and "*" matches everything (it's the default case).
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*)
+  # As of 2018-08-14, Bazel on Windows only supports MSYS Bash.
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  # Disable MSYS path conversion that converts path-looking command arguments to
+  # Windows paths (even if they arguments are not in fact paths).
   export MSYS_NO_PATHCONV=1
   export MSYS2_ARG_CONV_EXCL="*"
-}
+fi
 
 function test_local_rule_test_in_root() {
-  create_new_workspace
   cat > BUILD <<EOF
 genrule(
     name = "turtle",
@@ -75,7 +91,6 @@ EOF
 }
 
 function test_local_rule_test_in_subpackage() {
-  create_new_workspace
   mkdir p
   cat > p/BUILD <<EOF
 genrule(
@@ -103,7 +118,6 @@ EOF
 }
 
 function test_repository_rule_test_in_root() {
-  create_new_workspace
   mkdir -p r
 
   cat >> WORKSPACE <<EOF
@@ -139,7 +153,6 @@ EOF
 }
 
 function test_repository_rule_test_in_subpackage() {
-  create_new_workspace
   mkdir -p r
 
   cat >> WORKSPACE <<EOF

--- a/src/test/shell/bazel/skylark_git_repository_test.sh
+++ b/src/test/shell/bazel/skylark_git_repository_test.sh
@@ -26,6 +26,8 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
 #
 # Unpacks the test Git repositories in the test temporary directory.
 function set_up() {
+  testenv_set_up
+
   bazel clean --expunge
   local repos_dir=$TEST_TMPDIR/repos
   if [ -e "$repos_dir" ]; then

--- a/src/test/shell/bazel/skylark_repository_test.sh
+++ b/src/test/shell/bazel/skylark_repository_test.sh
@@ -1074,7 +1074,7 @@ function tear_down() {
   if [ -d "${TEST_TMPDIR}/server_dir" ]; then
     rm -fr "${TEST_TMPDIR}/server_dir"
   fi
-  true
+  testenv_tear_down
 }
 
 run_suite "local repository tests"

--- a/src/test/shell/bazel/toolchain_test.sh
+++ b/src/test/shell/bazel/toolchain_test.sh
@@ -23,7 +23,7 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 function set_up() {
-  create_new_workspace
+  testenv_set_up
 
   # Create shared report rule for printing toolchain info.
   mkdir report

--- a/src/test/shell/integration/action_env_test.sh
+++ b/src/test/shell/integration/action_env_test.sh
@@ -27,6 +27,7 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
 set -e
 
 function set_up() {
+  testenv_set_up
   mkdir -p pkg
   cat > pkg/BUILD <<EOF
 genrule(

--- a/src/test/shell/integration/bazel_command_log_test.sh
+++ b/src/test/shell/integration/bazel_command_log_test.sh
@@ -24,6 +24,7 @@ log="$(bazel --batch info command_log)"
 function tear_down() {
   # Clean up after ourselves.
   bazel --nobatch shutdown
+  testenv_tear_down
 }
 
 function strip_lines_from_bazel_cc() {

--- a/src/test/shell/integration/bazel_query_test.sh
+++ b/src/test/shell/integration/bazel_query_test.sh
@@ -499,6 +499,7 @@ EOF
 
 function tear_down() {
   bazel shutdown
+  testenv_tear_down
 }
 
 run_suite "${PRODUCT_NAME} query tests"

--- a/src/test/shell/integration/bazel_worker_test.sh
+++ b/src/test/shell/integration/bazel_worker_test.sh
@@ -39,6 +39,7 @@ add_to_bazelrc "build --debug_print_action_contexts"
 add_to_bazelrc "build ${ADDITIONAL_BUILD_FLAGS}"
 
 function set_up() {
+  testenv_set_up
   # Run each test in a separate folder so that their output files don't get cached.
   WORKSPACE_SUBDIR=$(basename $(mktemp -d ${WORKSPACE_DIR}/testXXXXXX))
   cd ${WORKSPACE_SUBDIR}

--- a/src/test/shell/integration/build_event_stream_test.sh
+++ b/src/test/shell/integration/build_event_stream_test.sh
@@ -28,7 +28,7 @@ add_to_bazelrc "build --experimental_build_event_upload_strategy=local"
 set -e
 
 function set_up() {
-  create_new_workspace
+  testenv_set_up
 
   mkdir -p pkg
   touch pkg/somesourcefile

--- a/src/test/shell/integration/client_sigint_test.sh
+++ b/src/test/shell/integration/client_sigint_test.sh
@@ -67,6 +67,7 @@ EOF
 function tear_down() {
   bazel shutdown
   rm -rf x
+  testenv_tear_down
 }
 
 function assert_sigint_stops_build() {

--- a/src/test/shell/integration/client_test.sh
+++ b/src/test/shell/integration/client_test.sh
@@ -21,6 +21,7 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
 
 
 function set_up() {
+  testenv_set_up
   write_default_bazelrc
   # Print client log statements to stderr so they get picked up by the test log
   # in the event of a failure.
@@ -30,6 +31,7 @@ function set_up() {
 
 function tear_down() {
   bazel --nobatch shutdown
+  testenv_set_up
 }
 
 #### TESTS #############################################################

--- a/src/test/shell/integration/discard_graph_edges_test.sh
+++ b/src/test/shell/integration/discard_graph_edges_test.sh
@@ -28,6 +28,7 @@ source "${CURRENT_DIR}/discard_graph_edges_lib.sh" \
 set -e
 
 function set_up() {
+  testenv_set_up
   mkdir -p testing || fail "Couldn't create directory"
   echo "cc_test(name='mytest', srcs=['mytest.cc'], malloc=':system_malloc')" > testing/BUILD || fail
   echo "cc_library(name='system_malloc', srcs=[])"                           >> testing/BUILD || fail

--- a/src/test/shell/integration/experimental_ui_test.sh
+++ b/src/test/shell/integration/experimental_ui_test.sh
@@ -61,6 +61,7 @@ add_to_bazelrc "build --genrule_strategy=local"
 add_to_bazelrc "test --test_strategy=standalone"
 
 function set_up() {
+  testenv_set_up
   if [[ -d pkg ]]; then
     # All tests share these scratch packages. No need to recreate them if they
     # already exist.

--- a/src/test/shell/integration/force_delete_output_test.sh
+++ b/src/test/shell/integration/force_delete_output_test.sh
@@ -27,6 +27,7 @@ function tear_down() {
   bazel clean
   bazel shutdown
   rm -rf x
+  testenv_tear_down
 }
 
 function test_delete_in_unwritable_dir() {

--- a/src/test/shell/integration/linux-sandbox_network_test.sh
+++ b/src/test/shell/integration/linux-sandbox_network_test.sh
@@ -37,6 +37,7 @@ readonly SANDBOX_DIR="${OUT_DIR}/sandbox"
 SANDBOX_DEFAULT_OPTS="-W $SANDBOX_DIR"
 
 function set_up {
+  testenv_set_up
   rm -rf $OUT_DIR
   mkdir -p $SANDBOX_DIR
 }

--- a/src/test/shell/integration/linux-sandbox_test.sh
+++ b/src/test/shell/integration/linux-sandbox_test.sh
@@ -41,6 +41,7 @@ readonly CPU_TIME_SPENDER="${CURRENT_DIR}/../../../test/shell/integration/spend_
 SANDBOX_DEFAULT_OPTS="-W $SANDBOX_DIR"
 
 function set_up {
+  testenv_set_up
   rm -rf $OUT_DIR
   mkdir -p $SANDBOX_DIR
 }

--- a/src/test/shell/integration/loading_phase_posix_test.sh
+++ b/src/test/shell/integration/loading_phase_posix_test.sh
@@ -49,11 +49,13 @@ TEST_stderr=$(dirname $TEST_log)/stderr
 #### HELPER FUNCTIONS ##################################################
 
 function set_up() {
+    testenv_set_up
     cd ${WORKSPACE_DIR}
 }
 
 function tear_down() {
     bazel shutdown
+    testenv_tear_down
 }
 
 #### TESTS #############################################################

--- a/src/test/shell/integration/loading_phase_test.sh
+++ b/src/test/shell/integration/loading_phase_test.sh
@@ -66,11 +66,13 @@ TEST_stderr=$(dirname $TEST_log)/stderr
 #### HELPER FUNCTIONS ##################################################
 
 function set_up() {
+    testenv_set_up
     cd ${WORKSPACE_DIR}
 }
 
 function tear_down() {
     bazel shutdown
+    testenv_tear_down
 }
 
 #### TESTS #############################################################

--- a/src/test/shell/integration/modify_execution_info_test.sh
+++ b/src/test/shell/integration/modify_execution_info_test.sh
@@ -25,10 +25,12 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
 
 function set_up() {
     cd ${WORKSPACE_DIR}
+    testenv_set_up
 }
 
 function tear_down() {
     bazel shutdown
+    testenv_tear_down
 }
 
 #### TESTS #############################################################

--- a/src/test/shell/integration/nonincremental_builds_test.sh
+++ b/src/test/shell/integration/nonincremental_builds_test.sh
@@ -67,6 +67,7 @@ fi
 
 function tear_down() {
     bazel shutdown || fail "Failed to shut down bazel"
+    testenv_tear_down
 }
 
 #### TESTS #############################################################

--- a/src/test/shell/integration/process-wrapper_test.sh
+++ b/src/test/shell/integration/process-wrapper_test.sh
@@ -34,6 +34,7 @@ readonly ERR="${OUT_DIR}/errfile"
 readonly EXIT_STATUS_SIGALRM=$((128 + 14))
 
 function set_up() {
+  testenv_set_up
   rm -rf $OUT_DIR
   mkdir -p $OUT_DIR
 }

--- a/src/test/shell/integration/stamping_test.sh
+++ b/src/test/shell/integration/stamping_test.sh
@@ -24,6 +24,7 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
 set -e
 
 function set_up() {
+  testenv_set_up
   mkdir -p pkg
   cat > pkg/BUILD <<EOF
 genrule(

--- a/src/test/shell/integration/stub_finds_runfiles_test.sh
+++ b/src/test/shell/integration/stub_finds_runfiles_test.sh
@@ -35,6 +35,7 @@ fi
 #### HELPER FUNCTIONS ##################################################
 
 function set_up() {
+  testenv_set_up
   mkdir -p pkg pkg/java
   cat > pkg/BUILD << 'EOF'
 java_binary(name = "javabin",
@@ -97,6 +98,7 @@ EOF
 
 function tear_down() {
   rm -rf pkg pkg/java
+  testenv_tear_down
 }
 
 #### TESTS #############################################################

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -450,9 +450,31 @@ function cleanup() {
   fi
 }
 
+function set_up() {
+  create_and_cd_client
+}
+
 function tear_down() {
   cleanup_workspace
 }
+
+# Define testenv_set_up and testenv_tear_down as copies of set_up/tear_down.
+#
+# Tests that define "set_up" will override the existing set_up definition.
+# For correct behavior they should explicitly call "testenv_set_up" at the
+# start of their "set_up" implementation. Similarly, tests that define
+# "tear_down" should call "testenv_tear_down" at the end of their "tear_down".
+#
+# Tests that do not define "set_up" (or "tear_down") will inherit the existing 
+# the definition and the test framework will run that for them.
+function declare_testenv_setup_teardown() {
+  for func in set_up tear_down; do
+    local function_definition=$(declare -f $func)
+    function_definition="testenv_${function_definition}"
+    eval "$function_definition"
+  done
+}
+declare_testenv_setup_teardown
 
 #
 # Simples assert to make the tests more readable
@@ -529,7 +551,3 @@ function create_and_cd_client() {
   echo "workspace(name = '$WORKSPACE_NAME')" >WORKSPACE
   touch .bazelrc
 }
-
-################### Extra ############################
-# Functions that need to be called before each test.
-create_and_cd_client

--- a/src/test/shell/unittest_test.sh
+++ b/src/test/shell/unittest_test.sh
@@ -43,6 +43,7 @@ source "$(rlocation "io_bazel/src/test/shell/unittest.bash")" \
   || { echo "Could not source unittest.bash" >&2; exit 1; }
 
 function set_up() {
+  testenv_set_up
   tmp_TEST_TMPDIR=$TEST_TMPDIR
   TEST_TMPDIR=$TEST_TMPDIR/$TEST_name
   mkdir -p $TEST_TMPDIR
@@ -50,6 +51,7 @@ function set_up() {
 
 function tear_down() {
   TEST_TMPDIR=$tmp_TEST_TMPDIR
+  testenv_tear_down
 }
 
 function test_1() {


### PR DESCRIPTION
Bash scripts may silently override functions,
losing the original definition.

testenv.sh defines set_up and tear_down that every
test needs to run, but overriding these functions
loses the original definition.

This patch:

- introduces testenv_set_up and testenv_tear_down,
  which are copies of the original set_up and
  tear_down methods in testenv.sh

- updates every test that overrides set_up and/or
  tear_down to explicitly call the original
  functions

This changes ensures that every test method runs
in a similar mock workspace.

Change-Id: I51584df63f1aebfe90767abcd57d647d76bce1a0