### PR TITLE
CROSSTOOL linker flags are incorrect for dead_strip feature which lea…

### DIFF
--- a/tools/osx/crosstool/CROSSTOOL.tpl
+++ b/tools/osx/crosstool/CROSSTOOL.tpl
@@ -1065,8 +1065,8 @@ toolchain {
       action: "objc-executable"
       action: "objc++-executable"
       flag_group {
-        flag: "--dead_strip"
-        flag: "--no_dead_strip_inits_and_terms"
+        flag: "-dead_strip"
+        flag: "-no_dead_strip_inits_and_terms"
       }
     }
     requires {
@@ -2724,8 +2724,8 @@ toolchain {
       action: "objc-executable"
       action: "objc++-executable"
       flag_group {
-        flag: "--dead_strip"
-        flag: "--no_dead_strip_inits_and_terms"
+        flag: "-dead_strip"
+        flag: "-no_dead_strip_inits_and_terms"
       }
     }
     requires {
@@ -4391,8 +4391,8 @@ toolchain {
       action: "objc-executable"
       action: "objc++-executable"
       flag_group {
-        flag: "--dead_strip"
-        flag: "--no_dead_strip_inits_and_terms"
+        flag: "-dead_strip"
+        flag: "-no_dead_strip_inits_and_terms"
       }
     }
     requires {
@@ -6057,8 +6057,8 @@ toolchain {
       action: "objc-executable"
       action: "objc++-executable"
       flag_group {
-        flag: "--dead_strip"
-        flag: "--no_dead_strip_inits_and_terms"
+        flag: "-dead_strip"
+        flag: "-no_dead_strip_inits_and_terms"
       }
     }
     requires {
@@ -7752,8 +7752,8 @@ toolchain {
       action: "objc-executable"
       action: "objc++-executable"
       flag_group {
-        flag: "--dead_strip"
-        flag: "--no_dead_strip_inits_and_terms"
+        flag: "-dead_strip"
+        flag: "-no_dead_strip_inits_and_terms"
       }
     }
     requires {
@@ -9417,8 +9417,8 @@ toolchain {
       action: "objc-executable"
       action: "objc++-executable"
       flag_group {
-        flag: "--dead_strip"
-        flag: "--no_dead_strip_inits_and_terms"
+        flag: "-dead_strip"
+        flag: "-no_dead_strip_inits_and_terms"
       }
     }
     requires {
@@ -11072,8 +11072,8 @@ toolchain {
       action: "objc-executable"
       action: "objc++-executable"
       flag_group {
-        flag: "--dead_strip"
-        flag: "--no_dead_strip_inits_and_terms"
+        flag: "-dead_strip"
+        flag: "-no_dead_strip_inits_and_terms"
       }
     }
     requires {
@@ -12726,8 +12726,8 @@ toolchain {
       action: "objc-executable"
       action: "objc++-executable"
       flag_group {
-        flag: "--dead_strip"
-        flag: "--no_dead_strip_inits_and_terms"
+        flag: "-dead_strip"
+        flag: "-no_dead_strip_inits_and_terms"
       }
     }
     requires {
@@ -14409,8 +14409,8 @@ toolchain {
       action: "objc-executable"
       action: "objc++-executable"
       flag_group {
-        flag: "--dead_strip"
-        flag: "--no_dead_strip_inits_and_terms"
+        flag: "-dead_strip"
+        flag: "-no_dead_strip_inits_and_terms"
       }
     }
     requires {
@@ -16063,8 +16063,8 @@ toolchain {
       action: "objc-executable"
       action: "objc++-executable"
       flag_group {
-        flag: "--dead_strip"
-        flag: "--no_dead_strip_inits_and_terms"
+        flag: "-dead_strip"
+        flag: "-no_dead_strip_inits_and_terms"
       }
     }
     requires {


### PR DESCRIPTION
…ds to linker errors. This mainly affects the `objc_enable_binary_stripping` feature and leads to bloated applications