### PR TITLE
Correct error message for invalid build_request_id

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -145,7 +145,7 @@ public class CommonCommandOptions extends OptionsBase {
         UUID.fromString(input.substring(uuidStartIndex));
       } catch (IllegalArgumentException | IndexOutOfBoundsException e) {
         throw new OptionsParsingException(
-            String.format("Value '%s' does end in a valid UUID.", input), e);
+            String.format("Value '%s' does not end in a valid UUID.", input), e);
       }
       return input;
     }


### PR DESCRIPTION
Message is printed when build_request_id does *not* end in a valid uuid