### PR TITLE
Acknowledge profdata files in CoverageOutputGenerator.

### DIFF
--- a/src/test/shell/bazel/bazel_coverage_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_test.sh
@@ -231,8 +231,9 @@ function test_cc_test_llvm_coverage_doesnt_fail() {
 
   # Only test that bazel coverage doesn't crash when invoked for llvm native
   # coverage.
-  (BAZEL_USE_LLVM_NATIVE_COVERAGE=1 GCOV=llvm-profdata CC=clang++ \
-    bazel coverage //:t) &>$TEST_log || fail "Coverage for //:t failed"
+  BAZEL_USE_LLVM_NATIVE_COVERAGE=1 GCOV=$llvmprofdata CC=$clang_tool \
+      bazel coverage --dynamic_mode=off --test_output=all //:t &>$TEST_log \
+      || fail "Coverage for //:t failed"
 
   # Check to see if the coverage output file was created.
   [ -f "$(get_coverage_file_path_from_test_log)" ] \

--- a/src/test/shell/bazel/bazel_coverage_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_test.sh
@@ -232,10 +232,11 @@ function test_cc_test_llvm_coverage_doesnt_fail() {
   # Only test that bazel coverage doesn't crash when invoked for llvm native
   # coverage.
   BAZEL_USE_LLVM_NATIVE_COVERAGE=1 GCOV=$llvmprofdata CC=$clang_tool \
-      bazel coverage --dynamic_mode=off --test_output=all //:t &>$TEST_log \
+      bazel coverage --test_output=all //:t &>$TEST_log \
       || fail "Coverage for //:t failed"
 
-  # Check to see if the coverage output file was created.
+  # Check to see if the coverage output file was created. Cannot check its
+  # contents because it's a binary.
   [ -f "$(get_coverage_file_path_from_test_log)" ] \
       || fail "Coverage output file was not created."
 }

--- a/src/test/shell/bazel/bazel_coverage_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_test.sh
@@ -214,6 +214,65 @@ end_of_record"
   assert_contains 'name: "baseline.lcov"' bep.txt
 }
 
+function test_cc_test_llvm_coverage_doesnt_fail() {
+  local -r llvmprofdata=$(which llvm-profdata)
+  if [[ ! -x ${llvmprofdata:-/usr/bin/llvm-profdata} ]]; then
+    echo "llvm-profdata not installed. Skipping test."
+    return
+  fi
+
+  local -r clang_tool=$(which clang)
+  if [[ ! -x ${clang_tool:-/usr/bin/clang_tool} ]]; then
+    echo "clang not installed. Skipping test."
+    return
+  fi
+
+  cat << EOF > BUILD
+cc_library(
+    name = "a",
+    srcs = ["a.cc"],
+    hdrs = ["a.h"],
+)
+
+cc_test(
+    name = "t",
+    srcs = ["t.cc"],
+    deps = [":a"],
+)
+EOF
+
+  cat << EOF > a.h
+int a(bool what);
+EOF
+
+  cat << EOF > a.cc
+#include "a.h"
+
+int a(bool what) {
+  if (what) {
+    return 1;
+  } else {
+    return 2;
+  }
+}
+EOF
+
+  cat << EOF > t.cc
+#include <stdio.h>
+#include "a.h"
+
+int main(void) {
+  a(true);
+}
+EOF
+
+  # Only test that bazel coverage doesn't crash when invoked for llvm native
+  # coverage.
+  BAZEL_USE_LLVM_NATIVE_COVERAGE=1 GCOV=llvm-profdata CC=clang bazel coverage //:t \
+      &>$TEST_log || fail "Coverage for //:t failed"
+}
+
+
 function test_failed_coverage() {
   local -r LCOV=$(which lcov)
   if [[ ! -x ${LCOV:-/usr/bin/lcov} ]]; then

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Constants.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Constants.java
@@ -36,8 +36,9 @@ class Constants {
   static final String END_OF_RECORD_MARKER = "end_of_record";
   static final String TAKEN = "-";
   static final String TRACEFILE_EXTENSION = ".dat";
-  static final String DELIMITER = ",";
   static final String GCOV_EXTENSION = ".gcov";
+  static final String PROFDATA_EXTENSION = ".profdata";
+  static final String DELIMITER = ",";
   static final String GCOV_VERSION_MARKER = "version:";
   static final String GCOV_CWD_MARKER = "cwd:";
   static final String GCOV_FILE_MARKER = "file:";

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
@@ -107,7 +107,7 @@ public class Main {
         // of files, so CoverageOutputGenerator will only copy them to the output.
         logger.log(Level.INFO, "One profdata file was found. Skipping converting to lcov.");
         try (FileChannel profdataChannel = new FileInputStream(profdataFiles.get(0)).getChannel();
-            FileChannel outputChannel = new FileInputStream(outputFile).getChannel()) {
+            FileChannel outputChannel = new FileOutputStream(outputFile).getChannel()) {
           outputChannel.transferFrom(profdataChannel, 0, profdataChannel.size());
         } catch (IOException e) {
           logger.log(Level.SEVERE,
@@ -214,7 +214,8 @@ public class Main {
               .filter(
                   p ->
                       p.toString().endsWith(TRACEFILE_EXTENSION)
-                          || p.toString().endsWith(GCOV_EXTENSION))
+                          || p.toString().endsWith(GCOV_EXTENSION)
+                          || p.toString().endsWith(PROFDATA_EXTENSION))
               .map(path -> path.toFile())
               .collect(Collectors.toList());
     } catch (IOException ex) {

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
@@ -77,7 +77,6 @@ public class Main {
         // not ideal but it unblocks some Bazel C++
         // coverage users.
         // TODO(#5881): Add support for profdata files.
-        logger.log(Level.INFO, "One profdata file was found. Skipping converting to lcov.");
         try {
           Files.copy(profdataFile.toPath(), outputFile.toPath(), REPLACE_EXISTING);
         } catch (IOException e) {
@@ -175,7 +174,7 @@ public class Main {
           + profdataFiles.size() + " .profadata files were found instead.");
       return null;
     }
-    logger.log(Level.INFO, "Found one .profdata files.");
+    logger.log(Level.INFO, "Found one .profdata file.");
     return profdataFiles.get(0);
   }
 

--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -213,12 +213,8 @@ function get_source_or_header_file() {
 function main() {
   init_gcov
 
-  # If llvm code coverage is used, we output the raw code coverage report in
-  # the $COVERAGE_OUTPUT_FILE. This report will not be converted to any other
-  # format by LcovMerger.
-  # TODO(#5881): Convert profdata reports to lcov.
   if uses_llvm; then
-    llvm_coverage "$COVERAGE_OUTPUT_FILE" && exit 0
+    BAZEL_CC_COVERAGE_TOOL="PROFDATA"
   fi
 
   # When using either gcov or lcov, have an output file specific to the test
@@ -232,6 +228,7 @@ function main() {
   case "$BAZEL_CC_COVERAGE_TOOL" in
         ("GCOV") gcov_coverage "$COVERAGE_DIR/_cc_coverage.gcov" ;;
         ("LCOV") lcov_coverage "$COVERAGE_DIR/_cc_coverage.dat" ;;
+        ("PROFDATA") llvm_coverage "$COVERAGE_DIR/_cc_coverage.profdata" ;;
         (*) echo "Coverage tool $BAZEL_CC_COVERAGE_TOOL not supported" \
             && exit 1
   esac

--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -219,14 +219,15 @@ function main() {
     BAZEL_CC_COVERAGE_TOOL="PROFDATA"
   fi
 
-  # When using either gcov or lcov, have an output file specific to the test
-  # and format used. For lcov we generate a ".dat" output file and for gcov
-  # a ".gcov" output file. It is important that these files are generated under
-  # COVERAGE_DIR.
-  # When this script is invoked by tools/test/collect_coverage.sh either of
-  # these two coverage reports will be picked up by LcovMerger and their
+  # All the output files must be generated under COVERAGE_DIR.
+  #
+  # When this script is invoked by tools/test/collect_coverage.sh the
+  # .dat and .gcov files will be picked up by CoverageOutputGenerator and their
   # content will be converted and/or merged with other reports to an lcov
   # format, generating the final code coverage report.
+  # The .profdata file will also be picked up by CoverageOutputGenerator but it
+  # won't be merged or converted to lcov, but its content will be copied to the
+  # final code coverage report.
   case "$BAZEL_CC_COVERAGE_TOOL" in
         ("GCOV") gcov_coverage "$COVERAGE_DIR/_cc_coverage.gcov" ;;
         ("LCOV") lcov_coverage "$COVERAGE_DIR/_cc_coverage.dat" ;;

--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -63,6 +63,8 @@ function init_gcov() {
 # Writes the collected coverage into the given output file.
 function llvm_coverage() {
   local output_file="${1}"; shift
+
+  touch "$output_file"
   export LLVM_PROFILE_FILE="${COVERAGE_DIR}/%h-%p-%m.profraw"
   "${COVERAGE_GCOV_PATH}" merge -output "${output_file}" \
       "${COVERAGE_DIR}"/*.profraw

--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -63,8 +63,6 @@ function init_gcov() {
 # Writes the collected coverage into the given output file.
 function llvm_coverage() {
   local output_file="${1}"; shift
-
-  touch "$output_file"
   export LLVM_PROFILE_FILE="${COVERAGE_DIR}/%h-%p-%m.profraw"
   "${COVERAGE_GCOV_PATH}" merge -output "${output_file}" \
       "${COVERAGE_DIR}"/*.profraw


### PR DESCRIPTION
This PR makes `CoverageOutputGenerator` aware that `collect_coverage.sh` might generate `.profdata` files. 

There must at most one `.profdata` file generated per test otherwise `CoverageOutputGenerator` doesn't know how to merge them.

If there is one `.profdata` file then there must be no other type of coverage reports (`.dat`, `.gcov`) generated before `CoverageOutputGenerator` is invoked, otherwise there is no way to merge them.

If there is one `.profdata` file and no other coverage reports we copy the content of the `.profdata` file to the final coverage output file. This is not ideal but it unblocks some Bazel C++ coverage users.

This is temporary until #5881 will be fixed.