### PR TITLE
Apply --source_file_manifest for C++ targets.

### DIFF
--- a/src/test/shell/bazel/bazel_coverage_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_test.sh
@@ -110,6 +110,8 @@ function test_cc_test_coverage_lcov() {
   local coverage_output_file="$( get_coverage_file_path_from_test_log )"
 
   # Check the expected coverage for a.cc in the coverage file.
+  # Note that t.cc is not included in the coverage report because it is
+  # coming from a cc_test whose code is not included in the report by default.
   local expected_result_a_cc="SF:a.cc
 FN:3,_Z1ab
 FNDA:1,_Z1ab
@@ -123,21 +125,6 @@ LH:3
 LF:4
 end_of_record"
   assert_coverage_result "$expected_result_a_cc" "$coverage_output_file"
-
-
-  # Check the expected coverage for t.cc in the coverage file.
-  local expected_result_t_cc="SF:t.cc
-FN:4,main
-FNDA:1,main
-FNF:1
-FNH:1
-DA:4,1
-DA:5,1
-DA:6,1
-LH:3
-LF:3
-end_of_record"
-  assert_coverage_result "$expected_result_t_cc" "$coverage_output_file"
 
   # Verify that this is also true for cached coverage actions.
   bazel coverage --test_output=all --build_event_text_file=bep.txt //:t \
@@ -183,20 +170,6 @@ LH:3
 LF:4
 end_of_record"
   assert_coverage_result "$expected_result_a_cc" "$coverage_file_path"
-
-  # Check the expected coverage for t.cc in the coverage file.
-  local expected_result_t_cc="SF:t.cc
-FN:4,main
-FNDA:1,main
-FNF:1
-FNH:1
-DA:4,1
-DA:5,1
-DA:6,1
-LH:3
-LF:3
-end_of_record"
-  assert_coverage_result "$expected_result_t_cc" "$coverage_file_path"
 
   # Verify that this is also true for cached coverage actions.
   bazel coverage --experimental_cc_coverage --test_output=all \

--- a/src/test/shell/bazel/bazel_coverage_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_test.sh
@@ -154,6 +154,8 @@ function test_cc_test_coverage_gcov() {
   local coverage_file_path="$( get_coverage_file_path_from_test_log )"
 
   # Check the expected coverage for a.cc in the coverage file.
+  # Note that t.cc is not included in the coverage report because it is
+  # coming from a cc_test whose code is not included in the report by default.
   local expected_result_a_cc="SF:a.cc
 FN:3,_Z1ab
 FNDA:1,_Z1ab

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
@@ -65,10 +65,11 @@ public class Main {
     }
 
     if (flags.hasSourceFileManifest()) {
-      Set<String> sources = getSourcesFromSourceFileManifest(flags.sourceFileManifest());
-      if (!sources.isEmpty()) {
+      // The source file manifest is only required for C++ code coverage.
+      Set<String> ccSources = getCcSourcesFromSourceFileManifest(flags.sourceFileManifest());
+      if (!ccSources.isEmpty()) {
         // Only filter out coverage if there were C++ sources found in the coverage manifest.
-        coverage = Coverage.getOnlyTheseSources(coverage, sources);
+        coverage = Coverage.getOnlyTheseSources(coverage, ccSources);
       }
     }
 
@@ -96,16 +97,15 @@ public class Main {
    * <p>The manifest contains file names line by line. Each file can either be a source file (e.g.
    * .java, .cc) or a coverage metadata file (e.g. .gcno, .em).
    *
-   * <p>This method only returns the source files, ignoring the coverage metadata files as they are
-   * not relevant when putting together the final coverage report.
+   * <p>This method only returns the C++ source files, ignoring the other files as they are not
+   * necessary when putting together the final coverage report.
    */
-  private static Set<String> getSourcesFromSourceFileManifest(String sourceFileManifest) {
+  private static Set<String> getCcSourcesFromSourceFileManifest(String sourceFileManifest) {
     Set<String> sourceFiles = new HashSet<>();
     try (FileInputStream inputStream = new FileInputStream(new File(sourceFileManifest));
         InputStreamReader inputStreamReader = new InputStreamReader(inputStream, UTF_8);
         BufferedReader reader = new BufferedReader(inputStreamReader)) {
       for (String line = reader.readLine(); line != null; line = reader.readLine()) {
-        // The source file manifest is only required for C++ code coverage.
         if (!isMetadataFile(line) && isCcFile(line)) {
           sourceFiles.add(line);
         }

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
@@ -80,7 +80,6 @@ public class Main {
     int exitStatus = 0;
     String outputFile = flags.outputFile();
     try {
-      logger.log(Level.INFO, "Writing coverage to outputfile " + outputFile);
       LcovPrinter.print(new FileOutputStream(new File(outputFile)), coverage);
     } catch (IOException e) {
       logger.log(
@@ -102,12 +101,10 @@ public class Main {
    */
   private static Set<String> getSourcesFromSourceFileManifest(String sourceFileManifest) {
     Set<String> sourceFiles = new HashSet<>();
-    logger.log(Level.INFO, "Lines of source file manifest:");
     try (FileInputStream inputStream = new FileInputStream(new File(sourceFileManifest));
         InputStreamReader inputStreamReader = new InputStreamReader(inputStream, UTF_8);
         BufferedReader reader = new BufferedReader(inputStreamReader)) {
       for (String line = reader.readLine(); line != null; line = reader.readLine()) {
-        logger.log(Level.INFO, line);
         // The source file manifest is only required for C++ code coverage.
         if (!isMetadataFile(line) && isCcFile(line)) {
           sourceFiles.add(line);
@@ -116,7 +113,6 @@ public class Main {
     } catch (IOException e) {
       logger.log(Level.SEVERE, "Error reading file " + sourceFileManifest + ": " + e.getMessage());
     }
-    logger.log(Level.INFO, "Found " + sourceFiles.size() + " source files in the coverage manifest.");
     return sourceFiles;
   }
 

--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -127,7 +127,8 @@ export LCOV_MERGER_CMD="${LCOV_MERGER} --coverage_dir=${COVERAGE_DIR} \
   --output_file=${COVERAGE_OUTPUT_FILE} \
   --filter_sources=/usr/bin/.+ \
   --filter_sources=/usr/lib/.+ \
-  --filter_sources=.*external/.+"
+  --filter_sources=.*external/.+ \
+  --source_file_manifest=${COVERAGE_MANIFEST}"
 
 
 if [[ $DISPLAY_LCOV_CMD ]] ; then

--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -112,17 +112,26 @@ if [[ "$CC_CODE_COVERAGE_SCRIPT" ]]; then
 fi
 
 # Export the command line that invokes LcovMerger with the flags:
-# --coverage_dir      The absolute path of the directory where the intermediate
-#                     coverage reports are located. LcovMerger will search for
-#                     files with the .dat and .gcov extension under this
-#                     directory
-#                     and will merge everything it found in the output report.
-# --output_file       The absolute path of the merged coverage report.
-# --filter_sources    Filters out the sources that match the given regexes
-#                     from the final coverage report. This is needed because
-#                     some coverage tools (e.g. gcov) do not have any way of
-#                     specifying what sources to exclude when generating the
-#                     code coverage report (in this case the syslib sources).
+# --coverage_dir          The absolute path of the directory where the
+#                         intermediate coverage reports are located.
+#                         CoverageOutputGenerator will search for files with
+#                         the .dat and .gcov extension under this directory and
+#                         will merge everything it found in the output report.
+#
+# --output_file           The absolute path of the merged coverage report.
+#
+# --filter_sources        Filters out the sources that match the given regexes
+#                         from the final coverage report. This is needed
+#                         because some coverage tools (e.g. gcov) do not have
+#                         any way of specifying what sources to exclude when
+#                         generating the code coverage report (in this case the
+#                         syslib sources).
+#
+# --source_file_manifest  The absolute path of the coverage source file
+#                         manifest. CoverageOutputGenerator uses this file to
+#                         keep only the C++ sources found in the manifest.
+#                         For other languages the sources in the manifest are
+#                         ignored.
 export LCOV_MERGER_CMD="${LCOV_MERGER} --coverage_dir=${COVERAGE_DIR} \
   --output_file=${COVERAGE_OUTPUT_FILE} \
   --filter_sources=/usr/bin/.+ \


### PR DESCRIPTION
When putting together the final coverage report in `CoverageOutputGenerator` keep coverage only for the C++ sources found in the source file manifest, and all other type of sources.

A source file manifest contains metadata files (e.g. `.gcno`) and source files (e.g. `.cc`). We need this filtering for C++ targets because the source file manifest sometimes contains more `.gcno` files than source files. 

For example if the source file manifest contains:
```
src/a.gcno
src/b.gcno
src/c.gcno
src/a.cc
src/b.cc
```

the final coverage report must only have coverage data for `src/a.cc` and `src/b.cc`. 