### PR TITLE
Print a message on server timeout

### DIFF
--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -925,6 +925,22 @@ EOF
 }
 
 
+function test_server_timeout() {
+  startup_timeout_server $PWD
+
+  cat > WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "repo",
+    url = "http://127.0.0.1:$fileserver_port/some_archive.zip",
+)
+EOF
+  bazel build @repo//... &> $TEST_log 2>&1 && fail "Expected to fail"
+  expect_log "Error downloading \\[http://127.0.0.1:$fileserver_port/some_archive.zip\\] to"
+  expect_log "Read timed out"
+  shutdown_server
+}
+
 
 function test_same_name() {
   mkdir ext

--- a/src/test/shell/bazel/remote_helpers.sh
+++ b/src/test/shell/bazel/remote_helpers.sh
@@ -209,6 +209,16 @@ function startup_auth_server() {
   wait_for_server_startup
 }
 
+function startup_timeout_server() {
+  fileserver_port=$(pick_random_unused_tcp_port) || exit 1
+  # We allow only for one response from the server.
+  # wait_for_server_startup uses this response to make sure that the
+  # timeout server is ready.
+  python $python_server --port=$fileserver_port --max_responses=1 &
+  fileserver_pid=$!
+  wait_for_server_startup
+}
+
 function shutdown_server() {
   # Try to kill nc, otherwise the test will time out if Bazel has a bug and
   # didn't make a request to it.


### PR DESCRIPTION
This is related to: https://github.com/bazelbuild/bazel/issues/3851
When Bazel tries to download a file from a repository, but the Server does not respond then Bazel does not print an informative message, as it does for other network failures.

More specifically, a SocketTimeoutException is thrown from HttpConnector (https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java)
The reason that no message is print is that exception caught is an InterruptedIOException (https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java#L229),
that is a super-class of SocketTimeoutException.

Fixing that by catching a SocketTimeoutException first.