### PR TITLE
C++: de-flake profiler test

### DIFF
--- a/src/test/cpp/util/profiler_test.cc
+++ b/src/test/cpp/util/profiler_test.cc
@@ -59,7 +59,7 @@ TEST(ProfilerTest, TestScopedTaskMeasuresElapsedTime) {
     SleepMeasurably();
     SleepMeasurably();
   }
-  ASSERT_GT(scope2.GetDuration().micros_, scope1.GetDuration().micros_);
+  ASSERT_GT(scope_both.GetDuration().micros_, scope1.GetDuration().micros_);
   ASSERT_GT(scope_both.GetDuration().micros_, scope2.GetDuration().micros_);
   ASSERT_EQ(scope1.GetCalls(), 1u);
   ASSERT_EQ(scope2.GetCalls(), 1u);


### PR DESCRIPTION
There's no upper limit on the SleepMeasurably
call's sleep duration, therefore on rare occasions
a single SleepMeasurably call might take longer
than two separate, consecutive SleepMeasurably
calls.

For that reason, this patch changes the test to
only compare sleep durations where the clocks
measuring the durations were measuring the *same*
sleep calls, and not the same *number of* sleep
calls.

Change-Id: I8510e8ac3b202424237655968e3a5448527719e3