### PR TITLE
Add option to use JDK from remote repository instead of the embedded JDK as default host javabase.

### DIFF
--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -11,6 +11,12 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_x86_64",
+    values = {"cpu": "k8"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "linux_aarch64",
     values = {"cpu": "aarch64"},
     visibility = ["//visibility:public"],

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -82,3 +82,51 @@ bind(
     name = "jdk-default",
     actual = "@local_jdk//:jdk",
 )
+
+# OpenJDK distributions that should only be downloaded on demand (e.g. when
+# building a java_library or a genrule that uses java make variables).
+# This will allow us to stop bundling the full JDK with Bazel.
+# Note that while these are currently the same as the openjdk_* rules in
+# Bazel's WORKSPACE file, but they don't have to be the same.
+new_http_archive(
+    name = "remotejdk_linux",
+    sha256 = "f27cb933de4f9e7fe9a703486cf44c84bc8e9f138be0c270c9e5716a32367e87",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz",
+    ],
+    build_file = __embedded_dir__ + "/jdk.BUILD",
+    strip_prefix = "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules",
+)
+
+new_http_archive(
+    name = "remotejdk_macos",
+    sha256 = "404e7058ff91f956612f47705efbee8e175a38b505fb1b52d8c1ea98718683de",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-macosx_x64-allmodules.tar.gz",
+    ],
+    build_file = __embedded_dir__ + "/jdk.BUILD",
+    strip_prefix = "zulu9.0.7.1-jdk9.0.7-macosx_x64-allmodules",
+)
+
+new_http_archive(
+    name = "remotejdk_win",
+    sha256 = "e738829017f107e7a7cd5069db979398ec3c3f03ef56122f89ba38e7374f63ed",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-win_x64-allmodules.zip",
+    ],
+    build_file = __embedded_dir__ + "/jdk.BUILD",
+    strip_prefix = "zulu9.0.7.1-jdk9.0.7-win_x64-allmodules",
+)
+
+# The source-code for this OpenJDK can be found at:
+# https://openjdk.linaro.org/releases/jdk9-src-1708.tar.xz
+new_http_archive(
+    name = "remotejdk_linux_aarch64",
+    sha256 = "72e7843902b0395e2d30e1e9ad2a5f05f36a4bc62529828bcbc698d54aec6022",
+    urls = [
+        # When you update this, also update the link to the source-code above.
+        "http://openjdk.linaro.org/releases/jdk9-server-release-1708.tar.xz",
+    ],
+    build_file = __embedded_dir__ + "/jdk.BUILD",
+    strip_prefix = "jdk9-server-release-1708",
+)

--- a/src/test/shell/integration/bazel_java_test.sh
+++ b/src/test/shell/integration/bazel_java_test.sh
@@ -72,6 +72,15 @@ EOF
   # Note that this will change in the future but is the current state.
   bazel aquery --output=text //java:javalib >& $TEST_log
   expect_log "exec external/embedded_jdk/bin/java"
+
+  bazel aquery --output=text --incompatible_use_remotejdk_as_host_javabase \
+    //java:javalib >& $TEST_log
+  expect_log "exec external/remotejdk_.*/bin/java"
+
+  bazel aquery --output=text --host_javabase=//:host_javabase \
+    --incompatible_use_remotejdk_as_host_javabase //java:javalib >& $TEST_log
+  expect_log "exec .*foobar/bin/java"
+  expect_not_log "exec external/remotejdk_.*/bin/java"
 }
 
 function test_javabase() {
@@ -209,16 +218,34 @@ EOF
   expect_not_log "foo"
   expect_not_log "bar"
   expect_not_log "embedded_jdk"
+  expect_not_log "remotejdk"
 
   bazel cquery --implicit_deps 'deps(//:with_java)' >& $TEST_log
   expect_not_log "foo"
   expect_log "bar"
   expect_log "embedded_jdk"
+  expect_not_log "remotejdk"
 
   bazel cquery --implicit_deps 'deps(//:with_java)' --host_javabase=:foo_javabase >& $TEST_log
   expect_log "foo"
   expect_log "bar"
   expect_not_log "embedded_jdk"
+  expect_not_log "remotejdk"
+
+  bazel cquery --implicit_deps 'deps(//:with_java)' \
+    --incompatible_use_remotejdk_as_host_javabase >& $TEST_log
+  expect_not_log "foo"
+  expect_log "bar"
+  expect_not_log "embedded_jdk"
+  expect_log "remotejdk"
+
+  bazel cquery --implicit_deps 'deps(//:with_java)' \
+    --host_javabase=:foo_javabase \
+    --incompatible_use_remotejdk_as_host_javabase >& $TEST_log
+  expect_log "foo"
+  expect_log "bar"
+  expect_not_log "embedded_jdk"
+  expect_not_log "remotejdk"
 }
 
 run_suite "Tests of specifying custom server_javabase/host_javabase and javabase."

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -315,3 +315,18 @@ test_suite(
     tests = [":windows_tests"],
     visibility = ["//tools:__pkg__"],
 )
+
+# Replacement for the embedded JDK as host javabase.
+alias(
+    name = "remote_jdk",
+    actual = select({
+        "//src/conditions:darwin": "@remotejdk_macos//:jdk",
+        "//src/conditions:darwin_x86_64": "@remotejdk_macos//:jdk",
+        "//src/conditions:windows": "@remotejdk_win//:jdk",
+        "//src/conditions:linux_aarch64": "@remotejdk_linux_aarch64//:jdk",
+        "//src/conditions:linux_x86_64": "@remotejdk_linux//:jdk",
+        # Fall back to the local JDK on any other platform.
+        "//conditions:default": "@local_jdk//:jdk",
+    }),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
After 09cf76e753e9f95070ee862dd19aa7bf579dff8c we should only download
that remote JDK if we actually need it.

We plan to hide the embedded JDK so that minimize it in order to shrink
Bazel's binary size. Users that don't need the JDK shouldn't pay the
price for it.
The minimizing step will reduce Bazel's binary size by about 40MB to
~130MB.

RELNOTES[INC]: Add --incompatible_use_remotejdk_as_host_javabase to default the host javabase to remote repository.