### PR TITLE
Fix the bootstrap scripts to use the correct BUILD file for tools/sh.

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -234,6 +234,13 @@ EOF
       "${BAZEL_TOOLS_REPO}/tools/cpp/runfiles/runfiles.cc"
   link_file "${PWD}/tools/cpp/runfiles/BUILD.tools" \
       "${BAZEL_TOOLS_REPO}/tools/cpp/runfiles/BUILD"
+
+  # Create @bazel_tools//tools/sh
+  mkdir -p ${BAZEL_TOOLS_REPO}/tools/sh
+  link_file "${PWD}/tools/sh/sh_configure.bzl" "${BAZEL_TOOLS_REPO}/tools/sh/sh_configure.bzl"
+  link_file "${PWD}/tools/sh/sh_toolchain.bzl" "${BAZEL_TOOLS_REPO}/tools/sh/sh_toolchain.bzl"
+  link_file "${PWD}/tools/sh/BUILD.tools" "${BAZEL_TOOLS_REPO}/tools/sh/BUILD"
+
   # Create the rest of @bazel_tools//tools/...
   link_children "${PWD}" tools/cpp "${BAZEL_TOOLS_REPO}"
   link_children "${PWD}" tools "${BAZEL_TOOLS_REPO}"


### PR DESCRIPTION
This will be required after
https://github.com/bazelbuild/bazel/pull/6235 requires actual
dependencies on toolchain_type targets.

Part of the work on #6015.

Change-Id: I21e5399dc0c43bb7b4d42e1f1bd5b9a1c820075e