### PR TITLE
[WIP] Objc modular imports

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationContext.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationContext.java
@@ -70,8 +70,6 @@ public final class CcCompilationContext implements CcCompilationContextApi {
   private final CppModuleMap cppModuleMap;
   private final CppModuleMap verificationModuleMap;
 
-  private final boolean propagateModuleMapAsActionInput;
-
   // Derived from depsContexts.
   private final ImmutableSet<Artifact> compilationPrerequisites;
 
@@ -92,7 +90,6 @@ public final class CcCompilationContext implements CcCompilationContextApi {
       ImmutableList<Artifact> directModuleMaps,
       CppModuleMap cppModuleMap,
       @Nullable CppModuleMap verificationModuleMap,
-      boolean propagateModuleMapAsActionInput,
       CppConfiguration.HeadersCheckingMode headersCheckingMode) {
     Preconditions.checkNotNull(commandLineCcCompilationContext);
     this.commandLineCcCompilationContext = commandLineCcCompilationContext;
@@ -107,7 +104,6 @@ public final class CcCompilationContext implements CcCompilationContextApi {
     this.nonCodeInputs = nonCodeInputs;
     this.verificationModuleMap = verificationModuleMap;
     this.compilationPrerequisites = compilationPrerequisites;
-    this.propagateModuleMapAsActionInput = propagateModuleMapAsActionInput;
     this.headersCheckingMode = headersCheckingMode;
   }
 
@@ -252,7 +248,7 @@ public final class CcCompilationContext implements CcCompilationContextApi {
     NestedSetBuilder<Artifact> builder = NestedSetBuilder.stableOrder();
     builder.addAll(directModuleMaps);
     builder.addTransitive(nonCodeInputs);
-    if (cppModuleMap != null && propagateModuleMapAsActionInput) {
+    if (cppModuleMap != null) {
       builder.add(cppModuleMap.getArtifact());
     }
     return builder.build();
@@ -302,7 +298,6 @@ public final class CcCompilationContext implements CcCompilationContextApi {
         ccCompilationContext.directModuleMaps,
         ccCompilationContext.cppModuleMap,
         ccCompilationContext.verificationModuleMap,
-        ccCompilationContext.propagateModuleMapAsActionInput,
         ccCompilationContext.headersCheckingMode);
   }
 
@@ -366,7 +361,6 @@ public final class CcCompilationContext implements CcCompilationContextApi {
     private final Set<String> defines = new LinkedHashSet<>();
     private CppModuleMap cppModuleMap;
     private CppModuleMap verificationModuleMap;
-    private boolean propagateModuleMapAsActionInput = true;
     private CppConfiguration.HeadersCheckingMode headersCheckingMode =
         CppConfiguration.HeadersCheckingMode.STRICT;
 
@@ -554,14 +548,6 @@ public final class CcCompilationContext implements CcCompilationContextApi {
     }
 
     /**
-     * Causes the module map to be passed as an action input to dependant compilations.
-     */
-    public Builder setPropagateCppModuleMapAsActionInput(boolean propagateModuleMap) {
-      this.propagateModuleMapAsActionInput = propagateModuleMap;
-      return this;
-    }
-
-    /**
      * Sets the C++ header module in non-pic mode.
      *
      * @param headerModule The .pcm file generated for this library.
@@ -621,7 +607,6 @@ public final class CcCompilationContext implements CcCompilationContextApi {
           ImmutableList.copyOf(directModuleMaps),
           cppModuleMap,
           verificationModuleMap,
-          propagateModuleMapAsActionInput,
           headersCheckingMode);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -1354,7 +1354,6 @@ public final class CcCompilationHelper {
         ImmutableList.Builder new_copts = ImmutableList.builder();
         new_copts.addAll(copts);
         if (module != null) {
-          System.out.println("DEBUG: rule '" + ruleContext.getRule().getName() + "' adding module: " + module.getExecPathString());
           new_copts.add("-fmodule-map-file=" + module.getExecPathString());
         }
         setCopts(new_copts.build());

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -1348,6 +1348,19 @@ public final class CcCompilationHelper {
     }
     outputNameMap = calculateOutputNameMapByType(compilationUnitSources, outputNamePrefixDir);
 
+    if (ruleContext.attributes().has("enable_modules") &&
+        ruleContext.attributes().get("enable_modules", Type.BOOLEAN)) {
+      for (Artifact module : ccCompilationContext.getDirectModuleMaps()) {
+        ImmutableList.Builder new_copts = ImmutableList.builder();
+        new_copts.addAll(copts);
+        if (module != null) {
+          System.out.println("DEBUG: rule '" + ruleContext.getRule().getName() + "' adding module: " + module.getExecPathString());
+          new_copts.add("-fmodule-map-file=" + module.getExecPathString());
+        }
+        setCopts(new_copts.build());
+      }
+    }
+
     for (CppSource source : compilationUnitSources.values()) {
       Artifact sourceArtifact = source.getSource();
       Label sourceLabel = source.getLabel();
@@ -1736,18 +1749,6 @@ public final class CcCompilationHelper {
       boolean bitcodeOutput =
           featureConfiguration.isEnabled(CppRuleClasses.THIN_LTO)
               && CppFileTypes.LTO_SOURCE.matches(sourceArtifact.getFilename());
-
-      if (ruleContext.attributes().has("enable_modules") &&
-          ruleContext.attributes().get("enable_modules", Type.BOOLEAN)) {
-        for (Artifact module : ccCompilationContext.getDirectModuleMaps()) {
-          ImmutableList.Builder new_copts = ImmutableList.builder();
-          new_copts.addAll(copts);
-          if (module != null) {
-            new_copts.add("-fmodule-map-file=" + module.getExecPathString());
-          }
-          setCopts(new_copts.build());
-        }
-      }
 
       // Create PIC compile actions (same as no-PIC, but use -fPIC and
       // generate .pic.o, .pic.d, .pic.gcno instead of .o, .d, .gcno.)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -289,7 +289,6 @@ public final class CcCompilationHelper {
   private final SourceCategory sourceCategory;
   private final List<VariablesExtension> variablesExtensions = new ArrayList<>();
   @Nullable private CppModuleMap cppModuleMap;
-  private boolean propagateModuleMapToCompileAction = true;
 
   private final FeatureConfiguration featureConfiguration;
   private final CcToolchainProvider ccToolchain;
@@ -481,7 +480,7 @@ public final class CcCompilationHelper {
       compilationUnitSources.put(
           privateHeader, CppSource.create(privateHeader, label, CppSource.Type.HEADER));
     }
-    
+
     this.privateHeaders.add(privateHeader);
     return this;
   }
@@ -692,12 +691,6 @@ public final class CcCompilationHelper {
   public CcCompilationHelper setCppModuleMap(CppModuleMap cppModuleMap) {
     Preconditions.checkNotNull(cppModuleMap);
     this.cppModuleMap = cppModuleMap;
-    return this;
-  }
-
-  /** Signals that this target's module map should not be an input to c++ compile actions. */
-  public CcCompilationHelper setPropagateModuleMapToCompileAction(boolean propagatesModuleMap) {
-    this.propagateModuleMapToCompileAction = propagatesModuleMap;
     return this;
   }
 
@@ -1062,8 +1055,6 @@ public final class CcCompilationHelper {
         cppModuleMap = CppHelper.createDefaultCppModuleMap(ruleContext, /*suffix=*/ "");
       }
 
-      ccCompilationContextBuilder.setPropagateCppModuleMapAsActionInput(
-          propagateModuleMapToCompileAction);
       ccCompilationContextBuilder.setCppModuleMap(cppModuleMap);
       // There are different modes for module compilation:
       // 1. We create the module map and compile the module so that libraries depending on us can

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -53,6 +53,7 @@ import com.google.devtools.build.lib.rules.cpp.CppConfiguration.HeadersCheckingM
 import com.google.devtools.build.lib.rules.cpp.FdoProvider.FdoMode;
 import com.google.devtools.build.lib.skylarkbuildapi.cpp.CompilationInfoApi;
 import com.google.devtools.build.lib.syntax.SkylarkNestedSet;
+import com.google.devtools.build.lib.syntax.Type;
 import com.google.devtools.build.lib.util.FileTypeSet;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
@@ -1735,6 +1736,18 @@ public final class CcCompilationHelper {
       boolean bitcodeOutput =
           featureConfiguration.isEnabled(CppRuleClasses.THIN_LTO)
               && CppFileTypes.LTO_SOURCE.matches(sourceArtifact.getFilename());
+
+      if (ruleContext.attributes().has("enable_modules") &&
+          ruleContext.attributes().get("enable_modules", Type.BOOLEAN)) {
+        for (Artifact module : ccCompilationContext.getDirectModuleMaps()) {
+          ImmutableList.Builder new_copts = ImmutableList.builder();
+          new_copts.addAll(copts);
+          if (module != null) {
+            new_copts.add("-fmodule-map-file=" + module.getExecPathString());
+          }
+          setCopts(new_copts.build());
+        }
+      }
 
       // Create PIC compile actions (same as no-PIC, but use -fPIC and
       // generate .pic.o, .pic.d, .pic.gcno instead of .o, .d, .gcno.)

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
@@ -344,7 +344,6 @@ public class CompilationSupport {
             .addIncludeDirs(objcProvider.get(INCLUDE))
             .addSystemIncludeDirs(objcProvider.get(INCLUDE_SYSTEM))
             .setCppModuleMap(intermediateArtifacts.moduleMap())
-            .setPropagateModuleMapToCompileAction(false)
             .addVariableExtension(extension)
             .setPurpose(purpose);
 

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcLibrary.java
@@ -96,16 +96,8 @@ public class ObjcLibrary implements RuleConfiguredTargetFactory {
     J2ObjcEntryClassProvider j2ObjcEntryClassProvider = new J2ObjcEntryClassProvider.Builder()
       .addTransitive(ruleContext.getPrerequisites("deps", Mode.TARGET,
           J2ObjcEntryClassProvider.class)).build();
-    CcCompilationContext ccCompilationContext =
-        new CcCompilationContext.Builder(ruleContext)
-            .addDeclaredIncludeSrcs(
-                CompilationAttributes.Builder.fromRuleContext(ruleContext)
-                    .build()
-                    .hdrs()
-                    .toCollection())
-            .addTextualHdrs(common.getTextualHdrs())
-            .addDeclaredIncludeSrcs(common.getTextualHdrs())
-            .build();
+
+    CcCompilationContext ccCompilationContext = compilationSupport.getCcCompilationContext();
 
     CcCompilationInfo.Builder ccCompilationInfoBuilder = CcCompilationInfo.Builder.create();
     ccCompilationInfoBuilder.setCcCompilationContext(ccCompilationContext);

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -380,7 +380,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
     assertThat(getArifactPaths(target, HEADER))
         .containsExactly("objc/a.h", "objc/b.h", "objc/f.m");
     assertThat(getArifactPaths(depender, HEADER))
-        .containsExactly("objc/a.h", "objc/b.h", "objc/f.m", "objc2/d.h", "objc2/e.m");
+        .containsExactly("objc/a.h", "objc/b.h", "objc/f.m", "objc/private.h", "objc2/d.h", "objc2/e.m");
   }
 
   @Test
@@ -613,7 +613,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
         .containsAllIn(moduleMapArtifactArguments("//objc/library", "lib@a-foo_foobar"));
     assertThat(compileActionA.getArguments()).contains("-fmodule-maps");
     assertThat(Artifact.toRootRelativePaths(compileActionA.getInputs()))
-        .doesNotContain("objc/library/lib@a-foo_foobar.modulemaps/module.modulemap");
+        .contains("objc/library/lib@a-foo_foobar.modulemaps/module.modulemap");
   }
 
   @Test
@@ -1066,7 +1066,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
     assertThat(getArifactPaths(target, HEADER))
         .containsExactly("objc/a.h", "objc/b.h");
     assertThat(getArifactPaths(depender, HEADER))
-        .containsExactly("objc/a.h", "objc/b.h", "objc2/c.h", "objc2/d.h");
+        .containsExactly("objc/a.h", "objc/b.h", "objc/private.h", "objc2/c.h", "objc2/d.h");
   }
 
   private Iterable<String> getArifactPaths(ConfiguredTarget target, Key<Artifact> artifactKey) {

--- a/src/test/shell/bazel/apple/bazel_objc_test.sh
+++ b/src/test/shell/bazel/apple/bazel_objc_test.sh
@@ -157,4 +157,35 @@ EOF
     || fail "should fail to find symbol addOne"
 }
 
+function test_modular_imports() {
+    rm -rf atimport
+    mkdir -p atimport
+    cat > atimport/BUILD <<EOF
+objc_library(
+    name = 'lib',
+    enable_modules = True,
+    srcs = ['lib.m'],
+    hdrs = ['lib.h'],
+    deps = [':dep'],
+)
+
+objc_library(
+    name = 'dep',
+    module_name = 'dep',
+    enable_modules = True,
+    srcs = ['dep.m'],
+    hdrs = ['dep.h'],
+)
+EOF
+    touch atimport/lib.h atimport/dep.h atimport/dep.m
+    cat > atimport/lib.m <<EOF
+@import dep;
+EOF
+    bazel build --verbose_failures \
+          --experimental_objc_enable_module_maps \
+          //atimport:lib > "$TEST_log" 2>&1 \
+        || fail "Should support @import"
+
+}
+
 run_suite "objc/ios test suite"


### PR DESCRIPTION
This adds support for using modular imports (`@import module`)  from `objc_library` rules. 

Implementation note:

I again had to remove the extraneous `CcCompilationContext` mentioned in #5954, and still have the same question from that PR.

I also cleaned up what looked like unused code (that's why there are two commits).