### PR TITLE
fix: `rlocation` to resolve directories

### DIFF
--- a/tools/bash/runfiles/runfiles.bash
+++ b/tools/bash/runfiles/runfiles.bash
@@ -97,7 +97,7 @@ function rlocation() {
     fi
     return 1
   else
-    if [[ -f "${RUNFILES_DIR:-/dev/null}/$1" ]]; then
+    if [[ -e "${RUNFILES_DIR:-/dev/null}/$1" ]]; then
       if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
         echo >&2 "INFO[runfiles.bash]: rlocation($1): found under RUNFILES_DIR ($RUNFILES_DIR), return"
       fi
@@ -107,7 +107,7 @@ function rlocation() {
         echo >&2 "INFO[runfiles.bash]: rlocation($1): looking in RUNFILES_MANIFEST_FILE ($RUNFILES_MANIFEST_FILE)"
       fi
       local -r result=$(grep -m1 "^$1 " "${RUNFILES_MANIFEST_FILE}" | cut -d ' ' -f 2-)
-      if [[ -f "${result:-/dev/null}" ]]; then
+      if [[ -e "${result:-/dev/null}" ]]; then
         if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
           echo >&2 "INFO[runfiles.bash]: rlocation($1): found in manifest as ($result)"
         fi

--- a/tools/bash/runfiles/runfiles_test.bash
+++ b/tools/bash/runfiles/runfiles_test.bash
@@ -138,8 +138,10 @@ function test_init_manifest_based_runfiles() {
   cat > $tmpdir/foo.runfiles_manifest << EOF
 a/b $tmpdir/c/d
 e/f $tmpdir/g h
+y $tmpdir/y
 EOF
   mkdir "${tmpdir}/c"
+  mkdir "${tmpdir}/y"
   touch "${tmpdir}/c/d" "${tmpdir}/g h"
 
   export RUNFILES_DIR=
@@ -150,9 +152,11 @@ EOF
   [[ -z "$(rlocation c/d)" ]] || fail
   [[ "$(rlocation a/b)" == "$tmpdir/c/d" ]] || fail
   [[ "$(rlocation e/f)" == "$tmpdir/g h" ]] || fail
-  rm "$tmpdir/c/d" "$tmpdir/g h"
+  [[ "$(rlocation y)" == "$tmpdir/y" ]] || fail
+  rm -r "$tmpdir/c/d" "$tmpdir/g h" "$tmpdir/y"
   [[ -z "$(rlocation a/b)" ]] || fail
   [[ -z "$(rlocation e/f)" ]] || fail
+  [[ -z "$(rlocation y)" ]] || fail
 }
 
 function test_manifest_based_envvars() {
@@ -178,12 +182,13 @@ function test_init_directory_based_runfiles() {
 
   mkdir -p "$RUNFILES_DIR/a"
   touch "$RUNFILES_DIR/a/b" "$RUNFILES_DIR/c d"
-  [[ -z "$(rlocation a)" ]] || fail
+  [[ "$(rlocation a)" == "$RUNFILES_DIR/a" ]] || fail
   [[ -z "$(rlocation c/d)" ]] || fail
   [[ "$(rlocation a/b)" == "$RUNFILES_DIR/a/b" ]] || fail
   [[ "$(rlocation "c d")" == "$RUNFILES_DIR/c d" ]] || fail
   [[ -z "$(rlocation "c")" ]] || fail
-  rm "$RUNFILES_DIR/a/b" "$RUNFILES_DIR/c d"
+  rm -r "$RUNFILES_DIR/a" "$RUNFILES_DIR/c d"
+  [[ -z "$(rlocation a)" ]] || fail
   [[ -z "$(rlocation a/b)" ]] || fail
   [[ -z "$(rlocation "c d")" ]] || fail
 }


### PR DESCRIPTION
In case in the runfiles `MANIFEST` the tree-artifact is a directory it won't be resolved with `rlocation` due to the `-f` flag that matches only files.

`f` check if the path exists and is a file
`-e` just check that the path exists and is anything

//cc @gregmagolan