### PR TITLE
[singlejar] Port test_util to Windows

### DIFF
--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -125,7 +125,7 @@ cc_test(
         ":input_jar",
         ":test_util",
         "//src/main/cpp/util",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -141,7 +141,7 @@ cc_test(
         ":input_jar",
         ":test_util",
         "//src/main/cpp/util",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -162,7 +162,7 @@ cc_test(
     deps = [
         ":input_jar",
         ":test_util",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -178,7 +178,7 @@ cc_test(
     deps = [
         ":input_jar",
         ":test_util",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -190,7 +190,7 @@ cc_test(
     deps = [
         ":input_jar",
         ":test_util",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -232,15 +232,16 @@ cc_test(
         ":test1",
         ":test2",
         "@local_jdk//:jar",
-        "@local_jdk//:jdk-default",
+        "@local_jdk//:jdk",
     ],
     deps = [
         ":input_jar",
         ":options",
         ":output_jar",
+        ":port",
         ":test_util",
         "//src/main/cpp/util",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -252,7 +253,7 @@ cc_test(
     deps = [
         ":test_util",
         ":token_stream",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -270,7 +271,7 @@ cc_test(
         ":input_jar",
         ":test_util",
         "//third_party/zlib",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -415,7 +416,8 @@ cc_library(
     hdrs = ["test_util.h"],
     deps = [
         "//src/main/cpp/util",
-        "@com_google_googletest//:gtest_main",
+        "@bazel_tools//tools/cpp/runfiles",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -125,7 +125,7 @@ cc_test(
         ":input_jar",
         ":test_util",
         "//src/main/cpp/util",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -141,7 +141,7 @@ cc_test(
         ":input_jar",
         ":test_util",
         "//src/main/cpp/util",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -162,7 +162,7 @@ cc_test(
     deps = [
         ":input_jar",
         ":test_util",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -178,7 +178,7 @@ cc_test(
     deps = [
         ":input_jar",
         ":test_util",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -190,7 +190,7 @@ cc_test(
     deps = [
         ":input_jar",
         ":test_util",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -241,7 +241,7 @@ cc_test(
         ":port",
         ":test_util",
         "//src/main/cpp/util",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -253,7 +253,7 @@ cc_test(
     deps = [
         ":test_util",
         ":token_stream",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -271,7 +271,7 @@ cc_test(
         ":input_jar",
         ":test_util",
         "//third_party/zlib",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -416,8 +416,9 @@ cc_library(
     hdrs = ["test_util.h"],
     deps = [
         "//src/main/cpp/util",
-        "@bazel_tools//tools/cpp/runfiles",
-        "@com_google_googletest//:gtest",
+        # TODO(laszlocsomor) Use @bazel_tools//tools/cpp/runfiles
+        "//tools/cpp/runfiles",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -414,6 +414,7 @@ cc_library(
     name = "test_util",
     srcs = ["test_util.cc"],
     hdrs = ["test_util.h"],
+    testonly = 1,
     deps = [
         "//src/main/cpp/util",
         # TODO(laszlocsomor) Use @bazel_tools//tools/cpp/runfiles

--- a/src/tools/singlejar/test_util.cc
+++ b/src/tools/singlejar/test_util.cc
@@ -135,19 +135,4 @@ string CreateTextFile(const string& relpath, const char *contents) {
   return string("");
 }
 
-Runfiles* runfiles = nullptr;
-
 }  // namespace singlejar_test_util
-
-int main(int argc, char** argv) {
-  std::string error;
-  std::unique_ptr<singlejar_test_util::Runfiles> runfiles(
-      singlejar_test_util::Runfiles::Create(argv[0], &error));
-  if (runfiles == nullptr) {
-    perror(error.c_str());
-    exit(1);
-  }
-  singlejar_test_util::runfiles = runfiles.get();
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/tools/singlejar/test_util.cc
+++ b/src/tools/singlejar/test_util.cc
@@ -108,7 +108,11 @@ string GetEntryContents(const string &zip_path, const string &entry_name) {
   string command;
   blaze_util::StringPrintf(&command, "unzip -p %s %s", zip_path.c_str(),
                            entry_name.c_str());
+#ifdef _WIN32
   FILE *fp = popen(command.c_str(), "rb");
+#else
+  FILE *fp = popen(command.c_str(), "r");
+#endif
   if (!fp) {
     ADD_FAILURE() << "Command " << command << " failed.";
     return string("");

--- a/src/tools/singlejar/test_util.cc
+++ b/src/tools/singlejar/test_util.cc
@@ -18,6 +18,10 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
 #include <string>
 
 #include "src/main/cpp/util/file.h"
@@ -27,9 +31,25 @@
 
 #include "googletest/include/gtest/gtest.h"
 
+#ifdef _WIN32
+#define popen _popen
+#define pclose _pclose
+#endif
+
 namespace singlejar_test_util {
 
 bool AllocateFile(const string &name, size_t size) {
+#ifdef _WIN32
+  int fd = _sopen(name.c_str(), _O_RDWR | _O_CREAT | _O_BINARY, _SH_DENYNO,
+                  _S_IREAD | _S_IWRITE);
+  int success = _chsize_s(fd, size);
+  _close(fd);
+  if (success < 0) {
+    perror(strerror(errno));
+    return false;
+  }
+  return true;
+#else
   int fd = open(name.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0777);
   if (fd < 0) {
     perror(name.c_str());
@@ -47,6 +67,7 @@ bool AllocateFile(const string &name, size_t size) {
   } else {
     return close(fd) == 0;
   }
+#endif
 }
 
 int RunCommand(const char *cmd, ...) {
@@ -87,7 +108,7 @@ string GetEntryContents(const string &zip_path, const string &entry_name) {
   string command;
   blaze_util::StringPrintf(&command, "unzip -p %s %s", zip_path.c_str(),
                            entry_name.c_str());
-  FILE *fp = popen(command.c_str(), "r");
+  FILE *fp = popen(command.c_str(), "rb");
   if (!fp) {
     ADD_FAILURE() << "Command " << command << " failed.";
     return string("");
@@ -114,4 +135,19 @@ string CreateTextFile(const string& relpath, const char *contents) {
   return string("");
 }
 
+Runfiles* runfiles = nullptr;
+
 }  // namespace singlejar_test_util
+
+int main(int argc, char** argv) {
+  std::string error;
+  std::unique_ptr<singlejar_test_util::Runfiles> runfiles(
+      singlejar_test_util::Runfiles::Create(argv[0], &error));
+  if (runfiles == nullptr) {
+    perror(error.c_str());
+    exit(1);
+  }
+  singlejar_test_util::runfiles = runfiles.get();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/tools/singlejar/test_util.h
+++ b/src/tools/singlejar/test_util.h
@@ -49,12 +49,5 @@ namespace singlejar_test_util {
   // return file's path.
   string CreateTextFile(const string& file_path, const char *contents);
 
-  using bazel::tools::cpp::runfiles::Runfiles;
-  // Pointer to Bazel Runfiles object.
-  extern Runfiles* runfiles;
-
 }  // namespace singlejar_test_util
 #endif  //  SRC_TOOLS_SINGLEJAR_TEST_UTIL_H_
-
-// Custom main entry to set up Bazel Runfiles and Googletest.
-int main(int argc, char** argv);

--- a/src/tools/singlejar/test_util.h
+++ b/src/tools/singlejar/test_util.h
@@ -14,8 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <unistd.h>
 #include <string>
+#include <vector>
+
+#include "tools/cpp/runfiles/runfiles.h"
 
 namespace singlejar_test_util {
   using std::string;
@@ -47,5 +49,12 @@ namespace singlejar_test_util {
   // return file's path.
   string CreateTextFile(const string& file_path, const char *contents);
 
+  using bazel::tools::cpp::runfiles::Runfiles;
+  // Pointer to Bazel Runfiles object.
+  extern Runfiles* runfiles;
+
 }  // namespace singlejar_test_util
 #endif  //  SRC_TOOLS_SINGLEJAR_TEST_UTIL_H_
+
+// Custom main entry to set up Bazel Runfiles and Googletest.
+int main(int argc, char** argv);

--- a/src/tools/singlejar/test_util.h
+++ b/src/tools/singlejar/test_util.h
@@ -16,7 +16,7 @@
 
 #include <string>
 
-#include "tools/cpp/runfiles/runfiles.h"
+#include "tools/cpp/runfiles/runfiles_src.h"
 
 namespace singlejar_test_util {
   using std::string;

--- a/src/tools/singlejar/test_util.h
+++ b/src/tools/singlejar/test_util.h
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 #include <string>
-#include <vector>
 
 #include "tools/cpp/runfiles/runfiles.h"
 

--- a/tools/cpp/runfiles/BUILD
+++ b/tools/cpp/runfiles/BUILD
@@ -42,6 +42,8 @@ cc_library(
     testonly = 1,
     srcs = ["runfiles_src.cc"],
     hdrs = ["runfiles_src.h"],
+    # TODO(laszlocsomor) Use @bazel_tools//tools/cpp/runfiles in singlejar
+    visibility = ["//src/tools/singlejar:__pkg__"],
 )
 
 cc_test(


### PR DESCRIPTION
- Port various functions in `test_util` to Windows.
- Replace `@local_jdk//:jdk-default` with `@bazel_tools//tools/jdk:current_java_runtime`.

See #2241