### PR TITLE
Flip --experimental_strict_action_env on by default.

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -93,6 +93,7 @@ log "Building output/bazel"
 # We set host and target platform directly since the defaults in @bazel_tools
 # have not yet been generated.
 bazel_build "src:bazel_nojdk${EXE_EXT}" \
+  --action_env=PATH \
   --host_platform=@bazel_tools//platforms:host_platform \
   --platforms=@bazel_tools//platforms:target_platform \
   || fail "Could not build Bazel"

--- a/site/docs/remote-caching.md
+++ b/site/docs/remote-caching.md
@@ -333,12 +333,6 @@ You can pass a user-specific path to the `--disk_cache` flag using the `~` alias
 when enabling the disk cache for all developers of a project via the project's
 checked in `.bazelrc` file.
 
-To enable cache hits across different workspaces, use the following flag:
-
-```
-build --experimental_strict_action_env
-```
-
 ## Known issues
 
 **Input file modification during a build**
@@ -353,15 +347,14 @@ build.
 
 **Environment variables leaking into an action**
 
-An action definition contains environment variables. This can be a problem
-for sharing remote cache hits across machines. For example, environments
-with different `$PATH` variables won't share cache hits. You can specify
-`--experimental_strict_action_env` to ensure that that's not the case and
-that only environment variables explicitly whitelisted via `--action_env`
-are included in an action definition. Bazel's Debian/Ubuntu package used
-to install `/etc/bazel.bazelrc` with a whitelist of environment variables
-including `$PATH`. If you are getting fewer cache hits than expected, check
-that your environment doesn't have an old `/etc/bazel.bazelrc` file.
+An action definition contains environment variables. This can be a problem for
+sharing remote cache hits across machines. For example, environments with
+different `$PATH` variables won't share cache hits. Only environment variables
+explicitly whitelisted via `--action_env` are included in an action
+definition. Bazel's Debian/Ubuntu package used to install `/etc/bazel.bazelrc`
+with a whitelist of environment variables including `$PATH`. If you are getting
+fewer cache hits than expected, check that your environment doesn't have an old
+`/etc/bazel.bazelrc` file.
 
 
 **Bazel does not track tools outside a workspace**

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -111,7 +111,7 @@ public class BazelRuleClassProvider {
   public static class StrictActionEnvOptions extends FragmentOptions {
     @Option(
         name = "experimental_strict_action_env",
-        defaultValue = "false",
+        defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
         effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
         help =

--- a/src/test/py/bazel/windows_remote_test.py
+++ b/src/test/py/bazel/windows_remote_test.py
@@ -33,7 +33,6 @@ class WindowsRemoteTest(test_base.TestBase):
             '--define=EXECUTOR=remote',
             '--remote_executor=localhost:' + str(self._worker_port),
             '--remote_cache=localhost:' + str(self._worker_port),
-            '--experimental_strict_action_env=true',
             '--remote_timeout=3600',
             '--auth_enabled=false',
             '--remote_accept_cached=false',


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/2574. For a while, many actions did not respect the --action_env command line option, but those have been fixed now. So, I think it's time to flip on this flag for greater hermeticity by default.