### PR TITLE
C++, runfiles: add Runfiles::CreateForTest

### DIFF
--- a/tools/cpp/runfiles/runfiles_src.cc
+++ b/tools/cpp/runfiles/runfiles_src.cc
@@ -90,6 +90,10 @@ bool IsDirectory(const string& path) {
 }
 
 bool PathsFrom(const std::string& argv0, std::string runfiles_manifest_file,
+               std::string runfiles_dir, std::string* out_manifest,
+               std::string* out_directory);
+
+bool PathsFrom(const std::string& argv0, std::string runfiles_manifest_file,
                std::string runfiles_dir,
                std::function<bool(const std::string&)> is_runfiles_manifest,
                std::function<bool(const std::string&)> is_runfiles_directory,
@@ -104,16 +108,8 @@ Runfiles* Runfiles::Create(const string& argv0,
                            const string& runfiles_manifest_file,
                            const string& runfiles_dir, string* error) {
   string manifest, directory;
-  if (!PathsFrom(argv0, runfiles_manifest_file, runfiles_dir,
-                 [](const string& path) {
-                   return (ends_with(path, "MANIFEST") ||
-                           ends_with(path, ".runfiles_manifest")) &&
-                          IsReadableFile(path);
-                 },
-                 [](const string& path) {
-                   return ends_with(path, ".runfiles") && IsDirectory(path);
-                 },
-                 &manifest, &directory)) {
+  if (!PathsFrom(argv0, runfiles_manifest_file, runfiles_dir, &manifest,
+                 &directory)) {
     if (error) {
       std::ostringstream err;
       err << "ERROR: " << __FILE__ << "(" << __LINE__
@@ -156,14 +152,14 @@ string GetEnv(const string& key) {
 #ifdef _WIN32
   DWORD size = ::GetEnvironmentVariableA(key.c_str(), NULL, 0);
   if (size == 0) {
-    return std::move(string());  // unset or empty envvar
+    return string();  // unset or empty envvar
   }
   std::unique_ptr<char[]> value(new char[size]);
   ::GetEnvironmentVariableA(key.c_str(), value.get(), size);
-  return std::move(string(value.get()));
+  return value.get();
 #else
   char* result = getenv(key.c_str());
-  return std::move((result == NULL) ? string() : string(result));
+  return (result == NULL) ? string() : string(result);
 #endif
 }
 
@@ -243,7 +239,20 @@ Runfiles* Runfiles::Create(const string& argv0, string* error) {
                           GetEnv("RUNFILES_DIR"), error);
 }
 
+Runfiles* Runfiles::CreateForTest(std::string* error) {
+  return Runfiles::Create(std::string(), GetEnv("RUNFILES_MANIFEST_FILE"),
+                          GetEnv("TEST_SRCDIR"), error);
+}
+
 namespace {
+
+bool PathsFrom(const string& argv0, string mf, string dir, string* out_manifest,
+               string* out_directory) {
+  return PathsFrom(argv0, mf, dir,
+                   [](const string& path) { return IsReadableFile(path); },
+                   [](const string& path) { return IsDirectory(path); },
+                   out_manifest, out_directory);
+}
 
 bool PathsFrom(const string& argv0, string mf, string dir,
                function<bool(const string&)> is_runfiles_manifest,
@@ -255,7 +264,7 @@ bool PathsFrom(const string& argv0, string mf, string dir,
   bool mfValid = is_runfiles_manifest(mf);
   bool dirValid = is_runfiles_directory(dir);
 
-  if (!mfValid && !dirValid) {
+  if (!argv0.empty() && !mfValid && !dirValid) {
     mf = argv0 + ".runfiles/MANIFEST";
     dir = argv0 + ".runfiles";
     mfValid = is_runfiles_manifest(mf);
@@ -279,7 +288,8 @@ bool PathsFrom(const string& argv0, string mf, string dir,
     }
   }
 
-  if (!dirValid) {
+  if (!dirValid &&
+      (ends_with(mf, ".runfiles_manifest") || ends_with(mf, "/MANIFEST"))) {
     static const size_t kSubstrLen = 9;  // "_manifest" or "/MANIFEST"
     dir = mf.substr(0, mf.size() - kSubstrLen);
     dirValid = is_runfiles_directory(dir);

--- a/tools/cpp/runfiles/runfiles_src.h
+++ b/tools/cpp/runfiles/runfiles_src.h
@@ -35,6 +35,12 @@
 //         std::string error;
 //         std::unique_ptr<Runfiles> runfiles(
 //             Runfiles::Create(argv[0], &error));
+//
+//         // Important:
+//         //   If this is a test, use Runfiles::CreateForTest(&error).
+//         //   Otherwise, if you don't have the value for argv[0] for whatever
+//         //   reason, then use Runfiles::Create(&error).
+//
 //         if (runfiles == nullptr) {
 //           ...  // error handling
 //         }
@@ -89,20 +95,40 @@ class Runfiles {
 
   // Returns a new `Runfiles` instance.
   //
+  // Use this from within `cc_test` rules.
+  //
+  // Returns nullptr on error. If `error` is provided, the method prints an
+  // error message into it.
+  //
+  // This method looks at the RUNFILES_MANIFEST_FILE and TEST_SRCDIR
+  // environment variables.
+  static Runfiles* CreateForTest(std::string* error = nullptr);
+
+  // Returns a new `Runfiles` instance.
+  //
+  // Use this from `cc_binary` or `cc_library` rules. You may pass an empty
+  // `argv0` if `argv[0]` from the `main` method is unknown.
+  //
   // Returns nullptr on error. If `error` is provided, the method prints an
   // error message into it.
   //
   // This method looks at the RUNFILES_MANIFEST_FILE and RUNFILES_DIR
   // environment variables. If either is empty, the method looks for the
-  // manifest or directory using the other environment variable, or using argv0.
+  // manifest or directory using the other environment variable, or using argv0
+  // (unless it's empty).
   static Runfiles* Create(const std::string& argv0,
                           std::string* error = nullptr);
 
   // Returns a new `Runfiles` instance.
   //
-  // Same as `Create(argv0, error)`, except it uses `runfiles_manifest_file` and
-  // `runfiles_dir` as the corresponding environment variable values, instead of
-  // looking up the actual environment variables.
+  // Use this from any `cc_*` rule if you want to manually specify the paths to
+  // the runfiles manifest and/or runfiles directory. You may pass an empty
+  // `argv0` if `argv[0]` from the `main` method is unknown.
+  //
+  // This method is the same as `Create(argv0, error)`, except it uses
+  // `runfiles_manifest_file` and `runfiles_dir` as the corresponding
+  // environment variable values, instead of looking up the actual environment
+  // variables.
   static Runfiles* Create(const std::string& argv0,
                           const std::string& runfiles_manifest_file,
                           const std::string& runfiles_dir,

--- a/tools/cpp/runfiles/runfiles_test.cc
+++ b/tools/cpp/runfiles/runfiles_test.cc
@@ -307,29 +307,17 @@ TEST_F(RunfilesTest, ManifestAndDirectoryBasedRunfilesRlocationAndEnvVars) {
 }
 
 TEST_F(RunfilesTest, ManifestBasedRunfilesEnvVars) {
-  const vector<string> suffixes({"/MANIFEST", ".runfiles_manifest",
-                                 "runfiles_manifest", ".runfiles", ".manifest",
-                                 ".txt"});
-  for (vector<string>::size_type i = 0; i < suffixes.size(); ++i) {
-    unique_ptr<MockFile> mf(
-        MockFile::Create(string("foo" LINE_AS_STRING()) + suffixes[i]));
-    EXPECT_TRUE(mf != nullptr) << " (suffix=\"" << suffixes[i] << "\")";
+  unique_ptr<MockFile> mf(
+      MockFile::Create(string("foo" LINE_AS_STRING() ".runfiles_manifest")));
+  EXPECT_TRUE(mf != nullptr);
 
-    string error;
-    unique_ptr<Runfiles> r(
-        Runfiles::Create("ignore-argv0", mf->Path(), "", &error));
-    if (i < 2) {
-      ASSERT_NE(r, nullptr) << " (suffix=\"" << suffixes[i] << "\")";
-      EXPECT_TRUE(error.empty());
+  string error;
+  unique_ptr<Runfiles> r(
+      Runfiles::Create("ignore-argv0", mf->Path(), "", &error));
+  ASSERT_NE(r, nullptr);
+  EXPECT_TRUE(error.empty());
 
-      // The object can compute the runfiles directory when i=0 and i=1, but not
-      // when i>1 because the manifest file's name doesn't end in a well-known
-      // way.
-      AssertEnvvars(*r, mf->Path(), "");
-    } else {
-      ASSERT_EQ(r, nullptr) << " (suffix=\"" << suffixes[i] << "\")";
-    }
-  }
+  AssertEnvvars(*r, mf->Path(), "");
 }
 
 TEST_F(RunfilesTest, CreatesDirectoryBasedRunfilesFromDirectoryNextToBinary) {


### PR DESCRIPTION
Add a new factory method for Runfiles, to be used
in cc_test rules.

RELNOTES[NEW]: C++, runfiles in cc_test: the C++ runfiles library (`@bazel_tools//tools/cpp/runfiles`) can now create Runfiles objects for tests. See `//tools/cpp/runfiles/runfiles_src.h` (in the Bazel source tree) for documentation.

Change-Id: I5292caa734bbfb3b7b3ed2a7f4d443216abd0d94