### PR TITLE
Add flogger jars filegroup, similar to auto_value filegroup

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -388,6 +388,16 @@ java_import(
     ],
 )
 
+# For bootstrapping JavaBuilder
+filegroup(
+    name = "flogger-jars",
+    srcs = [
+        "flogger/flogger-0.3.1.jar",
+        "flogger/flogger-system-backend-0.3.1.jar",
+        "flogger/google-extensions-0.3.1.jar",
+    ]
+)
+
 java_import(
     name = "instrumentation",
     jars = [

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -388,7 +388,6 @@ java_import(
     ],
 )
 
-# For bootstrapping JavaBuilder
 filegroup(
     name = "flogger-jars",
     srcs = [


### PR DESCRIPTION
Needed for bootstrapping JavaBuilder (will be used in
https://source.bazel.build/bazel/+/master:src/main/java/com/google/devtools/build/lib/shell/BUILD;l=35).