### PR TITLE
Capture build-runfiles output.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -511,7 +511,7 @@ public class RunCommand implements BlazeCommand  {
         runfilesSupport.getRunfilesDirectory(),
         false);
     helper.createSymlinksUsingCommand(
-        env.getExecRoot(), env.getBlazeWorkspace().getBinTools(), ImmutableMap.of());
+        env.getExecRoot(), env.getBlazeWorkspace().getBinTools(), ImmutableMap.of(), null);
     return workingDir;
   }
 


### PR DESCRIPTION
As https://github.com/bazelbuild/bazel/issues/6176 shows, it's very hard to debug runfiles building failures when all output is eaten.