### PR TITLE
Temporarily restore processing of workspace-wide tools/bazel.rc file.

### DIFF
--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -322,6 +322,9 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
       SearchNullaryOption(cmd_line->startup_args, "workspace_rc", true)) {
     const std::string workspaceRcFile =
         blaze_util::JoinPath(workspace, kRcBasename);
+    // Legacy behavior.
+    rc_files.push_back(
+        workspace_layout->GetWorkspaceRcPath(workspace, cmd_line->startup_args));
     rc_files.push_back(workspaceRcFile);
   }
 
@@ -415,6 +418,16 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
            "their contents or import their path into one of the standard rc "
            "files:\n"
         << joined_lost_rcs;
+  }
+
+  std::string legacy_workspace_file = workspace_layout->GetWorkspaceRcPath(workspace, cmd_line->startup_args);
+  if (old_files.find(legacy_workspace_file) != old_files.end()) {
+    BAZEL_LOG(WARNING)
+        << "Processed legacy workspace file "
+        << legacy_workspace_file
+        << ". This file will not be processed in the next release of Bazel. "
+        << " Please read https://github.com/bazelbuild/bazel/issues/6319 for further information, "
+        << " including how to upgrade.";
   }
 
   return blaze_exit_code::SUCCESS;

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -261,8 +261,39 @@ TEST_F(GetRcFileTest, GetRcFilesWarnsAboutIgnoredMasterRcFiles) {
   // read as expected.
   EXPECT_THAT(output,
               HasSubstr("The following rc files are no longer being read"));
-  EXPECT_THAT(output, HasSubstr(workspace_rc));
   EXPECT_THAT(output, HasSubstr(binary_rc));
+
+  EXPECT_THAT(output,
+              HasSubstr("Processed legacy workspace file"));
+  EXPECT_THAT(output, HasSubstr(workspace_rc));
+}
+
+TEST_F(GetRcFileTest, GetRcFilesWarnsAboutLegacyWorkspaceFile) {
+  std::string workspace_rc;
+  ASSERT_TRUE(SetUpLegacyMasterRcFileInWorkspace("", &workspace_rc));
+
+  const CommandLine cmd_line = CommandLine(binary_path_, {}, "build", {});
+  std::string error = "check that this string is not modified";
+  std::vector<std::unique_ptr<RcFile>> parsed_rcs;
+
+  testing::internal::CaptureStderr();
+  const blaze_exit_code::ExitCode exit_code =
+      option_processor_->GetRcFiles(workspace_layout_.get(), workspace_, cwd_,
+                                    &cmd_line, &parsed_rcs, &error);
+  const std::string output = testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(blaze_exit_code::SUCCESS, exit_code);
+  EXPECT_EQ("check that this string is not modified", error);
+
+  // tools/blaze.rc should be read...
+  EXPECT_THAT(output,
+              Not(HasSubstr("The following rc files are no longer being read")));
+
+  // ... but reported specially.
+  // (cf https://github.com/bazelbuild/bazel/issues/6321).
+  EXPECT_THAT(output,
+              HasSubstr("Processed legacy workspace file"));
+  EXPECT_THAT(output, HasSubstr(workspace_rc));
 }
 
 TEST_F(


### PR DESCRIPTION
Fixes #6321.

Change-Id: I5f1e1ac4f9ae9b0001b6ea707c981686bf91aa12