### PR TITLE
Don't add carriage returns to genrule-setup.sh.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 *.bzl linguist-language=Python
 BUILD linguist-language=Python
 site/* linguist-documentation
+
+# Files that should not use CRLF line endings, even on Windows.
+tools/genrule/genrule-setup.sh -text


### PR DESCRIPTION
This file is used as an input for genrule() directives. When performing
remote builds on UNIX-based systems from a Windows host, we should
ensure these files do use UNIX-style newlines, as Bash doesn't parse
them properly otherwise.

Fixes: #6323