### PR TITLE
Don't let proxy configuration interfere with remote execution.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java
@@ -144,12 +144,6 @@ public class ProxyHelper {
       }
     }
 
-    // We need to set both of these because jgit uses whichever the resource dictates
-    System.setProperty("https.proxyHost", hostname);
-    System.setProperty("https.proxyPort", Integer.toString(port));
-    System.setProperty("http.proxyHost", hostname);
-    System.setProperty("http.proxyPort", Integer.toString(port));
-
     if (username != null) {
       if (password == null) {
         throw new IOException("No password given for proxy " + cleanProxyAddress);
@@ -158,11 +152,6 @@ public class ProxyHelper {
       // We need to make sure the proxy password is not url encoded; some special characters in
       // proxy passwords require url encoding for shells and other tools to properly consume.
       final String decodedPassword = URLDecoder.decode(password, "UTF-8");
-      System.setProperty("http.proxyUser", username);
-      System.setProperty("http.proxyPassword", decodedPassword);
-      System.setProperty("https.proxyUser", username);
-      System.setProperty("https.proxyPassword", decodedPassword);
-
       Authenticator.setDefault(
           new Authenticator() {
             @Override

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelperTest.java
@@ -169,26 +169,18 @@ public class ProxyHelperTest {
     Proxy proxy = ProxyHelper.createProxy("http://my.example.com");
     assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
     assertThat(proxy.toString()).endsWith(":80");
-    assertThat(System.getProperty("http.proxyHost")).isEqualTo("my.example.com");
-    assertThat(System.getProperty("http.proxyPort")).isEqualTo("80");
 
     proxy = ProxyHelper.createProxy("https://my.example.com");
     assertThat(proxy.toString()).endsWith(":443");
-    assertThat(System.getProperty("https.proxyHost")).isEqualTo("my.example.com");
-    assertThat(System.getProperty("https.proxyPort")).isEqualTo("443");
   }
 
   @Test
   public void testProxyExplicitPort() throws Exception {
     Proxy proxy = ProxyHelper.createProxy("http://my.example.com:12345");
     assertThat(proxy.toString()).endsWith(":12345");
-    assertThat(System.getProperty("http.proxyHost")).isEqualTo("my.example.com");
-    assertThat(System.getProperty("http.proxyPort")).isEqualTo("12345");
 
     proxy = ProxyHelper.createProxy("https://my.example.com:12345");
     assertThat(proxy.toString()).endsWith(":12345");
-    assertThat(System.getProperty("https.proxyHost")).isEqualTo("my.example.com");
-    assertThat(System.getProperty("https.proxyPort")).isEqualTo("12345");
   }
 
   @Test
@@ -230,17 +222,9 @@ public class ProxyHelperTest {
     Proxy proxy = ProxyHelper.createProxy("http://foo:barbaz@my.example.com");
     assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
     assertThat(proxy.toString()).endsWith(":80");
-    assertThat(System.getProperty("http.proxyHost")).isEqualTo("my.example.com");
-    assertThat(System.getProperty("http.proxyPort")).isEqualTo("80");
-    assertThat(System.getProperty("http.proxyUser")).isEqualTo("foo");
-    assertThat(System.getProperty("http.proxyPassword")).isEqualTo("barbaz");
 
     proxy = ProxyHelper.createProxy("https://biz:bat@my.example.com");
     assertThat(proxy.toString()).endsWith(":443");
-    assertThat(System.getProperty("https.proxyHost")).isEqualTo("my.example.com");
-    assertThat(System.getProperty("https.proxyPort")).isEqualTo("443");
-    assertThat(System.getProperty("https.proxyUser")).isEqualTo("biz");
-    assertThat(System.getProperty("https.proxyPassword")).isEqualTo("bat");
   }
 
   @Test
@@ -248,10 +232,6 @@ public class ProxyHelperTest {
     Proxy proxy = ProxyHelper.createProxy("http://foo:b%40rb%40z@my.example.com");
     assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
     assertThat(proxy.toString()).endsWith(":80");
-    assertThat(System.getProperty("http.proxyHost")).isEqualTo("my.example.com");
-    assertThat(System.getProperty("http.proxyPort")).isEqualTo("80");
-    assertThat(System.getProperty("http.proxyUser")).isEqualTo("foo");
-    assertThat(System.getProperty("http.proxyPassword")).isEqualTo("b@rb@z");
   }
 
   @Test
@@ -269,8 +249,6 @@ public class ProxyHelperTest {
     Proxy proxy = ProxyHelper.createProxy("http://localhost:3128/");
     assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
     assertThat(proxy.toString()).endsWith(":3128");
-    assertThat(System.getProperty("http.proxyHost")).isEqualTo("localhost");
-    assertThat(System.getProperty("http.proxyPort")).isEqualTo("3128");
   }
 
   @Test
@@ -278,9 +256,5 @@ public class ProxyHelperTest {
     Proxy proxy = ProxyHelper.createProxy("http://foo:bar@example.com:8000/");
     assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
     assertThat(proxy.toString()).endsWith(":8000");
-    assertThat(System.getProperty("http.proxyHost")).isEqualTo("example.com");
-    assertThat(System.getProperty("http.proxyPort")).isEqualTo("8000");
-    assertThat(System.getProperty("http.proxyUser")).isEqualTo("foo");
-    assertThat(System.getProperty("http.proxyPassword")).isEqualTo("bar");
   }
 }


### PR DESCRIPTION
The existing proxy helper code adjusts JVM properties for setting the
HTTP proxy. This is, based on the source code comments, done to make
jgit use the right proxy.

This code is problematic for three reasons:

- The properties are never cleared between
  ProxyHelper.createProxyIfNeeded() calls, meaning that if a successive
  Git repository were to be part of NO_PROXY, it would still use the
  previously configured proxy.

- Credentials are never cleared, meaning that credentials belonging to
  one proxy may later be sent to the next one.

- The proxy settings end up being used by gRPC for remote execution
  later on, which completely breaks remote builds.

As the new git_repository() no longer uses jgit, remove the code that
sets the JVM properties. It's simply too brittle.