### PR TITLE
add %virtual_includes% includes substitution

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCommon.java
@@ -621,9 +621,19 @@ public final class CcCommon {
                 + packageFragment
                 + "'. This will be an error in the future");
       }
-      result.add(includesPath);
-      result.add(ruleContext.getConfiguration().getGenfilesFragment().getRelative(includesPath));
-      result.add(ruleContext.getConfiguration().getBinFragment().getRelative(includesPath));
+      int packageFragmentSegmentCount = packageFragment.segmentCount();
+      if (includesPath.segmentCount() > packageFragmentSegmentCount
+          && includesPath.getSegment(packageFragmentSegmentCount).equals("%virtual_includes%")) {
+        result.add(ruleContext
+            .getBinOrGenfilesDirectory()
+            .getExecPath()
+            .getRelative(ruleContext.getUniqueDirectory("_virtual_includes"))
+            .getRelative(includesPath.subFragment(packageFragmentSegmentCount + 1, includesPath.segmentCount())));
+      } else {
+        result.add(includesPath);
+        result.add(ruleContext.getConfiguration().getGenfilesFragment().getRelative(includesPath));
+        result.add(ruleContext.getConfiguration().getBinFragment().getRelative(includesPath));
+      }
     }
     return result;
   }


### PR DESCRIPTION
use of `include_prefix` prevents the facility of `includes` from supplying
the virtual_includes prefix without a substitution pattern. The
system_include_paths configuration list will contain, for each member of
`includes`, the _virtual_includes root in place of the string
`%virtual_includes%`.