### PR TITLE
Ensure that output files of targets passed to sh_binary(data = ...) are included.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/ShBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/ShBinary.java
@@ -80,6 +80,7 @@ public class ShBinary implements RuleConfiguredTargetFactory {
     Runfiles runfiles =
         runfilesBuilder
             .addTransitiveArtifacts(filesToBuild)
+            .addArtifacts(ruleContext.getPrerequisiteArtifacts("data", Mode.DONT_CHECK).list())
             .addRunfiles(ruleContext, RunfilesProvider.DEFAULT_RUNFILES)
             .build();
 


### PR DESCRIPTION
The Bazel LaTeX rules provide a _view target that can be run to view a
LaTeX document using your system's PDF viewer. This _view target is
implemented as an sh_binary() that should ideally look like this:

    sh_binary(
        name = "mydocument_view",
        srcs = [":mydocument_view_launcher_script"],
        data = [":mydocument"],
    )

Unfortunately, the document itself doesn't actually become part of the
data when modeled this way. The data argument seems to be ignored. I can
work around this by adding an intermediate sh_library() for which the
data argument does work.

Fix this by adding all data artifacts to filesToBuild.