### PR TITLE
cc_configure: Remove hardcoded link option "-B/usr/bin"

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/MOCK_CROSSTOOL
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/MOCK_CROSSTOOL
@@ -62,7 +62,6 @@ toolchain {
   tool_path { name: "gcc" path: "/usr/bin/gcc" }
   cxx_flag: "-std=c++0x"
   linker_flag: "-lstdc++"
-  linker_flag: "-B/usr/bin/"
 
   # TODO(bazel-team): In theory, the path here ought to exactly match the path
   # used by gcc. That works because bazel currently doesn't track files at

--- a/src/test/shell/bazel/testdata/bazel_toolchain_test_data/tools/arm_compiler/CROSSTOOL
+++ b/src/test/shell/bazel/testdata/bazel_toolchain_test_data/tools/arm_compiler/CROSSTOOL
@@ -155,8 +155,6 @@ toolchain {
   compiler_flag: "-fstack-protector"
   compiler_flag: "-Wall"
   compiler_flag: "-Wl,-z,-relro,-z,now"
-  compiler_flag: "-B/usr/bin"
-  compiler_flag: "-B/usr/bin"
   compiler_flag: "-Wunused-but-set-parameter"
   compiler_flag: "-Wno-free-nonheap-object"
   compiler_flag: "-fno-omit-frame-pointer"
@@ -173,8 +171,6 @@ toolchain {
   linker_flag: "-lstdc++"
   linker_flag: "-lm"
   linker_flag: "-Wl,-no-as-needed"
-  linker_flag: "-B/usr/bin"
-  linker_flag: "-B/usr/bin"
   linker_flag: "-pass-exit-codes"
   needsPic: true
   objcopy_embed_flag: "-I"

--- a/tools/cpp/CROSSTOOL
+++ b/tools/cpp/CROSSTOOL
@@ -59,7 +59,6 @@ toolchain {
   tool_path { name: "gcc" path: "/usr/bin/gcc" }
   cxx_flag: "-std=c++0x"
   linker_flag: "-lstdc++"
-  linker_flag: "-B/usr/bin/"
 
   # TODO(bazel-team): In theory, the path here ought to exactly match the path
   # used by gcc. That works because bazel currently doesn't track files at
@@ -271,7 +270,6 @@ toolchain {
   tool_path { name: "gcc" path: "/usr/bin/clang" }
   cxx_flag: "-std=c++0x"
   linker_flag: "-lstdc++"
-  linker_flag: "-B/usr/bin/"
 
   # TODO(bazel-team): In theory, the path here ought to exactly match the path
   # used by gcc. That works because bazel currently doesn't track files at

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -282,8 +282,6 @@ def _crosstool_content(repository_ctx, cc, cpu_value, darwin):
                 "dynamic_lookup",
                 "-headerpad_max_install_names",
             ] if darwin else bin_search_flag + [
-                # Always have -B/usr/bin, see https://github.com/bazelbuild/bazel/issues/760.
-                "-B/usr/bin",
                 # Gold linker only? Can we enable this by default?
                 # "-Wl,--warn-execstack",
                 # "-Wl,--detect-odr-violations"
@@ -318,10 +316,7 @@ def _crosstool_content(repository_ctx, cc, cpu_value, darwin):
         ] + ((
             _add_compiler_option_if_supported(repository_ctx, cc, "-Wthread-safety") +
             _add_compiler_option_if_supported(repository_ctx, cc, "-Wself-assign")
-        ) if darwin else bin_search_flag + [
-            # Always have -B/usr/bin, see https://github.com/bazelbuild/bazel/issues/760.
-            "-B/usr/bin",
-        ]) + (
+        )) + (
             # Disable problematic warnings.
             _add_compiler_option_if_supported(repository_ctx, cc, "-Wunused-but-set-parameter") +
             # has false positives


### PR DESCRIPTION
Putting -B/usr/bin on the link line breaks use of custom C/C++ toolchain
since support binaries such as ld, as, etc., will incorrectly "leak" to
the build machine.

Fixes https://github.com/bazelbuild/bazel/issues/5634

Archeaology: It looks like this logic was originally added here:

  810d60a7dc Apr 22 2016 dmarting@google.com
  "cc_configure: Add -B to compiler flag too"

.. and that that was done to get Tensor Flow building on some (but failing
on other?) versions of RedHat. https://github.com/bazelbuild/bazel/issues/1152.

This may have also "fixed" the hombrew builds for
https://github.com/bazelbuild/bazel/issues/1177.

Testing Done:

* Building envoy on older Centos host using non-host
  crosscompiler. Build fails without the fix and succeeds with the fix.

* bazel test //src/test/java/com/google/devtools/build/lib:all
  1 flaky test failed before and after:
  bazel test //src/test/java/com/google/devtools/build/lib:vfs_test