### PR TITLE
Change default apple_platform_type to macOS

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
@@ -221,7 +221,7 @@ public class AppleCommandLineOptions extends FragmentOptions {
 
   @Option(
     name = "apple_platform_type",
-    defaultValue = "IOS",
+    defaultValue = "MACOS",
     converter = PlatformTypeConverter.class,
     documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
     effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},

--- a/src/test/java/com/google/devtools/build/lib/rules/apple/XcodeConfigTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/apple/XcodeConfigTest.java
@@ -682,7 +682,8 @@ public class XcodeConfigTest extends BuildViewTestCase {
         "    version = '5.1.2',",
         ")");
 
-    useConfiguration("--apple_bitcode=embedded", "--apple_split_cpu=arm64");
+    useConfiguration("--apple_platform_type=ios", "--apple_bitcode=embedded",
+        "--apple_split_cpu=arm64");
 
     reporter.removeHandler(failFastHandler);
     getConfiguredTarget("//xcode:foo");

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/AppleStaticLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/AppleStaticLibraryTest.java
@@ -407,7 +407,7 @@ public class AppleStaticLibraryTest extends ObjcRuleTestCase {
   @Test
   public void testAppleSdkIphoneosPlatformEnv() throws Exception {
     RULE_TYPE.scratchTarget(scratch, "platform_type", "'ios'");
-    useConfiguration("--cpu=ios_arm64");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_arm64");
 
     CommandAction action = linkLibAction("//x:x");
 

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/AppleToolchainSelectionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/AppleToolchainSelectionTest.java
@@ -41,12 +41,12 @@ public class AppleToolchainSelectionTest extends ObjcRuleTestCase {
 
     assertThat(cppConfig.getRuleProvidingCcToolchainProvider().toString())
         .isEqualTo("//tools/osx/crosstool:crosstool");
-    assertThat(cppConfig.getTransformedCpuFromOptions()).isEqualTo("ios_x86_64");
+    assertThat(cppConfig.getTransformedCpuFromOptions()).isEqualTo("darwin_x86_64");
   }
 
   @Test
   public void testToolchainSelectionIosDevice() throws Exception {
-    useConfiguration("--cpu=ios_armv7");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_armv7");
     createLibraryTargetWriter("//a:lib").write();
     CppConfiguration cppConfig =
         getAppleCrosstoolConfiguration().getFragment(CppConfiguration.class);
@@ -81,7 +81,7 @@ public class AppleToolchainSelectionTest extends ObjcRuleTestCase {
 
   @Test
   public void testToolchainSelectionCcDepDevice() throws Exception {
-    useConfiguration("--cpu=ios_armv7");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_armv7");
     ScratchAttributeWriter
         .fromLabelString(this, "cc_library", "//b:lib")
         .setList("srcs", "b.cc")

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/BazelJ2ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/BazelJ2ObjcLibraryTest.java
@@ -1173,7 +1173,7 @@ public class BazelJ2ObjcLibraryTest extends J2ObjcLibraryTest {
 
   @Test
   public void testCompileActionTemplateFromGenJar() throws Exception {
-    useConfiguration("--cpu=ios_i386", "--ios_minimum_os=1.0");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_i386", "--ios_minimum_os=1.0");
     addSimpleJ2ObjcLibraryWithJavaPlugin();
     Artifact archive = j2objcArchive("//java/com/google/app/test:transpile", "test");
     CommandAction archiveAction = (CommandAction) getGeneratingAction(archive);

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcBuildVariablesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcBuildVariablesTest.java
@@ -80,7 +80,7 @@ public class ObjcBuildVariablesTest extends LinkBuildVariablesTestCase {
      useConfiguration(
          "--crosstool_top=//tools/osx/crosstool", "--xcode_version=5.8",
          "--ios_minimum_os=12.345", "--watchos_minimum_os=11.111",
-         "--cpu=ios_x86_64");
+         "--cpu=ios_x86_64", "--apple_platform_type=ios");
      scratch.file(
         "x/BUILD",
         "cc_binary(",
@@ -202,6 +202,7 @@ public class ObjcBuildVariablesTest extends LinkBuildVariablesTestCase {
   public void testDefaultBuildVariablesIos() throws Exception {
      MockObjcSupport.setup(mockToolsConfig);
      useConfiguration(
+         "--apple_platform_type=ios",
          "--crosstool_top=//tools/osx/crosstool", "--cpu=ios_x86_64");
      scratch.file(
         "x/BUILD",

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -100,7 +100,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
         ")");
 
     useConfiguration(
-        "--cpu=ios_x86_64",
+        "--apple_platform_type=ios", "--cpu=ios_x86_64",
         "--crosstool_top=" + MockObjcSupport.DEFAULT_OSX_CROSSTOOL);
 
     ConfiguredTarget cc = getConfiguredTarget("//bin:cc");
@@ -176,6 +176,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   @Test
   public void testObjcPlusPlusCompile() throws Exception {
     useConfiguration(
+        "--apple_platform_type=ios",
         "--cpu=ios_i386",
         "--ios_cpu=i386",
         "--ios_minimum_os=9.10.11");
@@ -406,6 +407,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   @Test
   public void testCompilationActions_simulator() throws Exception {
     useConfiguration(
+        "--apple_platform_type=ios",
         "--cpu=ios_i386",
         "--ios_cpu=i386");
 
@@ -458,6 +460,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   @Test
   public void testCompilationActions_device() throws Exception {
     useConfiguration(
+        "--apple_platform_type=ios",
         "--cpu=ios_armv7",
         "--ios_cpu=armv7");
 
@@ -552,7 +555,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testCompilationActionsWithCopts() throws Exception {
-    useConfiguration("--cpu=ios_i386", "--ios_cpu=i386");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_i386", "--ios_cpu=i386");
     createLibraryTargetWriter("//objc:lib")
         .setAndCreateFiles("srcs", "a.m", "b.m", "private.h")
         .setAndCreateFiles("hdrs", "c.h")
@@ -619,6 +622,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   @Test
   public void testCompilationActionsWithEmbeddedBitcode() throws Exception {
     useConfiguration(
+        "--apple_platform_type=ios",
         "--ios_multi_cpus=arm64",
         "--apple_bitcode=embedded");
     createLibraryTargetWriter("//objc:lib")
@@ -634,6 +638,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   @Test
   public void testCompilationActionsWithEmbeddedBitcodeMarkers() throws Exception {
     useConfiguration(
+        "--apple_platform_type=ios",
         "--ios_multi_cpus=arm64",
         "--apple_bitcode=embedded_markers");
 
@@ -750,6 +755,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   @Test
   public void testArchiveAction_simulator() throws Exception {
     useConfiguration(
+        "--apple_platform_type=ios",
         "--cpu=ios_i386",
         "--ios_cpu=i386");
     createLibraryTargetWriter("//objc:lib")
@@ -781,6 +787,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   @Test
   public void testArchiveAction_device() throws Exception {
     useConfiguration(
+        "--apple_platform_type=ios",
         "--cpu=ios_armv7",
         "--ios_cpu=armv7");
     createLibraryTargetWriter("//objc:lib")
@@ -812,6 +819,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   @Test
   public void testFullyLinkArchiveAction_simulator() throws Exception {
     useConfiguration(
+        "--apple_platform_type=ios",
         "--cpu=ios_i386",
         "--ios_cpu=i386");
     createLibraryTargetWriter("//objc:lib_dep")
@@ -851,6 +859,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   @Test
   public void testFullyLinkArchiveAction_device() throws Exception {
     useConfiguration(
+        "--apple_platform_type=ios",
         "--cpu=ios_armv7",
         "--ios_cpu=armv7");
     createLibraryTargetWriter("//objc:lib_dep")
@@ -921,6 +930,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   @Test
   public void testPropagatesDefinesToDependersTransitively() throws Exception {
     useConfiguration(
+        "--apple_platform_type=ios",
         "--cpu=ios_x86_64",
         "--ios_cpu=x86_64");
     createLibraryTargetWriter("//lib1:lib1")
@@ -1241,6 +1251,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testAppleSdkVersionEnv() throws Exception {
+    useConfiguration("--apple_platform_type=ios");
     createLibraryTargetWriter("//objc:lib")
         .setAndCreateFiles("srcs", "a.m", "b.m", "private.h")
         .setAndCreateFiles("hdrs", "c.h")
@@ -1252,7 +1263,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testNonDefaultAppleSdkVersionEnv() throws Exception {
-    useConfiguration("--ios_sdk_version=8.1");
+    useConfiguration("--apple_platform_type=ios", "--ios_sdk_version=8.1");
 
     createLibraryTargetWriter("//objc:lib")
         .setAndCreateFiles("srcs", "a.m", "b.m", "private.h")
@@ -1403,6 +1414,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testCompilationActionsWithPch() throws Exception {
+    useConfiguration("--apple_platform_type=ios");
     ApplePlatform platform = ApplePlatform.IOS_SIMULATOR;
     scratch.file("objc/foo.pch");
     createLibraryTargetWriter("//objc:lib")
@@ -1720,6 +1732,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testAppleSdkDefaultPlatformEnv() throws Exception {
+    useConfiguration("--apple_platform_type=ios");
     createLibraryTargetWriter("//objc:lib")
         .setAndCreateFiles("srcs", "a.m", "b.m", "private.h")
         .setAndCreateFiles("hdrs", "c.h")
@@ -1731,7 +1744,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testAppleSdkDevicePlatformEnv() throws Exception {
-    useConfiguration("--cpu=ios_arm64");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_arm64");
 
     createLibraryTargetWriter("//objc:lib")
         .setAndCreateFiles("srcs", "a.m", "b.m", "private.h")

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcProtoLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcProtoLibraryTest.java
@@ -461,7 +461,7 @@ public class ObjcProtoLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testCompilationAction() throws Exception {
-    useConfiguration("--cpu=ios_i386");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_i386");
     ApplePlatform platform = ApplePlatform.IOS_SIMULATOR;
 
     // Because protos are linked/compiled within the apple_binary context, we need to traverse the
@@ -537,7 +537,7 @@ public class ObjcProtoLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testLibraryLinkAction() throws Exception {
-    useConfiguration("--cpu=ios_armv7");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_armv7");
 
     // Because protos are linked within the apple_binary context, we need to traverse the action
     // graph to find the linked protos (.a).

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcRuleTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcRuleTestCase.java
@@ -1127,16 +1127,18 @@ public abstract class ObjcRuleTestCase extends BuildViewTestCase {
 
     switch (codeCoverageMode) {
       case NONE:
-        useConfiguration("--compilation_mode=" + compilationModeFlag(mode));
+        useConfiguration("--apple_platform_type=ios",
+            "--compilation_mode=" + compilationModeFlag(mode));
         break;
       case GCOV:
         allExpectedCoptsBuilder.addAll(CompilationSupport.CLANG_GCOV_COVERAGE_FLAGS);
-        useConfiguration("--collect_code_coverage",
+        useConfiguration("--apple_platform_type=ios", "--collect_code_coverage",
             "--compilation_mode=" + compilationModeFlag(mode));
         break;
       case LLVMCOV:
         allExpectedCoptsBuilder.addAll(CompilationSupport.CLANG_LLVM_COVERAGE_FLAGS);
-        useConfiguration("--collect_code_coverage", "--experimental_use_llvm_covmap",
+        useConfiguration("--apple_platform_type=ios",
+            "--collect_code_coverage", "--experimental_use_llvm_covmap",
             "--compilation_mode=" + compilationModeFlag(mode));
         break;
     }
@@ -1155,7 +1157,8 @@ public abstract class ObjcRuleTestCase extends BuildViewTestCase {
         .addAll(CompilationSupport.DEFAULT_COMPILER_FLAGS)
         .addAll(ObjcConfiguration.DBG_COPTS);
 
-    useConfiguration("--compilation_mode=dbg", "--objc_debug_with_GLIBCXX=false");
+    useConfiguration("--apple_platform_type=ios", "--compilation_mode=dbg",
+        "--objc_debug_with_GLIBCXX=false");
     scratch.file("x/a.m");
     ruleType.scratchTarget(scratch,
         "srcs", "['a.m']");
@@ -1754,8 +1757,7 @@ public abstract class ObjcRuleTestCase extends BuildViewTestCase {
 
   protected void checkAppleSdkIphoneosPlatformEnv(RuleType ruleType) throws Exception {
     ruleType.scratchTarget(scratch);
-    useConfiguration(
-        "--cpu=ios_arm64");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_arm64");
 
     CommandAction action = linkAction("//x:x");
 
@@ -2113,6 +2115,7 @@ public abstract class ObjcRuleTestCase extends BuildViewTestCase {
   private void checkCustomModuleMap(RuleType ruleType, boolean targetUnderTestShouldPropagate)
       throws Exception {
     useConfiguration(
+        "--apple_platform_type=ios",
         "--experimental_objc_enable_module_maps",
         "--incompatible_strict_objc_module_maps");
     ruleType.scratchTarget(scratch, "deps", "['//z:a']");

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcSkylarkTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcSkylarkTest.java
@@ -307,7 +307,7 @@ public class ObjcSkylarkTest extends ObjcRuleTestCase {
         "   name='my_target',",
         ")");
 
-    useConfiguration("--cpu=ios_i386", "--xcode_version=7.3");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_i386", "--xcode_version=7.3");
     ConfiguredTarget skylarkTarget = getConfiguredTarget("//examples/apple_skylark:my_target");
 
 
@@ -496,7 +496,7 @@ public class ObjcSkylarkTest extends ObjcRuleTestCase {
         "   name='my_target',",
         ")");
 
-    useConfiguration("--cpu=ios_i386");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_i386");
     ConfiguredTarget skylarkTarget = getConfiguredTarget("//examples/apple_skylark:my_target");
 
     String platformDevFrameworksDir =

--- a/src/test/shell/bazel/apple/bazel_objc_test.sh
+++ b/src/test/shell/bazel/apple/bazel_objc_test.sh
@@ -49,7 +49,7 @@ function test_build_app() {
   setup_objc_test_support
   make_lib
 
-  bazel build --verbose_failures \
+  bazel build --verbose_failures --apple_platform_type=ios \
       --ios_sdk_version=$IOS_SDK_VERSION \
       //ios:lib >$TEST_log 2>&1 || fail "should pass"
   ls bazel-out/apl-ios_x86_64-fastbuild/bin/ios/liblib.a \
@@ -60,7 +60,8 @@ function test_invalid_ios_sdk_version() {
   setup_objc_test_support
   make_lib
 
-  ! bazel build --verbose_failures --ios_sdk_version=2.34 \
+  ! bazel build --verbose_failures --apple_platform_type=ios \
+      --ios_sdk_version=2.34 \
       //ios:lib >$TEST_log 2>&1 || fail "should fail"
   expect_log "SDK \"iphonesimulator2.34\" cannot be located."
 }
@@ -102,7 +103,7 @@ int aFunction() {
 }
 EOF
 
-  bazel build --verbose_failures \
+  bazel build --verbose_failures --apple_platform_type=ios \
       --ios_sdk_version=$IOS_SDK_VERSION //objclib:objclib >"$TEST_log" 2>&1 \
       || fail "Should build objc_library"
 
@@ -147,6 +148,7 @@ objc_library(name = 'main',
 EOF
 
   bazel build --verbose_failures \
+      --apple_platform_type=ios \
       --ios_sdk_version=$IOS_SDK_VERSION \
       --objc_enable_binary_stripping=true \
       --compilation_mode=opt \


### PR DESCRIPTION
When using rules for Apple platforms that aren't platform specific, such
as `swift_binary`, the default of iOS doesn't make sense, instead we
should default this to the current platform, which currently can only be
macOS.

More details about this issue can be found here https://github.com/bazelbuild/rules_swift/issues/51