### PR TITLE
Do not fail all the coverage run when there are malformed lines or no coverage.

### DIFF
--- a/src/test/shell/bazel/bazel_coverage_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_test.sh
@@ -1796,4 +1796,31 @@ end_of_record"
   assert_coverage_result "$coverage_result_orange_lib" "$coverage_file_path"
 }
 
+function test_coverage_doesnt_fail_on_empty_output() {
+    if is_gcov_missing_or_wrong_version; then
+        echo "Skipping test." && return
+    fi
+    mkdir empty_cov
+    cat << EOF > empty_cov/t.cc
+#include <stdio.h>
+
+int main(void) {
+    return 0;
+}
+EOF
+
+    cat << EOF > empty_cov/BUILD
+cc_test(
+    name = "empty-cov-test",
+    srcs = ["t.cc"]
+)
+EOF
+
+    bazel coverage --experimental_cc_coverage --test_output=all \
+        //empty_cov:empty-cov-test  &>"$TEST_log" \
+     || fail "Coverage for //empty_cov:empty-cov-test failed"
+
+    expect_log "WARNING: There was no coverage found."
+}
+
 run_suite "test tests"

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovParser.java
@@ -71,7 +71,8 @@ public class GcovParser {
     }
     endSourceFile();
     if (malformedInput) {
-      throw new IOException("gcov intermediate input is malformed.");
+      logger.log(Level.WARNING, "gcov intermediate input was malformed, some lines might not have been parsed. "
+      + "Check the previous log entries for more information.");
     }
     return allSourceFiles;
   }
@@ -89,6 +90,9 @@ public class GcovParser {
   }
 
   private boolean parseLine(String line) {
+    if (line.isEmpty()) {
+      return true;
+    }
     if (line.startsWith(GCOV_FILE_MARKER)) {
       endSourceFile();
       return parseSource(line);
@@ -106,6 +110,7 @@ public class GcovParser {
       // Ignore these fields for now as they are not necessary.
       return true;
     }
+    logger.log(Level.WARNING, "Line <" + line + "> does not respect the gcov intermediate format and was ignored.");
     return false;
   }
 

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
@@ -68,8 +68,8 @@ public class Main {
     if (coverage.isEmpty()) {
       int exitStatus = 0;
       if (profdataFile == null) {
-        logger.log(Level.SEVERE, "There was no coverage found.");
-        exitStatus = 1;
+        logger.log(Level.WARNING, "There was no coverage found.");
+        exitStatus = 0;
       } else {
         // Bazel doesn't support yet converting profdata files to lcov. We still want to output a
         // coverage report so we copy the content of the profdata file to the output file. This is
@@ -98,9 +98,9 @@ public class Main {
       // no way to merge them.
       // TODO(#5881): Add support for profdata files.
       logger.log(
-          Level.SEVERE,
+          Level.WARNING,
           "Bazel doesn't support LLVM profdata coverage amongst other coverage formats.");
-      System.exit(1);
+      System.exit(0);
     }
 
     if (!flags.filterSources().isEmpty()) {
@@ -117,8 +117,8 @@ public class Main {
     }
 
     if (coverage.isEmpty()) {
-      logger.log(Level.SEVERE, "There was no coverage found.");
-      System.exit(1);
+      logger.log(Level.WARNING, "There was no coverage found.");
+      System.exit(0);
     }
 
     int exitStatus = 0;

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/GcovParserTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/GcovParserTest.java
@@ -114,9 +114,10 @@ public class GcovParserTest {
           "branch:35,nottaken",
           "lcount:36,1");
 
-  @Test(expected = IOException.class)
+  @Test
   public void testParseInvalidFile() throws IOException {
-    GcovParser.parse(new ByteArrayInputStream("Invalid gcov file".getBytes(UTF_8)));
+    assertThat(GcovParser.parse(new ByteArrayInputStream("Invalid gcov file".getBytes(UTF_8))))
+        .isEmpty();
   }
 
   @Test


### PR DESCRIPTION
Some tests will not output any coverage information and we shouldn't fail the coverage command. This is important when we want to compute a combined report after running a batch of tests. In that case if one test doesn't have any coverage information, the combined report will not be created. We want to create the combined report and mark the test as passed.

gcov may also output some malformed line (not often, but it can happen) and we shouldn't fail the whole command because of one line out of thousands.

Fixes #4309.