### PR TITLE
Windows,test-wrapper: impl. directory traversal

### DIFF
--- a/src/test/cpp/util/BUILD
+++ b/src/test/cpp/util/BUILD
@@ -115,6 +115,7 @@ cc_library(
     visibility = [
         "//src/test/cpp:__subpackages__",
         "//src/test/native:__subpackages__",
+        "//tools/test:__pkg__",
     ],
 )
 

--- a/src/test/cpp/util/windows_test_util.cc
+++ b/src/test/cpp/util/windows_test_util.cc
@@ -87,7 +87,7 @@ bool DeleteAllUnder(wstring path) {
   return result;
 }
 
-bool CreateDummyFile(const wstring& path) {
+bool CreateDummyFile(const wstring& path, const std::string& content) {
   HANDLE handle =
       ::CreateFileW(path.c_str(), GENERIC_WRITE, FILE_SHARE_READ, NULL,
                     CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -96,8 +96,9 @@ bool CreateDummyFile(const wstring& path) {
   }
   bool result = true;
   DWORD actually_written = 0;
-  if (!::WriteFile(handle, "hello", 5, &actually_written, NULL) &&
-      actually_written != 5) {
+  if (!::WriteFile(handle, content.c_str(), content.size(), &actually_written,
+                   NULL) &&
+      actually_written != content.size()) {
     result = false;
   }
   CloseHandle(handle);

--- a/src/test/cpp/util/windows_test_util.h
+++ b/src/test/cpp/util/windows_test_util.h
@@ -18,20 +18,19 @@
 
 namespace blaze_util {
 
-using std::wstring;
-
 // Returns $TEST_TMPDIR as a wstring.
 // The result will have backslashes as directory separators, but no UNC prefix.
 // The result will also not have a trailing backslash.
-wstring GetTestTmpDirW();
+std::wstring GetTestTmpDirW();
 
 // Deletes all files and directories under `path`.
 // `path` must be a valid Windows path, but doesn't need to have a UNC prefix.
-bool DeleteAllUnder(wstring path);
+bool DeleteAllUnder(std::wstring path);
 
 // Creates a dummy file under `path`.
 // `path` must be a valid Windows path, and have a UNC prefix if necessary.
-bool CreateDummyFile(const wstring& path);
+bool CreateDummyFile(const std::wstring& path,
+                     const std::string& content = "hello");
 
 }  // namespace blaze_util
 

--- a/src/test/shell/bazel/testdata/embedded_tools_srcs_deps
+++ b/src/test/shell/bazel/testdata/embedded_tools_srcs_deps
@@ -3,6 +3,7 @@
 @com_google_protobuf//:protobuf
 @com_google_protobuf//:protobuf_lite
 //tools/test:tw
+//tools/test:tw_lib
 //third_party/ijar:zipper
 //third_party/ijar:ijar
 //third_party/ijar:zip

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -44,7 +44,7 @@ filegroup(
 cc_binary(
     name = "tw",
     visibility = ["//visibility:private"],
-    deps = [":tw-lib"],
+    deps = [":tw_lib"],
 )
 
 # Test wrapper binary to run tests on Windows.

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -43,6 +43,7 @@ filegroup(
 # See https://github.com/bazelbuild/bazel/issues/5508
 cc_binary(
     name = "tw",
+    srcs = ["windows/tw_main.cc"],
     visibility = ["//visibility:private"],
     deps = [":tw_lib"],
 )

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -39,12 +39,25 @@ filegroup(
 )
 
 # Test wrapper binary to run tests on Windows.
+# This target just wraps the actual code in "tw_lib" to make it into a binary.
 # See https://github.com/bazelbuild/bazel/issues/5508
 cc_binary(
     name = "tw",
+    visibility = ["//visibility:private"],
+    deps = [":tw-lib"],
+)
+
+# Test wrapper binary to run tests on Windows.
+# See https://github.com/bazelbuild/bazel/issues/5508
+cc_library(
+    name = "tw_lib",
     srcs = select({
-        "@bazel_tools//src/conditions:windows": ["windows/test_wrapper.cc"],
+        "@bazel_tools//src/conditions:windows": ["windows/tw.cc"],
         "//conditions:default": ["empty_test_wrapper.cc"],
+    }),
+    hdrs = select({
+        "@bazel_tools//src/conditions:windows": ["windows/tw.h"],
+        "//conditions:default": [],
     }),
     linkopts = select({
         "//src/conditions:windows": [
@@ -59,6 +72,25 @@ cc_binary(
             "//src/main/cpp/util:strings",
             "//src/main/native/windows:lib-file",
             "@bazel_tools//tools/cpp/runfiles",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+cc_test(
+    name = "tw_test",
+    srcs = select({
+        "@bazel_tools//src/conditions:windows": ["windows/tw_test.cc"],
+        "//conditions:default": ["empty_test.cc"],
+    }),
+    deps = [
+        ":tw_lib",
+        "//src/main/cpp/util:filesystem",
+        "//src/test/cpp/util:windows_test_util",
+        "@com_google_googletest//:gtest_main",
+    ] + select({
+        "@bazel_tools//src/conditions:windows": [
+            "//src/main/native/windows:lib-file",
         ],
         "//conditions:default": [],
     }),

--- a/tools/test/empty_test.cc
+++ b/tools/test/empty_test.cc
@@ -1,0 +1,15 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+int main(void) { return 0; }

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -35,6 +35,7 @@
 #include "src/main/cpp/util/strings.h"
 #include "src/main/native/windows/file.h"
 #include "tools/cpp/runfiles/runfiles.h"
+#include "tools/test/windows/tw.h"
 
 namespace {
 
@@ -43,9 +44,17 @@ class Defer {
   explicit Defer(std::function<void()> f) : f_(f) {}
   ~Defer() { f_(); }
 
+  void DoNow() {
+    f_();
+    f_ = kEmpty;
+  }
+
  private:
   std::function<void()> f_;
+  static const std::function<void()> kEmpty;
 };
+
+const std::function<void()> Defer::kEmpty = []() {};
 
 // A lightweight path abstraction that stores a Unicode Windows path.
 //
@@ -350,6 +359,87 @@ bool ExportMiscEnvvars(const Path& cwd) {
     }
   }
   return true;
+}
+
+bool _GetFileListRelativeTo(
+    const std::wstring& unc_root, const std::wstring& subdir,
+    std::vector<bazel::tools::test_wrapper::FileInfo>* result) {
+  const std::wstring full_subdir =
+      unc_root + (subdir.empty() ? L"" : (L"\\" + subdir)) + L"\\*";
+  WIN32_FIND_DATAW info;
+  HANDLE handle = FindFirstFileW(full_subdir.c_str(), &info);
+  if (handle == INVALID_HANDLE_VALUE) {
+    DWORD err = GetLastError();
+    if (err == ERROR_FILE_NOT_FOUND) {
+      // No files found, nothing to do.
+      return true;
+    }
+    LogErrorWithArgAndValue(__LINE__, "Failed to list directory contents",
+                            full_subdir.c_str(), err);
+    return false;
+  }
+
+  Defer close_handle([handle]() { FindClose(handle); });
+  static const std::wstring kDot(1, L'.');
+  static const std::wstring kDotDot(2, L'.');
+  std::vector<std::wstring> subdirectories;
+  while (true) {
+    if (kDot != info.cFileName && kDotDot != info.cFileName) {
+      std::wstring rel_path =
+          subdir.empty() ? info.cFileName : (subdir + L"\\" + info.cFileName);
+      if (info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+        subdirectories.push_back(rel_path);
+      } else {
+        if (info.nFileSizeHigh > 0 || info.nFileSizeLow > INT_MAX) {
+          // devtools_ijar::Stat::total_size is declared as `int`, so the file
+          // size limit is INT_MAX. Additionally we limit the files to be below
+          // 4 GiB, not only because int is typically 4 bytes long, but also
+          // because such huge files are unreasonably large as an undeclared
+          // output.
+          LogErrorWithArgAndValue(__LINE__, "File is too large to archive",
+                                  rel_path.c_str(), 0);
+          return false;
+        }
+
+        result->push_back({rel_path,
+                           // File size is already validated to be smaller than
+                           // min(INT_MAX, 4 GiB)
+                           static_cast<int>(info.nFileSizeLow)});
+      }
+    }
+    if (FindNextFileW(handle, &info) == 0) {
+      DWORD err = GetLastError();
+      if (err == ERROR_NO_MORE_FILES) {
+        break;
+      }
+      LogErrorWithArgAndValue(__LINE__,
+                              "Failed to get next element in directory",
+                              (unc_root + L"\\" + subdir).c_str(), err);
+      return false;
+    }
+  }
+  close_handle.DoNow();
+
+  for (const auto& s : subdirectories) {
+    if (!_GetFileListRelativeTo(unc_root, s, result)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool GetFileListRelativeTo(
+    const Path& root,
+    std::vector<bazel::tools::test_wrapper::FileInfo>* result) {
+  if (!blaze_util::IsAbsolute(root.Get())) {
+    LogError(__LINE__, "Root should be absolute");
+    return false;
+  }
+
+  return _GetFileListRelativeTo(bazel::windows::HasUncPrefix(root.Get().c_str())
+                                    ? root.Get()
+                                    : L"\\\\?\\" + root.Get(),
+                                std::wstring(), result);
 }
 
 bool OpenFileForWriting(const std::wstring& path, HANDLE* result) {
@@ -687,6 +777,27 @@ Path Path::Dirname() const {
 }
 
 }  // namespace
+
+namespace bazel {
+namespace tools {
+namespace test_wrapper {
+namespace testing {
+
+bool TestOnly_GetEnv(const wchar_t* name, std::wstring* result) {
+  return GetEnv(name, result);
+}
+
+bool TestOnly_GetFileListRelativeTo(const std::wstring& abs_root,
+                                    std::vector<FileInfo>* result) {
+  Path root;
+  return blaze_util::IsAbsolute(abs_root) && root.Set(abs_root) &&
+         GetFileListRelativeTo(root, result);
+}
+
+}  // namespace testing
+}  // namespace test_wrapper
+}  // namespace tools
+}  // namespace bazel
 
 int wmain(int argc, wchar_t** argv) {
   Path argv0;

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -37,6 +37,9 @@
 #include "tools/cpp/runfiles/runfiles.h"
 #include "tools/test/windows/tw.h"
 
+namespace bazel {
+namespace tools {
+namespace test_wrapper {
 namespace {
 
 class Defer {
@@ -778,28 +781,7 @@ Path Path::Dirname() const {
 
 }  // namespace
 
-namespace bazel {
-namespace tools {
-namespace test_wrapper {
-namespace testing {
-
-bool TestOnly_GetEnv(const wchar_t* name, std::wstring* result) {
-  return GetEnv(name, result);
-}
-
-bool TestOnly_GetFileListRelativeTo(const std::wstring& abs_root,
-                                    std::vector<FileInfo>* result) {
-  Path root;
-  return blaze_util::IsAbsolute(abs_root) && root.Set(abs_root) &&
-         GetFileListRelativeTo(root, result);
-}
-
-}  // namespace testing
-}  // namespace test_wrapper
-}  // namespace tools
-}  // namespace bazel
-
-int wmain(int argc, wchar_t** argv) {
+int Main(int argc, wchar_t** argv) {
   Path argv0;
   std::wstring test_path_arg;
   bool suppress_output = false;
@@ -821,3 +803,21 @@ int wmain(int argc, wchar_t** argv) {
 
   return RunSubprocess(test_path, args);
 }
+
+namespace testing {
+
+bool TestOnly_GetEnv(const wchar_t* name, std::wstring* result) {
+  return GetEnv(name, result);
+}
+
+bool TestOnly_GetFileListRelativeTo(const std::wstring& abs_root,
+                                    std::vector<FileInfo>* result) {
+  Path root;
+  return blaze_util::IsAbsolute(abs_root) && root.Set(abs_root) &&
+         GetFileListRelativeTo(root, result);
+}
+
+}  // namespace testing
+}  // namespace test_wrapper
+}  // namespace tools
+}  // namespace bazel

--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -23,21 +23,35 @@ namespace bazel {
 namespace tools {
 namespace test_wrapper {
 
+// Info about a file in the results of TestOnly_GetFileListRelativeTo.
 struct FileInfo {
+  // The file's path, relative to the traversal root.
   std::wstring rel_path;
-  // devtools_ijar::Stat::total_size is declared as `int`, which is what we
-  // ultimately store the file size in, therefore this field is also `int`.
+
+  // The file's size, in bytes.
+  //
+  // Unfortunately this field has to be `int`, so it can only describe files up
+  // to 2 GiB in size. The reason is, devtools_ijar::Stat::total_size is
+  // declared as `int`, which is what we ultimately store the file size in,
+  // therefore this field is also `int`.
   int size;
 };
 
+// The main function of the test wrapper.
+int Main(int argc, wchar_t** argv);
+
+// The "testing" namespace contains functions that should only be used by tests.
 namespace testing {
 
+// Retrieves an environment variable.
 bool TestOnly_GetEnv(const wchar_t* name, std::wstring* result);
 
+// Lists all files under `abs_root`, with paths relative to `abs_root`.
 bool TestOnly_GetFileListRelativeTo(const std::wstring& abs_root,
                                     std::vector<FileInfo>* result);
 
 }  // namespace testing
+
 }  // namespace test_wrapper
 }  // namespace tools
 }  // namespace bazel

--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -1,0 +1,46 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BAZEL_TOOLS_TEST_WINDOWS_TW_H_
+#define BAZEL_TOOLS_TEST_WINDOWS_TW_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace bazel {
+namespace tools {
+namespace test_wrapper {
+
+struct FileInfo {
+  std::wstring rel_path;
+  // devtools_ijar::Stat::total_size is declared as `int`, which is what we
+  // ultimately store the file size in, therefore this field is also `int`.
+  int size;
+};
+
+namespace testing {
+
+bool TestOnly_GetEnv(const wchar_t* name, std::wstring* result);
+
+bool TestOnly_GetFileListRelativeTo(const std::wstring& abs_root,
+                                    std::vector<FileInfo>* result);
+
+}  // namespace testing
+}  // namespace test_wrapper
+}  // namespace tools
+}  // namespace bazel
+
+#endif  // BAZEL_TOOLS_TEST_WINDOWS_TW_H_
+

--- a/tools/test/windows/tw_main.cc
+++ b/tools/test/windows/tw_main.cc
@@ -1,0 +1,23 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test wrapper implementation for Windows.
+// Design:
+// https://github.com/laszlocsomor/proposals/blob/win-test-runner/designs/2018-07-18-windows-native-test-runner.md
+
+#include "tools/test/windows/tw.h"
+
+int wmain(int argc, wchar_t** argv) {
+  return bazel::tools::test_wrapper::Main(argc, argv);
+}

--- a/tools/test/windows/tw_test.cc
+++ b/tools/test/windows/tw_test.cc
@@ -1,0 +1,137 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for the Windows implementation of the test wrapper.
+
+#include <windows.h>
+
+#include <algorithm>
+
+#include "gtest/gtest.h"
+#include "src/main/cpp/util/path_platform.h"
+#include "src/test/cpp/util/windows_test_util.h"
+#include "src/main/native/windows/file.h"
+#include "tools/test/windows/tw.h"
+
+#if !defined(_WIN32) && !defined(__CYGWIN__)
+#error("This test should only be run on Windows")
+#endif  // !defined(_WIN32) && !defined(__CYGWIN__)
+
+namespace {
+
+using bazel::tools::test_wrapper::FileInfo;
+using bazel::tools::test_wrapper::testing::TestOnly_GetEnv;
+using bazel::tools::test_wrapper::testing::TestOnly_GetFileListRelativeTo;
+
+class TestWrapperWindowsTest : public ::testing::Test {
+ public:
+  void TearDown() override {
+    blaze_util::DeleteAllUnder(blaze_util::GetTestTmpDirW());
+  }
+};
+
+void GetTestTmpdir(std::wstring* result, int line) {
+  EXPECT_TRUE(TestOnly_GetEnv(L"TEST_TMPDIR", result))
+      << __FILE__ << "(" << line << "): assertion failed here";
+  ASSERT_GT(result->size(), 0)
+      << __FILE__ << "(" << line << "): assertion failed here";
+  std::replace(result->begin(), result->end(), L'/', L'\\');
+  if (!bazel::windows::HasUncPrefix(result->c_str())) {
+    *result = L"\\\\?\\" + *result;
+  }
+}
+
+void CreateJunction(const std::wstring& name, const std::wstring& target,
+                    int line) {
+  std::wstring wname;
+  std::wstring wtarget;
+  EXPECT_TRUE(blaze_util::AsWindowsPath(name, &wname, nullptr))
+      << __FILE__ << "(" << line << "): assertion failed here";
+  EXPECT_TRUE(blaze_util::AsWindowsPath(target, &wtarget, nullptr))
+      << __FILE__ << "(" << line << "): assertion failed here";
+  EXPECT_EQ(bazel::windows::CreateJunction(wname, wtarget, nullptr),
+            bazel::windows::CreateJunctionResult::kSuccess)
+      << __FILE__ << "(" << line << "): assertion failed here";
+}
+
+void CompareFileInfos(std::vector<FileInfo> actual,
+                      std::vector<FileInfo> expected, int line) {
+  ASSERT_EQ(actual.size(), expected.size())
+      << __FILE__ << "(" << line << "): assertion failed here";
+  std::sort(actual.begin(), actual.end(),
+            [](const FileInfo& a, const FileInfo& b) {
+              return a.rel_path > b.rel_path;
+            });
+  std::sort(expected.begin(), expected.end(),
+            [](const FileInfo& a, const FileInfo& b) {
+              return a.rel_path > b.rel_path;
+            });
+  for (std::vector<FileInfo>::size_type i = 0; i < actual.size(); ++i) {
+    ASSERT_EQ(actual[i].rel_path, expected[i].rel_path)
+        << __FILE__ << "(" << line << "): assertion failed here; index: " << i;
+    ASSERT_EQ(actual[i].size, expected[i].size)
+        << __FILE__ << "(" << line << "): assertion failed here; index: " << i;
+  }
+}
+
+#define GET_TEST_TMPDIR(result) GetTestTmpdir(result, __LINE__)
+#define CREATE_JUNCTION(name, target) CreateJunction(name, target, __LINE__)
+#define COMPARE_FILE_INFOS(actual, expected) \
+  CompareFileInfos(actual, expected, __LINE__)
+
+#define TOSTRING1(x) #x
+#define TOSTRING(x) TOSTRING1(x)
+#define TOWSTRING1(x) L##x
+#define TOWSTRING(x) TOWSTRING1(x)
+#define WLINE TOWSTRING(TOSTRING(__LINE__))
+
+TEST_F(TestWrapperWindowsTest, TestGetFileListRelativeTo) {
+  std::wstring tmpdir;
+  GET_TEST_TMPDIR(&tmpdir);
+
+  // Create a directory structure to parse.
+  std::wstring root = tmpdir + L"\\tmp" + WLINE;
+  EXPECT_TRUE(CreateDirectoryW(root.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo").c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo\\sub").c_str(), NULL));
+  EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\foo\\sub\\file1", ""));
+  EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\foo\\sub\\file2", "hello"));
+  EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\foo\\file1", "foo"));
+  EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\foo\\file2", "foobar"));
+  CREATE_JUNCTION(root + L"\\foo\\junc", root + L"\\foo\\sub");
+
+  // Assert traversal of "root" -- should include all files, and also traverse
+  // the junction.
+  std::vector<FileInfo> actual;
+  ASSERT_TRUE(TestOnly_GetFileListRelativeTo(root, &actual));
+
+  std::vector<FileInfo> expected = {
+    {L"foo\\sub\\file1", 0}, {L"foo\\sub\\file2", 5},
+    {L"foo\\file1", 3}, {L"foo\\file2", 6},
+    {L"foo\\junc\\file1", 0}, {L"foo\\junc\\file2", 5}};
+  COMPARE_FILE_INFOS(actual, expected);
+
+  // Assert traversal of "foo" -- should include all files, but now with paths
+  // relative to "foo".
+  actual.clear();
+  ASSERT_TRUE(TestOnly_GetFileListRelativeTo((root + L"\\foo").c_str(),
+              &actual));
+
+  expected = {
+    {L"sub\\file1", 0}, {L"sub\\file2", 5}, {L"file1", 3}, {L"file2", 6},
+    {L"junc\\file1", 0}, {L"junc\\file2", 5}};
+  COMPARE_FILE_INFOS(actual, expected);
+}
+
+}  // namespace


### PR DESCRIPTION
Implement and test directory traversal in the
native test wrapper.

The test wrapper will use this logic to discover
undeclared outputs of the test binary.

Also: rename test_wrapper.cc to tw.cc, so the file
name for the compilation command line is shorter.

See https://github.com/bazelbuild/bazel/issues/5508