### PR TITLE
Singlejar: fix bad use of $(JAVA) and $(locations)

### DIFF
--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -92,7 +92,7 @@ cc_test(
 cc_test(
     name = "desugar_checking_test",
     srcs = [
-        "combiners_test.cc",
+        "desugar_checking_test.cc",
         ":zip_headers",
         ":zlib_interface",
     ],

--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -144,9 +144,7 @@ cc_test(
         "input_jar_scan_entries_test.h",
         "input_jar_scan_jartool_test.cc",
     ],
-    # TODO(@rongjiecomputer): update copts to handle Windows and add
-    # ".exe" extension.
-    copts = ["-DJAR_TOOL_PATH=$(JAVA)/bin/jar"],
+    copts = ["-DJAR_TOOL_PATH=\\\"$(JAVABASE)/bin/jar\\\""],
     data = ["@bazel_tools//tools/jdk:current_java_runtime"],
     # Timing out, see https://github.com/bazelbuild/bazel/issues/1555
     tags = ["manual"],
@@ -218,7 +216,7 @@ cc_test(
     ],
     # TODO(@rongjiecomputer): update copts to handle Windows and add
     # ".exe" extension.
-    copts = ["-DJAR_TOOL_PATH=$(JAVA)/bin/jar"],
+    copts = ["-DJAR_TOOL_PATH=\\\"$(JAVABASE)/bin/jar\\\""],
     data = [
         ":data1",
         ":data2",
@@ -487,7 +485,7 @@ genrule(
         "@bazel_tools//tools/jdk:current_java_runtime",
     ],
     outs = ["stored.jar"],
-    cmd = "$(location @bazel_tools//tools/jdk:current_java_runtime) -0cf \"$@\" $(location :output_jar.cc)",
+    cmd = "$(JAVABASE)/bin/jar -0cf \"$@\" $(location :output_jar.cc)",
     toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
     tools = ["@bazel_tools//tools/jdk:current_java_runtime"],
 )

--- a/tools/cpp/runfiles/BUILD
+++ b/tools/cpp/runfiles/BUILD
@@ -59,6 +59,7 @@ cc_library(
     name = "runfiles_src_for_singlejar_only",
     visibility = ["//src/tools/singlejar:__pkg__"],
     deps = [":runfiles"],
+    testonly = 1,
 )
 
 cc_test(


### PR DESCRIPTION
I introduced these problems while editing the
Google-internal copy of https://github.com/bazelbuild/bazel/pull/6248
that was later pushed as https://github.com/bazelbuild/bazel/commit/68611b3d556544c307a1fa3a99c87e2aa1d13037.

See https://github.com/bazelbuild/bazel/issues/2241

Change-Id: Icd981a0fcdcd451a00cbb2babd107f7abb4d5170