### PR TITLE
Fix (?) "Disallow cfg = "data"" link

### DIFF
--- a/site/docs/skylark/backward-compatibility.md
+++ b/site/docs/skylark/backward-compatibility.md
@@ -52,7 +52,7 @@ Starlark Rules
 *   [Disallow tools in action inputs](#disallow-tools-in-action-inputs)
 *   [Expand directories in Args](#expand-directories-in-args)
 *   [Disable late bound option defaults](#disable-late-bound-option-defaults)
-*   [Disallow `cfg = "data"`](#disallow-cfg--data)
+*   [Disallow `cfg = "data"`](#disallow-cfg-data)
 
 Objc
 


### PR DESCRIPTION
I'm not sure if this is an improvement.

On https://github.com/bazelbuild/bazel/blob/master/site/docs/skylark/backward-compatibility.md, the link is #disallow-cfg--data.
On https://docs.bazel.build/versions/master/skylark/backward-compatibility.html, it's #disallow-cfg-data.

Maybe there's some way to consolidate the Jekyll vs. GitHub renderings. But if not, I guess we should prefer the website version?