### PR TITLE
Fix formatting typo in Concepts doc causing most of the article to be in monospaced font

### DIFF
--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -67,7 +67,7 @@ title: Concepts and Terminology
 
 <p>
   A package is defined as a directory containing a file
-  named <code>BUILD</code> or <code>BUILD.bazel</BUILD>,
+  named <code>BUILD</code> or <code>BUILD.bazel</code>,
   residing beneath the top-level directory in the
   workspace.  A package includes all files in its directory, plus all
   subdirectories beneath it, except those which themselves contain a BUILD


### PR DESCRIPTION
Noticed this while browsing the docs at https://docs.bazel.build/versions/master/build-ref.html#workspace