### PR TITLE
debian package: Relax JDK dependency to suggests

### DIFF
--- a/scripts/packages/debian/BUILD
+++ b/scripts/packages/debian/BUILD
@@ -9,12 +9,12 @@ load("//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
 pkg_tar(
     name = "bazel-bin",
     srcs = [
-        "//scripts/packages:without-jdk/bazel",
-        "//scripts/packages:without-jdk/bazel-real",
+        "//scripts/packages:with-jdk/bazel",
+        "//scripts/packages:with-jdk/bazel-real",
     ],
     mode = "0755",
     package_dir = "/usr/bin",
-    strip_prefix = "/scripts/packages/without-jdk",
+    strip_prefix = "/scripts/packages/with-jdk",
 )
 
 pkg_tar(

--- a/scripts/packages/debian/BUILD
+++ b/scripts/packages/debian/BUILD
@@ -77,7 +77,6 @@ pkg_deb(
     data = ":debian-data",
     depends = [
         # Keep in sync with Depends section in ./control
-        "google-jdk | java8-sdk-headless | java8-jdk | java8-sdk | oracle-java8-installer",
         "g++",
         "zlib1g-dev",
         "bash-completion",
@@ -88,6 +87,10 @@ pkg_deb(
     homepage = "http://bazel.build",
     maintainer = "The Bazel Authors <bazel-dev@googlegroups.com>",
     package = "bazel",
+    suggests = [
+        # Keep in sync with Suggests section in ./control
+        "google-jdk | java8-sdk-headless | java8-jdk | java8-sdk | oracle-java8-installer",
+    ],
     version_file = ":version.txt",
     visibility = ["//scripts/packages:__pkg__"],
 )

--- a/scripts/packages/debian/control
+++ b/scripts/packages/debian/control
@@ -10,7 +10,8 @@ Section: contrib/devel
 Priority: optional
 Architecture: amd64
 # Keep in sync with :bazel-debian in ./BUILD
-Depends: google-jdk | java8-sdk-headless | java8-jdk | java8-sdk | oracle-java8-installer, g++, zlib1g-dev, bash-completion, unzip, python
+Depends: g++, zlib1g-dev, bash-completion, unzip, python
+Suggests: google-jdk | java8-sdk-headless | java8-jdk | java8-sdk | oracle-java8-installer
 Description: Bazel is a tool that automates software builds and tests.
  Supported build tasks include running compilers and linkers to produce
  executable programs and libraries, and assembling deployable packages


### PR DESCRIPTION
The Bazel binary comes with a pre-bundled JRE/JDK so the hard
dependency on a JDK could be relaxed to a suggestion.

Closes #6412.