### PR TITLE
Fix documentation references to --xcode_config

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfigAlias.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfigAlias.java
@@ -33,8 +33,8 @@ import com.google.devtools.build.lib.rules.AliasConfiguredTarget;
  * Implementation of the {@code xcode_config_alias} rule.
  *
  * <p>This rule is an alias to the {@code xcode_config} rule currently in use, which is in turn
- * depends on the current configuration, in particular, the value of the {@code --xcode_version_config}
- * flag.
+ * depends on the current configuration, in particular, the value of the
+ * {@code --xcode_version_config} flag.
  */
 public class XcodeConfigAlias implements RuleConfiguredTargetFactory {
   @Override
@@ -56,8 +56,8 @@ public class XcodeConfigAlias implements RuleConfiguredTargetFactory {
    * Rule definition for the {@code xcode_config_alias} rule.
    *
    * <p>This rule is an alias to the {@code xcode_config} rule currently in use, which is in turn
-   * depends on the current configuration, in particular, the value of the {@code --xcode_version_config}
-   * flag.
+   * depends on the current configuration, in particular, the value of the
+   * {@code --xcode_version_config} flag.
    *
    * <p>This is intentionally undocumented for users; the workspace is expected to contain exactly
    * one instance of this rule under {@code @bazel_tools//tools/osx} and people who want to get

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfigAlias.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfigAlias.java
@@ -33,7 +33,7 @@ import com.google.devtools.build.lib.rules.AliasConfiguredTarget;
  * Implementation of the {@code xcode_config_alias} rule.
  *
  * <p>This rule is an alias to the {@code xcode_config} rule currently in use, which is in turn
- * depends on the current configuration, in particular, the value of the {@code --xcode_config}
+ * depends on the current configuration, in particular, the value of the {@code --xcode_version_config}
  * flag.
  */
 public class XcodeConfigAlias implements RuleConfiguredTargetFactory {
@@ -56,7 +56,7 @@ public class XcodeConfigAlias implements RuleConfiguredTargetFactory {
    * Rule definition for the {@code xcode_config_alias} rule.
    *
    * <p>This rule is an alias to the {@code xcode_config} rule currently in use, which is in turn
-   * depends on the current configuration, in particular, the value of the {@code --xcode_config}
+   * depends on the current configuration, in particular, the value of the {@code --xcode_version_config}
    * flag.
    *
    * <p>This is intentionally undocumented for users; the workspace is expected to contain exactly

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfigRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfigRule.java
@@ -82,8 +82,8 @@ public class XcodeConfigRule implements RuleDefinition {
 
 /*<!-- #BLAZE_RULE (NAME = xcode_config, TYPE = OTHER, FAMILY = Workspace)[GENERIC_RULE] -->
 
-<p>A single target of this rule can be referenced by the <code>--xcode_version_config</code> build flag to
-translate the <code>--xcode_version</code> flag into an accepted official xcode version. This
-allows selection of a an official xcode version from a number of registered aliases.</p>
+<p>A single target of this rule can be referenced by the <code>--xcode_version_config</code> build
+flag to translate the <code>--xcode_version</code> flag into an accepted official xcode version.
+This allows selection of a an official xcode version from a number of registered aliases.</p>
 
 <!-- #END_BLAZE_RULE -->*/

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfigRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfigRule.java
@@ -82,7 +82,7 @@ public class XcodeConfigRule implements RuleDefinition {
 
 /*<!-- #BLAZE_RULE (NAME = xcode_config, TYPE = OTHER, FAMILY = Workspace)[GENERIC_RULE] -->
 
-<p>A single target of this rule can be referenced by the <code>--xcode_config</code> build flag to
+<p>A single target of this rule can be referenced by the <code>--xcode_version_config</code> build flag to
 translate the <code>--xcode_version</code> flag into an accepted official xcode version. This
 allows selection of a an official xcode version from a number of registered aliases.</p>
 

--- a/src/test/java/com/google/devtools/build/lib/rules/apple/XcodeConfigTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/apple/XcodeConfigTest.java
@@ -689,7 +689,7 @@ public class XcodeConfigTest extends BuildViewTestCase {
     assertContainsEvent("apple_bitcode mode 'embedded' is unsupported");
   }
 
-  // Verifies that the --xcode_config configuration value can be accessed via the
+  // Verifies that the --xcode_version_config configuration value can be accessed via the
   // configuration_field() skylark method and used in a skylark rule.
   @Test
   public void testConfigurationFieldForRule() throws Exception {
@@ -723,7 +723,7 @@ public class XcodeConfigTest extends BuildViewTestCase {
     assertXcodeVersion("2.0", "//x:provider_grabber");
   }
 
-  // Verifies that the --xcode_config configuration value can be accessed via the
+  // Verifies that the --xcode_version_config configuration value can be accessed via the
   // configuration_field() skylark method and used in a skylark aspect.
   @Test
   public void testConfigurationFieldForAspect() throws Exception {


### PR DESCRIPTION
Some docs are mentioning `--xcode_config`, which doesn't exist. This changes those references to `--xcode_version_config`.