### PR TITLE
Windows: no error if python is not found on PATH

### DIFF
--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -1437,7 +1437,6 @@ static string GetBinaryFromPath(const string& binary_name) {
     start = end + 1;
   } while (true);
 
-  BAZEL_LOG(ERROR) << binary_name.c_str() << " not found on PATH";
   return string();
 }
 
@@ -1447,7 +1446,11 @@ static string LocateBash() {
     return msys_bash;
   }
 
-  return GetBinaryFromPath("bash.exe");
+  string result = GetBinaryFromPath("bash.exe");
+  if (result.empty()) {
+    BAZEL_LOG(ERROR) << "bash.exe not found on PATH";
+  }
+  return result;
 }
 
 void DetectBashOrDie() {

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -167,6 +167,12 @@ py_test(
 )
 
 py_test(
+    name = "first_time_use_test",
+    srcs = ["first_time_use_test.py"],
+    deps = [":test_base"],
+)
+
+py_test(
     name = "query_test",
     size = "medium",
     srcs = ["query_test.py"],

--- a/src/test/py/bazel/first_time_use_test.py
+++ b/src/test/py/bazel/first_time_use_test.py
@@ -1,0 +1,37 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from src.test.py.bazel import test_base
+
+
+class FirstTimeUseTest(test_base.TestBase):
+
+  def _FailWithOutput(self, output):
+    self.fail('FAIL:\n | %s\n---' % '\n | '.join(output))
+
+  def testNoPythonRequirement(self):
+    """Regression test for https://github.com/bazelbuild/bazel/issues/6463"""
+    self.ScratchFile('WORKSPACE')
+    exit_code, stdout, stderr = self.RunBazel(['info', 'release'])
+    self.AssertExitCode(exit_code, 0, stderr)
+    for line in stdout + stderr:
+      if 'python' in line and 'not found on PATH' in line:
+        self._FailWithOutput(stdout + stderr)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/6463
