### PR TITLE
Log repository_rule result as debug

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
@@ -131,7 +131,7 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
           new RepositoryResolvedEvent(
               rule, skylarkRepositoryContext.getAttr(), outputDirectory, retValue);
       if (resolved.isNewInformationReturned()) {
-        env.getListener().handle(Event.info(resolved.getMessage()));
+        env.getListener().handle(Event.debug(resolved.getMessage()));
       }
 
       String ruleClass =


### PR DESCRIPTION
Beginning with b42734f4213e505d9582def4cd25bd510f0909a9, `git_repository` and `new_git_repository` return a dictionary which is used to make reproducible builds via `--experimental_repository_resolved_file`. However this return value is logged at an `info` log level, which generates a lot of output for a project that uses many git repositories. Here's some example output: https://gist.githubusercontent.com/kastiglione/a289a10c05f67b2954a087d265935629/raw/c46e08723814cda10e0e26ef9622fdb466f49736/bazel-build.txt

This changes the log `.info` to `.debug`.