### PR TITLE
docs: restore docs for Bash/Zsh completion

### DIFF
--- a/scripts/serve-docs.sh
+++ b/scripts/serve-docs.sh
@@ -16,7 +16,7 @@
 set -eu
 
 readonly WORKING_DIR=$(mktemp -d)
-: ${HOST:=localhost}
+: ${HOST:=$(hostname)}
 : ${PORT:=12345}
 TARGET=
 SERVING_PREFIX=

--- a/scripts/serve-docs.sh
+++ b/scripts/serve-docs.sh
@@ -16,7 +16,7 @@
 set -eu
 
 readonly WORKING_DIR=$(mktemp -d)
-: ${HOST:=$(hostname)}
+: ${HOST:=localhost}
 : ${PORT:=12345}
 TARGET=
 SERVING_PREFIX=

--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -47,6 +47,7 @@ nav: docs
                    <li><a href="/versions/{{ site.version }}/install-os-x.html">Installing on macOS</a></li>
                    <li><a href="/versions/{{ site.version }}/install-windows.html">Installing on Windows</a></li>
                    <li><a href="/versions/{{ site.version }}/install-compile-source.html">Compiling from Source</a></li>
+                   <li><a href="/versions/{{ site.version }}/completion.html">Command-Line Completion</a></li>
                    <li><a href="/versions/{{ site.version }}/ide.html">Integrating with IDEs</a></li>
                  </ul>
                 </li>

--- a/site/docs/completion.md
+++ b/site/docs/completion.md
@@ -1,0 +1,90 @@
+---
+layout: documentation
+title: "Command-Line Completion"
+---
+
+# Command-Line Completion
+
+You can enable command-line completion (also known as tab-completion) in Bash
+and Zsh. This lets you tab-complete command names, flags names and flag values,
+and target names.
+
+<h2 id="bash">Bash completion</h2>
+
+Bazel comes with a Bash completion script.
+
+If you installed Bazel:
+
+*   From the APT repository, then you're done -- the Bash completion script is
+    already installed in `/etc/bash_completion.d`.
+
+*   From the installer downloaded from GitHub, then:
+    1.  Locate the absolute path of the completion file. The installer copied it
+        to the `bin` directory.  
+
+        Example: if you ran the installer with `--user`, this will be
+        `$HOME/.bazel/bin`. If you ran the installer as root, this will be
+        `/usr/local/bazel/bin`.
+    2.  Do one of the following:
+        *   Either copy this file to your completion directory (if you have
+            one).
+
+            Example: on Ubuntu this is the `/etc/bash_completion.d` directory.
+        *   Or source the completion file from Bash's RC file.
+
+            Add a line similar to the one below to your `~/.bashrc` (on Ubuntu)
+            or `~/.bash_profile` (on macOS), using the path to your completion
+            file's absolute path:
+
+            ```
+            source /path/to/bazel-complete.bash
+            ```
+
+*   Via [bootstrapping](install-compile-source.html), then:
+    1.  Build the completion script:
+
+        ```
+        bazel build //scripts:bazel-complete.bash
+        ```
+    2.  The completion file is built under
+        `bazel-bin/scripts/bazel-complete.bash`.
+
+        Do one of the following:
+        *   Either copy this file to your completion directory (if you have
+            one).
+
+            Example: on Ubuntu this is the `/etc/bash_completion.d` directory
+        *   Or copy it somewhere on your local disk, e.g. to `$HOME`, and
+            source the completion file from Bash's RC file.
+
+            Add a line similar to the one below to your `~/.bashrc` (on Ubuntu)
+            or `~/.bash_profile` (on macOS), using the path to your completion
+            file's absolute path:
+
+            ```
+            source /path/to/bazel-complete.bash
+            ```
+
+<h2 name="zsh">Zsh completion</h2>
+
+Bazel also comes with a Zsh completion script. To install it:
+
+1.  Add this script to a directory on your `$fpath`:
+
+    ```
+    fpath[1,0]=~/.zsh/completion/
+    mkdir -p ~/.zsh/completion/
+    cp scripts/zsh_completion/_bazel ~/.zsh/completion
+    ```
+
+    You may have to call `rm -f ~/.zcompdump; compinit`
+    the first time to make it work.
+
+2.  Optionally, add the following to your .zshrc.
+
+    ```
+    # This way the completion script does not have to parse Bazel's options
+    # repeatedly.  The directory in cache-path must be created manually.
+    zstyle ':completion:*' use-cache on
+    zstyle ':completion:*' cache-path ~/.zsh/cache
+    ```

--- a/site/docs/install-os-x.md
+++ b/site/docs/install-os-x.md
@@ -13,8 +13,8 @@ Install Bazel on macOS using one of the following methods:
 
 Bazel comes with two completion scripts. After installing Bazel, you can:
 
-*   Access the [bash completion script](install.md)
-*   Install the [zsh completion script](install.md)
+*   Access the [bash completion script](completion.md#bash)
+*   Install the [zsh completion script](completion.md#zsh)
 
 ## <a name="install-with-installer-mac-os-x"></a>Installing using binary installer
 

--- a/site/docs/install-ubuntu.md
+++ b/site/docs/install-ubuntu.md
@@ -18,8 +18,8 @@ Install Bazel on Ubuntu using one of the following methods:
 
 Bazel comes with two completion scripts. After installing Bazel, you can:
 
-*   Access the [bash completion script](install.md)
-*   Install the [zsh completion script](install.md)
+*   Access the [bash completion script](completion.md#bash)
+*   Install the [zsh completion script](completion.md#zsh)
 
 ## <a name="install-with-installer-ubuntu"></a>Installing using binary installer
 


### PR DESCRIPTION
The docs were removed seemingly by accident.

See https://github.com/bazelbuild/bazel/issues/4255#issuecomment-432120127

Fixes https://github.com/bazelbuild/bazel/issues/4255