### PR TITLE
Fix -Wunused-command-line-argument warnings when --force_pic is passed on Mac

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -106,3 +106,4 @@ Klaus Aehlig <aehlig@google.com>
 Robin Nabel <rnabel@ucdavis.edu>
 Jonathan Dierksen <dierksen@google.com>
 Tony Aiuto <aiuto@google.com>
+Jamie Snape <jamie.snape@kitware.com>

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
@@ -820,7 +820,12 @@ public class CppActionConfigs {
                     "    expand_if_all_available: 'force_pic'",
                     "    action: 'c++-link-executable'",
                     "    flag_group {",
-                    "      flag: '-pie'",
+                    ifLinux(
+                        platform,
+                        "      flag: '-pie'"),
+                    ifMac(
+                        platform,
+                        "      flag: '-Wl,-pie'"),
                     "    }",
                     "  }",
                     "}"),

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkBuildVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkBuildVariables.java
@@ -338,7 +338,8 @@ public enum LinkBuildVariables {
   private static Iterable<String> removePieIfCreatingSharedLibrary(
       boolean isCreatingSharedLibrary, Iterable<String> flags) {
     if (isCreatingSharedLibrary) {
-      return Iterables.filter(flags, Predicates.not(Predicates.equalTo("-pie")));
+      return Iterables.filter(flags, Predicates.not(Predicates.or(
+          Predicates.equalTo("-pie"), Predicates.equalTo("-Wl,-pie"))));
     } else {
       return flags;
     }

--- a/src/test/java/com/google/devtools/build/lib/packages/util/MOCK_OSX_CROSSTOOL
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/MOCK_OSX_CROSSTOOL
@@ -496,7 +496,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -2238,7 +2238,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -3991,7 +3991,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -5756,7 +5756,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -7524,7 +7524,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -9319,7 +9319,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -11084,7 +11084,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -12869,7 +12869,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -14657,7 +14657,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -16472,7 +16472,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }

--- a/tools/cpp/crosstool_lib.bzl
+++ b/tools/cpp/crosstool_lib.bzl
@@ -178,7 +178,7 @@ def get_features_to_appear_first(platform):
         simple_feature(
             "force_pic_flags",
             ["c++-link-executable"],
-            ["-pie"],
+            [_force_pic_flag(platform)],
             expand_if_all_available = ["force_pic"],
         ),
         simple_feature(
@@ -311,6 +311,16 @@ def _runtime_library_directory_flag(platform):
         return "-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}"
     elif _is_darwin(platform):
         return "-Wl,-rpath,@loader_path/%{runtime_library_search_directories}"
+    elif _is_msvc(platform):
+        fail("todo")
+    else:
+        fail("Unsupported platform: " + platform)
+
+def _force_pic_flag(platform):
+    if _is_linux(platform):
+        return "-pie"
+    elif _is_darwin(platform):
+        return "-Wl,-pie"
     elif _is_msvc(platform):
         fail("todo")
     else:

--- a/tools/osx/crosstool/CROSSTOOL.tpl
+++ b/tools/osx/crosstool/CROSSTOOL.tpl
@@ -489,7 +489,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -2135,7 +2135,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -3788,7 +3788,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -5438,7 +5438,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -7088,7 +7088,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -8732,7 +8732,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -10415,7 +10415,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -12068,7 +12068,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -13709,7 +13709,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }
@@ -15353,7 +15353,7 @@ toolchain {
     flag_set {
       action: "c++-link-executable"
       flag_group {
-        flag: "-pie"
+        flag: "-Wl,-pie"
       }
       expand_if_all_available: "force_pic"
     }


### PR DESCRIPTION
For `clang` on macOS, there is no `-pie` command line argument, so you need `-Wl,-pie` to pass the flag to the linker and avoid the following warning:
```
INFO: From Linking <executable>:
clang: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
```
