### PR TITLE
Windows, test wrapper: Zip entry list creation

### DIFF
--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -37,6 +37,36 @@ struct FileInfo {
   int size;
 };
 
+// Zip entry paths for devtools_ijar::ZipBuilder.
+// The function signatures mirror the signatures of ZipBuilder's functions.
+class ZipEntryPaths {
+ public:
+  // Initialize the strings in this object.
+  // `root` must be an absolute mixed-style path (Windows path with "/"
+  // separators).
+  // `files` must be relative, Unix-style paths.
+  void Create(const std::string& root, const std::vector<std::string>& files);
+
+  // Returns a mutable array of const pointers to const char data.
+  // Each pointer points to an absolute path: the file to archive.
+  // The pointers are owned by this object and become invalid when the object is
+  // destroyed.
+  // Each entry corresponds to the entry at the same index in `EntryPathPtrs`.
+  char const *const * AbsPathPtrs() const { return abs_path_ptrs_.get(); }
+
+  // Returns a mutable array of const pointers to const char data.
+  // Each pointer points to a relative path: an entry in the zip file.
+  // The pointers are owned by this object and become invalid when the object is
+  // destroyed.
+  // Each entry corresponds to the entry at the same index in `AbsPathPtrs`.
+  char const *const * EntryPathPtrs() const { return entry_path_ptrs_.get(); }
+
+ private:
+  std::unique_ptr<char[]> abs_paths_;
+  std::unique_ptr<char*[]> abs_path_ptrs_;
+  std::unique_ptr<char*[]> entry_path_ptrs_;
+};
+
 // The main function of the test wrapper.
 int Main(int argc, wchar_t** argv);
 
@@ -49,6 +79,12 @@ bool TestOnly_GetEnv(const wchar_t* name, std::wstring* result);
 // Lists all files under `abs_root`, with paths relative to `abs_root`.
 bool TestOnly_GetFileListRelativeTo(const std::wstring& abs_root,
                                     std::vector<FileInfo>* result);
+
+// Converts a list of files to ZIP file entry paths.a
+bool TestOnly_ToZipEntryPaths(
+    const std::wstring& abs_root,
+    const std::vector<bazel::tools::test_wrapper::FileInfo>& files,
+    ZipEntryPaths* result);
 
 }  // namespace testing
 


### PR DESCRIPTION
Implement a function that can create a list of zip
file entries. We'll use the list with
devtools_ijar::ZipBuilder, to archive undeclared
outputs from tests.

See https://github.com/bazelbuild/bazel/issues/5508

Change-Id: Idf703f768641a2827e371069b8511fb6e04adaa4