### PR TITLE
Windows, sh_toolchain, bugfix: cast path to string

### DIFF
--- a/tools/sh/sh_configure.bzl
+++ b/tools/sh/sh_configure.bzl
@@ -31,6 +31,9 @@ def _sh_config_impl(repository_ctx):
         if _is_windows(repository_ctx):
             sh_path = repository_ctx.which("bash.exe")
             if sh_path:
+                # repository_ctx.which returns a path object, convert that to
+                # string so we can call string.startswith on it.
+                sh_path = str(sh_path)
                 # When the Windows Subsystem for Linux is installed there's a
                 # bash.exe under %WINDIR%\system32\bash.exe that launches Ubuntu
                 # Bash which cannot run native Windows programs so it's not what


### PR DESCRIPTION
When DetectBashOrDie [1] is commented out from
src/main/cpp/blaze.cc, and BAZEL_SH is unset,
and PATH is set and "bash" is found on the PATH,
then sh_configure successfully finds bash using
repository_ctx.which, and this method returns a
"path" object.

The code used to believe this was a string, and
called a string method on it, causing a runtime
error.

[1] https://github.com/bazelbuild/bazel/blob/2fda17d46088f2bb07b049fa35759002ea1dd5db/src/main/cpp/blaze.cc#L1543

Fixes https://github.com/bazelbuild/bazel/issues/6498

Change-Id: I07fd36fd6c6e8433257b0394f1fc776bbe3e6928