### PR TITLE
Windows, test wrapper: implement zip support

### DIFF
--- a/third_party/ijar/BUILD
+++ b/third_party/ijar/BUILD
@@ -37,6 +37,11 @@ cc_library(
         "//conditions:default": [
         ],
     }),
+    visibility = [
+        "//src:__subpackages__",
+        "//third_party/ijar:__subpackages__",
+        "//tools/test:__pkg__",
+    ],
 )
 
 cc_library(

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -72,6 +72,7 @@ cc_library(
             "//src/main/cpp/util:filesystem",
             "//src/main/cpp/util:strings",
             "//src/main/native/windows:lib-file",
+            "//third_party/ijar:zip",
             "@bazel_tools//tools/cpp/runfiles",
         ],
         "//conditions:default": [],
@@ -92,6 +93,7 @@ cc_test(
     ] + select({
         "@bazel_tools//src/conditions:windows": [
             "//src/main/native/windows:lib-file",
+            "//third_party/ijar:zip",
         ],
         "//conditions:default": [],
     }),

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -550,23 +550,22 @@ bool TouchFile(const std::wstring& path) {
   return true;
 }
 
-bool ReadCompleteFile(HANDLE handle, uint8_t* dest, DWORD max_read_bytes) {
-  if (max_read_bytes == 0) {
+bool ReadCompleteFile(HANDLE handle, uint8_t* dest, DWORD max_read) {
+  if (max_read == 0) {
     return true;
   }
 
-  const DWORD max_read = std::min(
-      max_read_bytes, /* 100 MB */ static_cast<DWORD>(100000000));
   DWORD total_read = 0;
   DWORD read = 0;
   do {
-    if (!ReadFile(handle, dest + total_read, max_read, &read, NULL)) {
+    if (!ReadFile(handle, dest + total_read, max_read - total_read, &read,
+                  NULL)) {
       DWORD err = GetLastError();
       LogErrorWithValue(__LINE__, "Failed to read file", err);
       return false;
     }
     total_read += read;
-  } while (read > 0);
+  } while (read > 0 && total_read < max_read);
   return true;
 }
 

--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -47,6 +47,9 @@ class ZipEntryPaths {
   // `files` must be relative, Unix-style paths.
   void Create(const std::string& root, const std::vector<std::string>& files);
 
+  // Returns the number of paths in `AbsPathPtrs` and `EntryPathPtrs`.
+  size_t Size() const { return size_; }
+
   // Returns a mutable array of const pointers to const char data.
   // Each pointer points to an absolute path: the file to archive.
   // The pointers are owned by this object and become invalid when the object is
@@ -62,6 +65,7 @@ class ZipEntryPaths {
   char const* const* EntryPathPtrs() const { return entry_path_ptrs_.get(); }
 
  private:
+  size_t size_;
   std::unique_ptr<char[]> abs_paths_;
   std::unique_ptr<char*[]> abs_path_ptrs_;
   std::unique_ptr<char*[]> entry_path_ptrs_;
@@ -85,6 +89,13 @@ bool TestOnly_ToZipEntryPaths(
     const std::wstring& abs_root,
     const std::vector<bazel::tools::test_wrapper::FileInfo>& files,
     ZipEntryPaths* result);
+
+// Archives `files` into a zip file at `abs_zip` (absolute path to the zip).
+bool TestOnly_CreateZip(
+    const std::wstring& abs_root, const std::vector<FileInfo>& files,
+    const std::wstring& abs_zip);
+
+bool TestOnly_AsMixedPath(const std::wstring& path, std::string* result);
 
 }  // namespace testing
 

--- a/tools/test/windows/tw_test.cc
+++ b/tools/test/windows/tw_test.cc
@@ -23,6 +23,8 @@
 #include "src/main/cpp/util/path_platform.h"
 #include "src/main/native/windows/file.h"
 #include "src/test/cpp/util/windows_test_util.h"
+#include "third_party/ijar/common.h"
+#include "third_party/ijar/zip.h"
 #include "tools/test/windows/tw.h"
 
 #if !defined(_WIN32) && !defined(__CYGWIN__)
@@ -36,6 +38,8 @@ using bazel::tools::test_wrapper::ZipEntryPaths;
 using bazel::tools::test_wrapper::testing::TestOnly_GetEnv;
 using bazel::tools::test_wrapper::testing::TestOnly_GetFileListRelativeTo;
 using bazel::tools::test_wrapper::testing::TestOnly_ToZipEntryPaths;
+using bazel::tools::test_wrapper::testing::TestOnly_CreateZip;
+using bazel::tools::test_wrapper::testing::TestOnly_AsMixedPath;
 
 class TestWrapperWindowsTest : public ::testing::Test {
  public:
@@ -168,6 +172,7 @@ TEST_F(TestWrapperWindowsTest, TestToZipEntryPaths) {
 
   ZipEntryPaths actual;
   ASSERT_TRUE(TestOnly_ToZipEntryPaths(root, files, &actual));
+  ASSERT_EQ(actual.Size(), 6);
 
   std::vector<const char*> expected_abs_paths = {
       "c:/nul/root/foo/sub/file1",  "c:/nul/root/foo/sub/file2",
@@ -181,6 +186,118 @@ TEST_F(TestWrapperWindowsTest, TestToZipEntryPaths) {
       "foo/file2",     "foo/junc/file1", "foo/junc/file2",
   };
   COMPARE_ZIP_ENTRY_PATHS(actual.EntryPathPtrs(), expected_entry_paths);
+}
+
+TEST_F(TestWrapperWindowsTest, TestToZipEntryPathsLongPathRoot) {
+  // Pretend we already acquired a file list. The files don't have to exist.
+  // Assert that the root is allowed to have the `\\?\` prefix, but the zip
+  // entry paths won't have it.
+  std::wstring root = L"\\\\?\\c:\\nul\\unc";
+  std::vector<FileInfo> files = {
+      {L"foo\\sub\\file1", 0},  {L"foo\\sub\\file2", 5},
+      {L"foo\\file1", 3},       {L"foo\\file2", 6},
+      {L"foo\\junc\\file1", 0}, {L"foo\\junc\\file2", 5}};
+
+  ZipEntryPaths actual;
+  ASSERT_TRUE(TestOnly_ToZipEntryPaths(root, files, &actual));
+  ASSERT_EQ(actual.Size(), 6);
+
+  std::vector<const char*> expected_abs_paths = {
+      "c:/nul/unc/foo/sub/file1",  "c:/nul/unc/foo/sub/file2",
+      "c:/nul/unc/foo/file1",      "c:/nul/unc/foo/file2",
+      "c:/nul/unc/foo/junc/file1", "c:/nul/unc/foo/junc/file2",
+  };
+  COMPARE_ZIP_ENTRY_PATHS(actual.AbsPathPtrs(), expected_abs_paths);
+
+  std::vector<const char*> expected_entry_paths = {
+      "foo/sub/file1", "foo/sub/file2",  "foo/file1",
+      "foo/file2",     "foo/junc/file1", "foo/junc/file2",
+  };
+  COMPARE_ZIP_ENTRY_PATHS(actual.EntryPathPtrs(), expected_entry_paths);
+}
+
+class InMemoryExtractor : public devtools_ijar::ZipExtractorProcessor {
+ public:
+  struct ExtractedFile {
+    std::string path;
+    std::unique_ptr<devtools_ijar::u1[]> data;
+    size_t size;
+  };
+
+  InMemoryExtractor(std::vector<ExtractedFile>* extracted)
+      : extracted_(extracted) {}
+
+  bool Accept(const char* filename, const devtools_ijar::u4 attr) override {
+    return true;
+  }
+
+  void Process(const char* filename, const devtools_ijar::u4 attr,
+               const devtools_ijar::u1* data, const size_t size) override {
+    extracted_->push_back({});
+    extracted_->back().path = filename;
+    extracted_->back().data.reset(new devtools_ijar::u1[size]);
+    memcpy(extracted_->back().data.get(), data, size);
+    extracted_->back().size = size;
+  }
+
+ private:
+  std::vector<ExtractedFile>* extracted_;
+};
+
+TEST_F(TestWrapperWindowsTest, TestCreateZip) {
+  std::wstring tmpdir;
+  GET_TEST_TMPDIR(&tmpdir);
+
+  // Create a directory structure to archive.
+  std::wstring root = tmpdir + L"\\tmp" + WLINE;
+  EXPECT_TRUE(CreateDirectoryW(root.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo").c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo\\sub").c_str(), NULL));
+  EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\foo\\sub\\file1", ""));
+  EXPECT_TRUE(
+      blaze_util::CreateDummyFile(root + L"\\foo\\sub\\file2", "hello"));
+  EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\foo\\file1", "foo"));
+  EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\foo\\file2", "foobar"));
+  CREATE_JUNCTION(root + L"\\foo\\junc", root + L"\\foo\\sub");
+
+  std::vector<FileInfo> file_list = {
+      {L"foo\\sub\\file1", 0},  {L"foo\\sub\\file2", 5},
+      {L"foo\\file1", 3},       {L"foo\\file2", 6},
+      {L"foo\\junc\\file1", 0}, {L"foo\\junc\\file2", 5}};
+
+  ASSERT_TRUE(TestOnly_CreateZip(root, file_list, root + L"\\x.zip"));
+
+  std::string zip_path;
+  EXPECT_TRUE(TestOnly_AsMixedPath(root + L"\\x.zip", &zip_path));
+
+  // Extract the zip file into memory to verify its contents.
+  std::vector<InMemoryExtractor::ExtractedFile> extracted;
+  InMemoryExtractor extractor(&extracted);
+  std::unique_ptr<devtools_ijar::ZipExtractor> zip(
+      devtools_ijar::ZipExtractor::Create(zip_path.c_str(), &extractor));
+  EXPECT_NE(zip.get(), nullptr);
+  EXPECT_EQ(zip->ProcessAll(), 0);
+
+  EXPECT_EQ(extracted.size(), 6);
+
+  EXPECT_EQ(extracted[0].path, std::string("foo/sub/file1"));
+  EXPECT_EQ(extracted[1].path, std::string("foo/sub/file2"));
+  EXPECT_EQ(extracted[2].path, std::string("foo/file1"));
+  EXPECT_EQ(extracted[3].path, std::string("foo/file2"));
+  EXPECT_EQ(extracted[4].path, std::string("foo/junc/file1"));
+  EXPECT_EQ(extracted[5].path, std::string("foo/junc/file2"));
+
+  EXPECT_EQ(extracted[0].size, 0);
+  EXPECT_EQ(extracted[1].size, 5);
+  EXPECT_EQ(extracted[2].size, 3);
+  EXPECT_EQ(extracted[3].size, 6);
+  EXPECT_EQ(extracted[4].size, 0);
+  EXPECT_EQ(extracted[5].size, 5);
+
+  EXPECT_EQ(memcmp(extracted[1].data.get(), "hello", 5), 0);
+  EXPECT_EQ(memcmp(extracted[2].data.get(), "foo", 3), 0);
+  EXPECT_EQ(memcmp(extracted[3].data.get(), "foobar", 6), 0);
+  EXPECT_EQ(memcmp(extracted[5].data.get(), "hello", 5), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
The test wrapper can now create zip files. We will
use this feature to archive the test's undeclared
outputs.

See https://github.com/bazelbuild/bazel/issues/5508

Change-Id: I94f41a1cca128e5a0cfbbdc1e7c5f71248f9091a