### PR TITLE
Fix the name of the new message to reference the correct concept,

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainRule.java
@@ -71,7 +71,7 @@ public final class CcToolchainRule implements RuleDefinition {
           null,
           (rule, attributes, cppConfig) -> {
             Label cppConfigSysrootLabel =
-                cppConfig.disableSystoolfromConfiguration() ? null : cppConfig.getSysrootLabel();
+                cppConfig.disableSysrootfromConfiguration() ? null : cppConfig.getSysrootLabel();
             // This avoids analyzing the label from the CROSSTOOL if the attribute is set.
             return getLabel(attributes, "libc_top", cppConfigSysrootLabel);
           });

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -1260,7 +1260,7 @@ public final class CppConfiguration extends BuildConfiguration.Fragment
     return cppOptions.provideCcToolchainInfoFromCcToolchainSuite;
   }
 
-  public boolean disableSystoolfromConfiguration() {
-    return cppOptions.disableSystoolfromConfiguration;
+  public boolean disableSysrootfromConfiguration() {
+    return cppOptions.disableSysrootfromConfiguration;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -896,7 +896,7 @@ public class CppOptions extends FragmentOptions {
 
   // TODO(--incompatible_disable_systool_from_configration): Deprecate the feature and remove.
   @Option(
-      name = "incompatible_disable_systool_from_configration",
+      name = "incompatible_disable_sysroot_from_configuration",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
@@ -905,10 +905,10 @@ public class CppOptions extends FragmentOptions {
         OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
       },
       help =
-          "If true, cc_toolchain will no longer determine the systool from the CROSSTOOL "
+          "If true, cc_toolchain will no longer determine the sysroot from the CROSSTOOL "
               + "(default_grte_top property_ during configuration, instead only using the "
               + "libc_top attribute.")
-  public boolean disableSystoolfromConfiguration;
+  public boolean disableSysrootfromConfiguration;
 
   @Override
   public FragmentOptions getHost() {
@@ -952,7 +952,7 @@ public class CppOptions extends FragmentOptions {
     host.inmemoryDotdFiles = inmemoryDotdFiles;
 
     host.disableLegacyToolchainSkylarkApi = disableLegacyToolchainSkylarkApi;
-    host.disableSystoolfromConfiguration = disableSystoolfromConfiguration;
+    host.disableSysrootfromConfiguration = disableSysrootfromConfiguration;
 
     return host;
   }

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainTest.java
@@ -923,7 +923,7 @@ public class CcToolchainTest extends BuildViewTestCase {
         .setupCrosstool(
             mockToolsConfig,
             CrosstoolConfig.CToolchain.newBuilder().setDefaultGrteTop("//libc1").buildPartial());
-    useConfiguration("--incompatible_disable_systool_from_configration");
+    useConfiguration("--incompatible_disable_sysroot_from_configuration");
     ConfiguredTarget target = getConfiguredTarget("//a:b");
     CcToolchainProvider toolchainProvider =
         (CcToolchainProvider) target.get(ToolchainInfo.PROVIDER);


### PR DESCRIPTION
"sysroot".

Part of #6543.

RELNOTES: Add new flag `--incompatible_disable_sysroot_from_configuration` to
disable loading the systool from CppConfiguration.