### PR TITLE
Exchange "old" and "new" worker hashes in the debugging message.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
@@ -124,8 +124,8 @@ final class WorkerFactory extends BaseKeyedPooledObjectFactory<WorkerKey, Worker
       files.addAll(key.getWorkerFilesWithHashes().keySet());
       files.addAll(worker.getWorkerFilesWithHashes().keySet());
       for (PathFragment file : files) {
-        HashCode oldHash = key.getWorkerFilesWithHashes().get(file);
-        HashCode newHash = worker.getWorkerFilesWithHashes().get(file);
+        HashCode oldHash = worker.getWorkerFilesWithHashes().get(file);
+        HashCode newHash = key.getWorkerFilesWithHashes().get(file);
         if (!oldHash.equals(newHash)) {
           msg.append("\n")
               .append(file.getPathString())


### PR DESCRIPTION
In this code, the worker we're validating has the "old" hashes and the worker key has the "new" hashes.