### PR TITLE
Add an option for printing selected server logs on failure.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -247,6 +247,14 @@ class RemoteSpawnRunner implements SpawnRunner {
               try (SilentCloseable c = Profiler.instance().profile("Remote.executeRemotely")) {
                 reply = remoteExecutor.executeRemotely(request);
               }
+
+              FileOutErr outErr = context.getFileOutErr();
+              String message = reply.getMessage();
+              if ((reply.getResult().getExitCode() != 0 ||
+                   reply.getStatus().getCode() != Code.OK.value()) && !message.isEmpty()) {
+                outErr.printErr(message + "\n");
+              }
+
               try (SilentCloseable c =
                   Profiler.instance().profile("Remote.maybeDownloadServerLogs")) {
                 maybeDownloadServerLogs(reply, actionKey);
@@ -254,7 +262,7 @@ class RemoteSpawnRunner implements SpawnRunner {
 
               try (SilentCloseable c =
                   Profiler.instance().profile("Remote.downloadRemoteResults")) {
-                return downloadRemoteResults(reply.getResult(), context.getFileOutErr())
+                return downloadRemoteResults(reply.getResult(), outErr)
                     .setRunnerName(reply.getCachedResult() ? "remote cache hit" : getName())
                     .setCacheHit(reply.getCachedResult())
                     .build();

--- a/third_party/remoteapis/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/third_party/remoteapis/build/bazel/remote/execution/v2/remote_execution.proto
@@ -429,7 +429,8 @@ message Command {
   // A list of the output files that the client expects to retrieve from the
   // action. Only the listed files, as well as directories listed in
   // `output_directories`, will be returned to the client as output.
-  // Other files that may be created during command execution are discarded.
+  // Other files or directories that may be created during command execution
+  // are discarded.
   //
   // The paths are relative to the working directory of the action execution.
   // The paths are specified using a single forward slash (`/`) as a path
@@ -446,10 +447,12 @@ message Command {
   repeated string output_files = 3;
 
   // A list of the output directories that the client expects to retrieve from
-  // the action. Only the contents of the indicated directories (recursively
-  // including the contents of their subdirectories) will be
-  // returned, as well as files listed in `output_files`. Other files that may
-  // be created during command execution are discarded.
+  // the action. Only the listed directories will be returned (an entire
+  // directory structure will be returned as a
+  // [Tree][build.bazel.remote.execution.v2.Tree] message digest, see
+  // [OutputDirectory][build.bazel.remote.execution.v2.OutputDirectory]), as
+  // well as files listed in `output_files`. Other files or directories that
+  // may be created during command execution are discarded.
   //
   // The paths are relative to the working directory of the action execution.
   // The paths are specified using a single forward slash (`/`) as a path
@@ -1024,6 +1027,10 @@ message ExecuteResponse {
   // phase. The keys SHOULD be human readable so that a client can display them
   // to a user.
   map<string, LogFile> server_logs = 4;
+
+  // Freeform informational message with details on the execution of the action
+  // that may be displayed to the user upon failure or when requested explicitly.
+  string message = 5;
 }
 
 // Metadata about an ongoing


### PR DESCRIPTION
Bazel Buildbarn recently gained a web frontend called bbb_browser that
can be used to explore the CAS/AC. It allows users to get better insight
in how remote execution works under the hood. It also makes it possible
for users to more easily share information on build failures with their
peers.

In order to make it easy for people to access this service, we'd like
build failures to automatically print links to the corresponding page in
bbb_browser to the terminal. RE's server_logs feature is ideally suited
for this. Unfortunately, there exists no mechanism to print the output
of these files to the terminal yet.

This change adds a new command line flag, --print_server_log_on_failure,
that can print selected server logs to the terminal automatically. Logs
are identified by the key that was used to store them in the map.