### PR TITLE
Set a specific formatting specifier for rl.rlim_max.

### DIFF
--- a/src/test/cpp/blaze_util_posix_test.cc
+++ b/src/test/cpp/blaze_util_posix_test.cc
@@ -16,6 +16,7 @@
 #include <sys/resource.h>
 #include <sys/wait.h>
 
+#include <inttypes.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -187,7 +188,7 @@ TEST_F(UnlimitResourcesTest, Coredumps) {
   // limit is non-zero.
   struct rlimit rl = GetrlimitOrDie(RLIMIT_CORE);
   if (rl.rlim_max <= 1) {
-    fprintf(stderr, "Hard resource limit for RLIMIT_CORE is %ju"
+    fprintf(stderr, "Hard resource limit for RLIMIT_CORE is %" PRIuMAX
             "; cannot test anything meaningful\n", (uintmax_t)rl.rlim_max);
     return;
   }

--- a/src/test/cpp/blaze_util_posix_test.cc
+++ b/src/test/cpp/blaze_util_posix_test.cc
@@ -16,7 +16,6 @@
 #include <sys/resource.h>
 #include <sys/wait.h>
 
-#include <inttypes.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -188,8 +187,8 @@ TEST_F(UnlimitResourcesTest, Coredumps) {
   // limit is non-zero.
   struct rlimit rl = GetrlimitOrDie(RLIMIT_CORE);
   if (rl.rlim_max <= 1) {
-    fprintf(stderr, "Hard resource limit for RLIMIT_CORE is %" PRIuMAX
-            "; cannot test anything meaningful\n", rl.rlim_max);
+    fprintf(stderr, "Hard resource limit for RLIMIT_CORE is %ju"
+            "; cannot test anything meaningful\n", (uintmax_t)rl.rlim_max);
     return;
   }
   rl.rlim_cur = 1;

--- a/src/test/cpp/blaze_util_posix_test.cc
+++ b/src/test/cpp/blaze_util_posix_test.cc
@@ -16,7 +16,6 @@
 #include <sys/resource.h>
 #include <sys/wait.h>
 
-#include <inttypes.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -24,6 +23,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <cstdint>
 
 #include "src/main/cpp/blaze_util.h"
 #include "src/main/cpp/blaze_util_platform.h"
@@ -189,7 +189,8 @@ TEST_F(UnlimitResourcesTest, Coredumps) {
   struct rlimit rl = GetrlimitOrDie(RLIMIT_CORE);
   if (rl.rlim_max <= 1) {
     fprintf(stderr, "Hard resource limit for RLIMIT_CORE is %" PRIuMAX
-            "; cannot test anything meaningful\n", (uintmax_t)rl.rlim_max);
+            "; cannot test anything meaningful\n",
+            static_cast<uintmax_t>(rl.rlim_max));
     return;
   }
   rl.rlim_cur = 1;

--- a/src/test/cpp/blaze_util_posix_test.cc
+++ b/src/test/cpp/blaze_util_posix_test.cc
@@ -21,9 +21,9 @@
 
 #include <cerrno>
 #include <cstdarg>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <cstdint>
 
 #include "src/main/cpp/blaze_util.h"
 #include "src/main/cpp/blaze_util_platform.h"


### PR DESCRIPTION
Part of error message cleanup, #6594.