### PR TITLE
Directly export resources library for the client.

### DIFF
--- a/src/main/cpp/BUILD
+++ b/src/main/cpp/BUILD
@@ -75,7 +75,7 @@ cc_binary(
         "global_variables.h",
         "main.cc",
     ] + select({
-        "//src/conditions:windows": ["//src/main/native/windows:resources.o"],
+        "//src/conditions:windows": ["//src/main/native/windows:resources"],
         "//conditions:default": [],
     }),
     copts = select({

--- a/src/main/native/windows/BUILD
+++ b/src/main/native/windows/BUILD
@@ -1,10 +1,5 @@
 package(default_visibility = ["//visibility:private"])
 
-exports_files(
-    ["resources.o"],
-    visibility = ["//src/main/cpp:__pkg__"],
-)
-
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
@@ -60,4 +55,12 @@ cc_binary(
         "//src/test/java/com/google/devtools/build/lib:__subpackages__",
         "//src/tools/android/java/com/google/devtools/build/android:__subpackages__",
     ],
+)
+
+
+# Directly re-export resources.o so it can be consumed in the client.
+cc_library(
+    name = "resources",
+    srcs = ["resources.o"],
+    visibility = ["//src/main/cpp:__pkg__"],
 )


### PR DESCRIPTION
Part of log message cleanup, #6594.