### PR TITLE
Enable some tests on Bazel's CI

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -13,6 +13,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
   ubuntu1604:
@@ -28,6 +29,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
   ubuntu1804:
@@ -43,6 +45,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
   ubuntu1804_nojava:
@@ -57,6 +60,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     # We can't run Android tests without an installed Android SDK / NDK.
     - "-//src/test/java/com/google/devtools/build/android/..."
@@ -109,6 +113,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
   ubuntu1804_java10:
@@ -124,6 +129,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
   macos:
@@ -139,6 +145,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
   windows:

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -15,8 +15,6 @@ platforms:
     - "//src/test/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
-    # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/6479
-    - "-//src/test/shell/bazel:workspace_resolved_test"
   ubuntu1604:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -32,8 +30,6 @@ platforms:
     - "//src/test/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
-    # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/6479
-    - "-//src/test/shell/bazel:workspace_resolved_test"
   ubuntu1804:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -49,8 +45,6 @@ platforms:
     - "//src/test/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
-    # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/6479
-    - "-//src/test/shell/bazel:workspace_resolved_test"
   ubuntu1804_nojava:
     build_flags:
     - "--javabase=@openjdk_linux_archive//:runtime"
@@ -102,8 +96,6 @@ platforms:
     - "-//src/test/shell/integration:output_filter_test"
     - "-//src/test/shell/integration:stub_finds_runfiles_test"
     - "-//src/test/shell/integration:test_test"
-    # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/6479
-    - "-//src/test/shell/bazel:workspace_resolved_test"
   ubuntu1804_java9:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -119,8 +111,6 @@ platforms:
     - "//src/test/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
-    # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/6479
-    - "-//src/test/shell/bazel:workspace_resolved_test"
   ubuntu1804_java10:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -136,8 +126,6 @@ platforms:
     - "//src/test/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
-    # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/6479
-    - "-//src/test/shell/bazel:workspace_resolved_test"
   macos:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -153,8 +141,6 @@ platforms:
     - "//src/test/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
-    # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/6479
-    - "-//src/test/shell/bazel:workspace_resolved_test"
   windows:
     build_flags:
     - "--copt=-w"
@@ -173,8 +159,6 @@ platforms:
     test_targets:
     - "--"
     - "//src:all_windows_tests"
-    # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/6479
-    - "-//src/test/shell/bazel:workspace_resolved_test"
   rbe_ubuntu1604:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -100,6 +100,7 @@ platforms:
     - "-//src/test/shell/integration:output_filter_test"
     - "-//src/test/shell/integration:stub_finds_runfiles_test"
     - "-//src/test/shell/integration:test_test"
+    - "-//src/tools/singlejar:zip64_test"
   ubuntu1804_java9:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -13,6 +13,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
     # Disable Slow Tests
@@ -32,6 +33,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
     # Disable Slow Tests
@@ -51,6 +53,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
     # Disable Slow Tests
@@ -69,6 +72,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     # Disable Slow Tests
     - "-//src/test/shell/bazel:bazel_determinism_test"
@@ -123,6 +127,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
     # Disable Slow Tests
@@ -142,6 +147,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
     # Disable Slow Tests
@@ -161,6 +167,7 @@ platforms:
     - "--"
     - "//scripts/..."
     - "//src/test/..."
+    - "//src/tools/singlejar/..."
     - "//third_party/ijar/..."
     - "//tools/android/..."
     # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/4663

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -114,6 +114,7 @@ platforms:
     - "-//src/test/shell/integration:output_filter_test"
     - "-//src/test/shell/integration:stub_finds_runfiles_test"
     - "-//src/test/shell/integration:test_test"
+    - "-//src/tools/singlejar:zip64_test"
   ubuntu1804_java9:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#


### PR DESCRIPTION
- Re-enable workspace_resolved_test in postsubmit.
- Fix #6405: Test //src/tools/singlejar/... on CI.
