### PR TITLE
Enable --incompatible_disable_sysroot_from_configuration by default.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -897,7 +897,7 @@ public class CppOptions extends FragmentOptions {
   // TODO(--incompatible_disable_systool_from_configration): Deprecate the feature and remove.
   @Option(
       name = "incompatible_disable_sysroot_from_configuration",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainTest.java
@@ -904,7 +904,7 @@ public class CcToolchainTest extends BuildViewTestCase {
         .setupCrosstool(
             mockToolsConfig,
             CrosstoolConfig.CToolchain.newBuilder().setDefaultGrteTop("//libc1").buildPartial());
-    useConfiguration();
+    useConfiguration("--incompatible_disable_sysroot_from_configuration=false");
     ConfiguredTarget target = getConfiguredTarget("//a:b");
     CcToolchainProvider toolchainProvider =
         (CcToolchainProvider) target.get(ToolchainInfo.PROVIDER);


### PR DESCRIPTION
Incompatible change issue: #6565.
Part of overall sysroot cleanup in #6543.

RELNOTES: Turn on --incompatible_disable_sysroot_from_configuration