### PR TITLE
Windows, test-wrapper: rename flag in Bazel

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -36,6 +36,7 @@ import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDefinition;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
+import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingException;
 import com.google.devtools.common.options.TriState;
@@ -231,20 +232,23 @@ public class TestConfiguration extends Fragment {
     public Label coverageReportGenerator;
 
     @Option(
-        name = "windows_native_test_wrapper",
-        // Undocumented: this features is under development and not yet ready for production use.
-        // We define the flag to be able to test the feature.
+        name = "incompatible_windows_native_test_wrapper",
         // Design:
         // https://github.com/laszlocsomor/proposals/blob/win-test-runner/designs/2018-07-18-windows-native-test-runner.md
-        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        documentationCategory = OptionDocumentationCategory.TESTING,
         // Affects loading and analysis: this flag affects which target Bazel loads and creates test
         // actions with on Windows.
-        effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+        effectTags = {
+          OptionEffectTag.LOADING_AND_ANALYSIS,
+          OptionEffectTag.TEST_RUNNER,
+        },
+        metadataTags = {
+          OptionMetadataTag.INCOMPATIBLE_CHANGE,
+          OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES,
+        },
         defaultValue = "false",
-        help =
-            "Do not use yet, this flag's functionality is not yet implemented. "
-                + "(On Windows: if true, uses the C++ test wrapper to run tests, otherwise uses "
-                + "tools/test/test-setup.sh as on other platforms. On other platforms: no-op.)")
+        help = "On Windows: if true, uses the C++ test wrapper to run tests, otherwise uses "
+                + "tools/test/test-setup.sh as on other platforms. On other platforms: no-op.")
     public boolean windowsNativeTestWrapper;
 
     @Override

--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -293,7 +293,7 @@ class TestWrapperTest(test_base.TestBase):
 
   def testTestExecutionWithTestSetupSh(self):
     self._CreateMockWorkspace()
-    flag = '--nowindows_native_test_wrapper'
+    flag = '--noincompatible_windows_native_test_wrapper'
     self._AssertPassingTest(flag)
     self._AssertFailingTest(flag)
     self._AssertPrintingTest(flag)
@@ -328,7 +328,7 @@ class TestWrapperTest(test_base.TestBase):
     # As of 2018-09-11, the Windows native test runner can run simple tests and
     # export a few envvars, though it does not completely set up the test's
     # environment yet.
-    flag = '--windows_native_test_wrapper'
+    flag = '--incompatible_windows_native_test_wrapper'
     self._AssertPassingTest(flag)
     self._AssertFailingTest(flag)
     self._AssertPrintingTest(flag)


### PR DESCRIPTION
Rename the "--windows_native_test_wrapper" flag to
"--incompatible_windows_native_test_wrapper", in
order to comply with the "Communicating Breaking
Changes in Bazel" policy (see
https://groups.google.com/forum/#!msg/bazel-dev/DKgObFj6Q-0/HRCm_xJRAAAJ)

The flag (and the feature it guards) is not yet in
use so this change should not affect anyone.

See:
https://github.com/bazelbuild/bazel/issues/5508
https://github.com/bazelbuild/bazel/issues/6622

Change-Id: I7606114ad3e82da662bece63997d03d1d9c2fc8e