### PR TITLE
WIP: Windows, test-wrapper: add directories to zip

### DIFF
--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -23,10 +23,27 @@ namespace bazel {
 namespace tools {
 namespace test_wrapper {
 
-// Info about a file in the results of TestOnly_GetFileListRelativeTo.
-struct FileInfo {
+// Info about a file/directory in the results of TestOnly_GetFileListRelativeTo.
+class FileInfo {
+ public:
+  // C'tor for a directory.
+  FileInfo(const std::wstring& rel_path)
+      : rel_path_(rel_path), size_(0), is_dir_(true) {}
+
+  // C'tor for a file.
+  // Marked "explicit" because `size` is just a `int`.
+  explicit FileInfo(const std::wstring& rel_path, int size)
+      : rel_path_(rel_path), size_(size), is_dir_(false) {}
+
+  inline const std::wstring& RelativePath() const { return rel_path_; }
+
+  inline int Size() const { return size_; }
+
+  inline bool IsDirectory() const { return is_dir_; }
+
+ private:
   // The file's path, relative to the traversal root.
-  std::wstring rel_path;
+  std::wstring rel_path_;
 
   // The file's size, in bytes.
   //
@@ -34,7 +51,10 @@ struct FileInfo {
   // to 2 GiB in size. The reason is, devtools_ijar::Stat::total_size is
   // declared as `int`, which is what we ultimately store the file size in,
   // therefore this field is also `int`.
-  int size;
+  int size_;
+
+  // Whether this is a directory (true) or a regular file (false).
+  bool is_dir_;
 };
 
 // Zip entry paths for devtools_ijar::ZipBuilder.
@@ -104,3 +124,4 @@ bool TestOnly_AsMixedPath(const std::wstring& path, std::string* result);
 }  // namespace bazel
 
 #endif  // BAZEL_TOOLS_TEST_WINDOWS_TW_H_
+

--- a/tools/test/windows/tw_test.cc
+++ b/tools/test/windows/tw_test.cc
@@ -178,26 +178,31 @@ TEST_F(TestWrapperWindowsTest, TestGetFileListRelativeTo) {
 TEST_F(TestWrapperWindowsTest, TestToZipEntryPaths) {
   // Pretend we already acquired a file list. The files don't have to exist.
   std::wstring root = L"c:\\nul\\root";
-  std::vector<FileInfo> files = {
-      FileInfo(L"foo\\sub\\file1", 0),  FileInfo(L"foo\\sub\\file2", 5),
-      FileInfo(L"foo\\file1", 3),       FileInfo(L"foo\\file2", 6),
-      FileInfo(L"foo\\junc\\file1", 0), FileInfo(L"foo\\junc\\file2", 5)};
+  std::vector<FileInfo> files = {FileInfo(L"foo"),
+                                 FileInfo(L"foo\\sub"),
+                                 FileInfo(L"foo\\sub\\file1", 0),
+                                 FileInfo(L"foo\\sub\\file2", 5),
+                                 FileInfo(L"foo\\file1", 3),
+                                 FileInfo(L"foo\\file2", 6),
+                                 FileInfo(L"foo\\junc"),
+                                 FileInfo(L"foo\\junc\\file1", 0),
+                                 FileInfo(L"foo\\junc\\file2", 5)};
 
   ZipEntryPaths actual;
   ASSERT_TRUE(TestOnly_ToZipEntryPaths(root, files, &actual));
-  ASSERT_EQ(actual.Size(), 6);
+  ASSERT_EQ(actual.Size(), 9);
 
   std::vector<const char*> expected_abs_paths = {
-      "c:/nul/root/foo/sub/file1",  "c:/nul/root/foo/sub/file2",
-      "c:/nul/root/foo/file1",      "c:/nul/root/foo/file2",
-      "c:/nul/root/foo/junc/file1", "c:/nul/root/foo/junc/file2",
-  };
+      "c:/nul/root/foo",           "c:/nul/root/foo/sub",
+      "c:/nul/root/foo/sub/file1", "c:/nul/root/foo/sub/file2",
+      "c:/nul/root/foo/file1",     "c:/nul/root/foo/file2",
+      "c:/nul/root/foo/junc",      "c:/nul/root/foo/junc/file1",
+      "c:/nul/root/foo/junc/file2"};
   COMPARE_ZIP_ENTRY_PATHS(actual.AbsPathPtrs(), expected_abs_paths);
 
   std::vector<const char*> expected_entry_paths = {
-      "foo/sub/file1", "foo/sub/file2",  "foo/file1",
-      "foo/file2",     "foo/junc/file1", "foo/junc/file2",
-  };
+      "foo",       "foo/sub",  "foo/sub/file1",  "foo/sub/file2", "foo/file1",
+      "foo/file2", "foo/junc", "foo/junc/file1", "foo/junc/file2"};
   COMPARE_ZIP_ENTRY_PATHS(actual.EntryPathPtrs(), expected_entry_paths);
 }
 
@@ -206,26 +211,31 @@ TEST_F(TestWrapperWindowsTest, TestToZipEntryPathsLongPathRoot) {
   // Assert that the root is allowed to have the `\\?\` prefix, but the zip
   // entry paths won't have it.
   std::wstring root = L"\\\\?\\c:\\nul\\unc";
-  std::vector<FileInfo> files = {
-      FileInfo(L"foo\\sub\\file1", 0),  FileInfo(L"foo\\sub\\file2", 5),
-      FileInfo(L"foo\\file1", 3),       FileInfo(L"foo\\file2", 6),
-      FileInfo(L"foo\\junc\\file1", 0), FileInfo(L"foo\\junc\\file2", 5)};
+  std::vector<FileInfo> files = {FileInfo(L"foo"),
+                                 FileInfo(L"foo\\sub"),
+                                 FileInfo(L"foo\\sub\\file1", 0),
+                                 FileInfo(L"foo\\sub\\file2", 5),
+                                 FileInfo(L"foo\\file1", 3),
+                                 FileInfo(L"foo\\file2", 6),
+                                 FileInfo(L"foo\\junc"),
+                                 FileInfo(L"foo\\junc\\file1", 0),
+                                 FileInfo(L"foo\\junc\\file2", 5)};
 
   ZipEntryPaths actual;
   ASSERT_TRUE(TestOnly_ToZipEntryPaths(root, files, &actual));
-  ASSERT_EQ(actual.Size(), 6);
+  ASSERT_EQ(actual.Size(), 9);
 
   std::vector<const char*> expected_abs_paths = {
-      "c:/nul/unc/foo/sub/file1",  "c:/nul/unc/foo/sub/file2",
-      "c:/nul/unc/foo/file1",      "c:/nul/unc/foo/file2",
-      "c:/nul/unc/foo/junc/file1", "c:/nul/unc/foo/junc/file2",
-  };
+      "c:/nul/unc/foo",           "c:/nul/unc/foo/sub",
+      "c:/nul/unc/foo/sub/file1", "c:/nul/unc/foo/sub/file2",
+      "c:/nul/unc/foo/file1",     "c:/nul/unc/foo/file2",
+      "c:/nul/unc/foo/junc",      "c:/nul/unc/foo/junc/file1",
+      "c:/nul/unc/foo/junc/file2"};
   COMPARE_ZIP_ENTRY_PATHS(actual.AbsPathPtrs(), expected_abs_paths);
 
   std::vector<const char*> expected_entry_paths = {
-      "foo/sub/file1", "foo/sub/file2",  "foo/file1",
-      "foo/file2",     "foo/junc/file1", "foo/junc/file2",
-  };
+      "foo",       "foo/sub",  "foo/sub/file1",  "foo/sub/file2", "foo/file1",
+      "foo/file2", "foo/junc", "foo/junc/file1", "foo/junc/file2"};
   COMPARE_ZIP_ENTRY_PATHS(actual.EntryPathPtrs(), expected_entry_paths);
 }
 
@@ -248,8 +258,10 @@ class InMemoryExtractor : public devtools_ijar::ZipExtractorProcessor {
                const devtools_ijar::u1* data, const size_t size) override {
     extracted_->push_back({});
     extracted_->back().path = filename;
-    extracted_->back().data.reset(new devtools_ijar::u1[size]);
-    memcpy(extracted_->back().data.get(), data, size);
+    if (size > 0) {
+      extracted_->back().data.reset(new devtools_ijar::u1[size]);
+      memcpy(extracted_->back().data.get(), data, size);
+    }
     extracted_->back().size = size;
   }
 
@@ -273,10 +285,15 @@ TEST_F(TestWrapperWindowsTest, TestCreateZip) {
   EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\foo\\file2", "foobar"));
   CREATE_JUNCTION(root + L"\\foo\\junc", root + L"\\foo\\sub");
 
-  std::vector<FileInfo> file_list = {
-      FileInfo(L"foo\\sub\\file1", 0),  FileInfo(L"foo\\sub\\file2", 5),
-      FileInfo(L"foo\\file1", 3),       FileInfo(L"foo\\file2", 6),
-      FileInfo(L"foo\\junc\\file1", 0), FileInfo(L"foo\\junc\\file2", 5)};
+  std::vector<FileInfo> file_list = {FileInfo(L"foo"),
+                                     FileInfo(L"foo\\sub"),
+                                     FileInfo(L"foo\\sub\\file1", 0),
+                                     FileInfo(L"foo\\sub\\file2", 5),
+                                     FileInfo(L"foo\\file1", 3),
+                                     FileInfo(L"foo\\file2", 6),
+                                     FileInfo(L"foo\\junc"),
+                                     FileInfo(L"foo\\junc\\file1", 0),
+                                     FileInfo(L"foo\\junc\\file2", 5)};
 
   ASSERT_TRUE(TestOnly_CreateZip(root, file_list, root + L"\\x.zip"));
 
@@ -291,26 +308,32 @@ TEST_F(TestWrapperWindowsTest, TestCreateZip) {
   EXPECT_NE(zip.get(), nullptr);
   EXPECT_EQ(zip->ProcessAll(), 0);
 
-  EXPECT_EQ(extracted.size(), 6);
+  EXPECT_EQ(extracted.size(), 9);
 
-  EXPECT_EQ(extracted[0].path, std::string("foo/sub/file1"));
-  EXPECT_EQ(extracted[1].path, std::string("foo/sub/file2"));
-  EXPECT_EQ(extracted[2].path, std::string("foo/file1"));
-  EXPECT_EQ(extracted[3].path, std::string("foo/file2"));
-  EXPECT_EQ(extracted[4].path, std::string("foo/junc/file1"));
-  EXPECT_EQ(extracted[5].path, std::string("foo/junc/file2"));
+  EXPECT_EQ(extracted[0].path, std::string("foo"));
+  EXPECT_EQ(extracted[1].path, std::string("foo/sub"));
+  EXPECT_EQ(extracted[2].path, std::string("foo/sub/file1"));
+  EXPECT_EQ(extracted[3].path, std::string("foo/sub/file2"));
+  EXPECT_EQ(extracted[4].path, std::string("foo/file1"));
+  EXPECT_EQ(extracted[5].path, std::string("foo/file2"));
+  EXPECT_EQ(extracted[6].path, std::string("foo/junc"));
+  EXPECT_EQ(extracted[7].path, std::string("foo/junc/file1"));
+  EXPECT_EQ(extracted[8].path, std::string("foo/junc/file2"));
 
   EXPECT_EQ(extracted[0].size, 0);
-  EXPECT_EQ(extracted[1].size, 5);
-  EXPECT_EQ(extracted[2].size, 3);
-  EXPECT_EQ(extracted[3].size, 6);
-  EXPECT_EQ(extracted[4].size, 0);
-  EXPECT_EQ(extracted[5].size, 5);
+  EXPECT_EQ(extracted[1].size, 0);
+  EXPECT_EQ(extracted[2].size, 0);
+  EXPECT_EQ(extracted[3].size, 5);
+  EXPECT_EQ(extracted[4].size, 3);
+  EXPECT_EQ(extracted[5].size, 6);
+  EXPECT_EQ(extracted[6].size, 0);
+  EXPECT_EQ(extracted[7].size, 0);
+  EXPECT_EQ(extracted[8].size, 5);
 
-  EXPECT_EQ(memcmp(extracted[1].data.get(), "hello", 5), 0);
-  EXPECT_EQ(memcmp(extracted[2].data.get(), "foo", 3), 0);
-  EXPECT_EQ(memcmp(extracted[3].data.get(), "foobar", 6), 0);
-  EXPECT_EQ(memcmp(extracted[5].data.get(), "hello", 5), 0);
+  EXPECT_EQ(memcmp(extracted[3].data.get(), "hello", 5), 0);
+  EXPECT_EQ(memcmp(extracted[4].data.get(), "foo", 3), 0);
+  EXPECT_EQ(memcmp(extracted[5].data.get(), "foobar", 6), 0);
+  EXPECT_EQ(memcmp(extracted[8].data.get(), "hello", 5), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
In this commit:

- FileInfo now stores whether the entry is a file
  or a directory

- GetFileListRelativeTo will collect directories
  as well as files

- CreateZip will include directories in the zip as
  well as files

test-setup.sh also zips up directories so this
change will make the test wrapper compatible with
test-setup.sh.

See: https://github.com/bazelbuild/bazel/issues/5508

Change-Id: I8359b7a98ff334e0f689e90a7815d661669a40af