### PR TITLE
Windows, test-wrapper: add MIME type lookup

### DIFF
--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -115,6 +115,9 @@ bool TestOnly_CreateZip(const std::wstring& abs_root,
                         const std::vector<FileInfo>& files,
                         const std::wstring& abs_zip);
 
+// Returns the MIME type of a file. The file does not need to exist.
+std::string TestOnly_GetMimeType(const std::string& filename);
+
 bool TestOnly_AsMixedPath(const std::wstring& path, std::string* result);
 
 }  // namespace testing

--- a/tools/test/windows/tw_test.cc
+++ b/tools/test/windows/tw_test.cc
@@ -39,6 +39,7 @@ using bazel::tools::test_wrapper::testing::TestOnly_AsMixedPath;
 using bazel::tools::test_wrapper::testing::TestOnly_CreateZip;
 using bazel::tools::test_wrapper::testing::TestOnly_GetEnv;
 using bazel::tools::test_wrapper::testing::TestOnly_GetFileListRelativeTo;
+using bazel::tools::test_wrapper::testing::TestOnly_GetMimeType;
 using bazel::tools::test_wrapper::testing::TestOnly_ToZipEntryPaths;
 
 class TestWrapperWindowsTest : public ::testing::Test {
@@ -334,6 +335,13 @@ TEST_F(TestWrapperWindowsTest, TestCreateZip) {
   EXPECT_EQ(memcmp(extracted[4].data.get(), "foo", 3), 0);
   EXPECT_EQ(memcmp(extracted[5].data.get(), "foobar", 6), 0);
   EXPECT_EQ(memcmp(extracted[8].data.get(), "hello", 5), 0);
+}
+
+TEST_F(TestWrapperWindowsTest, TestGetMimeType) {
+  EXPECT_EQ(TestOnly_GetMimeType("foo.txt"), std::string("text/plain"));
+  EXPECT_EQ(TestOnly_GetMimeType("foo.png"), std::string("image/png"));
+  EXPECT_EQ(TestOnly_GetMimeType("foo"),
+            std::string("application/octet-stream"));
 }
 
 }  // namespace

--- a/tools/test/windows/tw_test.cc
+++ b/tools/test/windows/tw_test.cc
@@ -338,8 +338,14 @@ TEST_F(TestWrapperWindowsTest, TestCreateZip) {
 }
 
 TEST_F(TestWrapperWindowsTest, TestGetMimeType) {
-  EXPECT_EQ(TestOnly_GetMimeType("foo.txt"), std::string("text/plain"));
-  EXPECT_EQ(TestOnly_GetMimeType("foo.png"), std::string("image/png"));
+  // As of 2018-11-08, TestOnly_GetMimeType looks up the MIME type from the
+  // registry under `HKCR\<extension>\Content Type`, e.g.
+  // 'HKCR\.bmp\Content Type`.
+  // Bazel's CI machines run Windows Server 2016 Core, whose registry contains
+  // the Content Type for .ico and .bmp but not for common types such as .txt,
+  // hence the file types we choose to test for.
+  EXPECT_EQ(TestOnly_GetMimeType("foo.ico"), std::string("image/x-icon"));
+  EXPECT_EQ(TestOnly_GetMimeType("foo.bmp"), std::string("image/bmp"));
   EXPECT_EQ(TestOnly_GetMimeType("foo"),
             std::string("application/octet-stream"));
 }


### PR DESCRIPTION
In this commit:

- implement logic to look up the MIME type of a
  file from its name

We'll use this information to write the Undeclared
Outputs Manifest file, which lists the undeclared
outputs of the tests along with their size and
MIME type.

See: https://github.com/bazelbuild/bazel/issues/5508

Change-Id: I7606114ad3e82da662bece63997d03d1d9c2fc8e