### PR TITLE
Rename --experimental_enable_runfiles to --enable_runfiles

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfiguration.java
@@ -921,12 +921,12 @@ public class BuildConfiguration implements BuildConfigurationApi {
     public ConfigsMode configsMode;
 
     @Option(
-      name = "experimental_enable_runfiles",
+      name = "enable_runfiles",
+      oldName = "experimental_enable_runfiles",
       defaultValue = "auto",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = { OptionEffectTag.AFFECTS_OUTPUTS },
-      metadataTags = { OptionMetadataTag.EXPERIMENTAL },
-      help = "Enable runfiles; off on Windows, on on other platforms"
+      help = "Enable runfiles symlink tree; By default, it's off on Windows, on on other platforms."
     )
     public TriState enableRunfiles;
 

--- a/src/test/py/bazel/runfiles_test.py
+++ b/src/test/py/bazel/runfiles_test.py
@@ -189,7 +189,7 @@ class RunfilesTest(test_base.TestBase):
     for lang in [("java", "Java"), ("sh", "Bash"), ("cc", "C++")]:
       exit_code, _, stderr = self.RunBazel([
           "build", "--verbose_failures",
-          "--experimental_enable_runfiles=no", "//bar:bar-" + lang[0]
+          "--enable_runfiles=no", "//bar:bar-" + lang[0]
       ])
       self.AssertExitCode(exit_code, 0, stderr)
 

--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -196,7 +196,7 @@ class TestWrapperTest(test_base.TestBase):
         '-t-',
         '--test_output=all',
         # Ensure Bazel does not create a runfiles tree.
-        '--experimental_enable_runfiles=no',
+        '--enable_runfiles=no',
         flag,
     ])
     self.AssertExitCode(exit_code, 0, stderr)

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -406,11 +406,11 @@ EOF
  }
 
 # Runfiles is disabled by default on Windows, but we can test it on Unix by
-# adding flag --experimental_enable_runfiles=0
+# adding flag --enable_runfiles=0
 function test_build_and_run_hello_world_without_runfiles() {
   write_hello_library_files
 
-  bazel run --experimental_enable_runfiles=0 //java/main:main &> $TEST_log || fail "build failed"
+  bazel run --enable_runfiles=0 //java/main:main &> $TEST_log || fail "build failed"
   expect_log "Hello, Library!;Hello, World!"
 }
 

--- a/src/test/shell/bazel/bazel_windows_example_test.sh
+++ b/src/test/shell/bazel/bazel_windows_example_test.sh
@@ -227,7 +227,7 @@ function test_native_python() {
 }
 
 function test_native_python_with_runfiles() {
-  BUILD_FLAGS="--experimental_enable_runfiles --build_python_zip=0"
+  BUILD_FLAGS="--enable_runfiles --build_python_zip=0"
   bazel build -s --verbose_failures $BUILD_FLAGS //examples/py_native:bin \
     || fail "Failed to build //examples/py_native:bin with runfiles support"
   (

--- a/src/test/shell/bazel/git_repository_test.sh
+++ b/src/test/shell/bazel/git_repository_test.sh
@@ -46,7 +46,7 @@ if is_windows; then
   export MSYS_NO_PATHCONV=1
   export MSYS2_ARG_CONV_EXCL="*"
   # Enable symlink runfiles tree to make bazel run work
-  add_to_bazelrc "build --experimental_enable_runfiles"
+  add_to_bazelrc "build --enable_runfiles"
 fi
 
 # Global test setup.

--- a/src/test/shell/bazel/skylark_git_repository_test.sh
+++ b/src/test/shell/bazel/skylark_git_repository_test.sh
@@ -46,7 +46,7 @@ if is_windows; then
   export MSYS_NO_PATHCONV=1
   export MSYS2_ARG_CONV_EXCL="*"
   # Enable symlink runfiles tree to make bazel run work
-  add_to_bazelrc "build --experimental_enable_runfiles"
+  add_to_bazelrc "build --enable_runfiles"
 fi
 
 # Global test setup.

--- a/src/test/shell/integration/runfiles_test.sh
+++ b/src/test/shell/integration/runfiles_test.sh
@@ -55,7 +55,7 @@ if "$is_windows"; then
   export MSYS_NO_PATHCONV=1
   export MSYS2_ARG_CONV_EXCL="*"
   export EXT=".exe"
-  export EXTRA_BUILD_FLAGS="--experimental_enable_runfiles --build_python_zip=0"
+  export EXTRA_BUILD_FLAGS="--enable_runfiles --build_python_zip=0"
 else
   export EXT=""
   export EXTRA_BUILD_FLAGS=""


### PR DESCRIPTION
Building runfiles symlink tree is now well supported on Windows, we
should make this feature non-experimental.

Users will get a warning if they still try to use
--experimental_enable_runfiles, but this flag will be removed
eventually.
