### PR TITLE
Don't discard metadata attached to ExecuteResponse's status.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ExecutionStatusException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ExecutionStatusException.java
@@ -15,8 +15,10 @@ package com.google.devtools.build.lib.remote;
 
 import build.bazel.remote.execution.v2.ExecuteResponse;
 import com.google.rpc.Status;
+import io.grpc.Metadata;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.lite.ProtoLiteUtils;
 import javax.annotation.Nullable;
 
 /**
@@ -28,8 +30,19 @@ public class ExecutionStatusException extends StatusRuntimeException {
   private final Status status;
   private final ExecuteResponse response;
 
+  private static final Metadata.Key<com.google.rpc.Status> STATUS_DETAILS_KEY =
+      Metadata.Key.of(
+          "grpc-status-details-bin",
+          ProtoLiteUtils.metadataMarshaller(com.google.rpc.Status.getDefaultInstance()));
+
+  private static final Metadata getMetadata(Status status) {
+    Metadata metadata = new Metadata();
+    metadata.put(STATUS_DETAILS_KEY, status);
+    return metadata;
+  }
+
   public ExecutionStatusException(Status status, @Nullable ExecuteResponse response) {
-    super(convertStatus(status, response));
+    super(convertStatus(status, response), getMetadata(status));
     this.status = status;
     this.response = response;
   }


### PR DESCRIPTION
When executing builds for which input files got removed between
FindMissing() and Execute(), Buildbarn workers will return
FAILED_PRECONDITION errors through ExecuteResponse's status field.
Attached to this status is a violation entry, indicating that the failed
precondition is due to the absence of a blob.

This should cause RemoteModule's RETRIABLE_EXEC_ERRORS to treat this as
a retriable error, causing Bazel to restart the build process for that
action entirely. Unfortunately, it does not, due to the fact that
ExecutionStatusException currently throws away the metadata. Only the
code and message are preserved.

This change extends ExecutionStatusException to create a proper Metadata
object just like io.grpc.protobuf.StatusProto does, granting raw access
to the underlying metadata.