### PR TITLE
Convert googleapis and remoteapis into local_repository repos.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -69,6 +69,11 @@ pkg_tar(
     name = "bazel-srcs",
     srcs = [":srcs"],
     strip_prefix = ".",
+    remap_paths = {
+        # Rewrite paths coming from local repositories back into third_party.
+        '../googleapis': 'third_party/googleapis',
+        '../remoteapis': 'third_party/remoteapis',
+    },
     # Public but bazel-only visibility.
     visibility = ["//:__subpackages__"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -75,15 +75,13 @@ new_local_repository(
     path = "./third_party/protobuf/3.6.1/",
 )
 
-new_local_repository(
+local_repository(
     name = "googleapis",
-    build_file = "./third_party/googleapis/BUILD",
     path = "./third_party/googleapis/",
 )
 
-new_local_repository(
+local_repository(
     name = "remoteapis",
-    build_file = "./third_party/remoteapis/BUILD.bazel",
     path = "./third_party/remoteapis/",
 )
 

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -32,10 +32,10 @@ filegroup(
         "//third_party/py/six:srcs",
         "//third_party/zlib:srcs",
         "//third_party/nanopb:srcs",
-        "//third_party/googleapis:srcs",
         "//third_party/def_parser:srcs",
         "//third_party/pprof:srcs",
-        "//third_party/remoteapis:srcs",
+        "@googleapis//:srcs",
+        "@remoteapis//:srcs",
     ],
 )
 

--- a/third_party/googleapis/BUILD.bazel
+++ b/third_party/googleapis/BUILD.bazel
@@ -10,23 +10,23 @@ load("@io_bazel//tools/build_rules:utilities.bzl", "java_library_srcs")
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
-    visibility = ["//third_party:__pkg__"],
+    visibility = ["@//third_party:__pkg__"],
 )
 
 JAVA_LIBRARY_PROTOS = [
-  "google_api_auth",
-  "google_api_http",
-  "google_api_annotations",
-  "google_watch_v1",
-  "google_rpc_status",
-  "google_rpc_error_details",
-  "google_rpc_code",
-  "google_longrunning_operations",
-  "google_devtools_remoteexecution_v1test_remote_execution",
-  "google_devtools_build_v1_publish_build_event",
-  "google_bytestream_bytestream",
-  "google_devtools_build_v1_build_status",
-  "google_devtools_build_v1_build_events",
+    "google_api_auth",
+    "google_api_http",
+    "google_api_annotations",
+    "google_watch_v1",
+    "google_rpc_status",
+    "google_rpc_error_details",
+    "google_rpc_code",
+    "google_longrunning_operations",
+    "google_devtools_remoteexecution_v1test_remote_execution",
+    "google_devtools_build_v1_publish_build_event",
+    "google_bytestream_bytestream",
+    "google_devtools_build_v1_build_status",
+    "google_devtools_build_v1_build_events",
 ]
 
 [java_library_srcs(
@@ -37,12 +37,11 @@ JAVA_LIBRARY_PROTOS = [
 # for bootstrapping
 filegroup(
     name = "dist_jars",
-    srcs = [":" + proto + "_java_proto_srcs" for proto in JAVA_LIBRARY_PROTOS]
-    + [
-      ":google_devtools_build_v1_publish_build_event_java_grpc_srcs",
-      ":google_bytestream_bytestream_java_grpc_srcs",
-      ":google_devtools_remoteexecution_v1test_remote_execution_java_grpc_srcs",
-      ":google_watch_v1_java_grpc_srcs",
+    srcs = [":" + proto + "_java_proto_srcs" for proto in JAVA_LIBRARY_PROTOS] + [
+        ":google_devtools_build_v1_publish_build_event_java_grpc_srcs",
+        ":google_bytestream_bytestream_java_grpc_srcs",
+        ":google_devtools_remoteexecution_v1test_remote_execution_java_grpc_srcs",
+        ":google_watch_v1_java_grpc_srcs",
     ],
     visibility = ["@//src:__pkg__"],
 )

--- a/third_party/googleapis/WORKSPACE
+++ b/third_party/googleapis/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "googleapis")

--- a/third_party/remoteapis/BUILD.bazel
+++ b/third_party/remoteapis/BUILD.bazel
@@ -10,7 +10,7 @@ load("@io_bazel//tools/build_rules:utilities.bzl", "java_library_srcs")
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
-    visibility = ["//third_party:__pkg__"],
+    visibility = ["@//third_party:__pkg__"],
 )
 
 JAVA_LIBRARY_PROTOS = [

--- a/third_party/remoteapis/WORKSPACE
+++ b/third_party/remoteapis/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "remoteapis")


### PR DESCRIPTION
local_repository, unlike new_local_repository, contains its own
WORKSPACE and correctly detects attemps to directly use the package,
instead of using the @repository name.

This adds the needed WORKSPACE files, updates the master WORKSPACE, and
cleans up references and tests.

Fixes #6601.