### PR TITLE
Describe known issue when in-mem state is lost when running bazel builds inside docker containers e.g. in CI

### DIFF
--- a/site/docs/remote-caching.md
+++ b/site/docs/remote-caching.md
@@ -371,6 +371,12 @@ two users with different compilers installed will wrongly share cache hits
 because the outputs are different but they have the same action hash. Please
 watch [issue #4558] for updates.
 
+**Incremental in-memory state is lost when running builds inside docker containers**
+Bazel use server/client architecture even when running in single docker container.
+On server side Bazel maintain in-memory state which speed up builds so when running
+builds inside docker containers e.g. in CI, in-memory state is lost so Bazel
+must rebuild it before using remote cache.
+
 ## External Links
 
 * **Your Build in a Datacenter:** The Bazel team gave a [talk](https://fosdem.org/2018/schedule/event/datacenter_build/) about remote caching and execution at FOSDEM 2018.


### PR DESCRIPTION
I hit that problem and discovered answer by reading that doc: https://docs.bazel.build/versions/master/user-manual.html#flag--batch 

I was trying to understand why my jobs on CI takes around 20s even with caching but in dockers when locally it was like 200 ms. So maybe it would be better to place it in docs for future generations.
