### PR TITLE
Windows, test-wrapper: write undecl. out annot.

### DIFF
--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -1065,10 +1065,16 @@ bool ArchiveUndeclaredOutputs(const UndeclaredOutputs& undecl) {
            CreateUndeclaredOutputsManifest(files, undecl.manifest)));
 }
 
+// Creates the Undeclared Outputs Annotations file.
+//
+// This file is a concatenation of every *.part file directly under
+// `undecl_annot_dir`. The file is written to `output`.
 bool CreateUndeclaredOutputsAnnotations(const Path& undecl_annot_dir,
                                         const Path& output) {
   if (undecl_annot_dir.Get().empty()) {
-    // TEST_UNDECLARED_OUTPUTS_ANNOTATIONS_DIR was undefined, nothing to do.
+    // The directory's environment variable
+    // (TEST_UNDECLARED_OUTPUTS_ANNOTATIONS_DIR) was probably undefined, nothing
+    // to do.
     return true;
   }
 
@@ -1079,6 +1085,7 @@ bool CreateUndeclaredOutputsAnnotations(const Path& undecl_annot_dir,
                  undecl_annot_dir.Get() + L"\"").c_str());
     return false;
   }
+  // There are no *.part files under `undecl_annot_dir`, nothing to do.
   if (files.empty()) {
     return true;
   }
@@ -1086,7 +1093,7 @@ bool CreateUndeclaredOutputsAnnotations(const Path& undecl_annot_dir,
   HANDLE handle;
   if (!OpenFileForWriting(output.Get(), &handle)) {
     LogError(__LINE__,
-             (std::wstring(L"Failed to get open for writing \"") +
+             (std::wstring(L"Failed to open for writing \"") +
                  output.Get() + L"\"").c_str());
     return false;
   }

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -374,6 +374,7 @@ bool ExportMiscEnvvars(const Path& cwd) {
 
 bool _GetFileListRelativeTo(const std::wstring& unc_root,
                             const std::wstring& subdir,
+                            int depth_limit,
                             std::vector<FileInfo>* result) {
   const std::wstring full_subdir =
       unc_root + (subdir.empty() ? L"" : (L"\\" + subdir)) + L"\\*";
@@ -399,7 +400,12 @@ bool _GetFileListRelativeTo(const std::wstring& unc_root,
       std::wstring rel_path =
           subdir.empty() ? info.cFileName : (subdir + L"\\" + info.cFileName);
       if (info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-        subdirectories.push_back(rel_path);
+        if (depth_limit != 0) {
+          // depth_limit is negative ==> unlimited depth
+          // depth_limit is zero     ==> do not recurse further
+          // depth_limit is positive ==> recurse further
+          subdirectories.push_back(rel_path);
+        }
         result->push_back(FileInfo(rel_path));
       } else {
         if (info.nFileSizeHigh > 0 || info.nFileSizeLow > INT_MAX) {
@@ -432,15 +438,23 @@ bool _GetFileListRelativeTo(const std::wstring& unc_root,
   }
   close_handle.DoNow();
 
-  for (const auto& s : subdirectories) {
-    if (!_GetFileListRelativeTo(unc_root, s, result)) {
-      return false;
+  if (depth_limit != 0) {
+    // depth_limit is negative ==> unlimited depth
+    // depth_limit is zero     ==> do not recurse further
+    // depth_limit is positive ==> recurse further
+    for (const auto& s : subdirectories) {
+      if (!_GetFileListRelativeTo(
+            unc_root, s, depth_limit > 0 ? depth_limit - 1 : depth_limit,
+            result)) {
+        return false;
+      }
     }
   }
   return true;
 }
 
-bool GetFileListRelativeTo(const Path& root, std::vector<FileInfo>* result) {
+bool GetFileListRelativeTo(const Path& root, std::vector<FileInfo>* result,
+                           int depth_limit = -1) {
   if (!blaze_util::IsAbsolute(root.Get())) {
     LogError(__LINE__, "Root should be absolute");
     return false;
@@ -449,7 +463,7 @@ bool GetFileListRelativeTo(const Path& root, std::vector<FileInfo>* result) {
   return _GetFileListRelativeTo(bazel::windows::HasUncPrefix(root.Get().c_str())
                                     ? root.Get()
                                     : L"\\\\?\\" + root.Get(),
-                                std::wstring(), result);
+                                std::wstring(), depth_limit, result);
 }
 
 bool ToZipEntryPaths(const Path& root, const std::vector<FileInfo>& files,
@@ -584,6 +598,42 @@ bool WriteToFile(HANDLE output, const void* buffer, const size_t size) {
       return false;
     }
     total_written += written;
+  }
+  return true;
+}
+
+bool AppendFileTo(const Path& file, const size_t total_size, HANDLE output) {
+  HANDLE input;
+  if (!OpenExistingFileForRead(file, &input)) {
+    LogError(__LINE__,
+             (std::wstring(L"Failed to open file \"") + file.Get() + L"\"")
+                 .c_str());
+    return false;
+  }
+  Defer close_input_file([input]() { CloseHandle(input); });
+
+  const size_t buf_size = std::min<size_t>(total_size, /* 10 MB */ 10000000);
+  std::unique_ptr<uint8_t[]> buffer(new uint8_t[buf_size]);
+
+  while (true) {
+    // Read at most `buf_size` many bytes from the input file.
+    DWORD read = 0;
+    if (!ReadFile(input, buffer.get(), buf_size, &read, NULL)) {
+      DWORD err = GetLastError();
+      LogErrorWithArgAndValue(__LINE__, "Failed to read file",
+                              file.Get().c_str(), err);
+      return false;
+    }
+    if (read == 0) {
+      // Reached end of input file.
+      return true;
+    }
+    if (!WriteToFile(output, buffer.get(), read)) {
+      LogError(__LINE__, (std::wstring(L"Failed to append file \"") +
+                          file.Get().c_str() + L"\"")
+                             .c_str());
+      return false;
+    }
   }
   return true;
 }
@@ -1015,6 +1065,50 @@ bool ArchiveUndeclaredOutputs(const UndeclaredOutputs& undecl) {
            CreateUndeclaredOutputsManifest(files, undecl.manifest)));
 }
 
+bool CreateUndeclaredOutputsAnnotations(const Path& undecl_annot_dir,
+                                        const Path& output) {
+  if (undecl_annot_dir.Get().empty()) {
+    // TEST_UNDECLARED_OUTPUTS_ANNOTATIONS_DIR was undefined, nothing to do.
+    return true;
+  }
+
+  std::vector<FileInfo> files;
+  if (!GetFileListRelativeTo(undecl_annot_dir, &files, 0)) {
+    LogError(__LINE__,
+             (std::wstring(L"Failed to get files under \"") +
+                 undecl_annot_dir.Get() + L"\"").c_str());
+    return false;
+  }
+  if (files.empty()) {
+    return true;
+  }
+
+  HANDLE handle;
+  if (!OpenFileForWriting(output.Get(), &handle)) {
+    LogError(__LINE__,
+             (std::wstring(L"Failed to get open for writing \"") +
+                 output.Get() + L"\"").c_str());
+    return false;
+  }
+  Defer close_file([handle]() { CloseHandle(handle); });
+
+  for (const auto& e : files) {
+    if (!e.IsDirectory() &&
+        e.RelativePath().rfind(L".part") == e.RelativePath().size() - 5) {
+      // Only consume "*.part" files.
+      Path path;
+      if (!path.Set(undecl_annot_dir.Get() + L"\\" + e.RelativePath()) ||
+          !AppendFileTo(path, e.Size(), handle)) {
+        LogError(__LINE__, (std::wstring(L"Failed to append file \"") +
+                            path.Get() + L"\" to \"" + output.Get() + L"\"")
+                               .c_str());
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 bool ParseArgs(int argc, wchar_t** argv, Path* out_argv0,
                std::wstring* out_test_path_arg, bool* out_suppress_output,
                std::vector<const wchar_t*>* out_args) {
@@ -1167,7 +1261,11 @@ int Main(int argc, wchar_t** argv) {
   if (result != 0) {
     return result;
   }
-  return ArchiveUndeclaredOutputs(undecl) ? 0 : 1;
+  return (ArchiveUndeclaredOutputs(undecl) &&
+          CreateUndeclaredOutputsAnnotations(undecl.annotations_dir,
+                                             undecl.annotations))
+             ? 0
+             : 1;
 }
 
 namespace testing {
@@ -1177,10 +1275,11 @@ bool TestOnly_GetEnv(const wchar_t* name, std::wstring* result) {
 }
 
 bool TestOnly_GetFileListRelativeTo(const std::wstring& abs_root,
-                                    std::vector<FileInfo>* result) {
+                                    std::vector<FileInfo>* result,
+                                    int depth_limit) {
   Path root;
   return blaze_util::IsAbsolute(abs_root) && root.Set(abs_root) &&
-         GetFileListRelativeTo(root, result);
+         GetFileListRelativeTo(root, result, depth_limit);
 }
 
 bool TestOnly_ToZipEntryPaths(const std::wstring& abs_root,
@@ -1207,6 +1306,14 @@ std::string TestOnly_GetMimeType(const std::string& filename) {
 bool TestOnly_CreateUndeclaredOutputsManifest(
     const std::vector<FileInfo>& files, std::string* result) {
   return CreateUndeclaredOutputsManifestContent(files, result);
+}
+
+bool TestOnly_CreateUndeclaredOutputsAnnotations(
+    const std::wstring& abs_root, const std::wstring& abs_output) {
+  Path root, output;
+  return blaze_util::IsAbsolute(abs_root) && root.Set(abs_root) &&
+         blaze_util::IsAbsolute(abs_output) && output.Set(abs_output) &&
+         CreateUndeclaredOutputsAnnotations(root, output);
 }
 
 bool TestOnly_AsMixedPath(const std::wstring& path, std::string* result) {

--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -101,8 +101,14 @@ namespace testing {
 bool TestOnly_GetEnv(const wchar_t* name, std::wstring* result);
 
 // Lists all files under `abs_root`, with paths relative to `abs_root`.
+// Limits the directory depth to `depth_limit` many directories below
+// `abs_root`.
+// A negative depth means unlimited depth. 0 depth means searching only
+// `abs_root`, while a positive depth limit allows matches in up to that many
+// subdirectories.
 bool TestOnly_GetFileListRelativeTo(const std::wstring& abs_root,
-                                    std::vector<FileInfo>* result);
+                                    std::vector<FileInfo>* result,
+                                    int depth_limit = -1);
 
 // Converts a list of files to ZIP file entry paths.a
 bool TestOnly_ToZipEntryPaths(
@@ -121,6 +127,9 @@ std::string TestOnly_GetMimeType(const std::string& filename);
 // Returns the contents of the Undeclared Outputs manifest.
 bool TestOnly_CreateUndeclaredOutputsManifest(
     const std::vector<FileInfo>& files, std::string* result);
+
+bool TestOnly_CreateUndeclaredOutputsAnnotations(
+    const std::wstring& abs_root, const std::wstring& abs_output);
 
 bool TestOnly_AsMixedPath(const std::wstring& path, std::string* result);
 

--- a/tools/test/windows/tw_test.cc
+++ b/tools/test/windows/tw_test.cc
@@ -37,6 +37,8 @@ using bazel::tools::test_wrapper::FileInfo;
 using bazel::tools::test_wrapper::ZipEntryPaths;
 using bazel::tools::test_wrapper::testing::TestOnly_AsMixedPath;
 using bazel::tools::test_wrapper::testing::
+    TestOnly_CreateUndeclaredOutputsAnnotations;
+using bazel::tools::test_wrapper::testing::
     TestOnly_CreateUndeclaredOutputsManifest;
 using bazel::tools::test_wrapper::testing::TestOnly_CreateZip;
 using bazel::tools::test_wrapper::testing::TestOnly_GetEnv;
@@ -175,6 +177,22 @@ TEST_F(TestWrapperWindowsTest, TestGetFileListRelativeTo) {
               FileInfo(L"junc"),
               FileInfo(L"junc\\file1", 0),
               FileInfo(L"junc\\file2", 5)};
+  COMPARE_FILE_INFOS(actual, expected);
+
+  // Assert traversal limited to the current directory (depth of 0).
+  actual.clear();
+  ASSERT_TRUE(TestOnly_GetFileListRelativeTo(root, &actual, 0));
+  expected = {FileInfo(L"foo")};
+  COMPARE_FILE_INFOS(actual, expected);
+
+  // Assert traversal limited to depth of 1.
+  actual.clear();
+  ASSERT_TRUE(TestOnly_GetFileListRelativeTo(root, &actual, 1));
+  expected = {FileInfo(L"foo"),
+              FileInfo(L"foo\\sub"),
+              FileInfo(L"foo\\file1", 3),
+              FileInfo(L"foo\\file2", 6),
+              FileInfo(L"foo\\junc")};
   COMPARE_FILE_INFOS(actual, expected);
 }
 
@@ -367,6 +385,38 @@ TEST_F(TestWrapperWindowsTest, TestUndeclaredOutputsManifest) {
   ASSERT_EQ(content, std::string("foo/sub/file1.ico\t0\timage/x-icon\n"
                                  "foo/sub/file2.bmp\t5\timage/bmp\n"
                                  "foo/file2\t6\tapplication/octet-stream\n"));
+}
+
+TEST_F(TestWrapperWindowsTest, TestCreateUndeclaredOutputsAnnotations) {
+  std::wstring tmpdir;
+  GET_TEST_TMPDIR(&tmpdir);
+
+  // Create a directory structure to parse.
+  std::wstring root = tmpdir + L"\\tmp" + WLINE;
+  EXPECT_TRUE(CreateDirectoryW(root.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo").c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW((root + L"\\bar.part").c_str(), NULL));
+  EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\a.part", "Hello a"));
+  EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\b.txt", "Hello b"));
+  EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\c.part", "Hello c"));
+  EXPECT_TRUE(
+      blaze_util::CreateDummyFile(root + L"\\foo\\d.part", "Hello d"));
+  EXPECT_TRUE(
+      blaze_util::CreateDummyFile(root + L"\\bar.part\\e.part", "Hello e"));
+
+  std::wstring annot = root + L"\\x.annot";
+  ASSERT_TRUE(TestOnly_CreateUndeclaredOutputsAnnotations(root, annot));
+
+  HANDLE h = CreateFileW(annot.c_str(), GENERIC_READ,
+                         FILE_SHARE_READ | FILE_SHARE_DELETE, NULL,
+                         OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+  ASSERT_NE(h, INVALID_HANDLE_VALUE);
+  char content[100];
+  DWORD read;
+  bool success = ReadFile(h, content, 100, &read, NULL) != FALSE;
+  CloseHandle(h);
+  EXPECT_TRUE(success);
+  ASSERT_EQ(std::string(content, read), std::string("Hello aHello c"));
 }
 
 }  // namespace


### PR DESCRIPTION
In this commit:

- Implement logic to write the undeclared outputs
  annotations file. This file is just a
  concatenation of all *.part files directly under
  $TEST_UNDECLARED_OUTPUTS_ANNOTATIONS_DIR.

- Implement depth limit support for the method
  that retrieves the contents of a directory and
  all of its subdirectories
  (GetFileListRelativeTo). We need this feature to
  limit the *.part file search to just the
  $TEST_UNDECLARED_OUTPUTS_ANNOTATIONS_DIR,
  excluding its subdirectories.

See: https://github.com/bazelbuild/bazel/issues/5508

Change-Id: I566bc7e713bce2fe9950707295a85878e8cf49f8