### PR TITLE
Don't automatically register cc toolchains from @local_config_cc.

### DIFF
--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -94,7 +94,7 @@ def cc_configure():
     """A C++ configuration rules that generate the crosstool file."""
     cc_autoconf(name = "local_config_cc")
     native.bind(name = "cc_toolchain", actual = "@local_config_cc//:toolchain")
-    native.register_toolchains(
-        # Use register_toolchain's target pattern expansion to register all toolchains in the package.
-        "@local_config_cc//:all",
-    )
+    #native.register_toolchains(
+    #    # Use register_toolchain's target pattern expansion to register all toolchains in the package.
+    #    "@local_config_cc//:all",
+    #)


### PR DESCRIPTION
Part of #6662.

RELNOTES: cc_toolchains from @local_config_cc are not longer
automatically registered for toolchain resolution. If you need this,
add "register_toolchains('@local_config_cc//:all')" to your WORKSPACE.