### PR TITLE
Windows, test wrapper: implement `tee` for HANDLEs

### DIFF
--- a/src/main/native/windows/util.h
+++ b/src/main/native/windows/util.h
@@ -32,8 +32,9 @@ class AutoHandle {
   AutoHandle(HANDLE handle = INVALID_HANDLE_VALUE) : handle_(handle) {}
 
   ~AutoHandle() {
-    ::CloseHandle(handle_);  // succeeds if handle == INVALID_HANDLE_VALUE
-    handle_ = INVALID_HANDLE_VALUE;
+    if (IsValid()) {
+      ::CloseHandle(handle_);
+    }
   }
 
   HANDLE Release() {

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -94,6 +94,7 @@ cc_test(
     ] + select({
         "@bazel_tools//src/conditions:windows": [
             "//src/main/native/windows:lib-file",
+            "//src/main/native/windows:lib-util",
             "//third_party/ijar:zip",
         ],
         "//conditions:default": [],

--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -91,6 +91,18 @@ class ZipEntryPaths {
   std::unique_ptr<char*[]> entry_path_ptrs_;
 };
 
+// Streams data from an input to two outputs.
+// Inspired by tee(1) in the GNU coreutils.
+class Tee {
+ public:
+  virtual ~Tee() {}
+
+ protected:
+  Tee() {}
+  Tee(const Tee&) = delete;
+  Tee& operator=(const Tee&) = delete;
+};
+
 // The main function of the test wrapper.
 int Main(int argc, wchar_t** argv);
 
@@ -132,6 +144,11 @@ bool TestOnly_CreateUndeclaredOutputsAnnotations(
     const std::wstring& abs_root, const std::wstring& abs_output);
 
 bool TestOnly_AsMixedPath(const std::wstring& path, std::string* result);
+
+// Creates a Tee object. See the Tee class declaration for more info.
+bool TestOnly_CreateTee(void* /* HANDLE */ input, void* /* HANDLE */ output1,
+                        void* /* HANDLE */ output2,
+                        std::unique_ptr<Tee>* result);
 
 }  // namespace testing
 


### PR DESCRIPTION
Implement a GNU coreutils tee(1)-inspired class
for HANDLEs. It copies data from an input HANDLE
to two output HANDLEs.

I will use this logic to redirect the stdout and
stderr of the test process to a log file and to
the test wrapper process' stdout. That is what
test-setup.sh also does.

See https://github.com/bazelbuild/bazel/issues/5508

Change-Id: I1882c1f0f4c1f5375e354849aef80acae73f28bb