### PR TITLE
Make sure action execution continuation state is dropped if establishSkyframeDependencies fails.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -185,6 +185,8 @@ public class ActionExecutionFunction implements SkyFunction, CompletionReceiver 
     try {
       skyframeDepsResult = establishSkyframeDependencies(env, action);
     } catch (ActionExecutionException e) {
+      // Remove action from state map in case it's there (won't be unless it discovers inputs).
+      stateMap.remove(action);
       throw new ActionExecutionFunctionException(e);
     }
     if (env.valuesMissing()) {


### PR DESCRIPTION
I think this is just a latent bug because there are no input-discovering-skyframe-aware actions currently.