### PR TITLE
HttpBlobStore add hostname and port to SSL Connection constructor

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStore.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStore.java
@@ -187,7 +187,8 @@ public final class HttpBlobStore implements SimpleBlobStore {
     } else {
       sslCtx = null;
     }
-
+    final int port = uri.getPort();
+    final String hostname = uri.getHost();
     this.eventLoop = newEventLoopGroup.apply(2);
     Bootstrap clientBootstrap =
         new Bootstrap()
@@ -208,7 +209,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
           public void channelCreated(Channel ch) {
             ChannelPipeline p = ch.pipeline();
             if (sslCtx != null) {
-              SSLEngine engine = sslCtx.newEngine(ch.alloc());
+              SSLEngine engine = sslCtx.newEngine(ch.alloc(), hostname, port);
               engine.setUseClientMode(true);
               p.addFirst("ssl-handler", new SslHandler(engine));
             }


### PR DESCRIPTION
this change adds host and port parameters to SSL connection contrcutor
with out which the blobstore download client cannot talk to endpoints
sharing SSL certificates.

Fixes #6551