### PR TITLE
Uncomment android_sdk/ndk_repository on Windows

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -150,6 +150,8 @@ platforms:
     - "//third_party/ijar/..."
     - "//tools/android/..."
   windows:
+    batch_commands:
+    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
     build_flags:
     - "--copt=-w"
     - "--host_copt=-w"

--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -161,10 +161,6 @@ platforms:
     - "--copt=-w"
     - "--host_copt=-w"
     - "--test_env=JAVA_HOME"
-    # TODO(pcloudy): Need this for WindowsSubprocessTest.java.
-    # Remove this when release version Bazel sets SYSTEMDRIVE
-    # on Windows by default.
-    - "--test_env=SYSTEMDRIVE"
     - "--test_timeout=1200"
     test_targets:
     - "--"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -188,9 +188,7 @@ platforms:
     - "-//src/test/shell/bazel/android:android_integration_test"
   windows:
     batch_commands:
-    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
-    shell_commands:
-    - type WORKSPACE
+    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE; Get-Content WORKSPACE"
     build_flags:
     - "--copt=-w"
     - "--host_copt=-w"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -188,8 +188,7 @@ platforms:
     - "-//src/test/shell/bazel/android:android_integration_test"
   windows:
     batch_commands:
-    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE; Get-Content WORKSPACE; Write-Host 'ANDROID_HOME: $([Environment]::GetEnvironme
-ntVariable(\"ANDROID_HOME\", \"Machine\"))'"
+    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE; Get-Content WORKSPACE; Write-Host 'ANDROID_HOME: $([Environment]::GetEnvironmentVariable(\"ANDROID_HOME\", \"Machine\"))'"
     build_flags:
     - "--copt=-w"
     - "--host_copt=-w"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -189,6 +189,8 @@ platforms:
   windows:
     batch_commands:
     - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
+    shell_commands:
+    - type WORKSPACE
     build_flags:
     - "--copt=-w"
     - "--host_copt=-w"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -198,10 +198,6 @@ platforms:
     - "--copt=-w"
     - "--host_copt=-w"
     - "--test_env=JAVA_HOME"
-    # TODO(pcloudy): Need this for WindowsSubprocessTest.java.
-    # Remove this when release version Bazel sets SYSTEMDRIVE
-    # on Windows by default.
-    - "--test_env=SYSTEMDRIVE"
     - "--test_timeout=1200"
     test_targets:
     - "--"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -187,6 +187,8 @@ platforms:
     - "-//src/test/shell/bazel/android:aar_integration_test"
     - "-//src/test/shell/bazel/android:android_integration_test"
   windows:
+    batch_commands:
+    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
     build_flags:
     - "--copt=-w"
     - "--host_copt=-w"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -188,7 +188,7 @@ platforms:
     - "-//src/test/shell/bazel/android:android_integration_test"
   windows:
     batch_commands:
-    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE; Get-Content WORKSPACE; Write-Host 'ANDROID_HOME=$([Environment]::GetEnvironmentVariable(\"ANDROID_HOME\", \"Machine\"))'"
+    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE; Get-Content WORKSPACE; $x = 'x=' + [Environment]::GetEnvironmentVariable('ANDROID_HOME', 'Machine'); $y = 'y=' + [Environment]::GetEnvironmentVariable(\"ANDROID_HOME\"); Write-Host $x; Write-Host $y"
     build_flags:
     - "--copt=-w"
     - "--host_copt=-w"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -188,7 +188,7 @@ platforms:
     - "-//src/test/shell/bazel/android:android_integration_test"
   windows:
     batch_commands:
-    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE; Get-Content WORKSPACE; Write-Host 'ANDROID_HOME: $([Environment]::GetEnvironmentVariable(\"ANDROID_HOME\", \"Machine\"))'"
+    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE; Get-Content WORKSPACE; Write-Host 'ANDROID_HOME=$([Environment]::GetEnvironmentVariable(\"ANDROID_HOME\", \"Machine\"))'"
     build_flags:
     - "--copt=-w"
     - "--host_copt=-w"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -188,7 +188,8 @@ platforms:
     - "-//src/test/shell/bazel/android:android_integration_test"
   windows:
     batch_commands:
-    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE; Get-Content WORKSPACE"
+    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE; Get-Content WORKSPACE; Write-Host 'ANDROID_HOME: $([Environment]::GetEnvironme
+ntVariable(\"ANDROID_HOME\", \"Machine\"))'"
     build_flags:
     - "--copt=-w"
     - "--host_copt=-w"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -188,7 +188,7 @@ platforms:
     - "-//src/test/shell/bazel/android:android_integration_test"
   windows:
     batch_commands:
-    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE; Get-Content WORKSPACE; $x = 'x=' + [Environment]::GetEnvironmentVariable('ANDROID_HOME', 'Machine'); $y = 'y=' + [Environment]::GetEnvironmentVariable(\"ANDROID_HOME\"); Write-Host $x; Write-Host $y"
+    - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
     build_flags:
     - "--copt=-w"
     - "--host_copt=-w"

--- a/src/test/java/com/google/devtools/build/android/dexer/BUILD
+++ b/src/test/java/com/google/devtools/build/android/dexer/BUILD
@@ -55,9 +55,9 @@ java_test(
         ":tests",
     ],
     jvm_flags = [
-        "-Dtestmaindexlist=$(location :test_main_dex_list.txt)",
-        "-Dtestinputjar=$(location :tests)",
-        "-Dtestinputjar2=$(location :testdata)",
+        "-Dtestmaindexlist=io_bazel/$(location :test_main_dex_list.txt)",
+        "-Dtestinputjar=io_bazel/$(location :tests)",
+        "-Dtestinputjar2=io_bazel/$(location :testdata)",
     ],
     runtime_deps = [
         ":tests",

--- a/src/test/java/com/google/devtools/build/android/dexer/BUILD
+++ b/src/test/java/com/google/devtools/build/android/dexer/BUILD
@@ -34,6 +34,7 @@ java_library(
         "//third_party:junit4",
         "//third_party:mockito",
         "//third_party:truth",
+        "@bazel_tools//tools/java/runfiles",
     ] + select({
         "//external:has_androidsdk": ["//external:android/dx_jar_import"],
         "//conditions:default": [],

--- a/src/test/java/com/google/devtools/build/android/dexer/DexBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/DexBuilderTest.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.android.dex.Dex;
 import com.android.dx.dex.code.PositionList;
 import com.google.common.io.ByteStreams;
+import com.google.devtools.build.runfiles.Runfiles;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -34,13 +35,12 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DexBuilderTest {
 
-  private static final Path WORKING_DIR = Paths.get(System.getProperty("user.dir"));
-
   @Test
   public void testBuildDexArchive() throws Exception {
     DexBuilder.Options options = new DexBuilder.Options();
     // Use Jar file that has this test in it as the input Jar
-    options.inputJar = WORKING_DIR.resolve(System.getProperty("testinputjar"));
+    Runfiles runfiles = Runfiles.create();
+    options.inputJar = runfiles.rlocation(System.getProperty("testinputjar"));
     options.outputZip =
         FileSystems.getDefault().getPath(System.getenv("TEST_TMPDIR"), "dex_builder_test.zip");
     options.maxThreads = 1;

--- a/src/test/java/com/google/devtools/build/android/dexer/DexBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/DexBuilderTest.java
@@ -40,7 +40,7 @@ public class DexBuilderTest {
     DexBuilder.Options options = new DexBuilder.Options();
     // Use Jar file that has this test in it as the input Jar
     Runfiles runfiles = Runfiles.create();
-    options.inputJar = runfiles.rlocation(System.getProperty("testinputjar"));
+    options.inputJar = Paths.get(runfiles.rlocation(System.getProperty("testinputjar")));
     options.outputZip =
         FileSystems.getDefault().getPath(System.getenv("TEST_TMPDIR"), "dex_builder_test.zip");
     options.maxThreads = 1;

--- a/src/test/java/com/google/devtools/build/android/dexer/DexFileMergerTest.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/DexFileMergerTest.java
@@ -51,8 +51,8 @@ import org.junit.runners.JUnit4;
 public class DexFileMergerTest {
 
   private static final Runfiles runfiles = Runfiles.create();
-  private static final Path INPUT_JAR = runfiles.rlocation(System.getProperty("testinputjar"));
-  private static final Path INPUT_JAR2 = runfiles.rlocation(System.getProperty("testinputjar2"));
+  private static final Path INPUT_JAR = Paths.get(runfiles.rlocation(System.getProperty("testinputjar")));
+  private static final Path INPUT_JAR2 = Paths.get(runfiles.rlocation(System.getProperty("testinputjar2")));
   private static final Path MAIN_DEX_LIST_FILE =
       WORKING_DIR.resolve(System.getProperty("testmaindexlist"));
   static final String DEX_PREFIX = "classes";

--- a/src/test/java/com/google/devtools/build/android/dexer/DexFileMergerTest.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/DexFileMergerTest.java
@@ -54,7 +54,7 @@ public class DexFileMergerTest {
   private static final Path INPUT_JAR = Paths.get(runfiles.rlocation(System.getProperty("testinputjar")));
   private static final Path INPUT_JAR2 = Paths.get(runfiles.rlocation(System.getProperty("testinputjar2")));
   private static final Path MAIN_DEX_LIST_FILE =
-      WORKING_DIR.resolve(System.getProperty("testmaindexlist"));
+      Paths.get(runfiles.rlocation(System.getProperty("testmaindexlist")));
   static final String DEX_PREFIX = "classes";
 
   /** Exercises DexFileMerger to write a single .dex file. */

--- a/src/test/java/com/google/devtools/build/android/dexer/DexFileMergerTest.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/DexFileMergerTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
+import com.google.devtools.build.runfiles.Runfiles;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -49,9 +50,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DexFileMergerTest {
 
-  private static final Path WORKING_DIR = Paths.get(System.getProperty("user.dir"));
-  private static final Path INPUT_JAR = WORKING_DIR.resolve(System.getProperty("testinputjar"));
-  private static final Path INPUT_JAR2 = WORKING_DIR.resolve(System.getProperty("testinputjar2"));
+  private static final Runfiles runfiles = Runfiles.create();
+  private static final Path INPUT_JAR = runfiles.rlocation(System.getProperty("testinputjar"));
+  private static final Path INPUT_JAR2 = runfiles.rlocation(System.getProperty("testinputjar2"));
   private static final Path MAIN_DEX_LIST_FILE =
       WORKING_DIR.resolve(System.getProperty("testmaindexlist"));
   static final String DEX_PREFIX = "classes";

--- a/src/test/java/com/google/devtools/build/android/dexer/DexFileMergerTest.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/DexFileMergerTest.java
@@ -50,12 +50,22 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DexFileMergerTest {
 
-  private static final Runfiles runfiles = Runfiles.create();
-  private static final Path INPUT_JAR = Paths.get(runfiles.rlocation(System.getProperty("testinputjar")));
-  private static final Path INPUT_JAR2 = Paths.get(runfiles.rlocation(System.getProperty("testinputjar2")));
-  private static final Path MAIN_DEX_LIST_FILE =
-      Paths.get(runfiles.rlocation(System.getProperty("testmaindexlist")));
+  private static final Path INPUT_JAR;
+  private static final Path INPUT_JAR2;
+  private static final Path MAIN_DEX_LIST_FILE;
   static final String DEX_PREFIX = "classes";
+
+  static {
+    try {
+      Runfiles runfiles = Runfiles.create();
+
+      INPUT_JAR = Paths.get(runfiles.rlocation(System.getProperty("testinputjar")));
+      INPUT_JAR2 = Paths.get(runfiles.rlocation(System.getProperty("testinputjar2")));
+      MAIN_DEX_LIST_FILE = Paths.get(runfiles.rlocation(System.getProperty("testmaindexlist")));
+    } catch (Exception e) {
+      throw new throw new ExceptionInInitializerError(e);
+    }
+  }
 
   /** Exercises DexFileMerger to write a single .dex file. */
   @Test

--- a/src/test/java/com/google/devtools/build/android/dexer/DexFileMergerTest.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/DexFileMergerTest.java
@@ -63,7 +63,7 @@ public class DexFileMergerTest {
       INPUT_JAR2 = Paths.get(runfiles.rlocation(System.getProperty("testinputjar2")));
       MAIN_DEX_LIST_FILE = Paths.get(runfiles.rlocation(System.getProperty("testmaindexlist")));
     } catch (Exception e) {
-      throw new throw new ExceptionInInitializerError(e);
+      throw new ExceptionInInitializerError(e);
     }
   }
 

--- a/src/test/java/com/google/devtools/build/android/dexer/DexFileSplitterTest.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/DexFileSplitterTest.java
@@ -57,7 +57,7 @@ public class DexFileSplitterTest {
       INPUT_JAR2 = Paths.get(runfiles.rlocation(System.getProperty("testinputjar2")));
       MAIN_DEX_LIST_FILE = Paths.get(runfiles.rlocation(System.getProperty("testmaindexlist")));
     } catch (Exception e) {
-      throw new throw new ExceptionInInitializerError(e);
+      throw new ExceptionInInitializerError(e);
     }
   }
 

--- a/src/test/java/com/google/devtools/build/android/dexer/DexFileSplitterTest.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/DexFileSplitterTest.java
@@ -48,7 +48,7 @@ public class DexFileSplitterTest {
   private static final Path INPUT_JAR = Paths.get(runfiles.rlocation(System.getProperty("testinputjar")));
   private static final Path INPUT_JAR2 = Paths.get(runfiles.rlocation(System.getProperty("testinputjar2")));
   private static final Path MAIN_DEX_LIST_FILE =
-      WORKING_DIR.resolve(System.getProperty("testmaindexlist"));
+      Paths.get(runfiles.rlocation(System.getProperty("testmaindexlist")));
   static final String DEX_PREFIX = "classes";
 
   @Test

--- a/src/test/java/com/google/devtools/build/android/dexer/DexFileSplitterTest.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/DexFileSplitterTest.java
@@ -44,12 +44,22 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DexFileSplitterTest {
 
-  private static final Runfiles runfiles = Runfiles.create();
-  private static final Path INPUT_JAR = Paths.get(runfiles.rlocation(System.getProperty("testinputjar")));
-  private static final Path INPUT_JAR2 = Paths.get(runfiles.rlocation(System.getProperty("testinputjar2")));
-  private static final Path MAIN_DEX_LIST_FILE =
-      Paths.get(runfiles.rlocation(System.getProperty("testmaindexlist")));
+  private static final Path INPUT_JAR;
+  private static final Path INPUT_JAR2;
+  private static final Path MAIN_DEX_LIST_FILE;
   static final String DEX_PREFIX = "classes";
+
+  static {
+    try {
+      Runfiles runfiles = Runfiles.create();
+
+      INPUT_JAR = Paths.get(runfiles.rlocation(System.getProperty("testinputjar")));
+      INPUT_JAR2 = Paths.get(runfiles.rlocation(System.getProperty("testinputjar2")));
+      MAIN_DEX_LIST_FILE = Paths.get(runfiles.rlocation(System.getProperty("testmaindexlist")));
+    } catch (Exception e) {
+      throw new throw new ExceptionInInitializerError(e);
+    }
+  }
 
   @Test
   public void testSingleInputSingleOutput() throws Exception {

--- a/src/test/java/com/google/devtools/build/android/dexer/DexFileSplitterTest.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/DexFileSplitterTest.java
@@ -45,8 +45,8 @@ import org.junit.runners.JUnit4;
 public class DexFileSplitterTest {
 
   private static final Runfiles runfiles = Runfiles.create();
-  private static final Path INPUT_JAR = runfiles.rlocation(System.getProperty("testinputjar"));
-  private static final Path INPUT_JAR2 = runfiles.rlocation(System.getProperty("testinputjar2"));
+  private static final Path INPUT_JAR = Paths.get(runfiles.rlocation(System.getProperty("testinputjar")));
+  private static final Path INPUT_JAR2 = Paths.get(runfiles.rlocation(System.getProperty("testinputjar2")));
   private static final Path MAIN_DEX_LIST_FILE =
       WORKING_DIR.resolve(System.getProperty("testmaindexlist"));
   static final String DEX_PREFIX = "classes";

--- a/src/test/java/com/google/devtools/build/android/dexer/DexFileSplitterTest.java
+++ b/src/test/java/com/google/devtools/build/android/dexer/DexFileSplitterTest.java
@@ -24,6 +24,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.devtools.build.runfiles.Runfiles;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystems;
@@ -43,9 +44,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DexFileSplitterTest {
 
-  private static final Path WORKING_DIR = Paths.get(System.getProperty("user.dir"));
-  private static final Path INPUT_JAR = WORKING_DIR.resolve(System.getProperty("testinputjar"));
-  private static final Path INPUT_JAR2 = WORKING_DIR.resolve(System.getProperty("testinputjar2"));
+  private static final Runfiles runfiles = Runfiles.create();
+  private static final Path INPUT_JAR = runfiles.rlocation(System.getProperty("testinputjar"));
+  private static final Path INPUT_JAR2 = runfiles.rlocation(System.getProperty("testinputjar2"));
   private static final Path MAIN_DEX_LIST_FILE =
       WORKING_DIR.resolve(System.getProperty("testmaindexlist"));
   static final String DEX_PREFIX = "classes";


### PR DESCRIPTION
Revive #5023 (by @philwo) so that we can try to revive #4797.

`shell_commands` will put the whole cmd string into an array (`[cmd]`) before passing it to `subprocess.run`. This will make `subprocess.run` thinks that the first element of the array is the full path of the program, hence the weird error in #5023. We work around it with `batch_commands` which pass the cmd string directly into `subprocess.run` and let `subprocess.run` do the heavy-lifting.

/cc @philwo @meteorcloudy 