### PR TITLE
Windows, client: GetHomeDir checks %USERPROFILE%

### DIFF
--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -417,6 +417,15 @@ string GetHomeDir() {
     ::CoTaskMemFree(wpath);
     return result;
   }
+
+  // On Windows 2016 Server, Datacenter edition, Nano server, FOLDERID_Profile
+  // us unknown but %USERPROFILE% is set.
+  // See https://github.com/bazelbuild/bazel/issues/6701
+  string userprofile = GetEnv("USERPROFILE");
+  if (!userprofile.empty()) {
+    return userprofile;
+  }
+
   return GetEnv("HOME");  // only defined in MSYS/Cygwin
 }
 

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -403,7 +403,9 @@ string GetOutputRoot() {
   if (home.empty()) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "Cannot find a good output root.\n"
-           "Set the HOME environment variable. Example (in cmd.exe):\n"
+           "Set the USERPROFILE or the HOME environment variable. Example (in cmd.exe):\n"
+           "    set USERPROFILE=c:\\_bazel\\<YOUR-USERNAME>\n";
+           "or:\n"
            "    set HOME=c:\\_bazel\\<YOUR-USERNAME>";
   }
   return home;

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -402,7 +402,9 @@ string GetOutputRoot() {
   string home = GetHomeDir();
   if (home.empty()) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "Cannot find a good output root. Use the --output_user_root flag.";
+        << "Cannot find a good output root.\n"
+           "Set the HOME environment variable. Example (in cmd.exe):\n"
+           "    set HOME=c:\\_bazel";
   }
   return home;
 }

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -403,8 +403,9 @@ string GetOutputRoot() {
   if (home.empty()) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "Cannot find a good output root.\n"
-           "Set the USERPROFILE or the HOME environment variable. Example (in cmd.exe):\n"
-           "    set USERPROFILE=c:\\_bazel\\<YOUR-USERNAME>\n";
+           "Set the USERPROFILE or the HOME environment variable.\n"
+           "Example (in cmd.exe):\n"
+           "    set USERPROFILE=c:\\_bazel\\<YOUR-USERNAME>\n"
            "or:\n"
            "    set HOME=c:\\_bazel\\<YOUR-USERNAME>";
   }

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -404,7 +404,7 @@ string GetOutputRoot() {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "Cannot find a good output root.\n"
            "Set the HOME environment variable. Example (in cmd.exe):\n"
-           "    set HOME=c:\\_bazel";
+           "    set HOME=c:\\_bazel\\<YOUR-USERNAME>";
   }
   return home;
 }


### PR DESCRIPTION
If GetHomeDir() fails to look up FOLDERID_Profile
(which can happen on Windows Nano Server), it will
now also check the %USERPROFILE% envvar, which
seems to be set on Nano server and happens to be
the default value of FOLDERID_Profile.

Also change the error message that the Bazel
client displays when
blaze_util_windows.cc::GetHomeDir() returns an
empty string (called indirectly from
StartupOptions c'tor).  The old error advised to
pass the `--output_user_root` flag, but apparently
that does not resolve the issue. Setting the
%HOME% envvar however does.

Fixes https://github.com/bazelbuild/bazel/issues/6701