### PR TITLE
Windows, test wrapper: add CdataEncode function

### DIFF
--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -1309,6 +1309,82 @@ int RunSubprocess(const Path& test_path,
   return WaitForSubprocess(process);
 }
 
+// Replace invalid XML characters and locate invalid CDATA sequences.
+//
+// The legal Unicode code points and ranges are U+0009, U+000A, U+000D,
+// U+0020..U+D7FF, U+E000..U+FFFD, and U+10000..U+10FFFF.
+//
+// Assuming the input is UTF-8 encoded, that translates to the following
+// regexps:
+//   [\x9\xa\xd\x20-\x7f]                         <--- (9,A,D,20-7F)
+//   [\xc0-\xdf][\x80-\xbf]                       <--- (0080-07FF)
+//   [\xe0-\xec][\x80-\xbf][\x80-\xbf]            <--- (0800-CFFF)
+//   [\xed][\x80-\x9f][\x80-\xbf]                 <--- (D000-D7FF)
+//   [\xee][\x80-\xbf][\x80-\xbf]                 <--- (E000-EFFF)
+//   [\xef][\x80-\xbe][\x80-\xbf]                 <--- (F000-FFEF)
+//   [\xef][\xbf][\x80-\xbd]                      <--- (FFF0-FFFD)
+//   [\xf0-\xf7][\x80-\xbf][\x80-\xbf][\x80-\xbf] <--- (010000-10FFFF)
+//
+// (See https://github.com/bazelbuild/bazel/issues/4691#issuecomment-408089257)
+//
+// Every octet-sequence matching one of these regexps will be left alone, all
+// other octet-sequences will be replaced by '?' characters.
+//
+// This function also memorizes the locations of "]]>" in `cdata_end_locations`.
+// The reason is "]]>" ends the CDATA section prematurely and cannot be escaped
+// (see https://stackoverflow.com/a/223782/7778502). A separate filtering step
+// can replace those sequences with the string "]]>]]&gt;<![CDATA[" (which ends
+// the current CDATA segment, adds "]]&gt;", then starts a new CDATA segment).
+void CdataEscape(uint8_t* p, const size_t size,
+                 std::vector<uint8_t*>* cdata_end_locations) {
+  for (size_t i = 0; i < size; ++i, ++p) {
+    if (p[0] == ']' && (i + 2 < size) && p[1] == ']' && p[2] == '>') {
+      // Mark where "]]>" is, then skip the next two octets.
+      cdata_end_locations->push_back(p);
+      i += 2;
+      p += 2;
+    } else if (*p == 0x9 || *p == 0xA || *p == 0xD ||
+               (*p >= 0x20 && *p <= 0x7F)) {
+      // Matched legal single-octet sequence. Nothing to do.
+    } else if ((i + 1 < size) &&
+               p[0] >= 0xC0 && p[0] <= 0xDF && p[1] >= 0x80 && p[1] <= 0xBF) {
+      // Matched legal double-octet sequence. Skip the next octet.
+      i += 1;
+      p += 1;
+    } else if ((i + 2 < size) &&
+         ((p[0] >= 0xE0 && p[0] <= 0xEC &&
+           p[1] >= 0x80 && p[1] <= 0xBF &&
+           p[2] >= 0x80 && p[2] <= 0xBF) ||
+          (p[0] == 0xED &&
+           p[1] >= 0x80 && p[1] <= 0x9F &&
+           p[2] >= 0x80 && p[2] <= 0xBF) ||
+          (p[0] == 0xEE &&
+           p[1] >= 0x80 && p[1] <= 0xBF &&
+           p[2] >= 0x80 && p[2] <= 0xBF) ||
+          (p[0] == 0xEF &&
+           p[1] >= 0x80 && p[1] <= 0xBE &&
+           p[2] >= 0x80 && p[2] <= 0xBF) ||
+          (p[0] == 0xEF &&
+           p[1] == 0xBF &&
+           p[2] >= 0x80 && p[2] <= 0xBD))) {
+      // Matched legal triple-octet sequence. Skip the next two octets.
+      i += 2;
+      p += 2;
+    } else if ((i + 3 < size) &&
+               p[0] >= 0xF0 && p[0] <= 0xF7 &&
+               p[1] >= 0x80 && p[1] <= 0xBF &&
+               p[2] >= 0x80 && p[2] <= 0xBF &&
+               p[3] >= 0x80 && p[3] <= 0xBF) {
+      // Matched legal quadruple-octet sequence. Skip the next three octets.
+      i += 3;
+      p += 3;
+    } else {
+      // Illegal octet; replace.
+      *p = '?';
+    }
+  }
+}
+
 bool Path::Set(const std::wstring& path) {
   std::wstring result;
   std::string error;
@@ -1485,6 +1561,13 @@ bool TestOnly_CreateTee(HANDLE input, HANDLE output1, HANDLE output2,
                         std::unique_ptr<Tee>* result) {
   return TeeImpl::Create(input, output1, output2, result);
 }
+
+bool TestOnly_CdataEncodeBuffer(uint8_t* buffer, const size_t size,
+                                std::vector<uint8_t*>* cdata_end_locations) {
+  CdataEscape(buffer, size, cdata_end_locations);
+  return true;
+}
+
 
 }  // namespace testing
 }  // namespace test_wrapper

--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -150,6 +150,10 @@ bool TestOnly_CreateTee(void* /* HANDLE */ input, void* /* HANDLE */ output1,
                         void* /* HANDLE */ output2,
                         std::unique_ptr<Tee>* result);
 
+bool TestOnly_CdataEncodeBuffer(uint8_t* buffer, const size_t size,
+                                std::vector<uint8_t*>* cdata_end_locations);
+
+
 }  // namespace testing
 
 }  // namespace test_wrapper

--- a/tools/test/windows/tw_test.cc
+++ b/tools/test/windows/tw_test.cc
@@ -37,6 +37,7 @@ namespace {
 using bazel::tools::test_wrapper::FileInfo;
 using bazel::tools::test_wrapper::ZipEntryPaths;
 using bazel::tools::test_wrapper::testing::TestOnly_AsMixedPath;
+using bazel::tools::test_wrapper::testing::TestOnly_CdataEncodeBuffer;
 using bazel::tools::test_wrapper::testing::TestOnly_CreateTee;
 using bazel::tools::test_wrapper::testing::
     TestOnly_CreateUndeclaredOutputsAnnotations;
@@ -451,6 +452,105 @@ TEST_F(TestWrapperWindowsTest, TestTee) {
   EXPECT_EQ(std::string(content, read), "foo");
 
   write1 = INVALID_HANDLE_VALUE;  // closes handle so the Tee thread can exit
+}
+
+void AssertCdataEncodeBuffer(
+    int line, const std::string& input, const std::string& expected_output,
+    const std::vector<int>& expected_cdata_end_indices) {
+  ASSERT_EQ(input.size(), expected_output.size());
+
+  std::unique_ptr<uint8_t[]> mutable_buffer(new uint8_t[input.size()]);
+  memcpy(mutable_buffer.get(), input.c_str(), input.size());
+
+  std::vector<uint8_t*> cdata_ends;
+  EXPECT_TRUE(
+      TestOnly_CdataEncodeBuffer(mutable_buffer.get(), input.size(),
+                                 &cdata_ends));
+  for (int i = 0; i < input.size(); ++i) {
+    EXPECT_EQ(mutable_buffer[i], static_cast<uint8_t>(expected_output[i]))
+        << "FAILED(in line " << line << "): mismatch at index " << i;
+  }
+
+  std::vector<int> actual_indices;
+  for (const auto& ptr : cdata_ends) {
+    actual_indices.push_back(ptr - mutable_buffer.get());
+  }
+  EXPECT_EQ(actual_indices, expected_cdata_end_indices);
+}
+
+TEST_F(TestWrapperWindowsTest, TestCdataEncodeBufferCdataEndings) {
+  AssertCdataEncodeBuffer(
+      __LINE__,
+      // === Input ===
+      // CDATA end sequence, followed by some arbitrary octet.
+      "]]>x"
+      // CDATA end sequence twice.
+      "]]>]]>x"
+      // CDATA end sequence at the end of the string.
+      "]]>",
+
+      // === Expected output ===
+      // "]]>" sequences are left alone but their position is stored in
+      "]]>x"
+      "]]>]]>x"
+      "]]>",
+
+      // === Expected CDATA end positions ===
+      {0, 4, 7, 11});
+}
+
+TEST_F(TestWrapperWindowsTest, TestCdataEncodeBufferSingleOctets) {
+  AssertCdataEncodeBuffer(
+      __LINE__,
+      // === Input ===
+      // Legal single-octets.
+      "AB\x9\xA\xD\x20\x7F"
+      // Illegal single-octets.
+      "\x8\xB\xC\x1F\x80\xFF"
+      "x",
+
+      // === Expected output ===
+      // Legal single-octets.
+      "AB\x9\xA\xD\x20\x7F"
+      // Illegal single-octets.
+      "??????"
+      "x", {});
+}
+
+TEST_F(TestWrapperWindowsTest, TestCdataEncodeBufferDoubleOctets) {
+  // Legal range: [\xc0-\xdf][\x80-\xbf]
+  AssertCdataEncodeBuffer(
+      __LINE__,
+      "x"
+      // Legal double-octet sequences.
+      "\xC0\x80"
+      "\xDE\xB0"
+      "\xDF\xBF"
+      // Illegal double-octet sequences, first octet is bad, second is good.
+      "\xBF\x80"  // each are matched as single bad octets
+      "\xE0\x80"
+      // Illegal double-octet sequences, first octet is good, second is bad.
+      "\xC0\x7F"  // 0x7F is legal as a single-octet, retained
+      "\xDF\xC0"  // 0xC0 starts a legal two-octet sequence...
+      // Illegal double-octet sequences, both octets bad.
+      "\xBF\xFF"  // ...and 0xBF finishes that sequence
+      "x",
+
+      // === Expected output ===
+      "x"
+      // Legal double-octet sequences.
+      "\xC0\x80"
+      "\xDE\xB0"
+      "\xDF\xBF"
+      // Illegal double-octet sequences, first octet is bad, second is good.
+      "??"
+      "??"
+      // Illegal double-octet sequences, first octet is good, second is bad.
+      "?\x7F"  // 0x7F is legal as a single-octet, retained
+      "?\xC0"  // 0xC0 starts a legal two-octet sequence...
+      // Illegal double-octet sequences, both octets bad.
+      "\xBF?"  // ...and 0xBF finishes that sequence
+      "x", {});
 }
 
 }  // namespace


### PR DESCRIPTION
The test wrapper must output a test XML file.

This XML file contains metadata about the test
(such as its name, duration it ran for, whether it
failed or passed), as well as the test's stdout
and stderr.

Because not every Unicode code point is allowed in
the XML file, and because the test's output is
stored in a CDATA section, we need to escape the
test's output.

This PR adds half of the escaping logic: the part
that replaces invalid octets with question marks.

The function also marks the locations of "]]>" in
the test output, because this string cannot be
embedded in a CDATA section, so a function I'll
add later will replace those in the output.

See https://github.com/bazelbuild/bazel/issues/5508