### PR TITLE
Remove the "autoconfigured" constraint.

### DIFF
--- a/tools/cpp/BUILD
+++ b/tools/cpp/BUILD
@@ -128,10 +128,8 @@ cc_toolchain(
 toolchain(
     name = "cc-toolchain-local",
     exec_compatible_with = [
-        "@bazel_tools//platforms:autoconfigured",
     ],
     target_compatible_with = [
-        "@bazel_tools//platforms:autoconfigured",
     ],
     toolchain = ":cc-compiler-local",
     toolchain_type = ":toolchain_type",

--- a/tools/cpp/BUILD.tpl
+++ b/tools/cpp/BUILD.tpl
@@ -72,8 +72,6 @@ cc_toolchain(
 toolchain(
     name = "cc-toolchain-%{name}",
     exec_compatible_with = [
-        # This toolchain will only work with the local autoconfigured platforms.
-        "@bazel_tools//platforms:autoconfigured",
         # TODO(katre): add autodiscovered constraints for host CPU and OS.
     ],
     target_compatible_with = [

--- a/tools/osx/crosstool/BUILD.tpl
+++ b/tools/osx/crosstool/BUILD.tpl
@@ -78,9 +78,6 @@ cc_toolchain_suite(
     toolchain(
         name = "cc-toolchain-" + arch,
         exec_compatible_with = [
-            # This toolchain will only work with the local autoconfigured
-            # platforms.
-            "@bazel_tools//platforms:autoconfigured",
             # TODO(katre): add autodiscovered constraints for host CPU and OS.
         ],
         target_compatible_with = [

--- a/tools/platforms/BUILD
+++ b/tools/platforms/BUILD
@@ -82,21 +82,6 @@ constraint_value(
     constraint_setting = ":os",
 )
 
-# A constraint that can only be matched by the autoconfigured platforms.
-constraint_setting(
-    name = "autoconfigure_status",
-    visibility = ["//visibility:private"],
-)
-
-constraint_value(
-    name = "autoconfigured",
-    constraint_setting = ":autoconfigure_status",
-    visibility = [
-        "@bazel_tools//:__subpackages__",
-        "@local_config_cc//:__subpackages__",
-    ],
-)
-
 # A default platform with nothing defined.
 platform(name = "default_platform")
 
@@ -105,7 +90,6 @@ platform(name = "default_platform")
 platform(
     name = "host_platform",
     constraint_values = [
-        ":autoconfigured",
     ],
     cpu_constraints = [
         ":x86_32",
@@ -127,7 +111,6 @@ platform(
 platform(
     name = "target_platform",
     constraint_values = [
-        ":autoconfigured",
     ],
     cpu_constraints = [
         ":x86_32",

--- a/tools/platforms/platforms.BUILD
+++ b/tools/platforms/platforms.BUILD
@@ -70,21 +70,6 @@ constraint_value(
     constraint_setting = ":os",
 )
 
-# A constraint that can only be matched by the autoconfigured platforms.
-constraint_setting(
-    name = "autoconfigure_status",
-    visibility = ["//visibility:private"],
-)
-
-constraint_value(
-    name = "autoconfigured",
-    constraint_setting = ":autoconfigure_status",
-    visibility = [
-        "@bazel_tools//:__subpackages__",
-        "@local_config_cc//:__subpackages__",
-    ],
-)
-
 # A default platform with nothing defined.
 platform(name = "default_platform")
 
@@ -93,7 +78,6 @@ platform(name = "default_platform")
 platform(
     name = "host_platform",
     constraint_values = [
-        ":autoconfigured",
     ],
     cpu_constraints = [
         ":x86_32",
@@ -115,7 +99,6 @@ platform(
 platform(
     name = "target_platform",
     constraint_values = [
-        ":autoconfigured",
     ],
     cpu_constraints = [
         ":x86_32",


### PR DESCRIPTION
This constraint was keeping custom platforms from being defined to work
with the autoconfigred toolchains.

Fixes #6694.