### PR TITLE
Add explicit dependency on SkylarkSemantics, to silence warnings.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -404,6 +404,8 @@ java_library(
         "//src/main/protobuf:invocation_policy_java_proto",
         "//third_party:guava",
         "//third_party:jsr305",
+        # TODO(https://github.com/bazelbuild/bazel/issues/5985): Added to suppress warnings.
+        "//src/main/java/com/google/devtools/build/lib:skylark-semantics",
     ],
 )
 
@@ -532,6 +534,8 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//third_party:guava",
+        # TODO(https://github.com/bazelbuild/bazel/issues/5985): Added to suppress warnings.
+        "//src/main/java/com/google/devtools/build/lib:skylark-semantics",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BUILD
@@ -24,5 +24,7 @@ java_library(
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party/protobuf:protobuf_java",
+        # TODO(https://github.com/bazelbuild/bazel/issues/5985): Added to suppress warnings.
+        "//src/main/java/com/google/devtools/build/lib:skylark-semantics",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/causes/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/causes/BUILD
@@ -13,6 +13,8 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        # TODO(https://github.com/bazelbuild/bazel/issues/5985): Added to suppress warnings.
+        "//src/main/java/com/google/devtools/build/lib:skylark-semantics",
         "//third_party:guava",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils/BUILD
@@ -26,6 +26,8 @@ java_library(
         "//third_party:junit4",
         "//third_party:truth",
         "//third_party/protobuf:protobuf_java",
+        # TODO(https://github.com/bazelbuild/bazel/issues/5985): Added to suppress warnings.
+        "//src/main/java/com/google/devtools/build/lib:skylark-semantics",
     ],
 )
 
@@ -39,6 +41,8 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",
         "//third_party:jsr305",
+        # TODO(https://github.com/bazelbuild/bazel/issues/5985): Added to suppress warnings.
+        "//src/main/java/com/google/devtools/build/lib:skylark-semantics",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -178,6 +178,8 @@ java_test(
         ":testutil",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        # TODO(https://github.com/bazelbuild/bazel/issues/5985): Added to suppress warnings.
+        "//src/main/java/com/google/devtools/build/lib:skylark-semantics",
     ],
 )
 


### PR DESCRIPTION
The "unknown enum constant" warnings are spurious, but until the
compiler can be fixed, this will silence the messages.

Mitigates #5985.