### PR TITLE
docs: fix misspellings of “transitive”

### DIFF
--- a/site/docs/skylark/backward-compatibility.md
+++ b/site/docs/skylark/backward-compatibility.md
@@ -144,7 +144,7 @@ depset1.union(depset2)  # deprecated
 The recommended solution is to use the `depset` constructor:
 
 ``` python
-depset(transtive = [depset1, depset2])
+depset(transitive = [depset1, depset2])
 ```
 
 See the [`depset documentation`](depsets.md) for more information.

--- a/site/docs/skylark/depsets.md
+++ b/site/docs/skylark/depsets.md
@@ -274,7 +274,7 @@ def create(order):
   a = depset(["a"], order=order)
   b = depset(["b"], transitive = [a], order = order)
   c = depset(["c"], transitive = [a], order = order)
-  d = depset(["d"], transtive = [b, c], order = order)
+  d = depset(["d"], transitive = [b, c], order = order)
   return d
 
 print(create("postorder").to_list())    # ["a", "b", "c", "d"]


### PR DESCRIPTION
As of this commit, `git grep transtive` returns no results.