### PR TITLE
WIP, DON'T SUBMIT: Windows, test wrapper: impl. split XML generation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -180,6 +180,11 @@ public class BaseRuleClasses {
                   .singleArtifact()
                   .value(env.getToolsLabel("//tools/test:test_setup")))
           .add(
+              attr("$xml_generator", LABEL)
+                  .cfg(HostTransition.INSTANCE)
+                  .singleArtifact()
+                  .value(env.getToolsLabel("//tools/test:xml_generator")))
+          .add(
               attr("$xml_generator_script", LABEL)
                   .cfg(HostTransition.INSTANCE)
                   .singleArtifact()

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
@@ -184,6 +184,11 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
                 .singleArtifact()
                 .value(labelCache.getUnchecked(toolsRepository + "//tools/test:test_setup")))
         .add(
+            attr("$xml_generator", LABEL)
+                .cfg(HostTransition.INSTANCE)
+                .singleArtifact()
+                .value(labelCache.getUnchecked(toolsRepository + "//tools/test:xml_generator")))
+        .add(
             attr("$xml_generator_script", LABEL)
                 .cfg(HostTransition.INSTANCE)
                 .singleArtifact()

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -242,7 +242,9 @@ public final class TestActionBuilder {
 
     inputsBuilder.add(testActionExecutable);
     Artifact testXmlGeneratorScript =
-        ruleContext.getHostPrerequisiteArtifact("$xml_generator_script");
+        isUsingTestWrapperInsteadOfTestSetupScript
+            ? ruleContext.getHostPrerequisiteArtifact("$xml_generator")
+            : ruleContext.getHostPrerequisiteArtifact("$xml_generator_script");
     inputsBuilder.add(testXmlGeneratorScript);
 
     Artifact collectCoverageScript = null;

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -454,7 +454,7 @@ public class StandaloneTestStrategy extends TestStrategy {
     // TODO(ulfjack): This is incorrect for remote execution, where we need to consider the target
     // configuration, not the machine Bazel happens to run on. Change this to something like:
     // testAction.getConfiguration().getExecOS() == OS.WINDOWS
-    if (OS.getCurrent() == OS.WINDOWS) {
+    if (OS.getCurrent() == OS.WINDOWS && !action.isUsingTestWrapperInsteadOfTestSetupScript()) {
       args.add(action.getShExecutable().getPathString());
       args.add("-c");
       args.add("$0 $*");

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -131,6 +131,7 @@ public final class BazelAnalysisMock extends AnalysisMock {
         "/bazel_tools_workspace/tools/test/BUILD",
         "filegroup(name = 'runtime', srcs = ['test-setup.sh', 'test-xml-generator.sh'])",
         "filegroup(name = 'test_wrapper', srcs = ['test_wrapper_bin'])",
+        "filegroup(name = 'xml_generator', srcs = ['xmlg_bin'])",
         "filegroup(name = 'test_setup', srcs = ['test-setup.sh'])",
         "filegroup(name = 'test_xml_generator', srcs = ['test-xml-generator.sh'])",
         "filegroup(name = 'collect_coverage', srcs = ['collect_coverage.sh'])",

--- a/src/test/shell/bazel/testdata/embedded_tools_srcs_deps
+++ b/src/test/shell/bazel/testdata/embedded_tools_srcs_deps
@@ -4,6 +4,7 @@
 @com_google_protobuf//:protobuf_lite
 //tools/test:tw
 //tools/test:tw_lib
+//tools/test:xmlg
 //third_party/ijar:zipper
 //third_party/ijar:ijar
 //third_party/ijar:zip

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -48,6 +48,15 @@ cc_binary(
     deps = [":tw_lib"],
 )
 
+# XML generator binary to generate test XMLs on Windows.
+# This is only used when building with --experimental_split_xml_generation.
+cc_binary(
+    name = "xmlg",
+    srcs = ["windows/xml_main.cc"],
+    visibility = ["//visibility:private"],
+    deps = [":tw_lib"],
+)
+
 # Test wrapper binary to run tests on Windows.
 # See https://github.com/bazelbuild/bazel/issues/5508
 cc_library(
@@ -115,7 +124,10 @@ filegroup(
         "collect_coverage.sh",
         "collect_cc_coverage.sh",
     ] + glob(["LcovMerger/**"]) + select({
-        "@bazel_tools//src/conditions:windows": ["tw"],
+        "@bazel_tools//src/conditions:windows": [
+            ":tw",
+            ":xmlg",
+        ],
         "//conditions:default": [],
     }),
     visibility = ["//tools:__pkg__"],

--- a/tools/test/BUILD.tools
+++ b/tools/test/BUILD.tools
@@ -49,3 +49,15 @@ filegroup(
         "//conditions:default": ["tw"],
     }),
 )
+
+filegroup(
+    name = "xml_generator",
+    # "tw" is the Windows-native test wrapper. It has a short name because paths
+    # have short limits on Windows.
+    # On other platforms this binary is a no-op.
+    # See https://github.com/bazelbuild/bazel/issues/5508
+    srcs = select({
+        "@bazel_tools//src/conditions:windows": ["xmlg.exe"],
+        "//conditions:default": ["xmlg"],
+    }),
+)

--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -112,7 +112,9 @@ class Tee {
 };
 
 // The main function of the test wrapper.
-int Main(int argc, wchar_t** argv);
+int TestWrapperMain(int argc, wchar_t** argv);
+
+int XmlGeneratorMain(int argc, wchar_t** argv);
 
 // The "testing" namespace contains functions that should only be used by tests.
 namespace testing {

--- a/tools/test/windows/xml_main.cc
+++ b/tools/test/windows/xml_main.cc
@@ -19,5 +19,5 @@
 #include "tools/test/windows/tw.h"
 
 int wmain(int argc, wchar_t** argv) {
-  return bazel::tools::test_wrapper::TestWrapperMain(argc, argv);
+  return bazel::tools::test_wrapper::XmlGeneratorMain(argc, argv);
 }


### PR DESCRIPTION
With the --experimental_split_xml_generation flag,
Bazel can generate a test xml in case the
test-setup.sh or the test itself failed to do so.

Now this functionality is available on Windows
too, without the aid of generate-xml.sh

See https://github.com/bazelbuild/bazel/issues/5508