### PR TITLE
WIP: Windows, JNI: properly retrieve paths from jstring

### DIFF
--- a/src/main/cpp/util/path_windows.cc
+++ b/src/main/cpp/util/path_windows.cc
@@ -70,7 +70,7 @@ std::string ConvertPath(const std::string& path) {
         << "ConvertPath(" << path << "): AsWindowsPath failed: " << error;
   }
   std::transform(converted_path.begin(), converted_path.end(),
-                 converted_path.begin(), ::towlower);
+                 converted_path.begin(), ::tolower);
   return converted_path;
 }
 

--- a/src/main/native/windows/BUILD
+++ b/src/main/native/windows/BUILD
@@ -7,18 +7,12 @@ filegroup(
 )
 
 filegroup(
-    name = "cc-srcs",
+    name = "embedded_tools",
     srcs = glob([
         "*.cc",
         "*.h",
-    ]),
-)
-
-filegroup(
-    name = "embedded_tools",
-    srcs = [
+    ]) + [
         "BUILD",
-        ":cc-srcs",
     ],
     visibility = ["//src/main/native:__pkg__"],
 )
@@ -48,9 +42,16 @@ cc_library(
 cc_binary(
     name = "windows_jni.dll",
     srcs = [
-        ":cc-srcs",
+        "file-jni.cc",
+        "jni-util.h",
+        "jni-util.cc",
+        "processes-jni.cc",
         "//src/main/native:jni.h",
         "//src/main/native:jni_md.h",
+    ],
+    deps = [
+        ":lib-file",
+        ":lib-util",
     ],
     linkshared = 1,
     visibility = [

--- a/src/main/native/windows/jni-util.cc
+++ b/src/main/native/windows/jni-util.cc
@@ -15,6 +15,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+#include <algorithm>
 #include <type_traits>  // static_assert
 
 #include "src/main/native/windows/jni-util.h"
@@ -39,6 +40,12 @@ wstring GetJavaWstring(JNIEnv* env, jstring str) {
     result.assign(reinterpret_cast<const WCHAR*>(jstr));
     env->ReleaseStringChars(str, jstr);
   }
+  return result;
+}
+
+std::wstring GetJavaWpath(JNIEnv* env, jstring str) {
+  std::wstring result = GetJavaWstring(env, str);
+  std::replace(result.begin(), result.end(), L'/', L'\\');
   return result;
 }
 

--- a/src/main/native/windows/jni-util.h
+++ b/src/main/native/windows/jni-util.h
@@ -23,6 +23,8 @@ namespace windows {
 
 std::wstring GetJavaWstring(JNIEnv* env, jstring str);
 
+std::wstring GetJavaWpath(JNIEnv* env, jstring str);
+
 }  // namespace windows
 }  // namespace bazel
 

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -25,11 +25,8 @@
 
 #include "src/main/native/jni.h"
 #include "src/main/native/windows/jni-util.h"
+#include "src/main/native/windows/file.h"
 #include "src/main/native/windows/util.h"
-
-// Maximum command line length is 2^15 characters including the null terminator.
-// https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx
-static const size_t MAX_CMDLINE = 1 << 15;
 
 template <typename T>
 static std::wstring ToString(const T& e) {
@@ -68,8 +65,17 @@ struct NativeOutputStream {
   }
 };
 
+static inline bool IsDevNull(const std::wstring& path) {
+  return path.size() >= 3 && (path[0] == 'N' || path[0] == 'n') &&
+         (path[1] == 'U' || path[1] == 'u') &&
+         (path[2] == 'L' || path[2] == 'l');
+}
+
 static std::wstring AddUncPrefixMaybe(const std::wstring& path) {
-  return (path.size() >= MAX_PATH) ? (std::wstring(L"\\\\?\\") + path) : path;
+  return (path.empty() || IsDevNull(path) ||
+          bazel::windows::HasUncPrefix(path.c_str()))
+      ? path
+      : (std::wstring(L"\\\\?\\") + path);
 }
 
 struct NativeProcess {
@@ -151,12 +157,15 @@ static std::wstring CreateProcessWithExplicitHandles(
     /* __out       */ LPPROCESS_INFORMATION lpProcessInformation,
     /* __in        */ DWORD cHandlesToInherit,
     /* __in_ecount(cHandlesToInherit) */ HANDLE* handlesToInherit) {
-  if (wcsnlen_s(lpCommandLine, MAX_CMDLINE) == MAX_CMDLINE) {
+  // kMaxCmdline value: see lpCommandLine parameter of CreateProcessW.
+  static constexpr size_t kMaxCmdline = 32767;
+
+  if (wcsnlen_s(lpCommandLine, kMaxCmdline) == kMaxCmdline) {
     std::wstring cmd_sample(lpCommandLine, 200);
     cmd_sample.append(L"(...)");
     std::wstringstream error_msg;
     error_msg << L"command is longer than CreateProcessW's limit ("
-              << MAX_CMDLINE << L" characters)";
+              << kMaxCmdline << L" characters)";
     return bazel::windows::MakeErrorMessage(
         WSTR(__FILE__), __LINE__, L"CreateProcessWithExplicitHandles",
         cmd_sample.c_str(), error_msg.str().c_str());
@@ -251,7 +260,7 @@ Java_com_google_devtools_build_lib_windows_jni_WindowsProcesses_nativeCreateProc
   NativeProcess* result = new NativeProcess();
 
   std::wstring argv0;
-  std::wstring wpath(bazel::windows::GetJavaWstring(env, java_argv0));
+  std::wstring wpath(bazel::windows::GetJavaWpath(env, java_argv0));
   std::wstring error_msg(
       bazel::windows::AsExecutablePathForCreateProcess(wpath, &argv0));
   if (!error_msg.empty()) {
@@ -263,11 +272,11 @@ Java_com_google_devtools_build_lib_windows_jni_WindowsProcesses_nativeCreateProc
   std::wstring commandline =
       argv0 + L" " + bazel::windows::GetJavaWstring(env, java_argv_rest);
   std::wstring stdout_redirect = AddUncPrefixMaybe(
-      bazel::windows::GetJavaWstring(env, java_stdout_redirect));
+      bazel::windows::GetJavaWpath(env, java_stdout_redirect));
   std::wstring stderr_redirect = AddUncPrefixMaybe(
-      bazel::windows::GetJavaWstring(env, java_stderr_redirect));
+      bazel::windows::GetJavaWpath(env, java_stderr_redirect));
   std::wstring cwd;
-  std::wstring wcwd(bazel::windows::GetJavaWstring(env, java_cwd));
+  std::wstring wcwd(bazel::windows::GetJavaWpath(env, java_cwd));
   error_msg = bazel::windows::AsShortPath(wcwd, &cwd);
   if (!error_msg.empty()) {
     result->error_ = bazel::windows::MakeErrorMessage(
@@ -337,7 +346,8 @@ Java_com_google_devtools_build_lib_windows_jni_WindowsProcesses_nativeCreateProc
     if (!stdout_process.IsValid()) {
       DWORD err_code = GetLastError();
       result->error_ = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", stdout_redirect,
+          err_code);
       return PtrAsJlong(result);
     }
   } else {


### PR DESCRIPTION
Convert "/" to "\" in paths received from Java.
Always add UNC prefix to paths unless they are
empty or NUL.