### PR TITLE
Windows, JNI: update path retrieval and utils

### DIFF
--- a/src/main/cpp/util/path_windows.cc
+++ b/src/main/cpp/util/path_windows.cc
@@ -70,7 +70,7 @@ std::string ConvertPath(const std::string& path) {
         << "ConvertPath(" << path << "): AsWindowsPath failed: " << error;
   }
   std::transform(converted_path.begin(), converted_path.end(),
-                 converted_path.begin(), ::towlower);
+                 converted_path.begin(), ::tolower);
   return converted_path;
 }
 

--- a/src/main/native/windows/BUILD
+++ b/src/main/native/windows/BUILD
@@ -7,18 +7,12 @@ filegroup(
 )
 
 filegroup(
-    name = "cc-srcs",
+    name = "embedded_tools",
     srcs = glob([
         "*.cc",
         "*.h",
-    ]),
-)
-
-filegroup(
-    name = "embedded_tools",
-    srcs = [
+    ]) + [
         "BUILD",
-        ":cc-srcs",
     ],
     visibility = ["//src/main/native:__pkg__"],
 )
@@ -48,9 +42,16 @@ cc_library(
 cc_binary(
     name = "windows_jni.dll",
     srcs = [
-        ":cc-srcs",
+        "file-jni.cc",
+        "jni-util.h",
+        "jni-util.cc",
+        "processes-jni.cc",
         "//src/main/native:jni.h",
         "//src/main/native:jni_md.h",
+    ],
+    deps = [
+        ":lib-file",
+        ":lib-util",
     ],
     linkshared = 1,
     visibility = [

--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -28,6 +28,16 @@ namespace windows {
 using std::unique_ptr;
 using std::wstring;
 
+wstring AddUncPrefixMaybe(const wstring& path) {
+  return path.empty() || IsDevNull(path.c_str()) || HasUncPrefix(path.c_str())
+             ? path
+             : (wstring(L"\\\\?\\") + path);
+}
+
+wstring RemoveUncPrefixMaybe(const wstring& path) {
+  return bazel::windows::HasUncPrefix(path.c_str()) ? path.substr(4) : path;
+}
+
 static wstring uint32asHexString(uint32_t value) {
   WCHAR attr_str[8];
   for (int i = 0; i < 8; ++i) {

--- a/src/main/native/windows/file.h
+++ b/src/main/native/windows/file.h
@@ -34,6 +34,17 @@ bool HasUncPrefix(const char_type* path) {
          path[3] == '\\';
 }
 
+template <typename char_type>
+bool IsDevNull(const char_type* path) {
+  return (path[0] == 'N' || path[0] == 'n') &&
+         (path[1] == 'U' || path[1] == 'u') &&
+         (path[2] == 'L' || path[2] == 'l');
+}
+
+std::wstring AddUncPrefixMaybe(const std::wstring& path);
+
+std::wstring RemoveUncPrefixMaybe(const std::wstring& path);
+
 // Keep in sync with j.c.g.devtools.build.lib.windows.WindowsFileOperations
 enum {
   IS_JUNCTION_YES = 0,

--- a/src/main/native/windows/jni-util.cc
+++ b/src/main/native/windows/jni-util.cc
@@ -15,6 +15,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+#include <algorithm>
 #include <type_traits>  // static_assert
 
 #include "src/main/native/windows/jni-util.h"
@@ -39,6 +40,12 @@ wstring GetJavaWstring(JNIEnv* env, jstring str) {
     result.assign(reinterpret_cast<const WCHAR*>(jstr));
     env->ReleaseStringChars(str, jstr);
   }
+  return result;
+}
+
+std::wstring GetJavaWpath(JNIEnv* env, jstring str) {
+  std::wstring result = GetJavaWstring(env, str);
+  std::replace(result.begin(), result.end(), L'/', L'\\');
   return result;
 }
 

--- a/src/main/native/windows/jni-util.h
+++ b/src/main/native/windows/jni-util.h
@@ -23,6 +23,8 @@ namespace windows {
 
 std::wstring GetJavaWstring(JNIEnv* env, jstring str);
 
+std::wstring GetJavaWpath(JNIEnv* env, jstring str);
+
 }  // namespace windows
 }  // namespace bazel
 

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -203,14 +203,11 @@ void LogErrorWithArgAndValue(const int line, const std::string& msg,
 }
 
 std::wstring AddUncPrefixMaybe(const Path& p) {
-  return bazel::windows::HasUncPrefix(p.Get().c_str())
-             ? p.Get()
-             : (std::wstring(L"\\\\?\\") + p.Get());
+  return bazel::windows::AddUncPrefixMaybe(p.Get());
 }
 
 std::wstring RemoveUncPrefixMaybe(const Path& p) {
-  return bazel::windows::HasUncPrefix(p.Get().c_str()) ? p.Get().substr(4)
-                                                       : p.Get();
+  return bazel::windows::RemoveUncPrefixMaybe(p.Get());
 }
 
 inline bool CreateDirectories(const Path& path) {


### PR DESCRIPTION
In this commit:

- Properly retrieve paths from jstring objects, by
  converting "/" to "\" in paths received from
  Java.

- Add UNC-prefix utils to file.h

- Always add UNC prefix to paths unless they are
  empty or NUL.