### PR TITLE
Windows, JNI: duplicate stdout HANDLE when needed

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/windows/WindowsProcessesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/WindowsProcessesTest.java
@@ -249,6 +249,7 @@ public class WindowsProcessesTest {
             null,
             null,
             null);
+    assertNoProcessError();
 
     byte[] buf = new byte[4];
     assertThat(readStdout(buf, 0, 4)).isEqualTo(4);


### PR DESCRIPTION
When stderr is redirected into stdout, then don't
pass just a copy of stdout's HANDLE, make a proper
duplicate so the subprocess can close the HANDLEs
independently.