### PR TITLE
Windows, JNI: AutoAttributeList owns HANDLE array

### DIFF
--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -690,9 +690,8 @@ int ExecuteDaemon(const string& exe,
   // Create an attribute list.
   wstring werror;
   std::unique_ptr<AutoAttributeList> lpAttributeList;
-  HANDLE handlesToInherit[3] = {devnull, stdout_file, stderr_handle};
-  if (!AutoAttributeList::Create(handlesToInherit, 3, &lpAttributeList,
-                                 &werror)) {
+  if (!AutoAttributeList::Create(devnull, stdout_file, stderr_handle,
+                                 &lpAttributeList, &werror)) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "ExecuteDaemon(" << exe << "): attribute list creation failed: "
         << blaze_util::WstringToString(werror);
@@ -700,13 +699,7 @@ int ExecuteDaemon(const string& exe,
 
   PROCESS_INFORMATION processInfo = {0};
   STARTUPINFOEXA startupInfoEx = {0};
-
-  startupInfoEx.StartupInfo.cb = sizeof(startupInfoEx);
-  startupInfoEx.StartupInfo.hStdInput = devnull;
-  startupInfoEx.StartupInfo.hStdOutput = stdout_file;
-  startupInfoEx.StartupInfo.hStdError = stderr_handle;
-  startupInfoEx.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
-  startupInfoEx.lpAttributeList = *(lpAttributeList.get());
+  lpAttributeList->InitStartupInfoExA(&startupInfoEx);
 
   CmdLine cmdline;
   CreateCommandLine(&cmdline, exe, args_vector);

--- a/src/main/native/windows/util.cc
+++ b/src/main/native/windows/util.cc
@@ -112,7 +112,11 @@ bool AutoAttributeList::Create(HANDLE stdin_h, HANDLE stdout_h, HANDLE stderr_h,
 AutoAttributeList::AutoAttributeList(std::unique_ptr<uint8_t[]>&& data,
                                      HANDLE stdin_h, HANDLE stdout_h,
                                      HANDLE stderr_h)
-  : data_(std::move(data)) {}
+    : data_(std::move(data)) {
+  handles_.stdin_h = stdin_h;
+  handles_.stdout_h = stdout_h;
+  handles_.stderr_h = stderr_h;
+}
 
 AutoAttributeList::~AutoAttributeList() {
   DeleteProcThreadAttributeList(*this);

--- a/src/main/native/windows/util.cc
+++ b/src/main/native/windows/util.cc
@@ -94,10 +94,10 @@ bool AutoAttributeList::Create(HANDLE stdin_h, HANDLE stdout_h, HANDLE stderr_h,
 
   std::unique_ptr<AutoAttributeList> attr_list(
       new AutoAttributeList(std::move(data), stdin_h, stdout_h, stderr_h));
-  static constexpr size_t kHandleCount = 3;
   if (!UpdateProcThreadAttribute(attrs, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
                                  attr_list->handles_.handle_array,
-                                 kHandleCount * sizeof(HANDLE), NULL, NULL)) {
+                                 StdHandles::kHandleCount * sizeof(HANDLE),
+                                 NULL, NULL)) {
     if (error_msg) {
       DWORD err = GetLastError();
       *error_msg = MakeErrorMessage(WSTR(__FILE__), __LINE__,

--- a/src/main/native/windows/util.h
+++ b/src/main/native/windows/util.h
@@ -77,8 +77,9 @@ class AutoAttributeList {
 
  private:
   struct StdHandles {
+    static constexpr size_t kHandleCount = 3;
     union {
-      HANDLE handle_array[3];
+      HANDLE handle_array[kHandleCount];
       struct {
         HANDLE stdin_h;
         HANDLE stdout_h;

--- a/src/main/native/windows/util.h
+++ b/src/main/native/windows/util.h
@@ -66,17 +66,25 @@ class AutoHandle {
 
 class AutoAttributeList {
  public:
-  static bool Create(HANDLE* handles, size_t count,
+  static bool Create(HANDLE stdin_h, HANDLE stdout_h, HANDLE stderr_h,
                      std::unique_ptr<AutoAttributeList>* result,
                      wstring* error_msg = nullptr);
   ~AutoAttributeList();
-  operator LPPROC_THREAD_ATTRIBUTE_LIST() const;
+
+  void InitStartupInfoExA(STARTUPINFOEXA* startup_info) const;
+
+  void InitStartupInfoExW(STARTUPINFOEXW* startup_info) const;
 
  private:
-  AutoAttributeList(uint8_t* data);
+  AutoAttributeList(std::unique_ptr<uint8_t[]>* data,
+                    std::unique_ptr<HANDLE[]>* handles);
   AutoAttributeList(const AutoAttributeList&) = delete;
   AutoAttributeList& operator=(const AutoAttributeList&) = delete;
+
+  operator LPPROC_THREAD_ATTRIBUTE_LIST() const;
+
   std::unique_ptr<uint8_t[]> data_;
+  std::unique_ptr<HANDLE[]> handles_;
 };
 
 #define WSTR1(x) L##x

--- a/src/main/native/windows/util.h
+++ b/src/main/native/windows/util.h
@@ -76,15 +76,26 @@ class AutoAttributeList {
   void InitStartupInfoExW(STARTUPINFOEXW* startup_info) const;
 
  private:
-  AutoAttributeList(std::unique_ptr<uint8_t[]>* data,
-                    std::unique_ptr<HANDLE[]>* handles);
+  struct StdHandles {
+    union {
+      HANDLE handle_array[3];
+      struct {
+        HANDLE stdin_h;
+        HANDLE stdout_h;
+        HANDLE stderr_h;
+      };
+    };
+  };
+
+  AutoAttributeList(std::unique_ptr<uint8_t[]>&& data, HANDLE stdin_h,
+                    HANDLE stdout_h, HANDLE stderr_h);
   AutoAttributeList(const AutoAttributeList&) = delete;
   AutoAttributeList& operator=(const AutoAttributeList&) = delete;
 
   operator LPPROC_THREAD_ATTRIBUTE_LIST() const;
 
   std::unique_ptr<uint8_t[]> data_;
-  std::unique_ptr<HANDLE[]> handles_;
+  StdHandles handles_;
 };
 
 #define WSTR1(x) L##x


### PR DESCRIPTION
Also in this commit:

- AutoAttributeList can initialize a STARTUPINFOEX
  structure (both A and W)