### PR TITLE
Simplify code of getting rules in ExternalPackageUtil.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/repository/ExternalPackageUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/repository/ExternalPackageUtil.java
@@ -15,8 +15,10 @@
 package com.google.devtools.build.lib.repository;
 
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.BuildFileContainsErrorsException;
@@ -43,7 +45,7 @@ public class ExternalPackageUtil {
    */
   @Nullable
   private static List<Rule> getRules(
-      Environment env, boolean returnFirst, Function<Package, Iterable<Rule>> selector)
+      Environment env, boolean returnFirst, Function<Package, List<Rule>> selector)
       throws ExternalPackageException, InterruptedException {
     SkyKey packageLookupKey = PackageLookupValue.key(Label.EXTERNAL_PACKAGE_IDENTIFIER);
     PackageLookupValue packageLookupValue = (PackageLookupValue) env.getValue(packageLookupKey);
@@ -52,7 +54,7 @@ public class ExternalPackageUtil {
     }
     RootedPath workspacePath = packageLookupValue.getRootedPath(Label.EXTERNAL_PACKAGE_IDENTIFIER);
 
-    List<Rule> rules = ImmutableList.of();
+    List<Rule> rules = returnFirst ? ImmutableList.of() : Lists.newArrayList();
     SkyKey workspaceKey = WorkspaceFileValue.key(workspacePath);
     do {
       WorkspaceFileValue value = (WorkspaceFileValue) env.getValue(workspaceKey);
@@ -67,12 +69,12 @@ public class ExternalPackageUtil {
                 Label.EXTERNAL_PACKAGE_IDENTIFIER, "Could not load //external package"),
             Transience.PERSISTENT);
       }
-      Iterable<Rule> results = selector.apply(externalPackage);
-      if (results != null) {
-        rules = ImmutableList.copyOf(results);
-        if (returnFirst && !rules.isEmpty()) {
-          return ImmutableList.of(Iterables.getFirst(results, null));
+      List<Rule> results = selector.apply(externalPackage);
+      if (results != null && !results.isEmpty()) {
+        if (returnFirst) {
+          return ImmutableList.of(Preconditions.checkNotNull(Iterables.getFirst(results, null)));
         }
+        rules.addAll(results);
       }
       workspaceKey = value.next();
     } while (workspaceKey != null);
@@ -89,10 +91,10 @@ public class ExternalPackageUtil {
         getRules(
             env,
             true,
-            new Function<Package, Iterable<Rule>>() {
+            new Function<Package, List<Rule>>() {
               @Nullable
               @Override
-              public Iterable<Rule> apply(Package externalPackage) {
+              public List<Rule> apply(Package externalPackage) {
                 Rule rule = externalPackage.getRule(ruleName);
                 if (rule == null) {
                   return null;


### PR DESCRIPTION
Since we are reading all the iterable contents in the getRules() function anyway,
and we have the single caller of getRules(), which in fact only returns
a single item wrapped into a list,
we can already return List from selector callback.
This way it becomes easier to chek first found rule.

Also, since "rules" is intended to accumulate the rules,
makes no sence to have it immutable.
Change to ArrayList.