### PR TITLE
Decrease remote_timeout default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
@@ -78,7 +78,7 @@ public final class RemoteOptions extends OptionsBase {
 
   @Option(
     name = "remote_timeout",
-    defaultValue = "60",
+    defaultValue = "10",
     documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "The maximum number of seconds to wait for remote execution and cache calls."


### PR DESCRIPTION
A minute long timeout for hitting a remote server seems like a very long
default for this use case. I've arbitrarily decreased it to 10.

In our project we decrease this even more