### PR TITLE
Make default value of flavour in java_proto_common.create_java_lite_p…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/java/JavaProtoCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/java/JavaProtoCommonApi.java
@@ -67,7 +67,7 @@ public interface JavaProtoCommonApi<FileT extends FileApi,
               positional = false,
               named = true,
               type = String.class,
-              defaultValue = "java"
+              defaultValue = "'java'"
           )
       }
   )


### PR DESCRIPTION
…roto_compile_action a string

The default value for flavour was a global object called `java` instead of a string with the value `java`, resulting in a crash if this function was used.