### PR TITLE
Update protobuf and grpc bzl for incompatible changes

### DIFF
--- a/third_party/grpc/build_defs.bzl
+++ b/third_party/grpc/build_defs.bzl
@@ -41,7 +41,7 @@ _java_grpc_gensource = rule(
     attrs = {
         "srcs": attr.label_list(
             mandatory = True,
-            non_empty = True,
+            allow_empty = False,
             providers = ["proto"],
         ),
         "enable_deprecated": attr.bool(
@@ -51,8 +51,7 @@ _java_grpc_gensource = rule(
             default = Label("@com_google_protobuf//:protoc"),
             executable = True,
             cfg = "host",
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
         "_java_plugin": attr.label(
             default = Label("@io_bazel//third_party/grpc:grpc-java-plugin"),

--- a/third_party/protobuf/3.6.1/protobuf.bzl
+++ b/third_party/protobuf/3.6.1/protobuf.bzl
@@ -130,7 +130,7 @@ proto_gen = rule(
         "protoc": attr.label(
             cfg = "host",
             executable = True,
-            single_file = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "plugin": attr.label(

--- a/third_party/protobuf/3.6.1/protobuf.bzl
+++ b/third_party/protobuf/3.6.1/protobuf.bzl
@@ -266,7 +266,7 @@ def internal_gen_well_known_protos_java(srcs):
   Args:
     srcs: the well known protos
   """
-  root = Label("%s//protobuf_java" % (REPOSITORY_NAME)).workspace_root
+  root = Label("%s//protobuf_java" % repository_name()).workspace_root
   pkg = PACKAGE_NAME + "/" if PACKAGE_NAME else ""
   if root == "":
     include = " -I%ssrc " % pkg

--- a/third_party/protobuf/3.6.1/protobuf.bzl
+++ b/third_party/protobuf/3.6.1/protobuf.bzl
@@ -266,7 +266,7 @@ def internal_gen_well_known_protos_java(srcs):
   Args:
     srcs: the well known protos
   """
-  root = Label("%s//protobuf_java" % repository_name()).workspace_root
+  root = Label("%s//protobuf_java" % native.repository_name()).workspace_root
   pkg = PACKAGE_NAME + "/" if PACKAGE_NAME else ""
   if root == "":
     include = " -I%ssrc " % pkg


### PR DESCRIPTION
These deprecates were found with `--all_incompatible_changes` when
running buildifier through bazel.