### PR TITLE
singlejar, Windows: MappedFile allows empty files

### DIFF
--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -103,10 +103,6 @@ class TestWrapperTest(test_base.TestBase):
         '    name = "xml2_test",',
         '    srcs = ["xml2_test.py"],',
         ')',
-        'py_test(',
-        '    name = "slp_test",',
-        '    srcs = ["slp_test.py"],',
-        ')',
     ])
     self.ScratchFile('foo/passing.bat', ['@exit /B 0'], executable=True)
     self.ScratchFile('foo/failing.bat', ['@exit /B 1'], executable=True)
@@ -243,13 +239,6 @@ class TestWrapperTest(test_base.TestBase):
             'import os',
             'with open(os.environ.get("XML_OUTPUT_FILE"), "wt") as f:',
             '  f.write("leave this")'
-        ],
-        executable=True)
-
-    self.ScratchFile(
-        'foo/slp_test.py', [
-            'import time',
-            'time.sleep(2)',
         ],
         executable=True)
 
@@ -554,22 +543,6 @@ class TestWrapperTest(test_base.TestBase):
       xml_contents = [line.strip() for line in f.readlines()]
     self.assertListEqual(xml_contents, ['leave this'])
 
-  def _AssertTimeout(self, flag):
-    exit_code, bazel_testlogs, stderr = self.RunBazel(
-        ['info', 'bazel-testlogs'])
-    self.AssertExitCode(exit_code, 0, stderr)
-
-    bazel_testlogs = bazel_testlogs[0]
-    exit_code, _, stderr = self.RunBazel([
-        'test',
-        '//foo:slp_test',
-        '-t-',
-        '--test_timeout=1',
-        flag,
-    ])
-    self.AssertExitCode(exit_code, 3, stderr)
-
-
   def testTestExecutionWithTestSetupSh(self):
     self._CreateMockWorkspace()
     flag = '--noincompatible_windows_native_test_wrapper'
@@ -605,7 +578,6 @@ class TestWrapperTest(test_base.TestBase):
     self._AssertUndeclaredOutputsAnnotations(flag)
     self._AssertXmlGeneration(flag)
     self._AssertXmlGeneratedByTestIsRetained(flag)
-    self._AssertTimeout(flag)
 
   def testTestExecutionWithTestWrapperExe(self):
     self._CreateMockWorkspace()
@@ -640,7 +612,6 @@ class TestWrapperTest(test_base.TestBase):
     self._AssertUndeclaredOutputsAnnotations(flag)
     self._AssertXmlGeneration(flag)
     self._AssertXmlGeneratedByTestIsRetained(flag)
-    self._AssertTimeout(flag)
 
 
 if __name__ == '__main__':

--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -103,6 +103,10 @@ class TestWrapperTest(test_base.TestBase):
         '    name = "xml2_test",',
         '    srcs = ["xml2_test.py"],',
         ')',
+        'py_test(',
+        '    name = "slp_test",',
+        '    srcs = ["slp_test.py"],',
+        ')',
     ])
     self.ScratchFile('foo/passing.bat', ['@exit /B 0'], executable=True)
     self.ScratchFile('foo/failing.bat', ['@exit /B 1'], executable=True)
@@ -239,6 +243,13 @@ class TestWrapperTest(test_base.TestBase):
             'import os',
             'with open(os.environ.get("XML_OUTPUT_FILE"), "wt") as f:',
             '  f.write("leave this")'
+        ],
+        executable=True)
+
+    self.ScratchFile(
+        'foo/slp_test.py', [
+            'import time',
+            'time.sleep(2)',
         ],
         executable=True)
 
@@ -543,6 +554,22 @@ class TestWrapperTest(test_base.TestBase):
       xml_contents = [line.strip() for line in f.readlines()]
     self.assertListEqual(xml_contents, ['leave this'])
 
+  def _AssertTimeout(self, flag):
+    exit_code, bazel_testlogs, stderr = self.RunBazel(
+        ['info', 'bazel-testlogs'])
+    self.AssertExitCode(exit_code, 0, stderr)
+
+    bazel_testlogs = bazel_testlogs[0]
+    exit_code, _, stderr = self.RunBazel([
+        'test',
+        '//foo:slp_test',
+        '-t-',
+        '--test_timeout=1',
+        flag,
+    ])
+    self.AssertExitCode(exit_code, 3, stderr)
+
+
   def testTestExecutionWithTestSetupSh(self):
     self._CreateMockWorkspace()
     flag = '--noincompatible_windows_native_test_wrapper'
@@ -578,6 +605,7 @@ class TestWrapperTest(test_base.TestBase):
     self._AssertUndeclaredOutputsAnnotations(flag)
     self._AssertXmlGeneration(flag)
     self._AssertXmlGeneratedByTestIsRetained(flag)
+    self._AssertTimeout(flag)
 
   def testTestExecutionWithTestWrapperExe(self):
     self._CreateMockWorkspace()
@@ -612,6 +640,7 @@ class TestWrapperTest(test_base.TestBase):
     self._AssertUndeclaredOutputsAnnotations(flag)
     self._AssertXmlGeneration(flag)
     self._AssertXmlGeneratedByTestIsRetained(flag)
+    self._AssertTimeout(flag)
 
 
 if __name__ == '__main__':

--- a/src/tools/singlejar/mapped_file_windows.inc
+++ b/src/tools/singlejar/mapped_file_windows.inc
@@ -50,8 +50,7 @@ bool MappedFile::Open(const std::string& path) {
   size_t fileSize = temp.QuadPart;
 
   if (fileSize == 0) {
-    // This is where Windows implementation differs from POSIX's.
-    // CreateFileMapping cannot map empty file:
+    // Handle empty files specially, because CreateFileMapping cannot map them:
     //
     // From
     // https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-createfilemappinga
@@ -59,14 +58,10 @@ bool MappedFile::Open(const std::string& path) {
     // An attempt to map a file with a length of 0 (zero) fails with an error
     // code of ERROR_FILE_INVALID. Applications should test for files with a
     // length of 0 (zero) and reject those files.
-    //
-    // Since the test at //src/tools/singlerjar/input_jar_bad_jar_test expects
-    // empty file to fail anyway, returning error here shouldn't be a problem.
-    diag_warn("%s:%d: Windows MappedFile cannot handle empty file (%s)",
-              __FILE__, __LINE__, path.c_str());
-    _close(fd_);
-    fd_ = -1;
-    return false;
+    mapped_start_ = nullptr;
+    mapped_end_ = nullptr;
+    hMapFile_ = INVALID_HANDLE_VALUE;
+    return true;
   }
 
   hMapFile_ = ::CreateFileMapping(
@@ -107,10 +102,14 @@ bool MappedFile::Open(const std::string& path) {
 
 void MappedFile::Close() {
   if (is_open()) {
-    ::UnmapViewOfFile(mapped_start_);
-    ::CloseHandle(hMapFile_);
+    if (mapped_start_) {
+      ::UnmapViewOfFile(mapped_start_);
+    }
+    if (hMapFile_ != INVALID_HANDLE_VALUE) {
+      ::CloseHandle(hMapFile_);
+      hMapFile_ = INVALID_HANDLE_VALUE;
+    }
     _close(fd_);
-    hMapFile_ = INVALID_HANDLE_VALUE;
     fd_ = -1;
     mapped_start_ = mapped_end_ = nullptr;
   }

--- a/src/tools/singlejar/output_jar_shell_test.sh
+++ b/src/tools/singlejar/output_jar_shell_test.sh
@@ -69,7 +69,9 @@ function test_new_entries() {
 # Regression test https://github.com/bazelbuild/bazel/issues/6820
 function test_empty_resource_file() {
   local -r out_jar="${TEST_TMPDIR}/out.jar"
-  "$singlejar" --output "$out_jar" --resources /dev/null
+  local -r empty="${TEST_TMPDIR}/empty"
+  echo -n > "$empty"
+  "$singlejar" --output "$out_jar" --resources $empty
 }
 
 run_suite "Misc shell tests"

--- a/src/tools/singlejar/output_jar_shell_test.sh
+++ b/src/tools/singlejar/output_jar_shell_test.sh
@@ -66,6 +66,12 @@ function test_new_entries() {
     { echo "build-data.properties is not readable" >&2; exit 1; }
 }
 
+# Regression test https://github.com/bazelbuild/bazel/issues/6820
+function test_empty_resource_file() {
+  local -r out_jar="${TEST_TMPDIR}/out.jar"
+  "$singlejar" --output "$out_jar" --resources /dev/null
+}
+
 run_suite "Misc shell tests"
 #!/bin/bash
 


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/6820