### PR TITLE
Fixed unresolved `#bazelrc` labels in `user-manual.html`. 

### DIFF
--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -74,7 +74,7 @@ Package path elements may be specified in three formats:
 </ol>
 <p>
   If you use a non-default package path, we recommend that you specify
-  it in your <a href='#bazelrc'>Bazel configuration file</a> for
+  it in your <a href='guide.html#bazelrc'>Bazel configuration file</a> for
   convenience.
 </p>
 <p>
@@ -1301,7 +1301,7 @@ either to the terminal, or to additional log files.
   regression tests).  In the former case, the result information is
   very useful whereas in the latter case it is less so.  As with all
   options, this can be specified implicitly via
-  the <a href='#bazelrc'><code>.bazelrc</code></a> file.
+  the <a href='guide.html#bazelrc'><code>.bazelrc</code></a> file.
 </p>
 <p>
   The files are printed so as to make it easy to copy and paste the
@@ -1617,7 +1617,7 @@ echo "STABLE_USER_NAME $USER"
   In particular, the following options are strongly recommended:
 </p>
 <ul>
-  <li><a href='#bazelrc'><code class='flag'>--bazelrc=/dev/null</code></a></li>
+  <li><a href='guide.html#bazelrc'><code class='flag'>--bazelrc=/dev/null</code></a></li>
   <li><a href='#flag--keep_state_after_build'><code class='flag'>--nokeep_state_after_build</code></a></li>
 </ul>
 


### PR DESCRIPTION
That's it.

Part of `guide.html` was moved to `user-manual.html` since 0.19.2..  and some links became broken.

This patch fixed that.

Kind regards,
Vladimir.