### PR TITLE
Improved handling of corrupted external git repositories (`git_repository`, `new_git_repository`).

### DIFF
--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -53,6 +53,7 @@ def _clone_or_update(ctx):
 set -ex
 ( cd {working_dir} &&
     if ! ( cd '{dir_link}' && [[ "$(git rev-parse --git-dir)" == '.git' ]] ) >/dev/null 2>&1; then
+      cd {working_dir}
       rm -rf '{directory}' '{dir_link}'
       git clone {shallow} '{remote}' '{directory}' || git clone '{remote}' '{directory}'
     fi


### PR DESCRIPTION
When we notice broken repository, we remove the directory and fetch it again. Unfortunately, in Windows one can't simply delete current directory. This patch shall fix it.