### PR TITLE
[Remote Cache] Don't delete tree artifacts on failure

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -265,7 +265,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
           execRoot.getRelative(file.getPath()).delete();
         }
         for (OutputDirectory directory : result.getOutputDirectoriesList()) {
-          FileSystemUtils.deleteTree(execRoot.getRelative(directory.getPath()));
+          FileSystemUtils.deleteTreesBelow(execRoot.getRelative(directory.getPath()));
         }
         if (outErr != null) {
           outErr.getOutputPath().delete();

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -265,6 +265,8 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
           execRoot.getRelative(file.getPath()).delete();
         }
         for (OutputDirectory directory : result.getOutputDirectoriesList()) {
+          // Only delete the directories below the output directories because the output
+          // directories will not be re-created
           FileSystemUtils.deleteTreesBelow(execRoot.getRelative(directory.getPath()));
         }
         if (outErr != null) {

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -611,6 +611,31 @@ public class AbstractRemoteActionCacheTests {
   }
 
   @Test
+  public void downloadFailureMaintainsDirectories() throws Exception {
+    DefaultRemoteActionCache cache = newTestCache();
+    Tree tree = Tree.newBuilder().setRoot(Directory.newBuilder()).build();
+    Digest treeDigest = cache.addContents(tree.toByteArray());
+    Digest outputFileDigest = cache
+        .addException("outputdir/outputfile", new IOException("download failed"));
+    Digest otherFileDigest = cache.addContents("otherfile");
+
+    ActionResult.Builder result = ActionResult.newBuilder();
+    result.addOutputDirectoriesBuilder().setPath("outputdir").setTreeDigest(treeDigest);
+    result.addOutputFiles(
+            OutputFile.newBuilder().setPath("outputdir/outputfile").setDigest(outputFileDigest));
+    result.addOutputFiles(OutputFile.newBuilder().setPath("otherfile").setDigest(otherFileDigest));
+    try {
+      cache.download(result.build(), execRoot, null);
+      fail("Expected exception");
+    } catch (IOException expected) {
+      assertThat(cache.getNumFailedDownloads()).isEqualTo(1);
+      assertThat(execRoot.getRelative("outputdir").exists()).isTrue();
+      assertThat(execRoot.getRelative("outputdir/outputfile").exists()).isFalse();
+      assertThat(execRoot.getRelative("otherfile").exists()).isFalse();
+    }
+  }
+
+  @Test
   public void onErrorWaitForRemainingDownloadsToComplete() throws Exception {
     // If one or more downloads of output files / directories fail then the code should
     // wait for all downloads to have been completed before it tries to clean up partially


### PR DESCRIPTION
Previously if a remote cache request failed, bazel would cleanup all
directories that were marked as outputs for the action. These
directories wouldn't end up being re-created by bazel, and could lead to
failures if the actions didn't create the directories themselves. With
this patch bazel deletes all output files, and the child directories of
all output directories.

Fixes https://github.com/bazelbuild/bazel/issues/6260