### PR TITLE
Send and receive work requests via proxy and multiplexer

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
@@ -157,6 +157,8 @@ public class ExecutionRequirements {
   /** If an action supports running in persistent worker mode. */
   public static final String SUPPORTS_WORKERS = "supports-workers";
 
+  public static final String SUPPORTS_MULTIPLEX_WORKERS = "supports-multiplex-workers";
+
   public static final ImmutableMap<String, String> WORKER_MODE_ENABLED =
       ImmutableMap.of(SUPPORTS_WORKERS, "1");
 

--- a/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
@@ -73,6 +73,14 @@ public final class Spawns {
   }
 
   /**
+   * Returns whether a Spawn claims to support being executed with the persistent multiplex worker strategy
+   * according to its execution info tags.
+   */
+  public static boolean supportsMultiplexWorkers(Spawn spawn) {
+    return "1".equals(spawn.getExecutionInfo().get(ExecutionRequirements.SUPPORTS_MULTIPLEX_WORKERS));
+  }
+
+  /**
    * Parse the timeout key in the spawn execution info, if it exists. Otherwise, return -1.
    */
   public static Duration getTimeout(Spawn spawn) throws ExecException {

--- a/src/main/java/com/google/devtools/build/lib/worker/Worker.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/Worker.java
@@ -172,8 +172,9 @@ class Worker {
     return WorkResponse.parseDelimitedFrom(recordingStream);
   }
 
-  RecordingInputStream getRecordingStream() {
-    return recordingStream;
+  String getRecordingStreamMessage() {
+    recordingStream.readRemaining();
+    return recordingStream.getRecordedDataAsString();
   }
 
   public void prepareExecution(

--- a/src/main/java/com/google/devtools/build/lib/worker/Worker.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/Worker.java
@@ -41,10 +41,22 @@ import java.util.SortedMap;
  * class.
  */
 class Worker {
-  private final WorkerKey workerKey;
-  private final int workerId;
-  private final Path workDir;
-  private final Path logFile;
+  /**
+   * An unique identifier of the work process.
+   */
+  protected final WorkerKey workerKey;
+  /**
+   * An unique ID of the worker. It will be used in WorkRequest and WorkResponse as well.
+   */
+  protected final int workerId;
+  /**
+   * The execution root of the worker.
+   */
+  protected final Path workDir;
+  /**
+   * The path of the log file.
+   */
+  protected final Path logFile;
 
   private Subprocess process;
   private Thread shutdownHook;

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
@@ -62,6 +62,8 @@ final class WorkerFactory extends BaseKeyedPooledObjectFactory<WorkerKey, Worker
     if (sandboxed) {
       Path workDir = getSandboxedWorkerPath(key, workerId);
       worker = new SandboxedWorker(key, workerId, workDir, logFile);
+    } else if (key.proxied()) {
+      worker = new WorkerProxy(key, workerId, key.getExecRoot(), logFile);
     } else {
       worker = new Worker(key, workerId, key.getExecRoot(), logFile);
     }

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
@@ -62,7 +62,7 @@ final class WorkerFactory extends BaseKeyedPooledObjectFactory<WorkerKey, Worker
     if (sandboxed) {
       Path workDir = getSandboxedWorkerPath(key, workerId);
       worker = new SandboxedWorker(key, workerId, workDir, logFile);
-    } else if (key.proxied()) {
+    } else if (key.getProxied()) {
       worker = new WorkerProxy(key, workerId, key.getExecRoot(), logFile, WorkerMultiplexerManager.getInstance(key.hashCode()));
     } else {
       worker = new Worker(key, workerId, key.getExecRoot(), logFile);

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
@@ -63,7 +63,7 @@ final class WorkerFactory extends BaseKeyedPooledObjectFactory<WorkerKey, Worker
       Path workDir = getSandboxedWorkerPath(key, workerId);
       worker = new SandboxedWorker(key, workerId, workDir, logFile);
     } else if (key.proxied()) {
-      worker = new WorkerProxy(key, workerId, key.getExecRoot(), logFile);
+      worker = new WorkerProxy(key, workerId, key.getExecRoot(), logFile, WorkerMultiplexerManager.getInstance(key.hashCode()));
     } else {
       worker = new Worker(key, workerId, key.getExecRoot(), logFile);
     }

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerKey.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerKey.java
@@ -42,6 +42,10 @@ final class WorkerKey {
   private final HashCode workerFilesCombinedHash;
   private final SortedMap<PathFragment, HashCode> workerFilesWithHashes;
   private final boolean mustBeSandboxed;
+  /**
+   * A WorkerProxy will be instantiated if true, instantiate a regular Worker if false.
+   */
+  private final boolean proxied;
 
   WorkerKey(
       List<String> args,
@@ -50,14 +54,24 @@ final class WorkerKey {
       String mnemonic,
       HashCode workerFilesCombinedHash,
       SortedMap<PathFragment, HashCode> workerFilesWithHashes,
-      boolean mustBeSandboxed) {
+      boolean mustBeSandboxed,
+      boolean proxied) {
+    /** Build options. */
     this.args = ImmutableList.copyOf(Preconditions.checkNotNull(args));
+    /** Environment variables. */
     this.env = ImmutableMap.copyOf(Preconditions.checkNotNull(env));
+    /** Execution root of Bazel process. */
     this.execRoot = Preconditions.checkNotNull(execRoot);
+    /** Mnemonic of the worker. */
     this.mnemonic = Preconditions.checkNotNull(mnemonic);
+    /** One combined hash code for all files. */
     this.workerFilesCombinedHash = Preconditions.checkNotNull(workerFilesCombinedHash);
+    /** Worker files with the corresponding hash code. */
     this.workerFilesWithHashes = Preconditions.checkNotNull(workerFilesWithHashes);
+    /** Set it to true if this job should be run in sandbox. */
     this.mustBeSandboxed = mustBeSandboxed;
+    /** Set it to true if this job should be run with WorkerProxy. */
+    this.proxied = proxied;
   }
 
   public ImmutableList<String> getArgs() {
@@ -86,6 +100,10 @@ final class WorkerKey {
 
   public boolean mustBeSandboxed() {
     return mustBeSandboxed;
+  }
+
+  public boolean proxied() {
+    return proxied;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerKey.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerKey.java
@@ -42,9 +42,7 @@ final class WorkerKey {
   private final HashCode workerFilesCombinedHash;
   private final SortedMap<PathFragment, HashCode> workerFilesWithHashes;
   private final boolean mustBeSandboxed;
-  /**
-   * A WorkerProxy will be instantiated if true, instantiate a regular Worker if false.
-   */
+  /** A WorkerProxy will be instantiated if true, instantiate a regular Worker if false. */
   private final boolean proxied;
 
   WorkerKey(
@@ -74,35 +72,43 @@ final class WorkerKey {
     this.proxied = proxied;
   }
 
+  /** Getter function for variable args. */
   public ImmutableList<String> getArgs() {
     return args;
   }
 
+  /** Getter function for variable env. */
   public ImmutableMap<String, String> getEnv() {
     return env;
   }
 
+  /** Getter function for variable execRoot. */
   public Path getExecRoot() {
     return execRoot;
   }
 
+  /** Getter function for variable mnemonic. */
   public String getMnemonic() {
     return mnemonic;
   }
 
+  /** Getter function for variable workerFilesCombinedHash. */
   public HashCode getWorkerFilesCombinedHash() {
     return workerFilesCombinedHash;
   }
 
+  /** Getter function for variable workerFilesWithHashes. */
   public SortedMap<PathFragment, HashCode> getWorkerFilesWithHashes() {
     return workerFilesWithHashes;
   }
 
+  /** Getter function for variable mustBeSandboxed. */
   public boolean mustBeSandboxed() {
     return mustBeSandboxed;
   }
 
-  public boolean proxied() {
+  /** Getter function for variable proxied. */
+  public boolean getProxied() {
     return proxied;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -1,0 +1,211 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.worker;
+
+import com.google.devtools.build.lib.shell.Subprocess;
+import com.google.devtools.build.lib.shell.SubprocessBuilder;
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
+import com.google.devtools.build.lib.vfs.Path;
+import java.io.File;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+
+/** An intermediate worker that sends request and receives response from the worker processes. */
+public class WorkerMultiplexer extends Thread {
+  /**
+   * WorkerMultiplexer is running as a thread on its own. When worker process
+   * returns the WorkResponse, it is stored in this map and wait for
+   * WorkerProxy to retrieve the response.
+   */
+  private Map<Integer, InputStream> workerProcessResponse;
+  /**
+   * A semaphore to protect workerProcessResponse object.
+   */
+  private Semaphore semWorkerProcessResponse;
+  /**
+   * After sending the WorkRequest, WorkerProxy will wait on a semaphore to be
+   * released. WorkerMultiplexer is responsible to release the corresponding
+   * semaphore in order to signal WorkerProxy that the WorkerResponse has been
+   * received.
+   */
+  private Map<Integer, Semaphore> responseChecker;
+  /**
+   * A semaphore to protect responseChecker object.
+   */
+  private Semaphore semResponseChecker;
+  /**
+   * The worker process that this WorkerMultiplexer should be talking to.
+   */
+  private Subprocess process;
+
+  private Thread shutdownHook;
+  private Integer workerHash;
+
+  WorkerMultiplexer(Integer workerHash) {
+    semWorkerProcessResponse = new Semaphore(1);
+    semResponseChecker = new Semaphore(1);
+    responseChecker = new HashMap<>();
+    workerProcessResponse = new HashMap<>();
+    this.workerHash = workerHash;
+
+    final WorkerMultiplexer self = this;
+    this.shutdownHook =
+      new Thread(
+        () -> {
+          try {
+            self.shutdownHook = null;
+            self.destroyMultiplexer();
+          } finally {
+            // We can't do anything here.
+          }
+        });
+    Runtime.getRuntime().addShutdownHook(shutdownHook);
+  }
+
+  /**
+   * Only start one worker process for each WorkerMultiplexer, if it hasn't.
+   */
+  public synchronized void createProcess(WorkerKey workerKey, Path workDir, Path logFile) throws IOException {
+    if (this.process == null) {
+      List<String> args = workerKey.getArgs();
+      File executable = new File(args.get(0));
+      if (!executable.isAbsolute() && executable.getParent() != null) {
+        args = new ArrayList<>(args);
+        args.set(0, new File(workDir.getPathFile(), args.get(0)).getAbsolutePath());
+      }
+      SubprocessBuilder processBuilder = new SubprocessBuilder();
+      processBuilder.setArgv(args);
+      processBuilder.setWorkingDirectory(workDir.getPathFile());
+      processBuilder.setStderr(logFile.getPathFile());
+      processBuilder.setEnv(workerKey.getEnv());
+      this.process = processBuilder.start();
+    }
+    if (!this.isAlive()) {
+      this.start();
+    }
+  }
+
+  public synchronized void destroyMultiplexer() {
+    if (shutdownHook != null) {
+      Runtime.getRuntime().removeShutdownHook(shutdownHook);
+    }
+    if (this.process != null) {
+      destroyProcess(this.process);
+    }
+  }
+
+  private void destroyProcess(Subprocess process) {
+    boolean wasInterrupted = false;
+    try {
+      process.destroy();
+      while (true) {
+        try {
+          process.waitFor();
+          return;
+        } catch (InterruptedException ie) {
+          wasInterrupted = true;
+        }
+      }
+    } finally {
+      // Read this for detailed explanation: http://www.ibm.com/developerworks/library/j-jtp05236/
+      if (wasInterrupted) {
+        Thread.currentThread().interrupt(); // preserve interrupted status
+      }
+    }
+  }
+
+  public boolean isProcessAlive() {
+    return !this.process.finished();
+  }
+
+  /**
+   * Pass the WorkRequest to worker process.
+   */
+  public synchronized void putRequest(byte[] request) throws IOException {
+    OutputStream stdin = process.getOutputStream();
+    stdin.write(request);
+    stdin.flush();
+  }
+
+  /**
+   * A WorkerProxy waits on a semaphore for the WorkResponse returned from worker process.
+   */
+  public InputStream getResponse(Integer workerId) throws InterruptedException {
+    semResponseChecker.acquire();
+    Semaphore waitForResponse = responseChecker.get(workerId);
+    semResponseChecker.release();
+
+    // If there is a compilation error, the semaphore will throw InterruptedException.
+    waitForResponse.acquire();
+
+    semWorkerProcessResponse.acquire();
+    InputStream response = workerProcessResponse.get(workerId);
+    semWorkerProcessResponse.release();
+    return response;
+  }
+
+  /**
+   * Reset the map that indicates if the WorkResponses have been returned.
+   */
+  public void resetResponseChecker(Integer workerId) throws InterruptedException {
+    semResponseChecker.acquire();
+    responseChecker.put(workerId, new Semaphore(0));
+    semResponseChecker.release();
+  }
+
+  /**
+   * When it gets a WorkResponse from worker process, put that WorkResponse in
+   * workerProcessResponse and signal responseChecker.
+   */
+  private void waitResponse() throws InterruptedException, IOException {
+    InputStream stdout = process.getInputStream();
+    WorkResponse parsedResponse = WorkResponse.parseDelimitedFrom(stdout);
+
+    if (parsedResponse == null) return;
+
+    Integer workerId = parsedResponse.getRequestId();
+    ByteArrayOutputStream tempOs = new ByteArrayOutputStream();
+    parsedResponse.writeDelimitedTo(tempOs);
+
+    semWorkerProcessResponse.acquire();
+    workerProcessResponse.put(workerId, new ByteArrayInputStream(tempOs.toByteArray()));
+    semWorkerProcessResponse.release();
+
+    semResponseChecker.acquire();
+    responseChecker.get(workerId).release();
+    semResponseChecker.release();
+  }
+
+  /**
+   * A multiplexer thread that listens to the WorkResponses from worker process.
+   */
+  public void run() {
+    while (!this.interrupted()) {
+      try {
+        waitResponse();
+      } catch (Exception e) {
+        // We can't do anything here.
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -59,14 +59,12 @@ public class WorkerMultiplexer extends Thread {
   private Subprocess process;
 
   private Thread shutdownHook;
-  private Integer workerHash;
 
-  WorkerMultiplexer(Integer workerHash) {
+  WorkerMultiplexer() {
     semWorkerProcessResponse = new Semaphore(1);
     semResponseChecker = new Semaphore(1);
     responseChecker = new HashMap<>();
     workerProcessResponse = new HashMap<>();
-    this.workerHash = workerHash;
 
     final WorkerMultiplexer self = this;
     this.shutdownHook =

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -29,9 +29,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
+import java.util.logging.Logger;
 
 /** An intermediate worker that sends request and receives response from the worker processes. */
 public class WorkerMultiplexer extends Thread {
+  private static final Logger logger = Logger.getLogger(WorkerMultiplexer.class.getName());
   /**
    * WorkerMultiplexer is running as a thread on its own. When worker process
    * returns the WorkResponse, it is stored in this map and wait for
@@ -170,8 +172,10 @@ public class WorkerMultiplexer extends Thread {
       try {
         waitResponse();
       } catch (Exception e) {
-        // We can't do anything here.
+        logger.warning("Exception was caught while waiting for worker response. "
+            + "It could because the multiplexer was interrupted or the worker returned unparseable response.");
       }
     }
+    logger.warning("Multiplexer thread has been terminated.");
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -148,10 +148,7 @@ public class WorkerMultiplexer extends Thread {
    * workerProcessResponse and signal responseChecker.
    */
   private void waitResponse() throws InterruptedException, IOException {
-    InputStream stdout = process.getInputStream();
-    WorkResponse parsedResponse = WorkResponse.parseDelimitedFrom(stdout);
-
-    if (parsedResponse == null) return;
+    WorkResponse parsedResponse = WorkResponse.parseDelimitedFrom(process.getInputStream());
 
     Integer workerId = parsedResponse.getRequestId();
     ByteArrayOutputStream tempOs = new ByteArrayOutputStream();

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -150,6 +150,8 @@ public class WorkerMultiplexer extends Thread {
   private void waitResponse() throws InterruptedException, IOException {
     WorkResponse parsedResponse = WorkResponse.parseDelimitedFrom(process.getInputStream());
 
+    if (parsedResponse == null) return;
+
     Integer workerId = parsedResponse.getRequestId();
     ByteArrayOutputStream tempOs = new ByteArrayOutputStream();
     parsedResponse.writeDelimitedTo(tempOs);

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -38,9 +38,7 @@ public class WorkerMultiplexer extends Thread {
    * WorkerProxy to retrieve the response.
    */
   private Map<Integer, InputStream> workerProcessResponse;
-  /**
-   * A semaphore to protect workerProcessResponse object.
-   */
+  /** A semaphore to protect workerProcessResponse object. */
   private Semaphore semWorkerProcessResponse;
   /**
    * After sending the WorkRequest, WorkerProxy will wait on a semaphore to be
@@ -49,13 +47,9 @@ public class WorkerMultiplexer extends Thread {
    * received.
    */
   private Map<Integer, Semaphore> responseChecker;
-  /**
-   * A semaphore to protect responseChecker object.
-   */
+  /** A semaphore to protect responseChecker object. */
   private Semaphore semResponseChecker;
-  /**
-   * The worker process that this WorkerMultiplexer should be talking to.
-   */
+  /** The worker process that this WorkerMultiplexer should be talking to. */
   private Subprocess process;
 
   WorkerMultiplexer() {
@@ -67,9 +61,7 @@ public class WorkerMultiplexer extends Thread {
     final WorkerMultiplexer self = this;
   }
 
-  /**
-   * Only start one worker process for each WorkerMultiplexer, if it hasn't.
-   */
+  /** Only start one worker process for each WorkerMultiplexer, if it hasn't. */
   public synchronized void createProcess(WorkerKey workerKey, Path workDir, Path logFile) throws IOException {
     if (this.process == null) {
       List<String> args = workerKey.getArgs();
@@ -120,24 +112,20 @@ public class WorkerMultiplexer extends Thread {
     return !this.process.finished();
   }
 
-  /**
-   * Pass the WorkRequest to worker process.
-   */
+  /** Pass the WorkRequest to worker process. */
   public synchronized void putRequest(byte[] request) throws IOException {
     OutputStream stdin = process.getOutputStream();
     stdin.write(request);
     stdin.flush();
   }
 
-  /**
-   * A WorkerProxy waits on a semaphore for the WorkResponse returned from worker process.
-   */
+  /** A WorkerProxy waits on a semaphore for the WorkResponse returned from worker process. */
   public InputStream getResponse(Integer workerId) throws InterruptedException {
     semResponseChecker.acquire();
     Semaphore waitForResponse = responseChecker.get(workerId);
     semResponseChecker.release();
 
-    // If there is a compilation error, the semaphore will throw InterruptedException.
+    // The semaphore will throw InterruptedException when the process is terminated.
     waitForResponse.acquire();
 
     semWorkerProcessResponse.acquire();
@@ -146,9 +134,7 @@ public class WorkerMultiplexer extends Thread {
     return response;
   }
 
-  /**
-   * Reset the map that indicates if the WorkResponses have been returned.
-   */
+  /** Reset the map that indicates if the WorkResponses have been returned. */
   public void resetResponseChecker(Integer workerId) throws InterruptedException {
     semResponseChecker.acquire();
     responseChecker.put(workerId, new Semaphore(0));
@@ -178,9 +164,7 @@ public class WorkerMultiplexer extends Thread {
     semResponseChecker.release();
   }
 
-  /**
-   * A multiplexer thread that listens to the WorkResponses from worker process.
-   */
+  /** A multiplexer thread that listens to the WorkResponses from worker process. */
   public void run() {
     while (!this.interrupted()) {
       try {

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -58,8 +58,6 @@ public class WorkerMultiplexer extends Thread {
    */
   private Subprocess process;
 
-  private Thread shutdownHook;
-
   WorkerMultiplexer() {
     semWorkerProcessResponse = new Semaphore(1);
     semResponseChecker = new Semaphore(1);
@@ -67,17 +65,6 @@ public class WorkerMultiplexer extends Thread {
     workerProcessResponse = new HashMap<>();
 
     final WorkerMultiplexer self = this;
-    this.shutdownHook =
-      new Thread(
-        () -> {
-          try {
-            self.shutdownHook = null;
-            self.destroyMultiplexer();
-          } finally {
-            // We can't do anything here.
-          }
-        });
-    Runtime.getRuntime().addShutdownHook(shutdownHook);
   }
 
   /**
@@ -104,9 +91,6 @@ public class WorkerMultiplexer extends Thread {
   }
 
   public synchronized void destroyMultiplexer() {
-    if (shutdownHook != null) {
-      Runtime.getRuntime().removeShutdownHook(shutdownHook);
-    }
     if (this.process != null) {
       destroyProcess(this.process);
     }

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -63,6 +63,8 @@ public class WorkerMultiplexer extends Thread {
   private RecordingInputStream recordingStream;
   /** If worker process returns null, return null to WorkerProxy and discard all the responses. */
   private boolean isNull;
+  /** A flag to stop multiplexer thread. */
+  private boolean isInterrupted;
 
   WorkerMultiplexer() {
     semWorkerProcessResponse = new Semaphore(1);
@@ -71,6 +73,7 @@ public class WorkerMultiplexer extends Thread {
     workerProcessResponse = new HashMap<>();
     isUnparseable = false;
     isNull = false;
+    isInterrupted = false;
 
     final WorkerMultiplexer self = this;
   }
@@ -100,6 +103,7 @@ public class WorkerMultiplexer extends Thread {
     if (this.process != null) {
       destroyProcess(this.process);
     }
+    isInterrupted = true;
   }
 
   private void destroyProcess(Subprocess process) {
@@ -193,7 +197,7 @@ public class WorkerMultiplexer extends Thread {
 
   /** A multiplexer thread that listens to the WorkResponse from worker process. */
   public void run() {
-    while (!this.interrupted()) {
+    while (!isInterrupted) {
       try {
         waitResponse();
       } catch (IOException e) {

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -142,6 +142,14 @@ public class WorkerMultiplexer extends Thread {
     Semaphore waitForResponse = responseChecker.get(workerId);
     semResponseChecker.release();
 
+    if (waitForResponse == null) {
+      /**
+       * If multiplexer is interrupted when WorkerProxy is trying to send request,
+       * request is not sent so no need to wait for response.
+       */
+      return null;
+    }
+
     // The semaphore will throw InterruptedException when the multiplexer is terminated.
     waitForResponse.acquire();
 

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManager.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManager.java
@@ -1,0 +1,75 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.worker;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+
+/**
+ * An intermediate worker that sends request and receives response from the
+ * worker processes.
+ */
+public class WorkerMultiplexerManager {
+  /**
+   * There should only be one WorkerMultiplexer corresponding to workers with
+   * the same mnemonic. If the WorkerMultiplexer has been constructed, other
+   * workers should point to the same one. The hash of WorkerKey is used as
+   * key.
+   */
+  private static Map<Integer, WorkerMultiplexer> multiplexerInstance = new HashMap<>();
+  /**
+   * An accumulator of how many WorkerProxies are referencing a particular
+   * WorkerMultiplexer.
+   */
+  private static Map<Integer, Integer> multiplexerRefCount = new HashMap<>();
+  /**
+   * A semaphore to protect multiplexerInstance and multiplexerRefCount objects.
+   */
+  private static Semaphore semMultiplexer = new Semaphore(1);
+
+  /**
+   * Returns a WorkerMultiplexer instance to WorkerProxy. WorkerProxies with the
+   * same workerHash talk to the same WorkerMultiplexer. Also, record how many
+   * WorkerProxies are talking to this WorkerMultiplexer.
+   */
+  public static WorkerMultiplexer getInstance(Integer workerHash) throws InterruptedException {
+    semMultiplexer.acquire();
+    if (!multiplexerInstance.containsKey(workerHash)) {
+      multiplexerInstance.put(workerHash, new WorkerMultiplexer(workerHash));
+      multiplexerRefCount.put(workerHash, 0);
+    }
+    multiplexerRefCount.put(workerHash, multiplexerRefCount.get(workerHash) + 1);
+    WorkerMultiplexer workerMultiplexer = multiplexerInstance.get(workerHash);
+    semMultiplexer.release();
+    return workerMultiplexer;
+  }
+
+  /**
+   * Remove the WorkerMultiplexer instance and reference count since it is no
+   * longer in use.
+   */
+  public static void removeInstance(Integer workerHash) throws InterruptedException {
+    semMultiplexer.acquire();
+    multiplexerRefCount.put(workerHash, multiplexerRefCount.get(workerHash) - 1);
+    if (multiplexerRefCount.get(workerHash) == 0) {
+      multiplexerInstance.get(workerHash).interrupt();
+      multiplexerInstance.get(workerHash).destroyMultiplexer();
+      multiplexerInstance.remove(workerHash);
+      multiplexerRefCount.remove(workerHash);
+    }
+    semMultiplexer.release();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManager.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManager.java
@@ -27,7 +27,7 @@ public class WorkerMultiplexerManager {
    * key.
    */
   private static Map<Integer, WorkerMultiplexer> multiplexerInstance = new HashMap<>();
-  /** An accumulator of how many WorkerProxies are referencing a particular WorkerMultiplexer. */
+  /** A counter of how many WorkerProxies are referencing a particular WorkerMultiplexer. */
   private static Map<Integer, Integer> multiplexerRefCount = new HashMap<>();
   /** A semaphore to protect multiplexerInstance and multiplexerRefCount objects. */
   private static Semaphore semMultiplexer = new Semaphore(1);

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManager.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManager.java
@@ -18,10 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
 
-/**
- * An intermediate worker that sends request and receives response from the
- * worker processes.
- */
+/** A manager to instantiate and distroy multiplexers. */
 public class WorkerMultiplexerManager {
   /**
    * There should only be one WorkerMultiplexer corresponding to workers with

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManager.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManager.java
@@ -107,6 +107,7 @@ public class WorkerMultiplexerManager {
   }
 }
 
+/** Contains the WorkerMultiplexer instance and reference count */
 class InstanceInfo {
   private WorkerMultiplexer workerMultiplexer;
   private Integer refCount;

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManager.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManager.java
@@ -30,14 +30,9 @@ public class WorkerMultiplexerManager {
    * key.
    */
   private static Map<Integer, WorkerMultiplexer> multiplexerInstance = new HashMap<>();
-  /**
-   * An accumulator of how many WorkerProxies are referencing a particular
-   * WorkerMultiplexer.
-   */
+  /** An accumulator of how many WorkerProxies are referencing a particular WorkerMultiplexer. */
   private static Map<Integer, Integer> multiplexerRefCount = new HashMap<>();
-  /**
-   * A semaphore to protect multiplexerInstance and multiplexerRefCount objects.
-   */
+  /** A semaphore to protect multiplexerInstance and multiplexerRefCount objects. */
   private static Semaphore semMultiplexer = new Semaphore(1);
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManager.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManager.java
@@ -48,7 +48,7 @@ public class WorkerMultiplexerManager {
   public static WorkerMultiplexer getInstance(Integer workerHash) throws InterruptedException {
     semMultiplexer.acquire();
     if (!multiplexerInstance.containsKey(workerHash)) {
-      multiplexerInstance.put(workerHash, new WorkerMultiplexer(workerHash));
+      multiplexerInstance.put(workerHash, new WorkerMultiplexer());
       multiplexerRefCount.put(workerHash, 0);
     }
     multiplexerRefCount.put(workerHash, multiplexerRefCount.get(workerHash) + 1);

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
@@ -83,9 +83,7 @@ final class WorkerProxy extends Worker {
     }
   }
 
-  /**
-   * Send the WorkRequest to worker process.
-   */
+  /** Send the WorkRequest to worker process. */
   @Override
   void putRequest(WorkRequest request) throws IOException {
     ByteArrayOutputStream requestOutputStream = new ByteArrayOutputStream();

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
@@ -106,7 +106,6 @@ final class WorkerProxy extends Worker {
   /** Wait for WorkResponse from multiplexer. */
   @Override
   WorkResponse getResponse() throws IOException {
-    RecordingInputStream recordingStream = new RecordingInputStream(new ByteArrayInputStream(new byte[0]));
     try {
       recordingStream = new RecordingInputStream(workerMultiplexer.getResponse(workerId));
       recordingStream.startRecording(4096);

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
@@ -29,7 +29,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 
 /**
- * A proxy that talks to the multiplexers
+ * A proxy that talks to the multiplexer
  */
 final class WorkerProxy extends Worker {
   private static final Logger logger = Logger.getLogger(WorkerProxy.class.getName());
@@ -86,15 +86,12 @@ final class WorkerProxy extends Worker {
     }
   }
 
-  /** Send the WorkRequest to worker process. */
+  /** Send the WorkRequest to multiplexer. */
   @Override
   void putRequest(WorkRequest request) throws IOException {
-    ByteArrayOutputStream requestOutputStream = new ByteArrayOutputStream();
-    request.writeDelimitedTo(requestOutputStream);
-    requestOutputStream.flush();
     try {
       workerMultiplexer.resetResponseChecker(workerId);
-      workerMultiplexer.putRequest(requestOutputStream.toByteArray());
+      workerMultiplexer.putRequest(request);
     } catch (InterruptedException e) {
       /**
        * We can't throw InterruptedException to WorkerSpawnRunner because of the principle of override.
@@ -106,10 +103,7 @@ final class WorkerProxy extends Worker {
     }
   }
 
-  /**
-   * Wait for WorkResponse. We have to set the semaphore to 0
-   * in order to pause the WorkerProxy thread.
-   */
+  /** Wait for WorkResponse from multiplexer. */
   @Override
   WorkResponse getResponse() throws IOException {
     RecordingInputStream recordingStream = new RecordingInputStream(new ByteArrayInputStream(new byte[0]));

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.worker;
 
+import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.vfs.Path;
@@ -71,6 +72,8 @@ final class WorkerProxy extends Worker {
     } catch (InterruptedException e) {
       logger.warning("InterruptedException was caught while destroying multiplexer. "
           + "It could because the multiplexer was interrupted.");
+    } catch (UserExecException e) {
+      logger.warning(e.toString());
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
@@ -43,17 +43,6 @@ final class WorkerProxy extends Worker {
     this.workerMultiplexer = workerMultiplexer;
 
     final WorkerProxy self = this;
-    this.shutdownHook =
-      new Thread(
-        () -> {
-          try {
-            self.shutdownHook = null;
-            self.destroy();
-          } catch (IOException e) {
-            // We can't do anything here.
-          }
-        });
-    Runtime.getRuntime().addShutdownHook(shutdownHook);
   }
 
   @Override
@@ -75,9 +64,7 @@ final class WorkerProxy extends Worker {
 
   @Override
   synchronized void destroy() throws IOException {
-    if (shutdownHook != null) {
-      Runtime.getRuntime().removeShutdownHook(shutdownHook);
-    }
+    super.destroy();
     try {
       WorkerMultiplexerManager.removeInstance(workerKey.hashCode());
     } catch (InterruptedException e) {

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
@@ -14,7 +14,8 @@
 
 package com.google.devtools.build.lib.worker;
 
-import com.google.devtools.build.lib.sandbox.SandboxHelpers;
+import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxInputs;
+import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
@@ -57,7 +58,7 @@ final class WorkerProxy extends Worker {
 
   @Override
   public void prepareExecution(
-      Map<PathFragment, Path> inputFiles, SandboxHelpers.SandboxOutputs outputs, Set<PathFragment> workerFiles)
+      SandboxInputs inputFiles, SandboxOutputs outputs, Set<PathFragment> workerFiles)
       throws IOException {
     createProcess();
   }

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
@@ -1,0 +1,112 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.worker;
+
+import com.google.devtools.build.lib.sandbox.SandboxHelpers;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A proxy that talks to the multiplexers
+ */
+final class WorkerProxy extends Worker {
+  private Integer workerHash;
+  private ByteArrayOutputStream request;
+  private WorkerMultiplexer workerMultiplexer;
+  private Thread shutdownHook;
+
+  WorkerProxy(WorkerKey workerKey, int workerId, Path workDir, Path logFile) {
+    super(workerKey, workerId, workDir, logFile);
+    this.workerHash = workerKey.hashCode();
+    this.request = new ByteArrayOutputStream();
+    try {
+      this.workerMultiplexer = WorkerMultiplexerManager.getInstance(workerHash);
+    } catch (InterruptedException e) {
+      // We can't do anything here.
+    }
+
+    final WorkerProxy self = this;
+    this.shutdownHook =
+      new Thread(
+        () -> {
+          try {
+            self.shutdownHook = null;
+            self.destroy();
+          } catch (IOException e) {
+            // We can't do anything here.
+          }
+        });
+    Runtime.getRuntime().addShutdownHook(shutdownHook);
+  }
+
+  @Override
+  void createProcess() throws IOException {
+    workerMultiplexer.createProcess(workerKey, workDir, logFile);
+  }
+
+  @Override
+  boolean isAlive() {
+    return workerMultiplexer.isProcessAlive();
+  }
+
+  @Override
+  public void prepareExecution(
+      Map<PathFragment, Path> inputFiles, SandboxHelpers.SandboxOutputs outputs, Set<PathFragment> workerFiles)
+      throws IOException {
+    createProcess();
+  }
+
+  @Override
+  synchronized void destroy() throws IOException {
+    if (shutdownHook != null) {
+      Runtime.getRuntime().removeShutdownHook(shutdownHook);
+    }
+    try {
+      WorkerMultiplexerManager.removeInstance(workerHash);
+    } catch (InterruptedException e) {
+      // We can't do anything here.
+    }
+  }
+
+  /**
+   * Send the WorkRequest to worker process, and wait for WorkResponse. We have
+   * to set the semaphore to 0 in order to pause the WorkerProxy thread.
+   */
+  @Override
+  InputStream getInputStream() {
+    byte[] requestBytes = request.toByteArray();
+    request.reset();
+    try {
+      workerMultiplexer.resetResponseChecker(workerId);
+      workerMultiplexer.putRequest(requestBytes);
+      return workerMultiplexer.getResponse(workerId);
+    } catch (Exception e) {
+      // Return empty InputStream if exception occurs.
+      return new ByteArrayInputStream(new byte[0]);
+    }
+  }
+
+  @Override
+  OutputStream getOutputStream() {
+    return request;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
@@ -33,14 +33,10 @@ final class WorkerProxy extends Worker {
   private WorkerMultiplexer workerMultiplexer;
   private Thread shutdownHook;
 
-  WorkerProxy(WorkerKey workerKey, int workerId, Path workDir, Path logFile) {
+  WorkerProxy(WorkerKey workerKey, int workerId, Path workDir, Path logFile, WorkerMultiplexer workerMultiplexer) {
     super(workerKey, workerId, workDir, logFile);
     request = new ByteArrayOutputStream();
-    try {
-      this.workerMultiplexer = WorkerMultiplexerManager.getInstance(workerKey.hashCode());
-    } catch (InterruptedException e) {
-      // We can't do anything here.
-    }
+    this.workerMultiplexer = workerMultiplexer;
 
     final WorkerProxy self = this;
     this.shutdownHook =

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
@@ -99,7 +99,11 @@ final class WorkerProxy extends Worker {
   @Override
   WorkResponse getResponse() throws IOException {
     try {
-      return WorkResponse.parseDelimitedFrom(workerMultiplexer.getResponse(workerId));
+      InputStream inputStream = workerMultiplexer.getResponse(workerId);
+      if (inputStream == null) {
+        return null;
+      }
+      return WorkResponse.parseDelimitedFrom(inputStream);
     } catch (IOException e) {
       recordingStreamMessage = e.toString();
       throw new IOException("IOException was caught while waiting for worker response. "

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerProxy.java
@@ -29,17 +29,15 @@ import java.util.Set;
  * A proxy that talks to the multiplexers
  */
 final class WorkerProxy extends Worker {
-  private Integer workerHash;
   private ByteArrayOutputStream request;
   private WorkerMultiplexer workerMultiplexer;
   private Thread shutdownHook;
 
   WorkerProxy(WorkerKey workerKey, int workerId, Path workDir, Path logFile) {
     super(workerKey, workerId, workDir, logFile);
-    this.workerHash = workerKey.hashCode();
-    this.request = new ByteArrayOutputStream();
+    request = new ByteArrayOutputStream();
     try {
-      this.workerMultiplexer = WorkerMultiplexerManager.getInstance(workerHash);
+      this.workerMultiplexer = WorkerMultiplexerManager.getInstance(workerKey.hashCode());
     } catch (InterruptedException e) {
       // We can't do anything here.
     }
@@ -81,7 +79,7 @@ final class WorkerProxy extends Worker {
       Runtime.getRuntime().removeShutdownHook(shutdownHook);
     }
     try {
-      WorkerMultiplexerManager.removeInstance(workerHash);
+      WorkerMultiplexerManager.removeInstance(workerKey.hashCode());
     } catch (InterruptedException e) {
       // We can't do anything here.
     }

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -131,7 +131,7 @@ final class WorkerSpawnRunner implements SpawnRunner {
 
   @Override
   public boolean canExec(Spawn spawn) {
-    return Spawns.supportsWorkers(spawn);
+    return Spawns.supportsWorkers(spawn) || Spawns.supportsMultiplexWorkers(spawn);
   }
 
   private SpawnResult actuallyExec(Spawn spawn, SpawnExecutionContext context)

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -367,8 +367,7 @@ final class WorkerSpawnRunner implements SpawnRunner {
           // If protobuf couldn't parse the response, try to print whatever the failing worker wrote
           // to stdout - it's probably a stack trace or some kind of error message that will help
           // the user figure out why the compiler is failing.
-          RecordingInputStream recordingStream = worker.getRecordingStream();
-          recordingStream.readRemaining();
+          String recordingStreamMessage = worker.getRecordingStreamMessage();
           throw new UserExecException(
               ErrorMessage.builder()
                   .message(
@@ -376,7 +375,7 @@ final class WorkerSpawnRunner implements SpawnRunner {
                           + "Did you try to print something to stdout? Workers aren't allowed to "
                           + "do this, as it breaks the protocol between Bazel and the worker "
                           + "process.")
-                  .logText(recordingStream.getRecordedDataAsString())
+                  .logText(recordingStreamMessage)
                   .exception(e)
                   .build()
                   .toString());

--- a/src/main/protobuf/worker_protocol.proto
+++ b/src/main/protobuf/worker_protocol.proto
@@ -38,6 +38,10 @@ message WorkRequest {
   // The inputs that the worker is allowed to read during execution of this
   // request.
   repeated Input inputs = 2;
+
+  // To support multiplex worker, each WorkRequest must have an unique ID. This ID should
+  // be attached unchanged to the WorkResponse.
+  int32 request_id = 3;
 }
 
 // The worker sends this message to Blaze when it finished its work on the WorkRequest message.
@@ -48,4 +52,9 @@ message WorkResponse {
   // compiler warnings / errors etc. - thus we'll use a string type here, which gives us UTF-8
   // encoding.
   string output = 2;
+
+  // To support multiplex worker, each WorkResponse must have an unique ID. Since worker processes
+  // which support multiplex worker will handle multiple WorkRequests in parallel, this ID will
+  // be used to determined which WorkerProxy does this WorkResponse belong to.
+  int32 request_id = 3;
 }

--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -1595,6 +1595,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib:os_util",
         "//src/main/java/com/google/devtools/build/lib:resource-converter",
         "//src/main/java/com/google/devtools/build/lib:util",
+        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/sandbox",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs",

--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -1646,6 +1646,17 @@ java_binary(
     ],
 )
 
+java_binary(
+    name = "ExampleWorkerMultiplexer",
+    main_class = "com.google.devtools.build.lib.worker.ExampleWorkerMultiplexer",
+    visibility = [
+        "//src/test/shell/integration:__pkg__",
+    ],
+    runtime_deps = [
+        ":ExampleWorker-lib",
+    ],
+)
+
 TEST_SUITES = [
     "ziputils",
     "rules",

--- a/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexer.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexer.java
@@ -19,7 +19,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.devtools.build.lib.worker.ExampleWorkerOptions.ExampleWorkOptions;
+import com.google.devtools.build.lib.worker.ExampleWorkerMultiplexerOptions.ExampleWorkMultiplexerOptions;
 import com.google.devtools.build.lib.worker.WorkerProtocol.Input;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
@@ -61,11 +61,11 @@ public class ExampleWorkerMultiplexer {
     if (ImmutableSet.copyOf(args).contains("--persistent_worker")) {
       OptionsParser parser =
           OptionsParser.builder()
-              .optionsClasses(ExampleWorkerOptions.class)
+              .optionsClasses(ExampleWorkerMultiplexerOptions.class)
               .allowResidue(false)
               .build();
       parser.parse(args);
-      ExampleWorkerOptions workerOptions = parser.getOptions(ExampleWorkerOptions.class);
+      ExampleWorkerMultiplexerOptions workerOptions = parser.getOptions(ExampleWorkerMultiplexerOptions.class);
       Preconditions.checkState(workerOptions.persistentWorker);
 
       runPersistentWorker(workerOptions);
@@ -75,7 +75,7 @@ public class ExampleWorkerMultiplexer {
     }
   }
 
-  private static void runPersistentWorker(ExampleWorkerOptions workerOptions) throws IOException {
+  private static void runPersistentWorker(ExampleWorkerMultiplexerOptions workerOptions) throws IOException {
     PrintStream originalStdOut = System.out;
     PrintStream originalStdErr = System.err;
 
@@ -162,9 +162,9 @@ public class ExampleWorkerMultiplexer {
     }
 
     OptionsParser parser =
-        OptionsParser.builder().optionsClasses(ExampleWorkOptions.class).allowResidue(true).build();
+        OptionsParser.builder().optionsClasses(ExampleWorkMultiplexerOptions.class).allowResidue(true).build();
     parser.parse(expandedArgs.build());
-    ExampleWorkOptions options = parser.getOptions(ExampleWorkOptions.class);
+    ExampleWorkMultiplexerOptions options = parser.getOptions(ExampleWorkMultiplexerOptions.class);
 
     List<String> outputs = new ArrayList<>();
 

--- a/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexer.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexer.java
@@ -130,7 +130,7 @@ public class ExampleWorkerMultiplexer {
         }
 
         if (workerOptions.exitAfter > 0 && workUnitCounter > workerOptions.exitAfter) {
-          return;
+          System.in.close();
         }
       } finally {
         // Be a good worker process and consume less memory when idle.

--- a/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexer.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexer.java
@@ -49,6 +49,9 @@ public class ExampleWorkerMultiplexer {
   // A UUID that uniquely identifies this running worker process.
   static final UUID workerUuid = UUID.randomUUID();
 
+  // Creating Executor Service with a thread pool of Size 3.
+  static final int concurrentThreadNumber = 3;
+
   // A counter that increases with each work unit processed.
   static int workUnitCounter = 1;
 
@@ -80,8 +83,7 @@ public class ExampleWorkerMultiplexer {
     PrintStream originalStdOut = System.out;
     PrintStream originalStdErr = System.err;
 
-    // Creating Executor Service with a thread pool of Size 2.
-    ExecutorService executorService = Executors.newFixedThreadPool(2);
+    ExecutorService executorService = Executors.newFixedThreadPool(concurrentThreadNumber);
 
     while (true) {
       try {
@@ -186,6 +188,12 @@ public class ExampleWorkerMultiplexer {
     ExampleWorkMultiplexerOptions options = parser.getOptions(ExampleWorkMultiplexerOptions.class);
 
     List<String> outputs = new ArrayList<>();
+
+    if (options.delay) {
+      Integer randomDelay = new Random().nextInt(200) + 100;
+      TimeUnit.MILLISECONDS.sleep(randomDelay);
+      outputs.add("DELAY " + randomDelay + " MILLISECONDS");
+    }
 
     if (options.writeUUID) {
       outputs.add("UUID " + workerUuid.toString());

--- a/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexer.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexer.java
@@ -1,0 +1,206 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.worker;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.worker.ExampleWorkerOptions.ExampleWorkOptions;
+import com.google.devtools.build.lib.worker.WorkerProtocol.Input;
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
+import com.google.devtools.common.options.OptionsParser;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * An example implementation of a worker process that is used for integration tests.
+ */
+public class ExampleWorkerMultiplexer {
+
+  static final Pattern FLAG_FILE_PATTERN = Pattern.compile("(?:@|--?flagfile=)(.+)");
+
+  // A UUID that uniquely identifies this running worker process.
+  static final UUID workerUuid = UUID.randomUUID();
+
+  // A counter that increases with each work unit processed.
+  static int workUnitCounter = 1;
+
+  // If true, returns corrupt responses instead of correct protobufs.
+  static boolean poisoned = false;
+
+  // Keep state across multiple builds.
+  static final LinkedHashMap<String, String> inputs = new LinkedHashMap<>();
+
+  public static void main(String[] args) throws Exception {
+    if (ImmutableSet.copyOf(args).contains("--persistent_worker")) {
+      OptionsParser parser =
+          OptionsParser.builder()
+              .optionsClasses(ExampleWorkerOptions.class)
+              .allowResidue(false)
+              .build();
+      parser.parse(args);
+      ExampleWorkerOptions workerOptions = parser.getOptions(ExampleWorkerOptions.class);
+      Preconditions.checkState(workerOptions.persistentWorker);
+
+      runPersistentWorker(workerOptions);
+    } else {
+      // This is a single invocation of the example that exits after it processed the request.
+      processRequest(ImmutableList.copyOf(args));
+    }
+  }
+
+  private static void runPersistentWorker(ExampleWorkerOptions workerOptions) throws IOException {
+    PrintStream originalStdOut = System.out;
+    PrintStream originalStdErr = System.err;
+
+    while (true) {
+      try {
+        WorkRequest request = WorkRequest.parseDelimitedFrom(System.in);
+        Integer requestId = request.getRequestId();
+        if (request == null) {
+          break;
+        }
+
+        inputs.clear();
+        for (Input input : request.getInputsList()) {
+          inputs.put(input.getPath(), input.getDigest().toStringUtf8());
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int exitCode = 0;
+
+        try (PrintStream ps = new PrintStream(baos)) {
+          System.setOut(ps);
+          System.setErr(ps);
+
+          if (poisoned) {
+            if (workerOptions.hardPoison) {
+              throw new IllegalStateException("I'm a very poisoned worker and will just crash.");
+            }
+            System.out.println("I'm a poisoned worker and this is not a protobuf.");
+            System.out.println("Here's a fake stack trace for you:");
+            System.out.println("    at com.example.Something(Something.java:83)");
+            System.out.println("    at java.lang.Thread.run(Thread.java:745)");
+            System.out.print("And now, 8k of random bytes: ");
+            byte[] b = new byte[8192];
+            new Random().nextBytes(b);
+            System.out.write(b);
+          } else {
+            try {
+              processRequest(request.getArgumentsList());
+            } catch (Exception e) {
+              e.printStackTrace();
+              exitCode = 1;
+            }
+          }
+        } finally {
+          System.setOut(originalStdOut);
+          System.setErr(originalStdErr);
+        }
+
+        if (poisoned) {
+          baos.writeTo(System.out);
+        } else {
+          WorkResponse.newBuilder()
+              .setRequestId(requestId)
+              .setOutput(baos.toString())
+              .setExitCode(exitCode)
+              .build()
+              .writeDelimitedTo(System.out);
+        }
+        System.out.flush();
+
+        if (workerOptions.exitAfter > 0 && workUnitCounter > workerOptions.exitAfter) {
+          return;
+        }
+
+        if (workerOptions.poisonAfter > 0 && workUnitCounter > workerOptions.poisonAfter) {
+          poisoned = true;
+        }
+      } finally {
+        // Be a good worker process and consume less memory when idle.
+        System.gc();
+      }
+    }
+  }
+
+  private static void processRequest(List<String> args) throws Exception {
+    ImmutableList.Builder<String> expandedArgs = ImmutableList.builder();
+    for (String arg : args) {
+      Matcher flagFileMatcher = FLAG_FILE_PATTERN.matcher(arg);
+      if (flagFileMatcher.matches()) {
+        expandedArgs.addAll(Files.readAllLines(Paths.get(flagFileMatcher.group(1)), UTF_8));
+      } else {
+        expandedArgs.add(arg);
+      }
+    }
+
+    OptionsParser parser =
+        OptionsParser.builder().optionsClasses(ExampleWorkOptions.class).allowResidue(true).build();
+    parser.parse(expandedArgs.build());
+    ExampleWorkOptions options = parser.getOptions(ExampleWorkOptions.class);
+
+    List<String> outputs = new ArrayList<>();
+
+    if (options.writeUUID) {
+      outputs.add("UUID " + workerUuid.toString());
+    }
+
+    if (options.writeCounter) {
+      outputs.add("COUNTER " + workUnitCounter++);
+    }
+
+    String residueStr = Joiner.on(' ').join(parser.getResidue());
+    if (options.uppercase) {
+      residueStr = residueStr.toUpperCase();
+    }
+    outputs.add(residueStr);
+
+    if (options.printInputs) {
+      for (Map.Entry<String, String> input : inputs.entrySet()) {
+        outputs.add("INPUT " + input.getKey() + " " + input.getValue());
+      }
+    }
+
+    if (options.printEnv) {
+      for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
+        outputs.add(entry.getKey() + "=" + entry.getValue());
+      }
+    }
+
+    String outputStr = Joiner.on('\n').join(outputs);
+    if (options.outputFile.isEmpty()) {
+      System.out.println(outputStr);
+    } else {
+      try (PrintStream outputFile = new PrintStream(options.outputFile)) {
+        outputFile.println(outputStr);
+      }
+    }
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexerOptions.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexerOptions.java
@@ -89,6 +89,15 @@ public class ExampleWorkerMultiplexerOptions extends OptionsBase {
       help = "Randomly delay the worker response (between 100 to 300 ms)."
     )
     public boolean delay;
+
+    @Option(
+      name = "queue",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.NO_OP},
+      defaultValue = "false",
+      help = "Queue response and return it in opposite order."
+    )
+    public boolean queue;
   }
 
   @Option(

--- a/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexerOptions.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexerOptions.java
@@ -89,15 +89,6 @@ public class ExampleWorkerMultiplexerOptions extends OptionsBase {
       help = "Randomly delay the worker response (between 100 to 300 ms)."
     )
     public boolean delay;
-
-    @Option(
-      name = "queue",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-      effectTags = {OptionEffectTag.NO_OP},
-      defaultValue = "false",
-      help = "Queue response and return it in opposite order."
-    )
-    public boolean queue;
   }
 
   @Option(

--- a/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexerOptions.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexerOptions.java
@@ -1,0 +1,121 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.worker;
+
+import com.google.devtools.common.options.Option;
+import com.google.devtools.common.options.OptionDocumentationCategory;
+import com.google.devtools.common.options.OptionEffectTag;
+import com.google.devtools.common.options.OptionsBase;
+
+/**
+ * Options for the example worker itself.
+ */
+public class ExampleWorkerMultiplexerOptions extends OptionsBase {
+
+  /**
+   * Options for the example worker concerning single units of work.
+   */
+  public static class ExampleWorkMultiplexerOptions extends OptionsBase {
+    @Option(
+      name = "output_file",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.NO_OP},
+      defaultValue = "",
+      help = "Write the output to a file instead of stdout."
+    )
+    public String outputFile;
+
+    @Option(
+      name = "uppercase",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.NO_OP},
+      defaultValue = "false",
+      help = "Uppercase the input."
+    )
+    public boolean uppercase;
+
+    @Option(
+      name = "write_uuid",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.NO_OP},
+      defaultValue = "false",
+      help = "Writes a UUID into the output."
+    )
+    public boolean writeUUID;
+
+    @Option(
+      name = "write_counter",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.NO_OP},
+      defaultValue = "false",
+      help = "Writes a counter that increases with each work unit processed into the output."
+    )
+    public boolean writeCounter;
+
+    @Option(
+      name = "print_inputs",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.NO_OP},
+      defaultValue = "false",
+      help = "Writes a list of input files and their digests."
+    )
+    public boolean printInputs;
+
+    @Option(
+      name = "print_env",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.NO_OP},
+      defaultValue = "false",
+      help = "Prints a list of all environment variables."
+    )
+    public boolean printEnv;
+  }
+
+  @Option(
+    name = "persistent_worker",
+    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    effectTags = {OptionEffectTag.NO_OP},
+    defaultValue = "false"
+  )
+  public boolean persistentWorker;
+
+  @Option(
+    name = "exit_after",
+    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    effectTags = {OptionEffectTag.NO_OP},
+    defaultValue = "0",
+    help = "The worker exits after processing this many work units (default: disabled)."
+  )
+  public int exitAfter;
+
+  @Option(
+    name = "poison_after",
+    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    effectTags = {OptionEffectTag.NO_OP},
+    defaultValue = "0",
+    help =
+        "Poisons the worker after processing this many work units, so that it returns a "
+            + "corrupt response instead of a response protobuf from then on (default: disabled)."
+  )
+  public int poisonAfter;
+
+  @Option(
+    name = "hard_poison",
+    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    effectTags = {OptionEffectTag.NO_OP},
+    defaultValue = "false",
+    help = "Instead of writing an error message to stdout, write it to stderr and terminate."
+  )
+  public boolean hardPoison;
+}

--- a/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexerOptions.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexerOptions.java
@@ -80,6 +80,15 @@ public class ExampleWorkerMultiplexerOptions extends OptionsBase {
       help = "Prints a list of all environment variables."
     )
     public boolean printEnv;
+
+    @Option(
+      name = "delay",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.NO_OP},
+      defaultValue = "false",
+      help = "Randomly delay the worker response (between 100 to 300 ms)."
+    )
+    public boolean delay;
   }
 
   @Option(

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerFactoryTest.java
@@ -54,4 +54,52 @@ public class WorkerFactoryTest {
 
     assertThat(sandboxedWorkerPath.getBaseName()).isEqualTo("workspace");
   }
+
+  /**
+   * WorkerFactory should create correct worker type based on WorkerKey.
+   */
+  @Test
+  public void workerCreationTypeCheck() throws Exception {
+    Path workerBaseDir = fs.getPath("/outputbase/bazel-workers");
+    WorkerFactory workerFactory = new WorkerFactory(new WorkerOptions(), workerBaseDir);
+    WorkerKey sandboxedWorkerKey =
+        new WorkerKey(
+            /* args= */ ImmutableList.of(),
+            /* env= */ ImmutableMap.of(),
+            /* execRoot= */ fs.getPath("/outputbase/execroot/workspace"),
+            /* mnemonic= */ "dummy",
+            /* workerFilesCombinedHash= */ HashCode.fromInt(0),
+            /* workerFilesWithHashes= */ ImmutableSortedMap.of(),
+            /* mustBeSandboxed= */ true,
+            /* proxied= */ false);
+    Worker sandboxedWorker = workerFactory.create(sandboxedWorkerKey);
+
+    WorkerKey nonProxiedWorkerKey =
+        new WorkerKey(
+            /* args= */ ImmutableList.of(),
+            /* env= */ ImmutableMap.of(),
+            /* execRoot= */ fs.getPath("/outputbase/execroot/workspace"),
+            /* mnemonic= */ "dummy",
+            /* workerFilesCombinedHash= */ HashCode.fromInt(0),
+            /* workerFilesWithHashes= */ ImmutableSortedMap.of(),
+            /* mustBeSandboxed= */ false,
+            /* proxied= */ false);
+    Worker nonProxiedWorker = workerFactory.create(nonProxiedWorkerKey);
+
+    WorkerKey proxiedWorkerKey =
+        new WorkerKey(
+            /* args= */ ImmutableList.of(),
+            /* env= */ ImmutableMap.of(),
+            /* execRoot= */ fs.getPath("/outputbase/execroot/workspace"),
+            /* mnemonic= */ "dummy",
+            /* workerFilesCombinedHash= */ HashCode.fromInt(0),
+            /* workerFilesWithHashes= */ ImmutableSortedMap.of(),
+            /* mustBeSandboxed= */ false,
+            /* proxied= */ true);
+    Worker proxiedWorker = workerFactory.create(proxiedWorkerKey);
+
+    assertThat(sandboxedWorker.getClass()).isEqualTo(SandboxedWorker.class);
+    assertThat(nonProxiedWorker.getClass()).isEqualTo(Worker.class);
+    assertThat(proxiedWorker.getClass()).isEqualTo(WorkerProxy.class);
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerFactoryTest.java
@@ -42,13 +42,14 @@ public class WorkerFactoryTest {
     WorkerFactory workerFactory = new WorkerFactory(new WorkerOptions(), workerBaseDir);
     WorkerKey workerKey =
         new WorkerKey(
-            ImmutableList.of(),
-            ImmutableMap.of(),
-            fs.getPath("/outputbase/execroot/workspace"),
-            "dummy",
-            HashCode.fromInt(0),
-            ImmutableSortedMap.of(),
-            true);
+            /* args= */ ImmutableList.of(),
+            /* env= */ ImmutableMap.of(),
+            /* execRoot= */ fs.getPath("/outputbase/execroot/workspace"),
+            /* mnemonic= */ "dummy",
+            /* workerFilesCombinedHash= */ HashCode.fromInt(0),
+            /* workerFilesWithHashes= */ ImmutableSortedMap.of(),
+            /* mustBeSandboxed= */ true,
+            /* proxied= */ false);
     Path sandboxedWorkerPath = workerFactory.getSandboxedWorkerPath(workerKey, 1);
 
     assertThat(sandboxedWorkerPath.getBaseName()).isEqualTo("workspace");

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerFactoryTest.java
@@ -73,6 +73,7 @@ public class WorkerFactoryTest {
             /* mustBeSandboxed= */ true,
             /* proxied= */ false);
     Worker sandboxedWorker = workerFactory.create(sandboxedWorkerKey);
+    assertThat(sandboxedWorker.getClass()).isEqualTo(SandboxedWorker.class);
 
     WorkerKey nonProxiedWorkerKey =
         new WorkerKey(
@@ -85,6 +86,7 @@ public class WorkerFactoryTest {
             /* mustBeSandboxed= */ false,
             /* proxied= */ false);
     Worker nonProxiedWorker = workerFactory.create(nonProxiedWorkerKey);
+    assertThat(nonProxiedWorker.getClass()).isEqualTo(Worker.class);
 
     WorkerKey proxiedWorkerKey =
         new WorkerKey(
@@ -97,9 +99,9 @@ public class WorkerFactoryTest {
             /* mustBeSandboxed= */ false,
             /* proxied= */ true);
     Worker proxiedWorker = workerFactory.create(proxiedWorkerKey);
-
-    assertThat(sandboxedWorker.getClass()).isEqualTo(SandboxedWorker.class);
-    assertThat(nonProxiedWorker.getClass()).isEqualTo(Worker.class);
+    // If proxied = true, WorkerProxy is created along with a WorkerMultiplexer.
+    // Destroy WorkerMultiplexer to avoid unexpected behavior in WorkerMultiplexerManagerTest.
+    WorkerMultiplexerManager.removeInstance(proxiedWorkerKey.hashCode());
     assertThat(proxiedWorker.getClass()).isEqualTo(WorkerProxy.class);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerKeyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerKeyTest.java
@@ -1,0 +1,54 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.worker;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.hash.HashCode;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link WorkerKey}. */
+@RunWith(JUnit4.class)
+public class WorkerKeyTest {
+  final FileSystem fs = new InMemoryFileSystem();
+
+  Path workerBaseDir = fs.getPath("/outputbase/bazel-workers");
+  WorkerKey workerKey =
+    new WorkerKey(
+        /* args= */ ImmutableList.of("arg1", "arg2", "arg3"),
+        /* env= */ ImmutableMap.of("env1", "foo", "env2", "bar"),
+        /* execRoot= */ fs.getPath("/outputbase/execroot/workspace"),
+        /* mnemonic= */ "dummy",
+        /* workerFilesCombinedHash= */ HashCode.fromInt(0),
+        /* workerFilesWithHashes= */ ImmutableSortedMap.of(),
+        /* mustBeSandboxed= */ true,
+        /* proxied= */ true);
+
+  @Test
+  public void testWorkerKeyGetter() {
+    assertThat(workerKey.mustBeSandboxed()).isEqualTo(true);
+    assertThat(workerKey.getProxied()).isEqualTo(true);
+    // Hash code contains args, env, execRoot, and mnemonic.
+    assertThat(workerKey.hashCode()).isEqualTo(322455166);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManagerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerMultiplexerManagerTest.java
@@ -1,0 +1,74 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.worker;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.testutil.MoreAsserts.assertThrows;
+
+import com.google.devtools.build.lib.actions.UserExecException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link WorkerMultiplexerManager}. */
+@RunWith(JUnit4.class)
+public class WorkerMultiplexerManagerTest {
+
+  @Test
+  public void instanceCreationRemovalTest() throws Exception {
+    // Create a WorkerProxy hash and request for a WorkerMultiplexer.
+    Integer worker1Hash = "worker1".hashCode();
+    WorkerMultiplexer wm1 = WorkerMultiplexerManager.getInstance(worker1Hash);
+
+    assertThat(WorkerMultiplexerManager.getMultiplexer(worker1Hash)).isEqualTo(wm1);
+    assertThat(WorkerMultiplexerManager.getRefCount(worker1Hash)).isEqualTo(1);
+    assertThat(WorkerMultiplexerManager.getInstanceCount()).isEqualTo(1);
+
+    // Create another WorkerProxy hash and request for a WorkerMultiplexer.
+    Integer worker2Hash = "worker2".hashCode();
+    WorkerMultiplexer wm2 = WorkerMultiplexerManager.getInstance(worker2Hash);
+
+    assertThat(WorkerMultiplexerManager.getMultiplexer(worker2Hash)).isEqualTo(wm2);
+    assertThat(WorkerMultiplexerManager.getRefCount(worker2Hash)).isEqualTo(1);
+    assertThat(WorkerMultiplexerManager.getInstanceCount()).isEqualTo(2);
+
+    // Use the same WorkerProxy hash, it shouldn't instantiate a new WorkerMultiplexer.
+    WorkerMultiplexer wm2Annex = WorkerMultiplexerManager.getInstance(worker2Hash);
+
+    assertThat(wm2).isEqualTo(wm2Annex);
+    assertThat(WorkerMultiplexerManager.getRefCount(worker2Hash)).isEqualTo(2);
+    assertThat(WorkerMultiplexerManager.getInstanceCount()).isEqualTo(2);
+
+    // Remove an instance. If reference count is larger than 0, instance shouldn't be destroyed.
+    WorkerMultiplexerManager.removeInstance(worker2Hash);
+
+    assertThat(WorkerMultiplexerManager.getRefCount(worker2Hash)).isEqualTo(1);
+    assertThat(WorkerMultiplexerManager.getInstanceCount()).isEqualTo(2);
+
+    // Remove an instance. Reference count is down to 0, instance should be destroyed.
+    WorkerMultiplexerManager.removeInstance(worker2Hash);
+
+    assertThrows(UserExecException.class, () -> WorkerMultiplexerManager.getMultiplexer(worker2Hash));
+    assertThat(WorkerMultiplexerManager.getInstanceCount()).isEqualTo(1);
+
+    // WorkerProxy hash not found.
+    assertThrows(UserExecException.class, () -> WorkerMultiplexerManager.removeInstance(worker2Hash));
+
+    // Remove all the instances.
+    WorkerMultiplexerManager.removeInstance(worker1Hash);
+
+    assertThat(WorkerMultiplexerManager.getInstanceCount()).isEqualTo(0);
+  }
+}

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -458,6 +458,7 @@ sh_test(
         ":test-deps",
         "//src/test/java/com/google/devtools/build/lib:ExampleWorkerMultiplexer_deploy.jar",
     ],
+    shard_count = 2,
     tags = [
         "no_windows",
     ],

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -458,7 +458,7 @@ sh_test(
         ":test-deps",
         "//src/test/java/com/google/devtools/build/lib:ExampleWorkerMultiplexer_deploy.jar",
     ],
-    shard_count = 2,
+    shard_count = 3,
     tags = [
         "no_windows",
     ],

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -447,6 +447,23 @@ sh_test(
 )
 
 sh_test(
+    name = "bazel_worker_multiplexer_test",
+    size = "large",
+    srcs = ["bazel_worker_multiplexer_test.sh"],
+    args = [
+        "--worker_sandboxing=no",
+        "non-sandboxed",
+    ],
+    data = [
+        ":test-deps",
+        "//src/test/java/com/google/devtools/build/lib:ExampleWorkerMultiplexer_deploy.jar",
+    ],
+    tags = [
+        "no_windows",
+    ],
+)
+
+sh_test(
     name = "bazel_sandboxed_worker_test",
     size = "large",
     srcs = ["bazel_worker_test.sh"],

--- a/src/test/shell/integration/bazel_worker_multiplexer_test.sh
+++ b/src/test/shell/integration/bazel_worker_multiplexer_test.sh
@@ -49,49 +49,6 @@ function set_up() {
     || fail "'bazel build --worker_quit_after_build' during test set_up failed"
 }
 
-function write_hello_library_files() {
-  mkdir -p java/main
-  cat >java/main/BUILD <<EOF
-java_binary(name = 'main',
-    deps = [':hello_library'],
-    srcs = ['Main.java'],
-    main_class = 'main.Main')
-
-java_library(name = 'hello_library',
-             srcs = ['HelloLibrary.java']);
-EOF
-
-  cat >java/main/Main.java <<EOF
-package main;
-import main.HelloLibrary;
-public class Main {
-  public static void main(String[] args) {
-    HelloLibrary.funcHelloLibrary();
-    System.out.println("Hello, World!");
-  }
-}
-EOF
-
-  cat >java/main/HelloLibrary.java <<EOF
-package main;
-public class HelloLibrary {
-  public static void funcHelloLibrary() {
-    System.out.print("Hello, Library!;");
-  }
-}
-EOF
-}
-
-function test_compiles_hello_library_using_persistent_javac() {
-  write_hello_library_files
-
-  bazel build java/main:main &> $TEST_log \
-    || fail "build failed"
-  expect_log "Created new ${WORKER_TYPE_LOG_STRING} Javac worker (id [0-9]\+)"
-  $BINS/java/main/main | grep -q "Hello, Library!;Hello, World!" \
-    || fail "comparison failed"
-}
-
 function prepare_example_worker() {
   cp ${example_worker} worker_lib.jar
   chmod +w worker_lib.jar
@@ -170,7 +127,7 @@ java_binary(
 EOF
 }
 
-function test_example_worker() {
+function test_example_worker_multiplexer() {
   prepare_example_worker
   cat >>BUILD <<EOF
 work(

--- a/src/test/shell/integration/bazel_worker_multiplexer_test.sh
+++ b/src/test/shell/integration/bazel_worker_multiplexer_test.sh
@@ -510,28 +510,28 @@ EOF
   expect_log "Destroying Work worker (id [0-9]\+)"
 }
 
-# function test_crashed_worker_causes_log_dump() {
-#   prepare_example_worker
-#   cat >>BUILD <<'EOF'
-# [work(
-#   name = "hello_world_%s" % idx,
-#   worker = ":worker",
-#   worker_args = ["--poison_after=1", "--hard_poison"],
-#   args = ["--write_uuid", "--write_counter"],
-# ) for idx in range(10)]
-# EOF
+function test_crashed_worker_causes_log_dump() {
+  prepare_example_worker
+  cat >>BUILD <<'EOF'
+[work(
+  name = "hello_world_%s" % idx,
+  worker = ":worker",
+  worker_args = ["--poison_after=1", "--hard_poison"],
+  args = ["--write_uuid", "--write_counter"],
+) for idx in range(10)]
+EOF
 
-#   bazel build :hello_world_1 &> $TEST_log \
-#     || fail "build failed"
+  bazel build :hello_world_1 &> $TEST_log \
+    || fail "build failed"
 
-#   bazel build :hello_world_2 &> $TEST_log \
-#     && fail "expected build to fail" || true
+  bazel build :hello_world_2 &> $TEST_log \
+    && fail "expected build to fail" || true
 
-#   expect_log "^---8<---8<--- Start of log, file at /"
-#   expect_log "Worker process did not return a WorkResponse:"
-#   expect_log "I'm a very poisoned worker and will just crash."
-#   expect_log "^---8<---8<--- End of log ---8<---8<---"
-# }
+  expect_log "^---8<---8<--- Start of log, file at /"
+  expect_log "Worker process did not return a WorkResponse:"
+  expect_log "I'm a very poisoned worker and will just crash."
+  expect_log "^---8<---8<--- End of log ---8<---8<---"
+}
 
 function test_multiple_target_without_delay() {
   prepare_example_worker
@@ -588,31 +588,4 @@ EOF
   bazel build  :hello_world_1 :hello_world_2 :hello_world_3 &> $TEST_log \
     || fail "build failed"
 }
-
-# We just need to test the build completion, no assertion is needed.
-# function test_multiple_target_return_response_in_opposite_order() {
-#   prepare_example_worker
-#   cat >>BUILD <<EOF
-# work(
-#   name = "hello_world_1",
-#   worker = ":worker",
-#   args = ["--queue", "hello world 1"],
-# )
-
-# work(
-#   name = "hello_world_2",
-#   worker = ":worker",
-#   args = ["--queue", "hello world 2"],
-# )
-
-# work(
-#   name = "hello_world_3",
-#   worker = ":worker",
-#   args = ["--queue", "hello world 3"],
-# )
-# EOF
-
-#   bazel build  :hello_world_1 :hello_world_2 :hello_world_3 &> $TEST_log \
-#     || fail "build failed"
-# }
 run_suite "Worker multiplexer integration tests"

--- a/src/test/shell/integration/bazel_worker_multiplexer_test.sh
+++ b/src/test/shell/integration/bazel_worker_multiplexer_test.sh
@@ -151,4 +151,33 @@ EOF
     || fail "build failed"
   assert_equals "HELLO WORLD" "$(cat $BINS/hello_world_uppercase.out)"
 }
+
+function test_multiple_target_without_delay() {
+  prepare_example_worker
+  cat >>BUILD <<EOF
+work(
+  name = "hello_world_1",
+  worker = ":worker",
+  args = ["hello world 1"],
+)
+
+work(
+  name = "hello_world_2",
+  worker = ":worker",
+  args = ["hello world 2"],
+)
+
+work(
+  name = "hello_world_3",
+  worker = ":worker",
+  args = ["hello world 3"],
+)
+EOF
+
+  bazel build  :hello_world_1 :hello_world_2 :hello_world_3 &> $TEST_log \
+    || fail "build failed"
+  assert_equals "hello world 1" "$(cat $BINS/hello_world_1.out)"
+  assert_equals "hello world 2" "$(cat $BINS/hello_world_2.out)"
+  assert_equals "hello world 3" "$(cat $BINS/hello_world_3.out)"
+}
 run_suite "Worker multiplexer integration tests"

--- a/src/test/shell/integration/bazel_worker_multiplexer_test.sh
+++ b/src/test/shell/integration/bazel_worker_multiplexer_test.sh
@@ -82,15 +82,15 @@ public class HelloLibrary {
 EOF
 }
 
-# function test_compiles_hello_library_using_persistent_javac() {
-#   write_hello_library_files
+function test_compiles_hello_library_using_persistent_javac() {
+  write_hello_library_files
 
-#   bazel build java/main:main &> $TEST_log \
-#     || fail "build failed"
-#   expect_log "Created new ${WORKER_TYPE_LOG_STRING} Javac worker (id [0-9]\+)"
-#   $BINS/java/main/main | grep -q "Hello, Library!;Hello, World!" \
-#     || fail "comparison failed"
-# }
+  bazel build java/main:main &> $TEST_log \
+    || fail "build failed"
+  expect_log "Created new ${WORKER_TYPE_LOG_STRING} Javac worker (id [0-9]\+)"
+  $BINS/java/main/main | grep -q "Hello, Library!;Hello, World!" \
+    || fail "comparison failed"
+}
 
 function prepare_example_worker() {
   cp ${example_worker} worker_lib.jar

--- a/src/test/shell/integration/bazel_worker_multiplexer_test.sh
+++ b/src/test/shell/integration/bazel_worker_multiplexer_test.sh
@@ -34,7 +34,7 @@ example_worker=$(find $BAZEL_RUNFILES -name ExampleWorkerMultiplexer_deploy.jar)
 
 add_to_bazelrc "build -s"
 add_to_bazelrc "build --spawn_strategy=worker,standalone"
-add_to_bazelrc "build --worker_verbose --worker_max_instances=1"
+add_to_bazelrc "build --worker_verbose --worker_max_instances=3"
 add_to_bazelrc "build --debug_print_action_contexts"
 add_to_bazelrc "build ${ADDITIONAL_BUILD_FLAGS}"
 

--- a/src/test/shell/integration/bazel_worker_multiplexer_test.sh
+++ b/src/test/shell/integration/bazel_worker_multiplexer_test.sh
@@ -181,6 +181,7 @@ EOF
   assert_equals "hello world 3" "$(cat $BINS/hello_world_3.out)"
 }
 
+# We just need to test the build completion, no assertion is needed.
 function test_multiple_target_with_delay() {
   prepare_example_worker
   cat >>BUILD <<EOF
@@ -200,6 +201,33 @@ work(
   name = "hello_world_3",
   worker = ":worker",
   args = ["--delay", "hello world 3"],
+)
+EOF
+
+  bazel build  :hello_world_1 :hello_world_2 :hello_world_3 &> $TEST_log \
+    || fail "build failed"
+}
+
+# We just need to test the build completion, no assertion is needed.
+function test_multiple_target_return_response_in_opposite_order() {
+  prepare_example_worker
+  cat >>BUILD <<EOF
+work(
+  name = "hello_world_1",
+  worker = ":worker",
+  args = ["--queue", "hello world 1"],
+)
+
+work(
+  name = "hello_world_2",
+  worker = ":worker",
+  args = ["--queue", "hello world 2"],
+)
+
+work(
+  name = "hello_world_3",
+  worker = ":worker",
+  args = ["--queue", "hello world 3"],
 )
 EOF
 

--- a/src/test/shell/integration/bazel_worker_multiplexer_test.sh
+++ b/src/test/shell/integration/bazel_worker_multiplexer_test.sh
@@ -233,25 +233,25 @@ EOF
   assert_equals "1" $work_count
 }
 
-# function test_build_fails_when_worker_exits() {
-#   prepare_example_worker
-#   cat >>BUILD <<'EOF'
-# [work(
-#   name = "hello_world_%s" % idx,
-#   worker = ":worker",
-#   worker_args = ["--exit_after=1"],
-#   args = ["--write_uuid", "--write_counter"],
-# ) for idx in range(10)]
-# EOF
+function test_build_fails_when_worker_exits() {
+  prepare_example_worker
+  cat >>BUILD <<'EOF'
+[work(
+  name = "hello_world_%s" % idx,
+  worker = ":worker",
+  worker_args = ["--exit_after=1"],
+  args = ["--write_uuid", "--write_counter"],
+) for idx in range(10)]
+EOF
 
-#   bazel build :hello_world_1 &> $TEST_log \
-#     || fail "build failed"
+  bazel build :hello_world_1 &> $TEST_log \
+    || fail "build failed"
 
-#   bazel build :hello_world_2 &> $TEST_log \
-#     && fail "expected build to failed" || true
+  bazel build :hello_world_2 &> $TEST_log \
+    && fail "expected build to failed" || true
 
-#   expect_log "Worker process quit or closed its stdin stream when we tried to send a WorkRequest"
-# }
+  expect_log "Worker process quit or closed its stdin stream when we tried to send a WorkRequest"
+}
 
 function test_worker_restarts_when_worker_binary_changes() {
   prepare_example_worker

--- a/src/test/shell/integration/bazel_worker_multiplexer_test.sh
+++ b/src/test/shell/integration/bazel_worker_multiplexer_test.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+#
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Test rules provided in Bazel not tested by examples
+#
+
+set -u
+ADDITIONAL_BUILD_FLAGS=$1
+WORKER_TYPE_LOG_STRING=$2
+shift 2
+
+# Load the test setup defined in the parent directory
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CURRENT_DIR}/../integration_test_setup.sh" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+# TODO(philwo): Change this so the path to the custom worker gets passed in as an argument to the
+# test, once the bug that makes using the "args" attribute with sh_tests in Bazel impossible is
+# fixed.
+example_worker=$(find $BAZEL_RUNFILES -name ExampleWorkerMultiplexer_deploy.jar)
+
+add_to_bazelrc "build -s"
+add_to_bazelrc "build --spawn_strategy=worker,standalone"
+add_to_bazelrc "build --worker_verbose --worker_max_instances=1"
+add_to_bazelrc "build --debug_print_action_contexts"
+add_to_bazelrc "build ${ADDITIONAL_BUILD_FLAGS}"
+
+function set_up() {
+  # Run each test in a separate folder so that their output files don't get cached.
+  WORKSPACE_SUBDIR=$(basename $(mktemp -d ${WORKSPACE_DIR}/testXXXXXX))
+  cd ${WORKSPACE_SUBDIR}
+  BINS=$(bazel info $PRODUCT_NAME-bin)/${WORKSPACE_SUBDIR}
+
+  # This causes Bazel to shut down all running workers.
+  bazel build --worker_quit_after_build &> $TEST_log \
+    || fail "'bazel build --worker_quit_after_build' during test set_up failed"
+}
+
+function write_hello_library_files() {
+  mkdir -p java/main
+  cat >java/main/BUILD <<EOF
+java_binary(name = 'main',
+    deps = [':hello_library'],
+    srcs = ['Main.java'],
+    main_class = 'main.Main')
+
+java_library(name = 'hello_library',
+             srcs = ['HelloLibrary.java']);
+EOF
+
+  cat >java/main/Main.java <<EOF
+package main;
+import main.HelloLibrary;
+public class Main {
+  public static void main(String[] args) {
+    HelloLibrary.funcHelloLibrary();
+    System.out.println("Hello, World!");
+  }
+}
+EOF
+
+  cat >java/main/HelloLibrary.java <<EOF
+package main;
+public class HelloLibrary {
+  public static void funcHelloLibrary() {
+    System.out.print("Hello, Library!;");
+  }
+}
+EOF
+}
+
+function test_compiles_hello_library_using_persistent_javac() {
+  write_hello_library_files
+
+  bazel build java/main:main &> $TEST_log \
+    || fail "build failed"
+  expect_log "Created new ${WORKER_TYPE_LOG_STRING} Javac worker (id [0-9]\+)"
+  $BINS/java/main/main | grep -q "Hello, Library!;Hello, World!" \
+    || fail "comparison failed"
+}
+
+function prepare_example_worker() {
+  cp ${example_worker} worker_lib.jar
+  chmod +w worker_lib.jar
+  echo "exampledata" > worker_data.txt
+
+  mkdir worker_data_dir
+  echo "veryexample" > worker_data_dir/more_data.txt
+
+  cat >work.bzl <<'EOF'
+def _impl(ctx):
+  worker = ctx.executable.worker
+  output = ctx.outputs.out
+
+  argfile_inputs = []
+  argfile_arguments = []
+  if ctx.attr.multiflagfiles:
+    # Generate one flagfile per command-line arg, alternate between @ and --flagfile= style.
+    # This is used to test the code that handles multiple flagfiles and the --flagfile= style.
+    idx = 1
+    for arg in ["--output_file=" + output.path] + ctx.attr.args:
+      argfile = ctx.actions.declare_file("%s_worker_input_%s" % (ctx.label.name, idx))
+      ctx.actions.write(output=argfile, content=arg)
+      argfile_inputs.append(argfile)
+      flagfile_prefix = "@" if (idx % 2 == 0) else "--flagfile="
+      argfile_arguments.append(flagfile_prefix + argfile.path)
+      idx += 1
+  else:
+    # Generate the "@"-file containing the command-line args for the unit of work.
+    argfile = ctx.actions.declare_file("%s_worker_input" % ctx.label.name)
+    argfile_contents = "\n".join(["--output_file=" + output.path] + ctx.attr.args)
+    ctx.actions.write(output=argfile, content=argfile_contents)
+    argfile_inputs.append(argfile)
+    argfile_arguments.append("@" + argfile.path)
+
+  ctx.actions.run(
+      inputs=argfile_inputs + ctx.files.srcs,
+      outputs=[output],
+      executable=worker,
+      progress_message="Working on %s" % ctx.label.name,
+      mnemonic="Work",
+      execution_requirements={"supports-multiplex-workers": "1"},
+      arguments=ctx.attr.worker_args + argfile_arguments,
+  )
+
+work = rule(
+    implementation=_impl,
+    attrs={
+        "worker": attr.label(cfg="host", mandatory=True, allow_files=True, executable=True),
+        "worker_args": attr.string_list(),
+        "args": attr.string_list(),
+        "srcs": attr.label_list(allow_files=True),
+        "multiflagfiles": attr.bool(default=False),
+    },
+    outputs = {"out": "%{name}.out"},
+)
+EOF
+  cat >BUILD <<EOF
+load(":work.bzl", "work")
+
+java_import(
+  name = "worker_lib",
+  jars = ["worker_lib.jar"],
+)
+
+java_binary(
+  name = "worker",
+  main_class = "com.google.devtools.build.lib.worker.ExampleWorkerMultiplexer",
+  runtime_deps = [
+    ":worker_lib",
+  ],
+  data = [
+    ":worker_data.txt",
+    ":worker_data_dir",
+  ]
+)
+EOF
+}
+
+function test_example_worker() {
+  prepare_example_worker
+  cat >>BUILD <<EOF
+work(
+  name = "hello_world",
+  worker = ":worker",
+  args = ["hello world"],
+)
+
+work(
+  name = "hello_world_uppercase",
+  worker = ":worker",
+  args = ["--uppercase", "hello world"],
+)
+EOF
+
+  bazel build  :hello_world &> $TEST_log \
+    || fail "build failed"
+  assert_equals "hello world" "$(cat $BINS/hello_world.out)"
+
+  bazel build  :hello_world_uppercase &> $TEST_log \
+    || fail "build failed"
+  assert_equals "HELLO WORLD" "$(cat $BINS/hello_world_uppercase.out)"
+}
+run_suite "Worker multiplexer integration tests"

--- a/src/test/shell/integration/bazel_worker_multiplexer_test.sh
+++ b/src/test/shell/integration/bazel_worker_multiplexer_test.sh
@@ -49,49 +49,6 @@ function set_up() {
     || fail "'bazel build --worker_quit_after_build' during test set_up failed"
 }
 
-function write_hello_library_files() {
-  mkdir -p java/main
-  cat >java/main/BUILD <<EOF
-java_binary(name = 'main',
-    deps = [':hello_library'],
-    srcs = ['Main.java'],
-    main_class = 'main.Main')
-
-java_library(name = 'hello_library',
-             srcs = ['HelloLibrary.java']);
-EOF
-
-  cat >java/main/Main.java <<EOF
-package main;
-import main.HelloLibrary;
-public class Main {
-  public static void main(String[] args) {
-    HelloLibrary.funcHelloLibrary();
-    System.out.println("Hello, World!");
-  }
-}
-EOF
-
-  cat >java/main/HelloLibrary.java <<EOF
-package main;
-public class HelloLibrary {
-  public static void funcHelloLibrary() {
-    System.out.print("Hello, Library!;");
-  }
-}
-EOF
-}
-
-function test_compiles_hello_library_using_persistent_javac() {
-  write_hello_library_files
-
-  bazel build java/main:main &> $TEST_log \
-    || fail "build failed"
-  expect_log "Created new ${WORKER_TYPE_LOG_STRING} Javac worker (id [0-9]\+)"
-  $BINS/java/main/main | grep -q "Hello, Library!;Hello, World!" \
-    || fail "comparison failed"
-}
-
 function prepare_example_worker() {
   cp ${example_worker} worker_lib.jar
   chmod +w worker_lib.jar

--- a/src/test/shell/integration/bazel_worker_multiplexer_test.sh
+++ b/src/test/shell/integration/bazel_worker_multiplexer_test.sh
@@ -180,4 +180,30 @@ EOF
   assert_equals "hello world 2" "$(cat $BINS/hello_world_2.out)"
   assert_equals "hello world 3" "$(cat $BINS/hello_world_3.out)"
 }
+
+function test_multiple_target_with_delay() {
+  prepare_example_worker
+  cat >>BUILD <<EOF
+work(
+  name = "hello_world_1",
+  worker = ":worker",
+  args = ["--delay", "hello world 1"],
+)
+
+work(
+  name = "hello_world_2",
+  worker = ":worker",
+  args = ["--delay", "hello world 2"],
+)
+
+work(
+  name = "hello_world_3",
+  worker = ":worker",
+  args = ["--delay", "hello world 3"],
+)
+EOF
+
+  bazel build  :hello_world_1 :hello_world_2 :hello_world_3 &> $TEST_log \
+    || fail "build failed"
+}
 run_suite "Worker multiplexer integration tests"

--- a/src/test/shell/integration/bazel_worker_multiplexer_test.sh
+++ b/src/test/shell/integration/bazel_worker_multiplexer_test.sh
@@ -341,29 +341,29 @@ EOF
 
 # When a worker does not conform to the protocol and returns a response that is not a parseable
 # protobuf, it must be killed and a helpful error message should be printed.
-# function test_build_fails_when_worker_returns_junk() {
-#   prepare_example_worker
-#   cat >>BUILD <<'EOF'
-# [work(
-#   name = "hello_world_%s" % idx,
-#   worker = ":worker",
-#   worker_args = ["--poison_after=1"],
-#   args = ["--write_uuid", "--write_counter"],
-# ) for idx in range(10)]
-# EOF
+function test_build_fails_when_worker_returns_junk() {
+  prepare_example_worker
+  cat >>BUILD <<'EOF'
+[work(
+  name = "hello_world_%s" % idx,
+  worker = ":worker",
+  worker_args = ["--poison_after=1"],
+  args = ["--write_uuid", "--write_counter"],
+) for idx in range(10)]
+EOF
 
-#   bazel build :hello_world_1 &> $TEST_log \
-#     || fail "build failed"
+  bazel build :hello_world_1 &> $TEST_log \
+    || fail "build failed"
 
-#   # A failing worker should cause the build to fail.
-#   bazel build :hello_world_2 &> $TEST_log \
-#     && fail "expected build to fail" || true
+  # A failing worker should cause the build to fail.
+  bazel build :hello_world_2 &> $TEST_log \
+    && fail "expected build to fail" || true
 
-#   # Check that a helpful error message was printed.
-#   expect_log "Worker process returned an unparseable WorkResponse!"
-#   expect_log "Did you try to print something to stdout"
-#   expect_log "I'm a poisoned worker and this is not a protobuf."
-# }
+  # Check that a helpful error message was printed.
+  expect_log "Worker process returned an unparseable WorkResponse!"
+  expect_log "Did you try to print something to stdout"
+  expect_log "I'm a poisoned worker and this is not a protobuf."
+}
 
 function test_input_digests() {
   prepare_example_worker


### PR DESCRIPTION
This is the attempt to solve issue #2832.
The design doc has been approved [Multiplex persistent worker](https://docs.google.com/document/d/1OC0cVj1Y1QYo6n-wlK6mIwwG7xS2BJX7fuvf1r5LtnU/edit?usp=sharing).

Two minor design changes from design doc
- Number of WorkerProxy is still limited by `--worker_max_instances`.
- We merge worker multiplexer sender and receiver to one WorkerMultiplxer, WorkerProxy sends request to worker process directly.

# TODOs
- [x] Add tests.
- [x] Fix the issue that multiplexer silences unparseable responses from worker. Changes required in `WorkerMultiplexer.java` `run()`.
- [x] WorkerMultiplexer.waitResponse sometimes throws NP exceptions.