### PR TITLE
Fix a race condition in Bazel's Windows process management.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsSubprocess.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsSubprocess.java
@@ -201,7 +201,7 @@ public class WindowsSubprocess implements Subprocess {
 
   @Override
   public boolean finished() {
-    return !processFuture.isCancelled() && !processFuture.isDone();
+    return processFuture.isDone();
   }
 
   @Override

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -120,6 +120,14 @@ public:
     }
   }
 
+  // Return the last error as a human-readable string and clear it.
+  jstring getLastErrorAsString(JNIEnv *env) {
+    jstring result = env->NewString(reinterpret_cast<const jchar*>(
+        error_.c_str()), error_.size());
+    error_ = L"";
+    return result;
+  }
+
   HANDLE stdin_;
   NativeOutputStream stdout_;
   NativeOutputStream stderr_;
@@ -632,11 +640,7 @@ extern "C" JNIEXPORT jstring JNICALL
 Java_com_google_devtools_build_lib_windows_jni_WindowsProcesses_nativeProcessGetLastError(
     JNIEnv* env, jclass clazz, jlong process_long) {
   NativeProcess* process = reinterpret_cast<NativeProcess*>(process_long);
-  jstring result =
-      env->NewString(reinterpret_cast<const jchar*>(process->error_.c_str()),
-                     process->error_.size());
-  process->error_ = L"";
-  return result;
+  return process->getLastErrorAsString(env);
 }
 
 extern "C" JNIEXPORT jstring JNICALL

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -65,24 +65,6 @@ struct NativeOutputStream {
   }
 };
 
-struct NativeProcess {
-  HANDLE stdin_;
-  NativeOutputStream stdout_;
-  NativeOutputStream stderr_;
-  HANDLE process_;
-  HANDLE job_;
-  DWORD pid_;
-  std::wstring error_;
-
-  NativeProcess()
-      : stdin_(INVALID_HANDLE_VALUE),
-        stdout_(),
-        stderr_(),
-        process_(INVALID_HANDLE_VALUE),
-        job_(INVALID_HANDLE_VALUE),
-        error_(L"") {}
-};
-
 class JavaByteArray {
  public:
   JavaByteArray(JNIEnv* env, jbyteArray java_array)
@@ -109,6 +91,24 @@ class JavaByteArray {
   jbyteArray array_;
   jsize size_;
   jbyte* ptr_;
+};
+
+struct NativeProcess {
+  HANDLE stdin_;
+  NativeOutputStream stdout_;
+  NativeOutputStream stderr_;
+  HANDLE process_;
+  HANDLE job_;
+  DWORD pid_;
+  std::wstring error_;
+
+  NativeProcess()
+      : stdin_(INVALID_HANDLE_VALUE),
+        stdout_(),
+        stderr_(),
+        process_(INVALID_HANDLE_VALUE),
+        job_(INVALID_HANDLE_VALUE),
+        error_(L"") {}
 };
 
 static bool NestedJobsSupported() {

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -239,7 +239,7 @@ public:
       error_ = bazel::windows::MakeErrorMessage(
           WSTR(__FILE__), __LINE__, L"NativeProcess:WriteStdin",
           ToString(pid_), GetLastError());
-      bytes_written = -1;
+      return -1;
     }
 
     error_ = L"";

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -128,6 +128,12 @@ public:
     }
   }
 
+  jint GetPid() {
+    // MSDN says that GetProcessId cannot fail.
+    error_ = L"";
+    return GetProcessId(process_);
+  }
+
   // Terminates this process (and subprocesses, if job objects are available).
   jboolean Terminate() {
     static const UINT exit_code = 130;  // 128 + SIGINT, like on Linux
@@ -622,8 +628,7 @@ extern "C" JNIEXPORT jint JNICALL
 Java_com_google_devtools_build_lib_windows_jni_WindowsProcesses_nativeGetProcessPid(
     JNIEnv* env, jclass clazz, jlong process_long) {
   NativeProcess* process = reinterpret_cast<NativeProcess*>(process_long);
-  process->error_ = L"";
-  return GetProcessId(process->process_);  // MSDN says that this cannot fail
+  return process->GetPid();
 }
 
 extern "C" JNIEXPORT jboolean JNICALL

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -500,9 +500,7 @@ public:
   }
 
   jint GetPid() {
-    // MSDN says that GetProcessId cannot fail.
-    error_ = L"";
-    return GetProcessId(process_);
+    return pid_;
   }
 
   jint WriteStdin(JNIEnv* env, jbyteArray java_bytes, jint offset, jint length) {

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -130,7 +130,7 @@ struct NativeOutputStream {
   }
 
   // Return the last error as a human-readable string and clear it.
-  jstring getLastErrorAsString(JNIEnv* env) {
+  jstring GetLastErrorAsString(JNIEnv* env) {
     jstring result = env->NewString(reinterpret_cast<const jchar*>(
         error_.c_str()), error_.size());
     error_ = L"";
@@ -241,7 +241,7 @@ public:
   }
 
   // Return the last error as a human-readable string and clear it.
-  jstring getLastErrorAsString(JNIEnv *env) {
+  jstring GetLastErrorAsString(JNIEnv *env) {
     jstring result = env->NewString(reinterpret_cast<const jchar*>(
         error_.c_str()), error_.size());
     error_ = L"";
@@ -666,7 +666,7 @@ extern "C" JNIEXPORT jstring JNICALL
 Java_com_google_devtools_build_lib_windows_jni_WindowsProcesses_nativeProcessGetLastError(
     JNIEnv* env, jclass clazz, jlong process_long) {
   NativeProcess* process = reinterpret_cast<NativeProcess*>(process_long);
-  return process->getLastErrorAsString(env);
+  return process->GetLastErrorAsString(env);
 }
 
 extern "C" JNIEXPORT jstring JNICALL
@@ -674,5 +674,5 @@ Java_com_google_devtools_build_lib_windows_jni_WindowsProcesses_nativeStreamGetL
     JNIEnv* env, jclass clazz, jlong stream_long) {
   NativeOutputStream* stream =
       reinterpret_cast<NativeOutputStream*>(stream_long);
-  return stream->getLastErrorAsString(env);
+  return stream->GetLastErrorAsString(env);
 }

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -63,6 +63,14 @@ struct NativeOutputStream {
     CloseHandle(handle_);
     handle_ = INVALID_HANDLE_VALUE;
   }
+
+  // Return the last error as a human-readable string and clear it.
+  jstring getLastErrorAsString(JNIEnv* env) {
+    jstring result = env->NewString(reinterpret_cast<const jchar*>(
+        error_.c_str()), error_.size());
+    error_ = L"";
+    return result;
+  }
 };
 
 class JavaByteArray {
@@ -648,9 +656,5 @@ Java_com_google_devtools_build_lib_windows_jni_WindowsProcesses_nativeStreamGetL
     JNIEnv* env, jclass clazz, jlong stream_long) {
   NativeOutputStream* stream =
       reinterpret_cast<NativeOutputStream*>(stream_long);
-  jstring result =
-      env->NewString(reinterpret_cast<const jchar*>(stream->error_.c_str()),
-                     stream->error_.size());
-  stream->error_ = L"";
-  return result;
+  return stream->getLastErrorAsString(env);
 }

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -223,6 +223,14 @@ public:
     return GetProcessId(process_);
   }
 
+  NativeOutputStream* GetStdoutStream() {
+    return &stdout_;
+  }
+
+  NativeOutputStream* GetStderrStream() {
+    return &stderr_;
+  }
+
   // Terminates this process (and subprocesses, if job objects are available).
   jboolean Terminate() {
     static const UINT exit_code = 130;  // 128 + SIGINT, like on Linux
@@ -604,14 +612,14 @@ extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_devtools_build_lib_windows_jni_WindowsProcesses_nativeGetStdout(
     JNIEnv* env, jclass clazz, jlong process_long) {
   NativeProcess* process = reinterpret_cast<NativeProcess*>(process_long);
-  return PtrAsJlong(&process->stdout_);
+  return PtrAsJlong(process->GetStdoutStream());
 }
 
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_devtools_build_lib_windows_jni_WindowsProcesses_nativeGetStderr(
     JNIEnv* env, jclass clazz, jlong process_long) {
   NativeProcess* process = reinterpret_cast<NativeProcess*>(process_long);
-  return PtrAsJlong(&process->stderr_);
+  return PtrAsJlong(process->GetStderrStream());
 }
 
 extern "C" JNIEXPORT jint JNICALL

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -172,6 +172,288 @@ public:
     }
   }
 
+  void Create(JNIEnv* env, jstring java_argv0, jstring java_argv_rest,
+      jbyteArray java_env, jstring java_cwd, jstring java_stdout_redirect,
+      jstring java_stderr_redirect, jboolean redirectErrorStream) {
+    std::wstring argv0;
+    std::wstring wpath(bazel::windows::GetJavaWpath(env, java_argv0));
+    std::wstring error_msg(
+        bazel::windows::AsExecutablePathForCreateProcess(wpath, &argv0));
+    if (!error_msg.empty()) {
+      error_ = bazel::windows::MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, error_msg);
+      return;
+    }
+
+    std::wstring commandline =
+        argv0 + L" " + bazel::windows::GetJavaWstring(env, java_argv_rest);
+    std::wstring stdout_redirect = bazel::windows::AddUncPrefixMaybe(
+        bazel::windows::GetJavaWpath(env, java_stdout_redirect));
+    std::wstring stderr_redirect = bazel::windows::AddUncPrefixMaybe(
+        bazel::windows::GetJavaWpath(env, java_stderr_redirect));
+    std::wstring cwd;
+    std::wstring wcwd(bazel::windows::GetJavaWpath(env, java_cwd));
+    error_msg = bazel::windows::AsShortPath(wcwd, &cwd);
+    if (!error_msg.empty()) {
+      error_ = bazel::windows::MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, error_msg);
+      return;
+    }
+
+    const bool stdout_is_stream = stdout_redirect.empty();
+    const bool stderr_is_stream =
+        redirectErrorStream ? stdout_is_stream : stderr_redirect.empty();
+    const bool stderr_same_handle_as_stdout =
+        redirectErrorStream ||
+        (!stderr_redirect.empty() &&
+        stderr_redirect.size() == stdout_redirect.size() &&
+        _wcsnicmp(stderr_redirect.c_str(), stdout_redirect.c_str(),
+                  stderr_redirect.size()) == 0);
+
+    std::unique_ptr<WCHAR[]> mutable_commandline(
+        new WCHAR[commandline.size() + 1]);
+    wcsncpy(mutable_commandline.get(), commandline.c_str(),
+            commandline.size() + 1);
+
+    SECURITY_ATTRIBUTES sa = {0};
+    sa.nLength = sizeof(SECURITY_ATTRIBUTES);
+    sa.bInheritHandle = TRUE;
+
+    // Standard file handles are closed even if the process was successfully
+    // created. If this was not so, operations on these file handles would not
+    // return immediately if the process is terminated.
+    // Therefore we make these handles auto-closing (by using AutoHandle).
+    bazel::windows::AutoHandle stdin_process;
+    bazel::windows::AutoHandle stdout_process;
+    bazel::windows::AutoHandle stderr_process;
+    bazel::windows::AutoHandle thread;
+    PROCESS_INFORMATION process_info = {0};
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_info = {0};
+
+    JavaByteArray env_map(env, java_env);
+    if (env_map.ptr() != nullptr) {
+      if (env_map.size() < 4) {
+        error_ = bazel::windows::MakeErrorMessage(
+            WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath,
+            std::wstring(L"the environment must be at least 4 bytes long, was ") +
+                ToString(env_map.size()) + L" bytes");
+        return;
+      } else if (env_map.ptr()[env_map.size() - 1] != 0 ||
+                env_map.ptr()[env_map.size() - 2] != 0 ||
+                env_map.ptr()[env_map.size() - 3] != 0 ||
+                env_map.ptr()[env_map.size() - 4] != 0) {
+        error_ = bazel::windows::MakeErrorMessage(
+            WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath,
+            L"environment array must end with 4 null bytes");
+        return;
+      }
+    }
+
+    {
+      HANDLE pipe_read_h, pipe_write_h;
+      if (!CreatePipe(&pipe_read_h, &pipe_write_h, &sa, 0)) {
+        DWORD err_code = GetLastError();
+        error_ = bazel::windows::MakeErrorMessage(
+            WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+        return;
+      }
+      stdin_process = pipe_read_h;
+      stdin_ = pipe_write_h;
+    }
+
+    if (!stdout_is_stream) {
+      stdout_.Close();
+
+      stdout_process = CreateFileW(
+          /* lpFileName */ stdout_redirect.c_str(),
+          /* dwDesiredAccess */ GENERIC_WRITE,
+          /* dwShareMode */ 0,
+          /* lpSecurityAttributes */ &sa,
+          /* dwCreationDisposition */ OPEN_ALWAYS,
+          /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
+          /* hTemplateFile */ NULL);
+
+      if (!stdout_process.IsValid()) {
+        DWORD err_code = GetLastError();
+        error_ = bazel::windows::MakeErrorMessage(
+            WSTR(__FILE__), __LINE__, L"nativeCreateProcess", stdout_redirect,
+            err_code);
+        return;
+      }
+      if (!SetFilePointerEx(stdout_process, {0}, NULL, FILE_END)) {
+        DWORD err_code = GetLastError();
+        error_ = bazel::windows::MakeErrorMessage(
+            WSTR(__FILE__), __LINE__, L"nativeCreateProcess", stdout_redirect,
+            err_code);
+        return;
+      }
+    } else {
+      HANDLE pipe_read_h, pipe_write_h;
+      if (!CreatePipe(&pipe_read_h, &pipe_write_h, &sa, 0)) {
+        DWORD err_code = GetLastError();
+        error_ = bazel::windows::MakeErrorMessage(
+            WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+        return;
+      }
+      stdout_.SetHandle(pipe_read_h);
+      stdout_process = pipe_write_h;
+    }
+
+    if (stderr_same_handle_as_stdout) {
+      HANDLE stdout_process_dup_h;
+      if (!DuplicateHandle(GetCurrentProcess(), stdout_process,
+                          GetCurrentProcess(), &stdout_process_dup_h, 0, TRUE,
+                          DUPLICATE_SAME_ACCESS)) {
+        DWORD err_code = GetLastError();
+        error_ = bazel::windows::MakeErrorMessage(
+            WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+        return;
+      }
+      if (!stderr_is_stream) {
+        stderr_.Close();
+      }
+
+      stderr_process = stdout_process_dup_h;
+    } else if (!stderr_redirect.empty()) {
+      stderr_.Close();
+      stderr_process = CreateFileW(
+          /* lpFileName */ stderr_redirect.c_str(),
+          /* dwDesiredAccess */ GENERIC_WRITE,
+          /* dwShareMode */ 0,
+          /* lpSecurityAttributes */ &sa,
+          /* dwCreationDisposition */ OPEN_ALWAYS,
+          /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
+          /* hTemplateFile */ NULL);
+
+      if (!stderr_process.IsValid()) {
+        DWORD err_code = GetLastError();
+        error_ = bazel::windows::MakeErrorMessage(
+            WSTR(__FILE__), __LINE__, L"nativeCreateProcess", stderr_redirect,
+            err_code);
+        return;
+      }
+      if (!SetFilePointerEx(stderr_process, {0}, NULL, FILE_END)) {
+        DWORD err_code = GetLastError();
+        error_ = bazel::windows::MakeErrorMessage(
+            WSTR(__FILE__), __LINE__, L"nativeCreateProcess", stderr_redirect,
+            err_code);
+        return;
+      }
+    } else {
+      HANDLE pipe_read_h, pipe_write_h;
+      if (!CreatePipe(&pipe_read_h, &pipe_write_h, &sa, 0)) {
+        DWORD err_code = GetLastError();
+        error_ = bazel::windows::MakeErrorMessage(
+            WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+        return;
+      }
+      stderr_.SetHandle(pipe_read_h);
+      stderr_process = pipe_write_h;
+    }
+
+    // MDSN says that the default for job objects is that breakaway is not
+    // allowed. Thus, we don't need to do any more setup here.
+    HANDLE job = CreateJobObject(NULL, NULL);
+    if (job == NULL) {
+      DWORD err_code = GetLastError();
+      error_ = bazel::windows::MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+      return;
+    }
+
+    job_ = job;
+
+    job_info.BasicLimitInformation.LimitFlags =
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation,
+                                &job_info, sizeof(job_info))) {
+      DWORD err_code = GetLastError();
+      error_ = bazel::windows::MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+      return;
+    }
+
+    std::unique_ptr<bazel::windows::AutoAttributeList> attr_list;
+    if (!bazel::windows::AutoAttributeList::Create(stdin_process, stdout_process,
+                                                  stderr_process, &attr_list,
+                                                  &error_msg)) {
+      error_ = bazel::windows::MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", L"", error_msg);
+      return;
+    }
+
+    // kMaxCmdline value: see lpCommandLine parameter of CreateProcessW.
+    static constexpr size_t kMaxCmdline = 32767;
+
+    std::wstring cmd_sample = mutable_commandline.get();
+    if (cmd_sample.size() > 200) {
+      cmd_sample = cmd_sample.substr(0, 195) + L"(...)";
+    }
+    if (wcsnlen_s(mutable_commandline.get(), kMaxCmdline) == kMaxCmdline) {
+      std::wstringstream error_msg;
+      error_msg << L"command is longer than CreateProcessW's limit ("
+                << kMaxCmdline << L" characters)";
+      error_ = bazel::windows::MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"CreateProcessWithExplicitHandles",
+          cmd_sample, error_msg.str().c_str());
+      return;
+    }
+
+    STARTUPINFOEXW info;
+    attr_list->InitStartupInfoExW(&info);
+    if (!CreateProcessW(
+            /* lpApplicationName */ NULL,
+            /* lpCommandLine */ mutable_commandline.get(),
+            /* lpProcessAttributes */ NULL,
+            /* lpThreadAttributes */ NULL,
+            /* bInheritHandles */ TRUE,
+            /* dwCreationFlags */ CREATE_NO_WINDOW  // Don't create console window
+                | CREATE_NEW_PROCESS_GROUP  // So that Ctrl-Break isn't propagated
+                | CREATE_SUSPENDED  // So that it doesn't start a new job itself
+                | EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+            /* lpEnvironment */ env_map.ptr(),
+            /* lpCurrentDirectory */ cwd.empty() ? NULL : cwd.c_str(),
+            /* lpStartupInfo */ &info.StartupInfo,
+            /* lpProcessInformation */ &process_info)) {
+      DWORD err = GetLastError();
+      error_ = bazel::windows::MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"CreateProcessW", cmd_sample, err);
+      return;
+    }
+
+    pid_ = process_info.dwProcessId;
+    process_ = process_info.hProcess;
+    thread = process_info.hThread;
+
+    if (!AssignProcessToJobObject(job_, process_)) {
+      BOOL is_in_job = false;
+      if (IsProcessInJob(process_, NULL, &is_in_job) && is_in_job &&
+          !NestedJobsSupported()) {
+        // We are on a pre-Windows 8 system and the Bazel is already in a job.
+        // We can't create nested jobs, so just revert to TerminateProcess() and
+        // hope for the best. In batch mode, the launcher puts Bazel in a job so
+        // that will take care of cleanup once the command finishes.
+        CloseHandle(job_);
+        job_ = INVALID_HANDLE_VALUE;
+      } else {
+        DWORD err_code = GetLastError();
+        error_ = bazel::windows::MakeErrorMessage(
+            WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+        return;
+      }
+    }
+
+    // Now that we put the process in a new job object, we can start executing it
+    if (ResumeThread(thread) == -1) {
+      DWORD err_code = GetLastError();
+      error_ = bazel::windows::MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+      return;
+    }
+
+    error_ = L"";
+  }
+
   // Wait for this process to exit (or timeout).
   jint WaitFor(jlong timeout_msec) {
     DWORD win32_timeout = timeout_msec < 0 ? INFINITE : timeout_msec;
@@ -286,6 +568,18 @@ public:
     return result;
   }
 
+ private:
+  bool NestedJobsSupported() {
+    OSVERSIONINFOEX version_info;
+    version_info.dwOSVersionInfoSize = sizeof(version_info);
+    if (!GetVersionEx(reinterpret_cast<OSVERSIONINFO*>(&version_info))) {
+      return false;
+    }
+    
+    return version_info.dwMajorVersion > 6 ||
+          (version_info.dwMajorVersion == 6 && version_info.dwMinorVersion >= 2);
+  }
+
   HANDLE stdin_;
   NativeOutputStream stdout_;
   NativeOutputStream stderr_;
@@ -294,17 +588,6 @@ public:
   DWORD pid_;
   std::wstring error_;
 };
-
-static bool NestedJobsSupported() {
-  OSVERSIONINFOEX version_info;
-  version_info.dwOSVersionInfoSize = sizeof(version_info);
-  if (!GetVersionEx(reinterpret_cast<OSVERSIONINFO*>(&version_info))) {
-    return false;
-  }
-
-  return version_info.dwMajorVersion > 6 ||
-         (version_info.dwMajorVersion == 6 && version_info.dwMinorVersion >= 2);
-}
 
 // Ensure we can safely cast jlong to void*.
 static_assert(sizeof(jlong) == sizeof(void*),
@@ -321,284 +604,8 @@ Java_com_google_devtools_build_lib_windows_jni_WindowsProcesses_nativeCreateProc
     jbyteArray java_env, jstring java_cwd, jstring java_stdout_redirect,
     jstring java_stderr_redirect, jboolean redirectErrorStream) {
   NativeProcess* result = new NativeProcess();
-
-  std::wstring argv0;
-  std::wstring wpath(bazel::windows::GetJavaWpath(env, java_argv0));
-  std::wstring error_msg(
-      bazel::windows::AsExecutablePathForCreateProcess(wpath, &argv0));
-  if (!error_msg.empty()) {
-    result->error_ = bazel::windows::MakeErrorMessage(
-        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, error_msg);
-    return PtrAsJlong(result);
-  }
-
-  std::wstring commandline =
-      argv0 + L" " + bazel::windows::GetJavaWstring(env, java_argv_rest);
-  std::wstring stdout_redirect = bazel::windows::AddUncPrefixMaybe(
-      bazel::windows::GetJavaWpath(env, java_stdout_redirect));
-  std::wstring stderr_redirect = bazel::windows::AddUncPrefixMaybe(
-      bazel::windows::GetJavaWpath(env, java_stderr_redirect));
-  std::wstring cwd;
-  std::wstring wcwd(bazel::windows::GetJavaWpath(env, java_cwd));
-  error_msg = bazel::windows::AsShortPath(wcwd, &cwd);
-  if (!error_msg.empty()) {
-    result->error_ = bazel::windows::MakeErrorMessage(
-        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, error_msg);
-    return PtrAsJlong(result);
-  }
-
-  const bool stdout_is_stream = stdout_redirect.empty();
-  const bool stderr_is_stream =
-      redirectErrorStream ? stdout_is_stream : stderr_redirect.empty();
-  const bool stderr_same_handle_as_stdout =
-      redirectErrorStream ||
-      (!stderr_redirect.empty() &&
-       stderr_redirect.size() == stdout_redirect.size() &&
-       _wcsnicmp(stderr_redirect.c_str(), stdout_redirect.c_str(),
-                 stderr_redirect.size()) == 0);
-
-  std::unique_ptr<WCHAR[]> mutable_commandline(
-      new WCHAR[commandline.size() + 1]);
-  wcsncpy(mutable_commandline.get(), commandline.c_str(),
-          commandline.size() + 1);
-
-  SECURITY_ATTRIBUTES sa = {0};
-  sa.nLength = sizeof(SECURITY_ATTRIBUTES);
-  sa.bInheritHandle = TRUE;
-
-  // Standard file handles are closed even if the process was successfully
-  // created. If this was not so, operations on these file handles would not
-  // return immediately if the process is terminated.
-  // Therefore we make these handles auto-closing (by using AutoHandle).
-  bazel::windows::AutoHandle stdin_process;
-  bazel::windows::AutoHandle stdout_process;
-  bazel::windows::AutoHandle stderr_process;
-  bazel::windows::AutoHandle thread;
-  PROCESS_INFORMATION process_info = {0};
-  JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_info = {0};
-
-  JavaByteArray env_map(env, java_env);
-  if (env_map.ptr() != nullptr) {
-    if (env_map.size() < 4) {
-      result->error_ = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath,
-          std::wstring(L"the environment must be at least 4 bytes long, was ") +
-              ToString(env_map.size()) + L" bytes");
-      return PtrAsJlong(result);
-    } else if (env_map.ptr()[env_map.size() - 1] != 0 ||
-               env_map.ptr()[env_map.size() - 2] != 0 ||
-               env_map.ptr()[env_map.size() - 3] != 0 ||
-               env_map.ptr()[env_map.size() - 4] != 0) {
-      result->error_ = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath,
-          L"environment array must end with 4 null bytes");
-      return PtrAsJlong(result);
-    }
-  }
-
-  {
-    HANDLE pipe_read_h, pipe_write_h;
-    if (!CreatePipe(&pipe_read_h, &pipe_write_h, &sa, 0)) {
-      DWORD err_code = GetLastError();
-      result->error_ = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-      return PtrAsJlong(result);
-    }
-    stdin_process = pipe_read_h;
-    result->stdin_ = pipe_write_h;
-  }
-
-  if (!stdout_is_stream) {
-    result->stdout_.Close();
-
-    stdout_process = CreateFileW(
-        /* lpFileName */ stdout_redirect.c_str(),
-        /* dwDesiredAccess */ GENERIC_WRITE,
-        /* dwShareMode */ 0,
-        /* lpSecurityAttributes */ &sa,
-        /* dwCreationDisposition */ OPEN_ALWAYS,
-        /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
-        /* hTemplateFile */ NULL);
-
-    if (!stdout_process.IsValid()) {
-      DWORD err_code = GetLastError();
-      result->error_ = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", stdout_redirect,
-          err_code);
-      return PtrAsJlong(result);
-    }
-    if (!SetFilePointerEx(stdout_process, {0}, NULL, FILE_END)) {
-      DWORD err_code = GetLastError();
-      result->error_ = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", stdout_redirect,
-          err_code);
-      return PtrAsJlong(result);
-    }
-  } else {
-    HANDLE pipe_read_h, pipe_write_h;
-    if (!CreatePipe(&pipe_read_h, &pipe_write_h, &sa, 0)) {
-      DWORD err_code = GetLastError();
-      result->error_ = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-      return PtrAsJlong(result);
-    }
-    result->stdout_.SetHandle(pipe_read_h);
-    stdout_process = pipe_write_h;
-  }
-
-  if (stderr_same_handle_as_stdout) {
-    HANDLE stdout_process_dup_h;
-    if (!DuplicateHandle(GetCurrentProcess(), stdout_process,
-                         GetCurrentProcess(), &stdout_process_dup_h, 0, TRUE,
-                         DUPLICATE_SAME_ACCESS)) {
-      DWORD err_code = GetLastError();
-      result->error_ = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-      return PtrAsJlong(result);
-    }
-    if (!stderr_is_stream) {
-      result->stderr_.Close();
-    }
-
-    stderr_process = stdout_process_dup_h;
-  } else if (!stderr_redirect.empty()) {
-    result->stderr_.Close();
-    stderr_process = CreateFileW(
-        /* lpFileName */ stderr_redirect.c_str(),
-        /* dwDesiredAccess */ GENERIC_WRITE,
-        /* dwShareMode */ 0,
-        /* lpSecurityAttributes */ &sa,
-        /* dwCreationDisposition */ OPEN_ALWAYS,
-        /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
-        /* hTemplateFile */ NULL);
-
-    if (!stderr_process.IsValid()) {
-      DWORD err_code = GetLastError();
-      result->error_ = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", stderr_redirect,
-          err_code);
-      return PtrAsJlong(result);
-    }
-    if (!SetFilePointerEx(stderr_process, {0}, NULL, FILE_END)) {
-      DWORD err_code = GetLastError();
-      result->error_ = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", stderr_redirect,
-          err_code);
-      return PtrAsJlong(result);
-    }
-  } else {
-    HANDLE pipe_read_h, pipe_write_h;
-    if (!CreatePipe(&pipe_read_h, &pipe_write_h, &sa, 0)) {
-      DWORD err_code = GetLastError();
-      result->error_ = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-      return PtrAsJlong(result);
-    }
-    result->stderr_.SetHandle(pipe_read_h);
-    stderr_process = pipe_write_h;
-  }
-
-  // MDSN says that the default for job objects is that breakaway is not
-  // allowed. Thus, we don't need to do any more setup here.
-  HANDLE job = CreateJobObject(NULL, NULL);
-  if (job == NULL) {
-    DWORD err_code = GetLastError();
-    result->error_ = bazel::windows::MakeErrorMessage(
-        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-    return PtrAsJlong(result);
-  }
-
-  result->job_ = job;
-
-  job_info.BasicLimitInformation.LimitFlags =
-      JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-  if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation,
-                               &job_info, sizeof(job_info))) {
-    DWORD err_code = GetLastError();
-    result->error_ = bazel::windows::MakeErrorMessage(
-        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-    return PtrAsJlong(result);
-  }
-
-  std::unique_ptr<bazel::windows::AutoAttributeList> attr_list;
-  if (!bazel::windows::AutoAttributeList::Create(stdin_process, stdout_process,
-                                                 stderr_process, &attr_list,
-                                                 &error_msg)) {
-    result->error_ = bazel::windows::MakeErrorMessage(
-        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", L"", error_msg);
-    return PtrAsJlong(result);
-  }
-
-  // kMaxCmdline value: see lpCommandLine parameter of CreateProcessW.
-  static constexpr size_t kMaxCmdline = 32767;
-
-  std::wstring cmd_sample = mutable_commandline.get();
-  if (cmd_sample.size() > 200) {
-    cmd_sample = cmd_sample.substr(0, 195) + L"(...)";
-  }
-  if (wcsnlen_s(mutable_commandline.get(), kMaxCmdline) == kMaxCmdline) {
-    std::wstringstream error_msg;
-    error_msg << L"command is longer than CreateProcessW's limit ("
-              << kMaxCmdline << L" characters)";
-    result->error_ = bazel::windows::MakeErrorMessage(
-        WSTR(__FILE__), __LINE__, L"CreateProcessWithExplicitHandles",
-        cmd_sample, error_msg.str().c_str());
-    return PtrAsJlong(result);
-  }
-
-  STARTUPINFOEXW info;
-  attr_list->InitStartupInfoExW(&info);
-  if (!CreateProcessW(
-          /* lpApplicationName */ NULL,
-          /* lpCommandLine */ mutable_commandline.get(),
-          /* lpProcessAttributes */ NULL,
-          /* lpThreadAttributes */ NULL,
-          /* bInheritHandles */ TRUE,
-          /* dwCreationFlags */ CREATE_NO_WINDOW  // Don't create console window
-              | CREATE_NEW_PROCESS_GROUP  // So that Ctrl-Break isn't propagated
-              | CREATE_SUSPENDED  // So that it doesn't start a new job itself
-              | EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
-          /* lpEnvironment */ env_map.ptr(),
-          /* lpCurrentDirectory */ cwd.empty() ? NULL : cwd.c_str(),
-          /* lpStartupInfo */ &info.StartupInfo,
-          /* lpProcessInformation */ &process_info)) {
-    DWORD err = GetLastError();
-    result->error_ = bazel::windows::MakeErrorMessage(
-        WSTR(__FILE__), __LINE__, L"CreateProcessW", cmd_sample, err);
-    return PtrAsJlong(result);
-  }
-
-  result->pid_ = process_info.dwProcessId;
-  result->process_ = process_info.hProcess;
-  thread = process_info.hThread;
-
-  if (!AssignProcessToJobObject(result->job_, result->process_)) {
-    BOOL is_in_job = false;
-    if (IsProcessInJob(result->process_, NULL, &is_in_job) && is_in_job &&
-        !NestedJobsSupported()) {
-      // We are on a pre-Windows 8 system and the Bazel is already in a job.
-      // We can't create nested jobs, so just revert to TerminateProcess() and
-      // hope for the best. In batch mode, the launcher puts Bazel in a job so
-      // that will take care of cleanup once the command finishes.
-      CloseHandle(result->job_);
-      result->job_ = INVALID_HANDLE_VALUE;
-    } else {
-      DWORD err_code = GetLastError();
-      result->error_ = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-      return PtrAsJlong(result);
-    }
-  }
-
-  // Now that we put the process in a new job object, we can start executing it
-  if (ResumeThread(thread) == -1) {
-    DWORD err_code = GetLastError();
-    result->error_ = bazel::windows::MakeErrorMessage(
-        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-    return PtrAsJlong(result);
-  }
-
-  result->error_ = L"";
+  result->Create(env, java_argv0, java_argv_rest, java_env, java_cwd,
+                 java_stdout_redirect, java_stderr_redirect, redirectErrorStream);
   return PtrAsJlong(result);
 }
 


### PR DESCRIPTION
(Second version of this PR that fixes the issues from the last time and refactors the code a bit to make it easier to understand and maintain.)

While we did correctly terminate the job object of a process when calling Subprocess.destroy and we did correctly wait for the process itself to exit in Subprocess.waitFor, we didn't wait for its children to exit.

This is usually not a big problem, except when they keep open some file handles to files that Bazel immediately tris to delete after killing / waiting for the main process, in which case the files might still be in use. This is the reason why we're seeing errors like this on CI:

https://buildkite.com/bazel/bazel-bazel/builds/5774#27afa2c9-9ff1-4224-9df7-ba0253e7e317/193-303

"Caught I/O exception: Cannot delete path (something below $TEST_TMPDIR): Access is denied."

This CL modifies the behavior to explicitly terminate the job object in Subprocess.waitFor when the main process has exited and then wait for all transitive subprocesses to exit, before continuing.

Due to some interesting semantics, one cannot simply use WaitForSingleObject on the Job handle, instead one has to use an IoCompletionPort that gets a signal when the last job in the group has exited: https://blogs.msdn.microsoft.com/oldnewthing/20130405-00/?p=4743