### PR TITLE
C++ compilation: flag for header-validation debug

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -553,6 +553,10 @@ public final class CppConfiguration extends BuildConfiguration.Fragment
     return cppOptions.disableDepsetInUserFlags;
   }
 
+  public boolean getHeaderValidationDebug() {
+    return cppOptions.headerValidationDebug;
+  }
+
   public static PathFragment computeDefaultSysroot(String builtInSysroot) {
     if (builtInSysroot.isEmpty()) {
       return null;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -797,6 +797,17 @@ public class CppOptions extends FragmentOptions {
       help = "If enabled, cpu transformer is not used for CppConfiguration")
   public boolean doNotUseCpuTransformer;
 
+  // TODO(laszlocsomor): revert the commit that added this flag, after we found the root cause of
+  // https://github.com/bazelbuild/bazel/issues/6847
+  @Option(
+      name = "experimental_header_validation_debug",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.EXECUTION},
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help = "If enabled, CppCompileAction prints extra info about failed header validation.")
+  public boolean headerValidationDebug;
+
   @Override
   public FragmentOptions getHost() {
     CppOptions host = (CppOptions) getDefault();


### PR DESCRIPTION
Add the --[no]experimental_header_validation_debug
flag.

This flag tells Bazel to print extra debugging
information when a C++ compilation action fails
header inclusion validation.

We will enable this flag on BuildKite in hopes of
catching the culprit of https://github.com/bazelbuild/bazel/issues/6847.

After we find the culprit, this commit should be
reverted and the
--experimental_header_validation_debug flag from
BuildKite's configuration should be removed.

See https://github.com/bazelbuild/bazel/issues/6847