### PR TITLE
doc: remove misplaced period

### DIFF
--- a/site/docs/toolchains.md
+++ b/site/docs/toolchains.md
@@ -17,13 +17,10 @@ title: Toolchains
 
 This page describes the toolchain framework -- a way for rule authors to
 decouple their rule logic from platform-based selection of tools. It is
-recommended to read the
-[rules](skylark/rules.html)
-and
-[platforms](platforms.html).
-pages before continuing. This page covers why toolchains are needed, how to
-define and use them, and how Bazel selects an appropriate toolchain based on
-platform constraints.
+recommended to read the [rules](skylark/rules.html) and
+[platforms](platforms.html) pages before continuing. This page covers why
+toolchains are needed, how to define and use them, and how Bazel selects an
+appropriate toolchain based on platform constraints.
 
 ## Motivation
 


### PR DESCRIPTION
* Remove misplaced period after platforms link.
* Reflow.