### PR TITLE
Rename SymlinkEvent.to to SymlinkEvent.path and SymlinkEvent.from to SymlinkEvent.target.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -179,7 +179,11 @@ public final class WorkspaceRuleEvent implements ProgressLike {
   /** Creates a new WorkspaceRuleEvent for a symlink event. */
   public static WorkspaceRuleEvent newSymlinkEvent(
       String from, String to, String ruleLabel, Location location) {
-    SymlinkEvent e = WorkspaceLogProtos.SymlinkEvent.newBuilder().setFrom(from).setTo(to).build();
+    SymlinkEvent e =
+        WorkspaceLogProtos.SymlinkEvent.newBuilder()
+            .setTarget(from)
+            .setPath(to)
+            .build();
 
     WorkspaceLogProtos.WorkspaceEvent.Builder result =
         WorkspaceLogProtos.WorkspaceEvent.newBuilder();

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
@@ -81,9 +81,9 @@ message OsEvent {
 // Information on "symlink" event in repository_ctx.
 message SymlinkEvent {
   // path to which the symlink will point to
-  string from = 1;
+  string target = 1;
   // path of the symlink
-  string to = 2;
+  string path = 2;
 }
 
 // Information on "template" event in repository_ctx.

--- a/src/test/shell/bazel/bazel_workspaces_test.sh
+++ b/src/test/shell/bazel/bazel_workspaces_test.sh
@@ -277,8 +277,8 @@ function test_symlink() {
   ensure_contains_exactly 'location: .*repos.bzl:3:3' 1
   ensure_contains_atleast 'rule: "//external:repo"' 1
   ensure_contains_exactly 'symlink_event' 1
-  ensure_contains_exactly 'from: ".*symlink.txt"' 1
-  ensure_contains_exactly 'to: ".*symlink_out.txt"' 1
+  ensure_contains_exactly 'target: ".*symlink.txt"' 1
+  ensure_contains_exactly 'path: ".*symlink_out.txt"' 1
 }
 
 function test_template() {


### PR DESCRIPTION
This naming has the advantages of
1. Being more consistent with traditional symlink terminology (c.f. `man ln`), other workspace log events ("path" is used for the filesystem entry that is created in the other event messages), and Bazel Starlark APIs ("SymlinkEntry" uses "path" and "target_file").
2. Avoids field names that are likely to be language keywords. In particular, "from" is a keyword in Python.

I assume the compatibility breakage here is okay because the workspace log is all under --experimental_workspace_rules_log_file.

This fixes https://github.com/bazelbuild/bazel/issues/6887.