### PR TITLE
Pass macOS version min flag in osx CROSSTOOL

### DIFF
--- a/tools/osx/crosstool/CROSSTOOL.tpl
+++ b/tools/osx/crosstool/CROSSTOOL.tpl
@@ -1024,6 +1024,7 @@ toolchain {
       action: "objc-compile"
       action: "objc++-compile"
       flag_group {
+        flag: "-mmacosx-version-min=%{version_min}"
       }
     }
   }


### PR DESCRIPTION
This fixes an issue where cc_library targets that are dependent on from
swift_binaries weren't passed the version min flag which lead to linker
warnings about version mismatches.

More details: https://github.com/bazelbuild/rules_swift/issues/114