### PR TITLE
Bazel client: canonicalize all RcFile paths

### DIFF
--- a/src/main/cpp/blaze_util.cc
+++ b/src/main/cpp/blaze_util.cc
@@ -181,6 +181,10 @@ void SetDebugLog(bool enabled) {
   }
 }
 
+bool IsRunningInsideOfTest() {
+  return !GetEnv("TEST_TMPDIR").empty();
+}
+
 void WithEnvVars::SetEnvVars(const map<string, EnvVarValue>& vars) {
   for (const auto& var : vars) {
     switch (var.second.action) {

--- a/src/main/cpp/blaze_util.cc
+++ b/src/main/cpp/blaze_util.cc
@@ -181,7 +181,7 @@ void SetDebugLog(bool enabled) {
   }
 }
 
-bool IsRunningInsideOfTest() {
+bool IsRunningWithinTest() {
   return !GetEnv("TEST_TMPDIR").empty();
 }
 

--- a/src/main/cpp/blaze_util.h
+++ b/src/main/cpp/blaze_util.h
@@ -104,6 +104,10 @@ std::string ToString(const T &value) {
 // Revisit once client logging is fixed (b/32939567).
 void SetDebugLog(bool enabled);
 
+// Returns true if this Bazel instance is running inside of a Bazel test.
+// This method observes the TEST_SRCDIR envvar.
+bool IsRunningInsideOfTest();
+
 // What WithEnvVar should do with an environment variable
 enum EnvVarAction { UNSET, SET };
 

--- a/src/main/cpp/blaze_util.h
+++ b/src/main/cpp/blaze_util.h
@@ -105,8 +105,8 @@ std::string ToString(const T &value) {
 void SetDebugLog(bool enabled);
 
 // Returns true if this Bazel instance is running inside of a Bazel test.
-// This method observes the TEST_SRCDIR envvar.
-bool IsRunningInsideOfTest();
+// This method observes the TEST_TMPDIR envvar.
+bool IsRunningWithinTest();
 
 // What WithEnvVar should do with an environment variable
 enum EnvVarAction { UNSET, SET };

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -406,6 +406,12 @@ string GetOutputRoot() {
 }
 
 string GetHomeDir() {
+  if (IsRunningInsideOfTest()) {
+    // Bazel is running inside of a test. Respect $HOME that the test setup has
+    // set instead of using the actual home directory of the current user.
+    return GetEnv("HOME");
+  }
+
   PWSTR wpath;
   // Look up the user's home directory. The default value of "FOLDERID_Profile"
   // is the same as %USERPROFILE%, but it does not require the envvar to be set.

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -406,7 +406,7 @@ string GetOutputRoot() {
 }
 
 string GetHomeDir() {
-  if (IsRunningInsideOfTest()) {
+  if (IsRunningWithinTest()) {
     // Bazel is running inside of a test. Respect $HOME that the test setup has
     // set instead of using the actual home directory of the current user.
     return GetEnv("HOME");

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -321,7 +321,7 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
   if (SearchNullaryOption(cmd_line->startup_args, "system_rc", true)) {
     // MakeAbsoluteAndResolveWindowsEnvvars will standardize the form of the
     // provided path. This also means we accept relative paths, which is
-    // is convenient for testing.
+    // convenient for testing.
     internal::PushRcFileMaybe(&rc_files, system_rc);
   }
 

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -322,6 +322,12 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
     // MakeAbsoluteAndResolveWindowsEnvvars will standardize the form of the
     // provided path. This also means we accept relative paths, which is
     // convenient for testing.
+    if (system_rc.empty() ||
+        blaze_util::MakeCanonical(system_rc.c_str()).empty() ||
+        !blaze_util::CanReadFile(system_rc)) {
+      BAZEL_LOG(ERROR) << "Error: Unable to read --systemrc file '"
+                       << system_rc << "'.";
+    }
     internal::PushRcFileMaybe(&rc_files, system_rc);
   }
 

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -315,7 +315,7 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
 
   std::vector<std::string> rc_files;
 
-  const std::string system_rc = 
+  const std::string system_rc =
       blaze_util::MakeAbsoluteAndResolveWindowsEnvvars(system_bazelrc_path_);
   // Read the system rc (unless --nosystem_rc).
   if (SearchNullaryOption(cmd_line->startup_args, "system_rc", true)) {

--- a/src/main/cpp/rc_file.h
+++ b/src/main/cpp/rc_file.h
@@ -42,6 +42,7 @@ class RcFile {
       std::string workspace, ParseError* error, std::string* error_text);
 
   // Returns all relevant rc sources for this file (including itself).
+  // Paths in the result were canonicalized using blaze_util::MakeCanonical.
   const std::deque<std::string>& sources() const { return rcfile_paths_; }
 
   // Command -> all options for that command (in order of appearance).

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -98,8 +98,7 @@ StartupOptions::StartupOptions(const string &product_name,
       idle_server_tasks(true),
       original_startup_options_(std::vector<RcStartupFlag>()),
       unlimit_coredumps(false) {
-  bool testing = !blaze::GetEnv("TEST_TMPDIR").empty();
-  if (testing) {
+  if (blaze::IsRunningInsideOfTest()) {
     output_root = blaze_util::MakeAbsolute(blaze::GetEnv("TEST_TMPDIR"));
     max_idle_secs = 15;
     BAZEL_LOG(USER) << "$TEST_TMPDIR defined: output root default is '"

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -98,7 +98,7 @@ StartupOptions::StartupOptions(const string &product_name,
       idle_server_tasks(true),
       original_startup_options_(std::vector<RcStartupFlag>()),
       unlimit_coredumps(false) {
-  if (blaze::IsRunningInsideOfTest()) {
+  if (blaze::IsRunningWithinTest()) {
     output_root = blaze_util::MakeAbsolute(blaze::GetEnv("TEST_TMPDIR"));
     max_idle_secs = 15;
     BAZEL_LOG(USER) << "$TEST_TMPDIR defined: output root default is '"

--- a/src/main/cpp/workspace_layout.cc
+++ b/src/main/cpp/workspace_layout.cc
@@ -64,7 +64,8 @@ std::string WorkspaceLayout::GetWorkspaceRcPath(
   // TODO(b/36168162): Rename and remove the tools/ prefix. See
   // https://github.com/bazelbuild/bazel/issues/4502#issuecomment-372697374
   // for the final set of bazelrcs we want to have.
-  return blaze_util::JoinPath(workspace, "tools/bazel.rc");
+  return blaze_util::MakeCanonical(
+      blaze_util::JoinPath(workspace, "tools/bazel.rc").c_str());
 }
 
 bool WorkspaceLayout::WorkspaceRelativizeRcFilePath(const string &workspace,

--- a/src/main/cpp/workspace_layout.h
+++ b/src/main/cpp/workspace_layout.h
@@ -48,7 +48,7 @@ class WorkspaceLayout {
   // Returns if workspace is a valid build workspace.
   virtual bool InWorkspace(const std::string& workspace) const;
 
-  // Returns the path of the workspace rc file.
+  // Returns the canonical path of the workspace rc file.
   virtual std::string GetWorkspaceRcPath(
       const std::string& workspace,
       const std::vector<std::string>& startup_args) const;

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -125,7 +125,7 @@ class RcFileTest : public ::testing::Test {
         blaze_util::JoinPath(tools_dir, "bazel.rc");
     if (blaze_util::MakeDirectories(tools_dir, 0755) &&
         blaze_util::WriteFile(contents, workspace_rc_path, 0755)) {
-      *rcfile_path = workspace_rc_path;
+      *rcfile_path = blaze_util::MakeCanonical(workspace_rc_path.c_str());
       return true;
     }
     return false;
@@ -136,7 +136,7 @@ class RcFileTest : public ::testing::Test {
     const std::string binary_rc_path =
         blaze_util::JoinPath(binary_dir_, "bazel.bazelrc");
     if (blaze_util::WriteFile(contents, binary_rc_path, 0755)) {
-      *rcfile_path = binary_rc_path;
+      *rcfile_path = blaze_util::MakeCanonical(binary_rc_path.c_str());
       return true;
     }
     return false;

--- a/src/test/shell/integration/rc_options_test.sh
+++ b/src/test/shell/integration/rc_options_test.sh
@@ -121,8 +121,8 @@ function test_rc_files_no_longer_read() {
   [[ -f "$pkg/explain.txt" ]] || fail "expected .bazelrc to be read"
   [[ -f "$pkg/build_event_binary" ]] && fail "expected tools/bazel.rc not to be read" || true
   expect_log "The following rc files are no longer being read"
-  expect_log "$pkg[/\\]tools[/\\]bazel\\.rc$"
-  expect_not_log "$pkg[/\\]\\.bazelrc$"
+  expect_log "$pkg[/\\]tools[/\\]bazel\\.rc"
+  expect_not_log "$pkg[/\\]\\.bazelrc"
 }
 
 run_suite "Integration tests for rc options handling"

--- a/src/test/shell/integration/rc_options_test.sh
+++ b/src/test/shell/integration/rc_options_test.sh
@@ -121,8 +121,8 @@ function test_rc_files_no_longer_read() {
   [[ -f "$pkg/explain.txt" ]] || fail "expected .bazelrc to be read"
   [[ -f "$pkg/build_event_binary" ]] && fail "expected tools/bazel.rc not to be read" || true
   expect_log "The following rc files are no longer being read"
-  expect_log "$pkg[/\\\\]tools[/\\\\]bazel\\.rc$"
-  expect_not_log "$pkg[/\\\\]\\.bazelrc$"
+  expect_log "$pkg[/\\]tools[/\\]bazel\\.rc$"
+  expect_not_log "$pkg[/\\]\\.bazelrc$"
 }
 
 run_suite "Integration tests for rc options handling"


### PR DESCRIPTION
Make all bazelrc files canonical.

This aids for proper deduplication and proper
reporting of ignored RC files.

Also: respect $HOME on Windows when Bazel is
running inside of a test, to avoid picking up the
real RC file from the user's home directory.

Fixes https://github.com/bazelbuild/bazel/issues/6138