### PR TITLE
Bazel client: fix reporting of ignored RC files

### DIFF
--- a/src/main/cpp/blaze_util.cc
+++ b/src/main/cpp/blaze_util.cc
@@ -181,6 +181,10 @@ void SetDebugLog(bool enabled) {
   }
 }
 
+bool IsRunningWithinTest() {
+  return !GetEnv("TEST_TMPDIR").empty();
+}
+
 void WithEnvVars::SetEnvVars(const map<string, EnvVarValue>& vars) {
   for (const auto& var : vars) {
     switch (var.second.action) {

--- a/src/main/cpp/blaze_util.h
+++ b/src/main/cpp/blaze_util.h
@@ -104,6 +104,10 @@ std::string ToString(const T &value) {
 // Revisit once client logging is fixed (b/32939567).
 void SetDebugLog(bool enabled);
 
+// Returns true if this Bazel instance is running inside of a Bazel test.
+// This method observes the TEST_TMPDIR envvar.
+bool IsRunningWithinTest();
+
 // What WithEnvVar should do with an environment variable
 enum EnvVarAction { UNSET, SET };
 

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -406,6 +406,12 @@ string GetOutputRoot() {
 }
 
 string GetHomeDir() {
+  if (IsRunningWithinTest()) {
+    // Bazel is running inside of a test. Respect $HOME that the test setup has
+    // set instead of using the actual home directory of the current user.
+    return GetEnv("HOME");
+  }
+
   PWSTR wpath;
   // Look up the user's home directory. The default value of "FOLDERID_Profile"
   // is the same as %USERPROFILE%, but it does not require the envvar to be set.

--- a/src/main/cpp/option_processor-internal.h
+++ b/src/main/cpp/option_processor-internal.h
@@ -26,9 +26,11 @@ namespace blaze {
 namespace internal {
 
 // Returns the deduped set of bazelrc paths (with respect to its canonical form)
-// preserving the original order. The paths that cannot be resolved are
-// omitted.
-std::vector<std::string> GetExistingDedupedBazelrcPaths(
+// preserving the original order.
+// All paths in the result have been verified to exist (otherwise their
+// canonical form couldn't have been computed).The paths that cannot be resolved
+// are omitted.
+std::vector<std::string> DedupeBlazercPaths(
     const std::vector<std::string>& paths);
 
 // Given the set of already-ready files, warns if any of the newly loaded_rcs

--- a/src/main/cpp/option_processor-internal.h
+++ b/src/main/cpp/option_processor-internal.h
@@ -28,7 +28,7 @@ namespace internal {
 // Returns the deduped set of bazelrc paths (with respect to its canonical form)
 // preserving the original order. The paths that cannot be resolved are
 // omitted.
-std::vector<std::string> DedupeBlazercPaths(
+std::vector<std::string> GetExistingDedupedBazelrcPaths(
     const std::vector<std::string>& paths);
 
 // Given the set of already-ready files, warns if any of the newly loaded_rcs

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -190,16 +190,18 @@ std::set<std::string> GetOldRcPaths(
   if (!user_bazelrc_path.empty()) {
     candidate_bazelrc_paths.push_back(user_bazelrc_path);
   }
-  const std::vector<std::string> deduped_blazerc_paths =
-      internal::GetExistingDedupedBazelrcPaths(candidate_bazelrc_paths);
-  return std::set<std::string>(deduped_blazerc_paths.begin(),
-                               deduped_blazerc_paths.end());
+  // DedupeBlazercPaths returns paths whose canonical path could be computed,
+  // therefore these paths must exist.
+  const std::vector<std::string> deduped_existing_blazerc_paths =
+      internal::DedupeBlazercPaths(candidate_bazelrc_paths);
+  return std::set<std::string>(deduped_existing_blazerc_paths.begin(),
+                               deduped_existing_blazerc_paths.end());
 }
 
 // Deduplicates the given paths based on their canonical form.
 // Computes the canonical form using blaze_util::MakeCanonical.
 // Returns the unique paths in their original form (not the canonical one).
-std::vector<std::string> GetExistingDedupedBazelrcPaths(
+std::vector<std::string> DedupeBlazercPaths(
     const std::vector<std::string>& paths) {
   std::set<std::string> canonical_paths;
   std::vector<std::string> result;
@@ -380,7 +382,7 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
   // this isn't sufficient to prevent duplicate options, so we also warn if we
   // discover duplicate loads later. This also has the effect of removing paths
   // that don't point to real files.
-  rc_files = internal::GetExistingDedupedBazelrcPaths(rc_files);
+  rc_files = internal::DedupeBlazercPaths(rc_files);
 
   std::set<std::string> read_files_canonical_paths;
   // Parse these potential files, in priority order;

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -185,19 +185,21 @@ std::set<std::string> GetOldRcPaths(
         internal::FindRcAlongsideBinary(cwd, path_to_binary);
     candidate_bazelrc_paths = {workspace_rc, binary_rc, system_bazelrc_path};
   }
-  const std::vector<std::string> deduped_blazerc_paths =
-      internal::DedupeBlazercPaths(candidate_bazelrc_paths);
-  std::set<std::string> old_rc_paths(deduped_blazerc_paths.begin(),
-                                     deduped_blazerc_paths.end());
   string user_bazelrc_path = internal::FindLegacyUserBazelrc(
       SearchUnaryOption(startup_args, "--bazelrc"), workspace);
   if (!user_bazelrc_path.empty()) {
-    old_rc_paths.insert(user_bazelrc_path);
+    candidate_bazelrc_paths.push_back(user_bazelrc_path);
   }
-  return old_rc_paths;
+  const std::vector<std::string> deduped_blazerc_paths =
+      internal::GetExistingDedupedBazelrcPaths(candidate_bazelrc_paths);
+  return std::set<std::string>(deduped_blazerc_paths.begin(),
+                               deduped_blazerc_paths.end());
 }
 
-std::vector<std::string> DedupeBlazercPaths(
+// Deduplicates the given paths based on their canonical form.
+// Computes the canonical form using blaze_util::MakeCanonical.
+// Returns the unique paths in their original form (not the canonical one).
+std::vector<std::string> GetExistingDedupedBazelrcPaths(
     const std::vector<std::string>& paths) {
   std::set<std::string> canonical_paths;
   std::vector<std::string> result;
@@ -291,6 +293,20 @@ void WarnAboutDuplicateRcFiles(const std::set<std::string>& read_files,
   }
 }
 
+std::vector<std::string> GetLostFiles(
+    const std::set<std::string>& old_files,
+    const std::set<std::string>& read_files_canon) {
+  std::vector<std::string> result;
+  for (const auto& old : old_files) {
+    std::string old_canon = blaze_util::MakeCanonical(old.c_str());
+    if (!old_canon.empty() &&
+        read_files_canon.find(old_canon) == read_files_canon.end()) {
+      result.push_back(old);
+    }
+  }
+  return result;
+}
+
 }  // namespace internal
 
 // TODO(#4502) Consider simplifying result_rc_files to a vector of RcFiles, no
@@ -364,9 +380,9 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
   // this isn't sufficient to prevent duplicate options, so we also warn if we
   // discover duplicate loads later. This also has the effect of removing paths
   // that don't point to real files.
-  rc_files = internal::DedupeBlazercPaths(rc_files);
+  rc_files = internal::GetExistingDedupedBazelrcPaths(rc_files);
 
-  std::set<std::string> read_files;
+  std::set<std::string> read_files_canonical_paths;
   // Parse these potential files, in priority order;
   for (const std::string& top_level_bazelrc_path : rc_files) {
     std::unique_ptr<RcFile> parsed_rc;
@@ -377,9 +393,9 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
     }
 
     // Check that none of the rc files loaded this time are duplicate.
-    const std::deque<std::string>& sources = parsed_rc->sources();
-    internal::WarnAboutDuplicateRcFiles(read_files, sources);
-    read_files.insert(sources.begin(), sources.end());
+    const std::deque<std::string>& sources = parsed_rc->canonical_source_paths();
+    internal::WarnAboutDuplicateRcFiles(read_files_canonical_paths, sources);
+    read_files_canonical_paths.insert(sources.begin(), sources.end());
 
     result_rc_files->push_back(std::move(parsed_rc));
   }
@@ -394,16 +410,8 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
       workspace_layout, workspace, cwd, cmd_line->path_to_binary,
       cmd_line->startup_args, internal::FindSystemWideRc(system_bazelrc_path_));
 
-  //   std::vector<std::string> old_files = internal::GetOldRcPathsInOrder(
-  //       workspace_layout, workspace, cwd, cmd_line->path_to_binary,
-  //       cmd_line->startup_args);
-  //
-  //   std::sort(old_files.begin(), old_files.end());
-  std::vector<std::string> lost_files(old_files.size());
-  std::vector<std::string>::iterator end_iter = std::set_difference(
-      old_files.begin(), old_files.end(), read_files.begin(), read_files.end(),
-      lost_files.begin());
-  lost_files.resize(end_iter - lost_files.begin());
+  std::vector<std::string> lost_files =
+      internal::GetLostFiles(old_files, read_files_canonical_paths);
   if (!lost_files.empty()) {
     std::string joined_lost_rcs;
     blaze_util::JoinStrings(lost_files, '\n', &joined_lost_rcs);
@@ -625,7 +633,7 @@ std::vector<std::string> OptionProcessor::GetBlazercAndEnvCommandArgs(
   int cur_index = 1;
   std::map<std::string, int> rcfile_indexes;
   for (const auto& blazerc : blazercs) {
-    for (const std::string& source_path : blazerc->sources()) {
+    for (const std::string& source_path : blazerc->canonical_source_paths()) {
       // Deduplicate the rc_source list because the same file might be included
       // from multiple places.
       if (rcfile_indexes.find(source_path) != rcfile_indexes.end()) continue;

--- a/src/main/cpp/rc_file.cc
+++ b/src/main/cpp/rc_file.cc
@@ -63,10 +63,10 @@ RcFile::ParseError RcFile::ParseFile(const string& filename,
   const std::string canonical_filename =
       blaze_util::MakeCanonical(filename.c_str());
 
-  rcfile_paths_.push_back(canonical_filename);
-  // Keep a pointer to the canonical_filename string in rcfile_paths_ for the
-  // RcOptions.
-  string* filename_ptr = &rcfile_paths_.back();
+  canonical_rcfile_paths_.push_back(canonical_filename);
+  // Keep a pointer to the canonical_filename string in canonical_rcfile_paths_
+  // for the RcOptions.
+  string* filename_ptr = &canonical_rcfile_paths_.back();
 
   // A '\' at the end of a line continues the line.
   blaze_util::Replace("\\\r\n", "", &contents);

--- a/src/main/cpp/rc_file.h
+++ b/src/main/cpp/rc_file.h
@@ -42,7 +42,9 @@ class RcFile {
       std::string workspace, ParseError* error, std::string* error_text);
 
   // Returns all relevant rc sources for this file (including itself).
-  const std::deque<std::string>& sources() const { return rcfile_paths_; }
+  const std::deque<std::string>& canonical_source_paths() const {
+    return canonical_rcfile_paths_;
+  }
 
   // Command -> all options for that command (in order of appearance).
   using OptionMap = std::unordered_map<std::string, std::vector<RcOption>>;
@@ -68,9 +70,12 @@ class RcFile {
   const std::string workspace_;
 
   // Full closure of rcfile paths imported from this file (including itself).
+  // These are all canonical paths, created with blaze_util::MakeCanonical.
+  // This also means all of these paths should exist.
+  //
   // The RcOption structs point to the strings in here so they need to be stored
   // in a container that offers stable pointers, like a deque (and not vector).
-  std::deque<std::string> rcfile_paths_;
+  std::deque<std::string> canonical_rcfile_paths_;
   // All options parsed from the file.
   OptionMap options_;
 };

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -98,8 +98,7 @@ StartupOptions::StartupOptions(const string &product_name,
       idle_server_tasks(true),
       original_startup_options_(std::vector<RcStartupFlag>()),
       unlimit_coredumps(false) {
-  bool testing = !blaze::GetEnv("TEST_TMPDIR").empty();
-  if (testing) {
+  if (blaze::IsRunningWithinTest()) {
     output_root = blaze_util::MakeAbsolute(blaze::GetEnv("TEST_TMPDIR"));
     max_idle_secs = 15;
     BAZEL_LOG(USER) << "$TEST_TMPDIR defined: output root default is '"

--- a/src/test/cpp/option_processor_test.cc
+++ b/src/test/cpp/option_processor_test.cc
@@ -307,13 +307,13 @@ TEST_F(OptionProcessorTest, SplitCommandLineWithDashDash) {
 TEST_F(OptionProcessorTest, TestDedupePathsOmitsInvalidPath) {
   std::vector<std::string> input = {"foo"};
   std::vector<std::string> expected = {};
-  ASSERT_EQ(expected, internal::DedupeBlazercPaths(input));
+  ASSERT_EQ(expected, internal::GetExistingDedupedBazelrcPaths(input));
 }
 
 TEST_F(OptionProcessorTest, TestDedupePathsOmitsEmptyPath) {
   std::vector<std::string> input = {""};
   std::vector<std::string> expected = {};
-  ASSERT_EQ(expected, internal::DedupeBlazercPaths(input));
+  ASSERT_EQ(expected, internal::GetExistingDedupedBazelrcPaths(input));
 }
 
 TEST_F(OptionProcessorTest, TestDedupePathsWithDifferentFiles) {
@@ -324,7 +324,7 @@ TEST_F(OptionProcessorTest, TestDedupePathsWithDifferentFiles) {
   ASSERT_TRUE(blaze_util::WriteFile("bar", bar_path));
 
   std::vector<std::string> input = {foo_path, bar_path};
-  ASSERT_EQ(input, internal::DedupeBlazercPaths(input));
+  ASSERT_EQ(input, internal::GetExistingDedupedBazelrcPaths(input));
 }
 
 TEST_F(OptionProcessorTest, TestDedupePathsWithSameFile) {
@@ -334,7 +334,7 @@ TEST_F(OptionProcessorTest, TestDedupePathsWithSameFile) {
 
   std::vector<std::string> input = {foo_path, foo_path};
   std::vector<std::string> expected = {foo_path};
-  ASSERT_EQ(expected, internal::DedupeBlazercPaths(input));
+  ASSERT_EQ(expected, internal::GetExistingDedupedBazelrcPaths(input));
 }
 
 TEST_F(OptionProcessorTest, TestDedupePathsWithRelativePath) {
@@ -347,7 +347,7 @@ TEST_F(OptionProcessorTest, TestDedupePathsWithRelativePath) {
 
   std::vector<std::string> input = {foo_path, relative_foo_path};
   std::vector<std::string> expected = {foo_path};
-  ASSERT_EQ(expected, internal::DedupeBlazercPaths(input));
+  ASSERT_EQ(expected, internal::GetExistingDedupedBazelrcPaths(input));
 }
 
 #if !defined(_WIN32) && !defined(__CYGWIN__)
@@ -363,7 +363,7 @@ TEST_F(OptionProcessorTest, TestDedupePathsWithSymbolicLink) {
   ASSERT_TRUE(Symlink(foo_path, sym_foo_path));
   std::vector<std::string> input = {foo_path, sym_foo_path};
   std::vector<std::string> expected = {foo_path};
-  ASSERT_EQ(expected, internal::DedupeBlazercPaths(input));
+  ASSERT_EQ(expected, internal::GetExistingDedupedBazelrcPaths(input));
 }
 #endif  // !defined(_WIN32) && !defined(__CYGWIN__)
 

--- a/src/test/cpp/option_processor_test.cc
+++ b/src/test/cpp/option_processor_test.cc
@@ -307,13 +307,13 @@ TEST_F(OptionProcessorTest, SplitCommandLineWithDashDash) {
 TEST_F(OptionProcessorTest, TestDedupePathsOmitsInvalidPath) {
   std::vector<std::string> input = {"foo"};
   std::vector<std::string> expected = {};
-  ASSERT_EQ(expected, internal::GetExistingDedupedBazelrcPaths(input));
+  ASSERT_EQ(expected, internal::DedupeBlazercPaths(input));
 }
 
 TEST_F(OptionProcessorTest, TestDedupePathsOmitsEmptyPath) {
   std::vector<std::string> input = {""};
   std::vector<std::string> expected = {};
-  ASSERT_EQ(expected, internal::GetExistingDedupedBazelrcPaths(input));
+  ASSERT_EQ(expected, internal::DedupeBlazercPaths(input));
 }
 
 TEST_F(OptionProcessorTest, TestDedupePathsWithDifferentFiles) {
@@ -324,7 +324,7 @@ TEST_F(OptionProcessorTest, TestDedupePathsWithDifferentFiles) {
   ASSERT_TRUE(blaze_util::WriteFile("bar", bar_path));
 
   std::vector<std::string> input = {foo_path, bar_path};
-  ASSERT_EQ(input, internal::GetExistingDedupedBazelrcPaths(input));
+  ASSERT_EQ(input, internal::DedupeBlazercPaths(input));
 }
 
 TEST_F(OptionProcessorTest, TestDedupePathsWithSameFile) {
@@ -334,7 +334,7 @@ TEST_F(OptionProcessorTest, TestDedupePathsWithSameFile) {
 
   std::vector<std::string> input = {foo_path, foo_path};
   std::vector<std::string> expected = {foo_path};
-  ASSERT_EQ(expected, internal::GetExistingDedupedBazelrcPaths(input));
+  ASSERT_EQ(expected, internal::DedupeBlazercPaths(input));
 }
 
 TEST_F(OptionProcessorTest, TestDedupePathsWithRelativePath) {
@@ -347,7 +347,7 @@ TEST_F(OptionProcessorTest, TestDedupePathsWithRelativePath) {
 
   std::vector<std::string> input = {foo_path, relative_foo_path};
   std::vector<std::string> expected = {foo_path};
-  ASSERT_EQ(expected, internal::GetExistingDedupedBazelrcPaths(input));
+  ASSERT_EQ(expected, internal::DedupeBlazercPaths(input));
 }
 
 #if !defined(_WIN32) && !defined(__CYGWIN__)
@@ -363,7 +363,7 @@ TEST_F(OptionProcessorTest, TestDedupePathsWithSymbolicLink) {
   ASSERT_TRUE(Symlink(foo_path, sym_foo_path));
   std::vector<std::string> input = {foo_path, sym_foo_path};
   std::vector<std::string> expected = {foo_path};
-  ASSERT_EQ(expected, internal::GetExistingDedupedBazelrcPaths(input));
+  ASSERT_EQ(expected, internal::DedupeBlazercPaths(input));
 }
 #endif  // !defined(_WIN32) && !defined(__CYGWIN__)
 

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -173,8 +173,8 @@ TEST_F(GetRcFileTest, GetRcFilesLoadsAllDefaultBazelrcs) {
   ASSERT_EQ(2, parsed_rcs.size());
   const std::deque<std::string> expected_system_rc_que = {system_rc};
   const std::deque<std::string> expected_workspace_rc_que = {workspace_rc};
-  EXPECT_EQ(expected_system_rc_que, parsed_rcs[0].get()->sources());
-  EXPECT_EQ(expected_workspace_rc_que, parsed_rcs[1].get()->sources());
+  EXPECT_EQ(expected_system_rc_que, parsed_rcs[0].get()->canonical_source_paths());
+  EXPECT_EQ(expected_workspace_rc_que, parsed_rcs[1].get()->canonical_source_paths());
 }
 
 TEST_F(GetRcFileTest, GetRcFilesRespectsNoSystemRc) {
@@ -195,7 +195,7 @@ TEST_F(GetRcFileTest, GetRcFilesRespectsNoSystemRc) {
 
   ASSERT_EQ(1, parsed_rcs.size());
   const std::deque<std::string> expected_workspace_rc_que = {workspace_rc};
-  EXPECT_EQ(expected_workspace_rc_que, parsed_rcs[0].get()->sources());
+  EXPECT_EQ(expected_workspace_rc_que, parsed_rcs[0].get()->canonical_source_paths());
 }
 
 TEST_F(GetRcFileTest, GetRcFilesRespectsNoWorkspaceRc) {
@@ -216,7 +216,7 @@ TEST_F(GetRcFileTest, GetRcFilesRespectsNoWorkspaceRc) {
 
   ASSERT_EQ(1, parsed_rcs.size());
   const std::deque<std::string> expected_system_rc_que = {system_rc};
-  EXPECT_EQ(expected_system_rc_que, parsed_rcs[0].get()->sources());
+  EXPECT_EQ(expected_system_rc_que, parsed_rcs[0].get()->canonical_source_paths());
 }
 
 TEST_F(GetRcFileTest, GetRcFilesRespectsNoWorkspaceRcAndNoSystemCombined) {
@@ -317,8 +317,8 @@ TEST_F(GetRcFileTest, GetRcFilesReadsCommandLineRc) {
   // Because of the variety of path representations in windows, this
   // equality test does not attempt to check the entire path.
   ASSERT_EQ(1, parsed_rcs.size());
-  ASSERT_EQ(1, parsed_rcs[0].get()->sources().size());
-  EXPECT_THAT(parsed_rcs[0].get()->sources().front(), HasSubstr("mybazelrc"));
+  ASSERT_EQ(1, parsed_rcs[0].get()->canonical_source_paths().size());
+  EXPECT_THAT(parsed_rcs[0].get()->canonical_source_paths().front(), HasSubstr("mybazelrc"));
 }
 
 TEST_F(GetRcFileTest, GetRcFilesAcceptsNullCommandLineRc) {
@@ -338,7 +338,7 @@ TEST_F(GetRcFileTest, GetRcFilesAcceptsNullCommandLineRc) {
   // but it does technically count as a file
   ASSERT_EQ(1, parsed_rcs.size());
   const std::deque<std::string> expected_rc_que = {kNullDevice};
-  EXPECT_EQ(expected_rc_que, parsed_rcs[0].get()->sources());
+  EXPECT_EQ(expected_rc_que, parsed_rcs[0].get()->canonical_source_paths());
 }
 
 class ParseOptionsTest : public RcFileTest {


### PR DESCRIPTION
Compute the difference between the read RC files
and the ignored ones based on their canonical
paths, not on the textual value of the path.

This aids for proper reporting of ignored RC
files, while reporting them with a path familiar
to the user (e.g. paths the user passed with flags
rather than the potentially different canonical
version of the same path).

Also: respect $HOME on Windows when Bazel is
running inside of a test, to avoid picking up the
real RC file from the user's home directory. This
fixes //src/test/cpp:rc_file_test on Windows.

Fixes https://github.com/bazelbuild/bazel/issues/6138