### PR TITLE
WIP: Bazel client: refactor blaze_util::MakeCanonical

### DIFF
--- a/src/main/cpp/blaze_util.cc
+++ b/src/main/cpp/blaze_util.cc
@@ -182,12 +182,7 @@ void SetDebugLog(bool enabled) {
 }
 
 bool IsRunningWithinTest() {
-  // Cache the value of the envvar.
-  // There's no reason to expect it to change (what would change its value?),
-  // nor should it change (otherwise this function would return inconsistent
-  // results over time).
-  static const bool result = !GetEnv("TEST_TMPDIR").empty();
-  return result;
+  return !GetEnv("TEST_TMPDIR").empty();
 }
 
 void WithEnvVars::SetEnvVars(const map<string, EnvVarValue>& vars) {

--- a/src/main/cpp/blaze_util.cc
+++ b/src/main/cpp/blaze_util.cc
@@ -181,7 +181,14 @@ void SetDebugLog(bool enabled) {
   }
 }
 
-bool IsRunningWithinTest() { return !GetEnv("TEST_TMPDIR").empty(); }
+bool IsRunningWithinTest() {
+  // Cache the value of the envvar.
+  // There's no reason to expect it to change (what would change its value?),
+  // nor should it change (otherwise this function would return inconsistent
+  // results over time).
+  static const bool result = !GetEnv("TEST_TMPDIR").empty();
+  return result;
+}
 
 void WithEnvVars::SetEnvVars(const map<string, EnvVarValue>& vars) {
   for (const auto& var : vars) {

--- a/src/main/cpp/util/file_platform.h
+++ b/src/main/cpp/util/file_platform.h
@@ -150,7 +150,8 @@ bool PathExists(const std::string& path);
 // Returns the empty string upon error.
 //
 // This is a wrapper around realpath(3).
-std::string MakeCanonical(const char *path);
+bool MakeCanonical(const std::string& path, std::string* result,
+                   std::string* error = nullptr);
 
 // Returns true if `path` exists, is a file or symlink to one, and is readable.
 // Follows symlinks.

--- a/src/main/cpp/util/file_posix.cc
+++ b/src/main/cpp/util/file_posix.cc
@@ -268,15 +268,15 @@ bool PathExists(const string& path) {
   return access(path.c_str(), F_OK) == 0;
 }
 
-string MakeCanonical(const char *path) {
-  char *resolved_path = realpath(path, NULL);
+bool MakeCanonical(const std::string& path, std::string* result,
+                   std::string* error) {
+  char *resolved_path = realpath(path.c_str(), NULL);
   if (resolved_path == NULL) {
-    return "";
-  } else {
-    string ret = resolved_path;
-    free(resolved_path);
-    return ret;
+    return false;
   }
+  *result = resolved_path;
+  free(resolved_path);
+  return true;
 }
 
 static bool CanAccess(const string &path, bool read, bool write, bool exec) {

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -97,22 +97,16 @@ class RcFileTest : public ::testing::Test {
     const std::string system_rc_path =
         blaze_util::ConvertPath(blaze_util::JoinPath(cwd_, "bazel.bazelrc"));
 
-    if (blaze_util::WriteFile(contents, system_rc_path, 0755)) {
-      *rcfile_path = blaze_util::MakeCanonical(system_rc_path.c_str());
-      return true;
-    }
-    return false;
+    return blaze_util::WriteFile(contents, system_rc_path, 0755) &&
+           blaze_util::MakeCanonical(system_rc_path, rcfile_path);
   }
 
   bool SetUpWorkspaceRcFile(const std::string& contents,
                             std::string* rcfile_path) const {
     const std::string workspace_user_rc_path =
         blaze_util::JoinPath(workspace_, ".bazelrc");
-    if (blaze_util::WriteFile(contents, workspace_user_rc_path, 0755)) {
-      *rcfile_path =  blaze_util::MakeCanonical(workspace_user_rc_path.c_str());
-      return true;
-    }
-    return false;
+    return blaze_util::WriteFile(contents, workspace_user_rc_path, 0755) &&
+           blaze_util::MakeCanonical(workspace_user_rc_path, rcfile_path);
   }
 
   // TODO(b/36168162): Make it possible to configure the home directory so we

--- a/src/test/cpp/util/file_windows_test.cc
+++ b/src/test/cpp/util/file_windows_test.cc
@@ -290,8 +290,10 @@ TEST_F(FileWindowsTest, TestMakeCanonical) {
   // Assert the canonical path of foo.txt via the real path and via sym2.
   // The latter contains at least two junction components, shortened paths, and
   // mixed casing.
-  string dircanon(MakeCanonical(foo.c_str()));
-  string symcanon(MakeCanonical(symfoo.c_str()));
+  string dircanon;
+  EXPECT_TRUE(MakeCanonical(foo, &dircanon));
+  string symcanon;
+  EXPECT_TRUE(MakeCanonical(symfoo, &symcanon));
   string expected("directory\\subdirectory\\foo.txt");
   ASSERT_NE(symcanon, "");
   ASSERT_EQ(symcanon.find(expected), symcanon.size() - expected.size());


### PR DESCRIPTION
The function no longer indicates error by
returning an empty string. Instead it returns a
bool and sets an error message to a user-provided
string pointer.

The benefit of the change is that it's now visible
at call sites whether MakeCanonical's failure is
tolerated or not, and whether empty path is fine
or not. (There was also a TODO for me to do this
refactoring.)