### PR TITLE
Fix missing package due to typo in JulLogFactory

### DIFF
--- a/third_party/aws-sdk-auth-lite/src/main/java/com/amazonaws/log/JulLogFactory.java
+++ b/third_party/aws-sdk-auth-lite/src/main/java/com/amazonaws/log/JulLogFactory.java
@@ -11,7 +11,8 @@
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
- */package com.amazonaws.log;
+ */
+package com.amazonaws.log;
 
 import java.util.logging.Logger;
 


### PR DESCRIPTION
Fixes the following warning during build:

Warning: No package name string found in java source file: third_party/aws-sdk-auth-lite/src/main/java/com/amazonaws/log/JulLogFactory.java