### PR TITLE
Preprocess .asm files

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -489,6 +489,12 @@ static vector<string> GetArgumentArray(
   }
   result.insert(result.end(), user_options.begin(), user_options.end());
 
+  // Convert --[no]incompatible_preprocess_asm_files option to Java property.
+  // The property is read by the server.
+  if (globals->options->incompatible_preprocess_asm_files) {
+    result.push_back("-Dbazel.preprocess_asm_files");
+  }
+
   globals->options->AddJVMArgumentSuffix(real_install_dir,
                                          globals->ServerJarPath(), &result);
 

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -100,7 +100,8 @@ StartupOptions::StartupOptions(const string &product_name,
 #if defined(__APPLE__)
       macos_qos_class(QOS_CLASS_DEFAULT),
 #endif
-      unlimit_coredumps(false) {
+      unlimit_coredumps(false),
+      incompatible_preprocess_asm_files(false) {
   if (blaze::IsRunningWithinTest()) {
     output_root = blaze_util::MakeAbsolute(blaze::GetPathEnv("TEST_TMPDIR"));
     max_idle_secs = 15;
@@ -145,6 +146,8 @@ StartupOptions::StartupOptions(const string &product_name,
   RegisterNullaryStartupFlag("unlimit_coredumps");
   RegisterNullaryStartupFlag("watchfs");
   RegisterNullaryStartupFlag("write_command_log");
+  RegisterNullaryStartupFlag("incompatible_preprocess_asm_files");
+  RegisterNullaryStartupFlag("noincompatible_preprocess_asm_files");
   RegisterUnaryStartupFlag("command_port");
   RegisterUnaryStartupFlag("connect_timeout_secs");
   RegisterUnaryStartupFlag("digest_function");
@@ -423,6 +426,10 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
   } else if (GetNullaryOption(arg, "--nounlimit_coredumps")) {
     unlimit_coredumps = false;
     option_sources["unlimit_coredumps"] = rcfile;
+  } else if (GetNullaryOption(arg, "--incompatible_preprocess_asm_files")) {
+    incompatible_preprocess_asm_files = true;
+  } else if (GetNullaryOption(arg, "--noincompatible_preprocess_asm_files")) {
+    incompatible_preprocess_asm_files = false;
   } else {
     bool extra_argument_processed;
     blaze_exit_code::ExitCode process_extra_arg_exit_code = ProcessArgExtra(

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -314,6 +314,8 @@ class StartupOptions {
   // Whether to raise the soft coredump limit to the hard one or not.
   bool unlimit_coredumps;
 
+  bool incompatible_preprocess_asm_files;
+
 #if defined(__APPLE__)
   // The QoS class to apply to the Bazel server process.
   qos_class_t macos_qos_class;

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
@@ -497,4 +497,21 @@ public class BlazeServerStartupOptions extends OptionsBase {
               + "can be shared among them without changes. Possible values are: user-interactive, "
               + "user-initiated, default, utility, and background.")
   public String macosQosClass;
+
+  @Option(
+      name = "incompatible_preprocess_asm_files",
+      defaultValue = "false", // Only for documentation; value is set and used by the client.
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {
+        OptionEffectTag.ACTION_COMMAND_LINES,
+        OptionEffectTag.EXECUTION,
+      },
+      metadataTags = {
+        OptionMetadataTag.INCOMPATIBLE_CHANGE,
+        OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+      },
+      help =
+          "Run the C preprocessor on .asm files before assembling them. "
+              + "See https://github.com/bazelbuild/bazel/issues/4856")
+  public boolean preprocessAsmFiles;
 }


### PR DESCRIPTION
Assembler files with file extension ".asm" are now preprocessed.

The following assembly file extensions were hardcoded in Bazel:
 * ".s" and ".asm": Assumed to be generated by a compiler, and not
   preprocessed.
 * ".S": Assumed to be handwritten, and preprocessed.

There are Bazel users with large codebases where all handwritten
assembly files use file extension ".asm". ".asm" files are now treated
in the same way as ".S".

See https://github.com/bazelbuild/bazel/issues/4856