### PR TITLE
Don't include port in Host: header if it is a default port

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/AbstractHttpHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/AbstractHttpHandler.java
@@ -90,7 +90,10 @@ abstract class AbstractHttpHandler<T extends HttpObject> extends SimpleChannelIn
   }
 
   protected String constructHost(URI uri) {
-    return uri.getHost() + ":" + uri.getPort();
+    boolean includePort = (uri.getPort() > 0)
+        && ((uri.getScheme().equals("http") && uri.getPort() != 80)
+            || (uri.getScheme().equals("https") && uri.getPort() != 443));
+    return uri.getHost() + (includePort ? ":" + uri.getPort() : "");
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/AbstractHttpHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/AbstractHttpHandlerTest.java
@@ -57,4 +57,47 @@ public abstract class AbstractHttpHandlerTest {
     HttpRequest request = ch.readOutbound();
     assertThat(request.headers().contains(HttpHeaderNames.AUTHORIZATION)).isFalse();
   }
+
+  @Test
+  public void hostDoesntIncludePortHttp() throws Exception {
+    URI uri = new URI("http://does.not.exist/foo");
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null));
+    ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
+    DownloadCommand cmd = new DownloadCommand(uri, true, "abcdef", new ByteArrayOutputStream());
+    ChannelPromise writePromise = ch.newPromise();
+    ch.writeOneOutbound(cmd, writePromise);
+
+    HttpRequest request = ch.readOutbound();
+    assertThat(request.headers().get(HttpHeaderNames.HOST))
+        .isEqualTo("does.not.exist");
+  }
+
+  @Test
+  public void hostDoesntIncludePortHttps() throws Exception {
+    URI uri = new URI("https://does.not.exist/foo");
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null));
+    ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
+    DownloadCommand cmd = new DownloadCommand(uri, true, "abcdef", new ByteArrayOutputStream());
+    ChannelPromise writePromise = ch.newPromise();
+    ch.writeOneOutbound(cmd, writePromise);
+
+    HttpRequest request = ch.readOutbound();
+    assertThat(request.headers().get(HttpHeaderNames.HOST))
+        .isEqualTo("does.not.exist");
+  }
+
+  @Test
+  public void hostDoesIncludePort() throws Exception {
+    URI uri = new URI("http://does.not.exist:8080/foo");
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null));
+    ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
+    DownloadCommand cmd = new DownloadCommand(uri, true, "abcdef", new ByteArrayOutputStream());
+    ChannelPromise writePromise = ch.newPromise();
+    ch.writeOneOutbound(cmd, writePromise);
+
+    HttpRequest request = ch.readOutbound();
+    assertThat(request.headers().get(HttpHeaderNames.HOST))
+        .isEqualTo("does.not.exist:8080");
+  }
+
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpDownloadHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpDownloadHandlerTest.java
@@ -68,7 +68,7 @@ public class HttpDownloadHandlerTest extends AbstractHttpHandlerTest {
     HttpRequest request = ch.readOutbound();
     assertThat(request.method()).isEqualTo(HttpMethod.GET);
     assertThat(request.headers().get(HttpHeaderNames.HOST))
-        .isEqualTo(CACHE_URI.getHost() + ":" + CACHE_URI.getPort());
+        .isEqualTo(CACHE_URI.getHost());
     if (casDownload) {
       assertThat(request.uri()).isEqualTo("/cache-bucket/cas/abcdef");
     } else {


### PR DESCRIPTION
This changes the Host: header for remote cache operations to not include the port if it is the default port (80 or 443) for the scheme.

Fixes #6906
