### PR TITLE
Use sandbox execroot path in --sandbox_debug message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -133,7 +133,7 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
               true,
               sandbox.getArguments(),
               sandbox.getEnvironment(),
-              execRoot.getPathString(),
+              sandbox.getSandboxExecRoot().getPathString(),
               null);
     } else {
       failureMessage =


### PR DESCRIPTION
Currently the sandbox_debug message shows a cd command that points to the unsandboxed directory. This makes it match the sandboxed path.