### PR TITLE
Make ShowIncludesFilter ignore execroot differences

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1122,8 +1122,9 @@ public class CppCompileAction extends AbstractAction
     ShowIncludesFilter showIncludesFilterForStdout;
     ShowIncludesFilter showIncludesFilterForStderr;
     if (featureConfiguration.isEnabled(CppRuleClasses.PARSE_SHOWINCLUDES)) {
-      showIncludesFilterForStdout = new ShowIncludesFilter(getSourceFile().getFilename());
-      showIncludesFilterForStderr = new ShowIncludesFilter(getSourceFile().getFilename());
+      String workspaceName = actionExecutionContext.getExecRoot().getBaseName();
+      showIncludesFilterForStdout = new ShowIncludesFilter(getSourceFile().getFilename(), workspaceName);
+      showIncludesFilterForStderr = new ShowIncludesFilter(getSourceFile().getFilename(), workspaceName);
       FileOutErr originalOutErr = actionExecutionContext.getFileOutErr();
       FileOutErr tempOutErr = originalOutErr.childOutErr();
       spawnContext = actionExecutionContext.withFileOutErr(tempOutErr);

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilter.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilter.java
@@ -38,9 +38,11 @@ public class ShowIncludesFilter {
 
   private FilterShowIncludesOutputStream filterShowIncludesOutputStream;
   private final String sourceFileName;
+  private final String workspaceName;
 
-  public ShowIncludesFilter(String sourceFileName) {
+  public ShowIncludesFilter(String sourceFileName, String workspaceName) {
     this.sourceFileName = sourceFileName;
+    this.workspaceName = workspaceName;
   }
 
   /**
@@ -54,10 +56,12 @@ public class ShowIncludesFilter {
     private static final int NEWLINE = '\n';
     private static final String SHOW_INCLUDES_PREFIX = "Note: including file:";
     private final String sourceFileName;
+    private final String execRootSuffix;
 
-    public FilterShowIncludesOutputStream(OutputStream out, String sourceFileName) {
+    public FilterShowIncludesOutputStream(OutputStream out, String sourceFileName, String workspaceName) {
       super(out);
       this.sourceFileName = sourceFileName;
+      this.execRootSuffix = "execroot\\" + workspaceName + "\\";
     }
 
     @Override
@@ -66,7 +70,12 @@ public class ShowIncludesFilter {
       if (b == NEWLINE) {
         String line = buffer.toString(StandardCharsets.UTF_8.name());
         if (line.startsWith(SHOW_INCLUDES_PREFIX)) {
-          dependencies.add(line.substring(SHOW_INCLUDES_PREFIX.length()).trim());
+          line = line.substring(SHOW_INCLUDES_PREFIX.length()).trim();
+          int index = line.indexOf(execRootSuffix);
+          if (index != -1) {
+            line = line.substring(index + execRootSuffix.length());
+          }
+          dependencies.add(line);
         } else if (!line.trim().equals(sourceFileName)) {
           buffer.writeTo(out);
         }
@@ -94,7 +103,7 @@ public class ShowIncludesFilter {
 
   public FilterOutputStream getFilteredOutputStream(OutputStream outputStream) {
     filterShowIncludesOutputStream =
-        new FilterShowIncludesOutputStream(outputStream, sourceFileName);
+        new FilterShowIncludesOutputStream(outputStream, sourceFileName, workspaceName);
     return filterShowIncludesOutputStream;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilterTest.java
@@ -38,7 +38,7 @@ public class ShowIncludesFilterTest {
 
   @Before
   public void setUpOutputStreams() throws IOException {
-    showIncludesFilter = new ShowIncludesFilter("foo.cpp");
+    showIncludesFilter = new ShowIncludesFilter("foo.cpp", "__main__");
     output = new ByteArrayOutputStream();
     filterOutputStream = showIncludesFilter.getFilteredOutputStream(output);
     fs = new InMemoryFileSystem();
@@ -83,6 +83,19 @@ public class ShowIncludesFilterTest {
   public void testMatchAllOfNotePrefix() throws IOException {
     // "Note: including file:" is the prefix
     filterOutputStream.write(getBytes("Note: including file: bar.h"));
+    filterOutputStream.flush();
+    // flush to output should not work, waiting for newline
+    assertThat(output.toString()).isEmpty();
+    filterOutputStream.write(getBytes("\n"));
+    // It's a match, output should be filtered, dependency on bar.h should be found.
+    assertThat(output.toString()).isEmpty();
+    assertThat(showIncludesFilter.getDependencies()).contains("bar.h");
+  }
+
+  @Test
+  public void testMatchAllOfNotePrefixWithAbsolutePath() throws IOException {
+    // "Note: including file:" is the prefix
+    filterOutputStream.write(getBytes("Note: including file: C:\\tmp\\xxxx\\execroot\\__main__\\bar.h"));
     filterOutputStream.flush();
     // flush to output should not work, waiting for newline
     assertThat(output.toString()).isEmpty();


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/6847

After this change, the ShowIncludesFilter will look for the first `execroot\<workspace_name>` in the output header file paths, then it considers t`<some prefix>\execroot\<workspace_name>` as the execroot path. Because execroot path could be different if remote cache is hit, we ignore it and only add the relative path as dependencies.