### PR TITLE
Display the current documentation version in the title

### DIFF
--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -2,7 +2,9 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ page.title }} - Bazel</title>
+
+    <!-- Only show Bazel version in title if it's a release -->
+    <title>{{ page.title }} - Bazel {{ current_version | replace:'master','' }}</title>
 
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site_root }}">
 

--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -2,9 +2,14 @@
 nav: docs
 ---
 
+<!-- /versions/master/foo/bar -> ["master", "foo", "bar"] -->
+<!-- /versions/0.12.3/baz.md -> ["0.12.3", "baz.md"] -->
+{% assign versioned_url_parts = page.url | split: '/' | shift | shift %}
+{% assign current_version = versioned_url_parts.first %}
+
 <!DOCTYPE html>
 <html lang="en" itemscope itemtype="https://schema.org/WebPage">
-  {% include head.html %}
+  {% include head.html current_version=current_version %}
   <body>
     {% include header.html %}
 
@@ -24,10 +29,6 @@ nav: docs
           </a>
 
           <nav class="sidebar collapse" id="sidebar-nav">
-            <!-- /versions/master/foo/bar -> ["master", "foo", "bar"] -->
-            <!-- /versions/0.12.3/baz.md -> ["0.12.3", "baz.md"] -->
-            {% assign versioned_url_parts = page.url | split: '/' | shift | shift %}
-            {% assign current_version = versioned_url_parts.first %}
             <select onchange="location.href=this.value">
                 <option value="" selected disabled hidden>Version: {{ current_version }}</option>
                 {% for doc_version in site.doc_versions %}


### PR DESCRIPTION
I made it such that it only shows the version in the title if it's a release. I don't think "Bazel Overview - Bazel master" looks good, "Bazel Overview - Bazel" should be sufficient. On the other hand, "Bazel Overview - Bazel 0.20.0" looks fine.

![ss](https://user-images.githubusercontent.com/347918/50024247-be305b80-ffaf-11e8-9d78-1a27e48e8f30.png)
