### PR TITLE
Migrate all absolute links (/versions/master) in site/docs to use relative links to be compatible with versioned docs

### DIFF
--- a/site/docs/android-instrumentation-test.md
+++ b/site/docs/android-instrumentation-test.md
@@ -6,12 +6,12 @@ title: Android Instrumentation Tests
 # Android Instrumentation Tests
 
 _If you're new to Bazel, please start with the [Building Android with
-Bazel](https://docs.bazel.build/versions/master/tutorial/android-app.html)
+Bazel](tutorial/android-app.html)
 tutorial._
 
 ![Running Android instrumentation tests in parallel](/assets/android_test.gif)
 
-[`android_instrumentation_test`](https://docs.bazel.build/versions/master/be/android.html#android_instrumentation_test)
+[`android_instrumentation_test`](be/android.html#android_instrumentation_test)
 allows developers to test their apps on Android emulators and devices.
 It utilizes real Android framework APIs and the Android Test Library.
 
@@ -248,7 +248,7 @@ gmaven_rules()
 # Maven dependencies
 
 Use the
-[maven_jar](https://docs.bazel.build/versions/master/be/workspace.html#maven_jar)
+[maven_jar](be/workspace.html#maven_jar)
 repository rule for Maven dependencies not hosted on Google Maven. For example,
 to use JUnit 4.12 and Hamcrest 2, add the following lines to your `WORKSPACE`:
 
@@ -675,6 +675,6 @@ API_LEVELS = [
 - Improved external dependency management
 - Remote test caching and execution
 
-We are planning to rewrite the Android rules in [Starlark](https://docs.bazel.build/versions/master/skylark/concepts.html).
+We are planning to rewrite the Android rules in [Starlark](skylark/concepts.html).
 The `android_instrumentation_test` rule will be part of the rewrite, however,
 its usage will remain unchanged from the end-user perspective.

--- a/site/docs/android-ndk.md
+++ b/site/docs/android-ndk.md
@@ -6,8 +6,7 @@ title: Using the Android Native Development Kit with Bazel
 # Using the Android Native Development Kit with Bazel
 
 _If you're new to Bazel, please start with the [Building Android with
-Bazel](https://docs.bazel.build/versions/master/tutorial/android-app.html)
-tutorial._
+Bazel](tutorial/android-app.html) tutorial._
 
 ## Table of contents
 
@@ -48,8 +47,7 @@ android_ndk_repository(
 ```
 
 For more information on the `android_ndk_repository` rule, see its the [Build
-Encyclopedia
-entry](https://docs.bazel.build/versions/master/be/android.html#android_ndk_repository).
+Encyclopedia entry](be/android.html#android_ndk_repository).
 
 ## Quick start
 
@@ -243,8 +241,7 @@ bazel build //:app --cxxopt=-std=c++11
 ```
 
 Read more about passing compiler and linker flags with `--cxxopt`, `--copt`, and
-`--linkopt` in the [User
-Manual](https://docs.bazel.build/versions/master/user-manual.html#flag--cxxopt).
+`--linkopt` in the [User Manual](user-manual.html#flag--cxxopt).
 
 Compiler and linker flags can also be specified as attributes in `cc_library`
 using `copts` and `linkopts`. For example:
@@ -266,7 +263,7 @@ any special flags, except for `--fat_apk_cpu` and `--android_crosstool_top` for
 ABI and STL configuration.
 
 Behind the scenes, this automatic configuration uses Android [configuration
-transitions](https://docs.bazel.build/versions/master/skylark/rules.html#configurations).
+transitions](skylark/rules.html#configurations).
 
 A compatible rule, like `android_binary`, automatically changes the
 configuration of its dependencies to an Android configuration, so only
@@ -331,9 +328,8 @@ With this approach, the entire build tree is affected.
 
 Note that all of the targets on the command line must be compatible with
 building for Android when specifying these flags, which may make it difficult to
-use [Bazel
-wild-cards](https://docs.bazel.build/versions/master/command-line-reference.html#target-pattern-syntax)
-like `/...` and `:all`.
+use [Bazel wild-cards](command-line-reference.html#target-pattern-syntax) like
+`/...` and `:all`.
 
 These flags can be put into a `bazelrc` config (one for each ABI), in
 `<project>/.bazelrc`:

--- a/site/docs/bazel-and-android.md
+++ b/site/docs/bazel-and-android.md
@@ -25,20 +25,18 @@ Bazel has Android rules for building and testing Android apps, integrating with
 the SDK/NDK, and creating emulator images. There are also Bazel plugins for
 Android Studio and IntelliJ.
 
-*  [Android rules](https://docs.bazel.build/versions/master/be/android.html).
-   The Build Encyclopedia describes the rules you can use to build and test
-   Android apps with Bazel.
+*  [Android rules](be/android.html). The Build Encyclopedia describes the rules
+   you can use to build and test Android apps with Bazel.
 *  [Integration with Android Studio](ide.html). Bazel is compatible with
    Android Studio using the [Android Studio with Bazel](https://ij.bazel.build/)
    plugin.
 *  [`mobile-install` for Android](mobile-install.html). Bazel's `mobile-install`
    feature provides automated build-and-deploy functionality for building and
    testing Android apps directly on Android devices and emulators.
-*  [Android instrumentation testing](https://docs.bazel.build/versions/master/android-instrumentation-test.html)
-   on emulators and devices.
-*  [Android NDK integration](https://docs.bazel.build/versions/master/android-ndk.html).
-   Bazel supports compiling to native code through direct NDK integration and
-   the C++ rules.
+*  [Android instrumentation testing](android-instrumentation-test.html) on
+   emulators and devices.
+*  [Android NDK integration](android-ndk.html). Bazel supports compiling to
+   native code through direct NDK integration and the C++ rules.
 
 ## Further reading
 

--- a/site/docs/bazel-and-apple.md
+++ b/site/docs/bazel-and-apple.md
@@ -20,7 +20,7 @@ using Bazel to build and test for those platforms.
 The following resources will help you work with Bazel on macOS and iOS projects:
 
 *  [Tutorial: Building an iOS app](tutorial/ios-app.html)
-*  [Objective-C build rules](https://docs.bazel.build/versions/master/be/objective-c.html)
+*  [Objective-C build rules](be/objective-c.html)
 *  [General Apple rules](https://github.com/bazelbuild/rules_apple)
 *  [Integration with Xcode](ide.html)
 
@@ -37,7 +37,7 @@ in the migration guide to start building them with Bazel:
 You do not need it when getting started with Bazel.
 
 The following modules, configuration fragments, and providers will help you
-[extend Bazel's capabilities](https://docs.bazel.build/versions/master/skylark/concepts.html)
+[extend Bazel's capabilities](skylark/concepts.html)
 when building your macOS and iOS projects:
 
 *  Modules:

--- a/site/docs/bazel-and-cpp.md
+++ b/site/docs/bazel-and-cpp.md
@@ -22,7 +22,7 @@ The following resources will help you work with Bazel on C++ projects:
 
 *  [Tutorial: Building a C++ project](tutorial/cpp.html)
 *  [C++ common use cases](cpp-use-cases.html)
-*  [C/C++ rules](https://docs.bazel.build/versions/master/be/c-cpp.html)
+*  [C/C++ rules](be/c-cpp.html)
 *  [Understanding CROSSTOOL](crosstool-reference.html)
 *  [Configuring CROSSTOOL](tutorial/crosstool.html)
 
@@ -35,7 +35,7 @@ best practices specific to C++ projects.
 
 Follow the guidelines below when creating your BUILD files:
 
-*  Each BUILD file should contain one [`cc_library`](https://docs.bazel.build/versions/master/be/c-cpp.html#cc_library)
+*  Each BUILD file should contain one [`cc_library`](be/c-cpp.html#cc_library)
    rule target per compilation unit in the directory.
 
 *  We recommend that you granularize your C++ libraries as much as possible to
@@ -81,6 +81,6 @@ Follow these guidelines for include paths:
 
 *  For legacy or `third_party` code that requires includes pointing outside the
    project repository, such as external repository includes requiring a prefix,
-   use the [`include_prefix`](https://docs.bazel.build/versions/master/be/c-cpp.html#cc_library.include_prefix)
-   and [`strip_include_prefix`](https://docs.bazel.build/versions/master/be/c-cpp.html#cc_library.strip_include_prefix)
+   use the [`include_prefix`](be/c-cpp.html#cc_library.include_prefix) and
+   [`strip_include_prefix`](be/c-cpp.html#cc_library.strip_include_prefix)
    arguments on the `cc_library` rule target.

--- a/site/docs/bazel-and-java.md
+++ b/site/docs/bazel-and-java.md
@@ -23,7 +23,7 @@ Java projects with Bazel.
 The following resources will help you work with Bazel on Java projects:
 
 *  [Tutorial: Building a Java Project](tutorial/java.html)
-*  [Java rules](https://docs.bazel.build/versions/master/be/java.html)
+*  [Java rules](be/java.html)
 
 ## Migrating to Bazel
 
@@ -60,7 +60,7 @@ Follow these guidelines when creating your BUILD files:
 *  The name of the library should be the name of the directory containing the
    BUILD file.
 
-*  The sources should be a non-recursive [`glob`](https://docs.bazel.build/versions/master/be/functions.html#glob)
+*  The sources should be a non-recursive [`glob`](be/functions.html#glob)
    of all Java files in the directory.
 
 *  Tests should be in a matching directory under `src/test` and depend on this
@@ -72,7 +72,7 @@ Follow these guidelines when creating your BUILD files:
 You do not need it when getting started with Bazel.
 
 The following modules, configuration fragments, and providers will help you
-[extend Bazel's capabilities](https://docs.bazel.build/versions/master/skylark/concepts.html)
+[extend Bazel's capabilities](skylark/concepts.html)
 when building your Java projects:
 
 *  Modules:

--- a/site/docs/bazel-overview.md
+++ b/site/docs/bazel-overview.md
@@ -36,9 +36,8 @@ Bazel offers the following advantages:
     source files. It works with multiple repositories and user bases in the tens
     of thousands.
 
-*   **Bazel is extensible.** Many
-    [languages](https://docs.bazel.build/versions/master/be/overview.html#rules)
-    are supported, and you can extend Bazel to support any other language or
+*   **Bazel is extensible.** Many [languages](be/overview.html#rules) are
+    supported, and you can extend Bazel to support any other language or
     framework.
 
 
@@ -46,18 +45,18 @@ Bazel offers the following advantages:
 
 To build or test a project with Bazel, you typically do the following:
 
-1.  **Set up Bazel.** Download and [install Bazel](https://docs.bazel.build/versions/master/install.html).
+1.  **Set up Bazel.** Download and [install Bazel](install.html).
 
-2.  **Set up a project [workspace](https://docs.bazel.build/versions/master/build-ref.html#workspaces)**,
-    which is a directory where Bazel looks for build inputs and `BUILD` files,
-    and where it stores build outputs.
+2.  **Set up a project [workspace](build-ref.html#workspaces)**, which is a
+    directory where Bazel looks for build inputs and `BUILD` files, and where it
+    stores build outputs.
 
 3.  **Write a `BUILD` file**, which tells Bazel what to build and how to
     build it.
 
     You write your `BUILD` file by declaring build targets using
-    [Starlark](https://docs.bazel.build/versions/master/skylark/language.html),
-    a domain-specific language. (See example [here](https://github.com/bazelbuild/bazel/blob/master/examples/cpp/BUILD).)
+    [Starlark](skylark/language.html), a domain-specific language. (See example
+    [here](https://github.com/bazelbuild/bazel/blob/master/examples/cpp/BUILD).)
 
     A build target specifies a set of input artifacts that Bazel will build plus
     their dependencies, the build rule Bazel will use to build it, and options
@@ -68,12 +67,12 @@ To build or test a project with Bazel, you typically do the following:
     covering the most common artifact types in the supported languages on
     supported platforms.
 
-4. **Run Bazel** from the [command line](https://docs.bazel.build/versions/master/command-line-reference.html).
-   Bazel places your outputs within the workspace.
+4. **Run Bazel** from the [command line](command-line-reference.html). Bazel
+   places your outputs within the workspace.
 
-In addition to building, you can also use Bazel to run [tests](https://docs.bazel.build/versions/master/test-encyclopedia.html)
-and [query](https://docs.bazel.build/versions/master/query-how-to.html) the
-build to trace dependencies in your code.
+In addition to building, you can also use Bazel to run
+[tests](test-encyclopedia.html) and [query](master/query-how-to.html) the build
+to trace dependencies in your code.
 
 
 # How does Bazel work?
@@ -82,8 +81,9 @@ When running a build or a test, Bazel does the following:
 
 1.  **Loads** the `BUILD` files relevant to the target.
 
-2.  **Analyzes** the inputs and their [dependencies](https://docs.bazel.build/versions/master/build-ref.html#dependencies),
-    applies the specified build rules, and produces an [action](https://docs.bazel.build/versions/master/skylark/concepts.html#evaluation-model)
+2.  **Analyzes** the inputs and their
+    [dependencies](build-ref.html#dependencies), applies the specified build
+    rules, and produces an [action](skylark/concepts.html#evaluation-model)
     graph.
 
 3.  **Executes** the build actions on the inputs until the final build outputs
@@ -91,27 +91,27 @@ When running a build or a test, Bazel does the following:
 
 Since all previous build work is cached, Bazel can identify and reuse cached
 artifacts and only rebuild or retest what's changed. To further enforce
-correctness, you can set up Bazel to run builds and tests [hermetically](https://docs.bazel.build/versions/master/user-manual.html#sandboxing)
-through sandboxing, minimizing skew and maximizing [reproducibility](https://docs.bazel.build/versions/master/user-manual.html#correctness).
+correctness, you can set up Bazel to run builds and tests
+[hermetically](user-manual.html#sandboxing) through sandboxing, minimizing skew
+and maximizing [reproducibility](user-manual.html#correctness).
 
 
 ## What is the action graph?
 
 The action graph represents the build artifacts, the relationships between them,
 and the build actions that Bazel will perform. Thanks to this graph, Bazel can
-[track](https://docs.bazel.build/versions/master/user-manual.html#build-consistency-and-incremental-builds)
-changes to file content as well as changes to actions, such as build or test
-commands, and know what build work has previously been done. The graph also
-enables you to easily [trace dependencies](https://docs.bazel.build/versions/master/query-how-to.html)
-in your code.
+[track](user-manual.html#build-consistency-and-incremental-builds) changes to
+file content as well as changes to actions, such as build or test commands, and
+know what build work has previously been done. The graph also enables you to
+easily [trace dependencies](query-how-to.html) in your code.
 
 
 # How do I get started?
 
-To get started with Bazel, see [Getting Started](https://docs.bazel.build/versions/master/getting-started.html)
-or jump directly to the Bazel tutorials:
+To get started with Bazel, see [Getting Started](getting-started.html) or jump
+directly to the Bazel tutorials:
 
-*   [Tutorial: Build a C++ Project](https://docs.bazel.build/versions/master/tutorial/cpp.html)
-*   [Tutorial: Build a Java Project](https://docs.bazel.build/versions/master/tutorial/java.html)
-*   [Tutorial: Build an Android Application](https://docs.bazel.build/versions/master/tutorial/android-app.html)
-*   [Tutorial: Build an iOS Application](https://docs.bazel.build/versions/master/tutorial/ios-app.html)
+*   [Tutorial: Build a C++ Project](tutorial/cpp.html)
+*   [Tutorial: Build a Java Project](tutorial/java.html)
+*   [Tutorial: Build an Android Application](tutorial/android-app.html)
+*   [Tutorial: Build an iOS Application](tutorial/ios-app.html)

--- a/site/docs/bazel-vision.md
+++ b/site/docs/bazel-vision.md
@@ -78,7 +78,7 @@ any language.
     principles.
 1.  The rules need to be **remote-execution ready**. In practice, this means
     **configurable using the
-    [toolchains](https://docs.bazel.build/versions/master/toolchains.html)
+    [toolchains](master/toolchains.html)
     mechanism**.
 1.  The rules (and Bazel) need to interface with a **widely-used IDE** for the
     language, if there is one.

--- a/site/docs/build-javascript.md
+++ b/site/docs/build-javascript.md
@@ -36,8 +36,8 @@ This document assumes you are already familiar with Bazel and uses the
 to illustrate the recommended configuration. You can use the sample project as a
 starting point and add your own code to it to start building with Bazel.
 
-If you're new to Bazel, take a look at the ["Getting Started"](https://docs.bazel.build/versions/master/getting-started.html)
-material before proceeding.
+If you're new to Bazel, take a look at the ["Getting
+Started"](getting-started.html) material before proceeding.
 
 ## Setting up your environment
 
@@ -46,7 +46,7 @@ following:
 
 ### Step 1: Installing Bazel
 
-If you have not already done so, [Install Bazel](https://docs.bazel.build/versions/master/install.html).
+If you have not already done so, [Install Bazel](install.html).
 
 ### Step 2: Installing iBazel
 

--- a/site/docs/configurable-attributes.md
+++ b/site/docs/configurable-attributes.md
@@ -319,9 +319,8 @@ Without platforms, this might look something like
 bazel build //my_app:my_rocks --define color=white --define texture=smooth --define type=metamorphic
 ```
 
-Platforms are still under development. See the [documentation](
-https://docs.bazel.build/versions/master/platforms.html) and
-[roadmap](https://bazel.build/roadmaps/platforms.html) for details.
+Platforms are still under development. See the [documentation](platforms.html)
+and [roadmap](https://bazel.build/roadmaps/platforms.html) for details.
 
 ## Short Keys
 

--- a/site/docs/cquery.html
+++ b/site/docs/cquery.html
@@ -22,11 +22,11 @@ title: Cquery (configurable query)
   replace <code>query</code> as it does not support all of <code>query</code>'s functions.</p>
 <p>
   <code>cquery</code> achieves configuration awareness by running after the
-  <a href="https://docs.bazel.build/versions/master/skylark/concepts.html#evaluation-model">analysis phase</a>
+  <a href="skylark/concepts.html#evaluation-model">analysis phase</a>
   of a build, unlike traditional <code>query</code>, which runs after the loading phase.</p>
 <p>
   The most common use for <code>cquery</code> is obtaining answers that correctly evaluate
-  <a href="https://docs.bazel.build/versions/master/be/common-definitions.html#configurable-attributes"><code>select()</code></a>
+  <a href="be/common-definitions.html#configurable-attributes"><code>select()</code></a>
   statements in configurable attributes. For example:
 </p>
 
@@ -70,7 +70,7 @@ $ bazel cquery "deps(//tree:ash)" --define species=excelsior --noimplicit_deps
 <p>
   Keep in mind that <code>cquery</code> works only on the configured target graph. Because of this,
   it does not have insight into artifacts like build actions nor access to
-  <code><a href="https://docs.bazel.build/versions/master/be/general.html#test_suite">test_suite</a></code>
+  <code><a href="be/general.html#test_suite">test_suite</a></code>
   rules as they are not configured targets.
 </p>
 
@@ -85,7 +85,7 @@ $ bazel cquery "deps(//tree:ash)" --define species=excelsior --noimplicit_deps
 <ul>
   <li>
     <b><code>function(...)</code></b> is the function to run on the target. <code>cquery</code>
-    supports most of the same <a href="https://docs.bazel.build/versions/master/query.html#functions">functions</a>
+    supports most of the same <a href="query.html#functions">functions</a>
     as traditional <code>query</code>.
   </li>
   <li><b><code>//target</code></b> is the expression fed to the function. In this example, the
@@ -104,7 +104,7 @@ $ bazel cquery "deps(//tree:ash)" --define species=excelsior --noimplicit_deps
 <h2 id='functions'>Functions</h2>
 
 <p>
-  Of the <a href="https://docs.bazel.build/versions/master/query.html#functions" title="list of query functions">set of functions</a>
+  Of the <a href="query.html#functions" title="list of query functions">set of functions</a>
   supported by the traiditional <code>query</code>, <code>cquery</code> supports all but siblings, buildfiles, and tests. The
   functions listed below are <code>cquery</code>-specific.
 </p>
@@ -141,7 +141,7 @@ $ bazel cquery "deps(//tree:ash)" --define species=excelsior --noimplicit_deps
 
 <p>
   <code>cquery</code> runs on top of a regular Bazel build and thus inherits the set of
-  <a href="https://docs.bazel.build/versions/master/command-line-reference.html#build-options">options</a>
+  <a href="command-line-reference.html#build-options">options</a>
   available during a build.
 </p>
 
@@ -151,7 +151,7 @@ $ bazel cquery "deps(//tree:ash)" --define species=excelsior --noimplicit_deps
 
 <p>
   Often, the dependencies of configured targets go through
-  <a href="https://docs.bazel.build/versions/master/skylark/rules.html#configurations">transitions</a>,
+  <a href="skylark/rules.html#configurations">transitions</a>,
   which causes their configuration to differ from their dependent. This flag allows you to query
   a target as if it were built as a dependency or a transitive dependency of another target. For
   example:
@@ -173,7 +173,7 @@ cc_library(
 
 <p>
   Genrules configure their tools in the
-  <a href="https://docs.bazel.build/versions/master/skylark/rules.html#configurations">host configuration</a>
+  <a href="skylark/rules.html#configurations">host configuration</a>
   so the following queries would produce the following outputs:
 </p>
 
@@ -231,7 +231,7 @@ cc_library(
   Setting this flag to false filters out all configured targets for which the
   path from the queried target to them crosses a transition between the target
   configuration and the
-  <a href="https://docs.bazel.build/versions/master/skylark/rules.html#configurations">host configuration</a>.
+  <a href="skylark/rules.html#configurations">host configuration</a>.
   If the queried target is in a non-host configuration, setting <code>--nohost_deps</code> will
   only return targets that also are in non-host configurations. If the queried
   target is in a host configuration, setting <code>--nohost_deps</code> will only return
@@ -246,7 +246,7 @@ There are other options for exposing the results as well. </p>
 <h3> Transitions </h3>
 
 <p>
-  Configuration <a href="https://docs.bazel.build/versions/master/skylark/rules.html#configurations">transitions</a>
+  Configuration <a href="skylark/rules.html#configurations">transitions</a>
   are used to build targets underneath the top level targets in different configurations than the top
   level targets. For example, a target might impose a transition to the host transition on all
   dependencies in its <code>tools</code> attribute. These are known as attribute transitions.
@@ -271,15 +271,15 @@ There are other options for exposing the results as well. </p>
     hashes and there is no way for the user to input them (and thus to directly
     specify the configuration to query a target in).</li>
   <li>
-    <strong>No support for <a href="https://docs.bazel.build/versions/master/skylark/aspects.html">aspects</a>,
-    <a href="https://docs.bazel.build/versions/master/query.html#output-formats" title="list of query output formats">output
+    <strong>No support for <a href="skylark/aspects.html">aspects</a>,
+    <a href="query.html#output-formats" title="list of query output formats">output
     options</a>, or recursive target patterns (/...).</strong></li>
   <li>
     <strong>Non-deterministic output.</strong> <code>Cquery</code> does not automatically wipe the build
     graph from previous commands and is therefore prone to picking up results
     from past queries. For example, <code>genquery</code> exerts a host transition on its <code>tools</code>
     attribute - that is, it configures its tools in the
-    <a href="https://docs.bazel.build/versions/master/skylark/rules.html#configurations">host configuration</a>.
+    <a href="skylark/rules.html#configurations">host configuration</a>.
     We can see the lingering effects of that transition below.</li>
 </ul>
 

--- a/site/docs/crosstool-reference.md
+++ b/site/docs/crosstool-reference.md
@@ -74,7 +74,7 @@ The toolchain selection logic operates as follows:
 
 1.  User specifies a `cc_toolchain_suite` target in the `BUILD` file and points
     Bazel to the target using the
-    [`--crosstool_top` option](https://docs.bazel.build/versions/master/user-manual.html#flag--crosstool_top).
+    [`--crosstool_top` option](user-manual.html#flag--crosstool_top).
     The `CROSSTOOL` file must reside in the same directory as the
     `BUILD` file containing the `cc_toolchain_suite` target.
 

--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -69,4 +69,4 @@ To further explore Bazel, refer to the following resources:
 
 *   [Bazel User Manual](user-manual.html)
 
-*   [Build Encyclopedia](https://docs.bazel.build/versions/master/be/overview.html)
+*   [Build Encyclopedia](be/overview.html)

--- a/site/docs/migrate-xcode.md
+++ b/site/docs/migrate-xcode.md
@@ -63,11 +63,11 @@ converting an Xcode project to a Bazel project.
 
 Before you begin, do the following:
 
-1.  [Install Bazel](https://docs.bazel.build/versions/master/install.html) if
+1.  [Install Bazel](install.html) if
     you have not already done so.
 
 2.  If you're not familiar with Bazel and its concepts, complete the
-    [iOS app tutorial](https://docs.bazel.build/versions/master/tutorial/ios-app.html).
+    [iOS app tutorial](tutorial/ios-app.html).
     You should understand the Bazel workspace, including the `WORKSPACE` and
     `BUILD` files, as well as the concepts of targets, build rules, and Bazel
     packages.
@@ -80,7 +80,7 @@ Unlike Xcode, Bazel requires you to explicitly declare all dependencies for
 every target in the `BUILD` file.
 
 For more information on external dependencies, see
-[Working with external dependencies](https://docs.bazel.build/versions/master/external.html).
+[Working with external dependencies](external.html).
 
 ## Build or test an Xcode project with Bazel
 
@@ -137,7 +137,7 @@ initial build of the project as follows:
 *  [Step 3c: Add the library target(s)](#step-3c-add-the-library-target-s)
 
 **Tip:** To learn more about packages and other Bazel concepts, see
-[Bazel Terminology](https://docs.bazel.build/versions/master/build-ref.html).
+[Bazel Terminology](build-ref.html).
 
 #### Step 3a: Add the application target
 
@@ -193,7 +193,7 @@ simulator, also specify the `ios_application` target name as the value of the
 
 #### Step 3c: Add the library target(s)
 
-Add an [`objc_library`](https://docs.bazel.build/versions/master/be/objective-c.html#objc_library)
+Add an [`objc_library`](be/objective-c.html#objc_library)
 target for each Objective C library and a [`swift_library`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-swift.md)
 target for each Swift library on which the application and/or tests depend.
 
@@ -209,7 +209,7 @@ Add the library targets as follows:
 
 *   List the headers in the `hdrs` attribute.
 
-**Note:** You can use the [`glob`](https://docs.bazel.build/versions/master/be/functions.html#glob)
+**Note:** You can use the [`glob`](be/functions.html#glob)
 function to include all sources and/or headers of a certain type. Use it
 carefully as it might include files you do not want Bazel to build.
 

--- a/site/docs/query-how-to.html
+++ b/site/docs/query-how-to.html
@@ -183,7 +183,7 @@ if you're going to change some code, you might want to know what other code
 you're about to break.  You can use <code>rdeps(u, x)</code> to find the reverse
 dependencies of the targets in <code>x</code> within the transitive closure of <code>u</code>.</p>
 
-Bazel's <a href="https://docs.bazel.build/versions/master/query.html#sky-query">Sky Query</a>
+Bazel's <a href="query.html#sky-query">Sky Query</a>
 supports the <code>allrdeps</code> function which allows you to query rdeps in the entire
 universe of the build.
 <p><a name="Miscellaneous_Uses"></a></p>

--- a/site/docs/query.html
+++ b/site/docs/query.html
@@ -28,8 +28,7 @@ title: Query Language
 <h3> bazel cquery </h3>
 <p>Traditional bazel query runs on the post-loading phase target graph and therefore
   has no concept of configurations and their related concepts. Notably, this means it does not
-  correctly resolve
-  <a href = "https://docs.bazel.build/versions/master/be/functions.html#select">select statements</a>
+  correctly resolve <a href = "be/functions.html#select">select statements</a>
   and rather returns all possible resolutions of selects. A newer query environment, cquery,
   properly handles configurations but doesn't provide all of the functionality of this original
   query. For more information, see the <a href="cquery.html">Bazel cquery reference</a>.

--- a/site/docs/remote-execution-ci.md
+++ b/site/docs/remote-execution-ci.md
@@ -79,8 +79,8 @@ If your build or tests fail, it's likely due to the following:
 
 *   **Build or test targets are using rules that are incompatible with remote
     execution.** See
-    [Adapting Bazel Rules for Remote Execution](https://docs.bazel.build/versions/master/remote-execution-rules.html)
-    for details about compatibility with remote execution.
+    [Adapting Bazel Rules for Remote Execution](remote-execution-rules.html) for
+    details about compatibility with remote execution.
 
 ## Using a custom container in the `rbe_ubuntu1604` CI config
 
@@ -201,11 +201,10 @@ Container Registry as follows:
 
 ### Specifying the build platform definition
 
-You must include a
-[Bazel platform](https://docs.bazel.build/versions/master/platforms.html)
-configuration in your custom toolchain configuration, which allows Bazel to
-select a toolchain appropriate to the desired hardware/software platform. See
-this [example platform configuration](https://github.com/tensorflow/tensorflow/blob/master/third_party/toolchains/BUILD)
+You must include a [Bazel platform](platforms.html) configuration in your 
+custom toolchain configuration, which allows Bazel to select a toolchain 
+appropriate to the desired hardware/software platform. See this 
+[example platform configuration](https://github.com/tensorflow/tensorflow/blob/master/third_party/toolchains/BUILD)
 for the TensorFlow `ubuntu16-04` container.
 
 Create a similar configuration (that is, using the same constraints) but replace

--- a/site/docs/remote-execution-rules.md
+++ b/site/docs/remote-execution-rules.md
@@ -132,7 +132,7 @@ remote execution:
     build to fail on the remote execution platform as Bazel will not be able to
     locate them. Instead, create symlinks using standard build actions so that
     the symlinked tools and libraries are accessible from Bazel's `runfiles`
-    tree. Do not use [`repository_ctx.symlink`](https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#symlink)
+    tree. Do not use [`repository_ctx.symlink`](skylark/lib/repository_ctx.html#symlink)
     to symlink target files outside of the external repo directory.
 
 *   **Mutating the host platform.** Avoid creating files outside of the Bazel

--- a/site/docs/remote-execution-sandbox.md
+++ b/site/docs/remote-execution-sandbox.md
@@ -24,7 +24,7 @@ title: Troubleshooting Bazel Remote Execution with Docker Sandbox
 
 Bazel builds that succeed locally may fail when executed remotely due to
 restrictions and requirements that do not affect local builds. The most common
-causes of such failures are described in [Adapting Bazel Rules for Remote Execution](https://docs.bazel.build/versions/master/remote-execution-rules.html).
+causes of such failures are described in [Adapting Bazel Rules for Remote Execution](remote-execution-rules.html).
 
 This document describes how to identify and resolve the most common issues that
 arise with remote execution using the Docker sandbox feature, which imposes
@@ -114,7 +114,7 @@ machine and is a reliable way to confirm whether your build will succeed when
 executed remotely.
 
 However, with this method, locally installed tools, binaries, and data may leak
-into into your build, especially if it uses [configure-style WORKSPACE rules](https://docs.bazel.build/versions/master/remote-execution-rules.html#managing-configure-style-workspace-rules).
+into into your build, especially if it uses [configure-style WORKSPACE rules](remote-execution-rules.html#managing-configure-style-workspace-rules).
 Such leaks will cause problems with remote execution; to detect them, [troubleshoot in a Docker container](#troubleshooting-in-a-docker-container)
 in addition to troubleshooting natively.
 
@@ -165,7 +165,7 @@ The following are the most commonly encountered issues and their workarounds.
 
 *  **A file from `@local-jdk` is missing or causing errors.** The Java binaries
    on your local machine are leaking into the build while being incompatible with
-   it. Use [`java_toolchain`](https://docs.bazel.build/versions/master/be/java.html#java_toolchain)
+   it. Use [`java_toolchain`](be/java.html#java_toolchain)
    in your rules and targets instead of `@local_jdk`. Contact [bazel-discuss@google.com](mailto:bazel-discuss@google.com) if you need further help.
 
 *  **Other errors.** Contact [bazel-discuss@google.com](mailto:bazel-discuss@google.com) for help.
@@ -270,7 +270,7 @@ You can resolve build failures as follows:
 
 *   If the build fails during the analysis or loading phases, one or more of
     your build rules declared in the WORKSPACE file are not compatible with
-    remote execution. See [Adapting Bazel Rules for Remote Execution](https://docs.bazel.build/versions/master/remote-execution-rules.html)
+    remote execution. See [Adapting Bazel Rules for Remote Execution](remote-execution-rules.html)
     for possible causes and workarounds.
 
 *   If the build fails for any other reason, see the troubleshooting steps in [Step 2: Resolve detected issues](#step-2-resolve-detected-issues).

--- a/site/docs/remote-execution.md
+++ b/site/docs/remote-execution.md
@@ -46,4 +46,4 @@ To run Bazel with remote execution, you can use one of the following:
 
 Remote execution of Bazel builds imposes a set of mandatory configuration
 constraints on the build. For more information, see
-[Adapting Bazel Rules for Remote Execution](https://docs.bazel.build/versions/master/remote-execution-rules.html).
+[Adapting Bazel Rules for Remote Execution](remote-execution-rules.html).

--- a/site/docs/skylark/aspects.md
+++ b/site/docs/skylark/aspects.md
@@ -152,7 +152,7 @@ does not provide anything, so it returns an empty list.
 ### Invoking the aspect using the command line
 
 The simplest way to apply an aspect is from the command line using the
-[`--aspects`](https://docs.bazel.build/versions/master/command-line-reference.html#flag--aspects)
+[`--aspects`](../command-line-reference.html#flag--aspects)
 argument. Assuming the rule above were defined in a file named `print.bzl` this:
 
 ```bash

--- a/site/docs/skylark/backward-compatibility.md
+++ b/site/docs/skylark/backward-compatibility.md
@@ -709,9 +709,9 @@ config_setting(
 ### Disable depsets in C++ toolchain API in user flags
 
 If true, Bazel will no longer accept depsets in `user_compile_flags` for
-[create\_compile\_variables](https://docs.bazel.build/versions/master/skylark/lib/cc_common.html#create_compile_variables),
+[create\_compile\_variables](../skylark/lib/cc_common.html#create_compile_variables),
 and in `user_link_flags` for
-[create\_link\_variables](https://docs.bazel.build/versions/master/skylark/lib/cc_common.html#create_link_variables).
+[create\_link\_variables](../skylark/lib/cc_common.html#create_link_variables).
 Use plain lists instead.
 
 *   Flag: `--incompatible_disable_depset_in_cc_user_flags`
@@ -977,7 +977,7 @@ We have deprecated the `cc_toolchain` Starlark API returning legacy CROSSTOOL fi
 * mostly\_static\_link\_options
 * unfiltered\_compiler\_options
 
-Use the new API from [cc_common](https://docs.bazel.build/versions/master/skylark/lib/cc_common.html)
+Use the new API from [cc_common](../skylark/lib/cc_common.html)
 
 ```python
 # Before:

--- a/site/docs/skylark/concepts.md
+++ b/site/docs/skylark/concepts.md
@@ -8,7 +8,7 @@ title: Extension Overview
 <!-- [TOC] -->
 
 Bazel extensions are files ending in `.bzl`. Use a
-[load statement](https://docs.bazel.build/versions/master/build-ref.html#load)
+[load statement](../build-ref.html#load)
 to import a symbol from an extension.
 
 ## Macros and rules

--- a/site/docs/skylark/performance.md
+++ b/site/docs/skylark/performance.md
@@ -94,7 +94,7 @@ building your tests `//foo/tests/...`, or when importing an IDE project.
 
 **Note**: Today it is possible to flatten depsets implicitly by iterating over
 the depset the way you would a list, tuple, or dictionary, or by taking the
-depset's size via `len()`. This functionality is [deprecated](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#depset-is-no-longer-iterable).
+depset's size via `len()`. This functionality is [deprecated](../skylark/backward-compatibility.html#depset-is-no-longer-iterable).
 and will be removed.
 
 ### Avoid calling `len(depset)`

--- a/site/docs/skylark/rules.md
+++ b/site/docs/skylark/rules.md
@@ -644,7 +644,7 @@ of output files that may be requested together. For example, if a target
 `//pkg:mytarget` is of a rule type that has a `debug_files` output group, these
 files can be built by running
 `bazel build //pkg:mytarget --output_groups=debug_files`. See the [command line
-reference](https://docs.bazel.build/versions/master/command-line-reference.html#flag--output_groups)
+reference](../command-line-reference.html#flag--output_groups)
 for details on the `--output_groups` argument. Since non-predeclared outputs
 don't have labels, they can only be requested by appearing in the default
 outputs or an output group.

--- a/site/docs/skylark/skylint.md
+++ b/site/docs/skylark/skylint.md
@@ -5,7 +5,7 @@ title: Skylint
 
 # Skylint
 
-[Style guide](https://docs.bazel.build/versions/master/skylark/bzl-style.html)
+[Style guide](../skylark/bzl-style.html)
 
 This document explains how to use Skylint, the Starlark linter.
 
@@ -364,8 +364,7 @@ This way, the name is still re-exported but doesn't generate a warning.
 
 ### Deprecated API
 
-See [documentation](https://docs.bazel.build/versions/master/skylark/lib/ctx.html)
-for more information.
+See [documentation](../skylark/lib/ctx.html) for more information.
 
 ### Miscellaneous lints
 

--- a/site/docs/tutorial/android-app.md
+++ b/site/docs/tutorial/android-app.md
@@ -8,7 +8,7 @@ title: Build Tutorial - Android
 In this tutorial, you will learn how to build a simple Android app using Bazel.
 
 Bazel supports building Android apps using the [Android
-rules](https://docs.bazel.build/versions/master/be/android.html).
+rules](../be/android.html).
 
 This tutorial is intended for Windows, macOS and Linux users and does not
 require experience with Bazel or Android app development. You do not need to
@@ -182,7 +182,7 @@ from the `ANDROID_NDK_HOME` environment variable by default. The path can also
 be explicitly specified with a `path` attribute on `android_ndk_repository`.
 
 For more information, read [Using the Android Native Development Kit with
-Bazel](https://docs.bazel.build/versions/master/android-ndk.html).
+Bazel](../android-ndk.html).
 
 `api_level` is the version of the Android API that the SDK and NDK
 target - for example, 23 for Android 6.0 and 25 for Android 7.1. If not

--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -1509,7 +1509,7 @@ echo "STABLE_USER_NAME $USER"
   The platforms that are available as execution platforms to run actions.
   Platforms can be specified by exact target, or as a target pattern. These
   platforms will be considered before those declared in the WORKSPACE file by
-  <a href="https://docs.bazel.build/versions/master/skylark/lib/globals.html#register_execution_platforms">
+  <a href="skylark/lib/globals.html#register_execution_platforms">
   register_execution_platforms()</a>.
 </p>
 
@@ -1518,8 +1518,7 @@ echo "STABLE_USER_NAME $USER"
   The toolchain rules to be considered during toolchain resolution. Toolchains
   can be specified by exact target, or as a target pattern. These toolchains will
   be considered before those declared in the WORKSPACE file by
-  <a href="https://docs.bazel.build/versions/master/skylark/lib/globals.html#register_toolchains">
-  register_toolchains()</a>.
+  <a href="skylark/lib/globals.html#register_toolchains"> register_toolchains()</a>.
 </p>
 
 <h4 id="flag--toolchain_resolution_debug"><code class='flag'>--toolchain_resolution_debug=false</code></h4>


### PR DESCRIPTION
For files in..

* `site/docs`: `s;https://docs.bazel.build/versions/master/;;g`
* `site/docs/skylark`, `site/docs/tutorial`: `s;https://docs.bazel.build/versions/master/;..;g`
