### PR TITLE
WIP: Remote action cache: close outErr before deletion

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -270,6 +270,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
           FileSystemUtils.deleteTreesBelow(execRoot.getRelative(directory.getPath()));
         }
         if (outErr != null) {
+          outErr.close();
           outErr.getOutputPath().delete();
           outErr.getErrorPath().delete();
         }


### PR DESCRIPTION
**IMPORTANT**: this PR may or may not fix the referenced bug. This is unclear at the time of creation of this PR.

If downloading a remotely cached action's outErr
failed, the AbstractRemoteActionCache deletes the
files underlying the outErr.

For this deletion to succeed on Windows, the files
must be closed. This commit implements that.

Fixes https://github.com/bazelbuild/bazel/issues/6890

Change-Id: Ib15c4a255eb9029d5fd442617a9b7472f31e8f76