### PR TITLE
Windows: fix build of Bazel itself

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -338,7 +338,10 @@ genrule(
     name = "bazel-bin",
     srcs = [":bazel-bin_jdk_allmodules"],
     outs = ["bazel"],
-    cmd = "cp $(location :bazel-bin_jdk_allmodules) $@",
+    # In msys, a file path without .exe suffix(say foo), refers to a file with .exe
+    # suffix(say foo.exe), if foo.exe exists and foo doesn't. So, on windows, we
+    # need to remove bazel.exe first, so that cat to bazel won't fail.
+    cmd = "rm -f $@; cp $(location :bazel-bin_jdk_allmodules) $@",
     executable = 1,
     output_to_bindir = 1,
     visibility = [


### PR DESCRIPTION
Recently the //src:bazel-bin genrule was extracted
from the existing list comprehension that created
the //src:bazel-bin-* rules (see https://github.com/bazelbuild/bazel/commit/218e8f6b366376c96b757a27a850662fb74726f0)

The rule failed to build on Windows if you have an
old output tree (built before this commit was
upstreamd), because the new "bazel-bin" rule's
output already exists in the output tree, and the
rule fails to overwrite it.

This PR copies the code and comment from the old
bazel-bin-* rules' definition, to delete the
output of the new bazel-bin rule.