### PR TITLE
Fix shellcheck warning of BAZEL_REAL variable

### DIFF
--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -61,7 +61,8 @@ function get_realpath() {
     fi
 }
 
-export BAZEL_REAL="$(dirname "$(get_realpath "${BASH_SOURCE[0]}")")/bazel-real"
+BAZEL_REAL="$(dirname "$(get_realpath "${BASH_SOURCE[0]}")")/bazel-real"
+export BAZEL_REAL
 
 WORKSPACE_DIR="${PWD}"
 while [[ "${WORKSPACE_DIR}" != / ]]; do


### PR DESCRIPTION
This fixes the 'Declare and assign separately to avoid masking return values' warning from shellcheck.