### PR TITLE
Default to bazel with minimal embedded JDK.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -349,14 +349,14 @@ filegroup(
     "_nojdk",
 ]]
 
-genrule(
-    name = "bazel-bin",
-    srcs = [":bazel-bin_jdk_allmodules"],
-    outs = ["bazel"],
+[genrule(
+    name = "bazel-bin" + suffix,
+    srcs = [":bazel-bin" + jdk],
+    outs = ["bazel" + suffix],
     # In msys, a file path without .exe suffix(say foo), refers to a file with .exe
     # suffix(say foo.exe), if foo.exe exists and foo doesn't. So, on windows, we
     # need to remove bazel.exe first, so that cat to bazel won't fail.
-    cmd = "rm -f $@; cp $(location :bazel-bin_jdk_allmodules) $@",
+    cmd = "rm -f $@; cp $(location :bazel-bin" + jdk + ") $@",
     executable = 1,
     output_to_bindir = 1,
     visibility = [
@@ -365,7 +365,10 @@ genrule(
         "//src/java:__subpackages__",  # For command line reference generation
         "//src/test:__subpackages__",  # For integration tests
     ],
-)
+) for suffix, jdk in [
+    ("-dev", "_jdk_allmodules"),
+    ("", "_jdk_minimal"),
+]]
 
 # Build an executable named `bazel.exe`.
 # Works on all platforms but only makes sense on Windows.


### PR DESCRIPTION
This will save ~22MB of the final bazel binary and ~120MB in the
install_base.

RELNOTES[INC]: //src:bazel uses the minimal embedded JDK, if you want to
avoid the extra steps of minimizing the JDK, use //src:bazel-dev
instead.