### PR TITLE
Use artifact id and sha1 for cache key type for maven_jar artifacts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenDownloader.java
@@ -137,14 +137,14 @@ public class MavenDownloader extends HttpDownloader {
     jarDownload = outputDirectory.getRelative(artifact.getFile().getAbsolutePath());
     // Verify checksum.
     if (!Strings.isNullOrEmpty(sha1)) {
-      RepositoryCache.assertFileChecksum(sha1, jarDownload, KeyType.SHA1);
+      RepositoryCache.assertFileChecksum(sha1, jarDownload, KeyType.ID_PREFIXED_SHA1);
     }
 
     Path srcjarDownload = null;
     if (artifactWithSrcs.getFile() != null) {
       srcjarDownload = outputDirectory.getRelative(artifactWithSrcs.getFile().getAbsolutePath());
       if (!Strings.isNullOrEmpty(sha1Src)) {
-        RepositoryCache.assertFileChecksum(sha1Src, srcjarDownload, KeyType.SHA1);
+        RepositoryCache.assertFileChecksum(sha1Src, srcjarDownload, KeyType.ID_PREFIXED_SHA1);
       }
     }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/cache/RepositoryCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/cache/RepositoryCacheTest.java
@@ -99,6 +99,13 @@ public class RepositoryCacheTest {
         .isEqualTo(FileSystemUtils.readContent(cacheValue, Charset.defaultCharset()));
   }
 
+  @Test
+  public void testPutCacheValueWithoutHashThrowsWithIdPrefixedSha1KeyType() throws IOException {
+    thrown.expect(IllegalAccessException.class);
+    thrown.expectMessage("Cache key can't be computed from source path for key type: ID_PREFIXED_SHA-1");
+    repositoryCache.put(downloadedFile, KeyType.ID_PREFIXED_SHA1);
+  }
+
   /**
    * Test that the put method is idempotent, i.e. two successive put calls
    * should not affect the final state in the cache.


### PR DESCRIPTION
Previously the RepositoryCache was unable to provide any
identification of cached entries except for the sha1 value itself,
which makes it hard to verify that a retrieved value is what the user
expects. At least in the case of maven_jar rules, the artifactId
attribute has more user significance than the sha1.

This CL adds a new KeyType in the RepositoryCache called
ID_PREFIXED_SHA1 which takes a key that has a concatenated form of the
maven coordinates as a prefix to the sha1 portion of the key. This new
key type is used for resolving cached maven artifacts (and storing new
ones), which will ensure that the artifact id and sha1 match and are
valid.

https://github.com/bazelbuild/bazel/issues/5144