### PR TITLE
[singlejar] Fix Windows long path issue

### DIFF
--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -355,6 +355,7 @@ cc_library(
     deps = [
         ":diag",
         ":port",
+        "//src/main/cpp/util",
     ],
 )
 
@@ -413,10 +414,7 @@ cc_library(
     hdrs = ["test_util.h"],
     deps = [
         "//src/main/cpp/util",
-        # TODO(laszlocsomor) Use @bazel_tools//tools/cpp/runfiles after Bazel is
-        # released with
-        # https://github.com/bazelbuild/bazel/commit/23bc3bee79d8a8b8dc15bbfb6072ec9f965dff96.
-        "//tools/cpp/runfiles:runfiles_src_for_singlejar_only",
+        "@bazel_tools//tools/cpp/runfiles",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/tools/singlejar/diag.h
+++ b/src/tools/singlejar/diag.h
@@ -33,10 +33,10 @@
 #include <string.h>
 #include <windows.h>
 #define _diag_msg(prefix, msg, ...) \
-  { fprintf(stderr, prefix msg, __VA_ARGS__); }
+  { fprintf(stderr, prefix msg "\n", __VA_ARGS__); }
 #define _diag_msgx(exit_value, prefix, msg, ...) \
   { \
-    _diag_msg(prefix, msg "\n", __VA_ARGS__); \
+    _diag_msg(prefix, msg, __VA_ARGS__); \
     ::ExitProcess(exit_value); \
   }
 #define diag_err(exit_value, fmt, ...) \

--- a/src/tools/singlejar/diag.h
+++ b/src/tools/singlejar/diag.h
@@ -36,7 +36,7 @@
   { fprintf(stderr, prefix msg, __VA_ARGS__); }
 #define _diag_msgx(exit_value, prefix, msg, ...) \
   { \
-    _diag_msg(prefix, msg, __VA_ARGS__); \
+    _diag_msg(prefix, msg "\n", __VA_ARGS__); \
     ::ExitProcess(exit_value); \
   }
 #define diag_err(exit_value, fmt, ...) \

--- a/src/tools/singlejar/input_jar.h
+++ b/src/tools/singlejar/input_jar.h
@@ -45,6 +45,11 @@ class InputJar {
 
   ~InputJar() { Close(); }
 
+#ifndef _WIN32
+  // Used by Google-internal only. Do not add more usage of it.
+  int fd() const { return mapped_file.fd(); }
+#endif
+
   // Opens the file, memory maps it and locates Central Directory.
   bool Open(const std::string& path);
 

--- a/src/tools/singlejar/input_jar.h
+++ b/src/tools/singlejar/input_jar.h
@@ -45,8 +45,6 @@ class InputJar {
 
   ~InputJar() { Close(); }
 
-  int fd() const { return mapped_file_.fd(); }
-
   // Opens the file, memory maps it and locates Central Directory.
   bool Open(const std::string& path);
 

--- a/src/tools/singlejar/input_jar.h
+++ b/src/tools/singlejar/input_jar.h
@@ -47,7 +47,7 @@ class InputJar {
 
 #ifndef _WIN32
   // Used by Google-internal only. Do not add more usage of it.
-  int fd() const { return mapped_file.fd(); }
+  int fd() const { return mapped_file_.fd(); }
 #endif
 
   // Opens the file, memory maps it and locates Central Directory.

--- a/src/tools/singlejar/mapped_file.h
+++ b/src/tools/singlejar/mapped_file.h
@@ -50,6 +50,15 @@ class MappedFile {
   off64_t offset(const void *address) const {
     return reinterpret_cast<const unsigned char *>(address) - mapped_start_;
   }
+
+#ifndef _WIN32
+  // Used by Google-internal only. Do not add more usage of it.
+  // It is not available on Windows because Windows' implementation does not
+  // use fd at all and adding it would just make the implementation too
+  // complicated.
+  int fd() const { return fd_; }
+#endif
+
   size_t size() const { return mapped_end_ - mapped_start_; }
   bool is_open() const;
 

--- a/src/tools/singlejar/mapped_file.h
+++ b/src/tools/singlejar/mapped_file.h
@@ -50,16 +50,17 @@ class MappedFile {
   off64_t offset(const void *address) const {
     return reinterpret_cast<const unsigned char *>(address) - mapped_start_;
   }
-  int fd() const { return fd_; }
   size_t size() const { return mapped_end_ - mapped_start_; }
-  bool is_open() const { return fd_ >= 0; }
+  bool is_open() const;
 
  private:
   unsigned char *mapped_start_;
   unsigned char *mapped_end_;
-  int fd_;
 #ifdef _WIN32
+  /* HANDLE */ void *hFile_;
   /* HANDLE */ void *hMapFile_;
+#else
+  int fd_;
 #endif
 };
 

--- a/src/tools/singlejar/mapped_file_posix.inc
+++ b/src/tools/singlejar/mapped_file_posix.inc
@@ -69,4 +69,6 @@ void MappedFile::Close() {
   }
 }
 
+bool MappedFile::is_open() const { return fd_ >= 0; }
+
 #endif  // BAZEL_SRC_TOOLS_SINGLEJAR_MAPPED_FILE_POSIX_H_

--- a/src/tools/singlejar/mapped_file_windows.inc
+++ b/src/tools/singlejar/mapped_file_windows.inc
@@ -19,6 +19,7 @@
 #error This code is for 64 bit Windows.
 #endif
 
+#include "src/main/cpp/util/path_platform.h"
 #include "src/tools/singlejar/diag.h"
 
 #ifndef WIN32_LEAN_AND_MEAN
@@ -32,21 +33,32 @@
 MappedFile::MappedFile()
     : mapped_start_(nullptr),
       mapped_end_(nullptr),
-      fd_(-1),
+      hFile_(INVALID_HANDLE_VALUE),
       hMapFile_(INVALID_HANDLE_VALUE) {}
+
+bool MappedFile::is_open() const { return hFile_ != INVALID_HANDLE_VALUE; }
 
 bool MappedFile::Open(const std::string& path) {
   if (is_open()) {
     diag_errx(1, "%s:%d: This instance is already open", __FILE__, __LINE__);
   }
-  if ((fd_ = _open(path.c_str(), O_RDONLY | O_BINARY)) < 0) {
-    diag_warn("%s:%d: open %s:", __FILE__, __LINE__, path.c_str());
+
+  std::wstring wpath;
+  std::string error;
+  if (!blaze_util::AsAbsoluteWindowsPath(path, &wpath, &error)) {
+    diag_warn("%s:%d: AsAbsoluteWindowsPath failed: %s", __FILE__, __LINE__, error.c_str());
     return false;
   }
 
-  HANDLE hFile = reinterpret_cast<HANDLE>(_get_osfhandle(fd_));
+  hFile_ = CreateFileW(wpath.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL,
+                       OPEN_EXISTING, 0, NULL);
+  if (hFile_ == INVALID_HANDLE_VALUE) {
+    diag_warn("%s:%d: CreateFileW failed for %S", __FILE__, __LINE__, wpath.c_str());
+    return false;
+  }
+
   LARGE_INTEGER temp;
-  ::GetFileSizeEx(hFile, &temp);
+  ::GetFileSizeEx(hFile_, &temp);
   size_t fileSize = temp.QuadPart;
 
   if (fileSize == 0) {
@@ -65,7 +77,7 @@ bool MappedFile::Open(const std::string& path) {
   }
 
   hMapFile_ = ::CreateFileMapping(
-      hFile,
+      hFile_,
       nullptr,                             // default security
       PAGE_READONLY,                       // read-only permission
       static_cast<DWORD>(fileSize >> 32),  // size of mapping object, high
@@ -75,8 +87,8 @@ bool MappedFile::Open(const std::string& path) {
   if (hMapFile_ == nullptr) {
     diag_warn("%s:%d: CreateFileMapping for %s failed", __FILE__, __LINE__,
               path.c_str());
-    _close(fd_);
-    fd_ = -1;
+    ::CloseHandle(hFile_);
+    hFile_ = INVALID_HANDLE_VALUE;
     return false;
   }
 
@@ -90,9 +102,9 @@ bool MappedFile::Open(const std::string& path) {
     diag_warn("%s:%d: MapViewOfFile for %s failed", __FILE__, __LINE__,
               path.c_str());
     ::CloseHandle(hMapFile_);
-    _close(fd_);
+    ::CloseHandle(hFile_);
+    hFile_ = INVALID_HANDLE_VALUE;
     hMapFile_ = INVALID_HANDLE_VALUE;
-    fd_ = -1;
     return false;
   }
 
@@ -109,8 +121,8 @@ void MappedFile::Close() {
       ::CloseHandle(hMapFile_);
       hMapFile_ = INVALID_HANDLE_VALUE;
     }
-    _close(fd_);
-    fd_ = -1;
+    ::CloseHandle(hFile_);
+    hFile_ = INVALID_HANDLE_VALUE;
     mapped_start_ = mapped_end_ = nullptr;
   }
 }

--- a/src/tools/singlejar/mapped_file_windows.inc
+++ b/src/tools/singlejar/mapped_file_windows.inc
@@ -46,14 +46,16 @@ bool MappedFile::Open(const std::string& path) {
   std::wstring wpath;
   std::string error;
   if (!blaze_util::AsAbsoluteWindowsPath(path, &wpath, &error)) {
-    diag_warn("%s:%d: AsAbsoluteWindowsPath failed: %s", __FILE__, __LINE__, error.c_str());
+    diag_warn("%s:%d: AsAbsoluteWindowsPath failed: %s", __FILE__, __LINE__,
+              error.c_str());
     return false;
   }
 
   hFile_ = CreateFileW(wpath.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL,
                        OPEN_EXISTING, 0, NULL);
   if (hFile_ == INVALID_HANDLE_VALUE) {
-    diag_warn("%s:%d: CreateFileW failed for %S", __FILE__, __LINE__, wpath.c_str());
+    diag_warn("%s:%d: CreateFileW failed for %S", __FILE__, __LINE__,
+              wpath.c_str());
     return false;
   }
 

--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -283,7 +283,6 @@ bool OutputJar::Open() {
     diag_errx(1, "%s:%d: Cannot open output archive twice", __FILE__, __LINE__);
   }
 
-  // Set execute bits since we may produce an executable output file.
   int mode = O_CREAT | O_WRONLY | O_TRUNC;
 
 #ifdef _WIN32
@@ -307,6 +306,7 @@ bool OutputJar::Open() {
   mode |= _O_BINARY;
   int fd = _open_osfhandle(reinterpret_cast<intptr_t>(hFile), mode);
 #else
+  // Set execute bits since we may produce an executable output file.
   int fd = open(path(), mode, 0777);
 #endif
 

--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -289,7 +289,7 @@ bool OutputJar::Open() {
 #ifdef _WIN32
   std::wstring wpath;
   std::string error;
-  if (!blaze_util::AsAbsoluteWindowsPath(path, &wpath, &error)) {
+  if (!blaze_util::AsAbsoluteWindowsPath(path(), &wpath, &error)) {
     diag_warn("%s:%d: AsAbsoluteWindowsPath failed: %s", __FILE__, __LINE__,
               error.c_str());
     return false;
@@ -305,7 +305,7 @@ bool OutputJar::Open() {
 
   // Make sure output file is in binary mode, or \r\n will be converted to \n.
   mode |= _O_BINARY;
-  int fd = _open_osfhandle(hFile, mode);
+  int fd = _open_osfhandle(reinterpret_cast<intptr_t>(hFile), mode);
 #else
   int fd = open(path(), mode, 0777);
 #endif

--- a/src/tools/singlejar/test_util.h
+++ b/src/tools/singlejar/test_util.h
@@ -16,7 +16,7 @@
 
 #include <string>
 
-#include "tools/cpp/runfiles/runfiles_src.h"
+#include "tools/cpp/runfiles/runfiles.h"
 
 namespace singlejar_test_util {
   using std::string;


### PR DESCRIPTION
Fix #6990 

Drive-by:
- Add newline for `diag_*` macros. Singlejar error log should be easier to read now.
- Resolve a TODO for `test_util`.
- Remove `int fd()` for `InputJar` and `MappedFile`. source.bazel.build shows that no one is using them and the removal simplifies the implementation of `MappedFile` on Windows.