### PR TITLE
Windows installation using Scoop. #4950

### DIFF
--- a/site/docs/install-windows.md
+++ b/site/docs/install-windows.md
@@ -48,6 +48,7 @@ title: Installing Bazel on Windows
 ### Other ways to get Bazel
 
 *   [Install Bazel using the Chocolatey package manager](#install-using-chocolatey)
+*   [Install Bazel using the Scoop package manager](#install-using-scoop)
 *   [Compile Bazel from source](install-compile-source.html)
 
 #### Install using Chocolatey
@@ -65,6 +66,16 @@ title: Installing Bazel on Windows
 See [Chocolatey installation and package maintenance
 guide](https://bazel.build/windows-chocolatey-maintenance.html) for more
 information about the Chocolatey package.
+
+#### Install using Scoop
+
+1.  Install the [Scoop](https://scoop.sh/) package manager using PowerShell command:
+
+        iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+
+2.  Install the Bazel package:
+
+        scoop install bazel
 
 ### Using Bazel
 

--- a/site/docs/install-windows.md
+++ b/site/docs/install-windows.md
@@ -77,6 +77,10 @@ information about the Chocolatey package.
 
         scoop install bazel
 
+See [Scoop installation and package maintenance
+guide](https://bazel.build/windows-scoop-maintenance.html) for more
+information about the Scoop package.
+
 ### Using Bazel
 
 Once you have installed Bazel, see [Using Bazel on Windows](windows.html).


### PR DESCRIPTION
Added one more way to install Bazel for Windows to site.

Fixes #4950.

DO NOT MERGE until https://github.com/bazelbuild/bazel-website/pull/173 is released.