### PR TITLE
Remove period from a EnvironmentalExecException message.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -111,7 +111,7 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnActionConte
         }
       }
     } catch (IOException e) {
-      throw new EnvironmentalExecException("Unexpected IO error.", e);
+      throw new EnvironmentalExecException("Unexpected IO error", e);
     } catch (SpawnExecException e) {
       ex = e;
       spawnResult = e.getSpawnResult();


### PR DESCRIPTION
ActionExecutionException inserts a colon between the main exception message and the cause's message. Errors thus look better if the main exception message doesn't end with punctuation.