### PR TITLE
Remove RetryException.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -71,10 +71,6 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
     ((SettableFuture<byte[]>) EMPTY_BYTES).set(new byte[0]);
   }
 
-  public static boolean causedByCacheMiss(IOException t) {
-    return t.getCause() instanceof CacheNotFoundException;
-  }
-
   protected final RemoteOptions options;
   protected final DigestUtil digestUtil;
   private final Retrier retrier;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
@@ -16,42 +16,20 @@ package com.google.devtools.build.lib.remote;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-/**
- * Specific retry logic for remote execution/caching.
- *
- * <p>A call can disable retries by throwing a {@link PassThroughException}. <code>
- *   RemoteRetrier r = ...;
- *   try {
- *    r.execute(() -> {
- *      // Not retried.
- *      throw PassThroughException(new IOException("fail"));
- *    }
- *   } catch (RetryException e) {
- *     // e.getCause() is the IOException
- *     System.out.println(e.getCause());
- *   }
- * </code>
- */
+/** Specific retry logic for remote execution/caching. */
 public class RemoteRetrier extends Retrier {
-
-  /**
-   * Wraps around an {@link Exception} to make it pass through a single layer of retries.
-   */
-  public static class PassThroughException extends Exception {
-    public PassThroughException(Exception e) {
-      super(e);
-    }
-  }
 
   public static final Predicate<? super Exception> RETRIABLE_GRPC_ERRORS =
       e -> {
@@ -102,7 +80,7 @@ public class RemoteRetrier extends Retrier {
       Predicate<? super Exception> shouldRetry,
       ListeningScheduledExecutorService retryScheduler,
       CircuitBreaker circuitBreaker) {
-    super(backoff, supportPassthrough(shouldRetry), retryScheduler, circuitBreaker);
+    super(backoff, shouldRetry, retryScheduler, circuitBreaker);
   }
 
   @VisibleForTesting
@@ -112,28 +90,22 @@ public class RemoteRetrier extends Retrier {
       ListeningScheduledExecutorService retryScheduler,
       CircuitBreaker circuitBreaker,
       Sleeper sleeper) {
-    super(backoff, supportPassthrough(shouldRetry), retryScheduler, circuitBreaker, sleeper);
+    super(backoff, shouldRetry, retryScheduler, circuitBreaker, sleeper);
   }
 
+  /**
+   * Execute a callable with retries. {@link IOException} and {@link InterruptedException} are
+   * propagated directly to the caller. All other exceptions are wrapped in {@link RuntimeError}.
+   */
   @Override
-  public <T> T execute(Callable<T> call) throws RetryException, InterruptedException {
+  public <T> T execute(Callable<T> call) throws IOException, InterruptedException {
     try {
       return super.execute(call);
-    } catch (RetryException e) {
-      if (e.getCause() instanceof PassThroughException) {
-        PassThroughException passThrough = (PassThroughException) e.getCause();
-        throw new RetryException("Retries aborted because of PassThroughException",
-            e.getAttempts(), (Exception) passThrough.getCause());
-      }
-      throw e;
+    } catch (Exception e) {
+      Throwables.propagateIfInstanceOf(e, IOException.class);
+      Throwables.propagateIfInstanceOf(e, InterruptedException.class);
+      throw Throwables.propagate(e);
     }
-  }
-
-
-  private static Predicate<? super Exception> supportPassthrough(
-      Predicate<? super Exception> delegate) {
-    // PassThroughException is not retriable.
-    return e -> !(e instanceof PassThroughException) && delegate.test(e);
   }
 
   static class ExponentialBackoff implements Retrier.Backoff {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrierUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrierUtils.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.remote;
 
-import com.google.devtools.build.lib.remote.Retrier.RetryException;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
@@ -23,23 +22,22 @@ import io.grpc.StatusRuntimeException;
 public final class RemoteRetrierUtils {
 
   public static boolean causedByStatus(Throwable e, Status.Code expected) {
-    if (e instanceof RetryException) {
-      e = e.getCause();
-    }
     if (e instanceof StatusRuntimeException) {
       return ((StatusRuntimeException) e).getStatus().getCode() == expected;
     } else if (e instanceof StatusException) {
       return ((StatusException) e).getStatus().getCode() == expected;
+    } else if (e.getCause() != null) {
+      return causedByStatus(e.getCause(), expected);
     }
     return false;
   }
 
   public static boolean causedByExecTimeout(Throwable e) {
-    if (!(e instanceof RetryException)) {
-      return false;
+    if (e instanceof ExecutionStatusException) {
+      return ((ExecutionStatusException) e).isExecutionTimeout();
+    } else if (e.getCause() != null) {
+      return causedByExecTimeout(e.getCause());
     }
-    e = e.getCause();
-    return (e instanceof ExecutionStatusException
-        && ((ExecutionStatusException) e).isExecutionTimeout());
+    return false;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import io.grpc.CallCredentials;
 import io.grpc.Context;
+import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -73,6 +74,8 @@ class RemoteServerCapabilities {
               ? GetCapabilitiesRequest.getDefaultInstance()
               : GetCapabilitiesRequest.newBuilder().setInstanceName(instanceName).build();
       return retrier.execute(() -> capabilitiesBlockingStub().getCapabilities(request));
+    } catch (StatusRuntimeException e) {
+      throw new IOException(e);
     } finally {
       withMetadata.detach(previous);
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -155,15 +155,15 @@ final class RemoteSpawnCache implements SpawnCache {
                   .build();
           return SpawnCache.success(spawnResult);
         }
+      } catch (CacheNotFoundException e) {
+        // Intentionally left blank
       } catch (IOException e) {
-        if (!AbstractRemoteActionCache.causedByCacheMiss(e)) {
-          String errorMsg = e.getMessage();
-          if (isNullOrEmpty(errorMsg)) {
+        String errorMsg = e.getMessage();
+        if (isNullOrEmpty(errorMsg)) {
             errorMsg = e.getClass().getSimpleName();
-          }
+        }
           errorMsg = "Reading from Remote Cache:\n" + errorMsg;
           report(Event.warn(errorMsg));
-        }
       } finally {
         withMetadata.detach(previous);
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -52,7 +52,6 @@ import com.google.devtools.build.lib.exec.SpawnExecException;
 import com.google.devtools.build.lib.exec.SpawnRunner;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
-import com.google.devtools.build.lib.remote.Retrier.RetryException;
 import com.google.devtools.build.lib.remote.TreeNodeRepository.TreeNode;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.DigestUtil.ActionKey;
@@ -203,10 +202,7 @@ class RemoteSpawnRunner implements SpawnRunner {
                 .setCacheHit(true)
                 .setRunnerName("remote cache hit")
                 .build();
-          } catch (RetryException e) {
-            if (!AbstractRemoteActionCache.causedByCacheMiss(e)) {
-              throw e;
-            }
+          } catch (CacheNotFoundException e) {
             // No cache hit, so we fall through to local or remote execution.
             // We set acceptCachedResult to false in order to force the action re-execution.
             acceptCachedResult = false;
@@ -347,9 +343,7 @@ class RemoteSpawnRunner implements SpawnRunner {
     if (Thread.currentThread().isInterrupted()) {
       throw new InterruptedException();
     }
-    if (remoteOptions.remoteLocalFallback
-        && !(cause instanceof RetryException
-            && RemoteRetrierUtils.causedByExecTimeout((RetryException) cause))) {
+    if (remoteOptions.remoteLocalFallback && !RemoteRetrierUtils.causedByExecTimeout(cause)) {
       return execLocallyAndUpload(
           spawn, context, inputMap, remoteCache, actionKey, action, command, uploadLocalResults);
     }
@@ -358,9 +352,8 @@ class RemoteSpawnRunner implements SpawnRunner {
 
   private SpawnResult handleError(IOException exception, FileOutErr outErr, ActionKey actionKey)
       throws ExecException, InterruptedException, IOException {
-    final Throwable cause = exception.getCause();
-    if (cause instanceof ExecutionStatusException) {
-      ExecutionStatusException e = (ExecutionStatusException) cause;
+    if (exception.getCause() instanceof ExecutionStatusException) {
+      ExecutionStatusException e = (ExecutionStatusException) exception.getCause();
       if (e.getResponse() != null) {
         ExecuteResponse resp = e.getResponse();
         maybeDownloadServerLogs(resp, actionKey);
@@ -378,11 +371,9 @@ class RemoteSpawnRunner implements SpawnRunner {
       }
     }
     final Status status;
-    if (exception instanceof RetryException
-        && RemoteRetrierUtils.causedByStatus((RetryException) exception, Code.UNAVAILABLE)) {
+    if (RemoteRetrierUtils.causedByStatus(exception, Code.UNAVAILABLE)) {
       status = Status.EXECUTION_FAILED_CATASTROPHICALLY;
-    } else if (exception instanceof CacheNotFoundException
-        || cause instanceof CacheNotFoundException) {
+    } else if (exception instanceof CacheNotFoundException) {
       status = Status.REMOTE_CACHE_FAILED;
     } else {
       status = Status.EXECUTION_FAILED;

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -29,7 +29,6 @@ import com.google.devtools.build.lib.buildeventstream.PathConverter;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.ByteStreamUploaderTest.FixedBackoff;
 import com.google.devtools.build.lib.remote.ByteStreamUploaderTest.MaybeFailOnceUploadService;
-import com.google.devtools.build.lib.remote.Retrier.RetryException;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -240,7 +239,6 @@ public class ByteStreamBuildEventArtifactUploaderTest {
       artifactUploader.upload(filesToUpload).get();
       fail("exception expected.");
     } catch (ExecutionException e) {
-      assertThat(e.getCause()).isInstanceOf(RetryException.class);
       assertThat(Status.fromThrowable(e).getCode()).isEqualTo(Status.CANCELLED.getCode());
     }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -28,7 +28,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
-import com.google.devtools.build.lib.remote.Retrier.RetryException;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -418,8 +417,7 @@ public class ByteStreamUploaderTest {
     try {
       uploader.uploadBlob(chunker, true);
       fail("Should have thrown an exception.");
-    } catch (RetryException e) {
-      assertThat(e.getAttempts()).isEqualTo(2);
+    } catch (IOException e) {
       assertThat(RemoteRetrierUtils.causedByStatus(e, Code.INTERNAL)).isTrue();
     }
 
@@ -517,7 +515,7 @@ public class ByteStreamUploaderTest {
     try {
       uploader.uploadBlob(chunker, true);
       fail("Should have thrown an exception.");
-    } catch (RetryException e) {
+    } catch (IOException e) {
       assertThat(e).hasCauseThat().isInstanceOf(RejectedExecutionException.class);
     }
 
@@ -595,7 +593,7 @@ public class ByteStreamUploaderTest {
     try {
       uploader.uploadBlob(chunker, true);
       fail("Should have thrown an exception.");
-    } catch (RetryException e) {
+    } catch (IOException e) {
       assertThat(numCalls.get()).isEqualTo(1);
     }
 
@@ -662,7 +660,7 @@ public class ByteStreamUploaderTest {
     try {
       // This should fail
       uploader.uploadBlob(chunker, true);
-    } catch (RetryException e) {
+    } catch (IOException e) {
       if (e.getCause() instanceof StatusRuntimeException) {
         expected = (StatusRuntimeException) e.getCause();
       }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.testutil.MoreAsserts.assertThrows;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -366,12 +367,7 @@ public class RemoteSpawnRunnerTest {
                 digestUtil,
                 logDir));
 
-    try {
-      runner.exec(spawn, policy);
-      fail("Expected exception");
-    } catch (EnvironmentalExecException expected) {
-      // Intentionally left empty.
-    }
+    assertThrows(EnvironmentalExecException.class, () -> runner.exec(spawn, policy));
   }
 
   @Test
@@ -631,8 +627,7 @@ public class RemoteSpawnRunnerTest {
             .setStatus(timeoutStatus)
             .build();
     when(executor.executeRemotely(any(ExecuteRequest.class)))
-        .thenThrow(new Retrier.RetryException(
-                "", 1, new ExecutionStatusException(resp.getStatus(), resp)));
+        .thenThrow(new IOException(new ExecutionStatusException(resp.getStatus(), resp)));
     SettableFuture<Void> completed = SettableFuture.create();
     completed.set(null);
     when(cache.downloadFile(eq(logPath), eq(logDigest))).thenReturn(completed);
@@ -749,9 +744,7 @@ public class RemoteSpawnRunnerTest {
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(cachedResult);
-    Retrier.RetryException downloadFailure =
-        new Retrier.RetryException(
-            "", 1, new CacheNotFoundException(Digest.getDefaultInstance(), digestUtil));
+    Exception downloadFailure = new CacheNotFoundException(Digest.getDefaultInstance(), digestUtil);
     doThrow(downloadFailure)
         .when(cache)
         .download(eq(cachedResult), any(Path.class), any(FileOutErr.class));
@@ -804,9 +797,7 @@ public class RemoteSpawnRunnerTest {
                     .build())
             .build();
     when(executor.executeRemotely(any(ExecuteRequest.class)))
-        .thenThrow(
-            new Retrier.RetryException(
-                "", 1, new ExecutionStatusException(resp.getStatus(), resp)));
+        .thenThrow(new IOException(new ExecutionStatusException(resp.getStatus(), resp)));
 
     Spawn spawn = newSimpleSpawn();
 
@@ -853,9 +844,7 @@ public class RemoteSpawnRunnerTest {
                     .build())
             .build();
     when(executor.executeRemotely(any(ExecuteRequest.class)))
-        .thenThrow(
-            new Retrier.RetryException(
-                "", 1, new ExecutionStatusException(resp.getStatus(), resp)));
+        .thenThrow(new IOException(new ExecutionStatusException(resp.getStatus(), resp)));
 
     Spawn spawn = newSimpleSpawn();
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RetrierTest.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.testutil.MoreAsserts.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -28,7 +29,6 @@ import com.google.devtools.build.lib.remote.Retrier.Backoff;
 import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker;
 import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker.State;
 import com.google.devtools.build.lib.remote.Retrier.CircuitBreakerException;
-import com.google.devtools.build.lib.remote.Retrier.RetryException;
 import com.google.devtools.build.lib.remote.Retrier.ZeroBackoff;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -82,15 +82,19 @@ public class RetrierTest {
 
     Supplier<Backoff> s  = () -> new ZeroBackoff(/*maxRetries=*/2);
     Retrier r = new Retrier(s, RETRY_ALL, retryService, alwaysOpen);
+    AtomicInteger numCalls = new AtomicInteger();
     try {
-      r.execute(() -> {
-        throw new Exception("call failed");
-      });
+      r.execute(
+          () -> {
+            numCalls.incrementAndGet();
+            throw new Exception("call failed");
+          });
       fail("exception expected.");
-    } catch (RetryException e) {
-      assertThat(e.getAttempts()).isEqualTo(3);
+    } catch (Exception e) {
+      assertThat(e).hasMessageThat().isEqualTo("call failed");
     }
 
+    assertThat(numCalls.get()).isEqualTo(3);
     verify(alwaysOpen, times(3)).recordFailure();
     verify(alwaysOpen, never()).recordSuccess();
   }
@@ -102,15 +106,19 @@ public class RetrierTest {
 
     Supplier<Backoff> s  = () -> new ZeroBackoff(/*maxRetries=*/2);
     Retrier r = new Retrier(s, RETRY_NONE, retryService, alwaysOpen);
+    AtomicInteger numCalls = new AtomicInteger();
     try {
-      r.execute(() -> {
-        throw new Exception("call failed");
-      });
+      r.execute(
+          () -> {
+            numCalls.incrementAndGet();
+            throw new Exception("call failed");
+          });
       fail("exception expected.");
-    } catch (RetryException e) {
-      assertThat(e.getAttempts()).isEqualTo(1);
+    } catch (Exception e) {
+      assertThat(e).hasMessageThat().isEqualTo("call failed");
     }
 
+    assertThat(numCalls.get()).isEqualTo(1);
     verify(alwaysOpen, times(1)).recordFailure();
     verify(alwaysOpen, never()).recordSuccess();
   }
@@ -160,17 +168,8 @@ public class RetrierTest {
                       });
                 });
           });
-    } catch (RetryException outer) {
-      assertThat(outer.getAttempts()).isEqualTo(2);
-      // Propagate original cause.
-      assertThat(outer).hasCauseThat().hasMessageThat().isEqualTo("failure message");
-      // Compose the overall error message.
-      assertThat(outer)
-          .hasMessageThat()
-          .isEqualTo(
-              "Call failed after 1 retry attempts: "
-                  + "Call failed after 1 retry attempts: "
-                  + "Call failed after 1 retry attempts: failure message");
+    } catch (Exception e) {
+      assertThat(e).hasMessageThat().isEqualTo("failure message");
       assertThat(attemptsLvl0.get()).isEqualTo(2);
       assertThat(attemptsLvl1.get()).isEqualTo(4);
       assertThat(attemptsLvl2.get()).isEqualTo(8);
@@ -228,10 +227,11 @@ public class RetrierTest {
     cb.trialCall();
 
     try {
-      r.execute(() -> {
-        throw new Exception("call failed");
-      });
-    } catch (RetryException expected) {
+      r.execute(
+          () -> {
+            throw new Exception("call failed");
+          });
+    } catch (Exception expected) {
       // Intentionally left empty.
     }
 
@@ -243,34 +243,41 @@ public class RetrierTest {
     // Test that a call is not executed / retried if the current thread
     // is interrupted.
 
-    Supplier<Backoff> s  = () -> new ZeroBackoff(/*maxRetries=*/3);
-    TripAfterNCircuitBreaker cb = new TripAfterNCircuitBreaker(/*maxConsecutiveFailures=*/2);
+    Supplier<Backoff> s = () -> new ZeroBackoff(/*maxRetries=*/ 3);
+    TripAfterNCircuitBreaker cb = new TripAfterNCircuitBreaker(/*maxConsecutiveFailures=*/ 2);
     Retrier r = new Retrier(s, RETRY_ALL, retryService, cb);
 
-    try {
-      Thread.currentThread().interrupt();
-      r.execute(() -> 10);
-    } catch (InterruptedException expected) {
-      // Intentionally left empty.
-    }
+    AtomicInteger numCalls = new AtomicInteger();
+    Thread.currentThread().interrupt();
+    assertThrows(
+        InterruptedException.class,
+        () ->
+            r.execute(
+                () -> {
+                  numCalls.incrementAndGet();
+                  return 10;
+                }));
+    assertThat(numCalls.get()).isEqualTo(0);
   }
 
   @Test
   public void interruptsShouldNotBeRetried_exception() throws Exception {
     // Test that a call is not retried if an InterruptedException is thrown.
 
-    Supplier<Backoff> s  = () -> new ZeroBackoff(/*maxRetries=*/3);
-    TripAfterNCircuitBreaker cb = new TripAfterNCircuitBreaker(/*maxConsecutiveFailures=*/2);
+    Supplier<Backoff> s = () -> new ZeroBackoff(/*maxRetries=*/ 3);
+    TripAfterNCircuitBreaker cb = new TripAfterNCircuitBreaker(/*maxConsecutiveFailures=*/ 2);
     Retrier r = new Retrier(s, RETRY_ALL, retryService, cb);
 
-    try {
-      Thread.currentThread().interrupt();
-      r.execute(() -> {
-        throw new InterruptedException();
-      });
-    } catch (InterruptedException expected) {
-      // Intentionally left empty.
-    }
+    AtomicInteger numCalls = new AtomicInteger();
+    assertThrows(
+        InterruptedException.class,
+        () ->
+            r.execute(
+                () -> {
+                  numCalls.incrementAndGet();
+                  throw new InterruptedException();
+                }));
+    assertThat(numCalls.get()).isEqualTo(1);
   }
 
   @Test
@@ -280,19 +287,19 @@ public class RetrierTest {
 
     Supplier<Backoff> s = () -> new ZeroBackoff(/*maxRetries=*/ 2);
     Retrier r = new Retrier(s, RETRY_ALL, retryService, alwaysOpen);
+    AtomicInteger numCalls = new AtomicInteger();
     ListenableFuture<Void> res =
         r.executeAsync(
             () -> {
+              numCalls.incrementAndGet();
               throw new Exception("call failed");
             });
     try {
       res.get();
       fail("exception expected.");
     } catch (ExecutionException e) {
-      assertThat(e).hasCauseThat().isInstanceOf(RetryException.class);
-      assertThat(((RetryException) e.getCause()).getAttempts()).isEqualTo(3);
-      assertThat(e).hasCauseThat().hasMessageThat().contains("Exhausted retry attempts");
-      assertThat(e).hasCauseThat().hasMessageThat().contains("call failed");
+      assertThat(numCalls.get()).isEqualTo(3);
+      assertThat(e).hasCauseThat().hasMessageThat().isEqualTo("call failed");
     }
   }
 
@@ -303,18 +310,19 @@ public class RetrierTest {
 
     Supplier<Backoff> s = () -> new ZeroBackoff(/*maxRetries=*/ 2);
     Retrier r = new Retrier(s, RETRY_NONE, retryService, alwaysOpen);
+    AtomicInteger numCalls = new AtomicInteger();
     ListenableFuture<Void> res =
         r.executeAsync(
             () -> {
+              numCalls.incrementAndGet();
               throw new Exception("call failed");
             });
     try {
       res.get();
       fail("exception expected.");
     } catch (ExecutionException e) {
-      assertThat(e).hasCauseThat().isInstanceOf(RetryException.class);
-      assertThat(e).hasCauseThat().hasMessageThat().contains("not retriable");
-      assertThat(e).hasCauseThat().hasMessageThat().contains("call failed");
+      assertThat(e).hasCauseThat().hasMessageThat().isEqualTo("call failed");
+      assertThat(numCalls.get()).isEqualTo(1);
     }
   }
 
@@ -334,14 +342,11 @@ public class RetrierTest {
       res.get();
       fail("exception expected.");
     } catch (ExecutionException e) {
-      assertThat(e).hasCauseThat().isInstanceOf(RetryException.class);
-      assertThat(e).hasCauseThat().hasMessageThat().isEqualTo("Status not retriable.");
+      assertThat(e).hasCauseThat().hasMessageThat().isEqualTo("");
     }
   }
 
-  /**
-   * Simple circuit breaker that trips after N consecutive failures.
-   */
+  /** Simple circuit breaker that trips after N consecutive failures. */
   @ThreadSafe
   private static class TripAfterNCircuitBreaker implements CircuitBreaker {
 


### PR DESCRIPTION
Retries should be an implementation detail of the cache client implementation. No client is interested in the number of retry attempts, so it seems better to make the retry code transparent with respect to exceptions. The retry code also wrapped arbitrary exceptions with RetryException. It is now the responsibility of the cache implementation code to convert low-level exceptions to IOException or an error meaningful at higher layers like CacheNotFoundException. For example, the gRPC action cache and remote executor now explicitly convert StatusRuntimeException into IOException.

Also, remove PassThroughException, since it's unused.

This should fix https://github.com/bazelbuild/bazel/issues/6308.