### PR TITLE
Do not upload artifacts from the local execution of no-cache spawns.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -89,7 +89,10 @@ final class RemoteSpawnCache implements SpawnCache {
   @Override
   public CacheHandle lookup(Spawn spawn, SpawnExecutionContext context)
       throws InterruptedException, IOException, ExecException {
-    boolean checkCache = options.remoteAcceptCached && Spawns.mayBeCached(spawn);
+    if (!Spawns.mayBeCached(spawn)) {
+      return SpawnCache.NO_RESULT_NO_STORE;
+    }
+    boolean checkCache = options.remoteAcceptCached;
 
     if (checkCache) {
       context.report(ProgressStatus.CHECKING_CACHE, "remote-cache");
@@ -122,7 +125,7 @@ final class RemoteSpawnCache implements SpawnCache {
               digestUtil.compute(command),
               repository.getMerkleDigest(inputRoot),
               context.getTimeout(),
-              Spawns.mayBeCached(spawn));
+              true);
       // Look up action cache, and reuse the action output if it is found.
       actionKey = digestUtil.computeActionKey(action);
     }
@@ -197,10 +200,7 @@ final class RemoteSpawnCache implements SpawnCache {
               return;
             }
           }
-          boolean uploadAction =
-              Spawns.mayBeCached(spawn)
-                  && Status.SUCCESS.equals(result.status())
-                  && result.exitCode() == 0;
+          boolean uploadAction = Status.SUCCESS.equals(result.status()) && result.exitCode() == 0;
           Context previous = withMetadata.attach();
           Collection<Path> files =
               RemoteSpawnRunner.resolveActionInputs(execRoot, spawn.getOutputFiles());

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -142,6 +142,7 @@ class RemoteSpawnRunner implements SpawnRunner {
     if (!Spawns.mayBeExecutedRemotely(spawn) || remoteCache == null) {
       return execLocally(spawn, context);
     }
+    boolean spawnCachable = Spawns.mayBeCached(spawn);
 
     context.report(ProgressStatus.EXECUTING, getName());
     // Temporary hack: the TreeNodeRepository should be created and maintained upstream!
@@ -169,7 +170,7 @@ class RemoteSpawnRunner implements SpawnRunner {
               digestUtil.compute(command),
               repository.getMerkleDigest(inputRoot),
               context.getTimeout(),
-              Spawns.mayBeCached(spawn));
+              spawnCachable);
       actionKey = digestUtil.computeActionKey(action);
     }
 
@@ -178,8 +179,8 @@ class RemoteSpawnRunner implements SpawnRunner {
         TracingMetadataUtils.contextWithMetadata(buildRequestId, commandId, actionKey);
     Context previous = withMetadata.attach();
     try {
-      boolean acceptCachedResult = remoteOptions.remoteAcceptCached && Spawns.mayBeCached(spawn);
-      boolean uploadLocalResults = remoteOptions.remoteUploadLocalResults;
+      boolean acceptCachedResult = remoteOptions.remoteAcceptCached && spawnCachable;
+      boolean uploadLocalResults = remoteOptions.remoteUploadLocalResults && spawnCachable;
 
       try {
         // Try to lookup the action in the action cache.
@@ -511,10 +512,7 @@ class RemoteSpawnRunner implements SpawnRunner {
     if (!uploadLocalResults) {
       return result;
     }
-    boolean uploadAction =
-        Spawns.mayBeCached(spawn)
-            && Status.SUCCESS.equals(result.status())
-            && result.exitCode() == 0;
+    boolean uploadAction = Status.SUCCESS.equals(result.status()) && result.exitCode() == 0;
     Collection<Path> outputFiles = resolveActionInputs(execRoot, spawn.getOutputFiles());
     try (SilentCloseable c = Profiler.instance().profile("Remote.upload")) {
       remoteCache.upload(

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import build.bazel.remote.execution.v2.Action;
@@ -306,8 +307,7 @@ public class RemoteSpawnCacheTest {
   @Test
   public void noCacheSpawns() throws Exception {
     // Checks that spawns that have mayBeCached false are not looked up in the remote cache,
-    // and also that their result is not uploaded to the remote cache. The artifacts, however,
-    // are uploaded.
+    // and also that their result and artifacts are not uploaded to the remote cache.
     SimpleSpawn uncacheableSpawn =
         new SimpleSpawn(
             new FakeOwner("foo", "bar"),
@@ -328,16 +328,7 @@ public class RemoteSpawnCacheTest {
             .setRunnerName("test")
             .build();
     entry.store(result);
-    ImmutableList<Path> outputFiles = ImmutableList.of(fs.getPath("/random/file"));
-    verify(remoteCache)
-        .upload(
-            any(ActionKey.class),
-            any(Action.class),
-            any(Command.class),
-            any(Path.class),
-            eq(outputFiles),
-            eq(outErr),
-            eq(false));
+    verifyNoMoreInteractions(remoteCache);
     assertThat(progressUpdates).containsExactly();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
@@ -227,7 +228,7 @@ public class RemoteSpawnRunnerTest {
   @SuppressWarnings("unchecked")
   public void nonCachableSpawnsShouldNotBeCached_local() throws Exception {
     // Test that if a spawn is executed locally, due to the local fallback, that its result is not
-    // uploaded to the remote cache. However, the artifacts should still be uploaded.
+    // uploaded to the remote cache.
 
     options.remoteAcceptCached = true;
     options.remoteLocalFallback = true;
@@ -269,15 +270,7 @@ public class RemoteSpawnRunnerTest {
 
     verify(cache, never())
         .getCachedActionResult(any(ActionKey.class));
-    verify(cache)
-        .upload(
-            any(ActionKey.class),
-            any(Action.class),
-            any(Command.class),
-            any(Path.class),
-            any(Collection.class),
-            any(FileOutErr.class),
-            eq(false));
+    verifyNoMoreInteractions(cache);
   }
 
   @Test

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -307,9 +307,9 @@ EOF
       //a:test >& $TEST_log \
       && fail "Expected test failure" || true
    $(is_file_uploaded bazel-testlogs/a/test/test.log) \
-     || fail "Expected test log to be uploaded to remote execution"
+     && fail "Expected test log to not be uploaded to remote execution" || true
    $(is_file_uploaded bazel-testlogs/a/test/test.xml) \
-     || fail "Expected test xml to be uploaded to remote execution"
+     && fail "Expected test xml to not be uploaded to remote execution" || true
 }
 
 # Tests that the remote worker can return a 200MB blob that requires chunking.


### PR DESCRIPTION
Previously, marking a spawn "no-cache" resulted in its outputs being uploaded but not the action result protobuf. This was confusing to many users, who want to use "no-cache" to prevent actions with large outputs from filling the cache.

Fixes https://github.com/bazelbuild/bazel/issues/4343.

RELNOTES: Locally-executed spawns tagged "no-cache" no longer upload their outputs to the remote cache.