### PR TITLE
Fix a race in ByteStreamUploader.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -230,6 +230,10 @@ class ByteStreamUploader extends AbstractReferenceCounted {
       }
 
       final SettableFuture<Void> uploadResult = SettableFuture.create();
+      Context ctx = Context.current();
+      retrier.executeAsync(
+          () -> ctx.call(() -> startAsyncUpload(chunker, uploadResult)), uploadResult);
+      uploadsInProgress.put(digest, uploadResult);
       uploadResult.addListener(
           () -> {
             synchronized (lock) {
@@ -238,10 +242,6 @@ class ByteStreamUploader extends AbstractReferenceCounted {
             }
           },
           MoreExecutors.directExecutor());
-      Context ctx = Context.current();
-      retrier.executeAsync(
-          () -> ctx.call(() -> startAsyncUpload(chunker, uploadResult)), uploadResult);
-      uploadsInProgress.put(digest, uploadResult);
       return uploadResult;
     }
   }


### PR DESCRIPTION
Register the callback to remove a pending upload from the uploadsInProgressMap after adding it to the map. Before, the callback could execute in the caller's thread as soon as it was registered and vacously remove the pending upload from the map before it was added.

I was able to reproduce this race and verify it has been fixed with:
```
$ bazel test //src/test/java/com/google/devtools/build/lib:remote-tests --runs_per_test 50 --test_filter ByteStreamUploaderTest --test_timeout 15
```