### PR TITLE
Prevent race of upload and progress map update

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -238,10 +238,10 @@ class ByteStreamUploader extends AbstractReferenceCounted {
             }
           },
           MoreExecutors.directExecutor());
+      uploadsInProgress.put(digest, uploadResult);
       Context ctx = Context.current();
       retrier.executeAsync(
           () -> ctx.call(() -> startAsyncUpload(chunker, uploadResult)), uploadResult);
-      uploadsInProgress.put(digest, uploadResult);
       return uploadResult;
     }
   }


### PR DESCRIPTION
Ensure that uploadsInProgress are successfully and consistently removed
on completion from the map by adding them prior to beginning an
asynchronous upload.

Fixes #7014