### PR TITLE
Remove invariant forceUpload parameter and impl

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderFactory.java
@@ -13,10 +13,12 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote;
 
+import build.bazel.remote.execution.v2.Digest;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
 import com.google.devtools.build.lib.runtime.BuildEventArtifactUploaderFactory;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import io.grpc.Context;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -26,14 +28,19 @@ class ByteStreamBuildEventArtifactUploaderFactory implements
     BuildEventArtifactUploaderFactory {
 
   private final ByteStreamUploader uploader;
+  private final Set<Digest> uploadedBlobs;
   private final String remoteServerName;
   private final Context ctx;
   private final @Nullable String remoteInstanceName;
 
   ByteStreamBuildEventArtifactUploaderFactory(
-      ByteStreamUploader uploader, String remoteServerName, Context ctx,
+      ByteStreamUploader uploader,
+      Set<Digest> uploadedBlobs,
+      String remoteServerName,
+      Context ctx,
       @Nullable String remoteInstanceName) {
     this.uploader = uploader;
+    this.uploadedBlobs = uploadedBlobs;
     this.remoteServerName = remoteServerName;
     this.ctx = ctx;
     this.remoteInstanceName = remoteInstanceName;
@@ -43,6 +50,7 @@ class ByteStreamBuildEventArtifactUploaderFactory implements
   public BuildEventArtifactUploader create(CommandEnvironment env) {
     return new ByteStreamBuildEventArtifactUploader(
         uploader.retain(),
+        uploadedBlobs,
         remoteServerName,
         ctx,
         remoteInstanceName,

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
@@ -392,18 +392,11 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
    */
   private Digest uploadFileContents(Path file) throws IOException, InterruptedException {
     Digest digest = digestUtil.compute(file);
-    ImmutableSet<Digest> missing = getMissingDigests(ImmutableList.of(digest));
-    if (!missing.isEmpty()) {
-      uploader.uploadBlob(Chunker.builder(digestUtil).setInput(digest, file).build(), true);
-    }
-    return digest;
-  }
-
-  Digest uploadBlob(byte[] blob) throws IOException, InterruptedException {
-    Digest digest = digestUtil.compute(blob);
-    ImmutableSet<Digest> missing = getMissingDigests(ImmutableList.of(digest));
-    if (!missing.isEmpty()) {
-      uploader.uploadBlob(Chunker.builder(digestUtil).setInput(digest, blob).build(), true);
+    if (digest.getSizeBytes() != 0) {
+      ImmutableSet<Digest> missing = getMissingDigests(ImmutableList.of(digest));
+      if (!missing.isEmpty()) {
+        uploader.uploadBlob(Chunker.builder(digestUtil).setInput(digest, file).build());
+      }
     }
     return digest;
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
@@ -222,21 +222,17 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
       toUpload.add(
           Chunker.builder(digestUtil).setInput(commandDigest, command.toByteArray()).build());
     }
-    if (!missingTreeNodes.isEmpty()) {
-      for (Map.Entry<Digest, Directory> entry : missingTreeNodes.entrySet()) {
-        Digest digest = entry.getKey();
-        Directory d = entry.getValue();
-        toUpload.add(Chunker.builder(digestUtil).setInput(digest, d.toByteArray()).build());
-      }
+    for (Map.Entry<Digest, Directory> entry : missingTreeNodes.entrySet()) {
+      Digest digest = entry.getKey();
+      Directory d = entry.getValue();
+      toUpload.add(Chunker.builder(digestUtil).setInput(digest, d.toByteArray()).build());
     }
-    if (!missingActionInputs.isEmpty()) {
-      for (Map.Entry<Digest, ActionInput> entry : missingActionInputs.entrySet()) {
-        Digest digest = entry.getKey();
-        ActionInput actionInput = entry.getValue();
-        toUpload.add(Chunker.builder(digestUtil).setInput(digest, actionInput, execRoot).build());
-      }
+    for (Map.Entry<Digest, ActionInput> entry : missingActionInputs.entrySet()) {
+      Digest digest = entry.getKey();
+      ActionInput actionInput = entry.getValue();
+      toUpload.add(Chunker.builder(digestUtil).setInput(digest, actionInput, execRoot).build());
     }
-    uploader.uploadBlobs(toUpload, true);
+    uploader.uploadBlobs(toUpload);
   }
 
   @Override
@@ -374,7 +370,7 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
     }
 
     if (!filesToUpload.isEmpty()) {
-      uploader.uploadBlobs(filesToUpload, /*forceUpload=*/true);
+      uploader.uploadBlobs(filesToUpload);
     }
 
     // TODO(olaola): inline small stdout/stderr here.

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -19,6 +19,7 @@ import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
@@ -242,6 +243,7 @@ public final class RemoteModule extends BlazeModule {
         buildEventArtifactUploaderFactoryDelegate.init(
             new ByteStreamBuildEventArtifactUploaderFactory(
                 uploader,
+                Sets.newConcurrentHashSet(),
                 cacheChannel.authority(),
                 requestContext,
                 remoteOptions.remoteInstanceName));

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -229,7 +229,7 @@ public class ByteStreamUploaderTest {
 
     serviceRegistry.addService(new MaybeFailOnceUploadService(blobsByHash));
 
-    uploader.uploadBlobs(builders, true);
+    uploader.uploadBlobs(builders);
 
     blockUntilInternalStateConsistent(uploader);
 


### PR DESCRIPTION
The uploadBlobs method is neither called nor tested with non-forced
uploads, and preventing an upload invariably would make little sense if
the remote system has indicated that a blob is missing. This removes the
parameter, its associated behavior, and the uploadedBlobs storage. The
logic in ensureInputsPresent has also been cleaned up from the legacy
bulk uploader interface to simply iterate over digest entrySets.