### PR TITLE
Provide immediate failed future for chunker error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -259,14 +259,13 @@ class ByteStreamUploader extends AbstractReferenceCounted {
    */
   private ListenableFuture<Void> startAsyncUpload(
       Chunker chunker, ListenableFuture<Void> overallUploadResult) {
-    SettableFuture<Void> currUpload = SettableFuture.create();
     try {
       chunker.reset();
     } catch (IOException e) {
-      currUpload.setException(e);
-      return currUpload;
+      return Futures.immediateFailedFuture(e);
     }
 
+    SettableFuture<Void> currUpload = SettableFuture.create();
     AsyncUpload newUpload =
         new AsyncUpload(
             channel, callCredentials, callTimeoutSecs, instanceName, chunker, currUpload);


### PR DESCRIPTION
Simplify the chunker reset error condition in startAsyncUpload into an
immediate failed future without creating the settable future.