### PR TITLE
Enable, fix, and extend genrule stamping tests.

### DIFF
--- a/src/test/shell/integration/stamping_test.sh
+++ b/src/test/shell/integration/stamping_test.sh
@@ -48,11 +48,11 @@ genrule(
 EOF
 }
 
-function expect_equals() {
+function assert_equals() {
   [ "${1}" = "${2}" ]
 }
 
-function expect_not_equals() {
+function assert_not_equals() {
   [ "${1}" != "${2}" ]
 }
 
@@ -60,30 +60,30 @@ function test_source_date_epoch() {
   # test --nostamp
   bazel clean --expunge &> $TEST_log
   bazel build --nostamp //pkg:* &> $TEST_log || fail "failed to build //pkg:*"
-  expect_not_equals 0 $(cat bazel-genfiles/pkg/stamped.txt)
-  expect_equals 0 $(cat bazel-genfiles/pkg/unstamped.txt)
-  expect_equals 0 $(cat bazel-genfiles/pkg/unspecified.txt)
+  assert_not_equals 0 $(cat bazel-genfiles/pkg/stamped.txt)
+  assert_equals 0 $(cat bazel-genfiles/pkg/unstamped.txt)
+  assert_equals 0 $(cat bazel-genfiles/pkg/unspecified.txt)
 
   # test --nostamp, explicit epoch=0
   bazel clean --expunge &> $TEST_log
   SOURCE_DATE_EPOCH=0 bazel build --stamp //pkg:* &> $TEST_log || fail "failed to build //pkg:*"
-  expect_equals 0 $(cat bazel-genfiles/pkg/stamped.txt)
-  expect_equals 0 $(cat bazel-genfiles/pkg/unstamped.txt)
-  expect_equals 0 $(cat bazel-genfiles/pkg/unspecified.txt)
+  assert_equals 0 $(cat bazel-genfiles/pkg/stamped.txt)
+  assert_equals 0 $(cat bazel-genfiles/pkg/unstamped.txt)
+  assert_equals 0 $(cat bazel-genfiles/pkg/unspecified.txt)
 
   # test --stamp, explicit epoch=0
   bazel clean --expunge &> $TEST_log
   SOURCE_DATE_EPOCH=10 bazel build --stamp //pkg:* &> $TEST_log || fail "failed to build //pkg:*"
-  expect_equals 10 $(cat bazel-genfiles/pkg/stamped.txt)
-  expect_equals 0 $(cat bazel-genfiles/pkg/unstamped.txt)
-  expect_equals 0 $(cat bazel-genfiles/pkg/unspecified.txt)
+  assert_equals 10 $(cat bazel-genfiles/pkg/stamped.txt)
+  assert_equals 0 $(cat bazel-genfiles/pkg/unstamped.txt)
+  assert_equals 0 $(cat bazel-genfiles/pkg/unspecified.txt)
 
   # test no stamp flag, explicit epoch=10
   bazel clean --expunge &> $TEST_log
   SOURCE_DATE_EPOCH=10 bazel build //pkg:* &> $TEST_log || fail "failed to build //pkg:*"
-  expect_equals 10 $(cat bazel-genfiles/pkg/stamped.txt)
-  expect_equals 0 $(cat bazel-genfiles/pkg/unstamped.txt)
-  expect_equals 0 $(cat bazel-genfiles/pkg/unspecified.txt)
+  assert_equals 10 $(cat bazel-genfiles/pkg/stamped.txt)
+  assert_equals 0 $(cat bazel-genfiles/pkg/unstamped.txt)
+  assert_equals 0 $(cat bazel-genfiles/pkg/unspecified.txt)
 }
 
 run_suite "Tests for genrule stamping"


### PR DESCRIPTION
The genrule stamping tests were not enabled and were broken.

Further, I extended them to cover the behavior of no explicit stamp attr value being provided.