### PR TITLE
remote: fix timeout for http blob store

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
@@ -81,8 +81,8 @@ public final class RemoteOptions extends OptionsBase {
     defaultValue = "60",
     documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
     effectTags = {OptionEffectTag.UNKNOWN},
-    help = "The maximum number of seconds to wait for remote execution and cache calls."
-  )
+    help = "The maximum number of seconds to wait for remote execution and cache calls. For the "
+               + "REST cache, this is both the connect and the read timeout.")
   public int remoteTimeout;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
@@ -39,18 +39,17 @@ public final class SimpleBlobStoreFactory {
   public static SimpleBlobStore createRest(RemoteOptions options, Credentials creds) {
     try {
       URI uri = URI.create(options.remoteHttpCache);
-      int timeoutMillis = (int) TimeUnit.SECONDS.toMillis(options.remoteTimeout);
 
       if (options.remoteCacheProxy != null) {
         if (options.remoteCacheProxy.startsWith("unix:")) {
           return HttpBlobStore.create(
             new DomainSocketAddress(options.remoteCacheProxy.replaceFirst("^unix:", "")),
-              uri, timeoutMillis, options.remoteMaxConnections, creds);
+              uri, options.remoteTimeout, options.remoteMaxConnections, creds);
         } else {
           throw new Exception("Remote cache proxy unsupported: " + options.remoteCacheProxy);
         }
       } else {
-        return HttpBlobStore.create(uri, timeoutMillis, options.remoteMaxConnections, creds);
+        return HttpBlobStore.create(uri, options.remoteTimeout, options.remoteMaxConnections, creds);
       }
     } catch (Exception e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
The HTTP cache has a `ReadTimeoutHandler` to timeout slow downloads. However, its constructor expects seconds while bazel was passing in milliseconds, so the timeout functionality wasn't at all effective. We were occasionally seeing this problem in CI, causing our builds to timeout after hours.

This PR fixes the issue and handles the corresponding exception in the code by reporting a cache miss.

Tested with an hacked version version of bazel-remote that adds a sleep.

Following [this discussion](https://github.com/netty/netty/issues/5296), we might also consider switching to an [IdleStateHandler](https://netty.io/4.0/api/io/netty/handler/timeout/IdleStateHandler.html) to timeout uploads as well, not just downloads.