### PR TITLE
Java stub: add native library dirs to both java.library.path and LD_LIBRARY_PATH

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -279,10 +279,19 @@ if [[ -n "$TEST_TMPDIR" && -d "$TEST_TMPDIR" ]]; then
   JVM_FLAGS+=" -Djava.io.tmpdir=$TEST_TMPDIR"
 fi
 
+MORE_JVM_FLAGS=( %jvm_flags% )
+NATIVE_LIBRARY_PATH=( %native_library_path% )
+if [ ! -z "${NATIVE_LIBRARY_PATH[@]}" ]; then
+  MORE_JVM_FLAGS+=( "-Djava.library.path=${NATIVE_LIBRARY_PATH[@]}" )
+  LIBRARY_PATH=${NATIVE_LIBRARY_PATH[@]}:$LD_LIBRARY_PATH
+else
+  LIBRARY_PATH=$LD_LIBRARY_PATH
+fi
+
 ARGS=(
   ${JVM_DEBUG_FLAGS}
   ${JVM_FLAGS}
-  %jvm_flags%
+  "${MORE_JVM_FLAGS[@]}"
   "${JVM_FLAGS_CMDLINE[@]}"
   ${MAIN_ADVICE}
   %java_start_class%
@@ -337,7 +346,7 @@ function create_and_run_classpath_jar() {
     die "ERROR: $self failed because $JARBIN failed"
 
   # Execute JAVA command
-  $JAVABIN -classpath "$MANIFEST_JAR_FILE" "${ARGS[@]}"
+  LD_LIBRARY_PATH=$LIBRARY_PATH $JAVABIN -classpath "$MANIFEST_JAR_FILE" "${ARGS[@]}"
   exit_code=$?
   rm -f "$MANIFEST_FILE"
   rm -f "$MANIFEST_JAR_FILE"
@@ -356,5 +365,5 @@ if is_windows && (("${#CLASSPATH}" > ${CLASSPATH_LIMIT} )); then
 elif (("${#CLASSPATH}" > ${CLASSPATH_LIMIT})); then
   create_and_run_classpath_jar "local_jdk/bin/jar"
 else
-  exec $JAVABIN -classpath $CLASSPATH "${ARGS[@]}"
+  LD_LIBRARY_PATH=$LIBRARY_PATH exec $JAVABIN -classpath $CLASSPATH "${ARGS[@]}"
 fi

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidLocalTestBase.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidLocalTestBase.java
@@ -269,6 +269,7 @@ public abstract class AndroidLocalTestBase implements RuleConfiguredTargetFactor
         ruleContext,
         javaCommon,
         getJvmFlags(ruleContext, testClass),
+        /* nativeLibraryPath= */ "",
         executable,
         mainClass,
         originalMainClass,

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaBinary.java
@@ -197,12 +197,9 @@ public class JavaBinary implements RuleConfiguredTargetFactory {
 
     JavaTargetAttributes attributes = helper.getAttributes();
     List<Artifact> nativeLibraries = attributes.getNativeLibraries();
-    if (!nativeLibraries.isEmpty()) {
-      jvmFlags.add(
-          "-Djava.library.path="
-              + JavaCommon.javaLibraryPath(
-                  nativeLibraries, ruleContext.getRule().getPackage().getWorkspaceName()));
-    }
+    String nativeLibraryPath =
+        JavaCommon.javaLibraryPath(nativeLibraries,
+                                   ruleContext.getRule().getPackage().getWorkspaceName());
 
     JavaConfiguration javaConfig = ruleContext.getFragment(JavaConfiguration.class);
     if (attributes.hasMessages()) {
@@ -274,6 +271,7 @@ public class JavaBinary implements RuleConfiguredTargetFactory {
               ruleContext,
               common,
               jvmFlags,
+              nativeLibraryPath,
               executableForRunfiles,
               mainClass,
               originalMainClass,

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaSemantics.java
@@ -284,6 +284,7 @@ public interface JavaSemantics {
       RuleContext ruleContext,
       JavaCommon javaCommon,
       List<String> jvmFlags,
+      String nativeLibraryPath,
       Artifact executable,
       String javaStartClass,
       String javaExecutable)
@@ -303,6 +304,7 @@ public interface JavaSemantics {
       RuleContext ruleContext,
       JavaCommon javaCommon,
       List<String> jvmFlags,
+      String nativeLibraryPath,
       Artifact executable,
       String javaStartClass,
       String coverageStartClass,

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -45,6 +45,7 @@ static constexpr const char* JAR_BIN_PATH = "jar_bin_path";
 static constexpr const char* CLASSPATH = "classpath";
 static constexpr const char* JAVA_START_CLASS = "java_start_class";
 static constexpr const char* JVM_FLAGS = "jvm_flags";
+static constexpr const char* NATIVE_LIBRARY_PATH = "native_library_path";
 
 // Check if a string start with a certain prefix.
 // If it's true, store the substring without the prefix in value.
@@ -363,6 +364,10 @@ ExitCode JavaBinaryLauncher::Launch() {
   wstringstream jvm_flags_launch_info_ss(this->GetLaunchInfoByKey(JVM_FLAGS));
   while (getline(jvm_flags_launch_info_ss, flag, L'\t')) {
     jvm_flags.push_back(flag);
+  }
+  wstring native_library_path = this->GetLaunchInfoByKey(NATIVE_LIBRARY_PATH);
+  if (!native_library_path.empty()) {
+    jvm_flags.push_back(L"-Djava.library.path=" + native_library_path);
   }
 
   // Check if TEST_TMPDIR is available to use for scratch.


### PR DESCRIPTION
When a Java binary depends on a native shared library, Bazel adds the directory
containing the library to the binary's java.library.path system property.  This
allows the Java runtime to find the library when the binary dynamically loads
it using System.loadLibrary().

However, the library being loaded may depend on another shared library.  When
this is the case, the Unix dynamic linker, ldd, is responsible for loading that
dependency and ldd does not consult java.library.path.  Instead, ldd uses
several techniques to find the dependency.  One of the fallback techniques is
to search for the dependency in the directories listed in the LD_LIBRARY_PATH
environment variable.  This change adds all the directories in
java.library.path to LD_LIBRARY_PATH, so ldd can find the dependency.