### PR TITLE
Fix .bzl style guide link

### DIFF
--- a/site/docs/skylark/skylint.md
+++ b/site/docs/skylark/skylint.md
@@ -5,7 +5,7 @@ title: Skylint
 
 # Skylint
 
-[Style guide](../skylark/bzl-style.html)
+[Style guide](../skylark/bzl-style.md)
 
 This document explains how to use Skylint, the Starlark linter.
 


### PR DESCRIPTION
This was previously linking to an HTML file which doesn't exist.