### PR TITLE
Windows, test wrapper: native split-XML generation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -171,6 +171,11 @@ public class BaseRuleClasses {
                   .singleArtifact()
                   .value(env.getToolsLabel("//tools/test:test_wrapper")))
           .add(
+              attr("$xml_writer", LABEL)
+                  .cfg(HostTransition.INSTANCE)
+                  .singleArtifact()
+                  .value(env.getToolsLabel("//tools/test:xml_writer")))
+          .add(
               attr("$test_runtime", LABEL_LIST)
                   .cfg(HostTransition.INSTANCE)
                   .value(ImmutableList.of(env.getToolsLabel("//tools/test:runtime"))))

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
@@ -175,6 +175,11 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
                 .cfg(HostTransition.INSTANCE)
                 .singleArtifact()
                 .value(labelCache.getUnchecked(toolsRepository + "//tools/test:test_wrapper")))
+          .add(
+              attr("$xml_writer", LABEL)
+                  .cfg(HostTransition.INSTANCE)
+                  .singleArtifact()
+                .value(labelCache.getUnchecked(toolsRepository + "//tools/test:xml_writer")))
         .add(
             attr("$test_runtime", LABEL_LIST)
                 .cfg(HostTransition.INSTANCE)

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -241,9 +241,11 @@ public final class TestActionBuilder {
             : ruleContext.getHostPrerequisiteArtifact("$test_setup_script");
 
     inputsBuilder.add(testActionExecutable);
-    Artifact testXmlGeneratorScript =
-        ruleContext.getHostPrerequisiteArtifact("$xml_generator_script");
-    inputsBuilder.add(testXmlGeneratorScript);
+    Artifact testXmlGeneratorExecutable =
+        isUsingTestWrapperInsteadOfTestSetupScript
+            ? ruleContext.getHostPrerequisiteArtifact("$xml_writer")
+            : ruleContext.getHostPrerequisiteArtifact("$xml_generator_script");
+    inputsBuilder.add(testXmlGeneratorExecutable);
 
     Artifact collectCoverageScript = null;
     TreeMap<String, String> extraTestEnv = new TreeMap<>();
@@ -378,7 +380,7 @@ public final class TestActionBuilder {
                 inputs,
                 testActionExecutable,
                 isUsingTestWrapperInsteadOfTestSetupScript,
-                testXmlGeneratorScript,
+                testXmlGeneratorExecutable,
                 collectCoverageScript,
                 testLog,
                 cacheStatus,

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -451,7 +451,7 @@ public class StandaloneTestStrategy extends TestStrategy {
     // TODO(ulfjack): This is incorrect for remote execution, where we need to consider the target
     // configuration, not the machine Bazel happens to run on. Change this to something like:
     // testAction.getConfiguration().getExecOS() == OS.WINDOWS
-    if (OS.getCurrent() == OS.WINDOWS) {
+    if (OS.getCurrent() == OS.WINDOWS && !action.isUsingTestWrapperInsteadOfTestSetupScript()) {
       args.add(action.getShExecutable().getPathString());
       args.add("-c");
       args.add("$0 $*");

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -135,6 +135,7 @@ public final class BazelAnalysisMock extends AnalysisMock {
         "/bazel_tools_workspace/tools/test/BUILD",
         "filegroup(name = 'runtime', srcs = ['test-setup.sh', 'test-xml-generator.sh'])",
         "filegroup(name = 'test_wrapper', srcs = ['test_wrapper_bin'])",
+        "filegroup(name = 'xml_writer', srcs = ['dummy'])",
         "filegroup(name = 'test_setup', srcs = ['test-setup.sh'])",
         "filegroup(name = 'test_xml_generator', srcs = ['test-xml-generator.sh'])",
         "filegroup(name = 'collect_coverage', srcs = ['collect_coverage.sh'])",

--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -472,7 +472,7 @@ class TestWrapperTest(test_base.TestBase):
 
     self.assertListEqual(annot_content, ['Hello aHello c'])
 
-  def _AssertXmlGeneration(self, flag):
+  def _AssertXmlGeneration(self, flag, split_xml=False):
     exit_code, bazel_testlogs, stderr = self.RunBazel(
         ['info', 'bazel-testlogs'])
     self.AssertExitCode(exit_code, 0, stderr)
@@ -483,6 +483,8 @@ class TestWrapperTest(test_base.TestBase):
         '//foo:xml_test',
         '-t-',
         '--test_output=errors',
+        ('--experimental_split_xml_generation' if split_xml
+          else '--noexperimental_split_xml_generation'),
         flag,
     ])
     self.AssertExitCode(exit_code, 0, stderr)
@@ -521,7 +523,7 @@ class TestWrapperTest(test_base.TestBase):
         'stderr_line_2' not in stderr_lines[1]):
       self._FailWithOutput(xml_contents)
 
-  def _AssertXmlGeneratedByTestIsRetained(self, flag):
+  def _AssertXmlGeneratedByTestIsRetained(self, flag, split_xml=False):
     exit_code, bazel_testlogs, stderr = self.RunBazel(
         ['info', 'bazel-testlogs'])
     self.AssertExitCode(exit_code, 0, stderr)
@@ -532,6 +534,8 @@ class TestWrapperTest(test_base.TestBase):
         '//foo:xml2_test',
         '-t-',
         '--test_output=errors',
+        ('--experimental_split_xml_generation' if split_xml
+          else '--noexperimental_split_xml_generation'),
         flag,
     ])
     self.AssertExitCode(exit_code, 0, stderr)
@@ -576,8 +580,10 @@ class TestWrapperTest(test_base.TestBase):
         ])
     self._AssertUndeclaredOutputs(flag)
     self._AssertUndeclaredOutputsAnnotations(flag)
-    self._AssertXmlGeneration(flag)
-    self._AssertXmlGeneratedByTestIsRetained(flag)
+    self._AssertXmlGeneration(flag, split_xml=False)
+    self._AssertXmlGeneration(flag, split_xml=True)
+    self._AssertXmlGeneratedByTestIsRetained(flag, split_xml=False)
+    self._AssertXmlGeneratedByTestIsRetained(flag, split_xml=True)
 
   def testTestExecutionWithTestWrapperExe(self):
     self._CreateMockWorkspace()
@@ -610,8 +616,10 @@ class TestWrapperTest(test_base.TestBase):
         ])
     self._AssertUndeclaredOutputs(flag)
     self._AssertUndeclaredOutputsAnnotations(flag)
-    self._AssertXmlGeneration(flag)
-    self._AssertXmlGeneratedByTestIsRetained(flag)
+    self._AssertXmlGeneration(flag, split_xml=False)
+    self._AssertXmlGeneration(flag, split_xml=True)
+    self._AssertXmlGeneratedByTestIsRetained(flag, split_xml=False)
+    self._AssertXmlGeneratedByTestIsRetained(flag, split_xml=True)
 
 
 if __name__ == '__main__':

--- a/src/test/shell/bazel/testdata/embedded_tools_srcs_deps
+++ b/src/test/shell/bazel/testdata/embedded_tools_srcs_deps
@@ -4,6 +4,7 @@
 @com_google_protobuf//:protobuf_lite
 //tools/test:tw
 //tools/test:tw_lib
+//tools/test:xml
 //third_party/ijar:zipper
 //third_party/ijar:ijar
 //third_party/ijar:zip

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -48,6 +48,13 @@ cc_binary(
     deps = [":tw_lib"],
 )
 
+cc_binary(
+    name = "xml",
+    srcs = ["windows/xml_main.cc"],
+    visibility = ["//visibility:private"],
+    deps = [":tw_lib"],
+)
+
 # Test wrapper binary to run tests on Windows.
 # See https://github.com/bazelbuild/bazel/issues/5508
 cc_library(
@@ -115,7 +122,10 @@ filegroup(
         "collect_coverage.sh",
         "collect_cc_coverage.sh",
     ] + glob(["LcovMerger/**"]) + select({
-        "@bazel_tools//src/conditions:windows": ["tw"],
+        "@bazel_tools//src/conditions:windows": [
+            "tw",
+            "xml",
+        ],
         "//conditions:default": [],
     }),
     visibility = ["//tools:__pkg__"],

--- a/tools/test/BUILD.tools
+++ b/tools/test/BUILD.tools
@@ -49,3 +49,14 @@ filegroup(
         "//conditions:default": ["tw"],
     }),
 )
+
+filegroup(
+    name = "xml_writer",
+    # "xml" is the Windows-native test XML writer. It has a short name because
+    # paths have short limits on Windows.
+    # On other platforms this binary is a no-op.
+    srcs = select({
+        "@bazel_tools//src/conditions:windows": ["xml.exe"],
+        "//conditions:default": ["xml"],
+    }),
+)

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -47,6 +47,7 @@
 #include "third_party/ijar/zip.h"
 #include "tools/cpp/runfiles/runfiles.h"
 
+
 namespace bazel {
 namespace tools {
 namespace test_wrapper {
@@ -622,8 +623,8 @@ bool OpenFileForWriting(const Path& path, bazel::windows::AutoHandle* result) {
 bool OpenExistingFileForRead(const Path& abs_path,
                              bazel::windows::AutoHandle* result) {
   HANDLE h = CreateFileW(AddUncPrefixMaybe(abs_path).c_str(), GENERIC_READ,
-                         FILE_SHARE_READ | FILE_SHARE_DELETE, NULL,
-                         OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                         NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
   if (h == INVALID_HANDLE_VALUE) {
     DWORD err = GetLastError();
     LogErrorWithArgAndValue(__LINE__, "Failed to open file", abs_path.Get(),
@@ -634,7 +635,7 @@ bool OpenExistingFileForRead(const Path& abs_path,
   return true;
 }
 
-bool TouchFile(const Path& path) {
+bool CreateEmptyFile(const Path& path) {
   bazel::windows::AutoHandle handle;
   return OpenFileForWriting(path, &handle);
 }
@@ -826,7 +827,7 @@ bool ExportXmlPath(const Path& cwd, Path* test_outerr, Path* xml_log) {
          // TODO(ulfjack): Update Gunit to accept XML_OUTPUT_FILE and drop the
          // GUNIT_OUTPUT env variable.
          SetEnv(L"GUNIT_OUTPUT", L"xml:" + unix_result) &&
-         CreateDirectories(xml_log->Dirname()) && TouchFile(*test_outerr);
+         CreateDirectories(xml_log->Dirname()) && CreateEmptyFile(*test_outerr);
 }
 
 devtools_ijar::u4 GetZipAttr(const FileInfo& info) {
@@ -1206,8 +1207,9 @@ bool StartSubprocess(const Path& path, const std::vector<const wchar_t*>& args,
   }
 }
 
-int WaitForSubprocess(HANDLE process) {
+int WaitForSubprocess(HANDLE process, LARGE_INTEGER* end_time) {
   DWORD result = WaitForSingleObject(process, INFINITE);
+  QueryPerformanceCounter(end_time);
   switch (result) {
     case WAIT_OBJECT_0: {
       DWORD exit_code;
@@ -1313,6 +1315,43 @@ bool ParseArgs(int argc, wchar_t** argv, Path* out_argv0,
   return true;
 }
 
+bool ParseXmlWriterArgs(int argc, wchar_t** argv, const Path& cwd,
+                        Path* out_test_log, Path* out_xml_log,
+                        Duration* out_duration, int* out_exit_code) {
+  if (argc < 5) {
+    LogError(__LINE__, "Usage: $0 <test_output_path> <xml_log_path>"
+                       " <duration_in_seconds> <exit_code>");
+    return false;
+  }
+  if (!out_test_log->Set(argv[1]) || out_test_log->Get().empty()) {
+    LogError(__LINE__,
+             (std::wstring(L"Failed to parse test log path from \"") + argv[1] +
+                 L"\"") .c_str());
+    return false;
+  }
+  out_test_log->Absolutize(cwd);
+  if (!out_xml_log->Set(argv[2]) || out_xml_log->Get().empty()) {
+    LogError(__LINE__,
+             (std::wstring(L"Failed to parse XML log path from \"") + argv[2] +
+                 L"\"") .c_str());
+    return false;
+  }
+  out_xml_log->Absolutize(cwd);
+  if (!out_duration->FromString(argv[3])) {
+    LogError(__LINE__,
+             (std::wstring(L"Failed to parse test duration from \"") + argv[3] +
+                 L"\"") .c_str());
+    return false;
+  }
+  if (!ToInt(argv[4], out_exit_code)) {
+    LogError(__LINE__,
+             (std::wstring(L"Failed to parse exit code from \"") + argv[4] +
+                 L"\"").c_str());
+    return false;
+  }
+  return true;
+}
+
 bool TeeImpl::Create(bazel::windows::AutoHandle* input,
                      bazel::windows::AutoHandle* output1,
                      bazel::windows::AutoHandle* output2,
@@ -1356,8 +1395,7 @@ int RunSubprocess(const Path& test_path,
                            test_path.Get() + L"\"");
     return 1;
   }
-  int result = WaitForSubprocess(process);
-  QueryPerformanceCounter(&end);
+  int result = WaitForSubprocess(process, &end);
 
   QueryPerformanceFrequency(&freq);
   end.QuadPart -= start.QuadPart;
@@ -1539,15 +1577,40 @@ std::string CreateErrorTag(int exit_code) {
   }
 }
 
-bool CreateXmlLog(const Path& output, const Path& test_outerr,
-                  const Duration duration, const int exit_code) {
+bool ShouldCreateXml(const Path& xml_log, bool* result) {
+  *result = true;
+
+  DWORD attr = GetFileAttributesW(AddUncPrefixMaybe(xml_log).c_str());
+  if (attr != INVALID_FILE_ATTRIBUTES) {
+    // The XML file already exists, maybe the test framework wrote it.
+    // Leave the file alone.
+    *result = false;
+    return true;
+  }
+
   std::wstring split_xml_generation;
   if (!GetEnv(L"EXPERIMENTAL_SPLIT_XML_GENERATION", &split_xml_generation)) {
     LogError(__LINE__, "Failed to get %EXPERIMENTAL_SPLIT_XML_GENERATION%");
     return false;
   }
   if (split_xml_generation == L"1") {
-    // Bazel generates the test xml as a separate action.
+    // Bazel generates the test xml as a separate action, so we don't have to
+    // create it.
+    *result = false;
+  }
+
+  return true;
+}
+
+bool CreateXmlLog(const Path& output, const Path& test_outerr,
+                  const Duration duration, const int exit_code) {
+  bool should_create_xml;
+  if (!ShouldCreateXml(output, &should_create_xml)) {
+    LogError(__LINE__,
+             (std::wstring(L"CreateXmlLog(") + output.Get() + L")").c_str());
+    return false;
+  }
+  if (!should_create_xml) {
     return true;
   }
 
@@ -1557,13 +1620,6 @@ bool CreateXmlLog(const Path& output, const Path& test_outerr,
     // declared output.
     DeleteFileW(test_outerr.Get().c_str());
   });
-
-  DWORD attr = GetFileAttributesW(AddUncPrefixMaybe(output).c_str());
-  if (attr != INVALID_FILE_ATTRIBUTES) {
-    // The XML file already exists, maybe the test framework wrote it.
-    // Leave the file alone.
-    return true;
-  }
 
   std::wstring test_name;
   int errors = (exit_code == 0) ? 0 : 1;
@@ -1589,10 +1645,10 @@ bool CreateXmlLog(const Path& output, const Path& test_outerr,
   std::stringstream stm;
   stm << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
          "<testsuites>\n"
-         "    <testsuite name=\""
+         "<testsuite name=\""
       << acp_test_name << "\" tests=\"1\" failures=\"0\" errors=\"" << errors
       << "\">\n"
-         "    <testcase name=\""
+         "<testcase name=\""
       << acp_test_name << "\" status=\"run\" duration=\"" << duration.seconds
       << "\" time=\"" << duration.seconds << "\">" << error_msg
       << "</testcase>\n"
@@ -1716,7 +1772,7 @@ void ZipEntryPaths::Create(const std::string& root,
   entry_path_ptrs_.get()[relative_paths.size()] = nullptr;
 }
 
-int Main(int argc, wchar_t** argv) {
+int TestWrapperMain(int argc, wchar_t** argv) {
   Path argv0;
   std::wstring test_path_arg;
   Path test_path, exec_root, srcdir, tmpdir, test_outerr, xml_log;
@@ -1744,6 +1800,21 @@ int Main(int argc, wchar_t** argv) {
     return 1;
   }
   return result;
+}
+
+int XmlWriterMain(int argc, wchar_t** argv) {
+  Path cwd, test_outerr, test_xml_log;
+  Duration duration;
+  int exit_code = 0;
+
+  if (!GetCwd(&cwd) ||
+      !ParseXmlWriterArgs(argc, argv, cwd, &test_outerr, &test_xml_log,
+                          &duration, &exit_code) ||
+      !CreateXmlLog(test_xml_log, test_outerr, duration, exit_code)) {
+    return 1;
+  }
+
+  return 0;
 }
 
 namespace testing {

--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -112,7 +112,10 @@ class Tee {
 };
 
 // The main function of the test wrapper.
-int Main(int argc, wchar_t** argv);
+int TestWrapperMain(int argc, wchar_t** argv);
+
+// The main function of the test XML writer.
+int XmlWriterMain(int argc, wchar_t** argv);
 
 // The "testing" namespace contains functions that should only be used by tests.
 namespace testing {

--- a/tools/test/windows/xml_main.cc
+++ b/tools/test/windows/xml_main.cc
@@ -1,4 +1,4 @@
-// Copyright 2018 The Bazel Authors. All rights reserved.
+// Copyright 2019 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Test wrapper implementation for Windows.
-// Design:
-// https://github.com/laszlocsomor/proposals/blob/win-test-runner/designs/2018-07-18-windows-native-test-runner.md
+// Test XML writer implementation for Windows.
 
 #include "tools/test/windows/tw.h"
 
 int wmain(int argc, wchar_t** argv) {
-  return bazel::tools::test_wrapper::TestWrapperMain(argc, argv);
+  return bazel::tools::test_wrapper::XmlWriterMain(argc, argv);
 }
+


### PR DESCRIPTION
Replace generate-xml.sh by a native XML generator
when using --experimental_split_xml_generation
with --experimental_windows_native_test_wrapper
on Windows.

The XML generator is almost the same binary as the
native test wrapper, just with a different main
function.

See https://github.com/bazelbuild/bazel/issues/5508