### PR TITLE
Have Preconditions check more verbose

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -2392,13 +2392,15 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
         // set as being in error.
         eventHandler.post(PatternExpandingError.failed(targetPatterns, exc.getMessage()));
       } else {
+        Exception e = Preconditions.checkNotNull(errorInfo.getException());
+
         // TargetPatternPhaseFunction never directly throws. Thus, the only way
         // evalResult.hasError() && keepGoing can hold is if there are cycles, which is handled
         // above.
-        Preconditions.checkState(!keepGoing);
+        Preconditions.checkState(!keepGoing, e.getMessage());
+
         // Following SkyframeTargetPatternEvaluator, we convert any exception into a
         // TargetParsingException.
-        Exception e = Preconditions.checkNotNull(errorInfo.getException());
         exc =
             (e instanceof TargetParsingException)
                 ? (TargetParsingException) e


### PR DESCRIPTION
I experienced the precondition actually fail when some of the
packages used by the targets were not committed to the repository.
Unfortunately, I can not reproduce it on the simple example, but
I definitely think we should keep the error message in that assertion,
otherwise it;s hard to investigate.