### PR TITLE
Bazel: enable repository tests on Windows

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
@@ -9,18 +9,9 @@ filegroup(
     srcs = glob(["**"]) + [
         "//src/test/java/com/google/devtools/build/lib/bazel/repository/cache:srcs",
         "//src/test/java/com/google/devtools/build/lib/bazel/repository/downloader:srcs",
+        "//src/test/java/com/google/devtools/build/lib/bazel/repository/posix:srcs",
     ],
     visibility = ["//src/test/java/com/google/devtools/build/lib/bazel:__pkg__"],
-)
-
-genrule(
-    name = "empty-tarball",
-    outs = ["empty.tar.gz"],
-    cmd = """
-mkdir -p bar-1.2.3
-touch bar-1.2.3/whatever
-tar czf $@ bar-1.2.3
-""",
 )
 
 java_test(
@@ -28,9 +19,7 @@ java_test(
     srcs = glob([
         "**/*.java",
     ]),
-    data = [":empty-tarball"],
     tags = [
-        "no_windows",  # Runfiles aren't supported.
         "rules",
     ],
     test_class = "com.google.devtools.build.lib.AllTests",
@@ -85,6 +74,7 @@ test_suite(
         ":windows_tests",
         "//src/test/java/com/google/devtools/build/lib/bazel/repository/cache:all_windows_tests",
         "//src/test/java/com/google/devtools/build/lib/bazel/repository/downloader:all_windows_tests",
+        "//src/test/java/com/google/devtools/build/lib/bazel/repository/posix:all_windows_tests",
     ],
     visibility = ["//src/test/java/com/google/devtools/build/lib/bazel:__pkg__"],
 )

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunctionTest.java
@@ -107,47 +107,4 @@ public class LocalConfigPlatformFunctionTest {
       assertThat(LocalConfigPlatformFunction.osToConstraint(OS.UNKNOWN)).isNull();
     }
   }
-
-  /** Tests on overall functionality. */
-  @RunWith(JUnit4.class)
-  public static class FunctionTest extends BuildViewTestCase {
-    private static final ConstraintSettingInfo CPU_CONSTRAINT =
-        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("@bazel_tools//platforms:cpu"));
-    private static final ConstraintSettingInfo OS_CONSTRAINT =
-        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("@bazel_tools//platforms:os"));
-
-    private static final ConstraintValueInfo X86_64_CONSTRAINT =
-        ConstraintValueInfo.create(
-            CPU_CONSTRAINT, Label.parseAbsoluteUnchecked("@bazel_tools//platforms:x86_64"));
-    private static final ConstraintValueInfo LINUX_CONSTRAINT =
-        ConstraintValueInfo.create(
-            OS_CONSTRAINT, Label.parseAbsoluteUnchecked("@bazel_tools//platforms:linux"));
-
-    @Test
-    public void generateConfigRepository() throws Exception {
-      CPU.setForTesting(CPU.X86_64);
-      OS.setForTesting(OS.LINUX);
-
-      //    rewriteWorkspace("local_config_platform(name='local_config_platform_test')");
-      scratch.appendFile("WORKSPACE", "local_config_platform(name='local_config_platform_test')");
-      invalidatePackages();
-
-      // Verify the package was created as expected.
-      ConfiguredTarget hostPlatform = getConfiguredTarget("@local_config_platform_test//:host");
-      assertThat(hostPlatform).isNotNull();
-
-      PlatformInfo hostPlatformProvider = PlatformProviderUtils.platform(hostPlatform);
-      assertThat(hostPlatformProvider).isNotNull();
-
-      // Verify the OS and CPU constraints.
-      assertThat(hostPlatformProvider.constraints().has(CPU_CONSTRAINT)).isTrue();
-      assertThat(hostPlatformProvider.constraints().get(CPU_CONSTRAINT))
-          .isEqualTo(X86_64_CONSTRAINT);
-
-      assertThat(hostPlatformProvider.constraints().has(OS_CONSTRAINT)).isTrue();
-      assertThat(hostPlatformProvider.constraints().get(OS_CONSTRAINT)).isEqualTo(LINUX_CONSTRAINT);
-    }
-
-    // TODO(katre): check the host_platform_remote_properties_override flag
-  }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/posix/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/posix/BUILD
@@ -1,0 +1,55 @@
+package(
+    default_testonly = 1,
+    default_visibility = ["//src:__subpackages__"],
+)
+
+filegroup(
+    name = "srcs",
+    testonly = 0,
+    srcs = glob(["**"]),
+    visibility = ["//src/test/java/com/google/devtools/build/lib/bazel/repository:__pkg__"],
+)
+
+java_test(
+    name = "RepositoryTests",
+    srcs = glob([
+        "**/*.java",
+    ]),
+    tags = [
+        "no_windows",  # Tests require Linux.
+        "rules",
+    ],
+    test_class = "com.google.devtools.build.lib.AllTests",
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib:build-base",
+        "//src/main/java/com/google/devtools/build/lib:os_util",
+        "//src/main/java/com/google/devtools/build/lib:util",
+        "//src/main/java/com/google/devtools/build/lib/analysis/platform",
+        "//src/main/java/com/google/devtools/build/lib/analysis/platform:utils",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/test/java/com/google/devtools/build/lib:analysis_testutil",
+        "//third_party:guava",
+        "//third_party:guava-testlib",
+        "//third_party:jsr305",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+test_suite(
+    name = "windows_tests",
+    tags = [
+        "-no_windows",
+        "-slow",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+test_suite(
+    name = "all_windows_tests",
+    tests = [
+        ":windows_tests",
+    ],
+    visibility = ["//src/test/java/com/google/devtools/build/lib/bazel/repository:__pkg__"],
+)
+

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/posix/LocalConfigPlatformFunctionPosixTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/posix/LocalConfigPlatformFunctionPosixTest.java
@@ -1,0 +1,83 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.platform.ConstraintSettingInfo;
+import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
+import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
+import com.google.devtools.build.lib.analysis.platform.PlatformProviderUtils;
+import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.util.CPU;
+import com.google.devtools.build.lib.util.OS;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/** Posix-only tests for {@link LocalConfigPlatformFunction}. */
+@RunWith(Enclosed.class)
+public class LocalConfigPlatformFunctionPosixTest {
+
+  /** Tests on overall functionality. */
+  @RunWith(JUnit4.class)
+  public static class FunctionTest extends BuildViewTestCase {
+    private static final ConstraintSettingInfo CPU_CONSTRAINT =
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("@bazel_tools//platforms:cpu"));
+    private static final ConstraintSettingInfo OS_CONSTRAINT =
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("@bazel_tools//platforms:os"));
+
+    private static final ConstraintValueInfo X86_64_CONSTRAINT =
+        ConstraintValueInfo.create(
+            CPU_CONSTRAINT, Label.parseAbsoluteUnchecked("@bazel_tools//platforms:x86_64"));
+    private static final ConstraintValueInfo LINUX_CONSTRAINT =
+        ConstraintValueInfo.create(
+            OS_CONSTRAINT, Label.parseAbsoluteUnchecked("@bazel_tools//platforms:linux"));
+
+    @Test
+    public void generateConfigRepository() throws Exception {
+      CPU.setForTesting(CPU.X86_64);
+      OS.setForTesting(OS.LINUX);
+
+      //    rewriteWorkspace("local_config_platform(name='local_config_platform_test')");
+      scratch.appendFile("WORKSPACE", "local_config_platform(name='local_config_platform_test')");
+      invalidatePackages();
+
+      // Verify the package was created as expected.
+      ConfiguredTarget hostPlatform = getConfiguredTarget("@local_config_platform_test//:host");
+      assertThat(hostPlatform).isNotNull();
+
+      PlatformInfo hostPlatformProvider = PlatformProviderUtils.platform(hostPlatform);
+      assertThat(hostPlatformProvider).isNotNull();
+
+      // Verify the OS and CPU constraints.
+      assertThat(hostPlatformProvider.constraints().has(CPU_CONSTRAINT)).isTrue();
+      assertThat(hostPlatformProvider.constraints().get(CPU_CONSTRAINT))
+          .isEqualTo(X86_64_CONSTRAINT);
+
+      assertThat(hostPlatformProvider.constraints().has(OS_CONSTRAINT)).isTrue();
+      assertThat(hostPlatformProvider.constraints().get(OS_CONSTRAINT)).isEqualTo(LINUX_CONSTRAINT);
+    }
+
+    // TODO(katre): check the host_platform_remote_properties_override flag
+  }
+}


### PR DESCRIPTION
Also remove unnecessary data dependency from the
RepositoryTests rule, and move the Linux-specific
part of it to a subpackage.

Change-Id: I0bb1da57089cd51d5ae36588a6100c8ff3faafc6