### PR TITLE
Consult BAZEL_CXXOPTS when auto-detecting local CC toolchain.

### DIFF
--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -61,6 +61,7 @@ cc_autoconf = repository_rule(
         "ABI_VERSION",
         "BAZEL_COMPILER",
         "BAZEL_HOST_SYSTEM",
+        "BAZEL_CXXOPTS",
         "BAZEL_LINKOPTS",
         "BAZEL_PYTHON",
         "BAZEL_SH",


### PR DESCRIPTION
This allows for passing -stdlib=libc++ to $CC -E when detecting
cxx_builtin_include_directories in @local_config_cc//:CROSSTOOL,
which is enough to support linking against libc++.

$ clang -E -xc++ - -v

 /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/c++/6.3.0
 /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/x86_64-linux-gnu/c++/6.3.0
 /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/c++/6.3.0/backward
 /usr/include/clang/8.0.0/include
 /usr/local/include
 /usr/include/x86_64-linux-gnu
 /usr/include

$ clang -E -xc++ - -v -stdlib=libc++

 /usr/lib/llvm-8/bin/../include/c++/v1
 /usr/include/clang/8.0.0/include
 /usr/local/include
 /usr/include/x86_64-linux-gnu
 /usr/include

Signed-off-by: Piotr Sikora <piotrsikora@google.com>