### PR TITLE
Windows: fix new_local_repository correctness bug

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryFunction.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.rules.repository;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.actions.InconsistentFilesystemException;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
@@ -24,6 +25,7 @@ import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.skyframe.DirectoryListingValue;
 import com.google.devtools.build.lib.syntax.Printer;
 import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
@@ -32,6 +34,7 @@ import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.build.skyframe.SkyFunctionException;
 import com.google.devtools.build.skyframe.SkyFunctionException.Transience;
 import com.google.devtools.build.skyframe.SkyKey;
+import com.google.devtools.build.skyframe.SkyValue;
 import java.io.IOException;
 import java.util.Map;
 
@@ -90,10 +93,19 @@ public class NewLocalRepositoryFunction extends RepositoryFunction {
       throw new RepositoryFunctionException(e, Transience.PERSISTENT);
     }
 
-    // fetch() creates symlinks to each child under 'path' and DiffAwareness handles checking all
-    // of these files and directories for changes. However, if a new file/directory is added
-    // directly under 'path', Bazel doesn't know that this has to be symlinked in. Thus, this
-    // creates a dependency on the contents of the 'path' directory.
+    // fetch() creates symlinks to each child under 'path'.
+    //
+    // On Linux/macOS (i.e. where file symlinks are supported), DiffAwareness handles checking all
+    // of these files and directories for changes.
+    //
+    // On Windows (when file symlinks are disabled), the supposed symlinks are actually copies and
+    // DiffAwareness doesn't pick up changes of the "symlink" targets. To rectify that, we request
+    // FileValues for each child of 'path'.
+    // See https://github.com/bazelbuild/bazel/issues/7063
+    //
+    // Furthermore, if a new file/directory is added directly under 'path', Bazel doesn't know that
+    // this has to be symlinked in. So we also create a dependency on the contents of the 'path'
+    // directory.
     SkyKey dirKey = DirectoryListingValue.key(dirPath);
     DirectoryListingValue directoryValue;
     try {
@@ -106,6 +118,20 @@ public class NewLocalRepositoryFunction extends RepositoryFunction {
       return null;
     }
 
+    Map<SkyKey, SkyValue> fileValues =
+        env.getValues(
+            Iterables.transform(
+                directoryValue.getDirents(),
+                e -> (SkyKey) FileValue.key(
+                         RootedPath.toRootedPath(
+                             dirPath.getRoot(),
+                             dirPath.getRootRelativePath().getRelative(e.getName())))));
+    for (Map.Entry<?, ?> m : fileValues.entrySet()) {
+      if (m.getValue() == null) {
+        return null;
+      }
+    }
+
     // Link x/y/z to /some/path/to/y/z.
     if (!symlinkLocalRepositoryContents(outputDirectory, path)) {
       return null;
@@ -114,7 +140,8 @@ public class NewLocalRepositoryFunction extends RepositoryFunction {
     fileHandler.finishFile(rule, outputDirectory, markerData);
     env.getListener().post(resolve(rule, directories));
 
-    return RepositoryDirectoryValue.builder().setPath(outputDirectory).setSourceDir(directoryValue);
+    return RepositoryDirectoryValue.builder().setPath(outputDirectory).setSourceDir(directoryValue)
+               .setFileValues(fileValues);
   }
 
   @Override


### PR DESCRIPTION
The bugfix consists of two parts:

1.  NewLocalRepositoryFunction declares Skyframe
    dependencies on the files in the root of the
    repository. This yields a bunch of FileValues.

2.  RepositoryDirectoryValue stores the FileValues
    and considers them in equals() and hashCode().

Explanation:

new_local_repository creates symlinks to the files
in the root of the repository. When the symlink
targets change Bazel notices it and rebuilds
rules depending on the changed files.

However on Windows the supposed symlinks are
actually copies (because on Windows Bazel cannot
create file symlinks) and Bazel won't notice when
the "symlink" targets change.

The first part of the bugfix ensures that the
SkyFunction associated with the repository rule
notices the file changes, is re-evaluated, and
re-creates the symlinks (i.e. re-copies the files)
as a side-effect.

The second part ensures that the
SkyFunction-computed value will be different
(because some of the FileValues are different) so
change pruning in Skyframe won't believe that the
the repository's SkyValue stayed the same, and
will rebuild downstream SkyFunctions (i.e. rules).

Fixes https://github.com/bazelbuild/bazel/issues/7063