### PR TITLE
Add .H as a cpp header extension

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java
@@ -249,7 +249,7 @@ public class BazelCppRuleClasses {
             <li>C and C++ source files: <code>.c</code>, <code>.cc</code>, <code>.cpp</code>,
               <code>.cxx</code>, <code>.c++</code>, <code>.C</code></li>
             <li>C and C++ header files: <code>.h</code>, <code>.hh</code>, <code>.hpp</code>,
-              <code>.hxx</code>, <code>.inc</code></li>
+              <code>.hxx</code>, <code>.inc</code>, <code>.H</code></li>
             <li>Assembler with C preprocessor: <code>.S</code></li>
             <li>Archive: <code>.a</code>, <code>.pic.a</code></li>
             <li>"Always link" library: <code>.lo</code>, <code>.pic.lo</code></li>

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -35,7 +35,7 @@ public final class CppFileTypes {
       FileTypeSet.of(CppFileTypes.CPP_SOURCE, CppFileTypes.C_SOURCE);
 
   public static final FileType CPP_HEADER =
-      FileType.of(".h", ".hh", ".hpp", ".ipp", ".hxx", ".inc");
+      FileType.of(".h", ".hh", ".hpp", ".ipp", ".hxx", ".inc", ".H");
   public static final FileType PCH = FileType.of(".pch");
   public static final FileTypeSet OBJC_HEADER = FileTypeSet.of(CPP_HEADER, PCH);
   

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Constants.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Constants.java
@@ -53,5 +53,5 @@ class Constants {
   // Please keep in sync with the extensions in CppFileTypes.
   static final ImmutableList<String> CC_EXTENSIONS =
       ImmutableList.of(
-          ".cc", ".cpp", ".cxx", ".c++", ".C", ".c", ".h", ".hh", ".hpp", ".ipp", ".hxx", ".inc");
+          ".cc", ".cpp", ".cxx", ".c++", ".C", ".c", ".h", ".hh", ".hpp", ".ipp", ".hxx", ".inc", ".H");
 }


### PR DESCRIPTION
GCC recognizes `.H` as a C++ header extension: https://gcc.gnu.org/onlinedocs/gcc-4.2.4/gcc/Invoking-G_002b_002b.html

There's at least one large corporation, which uses `.C` and `.H` extensions for C++ sources and headers, respectively.

This change adds `.H` to the list of allowed C++ header extensions, to allow targets to specify them in `srcs` (e.g: when listing private headers).