### PR TITLE
Support the .txz file extensions for http_archive().

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorValue.java
@@ -59,15 +59,15 @@ public class DecompressorValue implements SkyValue {
       return TarFunction.INSTANCE;
     } else if (baseName.endsWith(".tar.gz") || baseName.endsWith(".tgz")) {
       return TarGzFunction.INSTANCE;
-    } else if (baseName.endsWith(".tar.xz")) {
+    } else if (baseName.endsWith(".tar.xz") || baseName.endsWith(".txz")) {
       return TarXzFunction.INSTANCE;
     } else if (baseName.endsWith(".tar.bz2")) {
       return TarBz2Function.INSTANCE;
     } else {
       throw new RepositoryFunctionException(
           new EvalException(null, String.format(
-              "Expected a file with a .zip, .jar, .war, .tar, .tar.gz, .tgz, .tar.xz, or .tar.bz2 "
-              + "suffix (got %s)",
+              "Expected a file with a .zip, .jar, .war, .tar, .tar.gz, .tgz, .tar.xz, .txz, or "
+              + ".tar.bz2 suffix (got %s)",
               archivePath)),
           Transience.PERSISTENT);
     }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/DecompressorValueTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/DecompressorValueTest.java
@@ -47,6 +47,8 @@ public class DecompressorValueTest {
     DecompressorDescriptor.builder().setArchivePath(path).build();
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tar.xz");
     DecompressorDescriptor.builder().setArchivePath(path).build();
+    path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.txz");
+    DecompressorDescriptor.builder().setArchivePath(path).build();
     path = fs.getPath("/foo/.external-repositories/some-repo/bar.baz.tar.bz2");
     DecompressorDescriptor.builder().setArchivePath(path).build();
   }


### PR DESCRIPTION
These extensions are used in the wild. For example, FreeBSD uses them
for both the base system and its packages:

http://ftp.nluug.nl/FreeBSD/releases/amd64/12.0-RELEASE/