### PR TITLE
Revert "Add repository map to label constructor."

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/BazelStarlarkContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/BazelStarlarkContext.java
@@ -42,11 +42,7 @@ public class BazelStarlarkContext implements StarlarkContext {
     this.repoMapping = repoMapping;
   }
 
-  /**
-   * @param toolsRepository the name of the tools repository, such as "@bazel_tools"
-   * @param repoMapping a map from RepositoryName to RepositoryName to be used for external
-   *     repository renaming
-   */
+  /** @param toolsRepository the name of the tools repository, such as "bazel_tools" */
   public BazelStarlarkContext(
       String toolsRepository, ImmutableMap<RepositoryName, RepositoryName> repoMapping) {
     this(toolsRepository, null, repoMapping);

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
@@ -753,16 +753,9 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
 
   @Override
   public Label label(
-      String labelString,
-      Boolean relativeToCallerRepository,
-      Location loc,
-      Environment env,
-      StarlarkContext context)
+      String labelString, Boolean relativeToCallerRepository, Location loc, Environment env)
       throws EvalException {
-
-    BazelStarlarkContext bazelStarlarkContext = (BazelStarlarkContext) context;
-
-    Label parentLabel;
+    Label parentLabel = null;
     if (relativeToCallerRepository) {
       parentLabel = env.getCallerLabel();
     } else {
@@ -771,9 +764,10 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
     try {
       if (parentLabel != null) {
         LabelValidator.parseAbsoluteLabel(labelString);
+        // TODO(dannark): pass the environment here
         labelString =
             parentLabel
-                .getRelativeWithRemapping(labelString, bazelStarlarkContext.getRepoMapping())
+                .getRelativeWithRemapping(labelString, ImmutableMap.of())
                 .getUnambiguousCanonicalForm();
       }
       return labelCache.get(labelString);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
-import com.google.devtools.build.lib.analysis.skylark.BazelStarlarkContext;
 import com.google.devtools.build.lib.bazel.repository.RepositoryResolvedEvent;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
@@ -89,13 +88,6 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
           com.google.devtools.build.lib.syntax.Environment.builder(mutability)
               .setSemantics(skylarkSemantics)
               .setEventHandler(env.getListener())
-              // The fetch phase does not need the tools repository or the fragment map because
-              // it happens before analysis
-              .setStarlarkContext(
-                  new BazelStarlarkContext(
-                      /* toolsRepository = */ null,
-                      /* fragmentNameToClass = */ null,
-                      rule.getPackage().getRepositoryMapping()))
               .build();
       SkylarkRepositoryContext skylarkRepositoryContext =
           new SkylarkRepositoryContext(

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleFunctionsApi.java
@@ -496,42 +496,34 @@ public interface SkylarkRuleFunctionsApi<FileApiT extends FileApi> {
 
   @SkylarkCallable(
       name = "Label",
-      doc =
-          "Creates a Label referring to a BUILD target. Use "
-              + "this function only when you want to give a default value for the label "
-              + "attributes. The argument must refer to an absolute label. "
-              + "Example: <br><pre class=language-python>Label(\"//tools:default\")</pre>",
+      doc = "Creates a Label referring to a BUILD target. Use "
+          + "this function only when you want to give a default value for the label attributes. "
+          + "The argument must refer to an absolute label. "
+          + "Example: <br><pre class=language-python>Label(\"//tools:default\")</pre>",
       parameters = {
-        @Param(
-            name = "label_string",
-            type = String.class,
-            legacyNamed = true,
-            doc = "the label string."),
-        @Param(
-            name = "relative_to_caller_repository",
-            type = Boolean.class,
-            defaultValue = "False",
-            named = true,
-            positional = false,
-            doc =
-                "Deprecated. Do not use. "
-                    + "When relative_to_caller_repository is True and the calling thread is a "
-                    + "rule's implementation function, then a repo-relative label //foo:bar is "
-                    + "resolved relative to the rule's repository.  For calls to Label from any "
-                    + "other thread, or calls in which the relative_to_caller_repository flag is "
-                    + "False, a repo-relative label is resolved relative to the file in which the "
-                    + "Label() call appears.")
+          @Param(name = "label_string", type = String.class, legacyNamed = true,
+              doc = "the label string."),
+          @Param(
+              name = "relative_to_caller_repository",
+              type = Boolean.class,
+              defaultValue = "False",
+              named = true,
+              positional = false,
+              doc = "Deprecated. Do not use. "
+                  + "When relative_to_caller_repository is True and the calling thread is a rule's "
+                  + "implementation function, then a repo-relative label //foo:bar is resolved "
+                  + "relative to the rule's repository.  For calls to Label from any other "
+                  + "thread, or calls in which the relative_to_caller_repository flag is False, "
+                  + "a repo-relative label is resolved relative to the file in which the "
+                  + "Label() call appears."
+          )
       },
       useLocation = true,
-      useEnvironment = true,
-      useContext = true)
+      useEnvironment = true
+  )
   @SkylarkConstructor(objectType = Label.class)
   public Label label(
-      String labelString,
-      Boolean relativeToCallerRepository,
-      Location loc,
-      Environment env,
-      StarlarkContext context)
+      String labelString, Boolean relativeToCallerRepository, Location loc, Environment env)
       throws EvalException;
 
   @SkylarkCallable(

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/FakeSkylarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/FakeSkylarkRuleFunctionsApi.java
@@ -149,13 +149,8 @@ public class FakeSkylarkRuleFunctionsApi implements SkylarkRuleFunctionsApi<File
   }
 
   @Override
-  public Label label(
-      String labelString,
-      Boolean relativeToCallerRepository,
-      Location loc,
-      Environment env,
-      StarlarkContext context)
-      throws EvalException {
+  public Label label(String labelString, Boolean relativeToCallerRepository, Location loc,
+      Environment env) throws EvalException {
     try {
       return Label.parseAbsolute(
           labelString,

--- a/src/test/shell/bazel/workspace_test.sh
+++ b/src/test/shell/bazel/workspace_test.sh
@@ -608,40 +608,6 @@ EOF
   expect_not_log "@a//:baz"
 }
 
-function test_remapping_label_constructor() {
-  # create foo repository
-  mkdir foo
-  touch foo/WORKSPACE
-  cat >foo/foo.bzl <<EOF
-x = Label("@a//blah:blah")
-print(x)
-EOF
-  cat >foo/BUILD <<EOF
-load(":foo.bzl", "x")
-genrule(
-  name = "bar",
-  outs = ["xyz"],
-  cmd = "touch \$(location xyz)",
-  visibility = ["//visibility:public"]
-)
-EOF
-
-  # Main repo assigns @a to @b within @foo
-  mkdir -p main
-  cat >main/WORKSPACE <<EOF
-workspace(name = "main")
-local_repository(name = "foo", path="../foo", repo_mapping = {"@a" : "@b"})
-local_repository(name = "b", path="../b")
-EOF
-  touch main/BUILD
-
-  cd main
-  bazel build --experimental_enable_repo_mapping @foo//:bar \
-      >& "$TEST_log" || fail "Expected build to succeed"
-  expect_log "@b//blah:blah"
-  expect_not_log "@a//blah:blah"
-}
-
 function test_workspace_addition_change_aspect() {
   mkdir -p repo_one
   mkdir -p repo_two


### PR DESCRIPTION
Fixes: #7102.

Reason for revert: This broke rules_closure and gerrit code review
that depend on rules_closure.

This reverts commit f0a9c167879edb0bd6425709db22058c0ef547cc.