### PR TITLE
Allow DexArchiveAspect to see 'JavaInfo' provider from Starlark aspects.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/DexArchiveAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/DexArchiveAspect.java
@@ -283,10 +283,7 @@ public final class DexArchiveAspect extends NativeAspectClass implements Configu
 
   private static Iterable<Artifact> getProducedRuntimeJars(
       ConfiguredTarget base, RuleContext ruleContext) {
-    JavaInfo javaInfo = JavaInfo.getJavaInfo(base);
-    if (javaInfo != null) {
-      return javaInfo.getDirectRuntimeJars();
-    } else if (isProtoLibrary(ruleContext)) {
+    if (isProtoLibrary(ruleContext)) {
       if (!ruleContext.getPrerequisites("srcs", Mode.TARGET).isEmpty()) {
         JavaRuleOutputJarsProvider outputJarsProvider =
             base.getProvider(JavaRuleOutputJarsProvider.class);
@@ -296,7 +293,17 @@ public final class DexArchiveAspect extends NativeAspectClass implements Configu
               .stream()
               .map(OutputJar::getClassJar)
               .collect(toImmutableList());
+        } else {
+          JavaInfo javaInfo = JavaInfo.getJavaInfo(base);
+          if (javaInfo != null) {
+            return javaInfo.getDirectRuntimeJars();
+          }
         }
+      }
+    } else {
+      JavaInfo javaInfo = JavaInfo.getJavaInfo(base);
+      if (javaInfo != null) {
+        return javaInfo.getDirectRuntimeJars();
       }
     }
     return null;


### PR DESCRIPTION
Currently the Android rules' dexing aspect can propagate over `proto_library` rules which are "aspected" by the native java_proto rules. This is pretty great when using the built-in `java_{lite_,}proto_library` rules, but there is still a gap in functionality--DexArchiveAspect cannot see the `JavaInfo` provider returned by Starlark aspects.

To allow the DexArchiveAspect to see the 'JavaInfo' provider returned by Starlark aspects two changes are necessary:
1. First change allows DexArchiveAspect to see JavaInfo provided by Starlark aspects for all rules except proto libraries
2. Second change needs to fall back to checking for JavaInfo if the special-cased proto library logic doesn't find any jars.

