### PR TITLE
Windows: fix rule_size_test for the test wrapper

### DIFF
--- a/src/rule_size_test.bzl
+++ b/src/rule_size_test.bzl
@@ -88,7 +88,10 @@ def _impl(ctx):
 
     if ctx.attr.is_windows:
         test_bin = ctx.actions.declare_file(ctx.label.name + ".bat")
-        ctx.actions.write(output = test_bin, content = "", is_executable = True)
+        # CreateProcessW can launch .bat files directly as long as they are NOT
+        # empty. Therefore we write a .bat file with a comment in it.
+        ctx.actions.write(output = test_bin, content = "@REM dummy",
+                          is_executable = True)
     else:
         test_bin = ctx.actions.declare_file(ctx.label.name + ".sh")
         ctx.actions.write(

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -1201,7 +1201,9 @@ bool StartSubprocess(const Path& path, const std::vector<const wchar_t*>& args,
     return true;
   } else {
     DWORD err = GetLastError();
-    LogErrorWithValue(__LINE__, "CreateProcessW failed", err);
+    LogErrorWithValue(__LINE__,
+                      (std::wstring(L"CreateProcessW failed (") + cmdline.get()
+                          + L")").c_str(), err);
     return false;
   }
 }


### PR DESCRIPTION
Fix //src:rule_size_test so it works when using
--experimental_windows_native_test_wrapper.

The test failed with the Windows-native test
wrapper because the test wrapper launches the test
binary directly, and the rule created an empty
.bat file as its executable, and CreateProcessW
apparently cannot run empty .bat files.

Also: log the failed command in the test wrapper
when CreateProcessW fails.

See https://github.com/bazelbuild/bazel/issues/5508