### PR TITLE
Use bazel without JDK in //scripts/packages:without-jdk/bazel.

### DIFF
--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -93,7 +93,7 @@ genrule(
 
 genrule(
     name = "rename-bazel-bin-without-jdk",
-    srcs = ["//src:bazel"],
+    srcs = ["//src:bazel_nojdk"],
     outs = ["without-jdk/bazel-real"],
     cmd = "mkdir -p $$(dirname $@); cp $< $@",
 )


### PR DESCRIPTION
Fixes #7167.

RELNOTES: None