### PR TITLE
Windows: all JNI methods verify their path arg.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -43,6 +43,7 @@ filegroup(
 ) for suffix, embedded_tools_target in {
     "_jdk_allmodules": [":embedded_tools_jdk_allmodules"],
     "_jdk_minimal": [":embedded_tools_jdk_minimal"],
+    "_dev_jdk": [":embedded_tools_dev_jdk"],
     "_nojdk": [":embedded_tools_nojdk"],
     "_notools": [],
 }.items()]
@@ -179,6 +180,7 @@ JAVA_TOOLS = [
 ) for suffix, jdk in {
     "_jdk_allmodules": [":embedded_jdk_allmodules"],
     "_jdk_minimal": [":embedded_jdk_minimal_cached"],
+    "_dev_jdk": [":embedded_jdk_minimal"],
     "_nojdk": [],
 }.items()]
 
@@ -294,6 +296,7 @@ filegroup(
 ) for suffix in [
     "_jdk_allmodules",
     "_jdk_minimal",
+    "_dev_jdk",
     "_nojdk",
 ]]
 
@@ -309,6 +312,7 @@ filegroup(
 ) for suffix in [
     "_jdk_allmodules",
     "_jdk_minimal",
+    "_dev_jdk",
     "_nojdk",
 ]]
 
@@ -333,6 +337,7 @@ filegroup(
 ) for suffix, embed in [
     ("_jdk_allmodules", True),
     ("_jdk_minimal", True),
+    ("_dev_jdk", True),
     ("_notools", False),
     ("_nojdk", True),
 ]]
@@ -359,6 +364,7 @@ filegroup(
 ) for suffix in [
     "_jdk_allmodules",
     "_jdk_minimal",
+    "_dev_jdk",
     "_notools",
     "_nojdk",
 ]]

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
@@ -211,6 +211,13 @@ public final class CcLinkingHelper {
     return this;
   }
 
+  public CcLinkingHelper addCcLinkingContexts(Iterable<CcLinkingContext> ccLinkingContexts) {
+    for (CcLinkingContext ccLinkingContext : ccLinkingContexts) {
+      ccLinkingInfos.add(ccLinkingContext.toCcLinkingInfo());
+    }
+    return this;
+  }
+
   /**
    * Adds the given linkstamps. Note that linkstamps are usually not compiled at the library level,
    * but only in the dependent binary rules.

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/ExtraLinkTimeLibraries.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/ExtraLinkTimeLibraries.java
@@ -20,7 +20,6 @@ import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
 import com.google.devtools.build.lib.rules.cpp.ExtraLinkTimeLibrary.BuildLibraryOutput;
-import com.google.devtools.build.lib.rules.cpp.LinkerInputs.LibraryToLink;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec.VisibleForSerialization;
 import java.util.Collection;
@@ -107,7 +106,7 @@ public final class ExtraLinkTimeLibraries {
   public BuildLibraryOutput buildLibraries(
       RuleContext ruleContext, boolean staticMode, boolean forDynamicLibrary)
       throws InterruptedException, RuleErrorException {
-    NestedSetBuilder<LibraryToLink> librariesToLink = NestedSetBuilder.linkOrder();
+    NestedSetBuilder<LibraryToLinkWrapper> librariesToLink = NestedSetBuilder.linkOrder();
     NestedSetBuilder<Artifact> runtimeLibraries = NestedSetBuilder.linkOrder();
     for (ExtraLinkTimeLibrary extraLibrary : getExtraLibraries()) {
       BuildLibraryOutput buildLibraryOutput =

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/ExtraLinkTimeLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/ExtraLinkTimeLibrary.java
@@ -18,7 +18,6 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
-import com.google.devtools.build.lib.rules.cpp.LinkerInputs.LibraryToLink;
 
 /**
  * An extra library to include in a link. The actual library is built at link time.
@@ -34,16 +33,16 @@ public interface ExtraLinkTimeLibrary {
 
   /** Output of {@link #buildLibraries}. Pair of libraries to link and runtime libraries. */
   class BuildLibraryOutput {
-    public NestedSet<LibraryToLink> librariesToLink;
+    public NestedSet<LibraryToLinkWrapper> librariesToLink;
     public NestedSet<Artifact> runtimeLibraries;
 
     public BuildLibraryOutput(
-        NestedSet<LibraryToLink> librariesToLink, NestedSet<Artifact> runtimeLibraries) {
+        NestedSet<LibraryToLinkWrapper> librariesToLink, NestedSet<Artifact> runtimeLibraries) {
       this.librariesToLink = librariesToLink;
       this.runtimeLibraries = runtimeLibraries;
     }
 
-    public NestedSet<LibraryToLink> getLibrariesToLink() {
+    public NestedSet<LibraryToLinkWrapper> getLibrariesToLink() {
       return librariesToLink;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
@@ -163,7 +163,7 @@ public class WindowsFileOperations {
   public static boolean deletePath(String path) throws IOException {
     WindowsJniLoader.loadJni();
     String[] error = new String[] {null};
-    int result = nativeDeletePath(asLongPath(path), error);
+    int result = nativeDeletePath(asLongPath(path.replace('/', '\\')), error);
     switch (result) {
       case DELETE_PATH_SUCCESS:
         return true;

--- a/src/main/native/windows/file-jni.cc
+++ b/src/main/native/windows/file-jni.cc
@@ -41,13 +41,14 @@ extern "C" JNIEXPORT jint JNICALL
 Java_com_google_devtools_build_lib_windows_jni_WindowsFileOperations_nativeIsJunction(
     JNIEnv* env, jclass clazz, jstring path, jobjectArray error_msg_holder) {
   std::wstring wpath(bazel::windows::GetJavaWstring(env, path));
-  int result = bazel::windows::IsJunctionOrDirectorySymlink(wpath.c_str());
+  std::wstring error;
+  int result = bazel::windows::IsJunctionOrDirectorySymlink(wpath.c_str(),
+                                                            &error);
   if (result == bazel::windows::IS_JUNCTION_ERROR &&
       CanReportError(env, error_msg_holder)) {
-    DWORD err_code = GetLastError();
     ReportLastError(
         bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
-                                         L"nativeIsJunction", wpath, err_code),
+                                         L"nativeIsJunction", wpath, error),
         env, error_msg_holder);
   }
   return result;

--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -72,30 +72,23 @@ static wstring uint32asHexString(uint32_t value) {
   return wstring(attr_str, 8);
 }
 
-static DWORD GetAttributesOfMaybeMissingFile(const WCHAR* path) {
-  // According to a comment in .NET CoreFX [1] (which is the only relevant
-  // information we found as of 2018-07-13) GetFileAttributesW may fail with
-  // ERROR_ACCESS_DENIED if the file is marked for deletion but not yet
-  // actually deleted, but FindFirstFileW should succeed even then.
-  //
-  // [1]
-  // https://github.com/dotnet/corefx/blob/f25eb288a449010574a6e95fe298f3ad880ada1e/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs#L205-L208
-  WIN32_FIND_DATAW find_data;
-  HANDLE find = FindFirstFileW(path, &find_data);
-  if (find == INVALID_HANDLE_VALUE) {
-    // The path is deleted and we couldn't create a directory there.
-    // Give up.
-    return INVALID_FILE_ATTRIBUTES;
+int IsJunctionOrDirectorySymlink(const WCHAR* path, wstring* error) {
+  if (!IsAbsoluteNormalizedWindowsPath(path)) {
+    if (error) {
+      *error = MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"IsJunctionOrDirectorySymlink", path,
+          L"expected an absolute Windows path");
+    }
+    return IS_JUNCTION_ERROR;
   }
-  FindClose(find);
-  // The path exists, yet we cannot open it for metadata-reading. Report at
-  // least the attributes, then give up.
-  return find_data.dwFileAttributes;
-}
 
-int IsJunctionOrDirectorySymlink(const WCHAR* path) {
   DWORD attrs = ::GetFileAttributesW(path);
   if (attrs == INVALID_FILE_ATTRIBUTES) {
+    DWORD err = GetLastError();
+    if (error) {
+      *error = MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"IsJunctionOrDirectorySymlink", path, err);
+    }
     return IS_JUNCTION_ERROR;
   } else {
     if ((attrs & FILE_ATTRIBUTE_DIRECTORY) &&
@@ -108,14 +101,20 @@ int IsJunctionOrDirectorySymlink(const WCHAR* path) {
 }
 
 wstring GetLongPath(const WCHAR* path, unique_ptr<WCHAR[]>* result) {
-  DWORD size = ::GetLongPathNameW(path, NULL, 0);
+  if (!IsAbsoluteNormalizedWindowsPath(path)) {
+    return MakeErrorMessage(WSTR(__FILE__), __LINE__, L"GetLongPath", path,
+                            L"expected an absolute Windows path");
+  }
+
+  std::wstring wpath(AddUncPrefixMaybe(path));
+  DWORD size = ::GetLongPathNameW(wpath.c_str(), NULL, 0);
   if (size == 0) {
     DWORD err_code = GetLastError();
     return MakeErrorMessage(WSTR(__FILE__), __LINE__, L"GetLongPathNameW", path,
                             err_code);
   }
   result->reset(new WCHAR[size]);
-  ::GetLongPathNameW(path, result->get(), size);
+  ::GetLongPathNameW(wpath.c_str(), result->get(), size);
   return L"";
 }
 
@@ -142,6 +141,23 @@ typedef struct _JunctionDescription {
 
 int CreateJunction(const wstring& junction_name, const wstring& junction_target,
                    wstring* error) {
+  if (!IsAbsoluteNormalizedWindowsPath(junction_name)) {
+    if (error) {
+      *error = MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"CreateJunction", junction_name,
+          L"expected an absolute Windows path for junction_name");
+    }
+    CreateJunctionResult::kError;
+  }
+  if (!IsAbsoluteNormalizedWindowsPath(junction_target)) {
+    if (error) {
+      *error = MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"CreateJunction", junction_target,
+          L"expected an absolute Windows path for junction_target");
+    }
+    CreateJunctionResult::kError;
+  }
+
   const wstring target = HasUncPrefix(junction_target.c_str())
                              ? junction_target.substr(4)
                              : junction_target;
@@ -220,23 +236,11 @@ int CreateJunction(const wstring& junction_name, const wstring& junction_target,
         return CreateJunctionResult::kDisappeared;
       }
 
-      wstring err_str = uint32asHexString(err);
       // The path seems to exist yet we cannot open it for metadata-reading.
       // Report as much information as we have, then give up.
-      DWORD attr = GetAttributesOfMaybeMissingFile(name.c_str());
-      if (attr == INVALID_FILE_ATTRIBUTES) {
-        if (error) {
-          *error = MakeErrorMessage(
-              WSTR(__FILE__), __LINE__, L"CreateFileW", name,
-              wstring(L"err=0x") + err_str + L", invalid attributes");
-        }
-      } else {
-        if (error) {
-          *error =
-              MakeErrorMessage(WSTR(__FILE__), __LINE__, L"CreateFileW", name,
-                               wstring(L"err=0x") + err_str + L", attr=0x" +
-                                   uint32asHexString(attr));
-        }
+      if (error) {
+        *error = MakeErrorMessage(WSTR(__FILE__), __LINE__, L"CreateFileW",
+                                  name, err);
       }
       return CreateJunctionResult::kError;
     }
@@ -429,7 +433,7 @@ int DeletePath(const wstring& path, wstring* error) {
         // The file disappeared, or one of its parent directories disappeared,
         // or one of its parent directories is no longer a directory.
         return DeletePathResult::kDoesNotExist;
-      } else if (err != ERROR_ACCESS_DENIED) {
+      } else {
         // Some unknown error occurred.
         if (error) {
           *error = MakeErrorMessage(WSTR(__FILE__), __LINE__,
@@ -437,14 +441,9 @@ int DeletePath(const wstring& path, wstring* error) {
         }
         return DeletePathResult::kError;
       }
-
-      attr = GetAttributesOfMaybeMissingFile(wpath);
-      if (attr == INVALID_FILE_ATTRIBUTES) {
-        // The path is already deleted.
-        return DeletePathResult::kDoesNotExist;
-      }
     }
 
+    // DeleteFileW failed with access denied, but the path exists.
     if (attr & FILE_ATTRIBUTE_DIRECTORY) {
       // It's a directory or a junction.
       if (!RemoveDirectoryW(wpath)) {

--- a/src/main/native/windows/file.h
+++ b/src/main/native/windows/file.h
@@ -45,6 +45,8 @@ std::wstring AddUncPrefixMaybe(const std::wstring& path);
 
 std::wstring RemoveUncPrefixMaybe(const std::wstring& path);
 
+bool IsAbsoluteNormalizedWindowsPath(const std::wstring& p);
+
 // Keep in sync with j.c.g.devtools.build.lib.windows.WindowsFileOperations
 enum {
   IS_JUNCTION_YES = 0,

--- a/src/main/native/windows/file.h
+++ b/src/main/native/windows/file.h
@@ -93,7 +93,7 @@ struct CreateJunctionResult {
 //   created using "mklink" instead of "mklink /d", as such symlinks don't
 //   behave the same way as directories (e.g. they can't be listed)
 // - IS_JUNCTION_ERROR, if `path` doesn't exist or some error occurred
-int IsJunctionOrDirectorySymlink(const WCHAR* path);
+int IsJunctionOrDirectorySymlink(const WCHAR* path, std::wstring* error);
 
 // Computes the long version of `path` if it has any 8dot3 style components.
 // Returns the empty string upon success, or a human-readable error message upon

--- a/src/test/native/windows/file_test.cc
+++ b/src/test/native/windows/file_test.cc
@@ -48,6 +48,32 @@ class WindowsFileOperationsTest : public ::testing::Test {
   void TearDown() override { DeleteAllUnder(GetTestTmpDirW()); }
 };
 
+TEST_F(WindowsFileOperationsTest, TestIsAbsoluteWindowsStylePath) {
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L""));
+  EXPECT_TRUE(IsAbsoluteNormalizedWindowsPath(L"NUL"));
+  EXPECT_TRUE(IsAbsoluteNormalizedWindowsPath(L"nul"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"c"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"\\\\?\\c"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"c:"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"\\\\?\\c:"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"c:/"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"\\\\?\\c:/"));
+  EXPECT_TRUE(IsAbsoluteNormalizedWindowsPath(L"c:\\"));
+  EXPECT_TRUE(IsAbsoluteNormalizedWindowsPath(L"\\\\?\\c:\\"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"c:\\foo/bar"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"\\\\?\\c:\\foo/bar"));
+  EXPECT_TRUE(IsAbsoluteNormalizedWindowsPath(L"c:\\foo\\bar"));
+  EXPECT_TRUE(IsAbsoluteNormalizedWindowsPath(L"\\\\?\\c:\\foo\\bar"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"foo"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"foo\\bar"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"c:\\foo\\."));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"\\\\?\\c:\\foo\\."));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"c:\\foo\\.\\bar"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"\\\\?\\c:\\foo\\.\\bar"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"c:\\foo\\..\\bar"));
+  EXPECT_FALSE(IsAbsoluteNormalizedWindowsPath(L"\\\\?\\c:\\foo\\..\\bar"));
+}
+
 TEST_F(WindowsFileOperationsTest, TestCreateJunction) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring target(tmp + L"\\junc_target");

--- a/src/test/native/windows/file_test.cc
+++ b/src/test/native/windows/file_test.cc
@@ -81,7 +81,8 @@ TEST_F(WindowsFileOperationsTest, TestCreateJunction) {
   wstring file1(target + L"\\foo");
   EXPECT_TRUE(blaze_util::CreateDummyFile(file1));
 
-  EXPECT_EQ(IS_JUNCTION_NO, IsJunctionOrDirectorySymlink(target.c_str()));
+  EXPECT_EQ(IS_JUNCTION_NO, IsJunctionOrDirectorySymlink(target.c_str(),
+                                                         nullptr));
   EXPECT_NE(INVALID_FILE_ATTRIBUTES, ::GetFileAttributesW(file1.c_str()));
 
   wstring name(tmp + L"\\junc_name");
@@ -99,13 +100,13 @@ TEST_F(WindowsFileOperationsTest, TestCreateJunction) {
 
   // Assert creation of the junctions.
   ASSERT_EQ(IS_JUNCTION_YES,
-            IsJunctionOrDirectorySymlink((name + L"1").c_str()));
+            IsJunctionOrDirectorySymlink((name + L"1").c_str(), nullptr));
   ASSERT_EQ(IS_JUNCTION_YES,
-            IsJunctionOrDirectorySymlink((name + L"2").c_str()));
+            IsJunctionOrDirectorySymlink((name + L"2").c_str(), nullptr));
   ASSERT_EQ(IS_JUNCTION_YES,
-            IsJunctionOrDirectorySymlink((name + L"3").c_str()));
+            IsJunctionOrDirectorySymlink((name + L"3").c_str(), nullptr));
   ASSERT_EQ(IS_JUNCTION_YES,
-            IsJunctionOrDirectorySymlink((name + L"4").c_str()));
+            IsJunctionOrDirectorySymlink((name + L"4").c_str(), nullptr));
 
   // Assert that the file is visible under all junctions.
   ASSERT_NE(INVALID_FILE_ATTRIBUTES,


### PR DESCRIPTION
Also remove the GetAttributesOfMaybeMissingFile
method because it's based on a false belief,
namely that FindFirstFile returns up-to-date
information. According to this OldNewThing post
that belief was wrong:
https://blogs.msdn.microsoft.com/oldnewthing/20111226-00/?p=8813

This PR is a follow-up to https://github.com/bazelbuild/bazel/pull/7176
