### PR TITLE
remote: refactor the code to make dead code obvious

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -87,25 +87,6 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
   }
 
   /**
-   * Ensures that the tree structure of the inputs, the input files themselves, and the command are
-   * available in the remote cache, such that the tree can be reassembled and executed on another
-   * machine given the root digest.
-   *
-   * <p>The cache may check whether files or parts of the tree structure are already present, and do
-   * not need to be uploaded again.
-   *
-   * <p>Note that this method is only required for remote execution, not for caching itself.
-   * However, remote execution uses a cache to store input files, and that may be a separate
-   * end-point from the executor itself, so the functionality lives here. A pure remote caching
-   * implementation that does not support remote execution may choose not to implement this
-   * function, and throw {@link UnsupportedOperationException} instead. If so, it should be clearly
-   * documented that it cannot be used for remote execution.
-   */
-  public abstract void ensureInputsPresent(
-      TreeNodeRepository repository, Path execRoot, TreeNode root, Action action, Command command)
-      throws IOException, InterruptedException;
-
-  /**
    * Attempts to look up the given action in the remote cache and return its result, if present.
    * Returns {@code null} if there is no such entry. Note that a successful result from this method
    * does not guarantee the availability of the corresponding output files in the remote cache.

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
@@ -189,10 +189,17 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
   }
 
   /**
-   * Upload enough of the tree metadata and data into remote cache so that the entire tree can be
-   * reassembled remotely using the root digest.
+   * Ensures that the tree structure of the inputs, the input files themselves, and the command are
+   * available in the remote cache, such that the tree can be reassembled and executed on another
+   * machine given the root digest.
+   *
+   * <p>The cache may check whether files or parts of the tree structure are already present, and do
+   * not need to be uploaded again.
+   *
+   * <p>Note that this method is only required for remote execution, not for caching itself.
+   * However, remote execution uses a cache to store input files, and that may be a separate
+   * end-point from the executor itself, so the functionality lives here.
    */
-  @Override
   public void ensureInputsPresent(
       TreeNodeRepository repository, Path execRoot, TreeNode root, Action action, Command command)
       throws IOException, InterruptedException {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.exec.ActionContextProvider;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.SpawnRunner;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.runtime.Command;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.vfs.Path;
@@ -40,26 +41,39 @@ import javax.annotation.Nullable;
  */
 final class RemoteActionContextProvider extends ActionContextProvider {
   private final CommandEnvironment env;
-  @Nullable private final AbstractRemoteActionCache cache;
+  private final AbstractRemoteActionCache cache;
   @Nullable private final GrpcRemoteExecutor executor;
   private final RemoteRetrier retrier;
   private final DigestUtil digestUtil;
-  private final Path logDir;
+  @Nullable private final Path logDir;
   private final AtomicReference<SpawnRunner> fallbackRunner = new AtomicReference<>();
 
-  RemoteActionContextProvider(
+  private RemoteActionContextProvider(
       CommandEnvironment env,
-      @Nullable AbstractRemoteActionCache cache,
+      AbstractRemoteActionCache cache,
       @Nullable GrpcRemoteExecutor executor,
       RemoteRetrier retrier,
       DigestUtil digestUtil,
-      Path logDir) {
-    this.env = env;
+      @Nullable Path logDir) {
+    this.env = Preconditions.checkNotNull(env, "env");
+    this.cache = Preconditions.checkNotNull(cache, "cache");
     this.executor = executor;
-    this.cache = cache;
     this.retrier = retrier;
     this.digestUtil = digestUtil;
     this.logDir = logDir;
+  }
+
+  public static RemoteActionContextProvider createForRemoteCaching(CommandEnvironment env,
+      AbstractRemoteActionCache cache, RemoteRetrier retrier, DigestUtil digestUtil) {
+    return new RemoteActionContextProvider(env, cache, /*executor=*/ null, retrier,
+        digestUtil, /*logDir=*/ null);
+  }
+
+  public static RemoteActionContextProvider createForRemoteExecution(CommandEnvironment env,
+      GrpcRemoteCache cache, GrpcRemoteExecutor executor, RemoteRetrier retrier,
+      DigestUtil digestUtil, Path logDir) {
+    return new RemoteActionContextProvider(env, cache, executor, retrier,
+        digestUtil, logDir);
   }
 
   @Override
@@ -70,7 +84,7 @@ final class RemoteActionContextProvider extends ActionContextProvider {
     String buildRequestId = env.getBuildRequestId();
     String commandId = env.getCommandId().toString();
 
-    if (executor == null && cache != null) {
+    if (executor == null) {
       RemoteSpawnCache spawnCache =
           new RemoteSpawnCache(
               env.getExecRoot(),
@@ -92,7 +106,7 @@ final class RemoteActionContextProvider extends ActionContextProvider {
               env.getReporter(),
               buildRequestId,
               commandId,
-              cache,
+              (GrpcRemoteCache) cache,
               executor,
               retrier,
               digestUtil,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -285,7 +285,7 @@ public final class RemoteModule extends BlazeModule {
             "Only the gRPC cache is support for remote execution");
         actionContextProvider = RemoteActionContextProvider.createForRemoteExecution(env,
             (GrpcRemoteCache) cache, executor, executeRetrier, digestUtil, logDir);
-      } else {
+      } else if (cache != null ){
         actionContextProvider = RemoteActionContextProvider.createForRemoteCaching(env, cache,
             executeRetrier, digestUtil);
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -52,6 +52,7 @@ import com.google.rpc.PreconditionFailure.Violation;
 import io.grpc.CallCredentials;
 import io.grpc.ClientInterceptor;
 import io.grpc.Context;
+import io.grpc.Grpc;
 import io.grpc.Status.Code;
 import io.grpc.protobuf.StatusProto;
 import java.io.IOException;
@@ -280,6 +281,8 @@ public final class RemoteModule extends BlazeModule {
                 GoogleAuthUtils.newCallCredentials(authAndTlsOptions),
                 retrier);
         execChannel.release();
+        Preconditions.checkState(cache instanceof GrpcRemoteCache,
+            "Only the gRPC cache is support for remote execution");
         actionContextProvider = RemoteActionContextProvider.createForRemoteExecution(env,
             (GrpcRemoteCache) cache, executor, executeRetrier, digestUtil, logDir);
       } else {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -280,9 +280,12 @@ public final class RemoteModule extends BlazeModule {
                 GoogleAuthUtils.newCallCredentials(authAndTlsOptions),
                 retrier);
         execChannel.release();
+        actionContextProvider = RemoteActionContextProvider.createForRemoteExecution(env,
+            (GrpcRemoteCache) cache, executor, executeRetrier, digestUtil, logDir);
+      } else {
+        actionContextProvider = RemoteActionContextProvider.createForRemoteCaching(env, cache,
+            executeRetrier, digestUtil);
       }
-      actionContextProvider =
-          new RemoteActionContextProvider(env, cache, executor, executeRetrier, digestUtil, logDir);
     } catch (IOException e) {
       env.getReporter().handle(Event.error(e.getMessage()));
       env.getBlazeModuleEnvironment()

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -26,6 +26,7 @@ import build.bazel.remote.execution.v2.LogFile;
 import build.bazel.remote.execution.v2.Platform;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -92,7 +93,7 @@ class RemoteSpawnRunner implements SpawnRunner {
   private final boolean verboseFailures;
 
   @Nullable private final Reporter cmdlineReporter;
-  @Nullable private final AbstractRemoteActionCache remoteCache;
+  private final GrpcRemoteCache remoteCache;
   @Nullable private final GrpcRemoteExecutor remoteExecutor;
   @Nullable private final RemoteRetrier retrier;
   private final String buildRequestId;
@@ -112,7 +113,7 @@ class RemoteSpawnRunner implements SpawnRunner {
       @Nullable Reporter cmdlineReporter,
       String buildRequestId,
       String commandId,
-      @Nullable AbstractRemoteActionCache remoteCache,
+      GrpcRemoteCache remoteCache,
       @Nullable GrpcRemoteExecutor remoteExecutor,
       @Nullable RemoteRetrier retrier,
       DigestUtil digestUtil,
@@ -121,7 +122,7 @@ class RemoteSpawnRunner implements SpawnRunner {
     this.remoteOptions = remoteOptions;
     this.executionOptions = executionOptions;
     this.fallbackRunner = fallbackRunner;
-    this.remoteCache = remoteCache;
+    this.remoteCache = Preconditions.checkNotNull(remoteCache, "remoteCache");
     this.remoteExecutor = remoteExecutor;
     this.verboseFailures = verboseFailures;
     this.cmdlineReporter = cmdlineReporter;
@@ -140,7 +141,7 @@ class RemoteSpawnRunner implements SpawnRunner {
   @Override
   public SpawnResult exec(Spawn spawn, SpawnExecutionContext context)
       throws ExecException, InterruptedException, IOException {
-    if (!Spawns.mayBeExecutedRemotely(spawn) || remoteCache == null) {
+    if (!Spawns.mayBeExecutedRemotely(spawn)) {
       return execLocally(spawn, context);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
@@ -72,21 +72,6 @@ public final class SimpleBlobStoreActionCache extends AbstractRemoteActionCache 
     this.storedBlobs = new ConcurrentHashMap<>();
   }
 
-  @Override
-  public void ensureInputsPresent(
-      TreeNodeRepository repository, Path execRoot, TreeNode root, Action action, Command command)
-          throws IOException, InterruptedException {
-    repository.computeMerkleDigests(root);
-    uploadBlob(action.toByteArray());
-    uploadBlob(command.toByteArray());
-    for (Directory directory : repository.treeToDirectories(root)) {
-      uploadBlob(directory.toByteArray());
-    }
-    for (TreeNode leaf : repository.leaves(root)) {
-      uploadFileContents(leaf.getActionInput(), execRoot, repository.getInputFileCache());
-    }
-  }
-
   public void downloadTree(Digest rootDigest, Path rootLocation)
       throws IOException, InterruptedException {
     rootLocation.createDirectoryAndParents();

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -719,13 +719,6 @@ public class AbstractRemoteActionCacheTests {
       return Utils.getFromFuture(f);
     }
 
-    @Override
-    public void ensureInputsPresent(
-        TreeNodeRepository repository, Path execRoot, TreeNode root, Action action, Command command)
-        throws IOException, InterruptedException {
-      throw new UnsupportedOperationException();
-    }
-
     @Nullable
     @Override
     ActionResult getCachedActionResult(ActionKey actionKey)

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -234,13 +234,6 @@ public class RemoteSpawnCacheTest {
     // All other methods on RemoteActionCache have side effects, so we verify all of them.
     verify(remoteCache).download(actionResult, execRoot, outErr);
     verify(remoteCache, never())
-        .ensureInputsPresent(
-            any(TreeNodeRepository.class),
-            any(Path.class),
-            any(TreeNode.class),
-            any(Action.class),
-            any(Command.class));
-    verify(remoteCache, never())
         .upload(
             any(ActionKey.class),
             any(Action.class),

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -114,7 +114,7 @@ public class RemoteSpawnRunnerTest {
   private RemoteOptions options;
   private RemoteRetrier retrier;
 
-  @Mock private AbstractRemoteActionCache cache;
+  @Mock private GrpcRemoteCache cache;
 
   @Mock
   private GrpcRemoteExecutor executor;


### PR DESCRIPTION
ensureInputsPresent(...) is only used during remote execution. The GrpcRemoteCache is the only supported remote cache for remote execution. This change makes this obvious through types.