### PR TITLE
remote: fix callside with incorrect path construction

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionInputHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionInputHelper.java
@@ -221,7 +221,7 @@ public final class ActionInputHelper {
   }
 
   /** Returns the {@link Path} for an {@link ActionInput}. */
-  public static Path toPath(ActionInput input, Path execRoot) {
+  public static Path toInputPath(ActionInput input, Path execRoot) {
     Preconditions.checkNotNull(input, "input");
     Preconditions.checkNotNull(execRoot, "execRoot");
 

--- a/src/main/java/com/google/devtools/build/lib/exec/SingleBuildFileCache.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SingleBuildFileCache.java
@@ -60,7 +60,7 @@ public class SingleBuildFileCache implements MetadataProvider {
           .get(
               input.getExecPathString(),
               () -> {
-                Path path = ActionInputHelper.toPath(input, execRoot);
+                Path path = ActionInputHelper.toInputPath(input, execRoot);
                 try {
                   FileArtifactValue metadata = FileArtifactValue.create(path);
                   if (metadata.getType().isDirectory()) {

--- a/src/main/java/com/google/devtools/build/lib/remote/Chunker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Chunker.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.vfs.Path;
@@ -284,7 +285,7 @@ public final class Chunker {
         inputStream =
             () -> {
               try {
-                return execRoot.getRelative(actionInput.getExecPathString()).getInputStream();
+                return ActionInputHelper.toInputPath(actionInput, execRoot).getInputStream();
               } catch (IOException e) {
                 throw new RuntimeException(e);
               }

--- a/src/main/java/com/google/devtools/build/lib/remote/TreeNodeRepository.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/TreeNodeRepository.java
@@ -340,7 +340,7 @@ public final class TreeNodeRepository {
       Preconditions.checkArgument(
           inputsStart == inputsEnd - 1, "Encountered two inputs with the same path.");
       ActionInput input = inputs.get(inputsStart);
-      Path leafPath = ActionInputHelper.toPath(input, execRoot);
+      Path leafPath = ActionInputHelper.toInputPath(input, execRoot);
       if (!(input instanceof VirtualActionInput) && uploadSymlinks) {
         FileStatus stat = leafPath.stat(Symlinks.NOFOLLOW);
         if (stat.isSymbolicLink()) {
@@ -405,7 +405,7 @@ public final class TreeNodeRepository {
           if (uploadSymlinks) {
             // We need to stat the input to check whether it is a symlink.
             // getInputMetadata only gives target metadata.
-            Path inputPath = ActionInputHelper.toPath(input, execRoot);
+            Path inputPath = ActionInputHelper.toInputPath(input, execRoot);
             FileStatus stat = inputPath.stat(Symlinks.NOFOLLOW);
             if (stat.isSymbolicLink()) {
               PathFragment target = inputPath.readSymbolicLink();


### PR DESCRIPTION
Like #7174, but only affecting remote execution. Also,
incorporate feedback from #7174 and rename toPath to toInputPath.