### PR TITLE
Handling exceptions from test runner for graceful termination

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/BazelTestRunner.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/BazelTestRunner.java
@@ -85,7 +85,7 @@ public class BazelTestRunner {
     } catch (Throwable e) {
       // An exception was thrown by the runner. Print the error to the output stream so it will be logged
       // by the executing strategy, and return a failure, so this process can gracefully shut down.
-      e.printStackTrace(System.err);
+      e.printStackTrace();
       exitCode = 1;
     }
 

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/BazelTestRunner.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/BazelTestRunner.java
@@ -79,7 +79,15 @@ public class BazelTestRunner {
       System.exit(2);
     }
 
-    int exitCode = runTestsInSuite(suiteClassName, args);
+    int exitCode;
+    try {
+      exitCode = runTestsInSuite(suiteClassName, args);
+    } catch (Throwable e) {
+      // An exception was thrown by the runner. Print the error to the output stream so it will be logged
+      // by the executing strategy, and return a failure, so this process can gracefully shut down.
+      e.printStackTrace(System.err);
+      exitCode = 1;
+    }
 
     System.err.printf("%nBazelTestRunner exiting with a return value of %d%n", exitCode);
     System.err.println("JVM shutdown hooks (if any) will run now.");

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/ExperimentalTestRunner.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/ExperimentalTestRunner.java
@@ -82,7 +82,15 @@ public class ExperimentalTestRunner {
       System.exit(2);
     }
 
-    int exitCode = runTestsInSuite(suiteClassName, args);
+    int exitCode;
+    try {
+      exitCode = runTestsInSuite(suiteClassName, args);
+    } catch (Throwable e) {
+      // An exception was thrown by the runner. Print the error to the output stream so it will be logged
+      // by the executing strategy, and return a failure, so this process can gracefully shut down.
+      e.printStackTrace(System.err);
+      exitCode = 1;
+    }
 
     System.err.printf("%nExperimentalTestRunner exiting with a return value of %d%n", exitCode);
     System.err.println("JVM shutdown hooks (if any) will run now.");

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/ExperimentalTestRunner.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/ExperimentalTestRunner.java
@@ -88,7 +88,7 @@ public class ExperimentalTestRunner {
     } catch (Throwable e) {
       // An exception was thrown by the runner. Print the error to the output stream so it will be logged
       // by the executing strategy, and return a failure, so this process can gracefully shut down.
-      e.printStackTrace(System.err);
+      e.printStackTrace();
       exitCode = 1;
     }
 


### PR DESCRIPTION
If an unhandled exception occurs during the execution of a test suite, it will cause the TestRunner process to hang, and only be terminated after a timeout from the executing strategy.
This PR wraps the actual test execution with a try/catch, allowing the test runner to report the error and gracefully terminate. This allows the exception text be written to `test.log`, and the executing strategy will create a `test.xml` out of it, so the error is correctly reported in the tools (such as Intellij)

Note: added the snippet to both `BazelTestRunner` and the `ExperimentalTestRunner`, but not sure if the latter is needed.