### PR TITLE
add infra to provide authentication headers to blaze modules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/AuthHeadersProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/AuthHeadersProvider.java
@@ -1,0 +1,44 @@
+package com.google.devtools.build.lib.runtime;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generic interface to provide authentication headers for http/grpc requests
+ * to bazel modules.
+ */
+public interface AuthHeadersProvider {
+
+  /**
+   * Returns the type of authentication mechanism used i.e. oauth.
+   */
+  String getType();
+
+  /**
+   * Returns request headers necessary for authentication to be added to the http/grpc request.
+   *
+   * <p>For auth tokens with a TTL attached an implementation is expected to transparently
+   * refresh the tokens and to always return headers with sufficient TTL left to complete
+   * the request.
+   */
+  Map<String, List<String>> getRequestHeaders(URI uri) throws IOException;
+
+  /**
+   * Refreshes the authentication credentials i.e. if an access token expired.
+   *
+   * <p>This method should be called by clients if a request fails due to expired authentication
+   * credentials. Clients may then retry the request by retrieving new headers via
+   * {@link #getRequestHeaders(URI)}.
+   */
+  void refresh() throws IOException;
+
+  /**
+   * Returns {@code true} if this provider is enabled and can provide
+   * auth headers.
+   *
+   * <p>This method is a necessity due to the way blaze modules work.
+   */
+  boolean isEnabled();
+}

--- a/src/main/java/com/google/devtools/build/lib/runtime/AuthHeadersProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/AuthHeadersProvider.java
@@ -4,11 +4,15 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Generic interface to provide authentication headers for http/grpc requests
  * to bazel modules.
+ *
+ * <p>Implementations need to be thread-safe.
  */
+@ThreadSafe
 public interface AuthHeadersProvider {
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -160,6 +160,7 @@ public final class BlazeRuntime {
   private final String productName;
   private final BuildEventArtifactUploaderFactoryMap buildEventArtifactUploaderFactoryMap;
   private final ActionKeyContext actionKeyContext;
+  private final ImmutableMap<String, AuthHeadersProvider> authHeadersProviderMap;
 
   // Workspace state (currently exactly one workspace per server)
   private BlazeWorkspace workspace;
@@ -184,7 +185,8 @@ public final class BlazeRuntime {
       InvocationPolicy moduleInvocationPolicy,
       Iterable<BlazeCommand> commands,
       String productName,
-      BuildEventArtifactUploaderFactoryMap buildEventArtifactUploaderFactoryMap) {
+      BuildEventArtifactUploaderFactoryMap buildEventArtifactUploaderFactoryMap,
+      ImmutableMap<String, AuthHeadersProvider> authHeadersProviderMap) {
     // Server state
     this.fileSystem = fileSystem;
     this.blazeModules = blazeModules;
@@ -213,6 +215,8 @@ public final class BlazeRuntime {
         new CommandNameCacheImpl(getCommandMap()));
     this.productName = productName;
     this.buildEventArtifactUploaderFactoryMap = buildEventArtifactUploaderFactoryMap;
+    this.authHeadersProviderMap =
+        Preconditions.checkNotNull(authHeadersProviderMap, "authHeadersProviderMap");
   }
 
   public BlazeWorkspace initWorkspace(BlazeDirectories directories, BinTools binTools)
@@ -1347,6 +1351,13 @@ public final class BlazeRuntime {
   }
 
   /**
+   * Returns a map of all registered {@link AuthHeadersProvider}s.
+   */
+  public ImmutableMap<String, AuthHeadersProvider> getAuthHeadersProvidersMap() {
+    return authHeadersProviderMap;
+  }
+
+  /**
    * A builder for {@link BlazeRuntime} objects. The only required fields are the {@link
    * BlazeDirectories}, and the {@link RuleClassProvider} (except for testing). All other fields
    * have safe default values.
@@ -1466,7 +1477,8 @@ public final class BlazeRuntime {
           serverBuilder.getInvocationPolicy(),
           serverBuilder.getCommands(),
           productName,
-          serverBuilder.getBuildEventArtifactUploaderMap());
+          serverBuilder.getBuildEventArtifactUploaderMap(),
+          serverBuilder.getAuthHeadersProvidersMap());
     }
 
     public Builder setProductName(String productName) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/ServerBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/ServerBuilder.java
@@ -45,6 +45,8 @@ public final class ServerBuilder {
       ImmutableList.builder();
   private final BuildEventArtifactUploaderFactoryMap.Builder buildEventArtifactUploaderFactories =
       new BuildEventArtifactUploaderFactoryMap.Builder();
+  private final ImmutableMap.Builder<String, AuthHeadersProvider> authHeadersProvidersMap =
+      ImmutableMap.builder();
 
   @VisibleForTesting
   public ServerBuilder() {}
@@ -180,5 +182,22 @@ public final class ServerBuilder {
       BuildEventArtifactUploaderFactory uploaderFactory, String name) {
     buildEventArtifactUploaderFactories.add(name, uploaderFactory);
     return this;
+  }
+
+  /**
+   * Register a provider of authentication headers that blaze modules can
+   * use. See {@link AuthHeadersProvider} for more details.
+   */
+  public ServerBuilder addAuthHeadersProvider(String name,
+      AuthHeadersProvider authHeadersProvider) {
+    authHeadersProvidersMap.put(name, authHeadersProvider);
+    return this;
+  }
+
+  /**
+   * Returns a map of all registered {@link AuthHeadersProvider}s.
+   */
+  public ImmutableMap<String, AuthHeadersProvider> getAuthHeadersProvidersMap() {
+    return authHeadersProvidersMap.build();
   }
 }


### PR DESCRIPTION
The authandtls package got us so far, but we can no longer have packages
directly depend on authentication libraries as else we'll also need
to maintain them inside the google repo.

This is a step towards being able to merge #6810.