### PR TITLE
Add symlink metadata to FileArtifactValue

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactFileMetadata.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactFileMetadata.java
@@ -252,13 +252,17 @@ public abstract class ArtifactFileMetadata {
   }
 
   /** Implementation of {@link ArtifactFileMetadata} for files that are symlinks. */
-  private static final class Symlink extends DifferentRealPath {
+  static final class Symlink extends DifferentRealPath {
     private final PathFragment linkTarget;
 
     private Symlink(
         PathFragment realPath, FileStateValue realFileStateValue, PathFragment linkTarget) {
       super(realPath, realFileStateValue);
       this.linkTarget = linkTarget;
+    }
+
+    public PathFragment getLinkTarget() {
+      return linkTarget;
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/actions/MetadataProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/MetadataProvider.java
@@ -28,15 +28,13 @@ public interface MetadataProvider {
    * then t >= p. Aside from these properties, t can be any value and may vary arbitrarily across
    * calls.
    *
-   * <p>Returned {@link FileArtifactValue} instance corresponds to the final target of a symlink and
-   * therefore must not have a type of {@link FileStateType#SYMLINK}.
-   *
    * <p>The return value is owned by the cache and must not be modified.
    *
    * @param input the input to retrieve the digest for
    * @return the artifact's digest or null if digest cannot be obtained (due to artifact
    *     non-existence, lookup errors, or any other reason)
-   * @throws DigestOfDirectoryException in case {@code input} is a directory.
+   * @throws DigestOfDirectoryException in case {@code input} is a directory, or a symlink to a
+   * directory.
    * @throws IOException If the file cannot be digested.
    */
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/exec/SingleBuildFileCache.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SingleBuildFileCache.java
@@ -19,6 +19,7 @@ import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.DigestOfDirectoryException;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.FileArtifactValue.SymlinkArtifactValue;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
@@ -63,7 +64,11 @@ public class SingleBuildFileCache implements MetadataProvider {
                 Path path = ActionInputHelper.toInputPath(input, execRoot);
                 try {
                   FileArtifactValue metadata = FileArtifactValue.create(path);
-                  if (metadata.getType().isDirectory()) {
+
+                  boolean isDirectory = metadata.getType().isDirectory();
+                  isDirectory = isDirectory || metadata.getType().isSymlink() &&
+                      ((SymlinkArtifactValue) metadata).getResolvedValue().getType().isDirectory();
+                  if (isDirectory) {
                     throw new DigestOfDirectoryException(
                         "Input is a directory: " + input.getExecPathString());
                   }


### PR DESCRIPTION
This change makes skyframe track symlinks in output files and
invalidate actions if symlink targets change. This change is
a preqrequisite to encoding symlink information in the open
source remote execution protocol.