### PR TITLE
Support subresource integrity format for `download()` checksums.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -84,6 +84,7 @@ public final class WorkspaceRuleEvent implements ProgressLike {
       List<URL> urls,
       String output,
       String sha256,
+      String integrity,
       Boolean executable,
       String ruleLabel,
       Location location) {
@@ -91,6 +92,7 @@ public final class WorkspaceRuleEvent implements ProgressLike {
         WorkspaceLogProtos.DownloadEvent.newBuilder()
             .setOutput(output)
             .setSha256(sha256)
+            .setIntegrity(integrity)
             .setExecutable(executable);
     for (URL u : urls) {
       e.addUrl(u.toString());
@@ -135,6 +137,7 @@ public final class WorkspaceRuleEvent implements ProgressLike {
       List<URL> urls,
       String output,
       String sha256,
+      String integrity,
       String type,
       String stripPrefix,
       String ruleLabel,
@@ -143,6 +146,7 @@ public final class WorkspaceRuleEvent implements ProgressLike {
         WorkspaceLogProtos.DownloadAndExtractEvent.newBuilder()
             .setOutput(output)
             .setSha256(sha256)
+            .setIntegrity(integrity)
             .setType(type)
             .setStripPrefix(stripPrefix);
     for (URL u : urls) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
@@ -44,10 +44,12 @@ message DownloadEvent {
   repeated string url = 1;
   // Output file
   string output = 2;
-  // sha256, if speficied
+  // sha256, if specified
   string sha256 = 3;
   // whether to make the resulting file executable
   bool executable = 4;
+  // checksum in Subresource Integrity format, if specified
+  string integrity = 5;
 }
 
 message ExtractEvent {
@@ -70,6 +72,8 @@ message DownloadAndExtractEvent {
   string type = 4;
   // A directory prefix to strip from extracted files.
   string strip_prefix = 5;
+  // checksum in Subresource Integrity format, if specified
+  string integrity = 6;
 }
 
 // Information on "file" event in repository_ctx.

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepositoryCache.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/RepositoryCache.java
@@ -37,7 +37,9 @@ public class RepositoryCache {
   /** The types of cache keys used. */
   public enum KeyType {
     SHA1("SHA-1", "\\p{XDigit}{40}", "sha1", Hashing.sha1()),
-    SHA256("SHA-256", "\\p{XDigit}{64}", "sha256", Hashing.sha256());
+    SHA256("SHA-256", "\\p{XDigit}{64}", "sha256", Hashing.sha256()),
+    SHA384("SHA-384", "\\p{XDigit}{96}", "sha384", Hashing.sha384()),
+    SHA512("SHA-512", "\\p{XDigit}{128}", "sha512", Hashing.sha512());
 
     private final String stringRepr;
     private final String regexp;
@@ -62,6 +64,10 @@ public class RepositoryCache {
 
     public Hasher newHasher() {
       return hashFunction.newHasher();
+    }
+
+    public String getHashName() {
+      return hashName;
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Checksum.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Checksum.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import com.google.common.hash.HashCode;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
+import java.util.Base64;
 
 /** The content checksum for an HTTP download, which knows its own type. */
 public class Checksum {
@@ -33,6 +34,47 @@ public class Checksum {
       throw new IllegalArgumentException("Invalid " + keyType + " checksum '" + hash + "'");
     }
     return new Checksum(keyType, HashCode.fromString(hash));
+  }
+
+  /** Constructs a new Checksum from a hash in Subresource Integrity format. */
+  public static Checksum fromSubresourceIntegrity(String integrity) {
+    Base64.Decoder decoder = Base64.getDecoder();
+    KeyType keyType = null;
+    byte[] hash = null;
+    int expectedLength = 0;
+
+    if (integrity.startsWith("sha256-")) {
+      keyType = KeyType.SHA256;
+      expectedLength = 32;
+      hash = decoder.decode(integrity.substring(7));
+    }
+    if (integrity.startsWith("sha384-")) {
+      keyType = KeyType.SHA384;
+      expectedLength = 48;
+      hash = decoder.decode(integrity.substring(7));
+    }
+    if (integrity.startsWith("sha512-")) {
+      keyType = KeyType.SHA512;
+      expectedLength = 64;
+      hash = decoder.decode(integrity.substring(7));
+    }
+
+    if (keyType == null) {
+      throw new IllegalArgumentException("Unsupported checksum algorithm: '"
+          + integrity
+          + "' (expected SHA-256, SHA-384, or SHA-512)");
+    }
+
+    if (hash.length != expectedLength) {
+      throw new IllegalArgumentException("Invalid " + keyType + " SRI checksum '" + integrity + "'");
+    }
+
+    return Checksum.fromString(keyType, HashCode.fromBytes(hash).toString());
+  }
+
+  public String toSubresourceIntegrity() {
+    String encoded = Base64.getEncoder().encodeToString(hashCode.asBytes());
+    return keyType.getHashName() + "-" + encoded;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -444,7 +444,7 @@ public class SkylarkRepositoryContext
     return null;
   }
 
-  private void warnAboutSha256Error(List<URL> urls, String sha256) {
+  private void warnAboutChecksumError(List<URL> urls, String errorMessage) {
     // Inform the user immediately, even though the file will still be downloaded.
     // This cannot be done by a regular error event, as all regular events are recorded
     // and only shown once the execution of the repository rule is finished.
@@ -453,7 +453,7 @@ public class SkylarkRepositoryContext
     if (urls.size() > 0) {
       url = urls.get(0).toString();
     }
-    reportProgress("Will fail after download of " + url + ". Invalid SHA256 '" + sha256 + "'");
+    reportProgress("Will fail after download of " + url + ". " + errorMessage);
   }
 
   @Override
@@ -465,26 +465,31 @@ public class SkylarkRepositoryContext
       Boolean allowFail,
       String canonicalId,
       SkylarkDict<String, SkylarkDict<Object, Object>> auth,
+      String integrity,
       Location location)
       throws RepositoryFunctionException, EvalException, InterruptedException {
     Map<URI, Map<String, String>> authHeaders = getAuthHeaders(auth);
 
     List<URL> urls = getUrls(url, /* ensureNonEmpty= */ !allowFail);
-    RepositoryFunctionException sha256Validation = validateSha256(sha256, location);
-    if (sha256Validation != null) {
-      warnAboutSha256Error(urls, sha256);
-      sha256 = "";
-    }
     Optional<Checksum> checksum;
-    if (sha256.isEmpty()) {
-      checksum = Optional.absent();
-    } else {
-      checksum = Optional.of(Checksum.fromString(KeyType.SHA256, sha256));
+    RepositoryFunctionException checksumValidation = null;
+    try {
+      checksum = validateChecksum(sha256, integrity, urls, location);
+    } catch (RepositoryFunctionException e) {
+      checksum = Optional.<Checksum>absent();
+      checksumValidation = e;
     }
+
     SkylarkPath outputPath = getPath("download()", output);
     WorkspaceRuleEvent w =
         WorkspaceRuleEvent.newDownloadEvent(
-            urls, output.toString(), sha256, executable, rule.getLabel().toString(), location);
+            urls,
+            output.toString(),
+            sha256,
+            integrity,
+            executable,
+            rule.getLabel().toString(),
+            location);
     env.getListener().post(w);
     Path downloadedPath;
     try {
@@ -515,20 +520,11 @@ public class SkylarkRepositoryContext
         throw new RepositoryFunctionException(e, Transience.TRANSIENT);
       }
     }
-    if (sha256Validation != null) {
-      throw sha256Validation;
+    if (checksumValidation != null) {
+      throw checksumValidation;
     }
-    String finalSha256;
-    try {
-      finalSha256 = calculateSha256(sha256, downloadedPath);
-    } catch (IOException e) {
-      throw new RepositoryFunctionException(
-          new IOException(
-              "Couldn't hash downloaded file (" + downloadedPath.getPathString() + ")", e),
-          Transience.PERSISTENT);
-    }
-    SkylarkDict<String, Object> dict = SkylarkDict.of(null, "sha256", finalSha256, "success", true);
-    return StructProvider.STRUCT.createStruct(dict, null);
+
+    return calculateDownloadResult(checksum, downloadedPath);
   }
 
   @Override
@@ -576,21 +572,19 @@ public class SkylarkRepositoryContext
       Boolean allowFail,
       String canonicalId,
       SkylarkDict<String, SkylarkDict<Object, Object>> auth,
+      String integrity,
       Location location)
       throws RepositoryFunctionException, InterruptedException, EvalException {
     Map<URI, Map<String, String>> authHeaders = getAuthHeaders(auth);
 
     List<URL> urls = getUrls(url, /* ensureNonEmpty= */ !allowFail);
-    RepositoryFunctionException sha256Validation = validateSha256(sha256, location);
-    if (sha256Validation != null) {
-      warnAboutSha256Error(urls, sha256);
-      sha256 = "";
-    }
     Optional<Checksum> checksum;
-    if (sha256.isEmpty()) {
-      checksum = Optional.absent();
-    } else {
-      checksum = Optional.of(Checksum.fromString(KeyType.SHA256, sha256));
+    RepositoryFunctionException checksumValidation = null;
+    try {
+      checksum = validateChecksum(sha256, integrity, urls, location);
+    } catch (RepositoryFunctionException e) {
+      checksum = Optional.<Checksum>absent();
+      checksumValidation = e;
     }
 
     WorkspaceRuleEvent w =
@@ -598,6 +592,7 @@ public class SkylarkRepositoryContext
             urls,
             output.toString(),
             sha256,
+            integrity,
             type,
             stripPrefix,
             rule.getLabel().toString(),
@@ -634,8 +629,8 @@ public class SkylarkRepositoryContext
         throw new RepositoryFunctionException(e, Transience.TRANSIENT);
       }
     }
-    if (sha256Validation != null) {
-      throw sha256Validation;
+    if (checksumValidation != null) {
+      throw checksumValidation;
     }
     env.getListener().post(w);
     DecompressorValue.decompress(
@@ -646,15 +641,8 @@ public class SkylarkRepositoryContext
             .setRepositoryPath(outputPath.getPath())
             .setPrefix(stripPrefix)
             .build());
-    String finalSha256 = null;
-    try {
-      finalSha256 = calculateSha256(sha256, downloadedPath);
-    } catch (IOException e) {
-      throw new RepositoryFunctionException(
-          new IOException(
-              "Couldn't hash downloaded file (" + downloadedPath.getPathString() + ")", e),
-          Transience.PERSISTENT);
-    }
+
+    StructImpl downloadResult = calculateDownloadResult(checksum, downloadedPath);
     try {
       if (downloadedPath.exists()) {
         downloadedPath.delete();
@@ -665,33 +653,84 @@ public class SkylarkRepositoryContext
               "Couldn't delete temporary file (" + downloadedPath.getPathString() + ")", e),
           Transience.TRANSIENT);
     }
-    SkylarkDict<String, Object> dict = SkylarkDict.of(null, "sha256", finalSha256, "success", true);
-    return StructProvider.STRUCT.createStruct(dict, null);
+    return downloadResult;
   }
 
-  private String calculateSha256(String originalSha, Path path)
+  private Checksum calculateChecksum(Optional<Checksum> originalChecksum, Path path)
       throws IOException, InterruptedException {
-    if (!Strings.isNullOrEmpty(originalSha)) {
-      // The sha is checked on download, so if we got here, the user provided sha is good
-      return originalSha;
+    if (originalChecksum.isPresent()) {
+      // The checksum is checked on download, so if we got here, the user provided checksum is good
+      return originalChecksum.get();
     }
-    return RepositoryCache.getChecksum(KeyType.SHA256, path);
+    return Checksum.fromString(KeyType.SHA256, RepositoryCache.getChecksum(KeyType.SHA256, path));
   }
 
-  private RepositoryFunctionException validateSha256(String sha256, Location loc) {
-    if (!sha256.isEmpty() && !KeyType.SHA256.isValid(sha256)) {
-      return new RepositoryFunctionException(
+  private Optional<Checksum> validateChecksum(
+      String sha256, String integrity, List<URL> urls, Location loc)
+      throws RepositoryFunctionException, EvalException {
+    if (!sha256.isEmpty()) {
+      if (!integrity.isEmpty()) {
+        throw new EvalException(loc, "Expected either 'sha256' or 'integrity', but not both");
+      }
+      try {
+        return Optional.of(Checksum.fromString(KeyType.SHA256, sha256));
+      } catch (IllegalArgumentException e) {
+        warnAboutChecksumError(urls, e.getMessage());
+        throw new RepositoryFunctionException(
+            new EvalException(
+                loc,
+                "Definition of repository "
+                    + rule.getName()
+                    + ": "
+                    + e.getMessage()
+                    + " at "
+                    + rule.getLocation()),
+            Transience.PERSISTENT);
+      }
+    }
+
+    if (integrity.isEmpty()) {
+      return Optional.absent();
+    }
+
+    try {
+      return Optional.of(Checksum.fromSubresourceIntegrity(integrity));
+    } catch (IllegalArgumentException e) {
+      warnAboutChecksumError(urls, e.getMessage());
+      throw new RepositoryFunctionException(
           new EvalException(
               loc,
               "Definition of repository "
                   + rule.getName()
-                  + ": Syntactically invalid SHA256 checksum: '"
-                  + sha256
-                  + "' at "
+                  + ": "
+                  + e.getMessage()
+                  + " at "
                   + rule.getLocation()),
           Transience.PERSISTENT);
     }
-    return null;
+  }
+
+  private StructImpl calculateDownloadResult(Optional<Checksum> checksum, Path downloadedPath)
+      throws EvalException, InterruptedException, RepositoryFunctionException {
+    Checksum finalChecksum;
+    try {
+      finalChecksum = calculateChecksum(checksum, downloadedPath);
+    } catch (IOException e) {
+      throw new RepositoryFunctionException(
+          new IOException(
+              "Couldn't hash downloaded file (" + downloadedPath.getPathString() + ")", e),
+          Transience.PERSISTENT);
+    }
+
+    ImmutableMap.Builder<String, Object> out = new ImmutableMap.Builder<>();
+    out.put("success", true);
+    out.put("integrity", finalChecksum.toSubresourceIntegrity());
+
+    // For compatibility with older Bazel versions that don't support non-SHA256 checksums.
+    if (finalChecksum.getKeyType() == KeyType.SHA256) {
+      out.put("sha256", finalChecksum.toString());
+    }
+    return StructProvider.STRUCT.createStruct(SkylarkDict.copyOf(null, out.build()), null);
   }
 
   private static ImmutableList<String> checkAllUrls(Iterable<?> urlList) throws EvalException {

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/SkylarkRepositoryContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/SkylarkRepositoryContextApi.java
@@ -314,7 +314,7 @@ public interface SkylarkRepositoryContextApi<RepositoryFunctionExceptionT extend
       name = "download",
       doc =
           "Downloads a file to the output path for the provided url and returns a struct containing"
-              + " a hash of the file with the field <code>sha256</code>.",
+              + " a hash of the file with the fields <code>sha256</code> and <code>integrity</code>.",
       useLocation = true,
       parameters = {
         @Param(
@@ -374,6 +374,18 @@ public interface SkylarkRepositoryContextApi<RepositoryFunctionExceptionT extend
             defaultValue = "{}",
             named = true,
             doc = "An optional dict specifying authentication information for some of the URLs."),
+        @Param(
+            name = "integrity",
+            type = String.class,
+            defaultValue = "''",
+            named = true,
+            positional = false,
+            doc =
+                "Expected checksum of the file downloaded, in Subresource Integrity format."
+                    + " This must match the checksum of the file downloaded. It is a security"
+                    + " risk to omit the checksum as remote files can change. At best omitting this"
+                    + " field will make your build non-hermetic. It is optional to make development"
+                    + " easier but should be set before shipping."),
       })
   public StructApi download(
       Object url,
@@ -383,6 +395,7 @@ public interface SkylarkRepositoryContextApi<RepositoryFunctionExceptionT extend
       Boolean allowFail,
       String canonicalId,
       SkylarkDict<String, SkylarkDict<Object, Object>> auth,
+      String integrity,
       Location location)
       throws RepositoryFunctionExceptionT, EvalException, InterruptedException;
 
@@ -433,8 +446,8 @@ public interface SkylarkRepositoryContextApi<RepositoryFunctionExceptionT extend
       name = "download_and_extract",
       doc =
           "Downloads a file to the output path for the provided url, extracts it, and returns"
-              + " a struct containing a hash of the downloaded file with the field"
-              + " <code>sha256</code>.",
+              + " a struct containing a hash of the downloaded file with the fields"
+              + " <code>sha256</code> and <code>integrity</code>.",
       useLocation = true,
       parameters = {
         @Param(
@@ -516,6 +529,18 @@ public interface SkylarkRepositoryContextApi<RepositoryFunctionExceptionT extend
             defaultValue = "{}",
             named = true,
             doc = "An optional dict specifying authentication information for some of the URLs."),
+        @Param(
+            name = "integrity",
+            type = String.class,
+            defaultValue = "''",
+            named = true,
+            positional = false,
+            doc =
+                "Expected checksum of the file downloaded, in Subresource Integrity format."
+                    + " This must match the checksum of the file downloaded. It is a security"
+                    + " risk to omit the checksum as remote files can change. At best omitting this"
+                    + " field will make your build non-hermetic. It is optional to make development"
+                    + " easier but should be set before shipping."),
       })
   public StructApi downloadAndExtract(
       Object url,
@@ -526,6 +551,7 @@ public interface SkylarkRepositoryContextApi<RepositoryFunctionExceptionT extend
       Boolean allowFail,
       String canonicalId,
       SkylarkDict<String, SkylarkDict<Object, Object>> auth,
+      String integrity,
       Location location)
       throws RepositoryFunctionExceptionT, InterruptedException, EvalException;
 }

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -901,7 +901,7 @@ http_archive(
 )
 EOF
   bazel build @repo//... &> $TEST_log && fail "Expected to fail"
-  expect_log "[Ii]nvalid SHA256 checksum"
+  expect_log "[Ii]nvalid SHA-256 checksum"
   shutdown_server
 }
 


### PR DESCRIPTION
Closes #4881

Notes for the reviewer:
* I will add tests (in the existing bash repository rule tests) after preliminary approval of the implementation.
* Supported digests are the minimal recommended set from https://www.w3.org/TR/SRI/: SHA-256, SHA-384, and SHA-512. I did not enable support for SHA-1 checksums in this PR.
* Do we want to make the struct returned by `download()` and `download_and_extract()` less strict about having a `sha256` field? If we allowed the returned field to depend on the integrity list, then users of SHA-384 and SHA-512 checksums wouldn't need to re-checksum the downloaded file.