### PR TITLE
remote: warning is not an error

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -168,7 +168,7 @@ final class RemoteSpawnCache implements SpawnCache {
           if (isNullOrEmpty(errorMsg)) {
             errorMsg = e.getClass().getSimpleName();
           }
-          errorMsg = "Error reading from the remote cache:\n" + errorMsg;
+          errorMsg = "Reading from Remote Cache:\n" + errorMsg;
           report(Event.warn(errorMsg));
         }
       } finally {
@@ -216,7 +216,7 @@ final class RemoteSpawnCache implements SpawnCache {
             if (isNullOrEmpty(errorMsg)) {
               errorMsg = e.getClass().getSimpleName();
             }
-            errorMsg = "Error writing to the remote cache:\n" + errorMsg;
+            errorMsg = "Writing to Remote Cache:\n" + errorMsg;
             report(Event.warn(errorMsg));
           } finally {
             withMetadata.detach(previous);


### PR DESCRIPTION
don't display a warning containing the word error as this
is confusing for users. Now it will read as

> WARNING: Read from Remote Cache:
> error message

instead of

> WARNING: Error reading from the remote cache:
> error message