### PR TITLE
Make "local" actions uncachable by the RemoteSpawnCache.

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
@@ -35,10 +35,10 @@
     executed remotely (but it may be cached remotely).
   </li>
 
-  <li><code>local</code> keyword results in the action or test never being
-    run remotely or inside the
+  <li><code>local</code> keyword precludes the action or test from being remotely cached,
+    remotely executed, or run inside the
     <a href="../user-manual.html#sandboxing">sandbox</a>.
-    For genrules and tests, marking the rule with the <code>local = 1</code>
+    For genrules and tests, marking the rule with the <code>local = True</code>
     attribute has the same effect.
   </li>
 

--- a/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
@@ -29,7 +29,8 @@ public final class Spawns {
    * Returns {@code true} if the result of {@code spawn} may be cached.
    */
   public static boolean mayBeCached(Spawn spawn) {
-    return !spawn.getExecutionInfo().containsKey(ExecutionRequirements.NO_CACHE);
+    return !spawn.getExecutionInfo().containsKey(ExecutionRequirements.NO_CACHE)
+        && !spawn.getExecutionInfo().containsKey(ExecutionRequirements.LOCAL);
   }
 
   /** Returns whether a Spawn can be executed in a sandbox environment. */

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -298,30 +298,32 @@ public class RemoteSpawnCacheTest {
 
   @Test
   public void noCacheSpawns() throws Exception {
-    // Checks that spawns that have mayBeCached false are not looked up in the remote cache,
+    // Checks that spawns satisfying Spawns.mayBeCached false are not looked up in the remote cache,
     // and also that their result and artifacts are not uploaded to the remote cache.
-    SimpleSpawn uncacheableSpawn =
-        new SimpleSpawn(
-            new FakeOwner("foo", "bar"),
-            /*arguments=*/ ImmutableList.of(),
-            /*environment=*/ ImmutableMap.of(),
-            ImmutableMap.of(ExecutionRequirements.NO_CACHE, ""),
-            /*inputs=*/ ImmutableList.of(),
-            /*outputs=*/ ImmutableList.of(ActionInputHelper.fromPath("/random/file")),
-            ResourceSet.ZERO);
-    CacheHandle entry = cache.lookup(uncacheableSpawn, simplePolicy);
-    verify(remoteCache, never())
-        .getCachedActionResult(any(ActionKey.class));
-    assertThat(entry.hasResult()).isFalse();
-    SpawnResult result =
-        new SpawnResult.Builder()
-            .setExitCode(0)
-            .setStatus(Status.SUCCESS)
-            .setRunnerName("test")
-            .build();
-    entry.store(result);
-    verifyNoMoreInteractions(remoteCache);
-    assertThat(progressUpdates).containsExactly();
+    for (String requirement :
+        ImmutableList.of(ExecutionRequirements.NO_CACHE, ExecutionRequirements.LOCAL)) {
+      SimpleSpawn uncacheableSpawn =
+          new SimpleSpawn(
+              new FakeOwner("foo", "bar"),
+              /*arguments=*/ ImmutableList.of(),
+              /*environment=*/ ImmutableMap.of(),
+              ImmutableMap.of(requirement, ""),
+              /*inputs=*/ ImmutableList.of(),
+              /*outputs=*/ ImmutableList.of(ActionInputHelper.fromPath("/random/file")),
+              ResourceSet.ZERO);
+      CacheHandle entry = cache.lookup(uncacheableSpawn, simplePolicy);
+      verify(remoteCache, never()).getCachedActionResult(any(ActionKey.class));
+      assertThat(entry.hasResult()).isFalse();
+      SpawnResult result =
+          new SpawnResult.Builder()
+              .setExitCode(0)
+              .setStatus(Status.SUCCESS)
+              .setRunnerName("test")
+              .build();
+      entry.store(result);
+      verifyNoMoreInteractions(remoteCache);
+      assertThat(progressUpdates).containsExactly();
+    }
   }
 
   @Test

--- a/src/test/shell/bazel/disk_cache_test.sh
+++ b/src/test/shell/bazel/disk_cache_test.sh
@@ -40,7 +40,7 @@ genrule(
     cmd = "echo run > $execution_file && cat \$< >\$@",
     srcs = ["$input_file"],
     outs = ["foo.txt"],
-    tags = ["local"],
+    tags = ["no-sandbox"],
 )
 EOF
 


### PR DESCRIPTION
This gives RemoteSpawnCache the same behavior on "local" actions as RemoteSpawnRunner.

Conceptually, the "local" execution requirement is big hammer that prevents Bazel from doing anything smart at all in the execution of the action including remote execution and sandboxing.