### PR TITLE
Windows: native launcher can run from a long path

### DIFF
--- a/src/test/py/bazel/launcher_test.py
+++ b/src/test/py/bazel/launcher_test.py
@@ -616,19 +616,19 @@ class LauncherTest(test_base.TestBase):
                     os.path.join(long_dir_path, f))
 
     long_binary_path = os.path.abspath(long_dir_path + '/bin_java.exe')
-    # To run a binary at a long path, we need to set shell=True
+    # subprocess doesn't support long path without shell=True
     exit_code, stdout, stderr = self.RunProgram([long_binary_path], shell=True)
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertEqual('helloworld', ''.join(stdout))
 
     long_binary_path = os.path.abspath(long_dir_path + '/bin_sh.exe')
-    # To run a binary at a long path, we need to set shell=True
+    # subprocess doesn't support long path without shell=True
     exit_code, stdout, stderr = self.RunProgram([long_binary_path], shell=True)
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertEqual('helloworld', ''.join(stdout))
 
     long_binary_path = os.path.abspath(long_dir_path + '/bin_py.exe')
-    # To run a binary at a long path, we need to set shell=True
+    # subprocess doesn't support long path without shell=True
     exit_code, stdout, stderr = self.RunProgram([long_binary_path], shell=True)
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertEqual('helloworld', ''.join(stdout))

--- a/src/test/py/bazel/launcher_test.py
+++ b/src/test/py/bazel/launcher_test.py
@@ -15,6 +15,7 @@
 
 import os
 import stat
+import string
 import unittest
 from src.test.py.bazel import test_base
 
@@ -605,7 +606,7 @@ class LauncherTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
 
     # Create a directory with a path longer than 260
-    long_dir_path = "./" + "/".join(["a" * 100, "b" * 100, "c" * 100])
+    long_dir_path = "./" + "/".join([(c * 8 + "." + c * 3) for c in string.ascii_lowercase])
 
     for f in [
         'bin_java.exe', 'bin_java.exe.runfiles_manifest',

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -310,7 +310,7 @@ class TestBase(unittest.TestCase):
       print('--------------------------')
       print('\n'.join(stderr_lines))
 
-  def RunProgram(self, args, env_remove=None, env_add=None):
+  def RunProgram(self, args, env_remove=None, env_add=None, shell=False):
     """Runs a program (args[0]), waits for it to exit.
 
     Args:
@@ -319,6 +319,8 @@ class TestBase(unittest.TestCase):
         to the program
       env_add: {string: string}; optional; environment variables to pass to
         the program, won't be removed by env_remove.
+      shell: {bool: bool}; optional; whether to use the shell as the program
+        to execute
     Returns:
       (int, [string], [string]) tuple: exit code, stdout lines, stderr lines
     """
@@ -329,7 +331,8 @@ class TestBase(unittest.TestCase):
             stdout=stdout,
             stderr=stderr,
             cwd=self._test_cwd,
-            env=self._EnvMap(env_remove, env_add))
+            env=self._EnvMap(env_remove, env_add),
+            shell=shell)
         exit_code = proc.wait()
 
         stdout.seek(0)

--- a/src/tools/launcher/util/data_parser.cc
+++ b/src/tools/launcher/util/data_parser.cc
@@ -17,6 +17,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "src/main/cpp/util/path_platform.h"
 #include "src/main/cpp/util/strings.h"
 #include "src/tools/launcher/util/data_parser.h"
 #include "src/tools/launcher/util/launcher_util.h"
@@ -89,7 +90,8 @@ bool LaunchDataParser::ParseLaunchData(LaunchInfo* launch_info,
 bool LaunchDataParser::GetLaunchInfo(const wstring& binary_path,
                                      LaunchInfo* launch_info) {
   unique_ptr<ifstream> binary =
-      make_unique<ifstream>(binary_path, ios::binary | ios::in);
+      make_unique<ifstream>(AsAbsoluteWindowsPath(binary_path.c_str()).c_str(),
+                            ios::binary | ios::in);
   int64_t data_size = ReadDataSize(binary.get());
   if (data_size == 0) {
     PrintError(L"No data appended, cannot launch anything!");


### PR DESCRIPTION
This change fixed a bug in `src/tools/launcher/util/data_parser.cc` when running the native launcher at a long path.