### PR TITLE
 Do not upload artifacts from the local execution of no-cache spawns. 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -90,7 +90,10 @@ final class RemoteSpawnCache implements SpawnCache {
   @Override
   public CacheHandle lookup(Spawn spawn, SpawnExecutionContext context)
       throws InterruptedException, IOException, ExecException {
-    boolean checkCache = options.remoteAcceptCached && Spawns.mayBeCached(spawn);
+    if (!Spawns.mayBeCached(spawn)) {
+      return SpawnCache.NO_RESULT_NO_STORE;
+    }
+    boolean checkCache = options.remoteAcceptCached;
 
     if (checkCache) {
       context.report(ProgressStatus.CHECKING_CACHE, "remote-cache");
@@ -122,7 +125,7 @@ final class RemoteSpawnCache implements SpawnCache {
               digestUtil.compute(command),
               repository.getMerkleDigest(inputRoot),
               context.getTimeout(),
-              Spawns.mayBeCached(spawn));
+              true);
       // Look up action cache, and reuse the action output if it is found.
       actionKey = digestUtil.computeActionKey(action);
     }
@@ -197,10 +200,7 @@ final class RemoteSpawnCache implements SpawnCache {
               return;
             }
           }
-          boolean uploadAction =
-              Spawns.mayBeCached(spawn)
-                  && Status.SUCCESS.equals(result.status())
-                  && result.exitCode() == 0;
+          boolean uploadAction = Status.SUCCESS.equals(result.status()) && result.exitCode() == 0;
           Context previous = withMetadata.attach();
           Collection<Path> files =
               RemoteSpawnRunner.resolveActionInputs(execRoot, spawn.getOutputFiles());

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import build.bazel.remote.execution.v2.Action;
@@ -298,8 +299,7 @@ public class RemoteSpawnCacheTest {
   @Test
   public void noCacheSpawns() throws Exception {
     // Checks that spawns that have mayBeCached false are not looked up in the remote cache,
-    // and also that their result is not uploaded to the remote cache. The artifacts, however,
-    // are uploaded.
+    // and also that their result and artifacts are not uploaded to the remote cache.
     SimpleSpawn uncacheableSpawn =
         new SimpleSpawn(
             new FakeOwner("foo", "bar"),
@@ -320,16 +320,7 @@ public class RemoteSpawnCacheTest {
             .setRunnerName("test")
             .build();
     entry.store(result);
-    ImmutableList<Path> outputFiles = ImmutableList.of(fs.getPath("/random/file"));
-    verify(remoteCache)
-        .upload(
-            any(ActionKey.class),
-            any(Action.class),
-            any(Command.class),
-            any(Path.class),
-            eq(outputFiles),
-            eq(outErr),
-            eq(false));
+    verifyNoMoreInteractions(remoteCache);
     assertThat(progressUpdates).containsExactly();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
@@ -227,7 +228,7 @@ public class RemoteSpawnRunnerTest {
   @SuppressWarnings("unchecked")
   public void nonCachableSpawnsShouldNotBeCached_local() throws Exception {
     // Test that if a spawn is executed locally, due to the local fallback, that its result is not
-    // uploaded to the remote cache. However, the artifacts should still be uploaded.
+    // uploaded to the remote cache.
 
     options.remoteAcceptCached = true;
     options.remoteLocalFallback = true;
@@ -269,15 +270,7 @@ public class RemoteSpawnRunnerTest {
 
     verify(cache, never())
         .getCachedActionResult(any(ActionKey.class));
-    verify(cache)
-        .upload(
-            any(ActionKey.class),
-            any(Action.class),
-            any(Command.class),
-            any(Path.class),
-            any(Collection.class),
-            any(FileOutErr.class),
-            eq(false));
+    verifyNoMoreInteractions(cache);
   }
 
   @Test

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -306,10 +306,10 @@ EOF
       --test_output=errors \
       //a:test >& $TEST_log \
       && fail "Expected test failure" || true
-   $(is_file_uploaded bazel-testlogs/a/test/test.log) \
-     || fail "Expected test log to be uploaded to remote execution"
-   $(is_file_uploaded bazel-testlogs/a/test/test.xml) \
-     || fail "Expected test xml to be uploaded to remote execution"
+   ($(is_file_uploaded bazel-testlogs/a/test/test.log) \
+     && fail "Expected test log to not be uploaded to remote execution") || true
+   ($(is_file_uploaded bazel-testlogs/a/test/test.xml) \
+     && fail "Expected test xml to not be uploaded to remote execution") || true
 }
 
 # Tests that the remote worker can return a 200MB blob that requires chunking.


### PR DESCRIPTION
Previously, marking a spawn "no-cache" resulted in its outputs being uploaded but not the action result protobuf. This was confusing to many users, who want to use "no-cache" to prevent actions with large outputs from filling the cache.

Progress on #4343.

RELNOTES: Locally-executed spawns tagged "no-cache" no longer upload their outputs to the remote cache.