### PR TITLE
remote: print server provided message on failed action. Closes #6591

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -250,6 +250,14 @@ class RemoteSpawnRunner implements SpawnRunner {
               try (SilentCloseable c = Profiler.instance().profile("Remote.executeRemotely")) {
                 reply = remoteExecutor.executeRemotely(request);
               }
+
+              FileOutErr outErr = context.getFileOutErr();
+              String message = reply.getMessage();
+              if ((reply.getResult().getExitCode() != 0 ||
+                   reply.getStatus().getCode() != Code.OK.value()) && !message.isEmpty()) {
+                outErr.printErr(message + "\n");
+              }
+
               try (SilentCloseable c =
                   Profiler.instance().profile("Remote.maybeDownloadServerLogs")) {
                 maybeDownloadServerLogs(reply, actionKey);
@@ -257,7 +265,7 @@ class RemoteSpawnRunner implements SpawnRunner {
 
               try (SilentCloseable c =
                   Profiler.instance().profile("Remote.downloadRemoteResults")) {
-                return downloadRemoteResults(reply.getResult(), context.getFileOutErr())
+                return downloadRemoteResults(reply.getResult(), outErr)
                     .setRunnerName(reply.getCachedResult() ? "remote cache hit" : getName())
                     .setCacheHit(reply.getCachedResult())
                     .build();


### PR DESCRIPTION
Bazel Buildbarn recently gained a web frontend called bbb_browser that
can be used to explore the CAS/AC. It allows users to get better insight
in how remote execution works under the hood. It also makes it possible
for users to more easily share information on build failures with their
peers.

In order to make it easy for people to access this service, we'd like
build failures to automatically print links to the corresponding page in
bbb_browser to the terminal. We want to use the remote execution APIs
message field for that.