### PR TITLE
Rewrite Retrier.executeAsync to use Guava future chaining.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
@@ -149,10 +149,8 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
 
   private ListenableFuture<FindMissingBlobsResponse> getMissingDigests(
       FindMissingBlobsRequest request) throws IOException, InterruptedException {
-    final SettableFuture<FindMissingBlobsResponse> outerF = SettableFuture.create();
     Context ctx = Context.current();
-    retrier.executeAsync(() -> ctx.call(() -> casFutureStub().findMissingBlobs(request)), outerF);
-    return outerF;
+    return retrier.executeAsync(() -> ctx.call(() -> casFutureStub().findMissingBlobs(request)));
   }
 
   private ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests)


### PR DESCRIPTION
Not only is this more succinct, it means cancellation properly propagates through executeAsync futures.