### PR TITLE
Add RULEDIR to genrule's cmd

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
@@ -326,29 +326,17 @@ public abstract class GenRuleBase implements RuleConfiguredTargetFactory {
         return expandSingletonArtifact(filesToBuild, "$@", "output file");
       }
 
-      if (variableName.equals("OUT_ROOT_DIR")) {
+      if (variableName.equals("RULEDIR")) {
         // The output root directory. This variable expands to the package's root directory
         // in the genfiles tree.
-        Path dirPath;
         PathFragment dirFragment;
         if (ruleContext.getRule().hasBinaryOutput()) {
-          dirPath = ruleContext.getConfiguration().getBinDir().getRoot().asPath();
           dirFragment = ruleContext.getConfiguration().getBinFragment();
         } else {
-          dirPath = ruleContext.getConfiguration().getGenfilesDir().getRoot().asPath();
           dirFragment = ruleContext.getConfiguration().getGenfilesFragment();
         }
-
         PathFragment relPath = ruleContext.getRule().getLabel().getPackageIdentifier().getSourceRoot();
-        // TODO: Instead of creating a new directory, use the root
-        String outDirStr = "testing-genrules";
-        Path outputRootDir = dirPath.getRelative(relPath).getRelative(outDirStr);
-        try {
-          outputRootDir.createDirectory();
-        } catch (IOException e) {
-          throw new UncheckedIOException(e);
-        }
-        return dirFragment.getRelative(relPath).getRelative(outDirStr).getPathString();
+        return dirFragment.getRelative(relPath).getPathString();
       }
 
       if (variableName.equals("@D")) {

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
@@ -48,12 +48,8 @@ import com.google.devtools.build.lib.rules.cpp.CcCommon.CcFlagsSupplier;
 import com.google.devtools.build.lib.rules.cpp.CppHelper;
 import com.google.devtools.build.lib.syntax.Type;
 import com.google.devtools.build.lib.util.LazyString;
-import com.google.devtools.build.lib.vfs.FileSystemUtils;
-import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
@@ -329,14 +329,9 @@ public abstract class GenRuleBase implements RuleConfiguredTargetFactory {
       if (variableName.equals("RULEDIR")) {
         // The output root directory. This variable expands to the package's root directory
         // in the genfiles tree.
-        PathFragment dirFragment;
-        if (ruleContext.getRule().hasBinaryOutput()) {
-          dirFragment = ruleContext.getConfiguration().getBinFragment();
-        } else {
-          dirFragment = ruleContext.getConfiguration().getGenfilesFragment();
-        }
+        PathFragment dir = ruleContext.getBinOrGenfilesDirectory().getExecPath();
         PathFragment relPath = ruleContext.getRule().getLabel().getPackageIdentifier().getSourceRoot();
-        return dirFragment.getRelative(relPath).getPathString();
+        return dir.getRelative(relPath).getPathString();
       }
 
       if (variableName.equals("@D")) {

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBaseRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBaseRule.java
@@ -161,8 +161,8 @@ public class GenRuleBaseRule implements RuleDefinition {
             <p>
               Note that <code>outs</code> are <i>not</i> included in this substitution. Output files
               are always generated into a predictable location (available via <code>$(@D)</code>,
-              <code>$@</code>, <code>$(OUTS)</code> or <code>$(location <i>output_name</i>)</code>;
-              see below).
+              <code>$@</code>, <code>$(OUTS)</code> or <code>$(OUT_ROOT_DIR)</code> or
+              <code>$(location <i>output_name</i>)</code>; see below).
             </p>
           </li>
           <li>

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBaseRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBaseRule.java
@@ -161,7 +161,7 @@ public class GenRuleBaseRule implements RuleDefinition {
             <p>
               Note that <code>outs</code> are <i>not</i> included in this substitution. Output files
               are always generated into a predictable location (available via <code>$(@D)</code>,
-              <code>$@</code>, <code>$(OUTS)</code> or <code>$(OUT_ROOT_DIR)</code> or
+              <code>$@</code>, <code>$(OUTS)</code> or <code>$(RULEDIR)</code> or
               <code>$(location <i>output_name</i>)</code>; see below).
             </p>
           </li>

--- a/src/main/java/com/google/devtools/build/lib/vfs/PathFragment.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/PathFragment.java
@@ -241,8 +241,9 @@ public final class PathFragment
   /**
    * Returns the {@link PathFragment} relative to the base {@link PathFragment}.
    *
-   * <p>For example, <code>FilePath.create("foo/bar/wiz").relativeTo(FilePath.create("foo"))</code>
-   * returns <code>"bar/wiz"</code>.
+   * <p>For example,
+   * <code>{@link PathFragment}.create("foo/bar/wiz").relativeTo({@link PathFragment}.create("foo"))
+   * </code> returns <code>"bar/wiz"</code>.
    *
    * <p>If the {@link PathFragment} is not a child of the passed {@link PathFragment} an {@link
    * IllegalArgumentException} is thrown. In particular, this will happen whenever the two {@link


### PR DESCRIPTION
###Description of the problem / feature request:
Add new Make variable to genrule's cmd which always points to the output directory containing output from running genrule. See #7248 for details.