### PR TITLE
remote: add --remote_verify_downloads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
@@ -274,12 +274,6 @@ public final class RemoteOptions extends OptionsBase {
               + "cachable actions that output symlinks will fail.")
   public boolean allowSymlinkUpload;
 
-  // The below options are not configurable by users, only tests.
-  // This is part of the effort to reduce the overall number of flags.
-
-  /** The maximum size of an outbound message sent via a gRPC channel. */
-  public int maxOutboundMessageSize = 1024 * 1024;
-
   @Option(
       name = "remote_result_cache_priority",
       defaultValue = "0",
@@ -312,4 +306,20 @@ public final class RemoteOptions extends OptionsBase {
               + "This value will also be used if the host platform is selected as the execution "
               + "platform for remote execution.")
   public String remoteDefaultPlatformProperties;
+
+  @Option(
+      name = "remote_verify_downloads",
+      defaultValue = "true",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "If set to true, Bazel will compute the hash sum of all remote downloads and "
+          + " discard the remotely cached values if they don't match the expected value."
+  )
+  public boolean remoteVerifyDownloads;
+
+  // The below options are not configurable by users, only tests.
+  // This is part of the effort to reduce the overall number of flags.
+
+  /** The maximum size of an outbound message sent via a gRPC channel. */
+  public int maxOutboundMessageSize = 1024 * 1024;
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
@@ -44,6 +44,7 @@ import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
 
 /**
  * A RemoteActionCache implementation that uses a simple blob store for files and action output.
@@ -226,15 +227,19 @@ public final class SimpleBlobStoreActionCache extends AbstractRemoteActionCache 
   @Override
   protected ListenableFuture<Void> downloadBlob(Digest digest, OutputStream out) {
     SettableFuture<Void> outerF = SettableFuture.create();
-    HashingOutputStream hashOut = digestUtil.newHashingOutputStream(out);
+    @Nullable HashingOutputStream hashOut = options.remoteVerifyDownloads
+        ? digestUtil.newHashingOutputStream(out)
+        : null;
     Futures.addCallback(
-        blobStore.get(digest.getHash(), hashOut),
+        blobStore.get(digest.getHash(), hashOut != null ? hashOut : out),
         new FutureCallback<Boolean>() {
           @Override
           public void onSuccess(Boolean found) {
             if (found) {
               try {
-                verifyContents(digest, hashOut);
+                if (hashOut != null) {
+                  verifyContents(digest, hashOut);
+                }
                 out.flush();
                 outerF.set(null);
               } catch (IOException e) {


### PR DESCRIPTION
Add this flag as a performance optimization for users who trust
the outputs of their remote cache i.e. because the remote cache
already verifies the correctness of the hashes.

@benjaminp 