### PR TITLE
Fix a race in ByteStreamUploader deduplication.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -28,7 +28,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.hash.HashCode;
-import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -231,7 +230,18 @@ class ByteStreamUploader extends AbstractReferenceCounted {
         return inProgress;
       }
 
-      final SettableFuture<Void> uploadResult = SettableFuture.create();
+      Context ctx = Context.current();
+      ListenableFuture<Void> uploadResult =
+          Futures.transform(
+              retrier.executeAsync(() -> ctx.call(() -> startAsyncUpload(chunker))),
+              (v) -> {
+                synchronized (lock) {
+                  uploadedBlobs.add(hash);
+                }
+                return null;
+              },
+              MoreExecutors.directExecutor());
+      uploadsInProgress.put(digest, uploadResult);
       uploadResult.addListener(
           () -> {
             synchronized (lock) {
@@ -239,26 +249,6 @@ class ByteStreamUploader extends AbstractReferenceCounted {
             }
           },
           MoreExecutors.directExecutor());
-      Futures.addCallback(
-          uploadResult,
-          new FutureCallback<Void>() {
-            @Override
-            public void onSuccess(Void result) {
-              synchronized (lock) {
-                uploadedBlobs.add(hash);
-              }
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-              // ignore
-            }
-          },
-          MoreExecutors.directExecutor());
-      uploadsInProgress.put(digest, uploadResult);
-      Context ctx = Context.current();
-      retrier.executeAsync(
-          () -> ctx.call(() -> startAsyncUpload(chunker, uploadResult)), uploadResult);
       return uploadResult;
     }
   }
@@ -270,12 +260,8 @@ class ByteStreamUploader extends AbstractReferenceCounted {
     }
   }
 
-  /**
-   * Starts a file upload an returns a future representing the upload. The {@code
-   * overallUploadResult} future propagates cancellations from the caller to the upload.
-   */
-  private ListenableFuture<Void> startAsyncUpload(
-      Chunker chunker, ListenableFuture<Void> overallUploadResult) {
+  /** Starts a file upload an returns a future representing the upload. */
+  private ListenableFuture<Void> startAsyncUpload(Chunker chunker) {
     try {
       chunker.reset();
     } catch (IOException e) {
@@ -286,9 +272,9 @@ class ByteStreamUploader extends AbstractReferenceCounted {
     AsyncUpload newUpload =
         new AsyncUpload(
             channel, callCredentials, callTimeoutSecs, instanceName, chunker, currUpload);
-    overallUploadResult.addListener(
+    currUpload.addListener(
         () -> {
-          if (overallUploadResult.isCancelled()) {
+          if (currUpload.isCancelled()) {
             newUpload.cancel();
           }
         },

--- a/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
@@ -21,7 +21,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.remote.Retrier.CircuitBreaker.State;
 import java.io.IOException;
 import java.util.concurrent.Callable;
@@ -255,14 +254,6 @@ public class Retrier {
   /** Executes an {@link AsyncCallable}, retrying execution in case of failure. */
   public <T> ListenableFuture<T> executeAsync(AsyncCallable<T> call) {
     return executeAsync(call, newBackoff());
-  }
-
-  /**
-   * Executes an {@link AsyncCallable}, retrying execution in case of failure and uses the provided
-   * {@code promise} to point to the result/error.
-   */
-  public <T> void executeAsync(AsyncCallable<T> call, SettableFuture<T> promise) {
-    promise.setFuture(executeAsync(call));
   }
 
   /**


### PR DESCRIPTION
The callback to add a completed digest to the uploadedBlobs set was added to the result future of uploadBlobAsync. The non-deterministic ordering of future callbacks meant a client of ByteStreamUploader could observe a completed upload before the digest was added to uploadedBlobs. The solution is to chain futures so that the digest is placed in uploadedBlobs before the final future fires.

I noticed this race caused a test failure in CI: https://storage.googleapis.com/bazel-buildkite-artifacts/f1b54300-cf87-4516-8767-410b93ab1ee9/src/test/java/com/google/devtools/build/lib/remote-tests/test.log

It also was readily reproducible for me with this command:
```
$ bazel test //src/test/java/com/google/devtools/build/lib:remote-tests --runs_per_test 50 --test_filter deduplicationOfUploadsShouldWork
There was 1 failure:
1) deduplicationOfUploadsShouldWork(com.google.devtools.build.lib.remote.ByteStreamUploaderTest)
expected: 1
but was : 2
        at com.google.devtools.build.lib.remote.ByteStreamUploaderTest.deduplicationOfUploadsShouldWork(ByteStreamUploaderTest.java:731)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```

We can also simplify things by removing the second parameter of startAsyncUpload. This in turn permits us to delete a Retrier.executeAsync overload.