### PR TITLE
remote: add network traffic metrics

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -1246,6 +1246,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/query2:aquery-utils",
         "//src/main/java/com/google/devtools/build/lib/query2:query-engine",
         "//src/main/java/com/google/devtools/build/lib/query2:query-output",
+        "//src/main/java/com/google/devtools/build/lib/remote/metrics",
         "//src/main/java/com/google/devtools/build/lib/shell",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:output_service",

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -29,6 +29,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote/blobstore",
         "//src/main/java/com/google/devtools/build/lib/remote/blobstore/http",
         "//src/main/java/com/google/devtools/build/lib/remote/logging",
+        "//src/main/java/com/google/devtools/build/lib/remote/metrics",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcMetricsInterceptor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcMetricsInterceptor.java
@@ -1,0 +1,69 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import com.google.common.base.Preconditions;
+import com.google.devtools.build.lib.remote.metrics.RemoteMetrics;
+import com.google.protobuf.Message;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+
+/**
+ * Collects read/write metrics for gRPC-based remote caching and execution.
+ */
+public class GrpcMetricsInterceptor implements ClientInterceptor {
+
+  private final RemoteMetrics metrics;
+
+  public GrpcMetricsInterceptor(RemoteMetrics metrics) {
+    this.metrics = Preconditions.checkNotNull(metrics);
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions, Channel channel) {
+    ClientCall<ReqT, RespT> call = channel.newCall(methodDescriptor, callOptions);
+    return new MetricsCollectingClientCall<>(call);
+  }
+
+  private class MetricsCollectingClientCall<ReqT, RespT> extends SimpleForwardingClientCall<ReqT, RespT> {
+
+    protected MetricsCollectingClientCall(ClientCall<ReqT, RespT> delegate) {
+      super(delegate);
+    }
+
+    @Override
+    public void sendMessage(ReqT message) {
+      metrics.bytesSent(((Message) message).getSerializedSize());
+      super.sendMessage(message);
+    }
+
+    @Override
+    public void start(Listener<RespT> responseListener, Metadata headers) {
+      super.start(new SimpleForwardingClientCallListener<RespT>(responseListener) {
+        @Override
+        public void onMessage(RespT message) {
+          metrics.bytesReceived(((Message) message).getSerializedSize());
+          super.onMessage(message);
+        }
+      }, headers);
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/BUILD
@@ -16,6 +16,7 @@ java_library(
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/remote/blobstore",
+        "//src/main/java/com/google/devtools/build/lib/remote/metrics",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:auth",

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/MetricsHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/MetricsHandler.java
@@ -1,0 +1,52 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.blobstore.http;
+
+import com.google.common.base.Preconditions;
+import com.google.devtools.build.lib.remote.metrics.RemoteMetrics;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+/**
+ * Collects read/write metrics of the {@link HttpBlobStore}.
+ */
+public class MetricsHandler extends ChannelDuplexHandler {
+
+  private final RemoteMetrics metrics;
+
+  public MetricsHandler(RemoteMetrics metrics) {
+    this.metrics = Preconditions.checkNotNull(metrics);
+  }
+
+  @Override
+  public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+      throws Exception {
+    if (msg instanceof ByteBuf) {
+      ByteBuf b = (ByteBuf) msg;
+      metrics.bytesSent(b.writableBytes());
+    }
+    super.write(ctx, msg, promise);
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+    if (msg instanceof ByteBuf) {
+      ByteBuf b = (ByteBuf) msg;
+      metrics.bytesReceived(b.readableBytes());
+    }
+    super.channelRead(ctx, msg);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/metrics/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/metrics/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//src:__subpackages__"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//src/main/java/com/google/devtools/build/lib:__pkg__"],
+)
+
+java_library(
+    name = "metrics",
+    srcs = glob(["*.java"]),
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib:events",
+        "//third_party:jsr305",
+    ],
+)

--- a/src/main/java/com/google/devtools/build/lib/remote/metrics/RemoteMetrics.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/metrics/RemoteMetrics.java
@@ -1,0 +1,44 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.metrics;
+
+import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Collects metrics and is posted over the event bus after a build.
+ */
+@ThreadSafe
+public class RemoteMetrics implements Postable {
+
+  private AtomicLong totalBytesSent = new AtomicLong();
+  private AtomicLong totalBytesReceived = new AtomicLong();
+
+  public void bytesSent(long bytes) {
+    totalBytesSent.addAndGet(bytes);
+  }
+
+  public void bytesReceived(long bytes) {
+    totalBytesReceived.addAndGet(bytes);
+  }
+
+  public long totalBytesReceived() {
+    return totalBytesReceived.get();
+  }
+
+  public long totalBytesSent() {
+    return totalBytesSent.get();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/runtime/BuildSummaryStatsModule.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BuildSummaryStatsModule.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.exec.ExecutorBuilder;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
+import com.google.devtools.build.lib.remote.metrics.RemoteMetrics;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +55,7 @@ public class BuildSummaryStatsModule extends BlazeModule {
   private long executionStartMillis;
   private long executionEndMillis;
   private SpawnStats spawnStats;
+  private RemoteMetrics remoteMetrics;
 
   @Override
   public void beforeCommand(CommandEnvironment env) {
@@ -97,6 +99,11 @@ public class BuildSummaryStatsModule extends BlazeModule {
   @AllowConcurrentEvents
   public void actionResultReceived(ActionResultReceivedEvent event) {
     spawnStats.countActionResult(event.getActionResult());
+  }
+
+  @Subscribe
+  public void remoteMetrics(RemoteMetrics metrics) {
+    this.remoteMetrics = metrics;
   }
 
   @Subscribe
@@ -161,6 +168,10 @@ public class BuildSummaryStatsModule extends BlazeModule {
       } else {
         reporter.handle(Event.info(Joiner.on(", ").join(items)));
         reporter.handle(Event.info(spawnSummary));
+        if (remoteMetrics != null) {
+          reporter.handle(Event.info(String.format("Network: %s remote upload, %s remote download",
+              bytesToHumanReadable(remoteMetrics.totalBytesSent()), bytesToHumanReadable(remoteMetrics.totalBytesReceived()))));
+        }
       }
 
       event.getResult().getBuildToolLogCollection()
@@ -168,5 +179,16 @@ public class BuildSummaryStatsModule extends BlazeModule {
     } finally {
       criticalPathComputer = null;
     }
+  }
+
+  private String bytesToHumanReadable(long bytes) {
+    String[] units = new String[]{"bytes", "KiB", "MiB", "GiB", "TiB"};
+    double num = bytes;
+    int unit = 0;
+    while (num >= 1024 && unit < units.length) {
+      num /= 1024;
+      unit++;
+    }
+    return String.format("%.1f %s", num, units[unit]);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStoreTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStoreTest.java
@@ -245,11 +245,13 @@ public class HttpBlobStoreTest {
       DomainSocketAddress domainSocketAddress = (DomainSocketAddress) socketAddress;
       URI uri = new URI("http://localhost");
       return HttpBlobStore.create(
-          domainSocketAddress, uri, timeoutSeconds, /* remoteMaxConnections= */ 0, creds);
+          domainSocketAddress, uri, timeoutSeconds, /* remoteMaxConnections= */ 0, creds,
+          /* metrics= */ null);
     } else if (socketAddress instanceof InetSocketAddress) {
       InetSocketAddress inetSocketAddress = (InetSocketAddress) socketAddress;
       URI uri = new URI("http://localhost:" + inetSocketAddress.getPort());
-      return HttpBlobStore.create(uri, timeoutSeconds, /* remoteMaxConnections= */ 0, creds);
+      return HttpBlobStore.create(uri, timeoutSeconds, /* remoteMaxConnections= */ 0, creds,
+          /* metrics= */ null);
     } else {
       throw new IllegalStateException(
           "unsupported socket address class " + socketAddress.getClass());

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
@@ -250,7 +250,7 @@ public final class RemoteWorker {
     // 2. Finally use a ConcurrentMap to back the blob store.
     final SimpleBlobStore blobStore;
     if (usingRemoteCache) {
-      blobStore = SimpleBlobStoreFactory.create(remoteOptions, null, null);
+      blobStore = SimpleBlobStoreFactory.create(remoteOptions, null, null, null);
     } else if (remoteWorkerOptions.casPath != null) {
       blobStore = new OnDiskBlobStore(fs.getPath(remoteWorkerOptions.casPath));
     } else {


### PR DESCRIPTION
Display basic network traffic metrics after a build/test when using
remote caching or execution.

For example:
```
INFO: 267 processes: 7 remote cache hit, 123 linux-sandbox, 137 worker.
INFO: Network: 160.1 KiB remote upload, 322.8 KiB remote download
INFO: Build completed successfully, 272 total actions
```

PTAL @werkt @benjaminp 