### PR TITLE
Add ability for a Spawn to declare a required local output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SimpleSpawn.java
@@ -37,6 +37,7 @@ public final class SimpleSpawn implements Spawn {
   private final RunfilesSupplier runfilesSupplier;
   private final Map<Artifact, ImmutableList<FilesetOutputSymlink>> filesetMappings;
   private final ImmutableList<? extends ActionInput> outputs;
+  private final ImmutableList<? extends ActionInput> requiredLocalOutputs;
   private final ResourceSet localResources;
 
   public SimpleSpawn(
@@ -49,6 +50,7 @@ public final class SimpleSpawn implements Spawn {
       ImmutableList<? extends ActionInput> inputs,
       ImmutableList<? extends ActionInput> tools,
       ImmutableList<? extends ActionInput> outputs,
+      ImmutableList<? extends ActionInput> requiredLocalOutputs,
       ResourceSet localResources) {
     this.owner = Preconditions.checkNotNull(owner);
     this.arguments = Preconditions.checkNotNull(arguments);
@@ -60,6 +62,7 @@ public final class SimpleSpawn implements Spawn {
         runfilesSupplier == null ? EmptyRunfilesSupplier.INSTANCE : runfilesSupplier;
     this.filesetMappings = filesetMappings;
     this.outputs = Preconditions.checkNotNull(outputs);
+    this.requiredLocalOutputs = Preconditions.checkNotNull(requiredLocalOutputs);
     this.localResources = Preconditions.checkNotNull(localResources);
   }
 
@@ -81,6 +84,7 @@ public final class SimpleSpawn implements Spawn {
         inputs,
         ImmutableList.<Artifact>of(),
         outputs,
+        /* requiredLocalOutputs= */ ImmutableList.of(),
         localResources);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/Spawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawn.java
@@ -97,6 +97,18 @@ public interface Spawn {
   Collection<? extends ActionInput> getOutputFiles();
 
   /**
+   * Returns the collection of files that this command must write and make available via
+   * Bazel's {@link com.google.devtools.build.lib.vfs.FileSystem}. The returned outputs
+   * are a subset of the spawns's output {@link #getOutputFiles()}.
+   *
+   * <p>This is for use with remote execution, where as an optimization we don't want to
+   * stage (i.e. download) all output files of a spawn on disk.
+   */
+  default Collection<? extends ActionInput> getRequiredLocalOutputs() {
+    return ImmutableList.of();
+  }
+
+  /**
    * Returns the resource owner for local fallback.
    */
   ActionExecutionMetadata getResourceOwner();

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -136,6 +136,7 @@ public class StandaloneTestStrategy extends TestStrategy {
             /*inputs=*/ ImmutableList.copyOf(action.getInputs()),
             /*tools=*/ ImmutableList.<Artifact>of(),
             ImmutableList.copyOf(action.getSpawnOutputs()),
+            /*requiredLocalOutputs=*/ ImmutableList.of(),
             localResourceUsage);
     return new StandaloneTestRunnerSpawn(
         action, actionExecutionContext, spawn, tmpDir, coverageDir, workingDirectory, execRoot);
@@ -435,6 +436,7 @@ public class StandaloneTestStrategy extends TestStrategy {
         /*inputs=*/ ImmutableList.of(action.getTestXmlGeneratorScript(), action.getTestLog()),
         /*tools=*/ ImmutableList.<Artifact>of(),
         /*outputs=*/ ImmutableList.of(ActionInputHelper.fromPath(action.getXmlOutputPath())),
+        /*requiredLocalOutputs=*/ ImmutableList.of(),
         SpawnAction.DEFAULT_RESOURCE_SET);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/SpawnBuilder.java
@@ -65,6 +65,7 @@ public final class SpawnBuilder {
         ImmutableList.copyOf(inputs),
         /*tools=*/ ImmutableList.<Artifact>of(),
         ImmutableList.copyOf(outputs),
+        /*requiredLocalOutputs=*/ ImmutableList.of(),
         ResourceSet.ZERO);
   }
 


### PR DESCRIPTION
Some native actions run both remotely and locally. For example,
the CppCompileAction runs compilation remotely but does .d file
pruning locally. This change adds the necessary infrastructure
for an action to tell a Spawn which of its outputs it needs on
the local filesytem.

Progress towards #6862