### PR TITLE
pkg_tar: Create tar files with non-zero mtime

### DIFF
--- a/tools/build_defs/pkg/archive.py
+++ b/tools/build_defs/pkg/archive.py
@@ -20,7 +20,10 @@ import os
 import subprocess
 import tarfile
 
-# Use a deterministic mtime that doesn't confuse other programs.
+# Use a deterministic mtime that doesn't confuse other programs such as Python
+# distutils and GNU tar (ex: "implausibly old time stamp" warnings).
+#
+# See https://github.com/bazelbuild/bazel/issues/1299
 MTIME = 946684800  # 2000-01-01 00:00:00.000 UTC
 
 class SimpleArFile(object):

--- a/tools/build_defs/pkg/archive.py
+++ b/tools/build_defs/pkg/archive.py
@@ -20,6 +20,8 @@ import os
 import subprocess
 import tarfile
 
+# Use a deterministic mtime that doesn't confuse other programs.
+MTIME = 946684800  # 2000-01-01 00:00:00.000 UTC
 
 class SimpleArFile(object):
   """A simple AR file reader.
@@ -118,7 +120,7 @@ class TarFileWriter(object):
       # The Tarfile class doesn't allow us to specify gzip's mtime attribute.
       # Instead, we manually re-implement gzopen from tarfile.py and set mtime.
       self.fileobj = gzip.GzipFile(
-          filename=name, mode='w', compresslevel=9, mtime=0)
+          filename=name, mode='w', compresslevel=9, mtime=MTIME)
     self.tar = tarfile.open(name=name, mode=mode, fileobj=self.fileobj)
     self.members = set([])
     self.directories = set([])
@@ -136,7 +138,7 @@ class TarFileWriter(object):
               gid=0,
               uname='',
               gname='',
-              mtime=0,
+              mtime=MTIME,
               mode=None,
               depth=100):
     """Recursively add a directory.
@@ -219,7 +221,7 @@ class TarFileWriter(object):
                gid=0,
                uname='',
                gname='',
-               mtime=0,
+               mtime=MTIME,
                mode=None):
     """Add a file to the current tar.
 
@@ -350,7 +352,7 @@ class TarFileWriter(object):
       intar = tarfile.open(name=tar, mode=inmode)
     for tarinfo in intar:
       if name_filter is None or name_filter(tarinfo.name):
-        tarinfo.mtime = 0
+        tarinfo.mtime = MTIME
         if rootuid is not None and tarinfo.uid == rootuid:
           tarinfo.uid = 0
           tarinfo.uname = 'root'

--- a/tools/build_defs/pkg/build_test.sh
+++ b/tools/build_defs/pkg/build_test.sh
@@ -155,13 +155,13 @@ function test_tar() {
   check_eq "./
 ./not-etc/
 ./not-etc/mapped-filename.conf" "$(get_tar_listing test-tar-files_dict.tar)"
-  check_eq "drwxr-xr-x 0/0               0 1970-01-01 00:00 ./
--rwxrwxrwx 0/0               0 1970-01-01 00:00 ./a
--rwxrwxrwx 0/0               0 1970-01-01 00:00 ./b" \
+  check_eq "drwxr-xr-x 0/0               0 2000-01-01 00:00 ./
+-rwxrwxrwx 0/0               0 2000-01-01 00:00 ./a
+-rwxrwxrwx 0/0               0 2000-01-01 00:00 ./b" \
       "$(get_tar_verbose_listing test-tar-empty_files.tar)"
-  check_eq "drwxr-xr-x 0/0               0 1970-01-01 00:00 ./
-drwxrwxrwx 0/0               0 1970-01-01 00:00 ./tmp/
-drwxrwxrwx 0/0               0 1970-01-01 00:00 ./pmt/" \
+  check_eq "drwxr-xr-x 0/0               0 2000-01-01 00:00 ./
+drwxrwxrwx 0/0               0 2000-01-01 00:00 ./tmp/
+drwxrwxrwx 0/0               0 2000-01-01 00:00 ./pmt/" \
       "$(get_tar_verbose_listing test-tar-empty_dirs.tar)"
 }
 


### PR DESCRIPTION
pkg_tar created tars whose contents had a fixed mtime of 0 so that the rule's
output was deterministic.  This can lead to undefined behavior in downstream
applications which process those files.  Work around this by choosing another
fixed but non-zero mtime value.

Resolves https://github.com/bazelbuild/bazel/issues/1299.

Testing Done:
- `bazel test tools/build_defs/pkg:all`