### PR TITLE
Pass the correct import path to protoc when using strict dependency checks or exports

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCompileActionBuilder.java
@@ -47,6 +47,7 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.util.LazyString;
+import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.HashSet;
 import java.util.List;
@@ -307,7 +308,7 @@ public class ProtoCompileActionBuilder {
     addIncludeMapArguments(
         getOutputDirectory(ruleContext),
         result,
-        areDepsStrict ? protoInfo.getStrictImportableProtoSources() : null,
+        areDepsStrict ? protoInfo.getStrictImportableProtoSourcesImportPaths() : null,
         protoInfo.getStrictImportableProtoSourceRoots(),
         protoInfo.getTransitiveProtoSources());
 
@@ -325,7 +326,7 @@ public class ProtoCompileActionBuilder {
       result.add("--disallow_services");
     }
     if (checkStrictImportPublic) {
-      NestedSet<Artifact> protosInExports = protoInfo.getExportedProtoSources();
+      NestedSet<Pair<Artifact,String>> protosInExports = protoInfo.getExportedProtoSourcesImportPaths();
       if (protosInExports.isEmpty()) {
         // This line is necessary to trigger the check.
         result.add("--allowed_public_imports=");
@@ -335,7 +336,7 @@ public class ProtoCompileActionBuilder {
             VectorArg.join(":")
                 .each(protosInExports)
                 .mapped(
-                    new ExpandToPathFn(
+                    new ExpandToPathFnWithImports(
                         getOutputDirectory(ruleContext),
                         protoInfo.getTransitiveProtoSourceRoots())));
       }
@@ -579,7 +580,7 @@ public class ProtoCompileActionBuilder {
     addIncludeMapArguments(
         outputDirectory,
         cmdLine,
-        strictDeps == Deps.STRICT ? protoInfo.getStrictImportableProtoSources() : null,
+        strictDeps == Deps.STRICT ? protoInfo.getStrictImportableProtoSourcesImportPaths() : null,
         protoInfo.getStrictImportableProtoSourceRoots(),
         protoInfo.getTransitiveProtoSources());
 
@@ -588,16 +589,16 @@ public class ProtoCompileActionBuilder {
     }
 
     if (useExports == Exports.USE) {
-      if (protoInfo.getExportedProtoSources().isEmpty()) {
+      if (protoInfo.getExportedProtoSourcesImportPaths().isEmpty()) {
         // This line is necessary to trigger the check.
         cmdLine.add("--allowed_public_imports=");
       } else {
         cmdLine.addAll(
             "--allowed_public_imports",
             VectorArg.join(":")
-                .each(protoInfo.getExportedProtoSources())
+                .each(protoInfo.getExportedProtoSourcesImportPaths())
                 .mapped(
-                    new ExpandToPathFn(outputDirectory, protoInfo.getExportedProtoSourceRoots())));
+                    new ExpandToPathFnWithImports(outputDirectory, protoInfo.getExportedProtoSourceRoots())));
       }
     }
 
@@ -616,7 +617,7 @@ public class ProtoCompileActionBuilder {
   static void addIncludeMapArguments(
       String outputDirectory,
       CustomCommandLine.Builder commandLine,
-      @Nullable NestedSet<Artifact> protosInDirectDependencies,
+      @Nullable NestedSet<Pair<Artifact,String>> protosInDirectDependencies,
       NestedSet<String> directProtoSourceRoots,
       NestedSet<Artifact> transitiveImports) {
     // For each import, include both the import as well as the import relativized against its
@@ -631,7 +632,7 @@ public class ProtoCompileActionBuilder {
             "--direct_dependencies",
             VectorArg.join(":")
                 .each(protosInDirectDependencies)
-                .mapped(new ExpandToPathFn(outputDirectory, directProtoSourceRoots)));
+                .mapped(new ExpandToPathFnWithImports(outputDirectory, directProtoSourceRoots)));
 
       } else {
         // The proto compiler requires an empty list to turn on strict deps checking
@@ -714,34 +715,38 @@ public class ProtoCompileActionBuilder {
 
   @AutoCodec
   @AutoCodec.VisibleForSerialization
-  static final class ExpandToPathFn implements CapturingMapFn<Artifact> {
+  static final class ExpandToPathFnWithImports implements CapturingMapFn<Pair<Artifact,String>> {
     private final String outputDirectory;
     private final NestedSet<String> directProtoSourceRoots;
 
-    public ExpandToPathFn(String outputDirectory, NestedSet<String> directProtoSourceRoots) {
+    public ExpandToPathFnWithImports(String outputDirectory, NestedSet<String> directProtoSourceRoots) {
       this.outputDirectory = outputDirectory;
       this.directProtoSourceRoots = directProtoSourceRoots;
     }
 
     @Override
-    public void expandToCommandLine(Artifact proto, Consumer<String> args) {
-      boolean repositoryPathAdded = false;
-      String pathIgnoringRepository = getPathIgnoringRepository(proto);
+    public void expandToCommandLine(Pair<Artifact,String> proto, Consumer<String> args) {
+      if (proto.second != null) {
+        args.accept(proto.second);
+      } else {
+        boolean repositoryPathAdded = false;
+        String pathIgnoringRepository = getPathIgnoringRepository(proto.first);
 
-      for (String directProtoSourceRoot : directProtoSourceRoots) {
-        PathFragment sourceRootPath = PathFragment.create(directProtoSourceRoot);
-        String arg = guessProtoPathUnderRoot(outputDirectory, sourceRootPath, proto);
-        if (arg != null) {
-          if (arg.equals(pathIgnoringRepository)) {
-            repositoryPathAdded = true;
+        for (String directProtoSourceRoot : directProtoSourceRoots) {
+          PathFragment sourceRootPath = PathFragment.create(directProtoSourceRoot);
+          String arg = guessProtoPathUnderRoot(outputDirectory, sourceRootPath, proto.first);
+          if (arg != null) {
+            if (arg.equals(pathIgnoringRepository)) {
+              repositoryPathAdded = true;
+            }
+            args.accept(arg);
           }
-          args.accept(arg);
         }
-      }
 
-      // TODO(lberki): This should really be removed. It's only there for backward compatibility.
-      if (!repositoryPathAdded) {
-        args.accept(pathIgnoringRepository);
+        // TODO(lberki): This should really be removed. It's only there for backward compatibility.
+        if (!repositoryPathAdded) {
+          args.accept(pathIgnoringRepository);
+        }
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoInfo.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.packages.BuiltinProvider;
 import com.google.devtools.build.lib.packages.NativeInfo;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.skylarkbuildapi.ProtoInfoApi;
+import com.google.devtools.build.lib.util.Pair;
 import javax.annotation.Nullable;
 
 /**
@@ -57,9 +58,10 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
   private final NestedSet<Artifact> transitiveProtoSources;
   private final NestedSet<String> transitiveProtoSourceRoots;
   private final NestedSet<Artifact> strictImportableProtoSourcesForDependents;
-  private final NestedSet<Artifact> strictImportableProtoSources;
+  private final NestedSet<Pair<Artifact,String>> strictImportableProtoSourcesImportPaths;
+  private final NestedSet<Pair<Artifact,String>> strictImportableProtoSourcesImportPathsForDependents;
   private final NestedSet<String> strictImportableProtoSourceRoots;
-  private final NestedSet<Artifact> exportedProtoSources;
+  private final NestedSet<Pair<Artifact,String>> exportedProtoSourcesImportPaths;
   private final NestedSet<String> exportedProtoSourceRoots;
   private final Artifact directDescriptorSet;
   private final NestedSet<Artifact> transitiveDescriptorSets;
@@ -71,9 +73,10 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
       NestedSet<Artifact> transitiveProtoSources,
       NestedSet<String> transitiveProtoSourceRoots,
       NestedSet<Artifact> strictImportableProtoSourcesForDependents,
-      NestedSet<Artifact> strictImportableProtoSources,
+      NestedSet<Pair<Artifact,String>> strictImportableProtoSourcesImportPaths,
+      NestedSet<Pair<Artifact,String>> strictImportableProtoSourcesImportPathsForDependents,
       NestedSet<String> strictImportableProtoSourceRoots,
-      NestedSet<Artifact> exportedProtoSources,
+      NestedSet<Pair<Artifact,String>> exportedProtoSourcesImportPaths,
       NestedSet<String> exportedProtoSourceRoots,
       Artifact directDescriptorSet,
       NestedSet<Artifact> transitiveDescriptorSets,
@@ -84,9 +87,10 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
     this.transitiveProtoSources = transitiveProtoSources;
     this.transitiveProtoSourceRoots = transitiveProtoSourceRoots;
     this.strictImportableProtoSourcesForDependents = strictImportableProtoSourcesForDependents;
-    this.strictImportableProtoSources = strictImportableProtoSources;
+    this.strictImportableProtoSourcesImportPaths = strictImportableProtoSourcesImportPaths;
+    this.strictImportableProtoSourcesImportPathsForDependents = strictImportableProtoSourcesImportPathsForDependents;
     this.strictImportableProtoSourceRoots = strictImportableProtoSourceRoots;
-    this.exportedProtoSources = exportedProtoSources;
+    this.exportedProtoSourcesImportPaths = exportedProtoSourcesImportPaths;
     this.exportedProtoSourceRoots = exportedProtoSourceRoots;
     this.directDescriptorSet = directDescriptorSet;
     this.transitiveDescriptorSets = transitiveDescriptorSets;
@@ -138,14 +142,25 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
   }
 
   /**
+   * Returns the set of source files and import paths importable by rules directly depending on
+   * the rule declaring this provider if strict dependency checking is in effect.
+   *
+   * <p>(strict dependency checking: when a target can only include / import source files from its
+   * direct dependencies, but not from transitive ones)
+   */
+  public NestedSet<Pair<Artifact,String>> getStrictImportableProtoSourcesImportPathsForDependents() {
+    return strictImportableProtoSourcesImportPathsForDependents;
+  }
+
+  /**
    * Returns the set of source files importable by the rule declaring this provider if strict
    * dependency checking is in effect.
    *
    * <p>(strict dependency checking: when a target can only include / import source files from its
    * direct dependencies, but not from transitive ones)
    */
-  public NestedSet<Artifact> getStrictImportableProtoSources() {
-    return strictImportableProtoSources;
+  public NestedSet<Pair<Artifact,String>> getStrictImportableProtoSourcesImportPaths() {
+    return strictImportableProtoSourcesImportPaths;
   }
 
   /**
@@ -163,8 +178,8 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
    * Returns the .proto files that are the direct srcs of the exported dependencies of this rule.
    */
   @Nullable
-  public NestedSet<Artifact> getExportedProtoSources() {
-    return exportedProtoSources;
+  public NestedSet<Pair<Artifact,String>> getExportedProtoSourcesImportPaths() {
+    return exportedProtoSourcesImportPaths;
   }
 
   public NestedSet<String> getExportedProtoSourceRoots() {


### PR DESCRIPTION
Currently, when strict dependency checks are enabled Bazel passes the full path of each directly dependent proto file to protoc via the `--direct_dependencies` flag. Similarly, when proto exports are used the full path of each export is passed to protoc via the `--allowed_public_imports` flag.

With the introduction of the `import_path` and `strip_import_path` proto_library attributes, it is no longer true that the full path of a .proto file is always its import path. Meaning that when the import path is modified, Bazel passes the incorrect import path to the `direct_dependencies` and `allowed_public_imports` protoc flags.

This issue is fixed by having `ProtoInfo` keep track of a pair of each .proto file and its import path. That way whenever the import path has been modified it can be used as the protoc command line argument rather than the .proto's full path.