### PR TITLE
Add target to build the allmodules JDK from the vanilla JDK.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -178,7 +178,7 @@ JAVA_TOOLS = [
         "//src/test:__subpackages__",  # For integration tests
     ],
 ) for suffix, jdk in {
-    "_jdk_allmodules": [":embedded_jdk_allmodules"],
+    "_jdk_allmodules": [":embedded_jdk_allmodules_cached"],
     "_jdk_minimal": [":embedded_jdk_minimal_cached"],
     "_dev_jdk": [":embedded_jdk_minimal"],
     "_nojdk": [],
@@ -195,7 +195,7 @@ rule_size_test(
 )
 
 filegroup(
-    name = "embedded_jdk_allmodules",
+    name = "embedded_jdk_allmodules_cached",
     srcs = select({
         "//src/conditions:darwin": [
             "@openjdk_macos//file",
@@ -274,6 +274,18 @@ filegroup(
     }),
 )
 
+filegroup(
+    name = "embedded_jdk_allmodules",
+    srcs = select({
+        "//src/conditions:windows": [
+            ":embedded_jdk_allmodules.zip",
+        ],
+        "//conditions:default": [
+            ":embedded_jdk_allmodules.tar.gz",
+        ],
+    }),
+)
+
 [genrule(
     name = "embedded_jdk_minimal" + suffix,
     srcs = [
@@ -283,6 +295,21 @@ filegroup(
     ],
     outs = ["minimal_jdk" + suffix],
     cmd = "$(location :minimize_jdk.sh) $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $(OUTS)",
+    visibility = ["//src/test/shell/bazel:__pkg__"],
+) for suffix in [
+    ".zip",
+    ".tar.gz",
+]]
+
+[genrule(
+    name = "embedded_jdk_allmodules" + suffix,
+    srcs = [
+        ":embedded_jdk_vanilla",
+        ":minimize_jdk.sh",
+        ":jdeps_modules.golden",
+    ],
+    outs = ["allmodules_jdk" + suffix],
+    cmd = "$(location :minimize_jdk.sh) --allmodules $(location :embedded_jdk_vanilla) $(location :jdeps_modules.golden) $(OUTS)",
     visibility = ["//src/test/shell/bazel:__pkg__"],
 ) for suffix in [
     ".zip",

--- a/src/minimize_jdk.sh
+++ b/src/minimize_jdk.sh
@@ -19,8 +19,13 @@
 
 set -euo pipefail
 
+if [ "$1" == "--allmodules" ]; then
+  shift
+  modules="ALL-MODULE-PATH"
+else
+  modules=$(cat "$2" | paste -sd "," - | tr -d '\r')
+fi
 fulljdk=$1
-modules=$(cat "$2" | paste -sd "," - | tr -d '\r')
 out=$3
 
 UNAME=$(uname -s | tr 'A-Z' 'a-z')
@@ -29,7 +34,6 @@ if [[ "$UNAME" =~ msys_nt* ]]; then
   set -x
   unzip "$fulljdk"
   cd zulu*
-  echo -e "MODULES: >>$modules<<\n"
   ./bin/jlink --module-path ./jmods/ --add-modules "$modules" \
     --vm=server --strip-debug --no-man-pages \
     --output reduced

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -653,12 +653,12 @@ sh_test(
     srcs = ["bazel_bootstrap_distfile_test.sh"],
     args = [
         "$(location //:bazel-distfile)",
-        "$(location //src:embedded_jdk_allmodules)",
+        "$(location //src:embedded_jdk_allmodules_cached)",
     ],
     data = [
         ":test-deps",
         "//:bazel-distfile",
-        "//src:embedded_jdk_allmodules",
+        "//src:embedded_jdk_allmodules_cached",
         "@bazel_tools//tools/bash/runfiles",
     ],
     tags = ["block-network"],
@@ -783,7 +783,7 @@ sh_test(
     data = [
         ":jdeps_class_blacklist.txt",
         ":test-deps",
-        "//src:embedded_jdk_allmodules",
+        "//src:embedded_jdk_allmodules_cached",
         "//src:jdeps_modules.golden",
         "//src/main/java/com/google/devtools/build/lib:bazel/BazelServer_deploy.jar",
         "@bazel_tools//tools/bash/runfiles",


### PR DESCRIPTION
With this we can also build the allmodules JDK in the buildkite
pipeline.

This is a necessary step for the upgrade to JDK 11, see #6592 and #6314.

RELNOTES: None