### PR TITLE
Windows, Bazel client: detect Bash early enough

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1537,10 +1537,12 @@ int Main(int argc, const char *argv[], WorkspaceLayout *workspace_layout,
   // Must be done before command line parsing.
   ComputeWorkspace(workspace_layout);
 
+#if defined(_WIN32) || defined(__CYGWIN__)
   // Must be done before command line parsing.
   // ParseOptions already populate --client_env, so detect bash before it
   // happens.
   DetectBashOrDie();
+#endif  // if defined(_WIN32) || defined(__CYGWIN__)
 
   globals->binary_path = CheckAndGetBinaryPath(argv[0]);
   ParseOptions(argc, argv);

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -260,7 +260,10 @@ bool UnlimitResources();
 // raised; false otherwise.
 bool UnlimitCoredumps();
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+std::string DetectBashAndExportBazelSh();
 void DetectBashOrDie();
+#endif  // if defined(_WIN32) || defined(__CYGWIN__)
 
 // This function has no effect on Unix platforms.
 // On Windows, this function looks into PATH to find python.exe, if python

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -830,10 +830,6 @@ bool UnlimitCoredumps() {
   return UnlimitResource(RLIMIT_CORE, true);
 }
 
-void DetectBashOrDie() {
-  // do nothing.
-}
-
 void EnsurePythonPathOption(vector<string>* options) {
   // do nothing.
 }

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -1458,12 +1458,15 @@ static string LocateBash() {
   return result;
 }
 
-void DetectBashOrDie() {
-  if (!blaze::GetEnv("BAZEL_SH").empty()) return;
+string DetectBashAndExportBazelSh() {
+  string bash = blaze::GetEnv("BAZEL_SH");
+  if (!bash.empty()) {
+    return bash;
+  }
 
   uint64_t start = blaze::GetMillisecondsMonotonic();
 
-  string bash = LocateBash();
+  bash = LocateBash();
   uint64_t end = blaze::GetMillisecondsMonotonic();
   BAZEL_LOG(INFO) << "BAZEL_SH detection took " << end - start
                   << " msec, found " << bash.c_str();
@@ -1471,7 +1474,13 @@ void DetectBashOrDie() {
   if (!bash.empty()) {
     // Set process environment variable.
     blaze::SetEnv("BAZEL_SH", bash);
-  } else {
+  }
+  return bash;
+}
+
+void DetectBashOrDie() {
+  string bash = DetectBashAndExportBazelSh();
+  if (bash.empty()) {
     // TODO(bazel-team) should this be printed to stderr? If so, it should use
     // BAZEL_LOG(ERROR)
     printf(

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -112,7 +112,7 @@ StartupOptions::StartupOptions(const string &product_name,
   }
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-  string windows_unix_root = WindowsUnixRoot(blaze::GetEnv("BAZEL_SH"));
+  string windows_unix_root = DetectBashAndExportBazelSh();
   if (!windows_unix_root.empty()) {
     host_jvm_args.push_back(string("-Dbazel.windows_unix_root=") +
                             windows_unix_root);
@@ -592,33 +592,5 @@ blaze_exit_code::ExitCode StartupOptions::AddJVMMemoryArguments(
     string *) const {
   return blaze_exit_code::SUCCESS;
 }
-
-#if defined(_WIN32) || defined(__CYGWIN__)
-// Extract the Windows path of "/" from $BAZEL_SH.
-// $BAZEL_SH usually has the form `<prefix>/usr/bin/bash.exe` or
-// `<prefix>/bin/bash.exe`, and this method returns that `<prefix>` part.
-// If $BAZEL_SH doesn't end with "usr/bin/bash.exe" or "bin/bash.exe" then this
-// method returns an empty string.
-string StartupOptions::WindowsUnixRoot(const string &bazel_sh) {
-  if (bazel_sh.empty()) {
-    return string();
-  }
-  std::pair<string, string> split = blaze_util::SplitPath(bazel_sh);
-  if (blaze_util::AsLower(split.second) != "bash.exe") {
-    return string();
-  }
-  split = blaze_util::SplitPath(split.first);
-  if (blaze_util::AsLower(split.second) != "bin") {
-    return string();
-  }
-
-  std::pair<string, string> split2 = blaze_util::SplitPath(split.first);
-  if (blaze_util::AsLower(split2.second) == "usr") {
-    return split2.first;
-  } else {
-    return split.first;
-  }
-}
-#endif  // defined(_WIN32) || defined(__CYGWIN__)
 
 }  // namespace blaze

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -326,10 +326,6 @@ class StartupOptions {
   std::string default_server_javabase_;
   // Contains the collection of startup flags that Bazel accepts.
   std::set<std::unique_ptr<StartupFlag>> valid_startup_flags;
-
-#if defined(_WIN32) || defined(__CYGWIN__)
-  static std::string WindowsUnixRoot(const std::string &bazel_sh);
-#endif
 };
 
 }  // namespace blaze


### PR DESCRIPTION
Detect Bash's path early enough to compute the
--windows_unix_root host JVM flag's value.

Now Bazel forwards Bash's location to the Bazel
server even if BAZEL_SH is undefined, and no
longer crashes when --compiler=msys-gcc but
BAZEL_SH is undefined.

Fixes https://github.com/bazelbuild/bazel/issues/6651