### PR TITLE
Windows: fix java_binary.jvm_flags escaping

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -751,6 +751,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/rules/java:java-rules",
         "//src/main/java/com/google/devtools/build/lib/rules/objc",
         "//src/main/java/com/google/devtools/build/lib/rules/platform",
+        "//src/main/java/com/google/devtools/build/lib/shell",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/skylarkbuildapi/android",
         "//src/main/java/com/google/devtools/build/lib/skylarkbuildapi/apple",

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaSemantics.java
@@ -304,7 +304,7 @@ public interface JavaSemantics {
       Artifact executable,
       String javaStartClass,
       String javaExecutable)
-      throws InterruptedException;
+      throws InterruptedException, RuleErrorException;
 
   /**
    * Same as {@link #createStubAction(RuleContext, JavaCommon, List, Artifact, String, String)}.
@@ -326,7 +326,7 @@ public interface JavaSemantics {
       NestedSetBuilder<Artifact> filesBuilder,
       String javaExecutable,
       boolean createCoverageMetadataJar)
-      throws InterruptedException;
+      throws InterruptedException, RuleErrorException;
 
   /**
    * Returns true if {@code createStubAction} considers {@code javaExecutable} as a substitution.

--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -45,18 +45,15 @@ ExitCode BashBinaryLauncher::Launch() {
   vector<wstring> origin_args = this->GetCommandlineArguments();
   wostringstream bash_command;
   wstring bash_main_file = GetBinaryPathWithoutExtension(origin_args[0]);
-  bash_command << GetEscapedArgument(bash_main_file,
-                                     /*escape_backslash = */ true);
+  bash_command << BashEscapeArg(bash_main_file);
   for (int i = 1; i < origin_args.size(); i++) {
     bash_command << L' ';
-    bash_command << GetEscapedArgument(origin_args[i],
-                                       /*escape_backslash = */ true);
+    bash_command << BashEscapeArg(origin_args[i]);
   }
 
   vector<wstring> args;
   args.push_back(L"-c");
-  args.push_back(
-      GetEscapedArgument(bash_command.str(), /*escape_backslash = */ true));
+  args.push_back(BashEscapeArg(bash_command.str()));
   return this->LaunchProcess(bash_binary, args);
 }
 

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -359,7 +359,7 @@ ExitCode JavaBinaryLauncher::Launch() {
     jvm_flags.push_back(flag);
   }
   wstringstream jvm_flags_launch_info_ss(this->GetLaunchInfoByKey(JVM_FLAGS));
-  while (getline(jvm_flags_launch_info_ss, flag, L' ')) {
+  while (getline(jvm_flags_launch_info_ss, flag, L'\t')) {
     jvm_flags.push_back(flag);
   }
 
@@ -411,8 +411,7 @@ ExitCode JavaBinaryLauncher::Launch() {
   vector<wstring> escaped_arguments;
   // Quote the arguments if having spaces
   for (const auto& arg : arguments) {
-    escaped_arguments.push_back(
-        GetEscapedArgument(arg, /*escape_backslash = */ false));
+    escaped_arguments.push_back(CreateProcessEscapeArg(arg));
   }
 
   ExitCode exit_code = this->LaunchProcess(java_bin, escaped_arguments);

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -49,7 +49,7 @@ ExitCode PythonBinaryLauncher::Launch() {
 
   // Escape arguments that has spaces
   for (int i = 1; i < args.size(); i++) {
-    args[i] = GetEscapedArgument(args[i], /*escape_backslash = */ false);
+    args[i] = CreateProcessEscapeArg(args[i]);
   }
 
   return this->LaunchProcess(python_binary, args);

--- a/src/tools/launcher/util/launcher_util.cc
+++ b/src/tools/launcher/util/launcher_util.cc
@@ -128,7 +128,7 @@ wstring GetBinaryPathWithExtension(const wstring& binary) {
   return GetBinaryPathWithoutExtension(binary) + L".exe";
 }
 
-wstring GetEscapedArgument(const wstring& argument, bool escape_backslash) {
+wstring BashEscapeArg(const wstring& argument) {
   wstring escaped_arg;
   // escaped_arg will be at least this long
   escaped_arg.reserve(argument.size());
@@ -150,8 +150,7 @@ wstring GetEscapedArgument(const wstring& argument, bool escape_backslash) {
         break;
 
       case L'\\':
-        // Escape back slashes if escape_backslash is true
-        escaped_arg += (escape_backslash ? L"\\\\" : L"\\");
+        escaped_arg += L"\\\\";
         break;
 
       default:
@@ -163,6 +162,87 @@ wstring GetEscapedArgument(const wstring& argument, bool escape_backslash) {
     escaped_arg += L'\"';
   }
   return escaped_arg;
+}
+
+std::wstring CreateProcessEscapeArg(const std::wstring& s) {
+  if (s.empty()) {
+    return L"\"\"";
+  } else {
+    bool needs_escaping = false;
+    for (const auto& c : s) {
+      if (c == ' ' || c == '"') {
+        needs_escaping = true;
+        break;
+      }
+    }
+    if (!needs_escaping) {
+      return s;
+    }
+  }
+
+  std::wostringstream result;
+  result << L'"';
+  int start = 0;
+  for (int i = 0; i < s.size(); ++i) {
+    char c = s[i];
+    if (c == '"' || c == '\\') {
+      // Copy the segment since the last special character.
+      if (start >= 0) {
+        result << s.substr(start, i - start);
+        start = -1;
+      }
+
+      // Handle the current special character.
+      if (c == '"') {
+        // This is a quote character. Escape it with a single backslash.
+        result << L"\\\"";
+      } else {
+        // This is a backslash (or the first one in a run of backslashes).
+        // Whether we escape it depends on whether the run ends with a quote.
+        int run_len = 1;
+        int j = i + 1;
+        while (j < s.size() && s[j] == '\\') {
+          run_len++;
+          j++;
+        }
+        if (j == s.size()) {
+          // The run of backslashes goes to the end.
+          // We have to escape every backslash with another backslash.
+          for (int k = 0; k < run_len * 2; ++k) {
+            result << L'\\';
+          }
+          break;
+        } else if (j < s.size() && s[j] == '"') {
+          // The run of backslashes is terminated by a quote.
+          // We have to escape every backslash with another backslash, and
+          // escape the quote with one backslash.
+          for (int k = 0; k < run_len * 2; ++k) {
+            result << L'\\';
+          }
+          result << L"\\\"";
+          i += run_len;  // 'i' is also increased in the loop iteration step
+        } else {
+          // No quote found. Each backslash counts for itself, they must not be
+          // escaped.
+          for (int k = 0; k < run_len; ++k) {
+            result << L'\\';
+          }
+          i += run_len - 1;  // 'i' is also increased in the loop iteration step
+        }
+      }
+    } else {
+      // This is not a special character. Start the segment if necessary.
+      if (start < 0) {
+        start = i;
+      }
+    }
+  }
+  // Save final segment after the last special character.
+  if (start != -1) {
+    result << s.substr(start);
+  }
+  result << L'"';
+  return result.str();
 }
 
 // An environment variable has a maximum size limit of 32,767 characters

--- a/src/tools/launcher/util/launcher_util.h
+++ b/src/tools/launcher/util/launcher_util.h
@@ -44,10 +44,11 @@ std::wstring GetBinaryPathWithExtension(const std::wstring& binary);
 // Escape a command line argument.
 //
 // If the argument has space, then we quote it.
-// Escape " to \"
-// Escape \ to \\ if escape_backslash is true
-std::wstring GetEscapedArgument(const std::wstring& argument,
-                                bool escape_backslash);
+// Escape " to \" .
+// Escape \ to \\ .
+std::wstring BashEscapeArg(const std::wstring& argument);
+
+std::wstring CreateProcessEscapeArg(const std::wstring& arg);
 
 // Convert a path to an absolute Windows path with \\?\ prefix.
 // This method will print an error and exit if it cannot convert the path.

--- a/src/tools/launcher/util/launcher_util_test.cc
+++ b/src/tools/launcher/util/launcher_util_test.cc
@@ -74,22 +74,74 @@ TEST_F(LaunchUtilTest, GetBinaryPathWithExtensionTest) {
   ASSERT_EQ(L"foo.sh.exe", GetBinaryPathWithExtension(L"foo.sh"));
 }
 
-TEST_F(LaunchUtilTest, GetEscapedArgumentTest) {
-  ASSERT_EQ(L"\"\"", GetEscapedArgument(L"", true));
-  ASSERT_EQ(L"foo", GetEscapedArgument(L"foo", true));
-  ASSERT_EQ(L"\"foo bar\"", GetEscapedArgument(L"foo bar", true));
-  ASSERT_EQ(L"\"\\\"foo bar\\\"\"", GetEscapedArgument(L"\"foo bar\"", true));
-  ASSERT_EQ(L"foo\\\\bar", GetEscapedArgument(L"foo\\bar", true));
-  ASSERT_EQ(L"foo\\\"bar", GetEscapedArgument(L"foo\"bar", true));
-  ASSERT_EQ(L"C:\\\\foo\\\\bar\\\\",
-            GetEscapedArgument(L"C:\\foo\\bar\\", true));
+TEST_F(LaunchUtilTest, BashEscapedArgTest) {
+  ASSERT_EQ(L"\"\"", BashEscapeArg(L""));
+  ASSERT_EQ(L"foo", BashEscapeArg(L"foo"));
+  ASSERT_EQ(L"\"foo bar\"", BashEscapeArg(L"foo bar"));
+  ASSERT_EQ(L"\"\\\"foo bar\\\"\"", BashEscapeArg(L"\"foo bar\""));
+  ASSERT_EQ(L"foo\\\\bar", BashEscapeArg(L"foo\\bar"));
+  ASSERT_EQ(L"foo\\\"bar", BashEscapeArg(L"foo\"bar"));
+  ASSERT_EQ(L"C:\\\\foo\\\\bar\\\\", BashEscapeArg(L"C:\\foo\\bar\\"));
   ASSERT_EQ(L"\"C:\\\\foo foo\\\\bar\\\\\"",
-            GetEscapedArgument(L"C:\\foo foo\\bar\\", true));
+            BashEscapeArg(L"C:\\foo foo\\bar\\"));
+}
 
-  ASSERT_EQ(L"foo\\bar", GetEscapedArgument(L"foo\\bar", false));
-  ASSERT_EQ(L"C:\\foo\\bar\\", GetEscapedArgument(L"C:\\foo\\bar\\", false));
-  ASSERT_EQ(L"\"C:\\foo foo\\bar\\\"",
-            GetEscapedArgument(L"C:\\foo foo\\bar\\", false));
+TEST_F(LaunchUtilTest, CreateProcessEscapeArgTest) {
+  ASSERT_EQ(L"\"\"", CreateProcessEscapeArg(L""));
+  ASSERT_EQ(L"\"with\\\"quote\"", CreateProcessEscapeArg(L"with\"quote"));
+  ASSERT_EQ(L"one\\backslash", CreateProcessEscapeArg(L"one\\backslash"));
+  ASSERT_EQ(L"\"one\\ backslash and \\space\"",
+            CreateProcessEscapeArg(L"one\\ backslash and \\space"));
+  ASSERT_EQ(L"two\\\\backslashes",
+            CreateProcessEscapeArg(L"two\\\\backslashes"));
+  ASSERT_EQ(L"\"two\\\\ backslashes \\\\and space\"",
+            CreateProcessEscapeArg(L"two\\\\ backslashes \\\\and space"));
+  ASSERT_EQ(L"\"one\\\\\\\"x\"", CreateProcessEscapeArg(L"one\\\"x"));
+  ASSERT_EQ(L"\"two\\\\\\\\\\\"x\"", CreateProcessEscapeArg(L"two\\\\\"x"));
+  ASSERT_EQ(L"\"a \\ b\"", CreateProcessEscapeArg(L"a \\ b"));
+  ASSERT_EQ(L"\"a \\\\\\\" b\"", CreateProcessEscapeArg(L"a \\\" b"));
+
+  ASSERT_EQ(L"A", CreateProcessEscapeArg(L"A"));
+  ASSERT_EQ(L"\"\\\"a\\\"\"", CreateProcessEscapeArg(L"\"a\""));
+
+  ASSERT_EQ(L"\"B C\"", CreateProcessEscapeArg(L"B C"));
+  ASSERT_EQ(L"\"\\\"b c\\\"\"", CreateProcessEscapeArg(L"\"b c\""));
+
+  ASSERT_EQ(L"\"D\\\"E\"", CreateProcessEscapeArg(L"D\"E"));
+  ASSERT_EQ(L"\"\\\"d\\\"e\\\"\"", CreateProcessEscapeArg(L"\"d\"e\""));
+
+  ASSERT_EQ(L"\"C:\\F G\"", CreateProcessEscapeArg(L"C:\\F G"));
+  ASSERT_EQ(L"\"\\\"C:\\f g\\\"\"", CreateProcessEscapeArg(L"\"C:\\f g\""));
+
+  ASSERT_EQ(L"\"C:\\H\\\"I\"", CreateProcessEscapeArg(L"C:\\H\"I"));
+  ASSERT_EQ(L"\"\\\"C:\\h\\\"i\\\"\"", CreateProcessEscapeArg(L"\"C:\\h\"i\""));
+
+  ASSERT_EQ(L"\"C:\\J\\\\\\\"K\"", CreateProcessEscapeArg(L"C:\\J\\\"K"));
+  ASSERT_EQ(L"\"\\\"C:\\j\\\\\\\"k\\\"\"",
+            CreateProcessEscapeArg(L"\"C:\\j\\\"k\""));
+
+  ASSERT_EQ(L"\"C:\\L M \"", CreateProcessEscapeArg(L"C:\\L M "));
+  ASSERT_EQ(L"\"\\\"C:\\l m \\\"\"",
+            CreateProcessEscapeArg(L"\"C:\\l m \""));
+
+  ASSERT_EQ(L"\"C:\\N O\\\\\"", CreateProcessEscapeArg(L"C:\\N O\\"));
+  ASSERT_EQ(L"\"\\\"C:\\n o\\\\\\\"\"",
+            CreateProcessEscapeArg(L"\"C:\\n o\\\""));
+
+  ASSERT_EQ(L"\"C:\\P Q\\ \"", CreateProcessEscapeArg(L"C:\\P Q\\ "));
+  ASSERT_EQ(L"\"\\\"C:\\p q\\ \\\"\"",
+            CreateProcessEscapeArg(L"\"C:\\p q\\ \""));
+
+  ASSERT_EQ(L"C:\\R\\S\\", CreateProcessEscapeArg(L"C:\\R\\S\\"));
+  ASSERT_EQ(L"\"C:\\R x\\S\\\\\"", CreateProcessEscapeArg(L"C:\\R x\\S\\"));
+  ASSERT_EQ(L"\"\\\"C:\\r\\s\\\\\\\"\"",
+            CreateProcessEscapeArg(L"\"C:\\r\\s\\\""));
+  ASSERT_EQ(L"\"\\\"C:\\r x\\s\\\\\\\"\"",
+            CreateProcessEscapeArg(L"\"C:\\r x\\s\\\""));
+
+  ASSERT_EQ(L"\"C:\\T U\\W\\\\\"", CreateProcessEscapeArg(L"C:\\T U\\W\\"));
+  ASSERT_EQ(L"\"\\\"C:\\t u\\w\\\\\\\"\"",
+            CreateProcessEscapeArg(L"\"C:\\t u\\w\\\""));
 }
 
 TEST_F(LaunchUtilTest, DoesFilePathExistTest) {


### PR DESCRIPTION
Bazel on Windows now correctly forwards
java_binary.jvm_flags to the binary.

Bazel Bash-tokenizes java_binary.jvm_flags.
On Linux/macOS, this is done by embedding the
flags into the Java stub script, which is a Bash
script, so Bash itself does the tokenization.

On Windows, java_binary is launched by a native
C++ binary. Therefore nothing could Bash-tokenize
the flags until now. From now on, Bazel itself
Bash-tokenizes the flags before embedding them in
the launcher. The launcher then escapes these
flags for CreateProcessW.

This PR also adds a new, CreateProcessW-aware
escaping method called CreateProcessEscapeArg, to
the launcher.

The pre-existing GetEscapedArgument escaped only
with Bash semantics in mind. This method is now
renamed to BashEscapeArg, and used only for the
Bash launcher. For the Python and Java launcher,
the new CreateProcessEscapeArg method is used.

Fixes https://github.com/bazelbuild/bazel/issues/7072

Change-Id: I48d675fcce39e4f6c95e3bad3e8569f0274f662a