### PR TITLE
Always set --no-canonical-prefixes if we can

### DIFF
--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -199,20 +199,21 @@ def _get_no_canonical_prefixes_opt(repository_ctx, cc):
     # (ie when they're shorter), it confuses Bazel's logic for verifying all
     # #included header files are listed as inputs to the action.
 
-    # The '-fno-canonical-system-headers' should be enough, but clang does not
-    # support it, so we also try '-no-canonical-prefixes' if first option does
-    # not work.
+    # The '-fno-canonical-system-headers' flag is enough in some
+    # cases, but clang does not support it, and gcc can be configured
+    # in a way where it is not sufficient to suppress symlink
+    # resolution, so we also try '-no-canonical-prefixes' if the
+    # compiler can use it without failing.
     opt = _add_compiler_option_if_supported(
         repository_ctx,
         cc,
         "-fno-canonical-system-headers",
     )
-    if len(opt) == 0:
-        return _add_compiler_option_if_supported(
+    opt.extend(_add_compiler_option_if_supported(
             repository_ctx,
             cc,
             "-no-canonical-prefixes",
-        )
+        ))
     return opt
 
 def get_env(repository_ctx):


### PR DESCRIPTION
Some configurations of gcc (I suspect --without-sysroot is the key
flag, but it's tricky to prove) will still resolve symlinks in the
compiler path even when -fno-canonical-system-headers is used. This
breaks remote execution in the presence of symlinks.

There's not much we can do other than include both flags - it's hard
to tell what will be correct when executing remotely. However, there
appears to be no real harm in adding --no-canonical-prefixes if it
passes the test in _is_linker_option_supported: prefix
canonicalisation is only required when gcc is invoked through a
symlink that does not also include the rest of its files, and the test
command will fail completely when this occurs.