### PR TITLE
Have repository functions delete files before writing to them

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -213,6 +213,7 @@ public class SkylarkRepositoryContext
     try {
       checkInOutputDirectory(p);
       makeDirectories(p.getPath());
+      p.getPath().delete();
       try (OutputStream stream = p.getPath().getOutputStream()) {
         stream.write(content.getBytes(StandardCharsets.UTF_8));
       }
@@ -251,6 +252,7 @@ public class SkylarkRepositoryContext
         tpl =
             StringUtilities.replaceAllLiteral(tpl, substitution.getKey(), substitution.getValue());
       }
+      p.getPath().delete();
       try (OutputStream stream = p.getPath().getOutputStream()) {
         stream.write(tpl.getBytes(StandardCharsets.UTF_8));
       }


### PR DESCRIPTION
It is common for underlying files in repositories to be populated with
symlinks, and then have BUILD files overlaid. If we attempt to use
repository_ctx.template or repository_ctx.file on a filename which has
already been created as a symlink, bazel will currently attempt to
write through this symlink, and often fail because the underlying file
is read-only (or worse, succeed and mutate something outside the
repository directory).

We solve this by deleting any pre-existing files before writing new
ones.