### PR TITLE
Implement environment variable substitution for unix platforms

### DIFF
--- a/site/docs/guide.html
+++ b/site/docs/guide.html
@@ -858,11 +858,15 @@ $ bazel fetch //...
   <li>
     Unless the <code class='flag'>--nosystem_rc</code> is present, Bazel looks for
     the system .bazelrc file: on Unix, it lives at <code>/etc/bazel.bazelrc</code>,
-    and on Windows at <code>%%ProgramData%%/bazel.bazelrc</code>.
+    and on Windows at <code>%ProgramData%/bazel.bazelrc</code>.
 
     If another system-specified location is required, this value can be
     changed by setting <code>BAZEL_SYSTEM_BAZELRC_PATH</code> in
     <code>src/main/cpp:option_processor</code> and using this custom Bazel binary.
+
+    The system-specified location may contain environment variable
+    substitutions, as <code>%var_name%</code> on Windows
+    or <code>${var_name}</code> on Unix.
   </li>
   <li>
     Unless the <code class='flag'>--noworkspace_rc</code> is present, Bazel looks

--- a/src/main/cpp/BUILD
+++ b/src/main/cpp/BUILD
@@ -132,6 +132,8 @@ cc_library(
         "//src/conditions:windows": [
             "/DBAZEL_SYSTEM_BAZELRC_PATH#\\\"%%ProgramData%%/bazel.bazelrc\\\"",
         ],
+        # For unix platforms, this can include environment variables in the
+        # form ${var_name}. Braces are required.
         "//conditions:default": [
             "-DBAZEL_SYSTEM_BAZELRC_PATH=\\\"/etc/bazel.bazelrc\\\"",
         ],

--- a/src/main/cpp/BUILD
+++ b/src/main/cpp/BUILD
@@ -125,14 +125,17 @@ cc_library(
     # The system bazelrc can be voided by setting BAZEL_SYSTEM_BAZELRC_PATH to
     # /dev/null.
     copts = select({
-        # We need to escape for multiple levels, here, this becomes
+        # For windows platforms, this can include environment
+        # variables in the form %ProgramData%. We need to escape for
+        # multiple levels, here, this becomes
         # /DBAZEL_SYSTEM_BAZELRC_PATH="%%ProgramData%%/bazel.bazelrc"',
-        # and the double % get reduced down to 1 by the compiler. A forward
-        # slash is used because \b is a special character, backspace.
+        # and the double % get reduced down to 1 by the compiler. A
+        # forward slash is used because \b is a special character,
+        # backspace.
         "//src/conditions:windows": [
             "/DBAZEL_SYSTEM_BAZELRC_PATH#\\\"%%ProgramData%%/bazel.bazelrc\\\"",
         ],
-        # For unix platforms, this can include environment variables in the
+        # For posix platforms, this can include environment variables in the
         # form ${var_name}. Braces are required.
         "//conditions:default": [
             "-DBAZEL_SYSTEM_BAZELRC_PATH=\\\"/etc/bazel.bazelrc\\\"",

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -220,7 +220,7 @@ std::vector<std::string> DedupeBlazercPaths(
 
 std::string FindSystemWideRc(const std::string& system_bazelrc_path) {
   const std::string path =
-      blaze_util::MakeAbsoluteAndResolveWindowsEnvvars(system_bazelrc_path);
+      blaze_util::MakeAbsoluteAndResolveEnvvars(system_bazelrc_path);
   if (blaze_util::CanReadFile(path)) {
     return path;
   }
@@ -325,11 +325,11 @@ blaze_exit_code::ExitCode OptionProcessor::GetRcFiles(
 
   // Get the system rc (unless --nosystem_rc).
   if (SearchNullaryOption(cmd_line->startup_args, "system_rc", true)) {
-    // MakeAbsoluteAndResolveWindowsEnvvars will standardize the form of the
+    // MakeAbsoluteAndResolveEnvvars will standardize the form of the
     // provided path. This also means we accept relative paths, which is
     // is convenient for testing.
     const std::string system_rc =
-        blaze_util::MakeAbsoluteAndResolveWindowsEnvvars(system_bazelrc_path_);
+        blaze_util::MakeAbsoluteAndResolveEnvvars(system_bazelrc_path_);
     rc_files.push_back(system_rc);
   }
 

--- a/src/main/cpp/util/path_platform.h
+++ b/src/main/cpp/util/path_platform.h
@@ -54,15 +54,15 @@ bool IsAbsolute(const std::string &path);
 //   MakeAbsolute("C:/foo") ---> "C:/foo"
 std::string MakeAbsolute(const std::string &path);
 
-// Returns the given path in absolute form, taking into account a possible
-// starting environment variable on the windows platform, so that we can
-// accept standard path variables like %USERPROFILE%. We do not support
-// unix-style envvars here: recreating that logic is error-prone and not
-// worthwhile, since they are less critical to standard paths as in Windows.
+// Returns the given path in absolute form, taking into account a
+// possible starting environment variable, so that we can accept
+// standard path variables like %USERPROFILE% or ${BAZEL}. For
+// simplicity, we implement only those two forms, not $BAZEL.
 //
 //   MakeAbsolute("foo") in wd "/bar" --> "/bar/foo"
-//   MakeAbsolute("%USERPROFILE%/foo") --> "C:\Users\bazel-user\foo"
-std::string MakeAbsoluteAndResolveWindowsEnvvars(const std::string &path);
+//   MakeAbsoluteAndResolveEnvvars("%USERPROFILE%/foo") --> "C:\Users\bazel-user\foo"
+//   MakeAbsoluteAndResolveEnvvars("${BAZEL}/foo") --> "/opt/bazel/foo"
+std::string MakeAbsoluteAndResolveEnvvars(const std::string &path);
 
 // TODO(bazel-team) consider changing the path(_platform) header split to be a
 // path.h and path_windows.h split, which would make it clearer what functions

--- a/src/main/cpp/util/path_posix.cc
+++ b/src/main/cpp/util/path_posix.cc
@@ -71,7 +71,7 @@ std::string MakeAbsolute(const std::string &path) {
 
 std::string ResolveEnvvars(const std::string &path) {
   std::string result = path;
-  static std::regex env("\\$\\{([^}]+)}");
+  static std::regex env("\\$\\{([^}]+)\\}");
   std::smatch m;
   while (std::regex_search(result, m, env)) {
     const char *value = getenv(m[1].str().c_str());

--- a/src/main/cpp/util/path_posix.cc
+++ b/src/main/cpp/util/path_posix.cc
@@ -74,15 +74,19 @@ std::string ResolveEnvvars(const std::string &path) {
     // Just match to the next }
     size_t end = result.find("}", start + 1);
     if (end == std::string::npos) {
-      // No more variables can exist
-      break;
+      BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
+          << "ResolveEnvvars(" << path
+          << "): incomplete variable at position "
+          << start;
     }
     // Extract the variable name
     const std::string name = result.substr(start + 2, end - start - 2);
     // Get the value from the environment
-    const char *value = getenv(name.c_str());
+    const char *c_value = getenv(name.c_str());
+    const std::string value = std::string(c_value ? c_value : "");
     result.erase(start, end - start + 1);
-    result.insert(start, value ? value : "");
+    result.insert(start, value);
+    start += value.length();
   }
   return result;
 }

--- a/src/main/cpp/util/path_windows.cc
+++ b/src/main/cpp/util/path_windows.cc
@@ -88,7 +88,7 @@ std::string MakeAbsolute(const std::string& path) {
       WstringToCstring(RemoveUncPrefixMaybe(wpath.c_str())).get());
 }
 
-std::string MakeAbsoluteAndResolveWindowsEnvvars(const std::string& path) {
+std::string MakeAbsoluteAndResolveEnvvars(const std::string& path) {
   // Get the size of the expanded string, so we know how big of a buffer to
   // provide. The returned size includes the null terminator.
   std::unique_ptr<CHAR[]> resolved(new CHAR[MAX_PATH]);

--- a/src/test/cpp/util/path_posix_test.cc
+++ b/src/test/cpp/util/path_posix_test.cc
@@ -163,6 +163,7 @@ TEST(PathPosixTest, MakeAbsoluteAndResolveEnvvars) {
   // Check that Unix-style envvars are resolved.
   const std::string tmpdir = getenv("TEST_TMPDIR");
   const std::string expected_tmpdir_bar = ConvertPath(tmpdir + "/bar");
+  setenv("PATH_POSIX_TEST_ENV", "${TEST_TMPDIR}", 1);
 
   // Using an existing environment variable
   EXPECT_EQ(expected_tmpdir_bar,
@@ -174,6 +175,10 @@ TEST(PathPosixTest, MakeAbsoluteAndResolveEnvvars) {
   // This style of variable is not supported
   EXPECT_EQ(JoinPath(GetCwd(), "$TEST_TMPDIR/bar"),
             MakeAbsoluteAndResolveEnvvars("$TEST_TMPDIR/bar"));
+
+  // Only one layer of variables is expanded, we do not recurse
+  EXPECT_EQ(JoinPath(GetCwd(), "${TEST_TMPDIR}/bar"),
+            MakeAbsoluteAndResolveEnvvars("${PATH_POSIX_TEST_ENV}/bar"));
 
   // Check that Windows-style envvars are not resolved when not on Windows.
   EXPECT_EQ(MakeAbsoluteAndResolveEnvvars("%PATH%"),

--- a/src/test/cpp/util/path_posix_test.cc
+++ b/src/test/cpp/util/path_posix_test.cc
@@ -159,14 +159,24 @@ TEST(PathPosixTest, MakeAbsolute) {
   EXPECT_EQ(MakeAbsolute(""), "");
 }
 
-TEST(PathPosixTest, MakeAbsoluteAndResolveWindowsEnvvars) {
-  // Check that Unix-style envvars are not resolved.
-  EXPECT_EQ(MakeAbsoluteAndResolveWindowsEnvvars("$PATH"),
-            JoinPath(GetCwd(), "$PATH"));
-  EXPECT_EQ(MakeAbsoluteAndResolveWindowsEnvvars("${PATH}"),
-            JoinPath(GetCwd(), "${PATH}"));
+TEST(PathPosixTest, MakeAbsoluteAndResolveEnvvars) {
+  // Check that Unix-style envvars are resolved.
+  const std::string tmpdir = getenv("TEST_TMPDIR");
+  const std::string expected_tmpdir_bar = ConvertPath(tmpdir + "/bar");
+
+  // Using an existing environment variable
+  EXPECT_EQ(expected_tmpdir_bar,
+            MakeAbsoluteAndResolveEnvvars("${TEST_TMPDIR}/bar"));
+  // Using an undefined environment variable (case-sensitive)
+  EXPECT_EQ("/bar",
+            MakeAbsoluteAndResolveEnvvars("${test_tmpdir}/bar"));
+
+  // This style of variable is not supported
+  EXPECT_EQ(JoinPath(GetCwd(), "$TEST_TMPDIR/bar"),
+            MakeAbsoluteAndResolveEnvvars("$TEST_TMPDIR/bar"));
+
   // Check that Windows-style envvars are not resolved when not on Windows.
-  EXPECT_EQ(MakeAbsoluteAndResolveWindowsEnvvars("%PATH%"),
+  EXPECT_EQ(MakeAbsoluteAndResolveEnvvars("%PATH%"),
             JoinPath(GetCwd(), "%PATH%"));
 }
 

--- a/src/test/cpp/util/path_windows_test.cc
+++ b/src/test/cpp/util/path_windows_test.cc
@@ -392,7 +392,7 @@ TEST(PathWindowsTest, MakeAbsolute) {
   EXPECT_EQ("", MakeAbsolute(""));
 }
 
-TEST(PathWindowsTest, MakeAbsoluteAndResolveWindowsEnvvars_WithTmpdir) {
+TEST(PathWindowsTest, MakeAbsoluteAndResolveEnvvars_WithTmpdir) {
   // We cannot test the system-default paths like %ProgramData% because these
   // are wiped from the test environment. TestTmpdir is set by Bazel though,
   // so serves as a fine substitute.
@@ -402,20 +402,20 @@ TEST(PathWindowsTest, MakeAbsoluteAndResolveWindowsEnvvars_WithTmpdir) {
   const std::string expected_tmpdir_bar = ConvertPath(tmpdir + "\\bar");
 
   EXPECT_EQ(expected_tmpdir_bar,
-            MakeAbsoluteAndResolveWindowsEnvvars("%TEST_TMPDIR%\\bar"));
+            MakeAbsoluteAndResolveEnvvars("%TEST_TMPDIR%\\bar"));
   EXPECT_EQ(expected_tmpdir_bar,
-            MakeAbsoluteAndResolveWindowsEnvvars("%Test_Tmpdir%\\bar"));
+            MakeAbsoluteAndResolveEnvvars("%Test_Tmpdir%\\bar"));
   EXPECT_EQ(expected_tmpdir_bar,
-            MakeAbsoluteAndResolveWindowsEnvvars("%test_tmpdir%\\bar"));
+            MakeAbsoluteAndResolveEnvvars("%test_tmpdir%\\bar"));
   EXPECT_EQ(expected_tmpdir_bar,
-            MakeAbsoluteAndResolveWindowsEnvvars("%test_tmpdir%/bar"));
+            MakeAbsoluteAndResolveEnvvars("%test_tmpdir%/bar"));
 }
 
-TEST(PathWindowsTest, MakeAbsoluteAndResolveWindowsEnvvars_LongPaths) {
+TEST(PathWindowsTest, MakeAbsoluteAndResolveEnvvars_LongPaths) {
   const std::string long_path = "c:\\" + std::string(MAX_PATH, 'a');
   blaze::SetEnv("long", long_path);
 
-  EXPECT_EQ(long_path, MakeAbsoluteAndResolveWindowsEnvvars("%long%"));
+  EXPECT_EQ(long_path, MakeAbsoluteAndResolveEnvvars("%long%"));
 }
 
 }  // namespace blaze_util


### PR DESCRIPTION
I want to be able to use this to redirect the bazel config file based
on the environment, for integration with our existing
environment-based mechanisms for selecting build configurations.

I found some opinions in comments which said this was too difficult,
which I have amended.