### PR TITLE
Use freshly built allmodules JDK for the jdeps test.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -284,6 +284,7 @@ filegroup(
             ":embedded_jdk_allmodules.tar.gz",
         ],
     }),
+    visibility = ["//src/test/shell/bazel:__pkg__"],
 )
 
 [genrule(

--- a/src/jdeps_modules.golden
+++ b/src/jdeps_modules.golden
@@ -1,4 +1,3 @@
-java.activation
 java.base
 java.compiler
 java.desktop
@@ -9,7 +8,6 @@ java.naming
 java.security.jgss
 java.sql
 java.xml
-java.xml.bind
 jdk.compiler
 jdk.management
 jdk.sctp

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -783,7 +783,7 @@ sh_test(
     data = [
         ":jdeps_class_blacklist.txt",
         ":test-deps",
-        "//src:embedded_jdk_allmodules_cached",
+        "//src:embedded_jdk_allmodules",
         "//src:jdeps_modules.golden",
         "//src/main/java/com/google/devtools/build/lib:bazel/BazelServer_deploy.jar",
         "@bazel_tools//tools/bash/runfiles",

--- a/src/test/shell/bazel/jdeps_test.sh
+++ b/src/test/shell/bazel/jdeps_test.sh
@@ -59,9 +59,8 @@ function test_jdeps() {
   else
     platform="linux"
   fi
-  cp $(rlocation openjdk_${platform}/file/zulu-${platform}.tar.gz) .
-  tar xf zulu-${platform}.tar.gz || fail "Failed to extract JDK."
-  find . | grep jdeps
+  cp $(rlocation io_bazel/src/allmodules_jdk.tar.gz) .
+  tar xf allmodules_jdk.tar.gz || fail "Failed to extract JDK."
   blacklist=$(rlocation io_bazel/src/test/shell/bazel/jdeps_class_blacklist.txt)
   deploy_jar=$(rlocation io_bazel/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar)
   cd ../bazeljar
@@ -73,7 +72,7 @@ function test_jdeps() {
   # src/test/shell/bazel/jdeps_class_blacklist.txt.
   find . -type f -iname \*class | \
     grep -vFf "$blacklist" | \
-    xargs ../jdk/zulu9.0.7.1-jdk9.0.7-*/bin/jdeps --list-reduced-deps | \
+    xargs ../jdk/reduced/bin/jdeps --list-reduced-deps | \
     grep -v "unnamed module" > ../jdeps \
     || fail "Failed to run jdeps on non blacklisted class files."
   cd ..


### PR DESCRIPTION
Otherwise we have a cliff every time we bump the embedded JDK version.

RELNOTES: None