### PR TITLE
Explicitly specifies -target and -arch flags for watchos arm64_32

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/packages/util/MOCK_OSX_CROSSTOOL
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/MOCK_OSX_CROSSTOOL
@@ -14465,6 +14465,1830 @@ toolchain {
   cc_target_os: "apple"
 }
 toolchain {
+  toolchain_identifier: "watchos_arm64_32"
+  host_system_name: "x86_64-apple-macosx"
+  target_system_name: "arm64_32-apple-watchos"
+  target_cpu: "watchos_arm64_32"
+  target_libc: "watchos"
+  compiler: "compiler"
+  abi_version: "local"
+  abi_libc_version: "local"
+  tool_path {
+    name: "ar"
+    path: "watchos/ar_wrapper"
+  }
+  tool_path {
+    name: "compat-ld"
+    path: "watchos/ld"
+  }
+  tool_path {
+    name: "cpp"
+    path: "watchos/cpp"
+  }
+  tool_path {
+    name: "gcov"
+    path: "watchos/gcov"
+  }
+  tool_path {
+    name: "gcc"
+    path: "watchos/clang"
+  }
+  tool_path {
+    name: "ld"
+    path: "watchos/ld"
+  }
+  tool_path {
+    name: "nm"
+    path: "watchos/nm"
+  }
+  tool_path {
+    name: "strip"
+    path: "watchos/strip"
+  }
+  tool_path {
+    name: "dwp"
+    path: "/usr/bin/dwp"
+  }
+  tool_path {
+    name: "objdump"
+    path: "/usr/bin/objdump"
+  }
+  make_variable {
+    name: "STACK_FRAME_UNLIMITED"
+    value: "-Wframe-larger-than=100000000 -Wno-vla"
+  }
+  cxx_builtin_include_directory: "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/"
+  cxx_builtin_include_directory: "/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/"
+  cxx_builtin_include_directory: "/Applications/Xcode_7.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/"
+  cxx_builtin_include_directory: "/Applications/Xcode_7.3.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/"
+  cxx_builtin_include_directory: "/Applications/Xcode_8.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/"
+  cxx_builtin_include_directory: "/Applications/Xcode_8.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/"
+  cxx_builtin_include_directory: "/Applications/Xcode_8.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/"
+  cxx_builtin_include_directory: "/Applications/Xcode_8.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/"
+  cxx_builtin_include_directory: "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs"
+  cxx_builtin_include_directory: "/Applications/Xcode-beta.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs"
+  cxx_builtin_include_directory: "/Applications/Xcode_7.2.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs"
+  cxx_builtin_include_directory: "/Applications/Xcode_7.3.1.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs"
+  cxx_builtin_include_directory: "/Applications/Xcode_8.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs"
+  cxx_builtin_include_directory: "/Applications/Xcode_8.1.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs"
+  cxx_builtin_include_directory: "/Applications/Xcode_8.2.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs"
+  cxx_builtin_include_directory: "/Applications/Xcode_8.2.1.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs"
+  cxx_builtin_include_directory: "/usr/include"
+  builtin_sysroot: ""
+  feature {
+    name: "no_legacy_features"
+  }
+  feature {
+    name: "fastbuild"
+    implies: "fastbuild_only_flag"
+  }
+  feature {
+    name: "opt"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-g0"
+      }
+      with_feature {
+        feature: "no_generate_debug_symbols"
+      }
+    }
+    implies: "opt_only_flag"
+  }
+  feature {
+    name: "dbg"
+    implies: "dbg_only_flag"
+  }
+  feature {
+    name: "compile_all_modules"
+  }
+  feature {
+    name: "exclude_private_headers_in_module_maps"
+  }
+  feature {
+    name: "has_configured_linker_path"
+  }
+  feature {
+    name: "only_doth_headers_in_module_maps"
+  }
+  feature {
+    name: "is_not_test_target"
+  }
+  feature {
+    name: "default_compile_flags"
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "linkstamp-compile"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      action: "lto-backend"
+      action: "clif-match"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-DCOMPILER_GCC3"
+        flag: "-DCOMPILER_GCC4"
+        flag: "-Dunix"
+        flag: "-DOS_IOS"
+        flag: "-DU_HAVE_NL_LANGINFO_CODESET=0"
+        flag: "-DU_HAVE_STD_STRING"
+        flag: "-D__STDC_FORMAT_MACROS"
+        flag: "-fcolor-diagnostics"
+      }
+    }
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "linkstamp-compile"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      action: "lto-backend"
+      action: "clif-match"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-O0"
+        flag: "-DDEBUG"
+      }
+      with_feature {
+        feature: "fastbuild"
+      }
+    }
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "linkstamp-compile"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      action: "lto-backend"
+      action: "clif-match"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-Os"
+        flag: "-DNDEBUG"
+      }
+      with_feature {
+        feature: "opt"
+      }
+    }
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "linkstamp-compile"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      action: "lto-backend"
+      action: "clif-match"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-g"
+        flag: "-DDEBUG"
+      }
+      with_feature {
+        feature: "dbg"
+      }
+    }
+    flag_set {
+      action: "linkstamp-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      action: "lto-backend"
+      action: "clif-match"
+      flag_group {
+        flag: "-std=gnu++11"
+        flag: "-stdlib=libc++"
+      }
+    }
+    enabled: true
+  }
+  feature {
+    name: "generate_dsym_file"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-g"
+      }
+    }
+    flag_set {
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "DSYM_HINT_LINKED_BINARY=%{linked_binary}"
+        flag: "DSYM_HINT_DSYM_PATH=%{dsym_path}"
+      }
+    }
+  }
+  feature {
+    name: "no_generate_debug_symbols"
+  }
+  feature {
+    name: "generate_linkmap"
+    flag_set {
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-Xlinker -map"
+        flag: "-Xlinker %{linkmap_exec_path}"
+      }
+    }
+  }
+  feature {
+    name: "objc_actions"
+    implies: "objc-compile"
+    implies: "objc++-compile"
+    implies: "objc-fully-link"
+    implies: "objc-archive"
+    implies: "objc-executable"
+    implies: "objc++-executable"
+    implies: "assemble"
+    implies: "preprocess-assemble"
+    implies: "c-compile"
+    implies: "c++-compile"
+    implies: "c++-link-static-library"
+    implies: "c++-link-dynamic-library"
+    implies: "c++-link-nodeps-dynamic-library"
+    implies: "c++-link-executable"
+  }
+  feature {
+    name: "strip_debug_symbols"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "-Wl,-S"
+        expand_if_all_available: "strip_debug_symbols"
+      }
+    }
+  }
+  feature {
+    name: "symbol_counts"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "-Wl,--print-symbol-counts=%{symbol_counts_output}"
+        expand_if_all_available: "symbol_counts_output"
+      }
+    }
+  }
+  feature {
+    name: "shared_flag"
+    flag_set {
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "-shared"
+      }
+    }
+  }
+  feature {
+    name: "linkstamps"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "%{linkstamp_paths}"
+        iterate_over: "linkstamp_paths"
+        expand_if_all_available: "linkstamp_paths"
+      }
+    }
+  }
+  feature {
+    name: "output_execpath_flags"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "-o"
+        flag: "%{output_execpath}"
+        expand_if_all_available: "output_execpath"
+      }
+    }
+  }
+  feature {
+    name: "runtime_root_flags"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-static-library"
+      flag_group {
+        flag: "-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}"
+        iterate_over: "runtime_library_search_directories"
+        expand_if_all_available: "runtime_library_search_directories"
+      }
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-static-library"
+      flag_group {
+        flag: "%{runtime_root_flags}"
+        iterate_over: "runtime_root_flags"
+        expand_if_all_available: "runtime_root_flags"
+      }
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-static-library"
+      flag_group {
+        flag: "%{runtime_root_entries}"
+        iterate_over: "runtime_root_entries"
+        expand_if_all_available: "runtime_root_entries"
+      }
+    }
+  }
+  feature {
+    name: "archiver_flags"
+    flag_set {
+      action: "c++-link-static-library"
+      flag_group {
+        flag: "rcs"
+        flag: "%{output_execpath}"
+        expand_if_all_available: "output_execpath"
+      }
+    }
+  }
+  feature {
+    name: "input_param_flags"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-static-library"
+      flag_group {
+        flag: "-L%{library_search_directories}"
+        iterate_over: "library_search_directories"
+        expand_if_all_available: "library_search_directories"
+      }
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-static-library"
+      flag_group {
+        flag: "%{libopts}"
+        iterate_over: "libopts"
+        expand_if_all_available: "libopts"
+      }
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-static-library"
+      flag_group {
+        flag: "-Wl,-force_load,%{whole_archive_linker_params}"
+        iterate_over: "whole_archive_linker_params"
+        expand_if_all_available: "whole_archive_linker_params"
+      }
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-static-library"
+      flag_group {
+        flag: "%{linker_input_params}"
+        iterate_over: "linker_input_params"
+        expand_if_all_available: "linker_input_params"
+      }
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-static-library"
+      flag_group {
+        flag_group {
+          flag: "-Wl,--start-lib"
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "object_file_group"
+          }
+        }
+        flag_group {
+          flag_group {
+            flag: "%{libraries_to_link.object_files}"
+            expand_if_false: "libraries_to_link.is_whole_archive"
+          }
+          flag_group {
+            flag: "-Wl,-force_load,%{libraries_to_link.object_files}"
+            expand_if_true: "libraries_to_link.is_whole_archive"
+          }
+          iterate_over: "libraries_to_link.object_files"
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "object_file_group"
+          }
+        }
+        flag_group {
+          flag: "-Wl,--end-lib"
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "object_file_group"
+          }
+        }
+        flag_group {
+          flag_group {
+            flag: "%{libraries_to_link.name}"
+            expand_if_false: "libraries_to_link.is_whole_archive"
+          }
+          flag_group {
+            flag: "-Wl,-force_load,%{libraries_to_link.name}"
+            expand_if_true: "libraries_to_link.is_whole_archive"
+          }
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "object_file"
+          }
+        }
+        flag_group {
+          flag_group {
+            flag: "%{libraries_to_link.name}"
+            expand_if_false: "libraries_to_link.is_whole_archive"
+          }
+          flag_group {
+            flag: "-Wl,-force_load,%{libraries_to_link.name}"
+            expand_if_true: "libraries_to_link.is_whole_archive"
+          }
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "interface_library"
+          }
+        }
+        flag_group {
+          flag_group {
+            flag: "%{libraries_to_link.name}"
+            expand_if_false: "libraries_to_link.is_whole_archive"
+          }
+          flag_group {
+            flag: "-Wl,-force_load,%{libraries_to_link.name}"
+            expand_if_true: "libraries_to_link.is_whole_archive"
+          }
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "static_library"
+          }
+        }
+        flag_group {
+          flag_group {
+            flag: "-l%{libraries_to_link.name}"
+            expand_if_false: "libraries_to_link.is_whole_archive"
+          }
+          flag_group {
+            flag: "-Wl,-force_load,-l%{libraries_to_link.name}"
+            expand_if_true: "libraries_to_link.is_whole_archive"
+          }
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "dynamic_library"
+          }
+        }
+        flag_group {
+          flag_group {
+            flag: "-l:%{libraries_to_link.name}"
+            expand_if_false: "libraries_to_link.is_whole_archive"
+          }
+          flag_group {
+            flag: "-Wl,-force_load,-l:%{libraries_to_link.name}"
+            expand_if_true: "libraries_to_link.is_whole_archive"
+          }
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "versioned_dynamic_library"
+          }
+        }
+        iterate_over: "libraries_to_link"
+        expand_if_all_available: "libraries_to_link"
+      }
+    }
+  }
+  feature {
+    name: "force_pic_flags"
+    flag_set {
+      action: "c++-link-executable"
+      flag_group {
+        flag: "-Wl,-pie"
+        expand_if_all_available: "force_pic"
+      }
+    }
+  }
+  feature {
+    name: "pch"
+    flag_set {
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "c-compile"
+      action: "c++-compile"
+      flag_group {
+        flag: "-include"
+        flag: "%{pch_file}"
+      }
+    }
+  }
+  feature {
+    name: "module_maps"
+  }
+  feature {
+    name: "use_objc_modules"
+    flag_set {
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-fmodule-name=%{module_name}"
+        flag: "-iquote"
+        flag: "%{module_maps_dir}"
+        flag: "-fmodules-cache-path=%{modules_cache_path}"
+      }
+    }
+  }
+  feature {
+    name: "no_enable_modules"
+    flag_set {
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-fmodule-maps"
+      }
+    }
+    requires {
+      feature: "use_objc_modules"
+    }
+  }
+  feature {
+    name: "apply_default_warnings"
+    flag_set {
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-Wshorten-64-to-32"
+        flag: "-Wbool-conversion"
+        flag: "-Wconstant-conversion"
+        flag: "-Wduplicate-method-match"
+        flag: "-Wempty-body"
+        flag: "-Wenum-conversion"
+        flag: "-Wint-conversion"
+        flag: "-Wunreachable-code"
+        flag: "-Wmismatched-return-types"
+        flag: "-Wundeclared-selector"
+        flag: "-Wuninitialized"
+        flag: "-Wunused-function"
+        flag: "-Wunused-variable"
+      }
+    }
+  }
+  feature {
+    name: "preprocessor_defines"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-D%{preprocessor_defines}"
+        iterate_over: "preprocessor_defines"
+      }
+    }
+  }
+  feature {
+    name: "xcode_5.0"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-header-preprocessing"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-DXCODE_FEATURE_FOR_TESTING=xcode_5.0"
+      }
+    }
+  }
+  feature {
+    name: "xcode_5.8"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-header-preprocessing"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-DXCODE_FEATURE_FOR_TESTING=xcode_5.8"
+      }
+    }
+  }
+  feature {
+    name: "xcode_7.3"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-header-preprocessing"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-DXCODE_FEATURE_FOR_TESTING=xcode_7.3"
+      }
+    }
+  }
+  feature {
+    name: "framework_paths"
+    flag_set {
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-F%{framework_paths}"
+        iterate_over: "framework_paths"
+      }
+    }
+  }
+  feature {
+    name: "apply_default_compiler_flags"
+    flag_set {
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-DOS_IOS"
+        flag: "-fno-autolink"
+      }
+    }
+  }
+  feature {
+    name: "include_system_dirs"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "c++-header-parsing"
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "objc-executable"
+      action: "objc++-executable"
+      action: "assemble"
+      action: "preprocess-assemble"
+      flag_group {
+        flag: "-isysroot"
+        flag: "%{sdk_dir}"
+        flag: "-F%{sdk_framework_dir}"
+        flag: "-F%{platform_developer_framework_dir}"
+      }
+    }
+  }
+  feature {
+    name: "objc_arc"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "c++-header-parsing"
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-fobjc-arc"
+        expand_if_all_available: "objc_arc"
+      }
+    }
+  }
+  feature {
+    name: "no_objc_arc"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "c++-header-parsing"
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-fno-objc-arc"
+        expand_if_all_available: "no_objc_arc"
+      }
+    }
+  }
+  feature {
+    name: "apple_env"
+    env_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "c++-header-parsing"
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "objc-archive"
+      action: "objc-fully-link"
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-static-library"
+      action: "objc-executable"
+      action: "objc++-executable"
+      env_entry {
+        key: "XCODE_VERSION_OVERRIDE"
+        value: "%{xcode_version_override_value}"
+      }
+      env_entry {
+        key: "APPLE_SDK_VERSION_OVERRIDE"
+        value: "%{apple_sdk_version_override_value}"
+      }
+      env_entry {
+        key: "APPLE_SDK_PLATFORM"
+        value: "%{apple_sdk_platform_value}"
+      }
+    }
+  }
+  feature {
+    name: "user_link_flags"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "%{user_link_flags}"
+        iterate_over: "user_link_flags"
+        expand_if_all_available: "user_link_flags"
+      }
+    }
+    enabled: true
+  }
+  feature {
+    name: "default_link_flags"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-lc++"
+        flag: "-target"
+        flag: "armv7-apple-watchos"
+      }
+    }
+    enabled: true
+  }
+  feature {
+    name: "version_min"
+    flag_set {
+      action: "objc-executable"
+      action: "objc++-executable"
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-mwatchos-version-min=%{version_min}"
+      }
+    }
+  }
+  feature {
+    name: "dead_strip"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-dead_strip"
+        flag: "-no_dead_strip_inits_and_terms"
+      }
+      with_feature {
+        feature: "is_not_test_target"
+      }
+    }
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-g"
+      }
+    }
+    requires {
+      feature: "opt"
+    }
+  }
+  feature {
+    name: "dependency_file"
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "c++-header-parsing"
+      flag_group {
+        flag: "-MD"
+        flag: "-MF"
+        flag: "%{dependency_file}"
+        expand_if_all_available: "dependency_file"
+      }
+    }
+  }
+  feature {
+    name: "random_seed"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-codegen"
+      action: "c++-module-compile"
+      flag_group {
+        flag: "-frandom-seed=%{output_file}"
+        expand_if_all_available: "output_file"
+      }
+    }
+  }
+  feature {
+    name: "pic"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-codegen"
+      action: "c++-module-compile"
+      action: "preprocess-assemble"
+      flag_group {
+        flag: "-fPIC"
+        expand_if_all_available: "pic"
+      }
+    }
+  }
+  feature {
+    name: "per_object_debug_info"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-codegen"
+      action: "assemble"
+      action: "preprocess-assemble"
+      flag_group {
+        flag: "-gsplit-dwarf"
+        expand_if_all_available: "per_object_debug_info_file"
+      }
+    }
+  }
+  feature {
+    name: "includes"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "linkstamp-compile"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "clif-match"
+      flag_group {
+        flag: "-include"
+        flag: "%{includes}"
+        iterate_over: "includes"
+        expand_if_all_available: "includes"
+      }
+    }
+    enabled: true
+  }
+  feature {
+    name: "include_paths"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "clif-match"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-iquote"
+        flag: "%{quote_include_paths}"
+        iterate_over: "quote_include_paths"
+      }
+      flag_group {
+        flag: "-I%{include_paths}"
+        iterate_over: "include_paths"
+      }
+      flag_group {
+        flag: "-isystem"
+        flag: "%{system_include_paths}"
+        iterate_over: "system_include_paths"
+      }
+    }
+  }
+  feature {
+    name: "fdo_instrument"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-executable"
+      flag_group {
+        flag: "-fprofile-generate=%{fdo_instrument_path}"
+        flag: "-fno-data-sections"
+        expand_if_all_available: "fdo_instrument_path"
+      }
+    }
+    provides: "profile"
+  }
+  feature {
+    name: "fdo_optimize"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      flag_group {
+        flag: "-fprofile-use=%{fdo_profile_path}"
+        flag: "-Xclang-only=-Wno-profile-instr-unprofiled"
+        flag: "-Xclang-only=-Wno-profile-instr-out-of-date"
+        flag: "-fprofile-correction"
+        expand_if_all_available: "fdo_profile_path"
+      }
+    }
+    provides: "profile"
+  }
+  feature {
+    name: "autofdo"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      flag_group {
+        flag: "-fauto-profile=%{fdo_profile_path}"
+        flag: "-fprofile-correction"
+        expand_if_all_available: "fdo_profile_path"
+      }
+    }
+    provides: "profile"
+  }
+  feature {
+    name: "lipo"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      flag_group {
+        flag: "-fripa"
+      }
+    }
+    requires {
+      feature: "autofdo"
+    }
+    requires {
+      feature: "fdo_optimize"
+    }
+    requires {
+      feature: "fdo_instrument"
+    }
+  }
+  feature {
+    name: "asan"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-O1"
+        flag: "-gmlt"
+        flag: "-fsanitize=address,bool,float-cast-overflow,integer-divide-by-zero,return,returns-nonnull-attribute,shift-exponent,unreachable,vla-bound"
+        flag: "-fno-sanitize-recover=all"
+        flag: "-DHEAPCHECK_DISABLE"
+        flag: "-DADDRESS_SANITIZER"
+        flag: "-D_GLIBCXX_ADDRESS_SANITIZER_ANNOTATIONS"
+        flag: "-fno-omit-frame-pointer"
+      }
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-fsanitize=address,bool,float-cast-overflow,integer-divide-by-zero,return,returns-nonnull-attribute,shift-exponent,unreachable,vla-bound"
+        flag: "-fsanitize-link-c++-runtime"
+      }
+    }
+  }
+  feature {
+    name: "coverage"
+  }
+  feature {
+    name: "llvm_coverage_map_format"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-fprofile-instr-generate"
+        flag: "-fcoverage-mapping"
+        flag: "-g"
+      }
+    }
+    flag_set {
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-executable"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-fprofile-instr-generate"
+      }
+    }
+    requires {
+      feature: "coverage"
+    }
+    provides: "profile"
+  }
+  feature {
+    name: "gcc_coverage_map_format"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-fprofile-arcs"
+        flag: "-ftest-coverage"
+        flag: "-g"
+      }
+    }
+    flag_set {
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-executable"
+      flag_group {
+        flag: "-lgcov"
+      }
+    }
+    requires {
+      feature: "coverage"
+    }
+    provides: "profile"
+  }
+  feature {
+    name: "cpp_linker_flags"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+      }
+    }
+  }
+  feature {
+    name: "apply_implicit_frameworks"
+    flag_set {
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-framework Foundation"
+        flag: "-framework UIKit"
+      }
+    }
+  }
+  feature {
+    name: "link_cocoa"
+  }
+  feature {
+    name: "apply_simulator_compiler_flags"
+  }
+  feature {
+    name: "unfiltered_cxx_flags"
+  }
+  feature {
+    name: "bitcode_embedded_markers"
+    flag_set {
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-fembed-bitcode-marker"
+      }
+    }
+  }
+  feature {
+    name: "bitcode_embedded"
+    flag_set {
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-fembed-bitcode"
+      }
+    }
+    flag_set {
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-Xlinker"
+        flag: "-bitcode_verify"
+        flag: "-Xlinker"
+        flag: "-bitcode_hide_symbols"
+        flag: "-Xlinker"
+        flag: "-bitcode_symbol_map"
+        flag: "-Xlinker"
+        flag: "BITCODE_TOUCH_SYMBOL_MAP=%{bitcode_symbol_map_path}"
+      }
+    }
+  }
+  feature {
+    name: "user_compile_flags"
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "%{user_compile_flags}"
+        iterate_over: "user_compile_flags"
+        expand_if_all_available: "user_compile_flags"
+      }
+    }
+  }
+  feature {
+    name: "sysroot"
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "c++-header-parsing"
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "clif-match"
+      flag_group {
+        flag: "--sysroot=%{sysroot}"
+        expand_if_all_available: "sysroot"
+      }
+    }
+  }
+  feature {
+    name: "unfiltered_compile_flags"
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      flag_group {
+        flag: "-no-canonical-prefixes"
+        flag: "-pthread"
+        flag: "-target"
+        flag: "arm64_32-apple-watchos"
+      }
+    }
+  }
+  feature {
+    name: "linker_param_file"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "-Wl,@%{linker_param_file}"
+        expand_if_all_available: "linker_param_file"
+      }
+    }
+    flag_set {
+      action: "c++-link-static-library"
+      flag_group {
+        flag: "@%{linker_param_file}"
+        expand_if_all_available: "linker_param_file"
+      }
+    }
+  }
+  feature {
+    name: "compiler_input_flags"
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "linkstamp-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-c"
+        flag: "%{source_file}"
+        expand_if_all_available: "source_file"
+      }
+    }
+  }
+  feature {
+    name: "compiler_output_flags"
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "linkstamp-compile"
+      action: "c++-header-parsing"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-S"
+        expand_if_all_available: "output_assembly_file"
+      }
+      flag_group {
+        flag: "-E"
+        expand_if_all_available: "output_preprocess_file"
+      }
+      flag_group {
+        flag: "-o"
+        flag: "%{output_file}"
+        expand_if_all_available: "output_file"
+      }
+    }
+  }
+  feature {
+    name: "dbg_only_flag"
+    flag_set {
+      action: "objc-compile"
+      flag_group {
+        flag: "--DBG_ONLY_FLAG"
+      }
+    }
+  }
+  feature {
+    name: "fastbuild_only_flag"
+    flag_set {
+      action: "objc-compile"
+      flag_group {
+        flag: "--FASTBUILD_ONLY_FLAG"
+      }
+    }
+  }
+  feature {
+    name: "opt_only_flag"
+    flag_set {
+      action: "objc-compile"
+      flag_group {
+        flag: "--OPT_ONLY_FLAG"
+      }
+    }
+  }
+  action_config {
+    config_name: "strip"
+    action_name: "strip"
+    tool {
+      tool_path: "watchos/strip"
+    }
+    flag_set {
+      flag_group {
+        flag: "-S"
+        flag: "-o"
+        flag: "%{output_file}"
+      }
+      flag_group {
+        flag: "%{stripopts}"
+        iterate_over: "stripopts"
+      }
+      flag_group {
+        flag: "%{input_file}"
+      }
+    }
+  }
+  action_config {
+    config_name: "c-compile"
+    action_name: "c-compile"
+    tool {
+      tool_path: "watchos/wrapped_clang"
+      execution_requirement: "requires-darwin"
+    }
+    flag_set {
+      flag_group {
+        flag: "-arch arm64_32"
+      }
+    }
+    implies: "preprocessor_defines"
+    implies: "include_system_dirs"
+    implies: "version_min"
+    implies: "objc_arc"
+    implies: "no_objc_arc"
+    implies: "apple_env"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+    implies: "compiler_input_flags"
+    implies: "compiler_output_flags"
+  }
+  action_config {
+    config_name: "c++-compile"
+    action_name: "c++-compile"
+    tool {
+      tool_path: "watchos/wrapped_clang"
+      execution_requirement: "requires-darwin"
+    }
+    flag_set {
+      flag_group {
+        flag: "-arch arm64_32"
+      }
+    }
+    implies: "preprocessor_defines"
+    implies: "include_system_dirs"
+    implies: "version_min"
+    implies: "objc_arc"
+    implies: "no_objc_arc"
+    implies: "apple_env"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+    implies: "compiler_input_flags"
+    implies: "compiler_output_flags"
+  }
+  action_config {
+    config_name: "linkstamp-compile"
+    action_name: "linkstamp-compile"
+    tool {
+      tool_path: "watchos/wrapped_clang"
+      execution_requirement: "requires-darwin"
+    }
+    flag_set {
+      flag_group {
+        flag: "-arch arm64_32"
+      }
+    }
+    implies: "preprocessor_defines"
+    implies: "include_system_dirs"
+    implies: "version_min"
+    implies: "objc_arc"
+    implies: "no_objc_arc"
+    implies: "apple_env"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+    implies: "compiler_input_flags"
+    implies: "compiler_output_flags"
+  }
+  action_config {
+    config_name: "c++-module-compile"
+    action_name: "c++-module-compile"
+    tool {
+      tool_path: "watchos/wrapped_clang"
+      execution_requirement: "requires-darwin"
+    }
+    implies: "preprocessor_defines"
+    implies: "include_system_dirs"
+    implies: "version_min"
+    implies: "objc_arc"
+    implies: "no_objc_arc"
+    implies: "apple_env"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+    implies: "compiler_input_flags"
+    implies: "compiler_output_flags"
+  }
+  action_config {
+    config_name: "c++-header-parsing"
+    action_name: "c++-header-parsing"
+    tool {
+      tool_path: "watchos/wrapped_clang"
+      execution_requirement: "requires-darwin"
+    }
+    implies: "preprocessor_defines"
+    implies: "include_system_dirs"
+    implies: "version_min"
+    implies: "objc_arc"
+    implies: "no_objc_arc"
+    implies: "apple_env"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+    implies: "compiler_input_flags"
+    implies: "compiler_output_flags"
+  }
+  action_config {
+    config_name: "objc-compile"
+    action_name: "objc-compile"
+    tool {
+      tool_path: "watchos/wrapped_clang"
+      execution_requirement: "requires-darwin"
+    }
+    flag_set {
+      flag_group {
+        flag: "-arch arm64_32"
+      }
+    }
+    implies: "objc_actions"
+    implies: "apply_default_compiler_flags"
+    implies: "apply_default_warnings"
+    implies: "framework_paths"
+    implies: "preprocessor_defines"
+    implies: "include_system_dirs"
+    implies: "version_min"
+    implies: "objc_arc"
+    implies: "no_objc_arc"
+    implies: "apple_env"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+    implies: "compiler_input_flags"
+    implies: "compiler_output_flags"
+  }
+  action_config {
+    config_name: "objc++-compile"
+    action_name: "objc++-compile"
+    tool {
+      tool_path: "watchos/wrapped_clang"
+      execution_requirement: "requires-darwin"
+    }
+    flag_set {
+      flag_group {
+        flag: "-arch arm64_32"
+        flag: "-stdlib=libc++"
+        flag: "-std=gnu++11"
+      }
+    }
+    implies: "apply_default_compiler_flags"
+    implies: "apply_default_warnings"
+    implies: "framework_paths"
+    implies: "preprocessor_defines"
+    implies: "include_system_dirs"
+    implies: "version_min"
+    implies: "objc_arc"
+    implies: "no_objc_arc"
+    implies: "apple_env"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+    implies: "compiler_input_flags"
+    implies: "compiler_output_flags"
+  }
+  action_config {
+    config_name: "assemble"
+    action_name: "assemble"
+    tool {
+      tool_path: "watchos/wrapped_clang"
+      execution_requirement: "requires-darwin"
+    }
+    implies: "objc_arc"
+    implies: "no_objc_arc"
+    implies: "include_system_dirs"
+    implies: "apple_env"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+    implies: "compiler_input_flags"
+    implies: "compiler_output_flags"
+  }
+  action_config {
+    config_name: "preprocess-assemble"
+    action_name: "preprocess-assemble"
+    tool {
+      tool_path: "watchos/wrapped_clang"
+      execution_requirement: "requires-darwin"
+    }
+    implies: "preprocessor_defines"
+    implies: "include_system_dirs"
+    implies: "version_min"
+    implies: "objc_arc"
+    implies: "no_objc_arc"
+    implies: "apple_env"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+    implies: "compiler_input_flags"
+    implies: "compiler_output_flags"
+  }
+  action_config {
+    config_name: "objc-archive"
+    action_name: "objc-archive"
+    tool {
+      tool_path: "watchos/libtool"
+      execution_requirement: "requires-darwin"
+    }
+    flag_set {
+      flag_group {
+        flag: "-static"
+        flag: "-filelist"
+        flag: "%{obj_list_path}"
+        flag: "-arch_only"
+        flag: "arm64_32"
+        flag: "-syslibroot"
+        flag: "%{sdk_dir}"
+        flag: "-o"
+        flag: "%{archive_path}"
+      }
+    }
+    implies: "apple_env"
+  }
+  action_config {
+    config_name: "objc-executable"
+    action_name: "objc-executable"
+    tool {
+      tool_path: "watchos/wrapped_clang"
+      execution_requirement: "requires-darwin"
+    }
+    flag_set {
+      flag_group {
+        flag: "-arch arm64_32"
+      }
+      flag_group {
+        flag: "-Xlinker"
+        flag: "-objc_abi_version"
+        flag: "-Xlinker"
+        flag: "2"
+        flag: "-Xlinker"
+        flag: "-rpath"
+        flag: "-Xlinker"
+        flag: "@executable_path/Frameworks"
+        flag: "-fobjc-link-runtime"
+        flag: "-ObjC"
+      }
+      flag_group {
+        flag: "-framework %{framework_names}"
+        iterate_over: "framework_names"
+      }
+      flag_group {
+        flag: "-weak_framework %{weak_framework_names}"
+        iterate_over: "weak_framework_names"
+      }
+      flag_group {
+        flag: "-l%{library_names}"
+        iterate_over: "library_names"
+      }
+      flag_group {
+        flag: "-filelist %{filelist}"
+      }
+      flag_group {
+        flag: "-o %{linked_binary}"
+      }
+      flag_group {
+        flag: "-force_load %{force_load_exec_paths}"
+        iterate_over: "force_load_exec_paths"
+      }
+      flag_group {
+        flag: "%{dep_linkopts}"
+        iterate_over: "dep_linkopts"
+      }
+      flag_group {
+        flag: "-Wl,%{attr_linkopts}"
+        iterate_over: "attr_linkopts"
+      }
+    }
+    implies: "include_system_dirs"
+    implies: "framework_paths"
+    implies: "version_min"
+    implies: "apple_env"
+    implies: "apply_implicit_frameworks"
+  }
+  action_config {
+    config_name: "objc++-executable"
+    action_name: "objc++-executable"
+    tool {
+      tool_path: "watchos/wrapped_clang++"
+      execution_requirement: "requires-darwin"
+    }
+    flag_set {
+      flag_group {
+        flag: "-stdlib=libc++"
+        flag: "-std=gnu++11"
+      }
+      flag_group {
+        flag: "-arch arm64_32"
+      }
+      flag_group {
+        flag: "-Xlinker"
+        flag: "-objc_abi_version"
+        flag: "-Xlinker"
+        flag: "2"
+        flag: "-Xlinker"
+        flag: "-rpath"
+        flag: "-Xlinker"
+        flag: "@executable_path/Frameworks"
+        flag: "-fobjc-link-runtime"
+        flag: "-ObjC"
+      }
+      flag_group {
+        flag: "-framework %{framework_names}"
+        iterate_over: "framework_names"
+      }
+      flag_group {
+        flag: "-weak_framework %{weak_framework_names}"
+        iterate_over: "weak_framework_names"
+      }
+      flag_group {
+        flag: "-l%{library_names}"
+        iterate_over: "library_names"
+      }
+      flag_group {
+        flag: "-filelist %{filelist}"
+      }
+      flag_group {
+        flag: "-o %{linked_binary}"
+      }
+      flag_group {
+        flag: "-force_load %{force_load_exec_paths}"
+        iterate_over: "force_load_exec_paths"
+      }
+      flag_group {
+        flag: "%{dep_linkopts}"
+        iterate_over: "dep_linkopts"
+      }
+      flag_group {
+        flag: "-Wl,%{attr_linkopts}"
+        iterate_over: "attr_linkopts"
+      }
+    }
+    implies: "include_system_dirs"
+    implies: "framework_paths"
+    implies: "version_min"
+    implies: "apple_env"
+    implies: "apply_implicit_frameworks"
+  }
+  action_config {
+    config_name: "c++-link-executable"
+    action_name: "c++-link-executable"
+    tool {
+      tool_path: "watchos/clang"
+      execution_requirement: "requires-darwin"
+    }
+    implies: "symbol_counts"
+    implies: "linkstamps"
+    implies: "output_execpath_flags"
+    implies: "runtime_root_flags"
+    implies: "input_param_flags"
+    implies: "force_pic_flags"
+    implies: "strip_debug_symbols"
+    implies: "linker_param_file"
+    implies: "version_min"
+    implies: "apple_env"
+    implies: "cpp_linker_flags"
+    implies: "sysroot"
+  }
+  action_config {
+    config_name: "c++-link-dynamic-library"
+    action_name: "c++-link-dynamic-library"
+    tool {
+      tool_path: "watchos/clang"
+      execution_requirement: "requires-darwin"
+    }
+    implies: "has_configured_linker_path"
+    implies: "symbol_counts"
+    implies: "shared_flag"
+    implies: "linkstamps"
+    implies: "output_execpath_flags"
+    implies: "runtime_root_flags"
+    implies: "input_param_flags"
+    implies: "strip_debug_symbols"
+    implies: "linker_param_file"
+    implies: "version_min"
+    implies: "apple_env"
+    implies: "cpp_linker_flags"
+    implies: "sysroot"
+  }
+  action_config {
+    config_name: "c++-link-nodeps-dynamic-library"
+    action_name: "c++-link-nodeps-dynamic-library"
+    tool {
+      tool_path: "watchos/clang"
+      execution_requirement: "requires-darwin"
+    }
+    implies: "has_configured_linker_path"
+    implies: "symbol_counts"
+    implies: "shared_flag"
+    implies: "linkstamps"
+    implies: "output_execpath_flags"
+    implies: "runtime_root_flags"
+    implies: "input_param_flags"
+    implies: "strip_debug_symbols"
+    implies: "linker_param_file"
+    implies: "version_min"
+    implies: "apple_env"
+    implies: "cpp_linker_flags"
+    implies: "sysroot"
+  }
+  action_config {
+    config_name: "c++-link-static-library"
+    action_name: "c++-link-static-library"
+    tool {
+      tool_path: "watchos/ar_wrapper"
+      execution_requirement: "requires-darwin"
+    }
+    implies: "runtime_root_flags"
+    implies: "archiver_flags"
+    implies: "input_param_flags"
+    implies: "linker_param_file"
+    implies: "apple_env"
+  }
+  action_config {
+    config_name: "objc-fully-link"
+    action_name: "objc-fully-link"
+    tool {
+      tool_path: "watchos/libtool"
+      execution_requirement: "requires-darwin"
+    }
+    flag_set {
+      flag_group {
+        flag: "-static"
+        flag: "-arch_only"
+        flag: "arm64_32"
+        flag: "-syslibroot"
+        flag: "%{sdk_dir}"
+        flag: "-o"
+        flag: "%{fully_linked_archive_path}"
+      }
+      flag_group {
+        flag: "%{objc_library_exec_paths}"
+        iterate_over: "objc_library_exec_paths"
+      }
+      flag_group {
+        flag: "%{cc_library_exec_paths}"
+        iterate_over: "cc_library_exec_paths"
+      }
+      flag_group {
+        flag: "%{imported_library_exec_paths}"
+        iterate_over: "imported_library_exec_paths"
+      }
+    }
+    implies: "apple_env"
+  }
+  cc_target_os: "apple"
+}
+toolchain {
   toolchain_identifier: "tvos_arm64"
   host_system_name: "x86_64-apple-macosx"
   target_system_name: "arm64-apple-tvos"

--- a/src/test/java/com/google/devtools/build/lib/packages/util/MockObjcSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/MockObjcSupport.java
@@ -283,6 +283,7 @@ public final class MockObjcSupport {
               "darwin_x86_64",
               "watchos_i386",
               "watchos_armv7k",
+              "watchos_arm64_32",
               "tvos_x86_64",
               "tvos_arm64")) {
         crosstoolBuild.add(

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/AppleBinaryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/AppleBinaryTest.java
@@ -138,7 +138,7 @@ public class AppleBinaryTest extends ObjcRuleTestCase {
     getRuleType().scratchTarget(scratch,
         "platform_type", "'watchos'");
 
-    useConfiguration("--watchos_cpus=i386,armv7k", "--xcode_version=7.3",
+    useConfiguration("--watchos_cpus=i386,armv7k,arm64_32", "--xcode_version=7.3",
         "--watchos_sdk_version=2.1");
 
     CommandAction action = (CommandAction) lipoBinAction("//x:x");
@@ -163,7 +163,7 @@ public class AppleBinaryTest extends ObjcRuleTestCase {
     getRuleType().scratchTarget(scratch,
         "platform_type", "'watchos'");
 
-    useConfiguration("--watchos_cpus=i386,armv7k",
+    useConfiguration("--watchos_cpus=i386,armv7k,arm64_32",
         "--xcode_version=7.3", "--watchos_sdk_version=2");
 
     CommandAction action = (CommandAction) lipoBinAction("//x:x");
@@ -1138,11 +1138,12 @@ public class AppleBinaryTest extends ObjcRuleTestCase {
 
     useConfiguration("--define=use_watch=1",
         "--ios_multi_cpus=armv7,arm64",
-        "--watchos_cpus=armv7k");
+        "--watchos_cpus=armv7k,arm64_32");
 
     Action lipoAction = actionProducingArtifact("//examples:bin", "_lipobin");
 
     assertThat(getSingleArchBinary(lipoAction, "armv7k")).isNotNull();
+    assertThat(getSingleArchBinary(lipoAction, "arm64_32")).isNotNull();
   }
 
   private SkylarkDict<String, SkylarkDict<String, Artifact>>

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/AppleStaticLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/AppleStaticLibraryTest.java
@@ -239,21 +239,23 @@ public class AppleStaticLibraryTest extends ObjcRuleTestCase {
     RULE_TYPE.scratchTarget(scratch, "platform_type", "'watchos'");
 
     // Tests that ios_multi_cpus and ios_cpu are completely ignored.
-    useConfiguration("--ios_multi_cpus=x86_64", "--ios_cpu=x86_64", "--watchos_cpus=i386,armv7k");
+    useConfiguration("--ios_multi_cpus=x86_64", "--ios_cpu=x86_64", "--watchos_cpus=i386,armv7k,arm64_32");
 
     CommandAction action = (CommandAction) lipoLibAction("//x:x");
     String i386Bin = configurationBin("i386", ConfigurationDistinguisher.APPLEBIN_WATCHOS)
         + "x/x-fl.a";
     String armv7kBin = configurationBin("armv7k", ConfigurationDistinguisher.APPLEBIN_WATCHOS)
         + "x/x-fl.a";
+    String armv64_32Bin = configurationBin("arm64_32", ConfigurationDistinguisher.APPLEBIN_WATCHOS)
+        + "x/x-fl.a";
 
     assertThat(Artifact.toExecPaths(action.getInputs()))
-        .containsExactly(i386Bin, armv7kBin, MOCK_XCRUNWRAPPER_PATH,
+        .containsExactly(i386Bin, armv7kBin, armv64_32Bin, MOCK_XCRUNWRAPPER_PATH,
             MOCK_XCRUNWRAPPER_EXECUTABLE_PATH);
 
     assertContainsSublist(action.getArguments(), ImmutableList.of(
         MOCK_XCRUNWRAPPER_EXECUTABLE_PATH, LIPO, "-create"));
-    assertThat(action.getArguments()).containsAllOf(armv7kBin, i386Bin);
+    assertThat(action.getArguments()).containsAllOf(armv64_32Bin, armv7kBin, i386Bin);
     assertContainsSublist(action.getArguments(), ImmutableList.of(
         "-o", execPathEndingWith(action.getOutputs(), "x_lipo.a")));
 

--- a/src/test/shell/bazel/apple/bazel_apple_test.sh
+++ b/src/test/shell/bazel/apple/bazel_apple_test.sh
@@ -245,6 +245,14 @@ EOF
       || fail "expected output binary to be for armv7k architecture"
 
   bazel build --verbose_failures //package:lipo_out \
+      --watchos_cpus=arm64_32 \
+      --xcode_version=$XCODE_VERSION \
+      || fail "should build watch binary"
+
+  cat bazel-genfiles/package/lipo_out | grep "arm64_32" \
+      || fail "expected output binary to be for arm64_32 architecture"
+
+  bazel build --verbose_failures //package:lipo_out \
       --watchos_cpus=i386 \
       --xcode_version=$XCODE_VERSION \
       || fail "should build watch binary"

--- a/tools/osx/crosstool/CROSSTOOL.tpl
+++ b/tools/osx/crosstool/CROSSTOOL.tpl
@@ -6268,6 +6268,8 @@ toolchain {
       flag_group {
         flag: "-headerpad_max_install_names"
         flag: "-no-canonical-prefixes"
+        flag: "-target"
+        flag: "arm64_32-apple-watchos"
       }
     }
     enabled: true
@@ -6381,6 +6383,8 @@ toolchain {
         flag: "-D__DATE__=\"redacted\""
         flag: "-D__TIMESTAMP__=\"redacted\""
         flag: "-D__TIME__=\"redacted\""
+        flag: "-target"
+        flag: "arm64_32-apple-watchos"
       }
     }
   }

--- a/tools/osx/crosstool/CROSSTOOL.tpl
+++ b/tools/osx/crosstool/CROSSTOOL.tpl
@@ -8020,7 +8020,7 @@ toolchain {
       action: "objc-compile"
       action: "objc++-compile"
       flag_group {
-        flag: "-m<platform_for_version_min>-version-min=%{version_min}"
+        flag: "-mwatchos-version-min=%{version_min}"
       }
     }
   }
@@ -8310,7 +8310,7 @@ toolchain {
     flag_set {
       flag_group {
         flag: "-arch"
-        flag: "<architecture>"
+        flag: "arm64_32"
       }
     }
     implies: "compiler_input_flags"
@@ -8339,7 +8339,7 @@ toolchain {
     flag_set {
       flag_group {
         flag: "-arch"
-        flag: "<architecture>"
+        flag: "arm64_32"
         flag: "-stdlib=libc++"
         flag: "-std=gnu++11"
       }
@@ -8409,7 +8409,7 @@ toolchain {
         flag: "-filelist"
         flag: "%{obj_list_path}"
         flag: "-arch_only"
-        flag: "<architecture>"
+        flag: "arm64_32"
         flag: "-syslibroot"
         flag: "%{sdk_dir}"
         flag: "-o"
@@ -8445,7 +8445,7 @@ toolchain {
     flag_set {
       flag_group {
         flag: "-arch"
-        flag: "<architecture>"
+        flag: "arm64_32"
       }
       flag_group {
         flag: "-framework"
@@ -8504,7 +8504,7 @@ toolchain {
       }
       flag_group {
         flag: "-arch"
-        flag: "<architecture>"
+        flag: "arm64_32"
       }
       flag_group {
         flag: "-Xlinker"
@@ -8648,7 +8648,7 @@ toolchain {
         flag: "-no_warning_for_no_symbols"
         flag: "-static"
         flag: "-arch_only"
-        flag: "<architecture>"
+        flag: "arm64_32"
         flag: "-syslibroot"
         flag: "%{sdk_dir}"
         flag: "-o"

--- a/tools/osx/crosstool/CROSSTOOL.tpl
+++ b/tools/osx/crosstool/CROSSTOOL.tpl
@@ -7021,6 +7021,7 @@ toolchain {
     value: "-Wframe-larger-than=100000000 -Wno-vla"
   }
   %{cxx_builtin_include_directory}
+  builtin_sysroot: ""
   feature {
     name: "fastbuild"
   }
@@ -8004,6 +8005,8 @@ toolchain {
       flag_group {
         flag: "-headerpad_max_install_names"
         flag: "-no-canonical-prefixes"
+        flag: "-target"
+        flag: "arm64_32-apple-watchos"
       }
     }
     enabled: true

--- a/tools/osx/crosstool/CROSSTOOL.tpl
+++ b/tools/osx/crosstool/CROSSTOOL.tpl
@@ -8110,6 +8110,8 @@ toolchain {
         flag: "-D__DATE__=\"redacted\""
         flag: "-D__TIMESTAMP__=\"redacted\""
         flag: "-D__TIME__=\"redacted\""
+        flag: "-target"
+        flag: "arm64_32-apple-watchos"
       }
     }
   }


### PR DESCRIPTION
Prior to this change, building targets using --watchos_cpus=arm64_32 fails with error:
```
clang: error: unknown argument: '-m<platform_for_version_min>-version-min=4'
```
However, --watchos_cpus=armv7k works.

After this change, compiling with--watchos_cpus=arm64_32 succeeds. 