### PR TITLE
rules-cpp: Declare includeSrcs as mandatory inputs for TreeArtifacts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionTemplate.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionTemplate.java
@@ -143,6 +143,7 @@ public final class CppCompileActionTemplate implements ActionTemplate<CppCompile
     CppCompileActionBuilder builder = new CppCompileActionBuilder(cppCompileActionBuilder);
     builder.setAdditionalPrunableHeaders(privateHeaders);
     builder.setSourceFile(sourceTreeFileArtifact);
+    builder.addTransitiveMandatoryInputs(builder.getCcCompilationContext().getDeclaredIncludeSrcs());
     builder.setOutputs(outputTreeFileArtifact, null);
 
     CcToolchainVariables.Builder buildVariables =


### PR DESCRIPTION
It is possible to expand a TreeArtifact (e.g. a folder) which contains
multiple *.cpp files into one *.a file. In this case for each *.cpp a
CompileAction needs to be created.

Before this commit, necessary header files were not tracked as necessary
inputs, thus a change within a header file did not lead to a
recompilation, which might lead to inconsistencies.

Now all declared include srcs (within the CCCompilationContext) are
added as necssary inputs, resolving the mentioned inconsistencies.

Issue: #5785