### PR TITLE
ci: Reverts to using += for setting the files var

### DIFF
--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -50,8 +50,8 @@ cd "$(git rev-parse --show-toplevel)"
 # Get a list of the current files in package form by querying Bazel.
 files=()
 for file in $(git diff --name-only ${COMMIT_RANGE} ); do
-  IFS=$'\n' read -r -a files <<< "$(bazel query $file)"
-  bazel query $file
+  files+=($(bazel query $file))
+  echo $(bazel query $file)
 done
 
 # Query for the associated buildables


### PR DESCRIPTION
The read expression collected only the last test file. Reverts back to
the previous version of the script that used += instead of read.

Related issue: https://github.com/bazelbuild/bazel/issues/7088