### PR TITLE
zsh completion: Support BUILD.bazel files

### DIFF
--- a/scripts/zsh_completion/_bazel
+++ b/scripts/zsh_completion/_bazel
@@ -186,7 +186,7 @@ _get_build_packages() {
   fi
   paths=(${^package_roots}/${pfx}*(/))
   for p in ${paths[*]}; do
-    if [[ -f ${p}/BUILD ]]; then
+    if [[ -f ${p}/BUILD || -f ${p}/BUILD.bazel ]]; then
       final_paths+=(${p##*/}:)
     fi
     final_paths+=(${p##*/}/)
@@ -207,7 +207,7 @@ _bazel_complete_target() {
   if [[ "${(e)PREFIX}" != *:* ]]; then
     # There is no : in the prefix, completion can be either
     # a package or a target, if the cwd is a package itself.
-    if [[ -f $PWD/BUILD ]]; then
+    if [[ -f $PWD/BUILD || -f $PWD/BUILD.bazel ]]; then
       targets=($(_get_build_targets ""))
       _description build_target expl "BUILD target"
       compadd "${expl[@]}" -a targets


### PR DESCRIPTION
This script seems to predate support for `BUILD.bazel` files, and didn't get updated when the bash completion did.