### PR TITLE
Support Xcode betas with xcode-locator

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/DottedVersion.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/DottedVersion.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
  * {@code 5.0.1beta2}. Components must start with a non-negative integer and at least one component
  * must be present.
  *
- * <p>Specifically, the format of a component is {@code \d+([a-z]+\d*)?}.
+ * <p>Specifically, the format of a component is {@code \d+([a-z0-9]*?)?(\d+)?}.
  *
  * <p>Dotted versions are ordered using natural integer sorting on components in order from first to
  * last where any missing element is considered to have the value 0 if they don't contain any
@@ -122,9 +122,10 @@ public final class DottedVersion implements DottedVersionApi<DottedVersion> {
     return version == null ? null : new Option(version);
   }
   private static final Splitter DOT_SPLITTER = Splitter.on('.');
-  private static final Pattern COMPONENT_PATTERN = Pattern.compile("(\\d+)(?:([a-z]+)(\\d*))?");
+  private static final Pattern COMPONENT_PATTERN =
+      Pattern.compile("(\\d+)([a-z0-9]*?)?(\\d+)?", Pattern.CASE_INSENSITIVE);
   private static final String ILLEGAL_VERSION =
-      "Dotted version components must all be of the form \\d+([a-z]+\\d*)? but got %s";
+      "Dotted version components must all be of the form \\d+([a-z0-9]*?)?(\\d+)? but got %s";
   private static final String NO_ALPHA_SEQUENCE = null;
   private static final Component ZERO_COMPONENT = new Component(0, NO_ALPHA_SEQUENCE, 0, "0");
 
@@ -165,7 +166,7 @@ public final class DottedVersion implements DottedVersionApi<DottedVersion> {
     int secondNumber = 0;
     firstNumber = parseNumber(parsedComponent, 1, version);
 
-    if (parsedComponent.group(2) != null) {
+    if (!Strings.isNullOrEmpty(parsedComponent.group(2))) {
       alphaSequence = parsedComponent.group(2);
     }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/apple/DottedVersionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/apple/DottedVersionTest.java
@@ -42,6 +42,7 @@ public class DottedVersionTest {
         .addEqualityGroup(DottedVersion.fromString("1.2beta12.1"))
         .addEqualityGroup(DottedVersion.fromString("1.2.0"), DottedVersion.fromString("1.2"))
         .addEqualityGroup(DottedVersion.fromString("1.20"))
+        .addEqualityGroup(DottedVersion.fromString("10.2.0.10P99q"))
         .testCompare();
   }
 
@@ -52,6 +53,7 @@ public class DottedVersionTest {
         .addEqualityGroup(DottedVersion.fromString("0.1"), DottedVersion.fromString("0.01"))
         .addEqualityGroup(DottedVersion.fromString("0.2"), DottedVersion.fromString("0.2.0"))
         .addEqualityGroup(DottedVersion.fromString("1.2xy2"), DottedVersion.fromString("1.2xy2"))
+        .addEqualityGroup(DottedVersion.fromString("10.2.0.10P99q"), DottedVersion.fromString("10.2.0.10P99q0"))
         .addEqualityGroup(
             DottedVersion.fromString("1.2x"),
             DottedVersion.fromString("1.2x0"),

--- a/tools/osx/xcode_locator.m
+++ b/tools/osx/xcode_locator.m
@@ -176,6 +176,17 @@ static NSMutableDictionary<NSString *, XcodeVersionEntry *> *FindXcodes()
     NSLog(@"Version strings for %@: short=%@, expanded=%@",
           url, version, expandedVersion);
 
+    NSURL *versionPlistUrl = [url
+        URLByAppendingPathComponent:@"Contents/version.plist"];
+    NSDictionary *versionPlistContents = [[NSDictionary alloc]
+        initWithContentsOfURL:versionPlistUrl error:nil];
+    NSString *productVersion = [versionPlistContents
+            objectForKey:@"ProductBuildVersion"];
+    if (productVersion) {
+        expandedVersion = [expandedVersion
+            stringByAppendingFormat:@".%@", productVersion];
+    }
+
     NSURL *developerDir =
         [url URLByAppendingPathComponent:@"Contents/Developer"];
     XcodeVersionEntry *entry =
@@ -259,12 +270,6 @@ int main(int argc, const char * argv[]) {
         versionArg = @"";
       } else {
         versionArg = firstArg;
-        NSCharacterSet *versSet =
-            [NSCharacterSet characterSetWithCharactersInString:@"0123456789."];
-        if ([versionArg rangeOfCharacterFromSet:versSet.invertedSet].length
-            != 0) {
-          versionArg = nil;
-        }
       }
     }
     if (versionArg == nil) {


### PR DESCRIPTION
Previously if you had 2 builds of the same version of Xcode, for example
10.2.0 beta 1 and 10.2.0 beta 2, there was no way to disambiguate them.
This change appends the `ProductBuildVersion` of each Xcode version to
allow you to specify that if desired.
