### PR TITLE
Windows: bazel_rules_test no longer times out

### DIFF
--- a/src/test/shell/bazel/bazel_rules_test.sh
+++ b/src/test/shell/bazel/bazel_rules_test.sh
@@ -107,7 +107,7 @@ function test_extra_action() {
   # The workspace name is initialized in testenv.sh; use that var rather than
   # hardcoding it here. The extra sed pass is so we can selectively expand that
   # one var while keeping the rest of the heredoc literal.
-  cat | sed "s/{{WORKSPACE_NAME}}/$WORKSPACE_NAME/" > mypkg/echoer.sh << 'EOF'
+  cat << 'EOF' | sed "s/{{WORKSPACE_NAME}}/$WORKSPACE_NAME/" > mypkg/echoer.sh
 #!/bin/bash
 set -euo pipefail
 # --- begin runfiles.bash initialization ---

--- a/src/test/shell/bazel/bazel_rules_test.sh
+++ b/src/test/shell/bazel/bazel_rules_test.sh
@@ -107,7 +107,7 @@ function test_extra_action() {
   # The workspace name is initialized in testenv.sh; use that var rather than
   # hardcoding it here. The extra sed pass is so we can selectively expand that
   # one var while keeping the rest of the heredoc literal.
-  cat << 'EOF' | sed "s/{{WORKSPACE_NAME}}/$WORKSPACE_NAME/" > mypkg/echoer.sh
+  sed "s/{{WORKSPACE_NAME}}/$WORKSPACE_NAME/" > mypkg/echoer.sh << 'EOF'
 #!/bin/bash
 set -euo pipefail
 # --- begin runfiles.bash initialization ---


### PR DESCRIPTION
This PR fixes the hanging Bash command so the test
no longer times out on Windows.

It is still unknown:
- why the test works on Linux
- what caused the test to start timing out on
  Windows

Fixes https://github.com/bazelbuild/bazel/issues/7372