### PR TITLE
Always print the gRPC status code when it's not okay.

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1652,8 +1652,10 @@ bool GrpcBlazeServer::TryConnect(
   grpc::Status status = client->Ping(&context, request, &response);
 
   if (!status.ok() || !ProtoStringEqual(response.cookie(), response_cookie_)) {
-    BAZEL_LOG(INFO) << "Connection to server failed: "
-                    << status.error_message().c_str();
+    BAZEL_LOG(INFO) << "Connection to server failed ("
+                    << "error code: " << status.error_code() << ", "
+                    << "error message: " << status.error_message().c_str()
+                    << ")\n";
     return false;
   }
 
@@ -1808,7 +1810,9 @@ void GrpcBlazeServer::SendCancelMessage() {
   grpc::Status status = client_->Cancel(&context, request, &response);
   if (!status.ok()) {
     BAZEL_LOG(USER) << "\nCould not interrupt server ("
-                    << status.error_message().c_str() << ")\n";
+                    << "error code: " << status.error_code() << ", "
+                    << "error message: " << status.error_message().c_str()
+                    << ")\n";
   }
 }
 


### PR DESCRIPTION
Sometimes a failed grpc::Status doesn't have a message, in which case Bazel can log unhelpful messages like "Could not interrupt server ()". We should always log the Status's error code.

C++ gRPC doesn't provide a public API to convert a grpc::StatuCode enum value to a string (https://github.com/grpc/grpc/issues/17969), so the numeric code is just going to have to do for now.