### PR TITLE
Add a `doc` parameter to `repository_rule()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryModule.java
@@ -61,7 +61,8 @@ public class SkylarkRepositoryModule implements RepositoryModuleApi {
       Boolean local,
       SkylarkList<String> environ,
       FuncallExpression ast,
-      com.google.devtools.build.lib.syntax.Environment funcallEnv)
+      com.google.devtools.build.lib.syntax.Environment funcallEnv,
+      String doc)
       throws EvalException {
     SkylarkUtils.checkLoadingOrWorkspacePhase(funcallEnv, "repository_rule", ast.getLocation());
     // We'll set the name later, pass the empty string for now.

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryModule.java
@@ -60,9 +60,9 @@ public class SkylarkRepositoryModule implements RepositoryModuleApi {
       Object attrs,
       Boolean local,
       SkylarkList<String> environ,
+      String doc,
       FuncallExpression ast,
-      com.google.devtools.build.lib.syntax.Environment funcallEnv,
-      String doc)
+      com.google.devtools.build.lib.syntax.Environment funcallEnv)
       throws EvalException {
     SkylarkUtils.checkLoadingOrWorkspacePhase(funcallEnv, "repository_rule", ast.getLocation());
     // We'll set the name later, pass the empty string for now.

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/RepositoryModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/RepositoryModuleApi.java
@@ -78,6 +78,15 @@ public interface RepositoryModuleApi {
                     + "an environment variable in that list change, the repository will be "
                     + "refetched.",
             named = true,
+            positional = false),
+        @Param(
+            name = "doc",
+            type = String.class,
+            defaultValue = "''",
+            doc =
+                "A description of the repository rule that can be extracted by documentation "
+                    + "generating tools."
+            named = true,
             positional = false)
       },
       useAst = true,
@@ -88,6 +97,7 @@ public interface RepositoryModuleApi {
       Boolean local,
       SkylarkList<String> environ,
       FuncallExpression ast,
-      Environment env)
+      Environment env,
+      String doc)
       throws EvalException;
 }

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/RepositoryModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/RepositoryModuleApi.java
@@ -85,7 +85,7 @@ public interface RepositoryModuleApi {
             defaultValue = "''",
             doc =
                 "A description of the repository rule that can be extracted by documentation "
-                    + "generating tools."
+                    + "generating tools.",
             named = true,
             positional = false)
       },
@@ -96,8 +96,8 @@ public interface RepositoryModuleApi {
       Object attrs,
       Boolean local,
       SkylarkList<String> environ,
+      String doc, 
       FuncallExpression ast,
-      Environment env,
-      String doc)
+      Environment env)
       throws EvalException;
 }

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/repository/FakeRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/repository/FakeRepositoryModule.java
@@ -27,7 +27,7 @@ public class FakeRepositoryModule implements RepositoryModuleApi {
 
   @Override
   public BaseFunction repositoryRule(BaseFunction implementation, Object attrs, Boolean local,
-      SkylarkList<String> environ, FuncallExpression ast, Environment env) {
+      SkylarkList<String> environ, FuncallExpression ast, Environment env, String doc) {
     return implementation;
   }
 }

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/repository/FakeRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/repository/FakeRepositoryModule.java
@@ -27,7 +27,7 @@ public class FakeRepositoryModule implements RepositoryModuleApi {
 
   @Override
   public BaseFunction repositoryRule(BaseFunction implementation, Object attrs, Boolean local,
-      SkylarkList<String> environ, FuncallExpression ast, Environment env, String doc) {
+      SkylarkList<String> environ, String doc, FuncallExpression ast, Environment env) {
     return implementation;
   }
 }

--- a/src/test/java/com/google/devtools/build/skydoc/testdata/misc_apis_test/input.bzl
+++ b/src/test/java/com/google/devtools/build/skydoc/testdata/misc_apis_test/input.bzl
@@ -8,7 +8,10 @@ def my_rule_impl(ctx):
 def exercise_the_api():
     var1 = config_common.FeatureFlagInfo
     var2 = platform_common.TemplateVariableInfo
-    var3 = repository_rule(implementation = my_rule_impl)
+    var3 = repository_rule(
+        implementation = my_rule_impl,
+        doc = "This repository rule has documentation.",
+    )
     var4 = testing.ExecutionInfo({})
 
 exercise_the_api()


### PR DESCRIPTION
Based on https://github.com/bazelbuild/bazel/pull/6936 which fails to compile.

Fixes #6271.
Closes #6936.