### PR TITLE
Windows, launcher: implement correct escaping

### DIFF
--- a/src/tools/launcher/util/launcher_util.cc
+++ b/src/tools/launcher/util/launcher_util.cc
@@ -170,6 +170,15 @@ std::wstring BashEscapeArg(const std::wstring& arg) {
   return GetEscapedArgument(arg, /* escape_backslash */ true);
 }
 
+// Escape arguments for CreateProcessW.
+//
+// This algorithm is based on information found in
+// http://daviddeley.com/autohotkey/parameters/parameters.htm
+//
+// The following source specifies a similar algorithm:
+// https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+// unfortunately I found this algorithm only after creating the one below, but
+// fortunately they seem to do the same.
 std::wstring WindowsEscapeArg2(const std::wstring& s) {
   if (s.empty()) {
     return L"\"\"";

--- a/src/tools/launcher/util/launcher_util.cc
+++ b/src/tools/launcher/util/launcher_util.cc
@@ -170,9 +170,89 @@ std::wstring BashEscapeArg(const std::wstring& arg) {
   return GetEscapedArgument(arg, /* escape_backslash */ true);
 }
 
+std::wstring WindowsEscapeArg2(const std::wstring& s) {
+  if (s.empty()) {
+    return L"\"\"";
+  } else {
+    bool needs_escaping = false;
+    for (const auto& c : s) {
+      if (c == ' ' || c == '"') {
+        needs_escaping = true;
+        break;
+      }
+    }
+    if (!needs_escaping) {
+      return s;
+    }
+  }
+
+  std::wostringstream result;
+  result << L'"';
+  int start = 0;
+  for (int i = 0; i < s.size(); ++i) {
+    char c = s[i];
+    if (c == '"' || c == '\\') {
+      // Copy the segment since the last special character.
+      if (start >= 0) {
+        result << s.substr(start, i - start);
+        start = -1;
+      }
+
+      // Handle the current special character.
+      if (c == '"') {
+        // This is a quote character. Escape it with a single backslash.
+        result << L"\\\"";
+      } else {
+        // This is a backslash (or the first one in a run of backslashes).
+        // Whether we escape it depends on whether the run ends with a quote.
+        int run_len = 1;
+        int j = i + 1;
+        while (j < s.size() && s[j] == '\\') {
+          run_len++;
+          j++;
+        }
+        if (j == s.size()) {
+          // The run of backslashes goes to the end.
+          // We have to escape every backslash with another backslash.
+          for (int k = 0; k < run_len * 2; ++k) {
+            result << L'\\';
+          }
+          break;
+        } else if (j < s.size() && s[j] == '"') {
+          // The run of backslashes is terminated by a quote.
+          // We have to escape every backslash with another backslash, and
+          // escape the quote with one backslash.
+          for (int k = 0; k < run_len * 2; ++k) {
+            result << L'\\';
+          }
+          result << L"\\\"";
+          i += run_len;  // 'i' is also increased in the loop iteration step
+        } else {
+          // No quote found. Each backslash counts for itself, they must not be
+          // escaped.
+          for (int k = 0; k < run_len; ++k) {
+            result << L'\\';
+          }
+          i += run_len - 1;  // 'i' is also increased in the loop iteration step
+        }
+      }
+    } else {
+      // This is not a special character. Start the segment if necessary.
+      if (start < 0) {
+        start = i;
+      }
+    }
+  }
+  // Save final segment after the last special character.
+  if (start != -1) {
+    result << s.substr(start);
+  }
+  result << L'"';
+  return result.str();
+}
+
 std::wstring WindowsEscapeArg(const std::wstring& arg) {
-  // TODO(laszlocsomor): properly implement escaping syntax for CreateProcessW;
-  // it's different from Bash escaping syntax.
+  // TODO(laszlocsomor): use WindowsEscapeArg2 instead.
   return GetEscapedArgument(arg, /* escape_backslash */ false);
 }
 

--- a/src/tools/launcher/util/launcher_util.h
+++ b/src/tools/launcher/util/launcher_util.h
@@ -55,6 +55,11 @@ std::wstring BashEscapeArg(const std::wstring& arg);
 // implementation.)
 std::wstring WindowsEscapeArg(const std::wstring& arg);
 
+// TODO(laszlocsomor): Delete WindowsEscapeArg and use WindowsEscapeArg2.
+// WindowsEscapeArg escapes incorrectly while WindowsEscapeArg2 escapes
+// correctly.
+std::wstring WindowsEscapeArg2(const std::wstring& arg);
+
 // Convert a path to an absolute Windows path with \\?\ prefix.
 // This method will print an error and exit if it cannot convert the path.
 std::wstring AsAbsoluteWindowsPath(const wchar_t* path);

--- a/src/tools/launcher/util/launcher_util_test.cc
+++ b/src/tools/launcher/util/launcher_util_test.cc
@@ -102,10 +102,11 @@ TEST_F(LaunchUtilTest, BashEscapeArgTest) {
 // The method performs the second assertion by running "printarg.exe" (a
 // data-dependency of this test) once for each argument.
 void AssertSubprocessReceivesArgsAsIntended(
+    std::wstring (*escape_func)(const std::wstring& s),
     const std::vector<std::pair<wstring, wstring> >& args) {
   // Assert that the WindowsEscapeArg produces what we expect.
   for (const auto& i : args) {
-    ASSERT_EQ(WindowsEscapeArg(i.first), i.second);
+    ASSERT_EQ(escape_func(i.first), i.second);
   }
 
   // Create a Runfiles object.
@@ -172,7 +173,7 @@ void AssertSubprocessReceivesArgsAsIntended(
 
   // Copy printarg.exe's escaped path into the 'cmdline', and append a space.
   // We will append arguments to this command line in the for-loop below.
-  wprintarg = WindowsEscapeArg(wprintarg);
+  wprintarg = escape_func(wprintarg);
   wcsncpy(cmdline, wprintarg.c_str(), wprintarg.size());
   wchar_t* pcmdline = cmdline + wprintarg.size();
   *pcmdline++ = L' ';
@@ -180,7 +181,7 @@ void AssertSubprocessReceivesArgsAsIntended(
   // Run a subprocess for each of the arguments and assert that the argument
   // arrived to the subprocess as intended.
   for (const auto& i : args) {
-    // We already asserted for every element that WindowsEscapeArg(i.first)
+    // We already asserted for every element that escape_func(i.first)
     // produces the same output as i.second, so just use i.second instead of
     // converting i.first again.
     wcsncpy(pcmdline, i.second.c_str(), i.second.size());
@@ -252,7 +253,7 @@ void AssertSubprocessReceivesArgsAsIntended(
 
 TEST_F(LaunchUtilTest, WindowsEscapeArgTest) {
   // List of arguments with their expected WindowsEscapeArg-encoded version.
-  AssertSubprocessReceivesArgsAsIntended({
+  AssertSubprocessReceivesArgsAsIntended(WindowsEscapeArg, {
       // Each pair is:
       // - first: argument to pass (and expected output from subprocess)
       // - second: expected WindowsEscapeArg-encoded string
@@ -265,6 +266,55 @@ TEST_F(LaunchUtilTest, WindowsEscapeArgTest) {
       // semantics (not Bash semantics) and add more tests. The example below is
       // escaped incorrectly.
       // {L"C:\\foo bar\\", L"\"C:\\foo bar\\\""},
+  });
+}
+
+TEST_F(LaunchUtilTest, WindowsEscapeArg2Test) {
+  AssertSubprocessReceivesArgsAsIntended(WindowsEscapeArg2, {
+      {L"", L"\"\""},
+      {L" ", L"\" \""},
+      {L"\"", L"\"\\\"\""},
+      {L"\"\\", L"\"\\\"\\\\\""},
+      {L"\\", L"\\"},
+      {L"\\\"", L"\"\\\\\\\"\""},
+      {L"with space", L"\"with space\""},
+      {L"with^caret", L"with^caret"},
+      {L"space ^caret", L"\"space ^caret\""},
+      {L"caret^ space", L"\"caret^ space\""},
+      {L"with\"quote", L"\"with\\\"quote\""},
+      {L"with\\backslash", L"with\\backslash"},
+      {L"one\\ backslash and \\space", L"\"one\\ backslash and \\space\""},
+      {L"two\\\\backslashes", L"two\\\\backslashes"},
+      {L"two\\\\ backslashes \\\\and space",
+       L"\"two\\\\ backslashes \\\\and space\""},
+      {L"one\\\"x", L"\"one\\\\\\\"x\""},
+      {L"two\\\\\"x", L"\"two\\\\\\\\\\\"x\""},
+      {L"a \\ b", L"\"a \\ b\""},
+      {L"a \\\" b", L"\"a \\\\\\\" b\""},
+      {L"A", L"A"},
+      {L"\"a\"", L"\"\\\"a\\\"\""},
+      {L"B C", L"\"B C\""},
+      {L"\"b c\"", L"\"\\\"b c\\\"\""},
+      {L"D\"E", L"\"D\\\"E\""},
+      {L"\"d\"e\"", L"\"\\\"d\\\"e\\\"\""},
+      {L"C:\\F G", L"\"C:\\F G\""},
+      {L"\"C:\\f g\"", L"\"\\\"C:\\f g\\\"\""},
+      {L"C:\\H\"I", L"\"C:\\H\\\"I\""},
+      {L"\"C:\\h\"i\"", L"\"\\\"C:\\h\\\"i\\\"\""},
+      {L"C:\\J\\\"K", L"\"C:\\J\\\\\\\"K\""},
+      {L"\"C:\\j\\\"k\"", L"\"\\\"C:\\j\\\\\\\"k\\\"\""},
+      {L"C:\\L M ", L"\"C:\\L M \""},
+      {L"\"C:\\l m \"", L"\"\\\"C:\\l m \\\"\""},
+      {L"C:\\N O\\", L"\"C:\\N O\\\\\""},
+      {L"\"C:\\n o\\\"", L"\"\\\"C:\\n o\\\\\\\"\""},
+      {L"C:\\P Q\\ ", L"\"C:\\P Q\\ \""},
+      {L"\"C:\\p q\\ \"", L"\"\\\"C:\\p q\\ \\\"\""},
+      {L"C:\\R\\S\\", L"C:\\R\\S\\"},
+      {L"C:\\R x\\S\\", L"\"C:\\R x\\S\\\\\""},
+      {L"\"C:\\r\\s\\\"", L"\"\\\"C:\\r\\s\\\\\\\"\""},
+      {L"\"C:\\r x\\s\\\"", L"\"\\\"C:\\r x\\s\\\\\\\"\""},
+      {L"C:\\T U\\W\\", L"\"C:\\T U\\W\\\\\""},
+      {L"\"C:\\t u\\w\\\"", L"\"\\\"C:\\t u\\w\\\\\\\"\""},
   });
 }
 


### PR DESCRIPTION
Add a correct implementation of WindowsEscapeArg.

This is a follow-up to https://github.com/bazelbuild/bazel/pull/7402

Next steps:
- update Bazel to separate jvm_flags that are
  embedded in the native lauancher by some other
  character than space, so that arguments with
  spaces can be embedded

- replace the current WindowsEscapeArg
  implementation in the launcher with the new,
  correct one

See https://github.com/bazelbuild/bazel/issues/7072