### PR TITLE
Remove LcovMerger from tools/test:embedded_tools.

### DIFF
--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -121,7 +121,7 @@ filegroup(
         "generate-xml.sh",
         "collect_coverage.sh",
         "collect_cc_coverage.sh",
-    ] + glob(["LcovMerger/**"]) + select({
+    ] + glob(["CoverageOutputGenerator/**"]) + select({
         "@bazel_tools//src/conditions:windows": [
             "tw",
             "xml",

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -121,7 +121,7 @@ filegroup(
         "generate-xml.sh",
         "collect_coverage.sh",
         "collect_cc_coverage.sh",
-    ] + glob(["CoverageOutputGenerator/**"]) + select({
+    ] + select({
         "@bazel_tools//src/conditions:windows": [
             "tw",
             "xml",


### PR DESCRIPTION
 `CoverageOutputGenerator` is actually embedded into `bazel_tools` through [//tools:embedded_tools_srcs](https://github.com/bazelbuild/bazel/blob/master/tools/BUILD#L61).

The referenced changed in this PR is useless so I just deleted it.