### PR TITLE
Windows, subprocesses: add test for arg passing

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -514,6 +514,7 @@ java_test(
     srcs = WINDOWS_ON_WINDOWS_TESTS,
     data = [
         ":MockSubprocess_deploy.jar",
+        ":printarg",
     ] + JNI_LIB,
     jvm_flags = [
         "-Dbazel.windows_unix_root=C:/fake/msys",
@@ -534,6 +535,12 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/windows/jni",
         "@bazel_tools//tools/java/runfiles",
     ],
+)
+
+cc_binary(
+    name = "printarg",
+    testonly = 1,
+    srcs = ["windows/printarg.cc"],
 )
 
 java_library(

--- a/src/test/java/com/google/devtools/build/lib/windows/printarg.cc
+++ b/src/test/java/com/google/devtools/build/lib/windows/printarg.cc
@@ -1,0 +1,20 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+  printf("(%s)", argv[1]);
+  return 0;
+}


### PR DESCRIPTION
Add an integration test to assert that
subprocesses created with WindowsSubprocessFactory
receive arguments as intended.

Next steps:
- implement the same argument escaping logic in
  Bazel as windowsEscapeArg2 in https://github.com/bazelbuild/bazel/pull/7411
- replace WindowsProcesses.quoteCommandLine with
  the new escaper

See https://github.com/bazelbuild/bazel/issues/7122