### PR TITLE
gcc coverage: remove -b from gcov invocation

### DIFF
--- a/src/test/shell/bazel/bazel_cc_code_coverage_test.sh
+++ b/src/test/shell/bazel/bazel_cc_code_coverage_test.sh
@@ -288,8 +288,6 @@ function assert_gcov_coverage_srcs_a_cc() {
 function:4,1,_Z1ab
 lcount:4,1
 lcount:5,1
-branch:5,taken
-branch:5,nottaken
 lcount:6,1
 lcount:8,0"
     assert_coverage_entry_in_file "$expected_gcov_result_a_cc" "$output_file"
@@ -320,8 +318,6 @@ function assert_gcov_coverage_srcs_b_h() {
 function:1,1,_Z1bi
 lcount:1,1
 lcount:2,1
-branch:2,taken
-branch:2,nottaken
 lcount:3,1
 lcount:5,0"
     assert_coverage_entry_in_file "$expected_gcov_result" "$output_file"
@@ -382,9 +378,9 @@ function test_cc_test_coverage_gcov() {
     # This assertion is needed to make sure no other source files are included
     # in the output file.
     local nr_lines="$(wc -l < "$output_file")"
-    [[ "$nr_lines" == 21 ]] || \
+    [[ "$nr_lines" == 17 ]] || \
       fail "Number of lines in C++ gcov coverage output file is "\
-      "$nr_lines and different than 21"
+      "$nr_lines and different than 17"
 }
 
 run_suite "Testing tools/test/collect_cc_coverage.sh"

--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -135,8 +135,6 @@ function gcov_coverage() {
         # -i              Output gcov file in an intermediate text format.
         #                 The output is a single .gcov file per .gcda file.
         #                 No source code is required.
-        # -b              Write branch frequencies to the output file, and
-        #                 write branch summary info to the standard output.
         # -o directory    The directory containing the .gcno and
         #                 .gcda data files.
         # "${gcda"}       The input file name. gcov is looking for data files
@@ -146,7 +144,10 @@ function gcov_coverage() {
         # they correspond to. One .gcov file is produced for each source
         # (or header) file containing code which was compiled to produce the
         # .gcda files.
-        "${GCOV}" -i -b -o "$(dirname ${gcda})" "${gcda}" &> "$gcov_log"
+        # Don't generate branch coverage (-b) because of a gcov issue that
+        # segfaults when both -i and -b are used (see
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84879).
+        "${GCOV}" -i -o "$(dirname ${gcda})" "${gcda}" &> "$gcov_log"
 
         # Go through all the files that were created by the gcov command above
         # and append their content to the output .gcov file.


### PR DESCRIPTION
Removing branch coverage for gcc because of a gcov issue that segfaults when both `-i` and `-b` are used (gcov 0.7 and later).

Fixes #7417.

RELNTOES: Branch coverage for gcc (using the `--experimental_cc_coverage` flag) is not available anymore due to [a gcc segfault issue](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84879).