### PR TITLE
Windows, launcher: separate jvm_flags by TAB

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaSemantics.java
@@ -440,7 +440,11 @@ public class BazelJavaSemantics implements JavaSemantics {
                 "classpath",
                 ";",
                 Iterables.transform(classpath, Artifact.ROOT_RELATIVE_PATH_STRING))
-            .addJoinedValues("jvm_flags", " ", jvmFlags)
+            // TODO(laszlocsomor): Change the Launcher to accept multiple jvm_flags entries. As of
+            // 2019-02-13 the Launcher accepts just one jvm_flags entry, which contains all the
+            // flags, joined by TAB characters. The Launcher splits up the string to get the
+            // individual jvm_flags. This approach breaks with flags that contain a TAB character.
+            .addJoinedValues("jvm_flags", "\t", jvmFlags)
             .build();
 
     LauncherFileWriteAction.createAndRegister(ruleContext, javaLauncher, launchInfo);

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -359,7 +359,7 @@ ExitCode JavaBinaryLauncher::Launch() {
     jvm_flags.push_back(flag);
   }
   wstringstream jvm_flags_launch_info_ss(this->GetLaunchInfoByKey(JVM_FLAGS));
-  while (getline(jvm_flags_launch_info_ss, flag, L' ')) {
+  while (getline(jvm_flags_launch_info_ss, flag, L'\t')) {
     jvm_flags.push_back(flag);
   }
 


### PR DESCRIPTION
When Bazel embeds the jvm_flags data into the
java_binary launcher, it will now join the flags
on TAB instead of on space.

While TAB is just as much a legal character in
flags as space is, it is probably rarer, and as
such it's a slightly safer choice than joining the
flags on space (and thus losing the ability to
support flags with spaces in them).

This is a follow-up to https://github.com/bazelbuild/bazel/pull/7411

Next steps:

- Update Bazel to Bash-tokenize the jvm_flags
  before embedding them in the launcher. This is
  required because the jvm_flags attribute should
  support Bash-tokenization (according to the
  Build Encyclopedia).

- Update the launcher to escape the jvm_flags with
  WindowsEscapeArg2 instead of WindowsEscapeArg.

See https://github.com/bazelbuild/bazel/issues/7072