### PR TITLE
Some improvements to RunfilesSupplier.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/EmptyRunfilesSupplier.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/EmptyRunfilesSupplier.java
@@ -17,6 +17,8 @@ package com.google.devtools.build.lib.actions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.Map;
@@ -29,8 +31,8 @@ public class EmptyRunfilesSupplier implements RunfilesSupplier {
   private EmptyRunfilesSupplier() {}
 
   @Override
-  public Iterable<Artifact> getArtifacts() {
-    return ImmutableList.<Artifact>of();
+  public NestedSet<Artifact> getArtifacts() {
+    return NestedSetBuilder.<Artifact>stableOrder().build();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/actions/RunfilesSupplier.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/RunfilesSupplier.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.actions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.util.Map;
@@ -27,7 +28,7 @@ import java.util.Map;
 public interface RunfilesSupplier {
 
   /** @return the contained artifacts */
-  Iterable<Artifact> getArtifacts();
+  NestedSet<Artifact> getArtifacts();
 
   /** @return the runfiles' root directories. */
   ImmutableSet<PathFragment> getRunfilesDirs();

--- a/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupplierImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupplierImpl.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.BaseSpawn;
 import com.google.devtools.build.lib.actions.RunfilesSupplier;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
@@ -75,7 +76,7 @@ public class RunfilesSupplierImpl implements RunfilesSupplier {
   }
 
   @Override
-  public Iterable<Artifact> getArtifacts() {
+  public NestedSet<Artifact> getArtifacts() {
     return runfiles.getAllArtifacts();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -557,7 +557,6 @@ public class SpawnAction extends AbstractAction implements ExecutionInfoSpecifie
     private final NestedSetBuilder<Artifact> inputsBuilder = NestedSetBuilder.stableOrder();
     private final List<Artifact> outputs = new ArrayList<>();
     private final List<RunfilesSupplier> inputRunfilesSuppliers = new ArrayList<>();
-    private final List<RunfilesSupplier> toolRunfilesSuppliers = new ArrayList<>();
     private ResourceSet resourceSet = AbstractAction.DEFAULT_RESOURCE_SET;
     private ActionEnvironment actionEnvironment = null;
     private ImmutableMap<String, String> environment = ImmutableMap.of();
@@ -587,7 +586,6 @@ public class SpawnAction extends AbstractAction implements ExecutionInfoSpecifie
       this.inputsBuilder.addTransitive(other.inputsBuilder.build());
       this.outputs.addAll(other.outputs);
       this.inputRunfilesSuppliers.addAll(other.inputRunfilesSuppliers);
-      this.toolRunfilesSuppliers.addAll(other.toolRunfilesSuppliers);
       this.resourceSet = other.resourceSet;
       this.actionEnvironment = other.actionEnvironment;
       this.environment = other.environment;
@@ -702,8 +700,7 @@ public class SpawnAction extends AbstractAction implements ExecutionInfoSpecifie
               ? executionInfo
               : configuration.modifiedExecutionInfo(executionInfo, mnemonic),
           progressMessage,
-          new CompositeRunfilesSupplier(
-              Iterables.concat(this.inputRunfilesSuppliers, this.toolRunfilesSuppliers)),
+          CompositeRunfilesSupplier.fromSuppliers(this.inputRunfilesSuppliers),
           mnemonic);
     }
 
@@ -1045,7 +1042,7 @@ public class SpawnAction extends AbstractAction implements ExecutionInfoSpecifie
      */
     public Builder addTool(FilesToRunProvider tool) {
       addTransitiveTools(tool.getFilesToRun());
-      toolRunfilesSuppliers.add(tool.getRunfilesSupplier());
+      addRunfilesSupplier(tool.getRunfilesSupplier());
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraAction.java
@@ -89,7 +89,7 @@ public final class ExtraAction extends SpawnAction {
         env,
         ImmutableMap.copyOf(executionInfo),
         progressMessage,
-        new CompositeRunfilesSupplier(shadowedAction.getRunfilesSupplier(), runfilesSupplier),
+        CompositeRunfilesSupplier.of(shadowedAction.getRunfilesSupplier(), runfilesSupplier),
         mnemonic,
         false,
         null);

--- a/src/main/java/com/google/devtools/build/lib/rules/extra/ExtraActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/extra/ExtraActionFactory.java
@@ -81,7 +81,7 @@ public final class ExtraActionFactory implements RuleConfiguredTargetFactory {
         new ExtraActionSpec(
             shExecutable,
             commandHelper.getResolvedTools(),
-            new CompositeRunfilesSupplier(commandHelper.getToolsRunfilesSuppliers()),
+            CompositeRunfilesSupplier.fromSuppliers(commandHelper.getToolsRunfilesSuppliers()),
             resolvedData,
             outputTemplates,
             command,

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBase.java
@@ -235,7 +235,7 @@ public abstract class GenRuleBase implements RuleConfiguredTargetFactory {
             CommandLines.of(argv),
             ruleContext.getConfiguration().getActionEnvironment(),
             ImmutableMap.copyOf(executionInfo),
-            new CompositeRunfilesSupplier(commandHelper.getToolsRunfilesSuppliers()),
+            CompositeRunfilesSupplier.fromSuppliers(commandHelper.getToolsRunfilesSuppliers()),
             progressMessage));
 
     RunfilesProvider runfilesProvider = RunfilesProvider.withData(

--- a/src/test/java/com/google/devtools/build/lib/actions/BaseSpawnTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/BaseSpawnTest.java
@@ -58,10 +58,12 @@ public class BaseSpawnTest {
   @Test
   public void testGetEnvironmentDoesntAddRunfilesWhenMultipleManifestsSupplied() {
     Map<String, String> baseEnviron = ImmutableMap.of("HELLO", "world");
-    BaseSpawn underTest = minimalBaseSpawn(baseEnviron,
-        new CompositeRunfilesSupplier(
-            new RunfilesSupplierImpl(PathFragment.create("rfdir1"), Runfiles.EMPTY),
-            new RunfilesSupplierImpl(PathFragment.create("rfdir2"), Runfiles.EMPTY)));
+    BaseSpawn underTest =
+        minimalBaseSpawn(
+            baseEnviron,
+            CompositeRunfilesSupplier.of(
+                new RunfilesSupplierImpl(PathFragment.create("rfdir1"), Runfiles.EMPTY),
+                new RunfilesSupplierImpl(PathFragment.create("rfdir2"), Runfiles.EMPTY)));
 
     assertThat(underTest.getEnvironment()).isEqualTo(baseEnviron);
   }

--- a/src/test/java/com/google/devtools/build/lib/skylark/SkylarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skylark/SkylarkRuleImplementationFunctionsTest.java
@@ -684,8 +684,8 @@ public class SkylarkRuleImplementationFunctionsTest extends SkylarkTestCase {
         "foo_Smytool" + OsUtils.executableExtension() + "-runfiles",
         "t.exe");
     @SuppressWarnings("unchecked")
-    CompositeRunfilesSupplier runfilesSupplier =
-        new CompositeRunfilesSupplier((List<RunfilesSupplier>) lookup("input_manifests"));
+    RunfilesSupplier runfilesSupplier =
+        CompositeRunfilesSupplier.fromSuppliers((List<RunfilesSupplier>) lookup("input_manifests"));
     assertThat(runfilesSupplier.getMappings(ArtifactPathResolver.IDENTITY)).hasSize(1);
   }
 
@@ -759,8 +759,8 @@ public class SkylarkRuleImplementationFunctionsTest extends SkylarkTestCase {
         "foo_Smytool" + OsUtils.executableExtension() + "-runfiles",
         "t.exe");
     @SuppressWarnings("unchecked")
-    CompositeRunfilesSupplier runfilesSupplier =
-        new CompositeRunfilesSupplier((List<RunfilesSupplier>) lookup("input_manifests"));
+    RunfilesSupplier runfilesSupplier =
+        CompositeRunfilesSupplier.fromSuppliers((List<RunfilesSupplier>) lookup("input_manifests"));
     assertThat(runfilesSupplier.getMappings(ArtifactPathResolver.IDENTITY)).hasSize(1);
 
     SpawnAction action =


### PR DESCRIPTION
- Make getArtifacts() return a NestedSet.
- Remove the public constructor of CompositeRunfilesSupplier. Force all clients to go through factory methods that remove empty suppliers and prevent singleton composite suppliers.
- Remove SpawnAction.Builder.toolRunfilesSuppliers, since there was no reason for it to be distinct from inputRunfilesSuppliers.