### PR TITLE
Declare chocolatey dependency on VC redist package

### DIFF
--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -78,6 +78,7 @@ Supply like `--params="/option:'value' ..."` ([see docs for --params](https://gi
       <dependency id="chocolatey-core.extension" version="1.0.7"/>
       <dependency id="msys2" version="[20160719.1.0,20160719.1.1]"/>
       <dependency id="python2" version="[2.7.11,3.0)"/>
+      <dependency id="vcredist2015" version="14.0.24215.20170201"/>
     </dependencies>
     <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->
 

--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -78,7 +78,7 @@ Supply like `--params="/option:'value' ..."` ([see docs for --params](https://gi
       <dependency id="chocolatey-core.extension" version="1.0.7"/>
       <dependency id="msys2" version="[20160719.1.0,20160719.1.1]"/>
       <dependency id="python2" version="[2.7.11,3.0)"/>
-      <dependency id="vcredist2015" version="14.0.24215.20170201"/>
+      <dependency id="vcredist140" version="14.20.27508.1"/>
     </dependencies>
     <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->
 


### PR DESCRIPTION
Fixes #7376. Currently untested, am on holiday without my build environment.

cc @laszlocsomor, @RNabel, @vmax. 

To verify:
1. check out this branch on a Windows computer
1. `cd scripts/packages/chocolatey`
1. in powershell: `./build.ps1 -version 0.23.0 -mode rc -rc 2` (I think 0.23 release is in flight, and rc2 has not been pushed)
    * should produce `./bazel-0.23.0rc2.nupkg` (from memory; filename might vary)
1. `choco install --verbose --yes ./bazel-0.23.0rc2.nupkg`
    * should see `[INFO ] - [NuGet] Attempting to resolve dependency 'vcredist2015 (= 14.0.24215.20170201).' in log, where, previous to this change, would not be present in log.

![selfie-0](https://i.imgur.com/OZHeyFD.png)
[_GitHub Selfies_](https://github.com/thieman/github-selfies/)
