### PR TITLE
Ignore SIGABRT in test setup script

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -248,6 +248,8 @@ fi
 exitCode=0
 signals="$(trap -l | sed -E 's/[0-9]+\)//g')"
 for signal in $signals; do
+  # SIGCHLD is expected when a subprocess dies
+  [ "${signal}" = "SIGCHLD" ] && continue
   trap "write_xml_output_file ${signal}" ${signal}
 done
 start=$(date +%s)


### PR DESCRIPTION
SIGABRT is expected when a subprocess ends, and is not indicative of a
failure. So, when trapping on signals to detect issues, do not trap on
this signal.

This has become important with Bash 5, as it has begun propagating this
signal up to this level.

Fixes #7410