### PR TITLE
Properly invalidate actions that have tree artifact inputs and do input discovery

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -1342,7 +1342,10 @@ public final class CcCompilationHelper {
     SpecialArtifact outputFiles =
         CppHelper.getCompileOutputTreeArtifact(
             actionConstructionContext, label, sourceArtifact, outputName, usePic);
-    // TODO(rduan): Dotd file output is not supported yet.
+    SpecialArtifact dotdFiles =
+        CppHelper.getDotdOutputTreeArtifact(
+            actionConstructionContext, label, sourceArtifact, outputName, usePic);
+    // Dotd file output is specified in the execution phase.
     builder.setOutputs(outputFiles, /* dotdFile= */ null);
     builder.setVariables(
         setupCompileBuildVariables(
@@ -1361,6 +1364,7 @@ public final class CcCompilationHelper {
         new CppCompileActionTemplate(
             sourceArtifact,
             outputFiles,
+            dotdFiles,
             builder,
             ccToolchain,
             outputCategories,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionTemplate.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionTemplate.java
@@ -32,7 +32,6 @@ import com.google.devtools.build.lib.rules.cpp.CcCompilationHelper.SourceCategor
 import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
-import com.sun.org.apache.xalan.internal.xsltc.cmdline.Compile;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -209,11 +209,6 @@ public final class CppFileTypes {
       };
 
   public static final boolean headerDiscoveryRequired(Artifact source) {
-    // Sources from TreeArtifacts and TreeFileArtifacts will not generate dotd file.
-    if (source.isTreeArtifact() || source.hasParent()) {
-      return false;
-    }
-
     String fileName = source.getFilename();
     return !ASSEMBLER.matches(fileName)
         && !PIC_ASSEMBLER.matches(fileName)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -80,6 +80,8 @@ public class CppHelper {
 
   static final PathFragment OBJS = PathFragment.create("_objs");
   static final PathFragment PIC_OBJS = PathFragment.create("_pic_objs");
+  static final PathFragment DOTD_FILES = PathFragment.create("_dotd");
+  static final PathFragment PIC_DOTD_FILES = PathFragment.create("_pic_dotd");
 
   // TODO(bazel-team): should this use Link.SHARED_LIBRARY_FILETYPES?
   public static final FileTypeSet SHARED_LIBRARY_FILETYPES = FileTypeSet.of(
@@ -365,6 +367,15 @@ public class CppHelper {
       return AnalysisUtils.getUniqueDirectory(ruleLabel, PIC_OBJS);
     } else {
       return AnalysisUtils.getUniqueDirectory(ruleLabel, OBJS);
+    }
+  }
+
+  /** Returns the directory where object files are created. */
+  private static PathFragment getDotdDirectory(Label ruleLabel, boolean usePic) {
+    if (usePic) {
+      return AnalysisUtils.getUniqueDirectory(ruleLabel, PIC_DOTD_FILES);
+    } else {
+      return AnalysisUtils.getUniqueDirectory(ruleLabel, DOTD_FILES);
     }
   }
 
@@ -727,6 +738,17 @@ public class CppHelper {
       boolean usePic) {
     return actionConstructionContext.getTreeArtifact(
         getObjDirectory(label, usePic).getRelative(outputName), sourceTreeArtifact.getRoot());
+  }
+
+  /** Returns the corresponding dotd files TreeArtifact given the source TreeArtifact. */
+  public static SpecialArtifact getDotdOutputTreeArtifact(
+      ActionConstructionContext actionConstructionContext,
+      Label label,
+      Artifact sourceTreeArtifact,
+      String outputName,
+      boolean usePic) {
+    return actionConstructionContext.getTreeArtifact(
+        getDotdDirectory(label, usePic).getRelative(outputName), sourceTreeArtifact.getRoot());
   }
 
   public static String getArtifactNameForCategory(

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/FakeCppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/FakeCppCompileAction.java
@@ -160,7 +160,7 @@ public class FakeCppCompileAction extends CppCompileAction {
               .setDependencies(
                   processDepset(actionExecutionContext, execRoot, reply).getDependencies())
               .setPermittedSystemIncludePrefixes(getPermittedSystemIncludePrefixes(execRoot))
-              .setAllowedDerivedinputs(getAllowedDerivedInputs());
+              .setAllowedDerivedinputs(getAllowedDerivedInputs(actionExecutionContext.getArtifactExpander()));
 
       if (needsIncludeValidation) {
         discoveryBuilder.shouldValidateInclusions();

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
@@ -170,10 +170,6 @@ public class HeaderDiscovery {
         continue;
       }
 
-      if (inTreeArtifact(execPathFragment)) {
-        continue;
-      }
-
       // Abort if we see files that we can't resolve, likely caused by
       // undeclared includes or illegal include constructs.
       problems.add(execPathFragment.getPathString());
@@ -182,17 +178,6 @@ public class HeaderDiscovery {
       problems.assertProblemFree(action, sourceFile);
     }
     return inputs.build();
-  }
-
-  private boolean inTreeArtifact(PathFragment execPathFragment) {
-    PathFragment dir = execPathFragment.getParentDirectory();
-    Boolean allowed = allowedDirs.get(dir);
-    if (allowed != null) {
-      return allowed;
-    }
-    allowed = treeArtifactPaths.stream().anyMatch(p -> dir.startsWith(p));
-    allowedDirs.put(execPathFragment, allowed);
-    return allowed;
   }
 
   /** A Builder for HeaderDiscovery */

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -103,4 +103,114 @@ EOF
   bazel build :ok || fail "Should have found include at synthetic path"
 }
 
+function test_tree_artifact_headers_are_invalidated() {
+  mkdir -p "ta_headers"
+  cat > "ta_headers/BUILD" <<EOF
+load(":mygen.bzl", "cc_mygen_library")
+
+sh_binary(
+  name = "mygen_sh",
+  srcs = ["mygen.sh"],
+  visibility = ["//visibility:public"],
+)
+
+cc_mygen_library(
+    name = "mylib",
+    srcs = [":mydef.txt"],
+)
+
+cc_binary(
+    name = "myexec",
+    srcs = [],
+    deps = [":mylib"],
+)
+EOF
+  cat > "ta_headers/mygen.sh" <<'EOF'
+#!/bin/bash
+
+set -euo pipefail
+
+in_file=$1
+src_files=$2
+hdr_files=$3
+
+fc_name=`cat ${in_file}`
+
+mkdir -p ${src_files}
+mkdir -p ${hdr_files}
+
+cat > ${src_files}/main.c <<EOT
+#include "ta_headers/files.h/another.h"
+int main(void) {
+    return MYFC();
+}
+EOT
+
+cat > ${src_files}/another.c <<EOT
+#include "ta_headers/files.h/another.h"
+int ${fc_name}(void) {
+    return 0;
+}
+EOT
+
+cat > ${hdr_files}/another.h <<EOT
+#define MYFC ${fc_name}
+int ${fc_name}(void);
+EOT
+EOF
+  chmod +x ta_headers/mygen.sh
+  cat > "ta_headers/mygen.bzl" <<EOF
+def _mygen_impl(ctx):
+  args = ctx.actions.args()
+  treeC = ctx.actions.declare_directory("files.c")
+  treeH = ctx.actions.declare_directory("files.h")
+  args.add(ctx.files.srcs[0])
+  args.add(treeC.path)
+  args.add(treeH.path)
+  ctx.actions.run(
+      inputs = ctx.files.srcs,
+      outputs = [treeC, treeH],
+      arguments = [args],
+      executable = ctx.executable._mygen,
+  )
+  return [DefaultInfo(files=depset([treeC, treeH]))]
+
+mygen = rule(
+  implementation=_mygen_impl,
+  attrs={
+    "srcs": attr.label_list(allow_files=True),
+    "_mygen": attr.label(
+      cfg="host",
+      executable=True,
+      allow_files=True,
+      default=":mygen_sh",
+    ),
+  },
+)
+
+def cc_mygen_library(name, srcs):
+    mygen(
+        name="{}_generated".format(name),
+        srcs=srcs,
+    )
+
+    native.cc_library(
+        name = name,
+        srcs = [":{}_generated".format(name)],
+        hdrs = [":{}_generated".format(name)],
+    )
+EOF
+
+  # So we have another.h defining a macro that is used by both main.c and another.c. :main depends
+  # on :another, and gets the header through the tree artifact. First build is fine.
+  echo "fc1" > "ta_headers/mydef.txt"
+  bazel build //ta_headers:myexec
+
+  # Now we change the content of another.h to define a different macro. This test verifies that
+  # not only another.c is recompiled, but also main.c. This is a regression test
+  # for https://github.com/bazelbuild/bazel/issues/5785.
+  echo "fc2" > "ta_headers/mydef.txt"
+  bazel build //ta_headers:myexec
+}
+
 run_suite "cc_integration_test"


### PR DESCRIPTION
While we allowed tree artifact header inputs in C++ actions (header validation passed), we failed to invalidate these headers on change. This change fixes it by:

* We only allow expanded tree artifacts in header validation (this is safe and reasonable, we are in the execution phase anyway, and all tree artifact inputs must have been expanded already)
* We store expanded tree artifact inputs in action cache (This is the core of the bug this change fixes, if action cache doesn't know about the concrete input, it doesn't reexecute action on change)

Fixes https://github.com/bazelbuild/bazel/issues/5785
