### PR TITLE
Generate the content of the java_tools archive under a top level directory

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -616,6 +616,7 @@ pkg_tar(
     extension = "tar.gz",
     # Permissions -rwxr-xr-x
     mode = "755",
+    package_dir = "java_tools",
 )
 
 load(":compiler_config_setting.bzl", "create_compiler_config_setting")

--- a/third_party/java/java_tools/new_BUILD.pkg
+++ b/third_party/java/java_tools/new_BUILD.pkg
@@ -1,0 +1,69 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+filegroup(
+    name = "ExperimentalRunner",
+    srcs = ["java_tools/ExperimentalRunner_deploy.jar"],
+)
+
+filegroup(
+    name = "GenClass",
+    srcs = ["java_tools/GenClass_deploy.jar"],
+)
+
+filegroup(
+    name = "JacocoCoverage",
+    srcs = ["java_tools/JacocoCoverage_jarjar_deploy.jar"],
+)
+
+filegroup(
+    name = "JavaBuilder",
+    srcs = ["java_tools/JavaBuilder_deploy.jar"],
+)
+
+filegroup(
+    name = "Runner",
+    srcs = ["java_tools/Runner_deploy.jar"],
+)
+
+filegroup(
+    name = "VanillaJavaBuilder",
+    srcs = ["java_tools/VanillaJavaBuilder_deploy.jar"],
+)
+
+filegroup(
+    name = "SingleJar",
+    srcs = ["java_tools/bazel-singlejar_deploy.jar"],
+)
+
+filegroup(
+    name = "JarJar",
+    srcs = ["java_tools/jarjar_command_deploy.jar"],
+)
+
+filegroup(
+    name = "Turbine",
+    srcs = ["java_tools/turbine_deploy.jar"],
+)
+
+filegroup(
+    name = "TurbineDirect",
+    srcs = ["java_tools/turbine_direct_binary_deploy.jar"],
+)
+
+filegroup(
+    name = "javac_jar",
+    srcs = ["java_tools/javac-9+181-r4173-1.jar"],
+)
+
+filegroup(
+    name = "jdk_compiler_jar",
+    srcs = ["java_tools/jdk_compiler.jar"],
+)
+
+filegroup(
+    name = "java_compiler_jar",
+    srcs = ["java_tools/java_compiler.jar"],
+)
+


### PR DESCRIPTION
Place all the jars in the java tools archive under a top level `java_tools` directory.

Remote java tools don't work on Windows if not under a directory (see #7440 for more details).

Partial fix for #7440.