### PR TITLE
Add a new BUILD file for java_tools_pkg-0.4.tar.gz.

### DIFF
--- a/third_party/java/java_tools/BUILD
+++ b/third_party/java/java_tools/BUILD
@@ -15,5 +15,8 @@ filegroup(
     ) + select({
         "//src/conditions:arm": ["bazel-singlejar_deploy.jar"],
         "//conditions:default": [],
-    }) + ["BUILD.pkg"]
+    }) + [
+        "BUILD.pkg",
+        "BUILD-new.pkg",
+    ],
 )

--- a/third_party/java/java_tools/BUILD-new.pkg
+++ b/third_party/java/java_tools/BUILD-new.pkg
@@ -1,0 +1,69 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+filegroup(
+    name = "ExperimentalRunner",
+    srcs = ["java_tools/ExperimentalRunner_deploy.jar"],
+)
+
+filegroup(
+    name = "GenClass",
+    srcs = ["java_tools/GenClass_deploy.jar"],
+)
+
+filegroup(
+    name = "JacocoCoverage",
+    srcs = ["java_tools/JacocoCoverage_jarjar_deploy.jar"],
+)
+
+filegroup(
+    name = "JavaBuilder",
+    srcs = ["java_tools/JavaBuilder_deploy.jar"],
+)
+
+filegroup(
+    name = "Runner",
+    srcs = ["java_tools/Runner_deploy.jar"],
+)
+
+filegroup(
+    name = "VanillaJavaBuilder",
+    srcs = ["java_tools/VanillaJavaBuilder_deploy.jar"],
+)
+
+filegroup(
+    name = "SingleJar",
+    srcs = ["java_tools/bazel-singlejar_deploy.jar"],
+)
+
+filegroup(
+    name = "JarJar",
+    srcs = ["java_tools/jarjar_command_deploy.jar"],
+)
+
+filegroup(
+    name = "Turbine",
+    srcs = ["java_tools/turbine_deploy.jar"],
+)
+
+filegroup(
+    name = "TurbineDirect",
+    srcs = ["java_tools/turbine_direct_binary_deploy.jar"],
+)
+
+filegroup(
+    name = "javac_jar",
+    srcs = ["java_tools/javac-9+181-r4173-1.jar"],
+)
+
+filegroup(
+    name = "jdk_compiler_jar",
+    srcs = ["java_tools/jdk_compiler.jar"],
+)
+
+filegroup(
+    name = "java_compiler_jar",
+    srcs = ["java_tools/java_compiler.jar"],
+)
+


### PR DESCRIPTION
Create a new BUILD file for the new java tools archive (java_tools_pkg-0.4.tar.gz) where all the previous content is placed under a `java_tools` directory.

New archive `java_tools_pkg-0.4.tar.gz` is generated using the target in #7453.

We need to use an intermediate BUILD file because the `third_party` changes to the BUILD file have to be merged separately from the bazel change (#7456) and that would break the CI.

Partial fix for #7440.