### PR TITLE
Windows: Fix deleting directory in JNI code

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/SimpleJavaLibraryBuilder.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/SimpleJavaLibraryBuilder.java
@@ -211,6 +211,7 @@ public class SimpleJavaLibraryBuilder implements Closeable {
     if (protobufMetadataBuffer.size() > 0) {
       try (OutputStream outputStream = Files.newOutputStream(output)) {
         protobufMetadataBuffer.writeTo(outputStream);
+        outputStream.close();
       }
     } else if (Files.exists(output)) {
       // Delete stalled meta file.

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/SimpleJavaLibraryBuilder.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/SimpleJavaLibraryBuilder.java
@@ -211,7 +211,6 @@ public class SimpleJavaLibraryBuilder implements Closeable {
     if (protobufMetadataBuffer.size() > 0) {
       try (OutputStream outputStream = Files.newOutputStream(output)) {
         protobufMetadataBuffer.writeTo(outputStream);
-        outputStream.close();
       }
     } else if (Files.exists(output)) {
       // Delete stalled meta file.

--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -419,7 +419,7 @@ int CheckDirectoryStatus(const wstring& path) {
   }
   do {
     if (kDot != metadata.cFileName && kDotDot != metadata.cFileName) {
-      std::wstring child = winpath + L"\\" + metadata.cFileName;
+      std::wstring child = path + L"\\" + metadata.cFileName;
       HANDLE hFile = CreateFileW(child.c_str(),
         GENERIC_READ,
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,

--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -410,7 +410,7 @@ struct DirectoryStatus {
 int CheckDirectoryStatus(const wstring& path) {
   static const wstring kDot(L".");
   static const wstring kDotDot(L"..");
-  bool found_pending_delete_file = false;
+  bool found_pending_delete_child = false;
   WIN32_FIND_DATAW metadata;
   HANDLE handle = ::FindFirstFileW((path + L"\\*").c_str(), &metadata);
   if (handle == INVALID_HANDLE_VALUE) {
@@ -443,13 +443,13 @@ int CheckDirectoryStatus(const wstring& path) {
             error_code != ERROR_FILE_NOT_FOUND) {
           return DirectoryStatus::kDirectoryNotEmpty;
         } else if (error_code == ERROR_ACCESS_DENIED) {
-          found_pending_delete_file = true;
+          found_pending_delete_child = true;
         }
       }
     }
   } while (::FindNextFileW(handle, &metadata));
   ::FindClose(handle);
-  if (found_pending_delete_file) {
+  if (found_pending_delete_child) {
     return DirectoryStatus::kPendingDeleteChildExists;
   }
   return DirectoryStatus::kDirectoryEmpty;


### PR DESCRIPTION
`bazel clean` command sometimes fails on Windows with
"Directory not empty" error. But when checking the directory after the
failure, we don't see any file or directory under it.
After debugging, we cannot find any unclosed file handle, either.

However, when trying to delete the bazel output directory with `rm -rf" it
succeeds everytime. The reason is that Cygwin worked around a Windows
issue at this commit:
https://github.com/Alexpux/Cygwin/commit/28fa2a72f810670a0562ea061461552840f5eb70

The problem is, I quote:
""
Intensive testing shows that sometimes directories, for which
the delete disposition has already been set, and the deleting
handle is already closed, can linger in the parent dir for a
couple of ms for no apparent reason (Windows Defender or other
real-time scanners are suspect).
""

In this commit, we use a similar way to retry deleting the directory when
its "deleted" sub-dirs are still lingering under it.

Related https://github.com/bazelbuild/bazel/issues/5907