### PR TITLE
Add --mtime flag to build_tar.py. Use this feature for pkg_tar.

### DIFF
--- a/tools/build_defs/pkg/archive.py
+++ b/tools/build_defs/pkg/archive.py
@@ -289,7 +289,7 @@ class TarFileWriter(object):
                     mtime=mtime,
                     mode=0o755)
     tarinfo = tarfile.TarInfo(name)
-    if mtime < 0:
+    if mtime is None:
       mtime = self.default_mtime
     tarinfo.mtime = mtime
     tarinfo.uid = uid

--- a/tools/build_defs/pkg/build_tar.py
+++ b/tools/build_defs/pkg/build_tar.py
@@ -34,6 +34,11 @@ gflags.DEFINE_string('manifest', None,
 gflags.DEFINE_string('mode', None,
                      'Force the mode on the added files (in octal).')
 
+gflags.DEFINE_string('mtime', None,
+                     'Set mtime on tar file entries. May be an integer or the'
+                     ' value "portable", to get the value 2000-01-01, which is'
+                     ' is usable with non *nix OSes')
+
 gflags.DEFINE_multistring('empty_file', [], 'An empty file to add to the layer')
 
 gflags.DEFINE_multistring('empty_dir', [], 'An empty dir to add to the layer')
@@ -86,20 +91,22 @@ FLAGS = gflags.FLAGS
 
 
 class TarFile(object):
-  """A class to generates a Docker layer."""
+  """A class to generates a TAR file."""
 
   class DebError(Exception):
     pass
 
-  def __init__(self, output, directory, compression, root_directory):
+  def __init__(self, output, directory, compression, root_directory, default_mtime):
     self.directory = directory
     self.output = output
     self.compression = compression
     self.root_directory = root_directory
+    self.default_mtime = default_mtime
 
   def __enter__(self):
     self.tarfile = archive.TarFileWriter(self.output, self.compression,
-                                         self.root_directory)
+                                         self.root_directory,
+                                         default_mtime=self.default_mtime)
     return self
 
   def __exit__(self, t, v, traceback):
@@ -326,7 +333,7 @@ def main(unused_argv):
 
   # Add objects to the tar file
   with TarFile(FLAGS.output, FLAGS.directory, FLAGS.compression,
-               FLAGS.root_directory) as output:
+               FLAGS.root_directory, FLAGS.mtime) as output:
 
     def file_attributes(filename):
       if filename.startswith('/'):

--- a/tools/build_defs/pkg/pkg.bzl
+++ b/tools/build_defs/pkg/pkg.bzl
@@ -44,10 +44,15 @@ def _pkg_tar_impl(ctx):
         "--output=" + ctx.outputs.out.path,
         "--directory=" + ctx.attr.package_dir,
         "--mode=" + ctx.attr.mode,
-        "--mtime=" + ctx.attr.mtime,
         "--owner=" + ctx.attr.owner,
         "--owner_name=" + ctx.attr.ownername,
     ]
+    if ctx.attr.mtime >= 0:
+      if ctx.attr.portable_mtime:
+        fail("You man not set both mtime and portable_mtime")
+      args.append("--mtime=" + ctx.attr.mtime)
+    if ctx.attr.portable_mtime:
+      args.append("--mtime=portable")
 
     # Add runfiles if requested
     file_inputs = []
@@ -219,7 +224,8 @@ _real_pkg_tar = rule(
         "files": attr.label_keyed_string_dict(allow_files = True),
         "mode": attr.string(default = "0555"),
         "modes": attr.string_dict(),
-        "mtime": attr.string(default = "portable"),
+        "mtime": attr.int(default = -1),
+        "portable_mtime": attr.bool(default = True),
         "owner": attr.string(default = "0.0"),
         "ownername": attr.string(default = "."),
         "owners": attr.string_dict(),

--- a/tools/build_defs/pkg/pkg.bzl
+++ b/tools/build_defs/pkg/pkg.bzl
@@ -44,6 +44,7 @@ def _pkg_tar_impl(ctx):
         "--output=" + ctx.outputs.out.path,
         "--directory=" + ctx.attr.package_dir,
         "--mode=" + ctx.attr.mode,
+        "--mtime=" + ctx.attr.mtime,
         "--owner=" + ctx.attr.owner,
         "--owner_name=" + ctx.attr.ownername,
     ]
@@ -218,6 +219,7 @@ _real_pkg_tar = rule(
         "files": attr.label_keyed_string_dict(allow_files = True),
         "mode": attr.string(default = "0555"),
         "modes": attr.string_dict(),
+        "mtime": attr.string(default = "portable"),
         "owner": attr.string(default = "0.0"),
         "ownername": attr.string(default = "."),
         "owners": attr.string_dict(),

--- a/tools/build_defs/pkg/pkg.bzl
+++ b/tools/build_defs/pkg/pkg.bzl
@@ -47,12 +47,12 @@ def _pkg_tar_impl(ctx):
         "--owner=" + ctx.attr.owner,
         "--owner_name=" + ctx.attr.ownername,
     ]
-    if ctx.attr.mtime >= 0:
-      if ctx.attr.portable_mtime:
-        fail("You man not set both mtime and portable_mtime")
-      args.append("--mtime=" + ctx.attr.mtime)
+    if ctx.attr.mtime != -1:  # Note: Must match default in rule def.
+        if ctx.attr.portable_mtime:
+            fail("You may not set both mtime and portable_mtime")
+        args.append("--mtime=" + ctx.attr.mtime)
     if ctx.attr.portable_mtime:
-      args.append("--mtime=portable")
+        args.append("--mtime=portable")
 
     # Add runfiles if requested
     file_inputs = []


### PR DESCRIPTION
This effectively reverts part of https://github.com/bazelbuild/bazel/pull/7276.
archive.py no longer makes TAR files with the mtime 2000-01-01.
Now, only tar files made with the pkg_tar() rule will get that mtime value by default.
This means other users of archive.py (e.g. rules_docker) will not experience a sudden change in tar content when updating Bazel.
    
https://github.com/bazelbuild/bazel/issues/1299

@beasleyr-vmw: Can you test this in your process to see that it still solves issue 1299 for you?