### PR TITLE
Windows: add --incompatible_windows_escape_jvm_flags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -768,6 +768,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skylarkbuildapi/java",
         "//src/main/java/com/google/devtools/build/lib/skylarkbuildapi/proto",
         "//src/main/java/com/google/devtools/build/lib/skylarkbuildapi/python",
+        "//src/main/java/com/google/devtools/build/lib/shell",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/skyframe",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
@@ -177,6 +177,7 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
   private final ImmutableList<Label> pluginList;
   private final boolean requireJavaToolchainHeaderCompilerDirect;
   private final boolean disallowResourceJars;
+  private final boolean windowsEscapeJvmFlags;
 
   // TODO(dmarting): remove once we have a proper solution for #2539
   private final boolean useLegacyBazelJavaTest;
@@ -213,6 +214,7 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
     this.isJlplStrictDepsEnforced = javaOptions.isJlplStrictDepsEnforced;
     this.disallowResourceJars = javaOptions.disallowResourceJars;
     this.addTestSupportToCompileTimeDeps = javaOptions.addTestSupportToCompileTimeDeps;
+    this.windowsEscapeJvmFlags = javaOptions.windowsEscapeJvmFlags;
 
     ImmutableList.Builder<Label> translationsBuilder = ImmutableList.builder();
     for (String s : javaOptions.translationTargets) {
@@ -454,5 +456,9 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
 
   public boolean disallowResourceJars() {
     return disallowResourceJars;
+  }
+
+  public boolean windowsEscapeJvmFlags() {
+    return windowsEscapeJvmFlags;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -625,6 +625,27 @@ public class JavaOptions extends FragmentOptions {
           "Disables the resource_jars attribute; use java_import and deps or runtime_deps instead.")
   public boolean disallowResourceJars;
 
+  @Option(
+      name = "incompatible_windows_escape_jvm_flags",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+      effectTags = {
+        OptionEffectTag.ACTION_COMMAND_LINES,
+        OptionEffectTag.AFFECTS_OUTPUTS,
+      },
+      metadataTags = {
+        OptionMetadataTag.INCOMPATIBLE_CHANGE,
+        OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+      },
+      help =
+          "On Linux/macOS/non-Windows: no-op. On Windows: this flag affects how java_binary and"
+              + " java_test targets are built; in particular, how the launcher of these targets"
+              + " escapes flags at the time of running the java_binary/java_test. When the flag is"
+              + " true, the launcher escapes the JVM flags using Windows-style escaping (correct"
+              + " behavior). When the flag is false, the launcher uses Bash-style escaping"
+              + " (buggy behavior). See https://github.com/bazelbuild/bazel/issues/7072")
+  public boolean windowsEscapeJvmFlags;
+
   private Label getHostJavaBase() {
     if (hostJavaBase == null) {
       if (useJDK11AsHostJavaBase) {
@@ -697,6 +718,8 @@ public class JavaOptions extends FragmentOptions {
     host.requireJavaToolchainHeaderCompilerDirect = requireJavaToolchainHeaderCompilerDirect;
 
     host.disallowResourceJars = disallowResourceJars;
+
+    host.windowsEscapeJvmFlags = windowsEscapeJvmFlags;
 
     return host;
   }

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -582,6 +582,13 @@ sh_test(
     tags = ["no_windows"],
 )
 
+sh_test(
+    name = "jvm_flags_escaping_test",
+    srcs = ["jvm_flags_escaping_test.sh"],
+    data = [":test-deps"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
 ########################################################################
 # Test suites.
 

--- a/src/test/shell/integration/jvm_flags_escaping_test.sh
+++ b/src/test/shell/integration/jvm_flags_escaping_test.sh
@@ -274,7 +274,7 @@ function test_untokenizable_jvm_flag_when_escaping_is_disabled() {
     # to the launcher, which also just passes it to the JVM.  This is bad, the
     # flag should have been rejected because it cannot be Bash-tokenized.
     expect_program_runs "bazel-bin/$pkg/cannot_tokenize${EXE_EXT}"
-    expect_log "arg0=('a)"
+    expect_log "arg0=('abc)"
   else
     # On other platforms, Bazel will build the target but it fails to run.
     expect_program_cannot_run "bazel-bin/$pkg/cannot_tokenize${EXE_EXT}"

--- a/src/test/shell/integration/jvm_flags_escaping_test.sh
+++ b/src/test/shell/integration/jvm_flags_escaping_test.sh
@@ -69,9 +69,16 @@ fi
 # HELPER FUNCTIONS
 # ----------------------------------------------------------------------
 
+# Writes a java file that prints System.getProperty(argN).
+#
+# The program prints every JVM definition of the form argN, where N >= 0, until
+# the first N is found for which argN is empty.
+#
+# Args:
+# $1: directory (package path) where the file will be written
 function create_java_file_that_prints_jvm_args() {
-  local -r pkg="$1"
-  mkdir -p "$pkg"
+  local -r pkg="$1"; shift
+  mkdir -p "$pkg" || fail "mkdir -p $pkg"
   cat >"$pkg/A.java" <<'eof'
 public class A {
   public static void main(String[] args) {
@@ -88,9 +95,13 @@ public class A {
 eof
 }
 
+# Writes a BUILD file for a java_binary with an untokenizable jvm_flags entry.
+#
+# Args:
+# $1: directory (package path) where the file will be written
 function create_build_file_for_untokenizable_flag() {
-  local -r pkg="$1"
-  mkdir -p "$pkg"
+  local -r pkg="$1"; shift
+  mkdir -p "$pkg" || fail "mkdir -p $pkg"
   cat >"$pkg/BUILD" <<'eof'
 java_binary(
     name = "cannot_tokenize",
@@ -101,9 +112,15 @@ java_binary(
 eof
 }
 
+# Writes a BUILD file for a java_binary with many different jvm_flags entries.
+#
+# Use this together with assert_output_of_the_program_with_many_jvm_flags().
+#
+# Args:
+# $1: directory (package path) where the file will be written
 function create_build_file_with_many_jvm_flags() {
-  local -r pkg="$1"
-  mkdir -p "$pkg"
+  local -r pkg="$1"; shift
+  mkdir -p "$pkg" || fail "mkdir -p $pkg"
   cat >"$pkg/BUILD" <<'eof'
 java_binary(
     name = "x",
@@ -158,6 +175,10 @@ java_binary(
 eof
 }
 
+# Asserts that the $TEST_log contains all JVM definitions of the form argN.
+#
+# See create_build_file_with_many_jvm_flags() and
+# create_java_file_that_prints_jvm_args().
 function assert_output_of_the_program_with_many_jvm_flags() {
   expect_log 'arg0=()'
   expect_log 'arg1=( )'
@@ -204,16 +225,24 @@ function assert_output_of_the_program_with_many_jvm_flags() {
   expect_log 'arg42=("C:\\t u\\w\\")'
 }
 
+# Runs a program, expecting it to succeed. Redirects all output to $TEST_log.
+#
+# Args:
+# $1: path of the program
 function expect_program_runs() {
-  local -r path="$1"
+  local -r path="$1"; shift
   (RUNFILES_DIR= \
    RUNFILES_MANIFEST_FILE= \
    RUNFILES_MANIFEST_ONLY= \
    "$path" >&"$TEST_log" ; ) || fail "expected success"
 }
 
+# Runs a program, expecting it to fail. Redirects all output to $TEST_log.
+#
+# Args:
+# $1: path of the program
 function expect_program_cannot_run() {
-  local -r path="$1"
+  local -r path="$1"; shift
   (RUNFILES_DIR= \
    RUNFILES_MANIFEST_FILE= \
    RUNFILES_MANIFEST_ONLY= \
@@ -225,15 +254,14 @@ function expect_program_cannot_run() {
 # ----------------------------------------------------------------------
 
 function test_no_windows_jvm_flags_escaping() {
-  local -r pkg="${FUNCNAME[0]}"
-  local -r flag="--noincompatible_windows_escape_jvm_flags"
+  local -r pkg="${FUNCNAME[0]}"  # unique package name for this test
 
   create_java_file_that_prints_jvm_args "$pkg"
   create_build_file_with_many_jvm_flags "$pkg"
 
   # On all platforms, Bazel can build the target.
-  bazel build --verbose_failures "$flag" "${pkg}:x" &>"$TEST_log" \
-    || fail "expected success"
+  bazel build --verbose_failures --noincompatible_windows_escape_jvm_flags \
+    "${pkg}:x" &>"$TEST_log" || fail "expected success"
   if "$is_windows"; then
     # On Windows, the target cannot run.
     expect_program_cannot_run "bazel-bin/$pkg/x${EXE_EXT}"
@@ -246,29 +274,27 @@ function test_no_windows_jvm_flags_escaping() {
 }
 
 function test_windows_jvm_flags_escaping() {
-  local -r pkg="${FUNCNAME[0]}"
-  local -r flag="--incompatible_windows_escape_jvm_flags"
+  local -r pkg="${FUNCNAME[0]}"  # unique package name for this test
 
   create_java_file_that_prints_jvm_args "$pkg"
   create_build_file_with_many_jvm_flags "$pkg"
 
   # On all platforms, Bazel can build and run the target.
-  bazel build --verbose_failures "$flag" "${pkg}:x" &>"$TEST_log" \
-    || fail "expected success"
+  bazel build --verbose_failures --incompatible_windows_escape_jvm_flags \
+    "${pkg}:x" &>"$TEST_log" || fail "expected success"
   expect_program_runs "bazel-bin/$pkg/x${EXE_EXT}"
   assert_output_of_the_program_with_many_jvm_flags
 }
 
 function test_untokenizable_jvm_flag_when_escaping_is_disabled() {
-  local -r pkg="${FUNCNAME[0]}"
-  local -r flag="--noincompatible_windows_escape_jvm_flags"
+  local -r pkg="${FUNCNAME[0]}"  # unique package name for this test
 
   create_java_file_that_prints_jvm_args "$pkg"
   create_build_file_for_untokenizable_flag "$pkg"
 
   # On all platforms, Bazel can build the target.
-  bazel build "$flag" --verbose_failures "${pkg}:cannot_tokenize" \
-    2>"$TEST_log" || fail "expected success"
+  bazel build --verbose_failures --noincompatible_windows_escape_jvm_flags \
+    "${pkg}:cannot_tokenize" 2>"$TEST_log" || fail "expected success"
   if "$is_windows"; then
     # On Windows, Bazel will not check the flag. It will just propagate the flag
     # to the launcher, which also just passes it to the JVM.  This is bad, the
@@ -283,21 +309,22 @@ function test_untokenizable_jvm_flag_when_escaping_is_disabled() {
 }
 
 function test_untokenizable_jvm_flag_when_escaping_is_enabled() {
-  local -r pkg="${FUNCNAME[0]}"
-  local -r flag="--incompatible_windows_escape_jvm_flags"
+  local -r pkg="${FUNCNAME[0]}"  # unique package name for this test
+
   create_java_file_that_prints_jvm_args "$pkg"
   create_build_file_for_untokenizable_flag "$pkg"
 
+  local -r flag="--incompatible_windows_escape_jvm_flags"
   if "$is_windows"; then
     # On Windows, Bazel will check the flag. It will just propagate the flag
     # to the launcher, which also just passes it to the JVM.  This is bad, the
     # flag should have been rejected because it cannot be Bash-tokenized.
-    bazel build "$flag" --verbose_failures "${pkg}:cannot_tokenize" \
+    bazel build --verbose_failures "$flag" "${pkg}:cannot_tokenize" \
       2>"$TEST_log" && fail "expected failure" || true
     expect_log "ERROR:.*in jvm_flags attribute of java_binary rule"
   else
     # On other platforms, Bazel will build the target but it fails to run.
-    bazel build "$flag" --verbose_failures "${pkg}:cannot_tokenize" \
+    bazel build --verbose_failures "$flag" "${pkg}:cannot_tokenize" \
       2>"$TEST_log" || fail "expected success"
     expect_program_cannot_run "bazel-bin/$pkg/cannot_tokenize${EXE_EXT}"
     expect_log "syntax error near unexpected token"

--- a/src/test/shell/integration/jvm_flags_escaping_test.sh
+++ b/src/test/shell/integration/jvm_flags_escaping_test.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+#
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# --- begin runfiles.bash initialization ---
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
+set -euo pipefail
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+# `uname` returns the current platform, e.g "MSYS_NT-10.0" or "Linux".
+# `tr` converts all upper case letters to lower case.
+# `case` matches the result if the `uname | tr` expression to string prefixes
+# that use the same wildcards as names do in Bash, i.e. "msys*" matches strings
+# starting with "msys", and "*" matches everything (it's the default case).
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*)
+  # As of 2019-02-20, Bazel on Windows only supports MSYS Bash.
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  # Disable MSYS path conversion that converts path-looking command arguments to
+  # Windows paths (even if they arguments are not in fact paths).
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+  declare -r EXE_EXT=".exe"
+else
+  declare -r EXE_EXT=""
+fi
+
+function create_pkg() {
+  if [[ -d foo ]]; then
+    return
+  fi
+  mkdir foo || fail "mkdir foo"
+
+  cat >foo/BUILD <<'eof'
+java_binary(
+    name = "x",
+    srcs = ["A.java"],
+    main_class = "A",
+    jvm_flags = [
+        "-Darg0=''",
+        "-Darg1=' '",
+        "-Darg2='\"'",
+        "-Darg3='\"\\'",
+        "-Darg4='\\'",
+        "-Darg5='\\\"'",
+        "-Darg6='with space'",
+        "-Darg7='with^caret'",
+        "-Darg8='space ^caret'",
+        "-Darg9='caret^ space'",
+        "-Darg10='with\"quote'",
+        "-Darg11='with\\backslash'",
+        "-Darg12='one\\ backslash and \\space'",
+        "-Darg13='two\\\\backslashes'",
+        "-Darg14='two\\\\ backslashes \\\\and space'",
+        "-Darg15='one\\\"x'",
+        "-Darg16='two\\\\\"x'",
+        "-Darg17='a \\ b'",
+        "-Darg18='a \\\" b'",
+        "-Darg19='A'",
+        "-Darg20='\"a\"'",
+        "-Darg21='B C'",
+        "-Darg22='\"b c\"'",
+        "-Darg23='D\"E'",
+        "-Darg24='\"d\"e\"'",
+        "-Darg25='C:\\F G'",
+        "-Darg26='\"C:\\f g\"'",
+        "-Darg27='C:\\H\"I'",
+        "-Darg28='\"C:\\h\"i\"'",
+        "-Darg29='C:\\J\\\"K'",
+        "-Darg30='\"C:\\j\\\"k\"'",
+        "-Darg31='C:\\L M '",
+        "-Darg32='\"C:\\l m \"'",
+        "-Darg33='C:\\N O\\'",
+        "-Darg34='\"C:\\n o\\\"'",
+        "-Darg35='C:\\P Q\\ '",
+        "-Darg36='\"C:\\p q\\ \"'",
+        "-Darg37='C:\\R\\S\\'",
+        "-Darg38='C:\\R x\\S\\'",
+        "-Darg39='\"C:\\r\\s\\\"'",
+        "-Darg40='\"C:\\r x\\s\\\"'",
+        "-Darg41='C:\\T U\\W\\'",
+        "-Darg42='\"C:\\t u\\w\\\"'",
+    ],
+)
+
+java_binary(
+    name = "cannot_tokenize",
+    srcs = ["A.java"],
+    main_class = "A",
+    jvm_flags = ["-Darg0='abc"],
+)
+eof
+
+  cat >foo/A.java <<'eof'
+public class A {
+  public static void main(String[] args) {
+    for (int i = 0; ; ++i) {
+      String value = System.getProperty("arg" + i);
+      if (value == null) {
+        break;
+      } else {
+        System.out.printf("arg%d=(%s)%n", i, value);
+      }
+    }
+  }
+}
+eof
+}
+
+function assert_output() {
+  expect_log 'arg0=()'
+  expect_log 'arg1=( )'
+  expect_log 'arg2=(")'
+  expect_log 'arg3=("\\)'
+  expect_log 'arg4=(\\)'
+  expect_log 'arg5=(\\")'
+  expect_log 'arg6=(with space)'
+  expect_log 'arg7=(with^caret)'
+  expect_log 'arg8=(space ^caret)'
+  expect_log 'arg9=(caret^ space)'
+  expect_log 'arg10=(with"quote)'
+  expect_log 'arg11=(with\\backslash)'
+  expect_log 'arg12=(one\\ backslash and \\space)'
+  expect_log 'arg13=(two\\\\backslashes)'
+  expect_log 'arg14=(two\\\\ backslashes \\\\and space)'
+  expect_log 'arg15=(one\\"x)'
+  expect_log 'arg16=(two\\\\"x)'
+  expect_log 'arg17=(a \\ b)'
+  expect_log 'arg18=(a \\" b)'
+  expect_log 'arg19=(A)'
+  expect_log 'arg20=("a")'
+  expect_log 'arg21=(B C)'
+  expect_log 'arg22=("b c")'
+  expect_log 'arg23=(D"E)'
+  expect_log 'arg24=("d"e")'
+  expect_log 'arg25=(C:\\F G)'
+  expect_log 'arg26=("C:\\f g")'
+  expect_log 'arg27=(C:\\H"I)'
+  expect_log 'arg28=("C:\\h"i")'
+  expect_log 'arg29=(C:\\J\\"K)'
+  expect_log 'arg30=("C:\\j\\"k")'
+  expect_log 'arg31=(C:\\L M )'
+  expect_log 'arg32=("C:\\l m ")'
+  expect_log 'arg33=(C:\\N O\\)'
+  expect_log 'arg34=("C:\\n o\\")'
+  expect_log 'arg35=(C:\\P Q\\ )'
+  expect_log 'arg36=("C:\\p q\\ ")'
+  expect_log 'arg37=(C:\\R\\S\\)'
+  expect_log 'arg38=(C:\\R x\\S\\)'
+  expect_log 'arg39=("C:\\r\\s\\")'
+  expect_log 'arg40=("C:\\r x\\s\\")'
+  expect_log 'arg41=(C:\\T U\\W\\)'
+  expect_log 'arg42=("C:\\t u\\w\\")'
+}
+
+function assert_jvm_flags() {
+  local -r enable_windows_escaping=$1
+
+  create_pkg
+
+  if $enable_windows_escaping; then
+    local -r flag="--incompatible_windows_escape_jvm_flags"
+    local -r expect_run_fails=false
+    local -r expect_tokenization_succeeds=false
+  else
+    local -r flag="--noincompatible_windows_escape_jvm_flags"
+    local -r expect_run_fails=$is_windows
+    local -r expect_tokenization_succeeds=$is_windows
+  fi
+
+  # Assert how jvm_flags are tokenized and passed to the Java program.
+  bazel build $flag foo:x --verbose_failures 2>$TEST_log \
+    || fail "expected success"
+  if $is_windows && $expect_run_fails; then
+    (RUNFILES_DIR= \
+     RUNFILES_MANIFEST_FILE= \
+     RUNFILES_MANIFEST_ONLY= \
+     bazel-bin/foo/x${EXE_EXT} &>$TEST_log ; ) \
+       && fail "expected failure" || true
+    expect_not_log "LAUNCHER ERROR"
+    expect_log "Could not find or load main class"
+  else
+    (RUNFILES_DIR= \
+     RUNFILES_MANIFEST_FILE= \
+     RUNFILES_MANIFEST_ONLY= \
+     bazel-bin/foo/x${EXE_EXT} &>$TEST_log ; ) || fail "expected success"
+    if $is_windows; then
+      expect_not_log "LAUNCHER ERROR"
+    fi
+    assert_output
+  fi
+
+  # Assert that a badly quoted jvm_flag cannot be Bash-tokenized.
+  if $expect_tokenization_succeeds; then
+    bazel build $flag foo:cannot_tokenize --verbose_failures 2>$TEST_log \
+      || fail "expected success"
+    (RUNFILES_DIR= \
+     RUNFILES_MANIFEST_FILE= \
+     RUNFILES_MANIFEST_ONLY= \
+     bazel-bin/foo/cannot_tokenize${EXE_EXT} &>$TEST_log ;) \
+       || fail "excepted success"
+  else
+    if $is_windows; then
+      # On Windows: badly quoted jvm_flags are caught at build time.
+      bazel build $flag foo:cannot_tokenize --verbose_failures 2>$TEST_log \
+        && fail "excepted failure" || true
+      expect_log "ERROR:.*in jvm_flags attribute of java_binary rule"
+    else
+      # On Linux/macOS/non-Windows: badly quoted jvm_flags are caught at run
+      # time.
+      bazel build $flag foo:cannot_tokenize --verbose_failures 2>$TEST_log \
+        || fail "expected success"
+      (RUNFILES_DIR= \
+       RUNFILES_MANIFEST_FILE= \
+       RUNFILES_MANIFEST_ONLY= \
+       bazel-bin/foo/cannot_tokenize${EXE_EXT} &>$TEST_log ;) \
+         && fail "excepted failure" || true
+      expect_log "syntax error near unexpected token"
+    fi
+  fi
+}
+
+function test_no_windows_jvm_flags_escaping() {
+  # $1=false: build with --noincompatible_windows_escape_jvm_flags
+  assert_jvm_flags false
+}
+
+function test_windows_jvm_flags_escaping() {
+  # $1=true: build with --incompatible_windows_escape_jvm_flags
+  assert_jvm_flags true
+}
+
+run_suite "Tests about how Bazel passes java_binary.jvm_flags to the binary"

--- a/src/test/shell/integration/jvm_flags_escaping_test.sh
+++ b/src/test/shell/integration/jvm_flags_escaping_test.sh
@@ -65,13 +65,46 @@ else
   declare -r EXE_EXT=""
 fi
 
-function create_pkg() {
-  if [[ -d foo ]]; then
-    return
-  fi
-  mkdir foo || fail "mkdir foo"
+# ----------------------------------------------------------------------
+# HELPER FUNCTIONS
+# ----------------------------------------------------------------------
 
-  cat >foo/BUILD <<'eof'
+function create_java_file_that_prints_jvm_args() {
+  local -r pkg="$1"
+  mkdir -p "$pkg"
+  cat >"$pkg/A.java" <<'eof'
+public class A {
+  public static void main(String[] args) {
+    for (int i = 0; ; ++i) {
+      String value = System.getProperty("arg" + i);
+      if (value == null) {
+        break;
+      } else {
+        System.out.printf("arg%d=(%s)%n", i, value);
+      }
+    }
+  }
+}
+eof
+}
+
+function create_build_file_for_untokenizable_flag() {
+  local -r pkg="$1"
+  mkdir -p "$pkg"
+  cat >"$pkg/BUILD" <<'eof'
+java_binary(
+    name = "cannot_tokenize",
+    srcs = ["A.java"],
+    main_class = "A",
+    jvm_flags = ["-Darg0='abc"],
+)
+eof
+}
+
+function create_build_file_with_many_jvm_flags() {
+  local -r pkg="$1"
+  mkdir -p "$pkg"
+  cat >"$pkg/BUILD" <<'eof'
 java_binary(
     name = "x",
     srcs = ["A.java"],
@@ -122,32 +155,10 @@ java_binary(
         "-Darg42='\"C:\\t u\\w\\\"'",
     ],
 )
-
-java_binary(
-    name = "cannot_tokenize",
-    srcs = ["A.java"],
-    main_class = "A",
-    jvm_flags = ["-Darg0='abc"],
-)
-eof
-
-  cat >foo/A.java <<'eof'
-public class A {
-  public static void main(String[] args) {
-    for (int i = 0; ; ++i) {
-      String value = System.getProperty("arg" + i);
-      if (value == null) {
-        break;
-      } else {
-        System.out.printf("arg%d=(%s)%n", i, value);
-      }
-    }
-  }
-}
 eof
 }
 
-function assert_output() {
+function assert_output_of_the_program_with_many_jvm_flags() {
   expect_log 'arg0=()'
   expect_log 'arg1=( )'
   expect_log 'arg2=(")'
@@ -193,81 +204,104 @@ function assert_output() {
   expect_log 'arg42=("C:\\t u\\w\\")'
 }
 
-function assert_jvm_flags() {
-  local -r enable_windows_escaping=$1
-
-  create_pkg
-
-  if $enable_windows_escaping; then
-    local -r flag="--incompatible_windows_escape_jvm_flags"
-    local -r expect_run_fails=false
-    local -r expect_tokenization_succeeds=false
-  else
-    local -r flag="--noincompatible_windows_escape_jvm_flags"
-    local -r expect_run_fails=$is_windows
-    local -r expect_tokenization_succeeds=$is_windows
-  fi
-
-  # Assert how jvm_flags are tokenized and passed to the Java program.
-  bazel build $flag foo:x --verbose_failures 2>$TEST_log \
-    || fail "expected success"
-  if $is_windows && $expect_run_fails; then
-    (RUNFILES_DIR= \
-     RUNFILES_MANIFEST_FILE= \
-     RUNFILES_MANIFEST_ONLY= \
-     bazel-bin/foo/x${EXE_EXT} &>$TEST_log ; ) \
-       && fail "expected failure" || true
-    expect_not_log "LAUNCHER ERROR"
-    expect_log "Could not find or load main class"
-  else
-    (RUNFILES_DIR= \
-     RUNFILES_MANIFEST_FILE= \
-     RUNFILES_MANIFEST_ONLY= \
-     bazel-bin/foo/x${EXE_EXT} &>$TEST_log ; ) || fail "expected success"
-    if $is_windows; then
-      expect_not_log "LAUNCHER ERROR"
-    fi
-    assert_output
-  fi
-
-  # Assert that a badly quoted jvm_flag cannot be Bash-tokenized.
-  if $expect_tokenization_succeeds; then
-    bazel build $flag foo:cannot_tokenize --verbose_failures 2>$TEST_log \
-      || fail "expected success"
-    (RUNFILES_DIR= \
-     RUNFILES_MANIFEST_FILE= \
-     RUNFILES_MANIFEST_ONLY= \
-     bazel-bin/foo/cannot_tokenize${EXE_EXT} &>$TEST_log ;) \
-       || fail "excepted success"
-  else
-    if $is_windows; then
-      # On Windows: badly quoted jvm_flags are caught at build time.
-      bazel build $flag foo:cannot_tokenize --verbose_failures 2>$TEST_log \
-        && fail "excepted failure" || true
-      expect_log "ERROR:.*in jvm_flags attribute of java_binary rule"
-    else
-      # On Linux/macOS/non-Windows: badly quoted jvm_flags are caught at run
-      # time.
-      bazel build $flag foo:cannot_tokenize --verbose_failures 2>$TEST_log \
-        || fail "expected success"
-      (RUNFILES_DIR= \
-       RUNFILES_MANIFEST_FILE= \
-       RUNFILES_MANIFEST_ONLY= \
-       bazel-bin/foo/cannot_tokenize${EXE_EXT} &>$TEST_log ;) \
-         && fail "excepted failure" || true
-      expect_log "syntax error near unexpected token"
-    fi
-  fi
+function expect_program_runs() {
+  local -r path="$1"
+  (RUNFILES_DIR= \
+   RUNFILES_MANIFEST_FILE= \
+   RUNFILES_MANIFEST_ONLY= \
+   "$path" >&"$TEST_log" ; ) || fail "expected success"
 }
 
+function expect_program_cannot_run() {
+  local -r path="$1"
+  (RUNFILES_DIR= \
+   RUNFILES_MANIFEST_FILE= \
+   RUNFILES_MANIFEST_ONLY= \
+   "$path" >&"$TEST_log" ; ) && fail "expected failure" || true
+}
+
+# ----------------------------------------------------------------------
+# TESTS
+# ----------------------------------------------------------------------
+
 function test_no_windows_jvm_flags_escaping() {
-  # $1=false: build with --noincompatible_windows_escape_jvm_flags
-  assert_jvm_flags false
+  local -r pkg="${FUNCNAME[0]}"
+  local -r flag="--noincompatible_windows_escape_jvm_flags"
+
+  create_java_file_that_prints_jvm_args "$pkg"
+  create_build_file_with_many_jvm_flags "$pkg"
+
+  # On all platforms, Bazel can build the target.
+  bazel build --verbose_failures "$flag" "${pkg}:x" &>"$TEST_log" \
+    || fail "expected success"
+  if "$is_windows"; then
+    # On Windows, the target cannot run.
+    expect_program_cannot_run "bazel-bin/$pkg/x${EXE_EXT}"
+    expect_log "Could not find or load main class"
+  else
+    # On other platforms, the program can run fine.
+    expect_program_runs "bazel-bin/$pkg/x${EXE_EXT}"
+    assert_output_of_the_program_with_many_jvm_flags
+  fi
 }
 
 function test_windows_jvm_flags_escaping() {
-  # $1=true: build with --incompatible_windows_escape_jvm_flags
-  assert_jvm_flags true
+  local -r pkg="${FUNCNAME[0]}"
+  local -r flag="--incompatible_windows_escape_jvm_flags"
+
+  create_java_file_that_prints_jvm_args "$pkg"
+  create_build_file_with_many_jvm_flags "$pkg"
+
+  # On all platforms, Bazel can build and run the target.
+  bazel build --verbose_failures "$flag" "${pkg}:x" &>"$TEST_log" \
+    || fail "expected success"
+  expect_program_runs "bazel-bin/$pkg/x${EXE_EXT}"
+  assert_output_of_the_program_with_many_jvm_flags
+}
+
+function test_untokenizable_jvm_flag_when_escaping_is_disabled() {
+  local -r pkg="${FUNCNAME[0]}"
+  local -r flag="--noincompatible_windows_escape_jvm_flags"
+
+  create_java_file_that_prints_jvm_args "$pkg"
+  create_build_file_for_untokenizable_flag "$pkg"
+
+  # On all platforms, Bazel can build the target.
+  bazel build "$flag" --verbose_failures "${pkg}:cannot_tokenize" \
+    2>"$TEST_log" || fail "expected success"
+  if "$is_windows"; then
+    # On Windows, Bazel will not check the flag. It will just propagate the flag
+    # to the launcher, which also just passes it to the JVM.  This is bad, the
+    # flag should have been rejected because it cannot be Bash-tokenized.
+    expect_program_runs "bazel-bin/$pkg/cannot_tokenize${EXE_EXT}"
+    expect_log "arg0=('a)"
+  else
+    # On other platforms, Bazel will build the target but it fails to run.
+    expect_program_cannot_run "bazel-bin/$pkg/cannot_tokenize${EXE_EXT}"
+    expect_log "syntax error near unexpected token"
+  fi
+}
+
+function test_untokenizable_jvm_flag_when_escaping_is_enabled() {
+  local -r pkg="${FUNCNAME[0]}"
+  local -r flag="--incompatible_windows_escape_jvm_flags"
+  create_java_file_that_prints_jvm_args "$pkg"
+  create_build_file_for_untokenizable_flag "$pkg"
+
+  if "$is_windows"; then
+    # On Windows, Bazel will check the flag. It will just propagate the flag
+    # to the launcher, which also just passes it to the JVM.  This is bad, the
+    # flag should have been rejected because it cannot be Bash-tokenized.
+    bazel build "$flag" --verbose_failures "${pkg}:cannot_tokenize" \
+      2>"$TEST_log" && fail "expected failure" || true
+    expect_log "ERROR:.*in jvm_flags attribute of java_binary rule"
+  else
+    # On other platforms, Bazel will build the target but it fails to run.
+    bazel build "$flag" --verbose_failures "${pkg}:cannot_tokenize" \
+      2>"$TEST_log" || fail "expected success"
+    expect_program_cannot_run "bazel-bin/$pkg/cannot_tokenize${EXE_EXT}"
+    expect_log "syntax error near unexpected token"
+  fi
 }
 
 run_suite "Tests about how Bazel passes java_binary.jvm_flags to the binary"

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -43,6 +43,7 @@ static constexpr const char* JAR_BIN_PATH = "jar_bin_path";
 static constexpr const char* CLASSPATH = "classpath";
 static constexpr const char* JAVA_START_CLASS = "java_start_class";
 static constexpr const char* JVM_FLAGS = "jvm_flags";
+static constexpr const char* WINDOWS_STYLE_ESCAPE_JVM_FLAGS = "escape_jvmflags";
 
 // Check if a string start with a certain prefix.
 // If it's true, store the substring without the prefix in value.
@@ -408,10 +409,15 @@ ExitCode JavaBinaryLauncher::Launch() {
     arguments.push_back(arg);
   }
 
+  wstring (*const escape_arg_func)(const wstring&) =
+      this->GetLaunchInfoByKey(WINDOWS_STYLE_ESCAPE_JVM_FLAGS) == L"1"
+          ? WindowsEscapeArg2
+          : WindowsEscapeArg;
+
   vector<wstring> escaped_arguments;
   // Quote the arguments if having spaces
   for (const auto& arg : arguments) {
-    escaped_arguments.push_back(WindowsEscapeArg(arg));
+    escaped_arguments.push_back(escape_arg_func(arg));
   }
 
   ExitCode exit_code = this->LaunchProcess(java_bin, escaped_arguments);


### PR DESCRIPTION
Add --incompatible_windows_escape_jvm_flags flag
(default: false). This flag has no effect on
platforms other than Windows.

This flag affects how Bazel builds the launcher of
java_binary and java_test targets. (The launcher
is the .exe file that sets up the environment for
the Java program and launches the JVM.)

In particular, the flag controls whether or not
Bazel will Bash-tokenize the jvm_flags that were
declared in the BUILD file, and whether or not
these jvm_flags are escaped by the launcher when
it invokes the JVM.

When the flag is enabled:

- Bazel will Bash-tokenize java_binary.jvm_flags
  and java_test.jvm_flags (as documented by the
  Build Encyclopedia) before embedding them into
  the launcher. The build fails if an entry cannot
  be Bash-tokenized, e.g. if it has unterminated
  quotes.

- The launcher will properly escape these flags
  when it runs the JVM as a subprocess (using
  launcher_util::WindowsEscapeArg2).

- Result: the jvm_flags declared in the BUILD file
  will arrive to the Java program as intended.
  However, due to the extra Bash-tokenization
  step, some ill-formed flags are no longer
  accepted, e.g.  `jvm_flags=["-Dfoo='a"]` now
  results in a build error.

When the flag is disabled:

- Bazel does not Bash-tokenize the jvm_flags
  before embedding them in the launcher. This
  preserves quoting meant to be stripped away, and
  it also means Bazel won't check whether the
  argument is properly quoted.

- The launcher escapes the flags with a Bash-like
  escaping logic (launcher_util::WindowsEscapeArg)
  which cannot properly quote and escape
  everything.

- Result: the jvm_flags declared in the BUILD file
  might get messed up as they are passed to the
  JVM, or the launcher may not even be able to run
  the JVM. However, due to the lack of
  Bash-tokenization, Bazel propagates some flags
  to the Java binary that it would no longer
  accept if the new
  `--incompatible_windows_escape_jvm_flags` were
  enabled, e.g. `jvm_flags=["'a"]` is fine.

Incompatible flag: https://github.com/bazelbuild/bazel/issues/7486

Related: https://github.com/bazelbuild/bazel/issues/7072

RELNOTES[NEW]: Added --incompatible_windows_escape_jvm_flags flag: enables correct java_binary.jvm_flags and java_test.jvm_flags tokenization and escaping on Windows. (No-op on other platforms.)

Change-Id: I531cc63cdfeccbe4b6d48876cb82870c1726a723