### PR TITLE
Remove third_party/java/langtools from the bazel binary.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -119,7 +119,6 @@ py_binary(
 # The tools Bazel uses to compile Java.
 # TODO(#6316): Gradually remove the targets here.
 JAVA_TOOLS = [
-    "//third_party/java/jdk/langtools:test-srcs",
     "//third_party/java/proguard:embedded_tools",
     "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper:srcs",
     "//src/tools/singlejar:embedded_tools",


### PR DESCRIPTION
This was part of #7472 but was reverted by mistake by 9192ee393f0487f85b12b215a5bae847241b3548

The bazel binary gets down to 94M. :smiley: 

Progress on #6316.