### PR TITLE
Re-add some of the targets removed recently

### DIFF
--- a/src/create_embedded_tools.py
+++ b/src/create_embedded_tools.py
@@ -36,6 +36,8 @@ output_paths = [
     ('*jarjar_command_deploy.jar',
      lambda x: 'tools/jdk/jarjar_command_deploy.jar'),
     ('*BUILD-new.pkg', lambda x: 'tools/jdk/BUILD.pkg'),
+    ('*BUILD.javalangtools',
+     lambda x: 'third_party/java/jdk/langtools/BUILD'),
     ('*singlejar_local.exe', lambda x: 'tools/jdk/singlejar/singlejar.exe'),
     ('*singlejar_local', lambda x: 'tools/jdk/singlejar/singlejar'),
     ('*launcher.exe', lambda x: 'tools/launcher/launcher.exe'),

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaBinaryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaBinaryRule.java
@@ -104,7 +104,7 @@ public final class BazelJavaBinaryRule implements RuleDefinition {
                     }))
         .add(
             attr("$jacocorunner", LABEL)
-                .value(env.getToolsLabel("//tools/jdk:remote_jacoco_coverage_runner")))
+                .value(env.getToolsLabel("//tools/jdk:JacocoCoverageRunner")))
         .addRequiredToolchains(CppRuleClasses.ccToolchainTypeAttribute(env))
         .build();
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaTestRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaTestRule.java
@@ -73,7 +73,7 @@ public final class BazelJavaTestRule implements RuleDefinition {
                         "@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main")))
         .add(
             attr("$jacocorunner", LABEL)
-                .value(env.getToolsLabel("//tools/jdk:remote_jacoco_coverage_runner")))
+                .value(env.getToolsLabel("//tools/jdk:JacocoCoverageRunner")))
         /* <!-- #BLAZE_RULE(java_test).ATTRIBUTE(test_class) -->
         The Java class to be loaded by the test runner.<br/>
         <p>

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -141,7 +141,7 @@ public final class BazelAnalysisMock extends AnalysisMock {
         "  ijar = ['ijar'],",
         ")",
         "java_import(",
-        "  name = 'remote_jacoco_coverage_runner',",
+        "  name = 'JacocoCoverageRunner',",
         "  jars = ['JacocoCoverage_jarjar_deploy.jar'],",
         ")",
         "java_import(",

--- a/src/test/shell/integration/bazel_java_test.sh
+++ b/src/test/shell/integration/bazel_java_test.sh
@@ -87,13 +87,13 @@ EOF
 function test_javabase() {
   mkdir -p zoo/bin
   cat << EOF > BUILD
-load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_remote_java_toolchain", "JDK9_REMOTE_JVM_OPTS")
-default_remote_java_toolchain(
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain", "JDK9_JVM_OPTS")
+default_java_toolchain(
     name = "toolchain",
     # Implicitly use the host_javabase bootclasspath, since the target doesn't
     # exist in this test.
     bootclasspath = [],
-    jvm_opts = JDK9_REMOTE_JVM_OPTS,
+    jvm_opts = JDK9_JVM_OPTS,
     visibility = ["//visibility:public"],
 )
 java_runtime(

--- a/third_party/java/java_tools/BUILD
+++ b/third_party/java/java_tools/BUILD
@@ -10,6 +10,7 @@ filegroup(
 filegroup(
     name = "bazel_embedded_java_tools",
     srcs = [
+        "BUILD.javalangtools",
         "BUILD.pkg",
         "BUILD-new.pkg",
     ],

--- a/third_party/java/java_tools/BUILD.javalangtools
+++ b/third_party/java/java_tools/BUILD.javalangtools
@@ -1,0 +1,19 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+
+filegroup(
+    name = "javac_jar",
+    srcs = ["@remote_java_tools//:java_tools/javac-9+181-r4173-1.jar"],
+)
+
+filegroup(
+    name = "jdk_compiler_jar",
+    srcs = ["@remote_java_tools//:java_tools/jdk_compiler.jar"],
+)
+
+filegroup(
+    name = "java_compiler_jar",
+    srcs = ["@remote_java_tools//:java_tools/java_compiler.jar"],
+)

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -156,8 +156,23 @@ filegroup(
 )
 
 filegroup(
+    name = "GenClass_deploy.jar",
+    srcs = ["@remote_java_tools//:java_tools/GenClass_deploy.jar"],
+)
+
+filegroup(
+    name = "bazel-singlejar_deploy.jar",
+    srcs = ["@remote_java_tools//:java_tools/bazel-singlejar_deploy.jar"],
+)
+
+filegroup(
     name = "turbine",
     srcs = ["@remote_java_tools//:Turbine"],
+)
+
+filegroup(
+    name = "turbine_deploy.jar",
+    srcs = ["@remote_java_tools//:java_tools/turbine_deploy.jar"],
 )
 
 filegroup(
@@ -166,8 +181,18 @@ filegroup(
 )
 
 filegroup(
+    name = "turbine_direct_binary_deploy.jar",
+    srcs = ["@remote_java_tools//:java_tools/turbine_direct_binary_deploy.jar"],
+)
+
+filegroup(
     name = "javabuilder",
     srcs = ["@remote_java_tools//:JavaBuilder"],
+)
+
+filegroup(
+    name = "JavaBuilder_deploy.jar",
+    srcs = ["@remote_java_tools//:java_tools/JavaBuilder_deploy.jar"],
 )
 
 filegroup(
@@ -200,9 +225,19 @@ java_import(
     jars = ["@remote_java_tools//:java_tools/Runner_deploy.jar"],
 )
 
+filegroup(
+    name = "TestRunner_deploy.jar",
+    srcs = ["@remote_java_tools//:java_tools/Runner_deploy.jar"],
+)
+
 java_import(
     name = "ExperimentalTestRunner",
     jars = ["@remote_java_tools//:java_tools/ExperimentalRunner_deploy.jar"],
+)
+
+filegroup(
+    name = "ExperimentalRunner_deploy.jar",
+    srcs = ["@remote_java_tools//:java_tools/ExperimentalRunner_deploy.jar"],
 )
 
 BOOTCLASS_JARS = [
@@ -274,6 +309,12 @@ default_java_toolchain(
 # TODO(cushon): consider if/when we should increment this?
 default_java_toolchain(
     name = "toolchain",
+    source_version = "8",
+    target_version = "8",
+)
+
+default_java_toolchain(
+    name = "remote_toolchain",
     source_version = "8",
     target_version = "8",
 )

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -1,6 +1,6 @@
 load(
     "//tools/jdk:default_java_toolchain.bzl",
-    "default_remote_java_toolchain",
+    "default_java_toolchain",
     "java_runtime_files",
     "JDK8_JVM_OPTS",
     "bootclasspath",
@@ -151,22 +151,22 @@ filegroup(
 exports_files(["BUILD.pkg"])
 
 filegroup(
-    name = "remote-genclass",
+    name = "genclass",
     srcs = ["@remote_java_tools//:GenClass"],
 )
 
 filegroup(
-    name = "remote-turbine",
+    name = "turbine",
     srcs = ["@remote_java_tools//:Turbine"],
 )
 
 filegroup(
-    name = "remote-turbine_direct",
+    name = "turbine_direct",
     srcs = ["@remote_java_tools//:TurbineDirect"],
 )
 
 filegroup(
-    name = "remote-javabuilder",
+    name = "javabuilder",
     srcs = ["@remote_java_tools//:JavaBuilder"],
 )
 
@@ -268,14 +268,14 @@ bootclasspath(
     target_javabase = "current_java_runtime",
 )
 
-default_remote_java_toolchain(
+default_java_toolchain(
     name = "toolchain_hostjdk8",
     jvm_opts = JDK8_JVM_OPTS,
     source_version = "8",
     target_version = "8",
 )
 
-default_remote_java_toolchain(
+default_java_toolchain(
     name = "remote_toolchain_hostjdk8",
     jvm_opts = JDK8_JVM_OPTS,
     source_version = "8",
@@ -284,13 +284,13 @@ default_remote_java_toolchain(
 
 # Default to the Java 8 language level.
 # TODO(cushon): consider if/when we should increment this?
-default_remote_java_toolchain(
+default_java_toolchain(
     name = "toolchain",
     source_version = "8",
     target_version = "8",
 )
 
-default_remote_java_toolchain(
+default_java_toolchain(
     name = "remote_toolchain",
     source_version = "8",
     target_version = "8",
@@ -310,14 +310,14 @@ default_remote_java_toolchain(
 #
 # However it does allow using a wider range of `--host_javabase`s, including
 # versions newer than the current embedded JDK.
-default_remote_java_toolchain(
+default_java_toolchain(
     name = "toolchain_vanilla",
     forcibly_disable_header_compilation = True,
     javabuilder = [":vanillajavabuilder"],
     jvm_opts = [],
 )
 
-default_remote_java_toolchain(
+default_java_toolchain(
     name = "remote_toolchain_vanilla",
     forcibly_disable_header_compilation = True,
     javabuilder = ["@bazel_tools//tools/jdk:remote-vanillajavabuilder"],
@@ -327,7 +327,7 @@ default_remote_java_toolchain(
 RELEASES = (8, 9)
 
 [
-    default_remote_java_toolchain(
+    default_java_toolchain(
         name = "toolchain_java%d" % release,
         source_version = "%s" % release,
         target_version = "%s" % release,

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -172,31 +172,26 @@ filegroup(
 
 filegroup(
     name = "vanillajavabuilder",
-    srcs = ["//tools/jdk:VanillaJavaBuilder_deploy.jar"],
-)
-
-filegroup(
-    name = "remote-vanillajavabuilder",
     srcs = ["@remote_java_tools//:VanillaJavaBuilder"],
 )
 
 filegroup(
-    name = "remote-javac_jar",
+    name = "javac_jar",
     srcs = ["@remote_java_tools//:javac_jar"],
 )
 
 filegroup(
-    name = "remote-jdk_compiler_jar",
+    name = "jdk_compiler_jar",
     srcs = ["@remote_java_tools//:jdk_compiler_jar"],
 )
 
 filegroup(
-    name = "remote-java_compiler_jar",
+    name = "java_compiler_jar",
     srcs = ["@remote_java_tools//:java_compiler_jar"],
 )
 
 java_import(
-    name = "remote_jacoco_coverage_runner",
+    name = "JacocoCoverageRunner",
     jars = ["@remote_java_tools//:java_tools/JacocoCoverage_jarjar_deploy.jar"],
 )
 
@@ -275,23 +270,10 @@ default_java_toolchain(
     target_version = "8",
 )
 
-default_java_toolchain(
-    name = "remote_toolchain_hostjdk8",
-    jvm_opts = JDK8_JVM_OPTS,
-    source_version = "8",
-    target_version = "8",
-)
-
 # Default to the Java 8 language level.
 # TODO(cushon): consider if/when we should increment this?
 default_java_toolchain(
     name = "toolchain",
-    source_version = "8",
-    target_version = "8",
-)
-
-default_java_toolchain(
-    name = "remote_toolchain",
     source_version = "8",
     target_version = "8",
 )
@@ -314,13 +296,6 @@ default_java_toolchain(
     name = "toolchain_vanilla",
     forcibly_disable_header_compilation = True,
     javabuilder = [":vanillajavabuilder"],
-    jvm_opts = [],
-)
-
-default_java_toolchain(
-    name = "remote_toolchain_vanilla",
-    forcibly_disable_header_compilation = True,
-    javabuilder = ["@bazel_tools//tools/jdk:remote-vanillajavabuilder"],
     jvm_opts = [],
 )
 

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -84,7 +84,7 @@ DEFAULT_TOOLCHAIN_CONFIGURATION = {
 def default_java_toolchain(name, **kwargs):
     """Defines a remote java_toolchain with appropriate defaults for Bazel."""
 
-    toolchain_args = dict(DEFAULT_REMOTE_TOOLCHAIN_CONFIGURATION)
+    toolchain_args = dict(DEFAULT_TOOLCHAIN_CONFIGURATION)
     toolchain_args.update(kwargs)
 
     native.java_toolchain(

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -15,7 +15,7 @@
 """Bazel rules for creating Java toolchains."""
 
 JDK8_JVM_OPTS = [
-    "-Xbootclasspath/p:$(location @bazel_tools//tools/jdk:remote-javac_jar)",
+    "-Xbootclasspath/p:$(location @bazel_tools//tools/jdk:javac_jar)",
 ]
 
 JDK9_JVM_OPTS = [
@@ -34,8 +34,8 @@ JDK9_JVM_OPTS = [
     "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
 
     # override the javac in the JDK.
-    "--patch-module=java.compiler=$(location @bazel_tools//tools/jdk:remote-java_compiler_jar)",
-    "--patch-module=jdk.compiler=$(location @bazel_tools//tools/jdk:remote-jdk_compiler_jar)",
+    "--patch-module=java.compiler=$(location @bazel_tools//tools/jdk:java_compiler_jar)",
+    "--patch-module=jdk.compiler=$(location @bazel_tools//tools/jdk:jdk_compiler_jar)",
 
     # quiet warnings from com.google.protobuf.UnsafeUtil,
     # see: https://github.com/google/protobuf/issues/3781
@@ -68,10 +68,10 @@ DEFAULT_TOOLCHAIN_CONFIGURATION = {
     "header_compiler_direct": ["@bazel_tools//tools/jdk:turbine_direct"],
     "ijar": ["@bazel_tools//tools/jdk:ijar"],
     "javabuilder": ["@bazel_tools//tools/jdk:javabuilder"],
-    "javac": ["@bazel_tools//tools/jdk:remote-javac_jar"],
+    "javac": ["@bazel_tools//tools/jdk:javac_jar"],
     "tools": [
-        "@bazel_tools//tools/jdk:remote-java_compiler_jar",
-        "@bazel_tools//tools/jdk:remote-jdk_compiler_jar",
+        "@bazel_tools//tools/jdk:java_compiler_jar",
+        "@bazel_tools//tools/jdk:jdk_compiler_jar",
     ],
     "javac_supports_workers": 1,
     "jvm_opts": JDK9_JVM_OPTS,

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -18,7 +18,7 @@ JDK8_JVM_OPTS = [
     "-Xbootclasspath/p:$(location @bazel_tools//tools/jdk:remote-javac_jar)",
 ]
 
-JDK9_REMOTE_JVM_OPTS = [
+JDK9_JVM_OPTS = [
     # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
     # G1 collector and having compact strings enabled.
     "-XX:+UseParallelOldGC",
@@ -61,28 +61,27 @@ PROTO_JAVACOPTS = [
 COMPATIBLE_JAVACOPTS = {
     "proto": PROTO_JAVACOPTS,
 }
-
-DEFAULT_REMOTE_TOOLCHAIN_CONFIGURATION = {
+DEFAULT_TOOLCHAIN_CONFIGURATION = {
     "forcibly_disable_header_compilation": 0,
-    "genclass": ["@bazel_tools//tools/jdk:remote-genclass"],
-    "header_compiler": ["@bazel_tools//tools/jdk:remote-turbine"],
-    "header_compiler_direct": ["@bazel_tools//tools/jdk:remote-turbine_direct"],
+    "genclass": ["@bazel_tools//tools/jdk:genclass"],
+    "header_compiler": ["@bazel_tools//tools/jdk:turbine"],
+    "header_compiler_direct": ["@bazel_tools//tools/jdk:turbine_direct"],
     "ijar": ["@bazel_tools//tools/jdk:ijar"],
-    "javabuilder": ["@bazel_tools//tools/jdk:remote-javabuilder"],
+    "javabuilder": ["@bazel_tools//tools/jdk:javabuilder"],
     "javac": ["@bazel_tools//tools/jdk:remote-javac_jar"],
     "tools": [
         "@bazel_tools//tools/jdk:remote-java_compiler_jar",
         "@bazel_tools//tools/jdk:remote-jdk_compiler_jar",
     ],
     "javac_supports_workers": 1,
-    "jvm_opts": JDK9_REMOTE_JVM_OPTS,
+    "jvm_opts": JDK9_JVM_OPTS,
     "misc": DEFAULT_JAVACOPTS,
     "compatible_javacopts": COMPATIBLE_JAVACOPTS,
     "singlejar": ["@bazel_tools//tools/jdk:singlejar"],
     "bootclasspath": ["@bazel_tools//tools/jdk:platformclasspath"],
 }
 
-def default_remote_java_toolchain(name, **kwargs):
+def default_java_toolchain(name, **kwargs):
     """Defines a remote java_toolchain with appropriate defaults for Bazel."""
 
     toolchain_args = dict(DEFAULT_REMOTE_TOOLCHAIN_CONFIGURATION)


### PR DESCRIPTION
Commit c33ae8af469d615e490fbf503f7fad03e22ea1c6 removed some targets and replaced them with targets called "remote-X". This PR adds back the initial targets but now referencing remote tools.

Progress on #6316.