### PR TITLE
Make Xcode setup more resilient

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -64,7 +64,7 @@ def configure_osx_toolchain(repository_ctx, overriden_tools):
     ])
 
     xcode_toolchains = []
-    (xcode_toolchains, xcodeloc_err) = run_xcode_locator(
+    xcode_toolchains = run_xcode_locator(
         repository_ctx,
         paths["@bazel_tools//tools/osx:xcode_locator.m"],
     )
@@ -149,8 +149,6 @@ def configure_osx_toolchain(repository_ctx, overriden_tools):
         escaped_cxx_include_directories = []
         for path in escaped_include_paths:
             escaped_cxx_include_directories.append(("    \"%s\"," % path))
-        if xcodeloc_err:
-            escaped_cxx_include_directories.append("# Error: " + xcodeloc_err + "\n")
         repository_ctx.template(
             "cc_toolchain_config.bzl",
             paths["@bazel_tools//tools/osx/crosstool:cc_toolchain_config.bzl.tpl"],

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -64,6 +64,7 @@ def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir)
             err = xcodebuild_result.stderr,
             out = xcodebuild_result.stdout,
         )
+        print(error_msg)
         fail(error_msg)
     ios_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "iphoneos")
     tvos_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "appletvos")
@@ -136,6 +137,7 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
             err = xcrun_result.stderr,
             out = xcrun_result.stdout,
         )
+        print(error_msg)
         fail(error_msg)
 
     xcode_locator_result = repository_ctx.execute(["./xcode-locator-bin", "-v"], 30)
@@ -147,8 +149,9 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
             code = xcode_locator_result.return_code,
             err = xcode_locator_result.stderr,
             out = xcode_locator_result.stdout,
-        )
-        fail(error_msg.replace("\n", " "))
+        ).replace("\n", " ")
+        print(error_msg)
+        fail(error_msg)
     xcode_toolchains = []
 
     # xcode_dump is comprised of newlines with different installed xcode versions,


### PR DESCRIPTION
Previously if you tried to build a project from a entirely clean bazel
state, and ctrl-c'd while bazel was fetching the local_config_xcode
information, you would end up in a state where the
local_config_xcode/BUILD file contained error information, which made
the Apple crosstool unusable until you did a `clean --expunge`. Now the
Xcode setup calls `fail()` in those cases, which makes bazel re-run it
again the next time you try to build.

It is still possible to reproduce if you ctrl-c while the `xcodebuild
-version` command that determines if you have Xcode installed at all
runs. Because we want to support users who don't have Xcode installed on
macOS, we cannot fail in that case.

Fixes https://github.com/bazelbuild/bazel/issues/6056