### PR TITLE
Expose Go libraries for Build Event Streams.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package build_event_stream;
 
+option go_package = "github.com/bazelbuild/bazel/src/main/java/com/google/devtools/build/lib/buildeventstream/proto";
 option java_package = "com.google.devtools.build.lib.buildeventstream";
 option java_outer_classname = "BuildEventStreamProtos";
 

--- a/src/main/protobuf/command_line.proto
+++ b/src/main/protobuf/command_line.proto
@@ -15,6 +15,7 @@
 syntax = "proto3";
 package command_line;
 
+option go_package = "github.com/bazelbuild/bazel/src/main/protobuf";
 // option java_api_version = 2;
 option java_package = "com.google.devtools.build.lib.runtime.proto";
 

--- a/src/main/protobuf/invocation_policy.proto
+++ b/src/main/protobuf/invocation_policy.proto
@@ -15,6 +15,7 @@
 syntax = "proto2";
 package blaze.invocation_policy;
 
+option go_package = "github.com/bazelbuild/bazel/src/main/protobuf";
 // option java_api_version = 2;
 option java_package = "com.google.devtools.build.lib.runtime.proto";
 

--- a/src/main/protobuf/option_filters.proto
+++ b/src/main/protobuf/option_filters.proto
@@ -14,6 +14,7 @@
 syntax = "proto3";
 package options;
 
+option go_package = "github.com/bazelbuild/bazel/src/main/protobuf";
 // option java_api_version = 2;
 option java_package = "com.google.devtools.common.options.proto";
 


### PR DESCRIPTION
- Add go_package attributes to the .proto files, so that protoc can properly generate imports for files that are linked together.

- Manually add go_proto_library/go_library tags. Due to multiple .proto files being stored in one directory, Gazelle is not capable of automatically generating rules for them. See https://github.com/bazelbuild/bazel-gazelle/issues/7 for details.

**Note:** This patch causes the build to break, due to it introducing a dependency on `rules_go`. My question is, is such a dependency (un)desirable? I'd like to gain support for Go, because I'm working on integrating support for Build Event Streams into Buildbarn.