### PR TITLE
Windows, test wrapper: simplify IFStream

### DIFF
--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -1795,9 +1795,7 @@ DWORD IFStreamImpl::Peek(DWORD n, uint8_t* out) const {
   if (n1 > n) {
     n1 = n;  // all 'n' bytes are on the current page
   }
-  for (DWORD i = 0; i < n1; ++i) {
-    out[i] = pages_[pos_ + i];
-  }
+  memcpy(out, pages_.get() + pos_, n1);
   if (n1 == n) {
     return n;
   }
@@ -1807,9 +1805,7 @@ DWORD IFStreamImpl::Peek(DWORD n, uint8_t* out) const {
   if (n2 > next_size_) {
     n2 = next_size_;  // read no more than the other page's size
   }
-  for (DWORD i = 0; i < n2; ++i) {
-    out[n1 + i] = pages_[offs + i];
-  }
+  memcpy(out + n1, pages_.get() + offs, n2);
   return n1 + n2;
 }
 

--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -115,38 +115,32 @@ class Tee {
 // Buffered input stream (based on a HANDLE) with peek-ahead support.
 class IFStream {
  public:
+  enum {
+    kIFStreamErrorEOF = 256,
+    kIFStreamErrorIO = 257,
+  };
+
   virtual ~IFStream() {}
 
-  // Gets the current byte under the read cursor.
-  // Returns true upon success, returns false if there's no more data to read.
-  virtual bool Get(uint8_t* result) const = 0;
+  // Reads one byte from the stream, and moves the cursor ahead.
+  // Returns:
+  //   0..255: success, the value of the read byte
+  //   256 (kIFStreamErrorEOF): failure, EOF was reached
+  //   257 (kIFStreamErrorIO): failure, I/O error
+  virtual int Get() = 0;
 
-  // Advances the read cursor one byte ahead. May fetch data from the underlying
-  // HANDLE.
-  // Returns true if the cursor could be moved. Returns false if EOF was reached
-  // or if there was an I/O error.
-  virtual bool Advance() = 0;
-
-  // Peeks at the next byte after the read cursor. Returns true if there's at
-  // least one more byte in the stream.
-  bool Peek1(uint8_t* result) const { return PeekN(1, result); }
-
-  // Peeks at the next two bytes after the read cursor. Returns true if there
-  // are at least two more byte in the stream.
-  bool Peek2(uint8_t* result) const { return PeekN(2, result); }
-
-  // Peeks at the next three bytes after the read cursor. Returns true if there
-  // are at least three more byte in the stream.
-  bool Peek3(uint8_t* result) const { return PeekN(3, result); }
+  // Peeks at 'n' bytes starting at the current cursor position.
+  // Writes into 'out' the 0..'n' successfully peeked bytes.
+  // Returns:
+  //   0..n: the number of successfully peeked bytes
+  virtual DWORD Peek(DWORD n, uint8_t* out) const = 0;
 
  protected:
   IFStream() {}
+
+ private:
   IFStream(const IFStream&) = delete;
   IFStream& operator=(const IFStream&) = delete;
-
-  // Peeks ahead N bytes, writing them to 'result'. Returns true if successful.
-  // The result does not include the byte currently under the read cursor.
-  virtual bool PeekN(DWORD n, uint8_t* result) const = 0;
 };
 
 // The main function of the test wrapper.
@@ -203,8 +197,7 @@ bool TestOnly_CreateTee(bazel::windows::AutoHandle* input,
 bool TestOnly_CdataEncode(const uint8_t* buffer, const DWORD size,
                           std::basic_ostream<char>* out_stm);
 
-IFStream* TestOnly_CreateIFStream(bazel::windows::AutoHandle* handle,
-                                  DWORD page_size);
+IFStream* TestOnly_CreateIFStream(HANDLE handle, DWORD page_size);
 
 }  // namespace testing
 


### PR DESCRIPTION
Simplify IFStream:
- Get() now returns the byte under the cursor and
  moves forward.
- Peek() can peek any characters and returns the
  number peeked.
- Advance() and PeekN() is removed.

The benefit:
- Telling if we reached EOF is easy: Advance()
  used to return false on I/O error and EOF and we
  couldn't tell them apart.
- The semantics lend themselves easier for UTF-8
  stream escaping.

See https://github.com/bazelbuild/bazel/issues/5508