### PR TITLE
Windows, test wrapper: use IFStream to encode XML

### DIFF
--- a/src/test/cpp/util/windows_test_util.cc
+++ b/src/test/cpp/util/windows_test_util.cc
@@ -88,6 +88,11 @@ bool DeleteAllUnder(wstring path) {
 }
 
 bool CreateDummyFile(const wstring& path, const std::string& content) {
+  return CreateDummyFile(path, content.c_str(), content.size());
+}
+
+bool CreateDummyFile(const std::wstring& path, const void* content,
+                     const DWORD size) {
   HANDLE handle =
       ::CreateFileW(path.c_str(), GENERIC_WRITE, FILE_SHARE_READ, NULL,
                     CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -96,9 +101,8 @@ bool CreateDummyFile(const wstring& path, const std::string& content) {
   }
   bool result = true;
   DWORD actually_written = 0;
-  if (!::WriteFile(handle, content.c_str(), content.size(), &actually_written,
-                   NULL) &&
-      actually_written != content.size()) {
+  if (!::WriteFile(handle, content, size, &actually_written, NULL) &&
+      actually_written != size) {
     result = false;
   }
   CloseHandle(handle);

--- a/src/test/cpp/util/windows_test_util.h
+++ b/src/test/cpp/util/windows_test_util.h
@@ -32,6 +32,11 @@ bool DeleteAllUnder(std::wstring path);
 bool CreateDummyFile(const std::wstring& path,
                      const std::string& content = "hello");
 
+// Creates a dummy file under `path`.
+// `path` must be a valid Windows path, and have a UNC prefix if necessary.
+bool CreateDummyFile(const std::wstring& path,
+                     const void* content, const DWORD size);
+
 }  // namespace blaze_util
 
 #endif  // BAZEL_SRC_TEST_CPP_UTIL_WINDOWS_TEST_UTIL_H_

--- a/tools/test/windows/tw.h
+++ b/tools/test/windows/tw.h
@@ -194,8 +194,7 @@ bool TestOnly_CreateTee(bazel::windows::AutoHandle* input,
                         bazel::windows::AutoHandle* output2,
                         std::unique_ptr<Tee>* result);
 
-bool TestOnly_CdataEncode(const uint8_t* buffer, const DWORD size,
-                          std::basic_ostream<char>* out_stm);
+bool TestOnly_CdataEncode(IFStream* in_stm, std::basic_ostream<char>* out_stm);
 
 IFStream* TestOnly_CreateIFStream(HANDLE handle, DWORD page_size);
 

--- a/tools/test/windows/tw_test.cc
+++ b/tools/test/windows/tw_test.cc
@@ -142,12 +142,16 @@ HANDLE FopenRead(const std::wstring& unc_path) {
                      FILE_ATTRIBUTE_NORMAL, NULL);
 }
 
-HANDLE FopenContents(wchar_t* wline, const char* contents) {
+HANDLE FopenContents(const wchar_t* wline, const char* contents, DWORD size) {
   std::wstring tmpdir;
   GET_TEST_TMPDIR(&tmpdir);
   std::wstring filename = tmpdir + L"\\tmp" + wline;
-  EXPECT_TRUE(blaze_util::CreateDummyFile(filename, contents));
+  EXPECT_TRUE(blaze_util::CreateDummyFile(filename, contents, size));
   return FopenRead(filename);
+}
+
+HANDLE FopenContents(const wchar_t* wline, const char* contents) {
+  return FopenContents(wline, contents, strlen(contents));
 }
 
 TEST_F(TestWrapperWindowsTest, TestGetFileListRelativeTo) {
@@ -471,24 +475,27 @@ TEST_F(TestWrapperWindowsTest, TestTee) {
   write1 = INVALID_HANDLE_VALUE;  // closes handle so the Tee thread can exit
 }
 
-void AssertCdataEncodeBuffer(const char* input, DWORD size,
+void AssertCdataEncodeBuffer(const wchar_t* wline, const char* input, DWORD size,
                              const char* expected_output) {
+  bazel::windows::AutoHandle h(FopenContents(wline, input, size));
+  std::unique_ptr<IFStream> istm(TestOnly_CreateIFStream(h, /* page_size */ 4));
   std::stringstream out_stm;
-  ASSERT_TRUE(TestOnly_CdataEncode(reinterpret_cast<const uint8_t*>(input),
-                                   size, &out_stm));
+  ASSERT_TRUE(TestOnly_CdataEncode(istm.get(), &out_stm));
   ASSERT_EQ(expected_output, out_stm.str());
 }
 
-void AssertCdataEncodeBuffer(const char* input, const char* expected_output) {
-  AssertCdataEncodeBuffer(input, strlen(input), expected_output);
+void AssertCdataEncodeBuffer(const wchar_t* wline, const char* input,
+                             const char* expected_output) {
+  AssertCdataEncodeBuffer(wline, input, strlen(input), expected_output);
 }
 
 TEST_F(TestWrapperWindowsTest, TestCdataEscapeNullTerminator) {
-  AssertCdataEncodeBuffer("x\0y", 3, "x?y");
+  AssertCdataEncodeBuffer(WLINE, "x\0y", 3, "x?y");
 }
 
 TEST_F(TestWrapperWindowsTest, TestCdataEscapeCdataEndings) {
   AssertCdataEncodeBuffer(
+      WLINE,
       // === Input ===
       // CDATA end sequence, followed by some arbitrary octet.
       "]]>x"
@@ -504,7 +511,9 @@ TEST_F(TestWrapperWindowsTest, TestCdataEscapeCdataEndings) {
 }
 
 TEST_F(TestWrapperWindowsTest, TestCdataEscapeSingleOctets) {
-  AssertCdataEncodeBuffer(  // === Input ===
+  AssertCdataEncodeBuffer(
+      WLINE,
+      // === Input ===
                             // Legal single-octets.
       "AB\x9\xA\xD\x20\x7F"
       // Illegal single-octets.
@@ -522,6 +531,7 @@ TEST_F(TestWrapperWindowsTest, TestCdataEscapeSingleOctets) {
 TEST_F(TestWrapperWindowsTest, TestCdataEscapeDoubleOctets) {
   // Legal range: [\xc0-\xdf][\x80-\xbf]
   AssertCdataEncodeBuffer(
+      WLINE,
       "x"
       // Legal double-octet sequences.
       "\xC0\x80"
@@ -559,6 +569,7 @@ TEST_F(TestWrapperWindowsTest, TestCdataEscapeAndAppend) {
   GET_TEST_TMPDIR(&tmpdir);
 
   AssertCdataEncodeBuffer(
+      WLINE,
       // === Input ===
       "AB\xA\xC\xD"
       "]]>"


### PR DESCRIPTION
Use a buffered input file stream (IFStream) to
read the test log file and escape invalid UTF-8
characters and sequences that would be unsafe to
embed in the test XML's CDATA section.

The benefit: the code no longer reads the entire
test log into memory before said escaping, which
is great for memory usage because these log files
may get arbitrarily large.

See https://github.com/bazelbuild/bazel/issues/5508