### PR TITLE
Reorganize version_min osx feature

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl.tpl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl.tpl
@@ -3620,6 +3620,7 @@ def _impl(ctx):
     )
 
     if ctx.attr.cpu == "armeabi-v7a":
+        # This stub doesn't have a sensible value for this feature
         version_min_feature = feature(name = "version_min")
     elif (ctx.attr.cpu == "ios_i386"
         or ctx.attr.cpu == "ios_x86_64"):

--- a/tools/osx/crosstool/cc_toolchain_config.bzl.tpl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl.tpl
@@ -3619,35 +3619,8 @@ def _impl(ctx):
         ],
     )
 
-    if (ctx.attr.cpu == "armeabi-v7a"
-        or ctx.attr.cpu == "watchos_arm64_32"
-        or ctx.attr.cpu == "watchos_x86_64"):
-        version_min_feature = feature(
-            name = "version_min",
-            flag_sets = [
-                flag_set(
-                    actions = [
-                        "objc-executable",
-                        "objc++-executable",
-                        ACTION_NAMES.cpp_link_executable,
-                        ACTION_NAMES.cpp_link_dynamic_library,
-                        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
-                        ACTION_NAMES.preprocess_assemble,
-                        ACTION_NAMES.c_compile,
-                        ACTION_NAMES.cpp_compile,
-                        ACTION_NAMES.cpp_header_parsing,
-                        ACTION_NAMES.cpp_module_compile,
-                        ACTION_NAMES.objc_compile,
-                        ACTION_NAMES.objcpp_compile,
-                    ],
-                    flag_groups = [
-                        flag_group(
-                            flags = ["-m<platform_for_version_min>-version-min=%{version_min}"],
-                        ),
-                    ],
-                ),
-            ],
-        )
+    if ctx.attr.cpu == "armeabi-v7a":
+        version_min_feature = feature(name = "version_min")
     elif (ctx.attr.cpu == "ios_i386"
         or ctx.attr.cpu == "ios_x86_64"):
         version_min_feature = feature(
@@ -3732,7 +3705,7 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "watchos_i386"):
+    elif (ctx.attr.cpu == "watchos_i386" or ctx.attr.cpu == "watchos_x86_64"):
         version_min_feature = feature(
             name = "version_min",
             flag_sets = [
@@ -3759,7 +3732,7 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "watchos_armv7k"):
+    elif (ctx.attr.cpu == "watchos_armv7k" or ctx.attr.cpu == "watchos_arm64_32"):
         version_min_feature = feature(
             name = "version_min",
             flag_sets = [


### PR DESCRIPTION
The watchOS platforms weren't grouped together, and this placeholder
appears to not be handled