### PR TITLE
Make the existence of --bes_results_url more prominent.

### DIFF
--- a/site/docs/build-event-protocol.md
+++ b/site/docs/build-event-protocol.md
@@ -190,11 +190,12 @@ that we know of.
 
 ### Build Event Service Flags
 
-Bazel has several flags related to the [Build Event Service] protocol:
+Bazel has several flags related to the [Build Event Service] protocol, including:
 
 *  `--bes_backend`
 *  `--[no]bes_best_effort`
 *  `--[no]bes_lifecycle_events`
+*  `--bes_results_url`
 *  `--bes_timeout`
 *  `--project_id`
 


### PR DESCRIPTION
I guess that virtually everybody that uses a remote/centralized BES
wants to use a flag like this to gain access to the results. While
there, change the phrasing to imply that the list of command line
options is not exhaustive.