### PR TITLE
Add OS type "none" to platforms.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/util/OS.java
+++ b/src/main/java/com/google/devtools/build/lib/util/OS.java
@@ -23,6 +23,7 @@ public enum OS {
   FREEBSD("freebsd", "FreeBSD"),
   LINUX("linux", "Linux"),
   WINDOWS("windows", "Windows"),
+  NONE("none", "No OS"),
   UNKNOWN("unknown", "");
 
   private static final EnumSet<OS> POSIX_COMPATIBLE = EnumSet.of(DARWIN, FREEBSD, LINUX);

--- a/src/main/java/com/google/devtools/build/lib/util/OS.java
+++ b/src/main/java/com/google/devtools/build/lib/util/OS.java
@@ -23,7 +23,6 @@ public enum OS {
   FREEBSD("freebsd", "FreeBSD"),
   LINUX("linux", "Linux"),
   WINDOWS("windows", "Windows"),
-  NONE("none", "No OS"),
   UNKNOWN("unknown", "");
 
   private static final EnumSet<OS> POSIX_COMPATIBLE = EnumSet.of(DARWIN, FREEBSD, LINUX);

--- a/tools/platforms/BUILD
+++ b/tools/platforms/BUILD
@@ -82,6 +82,11 @@ constraint_value(
     constraint_setting = ":os",
 )
 
+constraint_value(
+    name = "none",
+    constraint_setting = ":os",
+)
+
 # A default platform with nothing defined.
 platform(name = "default_platform")
 

--- a/tools/platforms/platforms.BUILD
+++ b/tools/platforms/platforms.BUILD
@@ -70,6 +70,11 @@ constraint_value(
     constraint_setting = ":os",
 )
 
+constraint_value(
+    name = "none",
+    constraint_setting = ":os",
+)
+
 # A default platform with nothing defined.
 platform(name = "default_platform")
 


### PR DESCRIPTION
This pull request introduces the OS type "none" used in target triples for bare metal/embedded devices, so things like `rules_rust` can target freestanding hardware :smile:.