### PR TITLE
remote: properly reset state when using remote cache. Fixes #7555

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -331,6 +331,8 @@ public final class RemoteModule extends BlazeModule {
 
   @Override
   public void afterCommand() {
+    buildEventArtifactUploaderFactoryDelegate.reset();
+    actionContextProvider = null;
     if (rpcLogFile != null) {
       try {
         rpcLogFile.close();
@@ -340,7 +342,6 @@ public final class RemoteModule extends BlazeModule {
         rpcLogFile = null;
       }
     }
-    buildEventArtifactUploaderFactoryDelegate.reset();
   }
 
   @Override

--- a/src/test/shell/bazel/remote/remote_execution_http_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_http_test.sh
@@ -316,4 +316,29 @@ function test_directory_artifact_in_runfiles_skylark_rest_cache() {
       || fail "Remote cache hit generated different result"
 }
 
+
+function test_remote_state_cleared() {
+  # Regression test for https://github.com/bazelbuild/bazel/issues/7555
+  # Test that the remote cache state is properly reset, so that building without
+  # a remote cache works after previously building with a remote cache.
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = "gen1",
+  outs = ["out1"],
+  cmd = "touch $@",
+)
+EOF
+
+  bazel build \
+      --remote_http_cache=http://localhost:${http_port} \
+      //a:gen1 \
+    || fail "Failed to build //a:gen1 with remote cache"
+
+  bazel clean
+
+  bazel build //a:gen1 \
+    || fail "Failed to build //a:gen1 without remote cache"
+}
+
 run_suite "Remote execution and remote cache tests"


### PR DESCRIPTION
when using --remote_(http)_cache we wouldn't properly reset the state on
the bazel server and so on subsequent command invocations the server
would still think it's using remote caching. this would lead for bazel
to hang indefinitely.