### PR TITLE
Point to the new location of Buildbarn.

### DIFF
--- a/site/docs/remote-caching.md
+++ b/site/docs/remote-caching.md
@@ -387,7 +387,7 @@ watch [issue #4558] for updates.
 [AWS S3]: https://aws.amazon.com/s3
 [issue #3360]: https://github.com/bazelbuild/bazel/issues/3360
 [gRPC protocol]: https://github.com/googleapis/googleapis/blob/master/google/devtools/remoteexecution/v1test/remote_execution.proto
-[Buildbarn]: https://github.com/EdSchouten/bazel-buildbarn
+[Buildbarn]: https://github.com/buildbarn
 [Buildfarm]: https://github.com/bazelbuild/bazel-buildfarm
 [BuildGrid]: https://gitlab.com/BuildGrid/buildgrid
 [issue #4558]: https://github.com/bazelbuild/bazel/issues/4558

--- a/site/docs/remote-execution.md
+++ b/site/docs/remote-execution.md
@@ -31,7 +31,7 @@ To run Bazel with remote execution, you can use one of the following:
         [gRPC protocol](https://github.com/bazelbuild/remote-apis)
         directly to create your own remote execution service.
 *   Self-hosted
-    *   [Buildbarn](https://github.com/EdSchouten/bazel-buildbarn)
+    *   [Buildbarn](https://github.com/buildbarn)
     *   [Buildfarm](https://github.com/bazelbuild/bazel-buildfarm)
     *   [BuildGrid](https://gitlab.com/BuildGrid/buildgrid)
 *   Hosted


### PR DESCRIPTION
Bazel Buildbarn has been renamed to just Buildbarn. The project now also
has its own GitHub organisation.