### PR TITLE
Moved `static_link_msvcrt` to Starlark.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCommon.java
@@ -848,22 +848,6 @@ public final class CcCommon {
 
     ImmutableSet<String> allUnsupportedFeatures = unsupportedFeaturesBuilder.build();
 
-    // If STATIC_LINK_MSVCRT feature isn't specified by user, we add DYNAMIC_LINK_MSVCRT_* feature
-    // according to compilation mode.
-    // If STATIC_LINK_MSVCRT feature is specified, we add STATIC_LINK_MSVCRT_* feature
-    // according to compilation mode.
-    if (requestedFeatures.contains(CppRuleClasses.STATIC_LINK_MSVCRT)) {
-      allRequestedFeaturesBuilder.add(
-          toolchain.getCompilationMode() == CompilationMode.DBG
-              ? CppRuleClasses.STATIC_LINK_MSVCRT_DEBUG
-              : CppRuleClasses.STATIC_LINK_MSVCRT_NO_DEBUG);
-    } else {
-      allRequestedFeaturesBuilder.add(
-          toolchain.getCompilationMode() == CompilationMode.DBG
-              ? CppRuleClasses.DYNAMIC_LINK_MSVCRT_DEBUG
-              : CppRuleClasses.DYNAMIC_LINK_MSVCRT_NO_DEBUG);
-    }
-
     ImmutableList.Builder<String> allFeatures =
         new ImmutableList.Builder<String>()
             .addAll(ImmutableSet.of(toolchain.getCompilationMode().toString()))

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
@@ -324,21 +324,6 @@ public class CppRuleClasses {
   /** A string constant for a feature to copy dynamic libraries to the binary's directory. */
   public static final String COPY_DYNAMIC_LIBRARIES_TO_BINARY = "copy_dynamic_libraries_to_binary";
 
-  /** A string constant for a feature to statically link MSVCRT info on Windows. */
-  public static final String STATIC_LINK_MSVCRT = "static_link_msvcrt";
-
-  /** A string constant for a feature to statically link MSVCRT without debug info on Windows. */
-  public static final String STATIC_LINK_MSVCRT_NO_DEBUG = "static_link_msvcrt_no_debug";
-
-  /** A string constant for a feature to dynamically link MSVCRT without debug info on Windows. */
-  public static final String DYNAMIC_LINK_MSVCRT_NO_DEBUG = "dynamic_link_msvcrt_no_debug";
-
-  /** A string constant for a feature to statically link MSVCRT with debug info on Windows. */
-  public static final String STATIC_LINK_MSVCRT_DEBUG = "static_link_msvcrt_debug";
-
-  /** A string constant for a feature to dynamically link MSVCRT with debug info on Windows. */
-  public static final String DYNAMIC_LINK_MSVCRT_DEBUG = "dynamic_link_msvcrt_debug";
-
   /** A string constant for a feature to statically link the C++ runtimes. */
   public static final String STATIC_LINK_CPP_RUNTIMES = "static_link_cpp_runtimes";
 

--- a/tools/cpp/cc_toolchain_config.bzl.tpl
+++ b/tools/cpp/cc_toolchain_config.bzl.tpl
@@ -475,19 +475,63 @@ def _windows_msvc_impl(ctx):
 
     static_link_msvcrt_feature = feature(name = "static_link_msvcrt")
 
-    dynamic_link_msvcrt_debug_feature = feature(
-        name = "dynamic_link_msvcrt_debug",
+    link_msvcrt_debug_feature = feature(
+        name = "link_msvcrt_debug",
+        enabled = True,
         flag_sets = [
             flag_set(
                 actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                with_features = [with_feature_set(not_features=["static_link_msvcrt"])],
                 flag_groups = [flag_group(flags = ["/MDd"])],
             ),
             flag_set(
                 actions = all_link_actions,
+                with_features = [with_feature_set(not_features=["static_link_msvcrt"])],
                 flag_groups = [flag_group(flags = ["/DEFAULTLIB:msvcrtd.lib"])],
+            ),
+            flag_set(
+                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                with_features = [with_feature_set(features=["static_link_msvcrt"])],
+                flag_groups = [flag_group(flags = ["/MTd"])],
+            ),
+            flag_set(
+                actions = all_link_actions,
+                with_features = [with_feature_set(features=["static_link_msvcrt"])],
+                flag_groups = [flag_group(flags = ["/DEFAULTLIB:libcmtd.lib"])],
             ),
         ],
         requires = [feature_set(features = ["dbg"])],
+    )
+
+    link_msvcrt_no_debug_feature = feature(
+        name = "link_msvcrt_no_debug",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                with_features = [with_feature_set(not_features=["static_link_msvcrt"])],
+                flag_groups = [flag_group(flags = ["/MD"])],
+            ),
+            flag_set(
+                actions = all_link_actions,
+                with_features = [with_feature_set(not_features=["static_link_msvcrt"])],
+                flag_groups = [flag_group(flags = ["/DEFAULTLIB:msvcrt.lib"])],
+            ),
+            flag_set(
+                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                with_features = [with_feature_set(features=["static_link_msvcrt"])],
+                flag_groups = [flag_group(flags = ["/MT"])],
+            ),
+            flag_set(
+                actions = all_link_actions,
+                with_features = [with_feature_set(features=["static_link_msvcrt"])],
+                flag_groups = [flag_group(flags = ["/DEFAULTLIB:libcmt.lib"])],
+            ),
+          ],
+          requires = [
+              feature_set(features = ["fastbuild"]),
+              feature_set(features = ["opt"]),
+          ],
     )
 
     dbg_feature = feature(
@@ -643,24 +687,6 @@ def _windows_msvc_impl(ctx):
         ],
     )
 
-    dynamic_link_msvcrt_no_debug_feature = feature(
-        name = "dynamic_link_msvcrt_no_debug",
-        flag_sets = [
-            flag_set(
-                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
-                flag_groups = [flag_group(flags = ["/MD"])],
-            ),
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [flag_group(flags = ["/DEFAULTLIB:msvcrt.lib"])],
-            ),
-          ],
-          requires = [
-              feature_set(features = ["fastbuild"]),
-              feature_set(features = ["opt"]),
-          ],
-    )
-
     disable_assertions_feature = feature(
         name = "disable_assertions",
         enabled = True,
@@ -721,24 +747,6 @@ def _windows_msvc_impl(ctx):
                 ],
                 flag_groups = [flag_group(flags = ["/showIncludes"])],
             ),
-        ],
-    )
-
-    static_link_msvcrt_no_debug_feature = feature(
-        name = "static_link_msvcrt_no_debug",
-        flag_sets = [
-            flag_set(
-                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
-                flag_groups = [flag_group(flags = ["/MT"])],
-            ),
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [flag_group(flags = ["/DEFAULTLIB:libcmt.lib"])],
-            ),
-        ],
-        requires = [
-            feature_set(features = ["fastbuild"]),
-            feature_set(features = ["opt"]),
         ],
     )
 
@@ -816,21 +824,6 @@ def _windows_msvc_impl(ctx):
                 flag_groups = [flag_group(flags = ["/SUBSYSTEM:CONSOLE"])],
             ),
         ],
-    )
-
-    static_link_msvcrt_debug_feature = feature(
-        name = "static_link_msvcrt_debug",
-        flag_sets = [
-            flag_set(
-                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
-                flag_groups = [flag_group(flags = ["/MTd"])],
-            ),
-            flag_set(
-                actions = all_link_actions,
-                flag_groups = [flag_group(flags = ["/DEFAULTLIB:libcmtd.lib"])],
-            ),
-        ],
-        requires = [feature_set(features = ["dbg"])],
     )
 
     frame_pointer_feature = feature(
@@ -1033,10 +1026,8 @@ def _windows_msvc_impl(ctx):
         default_link_flags_feature,
         linker_param_file_feature,
         static_link_msvcrt_feature,
-        static_link_msvcrt_no_debug_feature,
-        dynamic_link_msvcrt_no_debug_feature,
-        static_link_msvcrt_debug_feature,
-        dynamic_link_msvcrt_debug_feature,
+        link_msvcrt_no_debug_feature,
+        link_msvcrt_debug_feature,
         dbg_feature,
         fastbuild_feature,
         opt_feature,


### PR DESCRIPTION
I guess that can fix #7578 and [remove few mentions of Windows](https://en.wikipedia.org/wiki/Microsoft_litigation) from Bazel code.

Can you please check if it can be merged?