### PR TITLE
Added explicit target architecture for archiver on Windows.

### DIFF
--- a/tools/cpp/cc_toolchain_config.bzl.tpl
+++ b/tools/cpp/cc_toolchain_config.bzl.tpl
@@ -457,6 +457,9 @@ def _windows_msvc_impl(ctx):
                         flags = ["/OUT:%{output_execpath}"],
                         expand_if_available = "output_execpath",
                     ),
+                    flag_group(
+                        flags = ["/MACHINE:X64"]
+                    ),
                 ],
             ),
         ],


### PR DESCRIPTION
I guess the code says for itself, for the sake of correctness let's specify target architecture for static libraries explicitly on Windows.

E.g. that will remove a warning when archiving `src/main/native/windows/resources.o`:
```
INFO: From Linking src/main/native/windows/resources.lib:
LINK : warning LNK4068: /MACHINE not specified; defaulting to X64
```
