### PR TITLE
JUnit black box tests: detect bin and gen files location with same flags

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/BlackBoxTestContext.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/BlackBoxTestContext.java
@@ -135,14 +135,15 @@ public final class BlackBoxTestContext {
    *
    * <p>Calls <code>bazel info bazel-genfiles</code>, caches the result.
    *
+   * @param bazel the instance of BuilderRunner to run info with
    * @param subPathUnderGen path to the file under bazel-gen directory
    * @return full path to the resolved file
    * @throws Exception if <code>bazel info</code> command fails
    */
-  public Path resolveGenPath(String subPathUnderGen) throws Exception {
+  public Path resolveGenPath(BuilderRunner bazel, String subPathUnderGen) throws Exception {
     if (genFilesPath == null) {
       genFilesPath =
-          PathUtils.resolve(workDir, bazel().info(productName + "-genfiles").outString());
+          PathUtils.resolve(workDir, bazel.info(productName + "-genfiles").outString());
     }
     return PathUtils.resolve(genFilesPath, subPathUnderGen);
   }
@@ -150,34 +151,35 @@ public final class BlackBoxTestContext {
   /**
    * Resolve a path relative to "bazel-bin".
    *
-   * <p>Calls <code>bazel info bazel-bin</code>, caches the result.
+   * <p>Calls <code>bazel info bazel-bin</code>
    *
+   * @param bazel the instance of BuilderRunner to run info with
    * @param subPathUnderBin path to the file under bazel-bin directory
    * @return full path to the resolved file
    * @throws Exception if <code>bazel info</code> command fails
    */
-  public Path resolveBinPath(String subPathUnderBin) throws Exception {
-    if (binFilesPaths == null) {
-      binFilesPaths = PathUtils.resolve(workDir, bazel().info(productName + "-bin").outString());
-    }
-    return PathUtils.resolve(binFilesPaths, subPathUnderBin);
+  public Path resolveBinPath(BuilderRunner bazel, String subPathUnderBin) throws Exception {
+    Path binPath = PathUtils.resolve(workDir, bazel.info(productName + "-bin").outString());
+    return PathUtils.resolve(binPath, subPathUnderBin);
   }
 
   /**
    * Runs the built executable. Calls <code>bazel info</code> to get the information about bazel-bin
-   * directory location, caches the result for the subsequent calls.
+   * directory location.
    *
+   * @param bazel the instance of BuilderRunner to run info with
    * @param subPathUnderBin path to the executable relative to bazel-bin directory
    * @param timeoutMillis timeout on the process execution
    * @return ProcessResult result of the execution with the process exit code and strings with
    *     stdout and stderr contents.
    * @throws Exception if <code>bazel info</code> command fails or executable invocation fails.
    */
-  public ProcessResult runBuiltBinary(String subPathUnderBin, long timeoutMillis) throws Exception {
+  public ProcessResult runBuiltBinary(BuilderRunner bazel, String subPathUnderBin,
+      long timeoutMillis) throws Exception {
     if (OS.WINDOWS.equals(OS.getCurrent()) && !subPathUnderBin.endsWith(".exe")) {
       subPathUnderBin += ".exe";
     }
-    Path executable = resolveBinPath(subPathUnderBin);
+    Path executable = resolveBinPath(bazel, subPathUnderBin);
     assertThat(Files.exists(executable)).isTrue();
     assertThat(Files.isRegularFile(executable)).isTrue();
     assertThat(Files.isExecutable(executable)).isTrue();

--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/BuilderRunner.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/BuilderRunner.java
@@ -48,6 +48,8 @@ public final class BuilderRunner {
   private final ExecutorService executorService;
   private long timeoutMillis;
   private boolean useDefaultRc = true;
+  private int errorCode = 0;
+  private List<String> flags;
 
   /**
    * Creates the BuilderRunner
@@ -77,6 +79,7 @@ public final class BuilderRunner {
     this.env = Maps.newHashMap(env);
     this.executorService = executorService;
     this.timeoutMillis = defaultTimeoutMillis;
+    this.flags = Lists.newArrayList();
   }
 
   /**
@@ -88,6 +91,17 @@ public final class BuilderRunner {
    */
   public BuilderRunner withEnv(String name, String value) {
     env.put(name, value);
+    return this;
+  }
+
+  /**
+   * Sets the expected error code.
+   *
+   * @param errorCode the value of the error code
+   * @return this BuildRunner instance
+   */
+  public BuilderRunner withErrorCode(int errorCode) {
+    this.errorCode = errorCode;
     return this;
   }
 
@@ -118,10 +132,25 @@ public final class BuilderRunner {
   }
 
   /**
-   * Runs <code>bazel info &lt;parameter&gt;</code> and returns the result. Asserts that the process
-   * exit code is zero. Does not assert that the error stream is empty.
+   * Specifies the flags to pass to Bazel.
    *
-   * @param parameter info command parameter
+   * We need it as a builder method, so that several consequent Bazel calls
+   * with the same set of flags could be performed:
+   * bazel build --flag1 --flag2 //...
+   * bazel info --flag1 --flag2 bazel-bin
+   *
+   * @return this BuilderRunner instance
+   */
+  public BuilderRunner withFlags(String... flags) {
+    Collections.addAll(this.flags, flags);
+    return this;
+  }
+
+  /**
+   * Runs <code>bazel info &lt;parameter&gt;</code> and returns the result.
+   * Asserts the process exit code. Does not assert that the error stream is empty.
+   *
+   * @param parameters info command parameter and/or some flags
    * @return ProcessResult with process exit code, strings with stdout and error streams contents
    * @throws TimeoutException in case of timeout
    * @throws IOException in case of the process startup/interaction problems
@@ -129,10 +158,27 @@ public final class BuilderRunner {
    * @throws ProcessRunnerException if the process return code is not zero or error stream is not
    *     empty when it was expected
    */
-  public ProcessResult info(String parameter) throws Exception {
+  public ProcessResult info(String... parameters) throws Exception {
     // additional expectations for the info time to be under the default timeout
     withTimeout(Math.min(DEFAULT_TIMEOUT_MILLIS, timeoutMillis));
-    return runBinary("info", parameter);
+    return runBinary("info", parameters);
+  }
+
+  /**
+   * Runs <code>bazel help</code> and returns the result. Asserts the process exit code.
+   * Does not assert that the error stream is empty.
+   *
+   * @return ProcessResult with process exit code, strings with stdout and error streams contents
+   * @throws TimeoutException in case of timeout
+   * @throws IOException in case of the process startup/interaction problems
+   * @throws InterruptedException if the current thread is interrupted while waiting
+   * @throws ProcessRunnerException if the process return code is not zero or error stream is not
+   *     empty when it was expected
+   */
+  public ProcessResult help() throws Exception {
+    // additional expectations for the info time to be under the default timeout
+    withTimeout(Math.min(DEFAULT_TIMEOUT_MILLIS, timeoutMillis));
+    return runBinary("help");
   }
 
   /**
@@ -211,6 +257,7 @@ public final class BuilderRunner {
       }
     }
     list.add(command);
+    list.addAll(this.flags);
     Collections.addAll(list, args);
 
     ProcessParameters parameters =
@@ -223,6 +270,7 @@ public final class BuilderRunner {
             // bazel writes info messages to error stream, so
             // we need to allow the error output stream be not empty
             .setExpectedEmptyError(false)
+            .setExpectedExitCode(errorCode)
             .build();
     return new ProcessRunner(parameters, executorService).runSynchronously();
   }

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/PythonBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/PythonBlackBoxTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.blackbox.bazel.PythonToolsSetup;
+import com.google.devtools.build.lib.blackbox.framework.BuilderRunner;
 import com.google.devtools.build.lib.blackbox.framework.ProcessResult;
 import com.google.devtools.build.lib.blackbox.framework.ToolsSetup;
 import com.google.devtools.build.lib.blackbox.junit.AbstractBlackBoxTest;
@@ -39,12 +40,13 @@ public class PythonBlackBoxTest extends AbstractBlackBoxTest {
   public void testCompileAndRunHelloWorldStub() throws Exception {
     writeHelloWorldFiles();
 
-    context().bazel().build("//python/hello:hello");
+    BuilderRunner bazel = context().bazel();
+    bazel.build("//python/hello:hello");
 
-    ProcessResult result = context().runBuiltBinary("python/hello/hello", -1);
+    ProcessResult result = context().runBuiltBinary(bazel, "python/hello/hello", -1);
     assertThat(result.outString()).isEqualTo(HELLO);
 
-    Path binaryPath = context().resolveBinPath("python/hello/hello.par");
+    Path binaryPath = context().resolveBinPath(bazel, "python/hello/hello.par");
     assertThat(Files.exists(binaryPath)).isFalse();
   }
 


### PR DESCRIPTION
- introduce withFlags method into BuilderRunner to simplify the construction of the bazel command with the same set of flags
- pass the BuilderRunner to resolveGenPath and resolveBinPath methods
- also allow to specify the expected error code in BuilderRunner, as sometimes it is expected in tests that the build fails

Going to be used in future workspace integration tests, which we need to rewrite in platform-independent manner to ensure that bundled Starlark repository rules work on all platforms.