### PR TITLE
Add first JUnit workspace black box test

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/blackbox/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/BUILD
@@ -29,6 +29,7 @@ java_library(
         "//src/test/java/com/google/devtools/build/lib:testutil",
         "//third_party:junit4",
         "//third_party:truth",
+        "//third_party:truth8",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/PathUtils.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/PathUtils.java
@@ -333,4 +333,18 @@ public class PathUtils {
           }
         });
   }
+
+  /**
+   * Returns the string to be used to refer to passed path in the Starlark file or directory.
+   * For Windows, we need to use forward slashes, so on ecan not use the standard Path#toString().
+   *
+   * @param path the path to file
+   * @return the string to use in Starlark file to point to passed path
+   */
+  public static String pathForStarlarkFile(Path path) {
+    if (OS.WINDOWS.equals(OS.getCurrent())) {
+      return path.toString().replace("\\", "/");
+    }
+    return path.toString();
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/blackbox/junit/AbstractBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/junit/AbstractBlackBoxTest.java
@@ -51,6 +51,7 @@ public abstract class AbstractBlackBoxTest {
           new JavaToolsSetup(),
           new CxxToolsSetup(),
           new CrossToolsSetup());
+  protected static final String WORKSPACE = "WORKSPACE";
 
   @Rule public TestName testName = new TestName();
 

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/BUILD
@@ -1,7 +1,9 @@
 filegroup(
     name = "srcs",
     testonly = 0,
-    srcs = glob(["**/**"]),
+    srcs = glob(["**"]) + [
+        "//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:srcs",
+    ],
     visibility = ["//src/test/java/com/google/devtools/build/lib/blackbox:__subpackages__"],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/BUILD
@@ -8,6 +8,7 @@ filegroup(
 java_library(
     name = "common_deps",
     testonly = 1,
+    visibility = ["//src/test/java/com/google/devtools/build/lib/blackbox/tests:__subpackages__"],
     exports = [
         "//src/test/java/com/google/devtools/build/lib/blackbox:base_deps",
         "//src/test/java/com/google/devtools/build/lib/blackbox:test_deps",
@@ -35,6 +36,7 @@ test_suite(
         "PythonBlackBoxTest",
         "//src/test/java/com/google/devtools/build/lib/blackbox/framework:framework_tests",
         "//src/test/java/com/google/devtools/build/lib/blackbox/junit:TimeoutTestWatcherTest",
+        "//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:ws_black_box_tests",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/BUILD
@@ -1,7 +1,7 @@
 filegroup(
     name = "srcs",
     testonly = 0,
-    srcs = glob(["**"]),
+    srcs = glob(["**/**"]),
     visibility = ["//src/test/java/com/google/devtools/build/lib/blackbox:__subpackages__"],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BUILD
@@ -1,3 +1,10 @@
+filegroup(
+    name = "srcs",
+    testonly = 0,
+    srcs = glob(["**"]),
+    visibility = ["//src/test/java/com/google/devtools/build/lib/blackbox/tests:__pkg__"],
+)
+
 common_deps = [
     "//src/test/java/com/google/devtools/build/lib/blackbox/tests:common_deps",
 ]

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BUILD
@@ -1,3 +1,5 @@
+package(default_testonly = 1)
+
 filegroup(
     name = "srcs",
     testonly = 0,

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BUILD
@@ -1,0 +1,34 @@
+common_deps = [
+    "//src/test/java/com/google/devtools/build/lib/blackbox/tests:common_deps",
+]
+
+java_test(
+    name = "RepoWithRuleWritingTextGeneratorTest",
+    timeout = "moderate",
+    srcs = [
+        "RepoWithRuleWritingTextGenerator.java",
+        "RepoWithRuleWritingTextGeneratorTest.java",
+    ],
+    tags = ["black_box_test"],
+    deps = common_deps,
+)
+
+java_test(
+    name = "WorkspaceBlackBoxTest",
+    timeout = "moderate",
+    srcs = [
+        "RepoWithRuleWritingTextGenerator.java",
+        "WorkspaceBlackBoxTest.java",
+    ],
+    tags = ["black_box_test"],
+    deps = common_deps,
+)
+
+test_suite(
+    name = "ws_black_box_tests",
+    tags = ["black_box_test"],
+    tests = [
+        "RepoWithRuleWritingTextGeneratorTest",
+        "WorkspaceBlackBoxTest",
+    ],
+)

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
@@ -1,0 +1,132 @@
+package com.google.devtools.build.lib.blackbox.tests.workspace;
+
+import com.google.devtools.build.lib.blackbox.framework.PathUtils;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Generator of the test local repository with:
+ *
+ * helper.bzl file,
+ *   where there is a write_to_file rule, which writes some text to the output file.
+ *
+ * empty WORKSPACE file,
+ *
+ * BUILD file,
+ *   with write_to_file target and pkg_tar target for packing the contents of the generated
+ *   repository.
+ *
+ * Intended to be used by workspace tests.
+ */
+public class RepoWithRuleWritingTextGenerator {
+  private static final String RULE_NAME = "write_to_file";
+  static final String HELLO = "HELLO";
+  static final String TARGET = "write_text";
+  static final String OUT_FILE = "out";
+
+  private static final String WRITE_TEXT_TO_FILE =
+      "def _impl(ctx):\n"
+          + "  out = ctx.actions.declare_file(ctx.attr.filename)\n"
+          + "  ctx.actions.write(out, ctx.attr.text)\n"
+          + "  return [DefaultInfo(files = depset([out]))]\n"
+          + "\n"
+          + RULE_NAME + " = rule(\n"
+          + "    implementation = _impl,\n"
+          + "    attrs = {\n"
+          + "        \"filename\": attr.string(default = \"out\"),\n"
+          + "        \"text\": attr.string()\n"
+          + "    }\n"
+          + ")";
+
+  private final Path root;
+  private String target;
+  private String outputText;
+  private String outFile;
+
+  /**
+   * Generator constructor
+   * @param root - the Path to the directory, where the repository contents should be placed
+   */
+  RepoWithRuleWritingTextGenerator(Path root) {
+    this.root = root;
+    this.target = TARGET;
+    this.outputText = HELLO;
+    this.outFile = OUT_FILE;
+  }
+
+  /**
+   * Specifies the text to be put into generated file by write_to_file rule target
+   * @param text - text to be put into a file
+   * @return this generator
+   */
+  RepoWithRuleWritingTextGenerator withOutputText(String text) {
+    outputText = text;
+    return this;
+  }
+
+  /**
+   * Specifies the name of the write_to_file target in the generated repository
+   * @param name - name of the target
+   * @return this generator
+   */
+  RepoWithRuleWritingTextGenerator withTarget(String name) {
+    target = name;
+    return this;
+  }
+
+  /**
+   * Specifies the output file name of the write_to_file rule target
+   * @param name - output file name
+   * @return this generator
+   */
+  RepoWithRuleWritingTextGenerator withOutFile(String name) {
+    outFile = name;
+    return this;
+  }
+
+  /**
+   * Generates the repository: WORKSPACE, BUILD, and helper.bzl files.
+   * @return repository directory
+   * @throws IOException if was not able to create or write to files
+   */
+  Path setupRepository() throws IOException {
+    Path workspace = PathUtils.writeFileInDir(root, "WORKSPACE");
+    PathUtils.writeFileInDir(root, "helper.bzl", WRITE_TEXT_TO_FILE);
+    PathUtils.writeFileInDir(root, "BUILD",
+        "load(\"@bazel_tools//tools/build_defs/pkg:pkg.bzl\", \"pkg_tar\")",
+        loadRule(""),
+        callRule(target, outFile, outputText),
+        String.format("pkg_tar(name = \"%s\", srcs = glob([\"*\"]),)", getPkgTarTarget()));
+    return workspace.getParent();
+  }
+
+  /**
+   * Returns the text to be put into a header of Starlark file, which is going to use
+   * write_to_file rule from the @repoName repository
+   *
+   * @param repoName the name of the repository
+   * @return load statement text
+   */
+  static String loadRule(String repoName) {
+    return String.format("load('%s//:helper.bzl', '%s')", repoName, RULE_NAME);
+  }
+
+  /**
+   * Returns the text with the write_to_file target
+   * @param name target name
+   * @param filename name of the output file
+   * @param text text to be put into output file
+   * @return the write_to_file target definition
+   */
+  static String callRule(String name, String filename, String text) {
+    return String.format("%s(name = '%s', filename = '%s', text ='%s')",
+        RULE_NAME, name, filename, text);
+  }
+
+  /**
+   * @return name of the generated pkg_tar target
+   */
+  String getPkgTarTarget() {
+    return "pkg_tar_" + target;
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
@@ -22,7 +22,7 @@ import java.nio.file.Path;
  * Generator of the test local repository with:
  *
  * helper.bzl file,
- *   where there is a write_to_file rule, which writes some text to the output file.
+ *   that contains a write_to_file rule, which writes some text to the output file.
  *
  * empty WORKSPACE file,
  *
@@ -33,6 +33,8 @@ import java.nio.file.Path;
  * Intended to be used by workspace tests.
  */
 public class RepoWithRuleWritingTextGenerator {
+
+  private static final String HELPER_FILE = "helper.bzl";
   private static final String RULE_NAME = "write_to_file";
   static final String HELLO = "HELLO";
   static final String TARGET = "write_text";
@@ -105,7 +107,7 @@ public class RepoWithRuleWritingTextGenerator {
    */
   Path setupRepository() throws IOException {
     Path workspace = PathUtils.writeFileInDir(root, "WORKSPACE");
-    PathUtils.writeFileInDir(root, "helper.bzl", WRITE_TEXT_TO_FILE);
+    PathUtils.writeFileInDir(root, HELPER_FILE, WRITE_TEXT_TO_FILE);
     PathUtils.writeFileInDir(root, "BUILD",
         "load(\"@bazel_tools//tools/build_defs/pkg:pkg.bzl\", \"pkg_tar\")",
         loadRule(""),
@@ -122,7 +124,7 @@ public class RepoWithRuleWritingTextGenerator {
    * @return load statement text
    */
   static String loadRule(String repoName) {
-    return String.format("load('%s//:helper.bzl', '%s')", repoName, RULE_NAME);
+    return String.format("load('%s//:%s', '%s')", repoName, HELPER_FILE, RULE_NAME);
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
@@ -1,3 +1,17 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.devtools.build.lib.blackbox.tests.workspace;
 
 import com.google.devtools.build.lib.blackbox.framework.PathUtils;

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGeneratorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGeneratorTest.java
@@ -1,3 +1,17 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.devtools.build.lib.blackbox.tests.workspace;
 
 import static com.google.common.truth.Truth8.assertThat;

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGeneratorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGeneratorTest.java
@@ -1,0 +1,77 @@
+package com.google.devtools.build.lib.blackbox.tests.workspace;
+
+import static com.google.common.truth.Truth8.assertThat;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.build.lib.blackbox.framework.PathUtils;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test for {@link RepoWithRuleWritingTextGenerator}. */
+@RunWith(JUnit4.class)
+public class RepoWithRuleWritingTextGeneratorTest {
+  private static final String BUILD_TEXT =
+      "load(\"@bazel_tools//tools/build_defs/pkg:pkg.bzl\", \"pkg_tar\")\n" +
+      "load('//:helper.bzl', 'write_to_file')\n"
+      + "write_to_file(name = 'write_text', filename = 'out', text ='HELLO')\n"
+      + "pkg_tar(name = \"pkg_tar_write_text\", srcs = glob([\"*\"]),)";
+  private static final String BUILD_TEXT_PARAMS =
+      "load(\"@bazel_tools//tools/build_defs/pkg:pkg.bzl\", \"pkg_tar\")\n" +
+      "load('//:helper.bzl', 'write_to_file')\n"
+      + "write_to_file(name = 'target', filename = 'file', text ='text')\n"
+      + "pkg_tar(name = \"pkg_tar_target\", srcs = glob([\"*\"]),)";
+
+  @Test
+  public void testOutput() throws IOException {
+    Path directory = Files.createTempDirectory("test_repo_output");
+    try {
+      RepoWithRuleWritingTextGenerator generator = new RepoWithRuleWritingTextGenerator(directory);
+
+      Path repository = generator.setupRepository();
+      assertThat(repository).isEqualTo(directory);
+      assertThat(Files.exists(repository)).isTrue();
+
+      String buildText = String.join("\n", PathUtils.readFile(repository.resolve("BUILD")));
+      assertThat(buildText).isEqualTo(BUILD_TEXT);
+      assertThat(generator.getPkgTarTarget()).isEqualTo("pkg_tar_write_text");
+    } finally {
+      PathUtils.deleteTree(directory);
+    }
+  }
+
+  @Test
+  public void testOutputWithParameters() throws IOException {
+    Path directory = Files.createTempDirectory("test_repo_output_with_parameters");
+    try {
+      RepoWithRuleWritingTextGenerator generator = new RepoWithRuleWritingTextGenerator(directory)
+          .withTarget("target")
+          .withOutFile("file")
+          .withOutputText("text");
+
+      Path repository = generator.setupRepository();
+      assertThat(repository).isEqualTo(directory);
+      assertThat(Files.exists(repository)).isTrue();
+
+      String buildText = String.join("\n", PathUtils.readFile(repository.resolve("BUILD")));
+      assertThat(buildText).isEqualTo(BUILD_TEXT_PARAMS);
+      assertThat(generator.getPkgTarTarget()).isEqualTo("pkg_tar_target");
+    } finally {
+      PathUtils.deleteTree(directory);
+    }
+  }
+
+  @Test
+  public void testStaticMethods() {
+    String loadText = RepoWithRuleWritingTextGenerator.loadRule("@my_repo");
+    assertThat(loadText).isEqualTo("load('@my_repo//:helper.bzl', 'write_to_file')");
+
+    String callText = RepoWithRuleWritingTextGenerator
+        .callRule("my_target", "filename", "out_text");
+    assertThat(callText).isEqualTo(
+        "write_to_file(name = 'my_target', filename = 'filename', text ='out_text')");
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
@@ -1,0 +1,54 @@
+package com.google.devtools.build.lib.blackbox.tests.workspace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.build.lib.blackbox.framework.PathUtils;
+import com.google.devtools.build.lib.blackbox.junit.AbstractBlackBoxTest;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * End to end test of workspace-related functionality.
+ */
+public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
+
+  @Test
+  public void testWorkspaceChanges() throws Exception {
+    Path repoA = context().getTmpDir().resolve("a");
+    new RepoWithRuleWritingTextGenerator(repoA).withOutputText("hi").setupRepository();
+
+    Path repoB = context().getTmpDir().resolve("b");
+    new RepoWithRuleWritingTextGenerator(repoB).withOutputText("bye").setupRepository();
+
+    context().write(WORKSPACE, String.format("local_repository(name = 'x', path = '%s',)",
+            PathUtils.pathForStarlarkFile(repoA)));
+    context().bazel().build("@x//:" + RepoWithRuleWritingTextGenerator.TARGET);
+
+    Path xPath = context().resolveBinPath(context().bazel(), "external/x/out");
+    assertThat(Files.exists(xPath)).isTrue();
+    List<String> lines = PathUtils.readFile(xPath);
+    assertThat(lines.size()).isEqualTo(1);
+    assertThat(lines.get(0)).isEqualTo("hi");
+
+    context().write(WORKSPACE, String.format("local_repository(name = 'x', path = '%s',)",
+            PathUtils.pathForStarlarkFile(repoB)));
+    context().bazel().build("@x//:" + RepoWithRuleWritingTextGenerator.TARGET);
+
+    assertThat(Files.exists(xPath)).isTrue();
+    lines = PathUtils.readFile(xPath);
+    assertThat(lines.size()).isEqualTo(1);
+    assertThat(lines.get(0)).isEqualTo("bye");
+  }
+
+  @Test
+  public void testPathWithSpace() throws Exception {
+    context().write("a b/WORKSPACE");
+    context().bazel().info();
+    context().bazel().help();
+  }
+
+  // TODO(ichern) move other tests from workspace_test.sh here.
+
+}

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
@@ -1,3 +1,17 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.devtools.build.lib.blackbox.tests.workspace;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1,4 +1,4 @@
-package(default_testonly = 1)
+package(default_visibility = ["//visibility:private"])
 
 filegroup(
     name = "srcs",

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:private"])
+package(default_testonly = 1)
 
 filegroup(
     name = "srcs",


### PR DESCRIPTION
- introduce test repository generator class: generates a directory with:

  helper.bzl with the "write_to_file" Starlark rule definition:
  the rule prints [parametrized by generation] text to a file;

  and the BUILD file with a target of "write_to_file" rule,
  and the pkg_tar target, which packs everything in this directory into
  a tar archive;

  so one can use this directory as a source for local_repository or
  produced tar archive as a source for http_archive with file:/// URI,
  and call some platform independent target from the generated repository.

- have a test for test repository generator class

- move one test from workspace_test.sh into WorkspaceBlackBoxTest.java
The test is platform independent, as it uses zero shell scripts.

To be continued, it is a part of verifying that bundled Starlark
repository rules are working on Windows without msys/mingw.