### PR TITLE
Allow a SpawnRunner to inject output metadata.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionInputHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionInputHelper.java
@@ -144,14 +144,14 @@ public final class ActionInputHelper {
    * that Artifact.
    */
   public static TreeFileArtifact treeFileArtifact(
-      SpecialArtifact parent, PathFragment relativePath) {
+      Artifact parent, PathFragment relativePath) {
     Preconditions.checkState(parent.isTreeArtifact(),
         "Given parent %s must be a TreeArtifact", parent);
     return new TreeFileArtifact(parent, relativePath);
   }
 
   public static TreeFileArtifact treeFileArtifact(
-      SpecialArtifact parent, PathFragment relativePath, ArtifactOwner artifactOwner) {
+      Artifact parent, PathFragment relativePath, ArtifactOwner artifactOwner) {
     Preconditions.checkState(parent.isTreeArtifact(),
         "Given parent %s must be a TreeArtifact", parent);
     return new TreeFileArtifact(
@@ -164,13 +164,13 @@ public final class ActionInputHelper {
    * Instantiates a concrete TreeFileArtifact with the given parent Artifact and path relative to
    * that Artifact.
    */
-  public static TreeFileArtifact treeFileArtifact(SpecialArtifact parent, String relativePath) {
+  public static TreeFileArtifact treeFileArtifact(Artifact parent, String relativePath) {
     return treeFileArtifact(parent, PathFragment.create(relativePath));
   }
 
   /** Returns an Iterable of TreeFileArtifacts with the given parent and parent relative paths. */
   public static Iterable<TreeFileArtifact> asTreeFileArtifacts(
-      final SpecialArtifact parent, Iterable<? extends PathFragment> parentRelativePaths) {
+      final Artifact parent, Iterable<? extends PathFragment> parentRelativePaths) {
     Preconditions.checkState(parent.isTreeArtifact(),
         "Given parent %s must be a TreeArtifact", parent);
     return Iterables.transform(
@@ -179,7 +179,7 @@ public final class ActionInputHelper {
 
   /** Returns a Set of TreeFileArtifacts with the given parent and parent-relative paths. */
   public static Set<TreeFileArtifact> asTreeFileArtifacts(
-      final SpecialArtifact parent, Set<? extends PathFragment> parentRelativePaths) {
+      final Artifact parent, Set<? extends PathFragment> parentRelativePaths) {
     Preconditions.checkState(parent.isTreeArtifact(),
         "Given parent %s must be a TreeArtifact", parent);
 

--- a/src/main/java/com/google/devtools/build/lib/actions/Artifact.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Artifact.java
@@ -618,7 +618,7 @@ public class Artifact
   @Immutable
   @AutoCodec
   public static final class TreeFileArtifact extends Artifact {
-    private final SpecialArtifact parentTreeArtifact;
+    private final Artifact parentTreeArtifact;
     private final PathFragment parentRelativePath;
 
     /**
@@ -627,7 +627,7 @@ public class Artifact
      * of the parent TreeArtifact.
      */
     @VisibleForTesting
-    public TreeFileArtifact(SpecialArtifact parent, PathFragment parentRelativePath) {
+    public TreeFileArtifact(Artifact parent, PathFragment parentRelativePath) {
       this(parent, parentRelativePath, parent.getArtifactOwner());
     }
 
@@ -637,7 +637,7 @@ public class Artifact
      */
     @AutoCodec.Instantiator
     TreeFileArtifact(
-        SpecialArtifact parentTreeArtifact, PathFragment parentRelativePath, ArtifactOwner owner) {
+        Artifact parentTreeArtifact, PathFragment parentRelativePath, ArtifactOwner owner) {
       super(
           parentTreeArtifact.getRoot(),
           parentTreeArtifact.getExecPath().getRelative(parentRelativePath),

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataHandler.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * <p>Note that implementations of this interface call chmod on output files if {@link
  * #discardOutputMetadata} has been called.
  */
-public interface MetadataHandler extends MetadataProvider {
+public interface MetadataHandler extends MetadataProvider, MetadataInjector {
   @Override
   FileArtifactValue getMetadata(ActionInput actionInput) throws IOException;
 
@@ -55,9 +55,6 @@ public interface MetadataHandler extends MetadataProvider {
    * <p>Must only be called after a call to {@link #discardOutputMetadata}.
    */
   void injectDigest(ActionInput output, FileStatus statNoFollow, byte[] digest);
-
-  /** Injects a file that is only stored remotely. */
-  void injectRemoteFile(Artifact output, byte[] digest, long size, int locationIndex);
 
   /**
    * Marks an artifact as intentionally omitted. Acknowledges that this Artifact could have existed,

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataHandler.java
@@ -57,14 +57,6 @@ public interface MetadataHandler extends MetadataProvider, MetadataInjector {
   void injectDigest(ActionInput output, FileStatus statNoFollow, byte[] digest);
 
   /**
-   * Marks an artifact as intentionally omitted. Acknowledges that this Artifact could have existed,
-   * but was intentionally not saved, most likely as an optimization.
-   *
-   * <p>Must only be called after a call to {@link #discardOutputMetadata}.
-   */
-  void markOmitted(ActionInput output);
-
-  /**
    * Returns true iff artifact was intentionally omitted (not saved).
    */
   // TODO(ulfjack): artifactOmitted always returns false unless we've just executed the action, and

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataInjector.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataInjector.java
@@ -1,0 +1,49 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.actions.cache;
+
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
+import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.util.Map;
+
+/**
+ * Allows to inject metadata of action outputs into skyframe.
+ */
+public interface MetadataInjector {
+
+  /**
+   * Injects metadata of a file that is stored remotely.
+   *
+   * @param file  a regular output file.
+   * @param digest  the digest of the file.
+   * @param sizeBytes the size of the file in bytes.
+   * @param locationIndex is only used in Blaze.
+   */
+  default void injectRemoteFile(Artifact file, byte[] digest, long sizeBytes, int locationIndex) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Inject the metadata of a tree artifact whose contents are stored remotely.
+   *
+   * @param treeArtifact  an output directory.
+   * @param children  the metadata of the files stored in the directory.
+   */
+  default void injectRemoteDirectory(SpecialArtifact treeArtifact,
+      Map<PathFragment, RemoteFileArtifactValue> children) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataInjector.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/MetadataInjector.java
@@ -1,4 +1,4 @@
-// Copyright 2018 The Bazel Authors. All rights reserved.
+// Copyright 2019 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 package com.google.devtools.build.lib.actions.cache;
 
+import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
-import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
 import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.Map;
@@ -27,23 +27,26 @@ public interface MetadataInjector {
   /**
    * Injects metadata of a file that is stored remotely.
    *
-   * @param file  a regular output file.
+   * @param output  a regular output file.
    * @param digest  the digest of the file.
-   * @param sizeBytes the size of the file in bytes.
+   * @param size the size of the file in bytes.
    * @param locationIndex is only used in Blaze.
    */
-  default void injectRemoteFile(Artifact file, byte[] digest, long sizeBytes, int locationIndex) {
-    throw new UnsupportedOperationException();
-  }
+  void injectRemoteFile(Artifact output, byte[] digest, long size, int locationIndex);
 
   /**
    * Inject the metadata of a tree artifact whose contents are stored remotely.
    *
-   * @param treeArtifact  an output directory.
-   * @param children  the metadata of the files stored in the directory.
+   * @param output  an output directory.
+   * @param children  the metadata of the files stored in the directory. The paths must be relative
+   * to the path of {@code output}.
    */
-  default void injectRemoteDirectory(SpecialArtifact treeArtifact,
-      Map<PathFragment, RemoteFileArtifactValue> children) {
-    throw new UnsupportedOperationException();
-  }
+  void injectRemoteDirectory(Artifact output,
+      Map<PathFragment, RemoteFileArtifactValue> children);
+
+  /**
+   * Marks an {@link Artifact} as intentionally omitted. Acknowledges that this artifact could have
+   * existed, but was intentionally not saved, most likely as an optimization.
+   */
+  void markOmitted(ActionInput output);
 }

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.actions.SpawnActionContext;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
 import com.google.devtools.build.lib.actions.Spawns;
+import com.google.devtools.build.lib.actions.cache.MetadataHandler;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.exec.SpawnCache.CacheHandle;
@@ -198,6 +199,11 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnActionConte
     @Override
     public MetadataProvider getMetadataProvider() {
       return actionExecutionContext.getMetadataProvider();
+    }
+    
+    @Override
+    public MetadataHandler getMetadataInjector() {
+      return actionExecutionContext.getMetadataHandler();
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.actions.FutureSpawn;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
+import com.google.devtools.build.lib.actions.cache.MetadataInjector;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
@@ -198,6 +199,14 @@ public interface SpawnRunner {
 
     /** Reports a progress update to the Spawn strategy. */
     void report(ProgressStatus state, String name);
+
+    /**
+     * Returns a {@link MetadataInjector} that allows a caller to inject metadata about spawn
+     * outputs that are stored remotely.
+     */
+    default MetadataInjector getMetadataInjector() {
+      throw new UnsupportedOperationException();
+    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
@@ -204,9 +204,7 @@ public interface SpawnRunner {
      * Returns a {@link MetadataInjector} that allows a caller to inject metadata about spawn
      * outputs that are stored remotely.
      */
-    default MetadataInjector getMetadataInjector() {
-      throw new UnsupportedOperationException();
-    }
+    MetadataInjector getMetadataInjector();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionMetadataHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionMetadataHandler.java
@@ -480,14 +480,23 @@ public final class ActionMetadataHandler implements MetadataHandler {
 
   @Override
   public void injectRemoteFile(Artifact output, byte[] digest, long size, int locationIndex) {
-    Preconditions.checkState(
-        executionMode.get(), "Tried to inject %s outside of execution.", output);
+    Preconditions.checkState(executionMode.get(),
+        "Tried to inject %s outside of execution.", output);
+    Preconditions.checkState(isKnownOutput(output),
+        output + " is not a declared output of this action");
     store.injectRemoteFile(output, digest, size, locationIndex);
   }
 
   @Override
-  public void injectRemoteDirectory(SpecialArtifact output,
+  public void injectRemoteDirectory(Artifact output,
       Map<PathFragment, RemoteFileArtifactValue> children) {
+    Preconditions.checkState(executionMode.get(),
+        "Tried to inject %s outside of execution.", output);
+    Preconditions.checkState(isKnownOutput(output),
+        output + " is not a declared output of this action");
+    Preconditions.checkState(output.isTreeArtifact(),
+        "output must be a tree artifact");
+
     ImmutableMap.Builder<TreeFileArtifact, FileArtifactValue> childFileValues = ImmutableMap.builder();
     for (Map.Entry<PathFragment, RemoteFileArtifactValue> child : children.entrySet()) {
       childFileValues.put(ActionInputHelper.treeFileArtifact(output, child.getKey()), child.getValue());

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionMetadataHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionMetadataHandler.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.skyframe;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -29,6 +30,7 @@ import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.ArtifactFileMetadata;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
 import com.google.devtools.build.lib.actions.FileStateValue;
 import com.google.devtools.build.lib.actions.cache.Md5Digest;
 import com.google.devtools.build.lib.actions.cache.MetadataHandler;
@@ -481,6 +483,18 @@ public final class ActionMetadataHandler implements MetadataHandler {
     Preconditions.checkState(
         executionMode.get(), "Tried to inject %s outside of execution.", output);
     store.injectRemoteFile(output, digest, size, locationIndex);
+  }
+
+  @Override
+  public void injectRemoteDirectory(SpecialArtifact output,
+      Map<PathFragment, RemoteFileArtifactValue> children) {
+    ImmutableMap.Builder<TreeFileArtifact, FileArtifactValue> childFileValues = ImmutableMap.builder();
+    for (Map.Entry<PathFragment, RemoteFileArtifactValue> child : children.entrySet()) {
+      childFileValues.put(ActionInputHelper.treeFileArtifact(output, child.getKey()), child.getValue());
+    }
+
+    TreeArtifactValue treeArtifactValue = TreeArtifactValue.create(childFileValues.build());
+    store.putTreeArtifactData(output, treeArtifactValue);
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/actions/util/ActionsTestUtil.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/util/ActionsTestUtil.java
@@ -47,6 +47,7 @@ import com.google.devtools.build.lib.actions.ArtifactResolver;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.Executor;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
 import com.google.devtools.build.lib.actions.MutableActionGraph;
 import com.google.devtools.build.lib.actions.MutableActionGraph.ActionConflictException;
 import com.google.devtools.build.lib.actions.PackageRootResolver;
@@ -737,6 +738,12 @@ public final class ActionsTestUtil {
 
     @Override
     public void injectRemoteFile(Artifact output, byte[] digest, long size, int locationIndex) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void injectRemoteDirectory(Artifact treeArtifact,
+        Map<PathFragment, RemoteFileArtifactValue> children) {
       throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunnerTest.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.actions.ResourceManager;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
+import com.google.devtools.build.lib.actions.cache.MetadataInjector;
 import com.google.devtools.build.lib.exec.BinTools;
 import com.google.devtools.build.lib.exec.SpawnRunner.ProgressStatus;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
@@ -257,6 +258,11 @@ public class LocalSpawnRunnerTest {
     @Override
     public void report(ProgressStatus state, String name) {
       reportedStatus.add(state);
+    }
+
+    @Override
+    public MetadataInjector getMetadataInjector() {
+      throw new UnsupportedOperationException();
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
@@ -52,6 +52,7 @@ import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.SimpleSpawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
+import com.google.devtools.build.lib.actions.cache.MetadataInjector;
 import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.authandtls.GoogleAuthUtils;
@@ -194,6 +195,11 @@ public class GrpcRemoteExecutionClientTest {
         @Override
         public void report(ProgressStatus state, String name) {
           // TODO(ulfjack): Test that the right calls are made.
+        }
+
+        @Override
+        public MetadataInjector getMetadataInjector() {
+          throw new UnsupportedOperationException();
         }
       };
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -42,6 +42,7 @@ import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.SimpleSpawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
+import com.google.devtools.build.lib.actions.cache.MetadataInjector;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventKind;
@@ -157,6 +158,11 @@ public class RemoteSpawnCacheTest {
         @Override
         public void report(ProgressStatus state, String name) {
           progressUpdates.add(Pair.of(state, name));
+        }
+
+        @Override
+        public MetadataInjector getMetadataInjector() {
+          throw new UnsupportedOperationException();
         }
       };
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -56,6 +56,7 @@ import com.google.devtools.build.lib.actions.SimpleSpawn;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
+import com.google.devtools.build.lib.actions.cache.MetadataInjector;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventKind;
@@ -1111,6 +1112,11 @@ public class RemoteSpawnRunnerTest {
     @Override
     public void report(ProgressStatus state, String name) {
       assertThat(state).isEqualTo(ProgressStatus.EXECUTING);
+    }
+
+    @Override
+    public MetadataInjector getMetadataInjector() {
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ActionMetadataHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ActionMetadataHandlerTest.java
@@ -17,6 +17,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ActionInputMap;
@@ -28,10 +29,12 @@ import com.google.devtools.build.lib.actions.ArtifactOwner;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
 import com.google.devtools.build.lib.testutil.Scratch;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
 import java.io.FileNotFoundException;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -273,11 +276,71 @@ public class ActionMetadataHandlerTest {
     assertThat(handler.getMetadata(artifact).getSize()).isEqualTo(10);
 
     // Inject a remote file of size 42.
-    handler.injectRemoteFile(artifact, new byte[] {1, 2, 3}, 42, 0);
+    handler.injectRemoteFile(artifact, new byte[]{1, 2, 3}, 42, 0);
     assertThat(handler.getMetadata(artifact).getSize()).isEqualTo(42);
 
     // Reset this output, which will make the handler stat the file again.
     handler.resetOutputs(ImmutableList.of(artifact));
     assertThat(handler.getMetadata(artifact).getSize()).isEqualTo(10);
+  }
+
+  @Test
+  public void injectRemoteArtifactMetadata() throws Exception {
+    PathFragment path = PathFragment.create("foo/bar");
+    Artifact artifact = new Artifact(path, outputRoot);
+    ActionMetadataHandler handler = new ActionMetadataHandler(
+        /* inputArtifactData= */ new ActionInputMap(0),
+        /* missingArtifactsAllowed= */ false,
+        /* outputs= */ ImmutableList.of(artifact),
+        /* tsgm= */ null,
+        ArtifactPathResolver.IDENTITY,
+        new OutputStore());
+    handler.discardOutputMetadata();
+
+    byte[] digest = new byte[]{1,2,3};
+    int size = 10;
+    handler.injectRemoteFile(artifact, digest, size, /* locationIndex= */ 1);
+
+    FileArtifactValue v = handler.getMetadata(artifact);
+    assertThat(v).isNotNull();
+    assertThat(v.getDigest()).isEqualTo(digest);
+    assertThat(v.getSize()).isEqualTo(size);
+  }
+
+  @Test
+  public void injectRemoteTreeArtifactMetadata() throws Exception {
+    PathFragment path = PathFragment.create("bin/dir");
+    SpecialArtifact treeArtifact =
+        new SpecialArtifact(
+            outputRoot, path, ArtifactOwner.NullArtifactOwner.INSTANCE, SpecialArtifactType.TREE);
+    OutputStore store = new OutputStore();
+    ActionMetadataHandler handler = new ActionMetadataHandler(
+        /* inputArtifactData= */ new ActionInputMap(0),
+        /* missingArtifactsAllowed= */ false,
+        /* outputs= */ ImmutableList.of(treeArtifact),
+        /* tsgm= */ null,
+        ArtifactPathResolver.IDENTITY,
+        store);
+    handler.discardOutputMetadata();
+
+    RemoteFileArtifactValue fooValue = new RemoteFileArtifactValue(new byte[]{1,2,3}, 5, 1);
+    RemoteFileArtifactValue barValue = new RemoteFileArtifactValue(new byte[]{4,5,6}, 10, 1);
+    Map<PathFragment, RemoteFileArtifactValue> children =
+        ImmutableMap.<PathFragment, RemoteFileArtifactValue>builder()
+            .put(PathFragment.create("foo"), fooValue)
+            .put(PathFragment.create("bar"), barValue)
+            .build();
+
+    handler.injectRemoteDirectory(treeArtifact, children);
+
+    FileArtifactValue value = handler.getMetadata(treeArtifact);
+    assertThat(value).isNotNull();
+    TreeArtifactValue treeValue = store.getTreeArtifactData(treeArtifact);
+    assertThat(treeValue).isNotNull();
+    assertThat(treeValue.getDigest()).isEqualTo(value.getDigest());
+
+    assertThat(treeValue.getChildPaths()).containsExactly(PathFragment.create("foo"),
+        PathFragment.create("bar"));
+    assertThat(treeValue.getChildValues().values()).containsExactly(fooValue, barValue);
   }
 }


### PR DESCRIPTION
Adds a MetadataInjector type that can be accessed via the
SpawnExecutionContext.

Progress towards #6862