### PR TITLE
Allow Bazel in JUnit black box tests to fail.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/BuilderRunner.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/BuilderRunner.java
@@ -50,6 +50,7 @@ public final class BuilderRunner {
   private boolean useDefaultRc = true;
   private int errorCode = 0;
   private List<String> flags;
+  private boolean shouldFail;
 
   /**
    * Creates the BuilderRunner
@@ -102,6 +103,16 @@ public final class BuilderRunner {
    */
   public BuilderRunner withErrorCode(int errorCode) {
     this.errorCode = errorCode;
+    return this;
+  }
+
+  /**
+   * Expect Bazel to fail. This method is needed when the exact error code can not be specified.
+   *
+   * @return this BuildRunner instance
+   */
+  public BuilderRunner shouldFail() {
+    this.shouldFail = true;
     return this;
   }
 
@@ -271,6 +282,7 @@ public final class BuilderRunner {
             // we need to allow the error output stream be not empty
             .setExpectedEmptyError(false)
             .setExpectedExitCode(errorCode)
+            .setExpectedToFail(shouldFail)
             .build();
     return new ProcessRunner(parameters, executorService).runSynchronously();
   }

--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/ProcessParameters.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/ProcessParameters.java
@@ -34,6 +34,8 @@ public abstract class ProcessParameters {
 
   abstract int expectedExitCode();
 
+  abstract boolean expectedToFail();
+
   abstract boolean expectedEmptyError();
 
   abstract Optional<ImmutableMap<String, String>> environment();
@@ -48,6 +50,7 @@ public abstract class ProcessParameters {
     return new AutoValue_ProcessParameters.Builder()
         .setExpectedExitCode(0)
         .setExpectedEmptyError(true)
+        .setExpectedToFail(false)
         .setTimeoutMillis(30 * 1000)
         .setArguments();
   }
@@ -69,6 +72,8 @@ public abstract class ProcessParameters {
     public abstract Builder setWorkingDirectory(File value);
 
     public abstract Builder setExpectedExitCode(int value);
+
+    public abstract Builder setExpectedToFail(boolean value);
 
     public abstract Builder setExpectedEmptyError(boolean value);
 

--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/ProcessRunner.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/ProcessRunner.java
@@ -70,7 +70,7 @@ public final class ProcessRunner {
     commandParts.add(parameters.name());
     commandParts.addAll(args);
 
-    logger.info("Running: " + commandParts.stream().collect(Collectors.joining(" ")));
+    logger.info("Running: " + String.join(" ", commandParts));
 
     ProcessBuilder processBuilder = new ProcessBuilder(commandParts);
     processBuilder.directory(parameters.workingDirectory());
@@ -108,24 +108,24 @@ public final class ProcessRunner {
               : Files.readAllLines(parameters.redirectOutput().get());
 
       int exitValue = process.exitValue();
+      boolean processFailed = exitValue != 0;
       boolean expectedToFail = parameters.expectedToFail() || parameters.expectedExitCode() != 0;
-      if ((exitValue == 0) == expectedToFail) {
+      if (processFailed != expectedToFail) {
+        // We want to check the exact exit code if it was explicitly set to something;
+        if (parameters.expectedExitCode() != 0 && parameters.expectedExitCode() != exitValue) {
+          throw new ProcessRunnerException(
+              String.format(
+                  "Expected exit code %d, but found %d.\nError: %s\nOutput: %s",
+                  parameters.expectedExitCode(),
+                  exitValue,
+                  StringUtilities.joinLines(err),
+                  StringUtilities.joinLines(out)));
+        }
         throw new ProcessRunnerException(
             String.format(
                 "Expected to %s, but %s.\nError: %s\nOutput: %s",
                 expectedToFail ? "fail" : "succeed",
-                exitValue == 0 ? "succeeded" : "failed",
-                StringUtilities.joinLines(err),
-                StringUtilities.joinLines(out)));
-      }
-      // We want to check the exact exit code if it was explicitly set to something;
-      // we already checked the variant when it is equal to zero above.
-      if (parameters.expectedExitCode() != 0 && parameters.expectedExitCode() != exitValue) {
-        throw new ProcessRunnerException(
-            String.format(
-                "Expected exit code %d, but found %d.\nError: %s\nOutput: %s",
-                parameters.expectedExitCode(),
-                exitValue,
+                processFailed ? "failed" : "succeeded",
                 StringUtilities.joinLines(err),
                 StringUtilities.joinLines(out)));
       }

--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/ProcessRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/ProcessRunnerTest.java
@@ -80,12 +80,26 @@ public final class ProcessRunnerTest {
   }
 
   @Test
-  public void testFailure() throws Exception {
+  public void testFailureWithCode() throws Exception {
     Files.write(
         path, createScriptText(/* exit code */ 124, /* output */ null, /* error */ "Failure"));
 
     ProcessParameters parameters =
         createBuilder().setExpectedExitCode(124).setExpectedEmptyError(false).build();
+    ProcessResult result = new ProcessRunner(parameters, executorService).runSynchronously();
+
+    assertThat(result.exitCode()).isEqualTo(124);
+    assertThat(result.outString()).isEmpty();
+    assertThat(result.errString()).isEqualTo("Failure");
+  }
+
+  @Test
+  public void testFailure() throws Exception {
+    Files.write(
+        path, createScriptText(/* exit code */ 124, /* output */ null, /* error */ "Failure"));
+
+    ProcessParameters parameters =
+        createBuilder().setExpectedToFail(true).setExpectedEmptyError(false).build();
     ProcessResult result = new ProcessRunner(parameters, executorService).runSynchronously();
 
     assertThat(result.exitCode()).isEqualTo(124);


### PR DESCRIPTION
This is needed to verify the failure in case we do not know the expected error code exactly.