### PR TITLE
Add more JUnit black box workspace tests.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/BuilderRunner.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/BuilderRunner.java
@@ -50,6 +50,7 @@ public final class BuilderRunner {
   private boolean useDefaultRc = true;
   private int errorCode = 0;
   private List<String> flags;
+  private boolean shouldFail;
 
   /**
    * Creates the BuilderRunner
@@ -102,6 +103,16 @@ public final class BuilderRunner {
    */
   public BuilderRunner withErrorCode(int errorCode) {
     this.errorCode = errorCode;
+    return this;
+  }
+
+  /**
+   * Expect Bazel to fail. This method is needed when the exact error code can not be specified.
+   *
+   * @return this BuildRunner instance
+   */
+  public BuilderRunner shouldFail() {
+    this.shouldFail = true;
     return this;
   }
 
@@ -271,6 +282,7 @@ public final class BuilderRunner {
             // we need to allow the error output stream be not empty
             .setExpectedEmptyError(false)
             .setExpectedExitCode(errorCode)
+            .setExpectedToFail(shouldFail)
             .build();
     return new ProcessRunner(parameters, executorService).runSynchronously();
   }

--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/PathUtils.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/PathUtils.java
@@ -1,4 +1,4 @@
-// Copyright 2018 The Bazel Authors. All rights reserved.
+// Copyright 2019 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -346,5 +346,19 @@ public class PathUtils {
       return path.toString().replace("\\", "/");
     }
     return path.toString();
+  }
+
+  /**
+   * Returns the file:///... URI to the passed path. Ensures the 'file:' is followed by three
+   * forward slahes on all platforms.
+   *
+   * @param path path to refer to
+   * @return file:///... URI to the passed path
+   */
+  public static String pathToFileURI(Path path) {
+    if (OS.WINDOWS.equals(OS.getCurrent())) {
+      return "file:///" + path.toString().replace("\\", "/");
+    }
+    return "file://" + path.toString();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/ProcessParameters.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/ProcessParameters.java
@@ -34,6 +34,8 @@ public abstract class ProcessParameters {
 
   abstract int expectedExitCode();
 
+  abstract boolean expectedToFail();
+
   abstract boolean expectedEmptyError();
 
   abstract Optional<ImmutableMap<String, String>> environment();
@@ -48,6 +50,7 @@ public abstract class ProcessParameters {
     return new AutoValue_ProcessParameters.Builder()
         .setExpectedExitCode(0)
         .setExpectedEmptyError(true)
+        .setExpectedToFail(false)
         .setTimeoutMillis(30 * 1000)
         .setArguments();
   }
@@ -69,6 +72,8 @@ public abstract class ProcessParameters {
     public abstract Builder setWorkingDirectory(File value);
 
     public abstract Builder setExpectedExitCode(int value);
+
+    public abstract Builder setExpectedToFail(boolean value);
 
     public abstract Builder setExpectedEmptyError(boolean value);
 

--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/ProcessRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/ProcessRunnerTest.java
@@ -80,12 +80,26 @@ public final class ProcessRunnerTest {
   }
 
   @Test
-  public void testFailure() throws Exception {
+  public void testFailureWithCode() throws Exception {
     Files.write(
         path, createScriptText(/* exit code */ 124, /* output */ null, /* error */ "Failure"));
 
     ProcessParameters parameters =
         createBuilder().setExpectedExitCode(124).setExpectedEmptyError(false).build();
+    ProcessResult result = new ProcessRunner(parameters, executorService).runSynchronously();
+
+    assertThat(result.exitCode()).isEqualTo(124);
+    assertThat(result.outString()).isEmpty();
+    assertThat(result.errString()).isEqualTo("Failure");
+  }
+
+  @Test
+  public void testFailure() throws Exception {
+    Files.write(
+        path, createScriptText(/* exit code */ 124, /* output */ null, /* error */ "Failure"));
+
+    ProcessParameters parameters =
+        createBuilder().setExpectedToFail(true).setExpectedEmptyError(false).build();
     ProcessResult result = new ProcessRunner(parameters, executorService).runSynchronously();
 
     assertThat(result.exitCode()).isEqualTo(124);

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BUILD
@@ -28,15 +28,34 @@ java_test(
     srcs = [
         "RepoWithRuleWritingTextGenerator.java",
         "WorkspaceBlackBoxTest.java",
+        "WorkspaceTestUtils.java",
     ],
     tags = ["black_box_test"],
     deps = common_deps,
+)
+
+java_test(
+    name = "BazelEmbeddedSkylarkBlackBoxTest",
+    timeout = "moderate",
+    srcs = [
+        "BazelEmbeddedSkylarkBlackBoxTest.java",
+        "RepoWithRuleWritingTextGenerator.java",
+        "WorkspaceTestUtils.java",
+    ],
+    tags = ["black_box_test"],
+    deps = common_deps + [
+        "//src/main/java/com/google/devtools/build/lib:build-base",
+        "//src/main/java/com/google/devtools/build/lib:bazel-repository",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/test/java/com/google/devtools/build/lib:foundations_testutil",
+    ],
 )
 
 test_suite(
     name = "ws_black_box_tests",
     tags = ["black_box_test"],
     tests = [
+        "BazelEmbeddedSkylarkBlackBoxTest",
         "RepoWithRuleWritingTextGeneratorTest",
         "WorkspaceBlackBoxTest",
     ],

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedSkylarkBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedSkylarkBlackBoxTest.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 import org.junit.Test;
 
 /**
- * Test that the embedded skylark code is compliant with --all_incompatible_changes.
+ * Test that the embedded Starlark code is compliant with --all_incompatible_changes.
  * To replace bazel_embedded_skylark_test.sh.
  */
 public class BazelEmbeddedSkylarkBlackBoxTest extends AbstractBlackBoxTest {
@@ -51,7 +51,7 @@ public class BazelEmbeddedSkylarkBlackBoxTest extends AbstractBlackBoxTest {
     context().write("main/bar.txt", "Hello World, again");
     context().write("main/BUILD",
         "load(\"@bazel_tools//tools/build_defs/pkg:pkg.bzl\", \"pkg_tar\")",
-        "pkg_tar(name = \"data\", srcs = glob([\"*.txt\"]),)");
+        "pkg_tar(name = \"data\", srcs = ['foo.txt', 'bar.txt'],)");
 
     BuilderRunner bazel = bazel();
     bazel.build("...");
@@ -65,8 +65,8 @@ public class BazelEmbeddedSkylarkBlackBoxTest extends AbstractBlackBoxTest {
     Map<String, Path> map = Arrays.stream(Objects.requireNonNull(directory.toFile().listFiles()))
         .collect(Collectors.toMap(File::getName, file -> Paths.get(file.getAbsolutePath())));
 
-    WorkspaceTestUtils.assertOneLineFile(map.get("foo.txt"), "Hello World");
-    WorkspaceTestUtils.assertOneLineFile(map.get("bar.txt"), "Hello World, again");
+    WorkspaceTestUtils.assertLinesExactly(map.get("foo.txt"), "Hello World");
+    WorkspaceTestUtils.assertLinesExactly(map.get("bar.txt"), "Hello World, again");
   }
 
   @Test
@@ -102,13 +102,13 @@ public class BazelEmbeddedSkylarkBlackBoxTest extends AbstractBlackBoxTest {
     bazel.build("@ext//:" + RepoWithRuleWritingTextGenerator.TARGET);
 
     Path xPath = context().resolveBinPath(bazel, "external/ext/out");
-    WorkspaceTestUtils.assertOneLineFile(xPath, HELLO_FROM_EXTERNAL_REPOSITORY);
+    WorkspaceTestUtils.assertLinesExactly(xPath, HELLO_FROM_EXTERNAL_REPOSITORY);
 
     // and use the rule from http_archive in the main repository
     bazel.build("//:call_from_main");
 
     Path mainOutPath = context().resolveBinPath(bazel, "main_out.txt");
-    WorkspaceTestUtils.assertOneLineFile(mainOutPath, HELLO_FROM_MAIN_REPOSITORY);
+    WorkspaceTestUtils.assertLinesExactly(mainOutPath, HELLO_FROM_MAIN_REPOSITORY);
   }
 
   private BuilderRunner bazel() {
@@ -117,7 +117,7 @@ public class BazelEmbeddedSkylarkBlackBoxTest extends AbstractBlackBoxTest {
 
   private Path decompress(Path dataTarPath)
       throws IOException, RepositoryFunctionException {
-    FileSystem fs = FileSystems.getJavaIoFileSystem();
+    FileSystem fs = FileSystems.getNativeFileSystem();
     com.google.devtools.build.lib.vfs.Path dataTarPathForDecompress =
         fs.getPath(dataTarPath.toAbsolutePath().toString());
 

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedSkylarkBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedSkylarkBlackBoxTest.java
@@ -1,0 +1,134 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.blackbox.tests.workspace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.build.lib.bazel.repository.DecompressorDescriptor;
+import com.google.devtools.build.lib.bazel.repository.TarFunction;
+import com.google.devtools.build.lib.blackbox.framework.BuilderRunner;
+import com.google.devtools.build.lib.blackbox.framework.PathUtils;
+import com.google.devtools.build.lib.blackbox.junit.AbstractBlackBoxTest;
+import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.util.FileSystems;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+/**
+ * Test that the embedded skylark code is compliant with --all_incompatible_changes.
+ * To replace bazel_embedded_skylark_test.sh.
+ */
+public class BazelEmbeddedSkylarkBlackBoxTest extends AbstractBlackBoxTest {
+
+  private static final String HELLO_FROM_EXTERNAL_REPOSITORY = "Hello from external repository!";
+  private static final String HELLO_FROM_MAIN_REPOSITORY = "Hello from main repository!";
+
+  @Test
+  public void testPkgTar() throws Exception {
+    context().write("main/WORKSPACE");
+    context().write("main/foo.txt", "Hello World");
+    context().write("main/bar.txt", "Hello World, again");
+    context().write("main/BUILD",
+        "load(\"@bazel_tools//tools/build_defs/pkg:pkg.bzl\", \"pkg_tar\")",
+        "pkg_tar(name = \"data\", srcs = glob([\"*.txt\"]),)");
+
+    BuilderRunner bazel = bazel();
+    bazel.build("...");
+
+    Path dataTarPath = context().resolveBinPath(bazel, "main/data.tar");
+    assertThat(Files.exists(dataTarPath)).isTrue();
+
+    Path directory = decompress(dataTarPath);
+    assertThat(directory.toFile().exists()).isTrue();
+
+    Map<String, Path> map = Arrays.stream(Objects.requireNonNull(directory.toFile().listFiles()))
+        .collect(Collectors.toMap(File::getName, file -> Paths.get(file.getAbsolutePath())));
+
+    WorkspaceTestUtils.assertOneLineFile(map.get("foo.txt"), "Hello World");
+    WorkspaceTestUtils.assertOneLineFile(map.get("bar.txt"), "Hello World, again");
+  }
+
+  @Test
+  public void testHttpArchive() throws Exception {
+    Path repo = context().getTmpDir().resolve("ext_repo");
+    RepoWithRuleWritingTextGenerator generator = new RepoWithRuleWritingTextGenerator(repo);
+    generator.withOutputText(HELLO_FROM_EXTERNAL_REPOSITORY).setupRepository();
+
+    // file where we will manually copy the built archive
+    Path zipFile = context().getTmpDir().resolve("ext_repo.tar");
+    assertThat(Files.exists(zipFile)).isFalse();
+
+    context().write("WORKSPACE",
+        "load(\"@bazel_tools//tools/build_defs/repo:http.bzl\", \"http_archive\")\n",
+        String.format("local_repository(name=\"ext_local\", path=\"%s\",)",
+            PathUtils.pathForStarlarkFile(repo)),
+        String.format("http_archive(name=\"ext\", urls=[\"%s\"],)",
+            PathUtils.pathToFileURI(zipFile)));
+
+    context().write("BUILD", RepoWithRuleWritingTextGenerator.loadRule("@ext"),
+        RepoWithRuleWritingTextGenerator.callRule("call_from_main", "main_out.txt",
+            HELLO_FROM_MAIN_REPOSITORY));
+
+    // first build the archive and copy it into zipFile
+    BuilderRunner bazel = bazel();
+    String tarTarget = generator.getPkgTarTarget();
+    bazel.build("@ext_local//:" + tarTarget);
+    Path packedFile = context().resolveBinPath(bazel,
+        String.format("external/ext_local/%s.tar", tarTarget));
+    Files.copy(packedFile, zipFile);
+
+    // now build the target from http_archive
+    bazel.build("@ext//:" + RepoWithRuleWritingTextGenerator.TARGET);
+
+    Path xPath = context().resolveBinPath(bazel, "external/ext/out");
+    WorkspaceTestUtils.assertOneLineFile(xPath, HELLO_FROM_EXTERNAL_REPOSITORY);
+
+    // and use the rule from http_archive in the main repository
+    bazel.build("//:call_from_main");
+
+    Path mainOutPath = context().resolveBinPath(bazel, "main_out.txt");
+    WorkspaceTestUtils.assertOneLineFile(mainOutPath, HELLO_FROM_MAIN_REPOSITORY);
+  }
+
+  private BuilderRunner bazel() {
+    return WorkspaceTestUtils.bazel(context()).withFlags("--all_incompatible_changes");
+  }
+
+  private Path decompress(Path dataTarPath)
+      throws IOException, RepositoryFunctionException {
+    FileSystem fs = FileSystems.getJavaIoFileSystem();
+    com.google.devtools.build.lib.vfs.Path dataTarPathForDecompress =
+        fs.getPath(dataTarPath.toAbsolutePath().toString());
+
+    com.google.devtools.build.lib.vfs.Path directory = TarFunction.INSTANCE
+        .decompress(DecompressorDescriptor
+            .builder()
+            .setArchivePath(dataTarPathForDecompress)
+            .setRepositoryPath(dataTarPathForDecompress.getParentDirectory())
+            .build());
+    return Paths.get(directory.getPathString());
+  }
+
+  // TODO(ichern) test tar quoting
+}

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceTestUtils.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceTestUtils.java
@@ -1,0 +1,68 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.blackbox.tests.workspace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.build.lib.blackbox.framework.BlackBoxTestContext;
+import com.google.devtools.build.lib.blackbox.framework.BuilderRunner;
+import com.google.devtools.build.lib.blackbox.framework.PathUtils;
+import com.google.devtools.build.lib.util.OS;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class WorkspaceTestUtils {
+  public static final String PATH = "PATH";
+  public static final String BAZEL_SH = "BAZEL_SH";
+
+  /**
+   * Create the BuilderRunner for workspace tests without MSYS/MINGW dependency on Windows.
+   * @param context - BlackBoxTestContext instance
+   * @return BuilderRunner for running Bazel
+   */
+  static BuilderRunner bazel(BlackBoxTestContext context) {
+    if (!OS.WINDOWS.equals(OS.getCurrent())) return context.bazel();
+    return context.bazel()
+        .withEnv(BAZEL_SH, "C:/foo/bar/usr/bin/bash.exe")
+        .withEnv(PATH, removeMsysFromPath(System.getenv(PATH)));
+  }
+
+  private static String removeMsysFromPath(String path) {
+    if (!OS.WINDOWS.equals(OS.getCurrent())) return path;
+    if (path.indexOf(';') == -1) {
+      return path;
+    }
+    String[] parts = path.split(";");
+    return Arrays.stream(parts)
+        .filter(s -> !s.contains("msys")).collect(Collectors.joining(";"));
+  }
+
+  /**
+   * Assert that the file exists and contains exactly one line with the certain text.
+   * @param path - path to file
+   * @param text - text expected in the file
+   * @throws IOException if any file operation failed
+   */
+  static void assertOneLineFile(Path path, String text) throws IOException {
+    assertThat(Files.exists(path)).isTrue();
+    List<String> lines = PathUtils.readFile(path);
+    assertThat(lines.size()).isEqualTo(1);
+    assertThat(lines.get(0)).isEqualTo(text);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceTestUtils.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceTestUtils.java
@@ -27,6 +27,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Utility class for helping JUnit black box workspace tests.
+ */
 public class WorkspaceTestUtils {
   public static final String PATH = "PATH";
   public static final String BAZEL_SH = "BAZEL_SH";
@@ -37,14 +40,18 @@ public class WorkspaceTestUtils {
    * @return BuilderRunner for running Bazel
    */
   static BuilderRunner bazel(BlackBoxTestContext context) {
-    if (!OS.WINDOWS.equals(OS.getCurrent())) return context.bazel();
+    if (!OS.WINDOWS.equals(OS.getCurrent())) {
+      return context.bazel();
+    }
     return context.bazel()
         .withEnv(BAZEL_SH, "C:/foo/bar/usr/bin/bash.exe")
         .withEnv(PATH, removeMsysFromPath(System.getenv(PATH)));
   }
 
   private static String removeMsysFromPath(String path) {
-    if (!OS.WINDOWS.equals(OS.getCurrent())) return path;
+    if (!OS.WINDOWS.equals(OS.getCurrent())) {
+      return path;
+    }
     if (path.indexOf(';') == -1) {
       return path;
     }


### PR DESCRIPTION
- remove MSYS directory from the PATH, passed to the child Bazel process, invoked in tests; put it into an utility method and use across the JUnit black box workspace tests;
- in WorkspaceBlackBoxTest, add test to verify that we are running on Windows without MSYS/MINGW on the path or as the BAZEL_SH: try to run "bash -c <command>" and verify that it fails;
- add pkg_tar and http_archive tests; more to come.