### PR TITLE
Add common envs attribute for *_binary and *_test rules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -23,6 +23,7 @@ import static com.google.devtools.build.lib.packages.BuildType.NODEP_LABEL_LIST;
 import static com.google.devtools.build.lib.syntax.Type.BOOLEAN;
 import static com.google.devtools.build.lib.syntax.Type.INTEGER;
 import static com.google.devtools.build.lib.syntax.Type.STRING;
+import static com.google.devtools.build.lib.syntax.Type.STRING_DICT;
 import static com.google.devtools.build.lib.syntax.Type.STRING_LIST;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -164,6 +165,7 @@ public class BaseRuleClasses {
                   .taggable()
                   .nonconfigurable("policy decision: should be consistent across configurations"))
           .add(attr("args", STRING_LIST))
+          .add(attr("envs", STRING_DICT))
           // Input files for every test action
           .add(
               attr("$test_wrapper", LABEL)
@@ -419,6 +421,7 @@ public class BaseRuleClasses {
     public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
       return builder
           .add(attr("args", STRING_LIST))
+          .add(attr("envs", STRING_DICT))
           .add(attr("output_licenses", LICENSE))
           .add(
               attr("$is_executable", BOOLEAN)

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
@@ -23,6 +23,7 @@ import static com.google.devtools.build.lib.syntax.SkylarkType.castMap;
 import static com.google.devtools.build.lib.syntax.Type.BOOLEAN;
 import static com.google.devtools.build.lib.syntax.Type.INTEGER;
 import static com.google.devtools.build.lib.syntax.Type.STRING;
+import static com.google.devtools.build.lib.syntax.Type.STRING_DICT;
 import static com.google.devtools.build.lib.syntax.Type.STRING_LIST;
 
 import com.google.common.base.Preconditions;
@@ -139,6 +140,7 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
   public static final RuleClass binaryBaseRule =
       new RuleClass.Builder("$binary_base_rule", RuleClassType.ABSTRACT, true, baseRule)
           .add(attr("args", STRING_LIST))
+          .add(attr("envs", STRING_DICT))
           .add(attr("output_licenses", LICENSE))
           .build();
 
@@ -169,6 +171,7 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
                 .nonconfigurable(
                     "policy decision: this should be consistent across configurations"))
         .add(attr("args", STRING_LIST))
+        .add(attr("envs", STRING_DICT))
         // Input files for every test action
         .add(
             attr("$test_wrapper", LABEL)

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -316,6 +316,11 @@ public final class TestActionBuilder {
           executable, null, shards);
     }
 
+    Object envObj = ruleContext.getRule().getAttributeContainer().getAttr("envs");
+    if (envObj != null) {
+      extraTestEnv.putAll((Map<String, String>)envObj);
+    }
+
     extraTestEnv.putAll(extraEnv);
 
     if (config.getRunUnder() != null) {

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -181,6 +181,21 @@ public class RunCommand implements BlazeCommand  {
     return args;
   }
 
+  /**
+   * Get any environement variables specified by the {@code envs=} attribute.
+   */
+  @Nullable
+  private Map<String, String> getEnvs(ConfiguredTarget targetToRun) {
+    Map<String, String> envs = new TreeMap<>();
+
+    FilesToRunProvider provider = targetToRun.getProvider(FilesToRunProvider.class);
+    RunfilesSupport runfilesSupport = provider == null ? null : provider.getRunfilesSupport();
+    if (runfilesSupport != null && !runfilesSupport.getEnvs().isEmpty()) {
+      envs.putAll(runfilesSupport.getEnvs());
+    }
+    return envs;
+  }
+
   private void constructCommandLine(List<String> cmdLine, List<String> prettyCmdLine,
       CommandEnvironment env, PathFragment shellExecutable, ConfiguredTarget targetToRun,
       ConfiguredTarget runUnderTarget, List<String> args) {
@@ -365,6 +380,8 @@ public class RunCommand implements BlazeCommand  {
     List<String> cmdLine = new ArrayList<>();
     List<String> prettyCmdLine = new ArrayList<>();
     Path workingDir;
+
+    runEnvironment.putAll(getEnvs(targetToRun));
 
     runEnvironment.put("BUILD_WORKSPACE_DIRECTORY", env.getWorkspace().getPathString());
     runEnvironment.put("BUILD_WORKING_DIRECTORY", env.getWorkingDirectory().getPathString());

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -135,7 +135,7 @@ EOF
 sh_test(
     name = "foo",
     srcs = ["testenv.sh"],
-    envs = {"FOO", "bar"},
+    envs = {"FOO" : "bar"},
 )
 EOF
 

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -128,12 +128,14 @@ EOF
 echo "pwd: $PWD"
 echo "src: $TEST_SRCDIR"
 echo "ws: $TEST_WORKSPACE"
+echo "foo: $FOO"
 EOF
   chmod +x foo/testenv.sh
   cat > foo/BUILD <<EOF
 sh_test(
     name = "foo",
     srcs = ["testenv.sh"],
+    envs = {"FOO", "bar"},
 )
 EOF
 
@@ -141,6 +143,7 @@ EOF
   expect_log "pwd: .*/foo.runfiles/bar$"
   expect_log "src: .*/foo.runfiles$"
   expect_log "ws: bar$"
+  expect_log "foo: bar"
 }
 
 function test_run_under_label_with_options() {

--- a/src/test/shell/integration/run_test.sh
+++ b/src/test/shell/integration/run_test.sh
@@ -265,7 +265,7 @@ function test_envs_attr() {
 sh_binary(
     name = "testing",
     srcs = ["test.sh"],
-    envs = {"FOO", "bar"},
+    envs = {"FOO" : "bar"},
 )
 EOF
   cat > some/testing/test.sh <<'EOF'

--- a/src/test/shell/integration/run_test.sh
+++ b/src/test/shell/integration/run_test.sh
@@ -259,6 +259,25 @@ EOF
   rm -rf x
 }
 
+function test_envs_attr() {
+  mkdir -p some/testing
+  cat > some/testing/BUILD <<'EOF'
+sh_binary(
+    name = "testing",
+    srcs = ["test.sh"],
+    envs = {"FOO", "bar"},
+)
+EOF
+  cat > some/testing/test.sh <<'EOF'
+#!/usr/bin/env bash
+echo "foo: $FOO"
+EOF
+  chmod +x some/testing/test.sh
+
+  bazel run //some/testing >$TEST_log || fail "Expected success"
+  expect_log "foo: bar"
+}
+
 # Test for $(location) in args list of sh_binary
 function test_location_in_args() {
   mkdir -p some/testing


### PR DESCRIPTION
Addresses #7364

`envs` is a `string_dict` attribute common for all *_binary and *_test rules. Bazel will set the environment variables specified in `envs` in the run/test environment before executing the given target. Variables specified in `--test_env` and `--action_env` will take priority over the `envs` attribute, and the `envs` attribute does not support bringing in environment values from the invocation environment.

Given the large impact of this change, I expect a lot of feedback. I thought it would be good to get this PR out early to get the discussion going.