### PR TITLE
Keeping `windows/dll` example simple.

### DIFF
--- a/examples/windows/dll/BUILD
+++ b/examples/windows/dll/BUILD
@@ -5,22 +5,16 @@ filegroup(
 )
 
 cc_library(
-    name = "hello-library-header",
-    hdrs = ["hello-library.h"],
-)
-
-cc_binary(
-    name = "hellolib.dll",
+    name = "hellolib",
     srcs = [
         "hello-library.cpp",
+    ],
+    hdrs = [
+        "hello-library.h",
     ],
     # Define COMPILING_DLL to export symbols during compiling the DLL.
     # See hello-library.h
     copts = ["/DCOMPILING_DLL"],
-    linkshared = 1,
-    deps = [
-        ":hello-library-header",
-    ],
 )
 
 # **Explicitly link to hellolib.dll**
@@ -31,39 +25,17 @@ cc_binary(
     srcs = [
         "hello_world-load-dll-at-runtime.cpp",
     ],
-    data = [":hellolib.dll"],
+    data = [":hellolib"],
 )
 
 # **Implicitly link to hellolib.dll**
 
-# Get the import library for hellolib.dll
-filegroup(
-    name = "hello_lib_import_lib",
-    srcs = [":hellolib.dll"],
-    output_group = "interface_library",
-)
-
-# Because we cannot directly depend on cc_binary from other cc rules in deps attribute,
-# we use cc_import as a bridge to depend on hellolib.dll
-cc_import(
-    name = "hellolib_dll_import",
-    interface_library = ":hello_lib_import_lib",
-    shared_library = ":hellolib.dll",
-)
-
-# Create a new cc_library to also include the headers needed for hellolib.dll
-cc_library(
-    name = "hellolib_dll",
-    deps = [
-        ":hello-library-header",
-        ":hellolib_dll_import",
-    ],
-)
-
+# Consume hellolib as a dependency in shared way.
 cc_binary(
     name = "hello_world-link-to-dll-via-lib",
     srcs = [
         "hello_world-link-to-dll-via-lib.cpp",
     ],
-    deps = [":hellolib_dll"],
+    deps = [":hellolib"],
+    linkstatic = 0,
 )


### PR DESCRIPTION
I wonder, is there any explanation why `windows/dll` example is so complicated?

This patch covers the same use cases as the original and also does not mention `.dll` extension (which is kinda cross-platform).