### PR TITLE
Windows: add --incompatible_windows_native_test_wrapper

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -33,6 +33,7 @@ import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDefinition;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
+import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingException;
 import com.google.devtools.common.options.TriState;
@@ -211,7 +212,7 @@ public class TestConfiguration extends Fragment {
     public Label coverageReportGenerator;
 
     @Option(
-        name = "experimental_windows_native_test_wrapper",
+        name = "incompatible_windows_native_test_wrapper",
         // Design:
         // https://github.com/laszlocsomor/proposals/blob/win-test-runner/designs/2018-07-18-windows-native-test-runner.md
         documentationCategory = OptionDocumentationCategory.TESTING,
@@ -220,6 +221,10 @@ public class TestConfiguration extends Fragment {
         effectTags = {
           OptionEffectTag.LOADING_AND_ANALYSIS,
           OptionEffectTag.TEST_RUNNER,
+        },
+        metadataTags = {
+          OptionMetadataTag.INCOMPATIBLE_CHANGE,
+          OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES,
         },
         defaultValue = "false",
         help =

--- a/src/test/py/bazel/test_wrapper_test.py
+++ b/src/test/py/bazel/test_wrapper_test.py
@@ -558,7 +558,7 @@ class TestWrapperTest(test_base.TestBase):
 
   def testTestExecutionWithTestSetupSh(self):
     self._CreateMockWorkspace()
-    flag = '--noexperimental_windows_native_test_wrapper'
+    flag = '--noincompatible_windows_native_test_wrapper'
     self._AssertPassingTest(flag)
     self._AssertFailingTest(flag)
     self._AssertPrintingTest(flag)
@@ -596,7 +596,7 @@ class TestWrapperTest(test_base.TestBase):
 
   def testTestExecutionWithTestWrapperExe(self):
     self._CreateMockWorkspace()
-    flag = '--experimental_windows_native_test_wrapper'
+    flag = '--incompatible_windows_native_test_wrapper'
     self._AssertPassingTest(flag)
     self._AssertFailingTest(flag)
     self._AssertPrintingTest(flag)


### PR DESCRIPTION
Add the --incompatible_windows_native_test_wrapper
flag (default: false). This flag has no effect on
platforms other than Windows.

When using `bazel test`, Bazel does not execute
tests directly. Instead Bazel runs a "test
wrapper" as a subprocess, which sets up the
environment for the test and runs the test.

By default, Bazel uses a Bash script
(`@bazel_tools//tools/test:test-setup.sh`) as the
test wrapper, on all platforms. The new flag
allows using an alternative test wrapper written
in C++ that does not depend on Bash.

Flag semantics:
- When true: Bazel uses the C++ test wrapper from
  `@bazel_tools//tools/test:tw`. This test wrapper
  does not depend on Bash.
- When false: Bazel uses the Bash script test
  wrapper also used on every other platform, from
  `@bazel_tools//tools/test:test-setup.sh`. This
  script requires Bash.

Incompatible flag: https://github.com/bazelbuild/bazel/issues/6622

Related: https://github.com/bazelbuild/bazel/issues/5508

RELNOTES[NEW]: Added --incompatible_windows_native_test_wrapper flag: enables using the Bash-less test wrapper on Windows. (No-op on other platforms.)