### PR TITLE
Flip --incompatible_windows_escape_jvm_flags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -643,7 +643,7 @@ public class JavaOptions extends FragmentOptions {
 
   @Option(
       name = "incompatible_windows_escape_jvm_flags",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {
         OptionEffectTag.ACTION_COMMAND_LINES,


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/bazel/issues/7486

RELNOTES[INC]: Flip --incompatible_windows_escape_jvm_flags to true. See https://github.com/bazelbuild/bazel/issues/7486