### PR TITLE
remote: significantly speed up remote unit tests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
@@ -84,7 +84,7 @@ public class RemoteRetrier extends Retrier {
   }
 
   @VisibleForTesting
-  RemoteRetrier(
+  public RemoteRetrier(
       Supplier<Backoff> backoff,
       Predicate<? super Exception> shouldRetry,
       ListeningScheduledExecutorService retryScheduler,

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -38,8 +38,10 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.AbstractRemoteActionCache.UploadManifest;
+import com.google.devtools.build.lib.remote.RemoteRetrier.ExponentialBackoff;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.DigestUtil.ActionKey;
+import com.google.devtools.build.lib.remote.util.TestUtils;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -48,6 +50,7 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import com.google.devtools.common.options.Options;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
@@ -667,9 +670,9 @@ public class AbstractRemoteActionCacheTests {
   }
 
   private DefaultRemoteActionCache newTestCache() {
-    RemoteOptions options = new RemoteOptions();
-    RemoteRetrier retrier =
-        new RemoteRetrier(options, (e) -> false, retryService, Retrier.ALLOW_ALL_CALLS);
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    RemoteRetrier retrier = TestUtils.newRemoteRetrier(() -> new ExponentialBackoff(options),
+        (e) -> false, retryService);
     return new DefaultRemoteActionCache(options, digestUtil, retrier);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.ByteStreamUploaderTest.FixedBackoff;
 import com.google.devtools.build.lib.remote.ByteStreamUploaderTest.MaybeFailOnceUploadService;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.remote.util.TestUtils;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
@@ -136,9 +137,8 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     }
     serviceRegistry.addService(new MaybeFailOnceUploadService(blobsByHash));
 
-    RemoteRetrier retrier =
-        new RemoteRetrier(
-            () -> new FixedBackoff(1, 0), (e) -> true, retryService, Retrier.ALLOW_ALL_CALLS);
+    RemoteRetrier retrier = TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0),
+        (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channel);
     ByteStreamUploader uploader =
         new ByteStreamUploader("instance", refCntChannel, null, 3, retrier);
@@ -226,8 +226,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     });
 
     RemoteRetrier retrier =
-        new RemoteRetrier(
-            () -> new FixedBackoff(1, 0), (e) -> true, retryService, Retrier.ALLOW_ALL_CALLS);
+        TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channel);
     ByteStreamUploader uploader =
         new ByteStreamUploader("instance", refCntChannel, null, 3, retrier);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteServerCapabilitiesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteServerCapabilitiesTest.java
@@ -30,6 +30,8 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.authandtls.GoogleAuthUtils;
+import com.google.devtools.build.lib.remote.RemoteRetrier.ExponentialBackoff;
+import com.google.devtools.build.lib.remote.util.TestUtils;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.common.options.Options;
 import io.grpc.CallCredentials;
@@ -134,12 +136,9 @@ public class RemoteServerCapabilitiesTest {
             new RequestHeadersValidator()));
 
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
-    RemoteRetrier retrier =
-        new RemoteRetrier(
-            remoteOptions,
-            RemoteRetrier.RETRIABLE_GRPC_ERRORS,
-            retryService,
-            Retrier.ALLOW_ALL_CALLS);
+    RemoteRetrier retrier = TestUtils.newRemoteRetrier(() -> new ExponentialBackoff(remoteOptions),
+        RemoteRetrier.RETRIABLE_GRPC_ERRORS,
+        retryService);
     ReferenceCountedChannel channel =
         new ReferenceCountedChannel(
             InProcessChannelBuilder.forName(fakeServerName).directExecutor().build());

--- a/src/test/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCacheTest.java
@@ -99,7 +99,8 @@ public class SimpleBlobStoreActionCacheTest {
                 },
             (e) -> false,
             retryService,
-            RemoteRetrier.ALLOW_ALL_CALLS);
+            RemoteRetrier.ALLOW_ALL_CALLS,
+            (millis) -> {});
     Path stdout = fs.getPath("/tmp/stdout");
     Path stderr = fs.getPath("/tmp/stderr");
     FileSystemUtils.createDirectoryAndParents(stdout.getParentDirectory());

--- a/src/test/java/com/google/devtools/build/lib/remote/util/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/BUILD
@@ -15,6 +15,7 @@ java_library(
     srcs = glob(["*.java"]),
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/remote",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//third_party:guava",
         "//third_party/protobuf:protobuf_java",

--- a/src/test/java/com/google/devtools/build/lib/remote/util/TestUtils.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/TestUtils.java
@@ -1,0 +1,148 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.util;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableScheduledFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.devtools.build.lib.remote.RemoteRetrier;
+import com.google.devtools.build.lib.remote.Retrier;
+import com.google.devtools.build.lib.remote.Retrier.Backoff;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public class TestUtils {
+
+  public static RemoteRetrier newRemoteRetrier(Supplier<Backoff> backoff,
+      Predicate<? super Exception> shouldRetry, ListeningScheduledExecutorService retryScheduler) {
+    ZeroDelayListeningScheduledExecutorService zeroDelayRetryScheduler =
+        new ZeroDelayListeningScheduledExecutorService(retryScheduler);
+    return new RemoteRetrier(backoff, shouldRetry, zeroDelayRetryScheduler, Retrier.ALLOW_ALL_CALLS,
+        (millis) -> { /* don't wait in tests */ });
+  }
+
+  /**
+   * Wraps around a {@link ListeningScheduledExecutorService} and schedules all tasks with zero
+   * delay.
+   */
+  private static class ZeroDelayListeningScheduledExecutorService
+      implements ListeningScheduledExecutorService {
+
+    private final ListeningScheduledExecutorService delegate;
+
+    ZeroDelayListeningScheduledExecutorService(ListeningScheduledExecutorService delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public ListenableScheduledFuture<?> schedule(Runnable runnable, long l, TimeUnit timeUnit) {
+      return delegate.schedule(runnable, 0, timeUnit);
+    }
+
+    @Override
+    public <V> ListenableScheduledFuture<V> schedule(Callable<V> callable, long l,
+        TimeUnit timeUnit) {
+      return delegate.schedule(callable, 0, timeUnit);
+    }
+
+    @Override
+    public ListenableScheduledFuture<?> scheduleAtFixedRate(Runnable runnable, long l, long l1,
+        TimeUnit timeUnit) {
+      return delegate.scheduleAtFixedRate(runnable, 0, 0, timeUnit);
+    }
+
+    @Override
+    public ListenableScheduledFuture<?> scheduleWithFixedDelay(Runnable runnable, long l, long l1,
+        TimeUnit timeUnit) {
+      return delegate.scheduleWithFixedDelay(runnable, 0, 0, timeUnit);
+    }
+
+    @Override
+    public void shutdown() {
+      delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+      return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> ListenableFuture<T> submit(Callable<T> callable) {
+      return delegate.submit(callable);
+    }
+
+    @Override
+    public ListenableFuture<?> submit(Runnable runnable) {
+      return delegate.submit(runnable);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+        throws InterruptedException {
+      return delegate.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
+        TimeUnit unit) throws InterruptedException {
+      return delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+        throws InterruptedException, ExecutionException {
+      return delegate.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+        throws InterruptedException, ExecutionException, TimeoutException {
+      return delegate.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> ListenableFuture<T> submit(Runnable runnable, T t) {
+      return delegate.submit(runnable, t);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+      delegate.execute(command);
+    }
+  }
+
+}


### PR DESCRIPTION
Never actually sleep() during retries in tests.
//src/test/j/c/g/d/b/lib/remote:remote runtime improves from 59s to 7s.

Progress towards #7530.

fyi @werkt 