### PR TITLE
Support changing the working directory of repository_ctx.execute

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/SkylarkRepositoryContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/SkylarkRepositoryContextApi.java
@@ -230,14 +230,22 @@ public interface SkylarkRepositoryContextApi<RepositoryFunctionExceptionT extend
             defaultValue = "True",
             named = true,
             doc = "If stdout and stderr should be printed to the terminal."),
+        @Param(
+            name = "working_directory",
+            type = String.class,
+            defaultValue = "\"\"",
+            named = true,
+            doc = "Working directory for command execution.\n"
+                + "Can be relative to the repository root or absolute."),
       })
   public SkylarkExecutionResultApi execute(
       SkylarkList<Object> arguments,
       Integer timeout,
       SkylarkDict<String, String> environment,
       boolean quiet,
+      String workingDirectory,
       Location location)
-      throws EvalException, RepositoryFunctionExceptionT;
+      throws EvalException, RepositoryFunctionExceptionT, InterruptedException;
 
   @SkylarkCallable(
       name = "which",

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
@@ -33,7 +33,7 @@ import java.nio.file.Path;
  */
 public class RepoWithRuleWritingTextGenerator {
 
-  private static final String HELPER_FILE = "helper.bzl";
+  static final String HELPER_FILE = "helper.bzl";
   static final String RULE_NAME = "write_to_file";
   static final String HELLO = "HELLO";
   static final String TARGET = "write_text";

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
@@ -34,12 +34,12 @@ import java.nio.file.Path;
 public class RepoWithRuleWritingTextGenerator {
 
   private static final String HELPER_FILE = "helper.bzl";
-  private static final String RULE_NAME = "write_to_file";
+  static final String RULE_NAME = "write_to_file";
   static final String HELLO = "HELLO";
   static final String TARGET = "write_text";
   static final String OUT_FILE = "out";
 
-  private static final String WRITE_TEXT_TO_FILE =
+  static final String WRITE_TEXT_TO_FILE =
       "def _impl(ctx):\n"
           + "  out = ctx.actions.declare_file(ctx.attr.filename)\n"
           + "  ctx.actions.write(out, ctx.attr.text)\n"

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
@@ -82,7 +82,7 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
 
   @Test
   public void testExecuteInWorkingDirectory() throws Exception {
-    String pwd = isWindows() ? "['echo', '%%cd%%']" : "['pwd']";
+    String pwd = isWindows() ? "['echo', '%cd%']" : "['pwd']";
     String buildFileText = "\"\"\"" + String.join("\n",
         RepoWithRuleWritingTextGenerator.loadRule("@main"),
         RepoWithRuleWritingTextGenerator.callRule("debug_me", "out", "%s")) +"\"\"\" % stdout";

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
@@ -82,7 +82,7 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
 
   @Test
   public void testExecuteInWorkingDirectory() throws Exception {
-    String pwd = isWindows() ? "['echo', '%cd%']" : "['pwd']";
+    String pwd = isWindows() ? "['cmd', '/c', '\"echo %cd%\"']" : "['pwd']";
     String buildFileText = "\"\"\"" + String.join("\n",
         RepoWithRuleWritingTextGenerator.loadRule("@main"),
         RepoWithRuleWritingTextGenerator.callRule("debug_me", "out", "%s")) +"\"\"\" % stdout";

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
@@ -14,11 +14,15 @@
 
 package com.google.devtools.build.lib.blackbox.tests.workspace;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.devtools.build.lib.blackbox.framework.BuilderRunner;
 import com.google.devtools.build.lib.blackbox.framework.PathUtils;
 import com.google.devtools.build.lib.blackbox.junit.AbstractBlackBoxTest;
 import com.google.devtools.build.lib.util.OS;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.Test;
 
 /** End to end test of workspace-related functionality. */
@@ -68,10 +72,71 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
 
     BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     // The build using "bash" should fail on Windows, and pass on Linux and Mac OS
-    if (OS.WINDOWS.equals(OS.getCurrent())) {
+    if (isWindows()) {
       bazel.shouldFail();
     }
     bazel.build("check");
+  }
+  //echo %cd%
+
+  @Test
+  public void testExecuteInWorkingDirectory() throws Exception {
+    String pwd = isWindows() ? "echo %cd%" : "pwd";
+    String ruleName = RepoWithRuleWritingTextGenerator.RULE_NAME;
+    String buildFileText = String.format(
+        "\"\"\"load('@main//:rule.bzl', '%s')\n%s(name = 'debug_me', text = '%%s')\"\"\" %% stdout",
+        ruleName, ruleName);
+    context().write("repo_rule.bzl",
+        "def _impl(rctx):",
+        String.format("  result = rctx.execute(['%s'], working_directory = rctx.attr.working_directory)", pwd),
+        "  if result.return_code != 0:",
+        "    fail('Execute failed: ' + result.stderr)",
+        // we want to compare the real paths,
+        // otherwise it is not clear how to verify the relative path variant
+        "  wd = str(rctx.path(rctx.attr.working_directory))",
+        // pwd returns the path with '\n' in the end of the line; cut it
+        "  stdout = result.stdout.strip(' \\n\\r')",
+        "  if wd != stdout:",
+        "    fail('Wrong current directory: **%s**, expecting **%s**' % (stdout, wd))",
+        // create BUILD file with a target so we can call it;
+        // rule of a target is defined in the main repository
+        "  rctx.file('BUILD', " + buildFileText + ")",
+        "check_wd = repository_rule(implementation = _impl,",
+        "  attrs = { 'working_directory': attr.string() }",
+        ")");
+
+    context().write("rule.bzl", RepoWithRuleWritingTextGenerator.WRITE_TEXT_TO_FILE);
+    context().write("BUILD");
+
+    Path tempDirectory = Files.createTempDirectory("temp-execute");
+    context().write(WORKSPACE,
+        "workspace(name = 'main')",
+        "load(':repo_rule.bzl', 'check_wd')",
+        "check_wd(name = 'relative', working_directory = 'relative')",
+        "check_wd(name = 'relative2', working_directory = '../relative2')",
+        String.format("check_wd(name = 'absolute', working_directory = '%s')",
+            tempDirectory.toString()),
+        String.format("check_wd(name = 'absolute2', working_directory = '%s')",
+            tempDirectory.resolve("non_existent_child").toString())
+        );
+
+    BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
+    bazel.build("@relative//:debug_me");
+    Path outFile = context().resolveBinPath(bazel, "external/relative/out");
+    assertThat(outFile.toFile().exists()).isTrue();
+    List<String> lines = PathUtils.readFile(outFile);
+    assertThat(lines.size()).isEqualTo(1);
+    assertThat(lines.get(0)).endsWith("external/relative/relative");
+
+    bazel.build("@relative2//:debug_me");
+    bazel.build("@absolute//:debug_me");
+
+    bazel.build("@absolute2//:debug_me");
+    Path outFile2 = context().resolveBinPath(bazel, "external/absolute2/out");
+    assertThat(outFile2.toFile().exists()).isTrue();
+    List<String> lines2 = PathUtils.readFile(outFile2);
+    assertThat(lines2.size()).isEqualTo(1);
+    assertThat(lines2.get(0)).isEqualTo(tempDirectory.resolve("non_existent_child").toString());
   }
 
   @Test
@@ -113,6 +178,9 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
     bazel.help();
   }
 
+  private boolean isWindows() {
+    return OS.WINDOWS.equals(OS.getCurrent());
+  }
   // TODO(ichern) move other tests from workspace_test.sh here.
 
 }

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
@@ -82,7 +82,7 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
 
   @Test
   public void testExecuteInWorkingDirectory() throws Exception {
-    String pwd = isWindows() ? "['cmd', '/c', '\"echo %cd%\"']" : "['pwd']";
+    String pwd = isWindows() ? "['cmd', '/c', 'echo %cd%']" : "['pwd']";
     String buildFileText = "\"\"\"" + String.join("\n",
         RepoWithRuleWritingTextGenerator.loadRule("@main"),
         RepoWithRuleWritingTextGenerator.callRule("debug_me", "out", "%s")) +"\"\"\" % stdout";

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
@@ -96,7 +96,7 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
         // otherwise it is not clear how to verify the relative path variant
         "  wd = str(rctx.path(rctx.attr.working_directory))",
         // pwd returns the path with '\n' in the end of the line; cut it
-        "  stdout = result.stdout.strip(' \\n\\r')",
+        "  stdout = result.stdout.strip(' \\n\\r').replace('\\\\', '/')",
         "  if wd != stdout:",
         "    fail('Wrong current directory: **%s**, expecting **%s**' % (stdout, wd))",
         // create BUILD file with a target so we can call it;


### PR DESCRIPTION
Fixes #4207.

As I am working on making bundled repository rule msys-independent, I see that this feature would really help me.
It is also needed, for instance, for running 'npm install' in the user's directory, so we really need to allow absolute paths here (at least those outside the external repository directory).