### PR TITLE
Allow for empty value in --remote_http_cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
@@ -91,6 +91,6 @@ public final class SimpleBlobStoreFactory {
   }
 
   static boolean isRestUrlOptions(RemoteOptions options) {
-    return options.remoteHttpCache != null;
+    return options.remoteHttpCache != null && !options.remoteHttpCache.isEmpty();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactoryTest.java
@@ -1,0 +1,48 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.devtools.common.options.Options;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link SimpleBlobStoreFactory}. */
+@RunWith(JUnit4.class)
+public class SimpleBlobStoreFactoryTest {
+  private RemoteOptions remoteOptions;
+
+  @Before
+  public final void setUp() throws Exception {
+    remoteOptions = Options.getDefaults(RemoteOptions.class);
+  }
+
+  @Test
+  public void testIsRemoteCacheOptions() throws Exception {
+    assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isFalse();
+
+    remoteOptions.remoteHttpCache = "";
+    assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isFalse();
+
+    remoteOptions.remoteHttpCache = "http://127.0.0.1";
+    assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isTrue();
+
+    remoteOptions.remoteHttpCache = null;
+    assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isFalse();
+  }
+}


### PR DESCRIPTION
In the current bazel version attempt to disable a remote HTTP caching
set in environment is not possible. Attempt to use --remote_http_cache=
result in a NullPointerException.
This commit handles option value empty string in the same way as if
not set at all.
Also added a simple test.

This will fix the problem reported in
https://github.com/bazelbuild/bazel/issues/6719
and my request in
https://groups.google.com/forum/#!topic/bazel-dev/xDNvAbYtkkI