### PR TITLE
Add missing fastbuild feature to Linux crosstool

### DIFF
--- a/tools/cpp/cc_toolchain_config.bzl.tpl
+++ b/tools/cpp/cc_toolchain_config.bzl.tpl
@@ -1517,6 +1517,8 @@ def _impl(ctx):
 
     dbg_feature = feature(name = "dbg")
 
+    fastbuild_feature = feature(name = "fastbuild")
+
     opt_feature = feature(name = "opt")
 
     sysroot_feature = feature(
@@ -1628,6 +1630,7 @@ def _impl(ctx):
         fdo_optimize_feature,
         supports_dynamic_linker_feature,
         dbg_feature,
+        fastbuild_feature,
         opt_feature,
         user_compile_flags_feature,
         sysroot_feature,


### PR DESCRIPTION
Without this rules that attempt to check if the configuration is fastbuild will get a false negative.