### PR TITLE
Fix validateDirectPrerequisiteFileTypes should not throw if prerequis…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -1873,6 +1873,9 @@ public final class RuleContext extends TargetContext
               "'" + prerequisite.getTarget().getLabel() + "' must produce a single file");
           return;
         }
+        if (Iterables.size(artifacts) == 0) {
+          return;
+        }
         for (Artifact sourceArtifact : artifacts) {
           if (allowedFileTypes.apply(sourceArtifact.getFilename())) {
             return;


### PR DESCRIPTION
…ite is empty

Closes https://github.com/bazelbuild/bazel/issues/1431