### PR TITLE
Add prefetchInputs calls to native Actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionInputPrefetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionInputPrefetcher.java
@@ -15,21 +15,16 @@ package com.google.devtools.build.lib.actions;
 
 import java.io.IOException;
 
-/** Prefetches files to local disk. */
+/** Supports prefetching of action inputs. */
 public interface ActionInputPrefetcher {
-  public static final ActionInputPrefetcher NONE =
-      new ActionInputPrefetcher() {
-        @Override
-        public void prefetchFiles(
-            Iterable<? extends ActionInput> inputs, MetadataProvider metadataProvider) {
-          // Do nothing.
-        }
-      };
+  ActionInputPrefetcher NONE = (inputs, metadataProvider) -> { /* Do nothing. */ };
 
   /**
-   * Initiates best-effort prefetching of all given inputs. This should not block.
+   * Prefetches input files to local disk.
    *
-   * <p>For any path not under this prefetcher's control, the call should be a no-op.
+   * <p>After this method returns all files under this prefetcher's control must be available
+   * via the local filesystem. For any path not under this prefetcher's control, the call should be
+   * a no-op.
    */
   void prefetchFiles(Iterable<? extends ActionInput> inputs, MetadataProvider metadataProvider)
       throws IOException, InterruptedException;

--- a/src/main/java/com/google/devtools/build/lib/actions/Actions.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Actions.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.vfs.OsPathPolicy;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -367,6 +368,22 @@ public final class Actions {
 
     public ImmutableList<ActionAnalysisMetadata> getActions() {
       return actions;
+    }
+  }
+
+  /**
+   * Utility method to prefetch action inputs that turns any {@link IOException} into an
+   * {@link ActionExecutionException}.
+   */
+  public static void prefetchInputs(Iterable<? extends ActionInput> inputs,
+      ActionExecutionContext actionExecutionContext, Action action) throws ActionExecutionException,
+      InterruptedException {
+    try {
+      actionExecutionContext
+          .getActionInputPrefetcher()
+          .prefetchFiles(inputs, actionExecutionContext.getMetadataProvider());
+    } catch (IOException e) {
+      throw new ActionExecutionException("Failed to (pre)fetch remote input files.", e, action, false);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/AbstractFileWriteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/AbstractFileWriteAction.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionException;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.ActionResult;
+import com.google.devtools.build.lib.actions.Actions;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.EnvironmentalExecException;
 import com.google.devtools.build.lib.actions.ExecException;
@@ -28,6 +29,7 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Collections;
 
 /**
  * Abstract Action to write to a file.
@@ -59,6 +61,7 @@ public abstract class AbstractFileWriteAction extends AbstractAction {
   @Override
   public final ActionResult execute(ActionExecutionContext actionExecutionContext)
       throws ActionExecutionException, InterruptedException {
+    Actions.prefetchInputs(getInputs(), actionExecutionContext, this);
     ActionResult actionResult;
     try {
       DeterministicWriter deterministicWriter;

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkAction.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.actions.ActionExecutionException;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.ActionResult;
+import com.google.devtools.build.lib.actions.Actions;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec.VisibleForSerialization;
@@ -162,7 +163,9 @@ public final class SymlinkAction extends AbstractAction {
 
   @Override
   public ActionResult execute(ActionExecutionContext actionExecutionContext)
-      throws ActionExecutionException {
+      throws ActionExecutionException, InterruptedException {
+    Actions.prefetchInputs(ImmutableList.of(getPrimaryInput()), actionExecutionContext,
+        this);
     maybeVerifyTargetIsExecutable(actionExecutionContext);
 
     Path srcPath;

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/TemplateExpansionAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/TemplateExpansionAction.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.actions.ActionExecutionException;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.ActionResult;
+import com.google.devtools.build.lib.actions.Actions;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.ExecException;
@@ -127,6 +128,7 @@ public final class TemplateExpansionAction extends AbstractAction {
   @Override
   public final ActionResult execute(ActionExecutionContext actionExecutionContext)
       throws ActionExecutionException, InterruptedException {
+    Actions.prefetchInputs(getInputs(), actionExecutionContext, this);
     TemplateExpansionContext expansionContext =
         actionExecutionContext.getContext(TemplateExpansionContext.class);
     try {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/SolibSymlinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/SolibSymlinkAction.java
@@ -62,7 +62,9 @@ public final class SolibSymlinkAction extends AbstractAction {
 
   @Override
   public ActionResult execute(ActionExecutionContext actionExecutionContext)
-      throws ActionExecutionException {
+      throws ActionExecutionException, InterruptedException {
+    Actions.prefetchInputs(ImmutableList.of(getPrimaryInput()), actionExecutionContext, this);
+
     Path mangledPath = actionExecutionContext.getInputPath(symlink);
     try {
       mangledPath.createSymbolicLink(actionExecutionContext.getInputPath(getPrimaryInput()));


### PR DESCRIPTION
Some actions in Bazel are implemented in Java and only ever
run inside the Bazel process and never remotely. However,
these actions can have files as inputs that were generated
on a remote system and with #6862 are not stored in the
output base.

I audited these actions manually and added prefetch calls
to the few native actions that didn't have them already.

Progress towards #6862