### PR TITLE
Windows: Bash is no longer required for everything

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1546,7 +1546,7 @@ int Main(int argc, const char *argv[], WorkspaceLayout *workspace_layout,
   // Must be done before command line parsing.
   // ParseOptions already populate --client_env, so detect bash before it
   // happens.
-  DetectBashOrDie();
+  DetectBashAndExportBazelSh();
 #endif  // if defined(_WIN32) || defined(__CYGWIN__)
 
   globals->binary_path = CheckAndGetBinaryPath(argv[0]);

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1546,7 +1546,7 @@ int Main(int argc, const char *argv[], WorkspaceLayout *workspace_layout,
   // Must be done before command line parsing.
   // ParseOptions already populate --client_env, so detect bash before it
   // happens.
-  DetectBashAndExportBazelSh();
+  (void) DetectBashAndExportBazelSh();
 #endif  // if defined(_WIN32) || defined(__CYGWIN__)
 
   globals->binary_path = CheckAndGetBinaryPath(argv[0]);

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -263,7 +263,7 @@ bool UnlimitResources();
 bool UnlimitCoredumps();
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-void DetectBashAndExportBazelSh();
+std::string DetectBashAndExportBazelSh();
 #endif  // if defined(_WIN32) || defined(__CYGWIN__)
 
 // This function has no effect on Unix platforms.

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -263,8 +263,7 @@ bool UnlimitResources();
 bool UnlimitCoredumps();
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-std::string DetectBashAndExportBazelSh();
-void DetectBashOrDie();
+void DetectBashAndExportBazelSh();
 #endif  // if defined(_WIN32) || defined(__CYGWIN__)
 
 // This function has no effect on Unix platforms.

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -1457,7 +1457,7 @@ static string LocateBashMaybe() {
   return msys_bash.empty() ? GetBinaryFromPath("bash.exe") : msys_bash;
 }
 
-void DetectBashAndExportBazelSh() {
+string DetectBashAndExportBazelSh() {
   string bash = blaze::GetEnv("BAZEL_SH");
   if (!bash.empty()) {
     return bash;
@@ -1476,6 +1476,8 @@ void DetectBashAndExportBazelSh() {
     // Set process environment variable.
     blaze::SetEnv("BAZEL_SH", bash);
   }
+
+  return bash;
 }
 
 void EnsurePythonPathOption(std::vector<string>* options) {


### PR DESCRIPTION
Bazel no longer reports an error if it fails to
locate Bash. This allows "bazel info release" to
work even in absence of Bash.

To clarify, Bazel still requires Bash to build
rules that depend on Bash. This PR simply removes
the fatal error Bazel used to display if Bash was
missing even when Bash was not required.

Fixes https://github.com/bazelbuild/bazel/issues/6462