### PR TITLE
Update cc-toolchain-config.md

### DIFF
--- a/site/docs/tutorial/cc-toolchain-config.md
+++ b/site/docs/tutorial/cc-toolchain-config.md
@@ -570,16 +570,16 @@ using an older release of Bazel, look for the "Configuring CROSSTOOL" tutorial.
              flag_sets = [
                  flag_set(
                      actions = [
-                         "ACTION_NAMES.assemble",
-                         "ACTION_NAMES.preprocess_assemble",
-                         "ACTION_NAMES.linkstamp_compile",
-                         "ACTION_NAMES.c_compile",
-                         "ACTION_NAMES.cpp_compile",
-                         "ACTION_NAMES.cpp_header_parsing",
-                         "ACTION_NAMES.cpp_module_compile",
-                         "ACTION_NAMES.cpp_module_codegen",
-                         "ACTION_NAMES.lto_backend",
-                         "ACTION_NAMES.clif_match",
+                         ACTION_NAMES.assemble,
+                         ACTION_NAMES.preprocess_assemble,
+                         ACTION_NAMES.linkstamp_compile,
+                         ACTION_NAMES.c_compile,
+                         ACTION_NAMES.cpp_compile,
+                         ACTION_NAMES.cpp_header_parsing,
+                         ACTION_NAMES.cpp_module_compile,
+                         ACTION_NAMES.cpp_module_codegen,
+                         ACTION_NAMES.lto_backend,
+                         ACTION_NAMES.clif_match,
                      ],
                      flag_groups = [
                          flag_group(


### PR DESCRIPTION
I had all sorts of trouble following this tutorial. Where the include flags where not being passed to the cpp_header_parsing action. This resulted a number of 'undeclared inclusion' errors. I ended up looking through the implementations [here](https://github.com/bazelbuild/bazel-toolchains/blob/2c2d36ef0b59756c6b27be3b381c23e3489473fc/configs/ubuntu16_04_clang/8.0.0/bazel_0.23.0/cc/cc_toolchain_config.bzl). I found that none of the implementations that bazel uses did not have quotes around the action names. I changed this in my toolchain config rule and was able to compile successfully.