### PR TITLE
Handle multiple VC++ tools from VS2017

### DIFF
--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -65,17 +65,19 @@ To build C++ targets, you need:
         [known issue](https://github.com/bazelbuild/bazel/issues/3949),
         please upgrade your VS 2017 to the latest version.
 
-*   The `BAZEL_VS` or `BAZEL_VC` environment variable. (They are *not* the same!)
+*   The `BAZEL_VS` , `BAZEL_VC` and `BAZEL_VC_TOOL` environment variable. (They are *not* the same!)
 
     Bazel tries to locate the C++ compiler the first time you build any
-    target. To tell Bazel where the compiler is, you can set one of the
+    target. To tell Bazel where the compiler is, we provide the
     following environment variables:
 
     *   `BAZEL_VS` storing the Visual Studio installation directory
 
     *   `BAZEL_VC` storing the Visual C++ Build Tools installation directory
 
-    Setting one of these variables is enough. For example:
+    *   `BAZEL_VC_TOOL` storing the Visual C++ tools directory (directory with ```cl.exe```)
+
+    For Visual Studio 2015 or older, setting one of `BAZEL_VC` or `BAZEL_VS` is enough. For example:
 
     ```
     set BAZEL_VS=C:\Program Files (x86)\Microsoft Visual Studio 14.0
@@ -90,7 +92,9 @@ To build C++ targets, you need:
     The first command sets the path to Visual Studio (BAZEL\_V<b>S</b>), the other
     sets the path to Visual C++ (BAZEL\_V<b>C</b>).
 
-    For Visual Studio 2017, with a default install, instead you might want
+    For Visual Studio 2017, you might have ambiguity with VC++ version.
+    In case if you have more than one VC++ version installed you also need
+    to set `BAZEL_VC_TOOL` to tell Bazel which version of VC++ you would like to use.
 
     ```
     set BAZEL_VS=C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools
@@ -101,6 +105,20 @@ To build C++ targets, you need:
      ```
     set BAZEL_VC=C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC
     ```
+
+    and (to specify exact VC++ version)
+
+     ```
+    set BAZEL_VC_TOOL=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\bin\Hostx64\x64
+    ```
+
+    The last command sets the path to Visual C++ tools.
+
+    If you have multiple VC++ versions installed, but you did not set `BAZEL_VC_TOOL` bazel will use latest VC++ version.
+
+    If you set `BAZEL_VC_TOOL` but you did not set any of `BAZEL_VS` or `BAZEL_VS` bazel will only search
+    for Visual C++ directory based on path provided in `BAZEL_VC_TOOL`
+    and will not check for register keys or any other directories.
 
 *   The [Windows
     SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk).

--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -73,6 +73,7 @@ cc_autoconf = repository_rule(
         "BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN",
         "BAZEL_USE_LLVM_NATIVE_COVERAGE",
         "BAZEL_VC",
+        "BAZEL_VC_TOOL",
         "BAZEL_VS",
         "BAZEL_LLVM",
         "USE_CLANG_CL",

--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -225,7 +225,7 @@ def setup_vc_env_vars(repository_ctx, vc_path):
 def find_msvc_tool(repository_ctx, vc_path, tool):
     """Find the exact path of a specific build tool in MSVC. Doesn't %-escape the result."""
     if "BAZEL_CV_TOOL" in repository_ctx.os.environ:
-        return repository_ctx.os.environp["BAZEL_CV_TOOL"] + "\\" + tool
+        return repository_ctx.os.environ["BAZEL_CV_TOOL"] + "\\" + tool
 
     tool_path = ""
     if _is_vs_2017(vc_path):

--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -224,7 +224,7 @@ def setup_vc_env_vars(repository_ctx, vc_path):
 
 def find_msvc_tool(repository_ctx, vc_path, tool):
     """Find the exact path of a specific build tool in MSVC. Doesn't %-escape the result."""
-    if "BAZEL_CV_TOOL" in repository_ctx.os.environ
+    if "BAZEL_CV_TOOL" in repository_ctx.os.environ:
         return repository_ctx.os.environp["BAZEL_CV_TOOL"] + "\\" + tool
 
     tool_path = ""

--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -224,8 +224,8 @@ def setup_vc_env_vars(repository_ctx, vc_path):
 
 def find_msvc_tool(repository_ctx, vc_path, tool):
     """Find the exact path of a specific build tool in MSVC. Doesn't %-escape the result."""
-    if "BAZEL_CV_TOOL" in repository_ctx.os.environ:
-        return repository_ctx.os.environ["BAZEL_CV_TOOL"] + "\\" + tool
+    if "BAZEL_VC_TOOL" in repository_ctx.os.environ:
+        return repository_ctx.os.environ["BAZEL_VC_TOOL"] + "\\" + tool
 
     tool_path = ""
     if _is_vs_2017(vc_path):
@@ -238,9 +238,9 @@ def find_msvc_tool(repository_ctx, vc_path, tool):
         # but we might have number of subdirs.
         # Each directory represents different VC++ version. We'd like to select latest one if possible.
         vc_version_paths = sorted([str(path) for path in dirs], key=repository_ctx.path.basename, reverse=True)
-        vc_tool_paths =  [vc_ver_path + "\\bin\\HostX64\\x64\\" + tool for vc_ver_path in vc_version_paths]
+        vc_tool_paths = [vc_ver_path + "\\bin\\HostX64\\x64\\" + tool for vc_ver_path in vc_version_paths]
         # VC tools should exist in the directory with the newest version,
-        # bbut iterate every directory to be more robust. (from newest to oldest)
+        # but iterate every directory to be more robust. (from newest to oldest)
         for path in vc_tool_paths:
             if repository_ctx.path(path).exists:
                 tool_path = path

--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -243,6 +243,7 @@ def find_msvc_tool(repository_ctx, vc_path, tool):
         # bbut iterate every directory to be more robust. (from newest to oldest)
         for path in vc_tool_paths:
             if repository_ctx.path(path).exists:
+                tool_path = path
                 break
     else:
         # For VS 2015 and older version, the tools are under:


### PR DESCRIPTION
Visual Studio 2017 can store multiple version of VC++ tools.
They all exist in same directory, default location is `C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC`
As an example, the following versions of VC++ can be installed simultaneously:
```
14.11.25503
14.12.25827
14.13.26020
14.13.26128
14.14.26405
14.14.26428
14.15.26706
14.15.26726
14.16.27023
```
Every update of VC++ will produce new directory. It might be a case when you need to use two or more different VC++ tools.  Currently there is no way to specify which VC++ tool bazel should use. The only option we have(rather than making costume toolchain) is BAZEL_VC and BAZEL_VS, but these options can only provide Visual Studio version, not compiler version. Even more, the current behavior looks invalid. Bazel just gets random VC++ version and use it. It can lead to extremely unobvious issues (you potentially can use different compilers on different `bazel build` runs).

To provide more predictable and flexible behavior I have added **`BAZEL_VC_TOOL`** setting. Using this environment variable developer is able to specify exact version of VC++(directory where right `cl.exe` exists). 
`$env:BAZEL_VC_TOOL="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.15.26726\bin\HostX64\x64"`

With only this option set it will automatically detect `%VC_PATH%` based on path provided. If any of `BAZEL_VC` or `BAZEL_VS` are set it will use locations provided in corresponding variables. Basically three variables together allow to change VC++ compiler without renaming/moving directories and without creating your own toolchain.

In addition to this option I have modified existing VC++-tool search strategy. Now it will always search for the latest version. Sometimes it can be unacceptable either, but definitely better than random choice. 