### PR TITLE
Use BUILD.pkg instead of BUILD-new.pkg

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -265,7 +265,7 @@ EOF
   link_children "${PWD}" tools "${BAZEL_TOOLS_REPO}"
 
   # The BUILD file needed for @remote_java_tools.
-  link_file "${PWD}/third_party/java/java_tools/BUILD-new.pkg" "${BAZEL_TOOLS_REPO}/tools/jdk/BUILD.pkg"
+  link_file "${PWD}/third_party/java/java_tools/BUILD.pkg" "${BAZEL_TOOLS_REPO}/tools/jdk/BUILD.pkg"
 
   # Set up @bazel_tools//platforms properly
   mkdir -p ${BAZEL_TOOLS_REPO}/platforms

--- a/src/create_embedded_tools.py
+++ b/src/create_embedded_tools.py
@@ -35,7 +35,7 @@ output_paths = [
      lambda x: 'tools/cpp/runfiles/' + os.path.basename(x)[len('generated_'):]),
     ('*jarjar_command_deploy.jar',
      lambda x: 'tools/jdk/jarjar_command_deploy.jar'),
-    ('*BUILD-new.pkg', lambda x: 'tools/jdk/BUILD.pkg'),
+    ('*BUILD.pkg', lambda x: 'tools/jdk/BUILD.pkg'),
     ('*BUILD.javalangtools', lambda x: 'third_party/java/jdk/langtools/BUILD'),
     ('*singlejar_local.exe', lambda x: 'tools/jdk/singlejar/singlejar.exe'),
     ('*singlejar_local', lambda x: 'tools/jdk/singlejar/singlejar'),

--- a/third_party/java/java_tools/BUILD-new.pkg
+++ b/third_party/java/java_tools/BUILD-new.pkg
@@ -66,4 +66,3 @@ filegroup(
     name = "java_compiler_jar",
     srcs = ["java_tools/java_compiler.jar"],
 )
-

--- a/third_party/java/java_tools/BUILD.pkg
+++ b/third_party/java/java_tools/BUILD.pkg
@@ -4,66 +4,65 @@ licenses(["notice"])  # Apache 2.0
 
 filegroup(
     name = "ExperimentalRunner",
-    srcs = ["ExperimentalRunner_deploy.jar"],
+    srcs = ["java_tools/ExperimentalRunner_deploy.jar"],
 )
 
 filegroup(
     name = "GenClass",
-    srcs = ["GenClass_deploy.jar"],
+    srcs = ["java_tools/GenClass_deploy.jar"],
 )
 
 filegroup(
     name = "JacocoCoverage",
-    srcs = ["JacocoCoverage_jarjar_deploy.jar"],
+    srcs = ["java_tools/JacocoCoverage_jarjar_deploy.jar"],
 )
 
 filegroup(
     name = "JavaBuilder",
-    srcs = ["JavaBuilder_deploy.jar"],
+    srcs = ["java_tools/JavaBuilder_deploy.jar"],
 )
 
 filegroup(
     name = "Runner",
-    srcs = ["Runner_deploy.jar"],
+    srcs = ["java_tools/Runner_deploy.jar"],
 )
 
 filegroup(
     name = "VanillaJavaBuilder",
-    srcs = ["VanillaJavaBuilder_deploy.jar"],
+    srcs = ["java_tools/VanillaJavaBuilder_deploy.jar"],
 )
 
 filegroup(
     name = "SingleJar",
-    srcs = ["bazel-singlejar_deploy.jar"],
+    srcs = ["java_tools/bazel-singlejar_deploy.jar"],
 )
 
 filegroup(
     name = "JarJar",
-    srcs = ["jarjar_command_deploy.jar"],
+    srcs = ["java_tools/jarjar_command_deploy.jar"],
 )
 
 filegroup(
     name = "Turbine",
-    srcs = ["turbine_deploy.jar"],
+    srcs = ["java_tools/turbine_deploy.jar"],
 )
 
 filegroup(
     name = "TurbineDirect",
-    srcs = ["turbine_direct_binary_deploy.jar"],
+    srcs = ["java_tools/turbine_direct_binary_deploy.jar"],
 )
 
 filegroup(
     name = "javac_jar",
-    srcs = ["javac-9+181-r4173-1.jar"],
+    srcs = ["java_tools/javac-9+181-r4173-1.jar"],
 )
 
 filegroup(
     name = "jdk_compiler_jar",
-    srcs = ["jdk_compiler.jar"],
+    srcs = ["java_tools/jdk_compiler.jar"],
 )
 
 filegroup(
     name = "java_compiler_jar",
-    srcs = ["java_compiler.jar"],
+    srcs = ["java_tools/java_compiler.jar"],
 )
-


### PR DESCRIPTION
`BUILD-new.pkg` was added as an intermediate BUILD.pkg file in order to facilitate a new data structure in the remote tools archive. It is not longer needed.

Progress on #6316.