### PR TITLE
Windows, JNI library: fix with WIN32_LEAN_AND_MEAN

### DIFF
--- a/src/main/native/windows/file-jni.cc
+++ b/src/main/native/windows/file-jni.cc
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 
 #include <windows.h>
 

--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #include <stdint.h>  // uint8_t
 #include <windows.h>
+#include <WinIoCtl.h>
 
 #include <memory>
 #include <sstream>

--- a/src/main/native/windows/jni-util.cc
+++ b/src/main/native/windows/jni-util.cc
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+
 #include <windows.h>
 
 #include <algorithm>

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 
 #include <wchar.h>
 #include <windows.h>


### PR DESCRIPTION
Bazel's JNI library can now be compiled with
`--copt=-DWIN32_LEAN_AND_MEAN`.