### PR TITLE
Add note about limitation of JAVA_HOME paths

### DIFF
--- a/site/docs/install-windows.md
+++ b/site/docs/install-windows.md
@@ -40,7 +40,10 @@ title: Installing Bazel on Windows
         Example: `c:\msys64\usr\bin\bash.exe`
     1.  **Add `JAVA_HOME`** (if you will build **Java** code). Its value must be
         the directory where you installed the Java JDK 8, for example
-        `C:\Program Files\Java\jdk1.8.0_152`
+        `C:\Program Files\Java\jdk1.8.0_152`. In order to use this with the
+        default local_jdk javabase, it must be installed on a volume which
+        Windows considers to be **local**, network mounted filesystems will not
+        work.
 
     **None of these paths should contain spaces or non-ASCII characters.**
 


### PR DESCRIPTION
Because bazel uses junction points to connect @local_jdk to JAVA_HOME,
and Windows does not support junction points referencing remote
filesystems, it is currently necessary to install Java on a "local"
filesystem.

Using remote_jdk is a partial workaround, but that's more complex and
doesn't belong in this document.