### PR TITLE
Windows, Bazel client: clean up path_platform.h

### DIFF
--- a/src/main/cpp/util/path.h
+++ b/src/main/cpp/util/path.h
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include "src/main/cpp/util/path_platform.h"
+
 namespace blaze_util {
 
 // Returns the part of the path before the final "/".  If there is a single

--- a/src/main/cpp/util/path_platform.h
+++ b/src/main/cpp/util/path_platform.h
@@ -83,71 +83,58 @@ std::pair<std::wstring, std::wstring> SplitPathW(const std::wstring &path);
 
 bool IsRootDirectoryW(const std::wstring &path);
 
-namespace testing {
-
 bool TestOnly_NormalizeWindowsPath(const std::string &path,
                                    std::string *result);
 
-}
+// Converts 'path' to Windows style.
+//
+// 'path' is UTF-8 encoded, absolute or relative or current-drive-relative (e.g.
+// "\foo"), non-normalized, possibly using slash as separator. If it starts with
+// the UNC prefix, the function won't process it further, just copies it to
+// 'result'.
+//
+// 'result' is UTF-8 encoded, normalized, using backslash as separator.
+bool AsWindowsPath(const std::string &path, std::string *result,
+                   std::string *error);
 
-// Converts a UTF8-encoded `path` to a normalized, widechar Windows path.
+// Converts 'path' to Windows style.
 //
-// Returns true if conversion succeeded and sets the contents of `result` to it.
-//
-// The input `path` may be an absolute or relative Windows path.
-//
-// The returned path is normalized (see NormalizeWindowsPath).
-//
-// If `path` had a "\\?\" prefix then the function assumes it's already Windows
-// style and converts it to wstring without any alterations.
-// Otherwise `path` is normalized and converted to a Windows path and the result
-// won't have a "\\?\" prefix even if it's longer than MAX_PATH (adding the
-// prefix is the caller's responsibility).
-//
-// The method recognizes current-drive-relative Windows paths ("\foo") turning
-// them into absolute paths ("c:\foo").
+// Same as the other AsWindowsPath methods, but 'path' is UTF-8 encoded and
+// 'result' is widechar.
 bool AsWindowsPath(const std::string &path, std::wstring *result,
                    std::string *error);
 
-template <typename char_type>
-bool AsWindowsPath(const std::basic_string<char_type> &path,
-                   std::basic_string<char_type> *result, std::string *error);
+// Converts 'path' to Windows style.
+//
+// Same as the other AsWindowsPath methods, but 'path' and 'result' are
+// widechar.
+bool AsWindowsPath(const std::wstring &path, std::wstring *result,
+                   std::string *error);
 
-template <typename char_type>
-bool AsWindowsPath(const char_type *path, std::basic_string<char_type> *result,
-                   std::string *error) {
-  return AsWindowsPath(std::basic_string<char_type>(path), result, error);
-}
+// Converts 'path' to absolute, Windows-style path.
+//
+// Same as AsWindowsPath, but 'result' is always absolute and always has a UNC
+// prefix.
+bool AsAbsoluteWindowsPath(const std::string& path, std::wstring *result,
+                           std::string *error);
 
-template <typename char_type>
-bool AsAbsoluteWindowsPath(const std::basic_string<char_type> &path,
-                           std::wstring *result, std::string *error);
+// Converts 'path' to absolute, Windows-style path.
+//
+// Same as AsWindowsPath, but 'result' is always absolute and always has a UNC
+// prefix.
+bool AsAbsoluteWindowsPath(const std::wstring& path, std::wstring *result,
+                           std::string *error);
 
-template <typename char_type>
-bool AsAbsoluteWindowsPath(const char_type *path, std::wstring *result,
-                           std::string *error) {
-  return AsAbsoluteWindowsPath(std::basic_string<char_type>(path), result,
-                               error);
-}
-
-// Explicit instantiate AsAbsoluteWindowsPath for char and wchar_t.
-template bool AsAbsoluteWindowsPath<char>(const char *, std::wstring *,
-                                          std::string *);
-template bool AsAbsoluteWindowsPath<wchar_t>(const wchar_t *, std::wstring *,
-                                             std::string *);
-
-// Same as `AsWindowsPath`, but returns a lowercase 8dot3 style shortened path.
-// Result will never have a UNC prefix, nor a trailing "/" or "\".
-// Works also for non-existent paths; shortens as much of them as it can.
-// Also works for non-existent drives.
+// Converts 'path' to absolute, shortened, Windows-style path.
+//
+// Same as `AsWindowsPath`, but 'result' is always absolute, lowercase,
+// 8dot3-style shortened path, without trailing backslash and without UNC
+// prefix.
+//
+// Works even for non-existent paths (and non-existent drives), shortening the
+// existing segments and leaving the rest unshortened.
 bool AsShortWindowsPath(const std::string &path, std::string *result,
                         std::string *error);
-
-template <typename char_type>
-bool IsPathSeparator(char_type ch);
-
-template <typename char_type>
-bool HasDriveSpecifierPrefix(const char_type *ch);
 
 #endif  // defined(_WIN32) || defined(__CYGWIN__)
 }  // namespace blaze_util

--- a/src/main/cpp/util/path_windows.cc
+++ b/src/main/cpp/util/path_windows.cc
@@ -65,7 +65,7 @@ std::string ConvertPath(const std::string& path) {
   // The path may not be Windows-style and may not be normalized, so convert it.
   std::string converted_path;
   std::string error;
-  if (!blaze_util::AsWindowsPath(path, &converted_path, &error)) {
+  if (!AsWindowsPath(path, &converted_path, &error)) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "ConvertPath(" << path << "): AsWindowsPath failed: " << error;
   }
@@ -372,8 +372,9 @@ static bool NormalizeWindowsPath(const std::basic_string<char_type>& path,
 }
 
 template <typename char_type>
-bool AsWindowsPath(const std::basic_string<char_type>& path,
-                   std::basic_string<char_type>* result, std::string* error) {
+static bool AsWindowsPathImpl(
+    const std::basic_string<char_type>& path,
+    std::basic_string<char_type>* result, std::string* error) {
   if (path.empty()) {
     result->clear();
     return true;
@@ -428,20 +429,23 @@ bool AsWindowsPath(const std::basic_string<char_type>& path,
   return true;
 }
 
-bool AsWindowsPath(const std::string& path, std::wstring* result,
-                   std::string* error) {
-  std::string normalized_win_path;
-  if (!AsWindowsPath(path, &normalized_win_path, error)) {
-    return false;
-  }
-
-  result->assign(CstringToWstring(normalized_win_path.c_str()).get());
-  return true;
+bool AsWindowsPath(const std::string &path, std::string *result,
+                   std::string *error) {
+  return AsWindowsPathImpl(path, result, error);
 }
 
-template <typename char_type>
-bool AsAbsoluteWindowsPath(const std::basic_string<char_type>& path,
-                           std::wstring* result, std::string* error) {
+bool AsWindowsPath(const std::string& path, std::wstring* result,
+                   std::string* error) {
+  return AsWindowsPathImpl(std::wstring(CstringToWstring(path.c_str()).get()), result, error);
+}
+
+bool AsWindowsPath(const std::wstring &path, std::wstring *result,
+                   std::string *error) {
+  return AsWindowsPathImpl(path, result, error);
+}
+
+static bool AsAbsoluteWindowsPathImpl(
+    const std::wstring& path, std::wstring* result, std::string* error) {
   if (path.empty()) {
     result->clear();
     return true;
@@ -464,6 +468,17 @@ bool AsAbsoluteWindowsPath(const std::basic_string<char_type>& path,
     *result = std::wstring(L"\\\\?\\") + *result;
   }
   return true;
+}
+
+bool AsAbsoluteWindowsPath(const std::string& path, std::wstring* result,
+                           std::string* error) {
+  return AsAbsoluteWindowsPathImpl(CstringToWstring(path.c_str()).get(), result,
+                                   error);
+}
+
+bool AsAbsoluteWindowsPath(const std::wstring& path, std::wstring* result,
+                           std::string* error) {
+  return AsAbsoluteWindowsPathImpl(path, result, error);
 }
 
 bool AsShortWindowsPath(const std::string& path, std::string* result,
@@ -573,13 +588,9 @@ static char GetCurrentDrive() {
   return 'a' + wdrive - offset;
 }
 
-namespace testing {
-
 bool TestOnly_NormalizeWindowsPath(const std::string& path,
                                    std::string* result) {
   return NormalizeWindowsPath(path, result);
 }
-
-}  // namespace testing
 
 }  // namespace blaze_util

--- a/src/test/cpp/util/path_windows_test.cc
+++ b/src/test/cpp/util/path_windows_test.cc
@@ -44,8 +44,7 @@ TEST(PathWindowsTest, TestNormalizeWindowsPath) {
 #define ASSERT_NORMALIZE(x, y)                                           \
   {                                                                      \
     std::string result;                                                  \
-    EXPECT_TRUE(                                                         \
-        blaze_util::testing::TestOnly_NormalizeWindowsPath(x, &result)); \
+    EXPECT_TRUE(blaze_util::TestOnly_NormalizeWindowsPath(x, &result));  \
     EXPECT_EQ(result, y);                                                \
   }
 


### PR DESCRIPTION
In this commit:
- path.h now includes path_platform.h
- cleaned up the messy declarations of
  AsWindowsPath and AsAbsoluteWindowsPath, and
  updated their comments