### PR TITLE
Add --incompatible_use_specific_tool_files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppSemantics.java
@@ -22,7 +22,10 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.rules.cpp.AspectLegalCppSemantics;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.FeatureConfiguration;
+import com.google.devtools.build.lib.rules.cpp.CcToolchainProvider;
+import com.google.devtools.build.lib.rules.cpp.CppActionNames;
 import com.google.devtools.build.lib.rules.cpp.CppCompileActionBuilder;
+import com.google.devtools.build.lib.rules.cpp.CppConfiguration;
 import com.google.devtools.build.lib.rules.cpp.CppConfiguration.HeadersCheckingMode;
 import com.google.devtools.build.lib.rules.cpp.IncludeProcessing;
 import com.google.devtools.build.lib.rules.cpp.NoProcessing;
@@ -43,10 +46,14 @@ public class BazelCppSemantics implements AspectLegalCppSemantics {
       BuildConfiguration configuration,
       FeatureConfiguration featureConfiguration,
       CppCompileActionBuilder actionBuilder) {
+    CcToolchainProvider toolchain = actionBuilder.getToolchain();
     actionBuilder
-        // Because Bazel does not support include scanning, we need the entire crosstool filegroup,
-        // including header files, as opposed to just the "compile" filegroup.
-        .addTransitiveMandatoryInputs(actionBuilder.getToolchain().getAllFiles())
+        .addTransitiveMandatoryInputs(
+            configuration.getFragment(CppConfiguration.class).useSpecificToolFiles()
+                ? (actionBuilder.getActionName().equals(CppActionNames.ASSEMBLE)
+                    ? toolchain.getAsFiles()
+                    : toolchain.getCompilerFiles())
+                : toolchain.getAllFiles())
         .setShouldScanIncludes(false);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
@@ -622,12 +622,11 @@ public final class CcLinkingHelper {
       throws RuleErrorException, InterruptedException {
     Artifact linkedArtifact = getLinkedArtifact(linkTargetTypeUsedForNaming);
     CppLinkAction action =
-        newLinkActionBuilder(linkedArtifact)
+        newLinkActionBuilder(linkedArtifact, linkTargetTypeUsedForNaming)
             .addObjectFiles(ccOutputs.getObjectFiles(usePic))
             .addNonCodeInputs(nonCodeLinkerInputs)
             .addLtoCompilationContext(ccOutputs.getLtoCompilationContext())
             .setUsePicForLtoBackendActions(usePic)
-            .setLinkType(linkTargetTypeUsedForNaming)
             .setLinkingMode(LinkingMode.STATIC)
             .addActionInputs(linkActionInputs)
             .setLibraryIdentifier(libraryIdentifier)
@@ -679,14 +678,13 @@ public final class CcLinkingHelper {
     }
 
     CppLinkActionBuilder dynamicLinkActionBuilder =
-        newLinkActionBuilder(linkerOutput)
+        newLinkActionBuilder(linkerOutput, dynamicLinkType)
             .setWholeArchive(wholeArchive)
             .setNativeDeps(nativeDeps)
             .setAdditionalLinkstampDefines(additionalLinkstampDefines.build())
             .setInterfaceOutput(soInterface)
             .addNonCodeInputs(ccOutputs.getHeaderTokenFiles())
             .addLtoCompilationContext(ccOutputs.getLtoCompilationContext())
-            .setLinkType(dynamicLinkType)
             .setLinkingMode(linkingMode)
             .setFake(fake)
             .addActionInputs(linkActionInputs)
@@ -823,7 +821,8 @@ public final class CcLinkingHelper {
     return hasBuiltDynamicLibrary;
   }
 
-  private CppLinkActionBuilder newLinkActionBuilder(Artifact outputArtifact) {
+  private CppLinkActionBuilder newLinkActionBuilder(
+      Artifact outputArtifact, LinkTargetType linkType) {
     return new CppLinkActionBuilder(
             ruleErrorConsumer,
             actionConstructionContext,
@@ -837,7 +836,12 @@ public final class CcLinkingHelper {
         .setGrepIncludes(grepIncludes)
         .setIsStampingEnabled(isStampingEnabled)
         .setTestOrTestOnlyTarget(isTestOrTestOnlyTarget)
-        .setLinkerFiles(ccToolchain.getLinkerFiles())
+        .setLinkType(linkType)
+        .setLinkerFiles(
+            (cppConfiguration.useSpecificToolFiles()
+                    && linkType.linkerOrArchiver() == LinkerOrArchiver.ARCHIVER)
+                ? ccToolchain.getArFiles()
+                : ccToolchain.getLinkerFiles())
         .setLinkArtifactFactory(linkArtifactFactory)
         .setUseTestOnlyFlags(useTestOnlyFlags);
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileActionBuilder.java
@@ -160,7 +160,7 @@ public class CppCompileActionBuilder {
     return mandatoryInputsBuilder.build();
   }
 
-  private String getActionName() {
+  public String getActionName() {
     if (actionName != null) {
       return actionName;
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -665,4 +665,8 @@ public final class CppConfiguration extends BuildConfiguration.Fragment
   public boolean useStandaloneLtoIndexingCommandLines() {
     return cppOptions.useStandaloneLtoIndexingCommandLines;
   }
+
+  public boolean useSpecificToolFiles() {
+    return cppOptions.useSpecificToolFiles;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -864,6 +864,22 @@ public class CppOptions extends FragmentOptions {
       help = "Save the state of enabled and requested feautres as an output of compilation.")
   public boolean saveFeatureState;
 
+  @Option(
+      name = "incompatible_use_specific_tool_files",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+      metadataTags = {
+        OptionMetadataTag.INCOMPATIBLE_CHANGE,
+        OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+      },
+      help =
+          "Use cc toolchain's compiler_files, as_files, and ar_files as inputs to appropriate "
+              + "actions. "
+              + "See https://github.com/bazelbuild/bazel/issues/6927 and "
+              + "https://github.com/bazelbuild/bazel/issues/6928.")
+  public boolean useSpecificToolFiles;
+
   @Override
   public FragmentOptions getHost() {
     CppOptions host = (CppOptions) getDefault();
@@ -918,6 +934,7 @@ public class CppOptions extends FragmentOptions {
     host.dontEnableHostNonhost = dontEnableHostNonhost;
     host.requireCtxInConfigureFeatures = requireCtxInConfigureFeatures;
     host.useStandaloneLtoIndexingCommandLines = useStandaloneLtoIndexingCommandLines;
+    host.useSpecificToolFiles = useSpecificToolFiles;
 
     // Save host options for further use.
     host.hostCoptList = hostCoptList;


### PR DESCRIPTION
This option makes
1. C++ compilation actions include only the toolchain's compiler_files artifacts as inputs not all_files.
2. Non-preprocessed assembler actions include only the toolchain's as_files artifacts as inputs not all_files.
3. Archiver link actions include the toolchain's ar_files artifacts as inputs rather than linker_files.

See #6927 and #6928.