### PR TITLE
Completely remove Spawn from SymlinkTreeHelper.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -1397,6 +1397,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/shell",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs",

--- a/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SymlinkTreeHelperTest.java
@@ -18,12 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
-import com.google.devtools.build.lib.actions.ActionInput;
-import com.google.devtools.build.lib.actions.ActionInputHelper;
-import com.google.devtools.build.lib.actions.ExecutionRequirements;
-import com.google.devtools.build.lib.actions.Spawn;
-import com.google.devtools.build.lib.exec.util.FakeOwner;
+import com.google.devtools.build.lib.shell.Command;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
@@ -38,32 +33,19 @@ public final class SymlinkTreeHelperTest {
 
   @Test
   public void checkCreatedSpawn() {
-    ActionExecutionMetadata owner = new FakeOwner("SymlinkTree", "Creating it");
     Path execRoot = fs.getPath("/my/workspace");
     Path inputManifestPath = execRoot.getRelative("input_manifest");
-    ActionInput inputManifest = ActionInputHelper.fromPath(inputManifestPath.asFragment());
     BinTools binTools =
         BinTools.forUnitTesting(execRoot, ImmutableList.of(SymlinkTreeHelper.BUILD_RUNFILES));
-    Spawn spawn =
-        new SymlinkTreeHelper(
-            inputManifestPath,
-            fs.getPath("/my/workspace/output/MANIFEST"),
-            false)
-        .createSpawn(
-            owner,
-            execRoot,
-            binTools,
-            ImmutableMap.of(),
-            inputManifest);
-    assertThat(spawn.getResourceOwner()).isSameAs(owner);
-    assertThat(spawn.getEnvironment()).isEmpty();
-    assertThat(spawn.getExecutionInfo()).containsExactly(
-        ExecutionRequirements.LOCAL, "",
-        ExecutionRequirements.NO_CACHE, "",
-        ExecutionRequirements.NO_SANDBOX, "");
-    assertThat(spawn.getInputFiles())
-        .containsExactly(inputManifest, binTools.getActionInput(SymlinkTreeHelper.BUILD_RUNFILES));
-    // At this time, the spawn does not declare any output files.
-    assertThat(spawn.getOutputFiles()).isEmpty();
+    Command command =
+        new SymlinkTreeHelper(inputManifestPath, execRoot.getRelative("output/MANIFEST"), false)
+            .createCommand(execRoot, binTools, ImmutableMap.of());
+    assertThat(command.getEnvironmentVariables()).isEmpty();
+    assertThat(command.getWorkingDirectory()).isEqualTo(execRoot.getPathFile());
+    String[] commandLine = command.getCommandLineElements();
+    assertThat(commandLine).hasLength(3);
+    assertThat(commandLine[0]).endsWith(SymlinkTreeHelper.BUILD_RUNFILES);
+    assertThat(commandLine[1]).isEqualTo("input_manifest");
+    assertThat(commandLine[2]).isEqualTo("output/MANIFEST");
   }
 }


### PR DESCRIPTION
e854c86bde5af363e03b87dcf46e629dce694c17 removed Spawn from the production path of SymlinkTreeHelper, but left SymlinkTreeHelper.createSpawn, presumably for the unit test. Change the unit test check the Command that SymlinkTreeHelper generates.