### PR TITLE
Unbundle all_android_tools_deploy.jar from embedded tools and save 11MB from the final binary size

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -327,6 +327,10 @@ public class BazelRuleClassProvider {
           try {
             builder.addWorkspaceFilePrefix(
                 ResourceFileLoader.loadResource(BazelAndroidSemantics.class, "android.WORKSPACE"));
+            builder.addWorkspaceFileSuffix(
+                ResourceFileLoader.loadResource(
+                    BazelAndroidSemantics.class,
+                    "android_remote_tools.WORKSPACE"));
           } catch (IOException e) {
             throw new IllegalStateException(e);
           }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -1,8 +1,15 @@
-load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
+# load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-java_import_external(
-    name = "remote_all_android_tools",
-    jar_urls = ["https://storage.googleapis.com/bazel-android-mirror/all_android_tools_deploy.jar"],
-    jar_sha256 = "806152c1801df848af7f6f55f824299f819b61e8b9b55ed4cf3d3e0850c432eb",
+# java_import_external(
+#     name = "remote_all_android_tools",
+#     jar_urls = ["https://storage.googleapis.com/bazel-android-mirror/all_android_tools_deploy.jar"],
+#     jar_sha256 = "806152c1801df848af7f6f55f824299f819b61e8b9b55ed4cf3d3e0850c432eb",
+# )
+
+http_archive(
+    name = "legacy_android_tools",
+    url = "https://github.com/jin/legacy_android_tools/archive/54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip",
+    strip_prefix = "legacy_android_tools-54eefc6aa7bf4c171fecb7b6022282c277a3824c",
+    sha256 = "c4cd965983b22272d20f5038f6fd8d143d344fac1bb638d765ec7f62e652486f",
 )
-

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -1,0 +1,8 @@
+load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
+
+java_import_external(
+    name = "remote_all_android_tools",
+    jar_urls = ["https://storage.googleapis.com/bazel-android-mirror/all_android_tools_deploy.jar"],
+    jar_sha256 = "806152c1801df848af7f6f55f824299f819b61e8b9b55ed4cf3d3e0850c432eb",
+)
+

--- a/src/tools/android/java/com/google/devtools/build/android/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/BUILD
@@ -6,7 +6,6 @@ filegroup(
     name = "embedded_tools",
     srcs = [
         "BUILD.tools",
-        ":all_android_tools_deploy.jar",
         "//src/tools/android/java/com/google/devtools/build/android/desugar:embedded_tools",
         "//src/tools/android/java/com/google/devtools/build/android/desugar/scan:embedded_tools",
         "//src/tools/android/java/com/google/devtools/build/android/dexer:embedded_tools",

--- a/src/tools/android/java/com/google/devtools/build/android/BUILD.tools
+++ b/src/tools/android/java/com/google/devtools/build/android/BUILD.tools
@@ -1,12 +1,16 @@
 package(default_visibility = ["//visibility:public"])
 
-java_import(
+alias(
     name = "all_android_tools",
-    jars = ["all_android_tools_deploy.jar"],
+    actual = "@remote_all_android_tools//jar",
 )
 
 java_binary(
     name = "ResourceProcessorBusyBox",
+    data = select({
+        "//src/conditions:windows": ["//src/main/native/windows:windows_jni.dll"],
+        "//conditions:default": [],
+    }),
     jvm_flags = [
         # quiet warnings from com.google.protobuf.UnsafeUtil,
         # see: https://github.com/google/protobuf/issues/3781
@@ -14,10 +18,6 @@ java_binary(
         "--add-opens=java.base/java.nio=ALL-UNNAMED",
         "--add-opens=java.base/java.lang=ALL-UNNAMED",
     ],
-    data = select({
-        "//src/conditions:windows": ["//src/main/native/windows:windows_jni.dll"],
-        "//conditions:default": [],
-    }),
     main_class = "com.google.devtools.build.android.ResourceProcessorBusyBox",
     runtime_deps = [
         ":all_android_tools",
@@ -32,6 +32,6 @@ java_binary(
     jvm_flags = ["-Xmx1600m"],
     main_class = "com.google.devtools.build.android.ZipFilterAction",
     runtime_deps = [
-        ":all_android_tools"
+        ":all_android_tools",
     ],
 )

--- a/src/tools/android/java/com/google/devtools/build/android/BUILD.tools
+++ b/src/tools/android/java/com/google/devtools/build/android/BUILD.tools
@@ -1,8 +1,13 @@
 package(default_visibility = ["//visibility:public"])
 
-alias(
+#alias(
+#    name = "all_android_tools",
+#    actual = "@remote_all_android_tools//jar",
+#)
+
+java_import(
     name = "all_android_tools",
-    actual = "@remote_all_android_tools//jar",
+    jars = ["@legacy_android_tools//:all_android_tools_deploy.jar"],
 )
 
 java_binary(


### PR DESCRIPTION
TODO: Version the deploy jar and host it on the official Bazel mirror.

Before:

```
$ ls -lah bazel-bin/src/bazel
-r-xr-xr-x 1 jingwen primarygroup 100M Mar 14 21:45 bazel-bin/src/bazel
```

After:

```
$ ls -lah bazel-bin/src/bazel
-r-xr-xr-x 1 jingwen primarygroup 89M Mar 14 21:46 bazel-bin/src/bazel
```
