### PR TITLE
Report when a SymlinkTreeAction starts running.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeStrategy.java
@@ -18,6 +18,7 @@ import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionException;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionStrategy;
+import com.google.devtools.build.lib.actions.RunningActionEvent;
 import com.google.devtools.build.lib.analysis.actions.SymlinkTreeAction;
 import com.google.devtools.build.lib.analysis.actions.SymlinkTreeActionContext;
 import com.google.devtools.build.lib.profiler.AutoProfiler;
@@ -47,6 +48,7 @@ public final class SymlinkTreeStrategy implements SymlinkTreeActionContext {
       ImmutableMap<String, String> shellEnvironment,
       boolean enableRunfiles)
       throws ActionExecutionException, InterruptedException {
+    actionExecutionContext.getEventHandler().post(new RunningActionEvent(action, null));
     try (AutoProfiler p =
         AutoProfiler.logged(
             "running " + action.prettyPrint(), logger, /*minTimeForLoggingInMilliseconds=*/ 100)) {


### PR DESCRIPTION
Before, SymlinkTreeActions using SymlinkTreeStrategy hung in an indeterminate started-but-not-running state for their entire execution. Resolve this by posting a RunningActionEvent.