### PR TITLE
add mips64 support

### DIFF
--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -53,6 +53,12 @@ config_setting(
 )
 
 config_setting(
+    name = "mips64",
+    values = {"cpu": "mips64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "linux_aarch64",
     values = {"cpu": "aarch64"},
     visibility = ["//visibility:public"],

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
@@ -59,6 +59,8 @@ public class AutoCpuConverter implements Converter<String> {
               return "aarch64";
             case S390X:
               return "s390x";
+            case MIPS64:
+              return "mips64";
             default:
               return "unknown";
           }
@@ -96,6 +98,8 @@ public class AutoCpuConverter implements Converter<String> {
       return Pair.of(CPU.ARM, OS.LINUX);
     } else if (input.equals("s390x")) {
       return Pair.of(CPU.S390X, OS.LINUX);
+    } else if (input.equals("mips64")) {
+      return Pair.of(CPU.MIPS64, OS.LINUX);
     }
 
     // Use the auto-detected values.

--- a/src/main/java/com/google/devtools/build/lib/util/CPU.java
+++ b/src/main/java/com/google/devtools/build/lib/util/CPU.java
@@ -27,6 +27,7 @@ public enum CPU {
   ARM("arm", ImmutableSet.of("arm", "armv7l")),
   AARCH64("aarch64", ImmutableSet.of("aarch64")),
   S390X("s390x", ImmutableSet.of("s390x", "s390")),
+  MIPS64("mips64", ImmutableSet.of("mips64el", "mips64")),
   UNKNOWN("unknown", ImmutableSet.<String>of());
 
   private final String canonicalName;

--- a/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockCcSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockCcSupport.java
@@ -36,7 +36,7 @@ public final class BazelMockCcSupport extends MockCcSupport {
   private BazelMockCcSupport() {}
 
   private static final ImmutableList<String> CROSSTOOL_ARCHS =
-      ImmutableList.of("piii", "k8", "armeabi-v7a", "ppc");
+      ImmutableList.of("piii", "k8", "armeabi-v7a", "ppc", "mips64");
 
   protected static void createBasePackage(MockToolsConfig config) throws IOException {
     config.create(

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CrosstoolConfigurationHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CrosstoolConfigurationHelper.java
@@ -70,6 +70,8 @@ public class CrosstoolConfigurationHelper {
           return "arm";
         case S390X:
           return "s390x";
+        case MIPS64:
+          return "mips64";
         default:
           return "unknown";
       }


### PR DESCRIPTION
Bazel can work on mips platform. Please help to support mips64.