### PR TITLE
Remove @remote_java_tools from deps computed in embedded_tools_deps_test.

### DIFF
--- a/src/test/shell/bazel/embedded_tools_deps_test.sh
+++ b/src/test/shell/bazel/embedded_tools_deps_test.sh
@@ -41,7 +41,7 @@ fi
 # latter depends on the bazel binary used to run the test.
 # Sort the targets for a deterministic diffing experience.
 current_deps="${TEST_TMPDIR}/current_deps"
-grep -v "^@bazel_tools//" \
+grep -v "^@bazel_tools//\|^@remote_java_tools" \
   "${TEST_SRCDIR}/io_bazel/src/test/shell/bazel/embedded_tools_deps" \
   | sort >"${current_deps}"
 

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -133,12 +133,7 @@ EOF
 # This function copies the tools directory from Bazel.
 function copy_tools_directory() {
   cp -RL ${tools_dir}/* tools
-  # tools/jdk/BUILD file for JDK 7 is generated.
-  # Only works if there's 0 or 1 matches.
-  # If there are multiple, the test fails.
-  if [ -f tools/jdk/BUILD.* ]; then
-    cp tools/jdk/BUILD.* tools/jdk/BUILD
-  fi
+  
   if [ -f tools/jdk/BUILD ]; then
     chmod +w tools/jdk/BUILD
   fi


### PR DESCRIPTION
Also remove test hack for java 7 in testenv.sh. It's not necessary anymore.