### PR TITLE
Update cpp-use-cases.md

### DIFF
--- a/site/docs/cpp-use-cases.md
+++ b/site/docs/cpp-use-cases.md
@@ -217,13 +217,13 @@ cc_test(
     copts = ["-Iexternal/gtest/include"],
     deps = [
         "@gtest//:main",
-        "//lib:hello-greet",
+        "//main:hello-greet",
     ],
 )
 ```
 
 Note that in order to make `hello-greet` visible to `hello-test`, we have to add
-`"//test:__pkg__",` to the `visibility` attribute in `./lib/BUILD`.
+`"//test:__pkg__",` to the `visibility` attribute in `./main/BUILD`.
 
 Now you can use `bazel test` to run the test.
 


### PR DESCRIPTION
fix a bug in the doc, the target 'hello-greet' should be in package 'main', not in 'lib'