### PR TITLE
Move cc_flags target into @bazel_tools//tools/cpp.

### DIFF
--- a/tools/cpp/BUILD
+++ b/tools/cpp/BUILD
@@ -423,3 +423,9 @@ filegroup(
 load(":compiler_flag.bzl", "compiler_flag")
 
 compiler_flag(name = "compiler")
+
+# Target that can provide the CC_FLAGS variable based on the current
+# cc_toolchain.
+load("@bazel_tools//tools/cpp:cc_flags_supplier.bzl", "cc_flags_supplier")
+
+cc_flags_supplier(name = "cc_flags")

--- a/tools/cpp/BUILD.tpl
+++ b/tools/cpp/BUILD.tpl
@@ -119,9 +119,3 @@ toolchain(
     toolchain = ":cc-compiler-armabi-v7a",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
-
-# Target that can provide the CC_FLAGS variable based on the current
-# cc_toolchain.
-load("@bazel_tools//tools/cpp:cc_flags_supplier.bzl", "cc_flags_supplier")
-
-cc_flags_supplier(name = "cc_flags")


### PR DESCRIPTION
Part of #6867.