### PR TITLE
Implement a native file OutputStream for Unix.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/CompressedTarFunction.java
@@ -17,14 +17,14 @@ package com.google.devtools.build.lib.bazel.repository;
 import static com.google.devtools.build.lib.bazel.repository.StripPrefixedPath.maybeDeprefixSymlink;
 
 import com.google.common.base.Optional;
+import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue.Decompressor;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
+import java.io.OutputStream;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -81,8 +81,9 @@ public abstract class CompressedTarFunction implements Decompressor {
                   filename, descriptor.repositoryPath().getRelative(linkName));
             }
           } else {
-            Files.copy(
-                tarStream, filename.getPathFile().toPath(), StandardCopyOption.REPLACE_EXISTING);
+            try (OutputStream out = filename.getOutputStream()) {
+              ByteStreams.copy(tarStream, out);
+            }
             filename.chmod(entry.getMode());
 
             // This can only be done on real files, not links, or it will skip the reader to

--- a/src/main/java/com/google/devtools/build/lib/unix/NativePosixFiles.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/NativePosixFiles.java
@@ -461,4 +461,21 @@ public final class NativePosixFiles {
    *     a directory
    */
   public static native void deleteTreesBelow(String dir) throws IOException;
+
+  /**
+   * Open a file descriptor for writing.
+   *
+   * <p>This is a low level API. The caller is responsible for calling {@link close} on the returned
+   * file descriptor.
+   *
+   * @param path file to open
+   * @param append whether to open is append mode
+   */
+  public static native int openWrite(String path, boolean append) throws FileNotFoundException;
+
+  /** Write a segment of data to a file descriptor. */
+  public static native int write(int fd, byte[] data, int off, int len) throws IOException;
+
+  /** Close a file descriptor. */
+  public static native int close(int fd) throws IOException;
 }

--- a/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
@@ -29,7 +29,9 @@ import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Symlinks;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -429,6 +431,75 @@ public class UnixFileSystem extends AbstractFileSystemWithCustomStat {
         NativePosixFiles.deleteTreesBelow(dir.toString());
       } finally {
         profiler.logSimpleTask(startTime, ProfilerTask.VFS_DELETE, dir.toString());
+      }
+    }
+  }
+
+  @Override
+  protected OutputStream createFileOutputStream(Path path, boolean append)
+      throws FileNotFoundException {
+    final String name = path.toString();
+    if (profiler.isActive()
+        && (profiler.isProfiling(ProfilerTask.VFS_WRITE)
+            || profiler.isProfiling(ProfilerTask.VFS_OPEN))) {
+      long startTime = Profiler.nanoTimeMaybe();
+      try {
+        return new ProfiledNativeFileOutputStream(NativePosixFiles.openWrite(name, append), name);
+      } finally {
+        profiler.logSimpleTask(startTime, ProfilerTask.VFS_OPEN, name);
+      }
+    } else {
+      return new NativeFileOutputStream(NativePosixFiles.openWrite(name, append));
+    }
+  }
+
+  private static class NativeFileOutputStream extends OutputStream {
+    private final int fd;
+    private boolean closed = false;
+
+    NativeFileOutputStream(int fd) {
+      this.fd = fd;
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (!closed) {
+        closed = true;
+        NativePosixFiles.close(fd);
+      }
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      write(new byte[] {(byte) (b & 0xFF)});
+    }
+
+    @Override
+    public void write(byte b[]) throws IOException {
+      write(b, 0, b.length);
+    }
+
+    @Override
+    public void write(byte b[], int off, int len) throws IOException {
+      NativePosixFiles.write(fd, b, off, len);
+    }
+  }
+
+  private static final class ProfiledNativeFileOutputStream extends NativeFileOutputStream {
+    private final String name;
+
+    public ProfiledNativeFileOutputStream(int fd, String name) throws FileNotFoundException {
+      super(fd);
+      this.name = name;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      long startTime = Profiler.nanoTimeMaybe();
+      try {
+        super.write(b, off, len);
+      } finally {
+        profiler.logSimpleTask(startTime, ProfilerTask.VFS_WRITE, name);
       }
     }
   }

--- a/src/main/native/unix_jni.cc
+++ b/src/main/native/unix_jni.cc
@@ -1129,6 +1129,72 @@ Java_com_google_devtools_build_lib_unix_NativePosixFiles_lgetxattr(JNIEnv *env,
   return ::getxattr_common(env, path, name, ::portable_lgetxattr);
 }
 
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_devtools_build_lib_unix_NativePosixFiles_openWrite(JNIEnv *env,
+                                                      jclass clazz,
+                                                      jstring path,
+                                                      jboolean append) {
+  const char *path_chars = GetStringLatin1Chars(env, path);
+  int flags = (O_WRONLY | O_CREAT) | (append ? O_APPEND : O_TRUNC);
+  int fd;
+  while ((fd = open(path_chars, flags, 0666)) == -1 && errno == EINTR) { }
+  if (fd == -1) {
+    // The interface only allows FileNotFoundException.
+    ::PostException(env, ENOENT,
+                  std::string(path_chars) + " (" + ErrorMessage(errno)
+                  + ")");
+  }
+  ReleaseStringLatin1Chars(path_chars);
+  return fd;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_devtools_build_lib_unix_NativePosixFiles_close(JNIEnv *env,
+                                                      jclass clazz,
+                                                      jint fd) {
+  if (close(fd) == -1) {
+    ::PostException(env, errno, "error when closing file");
+  }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_devtools_build_lib_unix_NativePosixFiles_write(JNIEnv *env,
+                                                      jclass clazz,
+                                                      jint fd,
+                                                      jbyteArray data,
+                                                      jint off,
+                                                      jint len) {
+  int data_len = env->GetArrayLength(data);
+  if (off < 0 || len < 0 || off > data_len || data_len - off < len) {
+    jclass oob = env->FindClass("java/lang/IndexOutOfBoundsException");
+    if (oob != nullptr) {
+      env->ThrowNew(oob, nullptr);
+    }
+    return;
+  }
+  jbyte *buf = static_cast<jbyte *>(malloc(len));
+  if (buf == nullptr) {
+    ::PostException(env, ENOMEM, "out of memory");
+    return;
+  }
+  env->GetByteArrayRegion(data, off, len, buf);
+  if (!env->ExceptionOccurred()) {
+    jbyte *p = buf;
+    while (len > 0) {
+      ssize_t res = write(fd, p, len);
+      if (res == -1) {
+        if (errno != EINTR) {
+          ::PostException(env, errno, "writing file failed");
+        }
+      } else {
+        p += res;
+        len -= res;
+      }
+    }
+  }
+  free(buf);
+}
+
 
 // Computes MD5 digest of "file", writes result in "result", which
 // must be of length Md5Digest::kDigestLength.  Returns zero on success, or


### PR DESCRIPTION
Bazel's VFS classes make the assumption that all filenames are encoded with latin-1. That theoretically allows roundtripping any sort of horrible byte pattern a Unix filesystem can produce through Bazel's Path class. This scheme falls apart, though, when trying to use the JDK I/O libraries. The filename encoding assumed by the JDK I/O libraries comes from the sun.jnu.encoding property, which can't be overriden with the normal -D JVM command line syntax. The Bazel client still tries quite hard to force this property to be latin-1: https://github.com/bazelbuild/bazel/blob/6641ad986f436926a75b31b47314c193a9a7e032/src/main/cpp/blaze.cc#L1467-L1473 But even a fusillade of 4 environmental variables is sometimes not enough. On macOS, the JDK simply hardcodes UTF-8 as sun.jnu.encoding. Even on Linux, if a the en_US.ISO-8859-1 locale isn't installed, glibc will fall back to an ASCII encoding. Since there's no public way to create a JDK FileOutputStream from either a byte[] filename or a raw file descriptor, I conclude the only workaround is to implement open() and write() in Bazel's unix_jni. This CL does that.

We should probably implement a native file InputStream, too, for completeness. However, as merely implementing OutputStream fixes the relevant issue, I'm only doing that in this CL.

Fixes https://github.com/bazelbuild/bazel/issues/7055.