### PR TITLE
Stop adding .d files to outputs when dependency_file is disabled

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -1552,7 +1552,8 @@ public final class CcCompilationHelper {
   /** Returns true if Dotd file should be generated. */
   private boolean isGenerateDotdFile(Artifact sourceArtifact) {
     return CppFileTypes.headerDiscoveryRequired(sourceArtifact)
-        && !featureConfiguration.isEnabled(CppRuleClasses.PARSE_SHOWINCLUDES);
+        && !featureConfiguration.isEnabled(CppRuleClasses.PARSE_SHOWINCLUDES)
+        && featureConfiguration.isEnabled(CppRuleClasses.DEPENDENCY_FILE);
   }
 
   private void createHeaderAction(


### PR DESCRIPTION
Previously if you disabled the dependency_file feature, your build would
fail because the .d file was still added to the outputs of the action
but would not be generated.

Fixes https://github.com/bazelbuild/bazel/issues/7769