### PR TITLE
Default runfiles to upwards directory as fallback

### DIFF
--- a/tools/bash/runfiles/runfiles.bash
+++ b/tools/bash/runfiles/runfiles.bash
@@ -45,6 +45,8 @@
 #           export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
 #         elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
 #           export RUNFILES_DIR="$0.runfiles"
+#         else
+#           export RUNFILES_DIR="..
 #         fi
 #       fi
 #       if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then


### PR DESCRIPTION
This is to fix cases where one depends on a binary that has the bash runfiles as one of their dependencies.

For background see: https://github.com/bazelbuild/rules_nodejs/pull/587

Posting the simple example here again:

Given a BUILD file
```
nodejs_binary(
    name = "app", 
    entry_point = "__main__/app.js",
    data = ["app.js", "@npm//somedep"],
)

sh_binary(
    name = "app",
    srcs = ["my_script.sh"],
    data = [":app"],
)
```
if `my_script.sh` tries to execute the `app` it will fail with `ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash`. I think this case should work without me having to know anything about how to set `RUNFILES` etc correctly for my dependency.

Happy to provide more information if needed.