### PR TITLE
remote: add support for in memory outputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -38,7 +38,7 @@ import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.concurrent.ThreadSafety;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
-import com.google.devtools.build.lib.remote.util.Utils;
+import com.google.devtools.build.lib.remote.util.RemoteUtils;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.FileStatus;
@@ -291,7 +291,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
 
   @VisibleForTesting
   protected <T> T getFromFuture(ListenableFuture<T> f) throws IOException, InterruptedException {
-    return Utils.getFromFuture(f);
+    return RemoteUtils.getFromFuture(f);
   }
 
   /** Tuple of {@code ListenableFuture, Path, boolean}. */

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -14,7 +14,7 @@
 
 package com.google.devtools.build.lib.remote;
 
-import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.RemoteUtils.getFromFuture;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
@@ -196,10 +196,8 @@ class RemoteSpawnRunner implements SpawnRunner {
             acceptCachedResult = false;
           } else {
             try (SilentCloseable c = Profiler.instance().profile("Remote.downloadRemoteResults")) {
-              return downloadRemoteResults(cachedResult, context.getFileOutErr())
-                  .setCacheHit(true)
-                  .setRunnerName("remote cache hit")
-                  .build();
+              remoteCache.download(cachedResult, execRoot, context.getFileOutErr());
+              return createSpawnResult(cachedResult.getExitCode(), /* cacheHit= */ true);
             } catch (CacheNotFoundException e) {
               // No cache hit, so we fall through to local or remote execution.
               // We set acceptCachedResult to false in order to force the action re-execution.
@@ -251,7 +249,8 @@ class RemoteSpawnRunner implements SpawnRunner {
 
               FileOutErr outErr = context.getFileOutErr();
               String message = reply.getMessage();
-              if ((reply.getResult().getExitCode() != 0
+              ActionResult actionResult = reply.getResult();
+              if ((actionResult.getExitCode() != 0
                       || reply.getStatus().getCode() != Code.OK.value())
                   && !message.isEmpty()) {
                 outErr.printErr(message + "\n");
@@ -264,11 +263,9 @@ class RemoteSpawnRunner implements SpawnRunner {
 
               try (SilentCloseable c =
                   Profiler.instance().profile("Remote.downloadRemoteResults")) {
-                return downloadRemoteResults(reply.getResult(), outErr)
-                    .setRunnerName(reply.getCachedResult() ? "remote cache hit" : getName())
-                    .setCacheHit(reply.getCachedResult())
-                    .build();
+                remoteCache.download(actionResult, execRoot, outErr);
               }
+              return createSpawnResult(actionResult.getExitCode(), reply.getCachedResult());
             });
       } catch (IOException e) {
         return execLocallyAndUploadOrFail(
@@ -330,13 +327,13 @@ class RemoteSpawnRunner implements SpawnRunner {
     }
   }
 
-  private SpawnResult.Builder downloadRemoteResults(ActionResult result, FileOutErr outErr)
-      throws ExecException, IOException, InterruptedException {
-    remoteCache.download(result, execRoot, outErr);
-    int exitCode = result.getExitCode();
+  private SpawnResult createSpawnResult(int exitCode, boolean cacheHit) {
     return new SpawnResult.Builder()
         .setStatus(exitCode == 0 ? Status.SUCCESS : Status.NON_ZERO_EXIT)
-        .setExitCode(exitCode);
+        .setExitCode(exitCode)
+        .setRunnerName(cacheHit ? getName() + " cache hit" : getName())
+        .setCacheHit(cacheHit)
+        .build();
   }
 
   private SpawnResult execLocally(Spawn spawn, SpawnExecutionContext context)

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/OnDiskBlobStore.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/OnDiskBlobStore.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.blobstore;
 
-import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.RemoteUtils.getFromFuture;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.ListenableFuture;

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStore.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStore.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.blobstore.http;
 
-import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.RemoteUtils.getFromFuture;
 
 import com.google.auth.Credentials;
 import com.google.common.util.concurrent.ListenableFuture;

--- a/src/main/java/com/google/devtools/build/lib/remote/util/RemoteUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/RemoteUtils.java
@@ -14,13 +14,18 @@
 package com.google.devtools.build.lib.remote.util;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.ExecutionRequirements;
+import com.google.devtools.build.lib.actions.Spawn;
+import com.google.devtools.build.lib.actions.SpawnResult;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
+import javax.annotation.Nullable;
 
 /** Utility methods for the remote package. * */
-public class Utils {
+public class RemoteUtils {
 
-  private Utils() {}
+  private RemoteUtils() {}
 
   /**
    * Returns the result of a {@link ListenableFuture} if successful, or throws any checked {@link
@@ -39,5 +44,24 @@ public class Utils {
       }
       throw new IOException(e.getCause());
     }
+  }
+
+  /**
+   * Returns the output file, if any, that should be provided in memory via
+   * {@link SpawnResult#getInMemoryOutput(ActionInput)}.
+   */
+  @Nullable
+  public static ActionInput getInlineOutputFile(Spawn spawn) {
+    String outputPath =
+        spawn.getExecutionInfo().get(ExecutionRequirements.REMOTE_EXECUTION_INLINE_OUTPUTS);
+    if (outputPath == null) {
+      return null;
+    }
+    for (ActionInput output : spawn.getOutputFiles()) {
+      if (output.getExecPathString().equals(outputPath)) {
+        return output;
+      }
+    }
+    return null;
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/actions/SpawnResultTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/SpawnResultTest.java
@@ -15,6 +15,8 @@ package com.google.devtools.build.lib.actions;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.devtools.build.lib.actions.SpawnResult.Status;
+import com.google.protobuf.ByteString;
 import java.time.Duration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,5 +51,23 @@ public final class SpawnResultTest {
             .build();
     assertThat(r.getDetailMessage("", "", false, false))
         .contains("(failed due to timeout.)");
+  }
+
+  @Test
+  public void inMemoryContents() throws Exception {
+    ActionInput output = ActionInputHelper.fromPath("/foo/bar");
+    ByteString contents = ByteString.copyFromUtf8("hello world");
+
+    SpawnResult r =
+        new SpawnResult.Builder()
+          .setStatus(Status.SUCCESS)
+          .setExitCode(0)
+          .setRunnerName("test")
+          .setInMemoryOutput(output, contents)
+          .build();
+
+    assertThat(ByteString.readFrom(r.getInMemoryOutput(output))).isEqualTo(contents);
+    assertThat(r.getInMemoryOutput(null)).isEqualTo(null);
+    assertThat(r.getInMemoryOutput(ActionInputHelper.fromPath("/does/not/exist"))).isEqualTo(null);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -40,7 +40,7 @@ import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.AbstractRemoteActionCache.UploadManifest;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.DigestUtil.ActionKey;
-import com.google.devtools.build.lib.remote.util.Utils;
+import com.google.devtools.build.lib.remote.util.RemoteUtils;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
@@ -714,7 +714,7 @@ public class AbstractRemoteActionCacheTests {
     @Override
     protected <T> T getFromFuture(ListenableFuture<T> f) throws IOException, InterruptedException {
       blockingDownloads.add(f);
-      return Utils.getFromFuture(f);
+      return RemoteUtils.getFromFuture(f);
     }
 
     @Nullable

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -10,6 +10,7 @@ filegroup(
         "//src/test/java/com/google/devtools/build/lib/remote/blobstore/http:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/logging:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/merkletree:srcs",
+        "//src/test/java/com/google/devtools/build/lib/remote/testutil:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/util:srcs",
     ],
     visibility = ["//src/test/java/com/google/devtools/build/lib:__pkg__"],
@@ -19,6 +20,9 @@ java_test(
     name = "remote",
     srcs = glob(["**/*.java"]),
     test_class = "com.google.devtools.build.lib.AllTests",
+    runtime_deps = [
+        "//src/test/java/com/google/devtools/build/lib:test_runner",
+    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib:build-base",
         "//src/main/java/com/google/devtools/build/lib:events",
@@ -39,9 +43,8 @@ java_test(
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/protobuf:remote_execution_log_java_proto",
         "//src/test/java/com/google/devtools/build/lib:analysis_testutil",
-        "//src/test/java/com/google/devtools/build/lib:test_runner",
         "//src/test/java/com/google/devtools/build/lib:testutil",
-        "//src/test/java/com/google/devtools/build/lib/remote/util",
+        "//src/test/java/com/google/devtools/build/lib/remote/testutil",
         "//third_party:api_client",
         "//third_party:guava",
         "//third_party:mockito",

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -30,7 +30,7 @@ import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.ByteStreamUploaderTest.FixedBackoff;
 import com.google.devtools.build.lib.remote.ByteStreamUploaderTest.MaybeFailOnceUploadService;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
-import com.google.devtools.build.lib.remote.util.TestUtils;
+import com.google.devtools.build.lib.remote.testutil.TestUtils;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -29,7 +29,7 @@ import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
-import com.google.devtools.build.lib.remote.util.TestUtils;
+import com.google.devtools.build.lib.remote.testutil.TestUtils;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.protobuf.ByteString;

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
@@ -14,7 +14,7 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.RemoteUtils.getFromFuture;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
@@ -54,8 +54,8 @@ import com.google.devtools.build.lib.remote.RemoteRetrier.ExponentialBackoff;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.DigestUtil.ActionKey;
-import com.google.devtools.build.lib.remote.util.StringActionInput;
-import com.google.devtools.build.lib.remote.util.TestUtils;
+import com.google.devtools.build.lib.remote.testutil.StringActionInput;
+import com.google.devtools.build.lib.remote.testutil.TestUtils;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.testutil.Scratch;
 import com.google.devtools.build.lib.util.io.FileOutErr;

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
@@ -65,7 +65,7 @@ import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.exec.util.FakeOwner;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ExponentialBackoff;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
-import com.google.devtools.build.lib.remote.util.TestUtils;
+import com.google.devtools.build.lib.remote.testutil.TestUtils;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteServerCapabilitiesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteServerCapabilitiesTest.java
@@ -31,7 +31,7 @@ import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.authandtls.GoogleAuthUtils;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ExponentialBackoff;
-import com.google.devtools.build.lib.remote.util.TestUtils;
+import com.google.devtools.build.lib.remote.testutil.TestUtils;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.common.options.Options;
 import io.grpc.CallCredentials;

--- a/src/test/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCacheTest.java
@@ -14,7 +14,7 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.RemoteUtils.getFromFuture;
 import static com.google.devtools.build.lib.testutil.MoreAsserts.assertThrows;
 import static java.nio.charset.StandardCharsets.UTF_8;
 

--- a/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStoreTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStoreTest.java
@@ -14,7 +14,7 @@
 package com.google.devtools.build.lib.remote.blobstore.http;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.RemoteUtils.getFromFuture;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;

--- a/src/test/java/com/google/devtools/build/lib/remote/logging/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/logging/BUILD
@@ -14,13 +14,15 @@ java_test(
     name = "logging",
     srcs = glob(["*.java"]),
     test_class = "com.google.devtools.build.lib.AllTests",
+    runtime_deps = [
+        "//src/test/java/com/google/devtools/build/lib:test_runner",
+    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib:io",
         "//src/main/java/com/google/devtools/build/lib/remote/logging",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/protobuf:remote_execution_log_java_proto",
-        "//src/test/java/com/google/devtools/build/lib:test_runner",
         "//src/test/java/com/google/devtools/build/lib:testutil",
         "//third_party:guava",
         "//third_party:mockito",

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/BUILD
@@ -14,8 +14,10 @@ java_test(
     name = "merkletree",
     srcs = glob(["*.java"]),
     test_class = "com.google.devtools.build.lib.AllTests",
+    runtime_deps = [
+        "//src/test/java/com/google/devtools/build/lib:test_runner",
+    ],
     deps = [
-        "//src/main/java/com/google/devtools/build/lib:io",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/clock",
         "//src/main/java/com/google/devtools/build/lib/remote/merkletree",
@@ -23,9 +25,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs",
-        "//src/test/java/com/google/devtools/build/lib:test_runner",
-        "//src/test/java/com/google/devtools/build/lib:testutil",
-        "//src/test/java/com/google/devtools/build/lib/remote/util",
+        "//src/test/java/com/google/devtools/build/lib/remote/testutil",
         "//third_party:guava",
         "//third_party:truth",
         "//third_party/protobuf:protobuf_java",

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/InputTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/InputTreeTest.java
@@ -26,7 +26,7 @@ import com.google.devtools.build.lib.remote.merkletree.InputTree.DirectoryNode;
 import com.google.devtools.build.lib.remote.merkletree.InputTree.FileNode;
 import com.google.devtools.build.lib.remote.merkletree.InputTree.Node;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
-import com.google.devtools.build.lib.remote.util.StringActionInput;
+import com.google.devtools.build.lib.remote.testutil.StringActionInput;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;

--- a/src/test/java/com/google/devtools/build/lib/remote/testutil/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/testutil/BUILD
@@ -10,21 +10,17 @@ filegroup(
     visibility = ["//src/test/java/com/google/devtools/build/lib/remote:__pkg__"],
 )
 
-java_test(
-    name = "http",
+java_library(
+    name = "testutil",
     srcs = glob(["*.java"]),
-    test_class = "com.google.devtools.build.lib.AllTests",
     runtime_deps = [
         "//src/test/java/com/google/devtools/build/lib:test_runner",
     ],
     deps = [
-        "//src/main/java/com/google/devtools/build/lib/remote/blobstore/http",
-        "//src/main/java/com/google/devtools/build/lib/remote/util",
-        "//third_party:api_client",
-        "//third_party:auth",
+        "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/remote",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",
-        "//third_party:mockito",
-        "//third_party:netty",
-        "//third_party:truth",
+        "//third_party/protobuf:protobuf_java",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/remote/testutil/StringActionInput.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/testutil/StringActionInput.java
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package com.google.devtools.build.lib.remote.util;
+package com.google.devtools.build.lib.remote.testutil;
 
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.vfs.PathFragment;

--- a/src/test/java/com/google/devtools/build/lib/remote/testutil/TestUtils.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/testutil/TestUtils.java
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package com.google.devtools.build.lib.remote.util;
+package com.google.devtools.build.lib.remote.testutil;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableScheduledFuture;

--- a/src/test/java/com/google/devtools/build/lib/remote/util/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/BUILD
@@ -10,14 +10,19 @@ filegroup(
     visibility = ["//src/test/java/com/google/devtools/build/lib/remote:__pkg__"],
 )
 
-java_library(
+java_test(
     name = "util",
     srcs = glob(["*.java"]),
+    test_class = "com.google.devtools.build.lib.AllTests",
+    runtime_deps = [
+        "//src/test/java/com/google/devtools/build/lib:test_runner",
+    ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
-        "//src/main/java/com/google/devtools/build/lib/remote",
-        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/actions:localhost_capacity",
+        "//src/main/java/com/google/devtools/build/lib/remote/util",
+        "//src/test/java/com/google/devtools/build/lib:analysis_testutil",
         "//third_party:guava",
-        "//third_party/protobuf:protobuf_java",
+        "//third_party:truth",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/remote/util/RemoteUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/RemoteUtilsTest.java
@@ -1,0 +1,52 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.ActionInputHelper;
+import com.google.devtools.build.lib.actions.ExecutionRequirements;
+import com.google.devtools.build.lib.actions.ResourceSet;
+import com.google.devtools.build.lib.actions.SimpleSpawn;
+import com.google.devtools.build.lib.actions.Spawn;
+import com.google.devtools.build.lib.exec.util.FakeOwner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link RemoteUtils. */
+@RunWith(JUnit4.class)
+public class RemoteUtilsTest {
+
+  @Test
+  public void getInlineOutputFile() {
+    ActionInput outputFile = ActionInputHelper.fromPath("/foo/bar");
+    ImmutableMap<String, String> executionInfo =
+        ImmutableMap.of(
+            ExecutionRequirements.REMOTE_EXECUTION_INLINE_OUTPUTS, outputFile.getExecPathString());
+    Spawn s = new SimpleSpawn(
+        new FakeOwner("foo", "bar"),
+        /*arguments=*/ ImmutableList.of(),
+        /*environment=*/ ImmutableMap.of(),
+        executionInfo,
+        /*inputs=*/ ImmutableList.of(),
+        /*outputs=*/ ImmutableList.of(outputFile),
+        ResourceSet.ZERO);
+
+    assertThat(RemoteUtils.getInlineOutputFile(s)).isEqualTo(outputFile);
+  }
+}

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ByteStreamServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ByteStreamServer.java
@@ -14,7 +14,7 @@
 
 package com.google.devtools.build.remote.worker;
 
-import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.RemoteUtils.getFromFuture;
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
 

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -14,7 +14,7 @@
 
 package com.google.devtools.build.remote.worker;
 
-import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.RemoteUtils.getFromFuture;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.SEVERE;


### PR DESCRIPTION
in preparation for #6862 add code that allows for Bazel rules to
request outputs in memory. It works by passing allowing an execution
requirement 'internal-inline-outputs' with a path to the output file
whose contents should be provided in memory.

this change introduces some necessary refactorings and adds code
implementing this functionality to the remote package but doesn't
turn this feature on. It will be enabled in a subsequent PR.