### PR TITLE
Correct parsing of bazel info command results in black box tests

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/BlackBoxTestContext.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/BlackBoxTestContext.java
@@ -142,7 +142,7 @@ public final class BlackBoxTestContext {
    */
   public Path resolveGenPath(BuilderRunner bazel, String subPathUnderGen) throws Exception {
     if (genFilesPath == null) {
-      genFilesPath = PathUtils.resolve(workDir, bazel.info(productName + "-genfiles").outString());
+      genFilesPath = PathUtils.resolve(workDir, getInfoValue(bazel, productName + "-genfiles"));
     }
     return PathUtils.resolve(genFilesPath, subPathUnderGen);
   }
@@ -158,8 +158,29 @@ public final class BlackBoxTestContext {
    * @throws Exception if <code>bazel info</code> command fails
    */
   public Path resolveBinPath(BuilderRunner bazel, String subPathUnderBin) throws Exception {
-    Path binPath = PathUtils.resolve(workDir, bazel.info(productName + "-bin").outString());
+    Path binPath = PathUtils.resolve(workDir, getInfoValue(bazel, productName + "-bin"));
     return PathUtils.resolve(binPath, subPathUnderBin);
+  }
+
+  /**
+   * Resolve a path relative to "execution_root".
+   * Useful for checking the contents of the generated external repositories.
+   *
+   * <p>Calls <code>bazel info execution_root</code>
+   *
+   * @param bazel the instance of BuilderRunner to run info with
+   * @param subPathUnderBin path to the file under execution_root directory
+   * @return full path to the resolved file
+   * @throws Exception if <code>bazel info</code> command fails
+   */
+  public Path resolveExecRootPath(BuilderRunner bazel, String subPathUnderBin) throws Exception {
+    Path binPath = PathUtils.resolve(workDir, getInfoValue(bazel, "execution_root"));
+    return PathUtils.resolve(binPath, subPathUnderBin);
+  }
+
+  private String getInfoValue(BuilderRunner bazel, String key) throws Exception {
+    String[] parts = bazel.info(key).outString().trim().split(" ");
+    return parts[parts.length - 1];
   }
 
   /**


### PR DESCRIPTION
- in case all progress messages will be printed, the resulting text of bazel info will also contain progress text; use ony the last word
- add a method for resolving paths under bazel exec root