### PR TITLE
Add /Applications/ to cxx_builtin_include_directories

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -44,6 +44,9 @@ def _get_escaped_xcode_cxx_inc_directories(repository_ctx, cc, xcode_toolchains)
     include_dirs = get_escaped_cxx_inc_directories(repository_ctx, cc, "-xc++")
     for toolchain in xcode_toolchains:
         include_dirs.append(escape_string(toolchain.developer_dir))
+
+    # Assume that all paths that point to /Applications/ are built in include paths
+    include_dirs.append("/Applications/")
     return include_dirs
 
 def configure_osx_toolchain(repository_ctx, overriden_tools):


### PR DESCRIPTION
This makes sure that all paths that point inside the Applications
directory on macOS are considered cxx_builtin_include_directories. The
goal here is to make sure that paths in produced `.d` files are
correctly translated by bazel to local paths when the `.d` files are
shared with the remote cache to machines that have Xcode installed in
different locations.

Fixes https://github.com/bazelbuild/bazel/issues/7772