### PR TITLE
Re-add @bazel_tools//third_party/jarjar

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -124,6 +124,7 @@ JAVA_TOOLS = [
     "//src/tools/singlejar:embedded_tools",
     "//src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps:embedded_tools",
     "//third_party/java/jacoco:srcs",
+    "//third_party/jarjar:embedded_build_and_license",
 ] + select({
     "//src/conditions:arm": [],
     "//conditions:default": [

--- a/src/create_embedded_tools.py
+++ b/src/create_embedded_tools.py
@@ -44,6 +44,8 @@ output_paths = [
     ('*def_parser.exe', lambda x: 'tools/def_parser/def_parser.exe'),
     ('*zipper.exe', lambda x: 'tools/zip/zipper/zipper.exe'),
     ('*zipper', lambda x: 'tools/zip/zipper/zipper'),
+    ('*third_party/jarjar/BUILD.tools', lambda x: 'third_party/jarjar/BUILD'),
+    ('*third_party/jarjar/LICENSE', lambda x: 'third_party/jarjar/LICENSE'),
     ('*src/objc_tools/*',
      lambda x: 'tools/objc/precomp_' + os.path.basename(x)),
     ('*xcode*StdRedirect.dylib', lambda x: 'tools/objc/StdRedirect.dylib'),

--- a/third_party/jarjar/BUILD
+++ b/third_party/jarjar/BUILD
@@ -7,6 +7,14 @@ filegroup(
     srcs = glob(["**"]),
 )
 
+filegroup(
+    name = "embedded_build_and_license",
+    srcs = [
+        "BUILD.tools",
+        "LICENSE",
+    ],
+)
+
 # jarjar_bin
 java_binary(
     name = "jarjar_command",

--- a/third_party/jarjar/BUILD.tools
+++ b/third_party/jarjar/BUILD.tools
@@ -1,0 +1,19 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+load(
+    "//tools/jdk:remote_java_tools_aliases.bzl",
+    "remote_java_tools_java_import",
+)
+
+remote_java_tools_java_import(
+    name = "jarjar_import",
+    target = ":JarJar",
+)
+
+java_binary(
+    name = "jarjar_bin",
+    main_class = "com.tonicsystems.jarjar.Main",
+    runtime_deps = [":jarjar_import"],
+)

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -1,17 +1,17 @@
 load(
     "//tools/jdk:default_java_toolchain.bzl",
-    "default_java_toolchain",
-    "java_runtime_files",
     "JDK8_JVM_OPTS",
     "bootclasspath",
+    "default_java_toolchain",
+    "java_runtime_files",
 )
 load(
     "//tools/jdk:java_toolchain_alias.bzl",
-    "java_toolchain_alias",
-    "java_runtime_alias",
     "java_host_runtime_alias",
-    "legacy_java_toolchain_alias",
+    "java_runtime_alias",
+    "java_toolchain_alias",
     "legacy_java_runtime_alias",
+    "legacy_java_toolchain_alias",
 )
 load(
     "//tools/jdk:remote_java_tools_aliases.bzl",
@@ -405,9 +405,9 @@ alias(
     actual = "//third_party/java/jacoco:blaze-agent",
 )
 
-java_import(
+remote_java_tools_java_import(
     name = "JarJar",
-    jars = [":jarjar_command_deploy.jar"],
+    target = ":JarJar",
 )
 
 test_suite(


### PR DESCRIPTION
`third_party/jarjar` was moved out of the `@bazel_tools` when the Java tools were moved to a remote repository. Adding the package back because there are users referencing it directly.

Fixes #7767.