### PR TITLE
Fix #7715.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/metrics/MetricsModule.java
+++ b/src/main/java/com/google/devtools/build/lib/metrics/MetricsModule.java
@@ -43,7 +43,9 @@ public class MetricsModule extends BlazeModule {
 
   @Override
   public Iterable<Class<? extends OptionsBase>> getCommandOptions(Command command) {
-    return ImmutableList.of(Options.class);
+    return "build".equals(command.name())
+        ? ImmutableList.of(Options.class)
+        : ImmutableList.of();
   }
 
   @Override


### PR DESCRIPTION
The flag bep_publish_used_heap_size_post_build is not meant to be
exposed to other commands than build since it has no effect there.

RELNOTES: None