### PR TITLE
Pass execution info to xml generating spawn. Fixes #7794

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -465,7 +465,9 @@ public class StandaloneTestStrategy extends TestStrategy {
             "TEST_TOTAL_SHARDS", Integer.toString(action.getExecutionSettings().getTotalShards()),
             "TEST_NAME", action.getTestName(),
             "TEST_BINARY", testBinaryName),
-        ImmutableMap.of(),
+        // Pass the execution info of the action which is identical to the supported tags set on the
+        // test target. In particular, this does not set the test timeout on the spawn.
+        ImmutableMap.copyOf(action.getExecutionInfo()),
         null,
         ImmutableMap.of(),
         /*inputs=*/ ImmutableList.of(action.getTestXmlGeneratorScript(), action.getTestLog()),

--- a/src/test/java/com/google/devtools/build/lib/exec/StandaloneTestStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/StandaloneTestStrategyTest.java
@@ -519,6 +519,7 @@ public final class StandaloneTestStrategyTest extends BuildViewTestCase {
         "    name = \"failing_test\",",
         "    size = \"small\",",
         "    srcs = [\"failing_test.sh\"],",
+        "    tags = [\"local\"],",
         ")");
     TestRunnerAction testRunnerAction = getTestAction("//standalone:failing_test");
 
@@ -538,6 +539,8 @@ public final class StandaloneTestStrategyTest extends BuildViewTestCase {
         .thenAnswer(
             (invocation) -> {
               Spawn spawn = invocation.getArgument(0);
+              // Test that both spawns have the local tag attached as a execution info
+              assertThat(spawn.getExecutionInfo()).containsKey("local");
               ActionExecutionContext context = invocation.getArgument(1);
               FileOutErr outErr = context.getFileOutErr();
               called.add(outErr);


### PR DESCRIPTION
Change [1] splits test execution into two spawns. The first spawn runs
the test and the second spawn generates the test.xml from the test.log
file. This change makes it so that the test.xml-generating spawn also
inherits the execution info from the test target. In particular, if a
test target is tagged with "no-remote" then the test.xml-generating
spawn will also be tagged.

[1] https://github.com/bazelbuild/bazel/commit/0858ae1f6eb890c1e203a2aa21130ba34ca36a27