### PR TITLE
remote: added REMOTE documentation category.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
@@ -28,7 +28,7 @@ public final class RemoteOptions extends OptionsBase {
     name = "remote_http_cache",
     oldName = "remote_rest_cache",
     defaultValue = "null",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help =
         "A base URL of a HTTP caching service. Both http:// and https:// are supported. BLOBs are "
@@ -39,7 +39,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
       name = "remote_cache_proxy",
       defaultValue = "null",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "Connect to the remote cache through a proxy. Currently this flag can only be used to "
@@ -50,7 +50,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
       name = "remote_max_connections",
       defaultValue = "100",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
       help =
           "The max. number of concurrent network connections to the remote cache/executor. By "
@@ -61,7 +61,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "remote_executor",
     defaultValue = "null",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "HOST or HOST:PORT of a remote execution endpoint."
   )
@@ -70,7 +70,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "remote_cache",
     defaultValue = "null",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "HOST or HOST:PORT of a remote caching endpoint."
   )
@@ -79,7 +79,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
       name = "remote_timeout",
       defaultValue = "60",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "The maximum number of seconds to wait for remote execution and cache calls. For the "
@@ -89,7 +89,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "remote_accept_cached",
     defaultValue = "true",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "Whether to accept remotely cached action results."
   )
@@ -98,7 +98,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "remote_local_fallback",
     defaultValue = "false",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "Whether to fall back to standalone local execution strategy if remote execution fails."
   )
@@ -107,7 +107,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
       name = "remote_local_fallback_strategy",
       defaultValue = "local",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "The strategy to use when remote execution has to fallback to local execution.")
   public String remoteLocalFallbackStrategy;
@@ -115,7 +115,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "remote_upload_local_results",
     defaultValue = "true",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "Whether to upload locally executed action results to the remote cache."
   )
@@ -124,7 +124,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "remote_instance_name",
     defaultValue = "",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "Value to pass as instance_name in the remote execution API."
   )
@@ -133,7 +133,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "experimental_remote_retry",
     defaultValue = "true",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "Whether to retry transient remote execution/cache errors."
   )
@@ -142,7 +142,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "experimental_remote_retry_start_delay_millis",
     defaultValue = "100",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "The initial delay before retrying a transient error."
   )
@@ -151,7 +151,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "experimental_remote_retry_max_delay_millis",
     defaultValue = "5000",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "The maximum delay before retrying a transient error."
   )
@@ -160,7 +160,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "experimental_remote_retry_max_attempts",
     defaultValue = "5",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "The maximum number of attempts to retry a transient error."
   )
@@ -169,7 +169,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "experimental_remote_retry_multiplier",
     defaultValue = "2",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "The multiplier by which to increase the retry delay on transient errors."
   )
@@ -178,7 +178,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "experimental_remote_retry_jitter",
     defaultValue = "0.1",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "The random factor to apply to retry delays on transient errors."
   )
@@ -188,7 +188,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "experimental_remote_spawn_cache",
     defaultValue = "false",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.NO_OP},
     help =
         "Whether to use the experimental spawn cache infrastructure for remote caching. "
@@ -211,7 +211,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
     name = "experimental_guard_against_concurrent_changes",
     defaultValue = "false",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help =
         "Turn this off to disable checking the ctime of input files of an action before "
@@ -224,7 +224,7 @@ public final class RemoteOptions extends OptionsBase {
     name = "experimental_remote_grpc_log",
     defaultValue = "",
     category = "remote",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+    documentationCategory = OptionDocumentationCategory.REMOTE,
     effectTags = {OptionEffectTag.UNKNOWN},
     help =
         "If specified, a path to a file to log gRPC call related details. This log consists "
@@ -277,7 +277,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
       name = "remote_result_cache_priority",
       defaultValue = "0",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "The relative priority of remote actions to be stored in remote cache. "
@@ -287,7 +287,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
       name = "remote_execution_priority",
       defaultValue = "0",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "The relative priority of actions to be executed remotely. "
@@ -298,7 +298,7 @@ public final class RemoteOptions extends OptionsBase {
       name = "remote_default_platform_properties",
       oldName = "host_platform_remote_properties_override",
       defaultValue = "",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "Set the default platform properties to be set for the remote execution API, "
@@ -310,7 +310,7 @@ public final class RemoteOptions extends OptionsBase {
   @Option(
       name = "remote_verify_downloads",
       defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "If set to true, Bazel will compute the hash sum of all remote downloads and "

--- a/src/main/java/com/google/devtools/common/options/OptionDocumentationCategory.java
+++ b/src/main/java/com/google/devtools/common/options/OptionDocumentationCategory.java
@@ -112,4 +112,9 @@ public enum OptionDocumentationCategory {
    * specific inputs.
    */
   GENERIC_INPUTS,
+
+  /**
+   * This option lets a user to configure the remote caching and/or the remote execution for a build.
+   */
+  REMOTE,
 }

--- a/src/main/java/com/google/devtools/common/options/OptionDocumentationCategory.java
+++ b/src/main/java/com/google/devtools/common/options/OptionDocumentationCategory.java
@@ -114,7 +114,7 @@ public enum OptionDocumentationCategory {
   GENERIC_INPUTS,
 
   /**
-   * This option lets a user to configure the remote caching and/or the remote execution for a build.
+   * A category of options to configure Bazel's remote caching and execution capabilities.
    */
   REMOTE,
 }

--- a/src/main/java/com/google/devtools/common/options/OptionFilterDescriptions.java
+++ b/src/main/java/com/google/devtools/common/options/OptionFilterDescriptions.java
@@ -89,7 +89,7 @@ public class OptionFilterDescriptions {
             OptionDocumentationCategory.GENERIC_INPUTS,
             "Options specifying or altering a generic input to a Bazel command that does not fall "
                 + "into other categories.")
-        .put(OptionDocumentationCategory.REMOTE, "Remote execution/caching options");
+        .put(OptionDocumentationCategory.REMOTE, "Remote caching and execution options");
     return optionCategoriesBuilder.build();
   }
 

--- a/src/main/java/com/google/devtools/common/options/OptionFilterDescriptions.java
+++ b/src/main/java/com/google/devtools/common/options/OptionFilterDescriptions.java
@@ -35,6 +35,7 @@ public class OptionFilterDescriptions {
     OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
     OptionDocumentationCategory.LOGGING,
     OptionDocumentationCategory.GENERIC_INPUTS,
+    OptionDocumentationCategory.REMOTE,
     OptionDocumentationCategory.UNCATEGORIZED
   };
 
@@ -87,7 +88,8 @@ public class OptionFilterDescriptions {
         .put(
             OptionDocumentationCategory.GENERIC_INPUTS,
             "Options specifying or altering a generic input to a Bazel command that does not fall "
-                + "into other categories.");
+                + "into other categories.")
+        .put(OptionDocumentationCategory.REMOTE, "Remote execution/caching options");
     return optionCategoriesBuilder.build();
   }
 


### PR DESCRIPTION
Docs for 'bazel build' are already quite difficult to read, “miscellaneous/uncategorised" section is particularly disordered and big. Therefore remote flags are moved into separate category.

Part of #7205 