### PR TITLE
remote: rename auth flags.

### DIFF
--- a/site/docs/build-event-protocol.md
+++ b/site/docs/build-event-protocol.md
@@ -211,9 +211,9 @@ these flags are also used for Bazel’s Remote Execution. This implies that the
 Build Event Service and Remote Execution Endpoints need to share the same
 authentication and TLS infrastructure.
 
-*  `--[no]google_default_credentials`
-*  `--google_credentials`
-*  `--google_auth_scopes`
+*  `--[no]gcloud_default_credentials`
+*  `--gcloud_credentials`
+*  `--gcloud_auth_scopes`
 *  `--tls_certificate`
 *  `--[no]tls_enabled`
 

--- a/site/docs/remote-caching.md
+++ b/site/docs/remote-caching.md
@@ -165,7 +165,7 @@ to/from your GCS bucket.
 
 4. Connect to Cloud Storage by adding the following flags to your Bazel command:
    * Pass the following URL to Bazel by using the flag: `--remote_http_cache=https://storage.googleapis.com/bucket-name` where `bucket-name` is the name of your storage bucket.
-   * Pass the authentication key using the flag: `--google_credentials=/path/to/your/secret-key.json`.
+   * Pass the authentication key using the flag: `--gcloud_auth_credentials=/path/to/your/secret-key.json`.
 
 5. You can configure Cloud Storage to automatically delete old files. To do so, see
 [Managing Object Lifecycles](https://cloud.google.com/storage/docs/managing-lifecycles).

--- a/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/AuthAndTLSOptions.java
@@ -27,8 +27,8 @@ import java.util.List;
  */
 public class AuthAndTLSOptions extends OptionsBase {
   @Option(
-    name = "google_default_credentials",
-    oldName = "auth_enabled",
+    name = "gcloud_default_credentials",
+    oldName = "google_default_credentials",
     defaultValue = "false",
     documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
     effectTags = {OptionEffectTag.UNKNOWN},
@@ -36,22 +36,22 @@ public class AuthAndTLSOptions extends OptionsBase {
         "Whether to use 'Google Application Default Credentials' for authentication."
             + " See https://cloud.google.com/docs/authentication for details. Disabled by default."
   )
-  public boolean useGoogleDefaultCredentials;
+  public boolean useGCloudDefaultCredentials;
 
   @Option(
-    name = "google_auth_scopes",
-    oldName = "auth_scope",
+    name = "gcloud_auth_scopes",
+    oldName = "google_auth_scopes",
     defaultValue = "https://www.googleapis.com/auth/cloud-platform",
     converter = CommaSeparatedOptionListConverter.class,
     documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
     effectTags = {OptionEffectTag.UNKNOWN},
     help = "A comma-separated list of Google Cloud authentication scopes."
   )
-  public List<String> googleAuthScopes;
+  public List<String> gCloudAuthScopes;
 
   @Option(
-    name = "google_credentials",
-    oldName = "auth_credentials",
+    name = "gocloud_credentials",
+    oldName = "google_auth_credentials",
     defaultValue = "null",
     documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
     effectTags = {OptionEffectTag.UNKNOWN},
@@ -59,7 +59,7 @@ public class AuthAndTLSOptions extends OptionsBase {
         "Specifies the file to get authentication credentials from. See "
             + "https://cloud.google.com/docs/authentication for details."
   )
-  public String googleCredentials;
+  public String gCloudCredentials;
 
   @Option(
     name = "tls_enabled",

--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -125,20 +125,20 @@ public final class GoogleAuthUtils {
   public static Credentials newCredentials(@Nullable AuthAndTLSOptions options) throws IOException {
     if (options == null) {
       return null;
-    } else if (options.googleCredentials != null) {
+    } else if (options.gCloudCredentials != null) {
       // Credentials from file
-      try (InputStream authFile = new FileInputStream(options.googleCredentials)) {
-        return newCredentials(authFile, options.googleAuthScopes);
+      try (InputStream authFile = new FileInputStream(options.gCloudCredentials)) {
+        return newCredentials(authFile, options.gCloudAuthScopes);
       } catch (FileNotFoundException e) {
         String message =
             String.format(
                 "Could not open auth credentials file '%s': %s",
-                options.googleCredentials, e.getMessage());
+                options.gCloudCredentials, e.getMessage());
         throw new IOException(message, e);
       }
-    } else if (options.useGoogleDefaultCredentials) {
+    } else if (options.useGCloudDefaultCredentials) {
       return newCredentials(
-          null /* Google Application Default Credentials */, options.googleAuthScopes);
+          null /* Google Cloud Default Credentials */, options.gCloudAuthScopes);
     }
     return null;
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
@@ -179,9 +179,9 @@ public class GrpcRemoteCacheTest {
 
   private GrpcRemoteCache newClient(RemoteOptions remoteOptions) throws IOException {
     AuthAndTLSOptions authTlsOptions = Options.getDefaults(AuthAndTLSOptions.class);
-    authTlsOptions.useGoogleDefaultCredentials = true;
-    authTlsOptions.googleCredentials = "/exec/root/creds.json";
-    authTlsOptions.googleAuthScopes = ImmutableList.of("dummy.scope");
+    authTlsOptions.useGCloudDefaultCredentials = true;
+    authTlsOptions.gCloudCredentials = "/exec/root/creds.json";
+    authTlsOptions.gCloudAuthScopes = ImmutableList.of("dummy.scope");
 
     GenericJson json = new GenericJson();
     json.put("type", "authorized_user");
@@ -189,11 +189,11 @@ public class GrpcRemoteCacheTest {
     json.put("client_secret", "foo");
     json.put("refresh_token", "bar");
     Scratch scratch = new Scratch();
-    scratch.file(authTlsOptions.googleCredentials, new JacksonFactory().toString(json));
+    scratch.file(authTlsOptions.gCloudCredentials, new JacksonFactory().toString(json));
 
     CallCredentials creds;
-    try (InputStream in = scratch.resolve(authTlsOptions.googleCredentials).getInputStream()) {
-      creds = GoogleAuthUtils.newCallCredentials(in, authTlsOptions.googleAuthScopes);
+    try (InputStream in = scratch.resolve(authTlsOptions.gCloudCredentials).getInputStream()) {
+      creds = GoogleAuthUtils.newCallCredentials(in, authTlsOptions.gCloudAuthScopes);
     }
     RemoteRetrier retrier =
         TestUtils.newRemoteRetrier(


### PR DESCRIPTION
--google_* flags only work with Google Cloud Authentication therefore --gcloud_* prefix would add some clarity for the potential usages
So instead of --google_* let's call them --gcloud_* (the old ones will continue working for a while).

So now there's two simple ways to authenticate with Google Cloud:
* bazel build --gcloud_default_credentials
* bazel build --gcloud_credentials=creds.json

Part of #7205.

RELNOTES: --google_* flags were renamed to --gcloud_* flags. The old names will continue to work for this release but will be removed in the next release.