### PR TITLE
remote: removed deprecated flag experimental_remote_spawn_cache.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java
@@ -184,18 +184,6 @@ public final class RemoteOptions extends OptionsBase {
   )
   public double experimentalRemoteRetryJitter;
 
-  @Deprecated
-  @Option(
-    name = "experimental_remote_spawn_cache",
-    defaultValue = "false",
-    documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-    effectTags = {OptionEffectTag.NO_OP},
-    help =
-        "Whether to use the experimental spawn cache infrastructure for remote caching. "
-            + "Enabling this flag makes Bazel ignore any setting for remote_executor."
-  )
-  public boolean experimentalRemoteSpawnCache;
-
   @Option(
     name = "disk_cache",
     defaultValue = "null",


### PR DESCRIPTION
This flag has already been enabled by default and deprecated for a while - there is no associated logic present, therefore removing it.

Part of #7205 

RELNOTES: previously deprecated flag --experimental_remote_spawn_cache was removed