### PR TITLE
Bubble aapt2 compile and link errors to Bazel

### DIFF
--- a/src/tools/android/java/com/google/devtools/build/android/ValidateAndLinkResourcesAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/ValidateAndLinkResourcesAction.java
@@ -14,6 +14,8 @@
 // Copyright 2017 The Bazel Authors. All rights reserved.
 package com.google.devtools.build.android;
 
+import static java.util.logging.Level.SEVERE;
+
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.android.aapt2.Aapt2ConfigOptions;
 import com.google.devtools.build.android.aapt2.CompiledResources;
@@ -29,6 +31,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /** Performs resource validation and static linking for compiled android resources. */
@@ -145,6 +148,8 @@ public class ValidateAndLinkResourcesAction {
     public Path sourceJarOut;
   }
 
+  private static final Logger logger = Logger.getLogger(ValidateAndLinkResourcesAction.class.getName());
+
   public static void main(String[] args) throws Exception {
     final OptionsParser optionsParser =
         OptionsParser.newOptionsParser(Options.class, Aapt2ConfigOptions.class);
@@ -190,6 +195,9 @@ public class ValidateAndLinkResourcesAction {
           .copySourceJarTo(options.sourceJarOut)
           .copyRTxtTo(options.rTxtOut);
       profiler.recordEndOf("link");
+    } catch (Exception e) {
+      logger.log(SEVERE, "Error while validating and linking resources", e);
+      throw e;
     }
   }
 }


### PR DESCRIPTION
Previously, if there were any errors from the aapt2 compile and link steps, the resource processor will silently swallow them in the `try` block without a catch. This change adds a catch block to log and rethrow the error.

RELNOTES: Fix an issue where the Android resource processor did not surface errors from aapt2 compile and link actions.