### PR TITLE
Export more files in androidsdk

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
@@ -56,15 +56,9 @@ filegroup(
 filegroup(
     name = "qemu2_x86",
     srcs = ["emulator/emulator"] + glob(["emulator/lib64/**", "emulator/lib/**"]) + select({
-        "@bazel_tools//src/conditions:darwin": [
-            "emulator/qemu/darwin-x86_64/qemu-system-i386",
-        ],
-        "@bazel_tools//src/conditions:darwin_x86_64": [
-            "emulator/qemu/darwin-x86_64/qemu-system-i386",
-        ],
-        "//conditions:default": [
-            "emulator/qemu/linux-x86_64/qemu-system-i386",
-        ]
+        "@bazel_tools//src/conditions:darwin": ["emulator/qemu/darwin-x86_64/qemu-system-i386"],
+        "@bazel_tools//src/conditions:darwin_x86_64": ["emulator/qemu/darwin-x86_64/qemu-system-i386"],
+        "//conditions:default": ["emulator/qemu/linux-x86_64/qemu-system-i386"]
     }),
 )
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
@@ -49,6 +49,11 @@ filegroup(
 )
 
 filegroup(
+    name = "system_images",
+    srcs = glob(["system-images/**"]),
+)
+
+filegroup(
     name = "sdk_path",
     srcs = ["."],
 )
@@ -56,8 +61,12 @@ filegroup(
 filegroup(
     name = "qemu2_x86",
     srcs = ["emulator/emulator"] + select({
-        "@bazel_tools//src/conditions:darwin": ["emulator/qemu/darwin-x86_64/qemu-system-i386"],
-        "@bazel_tools//src/conditions:darwin_x86_64": ["emulator/qemu/darwin-x86_64/qemu-system-i386"],
+        "@bazel_tools//src/conditions:darwin": [
+          "emulator/qemu/darwin-x86_64/qemu-system-i386",
+        ] + glob(["emulator/lib64/**", "emulator/lib/**"]),
+        "@bazel_tools//src/conditions:darwin_x86_64": [
+          "emulator/qemu/darwin-x86_64/qemu-system-i386",
+        ] + glob(["emulator/lib64/**", "emulator/lib/**"]),
         "//conditions:default": ["emulator/qemu/linux-x86_64/qemu-system-i386"],
     }),
 )
@@ -68,4 +77,4 @@ create_system_images_filegroups(
 )
 
 exports_files([
-%exported_files%] + glob(["system-images/**"]))
+%exported_files%] + glob(["system-images/**", "tools/bin/*", "tools/**", "emulator/**"]))

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
@@ -49,11 +49,6 @@ filegroup(
 )
 
 filegroup(
-    name = "system_images",
-    srcs = glob(["system-images/**"]),
-)
-
-filegroup(
     name = "sdk_path",
     srcs = ["."],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
@@ -72,4 +72,4 @@ create_system_images_filegroups(
 )
 
 exports_files([
-%exported_files%] + glob(["system-images/**", "tools/bin/*", "tools/**", "emulator/**"]))
+%exported_files%] + glob(["system-images/**", "tools/**", "emulator/**"]))

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
@@ -58,7 +58,7 @@ filegroup(
     srcs = ["emulator/emulator"] + glob(["emulator/lib64/**", "emulator/lib/**"]) + select({
         "@bazel_tools//src/conditions:darwin": ["emulator/qemu/darwin-x86_64/qemu-system-i386"],
         "@bazel_tools//src/conditions:darwin_x86_64": ["emulator/qemu/darwin-x86_64/qemu-system-i386"],
-        "//conditions:default": ["emulator/qemu/linux-x86_64/qemu-system-i386"]
+        "//conditions:default": ["emulator/qemu/linux-x86_64/qemu-system-i386"],
     }),
 )
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
@@ -55,14 +55,16 @@ filegroup(
 
 filegroup(
     name = "qemu2_x86",
-    srcs = ["emulator/emulator"] + select({
+    srcs = ["emulator/emulator"] + glob(["emulator/lib64/**", "emulator/lib/**"]) + select({
         "@bazel_tools//src/conditions:darwin": [
-          "emulator/qemu/darwin-x86_64/qemu-system-i386",
-        ] + glob(["emulator/lib64/**", "emulator/lib/**"]),
+            "emulator/qemu/darwin-x86_64/qemu-system-i386",
+        ],
         "@bazel_tools//src/conditions:darwin_x86_64": [
-          "emulator/qemu/darwin-x86_64/qemu-system-i386",
-        ] + glob(["emulator/lib64/**", "emulator/lib/**"]),
-        "//conditions:default": ["emulator/qemu/linux-x86_64/qemu-system-i386"],
+            "emulator/qemu/darwin-x86_64/qemu-system-i386",
+        ],
+        "//conditions:default": [
+            "emulator/qemu/linux-x86_64/qemu-system-i386",
+        ]
     }),
 )
 


### PR DESCRIPTION
This allows Android rule writers to access more file targets in `@androidsdk` directly.