### PR TITLE
remote: remove buildAction profiler call

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -113,15 +113,10 @@ final class RemoteSpawnCache implements SpawnCache {
     Command command =
         RemoteSpawnRunner.buildCommand(
             spawn.getOutputFiles(), spawn.getArguments(), spawn.getEnvironment(), platform);
-    Action action;
-    final ActionKey actionKey;
-    try (SilentCloseable c = Profiler.instance().profile("RemoteCache.buildAction")) {
-      action =
-          RemoteSpawnRunner.buildAction(
-              digestUtil.compute(command), merkleTreeRoot, context.getTimeout(), true);
-      // Look up action cache, and reuse the action output if it is found.
-      actionKey = digestUtil.computeActionKey(action);
-    }
+    Action action = RemoteSpawnRunner.buildAction(digestUtil.compute(command), merkleTreeRoot,
+        context.getTimeout(), true);
+    // Look up action cache, and reuse the action output if it is found.
+    ActionKey actionKey = digestUtil.computeActionKey(action);
 
     Context withMetadata =
         TracingMetadataUtils.contextWithMetadata(buildRequestId, commandId, actionKey);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -156,24 +156,13 @@ class RemoteSpawnRunner implements SpawnRunner {
     Platform platform =
         parsePlatform(spawn.getExecutionPlatform(), remoteOptions.remoteDefaultPlatformProperties);
 
-    final Command command;
-    final Digest commandHash;
-    final Action action;
-    final ActionKey actionKey;
-    try (SilentCloseable c = Profiler.instance().profile("Remote.buildAction")) {
-      command =
-          buildCommand(
-              spawn.getOutputFiles(), spawn.getArguments(), spawn.getEnvironment(), platform);
-      commandHash = digestUtil.compute(command);
-      action =
-          buildAction(
-              commandHash,
-              merkleTree.getRootDigest(),
-              context.getTimeout(),
-              Spawns.mayBeCached(spawn));
-      actionKey = digestUtil.computeActionKey(action);
-    }
-
+    Command command = buildCommand(spawn.getOutputFiles(), spawn.getArguments(),
+        spawn.getEnvironment(), platform);
+    Digest commandHash = digestUtil.compute(command);
+    Action action = buildAction(commandHash, merkleTree.getRootDigest(), context.getTimeout(),
+        Spawns.mayBeCached(spawn));
+    ActionKey actionKey = digestUtil.computeActionKey(action);
+    
     // Look up action cache, and reuse the action output if it is found.
     Context withMetadata =
         TracingMetadataUtils.contextWithMetadata(buildRequestId, commandId, actionKey);


### PR DESCRIPTION
the work done for building an action proto is trivial and not worth to
be included in the json profile. this is a left over from when we used
to build the merkle tree in buildAction, but this is no longer the case.