### PR TITLE
Add Asylo as an os constraint value

### DIFF
--- a/tools/platforms/platforms.BUILD
+++ b/tools/platforms/platforms.BUILD
@@ -38,6 +38,7 @@ constraint_value(
 )
 
 # These match values in //src/main/java/com/google/devtools/build/lib/util:OS.java
+# except for Asylo, which does not run Bazel natively yet.
 constraint_setting(name = "os")
 
 constraint_value(
@@ -57,6 +58,11 @@ constraint_value(
 
 constraint_value(
     name = "android",
+    constraint_setting = ":os",
+)
+
+constraint_value(
+    name = "asylo",
     constraint_setting = ":os",
 )
 


### PR DESCRIPTION
The Asylo project (https://asylo.dev) is using Bazel to support its toolchain.
We are providing a POSIX interface to enclave applications and operate slightly differently
from all the other POSIX operating systems. This appears to be the source of truth for what
os values there can be, so it'd be great to allow "asylo" to live among these so it's easier to
distinguish when a program is building for the Asylo platform. Ideally we wouldn't have to
state that "being on Asylo" is the same as "using the Asylo CROSSTOOL" since there is just
an ABI expectation.
