### PR TITLE
Add delete() method to repository context

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -200,6 +200,23 @@ public final class WorkspaceRuleEvent implements ProgressLike {
     return new WorkspaceRuleEvent(result.build());
   }
 
+  /** Creates a new WorkspaceRuleEvent for a file read event. */
+  public static WorkspaceRuleEvent newDeleteEvent(String path, String ruleLabel, Location location) {
+    WorkspaceLogProtos.DeleteEvent e =
+        WorkspaceLogProtos.DeleteEvent.newBuilder().setPath(path).build();
+
+    WorkspaceLogProtos.WorkspaceEvent.Builder result =
+        WorkspaceLogProtos.WorkspaceEvent.newBuilder();
+    result = result.setDeleteEvent(e);
+    if (location != null) {
+      result = result.setLocation(location.print());
+    }
+    if (ruleLabel != null) {
+      result = result.setRule(ruleLabel);
+    }
+    return new WorkspaceRuleEvent(result.build());
+  }
+
   /** Creates a new WorkspaceRuleEvent for an os event. */
   public static WorkspaceRuleEvent newOsEvent(String ruleLabel, Location location) {
     OsEvent e = WorkspaceLogProtos.OsEvent.getDefaultInstance();

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
@@ -88,6 +88,12 @@ message ReadEvent {
   string path = 1;
 }
 
+// Information on "delete" event in repository_ctx.
+message DeleteEvent {
+  // Path to the file to delete
+  string path = 1;
+}
+
 // Information on "os" event in repository_ctx.
 message OsEvent {
   // Takes no inputs
@@ -137,5 +143,6 @@ message WorkspaceEvent {
     WhichEvent which_event = 10;
     ExtractEvent extract_event = 11;
     ReadEvent read_event = 12;
+    DeleteEvent delete_event = 13;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -350,6 +350,24 @@ public class SkylarkRepositoryContext
   }
 
   @Override
+  public boolean delete(Object pathObject, Location location)
+      throws EvalException, RepositoryFunctionException, InterruptedException {
+    if (pathObject instanceof Label) {
+      throw new EvalException(Location.BUILTIN, "delete() can only take a path or a string.");
+    }
+    SkylarkPath skylarkPath = getPath("delete()", pathObject);
+    WorkspaceRuleEvent w = WorkspaceRuleEvent.newDeleteEvent(skylarkPath.toString(),
+        rule.getLabel().toString(), location);
+    env.getListener().post(w);
+    try {
+      Path path = skylarkPath.getPath();
+      return path.getFileSystem().delete(path);
+    } catch (IOException e) {
+      throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+    }
+  }
+
+  @Override
   public SkylarkPath which(String program, Location location) throws EvalException {
     WorkspaceRuleEvent w =
         WorkspaceRuleEvent.newWhichEvent(program, rule.getLabel().toString(), location);

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/SkylarkRepositoryContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/SkylarkRepositoryContextApi.java
@@ -275,6 +275,27 @@ public interface SkylarkRepositoryContextApi<RepositoryFunctionExceptionT extend
       throws EvalException, RepositoryFunctionExceptionT, InterruptedException;
 
   @SkylarkCallable(
+      name = "delete",
+      doc =
+          "Deletes a file or a directory. Returns a bool, indicating whether the file or directory"
+              + " was actually deleted by this call.",
+      useLocation = true,
+      parameters = {
+        @Param(
+            name = "path",
+            allowedTypes = {
+                @ParamType(type = String.class),
+                @ParamType(type = RepositoryPathApi.class)
+            },
+            doc = "Path of the file to delete, relative to the repository directory, or absolute."
+                + " Can be a path or a string."),
+      })
+  public boolean delete(
+      Object path,
+      Location location)
+      throws EvalException, RepositoryFunctionExceptionT, InterruptedException;
+
+  @SkylarkCallable(
       name = "which",
       doc =
           "Returns the path of the corresponding program or None "

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
@@ -15,7 +15,9 @@ filegroup(
 
 java_test(
     name = "RepositoryTests",
-    srcs = glob(["*.java"]),
+    srcs = glob(["*.java"]) + [
+        "skylark/SkylarkRepositoryContextTest.java",
+    ],
     data = [
         "test_decompress_archive.tar.gz",
         "test_decompress_archive.zip",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
@@ -40,9 +40,11 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.skyframe.SkyFunction;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
@@ -180,6 +182,20 @@ public class SkylarkRepositoryContextTest {
           .hasMessageThat()
           .isEqualTo("Cannot write outside of the repository directory for path /somepath");
     }
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    setUpContexForRule("testDelete");
+    context.createFile(context.path("foo/bar"), "content", true, true, null);
+    assertThat(context.delete("foo/bar", null)).isTrue();
+
+    assertThat(context.delete("abc/def", null)).isFalse();
+    Path tempFile = scratch.file("/abcde/b", "123");
+    assertThat(context.delete(context.path(tempFile.getPathString()), null)).isTrue();
+
+    Path innerDir = scratch.dir("/some/inner");
+    assertThat(context.delete(innerDir.toString(), null)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Unfortunately, it is problematic to delete directories in Windows.
This task is already solved in Bazel code, so allow Starlark repository rules access that.