### PR TITLE
Wrap StatusRuntimeExceptions from GrpcRemoteCache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
@@ -160,7 +160,11 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
   private ListenableFuture<FindMissingBlobsResponse> getMissingDigests(
       FindMissingBlobsRequest request) throws IOException, InterruptedException {
     Context ctx = Context.current();
-    return retrier.executeAsync(() -> ctx.call(() -> casFutureStub().findMissingBlobs(request)));
+    try {
+      return retrier.executeAsync(() -> ctx.call(() -> casFutureStub().findMissingBlobs(request)));
+    } catch (StatusRuntimeException e) {
+      throw new IOException(e);
+    }
   }
 
   private ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests)
@@ -274,6 +278,9 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
 
           @Override
           public void onFailure(Throwable t) {
+            if (t instanceof StatusRuntimeException) {
+              t = new IOException(t);
+            }
             outerF.setException(t);
           }
         },
@@ -289,12 +296,14 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
     Context ctx = Context.current();
     AtomicLong offset = new AtomicLong(0);
     ProgressiveBackoff progressiveBackoff = new ProgressiveBackoff(retrier::newBackoff);
-    return retrier.executeAsync(
-        () ->
-            ctx.call(
-                () ->
-                    requestRead(
-                        resourceName, offset, progressiveBackoff, digest, out, hashSupplier)));
+    return Futures.catchingAsync(
+        retrier.executeAsync(
+            () -> ctx.call(
+                () -> requestRead(resourceName, offset, progressiveBackoff, digest, out, hashSupplier)),
+            progressiveBackoff),
+        StatusRuntimeException.class,
+        (e) -> Futures.immediateFailedFuture(new IOException(e)),
+        MoreExecutors.directExecutor());
   }
 
   static class ProgressiveBackoff implements Backoff {

--- a/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
@@ -264,7 +264,7 @@ public class Retrier {
    * Executes an {@link AsyncCallable}, retrying execution in case of failure with the given
    * backoff.
    */
-  private <T> ListenableFuture<T> executeAsync(AsyncCallable<T> call, Backoff backoff) {
+  public <T> ListenableFuture<T> executeAsync(AsyncCallable<T> call, Backoff backoff) {
     try {
       return Futures.catchingAsync(
           call.call(),

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
@@ -1011,13 +1011,10 @@ public class GrpcRemoteCacheTest {
     boolean passedThroughDeadlineExceeded = false;
     try {
       getFromFuture(client.downloadBlob(digest));
-    } catch (RuntimeException e) {
+      fail("Should have thrown an exception.");
+    } catch (IOException e) {
       Status st = Status.fromThrowable(e);
-      if (st.getCode() != Status.Code.DEADLINE_EXCEEDED) {
-        throw e;
-      }
-      passedThroughDeadlineExceeded = true;
+      assertThat(st.getCode()).isEqualTo(Status.Code.DEADLINE_EXCEEDED);
     }
-    assertThat(passedThroughDeadlineExceeded).isTrue();
   }
 }


### PR DESCRIPTION
Exceptions that occur during remote interactions are expected to be
wrapped in IOException for observation by the RemoteSpawn{Runner,Cache}
layers.

Fixes #7856