### PR TITLE
Fix error message for `ctx.file` for non-allow_single_file labels.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkAttributesCollection.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkAttributesCollection.java
@@ -71,7 +71,7 @@ class SkylarkAttributesCollection implements SkylarkAttributesCollectionApi {
         StructProvider.STRUCT.create(
             singleFiles,
             "No attribute '%s' in file. Make sure there is a label type attribute marked "
-                + "as 'single_file' with this name");
+                + "as 'allow_single_file' with this name");
     filesObject =
         StructProvider.STRUCT.create(
             files,


### PR DESCRIPTION
The `single_file` option is deprecated in favor of `allow_single_file`
[1]. I suspect the error message was just left behind.

[1]
https://docs.bazel.build/versions/master/skylark/lib/attr.html#parameters-3