### PR TITLE
Add supports_pic feature for all osx CPUs

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl.tpl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl.tpl
@@ -5533,6 +5533,7 @@ def _impl(ctx):
                 linker_param_file_feature,
                 compiler_input_flags_feature,
                 compiler_output_flags_feature,
+                supports_pic_feature,
                 objcopy_embed_flags_feature,
             ]
     elif (ctx.attr.cpu == "darwin_x86_64"):
@@ -5605,6 +5606,7 @@ def _impl(ctx):
                 compiler_input_flags_feature,
                 compiler_output_flags_feature,
                 supports_dynamic_linker_feature,
+                supports_pic_feature,
                 objcopy_embed_flags_feature,
                 dynamic_linking_mode_feature,
             ]


### PR DESCRIPTION
Without this feature LibraryToLink's pic_static_library field will never
be populated