### PR TITLE
Flip the default value of the incompatible_disable_genrule_cc_toolchain_dependency

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -818,7 +818,7 @@ public class CppOptions extends FragmentOptions {
 
   @Option(
       name = "incompatible_disable_genrule_cc_toolchain_dependency",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/TemplateVariableInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/TemplateVariableInfoTest.java
@@ -64,7 +64,7 @@ public class TemplateVariableInfoTest extends BuildViewTestCase {
 
     @SuppressWarnings("unchecked")
     Map<String, String> makeVariables = (Map<String, String>) ct.get("variables");
-    assertThat(makeVariables).containsKey("CC_FLAGS");
+    assertThat(makeVariables).containsKey("CC");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleCommandSubstitutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleCommandSubstitutionTest.java
@@ -477,21 +477,4 @@ public class GenRuleCommandSubstitutionTest extends BuildViewTestCase {
             "        outs = ['out'],",
             "        cmd = '" + command + "')");
   }
-
-  @Test
-  public void testCcFlagsFromFeatureConfiguration() throws Exception {
-    AnalysisMock.get()
-        .ccSupport()
-        .setupCcToolchainConfig(
-            mockToolsConfig,
-            CcToolchainConfig.builder().withActionConfigs("cc_flags_action_config_foo_bar_baz"));
-    useConfiguration();
-    scratch.file(
-        "foo/BUILD",
-        "genrule(name = 'foo',",
-        "        outs = ['out'],",
-        "        cmd = '$(CC_FLAGS)')");
-    String command = getGenruleCommand("//foo");
-    assertThat(command).endsWith("foo bar baz");
-  }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/genrule/GenRuleConfiguredTargetTest.java
@@ -30,9 +30,6 @@ import com.google.devtools.build.lib.analysis.ShellConfiguration;
 import com.google.devtools.build.lib.analysis.actions.SpawnAction;
 import com.google.devtools.build.lib.analysis.configuredtargets.FileConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
-import com.google.devtools.build.lib.rules.cpp.CcToolchainProvider;
-import com.google.devtools.build.lib.rules.cpp.CppConfiguration.Tool;
-import com.google.devtools.build.lib.rules.cpp.CppHelper;
 import com.google.devtools.build.lib.testutil.TestRuleClassProvider;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.List;
@@ -89,16 +86,6 @@ public class GenRuleConfiguredTargetTest extends BuildViewTestCase {
 
     String cmd = getCommand("//a:gr");
     assertThat(cmd).endsWith("JAVABASE=REPLACED");
-  }
-
-  @Test
-  public void testToolchainDoesNotOverrideCcFlags() throws Exception {
-    scratch.file("a/BUILD",
-        "genrule(name='gr', srcs=[], outs=['out'], cmd='CC_FLAGS=$(CC_FLAGS)', toolchains=[':v'])",
-        "make_variable_tester(name='v', variables={'CC_FLAGS': 'REPLACED'})");
-
-    String cmd = getCommand("//a:gr");
-    assertThat(cmd).doesNotContain("CC_FLAGS=REPLACED");
   }
 
   @Test
@@ -301,51 +288,6 @@ public class GenRuleConfiguredTargetTest extends BuildViewTestCase {
     String expectedRegex = "touch b.{4}-out.*foo";
     assertThat(getCommand("//foo:bar")).containsMatch(expectedRegex);
     assertThat(getCommand("//foo:baz")).containsMatch(expectedRegex);
-  }
-
-  /** Ensure that variable $(CC) gets expanded correctly in the genrule cmd. */
-  @Test
-  public void testMakeVarExpansion() throws Exception {
-    scratch.file(
-        "foo/BUILD",
-        "genrule(name = 'bar',",
-        "        srcs = ['bar.cc'],",
-        "        cmd = '$(CC) -o $(OUTS) $(SRCS) $$shellvar',",
-        "        outs = ['bar.o'])");
-    FileConfiguredTarget barOutTarget = getFileConfiguredTarget("//foo:bar.o");
-    FileConfiguredTarget barInTarget = getFileConfiguredTarget("//foo:bar.cc");
-
-    SpawnAction barAction = (SpawnAction) getGeneratingAction(barOutTarget.getArtifact());
-
-    CcToolchainProvider toolchain =
-        CppHelper.getToolchainUsingDefaultCcToolchainAttribute(
-            getRuleContext(getConfiguredTarget("//foo:bar")));
-    String cc = toolchain.getToolPathFragment(Tool.GCC).getPathString();
-    String expected =
-        cc
-            + " -o "
-            + barOutTarget.getArtifact().getExecPathString()
-            + " "
-            + barInTarget.getArtifact().getRootRelativePath().getPathString()
-            + " $shellvar";
-    assertCommandEquals(expected, barAction.getArguments().get(2));
-  }
-
-  @Test
-  public void onlyHasCcToolchainDepWhenCcMakeVariablesArePresent() throws Exception {
-    scratch.file(
-        "foo/BUILD",
-        "genrule(name = 'no_cc',",
-        "        srcs = [],",
-        "        cmd = 'echo no CC variables here > $@',",
-        "        outs = ['no_cc.out'])",
-        "genrule(name = 'cc',",
-        "        srcs = [],",
-        "        cmd = 'echo $(CC) > $@',",
-        "        outs = ['cc.out'])");
-    String ccToolchainAttr = ":cc_toolchain";
-    assertThat(getPrerequisites(getConfiguredTarget("//foo:no_cc"), ccToolchainAttr)).isEmpty();
-    assertThat(getPrerequisites(getConfiguredTarget("//foo:cc"), ccToolchainAttr)).isNotEmpty();
   }
 
   // Returns the expansion of 'cmd' for the specified genrule.
@@ -671,26 +613,5 @@ public class GenRuleConfiguredTargetTest extends BuildViewTestCase {
             + "      tags = ['local'])");
     getConfiguredTarget("//foo:g");
     assertNoEvents();
-  }
-
-  @Test
-  public void testDisableGenruleCcToolchainDependency() throws Exception {
-    reporter.removeHandler(failFastHandler);
-    scratch.file(
-        "a/BUILD",
-        "genrule(",
-        "    name = 'a',",
-        "    outs = ['out.log'],",
-        "    cmd = 'echo $(CC_FLAGS) > $@',",
-        ")");
-
-    // Legacy behavior: CC_FLAGS is implicitly defined.
-    getConfiguredTarget("//a:a");
-    assertDoesNotContainEvent("$(CC_FLAGS) not defined");
-
-    // Updated behavior: CC_FLAGS must be explicitly supplied by a dependency.
-    useConfiguration("--incompatible_disable_genrule_cc_toolchain_dependency");
-    getConfiguredTarget("//a:a");
-    assertContainsEvent("$(CC_FLAGS) not defined");
   }
 }


### PR DESCRIPTION
Flip --incompatible_disable_genrule_cc_toolchain_dependency flag.

Fixes https://github.com/bazelbuild/bazel/issues/6867.

RELNOTES: The --incompatible_disable_genrule_cc_toolchain_dependency flag has been flipped (see https://github.com/bazelbuild/bazel/issues/6867 for details).