### PR TITLE
Use ArtifactPathResolver everywhere in StandaloneTestStrategy

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -105,7 +105,8 @@ public class StandaloneTestStrategy extends TestStrategy {
             binTools,
             action.getLocalShellEnvironment(),
             action.isEnableRunfiles());
-    Path tmpDir = tmpDirRoot.getChild(TestStrategy.getTmpDirName(action));
+    Path tmpDir = actionExecutionContext.getPathResolver()
+        .convertPath(tmpDirRoot.getChild(TestStrategy.getTmpDirName(action)));
     Map<String, String> env = setupEnvironment(
         action, actionExecutionContext.getClientEnv(), execRoot, runfilesDir, tmpDir);
     if (executionOptions.splitXmlGeneration) {

--- a/src/main/java/com/google/devtools/build/lib/exec/TestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/TestStrategy.java
@@ -357,7 +357,8 @@ public abstract class TestStrategy implements TestActionContext {
       throw new TestExecException("cannot run local tests with --nobuild_runfile_manifests");
     }
 
-    Path runfilesDir = execSettings.getRunfilesDir();
+    Path runfilesDir =
+        actionExecutionContext.getPathResolver().convertPath(execSettings.getRunfilesDir());
 
     // If the symlink farm is already created then return the existing directory. If not we
     // need to explicitly build it. This can happen when --nobuild_runfile_links is supplied


### PR DESCRIPTION
I discovered that some places in StandaloneTestStrategy don't properly
wrap their paths with ArtifactPathResolver. I manually audited the
StandaloneTestStrategy and fixed the remaining places.

Progress towards #6862 