### PR TITLE
remote: remote_http_cache flag renamed to remote_cache

### DIFF
--- a/site/docs/remote-caching-debug.md
+++ b/site/docs/remote-caching-debug.md
@@ -75,8 +75,7 @@ the steps in this section.
 
    a. Since cache-reading Bazel invocations will have a different command-line set
       up, take additional care to ensure that they are properly set up to
-      communicate with the remote cache. Ensure `--remote_cache` or
-      `--remote_http_cache` flags are set and there are no warnings in the output.
+      communicate with the remote cache. Ensure `--remote_cache` flag is set and there are no warnings in the output.
 
    b. Ensure your cache-reading Bazel invocations build the same targets as the
       cache-writing Bazel invocations.

--- a/site/docs/remote-caching.md
+++ b/site/docs/remote-caching.md
@@ -164,7 +164,7 @@ the key securely, as anyone with the key can read and write arbitrary data
 to/from your GCS bucket.
 
 4. Connect to Cloud Storage by adding the following flags to your Bazel command:
-   * Pass the following URL to Bazel by using the flag: `--remote_http_cache=https://storage.googleapis.com/bucket-name` where `bucket-name` is the name of your storage bucket.
+   * Pass the following URL to Bazel by using the flag: `--remote_cache=https://storage.googleapis.com/bucket-name` where `bucket-name` is the name of your storage bucket.
    * Pass the authentication key using the flag: `--google_credentials=/path/to/your/secret-key.json`.
 
 5. You can configure Cloud Storage to automatically delete old files. To do so, see
@@ -243,7 +243,7 @@ Use the following flags to:
 * disable sandboxing
 
 ```
-build --remote_http_cache=http://replace-with-your.host:port
+build --remote_cache=http://replace-with-your.host:port
 build --spawn_strategy=standalone
 ```
 
@@ -252,7 +252,7 @@ following flags to read and write from the remote cache with sandboxing
 enabled:
 
 ```
-build --remote_http_cache=http://replace-with-your.host:port
+build --remote_cache=http://replace-with-your.host:port
 ```
 
 ### Read only from the remote cache
@@ -261,7 +261,7 @@ Use the following flags to: read from the remote cache with sandboxing
 disabled.
 
 ```
-build --remote_http_cache=http://replace-with-your.host:port
+build --remote_cache=http://replace-with-your.host:port
 build --remote_upload_local_results=false
 build --spawn_strategy=standalone
 ```
@@ -270,7 +270,7 @@ Using the remote cache with sandboxing enabled is experimental. Use the
 following flags to read from the remote cache with sandboxing enabled:
 
 ```
-build --remote_http_cache=http://replace-with-your.host:port
+build --remote_cache=http://replace-with-your.host:port
 build --remote_upload_local_results=false
 ```
 
@@ -309,7 +309,7 @@ is similar to curl's `--unix-socket` flag. Use the following to configure unix
 domain socket:
 
 ```
-build --remote_http_cache=http://replace-with-your.host:port
+build --remote_cache=http://replace-with-your.host:port
 build --remote_cache_proxy=unix:/replace/with/socket/path
 ```
 

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
@@ -154,7 +154,10 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
   }
 
   public static boolean isRemoteCacheOptions(RemoteOptions options) {
-    return options.remoteCache != null;
+    // check against 'http' rather than 'grpc' because gRPC is a default protocol when none provided
+    return options.remoteCache != null
+        && !options.remoteCache.isEmpty()
+        && !options.remoteCache.startsWith("http");
   }
 
   private ListenableFuture<FindMissingBlobsResponse> getMissingDigests(

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
@@ -157,7 +157,7 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
     // check against 'http' rather than 'grpc' because gRPC is a default protocol when none provided
     return options.remoteCache != null
         && !options.remoteCache.isEmpty()
-        && !options.remoteCache.startsWith("http");
+        && !options.remoteCache.toLowerCase().startsWith("http");
   }
 
   private ListenableFuture<FindMissingBlobsResponse> getMissingDigests(

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
@@ -66,6 +66,8 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -154,10 +156,14 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
   }
 
   public static boolean isRemoteCacheOptions(RemoteOptions options) {
-    // check against 'http' rather than 'grpc' because gRPC is a default protocol when none provided
-    return options.remoteCache != null
-        && !options.remoteCache.isEmpty()
-        && !options.remoteCache.toLowerCase().startsWith("http");
+    if (options.remoteCache == null || options.remoteCache.isEmpty()) return false;
+    String scheme;
+    try {
+      scheme = new URI(options.remoteCache).getScheme();
+    } catch (URISyntaxException e) {
+      return false;
+    }
+    return scheme == null || scheme.toLowerCase().startsWith("grpc");
   }
 
   private ListenableFuture<FindMissingBlobsResponse> getMissingDigests(

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
@@ -156,7 +156,9 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
   }
 
   public static boolean isRemoteCacheOptions(RemoteOptions options) {
-    if (options.remoteCache == null || options.remoteCache.isEmpty()) return false;
+    if (options.remoteCache == null || options.remoteCache.isEmpty()) {
+      return false;
+    }
     String scheme;
     try {
       scheme = new URI(options.remoteCache).getScheme();

--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
@@ -124,7 +124,6 @@ public final class SimpleBlobStoreFactory {
 
   private static boolean isHttpUrlOptions(RemoteOptions options) {
     return options.remoteCache != null
-        && !options.remoteCache.isEmpty()
-        && options.remoteCache.startsWith("http");
+        && options.remoteCache.toLowerCase().startsWith("http");
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
@@ -72,8 +72,10 @@ public final class SimpleBlobStoreFactory {
   }
 
   private static SimpleBlobStore createHttp(RemoteOptions options, Credentials creds) {
+    Preconditions.checkNotNull(options.remoteCache, "remoteCache");
+    Preconditions.checkArgument(options.remoteCache.startsWith("http"), "remoteCache should start with http");
     try {
-      URI uri = URI.create(options.remoteHttpCache);
+      URI uri = URI.create(options.remoteCache);
 
       if (options.remoteCacheProxy != null) {
         if (options.remoteCacheProxy.startsWith("unix:")) {
@@ -121,6 +123,8 @@ public final class SimpleBlobStoreFactory {
   }
 
   private static boolean isHttpUrlOptions(RemoteOptions options) {
-    return options.remoteHttpCache != null && !options.remoteHttpCache.isEmpty();
+    return options.remoteCache != null
+        && !options.remoteCache.isEmpty()
+        && options.remoteCache.startsWith("http");
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
@@ -73,7 +73,7 @@ public final class SimpleBlobStoreFactory {
 
   private static SimpleBlobStore createHttp(RemoteOptions options, Credentials creds) {
     Preconditions.checkNotNull(options.remoteCache, "remoteCache");
-    Preconditions.checkArgument(options.remoteCache.startsWith("http"), "remoteCache should start with http");
+    Preconditions.checkArgument(options.remoteCache.toLowerCase().startsWith("http"), "remoteCache should start with http");
     try {
       URI uri = URI.create(options.remoteCache);
 

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -61,10 +61,9 @@ public final class RemoteOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
-        "A base URL of a caching service in the format PROTOCOL://HOST or PROTOCOL://HOST:PORT."
-            + "Supported protocols: http, https, grpc, grpcs. "
-            + "If no protocol provided, will default to gRPC."
-            + "Format: (http|https|grpc|grpcs)://host:port")
+          "A URI of a caching endpoint. The supported schemas are http(s) and grpc. "
+              + "If no schema is provided we'll default to grpc. "
+              + "See https://docs.bazel.build/versions/master/remote-caching.html")
   public String remoteCache;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -24,17 +24,6 @@ import com.google.devtools.common.options.OptionsBase;
 
 /** Options for remote execution and distributed caching. */
 public final class RemoteOptions extends OptionsBase {
-  @Option(
-      name = "remote_http_cache",
-      oldName = "remote_rest_cache",
-      defaultValue = "null",
-      documentationCategory = OptionDocumentationCategory.REMOTE,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      help =
-          "A base URL of a HTTP caching service. Both http:// and https:// are supported. BLOBs"
-              + " are stored with PUT and retrieved with GET. See remote/README.md for more"
-              + " information.")
-  public String remoteHttpCache;
 
   @Option(
       name = "remote_cache_proxy",
@@ -67,10 +56,15 @@ public final class RemoteOptions extends OptionsBase {
 
   @Option(
       name = "remote_cache",
+      oldName = "remote_http_cache",
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
-      help = "HOST or HOST:PORT of a remote caching endpoint.")
+      help =
+        "A base URL of a caching service in the format PROTOCOL://HOST or PROTOCOL://HOST:PORT."
+            + "Supported protocols: http, https, grpc, grpcs. "
+            + "If no protocol provided, will default to gRPC."
+            + "Format: (http|https|grpc|grpcs)://host:port")
   public String remoteCache;
 
   @Option(

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
@@ -1050,6 +1050,14 @@ public class GrpcRemoteCacheTest {
   }
 
   @Test
+  public void isRemoteCacheOptionsWhenHttpEnabledWithUpperCase() {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteCache = "HTTP://some-host.com";
+
+    assertThat(GrpcRemoteCache.isRemoteCacheOptions(options)).isFalse();
+  }
+
+  @Test
   public void isRemoteCacheOptionsWhenHttpsEnabled() {
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
     options.remoteCache = "https://some-host.com";

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
@@ -1016,4 +1016,59 @@ public class GrpcRemoteCacheTest {
       assertThat(st.getCode()).isEqualTo(Status.Code.DEADLINE_EXCEEDED);
     }
   }
+
+  @Test
+  public void isRemoteCacheOptionsWhenGrpcEnabled() {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteCache = "grpc://some-host.com";
+
+    assertThat(GrpcRemoteCache.isRemoteCacheOptions(options)).isTrue();
+  }
+
+  @Test
+  public void isRemoteCacheOptionsWhenGrpcsEnabled() {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteCache = "grpcs://some-host.com";
+
+    assertThat(GrpcRemoteCache.isRemoteCacheOptions(options)).isTrue();
+  }
+
+  @Test
+  public void isRemoteCacheOptionsWhenDefaultRemoteCacheEnabled() {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteCache = "some-host.com";
+
+    assertThat(GrpcRemoteCache.isRemoteCacheOptions(options)).isTrue();
+  }
+
+  @Test
+  public void isRemoteCacheOptionsWhenHttpEnabled() {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteCache = "http://some-host.com";
+
+    assertThat(GrpcRemoteCache.isRemoteCacheOptions(options)).isFalse();
+  }
+
+  @Test
+  public void isRemoteCacheOptionsWhenHttpsEnabled() {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteCache = "https://some-host.com";
+
+    assertThat(GrpcRemoteCache.isRemoteCacheOptions(options)).isFalse();
+  }
+
+  @Test
+  public void isRemoteCacheOptionsWhenEmptyCacheProvided() {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteCache = "";
+
+    assertThat(GrpcRemoteCache.isRemoteCacheOptions(options)).isFalse();
+  }
+
+  @Test
+  public void isRemoteCacheOptionsWhenRemoteCacheDisabled() {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+
+    assertThat(GrpcRemoteCache.isRemoteCacheOptions(options)).isFalse();
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactoryTest.java
@@ -52,7 +52,7 @@ public class SimpleBlobStoreFactoryTest {
 
   @Test
   public void createCombinedCacheWithExistingWorkingDirectory() throws IOException {
-    remoteOptions.remoteHttpCache = "http://doesnotexist.com";
+    remoteOptions.remoteCache = "http://doesnotexist.com";
     remoteOptions.diskCache = PathFragment.create("/etc/something/cache/here");
     fs.getPath("/etc/something/cache/here").createDirectoryAndParents();
 
@@ -64,7 +64,7 @@ public class SimpleBlobStoreFactoryTest {
 
   @Test
   public void createCombinedCacheWithNotExistingWorkingDirectory() throws IOException {
-    remoteOptions.remoteHttpCache = "http://doesnotexist.com";
+    remoteOptions.remoteCache = "http://doesnotexist.com";
     remoteOptions.diskCache = PathFragment.create("/etc/something/cache/here");
     assertThat(workingDirectory.exists()).isFalse();
 
@@ -78,7 +78,7 @@ public class SimpleBlobStoreFactoryTest {
   @Test
   public void createCombinedCacheWithMissingWorkingDirectoryShouldThrowException() {
     // interesting case: workingDirectory = null -> NPE.
-    remoteOptions.remoteHttpCache = "http://doesnotexist.com";
+    remoteOptions.remoteCache = "http://doesnotexist.com";
     remoteOptions.diskCache = PathFragment.create("/etc/something/cache/here");
 
     assertThrows(
@@ -90,7 +90,7 @@ public class SimpleBlobStoreFactoryTest {
 
   @Test
   public void createHttpCacheWithProxy() throws IOException {
-    remoteOptions.remoteHttpCache = "http://doesnotexist.com";
+    remoteOptions.remoteCache = "http://doesnotexist.com";
     remoteOptions.remoteCacheProxy = "unix://some-proxy";
 
     SimpleBlobStore blobStore =
@@ -101,7 +101,7 @@ public class SimpleBlobStoreFactoryTest {
 
   @Test
   public void createHttpCacheFailsWithUnsupportedProxyProtocol() {
-    remoteOptions.remoteHttpCache = "http://doesnotexist.com";
+    remoteOptions.remoteCache = "http://doesnotexist.com";
     remoteOptions.remoteCacheProxy = "bad-proxy";
 
     assertThat(
@@ -116,7 +116,7 @@ public class SimpleBlobStoreFactoryTest {
 
   @Test
   public void createHttpCacheWithoutProxy() throws IOException {
-    remoteOptions.remoteHttpCache = "http://doesnotexist.com";
+    remoteOptions.remoteCache = "http://doesnotexist.com";
 
     SimpleBlobStore blobStore =
         SimpleBlobStoreFactory.create(remoteOptions, /* creds= */ null, workingDirectory);
@@ -136,7 +136,13 @@ public class SimpleBlobStoreFactoryTest {
 
   @Test
   public void isRemoteCacheOptions_httpCacheEnabled() {
-    remoteOptions.remoteHttpCache = "http://doesnotexist:90";
+    remoteOptions.remoteCache = "http://doesnotexist:90";
+    assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isTrue();
+  }
+
+  @Test
+  public void isRemoteCacheOptions_httpsCacheEnabled() {
+    remoteOptions.remoteCache = "https://doesnotexist:90";
     assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isTrue();
   }
 
@@ -148,10 +154,32 @@ public class SimpleBlobStoreFactoryTest {
 
   @Test
   public void isRemoteCacheOptions_httpAndDiskCacheEnabled() {
-    remoteOptions.remoteHttpCache = "http://doesnotexist:90";
+    remoteOptions.remoteCache = "http://doesnotexist:90";
     remoteOptions.diskCache = PathFragment.create("/etc/something/cache/here");
 
     assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isTrue();
+  }
+
+  @Test
+  public void isRemoteCacheOptions_httpsAndDiskCacheEnabled() {
+    remoteOptions.remoteCache = "https://doesnotexist:90";
+    remoteOptions.diskCache = PathFragment.create("/etc/something/cache/here");
+
+    assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isTrue();
+  }
+
+  @Test
+  public void isRemoteCacheOptions_httpCacheDisabledWhenGrpcEnabled() {
+    remoteOptions.remoteCache = "grpc://doesnotexist:90";
+
+    assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isFalse();
+  }
+
+  @Test
+  public void isRemoteCacheOptions_httpCacheDisabledWhenNoProtocol() {
+    remoteOptions.remoteCache = "doesnotexist:90";
+
+    assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isFalse();
   }
 
   @Test
@@ -162,7 +190,7 @@ public class SimpleBlobStoreFactoryTest {
 
   @Test
   public void isRemoteCacheOptions_remoteHttpCacheOptionEmpty() {
-    remoteOptions.remoteHttpCache = "";
+    remoteOptions.remoteCache = "";
     assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isFalse();
   }
 
@@ -173,7 +201,7 @@ public class SimpleBlobStoreFactoryTest {
 
   @Test
   public void create_httpCacheWhenHttpAndDiskCacheEnabled() {
-    remoteOptions.remoteHttpCache = "http://doesnotexist.com";
+    remoteOptions.remoteCache = "http://doesnotexist.com";
     remoteOptions.diskCache = PathFragment.create("/etc/something/cache/here");
 
     SimpleBlobStore blobStore = SimpleBlobStoreFactory.create(remoteOptions, /* casPath= */ null);
@@ -183,7 +211,7 @@ public class SimpleBlobStoreFactoryTest {
 
   @Test
   public void create_httpCacheWithProxy() {
-    remoteOptions.remoteHttpCache = "http://doesnotexist.com";
+    remoteOptions.remoteCache = "http://doesnotexist.com";
     remoteOptions.remoteCacheProxy = "unix://some-proxy";
 
     SimpleBlobStore blobStore = SimpleBlobStoreFactory.create(remoteOptions, /* casPath= */ null);
@@ -193,7 +221,7 @@ public class SimpleBlobStoreFactoryTest {
 
   @Test
   public void create_httpCacheFailsWithUnsupportedProxyProtocol() {
-    remoteOptions.remoteHttpCache = "http://doesnotexist.com";
+    remoteOptions.remoteCache = "http://doesnotexist.com";
     remoteOptions.remoteCacheProxy = "bad-proxy";
 
     assertThat(
@@ -206,7 +234,7 @@ public class SimpleBlobStoreFactoryTest {
 
   @Test
   public void create_httpCacheWithoutProxy() {
-    remoteOptions.remoteHttpCache = "http://doesnotexist.com";
+    remoteOptions.remoteCache = "http://doesnotexist.com";
 
     SimpleBlobStore blobStore = SimpleBlobStoreFactory.create(remoteOptions, /* casPath= */ null);
 

--- a/src/test/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactoryTest.java
@@ -141,6 +141,12 @@ public class SimpleBlobStoreFactoryTest {
   }
 
   @Test
+  public void isRemoteCacheOptions_httpCacheEnabledInUpperCase() {
+    remoteOptions.remoteCache = "HTTP://doesnotexist:90";
+    assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isTrue();
+  }
+
+  @Test
   public void isRemoteCacheOptions_httpsCacheEnabled() {
     remoteOptions.remoteCache = "https://doesnotexist:90";
     assertThat(SimpleBlobStoreFactory.isRemoteCacheOptions(remoteOptions)).isTrue();

--- a/src/test/shell/bazel/remote/remote_execution_http_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_http_test.sh
@@ -64,17 +64,17 @@ function test_remote_http_cache_flag() {
   mkdir -p a
   cat > a/BUILD <<EOF
 genrule(
-  name = 'test-remote-http-cache',
+  name = 'foo',
   srcs = [],
-  outs = ["test.txt"],
+  outs = ["foo.txt"],
   cmd = "echo \"foo bar\" > \$@",
 )
 EOF
 
   bazel build \
       --remote_http_cache=http://localhost:${http_port} \
-      //a:test-remote-http-cache \
-      || fail "Failed to build //a:test-remote-http-cache with remote cache"
+      //a:foo \
+      || fail "Failed to build //a:foo with remote cache"
 }
 
 function test_cc_binary_http_cache() {


### PR DESCRIPTION
* the change is backward compatible
* `remote_http_cache` flag is now deprecated
* `remote_rest_cache` is now removed (has been deprecated for over a year)
* `remote_cache` flag to be used in the following format: `(http|https|grpc|grpcs)://host:port`
* for backward compatibility, missing protocol in `remote_cache` defaults to 'grpc'

RELNOTES: `--remote_rest_cache `was removed, `--remote_http_cache` is deprecated, `--remote_cache `to be used instead in the following format:` (http|https|grpc|grpcs)://host:port`