### PR TITLE
Add @bazel_tools//tools/jdk:javadoc

### DIFF
--- a/src/main/tools/jdk.BUILD
+++ b/src/main/tools/jdk.BUILD
@@ -68,6 +68,16 @@ filegroup(
 
 filegroup(
     deprecation = DEPRECATION_MESSAGE,
+    name = "javadoc",
+    srcs = select({
+        ":windows": ["bin/javadoc.exe"],
+        "//conditions:default": ["bin/javadoc"],
+    }),
+    data = [":jdk"],
+)
+
+filegroup(
+    deprecation = DEPRECATION_MESSAGE,
     name = "xjc",
     srcs = ["bin/xjc"],
 )

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -123,6 +123,11 @@ alias(
     actual = "@local_jdk//:javac",
 )
 
+alias(
+    name = "javadoc",
+    actual = "@local_jdk//:javadoc",
+)
+
 # On Windows, executables end in ".exe", but the label we reach it through
 # must be platform-independent. Thus, we create a little filegroup that
 # contains the appropriate platform-dependent file.


### PR DESCRIPTION
Fixes #6757

It adds a `@bazel_tools//tools/jdk:javadoc` alias similar to `@bazel_tools//tools/jdk:java`, which correctly maps to `javadoc.exe` on windows and `javadoc` elsewhere.
