### PR TITLE
Unbundle Android tools from Bazel's binary

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -322,25 +322,11 @@ http_archive(
     ],
 )
 
-# distdir_tar(
-#     name = "android_WORKSPACE_files",
-#     archives = [
-#         "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip",
-#     ],
-#     dirname = "android_WORKSPACE/distdir",
-#     sha256 = {
-#         "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip": "c4cd965983b22272d20f5038f6fd8d143d344fac1bb638d765ec7f62e652486f",
-#     },
-#     urls = {
-#         "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip": ["https://github.com/jin/legacy_android_tools/archive/54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip"],
-#     },
-# )
-
 # For testing, have an distdir_tar with all the archives implicit in every
 # WORKSPACE, to that they don't have to be refetched for every test
 # calling `bazel sync`.
 distdir_tar(
-    name = "jdk_WORKSPACE_files",
+    name = "test_WORKSPACE_files",
     archives = [
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz",
         "zulu9.0.7.1-jdk9.0.7-macosx_x64-allmodules.tar.gz",
@@ -359,9 +345,9 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip",
-        "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip",
+        "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip", # TODO(jin): do a proper release
     ],
-    dirname = "jdk_WORKSPACE/distdir",
+    dirname = "test_WORKSPACE/distdir",
     sha256 = {
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": "f27cb933de4f9e7fe9a703486cf44c84bc8e9f138be0c270c9e5716a32367e87",
         "zulu9.0.7.1-jdk9.0.7-macosx_x64-allmodules.tar.gz": "404e7058ff91f956612f47705efbee8e175a38b505fb1b52d8c1ea98718683de",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,7 +58,10 @@ list_source_repository(name = "local_bazel_source_list")
 #   2. Set the $ANDROID_HOME and $ANDROID_NDK_HOME environment variables
 #   3. Uncomment the two lines below
 #
-# android_sdk_repository(name = "androidsdk")
+android_sdk_repository(
+    name = "androidsdk",
+    path = "/usr/local/google/home/jingwen/sdk",
+)
 # android_ndk_repository(name = "androidndk")
 
 # In order to run //src/test/shell/bazel:maven_skylark_test, follow the
@@ -345,7 +348,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip",
-        "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip", # TODO(jin): do a proper release
+        "1a6aaad88aaaf186c168623c872c55ed80c05c5a.zip",  # TODO(jin): do a proper release
     ],
     dirname = "test_WORKSPACE/distdir",
     sha256 = {
@@ -366,7 +369,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": "f3f44b6235508e87b760bf37a49e186cc1fa4e9cd28384c4dbf5a33991921e08",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": "059f8e3484bf07b63a8f2820d5f528f473eff1befdb1896ee4f8ff06be3b8d8f",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": "e1f5b4ce1b9148140fae2fcfb8a96d1c9b7eac5b8df0e13fbcad9b8561284880",
-        "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip": "c4cd965983b22272d20f5038f6fd8d143d344fac1bb638d765ec7f62e652486f",
+        "1a6aaad88aaaf186c168623c872c55ed80c05c5a.zip": "19a32c3ba0d3e75985a962b9f9f85adf12c100188a54ae00bf957798a2fda728",
     },
     urls = {
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz"],
@@ -386,7 +389,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz"],
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip"],
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64.zip"],
-        "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip": ["https://github.com/jin/legacy_android_tools/archive/54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip"],
+        "1a6aaad88aaaf186c168623c872c55ed80c05c5a.zip": ["https://github.com/jin/legacy_android_tools/archive/1a6aaad88aaaf186c168623c872c55ed80c05c5a.zip"],
     },
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -326,7 +326,7 @@ http_archive(
 # WORKSPACE, to that they don't have to be refetched for every test
 # calling `bazel sync`.
 distdir_tar(
-    name = "test_WORKSPACE_files",
+    name = "jdk_WORKSPACE_files",
     archives = [
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz",
         "zulu9.0.7.1-jdk9.0.7-macosx_x64-allmodules.tar.gz",
@@ -345,9 +345,9 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip",
-        "1a6aaad88aaaf186c168623c872c55ed80c05c5a.zip",  # TODO(jin): do a proper release
+        "android_tools_pkg-0.1.tar.gz",  # TODO(jin): do a proper release
     ],
-    dirname = "test_WORKSPACE/distdir",
+    dirname = "jdk_WORKSPACE/distdir",
     sha256 = {
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": "f27cb933de4f9e7fe9a703486cf44c84bc8e9f138be0c270c9e5716a32367e87",
         "zulu9.0.7.1-jdk9.0.7-macosx_x64-allmodules.tar.gz": "404e7058ff91f956612f47705efbee8e175a38b505fb1b52d8c1ea98718683de",
@@ -366,7 +366,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": "f3f44b6235508e87b760bf37a49e186cc1fa4e9cd28384c4dbf5a33991921e08",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": "059f8e3484bf07b63a8f2820d5f528f473eff1befdb1896ee4f8ff06be3b8d8f",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": "e1f5b4ce1b9148140fae2fcfb8a96d1c9b7eac5b8df0e13fbcad9b8561284880",
-        "1a6aaad88aaaf186c168623c872c55ed80c05c5a.zip": "7210c2c5dcd2053165c68f00ae83c37ac4a6b04cd309193ded12fe828d875ed9",
+        "android_tools_pkg-0.1.tar.gz": "b71b10e8f067dd6bff446fb0d49239fe28b12cfd1ed24278d04b06cf54669862",
     },
     urls = {
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz"],
@@ -386,7 +386,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz"],
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip"],
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64.zip"],
-        "1a6aaad88aaaf186c168623c872c55ed80c05c5a.zip": ["https://github.com/jin/legacy_android_tools/archive/1a6aaad88aaaf186c168623c872c55ed80c05c5a.zip"],
+        "android_tools_pkg-0.1.tar.gz": ["https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.1.tar.gz"],
     },
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,10 +58,7 @@ list_source_repository(name = "local_bazel_source_list")
 #   2. Set the $ANDROID_HOME and $ANDROID_NDK_HOME environment variables
 #   3. Uncomment the two lines below
 #
-android_sdk_repository(
-    name = "androidsdk",
-    path = "/usr/local/google/home/jingwen/sdk",
-)
+# android_sdk_repository(name = "androidsdk")
 # android_ndk_repository(name = "androidndk")
 
 # In order to run //src/test/shell/bazel:maven_skylark_test, follow the

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -369,7 +369,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": "f3f44b6235508e87b760bf37a49e186cc1fa4e9cd28384c4dbf5a33991921e08",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": "059f8e3484bf07b63a8f2820d5f528f473eff1befdb1896ee4f8ff06be3b8d8f",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": "e1f5b4ce1b9148140fae2fcfb8a96d1c9b7eac5b8df0e13fbcad9b8561284880",
-        "1a6aaad88aaaf186c168623c872c55ed80c05c5a.zip": "19a32c3ba0d3e75985a962b9f9f85adf12c100188a54ae00bf957798a2fda728",
+        "1a6aaad88aaaf186c168623c872c55ed80c05c5a.zip": "7210c2c5dcd2053165c68f00ae83c37ac4a6b04cd309193ded12fe828d875ed9",
     },
     urls = {
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,6 +116,7 @@ distdir_tar(
         "2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz",
         "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz",
         "0.16.2.zip",
+        "android_tools_pkg-0.1.tar.gz",
     ],
     dirname = "derived/distdir",
     sha256 = {
@@ -128,6 +129,7 @@ distdir_tar(
         "2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz": "4a1318fed4831697b83ce879b3ab70ae09592b167e5bda8edaff45132d1c3b3f",
         "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz": "d868ce50d592ef4aad7dec4dd32ae68d2151261913450fac8390b3fd474bb898",
         "0.16.2.zip": "9b72bb0aea72d7cbcfc82a01b1e25bf3d85f791e790ddec16c65e2d906382ee0",
+        "android_tools_pkg-0.1.tar.gz": "b71b10e8f067dd6bff446fb0d49239fe28b12cfd1ed24278d04b06cf54669862",
     },
     urls = {
         "e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip": [
@@ -161,6 +163,9 @@ distdir_tar(
         "0.16.2.zip": [
             "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
             "https://github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
+        ],
+        "android_tools_pkg-0.1.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.1.tar.gz",
         ],
     },
 )
@@ -345,7 +350,6 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip",
-        "android_tools_pkg-0.1.tar.gz",  # TODO(jin): do a proper release
     ],
     dirname = "jdk_WORKSPACE/distdir",
     sha256 = {
@@ -366,7 +370,6 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": "f3f44b6235508e87b760bf37a49e186cc1fa4e9cd28384c4dbf5a33991921e08",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": "059f8e3484bf07b63a8f2820d5f528f473eff1befdb1896ee4f8ff06be3b8d8f",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": "e1f5b4ce1b9148140fae2fcfb8a96d1c9b7eac5b8df0e13fbcad9b8561284880",
-        "android_tools_pkg-0.1.tar.gz": "b71b10e8f067dd6bff446fb0d49239fe28b12cfd1ed24278d04b06cf54669862",
     },
     urls = {
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz"],
@@ -386,7 +389,6 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz"],
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip"],
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64.zip"],
-        "android_tools_pkg-0.1.tar.gz": ["https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.1.tar.gz"],
     },
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -331,7 +331,7 @@ http_archive(
 # WORKSPACE, to that they don't have to be refetched for every test
 # calling `bazel sync`.
 distdir_tar(
-    name = "jdk_WORKSPACE_files",
+    name = "test_WORKSPACE_files",
     archives = [
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz",
         "zulu9.0.7.1-jdk9.0.7-macosx_x64-allmodules.tar.gz",
@@ -350,8 +350,9 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip",
+        "android_tools_pkg-0.1.tar.gz",
     ],
-    dirname = "jdk_WORKSPACE/distdir",
+    dirname = "test_WORKSPACE/distdir",
     sha256 = {
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": "f27cb933de4f9e7fe9a703486cf44c84bc8e9f138be0c270c9e5716a32367e87",
         "zulu9.0.7.1-jdk9.0.7-macosx_x64-allmodules.tar.gz": "404e7058ff91f956612f47705efbee8e175a38b505fb1b52d8c1ea98718683de",
@@ -370,6 +371,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": "f3f44b6235508e87b760bf37a49e186cc1fa4e9cd28384c4dbf5a33991921e08",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": "059f8e3484bf07b63a8f2820d5f528f473eff1befdb1896ee4f8ff06be3b8d8f",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": "e1f5b4ce1b9148140fae2fcfb8a96d1c9b7eac5b8df0e13fbcad9b8561284880",
+        "android_tools_pkg-0.1.tar.gz": "b71b10e8f067dd6bff446fb0d49239fe28b12cfd1ed24278d04b06cf54669862",
     },
     urls = {
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz"],
@@ -389,6 +391,9 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz"],
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip"],
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64.zip"],
+        "android_tools_pkg-0.1.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.1.tar.gz",
+        ],
     },
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -322,6 +322,20 @@ http_archive(
     ],
 )
 
+# distdir_tar(
+#     name = "android_WORKSPACE_files",
+#     archives = [
+#         "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip",
+#     ],
+#     dirname = "android_WORKSPACE/distdir",
+#     sha256 = {
+#         "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip": "c4cd965983b22272d20f5038f6fd8d143d344fac1bb638d765ec7f62e652486f",
+#     },
+#     urls = {
+#         "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip": ["https://github.com/jin/legacy_android_tools/archive/54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip"],
+#     },
+# )
+
 # For testing, have an distdir_tar with all the archives implicit in every
 # WORKSPACE, to that they don't have to be refetched for every test
 # calling `bazel sync`.
@@ -345,6 +359,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip",
+        "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip",
     ],
     dirname = "jdk_WORKSPACE/distdir",
     sha256 = {
@@ -365,6 +380,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": "f3f44b6235508e87b760bf37a49e186cc1fa4e9cd28384c4dbf5a33991921e08",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": "059f8e3484bf07b63a8f2820d5f528f473eff1befdb1896ee4f8ff06be3b8d8f",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": "e1f5b4ce1b9148140fae2fcfb8a96d1c9b7eac5b8df0e13fbcad9b8561284880",
+        "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip": "c4cd965983b22272d20f5038f6fd8d143d344fac1bb638d765ec7f62e652486f",
     },
     urls = {
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz"],
@@ -384,6 +400,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz"],
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip"],
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64.zip"],
+        "54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip": ["https://github.com/jin/legacy_android_tools/archive/54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip"],
     },
 )
 

--- a/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/BUILD
+++ b/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/BUILD
@@ -14,7 +14,6 @@ filegroup(
     name = "embedded_tools",
     srcs = [
         "BUILD.tools",
-        ":ImportDepsChecker_deploy.jar",
     ],
 )
 

--- a/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/BUILD
+++ b/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/BUILD
@@ -49,6 +49,7 @@ java_binary(
     visibility = [
         "//src/java_tools/import_deps_checker:__subpackages__",
         "//tools/android:__pkg__",
+        "//tools/android/runtime_deps:__pkg__",
     ],
     deps = [
         ":import_deps_checker",

--- a/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/BUILD.tools
+++ b/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/BUILD.tools
@@ -2,7 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 java_import(
     name = "import_deps_checker_deploy_jar",
-    jars = ["@legacy_android_tools//:ImportDepsChecker_deploy.jar"],
+    jars = ["@android_tools//:ImportDepsChecker_deploy.jar"],
 )
 
 java_binary(

--- a/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/BUILD.tools
+++ b/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/BUILD.tools
@@ -2,13 +2,11 @@ package(default_visibility = ["//visibility:public"])
 
 java_import(
     name = "import_deps_checker_deploy_jar",
-    jars = [":ImportDepsChecker_deploy.jar"]
+    jars = ["@legacy_android_tools//:ImportDepsChecker_deploy.jar"],
 )
-
 
 java_binary(
     name = "ImportDepsChecker_embedded",
-    main_class = "com.google.devtools.build.importdeps.Main",
     jvm_flags = [
         # quiet warnings from com.google.protobuf.UnsafeUtil,
         # see: https://github.com/google/protobuf/issues/3781
@@ -16,7 +14,8 @@ java_binary(
         "--add-opens=java.base/java.nio=ALL-UNNAMED",
         "--add-opens=java.base/java.lang=ALL-UNNAMED",
     ],
+    main_class = "com.google.devtools.build.importdeps.Main",
     runtime_deps = [
-        ":import_deps_checker_deploy_jar"
+        ":import_deps_checker_deploy_jar",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -339,6 +339,10 @@ public class BazelRuleClassProvider {
           try {
             builder.addWorkspaceFilePrefix(
                 ResourceFileLoader.loadResource(BazelAndroidSemantics.class, "android.WORKSPACE"));
+            builder.addWorkspaceFileSuffix(
+                ResourceFileLoader.loadResource(
+                    BazelAndroidSemantics.class,
+                    "android_remote_tools.WORKSPACE"));
           } catch (IOException e) {
             throw new IllegalStateException(e);
           }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -1,8 +1,15 @@
-load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
+# load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-java_import_external(
-    name = "remote_all_android_tools",
-    jar_urls = ["https://storage.googleapis.com/bazel-android-mirror/all_android_tools_deploy.jar"],
-    jar_sha256 = "806152c1801df848af7f6f55f824299f819b61e8b9b55ed4cf3d3e0850c432eb",
+# java_import_external(
+#     name = "remote_all_android_tools",
+#     jar_urls = ["https://storage.googleapis.com/bazel-android-mirror/all_android_tools_deploy.jar"],
+#     jar_sha256 = "806152c1801df848af7f6f55f824299f819b61e8b9b55ed4cf3d3e0850c432eb",
+# )
+
+http_archive(
+    name = "legacy_android_tools",
+    url = "https://github.com/jin/legacy_android_tools/archive/54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip",
+    strip_prefix = "legacy_android_tools-54eefc6aa7bf4c171fecb7b6022282c277a3824c",
+    sha256 = "c4cd965983b22272d20f5038f6fd8d143d344fac1bb638d765ec7f62e652486f",
 )
-

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -1,11 +1,4 @@
-# load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-# java_import_external(
-#     name = "remote_all_android_tools",
-#     jar_urls = ["https://storage.googleapis.com/bazel-android-mirror/all_android_tools_deploy.jar"],
-#     jar_sha256 = "806152c1801df848af7f6f55f824299f819b61e8b9b55ed4cf3d3e0850c432eb",
-# )
 
 http_archive(
     name = "legacy_android_tools",

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -1,8 +1,10 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+ANDROID_TOOLS_COMMIT = "1a6aaad88aaaf186c168623c872c55ed80c05c5a"
+
 http_archive(
     name = "legacy_android_tools",
-    url = "https://github.com/jin/legacy_android_tools/archive/54eefc6aa7bf4c171fecb7b6022282c277a3824c.zip",
-    strip_prefix = "legacy_android_tools-54eefc6aa7bf4c171fecb7b6022282c277a3824c",
-    sha256 = "c4cd965983b22272d20f5038f6fd8d143d344fac1bb638d765ec7f62e652486f",
+    url = "https://github.com/jin/legacy_android_tools/archive/%s.zip" % ANDROID_TOOLS_COMMIT,
+    strip_prefix = "legacy_android_tools-%s" % ANDROID_TOOLS_COMMIT,
+    sha256 = "",
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -1,10 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-ANDROID_TOOLS_COMMIT = "1a6aaad88aaaf186c168623c872c55ed80c05c5a"
-
 http_archive(
-    name = "legacy_android_tools",
-    url = "https://github.com/jin/legacy_android_tools/archive/%s.zip" % ANDROID_TOOLS_COMMIT,
-    strip_prefix = "legacy_android_tools-%s" % ANDROID_TOOLS_COMMIT,
-    sha256 = "7210c2c5dcd2053165c68f00ae83c37ac4a6b04cd309193ded12fe828d875ed9",
+    name = "android_tools",
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.1.tar.gz",
+    sha256 = "b71b10e8f067dd6bff446fb0d49239fe28b12cfd1ed24278d04b06cf54669862",
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -1,0 +1,8 @@
+load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
+
+java_import_external(
+    name = "remote_all_android_tools",
+    jar_urls = ["https://storage.googleapis.com/bazel-android-mirror/all_android_tools_deploy.jar"],
+    jar_sha256 = "806152c1801df848af7f6f55f824299f819b61e8b9b55ed4cf3d3e0850c432eb",
+)
+

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -6,5 +6,5 @@ http_archive(
     name = "legacy_android_tools",
     url = "https://github.com/jin/legacy_android_tools/archive/%s.zip" % ANDROID_TOOLS_COMMIT,
     strip_prefix = "legacy_android_tools-%s" % ANDROID_TOOLS_COMMIT,
-    sha256 = "",
+    sha256 = "7210c2c5dcd2053165c68f00ae83c37ac4a6b04cd309193ded12fe828d875ed9",
 )

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -520,9 +520,9 @@ sh_test(
 )
 
 filegroup(
-    name = "jdk_WORKSPACE",
+    name = "test_WORKSPACE",
     srcs = [
-        "@jdk_WORKSPACE_files//:archives",
+        "@test_WORKSPACE_files//:archives",
     ],
 )
 
@@ -531,8 +531,8 @@ sh_test(
     size = "large",
     srcs = ["workspace_resolved_test.sh"],
     data = [
-        ":jdk_WORKSPACE",
         ":test-deps",
+        ":test_WORKSPACE",
     ],
     shard_count = 20,
     tags = [

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -526,13 +526,6 @@ filegroup(
     ],
 )
 
-filegroup(
-    name = "android_WORKSPACE",
-    srcs = [
-        "@android_WORKSPACE_files//:archives",
-    ],
-)
-
 sh_test(
     name = "workspace_resolved_test",
     size = "large",

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -520,9 +520,16 @@ sh_test(
 )
 
 filegroup(
-    name = "jdk_WORKSPACE",
+    name = "test_WORKSPACE",
     srcs = [
-        "@jdk_WORKSPACE_files//:archives",
+        "@test_WORKSPACE_files//:archives",
+    ],
+)
+
+filegroup(
+    name = "android_WORKSPACE",
+    srcs = [
+        "@android_WORKSPACE_files//:archives",
     ],
 )
 
@@ -531,7 +538,8 @@ sh_test(
     size = "large",
     srcs = ["workspace_resolved_test.sh"],
     data = [
-        ":jdk_WORKSPACE",
+        ":test_WORKSPACE",
+        ":android_WORKSPACE",
         ":test-deps",
     ],
     shard_count = 20,

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -520,9 +520,9 @@ sh_test(
 )
 
 filegroup(
-    name = "test_WORKSPACE",
+    name = "jdk_WORKSPACE",
     srcs = [
-        "@test_WORKSPACE_files//:archives",
+        "@jdk_WORKSPACE_files//:archives",
     ],
 )
 
@@ -531,7 +531,7 @@ sh_test(
     size = "large",
     srcs = ["workspace_resolved_test.sh"],
     data = [
-        ":test_WORKSPACE",
+        ":jdk_WORKSPACE",
         ":test-deps",
     ],
     shard_count = 20,

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -532,7 +532,6 @@ sh_test(
     srcs = ["workspace_resolved_test.sh"],
     data = [
         ":test_WORKSPACE",
-        ":android_WORKSPACE",
         ":test-deps",
     ],
     shard_count = 20,

--- a/src/test/shell/bazel/testdata/embedded_tools_srcs_deps
+++ b/src/test/shell/bazel/testdata/embedded_tools_srcs_deps
@@ -29,7 +29,6 @@
 //src/tools/launcher:launcher_base
 //src/tools/launcher/util:data_parser
 //src/tools/launcher/util:util
-//src/main/native/windows:windows_jni.dll
 //src/main/cpp/util:util
 //src/main/cpp/util:numbers
 //src/main/cpp/util:md5

--- a/src/test/shell/bazel/workspace_resolved_test.sh
+++ b/src/test/shell/bazel/workspace_resolved_test.sh
@@ -90,7 +90,7 @@ EOF
 
 test_git_return_value() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   export GIT_CONFIG_NOSYSTEM=YES
 
@@ -119,7 +119,7 @@ new_git_repository(
 EOF
 
 
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel shutdown
 
   cd ..
@@ -168,7 +168,7 @@ EOF
 
 test_git_follow_branch() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   export GIT_CONFIG_NOSYSTEM=YES
 
@@ -201,7 +201,7 @@ genrule(
   cmd = "cp $< $@",
 )
 EOF
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel build :out
   grep "CHANGED" `bazel info bazel-genfiles`/out.txt  \
        && fail "Unexpected content in out.txt" || :
@@ -217,7 +217,7 @@ EOF
 
   # First verify that `bazel sync` sees the new commit (we don't record it).
   cd branchcheckout
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir
   bazel build :out
   grep "CHANGED" `bazel info bazel-genfiles`/out.txt  \
        || fail "sync did not update the external repository"
@@ -260,7 +260,7 @@ EOF
 
 test_sync_follows_git_branch() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   export GIT_CONFIG_NOSYSTEM=YES
 
@@ -310,7 +310,7 @@ EOF
    git commit --author="A U Thor <author@example.com>" -m 'stable commit')
 
   # Verify that sync followed by build gets the correct version
-  (cd followbranch && bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir && bazel build :out \
+  (cd followbranch && bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir && bazel build :out \
        && cat `bazel info bazel-genfiles`/out.txt > "${TEST_log}")
   expect_log 'CHANGED'
   expect_not_log 'Hello Stable World'
@@ -318,7 +318,7 @@ EOF
 
 test_http_return_value() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   mkdir -p a
   touch a/WORKSPACE
@@ -343,7 +343,7 @@ EOF
   touch main/BUILD
 
   cd main
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir \
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir \
       --experimental_repository_resolved_file=../repo.bzl
 
   grep ${expected_sha256} ../repo.bzl || fail "didn't return commit"
@@ -351,7 +351,7 @@ EOF
 
 test_sync_calls_all() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   mkdir sync_calls_all && cd sync_calls_all
   rm -rf fetchrepo
@@ -384,7 +384,7 @@ trivial_rule(name = "d", comment = other)
 EOF
 
   bazel clean --expunge
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel shutdown
 
   cd ..
@@ -408,7 +408,7 @@ EOF
 
 test_sync_call_invalidates() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   mkdir sync_call_invalidates && cd sync_call_invalidates
   rm -rf fetchrepo
@@ -440,7 +440,7 @@ EOF
 
   bazel build @a//... @b//...
   echo; echo sync run; echo
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel shutdown
 
   cd ..
@@ -464,7 +464,7 @@ EOF
 
 test_sync_load_errors_reported() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   rm -rf fetchrepo
   mkdir fetchrepo
@@ -474,7 +474,7 @@ load("//does/not:exist.bzl", "randomfunction")
 
 radomfunction(name="foo")
 EOF
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir > "${TEST_log}" 2>&1 && fail "Expected failure" || :
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir > "${TEST_log}" 2>&1 && fail "Expected failure" || :
   expect_log '//does/not:exist.bzl'
 }
 
@@ -482,7 +482,7 @@ test_sync_reporting() {
   # Verify that debug and error messages in starlark functions are reported.
   # Also verify that the fact that the repository is fetched is reported as well.
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   rm -rf fetchrepo
   mkdir fetchrepo
@@ -503,7 +503,7 @@ load("//:rule.bzl", "broken_rule")
 
 broken_rule(name = "broken")
 EOF
-  bazel sync --curses=yes --experimental_ui_actions_shown=100 --distdir=${EXTREPODIR}/test_WORKSPACE/distdir > "${TEST_log}" 2>&1 && fail "expected failure" || :
+  bazel sync --curses=yes --experimental_ui_actions_shown=100 --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir > "${TEST_log}" 2>&1 && fail "expected failure" || :
   expect_log 'Fetching @broken'
   expect_log "DEBUG-message"
   expect_log "Failure-message"
@@ -511,7 +511,7 @@ EOF
 
 test_indirect_call() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   rm -rf fetchrepo
   mkdir fetchrepo
@@ -536,7 +536,7 @@ load("//:indirect.bzl", "call")
 
 call(trivial_rule, name="foo")
 EOF
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel shutdown
 
   cd ..
@@ -564,7 +564,7 @@ test_resolved_file_reading() {
   # file works as expected.
   EXTREPODIR=`pwd`
   export GIT_CONFIG_NOSYSTEM=YES
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   mkdir extgit
   (cd extgit && git init \
@@ -595,7 +595,7 @@ genrule(
   cmd = "cp $< $@",
 )
 EOF
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
   echo; cat resolved.bzl; echo
 
   bazel clean --expunge
@@ -612,7 +612,7 @@ test_label_resolved_value() {
   # Verify that label arguments in a repository rule end up in the resolved
   # file in a parsable form.
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
   mkdir ext
   echo Hello World > ext/file.txt
   zip ext.zip ext/*
@@ -638,7 +638,7 @@ genrule(
 )
 EOF
 
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
   rm WORKSPACE; touch WORKSPACE
   echo; cat resolved.bzl; echo
 
@@ -652,7 +652,7 @@ test_resolved_file_not_remembered() {
   # Verify that the --experimental_resolved_file_instead_of_workspace option
   # does not leak into a subsequent sync
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   export GIT_CONFIG_NOSYSTEM=YES
 
@@ -687,7 +687,7 @@ genrule(
 )
 EOF
   (cd followbranch \
-    && bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl)
+    && bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl)
   # New upstream commits on the branch followed
   echo CHANGED > gitdir/hello.txt
   (cd gitdir
@@ -700,7 +700,7 @@ EOF
   cat `bazel info bazel-genfiles`/out.txt > "${TEST_log}"
   expect_log 'Hello Stable World'
   expect_not_log 'CHANGED'
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
   bazel build --experimental_resolved_file_instead_of_workspace=resolved.bzl :out
   cat `bazel info bazel-genfiles`/out.txt > "${TEST_log}"
   expect_log 'CHANGED'
@@ -741,13 +741,13 @@ test_hash_included_and_reproducible() {
   # - change of the working directory, and
   # - and current time.
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   rm -rf fetchrepoA
   mkdir fetchrepoA
   cd fetchrepoA
   create_sample_repository
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel shutdown
 
   cd ..
@@ -777,7 +777,7 @@ EOF
   mkdir fetchrepoB
   cd fetchrepoB
   create_sample_repository
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel shutdown
 
   cd ..
@@ -790,7 +790,7 @@ EOF
 
 test_non_reproducibility_detected() {
     EXTREPODIR=`pwd`
-    tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+    tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
     # Verify that a non-reproducible rule is detected by hash verification
     mkdir repo
     cd repo
@@ -810,8 +810,8 @@ load("//:rule.bzl", "time_rule")
 time_rule(name="timestamprepo")
 EOF
 
-    bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
-    bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_hash_file=`pwd`/resolved.bzl \
+    bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
+    bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_hash_file=`pwd`/resolved.bzl \
           --experimental_verify_repository_rules='//:rule.bzl%time_rule' \
           > "${TEST_log}" 2>&1 && fail "expected failure" || :
     expect_log "timestamprepo.*hash"
@@ -821,7 +821,7 @@ test_chain_resolved() {
   # Verify that a cahin of dependencies in external repositories is reflected
   # in the resolved file in such a way, that the resolved file can be used.
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   mkdir rulerepo
   cat > rulerepo/rule.bzl <<'EOF'
@@ -856,7 +856,7 @@ genrule(
   cmd = "cp $< $@",
 )
 EOF
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir \
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir \
         --experimental_repository_resolved_file=resolved.bzl
   bazel clean --expunge
   echo; cat resolved.bzl; echo
@@ -870,7 +870,7 @@ test_usage_order_respected() {
    # statement between), then still the resolved file is such that it can
    # be used as a workspace replacement.
    EXTREPODIR=`pwd`
-   tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+   tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
    mkdir datarepo
    echo 'Pure data' > datarepo/data.txt
@@ -907,7 +907,7 @@ genrule(
   cmd = "cp $< $@",
 )
 EOF
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir \
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir \
      --experimental_repository_resolved_file=resolved.bzl
   bazel clean --expunge
   echo; cat resolved.bzl; echo
@@ -921,7 +921,7 @@ test_order_reproducible() {
   # Verify that the order of repositories in the resolved file is reproducible
   # and does not depend on the parameters or timing of the actual rules.
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   mkdir main
   cd main
@@ -954,7 +954,7 @@ sleep_rule(name="a", sleep=1)
 sleep_rule(name="c", sleep=3)
 sleep_rule(name="b", sleep=5)
 EOF
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir \
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir \
         --experimental_repository_resolved_file=repo.bzl
   bazel build //:order
   cp `bazel info bazel-genfiles`/order.txt order-first.txt
@@ -967,7 +967,7 @@ sleep_rule(name="a", sleep=5)
 sleep_rule(name="c", sleep=3)
 sleep_rule(name="b", sleep=1)
 EOF
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir \
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir \
         --experimental_repository_resolved_file=repo.bzl
   bazel build //:order
   cp `bazel info bazel-genfiles`/order.txt order-second.txt
@@ -982,7 +982,7 @@ test_non_starlarkrepo() {
   # Verify that entries in the WORKSPACE that are not starlark repositoires
   # are correctly reported in the resolved file.
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
 
   mkdir local
   touch local/WORKSPACE
@@ -1015,7 +1015,7 @@ EOF
 
   bazel build //:it || fail "Expected success"
 
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir \
+  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir \
         --experimental_repository_resolved_file=resolved.bzl
   echo > WORKSPACE # remove workspace, only work from the resolved file
   bazel clean --expunge

--- a/src/test/shell/bazel/workspace_resolved_test.sh
+++ b/src/test/shell/bazel/workspace_resolved_test.sh
@@ -90,7 +90,7 @@ EOF
 
 test_git_return_value() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   export GIT_CONFIG_NOSYSTEM=YES
 
@@ -119,7 +119,7 @@ new_git_repository(
 EOF
 
 
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel shutdown
 
   cd ..
@@ -168,7 +168,7 @@ EOF
 
 test_git_follow_branch() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   export GIT_CONFIG_NOSYSTEM=YES
 
@@ -201,7 +201,7 @@ genrule(
   cmd = "cp $< $@",
 )
 EOF
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel build :out
   grep "CHANGED" `bazel info bazel-genfiles`/out.txt  \
        && fail "Unexpected content in out.txt" || :
@@ -217,7 +217,7 @@ EOF
 
   # First verify that `bazel sync` sees the new commit (we don't record it).
   cd branchcheckout
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir
   bazel build :out
   grep "CHANGED" `bazel info bazel-genfiles`/out.txt  \
        || fail "sync did not update the external repository"
@@ -260,7 +260,7 @@ EOF
 
 test_sync_follows_git_branch() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   export GIT_CONFIG_NOSYSTEM=YES
 
@@ -310,7 +310,7 @@ EOF
    git commit --author="A U Thor <author@example.com>" -m 'stable commit')
 
   # Verify that sync followed by build gets the correct version
-  (cd followbranch && bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir && bazel build :out \
+  (cd followbranch && bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir && bazel build :out \
        && cat `bazel info bazel-genfiles`/out.txt > "${TEST_log}")
   expect_log 'CHANGED'
   expect_not_log 'Hello Stable World'
@@ -318,7 +318,7 @@ EOF
 
 test_http_return_value() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   mkdir -p a
   touch a/WORKSPACE
@@ -343,7 +343,7 @@ EOF
   touch main/BUILD
 
   cd main
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir \
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir \
       --experimental_repository_resolved_file=../repo.bzl
 
   grep ${expected_sha256} ../repo.bzl || fail "didn't return commit"
@@ -351,7 +351,7 @@ EOF
 
 test_sync_calls_all() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   mkdir sync_calls_all && cd sync_calls_all
   rm -rf fetchrepo
@@ -384,7 +384,7 @@ trivial_rule(name = "d", comment = other)
 EOF
 
   bazel clean --expunge
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel shutdown
 
   cd ..
@@ -408,7 +408,7 @@ EOF
 
 test_sync_call_invalidates() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   mkdir sync_call_invalidates && cd sync_call_invalidates
   rm -rf fetchrepo
@@ -440,7 +440,7 @@ EOF
 
   bazel build @a//... @b//...
   echo; echo sync run; echo
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel shutdown
 
   cd ..
@@ -464,7 +464,7 @@ EOF
 
 test_sync_load_errors_reported() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   rm -rf fetchrepo
   mkdir fetchrepo
@@ -474,7 +474,7 @@ load("//does/not:exist.bzl", "randomfunction")
 
 radomfunction(name="foo")
 EOF
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir > "${TEST_log}" 2>&1 && fail "Expected failure" || :
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir > "${TEST_log}" 2>&1 && fail "Expected failure" || :
   expect_log '//does/not:exist.bzl'
 }
 
@@ -482,7 +482,7 @@ test_sync_reporting() {
   # Verify that debug and error messages in starlark functions are reported.
   # Also verify that the fact that the repository is fetched is reported as well.
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   rm -rf fetchrepo
   mkdir fetchrepo
@@ -503,7 +503,7 @@ load("//:rule.bzl", "broken_rule")
 
 broken_rule(name = "broken")
 EOF
-  bazel sync --curses=yes --experimental_ui_actions_shown=100 --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir > "${TEST_log}" 2>&1 && fail "expected failure" || :
+  bazel sync --curses=yes --experimental_ui_actions_shown=100 --distdir=${EXTREPODIR}/test_WORKSPACE/distdir > "${TEST_log}" 2>&1 && fail "expected failure" || :
   expect_log 'Fetching @broken'
   expect_log "DEBUG-message"
   expect_log "Failure-message"
@@ -511,7 +511,7 @@ EOF
 
 test_indirect_call() {
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   rm -rf fetchrepo
   mkdir fetchrepo
@@ -536,7 +536,7 @@ load("//:indirect.bzl", "call")
 
 call(trivial_rule, name="foo")
 EOF
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel shutdown
 
   cd ..
@@ -564,7 +564,7 @@ test_resolved_file_reading() {
   # file works as expected.
   EXTREPODIR=`pwd`
   export GIT_CONFIG_NOSYSTEM=YES
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   mkdir extgit
   (cd extgit && git init \
@@ -595,7 +595,7 @@ genrule(
   cmd = "cp $< $@",
 )
 EOF
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
   echo; cat resolved.bzl; echo
 
   bazel clean --expunge
@@ -612,7 +612,7 @@ test_label_resolved_value() {
   # Verify that label arguments in a repository rule end up in the resolved
   # file in a parsable form.
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
   mkdir ext
   echo Hello World > ext/file.txt
   zip ext.zip ext/*
@@ -638,7 +638,7 @@ genrule(
 )
 EOF
 
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
   rm WORKSPACE; touch WORKSPACE
   echo; cat resolved.bzl; echo
 
@@ -652,7 +652,7 @@ test_resolved_file_not_remembered() {
   # Verify that the --experimental_resolved_file_instead_of_workspace option
   # does not leak into a subsequent sync
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   export GIT_CONFIG_NOSYSTEM=YES
 
@@ -687,7 +687,7 @@ genrule(
 )
 EOF
   (cd followbranch \
-    && bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl)
+    && bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl)
   # New upstream commits on the branch followed
   echo CHANGED > gitdir/hello.txt
   (cd gitdir
@@ -700,7 +700,7 @@ EOF
   cat `bazel info bazel-genfiles`/out.txt > "${TEST_log}"
   expect_log 'Hello Stable World'
   expect_not_log 'CHANGED'
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
   bazel build --experimental_resolved_file_instead_of_workspace=resolved.bzl :out
   cat `bazel info bazel-genfiles`/out.txt > "${TEST_log}"
   expect_log 'CHANGED'
@@ -741,13 +741,13 @@ test_hash_included_and_reproducible() {
   # - change of the working directory, and
   # - and current time.
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   rm -rf fetchrepoA
   mkdir fetchrepoA
   cd fetchrepoA
   create_sample_repository
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel shutdown
 
   cd ..
@@ -777,7 +777,7 @@ EOF
   mkdir fetchrepoB
   cd fetchrepoB
   create_sample_repository
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=../repo.bzl
   bazel shutdown
 
   cd ..
@@ -790,7 +790,7 @@ EOF
 
 test_non_reproducibility_detected() {
     EXTREPODIR=`pwd`
-    tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+    tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
     # Verify that a non-reproducible rule is detected by hash verification
     mkdir repo
     cd repo
@@ -810,8 +810,8 @@ load("//:rule.bzl", "time_rule")
 time_rule(name="timestamprepo")
 EOF
 
-    bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
-    bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir --experimental_repository_hash_file=`pwd`/resolved.bzl \
+    bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_resolved_file=resolved.bzl
+    bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir --experimental_repository_hash_file=`pwd`/resolved.bzl \
           --experimental_verify_repository_rules='//:rule.bzl%time_rule' \
           > "${TEST_log}" 2>&1 && fail "expected failure" || :
     expect_log "timestamprepo.*hash"
@@ -821,7 +821,7 @@ test_chain_resolved() {
   # Verify that a cahin of dependencies in external repositories is reflected
   # in the resolved file in such a way, that the resolved file can be used.
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   mkdir rulerepo
   cat > rulerepo/rule.bzl <<'EOF'
@@ -856,7 +856,7 @@ genrule(
   cmd = "cp $< $@",
 )
 EOF
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir \
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir \
         --experimental_repository_resolved_file=resolved.bzl
   bazel clean --expunge
   echo; cat resolved.bzl; echo
@@ -870,7 +870,7 @@ test_usage_order_respected() {
    # statement between), then still the resolved file is such that it can
    # be used as a workspace replacement.
    EXTREPODIR=`pwd`
-   tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+   tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
    mkdir datarepo
    echo 'Pure data' > datarepo/data.txt
@@ -907,7 +907,7 @@ genrule(
   cmd = "cp $< $@",
 )
 EOF
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir \
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir \
      --experimental_repository_resolved_file=resolved.bzl
   bazel clean --expunge
   echo; cat resolved.bzl; echo
@@ -921,7 +921,7 @@ test_order_reproducible() {
   # Verify that the order of repositories in the resolved file is reproducible
   # and does not depend on the parameters or timing of the actual rules.
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   mkdir main
   cd main
@@ -954,7 +954,7 @@ sleep_rule(name="a", sleep=1)
 sleep_rule(name="c", sleep=3)
 sleep_rule(name="b", sleep=5)
 EOF
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir \
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir \
         --experimental_repository_resolved_file=repo.bzl
   bazel build //:order
   cp `bazel info bazel-genfiles`/order.txt order-first.txt
@@ -967,7 +967,7 @@ sleep_rule(name="a", sleep=5)
 sleep_rule(name="c", sleep=3)
 sleep_rule(name="b", sleep=1)
 EOF
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir \
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir \
         --experimental_repository_resolved_file=repo.bzl
   bazel build //:order
   cp `bazel info bazel-genfiles`/order.txt order-second.txt
@@ -982,7 +982,7 @@ test_non_starlarkrepo() {
   # Verify that entries in the WORKSPACE that are not starlark repositoires
   # are correctly reported in the resolved file.
   EXTREPODIR=`pwd`
-  tar xvf ${TEST_SRCDIR}/jdk_WORKSPACE_files/archives.tar
+  tar xvf ${TEST_SRCDIR}/test_WORKSPACE_files/archives.tar
 
   mkdir local
   touch local/WORKSPACE
@@ -1015,7 +1015,7 @@ EOF
 
   bazel build //:it || fail "Expected success"
 
-  bazel sync --distdir=${EXTREPODIR}/jdk_WORKSPACE/distdir \
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir \
         --experimental_repository_resolved_file=resolved.bzl
   echo > WORKSPACE # remove workspace, only work from the resolved file
   bazel clean --expunge

--- a/src/test/shell/integration/discard_graph_edges_test.sh
+++ b/src/test/shell/integration/discard_graph_edges_test.sh
@@ -231,7 +231,7 @@ function test_packages_cleared() {
   package_count="$(extract_histogram_count "$histo_file" \
       'devtools\.build\.lib\..*\.Package$')"
   # A few packages aren't cleared.
-  [[ "$package_count" -le 10 ]] \
+  [[ "$package_count" -le 11 ]] \
       || fail "package count $package_count too high"
   glob_count="$(extract_histogram_count "$histo_file" "GlobValue$")"
   [[ "$glob_count" -le 1 ]] \

--- a/src/tools/android/java/com/google/devtools/build/android/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/BUILD
@@ -6,7 +6,6 @@ filegroup(
     name = "embedded_tools",
     srcs = [
         "BUILD.tools",
-        ":all_android_tools_deploy.jar",
         "//src/tools/android/java/com/google/devtools/build/android/desugar:embedded_tools",
         "//src/tools/android/java/com/google/devtools/build/android/desugar/scan:embedded_tools",
         "//src/tools/android/java/com/google/devtools/build/android/dexer:embedded_tools",

--- a/src/tools/android/java/com/google/devtools/build/android/BUILD.tools
+++ b/src/tools/android/java/com/google/devtools/build/android/BUILD.tools
@@ -1,12 +1,16 @@
 package(default_visibility = ["//visibility:public"])
 
-java_import(
+alias(
     name = "all_android_tools",
-    jars = ["all_android_tools_deploy.jar"],
+    actual = "@remote_all_android_tools//jar",
 )
 
 java_binary(
     name = "ResourceProcessorBusyBox",
+    data = select({
+        "//src/conditions:windows": ["//src/main/native/windows:windows_jni.dll"],
+        "//conditions:default": [],
+    }),
     jvm_flags = [
         # quiet warnings from com.google.protobuf.UnsafeUtil,
         # see: https://github.com/google/protobuf/issues/3781
@@ -14,10 +18,6 @@ java_binary(
         "--add-opens=java.base/java.nio=ALL-UNNAMED",
         "--add-opens=java.base/java.lang=ALL-UNNAMED",
     ],
-    data = select({
-        "//src/conditions:windows": ["//src/main/native/windows:windows_jni.dll"],
-        "//conditions:default": [],
-    }),
     main_class = "com.google.devtools.build.android.ResourceProcessorBusyBox",
     runtime_deps = [
         ":all_android_tools",
@@ -32,6 +32,6 @@ java_binary(
     jvm_flags = ["-Xmx1600m"],
     main_class = "com.google.devtools.build.android.ZipFilterAction",
     runtime_deps = [
-        ":all_android_tools"
+        ":all_android_tools",
     ],
 )

--- a/src/tools/android/java/com/google/devtools/build/android/BUILD.tools
+++ b/src/tools/android/java/com/google/devtools/build/android/BUILD.tools
@@ -1,8 +1,13 @@
 package(default_visibility = ["//visibility:public"])
 
-alias(
+#alias(
+#    name = "all_android_tools",
+#    actual = "@remote_all_android_tools//jar",
+#)
+
+java_import(
     name = "all_android_tools",
-    actual = "@remote_all_android_tools//jar",
+    jars = ["@legacy_android_tools//:all_android_tools_deploy.jar"],
 )
 
 java_binary(

--- a/src/tools/android/java/com/google/devtools/build/android/BUILD.tools
+++ b/src/tools/android/java/com/google/devtools/build/android/BUILD.tools
@@ -2,7 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 java_import(
     name = "all_android_tools",
-    jars = ["@legacy_android_tools//:all_android_tools_deploy.jar"],
+    jars = ["@android_tools//:all_android_tools_deploy.jar"],
 )
 
 java_binary(

--- a/src/tools/android/java/com/google/devtools/build/android/BUILD.tools
+++ b/src/tools/android/java/com/google/devtools/build/android/BUILD.tools
@@ -1,10 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 
-#alias(
-#    name = "all_android_tools",
-#    actual = "@remote_all_android_tools//jar",
-#)
-
 java_import(
     name = "all_android_tools",
     jars = ["@legacy_android_tools//:all_android_tools_deploy.jar"],

--- a/tools/android/BUILD
+++ b/tools/android/BUILD
@@ -208,7 +208,10 @@ filegroup(
             "*~",
             ".*",
         ],
-    ) + ["//tools/android/emulator:srcs"],
+    ) + [
+        "//tools/android/emulator:srcs",
+        "//tools/android/runtime_deps:srcs",
+    ],
 )
 
 filegroup(

--- a/tools/android/runtime_deps/BUILD.android_tools
+++ b/tools/android/runtime_deps/BUILD.android_tools
@@ -1,0 +1,4 @@
+exports_files([
+    "all_android_tools_deploy.jar",
+    "ImportDepsChecker_deploy.jar",
+])

--- a/tools/android/runtime_deps/BUILD.bazel
+++ b/tools/android/runtime_deps/BUILD.bazel
@@ -1,5 +1,15 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
+filegroup(
+    name = "srcs",
+    srcs = [
+        "BUILD.android_tools",
+        "WORKSPACE.android_tools",
+        "upload_android_tools.sh",
+        "BUILD.bazel",
+    ],
+)
+
 genrule(
     name = "strip_android_tools_suffix",
     srcs = [

--- a/tools/android/runtime_deps/BUILD.bazel
+++ b/tools/android/runtime_deps/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+genrule(
+    name = "strip_android_tools_suffix",
+    srcs = [
+        "BUILD.android_tools",
+        "WORKSPACE.android_tools",
+    ],
+    outs = ["BUILD", "WORKSPACE"],
+    cmd = """
+    cp $(location BUILD.android_tools) $(location BUILD) && \
+    cp $(location WORKSPACE.android_tools) $(location WORKSPACE)
+    """,
+    tags = [
+        "manual",
+        "no_windows",
+    ]
+)
+
+pkg_tar(
+    name = "android_tools",
+    extension = "tar.gz",
+    srcs = [
+        "BUILD",
+        "WORKSPACE",
+        "//src/tools/android/java/com/google/devtools/build/android:all_android_tools_deploy.jar",
+        "//src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps:ImportDepsChecker_deploy.jar",
+    ]
+)
+
+sh_binary(
+    name = "upload_android_tools",
+    srcs = ["upload_android_tools.sh"],
+    data = ["android_tools.tar.gz"],
+)

--- a/tools/android/runtime_deps/BUILD.bazel
+++ b/tools/android/runtime_deps/BUILD.bazel
@@ -8,6 +8,9 @@ filegroup(
         "upload_android_tools.sh",
         "BUILD.bazel",
     ],
+    visibility = [
+        "//tools/android:__pkg__",
+    ]
 )
 
 genrule(

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -1,15 +1,56 @@
 #!/bin/bash
 
-set -euo pipefail
+# Copyright 2014 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+# This script builds a new version of android_tools.tar.gz and uploads
+# it to Google Cloud Storage. This script is non-destructive and idempotent.
+#
+# To run this script, call `bazel run //tools/android/runtime_deps:upload_android_tools
+#
+# android_tools.tar.gz contains runtime jars required by the Android rules. We unbundled
+# these jars out from Bazel to keep its binary size small.
+#
+# If you make changes any tool bundled in android_tools.tar.gz and want them to be used for
+# the next Bazel release, increment the version number and run this script. Then, update the
+# following files with new version, URL, and sha256 of the new android_tools tarball:
+#
+# - WORKSPACE
+# - src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+#
+# More context: https://github.com/bazelbuild/bazel/issues/1055
+
+set -xeuo pipefail
+
+# The version of android_tools.tar.gz
 VERSION="0.1"
 VERSIONED_FILENAME="android_tools_pkg-$VERSION.tar.gz"
 
+# Create a temp directory to hold the versioned tarball, and clean it up when the script exits.
+tmpdir=$(mktemp -d)
+function cleanup {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+# Add the version to the tarball.
 android_tools_archive="tools/android/runtime_deps/android_tools.tar.gz"
-versioned_android_tools_archive="/tmp/$VERSIONED_FILENAME"
-
-rm -f $versioned_android_tools_archive
-
+versioned_android_tools_archive="$tmpdir/$VERSIONED_FILENAME"
 cp $android_tools_archive $versioned_android_tools_archive
 
-gsutil cp -n -a public-read $versioned_android_tools_archive gs://bazel-mirror/bazel_android_tools/$VERSIONED_FILENAME
+# Upload the tarball to GCS.
+# -n for no-clobber, so we don't overwrite existing files
+# -a public-read to make this tarball public
+gsutil cp -n -a public-read $versioned_android_tools_archive \
+  gs://bazel-mirror/bazel_android_tools/$VERSIONED_FILENAME

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -11,6 +11,5 @@ versioned_android_tools_archive="/tmp/$VERSIONED_FILENAME"
 rm -f $versioned_android_tools_archive
 
 cp $android_tools_archive $versioned_android_tools_archive
-tar tf $versioned_android_tools_archive
 
-gsutil cp -a public-read $versioned_android_tools_archive gs://bazel-mirror/bazel_android_tools/$VERSIONED_FILENAME
+gsutil cp -n -a public-read $versioned_android_tools_archive gs://bazel-mirror/bazel_android_tools/$VERSIONED_FILENAME

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 The Bazel Authors. All rights reserved.
+# Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+VERSION="0.1"
+VERSIONED_FILENAME="android_tools_pkg-$VERSION.tar.gz"
+
+android_tools_archive="tools/android/runtime_deps/android_tools.tar.gz"
+versioned_android_tools_archive="/tmp/$VERSIONED_FILENAME"
+
+rm -f $versioned_android_tools_archive
+
+cp $android_tools_archive $versioned_android_tools_archive
+tar tf $versioned_android_tools_archive
+
+gsutil cp -a public-read $versioned_android_tools_archive gs://bazel-mirror/bazel_android_tools/$VERSIONED_FILENAME


### PR DESCRIPTION
Fixes #1055 

RELNOTES: Bazel is now ~20MiB smaller, due to the unbundling of Android rules' runtime dependencies.