### PR TITLE
remote: introduce --experimental_remote_outputs=minimal

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -691,6 +691,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/profiler/memory:current_rule_tracker",
         "//src/main/java/com/google/devtools/build/lib/query2:aquery-utils",
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/rules/cpp:cpp_interface",
         "//src/main/java/com/google/devtools/build/lib/shell",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -393,7 +393,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
     if (!metadata.symlinks().isEmpty()) {
       throw new IOException(
           "Symlinks in action outputs are not yet supported by "
-              + "--experimental_remote_fetch_outputs");
+              + "--experimental_remote_download_outputs=minimal");
     }
 
     ActionInput inMemoryOutput = null;
@@ -443,7 +443,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
       if (!directory.symlinks().isEmpty()) {
         throw new IOException(
             "Symlinks in action outputs are not yet supported by "
-                + "--experimental_remote_fetch_outputs");
+                + "--experimental_remote_download_outputs=minimal");
       }
       ImmutableMap.Builder<PathFragment, RemoteFileArtifactValue> childMetadata =
           ImmutableMap.builder();

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -33,6 +33,8 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote/merkletree",
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
+        "//src/main/java/com/google/devtools/build/lib/rules/cpp",
+        "//src/main/java/com/google/devtools/build/lib/rules/java:java-compilation",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:auth",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -160,6 +160,14 @@ final class RemoteActionContextProvider extends ActionContextProvider {
     }
   }
 
+  /**
+   * Returns the remote cache object if any.
+   */
+  @Nullable
+  AbstractRemoteActionCache getRemoteCache() {
+    return cache;
+  }
+
   @Override
   public void executionPhaseEnding() {
     if (cache != null) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -39,7 +39,7 @@ import javax.annotation.concurrent.GuardedBy;
  * Stages output files that are stored remotely to the local filesystem.
  *
  * <p>This is necessary for remote caching/execution when {@code
- * --experimental_remote_fetch_outputs=minimal} is specified.
+ * --experimental_remote_download_outputs=minimal} is specified.
  */
 class RemoteActionInputFetcher implements ActionInputPrefetcher {
 
@@ -126,7 +126,7 @@ class RemoteActionInputFetcher implements ActionInputPrefetcher {
                   new IOException(
                       String.format(
                           "Failed to fetch file with hash '%s' because it does not exist remotely."
-                              + " --experimental_remote_fetch_outputs=minimal does not work if"
+                              + " --experimental_remote_download_outputs=minimal does not work if"
                               + " your remote cache evicts files during builds.",
                           ((CacheNotFoundException) e).getMissingDigest().getHash()));
             }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -14,6 +14,8 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.devtools.build.lib.remote.util.Utils.createSpawnResult;
+import static com.google.devtools.build.lib.remote.util.Utils.getInMemoryOutputPath;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
@@ -39,9 +41,11 @@ import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.options.RemoteOutputsStrategy;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.DigestUtil.ActionKey;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
+import com.google.devtools.build.lib.remote.util.Utils.InMemoryOutput;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import io.grpc.Context;
@@ -111,15 +115,14 @@ final class RemoteSpawnCache implements SpawnCache {
         RemoteSpawnRunner.parsePlatform(
             spawn.getExecutionPlatform(), options.remoteDefaultPlatformProperties);
 
-    Command command =
-        RemoteSpawnRunner.buildCommand(
-            spawn.getOutputFiles(), spawn.getArguments(), spawn.getEnvironment(), platform);
+    Command command = RemoteSpawnRunner.buildCommand(spawn.getOutputFiles(), spawn.getArguments(),
+        spawn.getEnvironment(), platform);
+    RemoteOutputsStrategy remoteOutputsStrategy = options.remoteOutputsStrategy;
     Action action =
-        RemoteSpawnRunner.buildAction(
-            digestUtil.compute(command), merkleTreeRoot, context.getTimeout(), true);
-    // Look up action cache, and reuse the action output if it is found.
+          RemoteSpawnRunner.buildAction(
+              digestUtil.compute(command), merkleTreeRoot, context.getTimeout(), true);
+      // Look up action cache, and reuse the action output if it is found.
     ActionKey actionKey = digestUtil.computeActionKey(action);
-
     Context withMetadata =
         TracingMetadataUtils.contextWithMetadata(buildRequestId, commandId, actionKey);
 
@@ -135,16 +138,24 @@ final class RemoteSpawnCache implements SpawnCache {
         if (result != null && result.getExitCode() == 0) {
           // In case if failed action returned (exit code != 0) we treat it as a cache miss
           // Otherwise, we know that result exists.
-          try (SilentCloseable c = Profiler.instance().profile("RemoteCache.download")) {
-            remoteCache.download(result, execRoot, context.getFileOutErr());
+          PathFragment inMemoryOutputPath = getInMemoryOutputPath(spawn);
+          InMemoryOutput inMemoryOutput = null;
+          switch (remoteOutputsStrategy) {
+            case MINIMAL:
+              try (SilentCloseable c = Profiler.instance().profile("RemoteCache.downloadMinimal")) {
+                inMemoryOutput = remoteCache.downloadMinimal(result, spawn.getOutputFiles(),
+                    inMemoryOutputPath, context.getFileOutErr(), execRoot,
+                    context.getMetadataInjector());
+              }
+              break;
+            case ALL:
+              try (SilentCloseable c = Profiler.instance().profile("RemoteCache.download")) {
+                remoteCache.download(result, execRoot, context.getFileOutErr());
+              }
+              break;
           }
-          SpawnResult spawnResult =
-              new SpawnResult.Builder()
-                  .setStatus(Status.SUCCESS)
-                  .setExitCode(result.getExitCode())
-                  .setCacheHit(true)
-                  .setRunnerName("remote cache hit")
-                  .build();
+          SpawnResult spawnResult = createSpawnResult(result.getExitCode(), /* cacheHit= */ true,
+              "remote", inMemoryOutput);
           return SpawnCache.success(spawnResult);
         }
       } catch (CacheNotFoundException e) {
@@ -160,6 +171,9 @@ final class RemoteSpawnCache implements SpawnCache {
         withMetadata.detach(previous);
       }
     }
+
+    context.prefetchInputs();
+
     if (options.remoteUploadLocalResults) {
       return new CacheHandle() {
         @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -14,7 +14,9 @@
 
 package com.google.devtools.build.lib.remote;
 
+import static com.google.devtools.build.lib.remote.util.Utils.createSpawnResult;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.Utils.getInMemoryOutputPath;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
@@ -53,9 +55,11 @@ import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.options.RemoteOutputsStrategy;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.DigestUtil.ActionKey;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
+import com.google.devtools.build.lib.remote.util.Utils.InMemoryOutput;
 import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.Path;
@@ -83,8 +87,8 @@ import javax.annotation.Nullable;
 
 /** A client for the remote execution service. */
 @ThreadSafe
-class RemoteSpawnRunner implements SpawnRunner {
-  private static final int POSIX_TIMEOUT_EXIT_CODE = /*SIGNAL_BASE=*/128 + /*SIGALRM=*/14;
+public class RemoteSpawnRunner implements SpawnRunner {
+  private static final int POSIX_TIMEOUT_EXIT_CODE = /*SIGNAL_BASE=*/ 128 + /*SIGALRM=*/ 14;
 
   private final Path execRoot;
   private final RemoteOptions remoteOptions;
@@ -147,7 +151,7 @@ class RemoteSpawnRunner implements SpawnRunner {
     boolean spawnCachable = Spawns.mayBeCached(spawn);
 
     context.report(ProgressStatus.EXECUTING, getName());
-
+    RemoteOutputsStrategy remoteOutputsStrategy = remoteOptions.remoteOutputsStrategy;
     SortedMap<PathFragment, ActionInput> inputMap = context.getInputMapping(true);
     final MerkleTree merkleTree =
         MerkleTree.build(inputMap, context.getMetadataProvider(), execRoot, digestUtil);
@@ -190,9 +194,9 @@ class RemoteSpawnRunner implements SpawnRunner {
             // Set acceptCachedResult to false in order to force the action re-execution
             acceptCachedResult = false;
           } else {
-            try (SilentCloseable c = Profiler.instance().profile("Remote.downloadRemoteResults")) {
-              remoteCache.download(cachedResult, execRoot, context.getFileOutErr());
-              return createSpawnResult(cachedResult.getExitCode(), /* cacheHit= */ true);
+            try {
+              return downloadAndFinalizeSpawnResult(cachedResult, /* cacheHit= */ true, spawn,
+                  context, remoteOutputsStrategy);
             } catch (CacheNotFoundException e) {
               // No cache hit, so we fall through to local or remote execution.
               // We set acceptCachedResult to false in order to force the action re-execution.
@@ -257,25 +261,53 @@ class RemoteSpawnRunner implements SpawnRunner {
                 maybeDownloadServerLogs(reply, actionKey);
               }
 
-              try (SilentCloseable c =
-                  Profiler.instance().profile("Remote.downloadRemoteResults")) {
-                remoteCache.download(actionResult, execRoot, outErr);
+              try {
+                return downloadAndFinalizeSpawnResult(actionResult, reply.getCachedResult(), spawn,
+                    context, remoteOutputsStrategy);
               } catch (CacheNotFoundException e) {
                 // No cache hit, so if we retry this execution, we must no longer accept
                 // cached results, it must be reexecuted
                 requestBuilder.setSkipCacheLookup(true);
                 throw e;
               }
-              return createSpawnResult(actionResult.getExitCode(), reply.getCachedResult());
             });
       } catch (IOException e) {
         return execLocallyAndUploadOrFail(
             spawn, context, inputMap, actionKey, action, command, uploadLocalResults, e);
       }
-
     } finally {
       withMetadata.detach(previous);
     }
+  }
+
+  private SpawnResult downloadAndFinalizeSpawnResult(ActionResult actionResult, boolean cacheHit,
+      Spawn spawn, SpawnExecutionContext context, RemoteOutputsStrategy remoteOutputsStrategy)
+    throws ExecException, IOException, InterruptedException {
+    SpawnResult.Status actionStatus =
+        actionResult.getExitCode() == 0 ? Status.SUCCESS : Status.NON_ZERO_EXIT;
+    // In case the action failed, download all outputs. It might be helpful for debugging
+    // and there is no point in injecting output metadata of a failed action.
+    RemoteOutputsStrategy effectiveOutputsStrategy = actionStatus == Status.SUCCESS
+        ? remoteOutputsStrategy
+        : RemoteOutputsStrategy.ALL;
+    PathFragment inMemoryOutputPath = getInMemoryOutputPath(spawn);
+    InMemoryOutput inMemoryOutput = null;
+    switch (effectiveOutputsStrategy) {
+      case MINIMAL:
+        try (SilentCloseable c = Profiler.instance().profile("Remote.downloadMinimal")) {
+          inMemoryOutput = remoteCache.downloadMinimal(actionResult, spawn.getOutputFiles(),
+              inMemoryOutputPath, context.getFileOutErr(), execRoot,
+              context.getMetadataInjector());
+        }
+        break;
+
+      case ALL:
+        try (SilentCloseable c = Profiler.instance().profile("Remote.downloadRemoteResults")) {
+          remoteCache.download(actionResult, execRoot, context.getFileOutErr());
+        }
+        break;
+    }
+    return createSpawnResult(actionResult.getExitCode(), cacheHit, getName(), inMemoryOutput);
   }
 
   @Override
@@ -326,15 +358,6 @@ class RemoteSpawnRunner implements SpawnRunner {
             Event.info("Server logs of failing action:\n   " + (logCount > 1 ? parent : logPath)));
       }
     }
-  }
-
-  private SpawnResult createSpawnResult(int exitCode, boolean cacheHit) {
-    return new SpawnResult.Builder()
-        .setStatus(exitCode == 0 ? Status.SUCCESS : Status.NON_ZERO_EXIT)
-        .setExitCode(exitCode)
-        .setRunnerName(cacheHit ? getName() + " cache hit" : getName())
-        .setCacheHit(cacheHit)
-        .build();
   }
 
   private SpawnResult execLocally(Spawn spawn, SpawnExecutionContext context)
@@ -403,11 +426,7 @@ class RemoteSpawnRunner implements SpawnRunner {
         /* forciblyRunRemotely= */ false);
   }
 
-  static Action buildAction(
-      Digest command,
-      Digest inputRoot,
-      Duration timeout,
-      boolean cacheable) {
+  static Action buildAction(Digest command, Digest inputRoot, Duration timeout, boolean cacheable) {
 
     Action.Builder action = Action.newBuilder();
     action.setCommandDigest(command);
@@ -499,7 +518,7 @@ class RemoteSpawnRunner implements SpawnRunner {
   }
 
   private Map<Path, Long> getInputCtimes(SortedMap<PathFragment, ActionInput> inputMap) {
-    HashMap<Path, Long>  ctimes = new HashMap<>();
+    HashMap<Path, Long> ctimes = new HashMap<>();
     for (Map.Entry<PathFragment, ActionInput> e : inputMap.entrySet()) {
       ActionInput input = e.getValue();
       if (input instanceof VirtualActionInput) {
@@ -577,8 +596,7 @@ class RemoteSpawnRunner implements SpawnRunner {
    */
   static Collection<Path> resolveActionInputs(
       Path execRoot, Collection<? extends ActionInput> actionInputs) {
-    return actionInputs
-        .stream()
+    return actionInputs.stream()
         .map((inp) -> execRoot.getRelative(inp.getExecPath()))
         .collect(ImmutableList.toImmutableList());
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/options/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/BUILD
@@ -8,7 +8,7 @@ filegroup(
 
 java_library(
     name = "options",
-    srcs = ["RemoteOptions.java"],
+    srcs = glob(["*.java"]),
     deps = [
         "//src/main/java/com/google/devtools/build/lib:util",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.remote.options;
 
 import com.google.devtools.build.lib.util.OptionsUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
@@ -216,8 +217,8 @@ public final class RemoteOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.EXECUTION},
       metadataTags = {
-        OptionMetadataTag.INCOMPATIBLE_CHANGE,
-        OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+          OptionMetadataTag.INCOMPATIBLE_CHANGE,
+          OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
       },
       help =
           "If set to true, Bazel will represent symlinks in action outputs "
@@ -246,6 +247,25 @@ public final class RemoteOptions extends OptionsBase {
               + "If this option is not enabled, "
               + "cachable actions that output symlinks will fail.")
   public boolean allowSymlinkUpload;
+
+  @Option(
+      name = "experimental_remote_download_outputs",
+      defaultValue = "all",
+      category = "remote",
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      converter = RemoteOutputsStrategyConverter.class,
+      help = "If set to 'minimal' doesn't download any remote build outputs to the local machine, "
+          + "except the ones required by local actions. This option can significantly reduce build "
+          + "times if network bandwidth is a bottleneck."
+  )
+  public RemoteOutputsStrategy remoteOutputsStrategy;
+
+  public static class RemoteOutputsStrategyConverter extends EnumConverter<RemoteOutputsStrategy> {
+    public RemoteOutputsStrategyConverter() {
+      super(RemoteOutputsStrategy.class, "download remote outputs");
+    }
+  }
 
   @Option(
       name = "remote_result_cache_priority",

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOutputsStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOutputsStrategy.java
@@ -1,0 +1,31 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.remote.options;
+
+/**
+ * Describes what kind of remote build outputs to download locally.
+ */
+public enum RemoteOutputsStrategy {
+
+  /** Download all remote outputs locally. */
+  ALL,
+  /** Generally don't download remote outputs. */
+  MINIMAL;
+
+  /** Returns {@code true} iff action outputs should always be downloaded. */
+  public boolean downloadAllOutputs() {
+    return this == ALL;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -124,6 +124,10 @@ public class ActionExecutionFunction implements SkyFunction, CompletionReceiver 
       PrecomputedValue.BUILD_ID.get(env);
     }
 
+    // Declare a dependency on precomputed value. If the flag changes every action should be
+    // invalidated.
+    PrecomputedValue.REMOTE_OUTPUTS_STRATEGY.get(env);
+
     // Look up the parts of the environment that influence the action.
     Map<SkyKey, SkyValue> clientEnvLookup =
         env.getValues(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PrecomputedValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PrecomputedValue.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.analysis.buildinfo.BuildInfoFactory.BuildIn
 import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.packages.RuleVisibility;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
+import com.google.devtools.build.lib.remote.options.RemoteOutputsStrategy;
 import com.google.devtools.build.lib.skyframe.SkyframeActionExecutor.ConflictException;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.syntax.StarlarkSemantics;
@@ -102,6 +103,9 @@ public class PrecomputedValue implements SkyValue {
 
   public static final Precomputed<PathPackageLocator> PATH_PACKAGE_LOCATOR =
       new Precomputed<>(Key.create("path_package_locator"));
+
+  public static final Precomputed<RemoteOutputsStrategy> REMOTE_OUTPUTS_STRATEGY =
+      new Precomputed<>(Key.create("remote_outputs_strategy"));
 
   private final Object value;
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -123,6 +123,8 @@ import com.google.devtools.build.lib.pkgcache.TransitivePackageLoader;
 import com.google.devtools.build.lib.profiler.AutoProfiler;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.options.RemoteOutputsStrategy;
 import com.google.devtools.build.lib.rules.repository.ResolvedFileFunction;
 import com.google.devtools.build.lib.rules.repository.ResolvedHashesFunction;
 import com.google.devtools.build.lib.runtime.KeepGoingOption;
@@ -1389,6 +1391,10 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
     this.skyframeActionExecutor.setActionLogBufferPathGenerator(actionLogBufferPathGenerator);
   }
 
+  private void setRemoteOutputsStrategy(RemoteOutputsStrategy remoteOutputsStrategy) {
+    PrecomputedValue.REMOTE_OUTPUTS_STRATEGY.set(injectable(), remoteOutputsStrategy);
+  }
+
   /**
    * Asks the Skyframe evaluator to build the value for BuildConfigurationCollection and returns the
    * result.
@@ -2411,6 +2417,10 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
       OptionsProvider options)
       throws InterruptedException, AbruptExitException {
     getActionEnvFromOptions(options);
+    RemoteOptions remoteOptions = options.getOptions(RemoteOptions.class);
+    if (remoteOptions != null) {
+      setRemoteOutputsStrategy(remoteOptions.remoteOutputsStrategy);
+    }
     syncPackageLoading(
         packageCacheOptions,
         pathPackageLocator,

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
@@ -143,7 +143,8 @@ public class GrpcRemoteExecutionClientTest {
   private static ListeningScheduledExecutorService retryService;
 
   private static final OutputFile DUMMY_OUTPUT =
-      OutputFile.newBuilder().setPath("dummy.txt").build();
+      OutputFile.newBuilder().setPath("dummy.txt")
+          .setDigest(Digest.newBuilder().setHash("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855").setSizeBytes(0).build()).build();
 
   private final SpawnExecutionContext simplePolicy =
       new SpawnExecutionContext() {
@@ -154,7 +155,6 @@ public class GrpcRemoteExecutionClientTest {
 
         @Override
         public void prefetchInputs() {
-          throw new UnsupportedOperationException();
         }
 
         @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -35,8 +36,10 @@ import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
+import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
+import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.SimpleSpawn;
@@ -54,12 +57,14 @@ import com.google.devtools.build.lib.exec.SpawnRunner.ProgressStatus;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.exec.util.FakeOwner;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.options.RemoteOutputsStrategy;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.DigestUtil.ActionKey;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
@@ -71,6 +76,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import org.junit.Before;
 import org.junit.Test;
@@ -105,6 +111,8 @@ public class RemoteSpawnCacheTest {
 
   private StoredEventHandler eventHandler = new StoredEventHandler();
 
+  private Reporter reporter;
+
   private final SpawnExecutionContext simplePolicy =
       new SpawnExecutionContext() {
         @Override
@@ -114,8 +122,6 @@ public class RemoteSpawnCacheTest {
 
         @Override
         public void prefetchInputs() {
-          // CachedLocalSpawnRunner should never prefetch itself, though the nested SpawnRunner may.
-          throw new UnsupportedOperationException();
         }
 
         @Override
@@ -167,7 +173,34 @@ public class RemoteSpawnCacheTest {
 
         @Override
         public MetadataInjector getMetadataInjector() {
-          throw new UnsupportedOperationException();
+          return new MetadataInjector() {
+            @Override
+            public void injectRemoteFile(Artifact output, byte[] digest, long size,
+                int locationIndex) {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void injectRemoteDirectory(Artifact output,
+                Map<PathFragment, RemoteFileArtifactValue> children) {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void markOmitted(ActionInput output) {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void addExpandedTreeOutput(TreeFileArtifact output) {
+              throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void injectDigest(ActionInput output, FileStatus statNoFollow, byte[] digest) {
+              throw new UnsupportedOperationException();
+            }
+          };
         }
       };
 
@@ -195,7 +228,7 @@ public class RemoteSpawnCacheTest {
     FileSystemUtils.createDirectoryAndParents(stderr.getParentDirectory());
     outErr = new FileOutErr(stdout, stderr);
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
-    Reporter reporter = new Reporter(new EventBus());
+    reporter = new Reporter(new EventBus());
     eventHandler = new StoredEventHandler();
     reporter.addHandler(eventHandler);
     cache =
@@ -523,5 +556,51 @@ public class RemoteSpawnCacheTest {
     CacheHandle entry = cache.lookup(simpleSpawn, simplePolicy);
 
     assertThat(entry.hasResult()).isFalse();
+  }
+
+  @Test
+  public void testDownloadMinimal() throws Exception {
+    // arrange
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.remoteOutputsStrategy = RemoteOutputsStrategy.MINIMAL;
+    cache = new RemoteSpawnCache(execRoot, remoteOptions, remoteCache, "build-req-id",
+        "command-id", reporter, digestUtil);
+
+    ActionResult success = ActionResult.newBuilder().setExitCode(0).build();
+    when(remoteCache.getCachedActionResult(any())).thenReturn(success);
+
+    // act
+    CacheHandle cacheHandle = cache.lookup(simpleSpawn, simplePolicy);
+
+    // assert
+    assertThat(cacheHandle.hasResult()).isTrue();
+    assertThat(cacheHandle.getResult().exitCode()).isEqualTo(0);
+    verify(remoteCache).downloadMinimal(any(), anyCollection(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testDownloadMinimalIoError() throws Exception {
+    // arrange
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.remoteOutputsStrategy = RemoteOutputsStrategy.MINIMAL;
+    cache = new RemoteSpawnCache(execRoot, remoteOptions, remoteCache, "build-req-id",
+        "command-id", reporter, digestUtil);
+    IOException downloadFailure = new IOException("downloadMinimal failed");
+
+    ActionResult success = ActionResult.newBuilder().setExitCode(0).build();
+    when(remoteCache.getCachedActionResult(any())).thenReturn(success);
+    when(remoteCache.downloadMinimal(any(), anyCollection(), any(), any(), any(), any()))
+        .thenThrow(downloadFailure);
+
+    // act
+    CacheHandle cacheHandle = cache.lookup(simpleSpawn, simplePolicy);
+
+    // assert
+    assertThat(cacheHandle.hasResult()).isFalse();
+    verify(remoteCache).downloadMinimal(any(), anyCollection(), any(), any(), any(), any());
+    assertThat(eventHandler.getEvents().size()).isEqualTo(1);
+    Event evt = eventHandler.getEvents().get(0);
+    assertThat(evt.getKind()).isEqualTo(EventKind.WARNING);
+    assertThat(evt.getMessage()).contains(downloadFailure.getMessage());
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.remote;
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -44,10 +45,13 @@ import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
+import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
 import com.google.devtools.build.lib.actions.CommandLines.ParamFileActionInput;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
+import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.actions.ParameterFile.ParameterFileType;
 import com.google.devtools.build.lib.actions.ResourceSet;
@@ -69,11 +73,13 @@ import com.google.devtools.build.lib.exec.SpawnRunner.ProgressStatus;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.exec.util.FakeOwner;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.options.RemoteOutputsStrategy;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.DigestUtil.ActionKey;
 import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
@@ -87,6 +93,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
@@ -118,7 +125,8 @@ public class RemoteSpawnRunnerTest {
   private RemoteOptions options;
   private RemoteRetrier retrier;
 
-  @Mock private GrpcRemoteCache cache;
+  @Mock
+  private GrpcRemoteCache cache;
 
   @Mock
   private GrpcRemoteExecutor executor;
@@ -1160,6 +1168,95 @@ public class RemoteSpawnRunnerTest {
     assertThat(RemoteSpawnRunner.parsePlatform(null, s)).isEqualTo(expected);
   }
 
+  @Test
+  public void testDownloadMinimalOnCacheHit() throws Exception {
+    // arrange
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteOutputsStrategy = RemoteOutputsStrategy.MINIMAL;
+
+    ActionResult succeededAction = ActionResult.newBuilder().setExitCode(0).build();
+    when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(succeededAction);
+
+    RemoteSpawnRunner runner = new RemoteSpawnRunner(execRoot, options,
+        Options.getDefaults(ExecutionOptions.class), new AtomicReference<>(localRunner),
+        true, /* cmdlineReporter= */ null,  "build-req-id", "command-id", cache,
+        executor, retrier, digestUtil, logDir);
+
+    Spawn spawn = newSimpleSpawn();
+    SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
+
+    // act
+    SpawnResult result = runner.exec(spawn, policy);
+    assertThat(result.exitCode()).isEqualTo(0);
+    assertThat(result.status()).isEqualTo(Status.SUCCESS);
+
+    // assert
+    verify(cache).downloadMinimal(eq(succeededAction), anyCollection(), any(), any(), any(), any());
+    verify(cache, never()).download(any(ActionResult.class), any(Path.class), eq(outErr));
+  }
+
+  @Test
+  public void testDownloadMinimalOnCacheMiss() throws Exception {
+    // arrange
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteOutputsStrategy = RemoteOutputsStrategy.MINIMAL;
+
+    ActionResult succeededAction = ActionResult.newBuilder().setExitCode(0).build();
+    ExecuteResponse succeeded = ExecuteResponse.newBuilder().setResult(succeededAction).build();
+    when(executor.executeRemotely(any(ExecuteRequest.class))).thenReturn(succeeded);
+
+    RemoteSpawnRunner runner = new RemoteSpawnRunner(execRoot, options,
+        Options.getDefaults(ExecutionOptions.class), new AtomicReference<>(localRunner),
+        true, /* cmdlineReporter= */ null,  "build-req-id", "command-id", cache,
+        executor, retrier, digestUtil, logDir);
+
+    Spawn spawn = newSimpleSpawn();
+    SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
+
+    // act
+    SpawnResult result = runner.exec(spawn, policy);
+    assertThat(result.exitCode()).isEqualTo(0);
+    assertThat(result.status()).isEqualTo(Status.SUCCESS);
+
+    // assert
+    verify(executor).executeRemotely(any());
+    verify(cache).downloadMinimal(eq(succeededAction), anyCollection(), any(), any(), any(), any());
+    verify(cache, never()).download(any(ActionResult.class), any(Path.class), eq(outErr));
+  }
+
+  @Test
+  public void testDownloadMinimalIoError() throws Exception {
+    // arrange
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteOutputsStrategy = RemoteOutputsStrategy.MINIMAL;
+
+    ActionResult succeededAction = ActionResult.newBuilder().setExitCode(0).build();
+    when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(succeededAction);
+    IOException downloadFailure = new IOException("downloadMinimal failed");
+    when(cache.downloadMinimal(any(), anyCollection(), any(), any(), any(), any()))
+        .thenThrow(downloadFailure);
+
+    RemoteSpawnRunner runner = new RemoteSpawnRunner(execRoot, options,
+        Options.getDefaults(ExecutionOptions.class), new AtomicReference<>(localRunner),
+        /* verboseFailures= */ false, /* cmdlineReporter= */ null,  "build-req-id", "command-id",
+        cache, executor, retrier, digestUtil, logDir);
+
+    Spawn spawn = newSimpleSpawn();
+    SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
+
+    // act
+    try {
+      runner.exec(spawn, policy);
+      fail("expected exception");
+    } catch (SpawnExecException e) {
+      assertThat(e.getMessage()).isEqualTo(downloadFailure.getMessage());
+    }
+
+    // assert
+    verify(cache).downloadMinimal(eq(succeededAction), anyCollection(), any(), any(), any(), any());
+    verify(cache, never()).download(any(ActionResult.class), any(Path.class), eq(outErr));
+  }
+
   private static Spawn newSimpleSpawn() {
     return new SimpleSpawn(
         new FakeOwner("foo", "bar"),
@@ -1189,12 +1286,12 @@ public class RemoteSpawnRunnerTest {
     }
 
     @Override
-    public void prefetchInputs() throws IOException {
+    public void prefetchInputs() {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public void lockOutputFiles() throws InterruptedException {
+    public void lockOutputFiles() {
       throw new UnsupportedOperationException();
     }
 
@@ -1238,7 +1335,33 @@ public class RemoteSpawnRunnerTest {
 
     @Override
     public MetadataInjector getMetadataInjector() {
-      throw new UnsupportedOperationException();
+      return new MetadataInjector() {
+        @Override
+        public void injectRemoteFile(Artifact output, byte[] digest, long size, int locationIndex) {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void injectRemoteDirectory(Artifact output,
+            Map<PathFragment, RemoteFileArtifactValue> children) {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void markOmitted(ActionInput output) {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addExpandedTreeOutput(TreeFileArtifact output) {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void injectDigest(ActionInput output, FileStatus statNoFollow, byte[] digest) {
+          throw new UnsupportedOperationException();
+        }
+      };
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -85,6 +85,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/collect",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TimestampBuilderTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TimestampBuilderTestCase.java
@@ -70,6 +70,7 @@ import com.google.devtools.build.lib.events.StoredEventHandler;
 import com.google.devtools.build.lib.exec.SingleBuildFileCache;
 import com.google.devtools.build.lib.packages.WorkspaceFileValue;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
+import com.google.devtools.build.lib.remote.options.RemoteOutputsStrategy;
 import com.google.devtools.build.lib.runtime.KeepGoingOption;
 import com.google.devtools.build.lib.skyframe.AspectValue.AspectKey;
 import com.google.devtools.build.lib.skyframe.ExternalFilesHelper.ExternalFileAction;
@@ -260,6 +261,7 @@ public abstract class TimestampBuilderTestCase extends FoundationTestCase {
     PrecomputedValue.BUILD_ID.set(differencer, UUID.randomUUID());
     PrecomputedValue.ACTION_ENV.set(differencer, ImmutableMap.<String, String>of());
     PrecomputedValue.PATH_PACKAGE_LOCATOR.set(differencer, pkgLocator.get());
+    PrecomputedValue.REMOTE_OUTPUTS_STRATEGY.set(differencer, RemoteOutputsStrategy.ALL);
 
     return new Builder() {
       private void setGeneratingActions() throws ActionConflictException {

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -796,7 +796,110 @@ EOF
            || fail "Failed to run //a:skylark_output_dir_test with remote execution"
 }
 
+function test_downloads_minimal() {
+  # Test that genrule outputs are not downloaded when using
+  # --experimental_remote_download_outputs=minimal
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = "foo",
+  srcs = [],
+  outs = ["foo.txt"],
+  cmd = "echo \"foo\" > \"$@\"",
+)
 
+genrule(
+  name = "foobar",
+  srcs = [":foo"],
+  outs = ["foobar.txt"],
+  cmd = "cat $(location :foo) > \"$@\" && echo \"bar\" >> \"$@\"",
+)
+EOF
+
+  bazel build \
+    --genrule_strategy=remote \
+    --remote_executor=localhost:${worker_port} \
+    --experimental_inmemory_jdeps_files \
+    --experimental_inmemory_dotd_files \
+    --experimental_remote_download_outputs=minimal \
+    //a:foobar || fail "Failed to build //a:foobar"
+
+  (! [[ -f bazel-bin/a/foo.txt ]] && ! [[ -f bazel-bin/a/foobar.txt ]]) \
+  || fail "Expected no files to have been downloaded"
+}
+
+function test_downloads_minimal_failure() {
+  # Test that outputs of failing actions are downloaded when using
+  # --experimental_remote_download_outputs=minimal
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = "fail",
+  srcs = [],
+  outs = ["fail.txt"],
+  cmd = "echo \"foo\" > \"$@\" && exit 1",
+)
+EOF
+
+  bazel build \
+    --spawn_strategy=remote \
+    --remote_executor=localhost:${worker_port} \
+    --experimental_inmemory_jdeps_files \
+    --experimental_inmemory_dotd_files \
+    --experimental_remote_download_outputs=minimal \
+    //a:fail && fail "Expected test failure" || true
+
+  [[ -f bazel-bin/a/fail.txt ]] \
+  || fail "Expected fail.txt of failing target //a:fail to be downloaded"
+}
+
+function test_downloads_minimal_prefetch() {
+  # Test that when using --experimental_remote_download_outputs=minimal a remote-only output that's
+  # an input to a local action is downloaded lazily before executing the local action.
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = "remote",
+  srcs = [],
+  outs = ["remote.txt"],
+  cmd = "echo -n \"remote\" > \"$@\"",
+)
+
+genrule(
+  name = "local",
+  srcs = [":remote"],
+  outs = ["local.txt"],
+  cmd = "cat $(location :remote) > \"$@\" && echo -n \"local\" >> \"$@\"",
+  tags = ["no-remote"],
+)
+EOF
+
+  bazel build \
+    --genrule_strategy=remote \
+    --remote_executor=localhost:${worker_port} \
+    --experimental_inmemory_jdeps_files \
+    --experimental_inmemory_dotd_files \
+    --experimental_remote_download_outputs=minimal \
+    //a:remote || fail "Failed to build //a:remote"
+
+  (! [[ -f bazel-bin/a/remote.txt ]]) \
+  || fail "Expected bazel-bin/a/remote.txt to have not been downloaded"
+
+  bazel build \
+    --genrule_strategy=remote \
+    --remote_executor=localhost:${worker_port} \
+    --experimental_inmemory_jdeps_files \
+    --experimental_inmemory_dotd_files \
+    --experimental_remote_download_outputs=minimal \
+    //a:local || fail "Failed to build //a:local"
+
+  localtxt="bazel-bin/a/local.txt"
+  [[ $(< ${localtxt}) == "remotelocal" ]] \
+  || fail "Unexpected contents in " ${localtxt} ": " $(< ${localtxt})
+
+  (! [[ -f bazel-bin/a/remote.txt ]]) \
+  || fail "Expected bazel-bin/a/remote.txt to have been deleted again"
+}
 # TODO(alpha): Add a test that fails remote execution when remote worker
 # supports sandbox.
 


### PR DESCRIPTION
This implements the first milestone of #6862. When specifying
--experimental_remote_outputs=minimal Bazel will avoid downloading
most action outputs. That is, it will only download an action's
stdout/stderr as well as .d and .jdeps output files when building
C++ and Java.

Enabling this mode currently requires specifying three flags:
```
$ bazel build ... \
  --experimental_inmemory_jdeps_files \
  --experimental_inmemory_dotd_files \
  --experimental_remote_outputs=minimal
```
Also, this mode does not yet interact well with the Build Event Service
(--bes_backend=...). Specifically, local file uploads and remote file
name conversions are disabled when --experimental_remote_outputs=minimal
is specified.