### PR TITLE
WIP: Windows: Path.readSymbolicLink works for junctions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -90,6 +90,12 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
+  protected PathFragment readSymbolicLink(Path path) throws IOException {
+    java.nio.file.Path nioPath = getNioPath(path);
+    return PathFragment.create(WindowsFileOperations.readJunction(nioPath.toString()));
+  }
+
+  @Override
   public boolean supportsSymbolicLinksNatively(Path path) {
     return false;
   }

--- a/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
@@ -78,7 +78,7 @@ public class WindowsFileOperations {
 
   private static native int nativeCreateJunction(String name, String target, String[] error);
 
-  private static native int nativeReadJunction(String path, String[] result, int[] target_len, String[] error);
+  private static native int nativeReadJunction(String path, String[] result, int[] DEBUG_target_len, String[] error);
 
   private static native int nativeDeletePath(String path, String[] error);
 
@@ -178,15 +178,15 @@ public class WindowsFileOperations {
   public static String readJunction(String path) throws IOException {
     WindowsJniLoader.loadJni();
     String[] target = new String[] {null};
-    int[] target_len = new int[] { 0 };
+    int[] DEBUG_target_len = new int[] { 0 };
     String[] error = new String[] {null};
 
     path = asLongPath(path);
-    int result = nativeReadJunction(path, target, target_len, error);
+    int result = nativeReadJunction(path, target, DEBUG_target_len, error);
     if (result == READ_JUNCTION_SUCCESS) {
       error[0] = removeUncPrefixAndUseSlashes(target[0]);
       System.err.printf(" | DEBUG | readJunc(%s) -> (%s) %d %d (%s)%n",
-          path, target[0], target_len[0], target[0].length(), error[0]);
+          path, target[0], DEBUG_target_len[0], target[0].length(), error[0]);
       return error[0];
     } else {
       switch (result) {

--- a/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
@@ -182,7 +182,7 @@ public class WindowsFileOperations {
 
     int result = nativeReadJunction(asLongPath(path), target, error);
     if (result == READ_JUNCTION_SUCCESS) {
-      return target[0];
+      return removeUncPrefixAndUseSlashes(target[0]);
     } else {
       switch (result) {
         case READ_JUNCTION_DOES_NOT_EXIST:

--- a/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
@@ -78,7 +78,7 @@ public class WindowsFileOperations {
 
   private static native int nativeCreateJunction(String name, String target, String[] error);
 
-  private static native int nativeReadJunction(String path, String[] result, String[] error);
+  private static native int nativeReadJunction(String path, String[] result, int[] target_len, String[] error);
 
   private static native int nativeDeletePath(String path, String[] error);
 
@@ -178,13 +178,15 @@ public class WindowsFileOperations {
   public static String readJunction(String path) throws IOException {
     WindowsJniLoader.loadJni();
     String[] target = new String[] {null};
+    int[] target_len = new int[] { 0 };
     String[] error = new String[] {null};
 
     path = asLongPath(path);
-    int result = nativeReadJunction(path, target, error);
+    int result = nativeReadJunction(path, target, target_len, error);
     if (result == READ_JUNCTION_SUCCESS) {
       error[0] = removeUncPrefixAndUseSlashes(target[0]);
-      System.err.printf(" | DEBUG | readJunc(%s) -> (%s) (%s)%n", path, target[0], error[0]);
+      System.err.printf(" | DEBUG | readJunc(%s) -> (%s) %d %d (%s)%n",
+          path, target[0], target_len[0], target[0].length(), error[0]);
       return error[0];
     } else {
       switch (result) {

--- a/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
@@ -180,9 +180,12 @@ public class WindowsFileOperations {
     String[] target = new String[] {null};
     String[] error = new String[] {null};
 
-    int result = nativeReadJunction(asLongPath(path), target, error);
+    path = asLongPath(path);
+    int result = nativeReadJunction(path, target, error);
     if (result == READ_JUNCTION_SUCCESS) {
-      return removeUncPrefixAndUseSlashes(target[0]);
+      error[0] = removeUncPrefixAndUseSlashes(target[0]);
+      System.err.printf(" | DEBUG | readJunc(%s) -> (%s) (%s)%n", path, target[0], error[0]);
+      return error[0];
     } else {
       switch (result) {
         case READ_JUNCTION_DOES_NOT_EXIST:

--- a/src/main/native/windows/file-jni.cc
+++ b/src/main/native/windows/file-jni.cc
@@ -97,21 +97,21 @@ Java_com_google_devtools_build_lib_windows_jni_WindowsFileOperations_nativeCreat
   return result;
 }
 
-extern "C" JNIEXPORT jboolean JNICALL
+extern "C" JNIEXPORT jint JNICALL
 Java_com_google_devtools_build_lib_windows_jni_WindowsFileOperations_nativeReadJunction(
     JNIEnv* env, jclass clazz, jstring path, jobjectArray result_holder,
-    jintArray result_len_holder, jobjectArray error_msg_holder) {
+    jintArray DEBUG_result_len_holder, jobjectArray error_msg_holder) {
   std::wstring target, error;
-  int target_len;
+  int DEBUG_target_len;
   std::wstring wpath(bazel::windows::GetJavaWstring(env, path));
-  int result = bazel::windows::ReadJunction(wpath, &target, &target_len, &error);
+  int result = bazel::windows::ReadJunction(wpath, &target, &DEBUG_target_len, &error);
   if (result == bazel::windows::ReadJunctionResult::kSuccess) {
     env->SetObjectArrayElement(
         result_holder, 0,
         env->NewString(reinterpret_cast<const jchar*>(target.c_str()),
                        target.size()));
-    jint targetlen = target_len;
-    env->SetIntArrayRegion(result_len_holder, 0, 1, &targetlen);
+    jint DEBUG_targetlen = DEBUG_target_len;
+    env->SetIntArrayRegion(DEBUG_result_len_holder, 0, 1, &DEBUG_targetlen);
   } else {
     if (!error.empty() && CanReportError(env, error_msg_holder)) {
       ReportLastError(

--- a/src/main/native/windows/file-jni.cc
+++ b/src/main/native/windows/file-jni.cc
@@ -100,15 +100,18 @@ Java_com_google_devtools_build_lib_windows_jni_WindowsFileOperations_nativeCreat
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_google_devtools_build_lib_windows_jni_WindowsFileOperations_nativeReadJunction(
     JNIEnv* env, jclass clazz, jstring path, jobjectArray result_holder,
-    jobjectArray error_msg_holder) {
+    jintArray result_len_holder, jobjectArray error_msg_holder) {
   std::wstring target, error;
+  int target_len;
   std::wstring wpath(bazel::windows::GetJavaWstring(env, path));
-  int result = bazel::windows::ReadJunction(wpath, &target, &error);
+  int result = bazel::windows::ReadJunction(wpath, &target, &target_len, &error);
   if (result == bazel::windows::ReadJunctionResult::kSuccess) {
     env->SetObjectArrayElement(
         result_holder, 0,
         env->NewString(reinterpret_cast<const jchar*>(target.c_str()),
                        target.size()));
+    jint targetlen = target_len;
+    env->SetIntArrayRegion(result_len_holder, 0, 1, &targetlen);
   } else {
     if (!error.empty() && CanReportError(env, error_msg_holder)) {
       ReportLastError(

--- a/src/main/native/windows/file-jni.cc
+++ b/src/main/native/windows/file-jni.cc
@@ -97,6 +97,29 @@ Java_com_google_devtools_build_lib_windows_jni_WindowsFileOperations_nativeCreat
   return result;
 }
 
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_google_devtools_build_lib_windows_jni_WindowsFileOperations_nativeReadJunction(
+    JNIEnv* env, jclass clazz, jstring path, jobjectArray result_holder,
+    jobjectArray error_msg_holder) {
+  std::wstring target, error;
+  std::wstring wpath(bazel::windows::GetJavaWstring(env, path));
+  int result = bazel::windows::ReadJunction(wpath, &target, &error);
+  if (result == bazel::windows::ReadJunctionResult::kSuccess) {
+    env->SetObjectArrayElement(
+        result_holder, 0,
+        env->NewString(reinterpret_cast<const jchar*>(target.c_str()),
+                       target.size()));
+  } else {
+    if (!error.empty() && CanReportError(env, error_msg_holder)) {
+      ReportLastError(
+          bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
+                                           L"nativeReadJunction", wpath, error),
+          env, error_msg_holder);
+    }
+  }
+  return result;
+}
+
 extern "C" JNIEXPORT jint JNICALL
 Java_com_google_devtools_build_lib_windows_jni_WindowsFileOperations_nativeDeletePath(
     JNIEnv* env, jclass clazz, jstring path, jobjectArray error_msg_holder) {

--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -419,7 +419,7 @@ int CreateJunction(const wstring& junction_name, const wstring& junction_target,
   return CreateJunctionResult::kSuccess;
 }
 
-int ReadJunction(const wstring& path, wstring* result, wstring* error) {
+int ReadJunction(const wstring& path, wstring* result, int* result_len, wstring* error) {
   AutoHandle handle(CreateFileW(
       path.c_str(), 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
       NULL, OPEN_EXISTING,
@@ -464,6 +464,7 @@ int ReadJunction(const wstring& path, wstring* result, wstring* error) {
   }
 
   result->assign(target_path);
+  *result_len = target_path_len;
   return ReadJunctionResult::kSuccess;
 }
 

--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -463,7 +463,7 @@ int ReadJunction(const wstring& path, wstring* result, wstring* error) {
     return ReadJunctionResult::kError;
   }
 
-  *result = std::wstring(target_path, target_path_len);
+  result->assign(target_path);
   return ReadJunctionResult::kSuccess;
 }
 

--- a/src/main/native/windows/file.h
+++ b/src/main/native/windows/file.h
@@ -134,7 +134,7 @@ wstring GetLongPath(const WCHAR* path, unique_ptr<WCHAR[]>* result);
 int CreateJunction(const wstring& junction_name, const wstring& junction_target,
                    wstring* error);
 
-int ReadJunction(const wstring& path, wstring* result, int* result_len,
+int ReadJunction(const wstring& path, wstring* result, int* DEBUG_result_len,
                  wstring* error);
 
 // Deletes the file, junction, or empty directory at `path`.

--- a/src/main/native/windows/file.h
+++ b/src/main/native/windows/file.h
@@ -77,6 +77,16 @@ struct CreateJunctionResult {
   };
 };
 
+struct ReadJunctionResult {
+  enum {
+    kSuccess = 0,
+    kError = 1,
+    kDoesNotExist = 2,
+    kAccessDenied = 3,
+    kNotAJunction = 4,
+  };
+};
+
 // Determines whether `path` is a junction (or directory symlink).
 //
 // `path` should be an absolute, normalized, Windows-style path, with "\\?\"
@@ -123,6 +133,8 @@ wstring GetLongPath(const WCHAR* path, unique_ptr<WCHAR[]>* result);
 // function will add the right prefixes as necessary.
 int CreateJunction(const wstring& junction_name, const wstring& junction_target,
                    wstring* error);
+
+int ReadJunction(const wstring& path, wstring* result, wstring* error);
 
 // Deletes the file, junction, or empty directory at `path`.
 // Returns DELETE_PATH_SUCCESS if it successfully deleted the path, otherwise

--- a/src/main/native/windows/file.h
+++ b/src/main/native/windows/file.h
@@ -134,7 +134,8 @@ wstring GetLongPath(const WCHAR* path, unique_ptr<WCHAR[]>* result);
 int CreateJunction(const wstring& junction_name, const wstring& junction_target,
                    wstring* error);
 
-int ReadJunction(const wstring& path, wstring* result, wstring* error);
+int ReadJunction(const wstring& path, wstring* result, int* result_len,
+                 wstring* error);
 
 // Deletes the file, junction, or empty directory at `path`.
 // Returns DELETE_PATH_SUCCESS if it successfully deleted the path, otherwise

--- a/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
@@ -331,4 +331,42 @@ public class WindowsFileSystemTest {
       assertThat(p.isFile()).isTrue();
     }
   }
+
+  @Test
+  public void testReadJunction() throws Exception {
+    testUtil.scratchFile("dir\\hello.txt", "hello");
+    testUtil.createJunctions(ImmutableMap.of("junc", "dir"));
+
+    Path dirPath = testUtil.createVfsPath(fs, "dir");
+    Path juncPath = testUtil.createVfsPath(fs, "junc");
+
+    assertThat(dirPath.isDirectory()).isTrue();
+    assertThat(juncPath.isDirectory()).isTrue();
+
+    assertThat(dirPath.isSymbolicLink()).isFalse();
+    assertThat(juncPath.isSymbolicLink()).isTrue();
+
+    try {
+      testUtil.createVfsPath(fs, "does-not-exist").readSymbolicLink();
+      fail("expected exception");
+    } catch (IOException expected) {
+      assertThat(expected).hasMessageThat().matches(".*path does not exist");
+    }
+
+    try {
+      testUtil.createVfsPath(fs, "dir\\hello.txt").readSymbolicLink();
+      fail("expected exception");
+    } catch (IOException expected) {
+      assertThat(expected).hasMessageThat().matches(".*not a junction");
+    }
+
+    try {
+      dirPath.readSymbolicLink();
+      fail("expected exception");
+    } catch (IOException expected) {
+      assertThat(expected).hasMessageThat().matches(".*not a junction");
+    }
+
+    assertThat(juncPath.readSymbolicLink()).isEqualTo(dirPath.asFragment());
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/7907