### PR TITLE
Rename RuleTransitionData to AttributeTransitionData.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/DependencyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/DependencyResolver.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.packages.AspectDescriptor;
 import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.Attribute.LateBoundDefault;
 import com.google.devtools.build.lib.packages.AttributeMap;
+import com.google.devtools.build.lib.packages.AttributeTransitionData;
 import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.ConfiguredAttributeMapper;
 import com.google.devtools.build.lib.packages.EnvironmentGroup;
@@ -45,7 +46,6 @@ import com.google.devtools.build.lib.packages.OutputFile;
 import com.google.devtools.build.lib.packages.PackageGroup;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.RuleClass;
-import com.google.devtools.build.lib.packages.RuleTransitionData;
 import com.google.devtools.build.lib.packages.RuleTransitionFactory;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.syntax.EvalException;
@@ -344,7 +344,7 @@ public abstract class DependencyResolver {
           aspects, attribute.getName(), entry.getKey().getOwningAspect(), propagatingAspects);
 
       ConfigurationTransition attributeTransition =
-          attribute.getTransitionFactory().create(RuleTransitionData.create(attributeMap));
+          attribute.getTransitionFactory().create(AttributeTransitionData.create(attributeMap));
       partiallyResolvedDeps.put(
           entry.getKey(),
           PartiallyResolvedDependency.of(toLabel, attributeTransition, propagatingAspects.build()));

--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -71,6 +71,7 @@ import com.google.devtools.build.lib.packages.Aspect;
 import com.google.devtools.build.lib.packages.AspectDescriptor;
 import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.AttributeMap;
+import com.google.devtools.build.lib.packages.AttributeTransitionData;
 import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.BuiltinProvider;
 import com.google.devtools.build.lib.packages.ConfigurationFragmentPolicy;
@@ -89,7 +90,6 @@ import com.google.devtools.build.lib.packages.RequiredProviders;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleErrorConsumer;
-import com.google.devtools.build.lib.packages.RuleTransitionData;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
@@ -843,7 +843,7 @@ public final class RuleContext extends TargetContext
             attributeDefinition
                 .getTransitionFactory()
                 .create(
-                    RuleTransitionData.create(
+                    AttributeTransitionData.create(
                         ConfiguredAttributeMapper.of(rule, configConditions)));
     BuildOptions fromOptions = getConfiguration().getOptions();
     List<BuildOptions> splitOptions = transition.split(fromOptions);
@@ -1173,7 +1173,7 @@ public final class RuleContext extends TargetContext
       throw new IllegalStateException(getRuleClassNameForLogging() + " attribute " + attributeName
         + " is not a label type attribute");
     }
-    TransitionFactory<RuleTransitionData> transitionFactory =
+    TransitionFactory<AttributeTransitionData> transitionFactory =
         attributeDefinition.getTransitionFactory();
     if (mode == Mode.HOST) {
       if (transitionFactory.isSplit()) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/StarlarkAttributeTransitionProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/StarlarkAttributeTransitionProvider.java
@@ -27,8 +27,8 @@ import com.google.devtools.build.lib.analysis.config.transitions.TransitionFacto
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.AttributeMap;
+import com.google.devtools.build.lib.packages.AttributeTransitionData;
 import com.google.devtools.build.lib.packages.ConfiguredAttributeMapper;
-import com.google.devtools.build.lib.packages.RuleTransitionData;
 import com.google.devtools.build.lib.packages.StructImpl;
 import com.google.devtools.build.lib.packages.StructProvider;
 import com.google.devtools.build.lib.skylarkbuildapi.SplitTransitionProviderApi;
@@ -52,7 +52,7 @@ import java.util.List;
  * instead of just labels (see {@link SkylarkAttributesCollection#addAttribute}).
  */
 public class StarlarkAttributeTransitionProvider
-    implements TransitionFactory<RuleTransitionData>, SplitTransitionProviderApi {
+    implements TransitionFactory<AttributeTransitionData>, SplitTransitionProviderApi {
   private final StarlarkDefinedConfigTransition starlarkDefinedConfigTransition;
 
   StarlarkAttributeTransitionProvider(
@@ -66,7 +66,7 @@ public class StarlarkAttributeTransitionProvider
   }
 
   @Override
-  public SplitTransition create(RuleTransitionData data) {
+  public SplitTransition create(AttributeTransitionData data) {
     AttributeMap attributeMap = data.attributes();
     Preconditions.checkArgument(attributeMap instanceof ConfiguredAttributeMapper);
     return new FunctionSplitTransition(

--- a/src/main/java/com/google/devtools/build/lib/packages/Attribute.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Attribute.java
@@ -86,11 +86,12 @@ public final class Attribute implements Comparable<Attribute> {
   // TODO(https://github.com/bazelbuild/bazel/issues/7814): Remove this, have callers create
   // factories.
   @AutoValue
-  abstract static class StaticTransitionFactory implements TransitionFactory<RuleTransitionData> {
+  abstract static class StaticTransitionFactory
+      implements TransitionFactory<AttributeTransitionData> {
     abstract ConfigurationTransition transition();
 
     @Override
-    public ConfigurationTransition create(RuleTransitionData unused) {
+    public ConfigurationTransition create(AttributeTransitionData unused) {
       return transition();
     }
 
@@ -104,7 +105,7 @@ public final class Attribute implements Comparable<Attribute> {
       return transition() instanceof SplitTransition;
     }
 
-    static TransitionFactory<RuleTransitionData> of(ConfigurationTransition transition) {
+    static TransitionFactory<AttributeTransitionData> of(ConfigurationTransition transition) {
       return new AutoValue_Attribute_StaticTransitionFactory(transition);
     }
   }
@@ -379,7 +380,7 @@ public final class Attribute implements Comparable<Attribute> {
   public static class ImmutableAttributeFactory {
     private final Type<?> type;
     private final String doc;
-    private final TransitionFactory<RuleTransitionData> transitionFactory;
+    private final TransitionFactory<AttributeTransitionData> transitionFactory;
     private final RuleClassNamePredicate allowedRuleClassesForLabels;
     private final RuleClassNamePredicate allowedRuleClassesForLabelsWarning;
     private final FileTypeSet allowedFileTypesForLabels;
@@ -399,7 +400,7 @@ public final class Attribute implements Comparable<Attribute> {
         String doc,
         ImmutableSet<PropertyFlag> propertyFlags,
         Object value,
-        TransitionFactory<RuleTransitionData> transitionFactory,
+        TransitionFactory<AttributeTransitionData> transitionFactory,
         RuleClassNamePredicate allowedRuleClassesForLabels,
         RuleClassNamePredicate allowedRuleClassesForLabelsWarning,
         FileTypeSet allowedFileTypesForLabels,
@@ -486,7 +487,8 @@ public final class Attribute implements Comparable<Attribute> {
   public static class Builder <TYPE> {
     private final String name;
     private final Type<TYPE> type;
-    private TransitionFactory<RuleTransitionData> transitionFactory = NoTransition.createFactory();
+    private TransitionFactory<AttributeTransitionData> transitionFactory =
+        NoTransition.createFactory();
     private RuleClassNamePredicate allowedRuleClassesForLabels = ANY_RULE;
     private RuleClassNamePredicate allowedRuleClassesForLabelsWarning = NO_RULE;
     private FileTypeSet allowedFileTypesForLabels;
@@ -622,7 +624,7 @@ public final class Attribute implements Comparable<Attribute> {
     }
 
     /** Defines the configuration transition for this attribute. */
-    public Builder<TYPE> cfg(TransitionFactory<RuleTransitionData> transitionFactory) {
+    public Builder<TYPE> cfg(TransitionFactory<AttributeTransitionData> transitionFactory) {
       Preconditions.checkNotNull(transitionFactory);
       Preconditions.checkState(
           NoTransition.isInstance(this.transitionFactory),
@@ -1924,7 +1926,7 @@ public final class Attribute implements Comparable<Attribute> {
   // (We assume a hypothetical Type.isValid(Object) predicate.)
   private final Object defaultValue;
 
-  private final TransitionFactory<RuleTransitionData> transitionFactory;
+  private final TransitionFactory<AttributeTransitionData> transitionFactory;
 
   /**
    * For label or label-list attributes, this predicate returns which rule
@@ -1981,7 +1983,7 @@ public final class Attribute implements Comparable<Attribute> {
       Type<?> type,
       Set<PropertyFlag> propertyFlags,
       Object defaultValue,
-      TransitionFactory<RuleTransitionData> transitionFactory,
+      TransitionFactory<AttributeTransitionData> transitionFactory,
       RuleClassNamePredicate allowedRuleClassesForLabels,
       RuleClassNamePredicate allowedRuleClassesForLabelsWarning,
       FileTypeSet allowedFileTypesForLabels,
@@ -2143,7 +2145,7 @@ public final class Attribute implements Comparable<Attribute> {
    * Returns the configuration transition factory for this attribute for label or label list
    * attributes. For other attributes it will always return {@code NONE}.
    */
-  public TransitionFactory<RuleTransitionData> getTransitionFactory() {
+  public TransitionFactory<AttributeTransitionData> getTransitionFactory() {
     return transitionFactory;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/packages/AttributeTransitionData.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/AttributeTransitionData.java
@@ -23,15 +23,15 @@ import com.google.devtools.build.lib.analysis.config.transitions.TransitionFacto
 // This class is in lib.packages in order to access AttributeMap, which is not available to
 // the lib.analysis.config.transitions package.
 @AutoValue
-public abstract class RuleTransitionData {
+public abstract class AttributeTransitionData {
   /** Returns the {@link AttributeMap} which can be used to create a transition. */
   public abstract AttributeMap attributes();
 
   // TODO(https://github.com/bazelbuild/bazel/issues/7814): Add further data fields as needed by
   // transition factory instances.
 
-  /** Returns a new {@link RuleTransitionData} instance. */
-  public static RuleTransitionData create(AttributeMap attributes) {
-    return new AutoValue_RuleTransitionData(attributes);
+  /** Returns a new {@link AttributeTransitionData} instance. */
+  public static AttributeTransitionData create(AttributeMap attributes) {
+    return new AutoValue_AttributeTransitionData(attributes);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/MultiArchSplitTransitionProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/MultiArchSplitTransitionProvider.java
@@ -26,8 +26,8 @@ import com.google.devtools.build.lib.analysis.config.BuildConfiguration.Options;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.transitions.SplitTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
+import com.google.devtools.build.lib.packages.AttributeTransitionData;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
-import com.google.devtools.build.lib.packages.RuleTransitionData;
 import com.google.devtools.build.lib.rules.apple.AppleCommandLineOptions;
 import com.google.devtools.build.lib.rules.apple.AppleConfiguration;
 import com.google.devtools.build.lib.rules.apple.AppleConfiguration.ConfigurationDistinguisher;
@@ -48,7 +48,9 @@ import java.util.stream.Collectors;
  */
 // TODO(https://github.com/bazelbuild/bazel/pull/7825): Rename to MultiArchSplitTransitionFactory.
 public class MultiArchSplitTransitionProvider
-    implements TransitionFactory<RuleTransitionData>, SplitTransitionProviderApi, SkylarkValue {
+    implements TransitionFactory<AttributeTransitionData>,
+        SplitTransitionProviderApi,
+        SkylarkValue {
 
   @VisibleForTesting
   static final String UNSUPPORTED_PLATFORM_TYPE_ERROR_FORMAT =
@@ -129,7 +131,7 @@ public class MultiArchSplitTransitionProvider
   }
 
   @Override
-  public SplitTransition create(RuleTransitionData data) {
+  public SplitTransition create(AttributeTransitionData data) {
     String platformTypeString = data.attributes().get(PlatformRule.PLATFORM_TYPE_ATTR_NAME, STRING);
     String minimumOsVersionString = data.attributes().get(PlatformRule.MINIMUM_OS_VERSION, STRING);
     PlatformType platformType;

--- a/src/test/java/com/google/devtools/build/lib/analysis/CircularDependencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/CircularDependencyTest.java
@@ -32,9 +32,9 @@ import com.google.devtools.build.lib.analysis.util.MockRule;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Location;
 import com.google.devtools.build.lib.packages.Attribute.LabelLateBoundDefault;
+import com.google.devtools.build.lib.packages.AttributeTransitionData;
 import com.google.devtools.build.lib.packages.NoSuchTargetException;
 import com.google.devtools.build.lib.packages.Package;
-import com.google.devtools.build.lib.packages.RuleTransitionData;
 import com.google.devtools.build.lib.testutil.TestRuleClassProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -269,9 +269,9 @@ public class CircularDependencyTest extends BuildViewTestCase {
                   .mandatory()
                   .allowedFileTypes()
                   .cfg(
-                      new TransitionFactory<RuleTransitionData>() {
+                      new TransitionFactory<AttributeTransitionData>() {
                         @Override
-                        public SplitTransition create(RuleTransitionData data) {
+                        public SplitTransition create(AttributeTransitionData data) {
                           return (BuildOptions options) -> {
                             String define = data.attributes().get("define", STRING);
                             BuildOptions newOptions = options.clone();

--- a/src/test/java/com/google/devtools/build/lib/packages/AttributeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/AttributeTest.java
@@ -283,7 +283,8 @@ public class AttributeTest {
     Attribute attr = attr("foo", LABEL).cfg(splitTransition).allowedFileTypes().build();
     assertThat(attr.hasSplitConfigurationTransition()).isTrue();
     ConfigurationTransition transition =
-        attr.getTransitionFactory().create(RuleTransitionData.create(FakeAttributeMapper.empty()));
+        attr.getTransitionFactory()
+            .create(AttributeTransitionData.create(FakeAttributeMapper.empty()));
     assertThat(transition).isEqualTo(splitTransition);
   }
 
@@ -294,7 +295,8 @@ public class AttributeTest {
         attr("foo", LABEL).cfg(splitTransitionProvider).allowedFileTypes().build();
     assertThat(attr.hasSplitConfigurationTransition()).isTrue();
     ConfigurationTransition transition =
-        attr.getTransitionFactory().create(RuleTransitionData.create(FakeAttributeMapper.empty()));
+        attr.getTransitionFactory()
+            .create(AttributeTransitionData.create(FakeAttributeMapper.empty()));
     assertThat(transition).isInstanceOf(TestSplitTransition.class);
   }
 
@@ -314,9 +316,9 @@ public class AttributeTest {
   }
 
   private static class TestSplitTransitionProvider
-      implements TransitionFactory<RuleTransitionData> {
+      implements TransitionFactory<AttributeTransitionData> {
     @Override
-    public SplitTransition create(RuleTransitionData data) {
+    public SplitTransition create(AttributeTransitionData data) {
       return new TestSplitTransition();
     }
 


### PR DESCRIPTION
Rule transitions will use a different data holder.

part of work on #7814.