### PR TITLE
remote: implement a naive action-scoped file system

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BUILD
@@ -35,6 +35,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/transports",
+        "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:auto_value",

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -43,9 +43,9 @@ import com.google.devtools.build.lib.buildeventstream.transports.TextFormatFileT
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.Reporter;
+import com.google.devtools.build.lib.profiler.AutoProfiler;
 import com.google.devtools.build.lib.runtime.BlazeCommandEventHandler;
 import com.google.devtools.build.lib.runtime.BlazeModule;
-import com.google.devtools.build.lib.runtime.BlazeModule.ModuleEnvironment;
 import com.google.devtools.build.lib.runtime.BuildEventStreamer;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.runtime.CountingArtifactGroupNamer;
@@ -284,7 +284,9 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
       }
 
       // Wait synchronously for all the futures to finish.
-      Uninterruptibles.getUninterruptibly(Futures.allAsList(closeFuturesMap.values()));
+      try (AutoProfiler p = AutoProfiler.logged("waiting for BES close", logger)) {
+        Uninterruptibles.getUninterruptibly(Futures.allAsList(closeFuturesMap.values()));
+      }
     } catch (ExecutionException exception) {
       throw new AbruptExitException(
           "Failed to close a build event transport",

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -34,6 +34,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:output_service",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:auth",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -1,0 +1,465 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import com.google.common.base.Preconditions;
+import com.google.devtools.build.lib.actions.ActionInputMap;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
+import com.google.devtools.build.lib.vfs.DelegateFileSystem;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.Dirent;
+import com.google.devtools.build.lib.vfs.FileStatus;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collection;
+import javax.annotation.Nullable;
+
+/**
+ * This is a basic implementation and incomplete implementation of an action file system that's
+ * been tuned to what native (none-spawn) actions in Bazel currently use.
+ *
+ * <p>The implementation mostly delegates to the local file system except for the case where
+ * an action input is a remotely stored action output. Most notably {@link #getInputStream(Path)}
+ * and {@link #createSymbolicLink(Path, PathFragment)}.
+ *
+ * <p>This implementation only supports creating local action outputs.
+ */
+public class RemoteActionFileSystem extends DelegateFileSystem {
+
+  private final Path execRoot;
+  private final Path outputBase;
+  private final ActionInputMap inputArtifactData;
+  private final RemoteActionInputFetcher inputFetcher;
+
+  public RemoteActionFileSystem(
+      FileSystem localDelegate,
+      PathFragment execRootFragment,
+      String relativeOutputPath,
+      ActionInputMap inputArtifactData,
+      RemoteActionInputFetcher inputFetcher) {
+    super(localDelegate);
+    this.execRoot = getPath(Preconditions.checkNotNull(execRootFragment, "execRootFragment"));
+    this.outputBase =
+        execRoot.getRelative(Preconditions.checkNotNull(relativeOutputPath, "relativeOutputPath"));
+    this.inputArtifactData = Preconditions.checkNotNull(inputArtifactData, "inputArtifactData");
+    this.inputFetcher = Preconditions.checkNotNull(inputFetcher, "inputFetcher");
+  }
+
+  @Override
+  public String getFileSystemType(Path path) {
+    return "remoteActionFS";
+  }
+
+  @Override
+  public boolean delete(Path path) throws IOException {
+    RemoteFileArtifactValue m = getRemoteInputMetadata(path);
+    if (m != null) {
+      return super.delete(path);
+    }
+    return true;
+  }
+
+  @Override
+  protected InputStream getInputStream(Path path) throws IOException {
+    downloadFileIfRemote(path);
+    return super.getInputStream(path);
+  }
+
+  @Override
+  public void setLastModifiedTime(Path path, long newTime) throws IOException {
+    RemoteFileArtifactValue m = getRemoteInputMetadata(path);
+    if (m == null) {
+      super.setLastModifiedTime(path, newTime);
+    }
+  }
+
+  @Override
+  protected byte[] getFastDigest(Path path) throws IOException {
+    RemoteFileArtifactValue m = getRemoteInputMetadata(path);
+    if (m != null) {
+      return m.getDigest();
+    }
+    return super.getFastDigest(path);
+  }
+
+  @Override
+  protected byte[] getDigest(Path path) throws IOException {
+    RemoteFileArtifactValue m = getRemoteInputMetadata(path);
+    if (m != null) {
+      return m.getDigest();
+    }
+    return super.getDigest(path);
+  }
+
+  // -------------------- File Permissions --------------------
+
+  @Override
+  protected boolean isReadable(Path path) throws IOException {
+    FileArtifactValue m = getRemoteInputMetadata(path);
+    return m != null || super.isReadable(path);
+  }
+
+  @Override
+  protected boolean isWritable(Path path) throws IOException {
+    FileArtifactValue m = getRemoteInputMetadata(path);
+    return m != null || super.isWritable(path);
+  }
+
+  @Override
+  protected boolean isExecutable(Path path) throws IOException {
+    FileArtifactValue m = getRemoteInputMetadata(path);
+    return m != null || super.isExecutable(path);
+  }
+
+  @Override
+  protected void setReadable(Path path, boolean readable) throws IOException {
+    RemoteFileArtifactValue m = getRemoteInputMetadata(path);
+    if (m == null) {
+      super.setReadable(path, readable);
+    }
+  }
+
+  @Override
+  public void setWritable(Path path, boolean writable) throws IOException {
+    RemoteFileArtifactValue m = getRemoteInputMetadata(path);
+    if (m == null) {
+      super.setWritable(path, writable);
+    }
+  }
+
+  @Override
+  protected void setExecutable(Path path, boolean executable) throws IOException {
+    RemoteFileArtifactValue m = getRemoteInputMetadata(path);
+    if (m == null) {
+      super.setExecutable(path, executable);
+    }
+  }
+
+  @Override
+  protected void chmod(Path path, int mode) throws IOException {
+    RemoteFileArtifactValue m = getRemoteInputMetadata(path);
+    if (m == null) {
+      super.chmod(path, mode);
+    }
+  }
+
+  // -------------------- Symlinks --------------------
+
+  @Override
+  protected PathFragment readSymbolicLink(Path path) throws IOException {
+    FileArtifactValue m = getRemoteInputMetadata(path);
+    if (m != null) {
+      // We don't support symlinks as remote action outputs.
+      throw new NotASymlinkException(path);
+    }
+    return super.readSymbolicLink(path);
+  }
+
+  @Override
+  protected void createSymbolicLink(Path linkPath, PathFragment targetFragment) throws IOException {
+    /*
+     * TODO(buchgr): Optimize the case where we are creating a symlink to a remote output. This does
+     * add a non-trivial amount of complications though (as symlinks tend to do).
+     */
+    downloadFileIfRemote(execRoot.getRelative(targetFragment));
+    super.createSymbolicLink(linkPath, targetFragment);
+  }
+
+  // -------------------- Implementations based on stat() --------------------
+
+  @Override
+  protected long getLastModifiedTime(Path path, boolean followSymlinks) throws IOException {
+    FileStatus stat = stat(path, followSymlinks);
+    return stat.getLastModifiedTime();
+  }
+
+  @Override
+  protected long getFileSize(Path path, boolean followSymlinks) throws IOException {
+    FileStatus stat = stat(path, followSymlinks);
+    return stat.getSize();
+  }
+
+  @Override
+  protected boolean isFile(Path path, boolean followSymlinks) {
+    FileStatus stat = statNullable(path, followSymlinks);
+    return stat != null && stat.isFile();
+  }
+
+  @Override
+  protected boolean isSymbolicLink(Path path) {
+    FileStatus stat = statNullable(path, /* followSymlinks= */ false);
+    return stat != null && stat.isSymbolicLink();
+  }
+
+  @Override
+  protected boolean isDirectory(Path path, boolean followSymlinks) {
+    FileStatus stat = statNullable(path, followSymlinks);
+    return stat != null && stat.isDirectory();
+  }
+
+  @Override
+  protected boolean isSpecialFile(Path path, boolean followSymlinks) {
+    FileStatus stat = statNullable(path, followSymlinks);
+    return stat != null && stat.isDirectory();
+  }
+
+  @Override
+  protected boolean exists(Path path, boolean followSymlinks) {
+    try {
+      return statIfFound(path, followSymlinks) != null;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public boolean exists(Path path) {
+    return exists(path, /* followSymlinks= */ true);
+  }
+
+  @Nullable
+  @Override
+  protected FileStatus statIfFound(Path path, boolean followSymlinks) throws IOException {
+    try {
+      return stat(path, followSymlinks);
+    } catch (FileNotFoundException e) {
+      return null;
+    }
+  }
+
+  @Nullable
+  @Override
+  protected FileStatus statNullable(Path path, boolean followSymlinks) {
+    try {
+      return stat(path, followSymlinks);
+    } catch (IOException e) {
+      return null;
+    }
+  }
+
+  @Override
+  protected FileStatus stat(Path path, boolean followSymlinks) throws IOException {
+    RemoteFileArtifactValue m = getRemoteInputMetadata(path);
+    if (m != null) {
+      return statFromRemoteMetadata(m);
+    }
+    return super.stat(path, followSymlinks);
+  }
+
+  private FileStatus statFromRemoteMetadata(RemoteFileArtifactValue m) {
+    return new FileStatus() {
+      @Override
+      public boolean isFile() {
+        return m.getType().isFile();
+      }
+
+      @Override
+      public boolean isDirectory() {
+        return m.getType().isDirectory();
+      }
+
+      @Override
+      public boolean isSymbolicLink() {
+        return m.getType().isSymlink();
+      }
+
+      @Override
+      public boolean isSpecialFile() {
+        return m.getType().isSpecialFile();
+      }
+
+      @Override
+      public long getSize() {
+        return m.getSize();
+      }
+
+      @Override
+      public long getLastModifiedTime() {
+        return m.getModifiedTime();
+      }
+
+      @Override
+      public long getLastChangeTime() {
+        return m.getModifiedTime();
+      }
+
+      @Override
+      public long getNodeId() {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  // -------------------- Delegates --------------------
+
+  @Override
+  public boolean supportsModifications(Path path) {
+    return super.supportsModifications(path);
+  }
+
+  @Override
+  public boolean supportsSymbolicLinksNatively(Path path) {
+    return super.supportsSymbolicLinksNatively(path);
+  }
+
+  @Override
+  protected boolean supportsHardLinksNatively(Path path) {
+    return super.supportsHardLinksNatively(path);
+  }
+
+  @Override
+  public boolean isFilePathCaseSensitive() {
+    return super.isFilePathCaseSensitive();
+  }
+
+  @Override
+  public boolean createDirectory(Path path) throws IOException {
+    return super.createDirectory(path);
+  }
+
+  @Override
+  public void createDirectoryAndParents(Path path) throws IOException {
+    super.createDirectoryAndParents(path);
+  }
+
+  @Override
+  public void deleteTree(Path path) throws IOException {
+    super.deleteTree(path);
+  }
+
+  @Override
+  public void deleteTreesBelow(Path dir) throws IOException {
+    super.deleteTreesBelow(dir);
+  }
+
+  @Override
+  public byte[] getxattr(Path path, String name, boolean followSymlinks) throws IOException {
+    return super.getxattr(path, name, followSymlinks);
+  }
+
+  @Override
+  protected PathFragment resolveOneLink(Path path) throws IOException {
+    return super.resolveOneLink(path);
+  }
+
+  @Override
+  protected Path resolveSymbolicLinks(Path path) throws IOException {
+    return super.resolveSymbolicLinks(path);
+  }
+
+  @Override
+  protected PathFragment readSymbolicLinkUnchecked(Path path) throws IOException {
+    return super.readSymbolicLinkUnchecked(path);
+  }
+
+  @Override
+  protected void prefetchPackageAsync(Path path, int maxDirs) {
+    super.prefetchPackageAsync(path, maxDirs);
+  }
+
+  @Override
+  public DigestHashFunction getDigestFunction() {
+    return super.getDigestFunction();
+  }
+
+  @Override
+  public Path getPath(String path) {
+    return super.getPath(path);
+  }
+
+  @Override
+  public Path getPath(PathFragment pathFragment) {
+    return super.getPath(pathFragment);
+  }
+
+  @Override
+  protected OutputStream getOutputStream(Path path, boolean append) throws IOException {
+    return super.getOutputStream(path, append);
+  }
+
+  @Override
+  public void renameTo(Path sourcePath, Path targetPath) throws IOException {
+    super.renameTo(sourcePath, targetPath);
+  }
+
+  // -------------------- Implementation Helpers --------------------
+
+  private String execPathString(Path path) {
+    return path.relativeTo(execRoot).getPathString();
+  }
+
+  @Nullable
+  private RemoteFileArtifactValue getRemoteInputMetadata(Path path) {
+    if (!path.startsWith(outputBase)) {
+      return null;
+    }
+    return getRemoteInputMetadata(execPathString(path));
+  }
+
+  @Nullable
+  private RemoteFileArtifactValue getRemoteInputMetadata(String execPathString) {
+    FileArtifactValue m = inputArtifactData.getMetadata(execPathString);
+    if (m != null && m.isRemote()) {
+      return (RemoteFileArtifactValue) m;
+    }
+    return null;
+  }
+
+  private void downloadFileIfRemote(Path path) throws IOException {
+    FileArtifactValue m = getRemoteInputMetadata(path);
+    if (m != null) {
+      try {
+        inputFetcher.downloadFile(toDelegatePath(path), m);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException(String.format("Received interrupt while fetching file '%s'", path), e);
+      }
+    }
+  }
+
+  /*
+   * -------------------- TODO(buchgr): Not yet implemented --------------------
+   *
+   * The below methods have not (yet) been properly implemented due to time constraints mostly and
+   * with little risk as they currently don't seem to be used by native actions in Bazel. However,
+   * before making the --experimental_remote_download_outputs flag non-experimental we should make
+   * sure to fully implement this file system.
+   */
+
+  @Override
+  protected Collection<String> getDirectoryEntries(Path path) throws IOException {
+    return super.getDirectoryEntries(path);
+  }
+
+  @Override
+  protected void createFSDependentHardLink(Path linkPath, Path originalPath) throws IOException {
+    super.createFSDependentHardLink(linkPath, originalPath);
+  }
+
+  @Override
+  protected Collection<Dirent> readdir(Path path, boolean followSymlinks) throws IOException {
+    return super.readdir(path, followSymlinks);
+  }
+
+  @Override
+  protected void createHardLink(Path linkPath, Path originalPath) throws IOException {
+    super.createHardLink(linkPath, originalPath);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteOutputService.java
@@ -1,0 +1,97 @@
+package com.google.devtools.build.lib.remote;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.actions.Action;
+import com.google.devtools.build.lib.actions.ActionInputMap;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.Artifact.SourceArtifact;
+import com.google.devtools.build.lib.actions.cache.MetadataHandler;
+import com.google.devtools.build.lib.events.EventHandler;
+import com.google.devtools.build.lib.vfs.BatchStat;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.ModifiedFileSet;
+import com.google.devtools.build.lib.vfs.OutputService;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.Root;
+import java.util.UUID;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+
+public class RemoteOutputService implements OutputService {
+
+  @Nullable
+  private RemoteActionInputFetcher actionInputFetcher;
+
+  void setActionInputFetcher(RemoteActionInputFetcher actionInputFetcher) {
+    this.actionInputFetcher = Preconditions.checkNotNull(actionInputFetcher, "actionInputFetcher");
+  }
+
+  @Override
+  public ActionFileSystemType actionFileSystemType() {
+    return actionInputFetcher != null
+        ? ActionFileSystemType.STAGE_REMOTE_FILES
+        : ActionFileSystemType.DISABLED;
+  }
+
+  @Nullable
+  @Override
+  public FileSystem createActionFileSystem(FileSystem sourceDelegate, PathFragment execRootFragment,
+      String relativeOutputPath, ImmutableList<Root> sourceRoots, ActionInputMap inputArtifactData,
+      Iterable<Artifact> outputArtifacts,
+      Function<PathFragment, SourceArtifact> sourceArtifactFactory) {
+    Preconditions.checkNotNull(actionInputFetcher, "actionInputFetcher");
+    return new RemoteActionFileSystem(sourceDelegate, execRootFragment, relativeOutputPath,
+        inputArtifactData, actionInputFetcher);
+  }
+
+  @Override
+  public String getFilesSystemName() {
+    return "remoteActionFS";
+  }
+
+  @Override
+  public ModifiedFileSet startBuild(EventHandler eventHandler, UUID buildId,
+      boolean finalizeActions) {
+    return ModifiedFileSet.EVERYTHING_MODIFIED;
+  }
+
+  @Override
+  public void finalizeBuild(boolean buildSuccessful) {
+    // Intentionally left empty.
+  }
+
+  @Override
+  public void finalizeAction(Action action, MetadataHandler metadataHandler) {
+    // Intentionally left empty.
+  }
+
+  @Nullable
+  @Override
+  public BatchStat getBatchStatter() {
+    return null;
+  }
+
+  @Override
+  public boolean canCreateSymlinkTree() {
+    /* TODO(buchgr): Optimize symlink creation for remote execution */
+    return false;
+  }
+
+  @Override
+  public void createSymlinkTree(Path inputManifest, Path outputManifest, boolean filesetTree,
+      PathFragment symlinkTreeRoot) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void clean() {
+    // Intentionally left empty.
+  }
+
+  @Override
+  public boolean isRemoteFile(Artifact file) {
+    return false;
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -1,0 +1,148 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.google.common.hash.HashCode;
+import com.google.common.util.concurrent.Futures;
+import com.google.devtools.build.lib.actions.ActionInputMap;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.ArtifactRoot;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
+import com.google.devtools.build.lib.clock.JavaClock;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Tests for {@link RemoteActionFileSystem} */
+@RunWith(JUnit4.class)
+public class RemoteActionFileSystemTest {
+
+  private static final DigestHashFunction HASH_FUNCTION = DigestHashFunction.SHA256;
+
+  @Mock
+  private RemoteActionInputFetcher inputFetcher;
+  private FileSystem fs;
+  private Path execRoot;
+  private ArtifactRoot outputRoot;
+
+  @Before
+  public void setUp() throws IOException {
+    MockitoAnnotations.initMocks(this);
+    fs = new InMemoryFileSystem(new JavaClock(), HASH_FUNCTION);
+    execRoot = fs.getPath("/exec");
+    outputRoot = ArtifactRoot.asDerivedRoot(execRoot, execRoot.getRelative("out"));
+    outputRoot.getRoot().asPath().createDirectoryAndParents();
+  }
+
+  @Test
+  public void testGetInputStream() throws Exception {
+    // arrange
+    ActionInputMap inputs = new ActionInputMap(2);
+    Artifact remoteArtifact = createRemoteArtifact("remote-file", "remote contents", inputs);
+    Artifact localArtifact = createLocalArtifact("local-file", "local contents", inputs);
+    FileSystem actionFs = newRemoteActionFileSystem(inputs);
+    doAnswer(invocationOnMock -> {
+      FileSystemUtils.writeContent(remoteArtifact.getPath(), StandardCharsets.UTF_8,
+          "remote contents");
+      return Futures.immediateFuture(null);
+    }).when(inputFetcher).downloadFile(eq(remoteArtifact.getPath()),
+        eq(inputs.getMetadata(remoteArtifact)));
+
+    // act
+    Path remoteActionFsPath = actionFs.getPath(remoteArtifact.getPath().asFragment());
+    String actualRemoteContents = FileSystemUtils.readContent(remoteActionFsPath,
+        StandardCharsets.UTF_8);
+
+    // assert
+    Path localActionFsPath = actionFs.getPath(localArtifact.getPath().asFragment());
+    String actualLocalContents = FileSystemUtils.readContent(localActionFsPath,
+        StandardCharsets.UTF_8);
+    assertThat(remoteActionFsPath.getFileSystem()).isSameAs(actionFs);
+    assertThat(actualRemoteContents).isEqualTo("remote contents");
+    assertThat(actualLocalContents).isEqualTo("local contents");
+    verify(inputFetcher).downloadFile(eq(remoteArtifact.getPath()),
+        eq(inputs.getMetadata(remoteArtifact)));
+    verifyNoMoreInteractions(inputFetcher);
+  }
+
+  @Test
+  public void testCreateSymbolicLink() throws InterruptedException, IOException {
+    // arrange
+    ActionInputMap inputs = new ActionInputMap(1);
+    Artifact remoteArtifact = createRemoteArtifact("remote-file", "remote contents", inputs);
+    Path symlink = outputRoot.getRoot().getRelative("symlink");
+    FileSystem actionFs = newRemoteActionFileSystem(inputs);
+    doAnswer(invocationOnMock -> {
+      FileSystemUtils.writeContent(remoteArtifact.getPath(), StandardCharsets.UTF_8,
+          "remote contents");
+      return Futures.immediateFuture(null);
+    }).when(inputFetcher).downloadFile(eq(remoteArtifact.getPath()), eq(inputs.getMetadata(remoteArtifact)));
+
+    // act
+    Path symlinkActionFs = actionFs.getPath(symlink.getPathString());
+    symlinkActionFs.createSymbolicLink(actionFs.getPath(remoteArtifact.getPath().asFragment()));
+
+    // assert
+    assertThat(symlinkActionFs.getFileSystem()).isSameAs(actionFs);
+    verify(inputFetcher).downloadFile(eq(remoteArtifact.getPath()),
+        eq(inputs.getMetadata(remoteArtifact)));
+    String symlinkTargetContents = FileSystemUtils.readContent(symlinkActionFs,
+        StandardCharsets.UTF_8);
+    assertThat(symlinkTargetContents).isEqualTo("remote contents");
+    verifyNoMoreInteractions(inputFetcher);
+  }
+
+  private FileSystem newRemoteActionFileSystem(ActionInputMap inputs) {
+    return new RemoteActionFileSystem(fs, execRoot.asFragment(),
+        outputRoot.getRoot().asPath().relativeTo(execRoot).getPathString(), inputs, inputFetcher);
+  }
+
+  /** Returns a remote artifact and puts its metadata into the action input map. */
+  private Artifact createRemoteArtifact(String pathFragment, String contents, ActionInputMap inputs) {
+    Path p = outputRoot.getRoot().asPath().getRelative(pathFragment);
+    Artifact a = new Artifact(p, outputRoot);
+    byte[] b = contents.getBytes(StandardCharsets.UTF_8);
+    HashCode h = HASH_FUNCTION.getHashFunction().hashBytes(b);
+    FileArtifactValue f =
+        new RemoteFileArtifactValue(h.asBytes(), b.length, /* locationIndex= */ 1);
+    inputs.putWithNoDepOwner(a, f);
+    return a;
+  }
+
+  /** Returns a local artifact and puts its metadata into the action input map. */
+  private Artifact createLocalArtifact(String pathFragment, String contents, ActionInputMap inputs) throws IOException {
+    Path p = outputRoot.getRoot().asPath().getRelative(pathFragment);
+    FileSystemUtils.writeContent(p, StandardCharsets.UTF_8, contents);
+    Artifact a = new Artifact(p, outputRoot);
+    inputs.putWithNoDepOwner(a, FileArtifactValue.create(a.getPath(), /* isShareable= */ true));
+    return a;
+  }
+}

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -937,6 +937,71 @@ EOF
   expect_log "1 process: 1 remote"
 }
 
+function test_downloads_minimal_native_prefetch() {
+  # Test that when using --experimental_remote_outputs=minimal a remotely stored output that's an
+  # input to a native action (ctx.actions.expand_template) is staged lazily for action execution.
+  mkdir -p a
+  cat > a/substitute_username.bzl <<'EOF'
+def _substitute_username_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file.template,
+        output = ctx.outputs.out,
+        substitutions = {
+            "{USERNAME}": ctx.attr.username,
+        },
+    )
+
+substitute_username = rule(
+    implementation = _substitute_username_impl,
+    attrs = {
+        "username": attr.string(mandatory = True),
+        "template": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+    },
+    outputs = {"out": "%{name}.txt"},
+)
+EOF
+
+  cat > a/BUILD <<'EOF'
+load(":substitute_username.bzl", "substitute_username")
+genrule(
+    name = "generate-template",
+    cmd = "echo -n \"Hello {USERNAME}!\" > $@",
+    outs = ["template.txt"],
+    srcs = [],
+)
+
+substitute_username(
+    name = "substitute-buchgr",
+    username = "buchgr",
+    template = ":generate-template",
+)
+EOF
+
+  bazel build \
+    --genrule_strategy=remote \
+    --remote_executor=localhost:${worker_port} \
+    --experimental_inmemory_jdeps_files \
+    --experimental_inmemory_dotd_files \
+    --experimental_remote_download_outputs=minimal \
+    //a:substitute-buchgr >& $TEST_log || fail "Failed to build //a:substitute-buchgr"
+
+  # The genrule //a:generate-template should run remotely and //a:substitute-buchgr
+  # should be a native action running locally.
+  expect_log "1 process: 1 remote"
+
+  outtxt="bazel-bin/a/substitute-buchgr.txt"
+  [[ $(< ${outtxt}) == "Hello buchgr!" ]] \
+  || fail "Unexpected contents in "${outtxt}":" $(< ${outtxt})
+
+  tree bazel-bin/
+
+  (! [[ -f bazel-bin/a/template.txt ]]) \
+  || fail "Expected bazel-bin/a/template.txt to have been deleted again"
+}
+
 # TODO(alpha): Add a test that fails remote execution when remote worker
 # supports sandbox.
 


### PR DESCRIPTION
This change accompanies d480c5f [1] in that it registers
an action-scoped filesystem that supports lazily fetching
action inputs that are remotely stored outputs of an upstream
action. While in theory any native java action in Bazel could
do arbitrary file system operations in practice this is mostly
useful for
 * AbstractFileWriteAction (calls Path.getInputStream())
 * TemplateExpansionAction (calls Path.getInputStream())
 * SymlinkAction (calls Path.(isFile|isExecutable|createSymbolicLink)())
 * SolibSymlinkAction (calls Path.createSymbolicLink())

For Starlark actions we found that only ctx.actions.expand_template(...)
directly interacts with the file system (via TemplateExpansionAction).
All other methods on ctx.actions create spawns internally which are
covered by d480c5f.

Progress towards #6862.

[1] https://github.com/bazelbuild/bazel/commit/d480c5f5a4f38a4053ed3e3bcc4eaef343923d2d