### PR TITLE
Remove --incompatible_cc_coverage

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -195,6 +195,8 @@ platforms:
     - "//tools/android/..."
     - "//tools/aquery_differ/..."
     - "-//src/test/shell/integration:minimal_jdk_test"
+      # C++ coverage is not supported on macOS yet.
+    - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
   windows:
     batch_commands:
     - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -236,10 +236,12 @@ platforms:
     - "//third_party/ijar/..."
     - "//tools/android/..."
     - "//tools/aquery_differ/..."
-    # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/4663
+      # C++ coverage is not supported on macOS yet.
+    - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
+      # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/4663
     - "-//src/test/shell/bazel/android:android_ndk_integration_test"
-    # The below tests have been disabled because they are too slow on macOS.
-    # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/4684
+      # The below tests have been disabled because they are too slow on macOS.
+      # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/4684
     - "-//src/test/shell/bazel:bazel_determinism_test"
     - "-//src/test/shell/bazel:bazel_java_test"
     - "-//src/test/shell/bazel:bazel_bootstrap_distfile_test"

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfiguration.java
@@ -585,25 +585,6 @@ public class BuildConfiguration implements BuildConfigurationApi {
     public boolean collectCodeCoverage;
 
     @Option(
-        name = "incompatible_cc_coverage",
-        defaultValue = "true",
-        documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
-        effectTags = {
-          OptionEffectTag.CHANGES_INPUTS,
-          OptionEffectTag.AFFECTS_OUTPUTS,
-          OptionEffectTag.LOADING_AND_ANALYSIS
-        },
-        oldName = "experimental_cc_coverage",
-        metadataTags = {
-          OptionMetadataTag.INCOMPATIBLE_CHANGE,
-          OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
-        },
-        help =
-            "If specified, Bazel will use gcov to collect code coverage for C++ test targets. "
-                + "This option only works for gcc compilation.")
-    public boolean useGcovCoverage;
-
-    @Option(
       name = "build_runfile_manifests",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,
@@ -1718,10 +1699,6 @@ public class BuildConfiguration implements BuildConfigurationApi {
   @Override
   public boolean isCodeCoverageEnabled() {
     return options.collectCodeCoverage;
-  }
-
-  public boolean useGcovCoverage() {
-    return options.useGcovCoverage;
   }
 
   public RunUnder getRunUnder() {

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -58,18 +58,12 @@ public final class TestActionBuilder {
   private static final String LCOV_MERGER = "LCOV_MERGER";
   // The coverage tool Bazel uses to generate a code coverage report for C++.
   private static final String BAZEL_CC_COVERAGE_TOOL = "BAZEL_CC_COVERAGE_TOOL";
+  private static final String GCOV_TOOL = "GCOV";
   // A file that contains a mapping between the reported source file path and the actual source
   // file path, relative to the workspace directory, if the two values are different. If the
   // reported source file is the same as the actual source path it will not be included in the file.
   private static final String COVERAGE_REPORTED_TO_ACTUAL_SOURCES_FILE =
       "COVERAGE_REPORTED_TO_ACTUAL_SOURCES_FILE";
-
-  enum CcCoverageTool {
-    GCOV,
-    LCOV,
-  }
-
-  private static final CcCoverageTool DEFAULT_BAZEL_CC_COVERAGE_TOOL = CcCoverageTool.LCOV;
 
   private final RuleContext ruleContext;
   private RunfilesSupport runfilesSupport;
@@ -272,11 +266,7 @@ public final class TestActionBuilder {
       }
 
       // lcov is the default CC coverage tool unless otherwise specified on the command line.
-      extraTestEnv.put(
-          BAZEL_CC_COVERAGE_TOOL,
-          ruleContext.getConfiguration().useGcovCoverage()
-              ? CcCoverageTool.GCOV.toString()
-              : DEFAULT_BAZEL_CC_COVERAGE_TOOL.toString());
+      extraTestEnv.put(BAZEL_CC_COVERAGE_TOOL, GCOV_TOOL);
 
       // We don't add this attribute to non-supported test target
       if (ruleContext.isAttrDefined("$lcov_merger", LABEL)) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -260,6 +260,22 @@ public class BazelRulesModule extends BlazeModule {
         help = "Obsolete, no effect.")
     public boolean disableLegacyToolchainSkylarkApi;
 
+    @Option(
+        name = "incompatible_cc_coverage",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {
+            OptionEffectTag.UNKNOWN,
+        },
+        oldName = "experimental_cc_coverage",
+        metadataTags = {
+            OptionMetadataTag.INCOMPATIBLE_CHANGE,
+            OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES,
+            OptionMetadataTag.DEPRECATED
+        },
+        help = "Obsolete, no effect.")
+    public boolean useGcovCoverage;
+
     @Deprecated
     @Option(
         name = "direct_run",

--- a/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
@@ -121,7 +121,7 @@ function test_cc_test_coverage_gcov() {
   fi
   setup_a_cc_lib_and_t_cc_test
 
-  bazel coverage --experimental_cc_coverage --test_output=all \
+  bazel coverage  --test_output=all \
      --build_event_text_file=bep.txt //:t &>"$TEST_log" \
      || fail "Coverage for //:t failed"
 
@@ -146,7 +146,7 @@ end_of_record"
   assert_not_contains "SF:t\.cc" "$coverage_file_path"
 
   # Verify that this is also true for cached coverage actions.
-  bazel coverage --experimental_cc_coverage --test_output=all \
+  bazel coverage  --test_output=all \
       --build_event_text_file=bep.txt //:t \
       &>"$TEST_log" || fail "Coverage for //:t failed"
   expect_log '//:t.*cached'
@@ -262,7 +262,7 @@ int main(int argc, char** argv) {
 EOF
 
   ########### Run bazel coverage ###########
-  bazel coverage --experimental_cc_coverage --test_output=all //examples/cpp:hello-world_test &>"$TEST_log" \
+  bazel coverage  --test_output=all //examples/cpp:hello-world_test &>"$TEST_log" \
      || fail "Coverage for //examples/cpp:hello-world_test failed"
 
   ########### Assert coverage results. ###########
@@ -376,7 +376,7 @@ int main(void) {
 EOF
 
   ############## Running bazel coverage ##############
-  bazel coverage --experimental_cc_coverage --test_output=all //:t \
+  bazel coverage  --test_output=all //:t \
       &>"$TEST_log" || fail "Coverage for //:t failed"
 
   ##### Putting together the expected coverage results #####
@@ -494,7 +494,7 @@ int main(void) {
 EOF
 
   ############## Running bazel coverage ##############
-  bazel coverage --experimental_cc_coverage --instrument_test_targets \
+  bazel coverage  --instrument_test_targets \
       --test_output=all //:t &>"$TEST_log" || fail "Coverage for //:t failed"
 
   ##### Putting together the expected coverage results #####
@@ -642,7 +642,7 @@ int main(void) {
 EOF
 
   ############## Running bazel coverage ##############
-  bazel coverage --experimental_cc_coverage --test_output=all //:t \
+  bazel coverage  --test_output=all //:t \
       &>"$TEST_log" || fail "Coverage for //:t failed"
 
   ##### Putting together the expected coverage results #####
@@ -807,7 +807,7 @@ int main(void) {
 EOF
 
   ############## Running bazel coverage ##############
-  bazel coverage --experimental_cc_coverage --test_output=all //:t \
+  bazel coverage  --test_output=all //:t \
       &>"$TEST_log" || fail "Coverage for //:t failed"
 
   ##### Putting together the expected coverage results #####
@@ -942,7 +942,7 @@ cc_test(
     srcs = ["t.cc"]
 )
 EOF
-     bazel coverage --experimental_cc_coverage --test_output=all \
+     bazel coverage  --test_output=all \
         //empty_cov:empty-cov-test  &>"$TEST_log" \
      || fail "Coverage for //empty_cov:empty-cov-test failed"
      expect_log "WARNING: There was no coverage found."

--- a/src/test/shell/bazel/bazel_coverage_sh_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_sh_test.sh
@@ -267,7 +267,7 @@ void HelloLib::greet(const string& thing) {
 EOF
 
   ########### Run bazel coverage ###########
-  bazel coverage --experimental_cc_coverage --test_output=all \
+  bazel coverage  --test_output=all \
       //:hello-sh &>$TEST_log || fail "Coverage for //:orange-sh failed"
 
   ########### Assert coverage results. ###########
@@ -454,7 +454,7 @@ public class orangeBin {
 EOF
 
   ########### Run bazel coverage ###########
-  bazel coverage --experimental_cc_coverage --test_output=all \
+  bazel coverage  --test_output=all \
       //:hello-sh &>$TEST_log || fail "Coverage for //:orange-sh failed"
 
   ########### Assert coverage results. ###########


### PR DESCRIPTION
Remove the flag --incompatible_cc_coverage (i.e. the C++ code coverage collection that used `lcov` instead of `gcov`).