### PR TITLE
Demonstrate that adding a parameter to global WORKSPACE file function…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
@@ -102,6 +102,16 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
       help = "If set to true, enables the APIs required to support the Android Starlark migration.")
   public boolean experimentalEnableAndroidMigrationApis;
 
+  @Option(
+      name = "experimental_demonstrational",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help = "TODO"
+  )
+  public boolean experimentalDemonstrational;
+
   // This flag is declared in StarlarkSemanticsOptions instead of JavaOptions because there is no
   // way to retrieve the java configuration from the Java implementation of
   // java_common.create_provider.
@@ -538,6 +548,7 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
         .experimentalBuildSettingApi(experimentalBuildSettingApi)
         .experimentalCcSkylarkApiEnabledPackages(experimentalCcSkylarkApiEnabledPackages)
         .experimentalEnableAndroidMigrationApis(experimentalEnableAndroidMigrationApis)
+        .experimentalDemonstrational(experimentalDemonstrational)
         .experimentalJavaCommonCreateProviderEnabledPackages(
             experimentalJavaCommonCreateProviderEnabledPackages)
         .experimentalPlatformsApi(experimentalPlatformsApi)

--- a/src/main/java/com/google/devtools/build/lib/packages/WorkspaceFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/WorkspaceFactory.java
@@ -54,6 +54,7 @@ import com.google.devtools.build.lib.syntax.SkylarkSignatureProcessor;
 import com.google.devtools.build.lib.syntax.SkylarkUtils;
 import com.google.devtools.build.lib.syntax.SkylarkUtils.Phase;
 import com.google.devtools.build.lib.syntax.StarlarkSemantics;
+import com.google.devtools.build.lib.syntax.StarlarkSemantics.FlagIdentifier;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.RootedPath;
@@ -305,7 +306,14 @@ public class WorkspaceFactory {
               + "description of the project, using underscores as separators, e.g., "
               + "github.com/bazelbuild/bazel should use com_github_bazelbuild_bazel. Names must "
               + "start with a letter and can only contain letters, numbers, and underscores.",
-      parameters = {@Param(name = "name", type = String.class, doc = "the name of the workspace.")},
+      parameters = {
+          @Param(name = "name", type = String.class, doc = "the name of the workspace."),
+          @Param(name = "fictive",
+              defaultValue = "\"\"",
+              type = String.class,
+              enableOnlyWithFlag = FlagIdentifier.EXPERIMENTAL_DEMONSTRATIONAL,
+              doc = "TODO")
+      },
       useAst = true,
       useEnvironment = true)
   private static final BuiltinFunction.Factory newWorkspaceFunction =
@@ -313,8 +321,8 @@ public class WorkspaceFactory {
         public BuiltinFunction create(boolean allowOverride, final RuleFactory ruleFactory) {
           if (allowOverride) {
             return new BuiltinFunction(
-                "workspace", FunctionSignature.namedOnly("name"), BuiltinFunction.USE_AST_ENV) {
-              public Object invoke(String name, FuncallExpression ast, Environment env)
+                "workspace", FunctionSignature.of(1, "name", "fictive"), BuiltinFunction.USE_AST_ENV) {
+              public Object invoke(String name, String fictive, FuncallExpression ast, Environment env)
                   throws EvalException, InterruptedException {
                 if (!isLegalWorkspaceName(name)) {
                   throw new EvalException(
@@ -352,8 +360,8 @@ public class WorkspaceFactory {
             };
           } else {
             return new BuiltinFunction(
-                "workspace", FunctionSignature.namedOnly("name"), BuiltinFunction.USE_AST) {
-              public Object invoke(String name, FuncallExpression ast) throws EvalException {
+                "workspace", FunctionSignature.of(1, "name", "fictive"), BuiltinFunction.USE_AST) {
+              public Object invoke(String name, String fictive, FuncallExpression ast) throws EvalException {
                 throw new EvalException(
                     ast.getLocation(),
                     "workspace() function should be used only at the top of the WORKSPACE file");

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
@@ -39,6 +39,7 @@ public abstract class StarlarkSemantics {
    * the exact name of the flag transformed to upper case (for error representation).
    */
   public enum FlagIdentifier {
+    EXPERIMENTAL_DEMONSTRATIONAL(StarlarkSemantics::experimentalDemonstrational),
     EXPERIMENTAL_ENABLE_ANDROID_MIGRATION_APIS(
         StarlarkSemantics::experimentalEnableAndroidMigrationApis),
     EXPERIMENTAL_BUILD_SETTING_API(StarlarkSemantics::experimentalBuildSettingApi),
@@ -119,6 +120,8 @@ public abstract class StarlarkSemantics {
   public abstract ImmutableList<String> experimentalCcSkylarkApiEnabledPackages();
 
   public abstract boolean experimentalEnableAndroidMigrationApis();
+
+  public abstract boolean experimentalDemonstrational();
 
   public abstract ImmutableList<String> experimentalJavaCommonCreateProviderEnabledPackages();
 
@@ -201,6 +204,7 @@ public abstract class StarlarkSemantics {
           .experimentalBuildSettingApi(false)
           .experimentalCcSkylarkApiEnabledPackages(ImmutableList.of())
           .experimentalEnableAndroidMigrationApis(false)
+          .experimentalDemonstrational(false)
           .experimentalJavaCommonCreateProviderEnabledPackages(ImmutableList.of())
           .experimentalPlatformsApi(false)
           .experimentalRestrictNamedParams(false)
@@ -246,6 +250,8 @@ public abstract class StarlarkSemantics {
     public abstract Builder experimentalCcSkylarkApiEnabledPackages(List<String> value);
 
     public abstract Builder experimentalEnableAndroidMigrationApis(boolean value);
+
+    public abstract Builder experimentalDemonstrational(boolean value);
 
     public abstract Builder experimentalJavaCommonCreateProviderEnabledPackages(List<String> value);
 

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
@@ -225,6 +225,14 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
     bazel.help();
   }
 
+  @Test
+  public void testShouldFail() throws Exception {
+    context().write(WORKSPACE,
+            "workspace(name = 'test_ws', fictive = 'abc')");
+    // should fail because we did not set the flag
+    context().bazel().shouldFail().info();
+  }
+
   private boolean isWindows() {
     return OS.WINDOWS.equals(OS.getCurrent());
   }

--- a/src/test/java/com/google/devtools/build/lib/packages/SkylarkSemanticsConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/SkylarkSemanticsConsistencyTest.java
@@ -125,6 +125,7 @@ public class SkylarkSemanticsConsistencyTest {
             + ","
             + rand.nextDouble(),
         "--experimental_enable_android_migration_apis=" + rand.nextBoolean(),
+        "--experimental_demonstrational=" + rand.nextBoolean(),
         "--experimental_java_common_create_provider_enabled_packages="
             + rand.nextDouble()
             + ","
@@ -173,6 +174,7 @@ public class SkylarkSemanticsConsistencyTest {
         .experimentalCcSkylarkApiEnabledPackages(
             ImmutableList.of(String.valueOf(rand.nextDouble()), String.valueOf(rand.nextDouble())))
         .experimentalEnableAndroidMigrationApis(rand.nextBoolean())
+        .experimentalDemonstrational(rand.nextBoolean())
         .experimentalJavaCommonCreateProviderEnabledPackages(
             ImmutableList.of(String.valueOf(rand.nextDouble()), String.valueOf(rand.nextDouble())))
         .experimentalPlatformsApi(rand.nextBoolean())


### PR DESCRIPTION
… is not properly guarded by a semantic flag