### PR TITLE
Split android common into two.

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -74,6 +74,20 @@ java_import(
     ],
 )
 
+# This target only contains the jars that are used for building / running Bazel.
+# The target below is for the Android tools that are not shipped with Bazel.
+java_import(
+    name = "android_common_25_0_0_lite",
+    jars = [
+        "android_common/com.android.tools.layoutlib_layoutlib_26.1.2.jar",
+        "android_common/com.android.tools_sdk-common_25.0.0.jar",
+        "android_common/com.android.tools_repository_25.0.0.jar",
+    ],
+    deps = [
+        "//third_party/jaxb",
+    ],
+)
+
 java_import(
     name = "android_common_25_0_0",
     jars = [


### PR DESCRIPTION
This helps to remove 3MB from Bazel's binary size immediately but also
will get us much closer to remove the dependency on the java.desktop
module.

It also allows us to remove the jdk.compiler module.

RELNOTES: None