### PR TITLE
Add directories to the default Windows PATH

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -16,8 +16,8 @@ package com.google.devtools.build.lib.bazel.rules;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.api.client.util.Strings;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.ActionEnvironment;

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -443,9 +443,10 @@ public class BazelRuleClassProvider {
       return "/bin:/usr/bin";
     }
 
+    String newPath = "";
     // Attempt to compute the MSYS root (the real Windows path of "/") from `sh`.
     if (sh != null && sh.getParentDirectory() != null) {
-      String newPath = sh.getParentDirectory().getPathString();
+      newPath = sh.getParentDirectory().getPathString();
       if (sh.getParentDirectory().endsWith(PathFragment.create("usr/bin"))) {
         newPath +=
             ";" + sh.getParentDirectory().getParentDirectory().replaceName("bin").getPathString();
@@ -454,13 +455,19 @@ public class BazelRuleClassProvider {
             ";" + sh.getParentDirectory().replaceName("usr").getRelative("bin").getPathString();
       }
       newPath = newPath.replace('/', '\\');
-
-      if (path != null) {
-        newPath += ";" + path;
-      }
-      return newPath;
-    } else {
-      return null;
     }
+    // On Windows, the following dirs should always be available in PATH:
+    //   C:\Windows
+    //   C:\Windows\System32
+    //   C:\Windows\System32\WindowsPowerShell\v1.0
+    // They are similar to /bin:/usr/bin, which makes the basic tools on the platform available.
+    String systemRoot = System.getenv("SYSTEMROOT");
+    newPath += ";" + systemRoot;
+    newPath += ";" + systemRoot + "\\System32";
+    newPath += ";" + systemRoot + "\\System32\\WindowsPowerShell\\v1.0";
+    if (path != null) {
+      newPath += ";" + path;
+    }
+    return newPath;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.bazel.rules;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.api.client.util.Strings;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -462,6 +463,9 @@ public class BazelRuleClassProvider {
     //   C:\Windows\System32\WindowsPowerShell\v1.0
     // They are similar to /bin:/usr/bin, which makes the basic tools on the platform available.
     String systemRoot = System.getenv("SYSTEMROOT");
+    if (Strings.isNullOrEmpty(systemRoot)) {
+      systemRoot = "C:\\Windows";
+    }
     newPath += ";" + systemRoot;
     newPath += ";" + systemRoot + "\\System32";
     newPath += ";" + systemRoot + "\\System32\\WindowsPowerShell\\v1.0";

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProviderTest.java
@@ -188,10 +188,15 @@ public class BazelRuleClassProviderTest {
 
   @Test
   public void pathOrDefaultOnWindows() {
-    assertThat(pathOrDefault(OS.WINDOWS, null, null)).isNull();
-    assertThat(pathOrDefault(OS.WINDOWS, "C:/mypath", null)).isNull();
+    String defaultWindowsPath = "";
+    String systemRoot = System.getenv("SYSTEMROOT");
+    defaultWindowsPath += ";" + systemRoot;
+    defaultWindowsPath += ";" + systemRoot + "\\System32";
+    defaultWindowsPath += ";" + systemRoot + "\\System32\\WindowsPowerShell\\v1.0";
+    assertThat(pathOrDefault(OS.WINDOWS, null, null)).isEqualTo(defaultWindowsPath);
+    assertThat(pathOrDefault(OS.WINDOWS, "C:/mypath", null)).isEqualTo("C:/mypath;" + defaultWindowsPath);
     assertThat(pathOrDefault(OS.WINDOWS, "C:/mypath", PathFragment.create("D:/foo/shell")))
-        .isEqualTo("D:\\foo;C:/mypath");
+        .isEqualTo("D:\\foo;C:/mypath;" + defaultWindowsPath);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProviderTest.java
@@ -18,7 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider.pathOrDefault;
 
-import com.google.api.client.util.Strings;
+import com.google.common.base.Strings;;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProviderTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider.pathOrDefault;
 
+import com.google.api.client.util.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.ActionEnvironment;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
@@ -190,13 +191,16 @@ public class BazelRuleClassProviderTest {
   public void pathOrDefaultOnWindows() {
     String defaultWindowsPath = "";
     String systemRoot = System.getenv("SYSTEMROOT");
+    if (Strings.isNullOrEmpty(systemRoot)) {
+      systemRoot = "C:\\Windows";
+    }
     defaultWindowsPath += ";" + systemRoot;
     defaultWindowsPath += ";" + systemRoot + "\\System32";
     defaultWindowsPath += ";" + systemRoot + "\\System32\\WindowsPowerShell\\v1.0";
     assertThat(pathOrDefault(OS.WINDOWS, null, null)).isEqualTo(defaultWindowsPath);
-    assertThat(pathOrDefault(OS.WINDOWS, "C:/mypath", null)).isEqualTo("C:/mypath;" + defaultWindowsPath);
+    assertThat(pathOrDefault(OS.WINDOWS, "C:/mypath", null)).isEqualTo(defaultWindowsPath + ";C:/mypath");
     assertThat(pathOrDefault(OS.WINDOWS, "C:/mypath", PathFragment.create("D:/foo/shell")))
-        .isEqualTo("D:\\foo;C:/mypath;" + defaultWindowsPath);
+        .isEqualTo("D:\\foo" + defaultWindowsPath + ";C:/mypath");
   }
 
   @Test


### PR DESCRIPTION
The following directories are similar to /bin:/usr/bin for Linxu,
which ensures the basic tools are available in Bazel action.
  C:\Windows
  C:\Windows\System32
  C:\Windows\System32\WindowsPowerShell\v1.0

Related:
https://github.com/bazelbuild/bazel/issues/7026#issuecomment-451971809