### PR TITLE
remote: implement --experimental_remote_download_outputs=toplevel

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
@@ -110,7 +110,8 @@ public final class AnalysisPhaseRunner {
       }
 
       for (BlazeModule module : env.getRuntime().getBlazeModules()) {
-        module.afterAnalysis(env, request, buildOptions, analysisResult.getTargetsToBuild());
+        module.afterAnalysis(env, request, buildOptions, analysisResult.getTargetsToBuild(),
+            analysisResult.getAspects());
       }
 
       reportTargets(analysisResult);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -17,7 +17,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.ActionContext;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ExecutionStrategy;
 import com.google.devtools.build.lib.actions.ExecutorInitException;
 import com.google.devtools.build.lib.exec.AbstractSpawnStrategy;
@@ -47,6 +49,7 @@ final class RemoteActionContextProvider extends ActionContextProvider {
   private final DigestUtil digestUtil;
   @Nullable private final Path logDir;
   private final AtomicReference<SpawnRunner> fallbackRunner = new AtomicReference<>();
+  private ImmutableSet<Artifact> topLevelOutputs = ImmutableSet.of();
 
   private RemoteActionContextProvider(
       CommandEnvironment env,
@@ -99,7 +102,8 @@ final class RemoteActionContextProvider extends ActionContextProvider {
               buildRequestId,
               commandId,
               env.getReporter(),
-              digestUtil);
+              digestUtil,
+              topLevelOutputs);
       return ImmutableList.of(spawnCache);
     } else {
       RemoteSpawnRunner spawnRunner =
@@ -116,7 +120,8 @@ final class RemoteActionContextProvider extends ActionContextProvider {
               executor,
               retrier,
               digestUtil,
-              logDir);
+              logDir,
+              topLevelOutputs);
       return ImmutableList.of(new RemoteSpawnStrategy(env.getExecRoot(), spawnRunner));
     }
   }
@@ -164,6 +169,10 @@ final class RemoteActionContextProvider extends ActionContextProvider {
   @Nullable
   AbstractRemoteActionCache getRemoteCache() {
     return cache;
+  }
+
+  void setTopLevelOutputs(ImmutableSet<Artifact> topLevelOutputs) {
+    this.topLevelOutputs = Preconditions.checkNotNull(topLevelOutputs, "topLevelOutputs");
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -19,8 +19,13 @@ import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.TopLevelArtifactHelper;
+import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.authandtls.GoogleAuthUtils;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
@@ -39,6 +44,7 @@ import com.google.devtools.build.lib.runtime.BuildEventArtifactUploaderFactory;
 import com.google.devtools.build.lib.runtime.Command;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
 import com.google.devtools.build.lib.runtime.ServerBuilder;
+import com.google.devtools.build.lib.skyframe.AspectValue;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.util.io.AsynchronousFileOutputStream;
@@ -310,6 +316,31 @@ public final class RemoteModule extends BlazeModule {
           .exit(
               new AbruptExitException(
                   "Error initializing RemoteModule", ExitCode.COMMAND_LINE_ERROR));
+    }
+  }
+
+  @Override
+  public void afterAnalysis(CommandEnvironment env, BuildRequest request, BuildOptions buildOptions,
+      Iterable<ConfiguredTarget> configuredTargets, ImmutableSet<AspectValue> aspects) {
+    if (remoteOutputsMode != null && remoteOutputsMode.downloadToplevelOutputsOnly()) {
+      Preconditions.checkState(actionContextProvider != null, "actionContextProvider was null");
+      // Collect all top level output artifacts of regular targets as well as aspects. This
+      // information is used by remote spawn runners to decide whether to download an artifact
+      // if --experimental_remote_download_outputs=toplevel is set
+      ImmutableSet.Builder<Artifact> topLevelOutputsBuilder = ImmutableSet.builder();
+      for (ConfiguredTarget configuredTarget : configuredTargets) {
+        topLevelOutputsBuilder.addAll(TopLevelArtifactHelper
+            .getAllArtifactsToBuild(configuredTarget, request.getTopLevelArtifactContext())
+            .getImportantArtifacts());
+      }
+
+      for (AspectValue aspect : aspects) {
+        topLevelOutputsBuilder.addAll(TopLevelArtifactHelper
+            .getAllArtifactsToBuild(aspect, request.getTopLevelArtifactContext())
+            .getImportantArtifacts());
+      }
+
+      actionContextProvider.setTopLevelOutputs(topLevelOutputsBuilder.build());
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -16,13 +16,18 @@ package com.google.devtools.build.lib.remote;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.devtools.build.lib.remote.util.Utils.createSpawnResult;
 import static com.google.devtools.build.lib.remote.util.Utils.getInMemoryOutputPath;
+import static com.google.devtools.build.lib.remote.util.Utils.hasTopLevelOutputs;
+import static com.google.devtools.build.lib.remote.util.Utils.shouldDownloadAllSpawnOutputs;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Platform;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ExecutionStrategy;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
@@ -58,12 +63,15 @@ import java.util.Set;
 import java.util.SortedMap;
 import javax.annotation.Nullable;
 
-/** A remote {@link SpawnCache} implementation. */
+/**
+ * A remote {@link SpawnCache} implementation.
+ */
 @ThreadSafe // If the RemoteActionCache implementation is thread-safe.
 @ExecutionStrategy(
     name = {"remote-cache"},
     contextType = SpawnCache.class)
 final class RemoteSpawnCache implements SpawnCache {
+
   private final Path execRoot;
   private final RemoteOptions options;
 
@@ -71,11 +79,20 @@ final class RemoteSpawnCache implements SpawnCache {
   private final String buildRequestId;
   private final String commandId;
 
-  @Nullable private final Reporter cmdlineReporter;
+  @Nullable
+  private final Reporter cmdlineReporter;
 
   private final Set<String> reportedErrors = new HashSet<>();
 
   private final DigestUtil digestUtil;
+
+  /**
+   * List of artifacts that are top level outputs
+   *
+   * <p>This set is empty unless {@link RemoteOutputsMode#TOPLEVEL} is specified. If so, this
+   * set is used to decide whether to download an output.
+   */
+  private final ImmutableSet<Artifact> topLevelOutputs;
 
   RemoteSpawnCache(
       Path execRoot,
@@ -84,7 +101,8 @@ final class RemoteSpawnCache implements SpawnCache {
       String buildRequestId,
       String commandId,
       @Nullable Reporter cmdlineReporter,
-      DigestUtil digestUtil) {
+      DigestUtil digestUtil,
+      ImmutableSet<Artifact> topLevelOutputs) {
     this.execRoot = execRoot;
     this.options = options;
     this.remoteCache = remoteCache;
@@ -92,7 +110,9 @@ final class RemoteSpawnCache implements SpawnCache {
     this.buildRequestId = buildRequestId;
     this.commandId = commandId;
     this.digestUtil = digestUtil;
+    this.topLevelOutputs = Preconditions.checkNotNull(topLevelOutputs, "topLevelOutputs");
   }
+
 
   @Override
   public CacheHandle lookup(Spawn spawn, SpawnExecutionContext context)
@@ -138,35 +158,34 @@ final class RemoteSpawnCache implements SpawnCache {
         try (SilentCloseable c = prof.profile(ProfilerTask.REMOTE_CACHE_CHECK, "check cache hit")) {
           result = remoteCache.getCachedActionResult(actionKey);
         }
+        // In case the remote cache returned a failed action (exit code != 0) we treat it as a
+        // cache miss
         if (result != null && result.getExitCode() == 0) {
-          // In case if failed action returned (exit code != 0) we treat it as a cache miss
-          // Otherwise, we know that result exists.
-          PathFragment inMemoryOutputPath = getInMemoryOutputPath(spawn);
           InMemoryOutput inMemoryOutput = null;
-          switch (remoteOutputsMode) {
-            case MINIMAL:
-              try (SilentCloseable c =
-                  prof.profile(ProfilerTask.REMOTE_DOWNLOAD, "download outputs minimal")) {
-                inMemoryOutput =
-                    remoteCache.downloadMinimal(
-                        result,
-                        spawn.getOutputFiles(),
-                        inMemoryOutputPath,
-                        context.getFileOutErr(),
-                        execRoot,
-                        context.getMetadataInjector());
-              }
-              break;
-            case ALL:
-              try (SilentCloseable c =
-                  prof.profile(ProfilerTask.REMOTE_DOWNLOAD, "download outputs")) {
-                remoteCache.download(result, execRoot, context.getFileOutErr());
-              }
-              break;
+          boolean downloadOutputs = shouldDownloadAllSpawnOutputs(remoteOutputsMode,
+              /* exitCode = */ 0, hasTopLevelOutputs(spawn.getOutputFiles(), topLevelOutputs));
+          if (downloadOutputs) {
+            try (SilentCloseable c =
+                prof.profile(ProfilerTask.REMOTE_DOWNLOAD, "download outputs")) {
+              remoteCache.download(result, execRoot, context.getFileOutErr());
+            }
+          } else {
+            PathFragment inMemoryOutputPath = getInMemoryOutputPath(spawn);
+            // inject output metadata
+            try (SilentCloseable c =
+                prof.profile(ProfilerTask.REMOTE_DOWNLOAD, "download outputs minimal")) {
+              inMemoryOutput =
+                  remoteCache.downloadMinimal(
+                      result,
+                      spawn.getOutputFiles(),
+                      inMemoryOutputPath,
+                      context.getFileOutErr(),
+                      execRoot,
+                      context.getMetadataInjector());
+            }
           }
-          SpawnResult spawnResult =
-              createSpawnResult(
-                  result.getExitCode(), /* cacheHit= */ true, "remote", inMemoryOutput);
+          SpawnResult spawnResult = createSpawnResult(result.getExitCode(), /* cacheHit= */ true,
+              "remote", inMemoryOutput);
           return SpawnCache.success(spawnResult);
         }
       } catch (CacheNotFoundException e) {
@@ -174,10 +193,10 @@ final class RemoteSpawnCache implements SpawnCache {
       } catch (IOException e) {
         String errorMsg = e.getMessage();
         if (isNullOrEmpty(errorMsg)) {
-            errorMsg = e.getClass().getSimpleName();
+          errorMsg = e.getClass().getSimpleName();
         }
-          errorMsg = "Reading from Remote Cache:\n" + errorMsg;
-          report(Event.warn(errorMsg));
+        errorMsg = "Reading from Remote Cache:\n" + errorMsg;
+        report(Event.warn(errorMsg));
       } finally {
         withMetadata.detach(previous);
       }
@@ -237,7 +256,8 @@ final class RemoteSpawnCache implements SpawnCache {
         }
 
         @Override
-        public void close() {}
+        public void close() {
+        }
 
         private void checkForConcurrentModifications() throws IOException {
           for (ActionInput input : inputMap.values()) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -20,6 +20,8 @@ import static com.google.devtools.build.lib.profiler.ProfilerTask.UPLOAD_TIME;
 import static com.google.devtools.build.lib.remote.util.Utils.createSpawnResult;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import static com.google.devtools.build.lib.remote.util.Utils.getInMemoryOutputPath;
+import static com.google.devtools.build.lib.remote.util.Utils.hasTopLevelOutputs;
+import static com.google.devtools.build.lib.remote.util.Utils.shouldDownloadAllSpawnOutputs;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
@@ -35,6 +37,7 @@ import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -109,6 +112,14 @@ public class RemoteSpawnRunner implements SpawnRunner {
   private final DigestUtil digestUtil;
   private final Path logDir;
 
+  /**
+   * List of artifacts that are top level outputs
+   *
+   * <p>This set is empty unless {@link RemoteOutputsMode#TOPLEVEL} is specified. If so, this
+   * set is used to decide whether to download an output.
+   */
+  private final ImmutableSet<Artifact> topLevelOutputs;
+
   // Used to ensure that a warning is reported only once.
   private final AtomicBoolean warningReported = new AtomicBoolean();
 
@@ -125,7 +136,8 @@ public class RemoteSpawnRunner implements SpawnRunner {
       @Nullable GrpcRemoteExecutor remoteExecutor,
       @Nullable RemoteRetrier retrier,
       DigestUtil digestUtil,
-      Path logDir) {
+      Path logDir,
+      ImmutableSet<Artifact> topLevelOutputs) {
     this.execRoot = execRoot;
     this.remoteOptions = remoteOptions;
     this.executionOptions = executionOptions;
@@ -139,6 +151,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
     this.retrier = retrier;
     this.digestUtil = digestUtil;
     this.logDir = logDir;
+    this.topLevelOutputs = Preconditions.checkNotNull(topLevelOutputs, "topLevelOutputs");
   }
 
   @Override
@@ -291,34 +304,27 @@ public class RemoteSpawnRunner implements SpawnRunner {
       SpawnExecutionContext context,
       RemoteOutputsMode remoteOutputsMode)
       throws ExecException, IOException, InterruptedException {
-    SpawnResult.Status actionStatus =
-        actionResult.getExitCode() == 0 ? Status.SUCCESS : Status.NON_ZERO_EXIT;
-    // In case the action failed, download all outputs. It might be helpful for debugging
-    // and there is no point in injecting output metadata of a failed action.
-    RemoteOutputsMode effectiveOutputsStrategy =
-        actionStatus == Status.SUCCESS ? remoteOutputsMode : RemoteOutputsMode.ALL;
-    PathFragment inMemoryOutputPath = getInMemoryOutputPath(spawn);
+    boolean downloadOutputs = shouldDownloadAllSpawnOutputs(remoteOutputsMode,
+        /* exitCode = */ actionResult.getExitCode(),
+        hasTopLevelOutputs(spawn.getOutputFiles(), topLevelOutputs));
     InMemoryOutput inMemoryOutput = null;
-    switch (effectiveOutputsStrategy) {
-      case MINIMAL:
-        try (SilentCloseable c =
-            Profiler.instance().profile(REMOTE_DOWNLOAD, "download outputs minimal")) {
-          inMemoryOutput =
-              remoteCache.downloadMinimal(
-                  actionResult,
-                  spawn.getOutputFiles(),
-                  inMemoryOutputPath,
-                  context.getFileOutErr(),
-                  execRoot,
-                  context.getMetadataInjector());
-        }
-        break;
-
-      case ALL:
-        try (SilentCloseable c = Profiler.instance().profile(REMOTE_DOWNLOAD, "download outputs")) {
-          remoteCache.download(actionResult, execRoot, context.getFileOutErr());
-        }
-        break;
+    if (downloadOutputs) {
+      try (SilentCloseable c = Profiler.instance().profile(REMOTE_DOWNLOAD, "download outputs")) {
+        remoteCache.download(actionResult, execRoot, context.getFileOutErr());
+      }
+    } else {
+      PathFragment inMemoryOutputPath = getInMemoryOutputPath(spawn);
+      try (SilentCloseable c =
+          Profiler.instance().profile(REMOTE_DOWNLOAD, "download outputs minimal")) {
+        inMemoryOutput =
+            remoteCache.downloadMinimal(
+                actionResult,
+                spawn.getOutputFiles(),
+                inMemoryOutputPath,
+                context.getFileOutErr(),
+                execRoot,
+                context.getMetadataInjector());
+      }
     }
     return createSpawnResult(actionResult.getExitCode(), cacheHit, getName(), inMemoryOutput);
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOutputsMode.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOutputsMode.java
@@ -24,10 +24,19 @@ public enum RemoteOutputsMode {
    * Generally don't download remote action outputs. The only outputs that are being downloaded are:
    * stdout, stderr and .d and .jdeps files for C++ and Java compilation actions.
    */
-  MINIMAL;
+  MINIMAL,
+
+  /**
+   * Like {@code MINIMAL} but downloads outputs of top level targets.
+   */
+  TOPLEVEL;
 
   /** Returns {@code true} iff action outputs should always be downloaded. */
   public boolean downloadAllOutputs() {
     return this == ALL;
+  }
+
+  public boolean downloadToplevelOutputsOnly() {
+    return this == TOPLEVEL;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
@@ -13,6 +13,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib:build-base",
         "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//third_party:guava",
         "//third_party/grpc:grpc-jar",

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeModule.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeModule.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.runtime;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.ExecutorInitException;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
@@ -30,6 +31,7 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.exec.ExecutorBuilder;
 import com.google.devtools.build.lib.packages.Package;
 import com.google.devtools.build.lib.packages.PackageFactory;
+import com.google.devtools.build.lib.skyframe.AspectValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.io.OutErr;
@@ -260,7 +262,8 @@ public abstract class BlazeModule {
       CommandEnvironment env,
       BuildRequest request,
       BuildOptions buildOptions,
-      Iterable<ConfiguredTarget> configuredTargets)
+      Iterable<ConfiguredTarget> configuredTargets,
+      ImmutableSet<AspectValue> aspects)
       throws InterruptedException, ViewCreationFailedException {}
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
@@ -306,7 +306,9 @@ public class GrpcRemoteExecutionClientTest {
             executor,
             RemoteModule.createExecuteRetrier(remoteOptions, retryService),
             DIGEST_UTIL,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
+
     inputDigest = fakeFileCache.createScratchInput(simpleSpawn.getInputFiles().get(0), "xyz");
     command =
         Command.newBuilder()

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -31,6 +31,7 @@ import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
@@ -238,7 +239,9 @@ public class RemoteSpawnCacheTest {
             "build-req-id",
             "command-id",
             reporter,
-            digestUtil);
+            digestUtil,
+            /* topLevelOutputs= */ ImmutableSet.of());
+
     fakeFileCache.createScratchInput(simpleSpawn.getInputFiles().get(0), "xyz");
   }
 
@@ -570,7 +573,8 @@ public class RemoteSpawnCacheTest {
             "build-req-id",
             "command-id",
             reporter,
-            digestUtil);
+            digestUtil,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     ActionResult success = ActionResult.newBuilder().setExitCode(0).build();
     when(remoteCache.getCachedActionResult(any())).thenReturn(success);
@@ -597,7 +601,9 @@ public class RemoteSpawnCacheTest {
             "build-req-id",
             "command-id",
             reporter,
-            digestUtil);
+            digestUtil,
+            /* topLevelOutputs= */ ImmutableSet.of());
+
     IOException downloadFailure = new IOException("downloadMinimal failed");
 
     ActionResult success = ActionResult.newBuilder().setExitCode(0).build();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -39,6 +39,7 @@ import build.bazel.remote.execution.v2.LogFile;
 import build.bazel.remote.execution.v2.Platform;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -49,6 +50,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.ArtifactPathResolver;
+import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.CommandLines.ParamFileActionInput;
 import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
@@ -194,7 +196,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     ExecuteResponse succeeded = ExecuteResponse.newBuilder().setResult(
         ActionResult.newBuilder().setExitCode(0).build()).build();
@@ -257,7 +260,8 @@ public class RemoteSpawnRunnerTest {
             null,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     // Throw an IOException to trigger the local fallback.
     when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(IOException.class);
@@ -304,7 +308,8 @@ public class RemoteSpawnRunnerTest {
                 null,
                 retrier,
                 digestUtil,
-                logDir));
+                logDir,
+                /* topLevelOutputs= */ ImmutableSet.of()));
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
@@ -362,7 +367,8 @@ public class RemoteSpawnRunnerTest {
                 null,
                 retrier,
                 digestUtil,
-                logDir));
+                logDir,
+                /* topLevelOutputs= */ ImmutableSet.of()));
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
 
@@ -420,7 +426,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     ExecuteResponse succeeded =
         ExecuteResponse.newBuilder()
@@ -463,7 +470,8 @@ public class RemoteSpawnRunnerTest {
             null,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
@@ -522,7 +530,8 @@ public class RemoteSpawnRunnerTest {
             null,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
@@ -563,7 +572,8 @@ public class RemoteSpawnRunnerTest {
             null,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
@@ -601,7 +611,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
     when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(new IOException());
@@ -638,7 +649,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     Digest logDigest = digestUtil.computeAsUtf8("bla");
     Path logPath = logDir.getRelative(simpleActionId).getRelative("logname");
@@ -680,7 +692,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     Digest logDigest = digestUtil.computeAsUtf8("bla");
     Path logPath = logDir.getRelative(simpleActionId).getRelative("logname");
@@ -724,7 +737,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     Digest logDigest = digestUtil.computeAsUtf8("bla");
     ActionResult result = ActionResult.newBuilder().setExitCode(31).build();
@@ -764,7 +778,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     Digest logDigest = digestUtil.computeAsUtf8("bla");
     ActionResult result = ActionResult.newBuilder().setExitCode(0).build();
@@ -806,7 +821,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(cachedResult);
@@ -849,7 +865,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
@@ -903,7 +920,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
@@ -950,7 +968,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
@@ -995,7 +1014,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
@@ -1037,7 +1057,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(null);
     when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(new IOException("reasons"));
@@ -1076,7 +1097,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     when(cache.getCachedActionResult(any(ActionKey.class))).thenThrow(new IOException("reasons"));
 
@@ -1112,7 +1134,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     ExecuteResponse succeeded =
         ExecuteResponse.newBuilder()
@@ -1190,7 +1213,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
@@ -1229,7 +1253,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
@@ -1271,7 +1296,8 @@ public class RemoteSpawnRunnerTest {
             executor,
             retrier,
             digestUtil,
-            logDir);
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
@@ -1289,14 +1315,57 @@ public class RemoteSpawnRunnerTest {
     verify(cache, never()).download(any(ActionResult.class), any(Path.class), eq(outErr));
   }
 
-  private static Spawn newSimpleSpawn() {
+  @Test
+  public void testDownloadTopLevel() throws Exception {
+    // arrange
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteOutputsMode = RemoteOutputsMode.TOPLEVEL;
+
+    ArtifactRoot outputRoot = ArtifactRoot.asDerivedRoot(execRoot, execRoot.getRelative("outs"));
+    Artifact topLevelOutput = new Artifact(outputRoot.getRoot().getRelative("foo.bin"), outputRoot);
+
+    ActionResult succeededAction = ActionResult.newBuilder().setExitCode(0).build();
+    when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(succeededAction);
+
+    RemoteSpawnRunner runner =
+        new RemoteSpawnRunner(
+            execRoot,
+            options,
+            Options.getDefaults(ExecutionOptions.class),
+            new AtomicReference<>(localRunner),
+            false,
+            /* cmdlineReporter= */ null,
+            "build-req-id",
+            "command-id",
+            cache,
+            executor,
+            retrier,
+            digestUtil,
+            logDir,
+            /* topLevelOutputs= */ ImmutableSet.of(topLevelOutput));
+
+    Spawn spawn = newSimpleSpawn(topLevelOutput);
+    SpawnExecutionContext policy = new FakeSpawnExecutionContext(spawn);
+
+    // act
+    SpawnResult result = runner.exec(spawn, policy);
+    assertThat(result.exitCode()).isEqualTo(0);
+    assertThat(result.status()).isEqualTo(Status.SUCCESS);
+
+    // assert
+    verify(cache).download(eq(succeededAction), any(Path.class), eq(outErr));
+    verify(cache, never()).downloadMinimal(eq(succeededAction), anyCollection(), any(), any(),
+        any(), any());
+  }
+
+  private static Spawn newSimpleSpawn(Artifact... outputs) {
     return new SimpleSpawn(
         new FakeOwner("foo", "bar"),
             /*arguments=*/ ImmutableList.of(),
             /*environment=*/ ImmutableMap.of(),
             /*executionInfo=*/ ImmutableMap.of(),
             /*inputs=*/ ImmutableList.of(),
-            /*outputs=*/ ImmutableList.<ActionInput>of(),
+            /*outputs=*/ ImmutableList.copyOf(outputs),
         ResourceSet.ZERO);
   }
 

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -938,8 +938,9 @@ EOF
 }
 
 function test_downloads_minimal_native_prefetch() {
-  # Test that when using --experimental_remote_outputs=minimal a remotely stored output that's an
-  # input to a native action (ctx.actions.expand_template) is staged lazily for action execution.
+  # Test that when using --experimental_remote_download_outputs=minimal a remotely stored output
+  # that's an input to a native action (ctx.actions.expand_template) is staged lazily for action
+  # execution.
   mkdir -p a
   cat > a/substitute_username.bzl <<'EOF'
 def _substitute_username_impl(ctx):
@@ -1000,6 +1001,59 @@ EOF
   || fail "Expected bazel-bin/a/template.txt to have been deleted again"
 }
 
+function test_downloads_toplevel() {
+  # Test that when using --experimental_remote_download_outputs=toplevel only the output of the
+  # toplevel target is being downloaded.
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = "foo",
+  srcs = [],
+  outs = ["foo.txt"],
+  cmd = "echo \"foo\" > \"$@\"",
+)
+
+genrule(
+  name = "foobar",
+  srcs = [":foo"],
+  outs = ["foobar.txt"],
+  cmd = "cat $(location :foo) > \"$@\" && echo \"bar\" >> \"$@\"",
+)
+EOF
+
+  bazel build \
+    --genrule_strategy=remote \
+    --remote_executor=localhost:${worker_port} \
+    --experimental_inmemory_jdeps_files \
+    --experimental_inmemory_dotd_files \
+    --experimental_remote_download_outputs=toplevel \
+    //a:foobar || fail "Failed to build //a:foobar"
+
+  (! [[ -f bazel-bin/a/foo.txt ]]) \
+  || fail "Expected intermediate output bazel-bin/a/foo.txt to not be downloaded"
+
+  [[ -f bazel-bin/a/foobar.txt ]] \
+  || fail "Expected toplevel output bazel-bin/a/foobar.txt to be downloaded"
+
+
+  # Delete the file to test that the action is re-run
+  rm -f bazel-bin/a/foobar.txt
+
+  bazel build \
+    --genrule_strategy=remote \
+    --remote_executor=localhost:${worker_port} \
+    --experimental_inmemory_jdeps_files \
+    --experimental_inmemory_dotd_files \
+    --experimental_remote_download_outputs=toplevel \
+    //a:foobar >& $TEST_log || fail "Failed to build //a:foobar"
+
+  expect_log "1 process: 1 remote cache hit"
+
+  [[ -f bazel-bin/a/foobar.txt ]] \
+  || fail "Expected toplevel output bazel-bin/a/foobar.txt to be re-downloaded"
+
+
+}
 # TODO(alpha): Add a test that fails remote execution when remote worker
 # supports sandbox.
 


### PR DESCRIPTION
This implements the second milestone of "Remote builds without the
Bytes" and introduces the "toplevel" option for the
--experimental_remote_download_outputs flag. This mode will only
download outputs of top level targets but not outputs of intermediate
actions.

On a build of Bazel against RBE I am still seeing a 50% speed up
compared to the "all" mode.

Progress towards #6862.