### PR TITLE
remote: deprecated unused experimental remote_retry flags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -453,8 +453,8 @@ public final class RemoteModule extends BlazeModule {
   static RemoteRetrier createExecuteRetrier(
       RemoteOptions options, ListeningScheduledExecutorService retryService) {
     return new RemoteRetrier(
-        options.remoteRetryMaxAttempts > 0
-            ? () -> new Retrier.ZeroBackoff(options.remoteRetryMaxAttempts)
+        options.remoteMaxRetryAttempts > 0
+            ? () -> new Retrier.ZeroBackoff(options.remoteMaxRetryAttempts)
             : () -> Retrier.RETRIES_DISABLED,
         RemoteModule.RETRIABLE_EXEC_ERRORS,
         retryService,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -453,8 +453,8 @@ public final class RemoteModule extends BlazeModule {
   static RemoteRetrier createExecuteRetrier(
       RemoteOptions options, ListeningScheduledExecutorService retryService) {
     return new RemoteRetrier(
-        options.experimentalRemoteRetry
-            ? () -> new Retrier.ZeroBackoff(options.experimentalRemoteRetryMaxAttempts)
+        options.remoteRetryMaxAttempts > 0
+            ? () -> new Retrier.ZeroBackoff(options.remoteRetryMaxAttempts)
             : () -> Retrier.RETRIES_DISABLED,
         RemoteModule.RETRIABLE_EXEC_ERRORS,
         retryService,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
@@ -68,7 +68,7 @@ public class RemoteRetrier extends Retrier {
       ListeningScheduledExecutorService retryScheduler,
       CircuitBreaker circuitBreaker) {
     this(
-        options.experimentalRemoteRetry
+        options.remoteRetryMaxAttempts > 0
             ? () -> new ExponentialBackoff(options)
             : () -> RETRIES_DISABLED,
         shouldRetry,
@@ -142,11 +142,11 @@ public class RemoteRetrier extends Retrier {
     }
 
     ExponentialBackoff(RemoteOptions options) {
-      this(Duration.ofMillis(options.experimentalRemoteRetryStartDelayMillis),
-          Duration.ofMillis(options.experimentalRemoteRetryMaxDelayMillis),
-          options.experimentalRemoteRetryMultiplier,
-          options.experimentalRemoteRetryJitter,
-          options.experimentalRemoteRetryMaxAttempts);
+      this(/* initial duration= */ Duration.ofMillis(100),
+          /* max duration= */ Duration.ofMillis(5000),
+          /* multiplier= */ 2,
+          /* jitter= */0.1,
+          options.remoteRetryMaxAttempts);
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
@@ -68,7 +68,7 @@ public class RemoteRetrier extends Retrier {
       ListeningScheduledExecutorService retryScheduler,
       CircuitBreaker circuitBreaker) {
     this(
-        options.remoteRetryMaxAttempts > 0
+        options.remoteMaxRetryAttempts > 0
             ? () -> new ExponentialBackoff(options)
             : () -> RETRIES_DISABLED,
         shouldRetry,
@@ -146,7 +146,7 @@ public class RemoteRetrier extends Retrier {
           /* max duration= */ Duration.ofMillis(5000),
           /* multiplier= */ 2,
           /* jitter= */0.1,
-          options.remoteRetryMaxAttempts);
+          options.remoteMaxRetryAttempts);
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -125,8 +125,8 @@ public final class RemoteOptions extends OptionsBase {
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       deprecationWarning = "Deprecated. Use --remote_retries instead.",
-      effectTags = {OptionEffectTag.UNKNOWN},
-      help = "Whether to retry transient remote execution/cache errors.")
+      effectTags = {OptionEffectTag.NO_OP},
+      help = "This flag is deprecated and has no effect. Use --remote_retries instead.")
   public boolean experimentalRemoteRetry;
 
   @Deprecated
@@ -134,9 +134,9 @@ public final class RemoteOptions extends OptionsBase {
       name = "experimental_remote_retry_start_delay_millis",
       defaultValue = "100",
       documentationCategory = OptionDocumentationCategory.REMOTE,
-      deprecationWarning = "Deprecated. See --remote_retries instead.",
+      deprecationWarning = "Deprecated. Use --remote_retries instead.",
       effectTags = {OptionEffectTag.UNKNOWN},
-      help = "The initial delay before retrying a transient error.")
+      help = "The initial delay before retrying a transient error. Use --remote_retries instead.")
   public long experimentalRemoteRetryStartDelayMillis;
 
   @Deprecated
@@ -144,9 +144,9 @@ public final class RemoteOptions extends OptionsBase {
       name = "experimental_remote_retry_max_delay_millis",
       defaultValue = "5000",
       documentationCategory = OptionDocumentationCategory.REMOTE,
-      deprecationWarning = "Deprecated. See --remote_retries instead.",
-      effectTags = {OptionEffectTag.UNKNOWN},
-      help = "The maximum delay before retrying a transient error.")
+      deprecationWarning = "Deprecated. Use --remote_retries instead.",
+      effectTags = {OptionEffectTag.NO_OP},
+      help = "This flag is deprecated and has no effect. Use --remote_retries instead.")
   public long experimentalRemoteRetryMaxDelayMillis;
 
   @Option(
@@ -155,18 +155,18 @@ public final class RemoteOptions extends OptionsBase {
       defaultValue = "5",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
-      help = "The maximum number of attempts to retry a transient error."
+      help = "The maximum number of attempts to retry a transient error. "
           + "If set to 0, retries are disabled.")
-  public int remoteRetryMaxAttempts;
+  public int remoteMaxRetryAttempts;
 
   @Deprecated
   @Option(
       name = "experimental_remote_retry_multiplier",
       defaultValue = "2",
       documentationCategory = OptionDocumentationCategory.REMOTE,
-      deprecationWarning = "Deprecated. See --remote_retries instead.",
-      effectTags = {OptionEffectTag.UNKNOWN},
-      help = "The multiplier by which to increase the retry delay on transient errors.")
+      deprecationWarning = "Deprecated. Use --remote_retries instead.",
+      effectTags = {OptionEffectTag.NO_OP},
+      help = "This flag is deprecated and has no effect. Use --remote_retries instead.")
   public double experimentalRemoteRetryMultiplier;
 
   @Deprecated
@@ -174,9 +174,9 @@ public final class RemoteOptions extends OptionsBase {
       name = "experimental_remote_retry_jitter",
       defaultValue = "0.1",
       documentationCategory = OptionDocumentationCategory.REMOTE,
-      deprecationWarning = "Deprecated. See --remote_retries instead.",
-      effectTags = {OptionEffectTag.UNKNOWN},
-      help = "The random factor to apply to retry delays on transient errors.")
+      deprecationWarning = "Deprecated. Use --remote_retries instead.",
+      effectTags = {OptionEffectTag.NO_OP},
+      help = "This flag is deprecated and has no effect. Use --remote_retries instead.")
   public double experimentalRemoteRetryJitter;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -119,50 +119,62 @@ public final class RemoteOptions extends OptionsBase {
       help = "Value to pass as instance_name in the remote execution API.")
   public String remoteInstanceName;
 
+  @Deprecated
   @Option(
       name = "experimental_remote_retry",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.REMOTE,
+      deprecationWarning = "Deprecated. Use --remote_retries instead.",
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "Whether to retry transient remote execution/cache errors.")
   public boolean experimentalRemoteRetry;
 
+  @Deprecated
   @Option(
       name = "experimental_remote_retry_start_delay_millis",
       defaultValue = "100",
       documentationCategory = OptionDocumentationCategory.REMOTE,
+      deprecationWarning = "Deprecated. See --remote_retries instead.",
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "The initial delay before retrying a transient error.")
   public long experimentalRemoteRetryStartDelayMillis;
 
+  @Deprecated
   @Option(
       name = "experimental_remote_retry_max_delay_millis",
       defaultValue = "5000",
       documentationCategory = OptionDocumentationCategory.REMOTE,
+      deprecationWarning = "Deprecated. See --remote_retries instead.",
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "The maximum delay before retrying a transient error.")
   public long experimentalRemoteRetryMaxDelayMillis;
 
   @Option(
-      name = "experimental_remote_retry_max_attempts",
+      name = "remote_retries",
+      oldName = "experimental_remote_retry_max_attempts",
       defaultValue = "5",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
-      help = "The maximum number of attempts to retry a transient error.")
-  public int experimentalRemoteRetryMaxAttempts;
+      help = "The maximum number of attempts to retry a transient error."
+          + "If set to 0, retries are disabled.")
+  public int remoteRetryMaxAttempts;
 
+  @Deprecated
   @Option(
       name = "experimental_remote_retry_multiplier",
       defaultValue = "2",
       documentationCategory = OptionDocumentationCategory.REMOTE,
+      deprecationWarning = "Deprecated. See --remote_retries instead.",
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "The multiplier by which to increase the retry delay on transient errors.")
   public double experimentalRemoteRetryMultiplier;
 
+  @Deprecated
   @Option(
       name = "experimental_remote_retry_jitter",
       defaultValue = "0.1",
       documentationCategory = OptionDocumentationCategory.REMOTE,
+      deprecationWarning = "Deprecated. See --remote_retries instead.",
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "The random factor to apply to retry delays on transient errors.")
   public double experimentalRemoteRetryJitter;

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteRetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteRetrierTest.java
@@ -97,7 +97,7 @@ public class RemoteRetrierTest {
   @Test
   public void testNoRetries() throws Exception {
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
-    options.experimentalRemoteRetry = false;
+    options.remoteRetryMaxAttempts = 0;
 
     RemoteRetrier retrier =
         Mockito.spy(new RemoteRetrier(options, (e) -> true, retryService, Retrier.ALLOW_ALL_CALLS));
@@ -148,7 +148,7 @@ public class RemoteRetrierTest {
     InterruptedException thrown = new InterruptedException();
 
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
-    options.experimentalRemoteRetry = false;
+    options.remoteRetryMaxAttempts = 0;
     RemoteRetrier retrier =
         new RemoteRetrier(options, (e) -> true, retryService, Retrier.ALLOW_ALL_CALLS);
     try {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteRetrierTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteRetrierTest.java
@@ -97,7 +97,7 @@ public class RemoteRetrierTest {
   @Test
   public void testNoRetries() throws Exception {
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
-    options.remoteRetryMaxAttempts = 0;
+    options.remoteMaxRetryAttempts = 0;
 
     RemoteRetrier retrier =
         Mockito.spy(new RemoteRetrier(options, (e) -> true, retryService, Retrier.ALLOW_ALL_CALLS));
@@ -148,7 +148,7 @@ public class RemoteRetrierTest {
     InterruptedException thrown = new InterruptedException();
 
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
-    options.remoteRetryMaxAttempts = 0;
+    options.remoteMaxRetryAttempts = 0;
     RemoteRetrier retrier =
         new RemoteRetrier(options, (e) -> true, retryService, Retrier.ALLOW_ALL_CALLS);
     try {

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -638,7 +638,7 @@ EOF
   bazel test \
       --spawn_strategy=remote \
       --remote_executor=bazel.does.not.exist:1234 \
-      --noexperimental_remote_retry \
+      --remote_retries=0 \
       --test_output=all \
       --test_env=USER=boo \
       //a:test >& $TEST_log \


### PR DESCRIPTION
Part of #7205 