### PR TITLE
standardize graph output indentation with 2 spaces

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/graph/DotOutputVisitor.java
+++ b/src/main/java/com/google/devtools/build/lib/graph/DotOutputVisitor.java
@@ -58,11 +58,11 @@ public class DotOutputVisitor<T> implements GraphVisitor<T> {
   public void visitEdge(Node<T> lhs, Node<T> rhs) {
     String s_lhs = disp.serialize(lhs);
     String s_rhs = disp.serialize(rhs);
-    out.println("\"" + s_lhs + "\" -> \"" + s_rhs + "\"");
+    out.println("\t\"" + s_lhs + "\" -> \"" + s_rhs + "\"");
   }
 
   @Override
   public void visitNode(Node<T> node) {
-    out.println("\"" + disp.serialize(node) + "\"");
+    out.println("\t\"" + disp.serialize(node) + "\"");
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/graph/DotOutputVisitor.java
+++ b/src/main/java/com/google/devtools/build/lib/graph/DotOutputVisitor.java
@@ -58,11 +58,11 @@ public class DotOutputVisitor<T> implements GraphVisitor<T> {
   public void visitEdge(Node<T> lhs, Node<T> rhs) {
     String s_lhs = disp.serialize(lhs);
     String s_rhs = disp.serialize(rhs);
-    out.println("\t\"" + s_lhs + "\" -> \"" + s_rhs + "\"");
+    out.println("  \"" + s_lhs + "\" -> \"" + s_rhs + "\"");
   }
 
   @Override
   public void visitNode(Node<T> node) {
-    out.println("\t\"" + disp.serialize(node) + "\"");
+    out.println("  \"" + disp.serialize(node) + "\"");
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/GraphOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/GraphOutputFormatter.java
@@ -92,7 +92,7 @@ class GraphOutputFormatter extends OutputFormatter {
           public void beginVisit() {
             super.beginVisit();
             // TODO(bazel-team): (2009) make this the default in Digraph.
-            out.printf("\tnode [shape=box];%s", options.getLineTerminator());
+            out.printf("  node [shape=box];%s", options.getLineTerminator());
           }
 
           @Override
@@ -103,7 +103,7 @@ class GraphOutputFormatter extends OutputFormatter {
                 getConditionsGraphLabel(
                     ImmutableSet.of(lhs), ImmutableSet.of(rhs), conditionalEdges);
             if (!outputLabel.isEmpty()) {
-              out.printf("\t[label=\"%s\"];\n", outputLabel);
+              out.printf("  [label=\"%s\"];\n", outputLabel);
             }
           }
         },

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/GraphOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/GraphOutputFormatter.java
@@ -92,7 +92,7 @@ class GraphOutputFormatter extends OutputFormatter {
           public void beginVisit() {
             super.beginVisit();
             // TODO(bazel-team): (2009) make this the default in Digraph.
-            out.printf("  node [shape=box];%s", options.getLineTerminator());
+            out.printf("\tnode [shape=box];%s", options.getLineTerminator());
           }
 
           @Override
@@ -103,7 +103,7 @@ class GraphOutputFormatter extends OutputFormatter {
                 getConditionsGraphLabel(
                     ImmutableSet.of(lhs), ImmutableSet.of(rhs), conditionalEdges);
             if (!outputLabel.isEmpty()) {
-              out.printf(" [label=\"%s\"];\n", outputLabel);
+              out.printf("\t[label=\"%s\"];\n", outputLabel);
             }
           }
         },


### PR DESCRIPTION
Currently, when outputting graphs from Bazel with `bazel query --output=graph`, the indentations for different types of lines are inconsistent:

- `node` is indented with 2 spaces
- edges and vertices are not indented
- labels are indented with 1 space

Example using [rules_go](https://github.com/bazelbuild/rules_go):

```
$ bazel query "deps(//go/platform:darwin)" --output=graph
digraph mygraph {
  node [shape=box];
"//go/platform:darwin"
"//go/platform:darwin" -> "//go/toolchain:darwin"
"//go/toolchain:darwin"
"//go/toolchain:darwin" -> "@bazel_tools//platforms:osx"
"@bazel_tools//platforms:osx"
"@bazel_tools//platforms:osx" -> "@bazel_tools//platforms:os"
"@bazel_tools//platforms:os"
}
Loading: 0 packages loaded
```

It would be nice for the indentations to be present (for edges and vertices), and consistent.

As for the indentation scheme, it seems inconclusive as to which type the language prefers:

- the [DOT Language Spec](https://www.graphviz.org/doc/info/lang.html) does not really specify tabs or spaces, but the examples used either contained no indentation (!) or one with 2 spaces
- the official [examples](https://www.graphviz.org/gallery/) contain samples of no indentation, tabs, or 2 spaces, with tabs being most popular
- the [Wikipedia page](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) uses tabs

I'm using 2 spaces to conform with skylark. This is the result from the same query with this PR:

```plaintext
$ /Users/ricky/workspace/bazel/bazel-bin/src/bazel query "deps(//go/platform:darwin)" --output=graph
Starting local Bazel server and connecting to it...
DEBUG: /private/var/tmp/_bazel_ricky/5c63e3be3c60ec773878bdf16f25adcc/external/bazel_toolchains/rules/version_check.bzl:45:9: 
Current running Bazel is not a release version and one was not defined explicitly in rbe_autoconfig target. Falling back to '0.23.0'
digraph mygraph {
  node [shape=box];
  "//go/platform:darwin"
  "//go/platform:darwin" -> "//go/toolchain:darwin"
  "//go/toolchain:darwin"
  "//go/toolchain:darwin" -> "@bazel_tools//platforms:osx"
  "@bazel_tools//platforms:osx"
  "@bazel_tools//platforms:osx" -> "@bazel_tools//platforms:os"
  "@bazel_tools//platforms:os"
}
Loading: 3 packages loaded
```