### PR TITLE
Relax "no hyphens" constraint for Python targets with "imports" attr

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/python/PyCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PyCommon.java
@@ -792,11 +792,12 @@ public final class PyCommon {
    */
   public List<Artifact> validateSrcs() {
     List<Artifact> sourceFiles = new ArrayList<>();
+    boolean emptyImports = getImports().isEmpty();
     // TODO(bazel-team): Need to get the transitive deps closure, not just the sources of the rule.
     for (TransitiveInfoCollection src :
         ruleContext.getPrerequisitesIf("srcs", Mode.TARGET, FileProvider.class)) {
       // Make sure that none of the sources contain hyphens.
-      if (Util.containsHyphen(src.getLabel().getPackageFragment())) {
+      if (Util.containsHyphen(src.getLabel().getPackageFragment()) && emptyImports) {
         ruleContext.attributeError("srcs",
             src.getLabel() + ": paths to Python packages may not contain '-'");
       }
@@ -819,7 +820,8 @@ public final class PyCommon {
    * Checks that the package name of this Python rule does not contain a '-'.
    */
   void validatePackageName() {
-    if (Util.containsHyphen(ruleContext.getLabel().getPackageFragment())) {
+    if (Util.containsHyphen(ruleContext.getLabel().getPackageFragment()) &&
+            getImports().isEmpty()) {
       ruleContext.ruleError("paths to Python packages may not contain '-'");
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/rules/python/PyBaseConfiguredTargetTestBase.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/python/PyBaseConfiguredTargetTestBase.java
@@ -143,6 +143,36 @@ public abstract class PyBaseConfiguredTargetTestBase extends BuildViewTestCase {
   }
 
   @Test
+  public void packageNameCanHaveHyphenIfImports() throws Exception {
+    scratchConfiguredTarget("pkg-hyphenated", "foo",
+            ruleName + "(",
+            "    name = 'foo',",
+            "    srcs = ['foo.py'],",
+            "    imports = ['.'],",
+            ")");
+    assertNoEvents();
+  }
+
+  @Test
+  public void depsPackageNameCanHaveHyphenIfImports() throws Exception {
+    scratch.file(
+            "pkg-hyphenated/BUILD", //
+            "py_library(",
+            "    name = 'bar',",
+            "    srcs = ['bar.py'],",
+            "    imports = ['.']",
+            ")");
+    scratchConfiguredTarget("otherpkg", "foo",
+            ruleName + "(",
+            "    name = 'foo',",
+            "    srcs = ['foo.py'],",
+            "    deps = ['//pkg-hyphenated:bar'],",
+            ")");
+    assertNoEvents();
+  }
+
+
+  @Test
   public void producesBothModernAndLegacyProviders_WithoutIncompatibleFlag() throws Exception {
     useConfiguration("--incompatible_disallow_legacy_py_provider=false");
     scratch.file(


### PR DESCRIPTION
Bazel has a constraint for Python rules where package names may not
contain hyphens.  This makes some sense in a monorepo where apps'
Python import paths are derived from their paths in SCM.  However,
Bazel also offers an import path escape hatch via the Python rules'
`imports` attribute.  When using this attribute, users no longer
need to rely on Bazel package paths to define their Python
package/module names.

This change relaxes the "no hyphens" constraint such that hyphens
are permitted whenever the relevant rule defines the `imports`
attribute.

Resolves https://github.com/bazelbuild/bazel/issues/6841.