### PR TITLE
Build java_tools for javac9 and javac10.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -433,6 +433,19 @@ http_archive(
     ],
 )
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+git_repository(
+    name = "java_tools_langtools_javac10",
+    branch = "langtools_javac10",
+    remote = "https://github.com/bazelbuild/java_tools.git",
+)
+
+git_repository(
+    name = "java_tools_langtools_javac9",
+    branch = "langtools_javac9",
+    remote = "https://github.com/bazelbuild/java_tools.git",
+)
+
 load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
 
 skydoc_repositories()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -435,14 +435,14 @@ http_archive(
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
-    name = "java_tools_langtools_javac10",
-    branch = "langtools_javac10",
+    name = "java_tools_langtools_javac9",
+    branch = "langtools_javac9",
     remote = "https://github.com/bazelbuild/java_tools.git",
 )
 
 git_repository(
-    name = "java_tools_langtools_javac9",
-    branch = "langtools_javac9",
+    name = "java_tools_langtools_javac10",
+    branch = "langtools_javac10",
     remote = "https://github.com/bazelbuild/java_tools.git",
 )
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -578,7 +578,7 @@ genrule(
         "@java_tools_langtools_javac9//:javac_jar",
     ],
     outs = ["jars_java_tools_java9.zip"],
-    cmd = "zip -q -j $@ $$(echo $(SRCS) | sort)",
+    cmd = "zip -qjX $@ $$(echo $(SRCS) | sort)",
     visibility = ["//visibility:private"],
 )
 
@@ -589,7 +589,7 @@ genrule(
         "@java_tools_langtools_javac10//:java_compiler_jar",
     ],
     outs = ["jars_java_tools_java10.zip"],
-    cmd = "zip -q -j $@ $$(echo $(SRCS) | sort)",
+    cmd = "zip -qjX $@ $$(echo $(SRCS) | sort)",
     visibility = ["//visibility:private"],
 )
 
@@ -607,7 +607,7 @@ JAVA_VERSIONS = ("9", "10")
             "@java_tools_langtools_javac" + java_version + "//:srcs",
         ],
         outs = ["java_tools_dist_javac" + java_version + ".zip"],
-        cmd = "zip -Xr -q $@ $$(echo $(SRCS) | sort)",
+        cmd = "zip -qXr $@ $$(echo $(SRCS) | sort)",
         output_to_bindir = 1,
     )
     for java_version in JAVA_VERSIONS

--- a/src/BUILD
+++ b/src/BUILD
@@ -555,61 +555,129 @@ sh_binary(
     visibility = ["//visibility:public"],
 )
 
+JAVA_TOOLS_DEPLOY_JARS = [
+    "//src/java_tools/buildjar:JavaBuilder_deploy.jar",
+    "//src/java_tools/buildjar:VanillaJavaBuilder_deploy.jar",
+    "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/genclass:GenClass_deploy.jar",
+    "//src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/javac:turbine_deploy.jar",
+    "//src/java_tools/buildjar/java/com/google/devtools/build/java/turbine:turbine_direct_binary_deploy.jar",
+    "//src/java_tools/junitrunner/java/com/google/testing/coverage:JacocoCoverage_jarjar_deploy.jar",
+    "//src/java_tools/junitrunner/java/com/google/testing/junit/runner:ExperimentalRunner_deploy.jar",
+    "//src/java_tools/junitrunner/java/com/google/testing/junit/runner:Runner_deploy.jar",
+    "//third_party/jarjar:jarjar_command_deploy.jar",
+] + select({
+    "//src/conditions:arm": ["//src/java_tools/singlejar/java/com/google/devtools/build/singlejar:bazel-singlejar_deploy.jar"],
+    "//conditions:default": [],
+})
+
 genrule(
-    name = "jars_java_tools_zip",
-    srcs = [
-        "//src/java_tools/buildjar:JavaBuilder_deploy.jar",
-        "//src/java_tools/buildjar:VanillaJavaBuilder_deploy.jar",
-        "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/genclass:GenClass_deploy.jar",
-        "//src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/javac:turbine_deploy.jar",
-        "//src/java_tools/buildjar/java/com/google/devtools/build/java/turbine:turbine_direct_binary_deploy.jar",
-        "//src/java_tools/junitrunner/java/com/google/testing/coverage:JacocoCoverage_jarjar_deploy.jar",
-        "//src/java_tools/junitrunner/java/com/google/testing/junit/runner:ExperimentalRunner_deploy.jar",
-        "//src/java_tools/junitrunner/java/com/google/testing/junit/runner:Runner_deploy.jar",
-        "//third_party/java/jdk/langtools:java_compiler_jar",
-        "//third_party/java/jdk/langtools:javac_jar",
-        "//third_party/java/jdk/langtools:jdk_compiler_jar",
-        "//third_party/jarjar:jarjar_command_deploy.jar",
-    ] + select({
-        "//src/conditions:arm": ["//src/java_tools/singlejar/java/com/google/devtools/build/singlejar:bazel-singlejar_deploy.jar"],
-        "//conditions:default": [],
-    }),
-    outs = ["jars_java_tools.zip"],
+    name = "jars_java_tools_java9_zip",
+    srcs = JAVA_TOOLS_DEPLOY_JARS + [
+        "@java_tools_langtools_javac9//:jdk_compiler_jar",
+        "@java_tools_langtools_javac9//:java_compiler_jar",
+        "@java_tools_langtools_javac9//:javac_jar",
+    ],
+    outs = ["jars_java_tools_java9.zip"],
     cmd = "zip -q -j $@ $$(echo $(SRCS) | sort)",
     visibility = ["//visibility:private"],
 )
 
 genrule(
-    name = "java_tools_dist",
-    srcs = [
-        "//src/java_tools/buildjar:srcs",
-        "//src/java_tools/junitrunner:srcs",
-        "//src/java_tools/singlejar:srcs",
-        "//src/tools/singlejar:embedded_java_tools",
-        "//third_party/jarjar:srcs",
-        "//third_party/java/jdk/langtools:license-and-srcs",
-        "//third_party/ijar:transitive_sources",
+    name = "jars_java_tools_java10_zip",
+    srcs = JAVA_TOOLS_DEPLOY_JARS + [
+        "@java_tools_langtools_javac10//:jdk_compiler_jar",
+        "@java_tools_langtools_javac10//:java_compiler_jar",
     ],
-    outs = ["java_tools_dist.zip"],
-    cmd = "zip -Xr $@ $$(echo $(SRCS) | sort)",
-    output_to_bindir = 1,
+    outs = ["jars_java_tools_java10.zip"],
+    cmd = "zip -q -j $@ $$(echo $(SRCS) | sort)",
+    visibility = ["//visibility:private"],
 )
+
+JAVA_VERSIONS = ("9", "10")
+[
+    genrule(
+        name = "java_tools_dist_java" + java_version,
+        srcs = [
+            "//src/java_tools/buildjar:srcs",
+            "//src/java_tools/junitrunner:srcs",
+            "//src/java_tools/singlejar:srcs",
+            "//src/tools/singlejar:embedded_java_tools",
+            "//third_party/jarjar:srcs",
+            "//third_party/ijar:transitive_sources",
+            "@java_tools_langtools_javac" + java_version + "//:srcs",
+        ],
+        outs = ["java_tools_dist_javac" + java_version + ".zip"],
+        cmd = "zip -Xr -q $@ $$(echo $(SRCS) | sort)",
+        output_to_bindir = 1,
+    )
+    for java_version in JAVA_VERSIONS
+]
+
+[
+    # Targets used by the java_tools_binaries Buildkite pipeline to build the
+    # java_tools_dist_java* zips and upload them to a tmp directory in GCS.
+    sh_binary(
+        name = "upload_java_tools_dist_java" + java_version,
+        srcs = ["upload_java_tools.sh"],
+        data = [":java_tools_dist_java"+ java_version],
+        deps = ["@bazel_tools//tools/bash/runfiles"],
+        args = [
+            "--java_tools_zip", "src/java_tools_dist_javac" + java_version + ".zip",
+            "--gcs_java_tools_dir", "tmp/dist",
+            "--java_version", java_version,
+            "--platform"] + select({
+                 "//src/conditions:darwin": ["darwin"],
+                "//src/conditions:darwin_x86_64": ["darwin_x86_64"],
+                "//src/conditions:windows": ["windows"],
+                "//src/conditions:linux_x86_64": ["linux"],
+                "//conditions:default": ["unknown"]
+            }),
+    )
+    for java_version in JAVA_VERSIONS
+]
 
 # Builds the remote Java tools archive. Not embedded or used in Bazel, but used
 # by the Java tools release process.
-genrule(
-    name = "java_tools_zip",
-    srcs = [
-        ":jars_java_tools_zip",
-        "//src/tools/singlejar:singlejar_transitive_zip",
-        "//third_party/ijar:ijar_transitive_zip",
-    ],
-    outs = ["java_tools.zip"],
-    cmd = "$(location //src:merge_zip_files) java_tools $@ $(SRCS)",
-    output_to_bindir = 1,
-    tools = ["//src:merge_zip_files"],
-    visibility = ["//src/test/shell/bazel:__pkg__"],
-)
+[
+    genrule(
+        name = "java_tools_java" + java_version + "_zip",
+        srcs = [
+            ":jars_java_tools_java" + java_version + ".zip",
+            "//src/tools/singlejar:singlejar_transitive_zip",
+            "//third_party/ijar:ijar_transitive_zip",
+        ],
+        outs = ["java_tools_java" + java_version + ".zip"],
+        cmd = "$(location //src:merge_zip_files) java_tools $@ $(SRCS)",
+        output_to_bindir = 1,
+        tools = ["//src:merge_zip_files"],
+        visibility = ["//src/test/shell/bazel:__pkg__"],
+    )
+    for java_version in JAVA_VERSIONS
+]
+
+[
+    # Targets used by the java_tools_binaries Buildkite pipeline to build the
+    # java_tools_java* zips and upload them to a tmp directory in GCS.
+    sh_binary(
+        name = "upload_java_tools_java" + java_version,
+        srcs = ["upload_java_tools.sh"],
+        data = [":java_tools_java"+ java_version +"_zip"],
+        deps = ["@bazel_tools//tools/bash/runfiles"],
+        args = [
+            "--java_tools_zip", "src/java_tools_java" + java_version + ".zip",
+            "--gcs_java_tools_dir", "tmp/build",
+            "--java_version", java_version,
+            "--platform"] + select({
+                 "//src/conditions:darwin": ["darwin"],
+                "//src/conditions:darwin_x86_64": ["darwin_x86_64"],
+                "//src/conditions:windows": ["windows"],
+                "//src/conditions:linux_x86_64": ["linux"],
+                "//conditions:default": ["unknown"]
+            }),
+    )
+    for java_version in JAVA_VERSIONS
+]
+
 
 # Part of the Java tools remote archive. Not embedded or used in Bazel.
 genrule(

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -149,7 +149,8 @@ sh_test(
     srcs = ["bazel_java_tools_test.sh"],
     data = [
         ":test-deps",
-        "//src:java_tools.zip",
+        "//src:java_tools_java10.zip",
+        "//src:java_tools_java9.zip",
         "@bazel_tools//tools/bash/runfiles",
     ],
 )

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -144,13 +144,25 @@ sh_test(
 )
 
 sh_test(
-    name = "bazel_java_tools_test",
+    name = "bazel_java_tools_javac9_test",
+    args = ["java9"],
+    size = "small",
+    srcs = ["bazel_java_tools_test.sh"],
+    data = [
+        ":test-deps",
+        "//src:java_tools_java9.zip",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+sh_test(
+    name = "bazel_java_tools_javac10_test",
+    args = ["java10"],
     size = "small",
     srcs = ["bazel_java_tools_test.sh"],
     data = [
         ":test-deps",
         "//src:java_tools_java10.zip",
-        "//src:java_tools_java9.zip",
         "@bazel_tools//tools/bash/runfiles",
     ],
 )

--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -16,6 +16,9 @@
 
 # Load the test setup defined in the parent directory
 set -euo pipefail
+
+JAVA_TOOLS_JAVA_VERSION="$1"; shift
+
 # --- begin runfiles.bash initialization ---
 if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
     if [[ -f "$0.runfiles_manifest" ]]; then
@@ -64,113 +67,91 @@ fi
 
 function expect_path_in_java_tools() {
   path="$1"; shift
-  java_version="$1"; shift
 
-  count=$(zipinfo -1 $(rlocation io_bazel/src/java_tools_${java_version}.zip) | grep -c "$path")
-  [[ "$count" -gt 0 ]] || fail "Path $path not found in java_tools_${java_version}.zip"
+  count=$(zipinfo -1 $(rlocation io_bazel/src/java_tools_${JAVA_TOOLS_JAVA_VERSION}.zip) | grep -c "$path")
+  [[ "$count" -gt 0 ]] || fail "Path $path not found in java_tools_${JAVA_TOOLS_JAVA_VERSION}.zip"
 }
 
 function test_java_tools_has_ijar() {
-  expect_path_in_java_tools "java_tools/ijar" java9
-  expect_path_in_java_tools "java_tools/ijar" java10
+  expect_path_in_java_tools "java_tools/ijar"
 }
 
 function test_java_tools_has_ijar_binary() {
-  expect_path_in_java_tools "java_tools/ijar/ijar" java9
-  expect_path_in_java_tools "java_tools/ijar/ijar" java10
+  expect_path_in_java_tools "java_tools/ijar/ijar"
 }
 
 function test_java_tools_has_zlib() {
-  expect_path_in_java_tools "java_tools/zlib" java9
-  expect_path_in_java_tools "java_tools/zlib" java10
+  expect_path_in_java_tools "java_tools/zlib"
 }
 
 function test_java_tools_has_native_windows() {
-  expect_path_in_java_tools "java_tools/src/main/native/windows" java9
-  expect_path_in_java_tools "java_tools/src/main/native/windows" java10
+  expect_path_in_java_tools "java_tools/src/main/native/windows"
 }
 
 function test_java_tools_has_cpp_util() {
-  expect_path_in_java_tools "java_tools/src/main/cpp/util" java9
-  expect_path_in_java_tools "java_tools/src/main/cpp/util" java10
+  expect_path_in_java_tools "java_tools/src/main/cpp/util"
 }
 
 function test_java_tools_has_desugar_deps() {
-  expect_path_in_java_tools \
-      "java_tools/src/main/protobuf/desugar_deps.proto" java9
-      expect_path_in_java_tools \
-      "java_tools/src/main/protobuf/desugar_deps.proto" java10
+  expect_path_in_java_tools "java_tools/src/main/protobuf/desugar_deps.proto"
 }
 
 function test_java_tools_has_singlejar() {
-  expect_path_in_java_tools "java_tools/src/tools/singlejar" java9
-  expect_path_in_java_tools "java_tools/src/tools/singlejar" java10
+  expect_path_in_java_tools "java_tools/src/tools/singlejar"
 }
 
 function test_java_tools_has_singlejar_local() {
-  expect_path_in_java_tools \
-      "java_tools/src/tools/singlejar/singlejar_local" java9
-      expect_path_in_java_tools \
-      "java_tools/src/tools/singlejar/singlejar_local" java10
+  expect_path_in_java_tools "java_tools/src/tools/singlejar/singlejar_local"
 }
 
 function test_java_tools_has_VanillaJavaBuilder() {
-  expect_path_in_java_tools "java_tools/VanillaJavaBuilder_deploy.jar" java9
-  expect_path_in_java_tools "java_tools/VanillaJavaBuilder_deploy.jar" java10
+  expect_path_in_java_tools "java_tools/VanillaJavaBuilder_deploy.jar"
 }
 
 function test_java_tools_has_JavaBuilder() {
-  expect_path_in_java_tools "java_tools/JavaBuilder_deploy.jar" java9
-  expect_path_in_java_tools "java_tools/JavaBuilder_deploy.jar" java10
+  expect_path_in_java_tools "java_tools/JavaBuilder_deploy.jar"
 }
 
 function test_java_tools_has_turbine_direct() {
-  expect_path_in_java_tools "java_tools/turbine_direct_binary_deploy.jar" java9
-  expect_path_in_java_tools "java_tools/turbine_direct_binary_deploy.jar" java10
+  expect_path_in_java_tools "java_tools/turbine_direct_binary_deploy.jar"
 }
 
 function test_java_tools_has_turbine_deploy() {
-  expect_path_in_java_tools "java_tools/turbine_deploy.jar" java9
-  expect_path_in_java_tools "java_tools/turbine_deploy.jar" java10
+  expect_path_in_java_tools "java_tools/turbine_deploy.jar"
 }
 
 function test_java_tools_has_Runner() {
-  expect_path_in_java_tools "java_tools/Runner_deploy.jar" java9
-  expect_path_in_java_tools "java_tools/Runner_deploy.jar" java10
+  expect_path_in_java_tools "java_tools/Runner_deploy.jar"
 }
 
 function test_java_tools_has_jdk_compiler() {
-  expect_path_in_java_tools "java_tools/jdk_compiler.jar" java9
-  expect_path_in_java_tools "java_tools/jdk_compiler.jar" java10
+  expect_path_in_java_tools "java_tools/jdk_compiler.jar"
 }
 
 function test_java_tools_has_java_compiler() {
-  expect_path_in_java_tools "java_tools/java_compiler.jar" java9
-  expect_path_in_java_tools "java_tools/java_compiler.jar" java10
+  expect_path_in_java_tools "java_tools/java_compiler.jar"
 }
 
 function test_java_tools_has_javac() {
-  expect_path_in_java_tools "java_tools/javac-9+181-r4173-1.jar" java9
+ if [[ "${JAVA_TOOLS_JAVA_VERSION}" == "java9" ]]; then
+  expect_path_in_java_tools "java_tools/javac-9+181-r4173-1.jar"
+ fi
 }
 
 function test_java_tools_has_jarjar() {
-  expect_path_in_java_tools "java_tools/jarjar_command_deploy.jar" java9
-  expect_path_in_java_tools "java_tools/jarjar_command_deploy.jar" java10
+  expect_path_in_java_tools "java_tools/jarjar_command_deploy.jar"
 }
 
 function test_java_tools_has_Jacoco() {
-  expect_path_in_java_tools "java_tools/JacocoCoverage_jarjar_deploy.jar" java9
-  expect_path_in_java_tools "java_tools/JacocoCoverage_jarjar_deploy.jar" java10
+  expect_path_in_java_tools "java_tools/JacocoCoverage_jarjar_deploy.jar"
 }
 
 function test_java_tools_has_GenClass() {
-  expect_path_in_java_tools "java_tools/GenClass_deploy.jar" java9
-  expect_path_in_java_tools "java_tools/GenClass_deploy.jar" java10
+  expect_path_in_java_tools "java_tools/GenClass_deploy.jar"
 }
 
 function test_java_tools_has_ExperimentalRunner() {
-  expect_path_in_java_tools "java_tools/ExperimentalRunner_deploy.jar" java9
-  expect_path_in_java_tools "java_tools/ExperimentalRunner_deploy.jar" java10
+  expect_path_in_java_tools "java_tools/ExperimentalRunner_deploy.jar"
 }
 
 run_suite "Java tools archive tests"

--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -64,89 +64,113 @@ fi
 
 function expect_path_in_java_tools() {
   path="$1"; shift
+  java_version="$1"; shift
 
-  count=$(zipinfo -1 $(rlocation io_bazel/src/java_tools.zip) | grep -c "$path")
-  [[ "$count" -gt 0 ]] || fail "Path $path not found in java_tools"
+  count=$(zipinfo -1 $(rlocation io_bazel/src/java_tools_${java_version}.zip) | grep -c "$path")
+  [[ "$count" -gt 0 ]] || fail "Path $path not found in java_tools_${java_version}.zip"
 }
 
 function test_java_tools_has_ijar() {
-  expect_path_in_java_tools "java_tools/ijar"
+  expect_path_in_java_tools "java_tools/ijar" java9
+  expect_path_in_java_tools "java_tools/ijar" java10
 }
 
 function test_java_tools_has_ijar_binary() {
-  expect_path_in_java_tools "java_tools/ijar/ijar"
+  expect_path_in_java_tools "java_tools/ijar/ijar" java9
+  expect_path_in_java_tools "java_tools/ijar/ijar" java10
 }
 
 function test_java_tools_has_zlib() {
-  expect_path_in_java_tools "java_tools/zlib"
+  expect_path_in_java_tools "java_tools/zlib" java9
+  expect_path_in_java_tools "java_tools/zlib" java10
 }
 
 function test_java_tools_has_native_windows() {
-  expect_path_in_java_tools "java_tools/src/main/native/windows"
+  expect_path_in_java_tools "java_tools/src/main/native/windows" java9
+  expect_path_in_java_tools "java_tools/src/main/native/windows" java10
 }
 
 function test_java_tools_has_cpp_util() {
-  expect_path_in_java_tools "java_tools/src/main/cpp/util"
+  expect_path_in_java_tools "java_tools/src/main/cpp/util" java9
+  expect_path_in_java_tools "java_tools/src/main/cpp/util" java10
 }
 
 function test_java_tools_has_desugar_deps() {
-  expect_path_in_java_tools "java_tools/src/main/protobuf/desugar_deps.proto"
+  expect_path_in_java_tools \
+      "java_tools/src/main/protobuf/desugar_deps.proto" java9
+      expect_path_in_java_tools \
+      "java_tools/src/main/protobuf/desugar_deps.proto" java10
 }
 
 function test_java_tools_has_singlejar() {
-  expect_path_in_java_tools "java_tools/src/tools/singlejar"
+  expect_path_in_java_tools "java_tools/src/tools/singlejar" java9
+  expect_path_in_java_tools "java_tools/src/tools/singlejar" java10
 }
 
 function test_java_tools_has_singlejar_local() {
-  expect_path_in_java_tools "java_tools/src/tools/singlejar/singlejar_local"
+  expect_path_in_java_tools \
+      "java_tools/src/tools/singlejar/singlejar_local" java9
+      expect_path_in_java_tools \
+      "java_tools/src/tools/singlejar/singlejar_local" java10
 }
 
 function test_java_tools_has_VanillaJavaBuilder() {
-  expect_path_in_java_tools "java_tools/VanillaJavaBuilder_deploy.jar"
+  expect_path_in_java_tools "java_tools/VanillaJavaBuilder_deploy.jar" java9
+  expect_path_in_java_tools "java_tools/VanillaJavaBuilder_deploy.jar" java10
 }
 
 function test_java_tools_has_JavaBuilder() {
-  expect_path_in_java_tools "java_tools/JavaBuilder_deploy.jar"
+  expect_path_in_java_tools "java_tools/JavaBuilder_deploy.jar" java9
+  expect_path_in_java_tools "java_tools/JavaBuilder_deploy.jar" java10
 }
 
 function test_java_tools_has_turbine_direct() {
-  expect_path_in_java_tools "java_tools/turbine_direct_binary_deploy.jar"
+  expect_path_in_java_tools "java_tools/turbine_direct_binary_deploy.jar" java9
+  expect_path_in_java_tools "java_tools/turbine_direct_binary_deploy.jar" java10
 }
 
 function test_java_tools_has_turbine_deploy() {
-  expect_path_in_java_tools "java_tools/turbine_deploy.jar"
+  expect_path_in_java_tools "java_tools/turbine_deploy.jar" java9
+  expect_path_in_java_tools "java_tools/turbine_deploy.jar" java10
 }
 
 function test_java_tools_has_Runner() {
-  expect_path_in_java_tools "java_tools/Runner_deploy.jar"
+  expect_path_in_java_tools "java_tools/Runner_deploy.jar" java9
+  expect_path_in_java_tools "java_tools/Runner_deploy.jar" java10
 }
 
 function test_java_tools_has_jdk_compiler() {
-  expect_path_in_java_tools "java_tools/jdk_compiler"
+  expect_path_in_java_tools "java_tools/jdk_compiler.jar" java9
+  expect_path_in_java_tools "java_tools/jdk_compiler.jar" java10
 }
 
 function test_java_tools_has_java_compiler() {
-  expect_path_in_java_tools "java_tools/java_compiler"
+  expect_path_in_java_tools "java_tools/java_compiler.jar" java9
+  expect_path_in_java_tools "java_tools/java_compiler.jar" java10
 }
 
 function test_java_tools_has_javac() {
-  expect_path_in_java_tools "java_tools/javac-9+181-r4173-1.jar"
+  expect_path_in_java_tools "java_tools/javac-9+181-r4173-1.jar" java9
 }
 
 function test_java_tools_has_jarjar() {
-  expect_path_in_java_tools "java_tools/jarjar_command_deploy.jar"
+  expect_path_in_java_tools "java_tools/jarjar_command_deploy.jar" java9
+  expect_path_in_java_tools "java_tools/jarjar_command_deploy.jar" java10
 }
 
 function test_java_tools_has_Jacoco() {
-  expect_path_in_java_tools "java_tools/JacocoCoverage_jarjar_deploy.jar"
+  expect_path_in_java_tools "java_tools/JacocoCoverage_jarjar_deploy.jar" java9
+  expect_path_in_java_tools "java_tools/JacocoCoverage_jarjar_deploy.jar" java10
 }
 
 function test_java_tools_has_GenClass() {
-  expect_path_in_java_tools "java_tools/GenClass_deploy.jar"
+  expect_path_in_java_tools "java_tools/GenClass_deploy.jar" java9
+  expect_path_in_java_tools "java_tools/GenClass_deploy.jar" java10
 }
 
 function test_java_tools_has_ExperimentalRunner() {
-  expect_path_in_java_tools "java_tools/ExperimentalRunner_deploy.jar"
+  expect_path_in_java_tools "java_tools/ExperimentalRunner_deploy.jar" java9
+  expect_path_in_java_tools "java_tools/ExperimentalRunner_deploy.jar" java10
 }
 
 run_suite "Java tools archive tests"

--- a/src/upload_java_tools.sh
+++ b/src/upload_java_tools.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script to upload a given java_tools zip on GCS. Used by the java_tools_binaries
+# Buildkite pipeline. It is not recommended to run this script manually.
+#
+# Mandatory flags:
+# --java_tools_zip       The workspace-relative path of a java_tools zip.
+# --gcs_java_tools_dir   The directory under bazel_java_tools on GCS where the zip is uploaded.
+# --java_version         The version of the javac the given zip embeds.
+# --platform             The name of the platform where the zip was built.
+
+set -euo pipefail
+
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+    if [[ -f "$0.runfiles_manifest" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+      export RUNFILES_DIR="$0.runfiles"
+    fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+# Parsing the flags.
+while [[ -n "$@" ]]; do
+  arg="$1"; shift
+  val="$1"; shift
+  case "$arg" in
+    "--java_tools_zip") java_tools_zip_name="$val" ;;
+    "--gcs_java_tools_dir") gcs_java_tools_dir="$val" ;;
+    "--java_version") java_version="$val" ;;
+    "--platform") platform="$val" ;;
+    *) echo "Flag $arg is not recognized." && exit 1 ;;
+  esac
+done
+
+java_tools_zip=$(rlocation io_bazel/${java_tools_zip_name})
+
+gsutil_cmd="gsutil"
+if [[ "$platform" == "windows" ]]; then
+  gsutil_cmd="gsutil.cmd"
+fi
+
+"$gsutil_cmd" cp "$java_tools_zip" \
+ "gs://bazel-mirror/bazel_java_tools/${gcs_java_tools_dir}/java_tools_javac${java_version}_${platform}-$(date +%s).zip"


### PR DESCRIPTION
The [bazelbuild/java_tools repo](https://github.com/bazelbuild/java_tools.git) now has branches for different versions of the javac jars:
* langtools_javac9
* langtools_javac10

This PR adds targets for building and uploading to GCS the zips for both Java 9 and Java 10. The [java_tools binaries Buildkite pipeline](https://buildkite.com/bazel-trusted/java-tools-binaries-java) runs the targets for uploading to GCS the release and dist zips.