### PR TITLE
Remove reference to Homebrew tap pinning

### DIFF
--- a/site/docs/install-os-x.md
+++ b/site/docs/install-os-x.md
@@ -94,7 +94,6 @@ Install the Bazel package via Homebrew as follows:
 
 ```bash
 brew tap bazelbuild/tap
-brew tap-pin bazelbuild/tap
 brew install bazelbuild/tap/bazel
 ```
 


### PR DESCRIPTION
Tap pinning is deprecated (Homebrew/brew#5925) in favor of using the fully qualified name.