### PR TITLE
fix zip64_test to work with absolute $(JAVABASE)

### DIFF
--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -327,6 +327,7 @@ cc_test(
 sh_test(
     name = "zip64_test",
     srcs = ["zip64_test.sh"],
+    args = ["$(JAVABASE)"],
     data = [
         ":singlejar",
         "//src/test/shell:bashunit",

--- a/src/tools/singlejar/zip64_test.sh
+++ b/src/tools/singlejar/zip64_test.sh
@@ -53,7 +53,15 @@ else
 fi
 
 singlejar="$(rlocation "io_bazel/src/tools/singlejar/singlejar${EXE_EXT}")"
-jartool="$(rlocation "local_jdk/bin/jar${EXE_EXT}")"
+javabase="$1"
+if [[ $javabase = /* ]]; then
+  jartool="$1/bin/jar${EXE_EXT}"
+else
+  if [[ $javabase = external/* ]]; then
+    javabase=${javabase#"external/"}
+  fi
+  jartool="$(rlocation "${javabase}/bin/jar${EXE_EXT}")"
+fi
 
 # Test that an archive with >64K entries can be created.
 function test_65Kentries() {

--- a/src/tools/singlejar/zip64_test.sh
+++ b/src/tools/singlejar/zip64_test.sh
@@ -54,7 +54,7 @@ fi
 
 singlejar="$(rlocation "io_bazel/src/tools/singlejar/singlejar${EXE_EXT}")"
 javabase="$1"
-if [[ $javabase = /* ]]; then
+if [[ $javabase = /* || $javabase =~ [A-Za-z]:[/\\] ]]; then
   jartool="$1/bin/jar${EXE_EXT}"
 else
   if [[ $javabase = external/* ]]; then

--- a/src/tools/singlejar/zip64_test.sh
+++ b/src/tools/singlejar/zip64_test.sh
@@ -58,7 +58,7 @@ if [[ $javabase = /* ]]; then
   jartool="$1/bin/jar${EXE_EXT}"
 else
   if [[ $javabase = external/* ]]; then
-    javabase=${javabase#"external/"}
+    javabase=${javabase#external/}
   fi
   jartool="$(rlocation "${javabase}/bin/jar${EXE_EXT}")"
 fi


### PR DESCRIPTION
Tested with an absolute $(JAVABASE) and --(no)legacy_external_runfiles.

Progress towards #8033