### PR TITLE
fix discard_analysis_cachetest.sh to properly depend on $(JAVABASE)

### DIFF
--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -202,9 +202,14 @@ sh_test(
 sh_test(
     name = "discard_analysis_cache_test",
     size = "medium",
+    args = ["$(JAVABASE)"],
     srcs = ["discard_analysis_cache_test.sh"],
-    data = [":test-deps"],
+    data = [
+        ":test-deps",
+         "@bazel_tools//tools/bash/runfiles",
+    ],
     tags = ["no_windows"],
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
 )
 
 sh_test(

--- a/src/test/shell/integration/discard_analysis_cache_test.sh
+++ b/src/test/shell/integration/discard_analysis_cache_test.sh
@@ -16,11 +16,6 @@
 #
 # A test for --discard_analysis_cache.
 
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../integration_test_setup.sh" \
-  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
-
 # --- begin runfiles.bash initialization ---
 if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
     if [[ -f "$0.runfiles_manifest" ]]; then
@@ -42,6 +37,9 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
 IS_WINDOWS=false
 case "$(uname | tr [:upper:] [:lower:])" in
 msys*|mingw*|cygwin*)
@@ -55,14 +53,10 @@ else
 fi
 
 javabase="$1"
-if [[ $javabase = /* || $javabase =~ [A-Za-z]:[/\\] ]]; then
-  jmaptool="$1/bin/jmap${EXE_EXT}"
-else
-  if [[ $javabase = external/* ]]; then
-    javabase=${javabase#external/}
-  fi
-  jmaptool="$(rlocation "${javabase}/bin/jmap${EXE_EXT}")"
+if [[ $javabase = external/* ]]; then
+  javabase=${javabase#external/}
 fi
+jmaptool="$(rlocation "${javabase}/bin/jmap${EXE_EXT}")"
 
 function write_hello_world_files() {
   mkdir -p hello || fail "mkdir hello failed"

--- a/src/test/shell/integration/discard_analysis_cache_test.sh
+++ b/src/test/shell/integration/discard_analysis_cache_test.sh
@@ -21,6 +21,49 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CURRENT_DIR}/../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+    if [[ -f "$0.runfiles_manifest" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+      export RUNFILES_DIR="$0.runfiles"
+    fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+IS_WINDOWS=false
+case "$(uname | tr [:upper:] [:lower:])" in
+msys*|mingw*|cygwin*)
+  IS_WINDOWS=true
+esac
+
+if "$IS_WINDOWS"; then
+  EXE_EXT=".exe"
+else
+  EXE_EXT=""
+fi
+
+javabase="$1"
+if [[ $javabase = /* || $javabase =~ [A-Za-z]:[/\\] ]]; then
+  jmaptool="$1/bin/jmap${EXE_EXT}"
+else
+  if [[ $javabase = external/* ]]; then
+    javabase=${javabase#external/}
+  fi
+  jmaptool="$(rlocation "${javabase}/bin/jmap${EXE_EXT}")"
+fi
+
 function write_hello_world_files() {
   mkdir -p hello || fail "mkdir hello failed"
   cat >hello/BUILD <<EOF
@@ -113,7 +156,7 @@ EOF
   new_server_pid="$(bazel info server_pid 2>> "$TEST_log")"
   [[ "$server_pid" == "$new_server_pid" ]] \
       || fail "unequal pids: $server_pid, $new_server_pid"
-  "$bazel_javabase"/bin/jmap -histo:live "$server_pid" > histo.txt
+  "$jmaptool" -histo:live "$server_pid" > histo.txt
   cat histo.txt >> "$TEST_log"
   ct_count="$(extract_histogram_count histo.txt 'RuleConfiguredTarget$')"
   aspect_count="$(extract_histogram_count histo.txt 'ConfiguredAspect$')"
@@ -125,7 +168,7 @@ EOF
   server_pid="$(bazel info server_pid 2> /dev/null)"
   bazel build --discard_analysis_cache //foo:foo >& "$TEST_log" \
       || fail "Expected success"
-  "$bazel_javabase"/bin/jmap -histo:live "$server_pid" > histo.txt
+  "$jmaptool" -histo:live "$server_pid" > histo.txt
   cat histo.txt >> "$TEST_log"
   ct_count="$(extract_histogram_count histo.txt 'RuleConfiguredTarget$')"
   aspect_count="$(extract_histogram_count histo.txt 'ConfiguredAspect$')"
@@ -143,7 +186,7 @@ EOF
   [[ -e "bazel-bin/foo/dep.out.aspect" ]] || fail "Aspect bar not run"
   # Make sure to clear out garbage, sometimes a spare aspect hangs around.
   bazel info used-heap-size-after-gc >& /dev/null
-  "$bazel_javabase"/bin/jmap -histo:live "$server_pid" > histo.txt
+  "$jmaptool" -histo:live "$server_pid" > histo.txt
   cat histo.txt >> "$TEST_log"
   ct_count="$(extract_histogram_count histo.txt 'RuleConfiguredTarget$')"
   aspect_count="$(extract_histogram_count histo.txt 'ConfiguredAspect$')"


### PR DESCRIPTION
- no longer uses $bazel_javabase from testenv.sh
- works with absolute $(JAVABASE) paths and JDK's other than local_jdk

Progress towards #8033