### PR TITLE
fix nonincremental_builds_test to properly depend on $(JAVABASE)

### DIFF
--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -408,11 +408,13 @@ sh_test(
     name = "nonincremental_builds_test",
     size = "medium",
     srcs = ["nonincremental_builds_test.sh"],
+    args = ["$(JAVABASE)"],
     data = [
         ":discard_graph_edges_lib.sh",
         ":test-deps",
         "@bazel_tools//tools/bash/runfiles",
     ],
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
 )
 
 sh_test(

--- a/src/test/shell/integration/nonincremental_builds_test.sh
+++ b/src/test/shell/integration/nonincremental_builds_test.sh
@@ -70,16 +70,11 @@ else
   EXE_EXT=""
 fi
 
- javabase="$1"
-if [[ $javabase = /* || $javabase =~ [A-Za-z]:[/\\] ]]; then
-  jmaptool="$1/bin/jmap${EXE_EXT}"
-else
-  if [[ $javabase = external/* ]]; then
-    javabase=${javabase#external/}
-  fi
-  jmaptool="$(rlocation "${javabase}/bin/jmap${EXE_EXT}")"
+javabase="$1"
+if [[ $javabase = external/* ]]; then
+  javabase=${javabase#external/}
 fi
-
+jmaptool="$(rlocation "${javabase}/bin/jmap${EXE_EXT}")"
 
 if ! type try_with_timeout >&/dev/null; then
   # Bazel's testenv.sh defines try_with_timeout but the Google-internal version


### PR DESCRIPTION
- no longer uses $bazel_javabase from testenv.sh
- works with absolute $(JAVABASE) paths and JDK's other than loc

Progress towards #8033