### PR TITLE
have bazel_example_test.sh properly depend on

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -67,12 +67,15 @@ sh_test(
     name = "bazel_example_test",
     size = "large",
     srcs = ["bazel_example_test.sh"],
+    args = ["$(JAVABASE)"],
     data = [
         ":test-deps",
         "//src/test/shell/bazel/apple:objc-deps",
+        "@bazel_tools//tools/bash/runfiles",
     ],
     shard_count = 3,
     tags = ["no_windows"],
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
 )
 
 sh_test(

--- a/src/test/shell/bazel/bazel_example_test.sh
+++ b/src/test/shell/bazel/bazel_example_test.sh
@@ -16,13 +16,8 @@
 #
 # Tests the examples provided in Bazel
 #
-
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../integration_test_setup.sh" \
-  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
-
 # --- begin runfiles.bash initialization ---
+set -euo pipefail
 if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
     if [[ -f "$0.runfiles_manifest" ]]; then
       export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
@@ -42,6 +37,9 @@ else
   exit 1
 fi
 # --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 # $1 is equal to the $(JAVABASE) make variable
 javabase="$1"

--- a/src/test/shell/bin/bazel
+++ b/src/test/shell/bin/bazel
@@ -22,4 +22,5 @@ bazel_bin=$(rlocation io_bazel/src/bazel)
 # has to detect its own runfiles
 unset RUNFILES_DIR
 unset RUNFILES_MANIFEST_FILE
+unset RUNFILES_MANIFEST_ONLY
 exec $bazel_bin --bazelrc=$TEST_TMPDIR/bazelrc "$@"

--- a/src/test/shell/bin/bazel
+++ b/src/test/shell/bin/bazel
@@ -17,4 +17,9 @@
 # Wrapper script to run bazel in the tests. Any change to this file will
 # affect all our integration tests.
 #
-exec $(rlocation io_bazel/src/bazel) --bazelrc=$TEST_TMPDIR/bazelrc "$@"
+bazel_bin=$(rlocation io_bazel/src/bazel)
+# unset runfiles environment so that the "inner bazel"
+# has to detect its own runfiles
+unset RUNFILES_DIR
+unset RUNFILES_MANIFEST_FILE
+exec $bazel_bin --bazelrc=$TEST_TMPDIR/bazelrc "$@"


### PR DESCRIPTION
- no longer uses $bazel_javabase from testenv.sh
- works with absolute $(JAVABASE) paths and JDK's other than
  local_jdk.

Progress towards #8033