### PR TITLE
Move UnloadedToolchainContext.load to ResolvedToolchainContext.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ResolvedToolchainContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ResolvedToolchainContext.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
+import com.google.devtools.build.lib.analysis.platform.PlatformProviderUtils;
 import com.google.devtools.build.lib.analysis.platform.ToolchainInfo;
 import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -28,6 +29,9 @@ import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.events.Location;
+import com.google.devtools.build.lib.rules.AliasConfiguredTarget;
+import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
+import com.google.devtools.build.lib.skyframe.ToolchainException;
 import com.google.devtools.build.lib.skylarkbuildapi.ToolchainContextApi;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkPrinter;
 import com.google.devtools.build.lib.skylarkinterface.StarlarkContext;
@@ -46,8 +50,64 @@ import javax.annotation.Nullable;
 @ThreadSafe
 public abstract class ResolvedToolchainContext implements ToolchainContextApi, ToolchainContext {
 
-  static Builder builder() {
-    return new AutoValue_ResolvedToolchainContext.Builder();
+  /**
+   * Finishes preparing the {@link ResolvedToolchainContext} by finding the specific toolchain
+   * providers to be used for each toolchain type.
+   */
+  public static ResolvedToolchainContext load(
+      UnloadedToolchainContext unloadedToolchainContext,
+      String targetDescription,
+      Iterable<ConfiguredTargetAndData> toolchainTargets)
+      throws ToolchainException {
+
+    ResolvedToolchainContext.Builder toolchainContext =
+        new AutoValue_ResolvedToolchainContext.Builder()
+            .setTargetDescription(targetDescription)
+            .setExecutionPlatform(unloadedToolchainContext.executionPlatform())
+            .setTargetPlatform(unloadedToolchainContext.targetPlatform())
+            .setRequiredToolchainTypes(unloadedToolchainContext.requiredToolchainTypes())
+            .setResolvedToolchainLabels(unloadedToolchainContext.resolvedToolchainLabels());
+
+    ImmutableMap.Builder<ToolchainTypeInfo, ToolchainInfo> toolchains =
+        new ImmutableMap.Builder<>();
+    ImmutableList.Builder<TemplateVariableInfo> templateVariableProviders =
+        new ImmutableList.Builder<>();
+    for (ConfiguredTargetAndData target : toolchainTargets) {
+      Label discoveredLabel;
+      // Aliases are in toolchainTypeToResolved by the original alias label, not via the final
+      // target's label.
+      if (target.getConfiguredTarget() instanceof AliasConfiguredTarget) {
+        discoveredLabel = ((AliasConfiguredTarget) target.getConfiguredTarget()).getOriginalLabel();
+      } else {
+        discoveredLabel = target.getConfiguredTarget().getLabel();
+      }
+      ToolchainTypeInfo toolchainType =
+          unloadedToolchainContext.toolchainTypeToResolved().inverse().get(discoveredLabel);
+      ToolchainInfo toolchainInfo = PlatformProviderUtils.toolchain(target.getConfiguredTarget());
+
+      // If the toolchainType hadn't been resolved to an actual target, resolution would have
+      // failed with an error much earlier. However, the target might still not be an actual
+      // toolchain.
+      if (toolchainType != null) {
+        if (toolchainInfo != null) {
+          toolchains.put(toolchainType, toolchainInfo);
+        } else {
+          throw new TargetNotToolchainException(toolchainType, discoveredLabel);
+        }
+      }
+
+      // Find any template variables present for this toolchain.
+      TemplateVariableInfo templateVariableInfo =
+          target.getConfiguredTarget().get(TemplateVariableInfo.PROVIDER);
+      if (templateVariableInfo != null) {
+        templateVariableProviders.add(templateVariableInfo);
+      }
+    }
+
+    return toolchainContext
+        .setToolchains(toolchains.build())
+        .setTemplateVariableProviders(templateVariableProviders.build())
+        .build();
   }
 
   /** Builder interface to help create new instances of {@link ResolvedToolchainContext}. */
@@ -178,5 +238,19 @@ public abstract class ResolvedToolchainContext implements ToolchainContextApi, T
             .filter(label -> label.equals(toolchainTypeLabel))
             .findAny();
     return matching.isPresent();
+  }
+
+  /**
+   * Exception used when a toolchain type is required but the resolved target does not have
+   * ToolchainInfo.
+   */
+  static final class TargetNotToolchainException extends ToolchainException {
+    TargetNotToolchainException(ToolchainTypeInfo toolchainType, Label resolvedTargetLabel) {
+      super(
+          String.format(
+              "toolchain type %s resolved to target %s, but that target does not provide"
+                  + " ToolchainInfo",
+              toolchainType.typeLabel(), resolvedTargetLabel));
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/ResolvedToolchainContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ResolvedToolchainContext.java
@@ -248,8 +248,8 @@ public abstract class ResolvedToolchainContext implements ToolchainContextApi, T
     TargetNotToolchainException(ToolchainTypeInfo toolchainType, Label resolvedTargetLabel) {
       super(
           String.format(
-              "toolchain type %s resolved to target %s, but that target does not provide"
-                  + " ToolchainInfo",
+              "toolchain type %s resolved to target %s, but that target does not provide "
+                  + ToolchainInfo.SKYLARK_NAME,
               toolchainType.typeLabel(), resolvedTargetLabel));
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/ToolchainResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ToolchainResolver.java
@@ -63,7 +63,6 @@ public class ToolchainResolver {
   private final BuildConfigurationValue.Key configurationKey;
 
   // Optional data.
-  private String targetDescription = "";
   private ImmutableSet<Label> requiredToolchainTypeLabels = ImmutableSet.of();
   private ImmutableSet<Label> execConstraintLabels = ImmutableSet.of();
 
@@ -80,15 +79,6 @@ public class ToolchainResolver {
   public ToolchainResolver(Environment env, BuildConfigurationValue.Key configurationKey) {
     this.environment = checkNotNull(env);
     this.configurationKey = checkNotNull(configurationKey);
-  }
-
-  /**
-   * Sets a description of the target that toolchains will be resolved for. This is primarily useful
-   * for printing informative error messages, so that users can tell which targets had difficulty.
-   */
-  public ToolchainResolver setTargetDescription(String targetDescription) {
-    this.targetDescription = targetDescription;
-    return this;
   }
 
   /**
@@ -117,7 +107,7 @@ public class ToolchainResolver {
    * then an {@link UnloadedToolchainContext} generated. The {@link UnloadedToolchainContext} will
    * report the specific toolchain targets to depend on, and those can be found using the typical
    * dependency machinery. Once dependencies, including toolchains, have been loaded, the {@link
-   * UnloadedToolchainContext#load} method can be called to generate the final {@link
+   * ResolvedToolchainContext#load} method can be called to generate the final {@link
    * ResolvedToolchainContext} to be used by the target.
    *
    * <p>This makes several SkyFrame calls, particularly to {@link
@@ -133,7 +123,6 @@ public class ToolchainResolver {
     try {
       UnloadedToolchainContext.Builder unloadedToolchainContext =
           UnloadedToolchainContext.builder();
-      unloadedToolchainContext.setTargetDescription(targetDescription);
 
       // Determine the configuration being used.
       BuildConfigurationValue value =

--- a/src/main/java/com/google/devtools/build/lib/analysis/UnloadedToolchainContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/UnloadedToolchainContext.java
@@ -42,9 +42,6 @@ public abstract class UnloadedToolchainContext implements ToolchainContext {
   /** Builder class to help create the {@link UnloadedToolchainContext}. */
   @AutoValue.Builder
   public interface Builder {
-    /** Sets a description of the target being used, for error messaging. */
-    Builder setTargetDescription(String targetDescription);
-
     /** Sets the selected execution platform that these toolchains use. */
     Builder setExecutionPlatform(PlatformInfo executionPlatform);
 
@@ -60,84 +57,11 @@ public abstract class UnloadedToolchainContext implements ToolchainContext {
     UnloadedToolchainContext build();
   }
 
-  /** Returns a description of the target being used, for error messaging. */
-  abstract String targetDescription();
-
   /** The map of toolchain type to resolved toolchain to be used. */
   abstract ImmutableBiMap<ToolchainTypeInfo, Label> toolchainTypeToResolved();
 
   @Override
   public ImmutableSet<Label> resolvedToolchainLabels() {
     return toolchainTypeToResolved().values();
-  }
-
-  /**
-   * Finishes preparing the {@link ResolvedToolchainContext} by finding the specific toolchain
-   * providers to be used for each toolchain type.
-   */
-  public ResolvedToolchainContext load(Iterable<ConfiguredTargetAndData> toolchainTargets)
-      throws ToolchainException {
-
-    ResolvedToolchainContext.Builder toolchainContext =
-        ResolvedToolchainContext.builder()
-            .setTargetDescription(targetDescription())
-            .setExecutionPlatform(executionPlatform())
-            .setTargetPlatform(targetPlatform())
-            .setRequiredToolchainTypes(requiredToolchainTypes())
-            .setResolvedToolchainLabels(resolvedToolchainLabels());
-
-    ImmutableMap.Builder<ToolchainTypeInfo, ToolchainInfo> toolchains =
-        new ImmutableMap.Builder<>();
-    ImmutableList.Builder<TemplateVariableInfo> templateVariableProviders =
-        new ImmutableList.Builder<>();
-    for (ConfiguredTargetAndData target : toolchainTargets) {
-      Label discoveredLabel;
-      // Aliases are in toolchainTypeToResolved by the original alias label, not via the final
-      // target's label.
-      if (target.getConfiguredTarget() instanceof AliasConfiguredTarget) {
-        discoveredLabel = ((AliasConfiguredTarget) target.getConfiguredTarget()).getOriginalLabel();
-      } else {
-        discoveredLabel = target.getConfiguredTarget().getLabel();
-      }
-      ToolchainTypeInfo toolchainType = toolchainTypeToResolved().inverse().get(discoveredLabel);
-      ToolchainInfo toolchainInfo = PlatformProviderUtils.toolchain(target.getConfiguredTarget());
-
-      // If the toolchainType hadn't been resolved to an actual target, resolution would have
-      // failed with an error much earlier. However, the target might still not be an actual
-      // toolchain.
-      if (toolchainType != null) {
-        if (toolchainInfo != null) {
-          toolchains.put(toolchainType, toolchainInfo);
-        } else {
-          throw new TargetNotToolchainException(toolchainType, discoveredLabel);
-        }
-      }
-
-      // Find any template variables present for this toolchain.
-      TemplateVariableInfo templateVariableInfo =
-          target.getConfiguredTarget().get(TemplateVariableInfo.PROVIDER);
-      if (templateVariableInfo != null) {
-        templateVariableProviders.add(templateVariableInfo);
-      }
-    }
-
-    return toolchainContext
-        .setToolchains(toolchains.build())
-        .setTemplateVariableProviders(templateVariableProviders.build())
-        .build();
-  }
-
-  /**
-   * Exception used when a toolchain type is required but the resolved target does not have
-   * ToolchainInfo.
-   */
-  static final class TargetNotToolchainException extends ToolchainException {
-    TargetNotToolchainException(ToolchainTypeInfo toolchainType, Label resolvedTargetLabel) {
-      super(
-          String.format(
-              "toolchain type %s resolved to target %s, but that target does not provide"
-                  + " ToolchainInfo",
-              toolchainType.typeLabel(), resolvedTargetLabel));
-    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
@@ -415,11 +415,6 @@ public final class AspectFunction implements SkyFunction {
           ImmutableSet<Label> requiredToolchains = aspect.getDefinition().getRequiredToolchains();
           unloadedToolchainContext =
               new ToolchainResolver(env, BuildConfigurationValue.key(configuration))
-                  .setTargetDescription(
-                      String.format(
-                          "aspect %s applied to %s",
-                          aspect.getDescriptor().getDescription(),
-                          associatedConfiguredTargetAndData.getTarget()))
                   .setRequiredToolchainTypes(requiredToolchains)
                   .resolve();
         } catch (ToolchainException e) {
@@ -463,8 +458,16 @@ public final class AspectFunction implements SkyFunction {
       // Load the requested toolchains into the ToolchainContext, now that we have dependencies.
       ResolvedToolchainContext toolchainContext = null;
       if (unloadedToolchainContext != null) {
+        String targetDescription =
+            String.format(
+                "aspect %s applied to %s",
+                aspect.getDescriptor().getDescription(),
+                associatedConfiguredTargetAndData.getTarget());
         toolchainContext =
-            unloadedToolchainContext.load(depValueMap.get(DependencyResolver.TOOLCHAIN_DEPENDENCY));
+            ResolvedToolchainContext.load(
+                unloadedToolchainContext,
+                targetDescription,
+                depValueMap.get(DependencyResolver.TOOLCHAIN_DEPENDENCY));
       }
 
       return createAspect(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
@@ -306,7 +306,6 @@ public final class ConfiguredTargetFunction implements SkyFunction {
           ImmutableSet<Label> execConstraintLabels = getExecutionPlatformConstraints(rule);
           unloadedToolchainContext =
               new ToolchainResolver(env, configuredTargetKey.getConfigurationKey())
-                  .setTargetDescription(rule.toString())
                   .setRequiredToolchainTypes(requiredToolchains)
                   .setExecConstraintLabels(execConstraintLabels)
                   .resolve();
@@ -345,8 +344,12 @@ public final class ConfiguredTargetFunction implements SkyFunction {
       // Load the requested toolchains into the ToolchainContext, now that we have dependencies.
       ResolvedToolchainContext toolchainContext = null;
       if (unloadedToolchainContext != null) {
+        String targetDescription = target.toString();
         toolchainContext =
-            unloadedToolchainContext.load(depValueMap.get(DependencyResolver.TOOLCHAIN_DEPENDENCY));
+            ResolvedToolchainContext.load(
+                unloadedToolchainContext,
+                targetDescription,
+                depValueMap.get(DependencyResolver.TOOLCHAIN_DEPENDENCY));
       }
 
       ConfiguredTargetValue ans =

--- a/src/test/java/com/google/devtools/build/lib/analysis/ResolvedToolchainContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/ResolvedToolchainContextTest.java
@@ -1,0 +1,154 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.analysis;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.testutil.MoreAsserts.assertThrows;
+
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.rules.platform.ToolchainTestCase;
+import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
+import com.google.devtools.build.lib.skyframe.ToolchainException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ResolvedToolchainContext}. */
+@RunWith(JUnit4.class)
+public class ResolvedToolchainContextTest extends ToolchainTestCase {
+
+  @Test
+  public void unloadedToolchainContext_load() throws Exception {
+    addToolchain(
+        "extra",
+        "extra_toolchain_linux",
+        ImmutableList.of("//constraints:linux"),
+        ImmutableList.of("//constraints:linux"),
+        "baz");
+
+    // Create a static UnloadedToolchainContext.
+    UnloadedToolchainContext unloadedToolchainContext =
+        UnloadedToolchainContext.builder()
+            .setExecutionPlatform(linuxPlatform)
+            .setTargetPlatform(linuxPlatform)
+            .setRequiredToolchainTypes(ImmutableSet.of(testToolchainType))
+            .setToolchainTypeToResolved(
+                ImmutableBiMap.<ToolchainTypeInfo, Label>builder()
+                    .put(
+                        testToolchainType,
+                        Label.parseAbsoluteUnchecked("//extra:extra_toolchain_linux_impl"))
+                    .build())
+            .build();
+
+    // Create the prerequisites.
+    ConfiguredTargetAndData toolchain =
+        getConfiguredTargetAndData(
+            Label.parseAbsoluteUnchecked("//extra:extra_toolchain_linux_impl"), targetConfig);
+
+    // Resolve toolchains.
+    ResolvedToolchainContext toolchainContext =
+        ResolvedToolchainContext.load(
+            unloadedToolchainContext, "test", ImmutableList.of(toolchain));
+    assertThat(toolchainContext).isNotNull();
+    assertThat(toolchainContext.forToolchainType(testToolchainType)).isNotNull();
+    assertThat(toolchainContext.forToolchainType(testToolchainType).hasField("data")).isTrue();
+    assertThat(toolchainContext.forToolchainType(testToolchainType).getValue("data"))
+        .isEqualTo("baz");
+  }
+
+  @Test
+  public void unloadedToolchainContext_load_notToolchain() throws Exception {
+    scratch.file("foo/BUILD", "filegroup(name = 'not_a_toolchain')");
+
+    // Create a static UnloadedToolchainContext.
+    UnloadedToolchainContext unloadedToolchainContext =
+        UnloadedToolchainContext.builder()
+            .setExecutionPlatform(linuxPlatform)
+            .setTargetPlatform(linuxPlatform)
+            .setRequiredToolchainTypes(ImmutableSet.of(testToolchainType))
+            .setToolchainTypeToResolved(
+                ImmutableBiMap.<ToolchainTypeInfo, Label>builder()
+                    .put(testToolchainType, Label.parseAbsoluteUnchecked("//foo:not_a_toolchain"))
+                    .build())
+            .build();
+
+    // Create the prerequisites, which is not actually a valid toolchain.
+    ConfiguredTargetAndData toolchain =
+        getConfiguredTargetAndData(
+            Label.parseAbsoluteUnchecked("//foo:not_a_toolchain"), targetConfig);
+    assertThrows(
+        ToolchainException.class,
+        () ->
+            ResolvedToolchainContext.load(
+                unloadedToolchainContext, "test", ImmutableList.of(toolchain)));
+  }
+
+  @Test
+  public void unloadedToolchainContext_load_withTemplateVariables() throws Exception {
+    // Add new toolchain rule that provides template variables.
+    Label variableToolchainTypeLabel =
+        Label.parseAbsoluteUnchecked("//variable:variable_toolchain_type");
+    ToolchainTypeInfo variableToolchainType = ToolchainTypeInfo.create(variableToolchainTypeLabel);
+    scratch.file(
+        "variable/variable_toolchain_def.bzl",
+        "def _impl(ctx):",
+        "  value = ctx.attr.value",
+        "  toolchain = platform_common.ToolchainInfo()",
+        "  template_variables = platform_common.TemplateVariableInfo({'VALUE': value})",
+        "  return [toolchain, template_variables]",
+        "variable_toolchain = rule(",
+        "    implementation = _impl,",
+        "    attrs = {'value': attr.string()})");
+
+    // Create instance of new toolchain and register it.
+    scratch.file(
+        "variable/BUILD",
+        "load('//variable:variable_toolchain_def.bzl', 'variable_toolchain')",
+        "toolchain_type(name = 'variable_toolchain_type')",
+        "variable_toolchain(",
+        "  name='variable_toolchain_impl',",
+        "  value = 'foo')");
+
+    // Create a static UnloadedToolchainContext.
+    UnloadedToolchainContext unloadedToolchainContext =
+        UnloadedToolchainContext.builder()
+            .setExecutionPlatform(linuxPlatform)
+            .setTargetPlatform(linuxPlatform)
+            .setRequiredToolchainTypes(ImmutableSet.of(variableToolchainType))
+            .setToolchainTypeToResolved(
+                ImmutableBiMap.<ToolchainTypeInfo, Label>builder()
+                    .put(
+                        variableToolchainType,
+                        Label.parseAbsoluteUnchecked("//variable:variable_toolchain_impl"))
+                    .build())
+            .build();
+
+    // Create the prerequisites.
+    ConfiguredTargetAndData toolchain =
+        getConfiguredTargetAndData(
+            Label.parseAbsoluteUnchecked("//variable:variable_toolchain_impl"), targetConfig);
+    ResolvedToolchainContext toolchainContext =
+        ResolvedToolchainContext.load(
+            unloadedToolchainContext, "test", ImmutableList.of(toolchain));
+    assertThat(toolchainContext).isNotNull();
+    assertThat(toolchainContext.forToolchainType(variableToolchainType)).isNotNull();
+    assertThat(toolchainContext.templateVariableProviders()).hasSize(1);
+    assertThat(toolchainContext.templateVariableProviders().get(0).getVariables())
+        .containsExactly("VALUE", "foo");
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/analysis/ToolchainResolverTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/ToolchainResolverTest.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.analysis;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.devtools.build.lib.testutil.MoreAsserts.assertThrows;
 import static com.google.devtools.build.skyframe.EvaluationResultSubjectFactory.assertThatEvaluationResult;
 
 import com.google.auto.value.AutoValue;
@@ -24,12 +23,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.ToolchainResolver.NoMatchingPlatformException;
 import com.google.devtools.build.lib.analysis.ToolchainResolver.UnresolvedToolchainsException;
-import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.rules.platform.ToolchainTestCase;
 import com.google.devtools.build.lib.skyframe.BuildConfigurationValue;
-import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
 import com.google.devtools.build.lib.skyframe.ConstraintValueLookupUtil.InvalidConstraintValueException;
 import com.google.devtools.build.lib.skyframe.PlatformLookupUtil.InvalidPlatformException;
 import com.google.devtools.build.lib.skyframe.ToolchainException;
@@ -95,8 +92,7 @@ public class ToolchainResolverTest extends ToolchainTestCase {
 
     useConfiguration("--platforms=//platforms:linux");
     ResolveToolchainsKey key =
-        ResolveToolchainsKey.create(
-            "test", ImmutableSet.of(testToolchainTypeLabel), targetConfigKey);
+        ResolveToolchainsKey.create(ImmutableSet.of(testToolchainTypeLabel), targetConfigKey);
 
     EvaluationResult<ResolveToolchainsValue> result = createToolchainContextBuilder(key);
 
@@ -124,8 +120,7 @@ public class ToolchainResolverTest extends ToolchainTestCase {
     rewriteWorkspace("register_execution_platforms('//platforms:mac', '//platforms:linux')");
 
     useConfiguration("--host_platform=//host:host", "--platforms=//platforms:linux");
-    ResolveToolchainsKey key =
-        ResolveToolchainsKey.create("test", ImmutableSet.of(), targetConfigKey);
+    ResolveToolchainsKey key = ResolveToolchainsKey.create(ImmutableSet.of(), targetConfigKey);
 
     EvaluationResult<ResolveToolchainsValue> result = createToolchainContextBuilder(key);
 
@@ -166,7 +161,6 @@ public class ToolchainResolverTest extends ToolchainTestCase {
     useConfiguration("--host_platform=//host:host", "--platforms=//platforms:linux");
     ResolveToolchainsKey key =
         ResolveToolchainsKey.create(
-            "test",
             ImmutableSet.of(),
             ImmutableSet.of(Label.parseAbsoluteUnchecked("//sample:demo_b")),
             targetConfigKey);
@@ -193,7 +187,6 @@ public class ToolchainResolverTest extends ToolchainTestCase {
     useConfiguration("--host_platform=//platforms:linux", "--platforms=//platforms:mac");
     ResolveToolchainsKey key =
         ResolveToolchainsKey.create(
-            "test",
             ImmutableSet.of(
                 testToolchainTypeLabel, Label.parseAbsoluteUnchecked("//fake/toolchain:type_1")),
             targetConfigKey);
@@ -216,7 +209,6 @@ public class ToolchainResolverTest extends ToolchainTestCase {
     useConfiguration("--host_platform=//platforms:linux", "--platforms=//platforms:mac");
     ResolveToolchainsKey key =
         ResolveToolchainsKey.create(
-            "test",
             ImmutableSet.of(
                 testToolchainTypeLabel,
                 Label.parseAbsoluteUnchecked("//fake/toolchain:type_1"),
@@ -237,8 +229,7 @@ public class ToolchainResolverTest extends ToolchainTestCase {
     scratch.file("invalid/BUILD", "filegroup(name = 'not_a_platform')");
     useConfiguration("--platforms=//invalid:not_a_platform");
     ResolveToolchainsKey key =
-        ResolveToolchainsKey.create(
-            "test", ImmutableSet.of(testToolchainTypeLabel), targetConfigKey);
+        ResolveToolchainsKey.create(ImmutableSet.of(testToolchainTypeLabel), targetConfigKey);
 
     EvaluationResult<ResolveToolchainsValue> result = createToolchainContextBuilder(key);
 
@@ -261,8 +252,7 @@ public class ToolchainResolverTest extends ToolchainTestCase {
     scratch.resolve("invalid").delete();
     useConfiguration("--platforms=//invalid:not_a_platform");
     ResolveToolchainsKey key =
-        ResolveToolchainsKey.create(
-            "test", ImmutableSet.of(testToolchainTypeLabel), targetConfigKey);
+        ResolveToolchainsKey.create(ImmutableSet.of(testToolchainTypeLabel), targetConfigKey);
 
     EvaluationResult<ResolveToolchainsValue> result = createToolchainContextBuilder(key);
 
@@ -283,8 +273,7 @@ public class ToolchainResolverTest extends ToolchainTestCase {
     scratch.file("invalid/BUILD", "filegroup(name = 'not_a_platform')");
     useConfiguration("--host_platform=//invalid:not_a_platform");
     ResolveToolchainsKey key =
-        ResolveToolchainsKey.create(
-            "test", ImmutableSet.of(testToolchainTypeLabel), targetConfigKey);
+        ResolveToolchainsKey.create(ImmutableSet.of(testToolchainTypeLabel), targetConfigKey);
 
     EvaluationResult<ResolveToolchainsValue> result = createToolchainContextBuilder(key);
 
@@ -305,8 +294,7 @@ public class ToolchainResolverTest extends ToolchainTestCase {
     scratch.file("invalid/BUILD", "filegroup(name = 'not_a_platform')");
     useConfiguration("--extra_execution_platforms=//invalid:not_a_platform");
     ResolveToolchainsKey key =
-        ResolveToolchainsKey.create(
-            "test", ImmutableSet.of(testToolchainTypeLabel), targetConfigKey);
+        ResolveToolchainsKey.create(ImmutableSet.of(testToolchainTypeLabel), targetConfigKey);
 
     EvaluationResult<ResolveToolchainsValue> result = createToolchainContextBuilder(key);
 
@@ -345,7 +333,6 @@ public class ToolchainResolverTest extends ToolchainTestCase {
     useConfiguration("--platforms=//platforms:linux");
     ResolveToolchainsKey key =
         ResolveToolchainsKey.create(
-            "test",
             ImmutableSet.of(testToolchainTypeLabel),
             ImmutableSet.of(Label.parseAbsoluteUnchecked("//constraints:linux")),
             targetConfigKey);
@@ -374,7 +361,6 @@ public class ToolchainResolverTest extends ToolchainTestCase {
   public void resolve_execConstraints_invalid() throws Exception {
     ResolveToolchainsKey key =
         ResolveToolchainsKey.create(
-            "test",
             ImmutableSet.of(testToolchainTypeLabel),
             ImmutableSet.of(Label.parseAbsoluteUnchecked("//platforms:linux")),
             targetConfigKey);
@@ -426,7 +412,6 @@ public class ToolchainResolverTest extends ToolchainTestCase {
     useConfiguration("--platforms=//platforms:linux");
     ResolveToolchainsKey key =
         ResolveToolchainsKey.create(
-            "test",
             ImmutableSet.of(
                 Label.parseAbsoluteUnchecked("//a:toolchain_type_A"),
                 Label.parseAbsoluteUnchecked("//b:toolchain_type_B")),
@@ -440,132 +425,6 @@ public class ToolchainResolverTest extends ToolchainTestCase {
         .isInstanceOf(NoMatchingPlatformException.class);
   }
 
-  @Test
-  public void unloadedToolchainContext_load() throws Exception {
-    addToolchain(
-        "extra",
-        "extra_toolchain_linux",
-        ImmutableList.of("//constraints:linux"),
-        ImmutableList.of("//constraints:linux"),
-        "baz");
-    rewriteWorkspace(
-        "register_toolchains('//extra:extra_toolchain_linux')",
-        "register_execution_platforms('//platforms:linux')");
-
-    useConfiguration("--platforms=//platforms:linux");
-    ResolveToolchainsKey key =
-        ResolveToolchainsKey.create(
-            "test", ImmutableSet.of(testToolchainTypeLabel), targetConfigKey);
-
-    // Create the UnloadedToolchainContext.
-    EvaluationResult<ResolveToolchainsValue> result = createToolchainContextBuilder(key);
-    assertThatEvaluationResult(result).hasNoError();
-    UnloadedToolchainContext unloadedToolchainContext = result.get(key).unloadedToolchainContext();
-    assertThat(unloadedToolchainContext).isNotNull();
-
-    // Create the prerequisites.
-    ConfiguredTargetAndData toolchain =
-        getConfiguredTargetAndData(
-            Label.parseAbsoluteUnchecked("//extra:extra_toolchain_linux_impl"), targetConfig);
-    ResolvedToolchainContext toolchainContext =
-        unloadedToolchainContext.load(ImmutableList.of(toolchain));
-    assertThat(toolchainContext).isNotNull();
-    assertThat(toolchainContext.forToolchainType(testToolchainType)).isNotNull();
-    assertThat(toolchainContext.forToolchainType(testToolchainType).hasField("data")).isTrue();
-    assertThat(toolchainContext.forToolchainType(testToolchainType).getValue("data"))
-        .isEqualTo("baz");
-  }
-
-  @Test
-  public void unloadedToolchainContext_load_notToolchain() throws Exception {
-    scratch.file(
-        "foo/BUILD",
-        "filegroup(name = 'not_a_toolchain')",
-        "toolchain_type(name = 'toolchain_type')",
-        "toolchain(",
-        "    name = 'test_toolchain',",
-        "    toolchain_type = ':toolchain_type',",
-        "    toolchain = ':not_a_toolchain')");
-    rewriteWorkspace("register_toolchains('//foo:test_toolchain')");
-
-    ResolveToolchainsKey key =
-        ResolveToolchainsKey.create(
-            "test",
-            ImmutableSet.of(Label.parseAbsoluteUnchecked("//foo:toolchain_type")),
-            targetConfigKey);
-
-    // Create the UnloadedToolchainContext.
-    EvaluationResult<ResolveToolchainsValue> result = createToolchainContextBuilder(key);
-    assertThatEvaluationResult(result).hasNoError();
-    UnloadedToolchainContext unloadedToolchainContext = result.get(key).unloadedToolchainContext();
-    assertThat(unloadedToolchainContext).isNotNull();
-
-    // Create the prerequisites, which is not actually a valid toolchain.
-    ConfiguredTargetAndData toolchain =
-        getConfiguredTargetAndData(
-            Label.parseAbsoluteUnchecked("//foo:not_a_toolchain"), targetConfig);
-    assertThrows(
-        ToolchainException.class, () -> unloadedToolchainContext.load(ImmutableList.of(toolchain)));
-  }
-
-  @Test
-  public void unloadedToolchainContext_load_withTemplateVariables() throws Exception {
-    // Add new toolchain rule that provides template variables.
-    Label variableToolchainTypeLabel =
-        Label.parseAbsoluteUnchecked("//variable:variable_toolchain_type");
-    ToolchainTypeInfo variableToolchainType = ToolchainTypeInfo.create(variableToolchainTypeLabel);
-    scratch.file(
-        "variable/variable_toolchain_def.bzl",
-        "def _impl(ctx):",
-        "  value = ctx.attr.value",
-        "  toolchain = platform_common.ToolchainInfo()",
-        "  template_variables = platform_common.TemplateVariableInfo({'VALUE': value})",
-        "  return [toolchain, template_variables]",
-        "variable_toolchain = rule(",
-        "    implementation = _impl,",
-        "    attrs = {'value': attr.string()})");
-
-    scratch.file("variable/BUILD", "toolchain_type(name = 'variable_toolchain_type')");
-
-    // Create instance of new toolchain and register it.
-    scratch.appendFile(
-        "BUILD",
-        "load('//variable:variable_toolchain_def.bzl', 'variable_toolchain')",
-        "toolchain(",
-        "    name = 'variable_toolchain',",
-        "    toolchain_type = '//variable:variable_toolchain_type',",
-        "    exec_compatible_with = [],",
-        "    target_compatible_with = [],",
-        "    toolchain = ':variable_toolchain_impl')",
-        "variable_toolchain(",
-        "  name='variable_toolchain_impl',",
-        "  value = 'foo')");
-
-    rewriteWorkspace("register_toolchains('//:variable_toolchain')");
-
-    ResolveToolchainsKey key =
-        ResolveToolchainsKey.create(
-            "test", ImmutableSet.of(variableToolchainTypeLabel), targetConfigKey);
-
-    // Create the UnloadedToolchainContext.
-    EvaluationResult<ResolveToolchainsValue> result = createToolchainContextBuilder(key);
-    assertThatEvaluationResult(result).hasNoError();
-    UnloadedToolchainContext unloadedToolchainContext = result.get(key).unloadedToolchainContext();
-    assertThat(unloadedToolchainContext).isNotNull();
-
-    // Create the prerequisites.
-    ConfiguredTargetAndData toolchain =
-        getConfiguredTargetAndData(
-            Label.parseAbsoluteUnchecked("//:variable_toolchain_impl"), targetConfig);
-    ResolvedToolchainContext toolchainContext =
-        unloadedToolchainContext.load(ImmutableList.of(toolchain));
-    assertThat(toolchainContext).isNotNull();
-    assertThat(toolchainContext.forToolchainType(variableToolchainType)).isNotNull();
-    assertThat(toolchainContext.templateVariableProviders()).hasSize(1);
-    assertThat(toolchainContext.templateVariableProviders().get(0).getVariables())
-        .containsExactly("VALUE", "foo");
-  }
-
   private static final SkyFunctionName RESOLVE_TOOLCHAINS_FUNCTION =
       SkyFunctionName.createHermetic("RESOLVE_TOOLCHAINS_FUNCTION");
 
@@ -576,8 +435,6 @@ public class ToolchainResolverTest extends ToolchainTestCase {
       return RESOLVE_TOOLCHAINS_FUNCTION;
     }
 
-    abstract String targetDescription();
-
     abstract ImmutableSet<Label> requiredToolchainTypes();
 
     abstract ImmutableSet<Label> execConstraintLabels();
@@ -585,23 +442,19 @@ public class ToolchainResolverTest extends ToolchainTestCase {
     abstract BuildConfigurationValue.Key configurationKey();
 
     public static ResolveToolchainsKey create(
-        String targetDescription,
         Set<Label> requiredToolchains,
         BuildConfigurationValue.Key configurationKey) {
       return create(
-          targetDescription,
           requiredToolchains,
           /* execConstraintLabels= */ ImmutableSet.of(),
           configurationKey);
     }
 
     public static ResolveToolchainsKey create(
-        String targetDescription,
         Set<Label> requiredToolchains,
         Set<Label> execConstraintLabels,
         BuildConfigurationValue.Key configurationKey) {
       return new AutoValue_ToolchainResolverTest_ResolveToolchainsKey(
-          targetDescription,
           ImmutableSet.copyOf(requiredToolchains),
           ImmutableSet.copyOf(execConstraintLabels),
           configurationKey);
@@ -638,7 +491,6 @@ public class ToolchainResolverTest extends ToolchainTestCase {
       ResolveToolchainsKey key = (ResolveToolchainsKey) skyKey;
       ToolchainResolver toolchainResolver =
           new ToolchainResolver(env, key.configurationKey())
-              .setTargetDescription(key.targetDescription())
               .setRequiredToolchainTypes(key.requiredToolchainTypes())
               .setExecConstraintLabels(key.execConstraintLabels());
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewForTesting.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewForTesting.java
@@ -493,8 +493,12 @@ public class BuildViewForTesting {
             configuredTarget,
             configurations,
             unloadedToolchainContext.resolvedToolchainLabels());
+    String targetDescription = target.toString();
     ResolvedToolchainContext toolchainContext =
-        unloadedToolchainContext.load(prerequisiteMap.get(DependencyResolver.TOOLCHAIN_DEPENDENCY));
+        ResolvedToolchainContext.load(
+            unloadedToolchainContext,
+            targetDescription,
+            prerequisiteMap.get(DependencyResolver.TOOLCHAIN_DEPENDENCY));
 
     return new RuleContext.Builder(
             env,


### PR DESCRIPTION
Also pass target description directly to load().

Part of work on execution transitions, #7935.