### PR TITLE
make bazel_sandboxing_cpp_test work with bazel-toolchains

### DIFF
--- a/src/test/shell/bazel/bazel_sandboxing_cpp_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_cpp_test.sh
@@ -105,9 +105,12 @@ EOF
   bazel build --spawn_strategy=sandboxed //examples/cpp:hello-lib &> $TEST_log \
     && fail "build should not have succeeded with missing header file"
 
-  fgrep "fatal error: examples/cpp/lib/hello-lib.h: No such file or directory" $TEST_log \
-    || fgrep "fatal error: 'examples/cpp/lib/hello-lib.h' file not found" $TEST_log \
-    || fail "could not find 'No such file or directory' error message in bazel output"
+  fgrep "No such file or directory" $TEST_log \
+    || fgrep "file not found" $TEST_log \
+    || fgrep "this rule is missing dependency declarations" $TEST_log \
+    || fail "could not find an indication of a missing file in bazel output"
+  fgrep "examples/cpp/lib/hello-lib.h" $TEST_log \
+    || fail "could not find 'examples/cpp/lib/hello-lib.h' bazel output"
 }
 
 # TODO(philwo) turns out, we have this special "hdrs" attribute and in theory you can only include


### PR DESCRIPTION
the generated error message due to the missing headers file is
dependent on the compiler. relax the pattern matching a bit to
also work with the clang ubuntu container
https://console.cloud.google.com/marketplace/details/google/clang-ubuntu

Progress towards #8033 