### PR TITLE
correctly access javabase in java_integration_test

### DIFF
--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -164,6 +164,7 @@ sh_test(
     data = [
         ":test-deps",
         "//src/test/shell:shell_utils",
+        "@bazel_tools//tools/bash/runfiles",
     ],
     shard_count = 5,
     tags = [

--- a/src/test/shell/integration/java_integration_test.sh
+++ b/src/test/shell/integration/java_integration_test.sh
@@ -60,7 +60,7 @@ add_to_bazelrc "build --package_path=%workspace%"
 
 function setup_local_jdk() {
   local -r dest="$1"
-  local -r src="${java_home}"
+  local -r src="${javabase}"
 
   mkdir -p "$dest" || fail "mkdir -p $dest"
   cp -LR "${src}"/* "$dest" || fail "cp -LR \"${src}\"/* \"$dest\""
@@ -274,9 +274,9 @@ function assert_singlejar_works() {
     setup_local_jdk "$local_jdk"
 
     ln -s "my_jdk" "$pkg/my_jdk.symlink"
-    local -r my_java_home="$(get_real_path "$pkg/my_jdk.symlink")"
+    local -r my_javabase="$(get_real_path "$pkg/my_jdk.symlink")"
   else
-    local -r my_java_home="${java_home}"
+    local -r my_javabase="${javabase}"
   fi
 
   mkdir -p "$pkg/jvm"
@@ -284,7 +284,7 @@ function assert_singlejar_works() {
 package(default_visibility=["//visibility:public"])
 java_runtime(
     name='runtime',
-    java_home='$my_java_home',
+    java_home='$my_javabase',
 )
 EOF
 

--- a/src/test/shell/integration/java_integration_test.sh
+++ b/src/test/shell/integration/java_integration_test.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 # These are end to end tests for building Java.
+set -euo pipefail
 # --- begin runfiles.bash initialization ---
 if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
     if [[ -f "$0.runfiles_manifest" ]]; then


### PR DESCRIPTION
java_integration_test assumes that $(JAVABASE) is always a runfiles
relative path. However, that's not correct as it purely depends on
the usage of java_runtime.

For example,

java_runtime(
name = "abs_path_jdk",
java_home = "/usr/local/lib/jdk",
)

when running with --javabase=//:abs_path_jdk then all $(JAVABASE)
make variables will contain "/usr/local/lib/jdk".

Progress towards #8033