### PR TITLE
enable some tests to run remotely

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -201,7 +201,7 @@ sh_test(
     data = [":test-deps"],
     shard_count = 3,
     tags = [
-        "local",
+        "no-sandbox",
         "no_windows",
     ],
 )
@@ -267,7 +267,7 @@ sh_test(
     srcs = ["bazel_localtest_test.sh"],
     data = [":test-deps"],
     tags = [
-        "local",
+        "no-sandbox",
         "no_windows",
     ],
 )
@@ -586,7 +586,7 @@ sh_test(
         "//src/test/shell:sandboxing_test_utils.sh",
     ],
     tags = [
-        "local",
+        "no-sandbox",
         "no_windows",
     ],
 )
@@ -599,7 +599,7 @@ sh_test(
         "//src/test/shell:sandboxing_test_utils.sh",
     ],
     tags = [
-        "local",
+        "no-sandbox",
         "no_windows",
     ],
 )

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -64,7 +64,7 @@ sh_test(
         "@bazel_tools//tools/bash/runfiles",
     ],
     tags = [
-        "local",
+        "no-sandbox",
     ],
 )
 
@@ -296,7 +296,7 @@ sh_test(
     # This test doesn't work with the sandbox on, see the source file
     # for details.
     tags = [
-        "local",
+        "no-sandbox",
         "no_windows",
     ],
 )


### PR DESCRIPTION
these tests were tagged "local" in order to not use a sandbox. The
"local" tag unfortunately also applies to remote execution. Mark
them "no-sandbox" so that they can run with remote execution.

Progress towards #8033