### PR TITLE
Windows, JNI: move static methods to class

### DIFF
--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -33,18 +33,324 @@
 #include "src/main/native/windows/jni-util.h"
 #include "src/main/native/windows/util.h"
 
-// These are the possible return values from the NativeProcess::WaitFor()
-// method.
-static const int kWaitSuccess = 0;
-static const int kWaitTimeout = 1;
-static const int kWaitError = 2;
-
 template <typename T>
 static std::wstring ToString(const T& e) {
   std::wstringstream s;
   s << e;
   return s.str();
 }
+
+namespace bazel {
+namespace windows {
+
+class WaitableProcess {
+ public:
+  // These are the possible return values from the NativeProcess::WaitFor()
+  // method.
+  enum {
+    kWaitSuccess = 0,
+    kWaitTimeout = 1,
+    kWaitError = 2,
+  };
+
+  static bool Create(const std::wstring& wpath, const std::wstring& argv_rest,
+                     void* env, const std::wstring& wcwd, HANDLE stdin_process,
+                     HANDLE stdout_process, HANDLE stderr_process,
+                     AutoHandle* out_job, AutoHandle* out_ioport,
+                     AutoHandle* out_process, DWORD* out_pid,
+                     std::wstring* error);
+
+  static int WaitFor(int64_t timeout_msec, DWORD pid,
+                     AutoHandle* in_out_job, AutoHandle* in_out_ioport,
+                     AutoHandle* in_out_process, DWORD* out_exit_code,
+                     std::wstring* error);
+
+  static int GetExitCode(const AutoHandle& process, DWORD pid,
+                         DWORD* out_exit_code, std::wstring* error);
+
+  static bool Terminate(const AutoHandle& job, const AutoHandle& process,
+                        DWORD pid, DWORD* out_exit_code, std::wstring* error);
+};
+
+bool WaitableProcess::Create(const std::wstring& wpath,
+                             const std::wstring& argv_rest, void* env,
+                             const std::wstring& wcwd, HANDLE stdin_process,
+                             HANDLE stdout_process, HANDLE stderr_process,
+                             AutoHandle* out_job, AutoHandle* out_ioport,
+                             AutoHandle* out_process, DWORD* out_pid,
+                             std::wstring* error) {
+  std::wstring cwd;
+  std::wstring error_msg(bazel::windows::AsShortPath(wcwd, &cwd));
+  if (!error_msg.empty()) {
+    *error = bazel::windows::MakeErrorMessage(
+        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, error_msg);
+    return false;
+  }
+
+  std::wstring argv0;
+  error_msg = bazel::windows::AsExecutablePathForCreateProcess(wpath, &argv0);
+  if (!error_msg.empty()) {
+    *error = bazel::windows::MakeErrorMessage(
+        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, error_msg);
+    return false;
+  }
+
+  std::wstring commandline =
+      argv_rest.empty() ? argv0 : (argv0 + L" " + argv_rest);
+  std::unique_ptr<WCHAR[]> mutable_commandline(
+      new WCHAR[commandline.size() + 1]);
+  wcsncpy(mutable_commandline.get(), commandline.c_str(),
+          commandline.size() + 1);
+  // MDSN says that the default for job objects is that breakaway is not
+  // allowed. Thus, we don't need to do any more setup here.
+  *out_job = CreateJobObject(NULL, NULL);
+  if (!out_job->IsValid()) {
+    DWORD err_code = GetLastError();
+    *error = bazel::windows::MakeErrorMessage(
+        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+    return false;
+  }
+
+  JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_info = {0};
+  job_info.BasicLimitInformation.LimitFlags =
+      JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+  if (!SetInformationJobObject(*out_job, JobObjectExtendedLimitInformation,
+                               &job_info, sizeof(job_info))) {
+    DWORD err_code = GetLastError();
+    *error = bazel::windows::MakeErrorMessage(
+        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+    return false;
+  }
+
+  *out_ioport = CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
+  if (!out_ioport->IsValid()) {
+    DWORD err_code = GetLastError();
+    *error = bazel::windows::MakeErrorMessage(
+        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+    return false;
+  }
+  JOBOBJECT_ASSOCIATE_COMPLETION_PORT port;
+  port.CompletionKey = *out_job;
+  port.CompletionPort = *out_ioport;
+  if (!SetInformationJobObject(*out_job,
+                               JobObjectAssociateCompletionPortInformation,
+                               &port, sizeof(port))) {
+    DWORD err_code = GetLastError();
+    *error = bazel::windows::MakeErrorMessage(
+        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+    return false;
+  }
+
+  std::unique_ptr<bazel::windows::AutoAttributeList> attr_list;
+  if (!bazel::windows::AutoAttributeList::Create(
+          stdin_process, stdout_process, stderr_process, &attr_list,
+          &error_msg)) {
+    *error = bazel::windows::MakeErrorMessage(
+        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", L"", error_msg);
+    return false;
+  }
+
+  // kMaxCmdline value: see lpCommandLine parameter of CreateProcessW.
+  static constexpr size_t kMaxCmdline = 32767;
+
+  std::wstring cmd_sample = mutable_commandline.get();
+  if (cmd_sample.size() > 200) {
+    cmd_sample = cmd_sample.substr(0, 195) + L"(...)";
+  }
+  if (wcsnlen_s(mutable_commandline.get(), kMaxCmdline) == kMaxCmdline) {
+    std::wstringstream error_msg;
+    error_msg << L"command is longer than CreateProcessW's limit ("
+              << kMaxCmdline << L" characters)";
+    *error = bazel::windows::MakeErrorMessage(
+        WSTR(__FILE__), __LINE__, L"CreateProcessWithExplicitHandles",
+        cmd_sample, error_msg.str().c_str());
+    return false;
+  }
+
+  PROCESS_INFORMATION process_info = {0};
+  STARTUPINFOEXW info;
+  attr_list->InitStartupInfoExW(&info);
+  if (!CreateProcessW(
+          /* lpApplicationName */ NULL,
+          /* lpCommandLine */ mutable_commandline.get(),
+          /* lpProcessAttributes */ NULL,
+          /* lpThreadAttributes */ NULL,
+          /* bInheritHandles */ TRUE,
+          /* dwCreationFlags */ CREATE_NO_WINDOW  // Don't create console
+                                                  // window
+              |
+              CREATE_NEW_PROCESS_GROUP  // So that Ctrl-Break isn't propagated
+              | CREATE_SUSPENDED  // So that it doesn't start a new job itself
+              | EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+          /* lpEnvironment */ env,
+          /* lpCurrentDirectory */ cwd.empty() ? NULL : cwd.c_str(),
+          /* lpStartupInfo */ &info.StartupInfo,
+          /* lpProcessInformation */ &process_info)) {
+    DWORD err = GetLastError();
+    *error = bazel::windows::MakeErrorMessage(
+        WSTR(__FILE__), __LINE__, L"CreateProcessW", cmd_sample, err);
+    return false;
+  }
+
+  *out_pid = process_info.dwProcessId;
+  *out_process = process_info.hProcess;
+  bazel::windows::AutoHandle thread(process_info.hThread);
+
+  if (!AssignProcessToJobObject(*out_job, *out_process)) {
+    BOOL is_in_job = false;
+    if (IsProcessInJob(*out_process, NULL, &is_in_job) && is_in_job &&
+        !IsWindows8OrGreater()) {
+      // Pre-Windows 8 systems don't support nested jobs, and Bazel is already
+      // in a job.  We can't create nested jobs, so just revert to
+      // TerminateProcess() and hope for the best. In batch mode, the launcher
+      // puts Bazel in a job so that will take care of cleanup once the
+      // command finishes.
+      *out_job = INVALID_HANDLE_VALUE;
+      *out_ioport = INVALID_HANDLE_VALUE;
+    } else {
+      DWORD err_code = GetLastError();
+      *error = bazel::windows::MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+      return false;
+    }
+  }
+
+  // Now that we put the process in a new job object, we can start executing
+  // it
+  if (ResumeThread(thread) == -1) {
+    DWORD err_code = GetLastError();
+    *error = bazel::windows::MakeErrorMessage(
+        WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
+    return false;
+  }
+
+  *error = L"";
+  return true;
+}
+
+int WaitableProcess::WaitFor(int64_t timeout_msec, DWORD pid,
+                             AutoHandle* in_out_job, AutoHandle* in_out_ioport,
+                             AutoHandle* in_out_process, DWORD* out_exit_code,
+                             std::wstring* error) {
+  DWORD win32_timeout = timeout_msec < 0 ? INFINITE : timeout_msec;
+  int result;
+  switch (WaitForSingleObject(*in_out_process, win32_timeout)) {
+    case WAIT_OBJECT_0:
+      result = kWaitSuccess;
+      break;
+
+    case WAIT_TIMEOUT:
+      result = kWaitTimeout;
+      break;
+
+    // Any other case is an error and should be reported back to Bazel.
+    default:
+      DWORD err_code = GetLastError();
+      *error = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
+                                                L"NativeProcess:WaitFor",
+                                                ToString(pid), err_code);
+      return kWaitError;
+  }
+
+  // Ensure that the process is really terminated (if WaitForSingleObject
+  // above timed out, we have to explicitly kill it) and that it doesn't
+  // leave behind any subprocesses.
+  if (!Terminate(*in_out_job, *in_out_process, pid, out_exit_code, error)) {
+    return kWaitError;
+  }
+
+  if (in_out_job->IsValid()) {
+    // Wait for the job object to complete, signalling that all subprocesses
+    // have exited.
+    DWORD CompletionCode;
+    ULONG_PTR CompletionKey;
+    LPOVERLAPPED Overlapped;
+    while (GetQueuedCompletionStatus(*in_out_ioport, &CompletionCode,
+                                     &CompletionKey, &Overlapped, INFINITE) &&
+           !((HANDLE)CompletionKey == (HANDLE)*in_out_job &&
+             CompletionCode == JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO)) {
+      // Still waiting...
+    }
+
+    *in_out_job = INVALID_HANDLE_VALUE;
+    *in_out_ioport = INVALID_HANDLE_VALUE;
+  }
+
+  // Fetch and store the exit code in case Bazel asks us for it later,
+  // because we cannot do this anymore after we closed the handle.
+  GetExitCode(*in_out_process, pid, out_exit_code, error);
+
+  if (in_out_process->IsValid()) {
+    *in_out_process = INVALID_HANDLE_VALUE;
+  }
+
+  return result;
+}
+
+int WaitableProcess::GetExitCode(const AutoHandle& process, DWORD pid,
+                                 DWORD* out_exit_code, std::wstring* error) {
+  if (*out_exit_code == STILL_ACTIVE) {
+    if (!GetExitCodeProcess(process, out_exit_code)) {
+      DWORD err_code = GetLastError();
+      *error = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
+                                                L"NativeProcess::GetExitCode",
+                                                ToString(pid), err_code);
+      return -1;
+    }
+  }
+
+  return *out_exit_code;
+}
+
+bool WaitableProcess::Terminate(const AutoHandle& job,
+                                const AutoHandle& process, DWORD pid,
+                                DWORD* out_exit_code, std::wstring* error) {
+  static constexpr UINT exit_code = 130;  // 128 + SIGINT, like on Linux
+
+  if (job.IsValid()) {
+    if (!TerminateJobObject(job, exit_code)) {
+      DWORD err_code = GetLastError();
+      *error = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
+                                                L"NativeProcess::Terminate",
+                                                ToString(pid), err_code);
+      return false;
+    }
+  } else if (process.IsValid()) {
+    if (!TerminateProcess(process, exit_code)) {
+      DWORD err_code = GetLastError();
+      std::wstring our_error = bazel::windows::MakeErrorMessage(
+          WSTR(__FILE__), __LINE__, L"NativeProcess::Terminate",
+          ToString(pid), err_code);
+
+      // If the process exited, despite TerminateProcess having failed, we're
+      // still happy and just ignore the error. It might have been a race
+      // where the process exited by itself just before we tried to kill it.
+      // However, if the process is *still* running at this point (evidenced
+      // by its exit code still being STILL_ACTIVE) then something went
+      // really unexpectedly wrong and we should report that error.
+      if (GetExitCode(process, pid, out_exit_code, error) == STILL_ACTIVE) {
+        // Restore the error message from TerminateProcess - it will be much
+        // more helpful for debugging in case something goes wrong here.
+        *error = our_error;
+        return false;
+      }
+    }
+
+    if (WaitForSingleObject(process, INFINITE) != WAIT_OBJECT_0) {
+      DWORD err_code = GetLastError();
+      *error = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
+                                                L"NativeProcess::Terminate",
+                                                ToString(pid), err_code);
+      return false;
+    }
+  }
+
+  *error = L"";
+  return true;
+}
+
+}  // namespace windows
+}  // namespace bazel
 
 extern "C" JNIEXPORT jint JNICALL
 Java_com_google_devtools_build_lib_windows_jni_WindowsProcesses_nativeGetpid(
@@ -318,166 +624,11 @@ class NativeProcess {
       stderr_.SetHandle(pipe_read_h);
       stderr_process = pipe_write_h;
     }
-    return Create(wpath, bazel::windows::GetJavaWstring(env, java_argv_rest),
-                  env_map.ptr(), bazel::windows::GetJavaWpath(env, java_cwd),
-                  stdin_process, stdout_process, stderr_process, &job_,
-                  &ioport_, &process_, &pid_, &error_);
-  }
-
-  static bool Create(const std::wstring& wpath, const std::wstring& argv_rest,
-                     void* env, const std::wstring& wcwd, HANDLE stdin_process,
-                     HANDLE stdout_process, HANDLE stderr_process,
-                     bazel::windows::AutoHandle* out_job,
-                     bazel::windows::AutoHandle* out_ioport,
-                     bazel::windows::AutoHandle* out_process, DWORD* out_pid,
-                     std::wstring* error) {
-    std::wstring cwd;
-    std::wstring error_msg(bazel::windows::AsShortPath(wcwd, &cwd));
-    if (!error_msg.empty()) {
-      *error = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, error_msg);
-      return false;
-    }
-
-    std::wstring argv0;
-    error_msg = bazel::windows::AsExecutablePathForCreateProcess(wpath, &argv0);
-    if (!error_msg.empty()) {
-      *error = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, error_msg);
-      return false;
-    }
-
-    std::wstring commandline =
-        argv_rest.empty() ? argv0 : (argv0 + L" " + argv_rest);
-    std::unique_ptr<WCHAR[]> mutable_commandline(
-        new WCHAR[commandline.size() + 1]);
-    wcsncpy(mutable_commandline.get(), commandline.c_str(),
-            commandline.size() + 1);
-    // MDSN says that the default for job objects is that breakaway is not
-    // allowed. Thus, we don't need to do any more setup here.
-    *out_job = CreateJobObject(NULL, NULL);
-    if (!out_job->IsValid()) {
-      DWORD err_code = GetLastError();
-      *error = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-      return false;
-    }
-
-    JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_info = {0};
-    job_info.BasicLimitInformation.LimitFlags =
-        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-    if (!SetInformationJobObject(*out_job, JobObjectExtendedLimitInformation,
-                                 &job_info, sizeof(job_info))) {
-      DWORD err_code = GetLastError();
-      *error = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-      return false;
-    }
-
-    *out_ioport = CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
-    if (!out_ioport->IsValid()) {
-      DWORD err_code = GetLastError();
-      *error = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-      return false;
-    }
-    JOBOBJECT_ASSOCIATE_COMPLETION_PORT port;
-    port.CompletionKey = *out_job;
-    port.CompletionPort = *out_ioport;
-    if (!SetInformationJobObject(*out_job,
-                                 JobObjectAssociateCompletionPortInformation,
-                                 &port, sizeof(port))) {
-      DWORD err_code = GetLastError();
-      *error = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-      return false;
-    }
-
-    std::unique_ptr<bazel::windows::AutoAttributeList> attr_list;
-    if (!bazel::windows::AutoAttributeList::Create(
-            stdin_process, stdout_process, stderr_process, &attr_list,
-            &error_msg)) {
-      *error = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", L"", error_msg);
-      return false;
-    }
-
-    // kMaxCmdline value: see lpCommandLine parameter of CreateProcessW.
-    static constexpr size_t kMaxCmdline = 32767;
-
-    std::wstring cmd_sample = mutable_commandline.get();
-    if (cmd_sample.size() > 200) {
-      cmd_sample = cmd_sample.substr(0, 195) + L"(...)";
-    }
-    if (wcsnlen_s(mutable_commandline.get(), kMaxCmdline) == kMaxCmdline) {
-      std::wstringstream error_msg;
-      error_msg << L"command is longer than CreateProcessW's limit ("
-                << kMaxCmdline << L" characters)";
-      *error = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"CreateProcessWithExplicitHandles",
-          cmd_sample, error_msg.str().c_str());
-      return false;
-    }
-
-    PROCESS_INFORMATION process_info = {0};
-    STARTUPINFOEXW info;
-    attr_list->InitStartupInfoExW(&info);
-    if (!CreateProcessW(
-            /* lpApplicationName */ NULL,
-            /* lpCommandLine */ mutable_commandline.get(),
-            /* lpProcessAttributes */ NULL,
-            /* lpThreadAttributes */ NULL,
-            /* bInheritHandles */ TRUE,
-            /* dwCreationFlags */ CREATE_NO_WINDOW  // Don't create console
-                                                    // window
-                |
-                CREATE_NEW_PROCESS_GROUP  // So that Ctrl-Break isn't propagated
-                | CREATE_SUSPENDED  // So that it doesn't start a new job itself
-                | EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
-            /* lpEnvironment */ env,
-            /* lpCurrentDirectory */ cwd.empty() ? NULL : cwd.c_str(),
-            /* lpStartupInfo */ &info.StartupInfo,
-            /* lpProcessInformation */ &process_info)) {
-      DWORD err = GetLastError();
-      *error = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"CreateProcessW", cmd_sample, err);
-      return false;
-    }
-
-    *out_pid = process_info.dwProcessId;
-    *out_process = process_info.hProcess;
-    bazel::windows::AutoHandle thread(process_info.hThread);
-
-    if (!AssignProcessToJobObject(*out_job, *out_process)) {
-      BOOL is_in_job = false;
-      if (IsProcessInJob(*out_process, NULL, &is_in_job) && is_in_job &&
-          !IsWindows8OrGreater()) {
-        // Pre-Windows 8 systems don't support nested jobs, and Bazel is already
-        // in a job.  We can't create nested jobs, so just revert to
-        // TerminateProcess() and hope for the best. In batch mode, the launcher
-        // puts Bazel in a job so that will take care of cleanup once the
-        // command finishes.
-        *out_job = INVALID_HANDLE_VALUE;
-        *out_ioport = INVALID_HANDLE_VALUE;
-      } else {
-        DWORD err_code = GetLastError();
-        *error = bazel::windows::MakeErrorMessage(
-            WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-        return false;
-      }
-    }
-
-    // Now that we put the process in a new job object, we can start executing
-    // it
-    if (ResumeThread(thread) == -1) {
-      DWORD err_code = GetLastError();
-      *error = bazel::windows::MakeErrorMessage(
-          WSTR(__FILE__), __LINE__, L"nativeCreateProcess", wpath, err_code);
-      return false;
-    }
-
-    *error = L"";
-    return true;
+    return bazel::windows::WaitableProcess::Create(
+        wpath, bazel::windows::GetJavaWstring(env, java_argv_rest),
+        env_map.ptr(), bazel::windows::GetJavaWpath(env, java_cwd),
+        stdin_process, stdout_process, stderr_process, &job_, &ioport_,
+        &process_, &pid_, &error_);
   }
 
   void CloseStdin() {
@@ -488,89 +639,15 @@ class NativeProcess {
 
   // Wait for this process to exit (or timeout).
   int WaitFor(int64_t timeout_msec) {
-    return WaitFor(timeout_msec, pid_, &job_, &ioport_, &process_, &exit_code_,
-                   &error_);
-  }
-
-  static int WaitFor(int64_t timeout_msec, DWORD pid,
-                     bazel::windows::AutoHandle* in_out_job,
-                     bazel::windows::AutoHandle* in_out_ioport,
-                     bazel::windows::AutoHandle* in_out_process,
-                     DWORD* out_exit_code, std::wstring* error) {
-    DWORD win32_timeout = timeout_msec < 0 ? INFINITE : timeout_msec;
-    int result;
-    switch (WaitForSingleObject(*in_out_process, win32_timeout)) {
-      case WAIT_OBJECT_0:
-        result = kWaitSuccess;
-        break;
-
-      case WAIT_TIMEOUT:
-        result = kWaitTimeout;
-        break;
-
-      // Any other case is an error and should be reported back to Bazel.
-      default:
-        DWORD err_code = GetLastError();
-        *error = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
-                                                  L"NativeProcess:WaitFor",
-                                                  ToString(pid), err_code);
-        return kWaitError;
-    }
-
-    // Ensure that the process is really terminated (if WaitForSingleObject
-    // above timed out, we have to explicitly kill it) and that it doesn't
-    // leave behind any subprocesses.
-    if (!Terminate(*in_out_job, *in_out_process, pid, out_exit_code, error)) {
-      return kWaitError;
-    }
-
-    if (in_out_job->IsValid()) {
-      // Wait for the job object to complete, signalling that all subprocesses
-      // have exited.
-      DWORD CompletionCode;
-      ULONG_PTR CompletionKey;
-      LPOVERLAPPED Overlapped;
-      while (GetQueuedCompletionStatus(*in_out_ioport, &CompletionCode,
-                                       &CompletionKey, &Overlapped, INFINITE) &&
-             !((HANDLE)CompletionKey == (HANDLE)*in_out_job &&
-               CompletionCode == JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO)) {
-        // Still waiting...
-      }
-
-      *in_out_job = INVALID_HANDLE_VALUE;
-      *in_out_ioport = INVALID_HANDLE_VALUE;
-    }
-
-    // Fetch and store the exit code in case Bazel asks us for it later,
-    // because we cannot do this anymore after we closed the handle.
-    GetExitCode(*in_out_process, pid, out_exit_code, error);
-
-    if (in_out_process->IsValid()) {
-      *in_out_process = INVALID_HANDLE_VALUE;
-    }
-
-    return result;
+    return bazel::windows::WaitableProcess::WaitFor(
+        timeout_msec, pid_, &job_, &ioport_, &process_, &exit_code_, &error_);
   }
 
   // Returns the exit code of the process if it has already exited. If the
   // process is still running, returns STILL_ACTIVE (= 259).
   int GetExitCode() {
-    return GetExitCode(process_, pid_, &exit_code_, &error_);
-  }
-
-  static int GetExitCode(const bazel::windows::AutoHandle& process, DWORD pid,
-                         DWORD* out_exit_code, std::wstring* error) {
-    if (*out_exit_code == STILL_ACTIVE) {
-      if (!GetExitCodeProcess(process, out_exit_code)) {
-        DWORD err_code = GetLastError();
-        *error = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
-                                                  L"NativeProcess::GetExitCode",
-                                                  ToString(pid), err_code);
-        return -1;
-      }
-    }
-
-    return *out_exit_code;
+    return bazel::windows::WaitableProcess::GetExitCode(process_, pid_,
+                                                        &exit_code_, &error_);
   }
 
   DWORD GetPid() { return pid_; }
@@ -606,54 +683,8 @@ class NativeProcess {
 
   // Terminates this process (and subprocesses, if job objects are available).
   bool Terminate() {
-    return Terminate(job_, process_, pid_, &exit_code_, &error_);
-  }
-
-  static bool Terminate(const bazel::windows::AutoHandle& job,
-                        const bazel::windows::AutoHandle& process, DWORD pid,
-                        DWORD* out_exit_code, std::wstring* error) {
-    static constexpr UINT exit_code = 130;  // 128 + SIGINT, like on Linux
-
-    if (job.IsValid()) {
-      if (!TerminateJobObject(job, exit_code)) {
-        DWORD err_code = GetLastError();
-        *error = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
-                                                  L"NativeProcess::Terminate",
-                                                  ToString(pid), err_code);
-        return false;
-      }
-    } else if (process.IsValid()) {
-      if (!TerminateProcess(process, exit_code)) {
-        DWORD err_code = GetLastError();
-        std::wstring our_error = bazel::windows::MakeErrorMessage(
-            WSTR(__FILE__), __LINE__, L"NativeProcess::Terminate",
-            ToString(pid), err_code);
-
-        // If the process exited, despite TerminateProcess having failed, we're
-        // still happy and just ignore the error. It might have been a race
-        // where the process exited by itself just before we tried to kill it.
-        // However, if the process is *still* running at this point (evidenced
-        // by its exit code still being STILL_ACTIVE) then something went
-        // really unexpectedly wrong and we should report that error.
-        if (GetExitCode(process, pid, out_exit_code, error) == STILL_ACTIVE) {
-          // Restore the error message from TerminateProcess - it will be much
-          // more helpful for debugging in case something goes wrong here.
-          *error = our_error;
-          return false;
-        }
-      }
-
-      if (WaitForSingleObject(process, INFINITE) != WAIT_OBJECT_0) {
-        DWORD err_code = GetLastError();
-        *error = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
-                                                  L"NativeProcess::Terminate",
-                                                  ToString(pid), err_code);
-        return false;
-      }
-    }
-
-    *error = L"";
-    return true;
+    return bazel::windows::WaitableProcess::Terminate(job_, process_, pid_,
+                                                      &exit_code_, &error_);
   }
 
   // Return the last error as a human-readable string and clear it.


### PR DESCRIPTION
Move the static methods of NativeProcess (Create,
WaitFor, GetExitCode, Terminate) to a utility
class (WaitableProcess).

Next step is to move the new class to a separate
file.