### PR TITLE
Update RBE platform

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -124,11 +124,24 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+constraint_setting(name = "machine_size")
+
+# A machine with "high cpu count".
+constraint_value(
+    name = "highcpu_machine",
+    constraint_setting = ":machine_size",
+    visibility = ["//visibility:public"],
+)
+
+# The default RBE platform where most actions run on
 platform(
-    name = "rbe_ubuntu1604_with_network_and_privileged",
-    parents = ["@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform"],
+    name = "rbe_ubuntu1604_default",
+    parents = ["@bazel_toolchains//configs/ubuntu16_04_clang/1.2:rbe_ubuntu1604"],
     remote_execution_properties = """
-        {PARENT_REMOTE_EXECUTION_PROPERTIES}
+        properties: {
+          name: "container-image"
+          value:"docker://gcr.io/bazel-untrusted/ubuntu1604_bazel_rbe@sha256:b60b641427ca8aa99134cc1f9889e3349e391eed85854b5cfbb462884ec3420b"
+        }
         properties: {
           name: "dockerNetwork"
           value: "standard"
@@ -136,6 +149,23 @@ platform(
         properties: {
           name: "dockerPrivileged"
           value: "true"
+        }
+        """,
+)
+
+# The highcpu RBE platform where heavy actions run on. In order to
+# use this platform add the highcpu_machine constraint to your target.
+platform(
+    name = "rbe_ubuntu1604_highcpu",
+    parents = [":rbe_ubuntu1604_default"],
+    constraint_values = [
+        ":highcpu_machine",
+    ],
+    remote_execution_properties = """
+        {PARENT_REMOTE_EXECUTION_PROPERTIES}
+        properties: {
+          name: "gceMachineType"
+          value: "n1-highcpu-32"
         }
         """,
 )

--- a/BUILD
+++ b/BUILD
@@ -136,7 +136,7 @@ constraint_value(
 platform(
     name = "default_host_platform",
     parents = ["@bazel_tools//platforms:host_platform"],
-    contraint_values = [
+    constraint_values = [
         ":highcpu_machine",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -133,6 +133,14 @@ constraint_value(
     visibility = ["//visibility:public"],
 )
 
+platform(
+    name = "default_host_platform",
+    parents = ["@bazel_tools//platforms:host_platform"],
+    contraint_values = [
+        ":highcpu_machine",
+    ],
+)
+
 # The default RBE platform where most actions run on
 platform(
     name = "rbe_ubuntu1604_default",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -461,3 +461,5 @@ node_repositories()
 load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 
 sass_repositories()
+
+register_execution_platforms("//:rbe_ubuntu1604_default", "//:rbe_ubuntu1604_highcpu");

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -462,4 +462,4 @@ load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 
 sass_repositories()
 
-register_execution_platforms("//:rbe_ubuntu1604_default", "//:rbe_ubuntu1604_highcpu", "//:default_host_platform");
+register_execution_platforms("//:default_host_platform");

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -462,4 +462,4 @@ load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 
 sass_repositories()
 
-register_execution_platforms("//:rbe_ubuntu1604_default", "//:rbe_ubuntu1604_highcpu");
+register_execution_platforms("//:rbe_ubuntu1604_default", "//:rbe_ubuntu1604_highcpu", "//:default_host_platform");

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -277,13 +277,13 @@ http_file(
 )
 
 http_archive(
-    name = "bazel_toolchains",
-    sha256 = "4b1468b254a572dbe134cc1fd7c6eab1618a72acd339749ea343bd8f55c3b7eb",
-    strip_prefix = "bazel-toolchains-d665ccfa3e9c90fa789671bf4ef5f7c19c5715c4",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/d665ccfa3e9c90fa789671bf4ef5f7c19c5715c4.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/archive/d665ccfa3e9c90fa789671bf4ef5f7c19c5715c4.tar.gz",
-    ],
+  name = "bazel_toolchains",
+  sha256 = "67335b3563d9b67dc2550b8f27cc689b64fadac491e69ce78763d9ba894cc5cc",
+  strip_prefix = "bazel-toolchains-cddc376d428ada2927ad359211c3e356bd9c9fbb",
+  urls = [
+    "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/cddc376d428ada2927ad359211c3e356bd9c9fbb.tar.gz",
+    "https://github.com/bazelbuild/bazel-toolchains/archive/cddc376d428ada2927ad359211c3e356bd9c9fbb.tar.gz",
+  ],
 )
 
 # Creates toolchain configuration for remote execution with BuildKite CI

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -173,6 +173,7 @@ sh_test(
     srcs = ["bazel_proto_library_test.sh"],
     data = [":test-deps"],
     tags = ["no_windows"],  # Doesn't work on Windows for unknown reason
+    exec_compatible_with = ["//:highcpu_machine"],
 )
 
 sh_test(
@@ -403,6 +404,7 @@ sh_test(
         "//src/test/shell/bazel/testdata:git-repos",
         "@bazel_tools//tools/bash/runfiles",
     ],
+    exec_compatible_with = ["//:highcpu_machine"],
 )
 
 sh_test(
@@ -695,6 +697,7 @@ sh_test(
         "@bazel_tools//tools/bash/runfiles",
     ],
     tags = ["block-network"],
+    exec_compatible_with = ["//:highcpu_machine"],
 )
 
 sh_test(
@@ -710,6 +713,7 @@ sh_test(
         "no_windows",
         "slow",
     ],
+    exec_compatible_with = ["//:highcpu_machine"],
 )
 
 sh_test(

--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -115,6 +115,8 @@ cc_test(
         "//third_party/zlib",
         "@com_google_googletest//:gtest_main",
     ],
+    # Requires at least 5 GiB of memory
+    exec_compatible_with = ["//:highcpu_machine"],
 )
 
 cc_test(


### PR DESCRIPTION
 - Use the docker container from gcr.io/bazel-untrusted/ubuntu1604_bazel_rbe
   which was built specifically for Bazel's tests on RBE.
 - Introduce a highcpu_machine constraint in order to map heavy tests to
 beefy RBE workers.
 - Add the highcpu_machine constraints to heavy test targets.

Progress towards #8033