### PR TITLE
Upload tmp java_tools zips to GCS in folders identified by their commit hash and java versions.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -624,7 +624,7 @@ JAVA_VERSIONS = ("9", "10")
             "--java_tools_zip",
             "src/java_tools_dist_javac" + java_version + ".zip",
             "--gcs_java_tools_dir",
-            "tmp/dist",
+            "tmp/sources",
             "--java_version",
             java_version,
             "--platform",

--- a/src/upload_java_tools.sh
+++ b/src/upload_java_tools.sh
@@ -97,4 +97,4 @@ fi
 
 # Upload the zip that contains the README.md to GCS.
 "$gsutil_cmd" cp "$tmp_zip" \
- "gs://bazel-mirror/bazel_java_tools/${gcs_java_tools_dir}/java_tools_javac${java_version}_${platform}-${commit_hash}-${timestamp}.zip"
+ "gs://bazel-mirror/bazel_java_tools/${gcs_java_tools_dir}/${commit_hash}-${timestamp}/java_tools_javac${java_version}_${platform}-${commit_hash}-${timestamp}.zip"

--- a/src/upload_java_tools.sh
+++ b/src/upload_java_tools.sh
@@ -97,4 +97,4 @@ fi
 
 # Upload the zip that contains the README.md to GCS.
 "$gsutil_cmd" cp "$tmp_zip" \
- "gs://bazel-mirror/bazel_java_tools/${gcs_java_tools_dir}/${commit_hash}-${timestamp}/java_tools_javac${java_version}_${platform}-${commit_hash}-${timestamp}.zip"
+ "gs://bazel-mirror/bazel_java_tools/${gcs_java_tools_dir}/${commit_hash}/java_tools_javac${java_version}_${platform}-${timestamp}.zip"

--- a/src/upload_java_tools.sh
+++ b/src/upload_java_tools.sh
@@ -97,4 +97,4 @@ fi
 
 # Upload the zip that contains the README.md to GCS.
 "$gsutil_cmd" cp "$tmp_zip" \
- "gs://bazel-mirror/bazel_java_tools/${gcs_java_tools_dir}/${commit_hash}/${java_version}/java_tools_javac${java_version}_${platform}-${timestamp}.zip"
+ "gs://bazel-mirror/bazel_java_tools/${gcs_java_tools_dir}/${commit_hash}/java${java_version}/java_tools_javac${java_version}_${platform}-${timestamp}.zip"

--- a/src/upload_java_tools.sh
+++ b/src/upload_java_tools.sh
@@ -97,4 +97,4 @@ fi
 
 # Upload the zip that contains the README.md to GCS.
 "$gsutil_cmd" cp "$tmp_zip" \
- "gs://bazel-mirror/bazel_java_tools/${gcs_java_tools_dir}/${commit_hash}/java_tools_javac${java_version}_${platform}-${timestamp}.zip"
+ "gs://bazel-mirror/bazel_java_tools/${gcs_java_tools_dir}/${commit_hash}/${java_version}/java_tools_javac${java_version}_${platform}-${timestamp}.zip"


### PR DESCRIPTION
This change makes it easier to identify the artifacts from the same build when releasing java_tools.