### PR TITLE
Fix link to sources in aquery docs

### DIFF
--- a/site/docs/aquery.html
+++ b/site/docs/aquery.html
@@ -277,7 +277,7 @@ $ bazel aquery 'inputs(".*cpp, deps(//src/target_a))'
 </p>
 
 <p>
-  The tool is available in the [bazelbuild/bazel](https://github.com/bazelbuild/bazel/tree/master/tools/aquery_differ) repository.
+  The tool is available in the <a href="https://github.com/bazelbuild/bazel/tree/master/tools/aquery_differ">bazelbuild/bazel</a> repository.
   To use it, clone the repository to your local machine. An example usage:
 </p>
 


### PR DESCRIPTION
This markdown link is in an html document. This changes it to an html link.