### PR TITLE
Conditionally use deprecated signature for initWithContentsOfURL

### DIFF
--- a/tools/osx/xcode_locator.m
+++ b/tools/osx/xcode_locator.m
@@ -177,8 +177,16 @@ static NSMutableDictionary<NSString *, XcodeVersionEntry *> *FindXcodes()
           url, version, expandedVersion);
 
     NSURL *versionPlistUrl = [url URLByAppendingPathComponent:@"Contents/version.plist"];
-    NSDictionary *versionPlistContents = [[NSDictionary alloc] initWithContentsOfURL:versionPlistUrl
-                                                                               error:nil];
+
+    // macOS 10.13 changed the signature of initWithContentsOfURL,
+    // and deprecated the old one.
+    NSDictionary *versionPlistContents;
+#if MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_12
+    versionPlistContents = [[NSDictionary alloc] initWithContentsOfURL:versionPlistUrl                                                                                                                   error:nil];
+#else
+    versionPlistContents = [[NSDictionary alloc] initWithContentsOfURL:versionPlistUrl];
+#endif
+
     NSString *productVersion = [versionPlistContents objectForKey:@"ProductBuildVersion"];
     if (productVersion) {
       expandedVersion = [expandedVersion stringByAppendingFormat:@".%@", productVersion];

--- a/tools/osx/xcode_locator.m
+++ b/tools/osx/xcode_locator.m
@@ -182,7 +182,8 @@ static NSMutableDictionary<NSString *, XcodeVersionEntry *> *FindXcodes()
     // and deprecated the old one.
     NSDictionary *versionPlistContents;
 #if MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_12
-    versionPlistContents = [[NSDictionary alloc] initWithContentsOfURL:versionPlistUrl                                                                                                                   error:nil];
+    versionPlistContents = [[NSDictionary alloc] initWithContentsOfURL:versionPlistUrl
+                                                                 error:nil];
 #else
     versionPlistContents = [[NSDictionary alloc] initWithContentsOfURL:versionPlistUrl];
 #endif


### PR DESCRIPTION
Homebrew's CI is breaking on 10.12 (Sierra), for Bazel 0.24+ due to the signature used for NSDictionary:initWithContentsOfURL introduced in the fix for #7371.

This signature with an error parameter is only available on 10.13+ (High Sierra). Here's Apple's documentation: https://developer.apple.com/documentation/foundation/nsdictionary/1416069-initwithcontentsofurl?language=objc

The Homebrew issue:
https://github.com/Homebrew/homebrew-core/pull/38651
