### PR TITLE
Unpack and repack Bazel's deploy jar without compression.

### DIFF
--- a/src/package-bazel.sh
+++ b/src/package-bazel.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+set -euo pipefail
 
 # This script bootstraps building a Bazel binary without Bazel then
 # use this compiled Bazel to bootstrap Bazel itself. It can also
@@ -34,9 +34,16 @@ mkdir -p "${PACKAGE_DIR}"
 trap "rm -fr ${PACKAGE_DIR}" EXIT
 
 cp $* ${PACKAGE_DIR}
+
+# Re"compress" the deploy jar. Saves ~10% of final binary size.
+unzip -q -d recompress  ${DEPLOY_JAR}
+cd recompress
+zip -0qr ../deploy-uncompressed.jar *
+cd ..
+
 # The server jar needs to be the first binary we extract. This is how the Bazel
 # client knows what .jar to pass to the JVM.
-cp ${DEPLOY_JAR} ${PACKAGE_DIR}/A-server.jar
+cp deploy-uncompressed.jar ${PACKAGE_DIR}/A-server.jar
 cp ${INSTALL_BASE_KEY} ${PACKAGE_DIR}/install_base_key
 # The timestamp of embedded tools should already be zeroed out in the input zip
 touch -t 198001010000.00 ${PACKAGE_DIR}/*
@@ -46,4 +53,4 @@ if [ -n "${EMBEDDED_TOOLS}" ]; then
   (cd ${PACKAGE_DIR}/embedded_tools && unzip -q "${WORKDIR}/${EMBEDDED_TOOLS}")
 fi
 
-(cd ${PACKAGE_DIR} && find . -type f | sort | zip -qDX@ "${WORKDIR}/${OUT}")
+(cd ${PACKAGE_DIR} && find . -type f | sort | zip -q9DX@ "${WORKDIR}/${OUT}")


### PR DESCRIPTION
This reduces final binary size by ~10%.

RELNOTES: None