### PR TITLE
Windows, test wrapper: use WaitableProcess

### DIFF
--- a/src/main/native/windows/process.cc
+++ b/src/main/native/windows/process.cc
@@ -33,6 +33,7 @@ bool WaitableProcess::Create(const std::wstring& argv0,
                              const std::wstring& argv_rest, void* env,
                              const std::wstring& wcwd, HANDLE stdin_process,
                              HANDLE stdout_process, HANDLE stderr_process,
+                             LARGE_INTEGER* opt_out_start_time,
                              std::wstring* error) {
   std::wstring cwd;
   std::wstring error_msg(AsShortPath(wcwd, &cwd));
@@ -177,11 +178,22 @@ bool WaitableProcess::Create(const std::wstring& argv0,
     return false;
   }
 
+  if (opt_out_start_time) {
+    QueryPerformanceCounter(opt_out_start_time);
+  }
   *error = L"";
   return true;
 }
 
-int WaitableProcess::WaitFor(int64_t timeout_msec, std::wstring* error) {
+int WaitableProcess::WaitFor(
+    int64_t timeout_msec, LARGE_INTEGER* opt_out_end_time,
+    std::wstring* error) {
+  struct Defer {
+    LARGE_INTEGER* t;
+    Defer(LARGE_INTEGER* cnt) : t(cnt) {}
+    ~Defer() { if (t) { QueryPerformanceCounter(t); } }
+  } defer_query_end_time(opt_out_end_time);
+
   DWORD win32_timeout = timeout_msec < 0 ? INFINITE : timeout_msec;
   int result;
   switch (WaitForSingleObject(process_, win32_timeout)) {

--- a/src/main/native/windows/process.h
+++ b/src/main/native/windows/process.h
@@ -42,9 +42,10 @@ class WaitableProcess {
   bool Create(const std::wstring& argv0, const std::wstring& argv_rest,
               void* env, const std::wstring& wcwd, HANDLE stdin_process,
               HANDLE stdout_process, HANDLE stderr_process,
-              std::wstring* error);
+              LARGE_INTEGER* opt_out_start_time, std::wstring* error);
 
-  int WaitFor(int64_t timeout_msec, std::wstring* error);
+  int WaitFor(int64_t timeout_msec, LARGE_INTEGER* opt_out_end_time,
+              std::wstring* error);
 
   int GetExitCode(std::wstring* error);
 

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -314,7 +314,7 @@ class NativeProcess {
     return proc_.Create(
         wpath, bazel::windows::GetJavaWstring(env, java_argv_rest),
         env_map.ptr(), bazel::windows::GetJavaWpath(env, java_cwd),
-        stdin_process, stdout_process, stderr_process, &error_);
+        stdin_process, stdout_process, stderr_process, nullptr, &error_);
   }
 
   void CloseStdin() {
@@ -325,7 +325,7 @@ class NativeProcess {
 
   // Wait for this process to exit (or timeout).
   int WaitFor(int64_t timeout_msec) {
-    return proc_.WaitFor(timeout_msec, &error_);
+    return proc_.WaitFor(timeout_msec, nullptr, &error_);
   }
 
   // Returns the exit code of the process if it has already exited. If the

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -79,6 +79,7 @@ cc_library(
             "//src/main/cpp/util:filesystem",
             "//src/main/cpp/util:strings",
             "//src/main/native/windows:lib-file",
+            "//src/main/native/windows:lib-process",
             "//src/main/native/windows:lib-util",
             "//src/tools/launcher/util",
             "//third_party/ijar:zip",


### PR DESCRIPTION
The Windows-native test wrapper now uses the JNI
library's WaitableProcess to create, wait for, and
terminate the subprocess.

This allows killing the whole subprocess tree and
not waiting for sub-subprocesses.

Fixes https://github.com/bazelbuild/bazel/issues/8005