### PR TITLE
Remove java.desktop module from building the embedded JDK.

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -20,6 +20,8 @@ platforms:
     - "//tools/aquery_differ/..."
     # TODO(iirina): Re-enable after #7952 was released.
     - "-//src/test/shell/bazel:embedded_tools_deps_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   ubuntu1604:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -40,6 +42,8 @@ platforms:
     - "//tools/aquery_differ/..."
     # TODO(iirina): Re-enable after #7952 was released.
     - "-//src/test/shell/bazel:embedded_tools_deps_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   ubuntu1804:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -60,6 +64,8 @@ platforms:
     - "//tools/aquery_differ/..."
     # TODO(iirina): Re-enable after #7952 was released.
     - "-//src/test/shell/bazel:embedded_tools_deps_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   ubuntu1804_nojava:
     build_flags:
     - "--javabase=@openjdk_linux_archive//:runtime"
@@ -119,6 +125,8 @@ platforms:
     - "-//src/tools/singlejar:zip64_test"
     # TODO(iirina): Re-enable after #7952 was released.
     - "-//src/test/shell/bazel:embedded_tools_deps_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   ubuntu1804_java9:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -139,6 +147,8 @@ platforms:
     - "//tools/aquery_differ/..."
     # TODO(iirina): Re-enable after #7952 was released.
     - "-//src/test/shell/bazel:embedded_tools_deps_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   ubuntu1804_java10:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -159,6 +169,8 @@ platforms:
     - "//tools/aquery_differ/..."
     # TODO(iirina): Re-enable after #7952 was released.
     - "-//src/test/shell/bazel:embedded_tools_deps_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   ubuntu1804_java11:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -184,6 +196,8 @@ platforms:
     - "-//src/test/shell/bazel:bazel_bootstrap_distfile_test"
     # TODO(iirina): Re-enable after #7952 was released.
     - "-//src/test/shell/bazel:embedded_tools_deps_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   macos:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -213,6 +227,8 @@ platforms:
     - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
     # TODO(iirina): Re-enable after #7952 was released.
     - "-//src/test/shell/bazel:embedded_tools_deps_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   windows:
     batch_commands:
     - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
@@ -236,6 +252,8 @@ platforms:
     - "//src:all_windows_tests"
     # TODO(iirina): Re-enable after #7952 was released.
     - "-//src/test/shell/bazel:embedded_tools_deps_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   rbe_ubuntu1604:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/'

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,6 +24,8 @@ platforms:
     - "-//src/test/shell/bazel:bazel_determinism_test"
     # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/4663
     - "-//src/test/shell/bazel/android:android_ndk_integration_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   ubuntu1604:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -48,6 +50,8 @@ platforms:
     - "-//src/test/shell/bazel:bazel_determinism_test"
     # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/4663
     - "-//src/test/shell/bazel/android:android_ndk_integration_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   ubuntu1804:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -72,6 +76,8 @@ platforms:
     - "-//src/test/shell/bazel:bazel_determinism_test"
     # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/4663
     - "-//src/test/shell/bazel/android:android_ndk_integration_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   ubuntu1804_nojava:
     build_flags:
     - "--javabase=@openjdk_linux_archive//:runtime"
@@ -133,6 +139,8 @@ platforms:
     - "-//src/test/shell/integration:stub_finds_runfiles_test"
     - "-//src/test/shell/integration:test_test"
     - "-//src/tools/singlejar:zip64_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   ubuntu1804_java9:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -157,6 +165,8 @@ platforms:
     - "-//src/test/shell/bazel:bazel_determinism_test"
     # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/4663
     - "-//src/test/shell/bazel/android:android_ndk_integration_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   ubuntu1804_java10:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -181,6 +191,8 @@ platforms:
     - "-//src/test/shell/bazel:bazel_determinism_test"
     # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/4663
     - "-//src/test/shell/bazel/android:android_ndk_integration_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   ubuntu1804_java11:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -210,6 +222,8 @@ platforms:
     - "-//src/test/shell/bazel:maven_test"
     # Re-enable once bootstrap works with Java 11
     - "-//src/test/shell/bazel:bazel_bootstrap_distfile_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   macos:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
@@ -254,6 +268,8 @@ platforms:
     - "-//src/test/shell/bazel/android:aar_integration_test"
     - "-//src/test/shell/bazel/android:android_integration_test"
     - "-//src/test/shell/integration:minimal_jdk_test"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   windows:
     batch_commands:
     - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
@@ -275,6 +291,8 @@ platforms:
     test_targets:
     - "--"
     - "//src:all_windows_tests"
+    # TODO(twerth): Re-enable after java.desktop has been removed.
+    - "-//src/test/shell/bazel:jdeps_test"
   rbe_ubuntu1604:
     shell_commands:
     - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/'

--- a/src/jdeps_modules.golden
+++ b/src/jdeps_modules.golden
@@ -1,6 +1,5 @@
 java.base
 java.compiler
-java.desktop
 java.instrument
 java.logging
 java.management


### PR DESCRIPTION
Disabling the jdeps test while doing so to get rid of the chicken-egg
problem that the necessary changes have to happen in third_party but
this test definition lives outside of third_party.

Commit 1/N

RELNOTES: None