### PR TITLE
Remove removal of ct.sym.

### DIFF
--- a/src/minimize_jdk.sh
+++ b/src/minimize_jdk.sh
@@ -46,10 +46,6 @@ if [[ "$UNAME" =~ msys_nt* ]]; then
     reduced/
   # These are necessary for --host_jvm_debug to work.
   cp bin/dt_socket.dll bin/jdwp.dll reduced/bin
-  if [[ "$modules" != "ALL-MODULE-PATH" ]]; then
-    # Only necessary for compilation, which doesn't happen with the minimal JDK.
-    rm reduced/lib/ct.sym
-  fi
   zip -r -9 ../reduced.zip reduced/
   cd ../..
   mv "tmp.$$/reduced.zip" "$out"
@@ -67,10 +63,6 @@ else
     cp lib/libdt_socket.dylib lib/libjdwp.dylib reduced/lib
   else
     cp lib/libdt_socket.so lib/libjdwp.so reduced/lib
-  fi
-  if [[ "$modules" != "ALL-MODULE-PATH" ]]; then
-    # Only necessary for compilation, which doesn't happen with the minimal JDK.
-    rm reduced/lib/ct.sym
   fi
   GZIP=-9 tar -zcf ../reduced.tgz reduced
   cd ..


### PR DESCRIPTION
Since we remove the jdk.compiler module in
3880ddc695f539c9fa185cc73bb0049b6cce0b6d, this is no longer included
anyway. Deleting it here breaks building the minimal jdk, which we need
to do for the java.desktop removal.

Commit 2/N

RELNOTES: None