### PR TITLE
WIP: Windows, JNI: WaitableProcess takes relative argv0

### DIFF
--- a/src/main/native/windows/BUILD
+++ b/src/main/native/windows/BUILD
@@ -40,7 +40,10 @@ cc_library(
     visibility = [
         "//tools/test:__pkg__",
     ],
-    deps = [":lib-util"],
+    deps = [
+        ":lib-file",
+        ":lib-util",
+    ],
 )
 
 cc_library(

--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -44,7 +44,7 @@ wstring RemoveUncPrefixMaybe(const wstring& path) {
   return bazel::windows::HasUncPrefix(path.c_str()) ? path.substr(4) : path;
 }
 
-bool HasDriveSpecifierPrefix(const wstring& p) {
+bool IsAbsolute(const std::wstring& p) {
   if (HasUncPrefix(p.c_str())) {
     return p.size() >= 7 && iswalpha(p[4]) && p[5] == ':' && p[6] == '\\';
   } else {
@@ -63,7 +63,7 @@ bool IsAbsoluteNormalizedWindowsPath(const wstring& p) {
     return false;
   }
 
-  return HasDriveSpecifierPrefix(p) && p.find(L".\\") != 0 &&
+  return IsAbsolute(p) && p.find(L".\\") != 0 &&
          p.find(L"\\.\\") == wstring::npos && p.find(L"\\.") != p.size() - 2 &&
          p.find(L"..\\") != 0 && p.find(L"\\..\\") == wstring::npos &&
          p.find(L"\\..") != p.size() - 3;

--- a/src/main/native/windows/file.h
+++ b/src/main/native/windows/file.h
@@ -45,6 +45,8 @@ std::wstring AddUncPrefixMaybe(const std::wstring& path);
 
 std::wstring RemoveUncPrefixMaybe(const std::wstring& path);
 
+bool IsAbsolute(const std::wstring& p);
+
 bool IsAbsoluteNormalizedWindowsPath(const std::wstring& p);
 
 // Keep in sync with j.c.g.devtools.build.lib.windows.WindowsFileOperations


### PR DESCRIPTION
WaitableProcess::Create's argv0 argument may now
be relative.

If argv0 is relative, and cwd has a value, then we
make argv0 relative to cwd.

If argv0 is relative, and cwd is empty, we make
argv0 relative to the current directory of the
process.

This change allows using WaitableProcess in
blaze_util_windows.cc in ExecuteProgram, which is
sometimes called with a relative path.