### PR TITLE
pkg_deb: support depends_file attribute

### DIFF
--- a/tools/build_defs/pkg/make_deb.py
+++ b/tools/build_defs/pkg/make_deb.py
@@ -329,7 +329,7 @@ def main(unused_argv):
       maintainer=FLAGS.maintainer,
       section=FLAGS.section,
       architecture=FLAGS.architecture,
-      depends=GetFlagValue(FLAGS.depends),
+      depends=GetFlagValues(FLAGS.depends),
       suggests=FLAGS.suggests,
       enhances=FLAGS.enhances,
       preDepends=FLAGS.pre_depends,

--- a/tools/build_defs/pkg/make_deb.py
+++ b/tools/build_defs/pkg/make_deb.py
@@ -329,7 +329,7 @@ def main(unused_argv):
       maintainer=FLAGS.maintainer,
       section=FLAGS.section,
       architecture=FLAGS.architecture,
-      depends=FLAGS.depends,
+      depends=GetFlagValue(FLAGS.depends),
       suggests=FLAGS.suggests,
       enhances=FLAGS.enhances,
       preDepends=FLAGS.pre_depends,

--- a/tools/build_defs/pkg/pkg.bzl
+++ b/tools/build_defs/pkg/pkg.bzl
@@ -184,6 +184,14 @@ def _pkg_deb_impl(ctx):
     elif ctx.attr.built_using:
         args += ["--built_using=" + ctx.attr.built_using]
 
+    if ctx.attr.depends_file:
+        if ctx.file.depends:
+            fail("Both depends and depends_file attributes were specified")
+        args += ["--depends=@" + ctx.attr.depends_file.path]
+        files += [ctx.file.depends_file]
+    elif ctx.attr.depends:
+        args += ["--depends=" + d for d in ctx.attr.depends]
+
     if ctx.attr.priority:
         args += ["--priority=" + ctx.attr.priority]
     if ctx.attr.section:
@@ -193,7 +201,6 @@ def _pkg_deb_impl(ctx):
 
     args += ["--distribution=" + ctx.attr.distribution]
     args += ["--urgency=" + ctx.attr.urgency]
-    args += ["--depends=" + d for d in ctx.attr.depends]
     args += ["--suggests=" + d for d in ctx.attr.suggests]
     args += ["--enhances=" + d for d in ctx.attr.enhances]
     args += ["--conflicts=" + d for d in ctx.attr.conflicts]
@@ -299,6 +306,7 @@ _pkg_deb = rule(
         "section": attr.string(),
         "homepage": attr.string(),
         "depends": attr.string_list(default = []),
+        "depends_file": attr.label(allow_single_file=True),
         "suggests": attr.string_list(default = []),
         "enhances": attr.string_list(default = []),
         "conflicts": attr.string_list(default = []),


### PR DESCRIPTION
Fixes #7886 by adding support for `depends_file` attribute in `pkg_deb`
Summoning @aiuto for review as he expressed the wish to do it.