### PR TITLE
Fix bash completion path

### DIFF
--- a/site/docs/completion.md
+++ b/site/docs/completion.md
@@ -24,7 +24,7 @@ If you installed Bazel:
 
         Example: if you ran the installer with `--user`, this will be
         `$HOME/.bazel/bin`. If you ran the installer as root, this will be
-        `/usr/local/bazel/bin`.
+        `/usr/local/lib/bazel/bin`.
     2.  Do one of the following:
         *   Either copy this file to your completion directory (if you have
             one).


### PR DESCRIPTION
The Bazel binary installer said
```
prefix="/usr/local"
bin="%prefix%/bin"
base="%prefix%/lib/bazel"
```
so the bash completion script should be in `/usr/local/lib/bazel/bin` when we run the installer as root.