### PR TITLE
Starlark API to allow rules and genrules to declare ResourceSets

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -227,6 +227,9 @@ public class SpawnAction extends AbstractAction implements ExecutionInfoSpecifie
   }
 
   @VisibleForTesting
+  public ResourceSet getResourceSet() { return resourceSet; }
+
+  @VisibleForTesting
   public CommandLines getCommandLines() {
     return commandLines;
   }

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -55,7 +55,9 @@ public final class TargetUtils {
           || tag.startsWith("supports-")
           || tag.startsWith("disable-")
           || tag.equals("local")
-          || tag.startsWith("cpu:");
+          || tag.startsWith("cpu:")
+          || tag.equals("cpu")
+          || tag.equals("memory");
     }
   };
 

--- a/src/test/java/com/google/devtools/build/lib/actions/ExecutionRequirementsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ExecutionRequirementsTest.java
@@ -1,0 +1,64 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.actions;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Test for {@link ExecutionRequirements}
+ */
+@RunWith(JUnit4.class)
+public class ExecutionRequirementsTest {
+  @Test
+  public void testTaggedRequirementsCPU() throws Exception {
+    int parsed;
+
+    parsed = ExecutionRequirements.TAGGED_CPU.parse("1");
+    assertThat(parsed).isEqualTo(1);
+
+    try {
+      ExecutionRequirements.TAGGED_CPU.parse("+04");
+      fail("Expected a ValidationException");
+    } catch (ExecutionRequirements.TaggedRequirement.ValidationException e) {
+      assertThat(e).hasMessageThat().contains("must be in canonical format");
+    }
+  }
+
+  @Test
+  public void testTaggedRequirementsMemory() throws Exception {
+    int parsed;
+
+    parsed = ExecutionRequirements.TAGGED_MEM_MB.parse("1536M");
+    assertThat(parsed).isEqualTo(1536);
+
+    parsed = ExecutionRequirements.TAGGED_MEM_MB.parse("1G");
+    assertThat(parsed).isEqualTo(1024);
+
+    parsed = ExecutionRequirements.TAGGED_MEM_MB.parse("1.5G");
+    assertThat(parsed).isEqualTo(1536);
+
+    try {
+      ExecutionRequirements.TAGGED_MEM_MB.parse("1024");
+      fail("Expected a ValidationException");
+    } catch (ExecutionRequirements.TaggedRequirement.ValidationException e) {
+      assertThat(e).hasMessageThat().contains("must match pattern");
+    }
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/skylark/SkylarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skylark/SkylarkRuleImplementationFunctionsTest.java
@@ -378,6 +378,27 @@ public class SkylarkRuleImplementationFunctionsTest extends SkylarkTestCase {
   }
 
   @Test
+  public void testCreateSpawnActionResourceSet() throws Exception {
+    SkylarkRuleContext ruleContext = createRuleContext("//foo:foo");
+    evalRuleContextCode(
+        ruleContext,
+        "ruleContext.actions.run_shell(",
+        "  inputs = ruleContext.files.srcs,",
+        "  outputs = ruleContext.files.srcs,",
+        "  env = {'a' : 'b'},",
+        "  execution_requirements = {'cpu': '4', 'memory': '1.5G'},",
+        "  mnemonic = 'DummyMnemonic',",
+        "  command = 'dummy_command',",
+        "  progress_message = 'dummy_message')");
+    SpawnAction action =
+        (SpawnAction)
+            Iterables.getOnlyElement(
+                ruleContext.getRuleContext().getAnalysisEnvironment().getRegisteredActions());
+    assertThat(action.getResourceSet().getCpuUsage()).isEqualTo(4.0);
+    assertThat(action.getResourceSet().getMemoryMb()).isEqualTo(1536.0);
+  }
+
+  @Test
   public void testCreateSpawnActionUnknownParam() throws Exception {
     SkylarkRuleContext ruleContext = createRuleContext("//foo:foo");
     checkErrorContains(


### PR DESCRIPTION
This change allows rule writers to define CPU and memory requirements for
rules.  It's intended to help avoid overcommitting a build host when
invoking multithreaded or memory-intensive commands.

The approach taken was discussed both in #6477 and
https://groups.google.com/d/msg/bazel-dev/HaZuVmx6dfk/h6WnlabHCQAJ.

In a future change, `TaggedRequirement` could replace (and be renamed
to) `ParseableRequirement`.

Resolves #6477.