### PR TITLE
Windows, JNI: WaitableProcess supports inv. HANDLE

### DIFF
--- a/src/main/native/windows/process.cc
+++ b/src/main/native/windows/process.cc
@@ -130,7 +130,7 @@ bool WaitableProcess::Create(const std::wstring& argv0,
           /* lpCommandLine */ mutable_commandline.get(),
           /* lpProcessAttributes */ NULL,
           /* lpThreadAttributes */ NULL,
-          /* bInheritHandles */ TRUE,
+          /* bInheritHandles */ attr_list->InheritAnyHandles() ? TRUE : FALSE,
           /* dwCreationFlags */ CREATE_NO_WINDOW  // Don't create console
                                                   // window
               | CREATE_NEW_PROCESS_GROUP  // So that Ctrl-Break isn't propagated

--- a/src/main/native/windows/util.cc
+++ b/src/main/native/windows/util.cc
@@ -73,12 +73,20 @@ wstring GetLastErrorString(DWORD error_code) {
 bool AutoAttributeList::Create(HANDLE stdin_h, HANDLE stdout_h, HANDLE stderr_h,
                                std::unique_ptr<AutoAttributeList>* result,
                                wstring* error_msg) {
+  if (stdin_h == INVALID_HANDLE_VALUE && stdout_h == INVALID_HANDLE_VALUE &&
+      stderr_h == INVALID_HANDLE_VALUE) {
+    result->reset(new AutoAttributeList());
+    return true;
+  }
+
   static constexpr DWORD kAttributeCount = 1;
 
   SIZE_T size = 0;
   // According to MSDN, the first call to InitializeProcThreadAttributeList is
   // expected to fail.
   InitializeProcThreadAttributeList(NULL, kAttributeCount, 0, &size);
+  SetLastError(ERROR_SUCCESS);
+
   std::unique_ptr<uint8_t[]> data(new uint8_t[size]);
   LPPROC_THREAD_ATTRIBUTE_LIST attrs =
       reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(data.get());
@@ -94,22 +102,26 @@ bool AutoAttributeList::Create(HANDLE stdin_h, HANDLE stdout_h, HANDLE stderr_h,
 
   std::unique_ptr<AutoAttributeList> attr_list(
       new AutoAttributeList(std::move(data), stdin_h, stdout_h, stderr_h));
-  if (attr_list->handles_.ValidHandlesCount() > 0) {
-    if (!UpdateProcThreadAttribute(attrs, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
-                                   attr_list->handles_.ValidHandles(),
-                                   attr_list->handles_.ValidHandlesCount() *
-                                       sizeof(HANDLE), NULL, NULL)) {
-      if (error_msg) {
-        DWORD err = GetLastError();
-        *error_msg = MakeErrorMessage(WSTR(__FILE__), __LINE__,
-                                      L"UpdateProcThreadAttribute", L"", err);
-      }
-      return false;
+  if (!UpdateProcThreadAttribute(attrs, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+                                 attr_list->handles_.ValidHandles(),
+                                 attr_list->handles_.ValidHandlesCount() *
+                                     sizeof(HANDLE), NULL, NULL)) {
+    if (error_msg) {
+      DWORD err = GetLastError();
+      *error_msg = MakeErrorMessage(WSTR(__FILE__), __LINE__,
+                                    L"UpdateProcThreadAttribute", L"", err);
     }
+    return false;
   }
   *result = std::move(attr_list);
   return true;
 }
+
+AutoAttributeList::StdHandles::StdHandles()
+    : valid_handles_(0),
+      stdin_h_(INVALID_HANDLE_VALUE),
+      stdout_h_(INVALID_HANDLE_VALUE),
+      stderr_h_(INVALID_HANDLE_VALUE) {}
 
 AutoAttributeList::StdHandles::StdHandles(HANDLE stdin_h, HANDLE stdout_h,
                                           HANDLE stderr_h)
@@ -144,21 +156,25 @@ AutoAttributeList::operator LPPROC_THREAD_ATTRIBUTE_LIST() const {
 void AutoAttributeList::InitStartupInfoExA(STARTUPINFOEXA* startup_info) const {
   ZeroMemory(startup_info, sizeof(STARTUPINFOEXA));
   startup_info->StartupInfo.cb = sizeof(STARTUPINFOEXA);
-  startup_info->StartupInfo.dwFlags = STARTF_USESTDHANDLES;
-  startup_info->StartupInfo.hStdInput = handles_.StdIn();
-  startup_info->StartupInfo.hStdOutput = handles_.StdOut();
-  startup_info->StartupInfo.hStdError = handles_.StdErr();
-  startup_info->lpAttributeList = *this;
+  if (InheritAnyHandles()) {
+    startup_info->StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+    startup_info->StartupInfo.hStdInput = handles_.StdIn();
+    startup_info->StartupInfo.hStdOutput = handles_.StdOut();
+    startup_info->StartupInfo.hStdError = handles_.StdErr();
+    startup_info->lpAttributeList = *this;
+  }
 }
 
 void AutoAttributeList::InitStartupInfoExW(STARTUPINFOEXW* startup_info) const {
   ZeroMemory(startup_info, sizeof(STARTUPINFOEXW));
   startup_info->StartupInfo.cb = sizeof(STARTUPINFOEXW);
-  startup_info->StartupInfo.dwFlags = STARTF_USESTDHANDLES;
-  startup_info->StartupInfo.hStdInput = handles_.StdIn();
-  startup_info->StartupInfo.hStdOutput = handles_.StdOut();
-  startup_info->StartupInfo.hStdError = handles_.StdErr();
-  startup_info->lpAttributeList = *this;
+  if (InheritAnyHandles()) {
+    startup_info->StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+    startup_info->StartupInfo.hStdInput = handles_.StdIn();
+    startup_info->StartupInfo.hStdOutput = handles_.StdOut();
+    startup_info->StartupInfo.hStdError = handles_.StdErr();
+    startup_info->lpAttributeList = *this;
+  }
 }
 
 static void QuotePath(const wstring& path, wstring* result) {

--- a/src/main/native/windows/util.cc
+++ b/src/main/native/windows/util.cc
@@ -121,7 +121,11 @@ AutoAttributeList::StdHandles::StdHandles()
     : valid_handles_(0),
       stdin_h_(INVALID_HANDLE_VALUE),
       stdout_h_(INVALID_HANDLE_VALUE),
-      stderr_h_(INVALID_HANDLE_VALUE) {}
+      stderr_h_(INVALID_HANDLE_VALUE) {
+  handle_array_[0] = INVALID_HANDLE_VALUE;
+  handle_array_[1] = INVALID_HANDLE_VALUE;
+  handle_array_[2] = INVALID_HANDLE_VALUE;
+}
 
 AutoAttributeList::StdHandles::StdHandles(HANDLE stdin_h, HANDLE stdout_h,
                                           HANDLE stderr_h)
@@ -129,6 +133,9 @@ AutoAttributeList::StdHandles::StdHandles(HANDLE stdin_h, HANDLE stdout_h,
       stdin_h_(stdin_h),
       stdout_h_(stdout_h),
       stderr_h_(stderr_h) {
+  handle_array_[0] = INVALID_HANDLE_VALUE;
+  handle_array_[1] = INVALID_HANDLE_VALUE;
+  handle_array_[2] = INVALID_HANDLE_VALUE;
   if (stdin_h != INVALID_HANDLE_VALUE) {
     handle_array_[valid_handles_++] = stdin_h;
   }

--- a/src/main/native/windows/util.h
+++ b/src/main/native/windows/util.h
@@ -66,6 +66,8 @@ class AutoHandle {
 
 class AutoAttributeList {
  public:
+  AutoAttributeList() {}
+
   static bool Create(HANDLE stdin_h, HANDLE stdout_h, HANDLE stderr_h,
                      std::unique_ptr<AutoAttributeList>* result,
                      std::wstring* error_msg = nullptr);
@@ -80,6 +82,7 @@ class AutoAttributeList {
  private:
   class StdHandles {
    public:
+    StdHandles();
     StdHandles(HANDLE stdin_h, HANDLE stdout_h, HANDLE stderr_h);
     size_t ValidHandlesCount() const { return valid_handles_; }
     HANDLE* ValidHandles() { return handle_array_; }

--- a/src/main/native/windows/util.h
+++ b/src/main/native/windows/util.h
@@ -68,24 +68,31 @@ class AutoAttributeList {
  public:
   static bool Create(HANDLE stdin_h, HANDLE stdout_h, HANDLE stderr_h,
                      std::unique_ptr<AutoAttributeList>* result,
-                     wstring* error_msg = nullptr);
+                     std::wstring* error_msg = nullptr);
   ~AutoAttributeList();
+
+  bool InheritAnyHandles() const { return handles_.ValidHandlesCount() > 0; }
 
   void InitStartupInfoExA(STARTUPINFOEXA* startup_info) const;
 
   void InitStartupInfoExW(STARTUPINFOEXW* startup_info) const;
 
  private:
-  struct StdHandles {
-    static constexpr size_t kHandleCount = 3;
-    union {
-      HANDLE handle_array[kHandleCount];
-      struct {
-        HANDLE stdin_h;
-        HANDLE stdout_h;
-        HANDLE stderr_h;
-      };
-    };
+  class StdHandles {
+   public:
+    StdHandles(HANDLE stdin_h, HANDLE stdout_h, HANDLE stderr_h);
+    size_t ValidHandlesCount() const { return valid_handles_; }
+    HANDLE* ValidHandles() { return handle_array_; }
+    HANDLE StdIn() const { return stdin_h_; }
+    HANDLE StdOut() const { return stdout_h_; }
+    HANDLE StdErr() const { return stderr_h_; }
+
+   private:
+    size_t valid_handles_;
+    HANDLE handle_array_[3];
+    HANDLE stdin_h_;
+    HANDLE stdout_h_;
+    HANDLE stderr_h_;
   };
 
   AutoAttributeList(std::unique_ptr<uint8_t[]>&& data, HANDLE stdin_h,


### PR DESCRIPTION
WaitableProcess and AutoAttributeList support
INVALID_HANDLE_VALUE for some or all of the std_*
handles of the subprocess.

AutoAttributeList initializes the inheritable
HANDLE array only for the valid HANDLEs.

WaitableProcess forbids HANDLE inheritance if all
std_* handles are invalid.