### PR TITLE
Shard //src/test/java/com/google/devtools/build/lib/rules/cpp:cpp-rul…

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -25,6 +25,7 @@ java_test(
         "//tools/cpp:lib_cc_configure",
     ],
     tags = ["rules"],
+    shard_count = 5,
     test_class = "com.google.devtools.build.lib.AllTests",
     deps = [
         ":CcImportBaseConfiguredTargetTest",

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -24,8 +24,8 @@ java_test(
         "//tools/cpp:cc_toolchain_config_lib.bzl",
         "//tools/cpp:lib_cc_configure",
     ],
-    tags = ["rules"],
     shard_count = 5,
+    tags = ["rules"],
     test_class = "com.google.devtools.build.lib.AllTests",
     deps = [
         ":CcImportBaseConfiguredTargetTest",


### PR DESCRIPTION
…es-tests

It is frequently one of the longest-running tests on CI.

Currently there are 63 test suites (classes) and 447 test cases
(methods) in this one test target.