### PR TITLE
Embed the java_tools BUILD file in the java tools archive.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -642,18 +642,49 @@ JAVA_VERSIONS = ("9", "10")
     for java_version in JAVA_VERSIONS
 ]
 
+genrule(
+    name = "create_java_tools_build_and_workspace",
+    srcs = ["//tools/jdk:BUILD.java_tools"],
+    outs = ["remote_java_tools/BUILD"],
+    cmd = "cp $< $@",
+)
+
+genrule(
+    name = "java_tools_build_and_workspace_files",
+    srcs = ["remote_java_tools/BUILD"],
+    outs = ["java_tools_build_workspace.zip"],
+    cmd = "zip -jX $@ $<"
+)
+
 # Builds the remote Java tools archive. Not embedded or used in Bazel, but used
 # by the Java tools release process.
 [
     genrule(
-        name = "java_tools_java" + java_version + "_zip",
+        name = "java_tools_java" + java_version + "_no_build_zip",
         srcs = [
             ":jars_java_tools_java" + java_version + ".zip",
+            ":java_tools_build_workspace.zip",
             "//src/tools/singlejar:singlejar_transitive_zip",
             "//third_party/ijar:ijar_transitive_zip",
         ],
-        outs = ["java_tools_java" + java_version + ".zip"],
+        outs = ["java_tools_java" + java_version + "_no_build.zip"],
         cmd = "$(location //src:merge_zip_files) java_tools $@ $(SRCS)",
+        output_to_bindir = 1,
+        tools = ["//src:merge_zip_files"],
+        visibility = ["//src/test/shell/bazel:__pkg__"],
+    )
+    for java_version in JAVA_VERSIONS
+]
+
+[
+    genrule(
+        name = "java_tools_java" + java_version + "_zip",
+        srcs = [
+            "java_tools_java" + java_version + "_no_build.zip",
+            "java_tools_build_workspace.zip",
+        ],
+        outs = ["java_tools_java" + java_version + ".zip"],
+        cmd = "$(location //src:merge_zip_files) - $@ $(SRCS)",
         output_to_bindir = 1,
         tools = ["//src:merge_zip_files"],
         visibility = ["//src/test/shell/bazel:__pkg__"],

--- a/src/BUILD
+++ b/src/BUILD
@@ -643,14 +643,14 @@ JAVA_VERSIONS = ("9", "10")
 ]
 
 genrule(
-    name = "create_java_tools_build_and_workspace",
+    name = "create_java_tools_build",
     srcs = ["//tools/jdk:BUILD.java_tools"],
     outs = ["remote_java_tools/BUILD"],
     cmd = "cp $< $@",
 )
 
 genrule(
-    name = "java_tools_build_and_workspace_files",
+    name = "java_tools_build_zip",
     srcs = ["remote_java_tools/BUILD"],
     outs = ["java_tools_build_workspace.zip"],
     cmd = "zip -jX $@ $<"

--- a/src/BUILD
+++ b/src/BUILD
@@ -652,7 +652,7 @@ genrule(
 genrule(
     name = "java_tools_build_zip",
     srcs = ["remote_java_tools/BUILD"],
-    outs = ["java_tools_build_workspace.zip"],
+    outs = ["java_tools_build.zip"],
     cmd = "zip -jX $@ $<"
 )
 
@@ -663,7 +663,7 @@ genrule(
         name = "java_tools_java" + java_version + "_no_build_zip",
         srcs = [
             ":jars_java_tools_java" + java_version + ".zip",
-            ":java_tools_build_workspace.zip",
+            ":java_tools_build.zip",
             "//src/tools/singlejar:singlejar_transitive_zip",
             "//third_party/ijar:ijar_transitive_zip",
         ],
@@ -681,7 +681,7 @@ genrule(
         name = "java_tools_java" + java_version + "_zip",
         srcs = [
             "java_tools_java" + java_version + "_no_build.zip",
-            "java_tools_build_workspace.zip",
+            "java_tools_build.zip",
         ],
         outs = ["java_tools_java" + java_version + ".zip"],
         cmd = "$(location //src:merge_zip_files) - $@ $(SRCS)",

--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -154,4 +154,8 @@ function test_java_tools_has_ExperimentalRunner() {
   expect_path_in_java_tools "java_tools/ExperimentalRunner_deploy.jar"
 }
 
+function test_java_tools_has_BUILD() {
+  expect_path_in_java_tools "BUILD"
+}
+
 run_suite "Java tools archive tests"

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -2,6 +2,60 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+java_toolchain(
+    name = "toolchain",
+    source_version = "8",
+    target_version = "8",
+    forcibly_disable_header_compilation = 0,
+    genclass = [":Genclass"],
+    header_compiler = [":turbine"],
+    header_compiler_direct = [":turbine_direct"],
+    ijar = [":ijar"],
+    javabuilder = [":javabuilder"],
+    javac = [":javac_jar"],
+    tools = [
+        ":java_compiler_jar",
+        ":jdk_compiler_jar",
+    ],
+    javac_supports_workers = 1,
+    jvm_opts = [
+       # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
+       # G1 collector and having compact strings enabled.
+       "-XX:+UseParallelOldGC",
+       "-XX:-CompactStrings",
+       # Allow JavaBuilder to access internal javac APIs.
+       "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+       "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+       "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+       "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+       "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+       "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+       "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+       "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+
+       # override the javac in the JDK.
+       "--patch-module=java.compiler=$(location :java_compiler_jar)",
+       "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
+
+       # quiet warnings from com.google.protobuf.UnsafeUtil,
+       # see: https://github.com/google/protobuf/issues/3781
+       # and: https://github.com/bazelbuild/bazel/issues/5599
+       "--add-opens=java.base/java.nio=ALL-UNNAMED",
+       "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    ],
+    misc = [
+       "-XDskipDuplicateBridges=true",
+       "-g",
+       "-parameters",
+   ],
+    compatible_javacopts = {
+        # Restrict protos to Java 7 so that they are compatible with Android.
+       "proto": ["-source", "7", "-target", "7"],
+    },
+    singlejar = [":singlejar"],
+    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
+)
+
 filegroup(
     name = "ExperimentalRunner",
     srcs = ["java_tools/ExperimentalRunner_deploy.jar"],


### PR DESCRIPTION
Also add a corresponding `java_toolchain` target in the BUILD file.

The advantage of this change is that every java tools release will come with its own embedded toolchain. That allows us to remove all the targets under `@bazel_tools//tools/jdk`. Additionally it allows straightforward definitions of `toolchain`s, so we can platformize the Java rules in Bazel.