### PR TITLE
Allow all targets to specify exec_compatible_with to add constraints on

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -41,7 +41,6 @@ import com.google.devtools.build.lib.packages.Attribute.LateBoundDefault.Resolve
 import com.google.devtools.build.lib.packages.AttributeMap;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
-import com.google.devtools.build.lib.packages.RuleClass.ExecutionPlatformConstraintsAllowed;
 import com.google.devtools.build.lib.packages.TestSize;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.syntax.Type;
@@ -208,7 +207,6 @@ public class BaseRuleClasses {
                           env.getToolsLabel(DEFAULT_COVERAGE_REPORT_GENERATOR_VALUE))))
           // The target itself and run_under both run on the same machine.
           .add(attr(":run_under", LABEL).value(RUN_UNDER).skipPrereqValidatorCheck())
-          .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET)
           .build();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
@@ -59,7 +59,6 @@ import com.google.devtools.build.lib.packages.PredicateWithMessage;
 import com.google.devtools.build.lib.packages.Provider;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
-import com.google.devtools.build.lib.packages.RuleClass.ExecutionPlatformConstraintsAllowed;
 import com.google.devtools.build.lib.packages.RuleFactory;
 import com.google.devtools.build.lib.packages.RuleFactory.BuildLangTypedAttributeValuesMap;
 import com.google.devtools.build.lib.packages.RuleFactory.InvalidRuleException;
@@ -220,7 +219,6 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
                             toolsRepository
                                 + BaseRuleClasses.DEFAULT_COVERAGE_REPORT_GENERATOR_VALUE))))
         .add(attr(":run_under", LABEL).value(RUN_UNDER))
-        .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET)
         .build();
   }
 
@@ -278,6 +276,7 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
       SkylarkList<?> toolchains,
       String doc,
       SkylarkList<?> providesArg,
+      // TODO(https://github.com/bazelbuild/bazel/issues/8026): Remove this.
       Boolean executionPlatformConstraintsAllowed,
       SkylarkList<?> execCompatibleWith,
       Object analysisTest,
@@ -397,9 +396,6 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
           collectConstraintLabels(
               execCompatibleWith.getContents(String.class, "exec_compatile_with"),
               ast.getLocation()));
-    }
-    if (executionPlatformConstraintsAllowed) {
-      builder.executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET);
     }
 
     return new SkylarkRuleFunction(builder, type, attributes, ast.getLocation());

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/BazelShRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/BazelShRuleClasses.java
@@ -26,7 +26,6 @@ import com.google.devtools.build.lib.packages.Attribute.AllowedValueSet;
 import com.google.devtools.build.lib.packages.PredicateWithMessage;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
-import com.google.devtools.build.lib.packages.RuleClass.ExecutionPlatformConstraintsAllowed;
 import com.google.devtools.build.lib.util.FileTypeSet;
 import javax.annotation.Nullable;
 
@@ -72,7 +71,6 @@ public final class BazelShRuleClasses {
               .allowedRuleClasses("sh_library")
               .allowedRuleClassesWithWarning(ALLOWED_RULES_IN_DEPS_WITH_WARNING)
               .allowedFileTypes())
-          .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET)
           .build();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBaseRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleBaseRule.java
@@ -29,7 +29,6 @@ import com.google.devtools.build.lib.packages.AttributeMap;
 import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
-import com.google.devtools.build.lib.packages.RuleClass.ExecutionPlatformConstraintsAllowed;
 import com.google.devtools.build.lib.util.FileTypeSet;
 
 /**
@@ -226,7 +225,6 @@ public class GenRuleBaseRule implements RuleDefinition {
         .add(attr("heuristic_label_expansion", BOOLEAN).value(false))
         .removeAttribute("data")
         .removeAttribute("deps")
-        .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET)
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
@@ -65,7 +65,6 @@ import com.google.devtools.build.lib.packages.Package;
 import com.google.devtools.build.lib.packages.RawAttributeMapper;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.RuleClass;
-import com.google.devtools.build.lib.packages.RuleClass.ExecutionPlatformConstraintsAllowed;
 import com.google.devtools.build.lib.packages.RuleClassProvider;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.packages.TargetUtils;
@@ -457,8 +456,7 @@ public final class ConfiguredTargetFunction implements SkyFunction {
 
     execConstraintLabels.addAll(rule.getRuleClassObject().getExecutionPlatformConstraints());
 
-    if (rule.getRuleClassObject().executionPlatformConstraintsAllowed()
-        == ExecutionPlatformConstraintsAllowed.PER_TARGET) {
+    if (mapper.has(RuleClass.EXEC_COMPATIBLE_WITH_ATTR, BuildType.LABEL_LIST)) {
       execConstraintLabels.addAll(
           mapper.get(RuleClass.EXEC_COMPATIBLE_WITH_ATTR, BuildType.LABEL_LIST));
     }

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleFunctionsApi.java
@@ -276,6 +276,7 @@ public interface SkylarkRuleFunctionsApi<FileApiT extends FileApi> {
             positional = false,
             defaultValue = "[]",
             doc = PROVIDES_DOC),
+        // TODO(https://github.com/bazelbuild/bazel/issues/8026): Remove this.
         @Param(
             name = "execution_platform_constraints_allowed",
             type = Boolean.class,

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -53,7 +53,6 @@ import com.google.devtools.build.lib.packages.ConfigurationFragmentPolicy.Missin
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.ThirdPartyLicenseExistencePolicy;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory;
-import com.google.devtools.build.lib.packages.RuleClass.ExecutionPlatformConstraintsAllowed;
 import com.google.devtools.build.lib.packages.RuleFactory.BuildLangTypedAttributeValuesMap;
 import com.google.devtools.build.lib.packages.util.PackageLoadingTestCase;
 import com.google.devtools.build.lib.syntax.BaseFunction;
@@ -920,7 +919,6 @@ public class RuleClassTest extends PackageLoadingTestCase {
         ThirdPartyLicenseExistencePolicy.USER_CONTROLLABLE,
         /*requiredToolchains=*/ ImmutableSet.of(),
         /*supportsPlatforms=*/ true,
-        ExecutionPlatformConstraintsAllowed.PER_RULE,
         /* executionPlatformConstraints= */ ImmutableSet.of(),
         OutputFile.Kind.FILE,
         ImmutableList.copyOf(attributes),
@@ -1078,12 +1076,11 @@ public class RuleClassTest extends PackageLoadingTestCase {
   }
 
   @Test
-  public void testExecutionPlatformConstraints_perRule() throws Exception {
+  public void testExecutionPlatformConstraints() throws Exception {
     RuleClass.Builder ruleClassBuilder =
         new RuleClass.Builder("ruleClass", RuleClassType.NORMAL, false)
             .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
-            .add(attr("tags", STRING_LIST))
-            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_RULE);
+            .add(attr("tags", STRING_LIST));
 
     ruleClassBuilder.addExecutionPlatformConstraints(
         Label.parseAbsolute("//constraints:cv1", ImmutableMap.of()),
@@ -1095,23 +1092,6 @@ public class RuleClassTest extends PackageLoadingTestCase {
         .containsExactly(
             Label.parseAbsolute("//constraints:cv1", ImmutableMap.of()),
             Label.parseAbsolute("//constraints:cv2", ImmutableMap.of()));
-    assertThat(ruleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isFalse();
-  }
-
-  @Test
-  public void testExecutionPlatformConstraints_perTarget() {
-    RuleClass.Builder ruleClassBuilder =
-        new RuleClass.Builder("ruleClass", RuleClassType.NORMAL, false)
-            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
-            .add(attr("tags", STRING_LIST));
-
-    ruleClassBuilder.executionPlatformConstraintsAllowed(
-        ExecutionPlatformConstraintsAllowed.PER_TARGET);
-
-    RuleClass ruleClass = ruleClassBuilder.build();
-
-    assertThat(ruleClass.executionPlatformConstraintsAllowed())
-        .isEqualTo(ExecutionPlatformConstraintsAllowed.PER_TARGET);
     assertThat(ruleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isTrue();
   }
 
@@ -1120,7 +1100,6 @@ public class RuleClassTest extends PackageLoadingTestCase {
     RuleClass parentRuleClass =
         new RuleClass.Builder("$parentRuleClass", RuleClassType.ABSTRACT, false)
             .add(attr("tags", STRING_LIST))
-            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_RULE)
             .addExecutionPlatformConstraints(
                 Label.parseAbsolute("//constraints:cv1", ImmutableMap.of()),
                 Label.parseAbsolute("//constraints:cv2", ImmutableMap.of()))
@@ -1135,7 +1114,40 @@ public class RuleClassTest extends PackageLoadingTestCase {
         .containsExactly(
             Label.parseAbsolute("//constraints:cv1", ImmutableMap.of()),
             Label.parseAbsolute("//constraints:cv2", ImmutableMap.of()));
-    assertThat(childRuleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isFalse();
+    assertThat(childRuleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isTrue();
+  }
+
+  @Test
+  public void testExecutionPlatformConstraints_inheritConstraintsFromParent_multiple()
+      throws Exception {
+    RuleClass parentRuleClass1 =
+        new RuleClass.Builder("$parentRuleClass1", RuleClassType.ABSTRACT, false)
+            .add(attr("tags", STRING_LIST))
+            .addExecutionPlatformConstraints(
+                Label.parseAbsolute("//constraints:cv1", ImmutableMap.of()),
+                Label.parseAbsolute("//constraints:cv2", ImmutableMap.of()))
+            .build();
+    RuleClass parentRuleClass2 =
+        new RuleClass.Builder("$parentRuleClass2", RuleClassType.ABSTRACT, false)
+            .add(attr("tags", STRING_LIST))
+            .addExecutionPlatformConstraints(
+                Label.parseAbsolute("//constraints:cv3", ImmutableMap.of()),
+                Label.parseAbsolute("//constraints:cv4", ImmutableMap.of()))
+            .build();
+
+    RuleClass childRuleClass =
+        new RuleClass.Builder(
+                "childRuleClass", RuleClassType.NORMAL, false, parentRuleClass1, parentRuleClass2)
+            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
+            .build();
+
+    assertThat(childRuleClass.getExecutionPlatformConstraints())
+        .containsExactly(
+            Label.parseAbsolute("//constraints:cv1", ImmutableMap.of()),
+            Label.parseAbsolute("//constraints:cv2", ImmutableMap.of()),
+            Label.parseAbsolute("//constraints:cv3", ImmutableMap.of()),
+            Label.parseAbsolute("//constraints:cv4", ImmutableMap.of()));
+    assertThat(childRuleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isTrue();
   }
 
   @Test
@@ -1148,7 +1160,6 @@ public class RuleClassTest extends PackageLoadingTestCase {
     RuleClass.Builder childRuleClassBuilder =
         new RuleClass.Builder("childRuleClass", RuleClassType.NORMAL, false, parentRuleClass)
             .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
-            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_RULE)
             .addExecutionPlatformConstraints(
                 Label.parseAbsolute("//constraints:cv1", ImmutableMap.of()),
                 Label.parseAbsolute("//constraints:cv2", ImmutableMap.of()));
@@ -1159,91 +1170,6 @@ public class RuleClassTest extends PackageLoadingTestCase {
         .containsExactly(
             Label.parseAbsolute("//constraints:cv1", ImmutableMap.of()),
             Label.parseAbsolute("//constraints:cv2", ImmutableMap.of()));
-    assertThat(childRuleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isFalse();
-  }
-
-  @Test
-  public void testExecutionPlatformConstraints_inherit_parentAllowsPerTarget() {
-    RuleClass parentRuleClass =
-        new RuleClass.Builder("parentRuleClass", RuleClassType.NORMAL, false)
-            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
-            .add(attr("tags", STRING_LIST))
-            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET)
-            .build();
-
-    RuleClass.Builder childRuleClassBuilder =
-        new RuleClass.Builder("childRuleClass", RuleClassType.NORMAL, false, parentRuleClass)
-            .factory(DUMMY_CONFIGURED_TARGET_FACTORY);
-
-    RuleClass childRuleClass = childRuleClassBuilder.build();
-
-    assertThat(childRuleClass.executionPlatformConstraintsAllowed())
-        .isEqualTo(ExecutionPlatformConstraintsAllowed.PER_TARGET);
-    assertThat(childRuleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isTrue();
-  }
-
-  @Test
-  public void testExecutionPlatformConstraints_inherit_multipleParents() {
-    RuleClass parentRuleClass1 =
-        new RuleClass.Builder("parentRuleClass1", RuleClassType.NORMAL, false)
-            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
-            .add(attr("tags", STRING_LIST))
-            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET)
-            .build();
-    RuleClass parentRuleClass2 =
-        new RuleClass.Builder("$parentRuleClass2", RuleClassType.ABSTRACT, false)
-            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_RULE)
-            .build();
-
-    RuleClass.Builder childRuleClassBuilder =
-        new RuleClass.Builder(
-                "childRuleClass", RuleClassType.NORMAL, false, parentRuleClass1, parentRuleClass2)
-            .factory(DUMMY_CONFIGURED_TARGET_FACTORY);
-
-    RuleClass childRuleClass = childRuleClassBuilder.build();
-
-    assertThat(childRuleClass.executionPlatformConstraintsAllowed())
-        .isEqualTo(ExecutionPlatformConstraintsAllowed.PER_TARGET);
-    assertThat(childRuleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isTrue();
-  }
-
-  @Test
-  public void testExecutionPlatformConstraints_inherit_parentAllowsPerTarget_override() {
-    RuleClass parentRuleClass =
-        new RuleClass.Builder("parentRuleClass", RuleClassType.NORMAL, false)
-            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
-            .add(attr("tags", STRING_LIST))
-            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET)
-            .build();
-
-    RuleClass.Builder childRuleClassBuilder =
-        new RuleClass.Builder("childRuleClass", RuleClassType.NORMAL, false, parentRuleClass)
-            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
-            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_RULE);
-
-    RuleClass childRuleClass = childRuleClassBuilder.build();
-
-    assertThat(childRuleClass.executionPlatformConstraintsAllowed())
-        .isEqualTo(ExecutionPlatformConstraintsAllowed.PER_RULE);
-  }
-
-  @Test
-  public void testExecutionPlatformConstraints_inherit_childAllowsPerTarget() {
-    RuleClass parentRuleClass =
-        new RuleClass.Builder("$parentRuleClass", RuleClassType.ABSTRACT, false)
-            .add(attr("tags", STRING_LIST))
-            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_RULE)
-            .build();
-
-    RuleClass.Builder childRuleClassBuilder =
-        new RuleClass.Builder("childRuleClass", RuleClassType.NORMAL, false, parentRuleClass)
-            .factory(DUMMY_CONFIGURED_TARGET_FACTORY)
-            .executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET);
-
-    RuleClass childRuleClass = childRuleClassBuilder.build();
-
-    assertThat(childRuleClass.executionPlatformConstraintsAllowed())
-        .isEqualTo(ExecutionPlatformConstraintsAllowed.PER_TARGET);
     assertThat(childRuleClass.hasAttr("exec_compatible_with", LABEL_LIST)).isTrue();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skylark/SkylarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skylark/SkylarkRuleClassFunctionsTest.java
@@ -37,7 +37,6 @@ import com.google.devtools.build.lib.packages.PredicateWithMessage;
 import com.google.devtools.build.lib.packages.RequiredProviders;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
-import com.google.devtools.build.lib.packages.RuleClass.ExecutionPlatformConstraintsAllowed;
 import com.google.devtools.build.lib.packages.SkylarkAspectClass;
 import com.google.devtools.build.lib.packages.SkylarkDefinedAspect;
 import com.google.devtools.build.lib.packages.SkylarkInfo;
@@ -1738,6 +1737,7 @@ public class SkylarkRuleClassFunctionsTest extends SkylarkTestCase {
         .containsExactly(makeLabel("//constraint:cv1"), makeLabel("//constraint:cv2"));
   }
 
+  // TODO(https://github.com/bazelbuild/bazel/issues/8026): Remove API.
   @Test
   public void testTargetsCanAddExecutionPlatformConstraints() throws Exception {
     registerDummyUserDefinedFunction();
@@ -1748,8 +1748,6 @@ public class SkylarkRuleClassFunctionsTest extends SkylarkTestCase {
         "  execution_platform_constraints_allowed=True,",
         ")");
     RuleClass c = ((SkylarkRuleFunction) lookup("r1")).getRuleClass();
-    assertThat(c.executionPlatformConstraintsAllowed())
-        .isEqualTo(ExecutionPlatformConstraintsAllowed.PER_TARGET);
   }
 
   @Test


### PR DESCRIPTION
the execution platform.

Remove the ExecutionPlatformConstraintsAllowed enum entirely.

Part of work on #8026.