### PR TITLE
Add incompatible_disallow_rule_execution_platform_constraints_allowed flag.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
@@ -286,7 +286,7 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
       FuncallExpression ast,
       Environment funcallEnv,
       StarlarkContext context)
-      throws EvalException, ConversionException {
+      throws EvalException {
     SkylarkUtils.checkLoadingOrWorkspacePhase(funcallEnv, "rule", ast.getLocation());
 
     BazelStarlarkContext bazelContext = (BazelStarlarkContext) context;
@@ -398,8 +398,13 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
               execCompatibleWith.getContents(String.class, "exec_compatile_with"),
               ast.getLocation()));
     }
-    if (executionPlatformConstraintsAllowed) {
+
+    if (funcallEnv.getSemantics().incompatibleDisallowRuleExecutionPlatformConstraintsAllowed()) {
       builder.executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET);
+    } else if (executionPlatformConstraintsAllowed) {
+      builder.executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET);
+    } else {
+      builder.executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_RULE);
     }
 
     return new SkylarkRuleFunction(builder, type, attributes, ast.getLocation());

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
@@ -399,9 +399,7 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
               ast.getLocation()));
     }
 
-    if (funcallEnv.getSemantics().incompatibleDisallowRuleExecutionPlatformConstraintsAllowed()) {
-      builder.executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET);
-    } else if (executionPlatformConstraintsAllowed) {
+    if (executionPlatformConstraintsAllowed) {
       builder.executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_TARGET);
     } else {
       builder.executionPlatformConstraintsAllowed(ExecutionPlatformConstraintsAllowed.PER_RULE);

--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
@@ -330,6 +330,20 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
   public boolean incompatibleDisallowNativeInBuildFile;
 
   @Option(
+      name = "incompatible_disallow_rule_execution_platform_constraints_allowed",
+      defaultValue = "False",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
+      metadataTags = {
+        OptionMetadataTag.INCOMPATIBLE_CHANGE,
+        OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+      },
+      help =
+          "If set to true, disallow the use of the execution_platform_constraints_allowed "
+              + "attribute on rule().")
+  public boolean incompatibleDisallowRuleExecutionPlatformConstraintsAllowed;
+
+  @Option(
       name = "incompatible_string_join_requires_strings",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
@@ -623,6 +637,8 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
         .incompatibleDisallowOldOctalNotation(incompatibleDisallowOldOctalNotation)
         .incompatibleDisallowOldStyleArgsAdd(incompatibleDisallowOldStyleArgsAdd)
         .incompatibleDisallowStructProviderSyntax(incompatibleDisallowStructProviderSyntax)
+        .incompatibleDisallowRuleExecutionPlatformConstraintsAllowed(
+            incompatibleDisallowRuleExecutionPlatformConstraintsAllowed)
         .incompatibleExpandDirectories(incompatibleExpandDirectories)
         .incompatibleNewActionsApi(incompatibleNewActionsApi)
         .incompatibleNoAttrLicense(incompatibleNoAttrLicense)

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleFunctionsApi.java
@@ -287,7 +287,9 @@ public interface SkylarkRuleFunctionsApi<FileApiT extends FileApi> {
                     + "label-list type is added, which must not already exist in "
                     + "<code>attrs</code>. Targets may use this attribute to specify additional "
                     + "constraints on the execution platform beyond those given in the "
-                    + "<code>exec_compatible_with</code> argument to <code>rule()</code>."),
+                    + "<code>exec_compatible_with</code> argument to <code>rule()</code>. "
+                    + "This will be deprecated and removed in the near future, and all rules will "
+                    + "be able to use <code>exec_compatible_with</code>."),
         @Param(
             name = "exec_compatible_with",
             type = SkylarkList.class,

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleFunctionsApi.java
@@ -282,6 +282,8 @@ public interface SkylarkRuleFunctionsApi<FileApiT extends FileApi> {
             named = true,
             positional = false,
             defaultValue = "False",
+            disableWithFlag = FlagIdentifier.INCOMPATIBLE_DISALLOW_RULE_EXECUTION_PLATFORM_CONSTRAINTS_ALLOWED,
+            valueWhenDisabled = "True",
             doc =
                 "If true, a special attribute named <code>exec_compatible_with</code> of "
                     + "label-list type is added, which must not already exist in "

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
@@ -54,7 +54,8 @@ public abstract class StarlarkSemantics {
     INCOMPATIBLE_NO_TARGET_OUTPUT_GROUP(StarlarkSemantics::incompatibleNoTargetOutputGroup),
     INCOMPATIBLE_NO_ATTR_LICENSE(StarlarkSemantics::incompatibleNoAttrLicense),
     INCOMPATIBLE_OBJC_FRAMEWORK_CLEANUP(StarlarkSemantics::incompatibleObjcFrameworkCleanup),
-    INCOMPATIBLE_DISALLOW_RULE_EXECUTION_PLATFORM_CONSTRAINTS_ALLOWED(StarlarkSemantics::incompatibleDisallowRuleExecutionPlatformConstraintsAllowed),
+    INCOMPATIBLE_DISALLOW_RULE_EXECUTION_PLATFORM_CONSTRAINTS_ALLOWED(
+        StarlarkSemantics::incompatibleDisallowRuleExecutionPlatformConstraintsAllowed),
     NONE(null);
 
     // Using a Function here makes the enum definitions far cleaner, and, since this is

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
@@ -164,6 +164,8 @@ public abstract class StarlarkSemantics {
 
   public abstract boolean incompatibleDisallowStructProviderSyntax();
 
+  public abstract boolean incompatibleDisallowRuleExecutionPlatformConstraintsAllowed();
+
   public abstract boolean incompatibleExpandDirectories();
 
   public abstract boolean incompatibleNewActionsApi();
@@ -235,6 +237,7 @@ public abstract class StarlarkSemantics {
           .incompatibleDisallowOldOctalNotation(false)
           .incompatibleDisallowOldStyleArgsAdd(true)
           .incompatibleDisallowStructProviderSyntax(false)
+          .incompatibleDisallowRuleExecutionPlatformConstraintsAllowed(false)
           .incompatibleExpandDirectories(true)
           .incompatibleNewActionsApi(false)
           .incompatibleNoAttrLicense(true)
@@ -305,6 +308,9 @@ public abstract class StarlarkSemantics {
     public abstract Builder incompatibleDisallowNativeInBuildFile(boolean value);
 
     public abstract Builder incompatibleDisallowStructProviderSyntax(boolean value);
+
+    public abstract Builder incompatibleDisallowRuleExecutionPlatformConstraintsAllowed(
+        boolean value);
 
     public abstract Builder incompatibleExpandDirectories(boolean value);
 

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
@@ -54,6 +54,7 @@ public abstract class StarlarkSemantics {
     INCOMPATIBLE_NO_TARGET_OUTPUT_GROUP(StarlarkSemantics::incompatibleNoTargetOutputGroup),
     INCOMPATIBLE_NO_ATTR_LICENSE(StarlarkSemantics::incompatibleNoAttrLicense),
     INCOMPATIBLE_OBJC_FRAMEWORK_CLEANUP(StarlarkSemantics::incompatibleObjcFrameworkCleanup),
+    INCOMPATIBLE_DISALLOW_RULE_EXECUTION_PLATFORM_CONSTRAINTS_ALLOWED(StarlarkSemantics::incompatibleDisallowRuleExecutionPlatformConstraintsAllowed),
     NONE(null);
 
     // Using a Function here makes the enum definitions far cleaner, and, since this is

--- a/src/test/java/com/google/devtools/build/lib/packages/SkylarkSemanticsConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/SkylarkSemanticsConsistencyTest.java
@@ -148,6 +148,7 @@ public class SkylarkSemanticsConsistencyTest {
         "--incompatible_disallow_old_octal_notation=" + rand.nextBoolean(),
         "--incompatible_disallow_old_style_args_add=" + rand.nextBoolean(),
         "--incompatible_disallow_struct_provider_syntax=" + rand.nextBoolean(),
+        "--incompatible_disallow_rule_execution_platform_constraints_allowed=" + rand.nextBoolean(),
         "--incompatible_expand_directories=" + rand.nextBoolean(),
         "--incompatible_new_actions_api=" + rand.nextBoolean(),
         "--incompatible_no_attr_license=" + rand.nextBoolean(),
@@ -199,6 +200,7 @@ public class SkylarkSemanticsConsistencyTest {
         .incompatibleDisallowOldOctalNotation(rand.nextBoolean())
         .incompatibleDisallowOldStyleArgsAdd(rand.nextBoolean())
         .incompatibleDisallowStructProviderSyntax(rand.nextBoolean())
+        .incompatibleDisallowRuleExecutionPlatformConstraintsAllowed(rand.nextBoolean())
         .incompatibleExpandDirectories(rand.nextBoolean())
         .incompatibleNewActionsApi(rand.nextBoolean())
         .incompatibleNoAttrLicense(rand.nextBoolean())

--- a/src/test/java/com/google/devtools/build/lib/skylark/SkylarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skylark/SkylarkRuleClassFunctionsTest.java
@@ -137,7 +137,7 @@ public class SkylarkRuleClassFunctionsTest extends SkylarkTestCase {
   }
 
   private void registerDummyUserDefinedFunction() throws Exception {
-    eval("def impl():\n" + "  return 0\n");
+    eval("def impl():", "  pass");
   }
 
   @Test
@@ -1747,10 +1747,9 @@ public class SkylarkRuleClassFunctionsTest extends SkylarkTestCase {
     ev = createEvaluationTestCase(semantics);
     ev.initialize();
 
+    registerDummyUserDefinedFunction();
     scratch.file("test/BUILD", "toolchain_type(name = 'my_toolchain_type')");
     evalAndExport(
-        "def impl():",
-        "  return 0",
         "r1 = rule(impl, ",
         "  toolchains=['//test:my_toolchain_type'],",
         "  execution_platform_constraints_allowed=True,",
@@ -1769,10 +1768,9 @@ public class SkylarkRuleClassFunctionsTest extends SkylarkTestCase {
     ev = createEvaluationTestCase(semantics);
     ev.initialize();
 
+    registerDummyUserDefinedFunction();
     scratch.file("test/BUILD", "toolchain_type(name = 'my_toolchain_type')");
     evalAndExport(
-        "def impl():",
-        "  return 0",
         "r1 = rule(impl, ",
         "  toolchains=['//test:my_toolchain_type'],",
         "  execution_platform_constraints_allowed=False,",
@@ -1792,10 +1790,9 @@ public class SkylarkRuleClassFunctionsTest extends SkylarkTestCase {
     ev.setFailFast(false);
     ev.initialize();
 
+    registerDummyUserDefinedFunction();
     scratch.file("test/BUILD", "toolchain_type(name = 'my_toolchain_type')");
     evalAndExport(
-        "def impl():",
-        "  return 0",
         "r1 = rule(impl, ",
         "  toolchains=['//test:my_toolchain_type'],",
         "  execution_platform_constraints_allowed=True,",


### PR DESCRIPTION


Part of #8136 and #8134.

RELNOTES: Adds
incompatible_disallow_rule_execution_platform_constraints_allowed, which
disallows the use of the "execution_platform_constraints_allowed"
attribute when defining new rules.