### PR TITLE
Extract runtime desugar lib dependencies to @android_tools

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -380,7 +380,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip",
-        "android_tools_pkg-0.1.tar.gz",
+        "android_tools_pkg-0.2.tar.gz",
     ],
     dirname = "test_WORKSPACE/distdir",
     sha256 = {
@@ -402,7 +402,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": "f3f44b6235508e87b760bf37a49e186cc1fa4e9cd28384c4dbf5a33991921e08",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": "059f8e3484bf07b63a8f2820d5f528f473eff1befdb1896ee4f8ff06be3b8d8f",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": "e1f5b4ce1b9148140fae2fcfb8a96d1c9b7eac5b8df0e13fbcad9b8561284880",
-        "android_tools_pkg-0.1.tar.gz": "b71b10e8f067dd6bff446fb0d49239fe28b12cfd1ed24278d04b06cf54669862",
+        "android_tools_pkg-0.2.tar.gz": "04f85f2dd049e87805511e3babc5cea3f5e72332b1627e34f3a5461cc38e815f",
     },
     urls = {
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz"],
@@ -423,8 +423,8 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz"],
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip"],
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64.zip"],
-        "android_tools_pkg-0.1.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.1.tar.gz",
+        "android_tools_pkg-0.2.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.2.tar.gz",
         ],
     },
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,7 +116,7 @@ distdir_tar(
         "2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz",
         "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz",
         "0.16.2.zip",
-        "android_tools_pkg-0.1.tar.gz",
+        "android_tools_pkg-0.2.tar.gz",
     ],
     dirname = "derived/distdir",
     sha256 = {
@@ -129,7 +129,7 @@ distdir_tar(
         "2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz": "4a1318fed4831697b83ce879b3ab70ae09592b167e5bda8edaff45132d1c3b3f",
         "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz": "d868ce50d592ef4aad7dec4dd32ae68d2151261913450fac8390b3fd474bb898",
         "0.16.2.zip": "9b72bb0aea72d7cbcfc82a01b1e25bf3d85f791e790ddec16c65e2d906382ee0",
-        "android_tools_pkg-0.1.tar.gz": "b71b10e8f067dd6bff446fb0d49239fe28b12cfd1ed24278d04b06cf54669862",
+        "android_tools_pkg-0.2.tar.gz": "04f85f2dd049e87805511e3babc5cea3f5e72332b1627e34f3a5461cc38e815f",
     },
     urls = {
         "e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip": [
@@ -164,8 +164,8 @@ distdir_tar(
             "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
             "https://github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
         ],
-        "android_tools_pkg-0.1.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.1.tar.gz",
+        "android_tools_pkg-0.2.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.2.tar.gz",
         ],
     },
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -2,6 +2,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "android_tools",
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.1.tar.gz",
-    sha256 = "b71b10e8f067dd6bff446fb0d49239fe28b12cfd1ed24278d04b06cf54669862",
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.2.tar.gz",
+    sha256 = "04f85f2dd049e87805511e3babc5cea3f5e72332b1627e34f3a5461cc38e815f",
 )

--- a/tools/android/BUILD
+++ b/tools/android/BUILD
@@ -191,15 +191,6 @@ py_test(
     ],
 )
 
-genrule(
-    name = "desugar_jdk_libs",
-    srcs = ["@desugar_jdk_libs"],
-    outs = ["desugar_jdk_libs.jar"],
-    cmd = "cp $< $@",
-    output_to_bindir = 1,
-    visibility = ["//visibility:private"],
-)
-
 filegroup(
     name = "srcs",
     srcs = glob(
@@ -225,7 +216,6 @@ filegroup(
             ".*",
         ],
     ) + [
-        ":desugar_jdk_libs.jar",
         "//tools/android/emulator:embedded_tools",
     ],
 )

--- a/tools/android/BUILD.tools
+++ b/tools/android/BUILD.tools
@@ -61,7 +61,7 @@ sh_binary(
 alias(
     name = "aar_import_deps_checker",
     actual = "//src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps:ImportDepsChecker_embedded",
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
 )
 
 alias(
@@ -142,7 +142,7 @@ filegroup(
 
 genrule(
     name = "desugar_java8_legacy_libs",
-    srcs = ["desugar_jdk_libs.jar"],
+    srcs = ["@android_tools//:desugar_jdk_libs.jar"],
     outs = ["desugared_java8_legacy_libs.jar"],
     cmd = """
     $(location :desugar_java8) \

--- a/tools/android/runtime_deps/BUILD.android_tools
+++ b/tools/android/runtime_deps/BUILD.android_tools
@@ -1,4 +1,5 @@
 exports_files([
     "all_android_tools_deploy.jar",
     "ImportDepsChecker_deploy.jar",
+    "desugar_jdk_libs.jar",
 ])

--- a/tools/android/runtime_deps/BUILD.bazel
+++ b/tools/android/runtime_deps/BUILD.bazel
@@ -45,7 +45,6 @@ genrule(
     srcs = ["@desugar_jdk_libs"],
     outs = ["desugar_jdk_libs.jar"],
     cmd = "cp $< $@",
-    output_to_bindir = 1,
 )
 
 pkg_tar(

--- a/tools/android/runtime_deps/BUILD.bazel
+++ b/tools/android/runtime_deps/BUILD.bazel
@@ -40,11 +40,20 @@ genrule(
     ],
 )
 
+genrule(
+    name = "desugar_jdk_libs",
+    srcs = ["@desugar_jdk_libs"],
+    outs = ["desugar_jdk_libs.jar"],
+    cmd = "cp $< $@",
+    output_to_bindir = 1,
+)
+
 pkg_tar(
     name = "android_tools",
     srcs = [
         "BUILD",
         "WORKSPACE",
+        ":desugar_jdk_libs.jar",
         "//src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps:ImportDepsChecker_deploy.jar",
         "//src/tools/android/java/com/google/devtools/build/android:all_android_tools_deploy.jar",
     ],

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -34,7 +34,7 @@
 set -xeuo pipefail
 
 # The version of android_tools.tar.gz
-VERSION="0.1"
+VERSION="0.2"
 VERSIONED_FILENAME="android_tools_pkg-$VERSION.tar.gz"
 
 # Create a temp directory to hold the versioned tarball, and clean it up when the script exits.


### PR DESCRIPTION
Before:

```
$ ls -al bazel-bin/src/bazel
-r-xr-xr-x 1 jingwen primarygroup 52307083 Apr 25 15:33 bazel-bin/src/bazel
```

After:

```
$ ls -al bazel-bin/src/bazel
-r-xr-xr-x 1 jingwen primarygroup 51351230 Apr 25 15:33 bazel-bin/src/bazel
```

The new filesize after this change is 49MiB. 