### PR TITLE
Add shell test for contents of @android_tools

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -147,6 +147,17 @@ sh_test(
 )
 
 sh_test(
+    name = "bazel_android_tools_test",
+    size = "small",
+    srcs = ["bazel_android_tools_test.sh"],
+    data = [
+        ":test-deps",
+        "//tools/android/runtime_deps:android_tools.tar.gz",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+sh_test(
     name = "bazel_java_tools_javac9_test",
     size = "small",
     srcs = ["bazel_java_tools_test.sh"],

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -155,6 +155,7 @@ sh_test(
         "//tools/android/runtime_deps:android_tools.tar.gz",
         "@bazel_tools//tools/bash/runfiles",
     ],
+    tags = ["no_windows"],
 )
 
 sh_test(

--- a/src/test/shell/bazel/bazel_android_tools_test.sh
+++ b/src/test/shell/bazel/bazel_android_tools_test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Load the test setup defined in the parent directory
+set -euo pipefail
+
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+    if [[ -f "$0.runfiles_manifest" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+      export RUNFILES_DIR="$0.runfiles"
+    fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+function expect_path_in_android_tools() {
+  local path="$1"; shift
+
+  count=$(tar tf $(rlocation io_bazel/tools/android/runtime_deps/android_tools.tar.gz) | grep -c "$path")
+  [[ "$count" -gt 0 ]] || fail "Path $path not found in android_tools.tar.gz"
+}
+
+function test_android_tools_has_WORKSPACE() {
+  expect_path_in_android_tools "WORKSPACE"
+}
+
+function test_android_tools_has_import_deps_checker_deploy() {
+  expect_path_in_android_tools "ImportDepsChecker_deploy.jar"
+}
+
+function test_android_tools_has_all_android_tools_deploy() {
+  expect_path_in_android_tools "all_android_tools_deploy.jar"
+}
+
+function test_android_tools_has_BUILD() {
+  expect_path_in_android_tools "BUILD"
+}
+
+run_suite "Android tools archive tests"

--- a/tools/android/runtime_deps/BUILD.bazel
+++ b/tools/android/runtime_deps/BUILD.bazel
@@ -49,6 +49,7 @@ pkg_tar(
         "//src/tools/android/java/com/google/devtools/build/android:all_android_tools_deploy.jar",
     ],
     extension = "tar.gz",
+    visibility = ["//src/test/shell/bazel:__subpackages__"],
 )
 
 sh_binary(


### PR DESCRIPTION
Add a shell test for the contents of `@android_tools`, the tarball containing runtime dependencies of Android rules.

This follows the test pattern for the runtime Java tools: https://github.com/bazelbuild/bazel/blob/68a27443901b98916052d9fd5b378c89a4110f36/src/test/shell/bazel/bazel_java_tools_test.sh