### PR TITLE
Prepare third_party/java/proguard to be bundled into remote java tools

### DIFF
--- a/third_party/java/proguard/BUILD
+++ b/third_party/java/proguard/BUILD
@@ -15,3 +15,24 @@ filegroup(
     ],
     visibility = ["//src:__pkg__"],
 )
+
+java_import(
+    name = "proguard_import",
+    jars = ["proguard5.3.3/lib/proguard.jar"],
+)
+
+java_binary(
+    name = "proguard",
+    main_class = "proguard.ProGuard",
+    runtime_deps = [":proguard_import"],
+)
+
+# To be bundled into remote Java tools
+filegroup(
+    name = "proguard_deploy_with_license",
+    srcs = [
+        "proguard5.3.3/docs/GPL.html",
+        ":proguard_deploy.jar",
+    ],
+    visibility = ["//src:__pkg__"],
+)


### PR DESCRIPTION
This is the //third_party change to add a new target to be bundled into the remote java tools. For the actual bundling, see see #8153.