### PR TITLE
Bundle proguard into remote java tools

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -567,6 +567,7 @@ JAVA_TOOLS_DEPLOY_JARS = [
     "//src/java_tools/junitrunner/java/com/google/testing/junit/runner:ExperimentalRunner_deploy.jar",
     "//src/java_tools/junitrunner/java/com/google/testing/junit/runner:Runner_deploy.jar",
     "//third_party/jarjar:jarjar_command_deploy.jar",
+    "//third_party/java/proguard:proguard_deploy_with_license",
 ] + select({
     "//src/conditions:arm": ["//src/java_tools/singlejar/java/com/google/devtools/build/singlejar:bazel-singlejar_deploy.jar"],
     "//conditions:default": [],


### PR DESCRIPTION
Blocked on #8152 

Once we get a new Java tools release containing proguard, we can changes all references to `@bazel_tools//third_party/java/proguard` to use the one in remote Java tools.