### PR TITLE
Add jacoco to the BUILD file that will be embedded into java tools.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -207,7 +207,7 @@ http_archive(
 
 http_archive(
     name = "remote_java_tools_linux",
-    build_file = "@bazel_tools//tools/jdk:BUILD.java_tools",
+    build_file = "@bazel_tools//tools/jdk:BUILD.java_tools.old",
     sha256 = "9163c9963f31e10101d538163c435db9534baf9db63d380508311b775fbe3c37",
     urls = [
         "https://mirror.bazel.build/bazel_java_tools/releases/java_tools_javac10_linux-x86_64-v2.1.zip",
@@ -216,7 +216,7 @@ http_archive(
 
 http_archive(
     name = "remote_java_tools_windows",
-    build_file = "@bazel_tools//tools/jdk:BUILD.java_tools",
+    build_file = "@bazel_tools//tools/jdk:BUILD.java_tools.old",
     sha256 = "a7a99e34213eb80384b81dda0217582a38f876f420c7b648900f254bf9ea3bd7",
     urls = [
         "https://mirror.bazel.build/bazel_java_tools/releases/java_tools_javac10_windows-x86_64-v2.1.zip",
@@ -225,7 +225,7 @@ http_archive(
 
 http_archive(
     name = "remote_java_tools_darwin",
-    build_file = "@bazel_tools//tools/jdk:BUILD.java_tools",
+    build_file = "@bazel_tools//tools/jdk:BUILD.java_tools.old",
     sha256 = "5f6a7abf7ec0c491dc2d0b15add6a2abb594e31809f4cabc2cfde41efa995f92",
     urls = [
         "https://mirror.bazel.build/bazel_java_tools/releases/java_tools_javac10_darwin-v2.1.zip",

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -147,7 +147,15 @@ remote_java_tools_filegroup(
     target = ":singlejar",
 )
 
-exports_files(["BUILD.java_tools", "BUILD.java_tools.old"])
+exports_files([
+    # The BUILD file embedded into the java tools releases starting with
+    # javac10 3.0 and javac9 1.0.
+    "BUILD.java_tools",
+    # Remove this file after java_tools javac 10 3.0 and java_tools javac 9 1.0 are
+    # released. This file is embedded in bazel and passed as a BUILD file to the
+    # remote java tools http_archives.
+    "BUILD.java_tools.old"
+])
 
 remote_java_tools_filegroup(
     name = "genclass",

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -147,7 +147,7 @@ remote_java_tools_filegroup(
     target = ":singlejar",
 )
 
-exports_files(["BUILD.java_tools"])
+exports_files(["BUILD.java_tools", "BUILD.java_tools.old"])
 
 remote_java_tools_filegroup(
     name = "genclass",
@@ -360,6 +360,7 @@ filegroup(
     srcs = [
         "BUILD.java_langtools",
         "BUILD.java_tools",
+        "BUILD.java_tools.old",
         "BUILD-jdk",  # Tools are build from the workspace for tests.
         "DumpPlatformClassPath.java",
         "default_java_toolchain.bzl",

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -121,6 +121,49 @@ filegroup(
     srcs = ["java_tools/java_compiler.jar"],
 )
 
+java_import(
+    name = "jacoco-agent",
+    jars = ["java_tools/third_party/java/jacoco/org.jacoco.agent-0.7.5.201505241946.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.agent-0.7.5.201505241946-src.jar",
+)
+
+java_import(
+    name = "jacoco-core",
+    jars = ["java_tools/third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946-src.jar",
+    exports = [
+        "//third_party:asm",
+        "//third_party:asm-commons",
+        "//third_party:asm-tree",
+    ],
+)
+
+filegroup(
+    name = "jacoco-core-jars",
+    srcs = ["java_tools/third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946.jar"],
+)
+
+java_import(
+    name = "jacoco-report",
+    jars = ["java_tools/third_party/java/jacoco/org.jacoco.report-0.7.5.201505241946.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.report-0.7.5.201505241946-src.jar",
+    exports = [
+        ":core",
+        "//third_party:asm",
+    ],
+)
+
+java_import(
+    name = "bazel-jacoco-agent",
+    jars = ["java_tools/third_party/java/jacoco/jacocoagent.jar"],
+)
+
+java_import(
+    name = "bazel-jacoco-agent-neverlink",
+    jars = ["java_tools/third_party/java/jacoco/jacocoagent.jar"],
+    neverlink = 1,
+)
+
 config_setting(
     name = "remote",
     values = {"define": "EXECUTOR=remote"},

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -132,9 +132,9 @@ java_import(
     jars = ["java_tools/third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946.jar"],
     srcjar = "java_tools/third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946-src.jar",
     exports = [
-        "//third_party:asm",
-        "//third_party:asm-commons",
-        "//third_party:asm-tree",
+        ":asm",
+        ":asm-commons",
+        ":asm-tree",
     ],
 )
 
@@ -148,8 +148,8 @@ java_import(
     jars = ["java_tools/third_party/java/jacoco/org.jacoco.report-0.7.5.201505241946.jar"],
     srcjar = "java_tools/third_party/java/jacoco/org.jacoco.report-0.7.5.201505241946-src.jar",
     exports = [
-        ":core",
-        "//third_party:asm",
+        ":jacoco-core",
+        ":asm",
     ],
 )
 
@@ -162,6 +162,26 @@ java_import(
     name = "bazel-jacoco-agent-neverlink",
     jars = ["java_tools/third_party/java/jacoco/jacocoagent.jar"],
     neverlink = 1,
+)
+
+java_import(
+    name = "asm",
+    jars = ["java_tools/third_party/java/jacoco/asm-7.0.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/asm-7.0-sources.jar",
+)
+
+java_import(
+    name = "asm-commons",
+    jars = ["java_tools/third_party/java/jacoco/asm-commons-7.0.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/asm-commons-7.0-sources.jar",
+    runtime_deps = [":asm-tree"],
+)
+
+java_import(
+    name = "asm-tree",
+    jars = ["java_tools/third_party/java/jacoco/asm-tree-7.0.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/asm-tree-7.0-sources.jar",
+    runtime_deps = [":asm"],
 )
 
 config_setting(

--- a/tools/jdk/BUILD.java_tools.old
+++ b/tools/jdk/BUILD.java_tools.old
@@ -1,0 +1,592 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+java_toolchain(
+    name = "toolchain",
+    source_version = "8",
+    target_version = "8",
+    forcibly_disable_header_compilation = 0,
+    genclass = [":Genclass"],
+    header_compiler = [":turbine"],
+    header_compiler_direct = [":turbine_direct"],
+    ijar = [":ijar"],
+    javabuilder = [":javabuilder"],
+    javac = [":javac_jar"],
+    tools = [
+        ":java_compiler_jar",
+        ":jdk_compiler_jar",
+    ],
+    javac_supports_workers = 1,
+    jvm_opts = [
+       # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
+       # G1 collector and having compact strings enabled.
+       "-XX:+UseParallelOldGC",
+       "-XX:-CompactStrings",
+       # Allow JavaBuilder to access internal javac APIs.
+       "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+       "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+       "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+       "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+       "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+       "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+       "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+       "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+
+       # override the javac in the JDK.
+       "--patch-module=java.compiler=$(location :java_compiler_jar)",
+       "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
+
+       # quiet warnings from com.google.protobuf.UnsafeUtil,
+       # see: https://github.com/google/protobuf/issues/3781
+       # and: https://github.com/bazelbuild/bazel/issues/5599
+       "--add-opens=java.base/java.nio=ALL-UNNAMED",
+       "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    ],
+    misc = [
+       "-XDskipDuplicateBridges=true",
+       "-g",
+       "-parameters",
+   ],
+    compatible_javacopts = {
+        # Restrict protos to Java 7 so that they are compatible with Android.
+       "proto": ["-source", "7", "-target", "7"],
+    },
+    singlejar = [":singlejar"],
+    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
+)
+
+filegroup(
+    name = "ExperimentalRunner",
+    srcs = ["java_tools/ExperimentalRunner_deploy.jar"],
+)
+
+filegroup(
+    name = "GenClass",
+    srcs = ["java_tools/GenClass_deploy.jar"],
+)
+
+filegroup(
+    name = "JacocoCoverage",
+    srcs = ["java_tools/JacocoCoverage_jarjar_deploy.jar"],
+)
+
+filegroup(
+    name = "JavaBuilder",
+    srcs = ["java_tools/JavaBuilder_deploy.jar"],
+)
+
+filegroup(
+    name = "Runner",
+    srcs = ["java_tools/Runner_deploy.jar"],
+)
+
+filegroup(
+    name = "VanillaJavaBuilder",
+    srcs = ["java_tools/VanillaJavaBuilder_deploy.jar"],
+)
+
+filegroup(
+    name = "SingleJar",
+    srcs = ["java_tools/bazel-singlejar_deploy.jar"],
+)
+
+filegroup(
+    name = "JarJar",
+    srcs = ["java_tools/jarjar_command_deploy.jar"],
+)
+
+filegroup(
+    name = "Turbine",
+    srcs = ["java_tools/turbine_deploy.jar"],
+)
+
+filegroup(
+    name = "TurbineDirect",
+    srcs = ["java_tools/turbine_direct_binary_deploy.jar"],
+)
+
+filegroup(
+    name = "javac_jar",
+    srcs = ["java_tools/javac-9+181-r4173-1.jar"],
+)
+
+filegroup(
+    name = "jdk_compiler_jar",
+    srcs = ["java_tools/jdk_compiler.jar"],
+)
+
+filegroup(
+    name = "java_compiler_jar",
+    srcs = ["java_tools/java_compiler.jar"],
+)
+
+config_setting(
+    name = "remote",
+    values = {"define": "EXECUTOR=remote"},
+)
+
+config_setting(
+    name = "linux_x86_64",
+    values = {"cpu": "k8"},
+)
+
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+)
+
+config_setting(
+    name = "darwin_x86_64",
+    values = {"cpu": "darwin_x86_64"},
+)
+
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+)
+
+config_setting(
+    name = "freebsd",
+    values = {"cpu": "freebsd"},
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "singlejar",
+    actual = select({
+         "//:remote": ":singlejar_cc_bin",
+         "//conditions:default": ":singlejar_prebuilt_or_cc_binary",
+     }),
+)
+
+alias(
+    name = "singlejar_prebuilt_or_cc_binary",
+    actual = select({
+          ":linux_x86_64": "java_tools/src/tools/singlejar/singlejar_local",
+          ":darwin": "java_tools/src/tools/singlejar/singlejar_local",
+          ":darwin_x86_64": "java_tools/src/tools/singlejar/singlejar_local",
+          ":windows": "java_tools/src/tools/singlejar/singlejar_local.exe",
+          "//conditions:default": "singlejar_cc_bin",
+      })
+)
+
+alias(
+  name = "ijar",
+  actual = select({
+      ":remote": ":ijar_cc_binary",
+      "//conditions:default": ":prebuilt_binary_or_cc_binary",
+  })
+)
+
+alias(
+  name = "prebuilt_binary_or_cc_binary",
+  actual = select({
+      ":linux_x86_64": ":ijar_prebuilt_binary",
+      ":darwin": ":ijar_prebuilt_binary",
+      ":darwin_x86_64": ":ijar_prebuilt_binary",
+      ":windows": ":ijar_prebuilt_binary",
+      "//conditions:default": ":ijar_cc_binary",
+  })
+)
+
+filegroup(
+    name = "ijar_prebuilt_binary",
+    srcs = select({
+       ":windows": ["java_tools/ijar/ijar.exe"],
+       "//conditions:default": ["java_tools/ijar/ijar"],
+   }),
+)
+
+cc_binary(
+    name = "ijar_cc_binary",
+    srcs = [
+        "java_tools/ijar/classfile.cc",
+        "java_tools/ijar/ijar.cc",
+    ],
+    deps = [":zip"],
+)
+
+cc_library(
+    name = "zip",
+    srcs = [
+        "java_tools/ijar/zip.cc",
+    ] + select({
+        ":windows": [
+            "java_tools/ijar/mapped_file_windows.cc",
+        ],
+        "//conditions:default": [
+            "java_tools/ijar/mapped_file_unix.cc",
+        ],
+    }),
+    hdrs = [
+        "java_tools/ijar/common.h",
+        "java_tools/ijar/mapped_file.h",
+        "java_tools/ijar/zip.h",
+    ],
+    deps = [
+        ":platform_utils",
+        ":zlib_client",
+    ] + select({
+        ":windows": [
+            ":errors",
+            ":filesystem",
+            ":logging",
+            ":strings",
+        ],
+        "//conditions:default": [
+        ],
+    }),
+    strip_include_prefix = "java_tools",
+    include_prefix = "third_party",
+)
+
+cc_library(
+    name = "platform_utils",
+    srcs = ["java_tools/ijar/platform_utils.cc"],
+    hdrs = [
+        "java_tools/ijar/common.h",
+        "java_tools/ijar/platform_utils.h",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":errors",
+        ":filesystem",
+        ":logging",
+    ],
+    strip_include_prefix = "java_tools",
+    include_prefix = "third_party",
+)
+
+cc_library(
+    name = "cpp_util",
+    hdrs = [
+        "java_tools/src/main/cpp/util/errors.h",
+        "java_tools/src/main/cpp/util/file.h",
+        "java_tools/src/main/cpp/util/file_platform.h",
+        "java_tools/src/main/cpp/util/md5.h",
+        "java_tools/src/main/cpp/util/numbers.h",
+        "java_tools/src/main/cpp/util/path.h",
+        "java_tools/src/main/cpp/util/path_platform.h",
+        "java_tools/src/main/cpp/util/port.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":blaze_exit_code",
+        ":errors",
+        ":filesystem",
+        ":md5",
+        ":numbers",
+        ":port",
+        ":strings",
+    ],
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "md5",
+    srcs = ["java_tools/src/main/cpp/util/md5.cc"],
+    hdrs = ["java_tools/src/main/cpp/util/md5.h"],
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "numbers",
+    srcs = ["java_tools/src/main/cpp/util/numbers.cc"],
+    hdrs = ["java_tools/src/main/cpp/util/numbers.h"],
+    deps = [":strings"],
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "filesystem",
+    srcs = [
+        "java_tools/src/main/cpp/util/file.cc",
+        "java_tools/src/main/cpp/util/path.cc",
+    ] + select({
+        ":windows": [
+            "java_tools/src/main/cpp/util/file_windows.cc",
+            "java_tools/src/main/cpp/util/path_windows.cc",
+        ],
+        "//conditions:default": [
+            "java_tools/src/main/cpp/util/file_posix.cc",
+            "java_tools/src/main/cpp/util/path_posix.cc",
+        ],
+    }),
+    hdrs = [
+        "java_tools/src/main/cpp/util/file.h",
+        "java_tools/src/main/cpp/util/file_platform.h",
+        "java_tools/src/main/cpp/util/path.h",
+        "java_tools/src/main/cpp/util/path_platform.h",
+    ],
+    deps = [
+        ":blaze_exit_code",
+        ":errors",
+        ":logging",
+        ":strings",
+    ] + select({
+        ":windows": [":lib-file"],
+        "//conditions:default": [],
+    }),
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "lib-file",
+    srcs = ["java_tools/src/main/native/windows/file.cc"],
+    hdrs = ["java_tools/src/main/native/windows/file.h"],
+    deps = [":lib-util"],
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "lib-util",
+    srcs = ["java_tools/src/main/native/windows/util.cc"],
+    hdrs = ["java_tools/src/main/native/windows/util.h"],
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "errors",
+    srcs = select({
+        ":windows": ["java_tools/src/main/cpp/util/errors_windows.cc"],
+        "//conditions:default": ["java_tools/src/main/cpp/util/errors_posix.cc"],
+    }),
+    hdrs = ["java_tools/src/main/cpp/util/errors.h"],
+    deps = [
+        ":logging",
+        ":port",
+        ":strings",
+    ],
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "strings",
+    srcs = ["java_tools/src/main/cpp/util/strings.cc"],
+    hdrs = ["java_tools/src/main/cpp/util/strings.h"],
+    # Automatically propagate the symbol definition to rules depending on this.
+    defines = [
+        "BLAZE_OPENSOURCE",
+    ],
+    deps = [":blaze_exit_code"],
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "blaze_exit_code",
+    hdrs = ["java_tools/src/main/cpp/util/exit_code.h"],
+    strip_include_prefix = "java_tools",
+)
+
+
+cc_library(
+    name = "port",
+    srcs = ["java_tools/src/main/cpp/util/port.cc"],
+    hdrs = ["java_tools/src/main/cpp/util/port.h"],
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "logging",
+    srcs = ["java_tools/src/main/cpp/util/logging.cc"],
+    hdrs = ["java_tools/src/main/cpp/util/logging.h"],
+    deps = [
+        ":blaze_exit_code",
+        ":strings",
+    ],
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "zlib_client",
+    srcs = ["java_tools/ijar/zlib_client.cc"],
+    hdrs = [
+        "java_tools/ijar/common.h",
+        "java_tools/ijar/zlib_client.h",
+    ],
+    deps = ["//java_tools/zlib"],
+    strip_include_prefix = "java_tools",
+    include_prefix = "third_party",
+)
+
+##################### singlejar
+
+cc_binary(
+    name = "singlejar_cc_bin",
+    srcs = [
+        "java_tools/src/tools/singlejar/singlejar_main.cc",
+    ],
+    linkopts = select({
+        ":freebsd": ["-lm"],
+        "//conditions:default": [],
+    }),
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":options",
+        ":output_jar",
+        "//java_tools/zlib",
+    ],
+)
+
+cc_binary(
+    name = "singlejar_local",
+    srcs = [
+        "java_tools/src/tools/singlejar/singlejar_local_main.cc",
+    ],
+    linkopts = select({
+        ":freebsd": ["-lm"],
+        "//conditions:default": [],
+    }),
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":combiners",
+        ":desugar_checking",
+        ":options",
+        ":output_jar",
+        "//java_tools/zlib",
+    ],
+)
+
+cc_library(
+    name = "combiners",
+    srcs = [
+        "java_tools/src/tools/singlejar/combiners.cc",
+    ],
+    hdrs = [
+        "java_tools/src/tools/singlejar/combiners.h",
+        ":transient_bytes",
+        ":zip_headers",
+    ],
+    strip_include_prefix = "java_tools",
+    deps = [
+        "//java_tools/zlib",
+    ],
+)
+
+proto_library(
+  name = "desugar_deps_proto",
+  srcs = ["java_tools/src/main/protobuf/desugar_deps.proto"]
+)
+
+cc_proto_library(
+    name = "desugar_deps_cc_proto",
+    deps = [":desugar_deps_proto"],
+)
+
+cc_library(
+    name = "desugar_checking",
+    srcs = ["java_tools/src/tools/singlejar/desugar_checking.cc"],
+    hdrs = ["java_tools/src/tools/singlejar/desugar_checking.h"],
+    strip_include_prefix = "java_tools",
+    deps = [
+        ":combiners",
+        ":desugar_deps_cc_proto",
+    ],
+)
+
+cc_library(
+    name = "diag",
+    hdrs = ["java_tools/src/tools/singlejar/diag.h"],
+    strip_include_prefix = "java_tools",
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "singlejar_port",
+    hdrs = ["java_tools/src/tools/singlejar/port.h"],
+    strip_include_prefix = "java_tools",
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "mapped_file",
+    srcs = ["java_tools/src/tools/singlejar/mapped_file.cc"],
+    hdrs = ["java_tools/src/tools/singlejar/mapped_file.h"] +
+        select({
+            ":windows": ["java_tools/src/tools/singlejar/mapped_file_windows.inc"],
+            "//conditions:default": ["java_tools/src/tools/singlejar/mapped_file_posix.inc"],
+        }),
+    visibility = ["//visibility:private"],
+    strip_include_prefix = "java_tools",
+    deps = [
+        ":diag",
+        ":singlejar_port",
+        ":cpp_util",
+    ],
+)
+
+cc_library(
+    name = "input_jar",
+    srcs = [
+        "java_tools/src/tools/singlejar/input_jar.cc",
+    ],
+    hdrs = [
+        "java_tools/src/tools/singlejar/input_jar.h",
+        "java_tools/src/tools/singlejar/zip_headers.h",
+    ],
+    deps = [
+        ":diag",
+        ":mapped_file",
+    ],
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "options",
+    srcs = [
+        "java_tools/src/tools/singlejar/options.cc",
+        "java_tools/src/tools/singlejar/options.h",
+    ],
+    hdrs = ["java_tools/src/tools/singlejar/options.h"],
+    deps = [
+        ":diag",
+        ":token_stream",
+    ],
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "output_jar",
+    srcs = [
+        "java_tools/src/tools/singlejar/output_jar.cc",
+        "java_tools/src/tools/singlejar/output_jar.h",
+        ":zip_headers",
+    ],
+    hdrs = ["java_tools/src/tools/singlejar/output_jar.h"],
+    deps = [
+        ":combiners",
+        ":diag",
+        ":input_jar",
+        ":mapped_file",
+        ":options",
+        ":singlejar_port",
+        ":cpp_util",
+        "//java_tools/zlib",
+    ],
+    strip_include_prefix = "java_tools",
+)
+
+cc_library(
+    name = "token_stream",
+    hdrs = ["java_tools/src/tools/singlejar/token_stream.h"],
+    deps = [":diag"],
+    strip_include_prefix = "java_tools",
+)
+
+filegroup(
+    name = "transient_bytes",
+    srcs = [
+        "java_tools/src/tools/singlejar/diag.h",
+        "java_tools/src/tools/singlejar/transient_bytes.h",
+        "java_tools/src/tools/singlejar/zlib_interface.h",
+        ":zip_headers",
+    ],
+)
+
+filegroup(
+    name = "zip_headers",
+    srcs = ["java_tools/src/tools/singlejar/zip_headers.h"],
+)


### PR DESCRIPTION
Starting with #8130 the java tools embed their own BUILD file. Starting with the next java tools releases they will use their own BUILD file instead of the one provided by the http_archive definitions.

In order to modify `BUILD.java_tools` we have to preserve the old content in an intermediate file until the new java tools releases (for javac9 and javac10). 