### PR TITLE
Remove third_party/checker_* from the binary.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -605,6 +605,8 @@ JAVA_VERSIONS = ("9", "10")
             "//src/java_tools/junitrunner:srcs",
             "//src/java_tools/singlejar:srcs",
             "//src/tools/singlejar:embedded_java_tools",
+            "//third_party/checker_framework_dataflow:srcs",
+            "//third_party/checker_framework_javacutil:srcs",
             "//third_party/jarjar:srcs",
             "//third_party/ijar:transitive_sources",
             "//third_party/java/jacoco:jacoco_source_jars_zip",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -26,6 +26,8 @@ filegroup(
         "//third_party/java/jdk/langtools:srcs",
         "//third_party/java/proguard:srcs",
         "//third_party/javascript/bootstrap:srcs",
+        "//third_party/checker_framework_dataflow:srcs",
+        "//third_party/checker_framework_javacutil:srcs",
         "//third_party/jformatstring:srcs",
         "//third_party/protobuf:srcs",
         "//third_party/py/abseil:srcs",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -26,8 +26,6 @@ filegroup(
         "//third_party/java/jdk/langtools:srcs",
         "//third_party/java/proguard:srcs",
         "//third_party/javascript/bootstrap:srcs",
-        "//third_party/checker_framework_dataflow:srcs",
-        "//third_party/checker_framework_javacutil:srcs",
         "//third_party/jformatstring:srcs",
         "//third_party/protobuf:srcs",
         "//third_party/py/abseil:srcs",
@@ -50,8 +48,6 @@ filegroup(
 filegroup(
     name = "gpl-srcs",
     srcs = [
-        "//third_party/checker_framework_dataflow:srcs",
-        "//third_party/checker_framework_javacutil:srcs",
         "//third_party/jformatstring:srcs",
     ],
 )


### PR DESCRIPTION
The binaries were there because there Java tooling needed it (until it
was moved to its own separate repository) and the sources were there for
GPL compliance (which is not the case anymore since we don't distribute
the binaries, either)

To be extra safe on the GPL compliance side, I checked with 
```
bazel query "rdeps(//...,//third_party/checker_framework_{javacutil,dataflow})"'
```

whether we have any dependencies on it that might end up being
distributed; turns out, the only dependencies are JavaBuilder (which is
not distributed with Bazel anymore, as proven by the above query) and some tests.