### PR TITLE
[Cpp] Allow .so files to have more extensions.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -161,21 +161,14 @@ public final class CppFileTypes {
   public static final FileType WINDOWS_DEF_FILE = FileType.of(".def");
 
   // Matches shared libraries with version names in the extension, i.e.
-  // libmylib.so.2 or libmylib.so.2.10.
+  // libmylib.so.2 or libmylib.so.2.10 or libmylib.so.1a_b35.
   private static final Pattern VERSIONED_SHARED_LIBRARY_PATTERN =
-     Pattern.compile("^.+\\.so(\\.\\d+)+$");
+     Pattern.compile("^.+\\.(so([\\.|\\w])+)$");
   public static final FileType VERSIONED_SHARED_LIBRARY =
       new FileType() {
         @Override
         public boolean apply(String path) {
-          // Because regex matching can be slow, we first do a quick digit check on the final
-          // character before risking the full-on regex match. This should eliminate the performance
-          // hit on practically every non-qualifying file type.
-          if (Character.isDigit(path.charAt(path.length() - 1))) {
-            return VERSIONED_SHARED_LIBRARY_PATTERN.matcher(path).matches();
-          } else {
-            return false;
-          }
+          return VERSIONED_SHARED_LIBRARY_PATTERN.matcher(path).matches();
         }
       };
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppFileTypesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppFileTypesTest.java
@@ -40,10 +40,12 @@ public class CppFileTypesTest {
     assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.so.20")).isTrue();
     assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.so.20.2")).isTrue();
     assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("a/somelibrary.so.2")).isTrue();
-    assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.so.e")).isFalse();
-    assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.so.2e")).isFalse();
-    assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.so.e2")).isFalse();
-    assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.so.20.e2")).isFalse();
+    assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.so.e")).isTrue();
+    assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.so.2e")).isTrue();
+    assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.so.e2")).isTrue();
+    assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.so.20.e2")).isTrue();
     assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.a.2")).isFalse();
+    assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.so.2$")).isFalse();
+    assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("somelibrary.so.1a_b2")).isTrue();
   }
 }


### PR DESCRIPTION
We have prebuilt `.so` files that end in strings like `.so.4a_b37`.  Other prebuilt libraries are not able to find these since bazel only allows shared libraries with specific names.  This change expands the allowable extensions for versioned shared libraries.