### PR TITLE
Add missing spaces to worker_max_instances docs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
@@ -92,9 +92,9 @@ public class WorkerOptions extends OptionsBase {
       help =
           "How many instances of a worker process (like the persistent Java compiler) may be "
               + "launched if you use the 'worker' strategy. May be specified as [name=value] to "
-              + "give a different value per worker mnemonic. Takes"
+              + "give a different value per worker mnemonic. Takes "
               + ResourceConverter.FLAG_SYNTAX
-              + ". 'auto' calculates a reasonable default based on machine capacity."
+              + ". 'auto' calculates a reasonable default based on machine capacity. "
               + "\"=value\" sets a default for unspecified mnemonics.",
       allowMultiple = true)
   public List<Map.Entry<String, Integer>> workerMaxInstances;


### PR DESCRIPTION
The docs at https://docs.bazel.build/versions/master/command-line-reference.html#flag--worker_max_instances were missing some spaces:

> How many instances of a worker process (like the persistent Java compiler) may be launched if you use the 'worker' strategy. May be specified as [name=value] to give a different value per worker mnemonic. Takesan integer, or a keyword ("auto", "HOST_CPUS", "HOST_RAM"), optionally followed by an operation ([-|\*]<float>) eg. "auto", "HOST_CPUS\*.5". 'auto' calculates a reasonable default based on machine capacity."=value" sets a default for unspecified mnemonics.

Specifically 'Takesan' and 'capacity."=value"'.