### PR TITLE
Python: 2to3 is now a write_file, not sh_binary

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -226,7 +226,13 @@ if [ -z "${BAZEL_SKIP_JAVA_COMPILATION}" ]; then
   cat <<EOF >${BAZEL_TOOLS_REPO}/WORKSPACE
 workspace(name = 'bazel_tools')
 EOF
-  link_dir ${PWD}/src ${BAZEL_TOOLS_REPO}/src
+
+  mkdir -p "${BAZEL_TOOLS_REPO}/src/conditions"
+  link_file "${PWD}/src/conditions/BUILD.tools" \
+      "${BAZEL_TOOLS_REPO}/src/conditions/BUILD"
+  link_children "${PWD}" src/conditions "${BAZEL_TOOLS_REPO}"
+  link_children "${PWD}" src "${BAZEL_TOOLS_REPO}"
+
   link_dir ${PWD}/third_party ${BAZEL_TOOLS_REPO}/third_party
 
   # Create @bazel_tools//tools/cpp/runfiles

--- a/tools/python/2to3.sh
+++ b/tools/python/2to3.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exit 1

--- a/tools/python/BUILD.tools
+++ b/tools/python/BUILD.tools
@@ -14,8 +14,17 @@ write_file(
         "//conditions:default": "2to3.sh",
     }),
     content = select({
-        "//src/conditions:host_windows": ["@exit /B 1"],
-        "//conditions:default": ["#!/bin/sh\nexit 1"],
+        "//src/conditions:host_windows": [
+            "@echo >&2 ERROR: 2to3 is not implemented in Bazel.",
+            "@echo >&2 See https://github.com/bazelbuild/bazel/issues/1393#issuecomment-431110617",
+            "@exit /B 1",
+        ],
+        "//conditions:default": [
+            "#!/bin/bash",
+            "echo >&2 'ERROR: 2to3 is not implemented in Bazel.'",
+            "echo >&2 'See https://github.com/bazelbuild/bazel/issues/1393#issuecomment-431110617'",
+            "exit 1",
+        ],
     }),
     is_executable = True,
 )

--- a/tools/python/BUILD.tools
+++ b/tools/python/BUILD.tools
@@ -1,11 +1,23 @@
 load(":python_version.bzl", "define_python_version_flag")
 load(":toolchain.bzl", "define_autodetecting_toolchain")
 
+# Please do not use write_file.bzl outside of this package.
+# See https://groups.google.com/d/msg/bazel-dev/I8IvJyoyo-s/AttqDcnOCgAJ
+load(":write_file.bzl", "write_file")
+
 package(default_visibility = ["//visibility:public"])
 
-sh_binary(
+write_file(
     name = "2to3",
-    srcs = ["2to3.sh"],
+    out = select({
+        "//src/conditions:host_windows": "2to3.bat",
+        "//conditions:default": "2to3.sh",
+    }),
+    content = select({
+        "//src/conditions:host_windows": ["@exit /B 1"],
+        "//conditions:default": ["#!/bin/sh\nexit 1"],
+    }),
+    is_executable = True,
 )
 
 # This target can be used to inspect the current Python major version. To use,

--- a/tools/python/write_file.bzl
+++ b/tools/python/write_file.bzl
@@ -29,7 +29,7 @@ Related discussion here [2].
 
 def _common_impl(ctx, is_executable):
     # ctx.actions.write creates a FileWriteAction which uses UTF-8 encoding.
-    out = ctx.actions.declare_file(ctx.outputs.out)
+    out = ctx.actions.declare_file(ctx.attr.out)
     ctx.actions.write(
         output = out,
         content = "\n".join(ctx.attr.content) if ctx.attr.content else "",

--- a/tools/python/write_file.bzl
+++ b/tools/python/write_file.bzl
@@ -1,0 +1,95 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""write_file() rule from bazel-skylib 0.8.0.
+
+This file is a copy of rules/private/write_file_private.bzl [1] with some edits:
+  - this DocString is different
+  - the rule's 'out' attribute does not create a label, so it is select()-able
+
+IMPORTANT: please do not use this rule outside of this package.
+Related discussion here [2].
+
+
+[1] https://github.com/bazelbuild/bazel-skylib/blob/3721d32c14d3639ff94320c780a60a6e658fb033/rules/private/write_file_private.bzl
+
+[2] https://groups.google.com/d/msg/bazel-dev/I8IvJyoyo-s/AttqDcnOCgAJ
+"""
+
+def _common_impl(ctx, is_executable):
+    # ctx.actions.write creates a FileWriteAction which uses UTF-8 encoding.
+    out = ctx.actions.declare_file(ctx.outputs.out)
+    ctx.actions.write(
+        output = out,
+        content = "\n".join(ctx.attr.content) if ctx.attr.content else "",
+        is_executable = is_executable,
+    )
+    files = depset(direct = [out])
+    runfiles = ctx.runfiles(files = [out])
+    if is_executable:
+        return [DefaultInfo(files = files, runfiles = runfiles, executable = out)]
+    else:
+        return [DefaultInfo(files = files, runfiles = runfiles)]
+
+def _impl(ctx):
+    return _common_impl(ctx, False)
+
+def _ximpl(ctx):
+    return _common_impl(ctx, True)
+
+_ATTRS = {
+    "content": attr.string_list(mandatory = False, allow_empty = True),
+    "out": attr.string(mandatory = True),
+}
+
+_write_file = rule(
+    implementation = _impl,
+    provides = [DefaultInfo],
+    attrs = _ATTRS,
+)
+
+_write_xfile = rule(
+    implementation = _ximpl,
+    executable = True,
+    provides = [DefaultInfo],
+    attrs = _ATTRS,
+)
+
+def write_file(name, out, content = [], is_executable = False, **kwargs):
+    """Creates a UTF-8 encoded text file.
+
+    Args:
+      name: Name of the rule.
+      out: Path of the output file, relative to this package.
+      content: A list of strings. Lines of text, the contents of the file.
+          Newlines are added automatically after every line except the last one.
+      is_executable: A boolean. Whether to make the output file executable. When
+          True, the rule's output can be executed using `bazel run` and can be
+          in the srcs of binary and test rules that require executable sources.
+      **kwargs: further keyword arguments, e.g. `visibility`
+    """
+    if is_executable:
+        _write_xfile(
+            name = name,
+            content = content,
+            out = out,
+            **kwargs
+        )
+    else:
+        _write_file(
+            name = name,
+            content = content,
+            out = out,
+            **kwargs
+        )


### PR DESCRIPTION
Now py_* rules no longer depend on a sh_* rule, so
Bazel can analyze them even with
--shell_executable="".

Change-Id: I8e74d86daf385442df9e91c2dc2f7a27b7c4b236