### PR TITLE
Add java integration tests for java_tools with various JDK versions.

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -242,6 +242,9 @@ platforms:
     - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
     # TODO(iirina): Re-enable after #7952 was released.
     - "-//src/test/shell/bazel:embedded_tools_deps_test"
+    - "-//src/test/shell/bazel:bazel_java_test_jdk9_toolchain_released"
+    - "-//src/test/shell/bazel:bazel_java_test_jdk9_toolchain_head"
+    - "-//src/test/shell/bazel:bazel_java_test_jdk10_toolchain_head"
   windows:
     batch_commands:
     - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -106,6 +106,7 @@ platforms:
     test_flags:
     - "--javabase=@openjdk9_linux_archive//:runtime"
     - "--test_timeout=1200"
+    - "--test_arg=-test_java_common_compile_sourcepath,-test_java_common_compile_sourcepath_with_implicit_class"
     test_targets:
     - "--"
     - "//scripts/..."
@@ -172,6 +173,7 @@ platforms:
     test_flags:
     - "--javabase=@openjdk10_linux_archive//:runtime"
     - "--test_timeout=1200"
+    - - "--test_arg=-test_java_common_compile_sourcepath,-test_java_common_compile_sourcepath_with_implicit_class
     test_targets:
     - "--"
     - "//scripts/..."
@@ -259,6 +261,9 @@ platforms:
       # Re-enable once fixed: https://github.com/bazelbuild/bazel/issues/4684
     - "-//src/test/shell/bazel:bazel_determinism_test"
     - "-//src/test/shell/bazel:bazel_java_test"
+    - "-//src/test/shell/bazel:bazel_java_test_jdk9_toolchain_released"
+    - "-//src/test/shell/bazel:bazel_java_test_jdk9_toolchain_head"
+    - "-//src/test/shell/bazel:bazel_java_test_jdk10_toolchain_head"
     - "-//src/test/shell/bazel:bazel_bootstrap_distfile_test"
     - "-//src/test/shell/bazel/remote:remote_execution_test"
     - "-//src/test/shell/bazel/remote:remote_execution_http_test"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -106,7 +106,6 @@ platforms:
     test_flags:
     - "--javabase=@openjdk9_linux_archive//:runtime"
     - "--test_timeout=1200"
-    - "--test_arg=-test_java_common_compile_sourcepath,-test_java_common_compile_sourcepath_with_implicit_class"
     test_targets:
     - "--"
     - "//scripts/..."
@@ -173,7 +172,6 @@ platforms:
     test_flags:
     - "--javabase=@openjdk10_linux_archive//:runtime"
     - "--test_timeout=1200"
-    - - "--test_arg=-test_java_common_compile_sourcepath,-test_java_common_compile_sourcepath_with_implicit_class
     test_targets:
     - "--"
     - "//scripts/..."

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -138,7 +138,66 @@ sh_test(
     size = "large",
     timeout = "eternal",
     srcs = ["bazel_java_test.sh"],
+    args = ["@bazel_tools//tools/jdk:toolchain"],
     data = [":test-deps"],
+    tags = [
+        # TODO(laszlocsomor): make this run on Windows. Currently fails because
+        # the java_common provider doesn't work on Windows.
+        "no_windows",
+    ],
+)
+
+sh_test(
+    name = "bazel_java_test_jdk9_released",
+    size = "large",
+    timeout = "eternal",
+    srcs = ["bazel_java_test.sh"],
+    args = select({
+        "//src/conditions:darwin": ["@remote_java_tools_javac9_test_darwin//:toolchain"],
+        "//src/conditions:darwin_x86_64": ["@remote_java_tools_javac9_test_darwin//:toolchain"],
+        "//src/conditions:linux_x86_64": ["@remote_java_tools_javac9_test_linux//:toolchain"],
+    }),
+    data = [":test-deps"],
+    tags = [
+        # TODO(laszlocsomor): make this run on Windows. Currently fails because
+        # the java_common provider doesn't work on Windows.
+        "no_windows",
+    ],
+)
+
+sh_test(
+    name = "bazel_java_test_jdk9_head",
+    size = "large",
+    timeout = "eternal",
+    srcs = ["bazel_java_test.sh"],
+    args = [
+        "@local_java_tools//:toolchain",
+        "src/java_tools_java9.zip",
+    ],
+    data = [
+        ":test-deps",
+        "//src:java_tools_java9_zip",
+    ],
+    tags = [
+        # TODO(laszlocsomor): make this run on Windows. Currently fails because
+        # the java_common provider doesn't work on Windows.
+        "no_windows",
+    ],
+)
+
+sh_test(
+    name = "bazel_java_test_jdk10_toolchain_head",
+    size = "large",
+    timeout = "eternal",
+    srcs = ["bazel_java_test.sh"],
+    args = [
+        "@local_java_tools//:toolchain",
+        "src/java_tools_java10.zip",
+    ],
+    data = [
+        ":test-deps",
+        "//src:java_tools_java10_zip",
+    ],
     tags = [
         # TODO(laszlocsomor): make this run on Windows. Currently fails because
         # the java_common provider doesn't work on Windows.

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -148,7 +148,7 @@ sh_test(
 )
 
 sh_test(
-    name = "bazel_java_test_jdk9_released",
+    name = "bazel_java_test_jdk9_toolchain_released",
     size = "large",
     timeout = "eternal",
     srcs = ["bazel_java_test.sh"],
@@ -166,7 +166,7 @@ sh_test(
 )
 
 sh_test(
-    name = "bazel_java_test_jdk9_head",
+    name = "bazel_java_test_jdk9_toolchain_head",
     size = "large",
     timeout = "eternal",
     srcs = ["bazel_java_test.sh"],

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -138,7 +138,10 @@ sh_test(
     size = "large",
     timeout = "eternal",
     srcs = ["bazel_java_test.sh"],
-    args = ["@bazel_tools//tools/jdk:toolchain"],
+    args = [
+        "@bazel_tools//tools/jdk:toolchain",
+        "released",
+    ],
     data = [":test-deps"],
     tags = [
         # TODO(laszlocsomor): make this run on Windows. Currently fails because
@@ -156,7 +159,12 @@ sh_test(
         "//src/conditions:darwin": ["@remote_java_tools_javac9_test_darwin//:toolchain"],
         "//src/conditions:darwin_x86_64": ["@remote_java_tools_javac9_test_darwin//:toolchain"],
         "//src/conditions:linux_x86_64": ["@remote_java_tools_javac9_test_linux//:toolchain"],
-    }),
+    }) + [
+        # java_tools zip to test
+        "released",
+        # --javabase value
+        "@openjdk9_linux_archive//:runtime",
+    ],
     data = [":test-deps"],
     tags = [
         # TODO(laszlocsomor): make this run on Windows. Currently fails because
@@ -171,8 +179,12 @@ sh_test(
     timeout = "eternal",
     srcs = ["bazel_java_test.sh"],
     args = [
+        # --java_toolchain
         "@local_java_tools//:toolchain",
+        # java_tools zip to test
         "src/java_tools_java9.zip",
+        # --javabase value
+        "@openjdk9_linux_archive//:runtime",
     ],
     data = [
         ":test-deps",
@@ -191,8 +203,12 @@ sh_test(
     timeout = "eternal",
     srcs = ["bazel_java_test.sh"],
     args = [
+        # --java_toolchain
         "@local_java_tools//:toolchain",
+        # java_tools zip to test
         "src/java_tools_java10.zip",
+        # --javabase value
+        "@openjdk10_linux_archive//:runtime",
     ],
     data = [
         ":test-deps",

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -466,7 +466,7 @@ java_custom_library = rule(
 )
 EOF
    bazel build //g:test &> $TEST_log || fail "Failed to build //g:test"
-   jar tf bazel-bin/g/libtest.jar >> $TEST_log || fail "Failed to jar tf bazel-bin/g/libtest.jar"
+   zipinfo -1 bazel-bin/g/libtest.jar >> $TEST_log || fail "Failed to zipinfo -1 bazel-bin/g/libtest.jar"
    expect_log "g/A.class"
    expect_not_log "g/B.class"
  }
@@ -543,7 +543,7 @@ java_custom_library = rule(
 )
 EOF
    bazel build //g:test &> $TEST_log || fail "Failed to build //g:test"
-   jar tf bazel-bin/g/libtest.jar >> $TEST_log || fail "Failed to jar tf bazel-bin/g/libtest.jar"
+   zipinfo -1 bazel-bin/g/libtest.jar >> $TEST_log || fail "Failed to zipinfo -1 bazel-bin/g/libtest.jar"
    expect_log "g/A.class"
    expect_log "g/B.class"
  }

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -25,6 +25,7 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
 echo "Test args are $@"
 
 JAVA_TOOLCHAIN="$1"; shift
+add_to_bazelrc "build --java_toolchain=${JAVA_TOOLCHAIN}"
 
 if [[ $# -eq 1 ]]; then
     JAVA_TOOLS_ZIP="$1"; shift
@@ -32,9 +33,6 @@ if [[ $# -eq 1 ]]; then
     echo "JAVA_TOOLS_ZIP_FILE_URL=$JAVA_TOOLS_ZIP_FILE_URL"
 fi
 JAVA_TOOLS_ZIP_FILE_URL=${JAVA_TOOLS_ZIP_FILE_URL:-}
- echo "JAVA_TOOLS_ZIP_FILE_URL=$JAVA_TOOLS_ZIP_FILE_URL"
-
-add_to_bazelrc "build --java_toolchain=${JAVA_TOOLCHAIN}"
 
 function set_up() {
     cat >>WORKSPACE <<EOF

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -57,21 +57,21 @@ EOF
 http_archive(
     name = "remote_java_tools_javac9_test_linux",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac9/v1.0/java_tools_javac9_linux-v1.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac9/v1.0/java_tools_javac9_linux-v1.0.zip",
     ],
 )
 
 http_archive(
     name = "remote_java_tools_javac9_test_windows",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac9/v1.0/java_tools_javac9_windows-v1.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac9/v1.0/java_tools_javac9_windows-v1.0.zip",
     ],
 )
 
 http_archive(
     name = "remote_java_tools_javac9_test_darwin",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac9/v1.0/java_tools_javac9_darwin-v1.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac9/v1.0/java_tools_javac9_darwin-v1.0.zip",
     ],
 )
 


### PR DESCRIPTION
New integration tests for the java_toolchain defined by:
* the latest JDK 9  java_tools release
* java_tools for JDK 9 and 10 built at HEAD