### PR TITLE
Windows: open files with at least read-sharing

### DIFF
--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -228,7 +228,9 @@ class NativeProcess {
       stdout_process = CreateFileW(
           /* lpFileName */ stdout_redirect.c_str(),
           /* dwDesiredAccess */ GENERIC_WRITE,
-          /* dwShareMode */ 0,
+          // Must share for reading, otherwise symlink-following file existence
+          // checks (e.g. java.nio.file.Files.exists()) fail.
+          /* dwShareMode */ FILE_SHARE_READ,
           /* lpSecurityAttributes */ &sa,
           /* dwCreationDisposition */ OPEN_ALWAYS,
           /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
@@ -280,7 +282,9 @@ class NativeProcess {
       stderr_process = CreateFileW(
           /* lpFileName */ stderr_redirect.c_str(),
           /* dwDesiredAccess */ GENERIC_WRITE,
-          /* dwShareMode */ 0,
+          // Must share for reading, otherwise symlink-following file existence
+          // checks (e.g. java.nio.file.Files.exists()) fail.
+          /* dwShareMode */ FILE_SHARE_READ,
           /* lpSecurityAttributes */ &sa,
           /* dwCreationDisposition */ OPEN_ALWAYS,
           /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,

--- a/src/main/tools/build-runfiles-windows.cc
+++ b/src/main/tools/build-runfiles-windows.cc
@@ -355,7 +355,10 @@ class RunfilesCreator {
         // Create an empty file
         HANDLE h = CreateFileW(it.first.c_str(),  // name of the file
                                GENERIC_WRITE,     // open for writing
-                               0,  // sharing mode, none in this case
+                               // Must share for reading, otherwise
+                               // symlink-following file existence checks (e.g.
+                               // java.nio.file.Files.exists()) fail.
+                               FILE_SHARE_READ,
                                0,  // use default security descriptor
                                CREATE_ALWAYS,  // overwrite if exists
                                FILE_ATTRIBUTE_NORMAL, 0);

--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -294,8 +294,11 @@ bool OutputJar::Open() {
     return false;
   }
 
-  HANDLE hFile = CreateFileW(wpath.c_str(), GENERIC_READ | GENERIC_WRITE, 0,
-                             NULL, CREATE_ALWAYS, 0, NULL);
+  HANDLE hFile = CreateFileW(wpath.c_str(), GENERIC_READ | GENERIC_WRITE,
+                             // Must share for reading, otherwise
+                             // symlink-following file existence checks (e.g.
+                             // java.nio.file.Files.exists()) fail.
+                             FILE_SHARE_READ, NULL, CREATE_ALWAYS, 0, NULL);
   if (hFile == INVALID_HANDLE_VALUE) {
     diag_warn("%s:%d: CreateFileW failed for %S", __FILE__, __LINE__,
               wpath.c_str());


### PR DESCRIPTION
If a process opens files without read-sharing
(FILE_SHARE_READ) and that file is symlink or
junction, then other processes can't check whether
the target of it exists.

In particular, if a process opens a file with
CreateProcessW(dwShareMode = 0) then
symlink-following file existence checks (such as
java.nio.file.Files.exists and
java.nio.file.Files.notExists) fail to check if
the symlink's target exists (even if the file is
not a symlink).

Fixes https://github.com/bazelbuild/bazel/issues/7392