### PR TITLE
Run tests after building java tools.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -704,8 +704,6 @@ genrule(
         name = "upload_java_tools_java" + java_version,
         srcs = ["upload_java_tools.sh"],
         args = [
-            "--java_tools_zip",
-            "src/java_tools_java" + java_version + ".zip",
             "--gcs_java_tools_dir",
             "tmp/build",
             "--java_version",

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -261,7 +261,7 @@ sh_test(
         # This test is only run by the java_tools binaries pipeline.
         tags = ["manual"]
     )
-    for java_version in (9, 10)
+    for java_version in ("9", "10")
 ]
 
 sh_test(

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -237,6 +237,56 @@ sh_test(
 )
 
 sh_test(
+    name = "bazel_java_test_local_java_tools_jdk9",
+    size = "large",
+    timeout = "eternal",
+    srcs = ["bazel_java_test.sh"],
+    args = [
+        # --java_toolchain
+        "@local_java_tools//:toolchain",
+        # java_tools zip to test
+        "$(LOCAL_JAVA_TOOLS_ZIP_URL)",
+        # --javabase value
+    ] + select({
+        "//src/conditions:darwin": ["@openjdk9_darwin_archive//:runtime"],
+        "//src/conditions:darwin_x86_64": ["@openjdk9_darwin_archive//:runtime"],
+        "//src/conditions:windows": ["@openjdk9_windows_archive//:runtime"],
+        "//src/conditions:linux_x86_64": ["@openjdk9_linux_archive//:runtime"],
+    }),
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+    # This test is only run by the java_tools binaries pipeline.
+    tags = ["manual"]
+)
+
+sh_test(
+    name = "bazel_java_test_local_java_tools_jdk10",
+    size = "large",
+    timeout = "eternal",
+    srcs = ["bazel_java_test.sh"],
+    args = [
+        # --java_toolchain
+        "@local_java_tools//:toolchain",
+        # java_tools zip to test
+        "$(LOCAL_JAVA_TOOLS_ZIP_URL)",
+        # --javabase value
+    ] + select({
+        "//src/conditions:darwin": ["@openjdk10_darwin_archive//:runtime"],
+        "//src/conditions:darwin_x86_64": ["@openjdk10_darwin_archive//:runtime"],
+        "//src/conditions:windows": ["@openjdk10_windows_archive//:runtime"],
+        "//src/conditions:linux_x86_64": ["@openjdk10_linux_archive//:runtime"],
+    }),
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+    # This test is only run by the java_tools binaries pipeline.
+    tags = ["manual"]
+)
+
+sh_test(
     name = "bazel_android_tools_test",
     size = "small",
     srcs = ["bazel_android_tools_test.sh"],

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -236,55 +236,33 @@ sh_test(
     ],
 )
 
-sh_test(
-    name = "bazel_java_test_local_java_tools_jdk9",
-    size = "large",
-    timeout = "eternal",
-    srcs = ["bazel_java_test.sh"],
-    args = [
-        # --java_toolchain
-        "@local_java_tools//:toolchain",
-        # java_tools zip to test
-        "$(LOCAL_JAVA_TOOLS_ZIP_URL)",
-        # --javabase value
-    ] + select({
-        "//src/conditions:darwin": ["@openjdk9_darwin_archive//:runtime"],
-        "//src/conditions:darwin_x86_64": ["@openjdk9_darwin_archive//:runtime"],
-        "//src/conditions:windows": ["@openjdk9_windows_archive//:runtime"],
-        "//src/conditions:linux_x86_64": ["@openjdk9_linux_archive//:runtime"],
-    }),
-    data = [
-        ":test-deps",
-        "@bazel_tools//tools/bash/runfiles",
-    ],
-    # This test is only run by the java_tools binaries pipeline.
-    tags = ["manual"]
-)
-
-sh_test(
-    name = "bazel_java_test_local_java_tools_jdk10",
-    size = "large",
-    timeout = "eternal",
-    srcs = ["bazel_java_test.sh"],
-    args = [
-        # --java_toolchain
-        "@local_java_tools//:toolchain",
-        # java_tools zip to test
-        "$(LOCAL_JAVA_TOOLS_ZIP_URL)",
-        # --javabase value
-    ] + select({
-        "//src/conditions:darwin": ["@openjdk10_darwin_archive//:runtime"],
-        "//src/conditions:darwin_x86_64": ["@openjdk10_darwin_archive//:runtime"],
-        "//src/conditions:windows": ["@openjdk10_windows_archive//:runtime"],
-        "//src/conditions:linux_x86_64": ["@openjdk10_linux_archive//:runtime"],
-    }),
-    data = [
-        ":test-deps",
-        "@bazel_tools//tools/bash/runfiles",
-    ],
-    # This test is only run by the java_tools binaries pipeline.
-    tags = ["manual"]
-)
+[
+    sh_test(
+        name = "bazel_java_test_local_java_tools_jdk" + java_version,
+        size = "large",
+        timeout = "eternal",
+        srcs = ["bazel_java_test.sh"],
+        args = [
+            # --java_toolchain
+            "@local_java_tools//:toolchain",
+            # java_tools zip to test
+            "$(LOCAL_JAVA_TOOLS_ZIP_URL)",
+            # --javabase value
+        ] + select({
+            "//src/conditions:darwin": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
+            "//src/conditions:darwin_x86_64": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
+            "//src/conditions:windows": ["@openjdk" + java_version + "_windows_archive//:runtime"],
+            "//src/conditions:linux_x86_64": ["@openjdk" + java_version + "_linux_archive//:runtime"],
+        }),
+        data = [
+            ":test-deps",
+            "@bazel_tools//tools/bash/runfiles",
+        ],
+        # This test is only run by the java_tools binaries pipeline.
+        tags = ["manual"]
+    )
+    for java_version in (9, 10)
+]
 
 sh_test(
     name = "bazel_android_tools_test",

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -59,9 +59,10 @@ JAVA_TOOLCHAIN="$1"; shift
 add_to_bazelrc "build --java_toolchain=${JAVA_TOOLCHAIN}"
 
 JAVA_TOOLS_ZIP="$1"; shift
-
 if [[ "${JAVA_TOOLS_ZIP}" != "released" ]]; then
-    if "$is_windows"; then
+    if [[ "${JAVA_TOOLS_ZIP}" == file* ]]; then
+        JAVA_TOOLS_ZIP_FILE_URL="${JAVA_TOOLS_ZIP}"
+    elif "$is_windows"; then
         JAVA_TOOLS_ZIP_FILE_URL="file:///$(rlocation io_bazel/$JAVA_TOOLS_ZIP)"
     else
         JAVA_TOOLS_ZIP_FILE_URL="file://$(rlocation io_bazel/$JAVA_TOOLS_ZIP)"
@@ -389,15 +390,6 @@ function test_strategy_picks_first_preferred_local() {
     --spawn_strategy=local,worker &> $TEST_log || fail "build failed"
   expect_not_log " processes: .*worker"
   expect_log " processes: .*local"
-}
-
-# This test builds a simple java deploy jar using remote singlejar and ijar
-# targets which compile them from source.
-function test_build_hello_world_with_remote_embedded_tool_targets() {
-  write_hello_library_files
-
-  bazel build //java/main:main_deploy.jar --define EXECUTOR=remote \
-    &> $TEST_log || fail "build failed"
 }
 
 # This test verifies that jars named by deploy_env are excluded from the final

--- a/src/test/shell/bazel/bazel_java_test_no_windows.sh
+++ b/src/test/shell/bazel/bazel_java_test_no_windows.sh
@@ -132,3 +132,13 @@ EOF
     # We're testing a formerly non-hermetic interaction, so disable the sandbox.
     bazel test --spawn_strategy=standalone --test_output=errors :check_runfiles
 }
+
+# This test builds a simple java deploy jar using remote singlejar and ijar
+# targets which compile them from source.
+# This test fails on Windows only when invoked from the java_tools binaries pipeline.
+function test_build_hello_world_with_remote_embedded_tool_targets() {
+  write_hello_library_files
+
+  bazel build //java/main:main_deploy.jar --define EXECUTOR=remote \
+    &> $TEST_log || fail "build failed"
+}

--- a/src/upload_all_java_tools.sh
+++ b/src/upload_all_java_tools.sh
@@ -16,12 +16,6 @@
 
 # A script to upload a given java_tools zip on GCS. Used by the java_tools_binaries
 # Buildkite pipeline. It is not recommended to run this script manually.
-#
-# Mandatory flags:
-# --java_tools_zip       The workspace-relative path of a java_tools zip.
-# --gcs_java_tools_dir   The directory under bazel_java_tools on GCS where the zip is uploaded.
-# --java_version         The version of the javac the given zip embeds.
-# --platform             The name of the platform where the zip was built.
 
 # Script used by the "java_tools binaries" Buildkite pipeline to build the java tools archives
 # and upload them on GCS.
@@ -32,6 +26,22 @@
 # The script cannot be invoked through a sh_binary using bazel because git
 # cannot be used through a sh_binary.
 
+set -euo pipefail
+
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*|mingw*|cygwin*)
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+fi
+
 commit_hash=$(git rev-parse HEAD)
 timestamp=$(date +%s)
 bazel_version=$(bazel info release | cut -d' ' -f2)
@@ -39,7 +49,29 @@ bazel_version=$(bazel info release | cut -d' ' -f2)
 # Passing the same commit_hash and timestamp to all targets to mark all the artifacts
 # uploaded on GCS with the same identifier.
 for java_version in 9 10; do
-  for target in src:upload_java_tools_java${java_version} src:upload_java_tools_dist_java${java_version}; do
-    bazel run ${target} -- --commit_hash ${commit_hash} --timestamp ${timestamp} --bazel_version ${bazel_version}
-  done
+
+    bazel build //src:java_tools_java${java_version}_zip
+    zip_path=${PWD}/bazel-bin/src/java_tools_java${java_version}.zip
+
+    if "$is_windows"; then
+        # Windows needs "file:///c:/foo/bar".
+        file_url="file:///$(cygpath -m ${zip_path})"
+    else
+        # Non-Windows needs "file:///foo/bar".
+        file_url="file://${zip_path}"
+    fi
+    bazel test --verbose_failures --test_output=all \
+      //src/test/shell/bazel:bazel_java_test_local_java_tools_jdk${java_version} \
+      --define=LOCAL_JAVA_TOOLS_ZIP_URL="${file_url}"
+
+    bazel run //src:upload_java_tools_java${java_version} -- \
+        --java_tools_zip src/java_tools_java${java_version}.zip \
+        --commit_hash ${commit_hash} \
+        --timestamp ${timestamp} \
+        --bazel_version ${bazel_version}
+
+    bazel run //src:upload_java_tools_dist_java${java_version} -- \
+        --commit_hash ${commit_hash} \
+        --timestamp ${timestamp} \
+        --bazel_version ${bazel_version}
 done

--- a/src/upload_all_java_tools.sh
+++ b/src/upload_all_java_tools.sh
@@ -60,7 +60,7 @@ for java_version in 9 10; do
         # Non-Windows needs "file:///foo/bar".
         file_url="file://${zip_path}"
     fi
-    bazel test --verbose_failures --test_output=all \
+    bazel test --verbose_failures --test_output=all --nocache_test_results \
       //src/test/shell/bazel:bazel_java_test_local_java_tools_jdk${java_version} \
       --define=LOCAL_JAVA_TOOLS_ZIP_URL="${file_url}"
 

--- a/src/upload_java_tools.sh
+++ b/src/upload_java_tools.sh
@@ -46,6 +46,20 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*|mingw*|cygwin*)
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+fi
+
 # Parsing the flags.
 while [[ -n "$@" ]]; do
   arg="$1"; shift
@@ -95,6 +109,14 @@ if [[ "$platform" == "windows" ]]; then
   gsutil_cmd="gsutil.cmd"
 fi
 
+
+ if "$is_windows"; then
+    zip_url=$(cygpath -m ${tmp_zip})
+else
+    # Non-Windows needs "file:///foo/bar".
+    zip_url=${tmp_zip}
+fi
+
 # Upload the zip that contains the README.md to GCS.
-"$gsutil_cmd" cp "$tmp_zip" \
+"$gsutil_cmd" cp "$zip_url" \
  "gs://bazel-mirror/bazel_java_tools/${gcs_java_tools_dir}/${commit_hash}/java${java_version}/java_tools_javac${java_version}_${platform}-${timestamp}.zip"


### PR DESCRIPTION
This PR adds a shell integration test for the java rules that is run with the java toolchain of the java tools build from head. The test is created and run by `src/upload_java_tools.sh` which is used by the Buildkite pipeline to generate the java tools zip. 

The generated java tools zip is uploaded to GCS only if the test succeeded. This provides testing before creating release candidates for the java tools.