### PR TITLE
Add patch failure fallback to -p1

### DIFF
--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -88,7 +88,11 @@ def _patch(ctx, bash_exe, patchfile, patch_args):
         return st
     new_args = [arg for arg in patch_args if arg != "-p0"]
     new_args.append("-p1")
-    return _run_patch(ctx, bash_exe, patchfile, new_args)
+    p1_st = _run_patch(ctx, bash_exe, patchfile, new_args)
+    if p1_st.return_code == 0:
+        return p1_st
+    # Return original failure if -p1 fails too.
+    return st
 
 def patch(ctx):
     """Implementation of patching an already extracted repository.

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -84,13 +84,14 @@ def _patch(ctx, bash_exe, patchfile, patch_args):
     if st.return_code == 0:
         return st
 
-    if "-p0" not in patch_args:
-        return st
-    new_args = [arg for arg in patch_args if arg != "-p0"]
-    new_args.append("-p1")
-    p1_st = _run_patch(ctx, bash_exe, patchfile, new_args)
-    if p1_st.return_code == 0:
-        return p1_st
+    # Retry with -p1 if first attempt used -p0.
+    if "-p0" in patch_args:
+        new_args = [arg for arg in patch_args if arg != "-p0"]
+        new_args.append("-p1")
+        p1_st = _run_patch(ctx, bash_exe, patchfile, new_args)
+        if p1_st.return_code == 0:
+            return p1_st
+
     # Return original failure if -p1 fails too.
     return st
 


### PR DESCRIPTION
The [default `patch_args`](https://github.com/bazelbuild/bazel/blob/852c11f6f1f433cc4381d08701a882f1e21493fa/tools/build_defs/repo/git.bzl#L184) uses `-p0`. I'm not sure which cases called for choosing `-p0` as the default, but using patches produced by `git` calls for `patch -p1`. The output of `git diff` commands add `a/` and `b/` prefixes to file paths, and these prefixes need to be stripped. For a `git_repository` rule, it seems `-p1` would probably always be used over `-p0`.

Since it may not be feasible to change the default to `-p1`, this adds `-p0` to `-p1` fallback. If a patch fails to apply and `-p0` is in the `patch_args`, then the `patch` is tried again with `-p1`.