### PR TITLE
Add delete() method to repository context

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -200,6 +200,23 @@ public final class WorkspaceRuleEvent implements ProgressLike {
     return new WorkspaceRuleEvent(result.build());
   }
 
+  /** Creates a new WorkspaceRuleEvent for a file read event. */
+  public static WorkspaceRuleEvent newDeleteEvent(String path, String ruleLabel, Location location) {
+    WorkspaceLogProtos.DeleteEvent e =
+        WorkspaceLogProtos.DeleteEvent.newBuilder().setPath(path).build();
+
+    WorkspaceLogProtos.WorkspaceEvent.Builder result =
+        WorkspaceLogProtos.WorkspaceEvent.newBuilder();
+    result = result.setDeleteEvent(e);
+    if (location != null) {
+      result = result.setLocation(location.print());
+    }
+    if (ruleLabel != null) {
+      result = result.setRule(ruleLabel);
+    }
+    return new WorkspaceRuleEvent(result.build());
+  }
+
   /** Creates a new WorkspaceRuleEvent for an os event. */
   public static WorkspaceRuleEvent newOsEvent(String ruleLabel, Location location) {
     OsEvent e = WorkspaceLogProtos.OsEvent.getDefaultInstance();

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
@@ -88,6 +88,12 @@ message ReadEvent {
   string path = 1;
 }
 
+// Information on "delete" event in repository_ctx.
+message DeleteEvent {
+  // Path to the file to delete
+  string path = 1;
+}
+
 // Information on "os" event in repository_ctx.
 message OsEvent {
   // Takes no inputs
@@ -137,5 +143,6 @@ message WorkspaceEvent {
     WhichEvent which_event = 10;
     ExtractEvent extract_event = 11;
     ReadEvent read_event = 12;
+    DeleteEvent delete_event = 13;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -19,6 +19,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.bazel.debug.WorkspaceRuleEvent;
 import com.google.devtools.build.lib.bazel.repository.DecompressorDescriptor;
@@ -34,6 +35,7 @@ import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.StructImpl;
 import com.google.devtools.build.lib.packages.StructProvider;
+import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
 import com.google.devtools.build.lib.rules.repository.WorkspaceAttributeMapper;
@@ -46,6 +48,7 @@ import com.google.devtools.build.lib.syntax.SkylarkList;
 import com.google.devtools.build.lib.syntax.SkylarkType;
 import com.google.devtools.build.lib.util.OsUtils;
 import com.google.devtools.build.lib.util.StringUtilities;
+import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -69,9 +72,11 @@ public class SkylarkRepositoryContext
     implements SkylarkRepositoryContextApi<RepositoryFunctionException> {
 
   private final Rule rule;
+  private final PathPackageLocator packageLocator;
   private final Path outputDirectory;
   private final StructImpl attrObject;
   private final SkylarkOS osObject;
+  private final ImmutableSet<PathFragment> blacklistedPatterns;
   private final Environment env;
   private final HttpDownloader httpDownloader;
   private final double timeoutScaling;
@@ -83,7 +88,9 @@ public class SkylarkRepositoryContext
    */
   SkylarkRepositoryContext(
       Rule rule,
+      PathPackageLocator packageLocator,
       Path outputDirectory,
+      ImmutableSet<PathFragment> blacklistedPatterns,
       Environment environment,
       Map<String, String> env,
       HttpDownloader httpDownloader,
@@ -91,7 +98,9 @@ public class SkylarkRepositoryContext
       Map<String, String> markerData)
       throws EvalException {
     this.rule = rule;
+    this.packageLocator = packageLocator;
     this.outputDirectory = outputDirectory;
+    this.blacklistedPatterns = blacklistedPatterns;
     this.env = environment;
     this.osObject = new SkylarkOS(env);
     this.httpDownloader = httpDownloader;
@@ -122,6 +131,25 @@ public class SkylarkRepositoryContext
   @Override
   public StructImpl getAttr() {
     return attrObject;
+  }
+
+  private SkylarkPath externalPath(String method, Object pathObject)
+      throws EvalException, InterruptedException {
+    SkylarkPath skylarkPath = getPath(method, pathObject);
+    Path path = skylarkPath.getPath();
+    if (packageLocator.getPathEntries().stream().noneMatch(root -> path.startsWith(root.asPath()))
+        || path.startsWith(outputDirectory)) {
+       return skylarkPath;
+    }
+    Path workspaceRoot = packageLocator.getWorkspaceFile().getParentDirectory();
+    PathFragment relativePath = path.relativeTo(workspaceRoot);
+    for (PathFragment blacklistedPattern : blacklistedPatterns) {
+      if (relativePath.startsWith(blacklistedPattern)) {
+        return skylarkPath;
+      }
+    }
+    throw new EvalException(Location.BUILTIN, method + " can only be applied to external paths"
+        + " (that is, outside the workspace or ignored in .bazelignore)");
   }
 
   @Override
@@ -347,6 +375,23 @@ public class SkylarkRepositoryContext
         .setTimeout(Math.round(timeout.longValue() * 1000 * timeoutScaling))
         .setQuiet(quiet)
         .execute();
+  }
+
+  @Override
+  public boolean delete(Object pathObject, Location location)
+      throws EvalException, RepositoryFunctionException, InterruptedException {
+    SkylarkPath skylarkPath = externalPath("delete()", pathObject);
+    WorkspaceRuleEvent w = WorkspaceRuleEvent.newDeleteEvent(skylarkPath.toString(),
+        rule.getLabel().toString(), location);
+    env.getListener().post(w);
+    try {
+      Path path = skylarkPath.getPath();
+      FileSystem fileSystem = path.getFileSystem();
+      fileSystem.deleteTreesBelow(path);
+      return fileSystem.delete(path);
+    } catch (IOException e) {
+      throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+    }
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
@@ -14,9 +14,11 @@
 
 package com.google.devtools.build.lib.bazel.repository.skylark;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.analysis.skylark.BazelStarlarkContext;
@@ -26,19 +28,24 @@ import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.Rule;
+import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.rules.repository.RepositoryDelegatorFunction;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction;
 import com.google.devtools.build.lib.rules.repository.ResolvedHashesValue;
+import com.google.devtools.build.lib.skyframe.BlacklistedPackagePrefixesValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
+import com.google.devtools.build.lib.skyframe.PrecomputedValue.Precomputed;
 import com.google.devtools.build.lib.syntax.BaseFunction;
 import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.Mutability;
 import com.google.devtools.build.lib.syntax.StarlarkSemantics;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.build.skyframe.SkyFunctionException.Transience;
 import com.google.devtools.build.skyframe.SkyKey;
+import com.google.devtools.build.skyframe.SkyValue;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
@@ -81,21 +88,35 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
       return null;
     }
     StarlarkSemantics starlarkSemantics = PrecomputedValue.STARLARK_SEMANTICS.get(env);
-    if (starlarkSemantics == null) {
+    if (env.valuesMissing()) {
       return null;
     }
 
     Set<String> verificationRules =
         RepositoryDelegatorFunction.OUTPUT_VERIFICATION_REPOSITORY_RULES.get(env);
-    if (verificationRules == null) {
+    if (env.valuesMissing()) {
       return null;
     }
     ResolvedHashesValue resolvedHashesValue =
         (ResolvedHashesValue) env.getValue(ResolvedHashesValue.key());
-    if (resolvedHashesValue == null) {
+    if (env.valuesMissing()) {
       return null;
     }
-    Map<String, String> resolvedHashes = resolvedHashesValue.getHashes();
+    Map<String, String> resolvedHashes =
+        Preconditions.checkNotNull(resolvedHashesValue).getHashes();
+
+    PathPackageLocator packageLocator = PrecomputedValue.PATH_PACKAGE_LOCATOR.get(env);
+    if (env.valuesMissing()) {
+      return null;
+    }
+
+    BlacklistedPackagePrefixesValue blacklistedPackagesValue =
+        (BlacklistedPackagePrefixesValue) env.getValue(BlacklistedPackagePrefixesValue.key());
+    if (env.valuesMissing()) {
+      return null;
+    }
+    ImmutableSet<PathFragment> blacklistedPatterns =
+        Preconditions.checkNotNull(blacklistedPackagesValue).getPatterns();
 
     try (Mutability mutability = Mutability.create("Starlark repository")) {
       com.google.devtools.build.lib.syntax.Environment buildEnv =
@@ -114,7 +135,9 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
       SkylarkRepositoryContext skylarkRepositoryContext =
           new SkylarkRepositoryContext(
               rule,
+              packageLocator,
               outputDirectory,
+              blacklistedPatterns,
               env,
               clientEnvironment,
               httpDownloader,

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/SkylarkRepositoryContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/SkylarkRepositoryContextApi.java
@@ -275,6 +275,27 @@ public interface SkylarkRepositoryContextApi<RepositoryFunctionExceptionT extend
       throws EvalException, RepositoryFunctionExceptionT, InterruptedException;
 
   @SkylarkCallable(
+      name = "delete",
+      doc =
+          "Deletes a file or a directory. Returns a bool, indicating whether the file or directory"
+              + " was actually deleted by this call.",
+      useLocation = true,
+      parameters = {
+        @Param(
+            name = "path",
+            allowedTypes = {
+                @ParamType(type = String.class),
+                @ParamType(type = RepositoryPathApi.class)
+            },
+            doc = "Path of the file to delete, relative to the repository directory, or absolute."
+                + " Can be a path or a string."),
+      })
+  public boolean delete(
+      Object path,
+      Location location)
+      throws EvalException, RepositoryFunctionExceptionT, InterruptedException;
+
+  @SkylarkCallable(
       name = "which",
       doc =
           "Returns the path of the corresponding program or None "

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
@@ -15,7 +15,9 @@ filegroup(
 
 java_test(
     name = "RepositoryTests",
-    srcs = glob(["*.java"]),
+    srcs = glob(["*.java"]) + [
+        "skylark/SkylarkRepositoryContextTest.java",
+    ],
     data = [
         "test_decompress_archive.tar.gz",
         "test_decompress_archive.zip",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
@@ -19,7 +19,10 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharStreams;
+import com.google.devtools.build.lib.analysis.BlazeDirectories;
+import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.events.Location;
@@ -29,14 +32,19 @@ import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.RuleClass;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
 import com.google.devtools.build.lib.packages.WorkspaceFactoryHelper;
+import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
+import com.google.devtools.build.lib.skyframe.BazelSkyframeExecutorConstants;
 import com.google.devtools.build.lib.syntax.Argument.Passed;
 import com.google.devtools.build.lib.syntax.BuiltinFunction;
+import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.FuncallExpression;
 import com.google.devtools.build.lib.syntax.Identifier;
 import com.google.devtools.build.lib.syntax.Type;
 import com.google.devtools.build.lib.testutil.Scratch;
+import com.google.devtools.build.lib.testutil.TestConstants;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.skyframe.SkyFunction;
@@ -67,8 +75,8 @@ public class SkylarkRepositoryContextTest {
   public void setUp() throws Exception {
     scratch = new Scratch("/");
     outputDirectory = scratch.dir("/outputDir");
-    root = Root.fromPath(scratch.dir("/"));
-    workspaceFile = scratch.file("/WORKSPACE");
+    root = Root.fromPath(scratch.dir("/wsRoot"));
+    workspaceFile = scratch.file("/wsRoot/WORKSPACE");
   }
 
   protected static RuleClass buildRuleClass(Attribute... attributes) {
@@ -78,11 +86,14 @@ public class SkylarkRepositoryContextTest {
       ruleClassBuilder.addOrOverrideAttribute(attr);
     }
     ruleClassBuilder.setWorkspaceOnly();
-    ruleClassBuilder.setConfiguredTargetFunction(new BuiltinFunction("test") {});
+    ruleClassBuilder.setConfiguredTargetFunction(new BuiltinFunction("test") {
+    });
     return ruleClassBuilder.build();
   }
 
-  protected void setUpContextForRule(Map<String, Object> kwargs, Attribute... attributes)
+  protected void setUpContextForRule(Map<String, Object> kwargs,
+      ImmutableSet<PathFragment> ignoredPathFragments,
+      Attribute... attributes)
       throws Exception {
     Package.Builder packageBuilder =
         Package.newExternalPackageBuilder(
@@ -99,25 +110,34 @@ public class SkylarkRepositoryContextTest {
     SkyFunction.Environment environment = Mockito.mock(SkyFunction.Environment.class);
     ExtendedEventHandler listener = Mockito.mock(ExtendedEventHandler.class);
     Mockito.when(environment.getListener()).thenReturn(listener);
+    BlazeDirectories directories = new BlazeDirectories(
+        new ServerDirectories(outputDirectory, outputDirectory, outputDirectory),
+        root.asPath(), /* defaultSystemJavabase= */ null, TestConstants.PRODUCT_NAME);
+    PathPackageLocator packageLocator = new PathPackageLocator(outputDirectory,
+        ImmutableList.of(root),
+        BazelSkyframeExecutorConstants.BUILD_FILES_BY_PRIORITY);
     context =
         new SkylarkRepositoryContext(
             rule,
+            packageLocator,
             outputDirectory,
+            ignoredPathFragments,
             environment,
             ImmutableMap.of("FOO", "BAR"),
             downloader,
             1.0,
-            new HashMap<String, String>());
+            new HashMap<>());
   }
 
   protected void setUpContexForRule(String name) throws Exception {
-    setUpContextForRule(ImmutableMap.<String, Object>of("name", name));
+    setUpContextForRule(ImmutableMap.of("name", name), ImmutableSet.of());
   }
 
   @Test
   public void testAttr() throws Exception {
     setUpContextForRule(
-        ImmutableMap.<String, Object>of("name", "test", "foo", "bar"),
+        ImmutableMap.of("name", "test", "foo", "bar"),
+        ImmutableSet.of(),
         Attribute.attr("foo", Type.STRING).build());
 
     assertThat(context.getAttr().getFieldNames()).contains("foo");
@@ -180,6 +200,40 @@ public class SkylarkRepositoryContextTest {
           .hasMessageThat()
           .isEqualTo("Cannot write outside of the repository directory for path /somepath");
     }
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    setUpContexForRule("testDelete");
+    Path bar = outputDirectory.getRelative("foo/bar");
+    SkylarkPath barPath = context.path(bar.getPathString());
+    context.createFile(barPath, "content", true, true, null);
+    assertThat(context.delete(barPath, null)).isTrue();
+
+    assertThat(context.delete(barPath, null)).isFalse();
+
+    Path tempFile = scratch.file("/abcde/b", "123");
+    assertThat(context.delete(context.path(tempFile.getPathString()), null)).isTrue();
+
+    Path innerDir = scratch.dir("/some/inner");
+    scratch.dir("/some/inner/deeper");
+    scratch.file("/some/inner/deeper.txt");
+    scratch.file("/some/inner/deeper/1.txt");
+    assertThat(context.delete(innerDir.toString(), null)).isTrue();
+
+    Path underWorkspace = root.getRelative("under_workspace");
+    try {
+      context.delete(underWorkspace.toString(), null);
+      fail();
+    } catch (EvalException expected) {
+      assertThat(expected.getMessage())
+          .startsWith("delete() can only be applied to external paths");
+    }
+
+    scratch.file(underWorkspace.getPathString(), "123");
+    setUpContextForRule(ImmutableMap.of("name", "test"),
+        ImmutableSet.of(PathFragment.create("under_workspace")));
+    assertThat(context.delete(underWorkspace.toString(), null)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Unfortunately, it is problematic to delete directories in Windows.
This task is already solved in Bazel code, so allow Starlark repository rules access that.