### PR TITLE
Enable bazel_coverage_java_test on Windows.

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoCoverageRunner.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoCoverageRunner.java
@@ -421,6 +421,7 @@ public class JacocoCoverageRunner {
         }
       }
     }
+    System.out.println("deployJars = " + deployJars);
 
     final ImmutableSet<String> pathsForCoverage = pathsForCoverageBuilder.build();
     final String metadataFileFinal = metadataFile;
@@ -523,12 +524,24 @@ public class JacocoCoverageRunner {
               }
             });
 
+    System.out.println("metadataFile = " + metadataFileFinal);
+    if (metadataFiles != null) {
+      System.out.println("metadataFiles = ");
+      for (File f : metadataFiles) {
+        System.out.println(f.getPath());
+      }
+    } else {
+      System.out.println("metadataFiles = null");
+    }
+
+
     // If running inside a deploy jar the classpath contains only that deploy jar.
     // It can happen that multiple deploy jars are on the classpath. In that case we are running
     // from a regular java binary where all the environment (e.g. JACOCO_MAIN_CLASS) is set
     // accordingly.
     boolean insideDeployJar =
         (deployJars == 1) && (metadataFilesFinal == null || metadataFilesFinal.length == 1);
+    System.out.println("insideDeployJar = " + insideDeployJar);
     Class<?> mainClass = getMainClass(insideDeployJar);
     Method main = mainClass.getMethod("main", String[].class);
     main.setAccessible(true);

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -379,9 +379,7 @@ sh_test(
     data = [
         ":test-deps",
         "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
-    ],
-    tags = [
-        "no_windows",
+        "@bazel_tools//tools/bash/runfiles",
     ],
 )
 
@@ -408,9 +406,7 @@ sh_test(
         data = [
             ":test-deps",
             "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
-        ],
-        tags = [
-            "no_windows",
+            "@bazel_tools//tools/bash/runfiles",
         ],
     )
     for java_version in JAVA_VERSIONS
@@ -437,9 +433,7 @@ sh_test(
             ":test-deps",
             "//src:java_tools_java" + java_version + "_zip",
             "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
-        ],
-        tags = [
-            "no_windows",
+            "@bazel_tools//tools/bash/runfiles",
         ],
     )
     for java_version in JAVA_VERSIONS

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -16,10 +16,43 @@
 
 set -eu
 
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../integration_test_setup.sh" \
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+    if [[ -f "$0.runfiles_manifest" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+      export RUNFILES_DIR="$0.runfiles"
+    fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*|mingw*|cygwin*)
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+fi
 
 JAVA_TOOLCHAIN="$1"; shift
 add_to_bazelrc "build --java_toolchain=${JAVA_TOOLCHAIN}"

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -61,6 +61,8 @@ JAVA_TOOLS_ZIP="$1"; shift
 if [[ "${JAVA_TOOLS_ZIP}" != "released" ]]; then
     if [[ "${JAVA_TOOLS_ZIP}" == file* ]]; then
         JAVA_TOOLS_ZIP_FILE_URL="${JAVA_TOOLS_ZIP}"
+    elif "$is_windows"; then
+        JAVA_TOOLS_ZIP_FILE_URL="file:///$(rlocation io_bazel/$JAVA_TOOLS_ZIP)"
     else
         JAVA_TOOLS_ZIP_FILE_URL="file://$(rlocation io_bazel/$JAVA_TOOLS_ZIP)"
     fi


### PR DESCRIPTION
Unfortunately bazel java coverage is not tested on Windows, which makes us oblivious to any existing issues.

This is the first step towards fixing #6407.