### PR TITLE
Fix for chocolatey build; github deprecated TLS 1.1, so ask powershell to use TLS 1.2

### DIFF
--- a/scripts/packages/chocolatey/build.ps1
+++ b/scripts/packages/chocolatey/build.ps1
@@ -43,7 +43,7 @@ remove-item -force -ErrorAction SilentlyContinue "./tools/params.*"
 if ($checksum -eq "") {
   remove-item -force -ErrorAction SilentlyContinue ./*.zip
 }
-
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 if (($mode -eq "release") -or ($mode -eq "rc")) {
   Invoke-WebRequest "$($tvUri).sha256" -UseBasicParsing -passthru -outfile sha256.txt
   $tvChecksum = (gc sha256.txt).split(' ')[0]


### PR DESCRIPTION
https://github.blog/2017-02-27-crypto-deprecation-notice/ and followups. I've had this patch locally for a while, oops.