### PR TITLE
Refactor git_repository and new_git_repository rules implementations …

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/BlackBoxTestContext.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/BlackBoxTestContext.java
@@ -225,6 +225,26 @@ public final class BlackBoxTestContext {
   }
 
   /**
+   * Runs external binary in the specified working directory. See {@link BuilderRunner}
+   *
+   * @param workingDirectory - working directory for running the binary
+   * @param processToRun - path to the binary to run
+   * @param arguments - arguments to pass to the binary
+   * @return ProcessResult - execution result
+   */
+  public ProcessResult runBinary(Path workingDirectory, String processToRun, String... arguments)
+      throws Exception {
+    ProcessParameters parameters =
+        ProcessParameters.builder()
+            .setWorkingDirectory(workingDirectory.toFile())
+            .setName(processToRun)
+            .setTimeoutMillis(getProcessTimeoutMillis(getProcessTimeoutMillis(-1)))
+            .setArguments(arguments)
+            .build();
+    return new ProcessRunner(parameters, executorService).runSynchronously();
+  }
+
+  /**
    * Take the value from environment variable and assert that it is a path, and the file or
    * directory, specified by this path, exists.
    *

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BUILD
@@ -51,11 +51,30 @@ java_test(
     ],
 )
 
+java_test(
+    name = "GitRepositoryBlackBoxTest",
+    timeout = "moderate",
+    srcs = [
+        "GitRepositoryBlackBoxTest.java",
+        "GitRepositoryHelper.java",
+        "RepoWithRuleWritingTextGenerator.java",
+        "WorkspaceTestUtils.java",
+    ],
+    tags = ["black_box_test"],
+    deps = common_deps + [
+        "//src/main/java/com/google/devtools/build/lib:build-base",
+        "//src/main/java/com/google/devtools/build/lib:bazel-repository",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/test/java/com/google/devtools/build/lib:foundations_testutil",
+    ],
+)
+
 test_suite(
     name = "ws_black_box_tests",
     tags = ["black_box_test"],
     tests = [
         "BazelEmbeddedSkylarkBlackBoxTest",
+        "GitRepositoryBlackBoxTest",
         "RepoWithRuleWritingTextGeneratorTest",
         "WorkspaceBlackBoxTest",
     ],

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/GitRepositoryBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/GitRepositoryBlackBoxTest.java
@@ -1,0 +1,121 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.blackbox.tests.workspace;
+
+import com.google.devtools.build.lib.blackbox.framework.BlackBoxTestContext;
+import com.google.devtools.build.lib.blackbox.framework.BuilderRunner;
+import com.google.devtools.build.lib.blackbox.framework.PathUtils;
+import com.google.devtools.build.lib.blackbox.junit.AbstractBlackBoxTest;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Test;
+
+/**
+ * Black box tests for git_repository/new_git_repository.
+ * On Windows, runs without MSYS {@link WorkspaceTestUtils#bazel}
+ */
+public class GitRepositoryBlackBoxTest extends AbstractBlackBoxTest {
+
+  private static final String HELLO_FROM_EXTERNAL_REPOSITORY = "Hello from GIT repository!";
+
+  @Test
+  public void testNewGitRepository() throws Exception {
+    Path repo = context().getTmpDir().resolve("ext_repo");
+    setupGitRepository(context(), repo);
+
+    String buildFileContent = String.format("%s\n%s", RepoWithRuleWritingTextGenerator.loadRule(""),
+        RepoWithRuleWritingTextGenerator.callRule("call_write_text", "out.txt",
+            HELLO_FROM_EXTERNAL_REPOSITORY));
+    context().write("WORKSPACE",
+        "load(\"@bazel_tools//tools/build_defs/repo:git.bzl\", \"new_git_repository\")",
+        "new_git_repository(",
+        "  name='ext',",
+        String.format("  remote='%s',", PathUtils.pathToFileURI(repo.resolve(".git"))),
+        "  tag='first',",
+        String.format("  build_file_content=\"\"\"%s\"\"\",", buildFileContent),
+        ")");
+
+    // This creates Bazel without MSYS, see implementation for details.
+    BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
+    bazel.build("@ext//:call_write_text");
+    Path outPath = context().resolveBinPath(bazel, "external/ext/out.txt");
+    WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
+  }
+
+  @Test
+  public void testCloneAtCommit() throws Exception {
+    Path repo = context().getTmpDir().resolve("ext_repo");
+    String commit = setupGitRepository(context(), repo);
+
+    String buildFileContent = String.format("%s\n%s", RepoWithRuleWritingTextGenerator.loadRule(""),
+        RepoWithRuleWritingTextGenerator.callRule("call_write_text", "out.txt",
+            HELLO_FROM_EXTERNAL_REPOSITORY));
+    context().write("WORKSPACE",
+        "load(\"@bazel_tools//tools/build_defs/repo:git.bzl\", \"new_git_repository\")",
+        "new_git_repository(",
+        "  name='ext',",
+        String.format("  remote='%s',", PathUtils.pathToFileURI(repo.resolve(".git"))),
+        String.format("  commit='%s',", commit),
+        String.format("  build_file_content=\"\"\"%s\"\"\",", buildFileContent),
+        ")");
+
+    // This creates Bazel without MSYS, see implementation for details.
+    BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
+    bazel.build("@ext//:call_write_text");
+    Path outPath = context().resolveBinPath(bazel, "external/ext/out.txt");
+    WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
+  }
+
+  @Test
+  public void testCloneAtMaster() throws Exception {
+    Path repo = context().getTmpDir().resolve("ext_repo");
+    setupGitRepository(context(), repo);
+
+    String buildFileContent = String.format("%s\n%s", RepoWithRuleWritingTextGenerator.loadRule(""),
+        RepoWithRuleWritingTextGenerator.callRule("call_write_text", "out.txt",
+            HELLO_FROM_EXTERNAL_REPOSITORY));
+    context().write("WORKSPACE",
+        "load(\"@bazel_tools//tools/build_defs/repo:git.bzl\", \"new_git_repository\")",
+        "new_git_repository(",
+        "  name='ext',",
+        String.format("  remote='%s',", PathUtils.pathToFileURI(repo.resolve(".git"))),
+        "  branch='master',",
+        String.format("  build_file_content=\"\"\"%s\"\"\",", buildFileContent),
+        ")");
+
+    // This creates Bazel without MSYS, see implementation for details.
+    BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
+    bazel.build("@ext//:call_write_text");
+    Path outPath = context().resolveBinPath(bazel, "external/ext/out.txt");
+    WorkspaceTestUtils.assertLinesExactly(outPath, HELLO_FROM_EXTERNAL_REPOSITORY);
+  }
+
+  private static String setupGitRepository(BlackBoxTestContext context, Path repo) throws Exception {
+    PathUtils.deleteTree(repo);
+    Files.createDirectories(repo);
+    GitRepositoryHelper gitRepository = new GitRepositoryHelper(context, repo);
+    gitRepository.init();
+
+    RepoWithRuleWritingTextGenerator generator = new RepoWithRuleWritingTextGenerator(repo);
+    generator.withOutputText(HELLO_FROM_EXTERNAL_REPOSITORY)
+        .skipBuildFile()
+        .setupRepository();
+
+    gitRepository.addAll();
+    gitRepository.commit("Initial commit");
+    gitRepository.tag("first");
+    return gitRepository.getHead();
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/GitRepositoryHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/GitRepositoryHelper.java
@@ -1,0 +1,60 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.blackbox.tests.workspace;
+
+import com.google.devtools.build.lib.blackbox.framework.BlackBoxTestContext;
+import com.google.devtools.build.lib.blackbox.framework.ProcessResult;
+import java.nio.file.Path;
+
+/**
+ * Helper class for working with local git repository in tests.
+ */
+public class GitRepositoryHelper {
+  private final BlackBoxTestContext context;
+  private final Path root;
+
+  public GitRepositoryHelper(BlackBoxTestContext context, Path root) {
+    this.context = context;
+    this.root = root;
+  }
+
+  Path init() throws Exception {
+    runGit("init");
+    runGit("config", "user.email", "'me@example.com'");
+    runGit("config", "user.name", "'E X Ample'");
+    return root;
+  }
+
+  String addAll() throws Exception {
+    return runGit("add", ".");
+  }
+
+  String commit(String commitMessage) throws Exception {
+    return runGit("commit", "-m", commitMessage);
+  }
+
+  String tag(String tagName) throws Exception {
+    return runGit("tag", tagName);
+  }
+
+  String getHead() throws Exception {
+    return runGit("rev-parse", "--short", "HEAD");
+  }
+
+  private String runGit(String... arguments) throws Exception {
+    ProcessResult result = context.runBinary(root, "git", arguments);
+    return result.outString();
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
@@ -58,6 +58,7 @@ public class RepoWithRuleWritingTextGenerator {
   private String target;
   private String outputText;
   private String outFile;
+  private boolean generateBuildFile;
 
   /**
    * Generator constructor
@@ -69,6 +70,7 @@ public class RepoWithRuleWritingTextGenerator {
     this.target = TARGET;
     this.outputText = HELLO;
     this.outFile = OUT_FILE;
+    generateBuildFile = true;
   }
 
   /**
@@ -105,6 +107,16 @@ public class RepoWithRuleWritingTextGenerator {
   }
 
   /**
+   * Specifies that BUILD file should not be generated
+   *
+   * @return this generator
+   */
+  RepoWithRuleWritingTextGenerator skipBuildFile() {
+    generateBuildFile = false;
+    return this;
+  }
+
+  /**
    * Generates the repository: WORKSPACE, BUILD, and helper.bzl files.
    *
    * @return repository directory
@@ -113,13 +125,15 @@ public class RepoWithRuleWritingTextGenerator {
   Path setupRepository() throws IOException {
     Path workspace = PathUtils.writeFileInDir(root, "WORKSPACE");
     PathUtils.writeFileInDir(root, HELPER_FILE, WRITE_TEXT_TO_FILE);
-    PathUtils.writeFileInDir(
-        root,
-        "BUILD",
-        "load(\"@bazel_tools//tools/build_defs/pkg:pkg.bzl\", \"pkg_tar\")",
-        loadRule(""),
-        callRule(target, outFile, outputText),
-        String.format("pkg_tar(name = \"%s\", srcs = glob([\"*\"]),)", getPkgTarTarget()));
+    if (generateBuildFile) {
+      PathUtils.writeFileInDir(
+          root,
+          "BUILD",
+          "load(\"@bazel_tools//tools/build_defs/pkg:pkg.bzl\", \"pkg_tar\")",
+          loadRule(""),
+          callRule(target, outFile, outputText),
+          String.format("pkg_tar(name = \"%s\", srcs = glob([\"*\"]),)", getPkgTarTarget()));
+    }
     return workspace.getParent();
   }
 

--- a/src/test/shell/bazel/skylark_git_repository_test.sh
+++ b/src/test/shell/bazel/skylark_git_repository_test.sh
@@ -640,7 +640,7 @@ EOF
 
   bazel fetch //planets:planet-info >& $TEST_log \
     || echo "Expect run to fail."
-  expect_log "error cloning"
+  expect_log "error running 'git fetch origin' while working with @pluto"
 }
 
 run_suite "skylark git_repository tests"

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -13,7 +13,8 @@
 # limitations under the License.
 """Rules for cloning external git repositories."""
 
-load(":utils.bzl", "patch", "update_attrs", "workspace_and_buildfile")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch", "update_attrs", "workspace_and_buildfile")
+load("@bazel_tools//tools/build_defs/repo:git_worker.bzl", "git_repo")
 
 def _clone_or_update(ctx):
     if ((not ctx.attr.tag and not ctx.attr.commit and not ctx.attr.branch) or
@@ -21,102 +22,22 @@ def _clone_or_update(ctx):
         (ctx.attr.tag and ctx.attr.branch) or
         (ctx.attr.commit and ctx.attr.branch)):
         fail("Exactly one of commit, tag, or branch must be provided")
-    shallow = ""
-    if ctx.attr.commit:
-        ref = ctx.attr.commit
-    elif ctx.attr.tag:
-        ref = "tags/" + ctx.attr.tag
-        shallow = "--depth=1"
-    else:
-        ref = ctx.attr.branch
-        shallow = "--depth=1"
-    directory = str(ctx.path("."))
+
+    root = ctx.path(".")
+    directory = str(root)
     if ctx.attr.strip_prefix:
         directory = directory + "-tmp"
-    if ctx.attr.shallow_since:
-        if ctx.attr.tag:
-            fail("shallow_since not allowed if a tag is specified; --depth=1 will be used for tags")
-        if ctx.attr.branch:
-            fail("shallow_since not allowed if a branch is specified; --depth=1 will be used for branches")
-        shallow = "--shallow-since=%s" % ctx.attr.shallow_since
 
-    ctx.report_progress("Cloning %s of %s" % (ref, ctx.attr.remote))
-    if (ctx.attr.verbose):
-        print("git.bzl: Cloning or updating %s repository %s using strip_prefix of [%s]" %
-              (
-                  " (%s)" % shallow if shallow else "",
-                  ctx.name,
-                  ctx.attr.strip_prefix if ctx.attr.strip_prefix else "None",
-              ))
-    bash_exe = ctx.os.environ["BAZEL_SH"] if "BAZEL_SH" in ctx.os.environ else "bash"
-    st = ctx.execute([bash_exe, "-c", """
-cd {working_dir}
-set -ex
-( cd {working_dir} &&
-    if ! ( cd '{dir_link}' && [[ "$(git rev-parse --git-dir)" == '.git' ]] ) >/dev/null 2>&1; then
-      rm -rf '{directory}' '{dir_link}'
-      git clone '{shallow}' '{remote}' '{directory}' || git clone '{remote}' '{directory}'
-    fi
-    git -C '{directory}' reset --hard {ref} || \
-    ((git -C '{directory}' fetch '{shallow}' origin {ref}:{ref} || \
-      git -C '{directory}' fetch origin {ref}:{ref}) && git -C '{directory}' reset --hard {ref})
-      git -C '{directory}' clean -xdf )
-  """.format(
-        working_dir = ctx.path(".").dirname,
-        dir_link = ctx.path("."),
-        directory = directory,
-        remote = ctx.attr.remote,
-        ref = ref,
-        shallow = shallow,
-    )], environment = ctx.os.environ)
-
-    if st.return_code:
-        fail("error cloning %s:\n%s" % (ctx.name, st.stderr))
+    git_ = git_repo(ctx, directory)
 
     if ctx.attr.strip_prefix:
         dest_link = "{}/{}".format(directory, ctx.attr.strip_prefix)
         if not ctx.path(dest_link).exists:
             fail("strip_prefix at {} does not exist in repo".format(ctx.attr.strip_prefix))
+        ctx.delete(root)
+        ctx.symlink(dest_link, root)
 
-        ctx.symlink(dest_link, ctx.path("."))
-    if ctx.attr.init_submodules:
-        ctx.report_progress("Updating submodules")
-        st = ctx.execute([bash_exe, "-c", """
-set -ex
-(   git -C '{directory}' submodule update --init --checkout --force )
-  """.format(
-            directory = ctx.path("."),
-        )], environment = ctx.os.environ)
-    if st.return_code:
-        fail("error updating submodules %s:\n%s" % (ctx.name, st.stderr))
-
-    ctx.report_progress("Recording actual commit")
-
-    # After the fact, determine the actual commit and its date
-    actual_commit = ctx.execute([
-        bash_exe,
-        "-c",
-        "(git -C '{directory}' log -n 1 --pretty='format:%H')".format(
-            directory = ctx.path("."),
-        ),
-    ]).stdout
-    shallow_date = ctx.execute([
-        bash_exe,
-        "-c",
-        "(git -C '{directory}' log -n 1 --pretty='format:%cd' --date=raw)".format(
-            directory = ctx.path("."),
-        ),
-    ]).stdout
-    return {"commit": actual_commit, "shallow_since": shallow_date}
-
-def _remove_dot_git(ctx):
-    # Remove the .git directory, if present
-    bash_exe = ctx.os.environ["BAZEL_SH"] if "BAZEL_SH" in ctx.os.environ else "bash"
-    ctx.execute([
-        bash_exe,
-        "-c",
-        "rm -rf '{directory}'".format(directory = ctx.path(".git")),
-    ])
+    return {"commit": git_.commit, "shallow_since": git_.shallow_since}
 
 def _update_git_attrs(orig, keys, override):
     result = update_attrs(orig, keys, override)
@@ -227,13 +148,13 @@ def _new_git_repository_implementation(ctx):
     update = _clone_or_update(ctx)
     workspace_and_buildfile(ctx)
     patch(ctx)
-    _remove_dot_git(ctx)
+    ctx.delete(ctx.path(".git"))
     return _update_git_attrs(ctx.attr, _new_git_repository_attrs.keys(), update)
 
 def _git_repository_implementation(ctx):
     update = _clone_or_update(ctx)
     patch(ctx)
-    _remove_dot_git(ctx)
+    ctx.delete(ctx.path(".git"))
     return _update_git_attrs(ctx.attr, _common_attrs.keys(), update)
 
 new_git_repository = repository_rule(

--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -1,0 +1,127 @@
+_GitRepo = provider(
+    doc = "Provider to organize precomputed arguments for calling git.",
+    fields = {
+        "directory": "Working directory path",
+        "shallow": "Defines the depth of a fetch. Either empty, --depth=1, or --shallow-since=<>",
+        "reset_ref": """Reference to use for resetting the git repository.
+Either commit hash, tag or branch.""",
+        "fetch_ref": """Reference for fetching. Can be empty (HEAD), tag or branch.
+Can not be a commit hash, since typically it is forbidden by git servers.""",
+        "remote": "URL of the git repository to fetch from.",
+        "init_submodules": """If True, submodules update command will be called after fetching
+and resetting to the specified reference.""",
+    },
+)
+
+def git_repo(ctx, directory):
+    if ctx.attr.shallow_since:
+        if ctx.attr.tag:
+            fail("shallow_since not allowed if a tag is specified; --depth=1 will be used for tags")
+        if ctx.attr.branch:
+            fail("shallow_since not allowed if a branch is specified; --depth=1 will be used for branches")
+
+    shallow = "--depth=1"
+    if ctx.attr.shallow_since:
+        shallow = "--shallow-since=%s" % ctx.attr.shallow_since
+    if ctx.attr.commit:
+        shallow = ""
+
+    reset_ref = ""
+    fetch_ref = ""
+    if ctx.attr.commit:
+        reset_ref = ctx.attr.commit
+    elif ctx.attr.tag:
+        reset_ref = "tags/" + ctx.attr.tag
+        fetch_ref = "tags/" + ctx.attr.tag + ":tags/" + ctx.attr.tag
+    elif ctx.attr.branch:
+        reset_ref = "origin/" + ctx.attr.branch
+        fetch_ref = ctx.attr.branch
+
+    git_repo = _GitRepo(
+        directory = ctx.path(directory),
+        shallow = shallow,
+        reset_ref = reset_ref,
+        fetch_ref = fetch_ref,
+        remote = ctx.attr.remote,
+        init_submodules = ctx.attr.init_submodules,
+    )
+
+    ctx.report_progress("Cloning %s of %s" % (reset_ref, ctx.attr.remote))
+    if (ctx.attr.verbose):
+        print("git.bzl: Cloning or updating %s repository %s using strip_prefix of [%s]" %
+              (
+                  " (%s)" % shallow if shallow else "",
+                  ctx.name,
+                  ctx.attr.strip_prefix if ctx.attr.strip_prefix else "None",
+              ))
+
+    _update(ctx, git_repo)
+    actual_commit = _get_head_commit(ctx, git_repo)
+    shallow_date = _get_head_date(ctx, git_repo)
+
+    return struct(commit = actual_commit, shallow_since = shallow_date)
+
+def _update(ctx, git_repo):
+    ctx.delete(git_repo.directory)
+
+    init(ctx, git_repo)
+    add_origin(ctx, git_repo, ctx.attr.remote)
+    fetch(ctx, git_repo)
+    reset(ctx, git_repo)
+    clean(ctx, git_repo)
+
+    if git_repo.init_submodules:
+        update_submodules(ctx, git_repo)
+
+def init(ctx, git_repo):
+    cl = ["git", "init", "%s" % git_repo.directory]
+    st = ctx.execute(cl, environment = ctx.os.environ)
+    if st.return_code != 0:
+        _error(ctx.name, cl, st.stderr)
+
+def add_origin(ctx, git_repo, remote):
+    _git(ctx, git_repo, "remote", "add", "origin", remote)
+
+def fetch(ctx, git_repo):
+    _git_maybe_shallow(ctx, git_repo, "fetch", "origin", git_repo.fetch_ref)
+
+def reset(ctx, git_repo):
+    _git_maybe_shallow(ctx, git_repo, "reset", "--hard", git_repo.reset_ref, "--")
+
+def clean(ctx, git_repo):
+    _git(ctx, git_repo, "clean", "-xdf")
+
+def update_submodules(ctx, git_repo):
+    _git(ctx, git_repo, "submodule", "update", "--init", "--checkout", "--force")
+
+def _get_head_commit(ctx, git_repo):
+    return _git(ctx, git_repo, "log", "-n", "1", "--pretty=format:%H")
+
+def _get_head_date(ctx, git_repo):
+    return _git(ctx, git_repo, "log", "-n", "1", "--pretty=format:%cd", "--date=raw")
+
+def _git(ctx, git_repo, command, *args):
+    start = ["git", command]
+    st = _execute(ctx, git_repo, start + list(args))
+    if st.return_code != 0:
+        _error(ctx.name, start + list(args), st.stderr)
+    return st.stdout
+
+def _git_maybe_shallow(ctx, git_repo, command, *args):
+    start = ["git", command]
+    args_list = list(args)
+    st = _execute(ctx, git_repo, start + ["'%s'" % git_repo.shallow] + args_list)
+    if st.return_code != 0:
+        st = _execute(ctx, git_repo, start + args_list)
+        if st.return_code != 0:
+            _error(ctx.name, start + args_list, st.stderr)
+
+def _execute(ctx, git_repo, args):
+    return ctx.execute(
+        args,
+        environment = ctx.os.environ,
+        working_directory = str(git_repo.directory),
+    )
+
+def _error(name, command, stderr):
+    fail("error running '%s' while working with @%s:\n%s" % (" ".join(command).strip(), name, stderr))

--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -53,7 +53,9 @@ def git_repo(ctx, directory):
     if ctx.attr.shallow_since:
         shallow = "--shallow-since=%s" % ctx.attr.shallow_since
     if ctx.attr.commit:
-        shallow = "--shallow-since=%s" % ctx.attr.commit
+        # We can not use the commit value in --shallow-since;
+        # And since we are fetching HEAD in this case, we can not use --depth=1
+        shallow = ""
 
     reset_ref = ""
     fetch_ref = ""
@@ -85,6 +87,7 @@ def git_repo(ctx, directory):
               ))
 
     _update(ctx, git_repo)
+    ctx.report_progress("Recording actual commit")
     actual_commit = _get_head_commit(ctx, git_repo)
     shallow_date = _get_head_date(ctx, git_repo)
 
@@ -100,6 +103,7 @@ def _update(ctx, git_repo):
     clean(ctx, git_repo)
 
     if git_repo.init_submodules:
+        ctx.report_progress("Updating submodules")
         update_submodules(ctx, git_repo)
 
 def init(ctx, git_repo):
@@ -115,7 +119,7 @@ def fetch(ctx, git_repo):
     _git_maybe_shallow(ctx, git_repo, "fetch", "origin", git_repo.fetch_ref)
 
 def reset(ctx, git_repo):
-    _git_maybe_shallow(ctx, git_repo, "reset", "--hard", git_repo.reset_ref, "--")
+    _git_maybe_shallow(ctx, git_repo, "reset", "--hard", git_repo.reset_ref)
 
 def clean(ctx, git_repo):
     _git(ctx, git_repo, "clean", "-xdf")

--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -30,13 +30,18 @@ and resetting to the specified reference.""",
 )
 
 def git_repo(ctx, directory):
-    """ Fetches data from git repository and checks out file tree at specified revision into
-    specified directory.
+    """ Fetches data from git repository and checks out file tree.
+
     Called by git_repository or new_git_repository rules.
 
     Args:
         ctx: Context of the calling rules, for reading the attributes.
+        Please refer to the git_repository and new_git_repository rules for the description.
         directory: Directory where to check out the file tree.
+    Returns:
+        The struct with the following fields:
+        commit: Actual HEAD commit of the checked out data.
+        shallow_since: Actual date and time of the HEAD commit of the checked out data.
     """
     if ctx.attr.shallow_since:
         if ctx.attr.tag:

--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -1,4 +1,20 @@
-_GitRepo = provider(
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Code for interacting with git binary to get the file tree checked out at the specified revision.
+"""
+
+_GitRepoInfo = provider(
     doc = "Provider to organize precomputed arguments for calling git.",
     fields = {
         "directory": "Working directory path",
@@ -14,6 +30,14 @@ and resetting to the specified reference.""",
 )
 
 def git_repo(ctx, directory):
+    """ Fetches data from git repository and checks out file tree at specified revision into
+    specified directory.
+    Called by git_repository or new_git_repository rules.
+
+    Args:
+        ctx: Context of the calling rules, for reading the attributes.
+        directory: Directory where to check out the file tree.
+    """
     if ctx.attr.shallow_since:
         if ctx.attr.tag:
             fail("shallow_since not allowed if a tag is specified; --depth=1 will be used for tags")
@@ -37,7 +61,7 @@ def git_repo(ctx, directory):
         reset_ref = "origin/" + ctx.attr.branch
         fetch_ref = ctx.attr.branch
 
-    git_repo = _GitRepo(
+    git_repo = _GitRepoInfo(
         directory = ctx.path(directory),
         shallow = shallow,
         reset_ref = reset_ref,

--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -50,12 +50,14 @@ def git_repo(ctx, directory):
             fail("shallow_since not allowed if a branch is specified; --depth=1 will be used for branches")
 
     shallow = "--depth=1"
-    if ctx.attr.shallow_since:
-        shallow = "--shallow-since=%s" % ctx.attr.shallow_since
     if ctx.attr.commit:
         # We can not use the commit value in --shallow-since;
         # And since we are fetching HEAD in this case, we can not use --depth=1
         shallow = ""
+
+    # Use shallow-since if given
+    if ctx.attr.shallow_since:
+        shallow = "--shallow-since=%s" % ctx.attr.shallow_since
 
     reset_ref = ""
     fetch_ref = ""


### PR DESCRIPTION
…so that they can be used with Bazel on Windows without MSYS

- do not use shell scripting, call git binary and use repository_context methods
- add black box tests for new_git_repository, so that they run on Windows without MSYS
- prefer fetch to clone, as in that case less content is fetched (with fetch, we specify both the reference and depth in the same command; on contrary, clone will fetch all branches)