### PR TITLE
MethodDescriptor.call: don't convert unchecked exceptions into EvalException.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/local/XcodeLocalEnvProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/XcodeLocalEnvProvider.java
@@ -93,7 +93,7 @@ public final class XcodeLocalEnvProvider implements LocalEnvProvider {
     String developerDir = "";
     if (containsXcodeVersion) {
       String version = env.get(AppleConfiguration.XCODE_VERSION_ENV_NAME);
-      developerDir = getDeveloperDir(binTools, DottedVersion.fromString(version));
+      developerDir = getDeveloperDir(binTools, DottedVersion.fromStringUnchecked(version));
       newEnvBuilder.put("DEVELOPER_DIR", developerDir);
     }
     if (containsAppleSdkVersion) {

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -210,7 +210,15 @@ public class RuleClass {
      * messaging should be done via {@link RuleErrorConsumer}; this exception only interrupts
      * configured target creation in cases where it can no longer continue.
      */
-    public static final class RuleErrorException extends Exception {}
+    public static final class RuleErrorException extends Exception {
+      public RuleErrorException() {
+        super();
+      }
+
+      public RuleErrorException(String message) {
+        super(message);
+      }
+    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleErrorConsumer.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleErrorConsumer.java
@@ -55,7 +55,7 @@ public interface RuleErrorConsumer {
    */
   default RuleErrorException throwWithRuleError(String message) throws RuleErrorException {
     ruleError(message);
-    throw new RuleErrorException();
+    throw new RuleErrorException(message);
   }
 
   /**
@@ -70,7 +70,7 @@ public interface RuleErrorConsumer {
   default RuleErrorException throwWithAttributeError(String attrName, String message)
       throws RuleErrorException {
     attributeError(attrName, message);
-    throw new RuleErrorException();
+    throw new RuleErrorException(message);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/ApplePlatform.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/ApplePlatform.java
@@ -192,6 +192,13 @@ public enum ApplePlatform implements ApplePlatformApi {
     printer.append(toString());
   }
 
+  /** Exception indicating an unknown or unsupported Apple platform type. */
+  public static class UnsupportedPlatformTypeException extends Exception {
+    public UnsupportedPlatformTypeException(String msg) {
+      super(msg);
+    }
+  }
+
   /**
    * Value used to describe Apple platform "type". A {@link ApplePlatform} is implied from a
    * platform type (for example, watchOS) together with a cpu value (for example, armv7).
@@ -222,15 +229,16 @@ public enum ApplePlatform implements ApplePlatformApi {
     /**
      * Returns the {@link PlatformType} with given name (case insensitive).
      *
-     * @throws IllegalArgumentException if the name does not match a valid platform type.
+     * @throws UnsupportedPlatformTypeException if the name does not match a valid platform type.
      */
-    public static PlatformType fromString(String name) {
+    public static PlatformType fromString(String name) throws UnsupportedPlatformTypeException {
       for (PlatformType platformType : PlatformType.values()) {
         if (name.equalsIgnoreCase(platformType.toString())) {
           return platformType;
         }
       }
-      throw new IllegalArgumentException(String.format("Unsupported platform type \"%s\"", name));
+      throw new UnsupportedPlatformTypeException(
+          String.format("Unsupported platform type \"%s\"", name));
     }
 
     /** Returns a Skylark struct that contains the instances of this enum. */

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleToolchain.java
@@ -106,7 +106,7 @@ public class AppleToolchain implements AppleToolchainApi<AppleConfiguration> {
       case IOS_SIMULATOR:
         if (xcodeConfig
                 .getSdkVersionForPlatform(targetPlatform)
-                .compareTo(DottedVersion.fromString("9.0"))
+                .compareTo(DottedVersion.fromStringUnchecked("9.0"))
             >= 0) {
           relativePath = SYSTEM_FRAMEWORK_PATH;
         } else {

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/DottedVersionConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/DottedVersionConverter.java
@@ -26,7 +26,7 @@ public class DottedVersionConverter implements Converter<DottedVersion.Option> {
   public DottedVersion.Option convert(String input) throws OptionsParsingException {
     try {
       return DottedVersion.option(DottedVersion.fromString(input));
-    } catch (IllegalArgumentException e) {
+    } catch (DottedVersion.InvalidDottedVersionException e) {
       throw new OptionsParsingException(e.getMessage());
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeConfig.java
@@ -37,7 +37,8 @@ import java.util.Map;
  * Implementation for the {@code xcode_config} rule.
  */
 public class XcodeConfig implements RuleConfiguredTargetFactory {
-  private static final DottedVersion MINIMUM_BITCODE_XCODE_VERSION = DottedVersion.fromString("7");
+  private static final DottedVersion MINIMUM_BITCODE_XCODE_VERSION =
+      DottedVersion.fromStringUnchecked("7");
 
   /**
    * An exception that signals that an Xcode config setup was invalid.

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeVersionProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeVersionProperties.java
@@ -79,20 +79,20 @@ public class XcodeVersionProperties extends NativeInfo implements XcodePropertie
     this.xcodeVersion = Optional.fromNullable(xcodeVersion);
     this.defaultIosSdkVersion =
         Strings.isNullOrEmpty(defaultIosSdkVersion)
-            ? DottedVersion.fromString(DEFAULT_IOS_SDK_VERSION)
-            : DottedVersion.fromString(defaultIosSdkVersion);
+            ? DottedVersion.fromStringUnchecked(DEFAULT_IOS_SDK_VERSION)
+            : DottedVersion.fromStringUnchecked(defaultIosSdkVersion);
     this.defaultWatchosSdkVersion =
         Strings.isNullOrEmpty(defaultWatchosSdkVersion)
-            ? DottedVersion.fromString(DEFAULT_WATCHOS_SDK_VERSION)
-            : DottedVersion.fromString(defaultWatchosSdkVersion);
+            ? DottedVersion.fromStringUnchecked(DEFAULT_WATCHOS_SDK_VERSION)
+            : DottedVersion.fromStringUnchecked(defaultWatchosSdkVersion);
     this.defaultTvosSdkVersion =
         Strings.isNullOrEmpty(defaultTvosSdkVersion)
-            ? DottedVersion.fromString(DEFAULT_TVOS_SDK_VERSION)
-            : DottedVersion.fromString(defaultTvosSdkVersion);
+            ? DottedVersion.fromStringUnchecked(DEFAULT_TVOS_SDK_VERSION)
+            : DottedVersion.fromStringUnchecked(defaultTvosSdkVersion);
     this.defaultMacosSdkVersion =
         Strings.isNullOrEmpty(defaultMacosSdkVersion)
-            ? DottedVersion.fromString(DEFAULT_MACOS_SDK_VERSION)
-            : DottedVersion.fromString(defaultMacosSdkVersion);
+            ? DottedVersion.fromStringUnchecked(DEFAULT_MACOS_SDK_VERSION)
+            : DottedVersion.fromStringUnchecked(defaultMacosSdkVersion);
   }
 
   /** Returns the xcode version, or null if the xcode version is unknown. */

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeVersionRuleData.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/XcodeVersionRuleData.java
@@ -45,8 +45,9 @@ public class XcodeVersionRuleData implements TransitiveInfoProvider {
         NonconfigurableAttributeMapper.of(rule);
 
     this.label = label;
-    DottedVersion xcodeVersion = DottedVersion.fromString(
-        attrMapper.get(XcodeVersionRule.VERSION_ATTR_NAME, Type.STRING));
+    DottedVersion xcodeVersion =
+        DottedVersion.fromStringUnchecked(
+            attrMapper.get(XcodeVersionRule.VERSION_ATTR_NAME, Type.STRING));
     String iosSdkVersionString =
         attrMapper.get(XcodeVersionRule.DEFAULT_IOS_SDK_VERSION_ATTR_NAME, Type.STRING);
     String watchosSdkVersionString =

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/AppleSkylarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/AppleSkylarkCommon.java
@@ -182,9 +182,7 @@ public class AppleSkylarkCommon
   @Override
   // This method is registered statically for skylark, and never called directly.
   public ObjcProvider newObjcProvider(
-      Boolean usesSwift,
-      SkylarkDict<?, ?> kwargs,
-      Environment environment) {
+      Boolean usesSwift, SkylarkDict<?, ?> kwargs, Environment environment) throws EvalException {
     ObjcProvider.Builder resultBuilder = new ObjcProvider.Builder(environment.getSemantics());
     if (usesSwift) {
       resultBuilder.add(ObjcProvider.FLAG, ObjcProvider.Flag.USES_SWIFT);
@@ -198,7 +196,7 @@ public class AppleSkylarkCommon
       } else if (entry.getKey().equals("direct_dep_providers")) {
         resultBuilder.addDirectDepProvidersFromSkylark(entry.getValue());
       } else {
-        throw new IllegalArgumentException(String.format(BAD_KEY_ERROR, entry.getKey()));
+        throw new EvalException(null, String.format(BAD_KEY_ERROR, entry.getKey()));
       }
     }
     return resultBuilder.build();
@@ -253,8 +251,12 @@ public class AppleSkylarkCommon
   }
 
   @Override
-  public DottedVersion dottedVersion(String version) {
-    return DottedVersion.fromString(version);
+  public DottedVersion dottedVersion(String version) throws EvalException {
+    try {
+      return DottedVersion.fromString(version);
+    } catch (DottedVersion.InvalidDottedVersionException e) {
+      throw new EvalException(null, e.getMessage());
+    }
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcProvider.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.rules.cpp.CppModuleMap;
 import com.google.devtools.build.lib.rules.cpp.LibraryToLink;
 import com.google.devtools.build.lib.rules.cpp.LibraryToLink.CcLinkingContext;
 import com.google.devtools.build.lib.skylarkbuildapi.apple.ObjcProviderApi;
+import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.EvalUtils;
 import com.google.devtools.build.lib.syntax.SkylarkList;
 import com.google.devtools.build.lib.syntax.SkylarkNestedSet;
@@ -1104,7 +1105,7 @@ public final class ObjcProvider extends Info implements ObjcProviderApi<Artifact
      * Add elements in toAdd with the given key from skylark. An error is thrown if toAdd is not an
      * appropriate SkylarkNestedSet.
      */
-    void addElementsFromSkylark(Key<?> key, Object skylarkToAdd) {
+    void addElementsFromSkylark(Key<?> key, Object skylarkToAdd) throws EvalException {
       Iterable<?> toAdd = ObjcProviderSkylarkConverters.convertToJava(key, skylarkToAdd);
       uncheckedAddAll(key, toAdd, this.items);
       if (ObjcProvider.KEYS_FOR_DIRECT.contains(key)) {
@@ -1117,16 +1118,18 @@ public final class ObjcProvider extends Info implements ObjcProviderApi<Artifact
      * ObjcProvider instances.
      */
     @SuppressWarnings("unchecked")
-    void addProvidersFromSkylark(Object toAdd) {
+    void addProvidersFromSkylark(Object toAdd) throws EvalException {
       if (!(toAdd instanceof Iterable)) {
-        throw new IllegalArgumentException(
+        throw new EvalException(
+            null,
             String.format(
                 AppleSkylarkCommon.BAD_PROVIDERS_ITER_ERROR, EvalUtils.getDataTypeName(toAdd)));
       } else {
         Iterable<Object> toAddIterable = (Iterable<Object>) toAdd;
         for (Object toAddObject : toAddIterable) {
           if (!(toAddObject instanceof ObjcProvider)) {
-            throw new IllegalArgumentException(
+            throw new EvalException(
+                null,
                 String.format(
                     AppleSkylarkCommon.BAD_PROVIDERS_ELEM_ERROR,
                     EvalUtils.getDataTypeName(toAddObject)));
@@ -1138,21 +1141,22 @@ public final class ObjcProvider extends Info implements ObjcProviderApi<Artifact
     }
 
     /**
-     * Adds the given providers from skylark, but propagate any normally-propagated items
-     * only to direct dependers. An error is thrown if toAdd is not an iterable of ObjcProvider
-     * instances.
+     * Adds the given providers from skylark, but propagate any normally-propagated items only to
+     * direct dependers. An error is thrown if toAdd is not an iterable of ObjcProvider instances.
      */
     @SuppressWarnings("unchecked")
-    void addDirectDepProvidersFromSkylark(Object toAdd) {
+    void addDirectDepProvidersFromSkylark(Object toAdd) throws EvalException {
       if (!(toAdd instanceof Iterable)) {
-        throw new IllegalArgumentException(
+        throw new EvalException(
+            null,
             String.format(
                 AppleSkylarkCommon.BAD_PROVIDERS_ITER_ERROR, EvalUtils.getDataTypeName(toAdd)));
       } else {
         Iterable<Object> toAddIterable = (Iterable<Object>) toAdd;
         for (Object toAddObject : toAddIterable) {
           if (!(toAddObject instanceof ObjcProvider)) {
-            throw new IllegalArgumentException(
+            throw new EvalException(
+                null,
                 String.format(
                     AppleSkylarkCommon.BAD_PROVIDERS_ELEM_ERROR,
                     EvalUtils.getDataTypeName(toAddObject)));

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcProviderSkylarkConverters.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcProviderSkylarkConverters.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.rules.objc.ObjcProvider.Key;
+import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.EvalUtils;
 import com.google.devtools.build.lib.syntax.SkylarkNestedSet;
 import com.google.devtools.build.lib.syntax.SkylarkType;
@@ -51,10 +52,9 @@ public class ObjcProviderSkylarkConverters {
     return CONVERTERS.get(javaKey.getType()).valueForSkylark(javaKey, javaValue);
   }
 
-  /**
-   * Returns a value for a java ObjcProvider given a key and a corresponding skylark value.
-   */
-  public static Iterable<?> convertToJava(Key<?> javaKey, Object skylarkValue) {
+  /** Returns a value for a java ObjcProvider given a key and a corresponding skylark value. */
+  public static Iterable<?> convertToJava(Key<?> javaKey, Object skylarkValue)
+      throws EvalException {
     return CONVERTERS.get(javaKey.getType()).valueForJava(javaKey, skylarkValue);
   }
 
@@ -79,10 +79,8 @@ public class ObjcProviderSkylarkConverters {
      */
     abstract Object valueForSkylark(Key<?> javaKey, NestedSet<?> javaValue);
 
-    /**
-     * Translates a skylark ObjcProvider value to a java ObjcProvider value.
-     */
-    abstract Iterable<?> valueForJava(Key<?> javaKey, Object skylarkValue);
+    /** Translates a skylark ObjcProvider value to a java ObjcProvider value. */
+    abstract Iterable<?> valueForJava(Key<?> javaKey, Object skylarkValue) throws EvalException;
   }
 
   /**
@@ -97,7 +95,7 @@ public class ObjcProviderSkylarkConverters {
     }
 
     @Override
-    public Iterable<?> valueForJava(Key<?> javaKey, Object skylarkValue) {
+    public Iterable<?> valueForJava(Key<?> javaKey, Object skylarkValue) throws EvalException {
       validateTypes(skylarkValue, javaKey.getType(), javaKey.getSkylarkKeyName());
       return ((SkylarkNestedSet) skylarkValue).toCollection();
     }
@@ -116,7 +114,7 @@ public class ObjcProviderSkylarkConverters {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Iterable<?> valueForJava(Key<?> javaKey, Object skylarkValue) {
+    public Iterable<?> valueForJava(Key<?> javaKey, Object skylarkValue) throws EvalException {
       validateTypes(skylarkValue, String.class, javaKey.getSkylarkKeyName());
       NestedSetBuilder<PathFragment> result = NestedSetBuilder.stableOrder();
       for (String path : ((SkylarkNestedSet) skylarkValue).toCollection(String.class)) {
@@ -143,7 +141,7 @@ public class ObjcProviderSkylarkConverters {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Iterable<?> valueForJava(Key<?> javaKey, Object skylarkValue) {
+    public Iterable<?> valueForJava(Key<?> javaKey, Object skylarkValue) throws EvalException {
       validateTypes(skylarkValue, String.class, javaKey.getSkylarkKeyName());
       NestedSetBuilder<SdkFramework> result = NestedSetBuilder.stableOrder();
       for (String path : ((SkylarkNestedSet) skylarkValue).toCollection(String.class)) {
@@ -153,15 +151,15 @@ public class ObjcProviderSkylarkConverters {
     }
   }
 
-  /**
-   * Throws an error if the given object is not a nested set of the given type.
-   */
-  private static void validateTypes(Object toCheck, Class<?> expectedSetType, String keyName) {
+  /** Throws an error if the given object is not a nested set of the given type. */
+  private static void validateTypes(Object toCheck, Class<?> expectedSetType, String keyName)
+      throws EvalException {
     if (!(toCheck instanceof SkylarkNestedSet)) {
-      throw new IllegalArgumentException(
-          String.format(NOT_SET_ERROR, keyName, EvalUtils.getDataTypeName(toCheck)));
+      throw new EvalException(
+          null, String.format(NOT_SET_ERROR, keyName, EvalUtils.getDataTypeName(toCheck)));
     } else if (!((SkylarkNestedSet) toCheck).getContentType().canBeCastTo(expectedSetType)) {
-      throw new IllegalArgumentException(
+      throw new EvalException(
+          null,
           String.format(
               BAD_SET_TYPE_ERROR,
               keyName,

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -138,6 +138,11 @@ public abstract class RepositoryFunction {
     RepositoryMissingDependencyException() {
       super(Location.BUILTIN, "Internal exception");
     }
+
+    @Override
+    public boolean canBeAddedToStackTrace() {
+      return false;
+    }
   }
   /**
    * repository functions can throw the result of this function to notify the RepositoryFunction

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/apple/AppleCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/apple/AppleCommonApi.java
@@ -279,32 +279,27 @@ public interface AppleCommonApi<
   public SplitTransitionProviderApi getMultiArchSplitProvider();
 
   @SkylarkCallable(
-    name = "new_objc_provider",
-    doc = "Creates a new ObjcProvider instance.",
-    parameters = {
-      @Param(
-        name = "uses_swift",
-        type = Boolean.class,
-        defaultValue = "False",
-        named = true,
-        positional = false,
-        doc = "Whether this provider should enable Swift support."
-      )
-    },
-    extraKeywords =
+      name = "new_objc_provider",
+      doc = "Creates a new ObjcProvider instance.",
+      parameters = {
         @Param(
-          name = "kwargs",
-          type = SkylarkDict.class,
-          defaultValue = "{}",
-          doc = "Dictionary of arguments."
-        ),
-    useEnvironment = true
-  )
+            name = "uses_swift",
+            type = Boolean.class,
+            defaultValue = "False",
+            named = true,
+            positional = false,
+            doc = "Whether this provider should enable Swift support.")
+      },
+      extraKeywords =
+          @Param(
+              name = "kwargs",
+              type = SkylarkDict.class,
+              defaultValue = "{}",
+              doc = "Dictionary of arguments."),
+      useEnvironment = true)
   // This method is registered statically for skylark, and never called directly.
   public ObjcProviderApi<?> newObjcProvider(
-      Boolean usesSwift,
-      SkylarkDict<?, ?> kwargs,
-      Environment environment);
+      Boolean usesSwift, SkylarkDict<?, ?> kwargs, Environment environment) throws EvalException;
 
   @SkylarkCallable(
     name = "new_dynamic_framework_provider",
@@ -403,17 +398,15 @@ public interface AppleCommonApi<
       throws EvalException, InterruptedException;
 
   @SkylarkCallable(
-    name = "dotted_version",
-    doc = "Creates a new <a href=\"DottedVersion.html\">DottedVersion</a> instance.",
-    parameters = {
-      @Param(
-        name = "version",
-        type = String.class,
-        doc = "The string representation of the DottedVersion."
-      )
-    }
-  )
-  public DottedVersionApi<?> dottedVersion(String version);
+      name = "dotted_version",
+      doc = "Creates a new <a href=\"DottedVersion.html\">DottedVersion</a> instance.",
+      parameters = {
+        @Param(
+            name = "version",
+            type = String.class,
+            doc = "The string representation of the DottedVersion.")
+      })
+  public DottedVersionApi<?> dottedVersion(String version) throws EvalException;
 
   @SkylarkCallable(
     name = "objc_proto_aspect",

--- a/src/main/java/com/google/devtools/build/lib/syntax/MethodDescriptor.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/MethodDescriptor.java
@@ -130,46 +130,54 @@ public final class MethodDescriptor {
   public Object call(Object obj, Object[] args, Location loc, Environment env)
       throws EvalException, InterruptedException {
     Preconditions.checkNotNull(obj);
+    Object result;
     try {
-      Object result = method.invoke(obj, args);
-      if (method.getReturnType().equals(Void.TYPE)) {
-        return Runtime.NONE;
-      }
-      if (result == null) {
-        if (isAllowReturnNones()) {
-          return Runtime.NONE;
-        } else {
-          throw new EvalException(
-              loc,
-              "method invocation returned None, please file a bug report: "
-                  + getName()
-                  + Printer.printAbbreviatedList(ImmutableList.copyOf(args), "(", ", ", ")", null));
-        }
-      }
-      // TODO(bazel-team): get rid of this, by having everyone use the Skylark data structures
-      result = SkylarkType.convertToSkylark(result, method, env);
-      if (result != null && !EvalUtils.isSkylarkAcceptable(result.getClass())) {
-        throw new EvalException(
-            loc,
-            Printer.format(
-                "method '%s' returns an object of invalid type %r", getName(), result.getClass()));
-      }
-      return result;
+      result = method.invoke(obj, args);
     } catch (IllegalAccessException e) {
       // TODO(bazel-team): Print a nice error message. Maybe the method exists
       // and an argument is missing or has the wrong type.
       throw new EvalException(loc, "Method invocation failed: " + e);
-    } catch (InvocationTargetException e) {
-      if (e.getCause() instanceof FuncallExpression.FuncallException) {
-        throw new EvalException(loc, e.getCause().getMessage());
-      } else if (e.getCause() != null) {
-        Throwables.throwIfInstanceOf(e.getCause(), InterruptedException.class);
-        throw new EvalException.EvalExceptionWithJavaCause(loc, e.getCause());
+    } catch (InvocationTargetException x) {
+      Throwable e = x.getCause();
+      if (e == null) {
+        // This is unlikely to happen.
+        throw new IllegalStateException(
+            String.format(
+                "causeless InvocationTargetException when calling %s with arguments %s at %s",
+                obj, Arrays.toString(args), loc),
+            x);
+      }
+      Throwables.propagateIfPossible(e, InterruptedException.class);
+      if (e instanceof FuncallExpression.FuncallException) {
+        throw new EvalException(loc, e.getMessage());
+      }
+      if (e instanceof EvalException) {
+        throw ((EvalException) e).ensureLocation(loc);
+      }
+      throw new EvalException.EvalExceptionWithJavaCause(loc, e);
+    }
+    if (method.getReturnType().equals(Void.TYPE)) {
+      return Runtime.NONE;
+    }
+    if (result == null) {
+      if (isAllowReturnNones()) {
+        return Runtime.NONE;
       } else {
-        // This is unlikely to happen
-        throw new EvalException(loc, "method invocation failed: " + e);
+        throw new IllegalStateException(
+            "method invocation returned None "
+                + getName()
+                + Printer.printAbbreviatedList(ImmutableList.copyOf(args), "(", ", ", ")", null));
       }
     }
+    // TODO(bazel-team): get rid of this, by having everyone use the Skylark data structures
+    result = SkylarkType.convertToSkylark(result, method, env);
+    if (result != null && !EvalUtils.isSkylarkAcceptable(result.getClass())) {
+      throw new EvalException(
+          loc,
+          Printer.format(
+              "method '%s' returns an object of invalid type %r", getName(), result.getClass()));
+    }
+    return result;
   }
 
   /** @see SkylarkCallable#name() */

--- a/src/test/java/com/google/devtools/build/lib/rules/apple/DottedVersionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/apple/DottedVersionTest.java
@@ -124,28 +124,33 @@ public class DottedVersionTest {
 
   @Test
   public void testIllegalVersion_noLeadingInteger() throws Exception {
-    IllegalArgumentException expected =
-        assertThrows(IllegalArgumentException.class, () -> DottedVersion.fromString("a"));
+    Throwable expected =
+        assertThrows(
+            DottedVersion.InvalidDottedVersionException.class, () -> DottedVersion.fromString("a"));
     assertThat(expected).hasMessageThat().contains("a");
   }
 
   @Test
   public void testIllegalVersion_empty() throws Exception {
-    assertThrows(IllegalArgumentException.class, () -> DottedVersion.fromString(""));
+    assertThrows(
+        DottedVersion.InvalidDottedVersionException.class, () -> DottedVersion.fromString(""));
   }
 
   @Test
   public void testIllegalVersion_punctuation() throws Exception {
-    assertThrows(IllegalArgumentException.class, () -> DottedVersion.fromString("2:3"));
+    assertThrows(
+        DottedVersion.InvalidDottedVersionException.class, () -> DottedVersion.fromString("2:3"));
   }
 
   @Test
   public void testIllegalVersion_emptyComponent() throws Exception {
-    assertThrows(IllegalArgumentException.class, () -> DottedVersion.fromString("1..3"));
+    assertThrows(
+        DottedVersion.InvalidDottedVersionException.class, () -> DottedVersion.fromString("1..3"));
   }
 
   @Test
   public void testIllegalVersion_negativeComponent() throws Exception {
-    assertThrows(IllegalArgumentException.class, () -> DottedVersion.fromString("1.-1"));
+    assertThrows(
+        DottedVersion.InvalidDottedVersionException.class, () -> DottedVersion.fromString("1.-1"));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcProviderTest.java
@@ -112,7 +112,7 @@ public class ObjcProviderTest {
   }
 
   @Test
-  public void directFieldsAddFromSkylark() {
+  public void directFieldsAddFromSkylark() throws Exception {
     ImmutableList<Artifact> artifacts =
         ImmutableList.of(createArtifact("/foo"), createArtifact("/bar"));
     SkylarkNestedSet set =

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcRuleTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcRuleTestCase.java
@@ -85,8 +85,7 @@ public abstract class ObjcRuleTestCase extends BuildViewTestCase {
   protected static final ImmutableList<String> FASTBUILD_COPTS = ImmutableList.of("-O0", "-DDEBUG");
 
   protected static final DottedVersion DEFAULT_IOS_SDK_VERSION =
-      DottedVersion.fromString(AppleCommandLineOptions.DEFAULT_IOS_SDK_VERSION);
-
+      DottedVersion.fromStringUnchecked(AppleCommandLineOptions.DEFAULT_IOS_SDK_VERSION);
 
   /**
    * Returns the configuration obtained by applying the apple crosstool configuration transtion to


### PR DESCRIPTION
Also, move some code that doesn't need to be in the try block out of it.