### PR TITLE
Fix reference to volatile-status.txt file name

### DIFF
--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -1462,7 +1462,7 @@ into binaries ("stamping")</h3>
     <p>
       "volatile" keys' values may change often. Bazel expects them to change all the time, like
       timestamps do, and duly updates the
-    <code>bazel-out/stable-status.txt</code>
+    <code>bazel-out/volatile-status.txt</code>
       file. In order to avoid
       rerunning stamped actions all the time though, <b>Bazel pretends that the volatile file never
       changes</b>. In other words, if the volatile status file is the only file whose contents has


### PR DESCRIPTION
Documentation for `workspace_status_command` erroneously referenced the `stable-status.txt` file twice instead of referencing both it and the `volatile-status.txt` file.