### PR TITLE
remote: deleted deprecated --experimental-remote-retry* flags

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -120,36 +120,6 @@ public final class RemoteOptions extends OptionsBase {
       help = "Value to pass as instance_name in the remote execution API.")
   public String remoteInstanceName;
 
-  @Deprecated
-  @Option(
-      name = "experimental_remote_retry",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.REMOTE,
-      deprecationWarning = "Deprecated. Use --remote_retries instead.",
-      effectTags = {OptionEffectTag.NO_OP},
-      help = "This flag is deprecated and has no effect. Use --remote_retries instead.")
-  public boolean experimentalRemoteRetry;
-
-  @Deprecated
-  @Option(
-      name = "experimental_remote_retry_start_delay_millis",
-      defaultValue = "100",
-      documentationCategory = OptionDocumentationCategory.REMOTE,
-      deprecationWarning = "Deprecated. Use --remote_retries instead.",
-      effectTags = {OptionEffectTag.UNKNOWN},
-      help = "The initial delay before retrying a transient error. Use --remote_retries instead.")
-  public long experimentalRemoteRetryStartDelayMillis;
-
-  @Deprecated
-  @Option(
-      name = "experimental_remote_retry_max_delay_millis",
-      defaultValue = "5000",
-      documentationCategory = OptionDocumentationCategory.REMOTE,
-      deprecationWarning = "Deprecated. Use --remote_retries instead.",
-      effectTags = {OptionEffectTag.NO_OP},
-      help = "This flag is deprecated and has no effect. Use --remote_retries instead.")
-  public long experimentalRemoteRetryMaxDelayMillis;
-
   @Option(
       name = "remote_retries",
       oldName = "experimental_remote_retry_max_attempts",
@@ -160,26 +130,6 @@ public final class RemoteOptions extends OptionsBase {
           "The maximum number of attempts to retry a transient error. "
               + "If set to 0, retries are disabled.")
   public int remoteMaxRetryAttempts;
-
-  @Deprecated
-  @Option(
-      name = "experimental_remote_retry_multiplier",
-      defaultValue = "2",
-      documentationCategory = OptionDocumentationCategory.REMOTE,
-      deprecationWarning = "Deprecated. Use --remote_retries instead.",
-      effectTags = {OptionEffectTag.NO_OP},
-      help = "This flag is deprecated and has no effect. Use --remote_retries instead.")
-  public double experimentalRemoteRetryMultiplier;
-
-  @Deprecated
-  @Option(
-      name = "experimental_remote_retry_jitter",
-      defaultValue = "0.1",
-      documentationCategory = OptionDocumentationCategory.REMOTE,
-      deprecationWarning = "Deprecated. Use --remote_retries instead.",
-      effectTags = {OptionEffectTag.NO_OP},
-      help = "This flag is deprecated and has no effect. Use --remote_retries instead.")
-  public double experimentalRemoteRetryJitter;
 
   @Option(
       name = "disk_cache",


### PR DESCRIPTION
Fixes #7895 

RELNOTES: deleted deprecated --experimental-remote-retry* flags, please use --remote_retries instead