### PR TITLE
Canonicalise install path for comparison

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1240,7 +1240,7 @@ static void EnsureCorrectRunningVersion(BlazeServer *server) {
   // ReadDirectorySymlink will realpath to remove all symlinks, and
   // install_base might have a symlink in it.
   string wanted_installation =
-      blaze_util::MakeCanonical(globals->options->install_base);
+      blaze_util::MakeCanonical(globals->options->install_base.c_str());
   if (!ok || !blaze_util::CompareAbsolutePaths(
                  prev_installation, wanted_installation)) {
     if (server->Connected()) {

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1236,13 +1236,15 @@ static void EnsureCorrectRunningVersion(BlazeServer *server) {
   string prev_installation;
   bool ok =
       blaze_util::ReadDirectorySymlink(installation_path, &prev_installation);
-  // Canonicalise this path for comparison, because
-  // ReadDirectorySymlink will realpath to remove all symlinks, and
-  // install_base might have a symlink in it.
+  // The windows vesion of ReadDirectorySymlink will RealPath the
+  // result, removing all symlinks. The posix version will not. In
+  // order to compare them consistently, we MakeCanonical both here.
+  string prev_canonical_installation =
+      blaze_util::MakeCanonical(prev_installation.c_str());
   string wanted_installation =
       blaze_util::MakeCanonical(globals->options->install_base.c_str());
   if (!ok || !blaze_util::CompareAbsolutePaths(
-                 prev_installation, wanted_installation)) {
+                 prev_canonical_installation, wanted_installation)) {
     if (server->Connected()) {
       BAZEL_LOG(INFO)
           << "Killing running server because it is using another version of "

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1236,8 +1236,13 @@ static void EnsureCorrectRunningVersion(BlazeServer *server) {
   string prev_installation;
   bool ok =
       blaze_util::ReadDirectorySymlink(installation_path, &prev_installation);
+  // Canonicalise this path for comparison, because
+  // ReadDirectorySymlink will realpath to remove all symlinks, and
+  // install_base might have a symlink in it.
+  string wanted_installation =
+      blaze_util::MakeCanonical(globals->options->install_base);
   if (!ok || !blaze_util::CompareAbsolutePaths(
-                 prev_installation, globals->options->install_base)) {
+                 prev_installation, wanted_installation)) {
     if (server->Connected()) {
       BAZEL_LOG(INFO)
           << "Killing running server because it is using another version of "


### PR DESCRIPTION
Currently, if the install directory is placed on a path with a symlink
in it, this function will always believe there is a new version,
because it compares realpath() of the symlink with its intended
resolution.

This change realpath()s both the symlink and its intended resolution,
which should give correct behaviour even in the presence of symlinks.