### PR TITLE
remote: flipped --incompatible_list_based_execution_strategy_selection flag to be true by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -59,7 +59,7 @@ public class ExecutionOptions extends OptionsBase {
 
   @Option(
       name = "incompatible_list_based_execution_strategy_selection",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.EXECUTION},
       metadataTags = {

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -260,10 +260,7 @@ EOF
       --remote_local_fallback_strategy=local \
       --build_event_text_file=gen1.log \
       //gen1 >& $TEST_log \
-      || fail "Expected success"
-
-  mv gen1.log $TEST_log
-  expect_log "1 process: 1 local"
+      && fail "Expected failure" || true
 }
 
 function test_local_fallback_with_local_strategy_lists() {
@@ -352,10 +349,7 @@ EOF
       --remote_local_fallback_strategy=sandboxed \
       --build_event_text_file=gen2.log \
       //gen2 >& $TEST_log \
-      || fail "Expected success"
-
-  mv gen2.log $TEST_log
-  expect_log "1 process: 1 .*-sandbox"
+      && fail "Expected failure" || true
 }
 
 function is_file_uploaded() {
@@ -899,7 +893,7 @@ EOF
   || fail "Expected bazel-bin/a/remote.txt to have not been downloaded"
 
   bazel build \
-    --genrule_strategy=remote \
+    --genrule_strategy=remote,local \
     --remote_executor=localhost:${worker_port} \
     --experimental_inmemory_jdeps_files \
     --experimental_inmemory_dotd_files \

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -104,7 +104,6 @@ EOF
 
   bazel clean >& $TEST_log
   bazel build \
-      --incompatible_list_based_execution_strategy_selection \
       --remote_executor=localhost:${worker_port} \
       //a:test >& $TEST_log \
       || fail "Failed to build //a:test with remote execution"
@@ -280,7 +279,6 @@ tags = ["no-remote"],
 EOF
 
   bazel build \
-      --incompatible_list_based_execution_strategy_selection \
       --spawn_strategy=remote,local \
       --remote_executor=localhost:${worker_port} \
       --build_event_text_file=gen1.log \
@@ -304,7 +302,6 @@ tags = ["no-remote"],
 EOF
 
   bazel build \
-      --incompatible_list_based_execution_strategy_selection \
       --spawn_strategy=remote,sandboxed,local \
       --remote_executor=localhost:${worker_port} \
       --build_event_text_file=gen1.log \
@@ -328,7 +325,6 @@ tags = ["no-remote"],
 EOF
 
   bazel build \
-      --incompatible_list_based_execution_strategy_selection \
       --remote_executor=localhost:${worker_port} \
       --build_event_text_file=gen1.log \
       //gen1 >& $TEST_log \

--- a/src/test/shell/integration/bazel_worker_test.sh
+++ b/src/test/shell/integration/bazel_worker_test.sh
@@ -460,16 +460,15 @@ EOF
   sed -i.bak '/execution_requirements/d' work.bzl
   rm -f work.bzl.bak
 
-  bazel build --worker_quit_after_build :hello_world &> $TEST_log || true
+  bazel build --worker_quit_after_build :hello_world &> $TEST_log && fail "Failure expected" || true
 
   expect_log "No usable spawn strategy found for spawn with mnemonic Work"
-  expect_not_log "Worker strategy cannot execute this Work action, because the action's execution info does not contain 'supports-workers=1'"
   expect_not_log "Created new ${WORKER_TYPE_LOG_STRING} Work worker (id [0-9]\+)"
   expect_not_log "Destroying Work worker (id [0-9]\+)"
 
   # WorkerSpawnStrategy falls back to standalone strategy, so we still expect the output to be generated.
   [ -e "$BINS/hello_world.out" ] \
-    || fail "Worker did not produce output"
+    && fail "Worker was not supposed to produce output" || true
 }
 
 function test_environment_is_clean() {

--- a/src/test/shell/integration/bazel_worker_test.sh
+++ b/src/test/shell/integration/bazel_worker_test.sh
@@ -460,10 +460,10 @@ EOF
   sed -i.bak '/execution_requirements/d' work.bzl
   rm -f work.bzl.bak
 
-  bazel build --worker_quit_after_build :hello_world &> $TEST_log \
-    || fail "build failed"
+  bazel build --worker_quit_after_build :hello_world &> $TEST_log || true
 
-  expect_log "Worker strategy cannot execute this Work action, because the action's execution info does not contain 'supports-workers=1'"
+  expect_log "No usable spawn strategy found for spawn with mnemonic Work"
+  expect_not_log "Worker strategy cannot execute this Work action, because the action's execution info does not contain 'supports-workers=1'"
   expect_not_log "Created new ${WORKER_TYPE_LOG_STRING} Work worker (id [0-9]\+)"
   expect_not_log "Destroying Work worker (id [0-9]\+)"
 

--- a/src/test/shell/integration/execution_strategies_test.sh
+++ b/src/test/shell/integration/execution_strategies_test.sh
@@ -44,16 +44,22 @@ fi
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-# Tests that you have to opt-in to list based strategy selection via an incompatible flag.
+# Tests that you cat opt-out from a list based strategy selection via an incompatible flag.
 function test_incompatible_flag_required() {
-  bazel build --spawn_strategy=worker,local --debug_print_action_contexts &> $TEST_log || true
+  bazel build --spawn_strategy=worker,local --debug_print_action_contexts \
+  --incompatible_list_based_execution_strategy_selection=false &> $TEST_log || true
   expect_log "incompatible_list_based_execution_strategy_selection was not enabled"
+}
+
+# Tests that a list based strategy selection is enabled by default
+function test_incompatible_flag_flipped() {
+  bazel build --spawn_strategy=worker,local --debug_print_action_contexts &> $TEST_log || fail
+  expect_not_log "incompatible_list_based_execution_strategy_selection was not enabled"
 }
 
 # Tests that you can set the spawn strategy flags to a list of strategies.
 function test_multiple_strategies() {
-  bazel build --incompatible_list_based_execution_strategy_selection \
-      --spawn_strategy=worker,local --debug_print_action_contexts &> $TEST_log || fail
+  bazel build --spawn_strategy=worker,local --debug_print_action_contexts &> $TEST_log || fail
   # Can't test for exact strategy names here, because they differ between platforms and products.
   expect_log "\"\" = \[.*, .*\]"
 }
@@ -61,8 +67,7 @@ function test_multiple_strategies() {
 # Tests that the hardcoded Worker strategies are not introduced with the new
 # strategy selection
 function test_no_worker_defaults() {
-  bazel build --incompatible_list_based_execution_strategy_selection \
-      --debug_print_action_contexts &> $TEST_log || fail
+  bazel build --debug_print_action_contexts &> $TEST_log || fail
   # Can't test for exact strategy names here, because they differ between platforms and products.
   expect_not_log "\"Closure\""
   expect_not_log "\"DexBuilder\""
@@ -71,21 +76,18 @@ function test_no_worker_defaults() {
 
 # Tests that Bazel catches an invalid strategy list that has an empty string as an element.
 function test_empty_strategy_in_list_is_forbidden() {
-  bazel build --incompatible_list_based_execution_strategy_selection \
-      --spawn_strategy=worker,,local --debug_print_action_contexts &> $TEST_log || true
+  bazel build --spawn_strategy=worker,,local --debug_print_action_contexts &> $TEST_log || true
   expect_log "--spawn_strategy=worker,,local: Empty values are not allowed as part of this comma-separated list of options"
 }
 
 # Test that when you set a strategy to the empty string, it gets removed from the map of strategies
 # and thus results in the default strategy being used (the one set via --spawn_strategy=).
 function test_empty_strategy_means_default() {
-  bazel build --incompatible_list_based_execution_strategy_selection \
-      --spawn_strategy=worker,local --strategy=FooBar=local \
+  bazel build --spawn_strategy=worker,local --strategy=FooBar=local \
       --debug_print_action_contexts &> $TEST_log || fail
   expect_log "\"FooBar\" = "
 
-  bazel build --incompatible_list_based_execution_strategy_selection \
-      --spawn_strategy=worker,local --strategy=FooBar=local --strategy=FooBar= \
+  bazel build --spawn_strategy=worker,local --strategy=FooBar=local --strategy=FooBar= \
       --debug_print_action_contexts &> $TEST_log || fail
   expect_not_log "\"FooBar\" = "
 }


### PR DESCRIPTION
Fixes #7480 

RELNOTES[INC]: flipped --incompatible_list_based_execution_strategy_selection flag to be true by default. See https://github.com/bazelbuild/bazel/issues/7480 for details.