### PR TITLE
Add explanation for --google_default_credentials

### DIFF
--- a/site/docs/remote-caching.md
+++ b/site/docs/remote-caching.md
@@ -167,7 +167,8 @@ to/from your GCS bucket.
    * Pass the following URL to Bazel by using the flag:
        `--remote_cache=https://storage.googleapis.com/bucket-name`
        where `bucket-name` is the name of your storage bucket.
-   * Pass the authentication key using the flag: `--google_credentials=/path/to/your/secret-key.json`.
+   * Pass the authentication key using the flag: `--google_credentials=/path/to/your/secret-key.json`, or
+     `--google_default_credentials` to use [Application Default Credentials].
 
 5. You can configure Cloud Storage to automatically delete old files. To do so, see
 [Managing Object Lifecycles](https://cloud.google.com/storage/docs/managing-lifecycles).
@@ -393,4 +394,4 @@ watch [issue #4558] for updates.
 [Buildfarm]: https://github.com/bazelbuild/bazel-buildfarm
 [BuildGrid]: https://gitlab.com/BuildGrid/buildgrid
 [issue #4558]: https://github.com/bazelbuild/bazel/issues/4558
-
+[Application Default Credentials]: https://cloud.google.com/docs/authentication/production


### PR DESCRIPTION
bazel supports application default credentials to access GCS bucket too.