### PR TITLE
Add javac11 testing.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -496,7 +496,6 @@ http_archive(
     ],
 )
 
-
 load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
 
 skydoc_repositories()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -488,6 +488,15 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "java_tools_langtools_javac11",
+    sha256 = "128a63f39d3f828a761f6afcfe3c6115279336a72ea77f60d7b3acf1841c9acb",
+    urls = [
+        "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk11.zip",
+    ],
+)
+
+
 load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
 
 skydoc_repositories()

--- a/src/BUILD
+++ b/src/BUILD
@@ -556,31 +556,23 @@ JAVA_TOOLS_DEPLOY_JARS = [
     "//conditions:default": [],
 })
 
-genrule(
-    name = "jars_java_tools_java9_zip",
-    srcs = JAVA_TOOLS_DEPLOY_JARS + [
-        "@java_tools_langtools_javac9//:jdk_compiler_jar",
-        "@java_tools_langtools_javac9//:java_compiler_jar",
-        "@java_tools_langtools_javac9//:javac_jar",
-    ],
-    outs = ["jars_java_tools_java9.zip"],
-    cmd = "zip -qjX $@ $$(echo $(SRCS) | sort)",
-    visibility = ["//visibility:private"],
-)
 
-genrule(
-    name = "jars_java_tools_java10_zip",
-    srcs = JAVA_TOOLS_DEPLOY_JARS + [
-        "@java_tools_langtools_javac10//:jdk_compiler_jar",
-        "@java_tools_langtools_javac10//:java_compiler_jar",
-        "@java_tools_langtools_javac10//:javac_jar",
-    ],
-    outs = ["jars_java_tools_java10.zip"],
-    cmd = "zip -qjX $@ $$(echo $(SRCS) | sort)",
-    visibility = ["//visibility:private"],
-)
+JAVA_VERSIONS = ("9", "10", "11")
 
-JAVA_VERSIONS = ("9", "10")
+[
+    genrule(
+        name = "jars_java_tools_java" + java_version + "_zip",
+        srcs = JAVA_TOOLS_DEPLOY_JARS + [
+            "@java_tools_langtools_javac" + java_version + "//:jdk_compiler_jar",
+            "@java_tools_langtools_javac" + java_version + "//:java_compiler_jar",
+            "@java_tools_langtools_javac" + java_version + "//:javac_jar",
+        ],
+        outs = ["jars_java_tools_java" + java_version + ".zip"],
+        cmd = "zip -qjX $@ $$(echo $(SRCS) | sort)",
+        visibility = ["//visibility:private"],
+    )
+    for java_version in JAVA_VERSIONS
+]
 
 [
     genrule(

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -243,7 +243,7 @@ JAVA_VERSIONS = ("9", "10", "11")
         # This test is only run by the java_tools binaries pipeline.
         tags = ["manual"],
     )
-    for java_version in ("9", "10")
+    for java_version in ("9", "10", "11")
 ]
 
 sh_test(

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -188,32 +188,12 @@ sh_test(
     ],
 )
 
-sh_test(
-    name = "bazel_java_test_jdk9_toolchain_head",
-    size = "large",
-    timeout = "eternal",
-    srcs = ["bazel_java_test.sh"],
-    args = [
-        # --java_toolchain
-        "@local_java_tools//:toolchain",
-        # java_tools zip to test
-        "src/java_tools_java9.zip",
-        # --javabase value
-    ] + select({
-        "//src/conditions:darwin": ["@openjdk9_darwin_archive//:runtime"],
-        "//src/conditions:darwin_x86_64": ["@openjdk9_darwin_archive//:runtime"],
-        "//src/conditions:windows": ["@openjdk9_windows_archive//:runtime"],
-        "//src/conditions:linux_x86_64": ["@openjdk9_linux_archive//:runtime"],
-    }),
-    data = [
-        ":test-deps",
-        "//src:java_tools_java9_zip",
-        "@bazel_tools//tools/bash/runfiles",
-    ],
-)
 
-sh_test(
-    name = "bazel_java_test_jdk10_toolchain_head",
+JAVA_VERSIONS = ("9", "10", "11")
+
+[
+    sh_test(
+    name = "bazel_java_test_jdk" + java_version + "_toolchain_head",
     size = "large",
     timeout = "eternal",
     srcs = ["bazel_java_test.sh"],
@@ -221,20 +201,22 @@ sh_test(
         # --java_toolchain
         "@local_java_tools//:toolchain",
         # java_tools zip to test
-        "src/java_tools_java10.zip",
+        "src/java_tools_java" + java_version + ".zip",
         # --javabase value
     ] + select({
-        "//src/conditions:darwin": ["@openjdk10_darwin_archive//:runtime"],
-        "//src/conditions:darwin_x86_64": ["@openjdk10_darwin_archive//:runtime"],
-        "//src/conditions:windows": ["@openjdk10_windows_archive//:runtime"],
-        "//src/conditions:linux_x86_64": ["@openjdk10_linux_archive//:runtime"],
+        "//src/conditions:darwin": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
+        "//src/conditions:darwin_x86_64": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
+        "//src/conditions:windows": ["@openjdk" + java_version + "_windows_archive//:runtime"],
+        "//src/conditions:linux_x86_64": ["@openjdk" + java_version + "_linux_archive//:runtime"],
     }),
     data = [
         ":test-deps",
-        "//src:java_tools_java10_zip",
+        "//src:java_tools_java" + java_version + "_zip",
         "@bazel_tools//tools/bash/runfiles",
     ],
-)
+    )
+    for java_version in JAVA_VERSIONS
+]
 
 [
     sh_test(

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -167,6 +167,33 @@ http_archive(
         "https://mirror.bazel.build/openjdk/azul-zulu10.2+3-jdk10.0.1/zulu10.2+3-jdk10.0.1-win_x64.zip",
     ],
 )
+
+http_archive(
+    name = "openjdk11_linux_archive",
+    build_file_content = "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
+    strip_prefix = "zulu11.31.11-ca-jdk11.0.3-linux_x64",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu11.31.11-ca-jdk11.0.3/zulu11.31.11-ca-jdk11.0.3-linux_x64.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "openjdk11_darwin_archive",
+    build_file_content = "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
+    strip_prefix = "zulu11.31.11-ca-jdk11.0.3-macosx_x64",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu11.31.11-ca-jdk11.0.3/zulu11.31.11-ca-jdk11.0.3-macosx_x64.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "openjdk11_windows_archive",
+    build_file_content = "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
+    strip_prefix = "zulu11.31.11-ca-jdk11.0.3-win_x64",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu11.31.11-ca-jdk11.0.3/zulu11.31.11-ca-jdk11.0.3-win_x64.zip",
+    ],
+)
 EOF
 }
 

--- a/src/upload_all_java_tools.sh
+++ b/src/upload_all_java_tools.sh
@@ -48,7 +48,7 @@ bazel_version=$(bazel info release | cut -d' ' -f2)
 
 # Passing the same commit_hash and timestamp to all targets to mark all the artifacts
 # uploaded on GCS with the same identifier.
-for java_version in 9 10; do
+for java_version in 9 10 11; do
 
     bazel build //src:java_tools_java${java_version}_zip
     zip_path=${PWD}/bazel-bin/src/java_tools_java${java_version}.zip


### PR DESCRIPTION
This change adds the following:
* a target that builds a java_tools zip containing javac from jdk11
* a test target that runs the java integration tests with the java_toolchain containing javac 11 and the java11 runtime