### PR TITLE
remote: deprecated --remote_local_fallback_strategy

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -96,12 +96,13 @@ public final class RemoteOptions extends OptionsBase {
           "Whether to fall back to standalone local execution strategy if remote execution fails.")
   public boolean remoteLocalFallback;
 
+  @Deprecated
   @Option(
       name = "remote_local_fallback_strategy",
       defaultValue = "local",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
-      help = "The strategy to use when remote execution has to fallback to local execution.")
+      help = "No-op, deprecated. See https://github.com/bazelbuild/bazel/issues/7480 for details.")
   public String remoteLocalFallbackStrategy;
 
   @Option(


### PR DESCRIPTION
The flag is no-op because the flag --strategy can now accept a list of strategies, therefore a fallback specific for particular strategy is not possible. See https://github.com/bazelbuild/bazel/issues/7480 for details.

RELNOTES: deprecated --remote_local_fallback_strategy. Use `--strategy=remote,local` instead. See https://github.com/bazelbuild/bazel/issues/7480.