### PR TITLE
Set default docs version to 0.25.0 instead of master

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -10,7 +10,8 @@ sass:
   sass_dir: _sass
 gems: [jekyll-paginate]
 
-version: "master"
+# Update this to the newest release for the default docs.bazel.build version.
+version: "0.25.0"
 
 # This must be kept in sync with //site/script/docs:versions.bzl
 doc_versions:

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -1,4 +1,10 @@
 ---
-layout: redirect
-redirect: bazel-overview.html
 ---
+
+<html>
+  <head>
+    <script>
+      window.location.replace("/versions/{{ site.version }}/bazel-overview.html");
+    </script>
+  </head>
+</html>


### PR DESCRIPTION
Now, when a user visits https://docs.bazel.build, they will get redirected to https://docs.bazel.build/versions/0.25.0/bazel-overview.html. 

Staging: https://bazel-docs-staging.netlify.com