### PR TITLE
Enable persistent worker mode in Android desugar actions

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,8 +58,8 @@ list_source_repository(name = "local_bazel_source_list")
 #   2. Set the $ANDROID_HOME and $ANDROID_NDK_HOME environment variables
 #   3. Uncomment the two lines below
 #
-# android_sdk_repository(name = "androidsdk")
-# android_ndk_repository(name = "androidndk")
+android_sdk_repository(name = "androidsdk")
+android_ndk_repository(name = "androidndk")
 
 # In order to run //src/test/shell/bazel:maven_skylark_test, follow the
 # instructions above for the Android integration tests and uncomment the

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,7 +116,7 @@ distdir_tar(
         "2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz",
         "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz",
         "0.16.2.zip",
-        "android_tools_pkg-0.3.tar.gz",
+        "android_tools_pkg-SNAPSHOT-DEV.tar.gz",
     ],
     dirname = "derived/distdir",
     sha256 = {
@@ -164,8 +164,8 @@ distdir_tar(
             "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
             "https://github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
         ],
-        "android_tools_pkg-0.3.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.3.tar.gz",
+        "android_tools_pkg-SNAPSHOT-DEV.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-SNAPSHOT-DEV.tar.gz",
         ],
     },
 )
@@ -390,7 +390,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip",
-        "android_tools_pkg-0.3.tar.gz",
+        "android_tools_pkg-SNAPSHOT-DEV.tar.gz",
     ],
     dirname = "test_WORKSPACE/distdir",
     sha256 = {
@@ -433,8 +433,8 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz"],
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip"],
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64.zip"],
-        "android_tools_pkg-0.3.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.3.tar.gz",
+        "android_tools_pkg-SNAPSHOT-DEV.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-SNAPSHOT-DEV.tar.gz",
         ],
     },
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,8 +58,8 @@ list_source_repository(name = "local_bazel_source_list")
 #   2. Set the $ANDROID_HOME and $ANDROID_NDK_HOME environment variables
 #   3. Uncomment the two lines below
 #
-android_sdk_repository(name = "androidsdk")
-android_ndk_repository(name = "androidndk")
+# android_sdk_repository(name = "androidsdk")
+# android_ndk_repository(name = "androidndk")
 
 # In order to run //src/test/shell/bazel:maven_skylark_test, follow the
 # instructions above for the Android integration tests and uncomment the

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,7 +116,7 @@ distdir_tar(
         "2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz",
         "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz",
         "0.16.2.zip",
-        "android_tools_pkg-0.4rc1.tar.gz",
+        "android_tools_pkg-0.4.tar.gz",
     ],
     dirname = "derived/distdir",
     sha256 = {
@@ -129,7 +129,7 @@ distdir_tar(
         "2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz": "4a1318fed4831697b83ce879b3ab70ae09592b167e5bda8edaff45132d1c3b3f",
         "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz": "d868ce50d592ef4aad7dec4dd32ae68d2151261913450fac8390b3fd474bb898",
         "0.16.2.zip": "9b72bb0aea72d7cbcfc82a01b1e25bf3d85f791e790ddec16c65e2d906382ee0",
-        "android_tools_pkg-0.4rc1.tar.gz": "9c95474954d3e92e85c7e4294bced6798df84a8bcaef0359d53eeb55c0ba0bad", # built at 58f892e0dc5fdac05f586b32702f39fb8298b921
+        "android_tools_pkg-0.4.tar.gz": "331e7706f2bcae8a68057d8ddd3e3f1574bca26c67c65802fc4a8ac6164fa912", # built at 0c7c89d43256217cce2a3aa4335efaa8eefcf5c4
     },
     urls = {
         "e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip": [
@@ -164,8 +164,8 @@ distdir_tar(
             "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
             "https://github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
         ],
-        "android_tools_pkg-0.4rc1.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.4rc1.tar.gz",
+        "android_tools_pkg-0.4.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.4.tar.gz",
         ],
     },
 )
@@ -390,7 +390,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip",
-        "android_tools_pkg-0.4rc1.tar.gz",
+        "android_tools_pkg-0.4.tar.gz",
     ],
     dirname = "test_WORKSPACE/distdir",
     sha256 = {
@@ -412,7 +412,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": "f3f44b6235508e87b760bf37a49e186cc1fa4e9cd28384c4dbf5a33991921e08",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": "059f8e3484bf07b63a8f2820d5f528f473eff1befdb1896ee4f8ff06be3b8d8f",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": "e1f5b4ce1b9148140fae2fcfb8a96d1c9b7eac5b8df0e13fbcad9b8561284880",
-        "android_tools_pkg-0.4rc1.tar.gz": "9c95474954d3e92e85c7e4294bced6798df84a8bcaef0359d53eeb55c0ba0bad", # built at 58f892e0dc5fdac05f586b32702f39fb8298b921
+        "android_tools_pkg-0.4.tar.gz": "331e7706f2bcae8a68057d8ddd3e3f1574bca26c67c65802fc4a8ac6164fa912", # built at 0c7c89d43256217cce2a3aa4335efaa8eefcf5c4
     },
     urls = {
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz"],
@@ -433,8 +433,8 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz"],
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip"],
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64.zip"],
-        "android_tools_pkg-0.4rc1.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.4rc1.tar.gz",
+        "android_tools_pkg-0.4.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.4.tar.gz",
         ],
     },
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,7 +116,7 @@ distdir_tar(
         "2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz",
         "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz",
         "0.16.2.zip",
-        "android_tools_pkg-SNAPSHOT-DEV.tar.gz",
+        "android_tools_pkg-0.4rc1.tar.gz",
     ],
     dirname = "derived/distdir",
     sha256 = {
@@ -129,7 +129,7 @@ distdir_tar(
         "2d9566b21fbe405acf5f7bf77eda30df72a4744c.tar.gz": "4a1318fed4831697b83ce879b3ab70ae09592b167e5bda8edaff45132d1c3b3f",
         "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz": "d868ce50d592ef4aad7dec4dd32ae68d2151261913450fac8390b3fd474bb898",
         "0.16.2.zip": "9b72bb0aea72d7cbcfc82a01b1e25bf3d85f791e790ddec16c65e2d906382ee0",
-        "android_tools_pkg-0.3.tar.gz": "04d25892234cdf8ae49d9c275a25b3371bcc26518179619dc785718db2812b5f", # built at 00ff4dbbf339d5f120a983e002815e37a3e8248e
+        "android_tools_pkg-0.4rc1.tar.gz": "9c95474954d3e92e85c7e4294bced6798df84a8bcaef0359d53eeb55c0ba0bad", # built at 58f892e0dc5fdac05f586b32702f39fb8298b921
     },
     urls = {
         "e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip": [
@@ -164,8 +164,8 @@ distdir_tar(
             "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
             "https://github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
         ],
-        "android_tools_pkg-SNAPSHOT-DEV.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-SNAPSHOT-DEV.tar.gz",
+        "android_tools_pkg-0.4rc1.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.4rc1.tar.gz",
         ],
     },
 )
@@ -390,7 +390,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip",
-        "android_tools_pkg-SNAPSHOT-DEV.tar.gz",
+        "android_tools_pkg-0.4rc1.tar.gz",
     ],
     dirname = "test_WORKSPACE/distdir",
     sha256 = {
@@ -412,7 +412,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": "f3f44b6235508e87b760bf37a49e186cc1fa4e9cd28384c4dbf5a33991921e08",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": "059f8e3484bf07b63a8f2820d5f528f473eff1befdb1896ee4f8ff06be3b8d8f",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": "e1f5b4ce1b9148140fae2fcfb8a96d1c9b7eac5b8df0e13fbcad9b8561284880",
-        "android_tools_pkg-0.3.tar.gz": "04d25892234cdf8ae49d9c275a25b3371bcc26518179619dc785718db2812b5f", # built at 00ff4dbbf339d5f120a983e002815e37a3e8248e
+        "android_tools_pkg-0.4rc1.tar.gz": "9c95474954d3e92e85c7e4294bced6798df84a8bcaef0359d53eeb55c0ba0bad", # built at 58f892e0dc5fdac05f586b32702f39fb8298b921
     },
     urls = {
         "zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-linux_x64-allmodules.tar.gz"],
@@ -433,8 +433,8 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz"],
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip"],
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64.zip"],
-        "android_tools_pkg-SNAPSHOT-DEV.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-SNAPSHOT-DEV.tar.gz",
+        "android_tools_pkg-0.4rc1.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.4rc1.tar.gz",
         ],
     },
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -2,6 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "android_tools",
+<<<<<<< HEAD
     url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.3.tar.gz",
     sha256 = "04d25892234cdf8ae49d9c275a25b3371bcc26518179619dc785718db2812b5f", # built at 00ff4dbbf339d5f120a983e002815e37a3e8248e
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "android_tools",
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.4rc1.tar.gz",
-    sha256 = "9c95474954d3e92e85c7e4294bced6798df84a8bcaef0359d53eeb55c0ba0bad", # built at 00ff4dbbf339d5f120a983e002815e37a3e8248e
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.4.tar.gz",
+    sha256 = "331e7706f2bcae8a68057d8ddd3e3f1574bca26c67c65802fc4a8ac6164fa912", # built at 0c7c89d43256217cce2a3aa4335efaa8eefcf5c4
 )
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -3,6 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "android_tools",
     url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.4rc1.tar.gz",
-    sha256 = "", # built at 00ff4dbbf339d5f120a983e002815e37a3e8248e
+    sha256 = "9c95474954d3e92e85c7e4294bced6798df84a8bcaef0359d53eeb55c0ba0bad", # built at 00ff4dbbf339d5f120a983e002815e37a3e8248e
 )
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -2,8 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "android_tools",
-<<<<<<< HEAD
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.3.tar.gz",
-    sha256 = "04d25892234cdf8ae49d9c275a25b3371bcc26518179619dc785718db2812b5f", # built at 00ff4dbbf339d5f120a983e002815e37a3e8248e
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.4rc1.tar.gz",
+    sha256 = "", # built at 00ff4dbbf339d5f120a983e002815e37a3e8248e
 )
 

--- a/src/main/java/com/google/devtools/build/lib/rules/android/DexArchiveAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/DexArchiveAspect.java
@@ -461,6 +461,7 @@ public final class DexArchiveAspect extends NativeAspectClass implements Configu
             .addOutput(result)
             .setMnemonic("Desugar")
             .setProgressMessage("Desugaring %s for Android", jar.prettyPrint())
+            .setExecutionInfo(ExecutionRequirements.WORKER_MODE_ENABLED)
             .addCommandLine(
                 // Always use params file, so we don't need to compute command line length first
                 args.build(), ParamFileInfo.builder(UNQUOTED).setUseAlways(true).build())

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/BUILD
@@ -35,6 +35,7 @@ java_library(
     deps = [
         ":deps_collector_api",
         "//src/main/java/com/google/devtools/common/options",
+        "//src/main/protobuf:worker_protocol_java_proto",
         "//src/tools/android/java/com/google/devtools/build/android:android_builder_lib",
         "//src/tools/android/java/com/google/devtools/build/android/desugar/io",
         "//third_party:asm",

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/Desugar.java
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/Desugar.java
@@ -976,15 +976,19 @@ class Desugar {
   }
 
   public static void main(String[] args) throws Exception {
+    // It is important that this method is called first. See its javadoc.
+    Path dumpDirectory = createAndRegisterLambdaDumpDirectory();
+    verifyLambdaDumpDirectoryRegistered(dumpDirectory);
+
     DesugarOptions options = parseCommandLineOptions(args);
     if (options.persistentWorker) {
-      runPersistentWorker();
+      runPersistentWorker(dumpDirectory);
     } else {
-      processRequest(options);
+      processRequest(options, dumpDirectory);
     }
   }
 
-  private static int runPersistentWorker() throws Exception {
+  private static int runPersistentWorker(Path dumpDirectory) throws Exception {
     while (true) {
       try {
         WorkRequest request = WorkRequest.parseDelimitedFrom(System.in);
@@ -998,7 +1002,7 @@ class Desugar {
 
         DesugarOptions options = parseCommandLineOptions(argList);
 
-        int exitCode = processRequest(options);
+        int exitCode = processRequest(options, dumpDirectory);
         WorkResponse.newBuilder()
             .setExitCode(exitCode)
             .build()
@@ -1012,11 +1016,7 @@ class Desugar {
     return 0;
   }
 
-  private static int processRequest(DesugarOptions options) throws Exception {
-    // It is important that this method is called first. See its javadoc.
-    Path dumpDirectory = createAndRegisterLambdaDumpDirectory();
-    verifyLambdaDumpDirectoryRegistered(dumpDirectory);
-
+  private static int processRequest(DesugarOptions options, Path dumpDirectory) throws Exception {
     checkArgument(!options.inputJars.isEmpty(), "--input is required");
     checkArgument(
         options.inputJars.size() == options.outputJars.size(),

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/Desugar.java
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/Desugar.java
@@ -997,7 +997,7 @@ class Desugar {
           break;
         }
 
-        String[] argList = new String[request.getArgumentsList().size()];
+        String[] argList = new String[request.getArgumentsCount()];
         argList = request.getArgumentsList().toArray(argList);
 
         DesugarOptions options = parseCommandLineOptions(argList);

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/Desugar.java
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/Desugar.java
@@ -46,6 +46,7 @@ import com.google.devtools.common.options.ShellQuotedParamsFilePreProcessor;
 import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
@@ -988,32 +989,26 @@ class Desugar {
     }
   }
 
-  private static int runPersistentWorker(Path dumpDirectory) throws Exception {
+  private static void runPersistentWorker(Path dumpDirectory) throws Exception {
     while (true) {
-      try {
-        WorkRequest request = WorkRequest.parseDelimitedFrom(System.in);
+      WorkRequest request = WorkRequest.parseDelimitedFrom(System.in);
 
-        if (request == null) {
-          break;
-        }
-
-        String[] argList = new String[request.getArgumentsCount()];
-        argList = request.getArgumentsList().toArray(argList);
-
-        DesugarOptions options = parseCommandLineOptions(argList);
-
-        int exitCode = processRequest(options, dumpDirectory);
-        WorkResponse.newBuilder()
-            .setExitCode(exitCode)
-            .build()
-            .writeDelimitedTo(System.out);
-        System.out.flush();
-      } catch (IOException e) {
-        e.printStackTrace();
-        return 1;
+      if (request == null) {
+        break;
       }
+
+      String[] argList = new String[request.getArgumentsCount()];
+      argList = request.getArgumentsList().toArray(argList);
+
+      DesugarOptions options = parseCommandLineOptions(argList);
+
+      int exitCode = processRequest(options, dumpDirectory);
+      WorkResponse.newBuilder()
+          .setExitCode(exitCode)
+          .build()
+          .writeDelimitedTo(System.out);
+      System.out.flush();
     }
-    return 0;
   }
 
   private static int processRequest(DesugarOptions options, Path dumpDirectory) throws Exception {

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -30,7 +30,7 @@
 set -euo pipefail
 
 # The version of android_tools.tar.gz
-VERSION="0.3"
+VERSION="SNAPSHOT-DEV"
 VERSIONED_FILENAME="android_tools_pkg-$VERSION.tar.gz"
 
 # Create a temp directory to hold the versioned tarball, and clean it up when the script exits.
@@ -47,7 +47,7 @@ cp $android_tools_archive $versioned_android_tools_archive
 
 # Upload the tarball to GCS.
 # -n for no-clobber, so we don't overwrite existing files
-gsutil cp -n $versioned_android_tools_archive \
+gsutil cp $versioned_android_tools_archive \
   gs://bazel-mirror/bazel_android_tools/$VERSIONED_FILENAME
 
 checksum=$(sha256sum $versioned_android_tools_archive | cut -f 1 -d ' ')

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -30,7 +30,7 @@
 set -euo pipefail
 
 # The version of android_tools.tar.gz
-VERSION="SNAPSHOT-DEV"
+VERSION="0.4rc1"
 VERSIONED_FILENAME="android_tools_pkg-$VERSION.tar.gz"
 
 # Create a temp directory to hold the versioned tarball, and clean it up when the script exits.

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -30,7 +30,7 @@
 set -euo pipefail
 
 # The version of android_tools.tar.gz
-VERSION="0.4rc1"
+VERSION="0.4"
 VERSIONED_FILENAME="android_tools_pkg-$VERSION.tar.gz"
 
 # Create a temp directory to hold the versioned tarball, and clean it up when the script exits.

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -47,7 +47,7 @@ cp $android_tools_archive $versioned_android_tools_archive
 
 # Upload the tarball to GCS.
 # -n for no-clobber, so we don't overwrite existing files
-gsutil cp $versioned_android_tools_archive \
+gsutil cp -n $versioned_android_tools_archive \
   gs://bazel-mirror/bazel_android_tools/$VERSIONED_FILENAME
 
 checksum=$(sha256sum $versioned_android_tools_archive | cut -f 1 -d ' ')


### PR DESCRIPTION
RELNOTES: The Android desugaring actions now support a persistent worker mode for faster build performance. Enable it with `--strategy=Desugar=worker`.

Fixes #8342 