### PR TITLE
Remove jacoco-rt from the bazel binary.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -112,7 +112,6 @@ JAVA_TOOLS = [
     "//third_party/java/proguard:embedded_tools",
     "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper:srcs",
     "//src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps:embedded_tools",
-    "//third_party/java/jacoco:srcs",
     "//third_party/jarjar:embedded_build_and_license",
 ]
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -174,7 +174,6 @@ public final class BazelAnalysisMock extends AnalysisMock {
         "filegroup(name='extdir', srcs=glob(['jdk/jre/lib/ext/*']))",
         "filegroup(name='java', srcs = ['jdk/jre/bin/java'])",
         "filegroup(name='JacocoCoverage', srcs = [])",
-        "filegroup(name='jacoco-blaze-agent', srcs = [])",
         "exports_files(['JavaBuilder_deploy.jar','SingleJar_deploy.jar','TestRunner_deploy.jar',",
         "               'JavaBuilderCanary_deploy.jar', 'ijar', 'GenClass_deploy.jar',",
         "               'turbine_deploy.jar','ExperimentalTestRunner_deploy.jar'])",

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -421,12 +421,6 @@ py_test(
     ],
 )
 
-# For java coverage
-alias(
-    name = "jacoco-blaze-agent",
-    actual = "//third_party/java/jacoco:blaze-agent",
-)
-
 remote_java_tools_java_import(
     name = "JarJar",
     target = ":JarJar",


### PR DESCRIPTION
This change shrinks the bazel binary by ~1M:

```
$ ls -lh ~/bazel-with-jacoco | cut -d' ' -f5
48M
$ ls -lh ~/bazel-without-jacoco | cut -d' ' -f5
47M
```