### PR TITLE
Java coverage: fix coverage when deploy jars end up on the classpath.

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
@@ -158,7 +158,7 @@ bootstrap_java_library(
         "//third_party:bootstrap_guava_and_error_prone-jars",
         "//third_party:jsr305-jars",
         "//third_party/protobuf:protobuf-jars",
-        "//third_party/java/jacoco:core-jars-0.8.3",
+        "//third_party/java/jacoco:core-jars",
         "//third_party/grpc:bootstrap-grpc-jars",
         "//third_party:tomcat_annotations_api-jars",
     ],

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
@@ -158,7 +158,7 @@ bootstrap_java_library(
         "//third_party:bootstrap_guava_and_error_prone-jars",
         "//third_party:jsr305-jars",
         "//third_party/protobuf:protobuf-jars",
-        "//third_party/java/jacoco:core-jars",
+        "//third_party/java/jacoco:core-jars-0.8.3",
         "//third_party/grpc:bootstrap-grpc-jars",
         "//third_party:tomcat_annotations_api-jars",
     ],

--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoCoverageRunner.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoCoverageRunner.java
@@ -76,45 +76,30 @@ public class JacocoCoverageRunner {
   private final ImmutableList<File> classesJars;
   private final InputStream executionData;
   private final File reportFile;
-  private final boolean isNewCoverageImplementation;
   private ExecFileLoader execFileLoader;
   private HashMap<String, byte[]> uninstrumentedClasses;
   private ImmutableSet<String> pathsForCoverage = ImmutableSet.of();
-
-  public JacocoCoverageRunner(InputStream jacocoExec, String reportPath, File... metadataJars) {
-    this(false, jacocoExec, reportPath, metadataJars);
-  }
 
   /**
    * Creates a new coverage runner extracting the classes jars from a wrapper file. Uses
    * javaRunfilesRoot to compute the absolute path of the jars inside the wrapper file.
    */
   public JacocoCoverageRunner(
-      boolean isNewCoverageImplementation,
-      InputStream jacocoExec,
-      String reportPath,
-      File wrapperFile,
-      String javaRunfilesRoot)
+      InputStream jacocoExec, String reportPath, File wrapperFile, String javaRunfilesRoot)
       throws IOException {
     executionData = jacocoExec;
     reportFile = new File(reportPath);
-    this.isNewCoverageImplementation = isNewCoverageImplementation;
     this.classesJars = getFilesFromFileList(wrapperFile, javaRunfilesRoot);
   }
 
   public JacocoCoverageRunner(
-      boolean isNewCoverageImplementation,
-      InputStream jacocoExec,
-      String reportPath,
-      File... metadataJars) {
+      InputStream jacocoExec, String reportPath, File... metadataJars) {
     executionData = jacocoExec;
     reportFile = new File(reportPath);
-    this.isNewCoverageImplementation = isNewCoverageImplementation;
     this.classesJars = ImmutableList.copyOf(metadataJars);
   }
 
   public JacocoCoverageRunner(
-      boolean isNewCoverageImplementation,
       InputStream jacocoExec,
       String reportPath,
       HashMap<String, byte[]> uninstrumentedClasses,
@@ -122,7 +107,6 @@ public class JacocoCoverageRunner {
       File... metadataJars) {
     executionData = jacocoExec;
     reportFile = new File(reportPath);
-    this.isNewCoverageImplementation = isNewCoverageImplementation;
     this.classesJars = ImmutableList.copyOf(metadataJars);
     this.uninstrumentedClasses = uninstrumentedClasses;
     this.pathsForCoverage = pathsForCoverage;
@@ -188,11 +172,7 @@ public class JacocoCoverageRunner {
     Set<String> alreadyInstrumentedClasses = new HashSet<>();
     if (uninstrumentedClasses == null) {
       for (File classesJar : classesJars) {
-        if (isNewCoverageImplementation) {
-          analyzeUninstrumentedClassesFromJar(analyzer, classesJar, alreadyInstrumentedClasses);
-        } else {
-          analyzer.analyzeAll(classesJar);
-        }
+        analyzeUninstrumentedClassesFromJar(analyzer, classesJar, alreadyInstrumentedClasses);
       }
     } else {
       for (Map.Entry<String, byte[]> entry : uninstrumentedClasses.entrySet()) {
@@ -213,11 +193,7 @@ public class JacocoCoverageRunner {
     Set<String> alreadyInstrumentedClasses = new HashSet<>();
     if (uninstrumentedClasses == null) {
       for (File classesJar : classesJars) {
-        if (isNewCoverageImplementation) {
-          analyzeUninstrumentedClassesFromJar(analyzer, classesJar, alreadyInstrumentedClasses);
-        } else {
-          analyzer.analyzeAll(classesJar);
-        }
+        analyzeUninstrumentedClassesFromJar(analyzer, classesJar, alreadyInstrumentedClasses);
         result.putAll(analyzer.getBranchDetails());
       }
     } else {
@@ -260,9 +236,6 @@ public class JacocoCoverageRunner {
    */
   @VisibleForTesting
   ImmutableSet<String> createPathsSet() throws IOException {
-    if (!isNewCoverageImplementation) {
-      return ImmutableSet.<String>of();
-    }
     if (!pathsForCoverage.isEmpty()) {
       return pathsForCoverage;
     }
@@ -299,36 +272,43 @@ public class JacocoCoverageRunner {
     }
   }
 
-  private static String getMainClass(String metadataJar, boolean isNewImplementation)
-      throws Exception {
-    final String jacocoMainClass = System.getenv("JACOCO_MAIN_CLASS");
-    if (jacocoMainClass != null) {
-      return jacocoMainClass;
-    }
-    if (!isNewImplementation && metadataJar != null) {
-      // Blaze guarantees that JACOCO_METADATA_JAR has a proper manifest with a Main-Class entry.
-      try (JarInputStream jarStream = new JarInputStream(new FileInputStream(metadataJar))) {
-        return jarStream.getManifest().getMainAttributes().getValue("Main-Class");
-      }
-    } else {
-      // If metadataJar was not set, we're running inside a deploy jar. We have to open the manifest
-      // and read the value of "Precoverage-Class", set by Blaze. Note ClassLoader#getResource()
-      // will only return the first result, most likely a manifest from the bootclasspath.
-      Enumeration<URL> manifests =
-          JacocoCoverageRunner.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
-      while (manifests.hasMoreElements()) {
-        Manifest manifest = new Manifest(manifests.nextElement().openStream());
-        Attributes attributes = manifest.getMainAttributes();
-        String className = attributes.getValue("Coverage-Main-Class");
-        if (className != null) {
-          return className;
+  private static Class<?> getMainClass(boolean insideDeployJar) throws Exception {
+    Class<?> mainClass;
+    // If we're running inside a deploy jar we have to open the manifest and read the value of
+    // "Coverage-Main-Class", set by bazel.
+    // Note ClassLoader#getResource() will only return the first result, most likely a manifest
+    // from the bootclasspath.
+    if (insideDeployJar) {
+      if (JacocoCoverageRunner.class.getClassLoader() != null) {
+        Enumeration<URL> manifests =
+            JacocoCoverageRunner.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
+        while (manifests.hasMoreElements()) {
+          Manifest manifest = new Manifest(manifests.nextElement().openStream());
+          Attributes attributes = manifest.getMainAttributes();
+          String className = attributes.getValue("Coverage-Main-Class");
+          if (className != null) {
+            // Some test frameworks use dummy Coverage-Main-Class in the deploy jars
+            // which should be ignored by JacocoCoverageRunner.
+            try {
+              mainClass = Class.forName(className);
+              return mainClass;
+            } catch (ClassNotFoundException e) {
+              // ignore this class and move on
+            }
+          }
         }
       }
-      throw new IllegalStateException(
-          "JACOCO_METADATA_JAR/JACOCO_MAIN_CLASS environment variables not set, and no"
-              + " META-INF/MANIFEST.MF on the classpath has a Coverage-Main-Class attribute. "
-              + " Cannot determine the name of the main class for the code under test.");
     }
+    // Check JACOCO_MAIN_CLASS after making sure we're not running inside a deploy jar, otherwise
+    // the deploy jar will be invoked using the wrong main class.
+    String jacocoMainClass = System.getenv("JACOCO_MAIN_CLASS");
+    if (jacocoMainClass != null) {
+      return Class.forName(jacocoMainClass);
+    }
+    throw new IllegalStateException(
+        "JACOCO_METADATA_JAR/JACOCO_MAIN_CLASS environment variables not set, and no"
+            + " META-INF/MANIFEST.MF on the classpath has a Coverage-Main-Class attribute. "
+            + " Cannot determine the name of the main class for the code under test.");
   }
 
   private static String getUniquePath(String pathTemplate, String suffix) throws IOException {
@@ -339,7 +319,7 @@ public class JacocoCoverageRunner {
     if (pathTemplate == null) {
       return File.createTempFile("coverage", suffix).getPath();
     } else {
-      // Blaze sets the path template to a file with the .dat extension. lcov_merger matches all
+      // bazel sets the path template to a file with the .dat extension. lcov_merger matches all
       // files having '.dat' in their name, so instead of appending we change the extension.
       File absolutePathTemplate = new File(pathTemplate).getAbsoluteFile();
       String prefix = absolutePathTemplate.getName();
@@ -368,69 +348,59 @@ public class JacocoCoverageRunner {
   public static void main(String[] args) throws Exception {
     String metadataFile = System.getenv("JACOCO_METADATA_JAR");
 
-    String javaCoverageNewImplementationValue = System.getenv("JAVA_COVERAGE_NEW_IMPLEMENTATION");
-    final boolean isNewImplementation =
-        (javaCoverageNewImplementationValue != null
-                && javaCoverageNewImplementationValue.equals("YES"))
-            || (metadataFile == null
-                ? false
-                : (metadataFile.endsWith(".txt") || metadataFile.endsWith("_merged_instr.jar")));
-
     File[] metadataFiles = null;
+    int deployJars = 0;
     final HashMap<String, byte[]> uninstrumentedClasses = new HashMap<>();
     ImmutableSet.Builder<String> pathsForCoverageBuilder = new ImmutableSet.Builder<>();
-    if (isNewImplementation) {
-      ClassLoader classLoader = ClassLoader.getSystemClassLoader();
-      if (classLoader instanceof URLClassLoader) {
-        URL[] urls = ((URLClassLoader) classLoader).getURLs();
-        metadataFiles = new File[urls.length];
-        for (int i = 0; i < urls.length; i++) {
-          String file = URLDecoder.decode(urls[i].getFile(), "UTF-8");
-          metadataFiles[i] = new File(file);
-          // Special case for deploy jars.
-          if (file.endsWith("_deploy.jar")) {
-            metadataFile = file;
-          } else if (file.endsWith(".jar")) {
-            // Collect
-            // - uninstrumented class files for coverage before starting the actual test
-            // - paths considered for coverage
-            // Collecting these in the shutdown hook is too expensive (we only have a 5s budget).
-            JarFile jarFile = new JarFile(file);
-            Enumeration<JarEntry> jarFileEntries = jarFile.entries();
-            while (jarFileEntries.hasMoreElements()) {
-              JarEntry jarEntry = jarFileEntries.nextElement();
-              String jarEntryName = jarEntry.getName();
-              if (jarEntryName.endsWith(".class.uninstrumented")
-                  && !uninstrumentedClasses.containsKey(jarEntryName)) {
-                uninstrumentedClasses.put(
-                    jarEntryName, ByteStreams.toByteArray(jarFile.getInputStream(jarEntry)));
-              } else if (jarEntryName.endsWith("-paths-for-coverage.txt")) {
-                BufferedReader bufferedReader =
-                    new BufferedReader(
-                        new InputStreamReader(jarFile.getInputStream(jarEntry), UTF_8));
-                String line;
-                while ((line = bufferedReader.readLine()) != null) {
-                  pathsForCoverageBuilder.add(line);
-                }
+    ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+    if (classLoader instanceof URLClassLoader) {
+      URL[] urls = ((URLClassLoader) classLoader).getURLs();
+      metadataFiles = new File[urls.length];
+      for (int i = 0; i < urls.length; i++) {
+        URL url = urls[i];
+        metadataFiles[i] = new File(url.getFile());
+        // Special case for when there is only one deploy jar on the classpath.
+        if (url.getFile().endsWith("_deploy.jar")) {
+          metadataFile = url.getFile();
+          deployJars++;
+        }
+        if (url.getFile().endsWith(".jar")) {
+          // Collect
+          // - uninstrumented class files for coverage before starting the actual test
+          // - paths considered for coverage
+          // Collecting these in the shutdown hook is too expensive (we only have a 5s budget).
+          JarFile jarFile = new JarFile(url.getFile());
+          Enumeration<JarEntry> jarFileEntries = jarFile.entries();
+          while (jarFileEntries.hasMoreElements()) {
+            JarEntry jarEntry = jarFileEntries.nextElement();
+            String jarEntryName = jarEntry.getName();
+            if (jarEntryName.endsWith(".class.uninstrumented")
+                && !uninstrumentedClasses.containsKey(jarEntryName)) {
+              uninstrumentedClasses.put(
+                  jarEntryName, ByteStreams.toByteArray(jarFile.getInputStream(jarEntry)));
+            } else if (jarEntryName.endsWith("-paths-for-coverage.txt")) {
+              BufferedReader bufferedReader =
+                  new BufferedReader(
+                      new InputStreamReader(jarFile.getInputStream(jarEntry), UTF_8));
+              String line;
+              while ((line = bufferedReader.readLine()) != null) {
+                pathsForCoverageBuilder.add(line);
               }
             }
           }
         }
       }
     }
+
     final ImmutableSet<String> pathsForCoverage = pathsForCoverageBuilder.build();
     final String metadataFileFinal = metadataFile;
     final File[] metadataFilesFinal = metadataFiles;
     final String javaRunfilesRoot = System.getenv("JACOCO_JAVA_RUNFILES_ROOT");
 
     boolean hasOneFile = false;
-    if (!isNewImplementation) {
-      // --noexperimental_java_coverage sets JACOCO_METADATA_JAR to the instrumented jar
-      // and it is only one file.
-      hasOneFile = true;
-    } else if (metadataFile != null
-        && (metadataFile.endsWith("_merged_instr.jar") || metadataFile.endsWith("_deploy.jar"))) {
-      // --experimental_java_coverage can set JACOCO_METADATA_JAR to either one file (a deploy jar
+    if (metadataFile != null && (metadataFile.endsWith("_merged_instr.jar")
+        || metadataFile.endsWith("_deploy.jar"))) {
+      // bazel can set JACOCO_METADATA_JAR to either one file (a deploy jar
       // or a merged jar) or to multiple jars.
       hasOneFile = true;
     }
@@ -503,19 +473,16 @@ public class JacocoCoverageRunner {
                               : getFilesFromFileList(new File(metadataFileFinal), javaRunfilesRoot)
                                   .toArray(new File[0]);
                     }
-
                     if (uninstrumentedClasses.isEmpty()) {
-                      new JacocoCoverageRunner(
-                              isNewImplementation, dataInputStream, coverageReport, metadataJars)
+                      new JacocoCoverageRunner(dataInputStream, coverageReport, metadataJars)
                           .create();
                     } else {
                       new JacocoCoverageRunner(
-                              isNewImplementation,
-                              dataInputStream,
-                              coverageReport,
-                              uninstrumentedClasses,
-                              pathsForCoverage,
-                              metadataJars)
+                          dataInputStream,
+                          coverageReport,
+                          uninstrumentedClasses,
+                          pathsForCoverage,
+                          metadataJars)
                           .create();
                     }
                   }
@@ -526,15 +493,21 @@ public class JacocoCoverageRunner {
               }
             });
 
+    // If running inside a deploy jar the classpath contains only that deploy jar.
+    // It can happen that multiple deploy jars are on the classpath. In that case we are running
+    // from a regular java binary where all the environment (e.g. JACOCO_MAIN_CLASS) is set
+    // accordingly.
+    boolean insideDeployJar =
+        (deployJars == 1) && (metadataFilesFinal == null || metadataFilesFinal.length == 1);
+    Class<?>  mainClass = getMainClass(insideDeployJar);
+    Method main = mainClass.getMethod("main", String[].class);
+    main.setAccessible(true);
     // Another option would be to run the tests in a separate JVM, let Jacoco dump out the coverage
     // data, wait for the subprocess to finish and then generate the lcov report. The only benefit
     // of doing this is not being constrained by the hard 5s limit of the shutdown hook. Setting up
     // the subprocess to match all JVM flags, runtime classpath, bootclasspath, etc is doable.
     // We'd share the same limitation if the system under test uses shutdown hooks internally, as
     // there's no way to collect coverage data on that code.
-    String mainClass = getMainClass(metadataFile, isNewImplementation);
-    Method main = Class.forName(mainClass).getMethod("main", String[].class);
-    main.setAccessible(true);
     main.invoke(null, new Object[] {args});
   }
 }

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -440,8 +440,6 @@ sh_test(
         ],
         tags = [
             "no_windows",
-            # TODO(iirina): Remove this tag after #8431 is merged.
-            "manual",
         ],
     )
     for java_version in JAVA_VERSIONS

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -355,4 +355,267 @@ EOF
   cmp result.dat "$coverage_file_path" || fail "Coverage output file is different than the expected file"
 }
 
+function test_run_jar_in_subprocess_empty_env() {
+  mkdir -p java/cov
+  mkdir -p javatests/cov
+  cat >java/cov/BUILD <<EOF
+package(default_visibility=['//visibility:public'])
+java_binary(name = 'Cov',
+            main_class = 'cov.Cov',
+            srcs = ['Cov.java'])
+EOF
+
+  cat >java/cov/Cov.java <<EOF
+package cov;
+public class Cov {
+  public static void main(String[] args) {
+    if (args.length == 1) {
+      if (Boolean.parseBoolean(args[0])) {
+        System.out.println("Boolean.parseBoolean returned true");  // line 6
+      } else {
+        System.out.println("Boolean.parseBoolean returned false"); // line 8
+      }
+    }
+  }
+}
+EOF
+
+  cat >javatests/cov/BUILD <<EOF
+java_test(name = 'CovTest',
+          srcs = ['CovTest.java'],
+          data = ['//java/cov:Cov_deploy.jar'],
+          test_class = 'cov.CovTest')
+EOF
+
+  cat >javatests/cov/CovTest.java <<EOF
+package cov;
+import junit.framework.TestCase;
+import java.io.*;
+import java.nio.channels.*;
+import java.net.InetAddress;
+public class CovTest extends TestCase {
+  private static Process startSubprocess(String arg) throws Exception {
+   String path = System.getenv("TEST_SRCDIR") + "/main/java/cov/Cov_deploy.jar";
+    String[] command = {
+      // Run the deploy jar by invoking JVM because the integration tests
+      // cannot use the java launcher (b/29388516).
+      System.getProperty("java.home") + "/bin/java", "-jar", path, arg
+    };
+    ProcessBuilder pb = new ProcessBuilder(command);
+    pb.environment().clear();
+    return pb.start();
+  }
+  public void testTrivial() throws Exception {
+    Process subprocessTrue = startSubprocess("true");
+    Process subprocessFalse = startSubprocess("false");
+    subprocessTrue.waitFor();
+    subprocessFalse.waitFor();
+    String line;
+    BufferedReader input = new BufferedReader(new InputStreamReader(subprocessTrue.getInputStream()));
+    while ((line = input.readLine()) != null) {
+      System.out.println(line);
+     }
+    input.close();
+    BufferedReader err = new BufferedReader(new InputStreamReader(subprocessTrue.getErrorStream()));
+    while ((line = err.readLine()) != null) {
+      System.out.println(line);
+     }
+    err.close();
+
+    input = new BufferedReader(new InputStreamReader(subprocessFalse.getInputStream()));
+    while ((line = input.readLine()) != null) {
+      System.out.println(line);
+     }
+    input.close();
+    err = new BufferedReader(new InputStreamReader(subprocessFalse.getErrorStream()));
+    while ((line = err.readLine()) != null) {
+      System.out.println(line);
+     }
+    err.close();
+  }
+}
+EOF
+
+  # Only assess that the coverage run was successful.
+  # --nooutputredirect is needed for blaze to print the output of the jar
+  bazel coverage --test_output=all --test_arg=--nooutputredirect \
+    javatests/cov:CovTest >"${TEST_log}" || fail "Expected success"
+  expect_not_log "JACOCO_METADATA_JAR/JACOCO_MAIN_CLASS environment variables not set"
+  expect_log "Boolean.parseBoolean returned true"
+  expect_log "Boolean.parseBoolean returned false"
+}
+
+function test_runtime_deploy_jar() {
+  mkdir -p java/cov
+  mkdir -p javatests/cov
+  cat >java/cov/BUILD <<EOF
+package(default_visibility=['//visibility:public'])
+java_binary(
+    name = 'RandomBinary',
+    main_class = 'cov.RandomBinary',
+    srcs = ['RandomBinary.java'],
+)
+
+java_library(
+    name = 'Cov',
+    srcs = ['Cov.java']
+)
+EOF
+
+  cat >java/cov/RandomBinary.java <<EOF
+package cov;
+public class RandomBinary {
+  public static void main(String[] args) throws Exception {
+    throw new Exception("RandomBinary should not be run!");
+  }
+}
+EOF
+
+  cat >java/cov/Cov.java <<EOF
+package cov;
+public class Cov {
+  public static void main(String[] args) {
+    if (args.length == 1) {
+      if (Boolean.parseBoolean(args[0])) {
+        System.out.println("Boolean.parseBoolean returned true");  // line 6
+      } else {
+        System.out.println("Boolean.parseBoolean returned false"); // line 8
+      }
+    }
+  }
+}
+EOF
+
+  cat >javatests/cov/BUILD <<EOF
+java_test(name = 'CovTest',
+          srcs = ['CovTest.java'],
+          deps = ['//java/cov:Cov'],
+          runtime_deps = ['//java/cov:RandomBinary_deploy.jar'],
+          test_class = 'cov.CovTest')
+EOF
+
+  cat >javatests/cov/CovTest.java <<EOF
+package cov;
+import junit.framework.TestCase;
+import java.io.*;
+import java.nio.channels.*;
+import java.net.InetAddress;
+public class CovTest extends TestCase {
+  public void testTrivial() throws Exception {
+    Cov.main(new String[] {"true"});
+    Cov.main(new String[] {"false"});
+  }
+}
+EOF
+
+  bazel coverage --test_output=all --instrumentation_filter=//java/cov \
+      javatests/cov:CovTest >"${TEST_log}"
+  local coverage_file_path="$( get_coverage_file_path_from_test_log )"
+  assert_coverage_result "java/cov/Cov.java" ${coverage_file_path}
+}
+
+function test_runtime_and_data_deploy_jars() {
+  mkdir -p java/cov
+  mkdir -p javatests/cov
+  cat >java/cov/BUILD <<EOF
+package(default_visibility=['//visibility:public'])
+java_binary(
+    name = 'RandomBinary',
+    main_class = 'cov.RandomBinary',
+    srcs = ['RandomBinary.java'],
+)
+
+java_binary(
+    name = 'Cov',
+    srcs = ['Cov.java'],
+    main_class = 'cov.Cov'
+)
+EOF
+
+  cat >java/cov/RandomBinary.java <<EOF
+package cov;
+public class RandomBinary {
+  public static void main(String[] args) throws Exception {
+    throw new Exception("RandomBinary should not be run!");
+  }
+}
+EOF
+
+  cat >java/cov/Cov.java <<EOF
+package cov;
+public class Cov {
+  public static void main(String[] args) {
+    if (args.length == 1) {
+      if (Boolean.parseBoolean(args[0])) {
+        System.out.println("Boolean.parseBoolean returned true");  // line 6
+      } else {
+        System.out.println("Boolean.parseBoolean returned false"); // line 8
+      }
+    }
+  }
+}
+EOF
+
+  cat >javatests/cov/BUILD <<EOF
+java_test(name = 'CovTest',
+          srcs = ['CovTest.java'],
+          data = ['//java/cov:Cov_deploy.jar'],
+          runtime_deps = ['//java/cov:RandomBinary_deploy.jar'],
+          test_class = 'cov.CovTest')
+EOF
+
+  cat >javatests/cov/CovTest.java <<EOF
+package cov;
+import junit.framework.TestCase;
+import java.io.*;
+import java.nio.channels.*;
+import java.net.InetAddress;
+public class CovTest extends TestCase {
+  private static Process startSubprocess(String arg) throws Exception {
+   String path = System.getenv("TEST_SRCDIR") + "/main/java/cov/Cov_deploy.jar";
+    String[] command = {
+      // Run the deploy jar by invoking JVM because the integration tests
+      // cannot use the java launcher (b/29388516).
+      System.getProperty("java.home") + "/bin/java", "-jar", path, arg
+    };
+    return new ProcessBuilder(command).start();
+  }
+  public void testTrivial() throws Exception {
+    Process subprocessTrue = startSubprocess("true");
+    Process subprocessFalse = startSubprocess("false");
+    subprocessTrue.waitFor();
+    subprocessFalse.waitFor();
+    String line;
+    BufferedReader input = new BufferedReader(new InputStreamReader(subprocessTrue.getInputStream()));
+    while ((line = input.readLine()) != null) {
+      System.out.println(line);
+     }
+    input.close();
+    BufferedReader err = new BufferedReader(new InputStreamReader(subprocessTrue.getErrorStream()));
+    while ((line = err.readLine()) != null) {
+      System.out.println(line);
+     }
+    err.close();
+
+    input = new BufferedReader(new InputStreamReader(subprocessFalse.getInputStream()));
+    while ((line = input.readLine()) != null) {
+      System.out.println(line);
+     }
+    input.close();
+    err = new BufferedReader(new InputStreamReader(subprocessFalse.getErrorStream()));
+    while ((line = err.readLine()) != null) {
+      System.out.println(line);
+     }
+    err.close();
+  }
+}
+EOF
+
+  # --nooutputredirect is needed for blaze to print the output of the deploy jar
+  bazel coverage --test_output=all --test_arg=--nooutputredirect \
+      --instrumentation_filter=//java/cov javatests/cov:CovTest >"${TEST_log}"
+  local coverage_file_path="$( get_coverage_file_path_from_test_log )"
+  assert_coverage_result "java/cov/Cov.java" ${coverage_file_path}
+}
+
 run_suite "test tests"

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -356,6 +356,11 @@ EOF
 }
 
 function test_run_jar_in_subprocess_empty_env() {
+  # These features don't work with java tools version javac11-v1.0,
+  # javac10-v3.1, javac9-v1.0 and lower.
+  # TODO(iirina): Remove this statement after new java tools versions are
+  # released.
+  [[ "${JAVA_TOOLS_ZIP}" == "released" ]] && echo "Skipping test" && return
   mkdir -p java/cov
   mkdir -p javatests/cov
   cat >java/cov/BUILD <<EOF
@@ -446,6 +451,11 @@ EOF
 }
 
 function test_runtime_deploy_jar() {
+  # These features don't work with java tools version javac11-v1.0,
+  # javac10-v3.1, javac9-v1.0 and lower.
+  # TODO(iirina): Remove this statement after new java tools versions are
+  # released.
+  [[ "${JAVA_TOOLS_ZIP}" == "released" ]] && echo "Skipping test" && return
   mkdir -p java/cov
   mkdir -p javatests/cov
   cat >java/cov/BUILD <<EOF
@@ -515,6 +525,12 @@ EOF
 }
 
 function test_runtime_and_data_deploy_jars() {
+  # These features don't work with java tools version javac11-v1.0,
+  # javac10-v3.1, javac9-v1.0 and lower.
+  # TODO(iirina): Remove this statement after new java tools versions are
+  # released.
+  [[ "${JAVA_TOOLS_ZIP}" == "released" ]] && echo "Skipping test" && return
+
   mkdir -p java/cov
   mkdir -p javatests/cov
   cat >java/cov/BUILD <<EOF

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -59,8 +59,7 @@ java_toolchain(
         ":java_compiler_jar",
         ":jdk_compiler_jar",
     ],
-    # TODO(iirina): Re-enable this after #8378 is merged.
-    # jacocorunner = ":jacoco_coverage_runner"
+    jacocorunner = ":jacoco_coverage_runner"
 )
 
 filegroup(

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -135,14 +135,14 @@ filegroup(
 
 java_import(
     name = "jacoco-agent",
-    jars = ["java_tools/third_party/java/jacoco/org.jacoco.agent-0.7.5.201505241946.jar"],
-    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.agent-0.7.5.201505241946-src.jar",
+    jars = ["java_tools/third_party/java/jacoco/org.jacoco.agent-0.8.3.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.agent-0.8.3-src.jar",
 )
 
 java_import(
     name = "jacoco-core",
-    jars = ["java_tools/third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946.jar"],
-    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946-src.jar",
+    jars = ["java_tools/third_party/java/jacoco/org.jacoco.core-0.8.3.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.core-0.8.3-src.jar",
     exports = [
         ":asm",
         ":asm-commons",
@@ -152,13 +152,13 @@ java_import(
 
 filegroup(
     name = "jacoco-core-jars",
-    srcs = ["java_tools/third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946.jar"],
+    srcs = ["java_tools/third_party/java/jacoco/org.jacoco.core-0.8.3.jar"],
 )
 
 java_import(
     name = "jacoco-report",
-    jars = ["java_tools/third_party/java/jacoco/org.jacoco.report-0.7.5.201505241946.jar"],
-    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.report-0.7.5.201505241946-src.jar",
+    jars = ["java_tools/third_party/java/jacoco/org.jacoco.report-0.8.3.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.report-sources.jar",
     exports = [
         ":asm",
         ":jacoco-core",
@@ -167,12 +167,12 @@ java_import(
 
 java_import(
     name = "bazel-jacoco-agent",
-    jars = ["java_tools/third_party/java/jacoco/jacocoagent.jar"],
+    jars = ["java_tools/third_party/java/jacoco/jacocoagent-0.8.3.jar"],
 )
 
 java_import(
     name = "bazel-jacoco-agent-neverlink",
-    jars = ["java_tools/third_party/java/jacoco/jacocoagent.jar"],
+    jars = ["java_tools/third_party/java/jacoco/jacocoagent-0.8.3.jar"],
     neverlink = 1,
 )
 

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -59,7 +59,8 @@ java_toolchain(
         ":java_compiler_jar",
         ":jdk_compiler_jar",
     ],
-    jacocorunner = ":jacoco_coverage_runner"
+    # TODO(iirina): Re-enable this after #8378 is merged.
+    # jacocorunner = ":jacoco_coverage_runner"
 )
 
 filegroup(


### PR DESCRIPTION
Handle the cases when a deploy jar is executed from a java program or when one or more deploy jars end up on the runtime classpath.

Also remove traces of the old variables referencing the 'new' implementation. The 'old' implementation is no longer in Bazel.

Make JacocoCoverageRunner compatible with JDK 9 (which made the system classloader no longer an instance of URLClassLoader).

Fixes #8472.

FYI: These cases are already handled in the internal JacocoCoverageRunner and this change syncs the two versions.