### PR TITLE
Windows: fix path joining in AsAbsoluteWindowsPath

### DIFF
--- a/src/main/cpp/util/path_windows.cc
+++ b/src/main/cpp/util/path_windows.cc
@@ -463,9 +463,15 @@ static bool AsAbsoluteWindowsPathImpl(const std::wstring& path,
     if (result->empty() || (result->size() == 1 && (*result)[0] == '.')) {
       *result = GetCwdW();
     } else {
-      *result = GetCwdW() + L"\\" + *result;
+      std::wstring wd = RemoveUncPrefixMaybe(GetCwdW().c_str());
+      std::wstring joined = wd + L"\\" + *result;
+      if (!NormalizeWindowsPath(joined, result)) {
+        BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
+            << "NormalizePath(" << WstringToCstring(joined.c_str()).get() << ")";
+      }
     }
   }
+
   if (!HasUncPrefix(result->c_str())) {
     *result = std::wstring(L"\\\\?\\") + *result;
   }

--- a/src/tools/launcher/util/data_parser.cc
+++ b/src/tools/launcher/util/data_parser.cc
@@ -92,6 +92,10 @@ bool LaunchDataParser::GetLaunchInfo(const wstring& binary_path,
   unique_ptr<ifstream> binary =
       make_unique<ifstream>(AsAbsoluteWindowsPath(binary_path.c_str()).c_str(),
                             ios::binary | ios::in);
+  if (!binary->good()) {
+    PrintError(L"Cannot open the binary to read launch data");
+    return false;
+  }
   int64_t data_size = ReadDataSize(binary.get());
   if (data_size == 0) {
     PrintError(L"No data appended, cannot launch anything!");

--- a/src/tools/launcher/util/launcher_util.cc
+++ b/src/tools/launcher/util/launcher_util.cc
@@ -118,8 +118,9 @@ bool DeleteDirectoryByPath(const wchar_t* path) {
 }
 
 wstring GetBinaryPathWithoutExtension(const wstring& binary) {
-  if (binary.find(L".exe", binary.size() - 4) != wstring::npos) {
-    return binary.substr(0, binary.length() - 4);
+  if (binary.size() >= 4 &&
+      binary.find(L".exe", binary.size() - 4) != wstring::npos) {
+    return binary.substr(0, binary.size() - 4);
   }
   return binary;
 }


### PR DESCRIPTION
The didn't normalize the result after joining it
with GetCwdW(). This created invalid paths when
the joined segment started with "..\".

Fixes https://github.com/bazelbuild/bazel/issues/8202