### PR TITLE
Disable jacoco test case when testing the content of the java_tools zip.

### DIFF
--- a/src/test/shell/bazel/bazel_java_tools_dist_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_dist_test.sh
@@ -146,7 +146,8 @@ function test_java_tools_has_jarjar() {
   expect_path_in_java_tools "third_party/jarjar/java/com/tonicsystems/jarjar"
 }
 
-function test_java_tools_has_jacocoagent() {
+# TOODO(iirina): Re-enable this and update jacoco version after #8376 is merged.
+function DISABLED_test_java_tools_has_jacocoagent() {
   expect_path_in_java_tools "third_party/java/jacoco/org.jacoco.agent-0.7.5.201505241946-src.jar"
   expect_path_in_java_tools "third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946-src.jar"
   expect_path_in_java_tools "third_party/java/jacoco/org.jacoco.report-0.7.5.201505241946-src.jar"

--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -156,7 +156,8 @@ function test_java_tools_has_BUILD() {
   expect_path_in_java_tools "BUILD"
 }
 
-function test_java_tools_has_jacocoagent() {
+# TOODO(iirina): Re-enable this and update jacoco version after #8376 is merged.
+function DISABLED_test_java_tools_has_jacocoagent() {
   expect_path_in_java_tools "java_tools/third_party/java/jacoco/jacocoagent.jar"
   expect_path_in_java_tools "java_tools/third_party/java/jacoco/org.jacoco.agent-0.7.5.201505241946.jar"
   expect_path_in_java_tools "java_tools/third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946.jar"


### PR DESCRIPTION
Temporarily disable the test to be able to merge #8376 without breaking the CI. The test change cannot happen atomically with #8376 because the third_party changes have to be merged separately.