### PR TITLE
Update toolchain resolution to load requested toolchain types.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunction.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.skyframe;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.stream.Collectors.joining;
 
 import com.google.auto.value.AutoValue;
@@ -21,6 +22,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Table;
 import com.google.devtools.build.lib.analysis.PlatformConfiguration;
@@ -35,6 +37,7 @@ import com.google.devtools.build.lib.skyframe.ConstraintValueLookupUtil.InvalidC
 import com.google.devtools.build.lib.skyframe.PlatformLookupUtil.InvalidPlatformException;
 import com.google.devtools.build.lib.skyframe.RegisteredToolchainsFunction.InvalidToolchainLabelException;
 import com.google.devtools.build.lib.skyframe.SingleToolchainResolutionFunction.NoToolchainFoundException;
+import com.google.devtools.build.lib.skyframe.ToolchainTypeLookupUtil.InvalidToolchainTypeException;
 import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyFunctionException;
 import com.google.devtools.build.skyframe.SkyKey;
@@ -76,6 +79,20 @@ public class ToolchainResolutionFunction implements SkyFunction {
       boolean debug =
           configuration.getOptions().get(PlatformOptions.class).toolchainResolutionDebug;
 
+      // Load the configured target for the toolchain types to ensure that they are valid and
+      // resolve aliases.
+      ImmutableMap<Label, ToolchainTypeInfo> resolvedToolchainTypes =
+          loadToolchainTypes(
+              env,
+              configuration,
+              key.requiredToolchainTypeLabels(),
+              key.shouldSanityCheckConfiguration());
+      builder.setRequestedLabelToToolchainType(resolvedToolchainTypes);
+      ImmutableSet<Label> resolvedToolchainTypeLabels =
+          resolvedToolchainTypes.values().stream()
+              .map(ToolchainTypeInfo::typeLabel)
+              .collect(toImmutableSet());
+
       // Create keys for all platforms that will be used, and validate them early.
       PlatformKeys platformKeys =
           loadPlatformKeys(
@@ -94,7 +111,7 @@ public class ToolchainResolutionFunction implements SkyFunction {
       determineToolchainImplementations(
           env,
           key.configurationKey(),
-          key.requiredToolchainTypeLabels(),
+          resolvedToolchainTypeLabels,
           builder,
           platformKeys,
           key.shouldSanityCheckConfiguration());
@@ -121,6 +138,27 @@ public class ToolchainResolutionFunction implements SkyFunction {
     } catch (ValueMissingException e) {
       return null;
     }
+  }
+
+  /** Returns a map from the requested toolchain type to the {@link ToolchainTypeInfo} provider. */
+  private ImmutableMap<Label, ToolchainTypeInfo> loadToolchainTypes(
+      Environment environment,
+      BuildConfiguration configuration,
+      ImmutableSet<Label> requestedToolchainTypeLabels,
+      boolean shouldSanityCheckConfiguration)
+      throws InvalidToolchainTypeException, InterruptedException, ValueMissingException {
+    ImmutableSet<ConfiguredTargetKey> toolchainTypeKeys =
+        requestedToolchainTypeLabels.stream()
+            .map(label -> ConfiguredTargetKey.of(label, configuration))
+            .collect(toImmutableSet());
+
+    ImmutableMap<Label, ToolchainTypeInfo> resolvedToolchainTypes =
+        ToolchainTypeLookupUtil.resolveToolchainTypes(
+            environment, toolchainTypeKeys, shouldSanityCheckConfiguration);
+    if (environment.valuesMissing()) {
+      throw new ValueMissingException();
+    }
+    return resolvedToolchainTypes;
   }
 
   @AutoValue

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainTypeLookupUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainTypeLookupUtil.java
@@ -1,0 +1,152 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.skyframe;
+
+import static java.util.stream.Collectors.joining;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.actions.MutableActionGraph.ActionConflictException;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.platform.PlatformProviderUtils;
+import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.packages.NoSuchThingException;
+import com.google.devtools.build.lib.skyframe.ConfiguredTargetFunction.ConfiguredValueCreationException;
+import com.google.devtools.build.skyframe.SkyFunction.Environment;
+import com.google.devtools.build.skyframe.SkyKey;
+import com.google.devtools.build.skyframe.ValueOrException3;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/** Helper class that looks up {@link ToolchainTypeInfo} data. */
+public class ToolchainTypeLookupUtil {
+
+  @Nullable
+  public static ImmutableMap<Label, ToolchainTypeInfo> resolveToolchainTypes(
+      Environment env,
+      Iterable<ConfiguredTargetKey> toolchainTypeKeys,
+      boolean sanityCheckConfiguration)
+      throws InterruptedException, InvalidToolchainTypeException {
+    Map<
+            SkyKey,
+            ValueOrException3<
+                ConfiguredValueCreationException, NoSuchThingException, ActionConflictException>>
+        values =
+            env.getValuesOrThrow(
+                toolchainTypeKeys,
+                ConfiguredValueCreationException.class,
+                NoSuchThingException.class,
+                ActionConflictException.class);
+    boolean valuesMissing = env.valuesMissing();
+    Map<Label, ToolchainTypeInfo> results = valuesMissing ? null : new HashMap<>();
+    for (ConfiguredTargetKey key : toolchainTypeKeys) {
+      Label originalLabel = key.getLabel();
+      ToolchainTypeInfo toolchainTypeInfo =
+          findToolchainTypeInfo(key, values.get(key), sanityCheckConfiguration);
+      if (!valuesMissing && toolchainTypeInfo != null) {
+        // These are only different if the toolchain type was aliased.
+        results.put(originalLabel, toolchainTypeInfo);
+        results.put(toolchainTypeInfo.typeLabel(), toolchainTypeInfo);
+      }
+    }
+    if (valuesMissing) {
+      return null;
+    }
+
+    return ImmutableMap.copyOf(results);
+  }
+
+  @Nullable
+  private static ToolchainTypeInfo findToolchainTypeInfo(
+      ConfiguredTargetKey key,
+      ValueOrException3<
+              ConfiguredValueCreationException, NoSuchThingException, ActionConflictException>
+          valueOrException,
+      boolean sanityCheckConfiguration)
+      throws InvalidToolchainTypeException {
+
+    try {
+      ConfiguredTargetValue ctv = (ConfiguredTargetValue) valueOrException.get();
+      if (ctv == null) {
+        return null;
+      }
+
+      ConfiguredTarget configuredTarget = ctv.getConfiguredTarget();
+      BuildConfigurationValue.Key configurationKey = configuredTarget.getConfigurationKey();
+      // This check is necessary because trimming for other rules assumes that platform resolution
+      // uses the platform fragment and _only_ the platform fragment. Without this check, it's
+      // possible another fragment could slip in without us realizing, and thus break this
+      // assumption.
+      if (sanityCheckConfiguration && !configurationKey.getFragments().isEmpty()) {
+        // No fragments may be present on a toolchain_type rule in retroactive
+        // trimming mode.
+        String extraFragmentDescription =
+            configurationKey.getFragments().stream()
+                .map(cl -> cl.getSimpleName())
+                .collect(joining(","));
+        throw new InvalidToolchainTypeException(
+            configuredTarget.getLabel(),
+            "has configuration fragments, "
+                + "which is forbidden in retroactive trimming mode: "
+                + "extra fragments are ["
+                + extraFragmentDescription
+                + "]");
+      }
+      ToolchainTypeInfo toolchainTypeInfo = PlatformProviderUtils.toolchainType(configuredTarget);
+      if (toolchainTypeInfo == null) {
+        throw new InvalidToolchainTypeException(configuredTarget.getLabel());
+      }
+
+      return toolchainTypeInfo;
+    } catch (ConfiguredValueCreationException e) {
+      throw new InvalidToolchainTypeException(key.getLabel(), e);
+    } catch (NoSuchThingException e) {
+      throw new InvalidToolchainTypeException(key.getLabel(), e);
+    } catch (ActionConflictException e) {
+      throw new InvalidToolchainTypeException(key.getLabel(), e);
+    }
+  }
+
+  /** Exception used when a toolchain type label is not a valid toolchain type. */
+  public static final class InvalidToolchainTypeException extends ToolchainException {
+    private static final String DEFAULT_ERROR = "does not provide ToolchainTypeInfo";
+
+    InvalidToolchainTypeException(Label label) {
+      super(formatError(label, DEFAULT_ERROR));
+    }
+
+    InvalidToolchainTypeException(Label label, ConfiguredValueCreationException e) {
+      super(formatError(label, DEFAULT_ERROR), e);
+    }
+
+    public InvalidToolchainTypeException(Label label, NoSuchThingException e) {
+      // Just propagate the inner exception, because it's directly actionable.
+      super(e);
+    }
+
+    public InvalidToolchainTypeException(Label label, ActionConflictException e) {
+      super(formatError(label, DEFAULT_ERROR), e);
+    }
+
+    InvalidToolchainTypeException(Label label, String error) {
+      super(formatError(label, error));
+    }
+
+    private static String formatError(Label label, String error) {
+      return String.format("Target %s was referenced as a toolchain type, but %s", label, error);
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/skyframe/UnloadedToolchainContext.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/UnloadedToolchainContext.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.skyframe;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.ToolchainContext;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
@@ -92,15 +93,36 @@ public abstract class UnloadedToolchainContext implements ToolchainContext, SkyV
     /** Sets the toolchain types that were requested. */
     Builder setRequiredToolchainTypes(Set<ToolchainTypeInfo> requiredToolchainTypes);
 
+    /**
+     * Maps from the actual toolchain type to the resolved toolchain implementation that should be
+     * used.
+     */
     Builder setToolchainTypeToResolved(
         ImmutableBiMap<ToolchainTypeInfo, Label> toolchainTypeToResolved);
+
+    /**
+     * Maps from the actual requested {@link Label} to the discovered {@link ToolchainTypeInfo}.
+     *
+     * <p>Note that the key may be different from {@link ToolchainTypeInfo#typeLabel()} if the
+     * requested {@link Label} is an {@code alias}.
+     */
+    Builder setRequestedLabelToToolchainType(
+        ImmutableMap<Label, ToolchainTypeInfo> requestedLabelToToolchainType);
 
     UnloadedToolchainContext build();
   }
 
   /** The map of toolchain type to resolved toolchain to be used. */
-  // TODO(https://github.com/bazelbuild/bazel/issues/7935): Make this package-protected again.
   public abstract ImmutableBiMap<ToolchainTypeInfo, Label> toolchainTypeToResolved();
+
+  /**
+   * Maps from the actual requested {@link Label} to the discovered {@link ToolchainTypeInfo}.
+   *
+   * <p>Note that the key may be different from {@link ToolchainTypeInfo#typeLabel()} if the
+   * requested {@link Label} is an {@code alias}. In this case, there will be two {@link Label
+   * labels} for the same {@link ToolchainTypeInfo}.
+   */
+  public abstract ImmutableMap<Label, ToolchainTypeInfo> requestedLabelToToolchainType();
 
   @Override
   public ImmutableSet<Label> resolvedToolchainLabels() {

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainTypeLookupUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainTypeLookupUtilTest.java
@@ -1,0 +1,225 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.skyframe;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.skyframe.EvaluationResultSubjectFactory.assertThatEvaluationResult;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.analysis.BlazeDirectories;
+import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
+import com.google.devtools.build.lib.analysis.util.AnalysisMock;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.rules.platform.ToolchainTestCase;
+import com.google.devtools.build.lib.skyframe.ToolchainTypeLookupUtil.InvalidToolchainTypeException;
+import com.google.devtools.build.lib.skyframe.util.SkyframeExecutorTestUtils;
+import com.google.devtools.build.skyframe.EvaluationResult;
+import com.google.devtools.build.skyframe.SkyFunction;
+import com.google.devtools.build.skyframe.SkyFunctionException;
+import com.google.devtools.build.skyframe.SkyFunctionName;
+import com.google.devtools.build.skyframe.SkyKey;
+import com.google.devtools.build.skyframe.SkyValue;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ToolchainTypeLookupUtil}. */
+@RunWith(JUnit4.class)
+public class ToolchainTypeLookupUtilTest extends ToolchainTestCase {
+
+  /**
+   * An {@link AnalysisMock} that injects {@link GetToolchainTypeInfoFunction} into the Skyframe
+   * executor.
+   */
+  private static final class AnalysisMockWithGetToolchainTypeInfoFunction
+      extends AnalysisMock.Delegate {
+    AnalysisMockWithGetToolchainTypeInfoFunction() {
+      super(AnalysisMock.get());
+    }
+
+    @Override
+    public ImmutableMap<SkyFunctionName, SkyFunction> getSkyFunctions(
+        BlazeDirectories directories) {
+      return ImmutableMap.<SkyFunctionName, SkyFunction>builder()
+          .putAll(super.getSkyFunctions(directories))
+          .put(GET_TOOLCHAIN_TYPE_INFO_FUNCTION, new GetToolchainTypeInfoFunction())
+          .build();
+    }
+  }
+
+  @Override
+  protected AnalysisMock getAnalysisMock() {
+    return new AnalysisMockWithGetToolchainTypeInfoFunction();
+  }
+
+  @Test
+  public void testToolchainTypeLookup() throws Exception {
+    ConfiguredTargetKey testToolchainTypeKey =
+        ConfiguredTargetKey.of(testToolchainTypeLabel, targetConfigKey, false);
+    GetToolchainTypeInfoKey key =
+        GetToolchainTypeInfoKey.create(ImmutableList.of(testToolchainTypeKey));
+
+    EvaluationResult<GetToolchainTypeInfoValue> result = getToolchainTypeInfo(key);
+
+    assertThatEvaluationResult(result).hasNoError();
+    assertThatEvaluationResult(result).hasEntryThat(key).isNotNull();
+
+    Map<Label, ToolchainTypeInfo> toolchainTypes = result.get(key).toolchainTypes();
+    assertThat(toolchainTypes)
+        .containsExactlyEntriesIn(ImmutableMap.of(testToolchainTypeLabel, testToolchainType));
+  }
+
+  @Test
+  public void testToolchainTypeLookup_toolchainAlias() throws Exception {
+    scratch.file(
+        "alias/BUILD", "alias(name = 'toolchain_type', actual = '" + testToolchainTypeLabel + "')");
+    Label aliasToolchainTypeLabel = makeLabel("//alias:toolchain_type");
+    ConfiguredTargetKey testToolchainTypeKey =
+        ConfiguredTargetKey.of(aliasToolchainTypeLabel, targetConfigKey, false);
+    GetToolchainTypeInfoKey key =
+        GetToolchainTypeInfoKey.create(ImmutableList.of(testToolchainTypeKey));
+
+    EvaluationResult<GetToolchainTypeInfoValue> result = getToolchainTypeInfo(key);
+
+    assertThatEvaluationResult(result).hasNoError();
+    assertThatEvaluationResult(result).hasEntryThat(key).isNotNull();
+
+    Map<Label, ToolchainTypeInfo> toolchainTypes = result.get(key).toolchainTypes();
+    assertThat(toolchainTypes)
+        .containsExactlyEntriesIn(
+            ImmutableMap.of(
+                testToolchainTypeLabel,
+                testToolchainType,
+                aliasToolchainTypeLabel,
+                testToolchainType));
+  }
+
+  @Test
+  public void testToolchainTypeLookup_targetNotToolchainType() throws Exception {
+    scratch.file("invalid/BUILD", "filegroup(name = 'not_a_toolchain_type')");
+
+    ConfiguredTargetKey targetKey =
+        ConfiguredTargetKey.of(makeLabel("//invalid:not_a_toolchain_type"), targetConfigKey, false);
+    GetToolchainTypeInfoKey key = GetToolchainTypeInfoKey.create(ImmutableList.of(targetKey));
+
+    EvaluationResult<GetToolchainTypeInfoValue> result = getToolchainTypeInfo(key);
+
+    assertThatEvaluationResult(result).hasError();
+    assertThatEvaluationResult(result)
+        .hasErrorEntryForKeyThat(key)
+        .hasExceptionThat()
+        .isInstanceOf(InvalidToolchainTypeException.class);
+    assertThatEvaluationResult(result)
+        .hasErrorEntryForKeyThat(key)
+        .hasExceptionThat()
+        .hasMessageThat()
+        .contains("//invalid:not_a_toolchain_type");
+  }
+
+  @Test
+  public void testToolchainTypeLookup_targetDoesNotExist() throws Exception {
+    ConfiguredTargetKey targetKey =
+        ConfiguredTargetKey.of(makeLabel("//fake:missing"), targetConfigKey, false);
+    GetToolchainTypeInfoKey key = GetToolchainTypeInfoKey.create(ImmutableList.of(targetKey));
+
+    EvaluationResult<GetToolchainTypeInfoValue> result = getToolchainTypeInfo(key);
+
+    assertThatEvaluationResult(result).hasError();
+    assertThatEvaluationResult(result)
+        .hasErrorEntryForKeyThat(key)
+        .hasExceptionThat()
+        .isInstanceOf(InvalidToolchainTypeException.class);
+    assertThatEvaluationResult(result)
+        .hasErrorEntryForKeyThat(key)
+        .hasExceptionThat()
+        .hasMessageThat()
+        .contains("no such package 'fake': BUILD file not found");
+  }
+
+  // Calls ToolchainTypeLookupUtil.getToolchainTypeInfo.
+  private static final SkyFunctionName GET_TOOLCHAIN_TYPE_INFO_FUNCTION =
+      SkyFunctionName.createHermetic("GET_TOOLCHAIN_TYPE_INFO_FUNCTION");
+
+  @AutoValue
+  abstract static class GetToolchainTypeInfoKey implements SkyKey {
+    @Override
+    public SkyFunctionName functionName() {
+      return GET_TOOLCHAIN_TYPE_INFO_FUNCTION;
+    }
+
+    abstract Iterable<ConfiguredTargetKey> toolchainTypeKeys();
+
+    public static GetToolchainTypeInfoKey create(Iterable<ConfiguredTargetKey> toolchainTypeKeys) {
+      return new AutoValue_ToolchainTypeLookupUtilTest_GetToolchainTypeInfoKey(toolchainTypeKeys);
+    }
+  }
+
+  EvaluationResult<GetToolchainTypeInfoValue> getToolchainTypeInfo(GetToolchainTypeInfoKey key)
+      throws InterruptedException {
+    try {
+      // Must re-enable analysis for Skyframe functions that create configured targets.
+      skyframeExecutor.getSkyframeBuildView().enableAnalysis(true);
+      return SkyframeExecutorTestUtils.evaluate(
+          skyframeExecutor, key, /*keepGoing=*/ false, reporter);
+    } finally {
+      skyframeExecutor.getSkyframeBuildView().enableAnalysis(false);
+    }
+  }
+
+  @AutoValue
+  abstract static class GetToolchainTypeInfoValue implements SkyValue {
+    abstract Map<Label, ToolchainTypeInfo> toolchainTypes();
+
+    static GetToolchainTypeInfoValue create(Map<Label, ToolchainTypeInfo> toolchainTypes) {
+      return new AutoValue_ToolchainTypeLookupUtilTest_GetToolchainTypeInfoValue(toolchainTypes);
+    }
+  }
+
+  private static final class GetToolchainTypeInfoFunction implements SkyFunction {
+
+    @Nullable
+    @Override
+    public SkyValue compute(SkyKey skyKey, Environment env)
+        throws SkyFunctionException, InterruptedException {
+      GetToolchainTypeInfoKey key = (GetToolchainTypeInfoKey) skyKey;
+      try {
+        Map<Label, ToolchainTypeInfo> toolchainTypes =
+            ToolchainTypeLookupUtil.resolveToolchainTypes(env, key.toolchainTypeKeys(), false);
+        if (env.valuesMissing()) {
+          return null;
+        }
+        return GetToolchainTypeInfoValue.create(toolchainTypes);
+      } catch (InvalidToolchainTypeException e) {
+        throw new GetToolchainTypeInfoFunctionException(e);
+      }
+    }
+
+    @Nullable
+    @Override
+    public String extractTag(SkyKey skyKey) {
+      return null;
+    }
+  }
+
+  private static class GetToolchainTypeInfoFunctionException extends SkyFunctionException {
+    public GetToolchainTypeInfoFunctionException(InvalidToolchainTypeException e) {
+      super(e, Transience.PERSISTENT);
+    }
+  }
+}


### PR DESCRIPTION
This allows Bazel to validate toolchain types earleir, and to deal with
aliases to toolchain types.

Fixes #7404.