### PR TITLE
Change visibility of Starlark target to public

### DIFF
--- a/src/main/java/com/google/devtools/starlark/BUILD
+++ b/src/main/java/com/google/devtools/starlark/BUILD
@@ -20,6 +20,7 @@ java_binary(
         "//src/main/java/com/google/devtools/build/lib:events",
         "//src/main/java/com/google/devtools/build/lib:packages-internal",
     ],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(


### PR DESCRIPTION
Changing visibility to public will make it possible to include the implementation of starlark in Java as an external dependency to other bazel projects.
Use case is creating a common test suite for starlark, more details here: https://github.com/bazelbuild/starlark/issues/10

+@laurentlb