### PR TITLE
Windows: Add BAZEL_VC_FULL_VERSION for windows cc configuration

### DIFF
--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -140,13 +140,13 @@ To build C++ targets, you need:
         [known issue](https://github.com/bazelbuild/bazel/issues/3949),
         please upgrade your VS 2017 to the latest version.
 
-*   The `BAZEL_VS` , `BAZEL_VC` and `BAZEL_VC_FULL_VERSION` environment variable. (They are *not* the same!)
+*   The `BAZEL_VS`, `BAZEL_VC` and `BAZEL_VC_FULL_VERSION` environment variable.
 
     Bazel tries to locate the C++ compiler the first time you build any
-    target. To tell Bazel where the compiler is, we provide the
+    target. To tell Bazel where the compiler is, you can set the
     following environment variables:
 
-    For Visual Studio 2017 and 2019, setting one of `BAZEL_VC` or `BAZEL_VS`, `BAZEL_VC_FULL_VERSION` is optional:
+    For Visual Studio 2017 and 2019, set one of `BAZEL_VC` or `BAZEL_VS`. Additionally you may also set `BAZEL_VC_FULL_VERSION`.
 
     *   `BAZEL_VS` the Visual Studio installation directory
 
@@ -167,7 +167,7 @@ To build C++ targets, you need:
         set BAZEL_VC_FULL_VERSION=14.16.27023
         ```
 
-    For Visual Studio 2015 or older, setting one of `BAZEL_VC` or `BAZEL_VS` is enough.
+    For Visual Studio 2015 or older, set `BAZEL_VC` or `BAZEL_VS`. (`BAZEL_VC_FULL_VERSION` is not supported.)
 
     *   `BAZEL_VS` the Visual Studio installation directory
 

--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -146,46 +146,39 @@ To build C++ targets, you need:
     target. To tell Bazel where the compiler is, we provide the
     following environment variables:
 
-    *   `BAZEL_VS` storing the Visual Studio installation directory
+    For Visual Studio 2017 and 2019, setting one of `BAZEL_VC` or `BAZEL_VS`, `BAZEL_VC_FULL_VERSION` is optional:
 
-    *   `BAZEL_VC` storing the Visual C++ Build Tools installation directory
+    *   `BAZEL_VS` the Visual Studio installation directory
 
-    *   `BAZEL_VC_FULL_VERSION` Only for Visual Studio 2017 & 2019, the full version number of your Visual C++ Build Tools
+        ```
+        set BAZEL_VS=C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools
+        ```
+
+    *   `BAZEL_VC` the Visual C++ Build Tools installation directory
+        ```
+        set BAZEL_VC=C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC
+        ```
+
+    *   `BAZEL_VC_FULL_VERSION` (Optional) Only for Visual Studio 2017 and 2019, the full version
+        number of your Visual C++ Build Tools. You can choose the exact Visual C++ Build Tools
+        version via `BAZEL_VC_FULL_VERSION` if more than one version are installed, otherwise Bazel
+        will choose the latest version.
+        ```
+        set BAZEL_VC_FULL_VERSION=14.16.27023
+        ```
 
     For Visual Studio 2015 or older, setting one of `BAZEL_VC` or `BAZEL_VS` is enough.
 
-    ```
-    set BAZEL_VS=C:\Program Files (x86)\Microsoft Visual Studio 14.0
-    ```
+    *   `BAZEL_VS` the Visual Studio installation directory
 
-    or
+        ```
+        set BAZEL_VS=C:\Program Files (x86)\Microsoft Visual Studio 14.0
+        ```
 
-    ```
-    set BAZEL_VC=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC
-    ```
-
-    The first command sets the path to Visual Studio (BAZEL\_V<b>S</b>), the other
-    sets the path to Visual C++ (BAZEL\_V<b>C</b>).
-
-    For Visual Studio 2017 & 2019, besides setting one of `BAZEL_VC` or `BAZEL_VS`, you can specify
-    the full version number of your Visual C++ Build Tools via `BAZEL_VC_FULL_VERSION` if more than
-    one version are installed, otherwise Bazel will choose the latest version.
-
-    ```
-    set BAZEL_VS=C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools
-    ```
-
-    or
-
-     ```
-    set BAZEL_VC=C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC
-    ```
-
-    and to specify the exact Visual C++ Build Tools version:
-
-    ```
-    set BAZEL_VC_FULL_VERSION=14.16.27023
-    ```
+    *   `BAZEL_VC` the Visual C++ Build Tools installation directory
+        ```
+        set BAZEL_VC=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC
+        ```
 
 *   The [Windows
     SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk).

--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -140,17 +140,19 @@ To build C++ targets, you need:
         [known issue](https://github.com/bazelbuild/bazel/issues/3949),
         please upgrade your VS 2017 to the latest version.
 
-*   The `BAZEL_VS` or `BAZEL_VC` environment variable. (They are *not* the same!)
+*   The `BAZEL_VS` , `BAZEL_VC` and `BAZEL_VC_FULL_VERSION` environment variable. (They are *not* the same!)
 
     Bazel tries to locate the C++ compiler the first time you build any
-    target. To tell Bazel where the compiler is, you can set one of the
+    target. To tell Bazel where the compiler is, we provide the
     following environment variables:
 
     *   `BAZEL_VS` storing the Visual Studio installation directory
 
     *   `BAZEL_VC` storing the Visual C++ Build Tools installation directory
 
-    Setting one of these variables is enough. For example:
+    *   `BAZEL_VC_FULL_VERSION` Only for Visual Studio 2017 & 2019, the full version number of your Visual C++ Build Tools
+
+    For Visual Studio 2015 or older, setting one of `BAZEL_VC` or `BAZEL_VS` is enough.
 
     ```
     set BAZEL_VS=C:\Program Files (x86)\Microsoft Visual Studio 14.0
@@ -165,7 +167,9 @@ To build C++ targets, you need:
     The first command sets the path to Visual Studio (BAZEL\_V<b>S</b>), the other
     sets the path to Visual C++ (BAZEL\_V<b>C</b>).
 
-    For Visual Studio 2017, with a default install, instead you might want
+    For Visual Studio 2017 & 2019, besides setting one of `BAZEL_VC` or `BAZEL_VS`, you can specify
+    the full version number of your Visual C++ Build Tools via `BAZEL_VC_FULL_VERSION` if more than
+    one version are installed, otherwise Bazel will choose the latest version.
 
     ```
     set BAZEL_VS=C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools
@@ -175,6 +179,12 @@ To build C++ targets, you need:
 
      ```
     set BAZEL_VC=C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC
+    ```
+
+    and to specify the exact Visual C++ Build Tools version:
+
+    ```
+    set BAZEL_VC_FULL_VERSION=14.16.27023
     ```
 
 *   The [Windows

--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -67,6 +67,7 @@ cc_autoconf = repository_rule(
         "BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN",
         "BAZEL_USE_LLVM_NATIVE_COVERAGE",
         "BAZEL_VC",
+        "BAZEL_VC_FULL_VERSION",
         "BAZEL_VS",
         "BAZEL_LLVM",
         "USE_CLANG_CL",

--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -282,9 +282,6 @@ def _get_latest_subversion(repository_ctx, vc_path):
       <vc_path>\\Tools\\MSVC\\14.10.24930\\bin\\HostX64\\x64
       <vc_path>\\Tools\\MSVC\\14.16.27023\\bin\\HostX64\\x64
     This function should return 14.16.27023 in this case."""
-    if not _is_vs_2017_or_2019(vc_path):
-        auto_configure_fail(repository_ctx, "Cannot calculate latest subversion from VC build tool older than 2017")
-
     versions = [path.basename for path in repository_ctx.path(vc_path + "\\Tools\\MSVC").readdir()]
     if len(versions) < 1:
         _auto_configure_warning_maybe(repository_ctx, "Cannot find any VC installation under BAZEL_VC(%s)" % vc_path)

--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -251,10 +251,15 @@ def setup_vc_env_vars(repository_ctx, vc_path):
     vcvarsall = _find_vcvarsall_bat_script(repository_ctx, vc_path)
     if not vcvarsall:
         return None
+    vcvars_ver = ""
+    if _is_vs_2017_or_2019(vc_path):
+        full_version = _get_vc_full_version(repository_ctx, vc_path)
+        if full_version:
+            vcvars_ver = "-vcvars_ver=" + full_version
     repository_ctx.file(
         "get_env.bat",
         "@echo off\n" +
-        "call \"" + vcvarsall + "\" amd64 > NUL \n" +
+        ("call \"%s\" amd64 %s > NUL \n" % (vcvarsall, vcvars_ver)) +
         "echo PATH=%PATH%,INCLUDE=%INCLUDE%,LIB=%LIB%,WINDOWSSDKDIR=%WINDOWSSDKDIR% \n",
         True,
     )
@@ -269,28 +274,47 @@ def setup_vc_env_vars(repository_ctx, vc_path):
         env_map[key] = escape_string(value.replace("\\", "\\\\"))
     return env_map
 
+def _get_latest_subversion(repository_ctx, vc_path):
+    """Get the latest subversion of a VS 2017/2019 installation.
+
+    For VS 2017 & 2019, there could be multiple versions of VC build tools.
+    The directories are like:
+      <vc_path>\\Tools\\MSVC\\14.10.24930\\bin\\HostX64\\x64
+      <vc_path>\\Tools\\MSVC\\14.16.27023\\bin\\HostX64\\x64
+    This function should return 14.16.27023 in this case."""
+    if not _is_vs_2017_or_2019(vc_path):
+        auto_configure_fail(repository_ctx, "Cannot calculate latest subversion from VC build tool older than 2017")
+
+    versions = [path.basename for path in repository_ctx.path(vc_path + "\\Tools\\MSVC").readdir()]
+    if len(versions) < 1:
+        _auto_configure_warning_maybe(repository_ctx, "Cannot find any VC installation under BAZEL_VC(%s)" % vc_path)
+        return None
+
+    versions = sorted(versions)
+    latest_version = versions[-1]
+
+    _auto_configure_warning_maybe(repository_ctx, "Found the following VC verisons:\n%s\n\nChoosing the latest version = %s" % ("\n".join(versions), latest_version))
+    return latest_version
+
+def _get_vc_full_version(repository_ctx, vc_path):
+    """Return the value of BAZEL_VC_FULL_VERSION if defined, otherwise the latest version."""
+    if "BAZEL_VC_FULL_VERSION" in repository_ctx.os.environ:
+        return repository_ctx.os.environ["BAZEL_VC_FULL_VERSION"]
+    return _get_latest_subversion(repository_ctx, vc_path)
+
 def find_msvc_tool(repository_ctx, vc_path, tool):
     """Find the exact path of a specific build tool in MSVC. Doesn't %-escape the result."""
-    tool_path = ""
+    tool_path = None
     if _is_vs_2017_or_2019(vc_path):
-        # For VS 2017 and 2019, the tools are under a directory like:
-        # C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Tools\MSVC\14.10.24930\bin\HostX64\x64
-        dirs = repository_ctx.path(vc_path + "\\Tools\\MSVC").readdir()
-        if len(dirs) < 1:
-            return None
-
-        # Normally there should be only one child directory under %VC_PATH%\TOOLS\MSVC,
-        # but iterate every directory to be more robust.
-        for path in dirs:
-            tool_path = str(path) + "\\bin\\HostX64\\x64\\" + tool
-            if repository_ctx.path(tool_path).exists:
-                break
+        full_version = _get_vc_full_version(repository_ctx, vc_path)
+        if full_version:
+            tool_path = "%s\\Tools\\MSVC\\%s\\bin\\HostX64\\x64\\%s" % (vc_path, full_version, tool)
     else:
         # For VS 2015 and older version, the tools are under:
         # C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64
         tool_path = vc_path + "\\bin\\amd64\\" + tool
 
-    if not repository_ctx.path(tool_path).exists:
+    if not tool_path or not repository_ctx.path(tool_path).exists:
         return None
 
     return tool_path.replace("\\", "/")

--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -287,8 +287,14 @@ def _get_latest_subversion(repository_ctx, vc_path):
         _auto_configure_warning_maybe(repository_ctx, "Cannot find any VC installation under BAZEL_VC(%s)" % vc_path)
         return None
 
-    versions = sorted(versions)
-    latest_version = versions[-1]
+    # Parse the version string into integers, then sort the integers to prevent textual sorting.
+    version_list = []
+    for version in versions:
+        parts = [int(i) for i in version.split(".")]
+        version_list.append((parts, version))
+
+    version_list = sorted(version_list)
+    latest_version = version_list[-1][1]
 
     _auto_configure_warning_maybe(repository_ctx, "Found the following VC verisons:\n%s\n\nChoosing the latest version = %s" % ("\n".join(versions), latest_version))
     return latest_version


### PR DESCRIPTION
This will support specifying the exact Visual C++ Build Tools version by `BAZEL_VC_FULL_VERSION` environment variable. 

Working towards: https://github.com/bazelbuild/bazel/issues/8353

This is a replacement of https://github.com/bazelbuild/bazel/pull/7686