### PR TITLE
Update BranchDetailAnalyzer.

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
@@ -86,7 +86,7 @@ java_library(
         "//src/main/protobuf:worker_protocol_java_proto",
         "//third_party:guava",
         "//third_party:jsr305",
-        "//third_party/java/jacoco:core",
+        "//third_party/java/jacoco:core-0.8.3",
         "//third_party/java/jdk/langtools:javac",
     ],
 )

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
@@ -158,7 +158,7 @@ bootstrap_java_library(
         "//third_party:bootstrap_guava_and_error_prone-jars",
         "//third_party:jsr305-jars",
         "//third_party/protobuf:protobuf-jars",
-        "//third_party/java/jacoco:core-jars",
+        "//third_party/java/jacoco:core-jars-0.8.3",
         "//third_party/grpc:bootstrap-grpc-jars",
         "//third_party:tomcat_annotations_api-jars",
     ],

--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/BranchDetailAnalyzer.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/BranchDetailAnalyzer.java
@@ -14,6 +14,9 @@
 
 package com.google.testing.coverage;
 
+import com.google.testing.coverage.BranchCoverageDetail;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -22,6 +25,7 @@ import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.ICoverageVisitor;
 import org.jacoco.core.data.ExecutionData;
 import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.internal.InputStreams;
 import org.jacoco.core.internal.data.CRC64;
 import org.jacoco.core.internal.flow.ClassProbesAdapter;
 import org.objectweb.asm.ClassReader;
@@ -38,14 +42,35 @@ public class BranchDetailAnalyzer extends Analyzer {
   private final Map<String, BranchCoverageDetail> branchDetails;
 
   public BranchDetailAnalyzer(final ExecutionDataStore executionData) {
-    super(executionData, new ICoverageVisitor() {
-      @Override
-      public void visitCoverage(IClassCoverage coverage) {
-      }
-    });
-
+    super(
+        executionData,
+        new ICoverageVisitor() {
+          @Override
+          public void visitCoverage(IClassCoverage coverage) {}
+        });
     this.executionData = executionData;
     this.branchDetails = new TreeMap<String, BranchCoverageDetail>();
+  }
+
+  // Override all analyzeClass methods.
+  @Override
+  public void analyzeClass(final InputStream input, final String location) throws IOException {
+    final byte[] buffer;
+    try {
+      buffer = InputStreams.readFully(input);
+    } catch (final IOException e) {
+      throw analyzerError(location, e);
+    }
+    analyzeClass(buffer, location);
+  }
+
+  @Override
+  public void analyzeClass(final byte[] buffer, final String location) throws IOException {
+    try {
+      analyzeClass(buffer);
+    } catch (final RuntimeException cause) {
+      throw analyzerError(location, cause);
+    }
   }
 
   @Override
@@ -76,6 +101,17 @@ public class BranchDetailAnalyzer extends Analyzer {
     if (detail.linesWithBranches().size() > 0) {
       branchDetails.put(reader.getClassName(), detail);
     }
+  }
+
+  private void analyzeClass(final byte[] source) {
+    final ClassReader reader = new ClassReader(source);
+    analyzeClass(reader);
+  }
+
+  private IOException analyzerError(final String location, final Exception cause) {
+    final IOException ex = new IOException(String.format("Error while analyzing %s.", location));
+    ex.initCause(cause);
+    return ex;
   }
 
   // Generate the line to probeExp map so that we can evaluate the coverage.

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -59,8 +59,7 @@ java_toolchain(
         ":java_compiler_jar",
         ":jdk_compiler_jar",
     ],
-    # TODO(iirina): Re-enable this after #8378 is merged.
-    # jacocorunner = ":jacoco_coverage_runner"
+    jacocorunner = ":jacoco_coverage_runner"
 )
 
 filegroup(

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -135,14 +135,14 @@ filegroup(
 
 java_import(
     name = "jacoco-agent",
-    jars = ["java_tools/third_party/java/jacoco/org.jacoco.agent-0.7.5.201505241946.jar"],
-    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.agent-0.7.5.201505241946-src.jar",
+    jars = ["java_tools/third_party/java/jacoco/org.jacoco.agent-0.8.3.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.agent-0.8.3-src.jar",
 )
 
 java_import(
     name = "jacoco-core",
-    jars = ["java_tools/third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946.jar"],
-    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946-src.jar",
+    jars = ["java_tools/third_party/java/jacoco/org.jacoco.core-0.8.3.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.core-0.8.3-src.jar",
     exports = [
         ":asm",
         ":asm-commons",
@@ -152,13 +152,13 @@ java_import(
 
 filegroup(
     name = "jacoco-core-jars",
-    srcs = ["java_tools/third_party/java/jacoco/org.jacoco.core-0.7.5.201505241946.jar"],
+    srcs = ["java_tools/third_party/java/jacoco/org.jacoco.core-0.8.3.jar"],
 )
 
 java_import(
     name = "jacoco-report",
-    jars = ["java_tools/third_party/java/jacoco/org.jacoco.report-0.7.5.201505241946.jar"],
-    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.report-0.7.5.201505241946-src.jar",
+    jars = ["java_tools/third_party/java/jacoco/org.jacoco.report-0.8.3.jar"],
+    srcjar = "java_tools/third_party/java/jacoco/org.jacoco.report-sources.jar",
     exports = [
         ":asm",
         ":jacoco-core",
@@ -167,12 +167,12 @@ java_import(
 
 java_import(
     name = "bazel-jacoco-agent",
-    jars = ["java_tools/third_party/java/jacoco/jacocoagent.jar"],
+    jars = ["java_tools/third_party/java/jacoco/jacocoagent-0.8.3.jar"],
 )
 
 java_import(
     name = "bazel-jacoco-agent-neverlink",
-    jars = ["java_tools/third_party/java/jacoco/jacocoagent.jar"],
+    jars = ["java_tools/third_party/java/jacoco/jacocoagent-0.8.3.jar"],
     neverlink = 1,
 )
 


### PR DESCRIPTION
BranchDetailAnalyzer should have also been updated as part of https://github.com/bazelbuild/bazel/commit/ff1f74501ae275e87bc0d62d2d81881a40a216a0 when the jacoco version in bazel was updated. Also upgrade the JavaBuilder dependency.

Changes like this will be avoided after #8378 is merged, because it enables testing with the java coverage tools at head.