### PR TITLE
Remove macOS version check from xcode-locator

### DIFF
--- a/tools/osx/xcode_locator.m
+++ b/tools/osx/xcode_locator.m
@@ -177,16 +177,7 @@ static NSMutableDictionary<NSString *, XcodeVersionEntry *> *FindXcodes()
           url, version, expandedVersion);
 
     NSURL *versionPlistUrl = [url URLByAppendingPathComponent:@"Contents/version.plist"];
-
-    // macOS 10.13 changed the signature of initWithContentsOfURL,
-    // and deprecated the old one.
-    NSDictionary *versionPlistContents;
-#if MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_12
-    versionPlistContents = [[NSDictionary alloc] initWithContentsOfURL:versionPlistUrl error:nil];
-#else
-    versionPlistContents = [[NSDictionary alloc] initWithContentsOfURL:versionPlistUrl];
-#endif
-
+    NSDictionary *versionPlistContents = [[NSDictionary alloc] initWithContentsOfURL:versionPlistUrl];
     NSString *productVersion = [versionPlistContents objectForKey:@"ProductBuildVersion"];
     if (productVersion) {
       expandedVersion = [expandedVersion stringByAppendingFormat:@".%@", productVersion];


### PR DESCRIPTION
This check was added in 231270c67d5aa771462245531fa9b2ee7d3d0ae8 because
the original version only supported 10.13 and up. It seems like the
check is still wrong for macOS 10.12 https://github.com/bazelbuild/bazel/issues/8422

This older API isn't explicitly marked as deprecated yet, so using it
doesn't produce a warning. Until it is we can use this for all macOS
versions. When we need to change it, if we still want to support the old
versions, we will probably want a runtime check instead.

Fixes https://github.com/bazelbuild/bazel/issues/8422