### PR TITLE
Allow negation of log file paths

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
@@ -73,7 +73,7 @@ public final class SpawnLogModule extends BlazeModule {
     FileSystem fileSystem = env.getRuntime().getFileSystem();
     Path workingDirectory = env.getWorkingDirectory();
 
-    if (executionOptions.executionLogBinaryFile != null) {
+    if (executionOptions.executionLogBinaryFile != null && !executionOptions.executionLogBinaryFile.isEmpty()) {
       outputStreams.addStream(
           new BinaryOutputStreamWrapper(
               workingDirectory
@@ -81,7 +81,7 @@ public final class SpawnLogModule extends BlazeModule {
                   .getOutputStream()));
     }
 
-    if (executionOptions.executionLogJsonFile != null) {
+    if (executionOptions.executionLogJsonFile != null && !executionOptions.executionLogJsonFile.isEmpty()) {
       outputStreams.addStream(
           new JsonOutputStreamWrapper(
               workingDirectory
@@ -90,7 +90,7 @@ public final class SpawnLogModule extends BlazeModule {
     }
 
     AsynchronousFileOutputStream outStream = null;
-    if (executionOptions.executionLogFile != null) {
+    if (executionOptions.executionLogFile != null && !executionOptions.executionLogFile.isEmpty()) {
       rawOutput = workingDirectory.getRelative(executionOptions.executionLogFile);
       outStream =
           new AsynchronousFileOutputStream(

--- a/src/test/shell/bazel/bazel_execlog_test.sh
+++ b/src/test/shell/bazel/bazel_execlog_test.sh
@@ -119,4 +119,28 @@ EOF
   wc output || fail "no output produced"
 }
 
+function test_negating_flags() {
+  cat > BUILD <<'EOF'
+genrule(
+      name = "rule",
+      outs = ["out.txt"],
+      cmd = "echo hello > $(location out.txt)"
+)
+EOF
+  bazel build //:all --experimental_execution_log_file=output --experimental_execution_log_file= 2>&1 >> $TEST_log || fail "could not build"
+  if [[ -e output ]]; then
+    fail "file shouldn't exist"
+  fi
+
+  bazel build //:all --execution_log_json_file=output --execution_log_json_file= 2>&1 >> $TEST_log || fail "could not build"
+  if [[ -e output ]]; then
+    fail "file shouldn't exist"
+  fi
+
+  bazel build //:all --execution_log_binary_file=output --execution_log_binary_file= 2>&1 >> $TEST_log || fail "could not build"
+  if [[ -e output ]]; then
+    fail "file shouldn't exist"
+  fi
+}
+
 run_suite "execlog_tests"


### PR DESCRIPTION
Previously when passing `experimental_execution_log_file`, you could pass a second empty version of this like `--experimental_execution_log_file=` to negate previous callers. This broke recently and the replacement flags didn't support this behavior. Now this is supported for all the related flags.

Fixes: https://github.com/bazelbuild/bazel/issues/8393