### PR TITLE
Fixed Python 3 incompatibility in make_rpm tool 

### DIFF
--- a/tools/build_defs/pkg/make_rpm.py
+++ b/tools/build_defs/pkg/make_rpm.py
@@ -250,7 +250,7 @@ class RpmBuilder(object):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         env={'LANG': 'C'})
-    output = p.communicate()[0]
+    output = p.communicate()[0].decode()
 
     if p.returncode == 0:
       # Find the created file.

--- a/tools/build_defs/pkg/make_rpm_test.py
+++ b/tools/build_defs/pkg/make_rpm_test.py
@@ -148,6 +148,32 @@ class MakeRpmTest(unittest.TestCase):
           self.assertTrue(FileExists('BUILD/file2.txt'))
           self.assertCountEqual(['Goodbye'], FileContents('BUILD/file2.txt'))
 
+  def testBuild(self):
+    with make_rpm.Tempdir() as outer:
+      dummy = os.sep.join([outer, 'rpmbuild'])
+      WriteFile(
+        dummy,
+        '#!/bin/sh',
+        'mkdir -p RPMS',
+        'touch RPMS/test.rpm',
+        'echo "Wrote: $PWD/RPMS/test.rpm"',
+      )
+      os.chmod(dummy, 0o777)
+
+      with PrependPath([outer]):
+        # Create the builder and exercise it.
+        builder = make_rpm.RpmBuilder('test', '1.0', '0', 'x86', False, None)
+
+        # Create spec_file, test files.
+        WriteFile('test.spec', 'Name: test', 'Version: 0.1',
+                  'Summary: test data')
+
+        # Call RpmBuilder.
+        builder.Build('test.spec', 'test.rpm')
+
+        # Make sure files exist.
+        self.assertTrue(FileExists('test.rpm'))
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This addresses #7914 , i.e. allowing the `pkg_rpm` rule to be used with either a PY2 or PY3 host configuration, by fixing a Python 3 incompatibility in `make_rpm.py`.

I added a test case that ensures the fixed codepath is covered. It effectively fakes out the `rpmbuild` executable with a shell script, so I'm not sure if there will be concerns with cross-platform compatibility. If so, I could create a Python script for this, or I'm open to other suggestions. 