### PR TITLE
Windows, launcher: support python/bash toolchain

### DIFF
--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -31,8 +31,10 @@ static constexpr const char* BASH_BIN_PATH = "bash_bin_path";
 ExitCode BashBinaryLauncher::Launch() {
   wstring bash_binary = this->GetLaunchInfoByKey(BASH_BIN_PATH);
 
-  // Rlocation returns the original path if bash_binary is an absolute path.
-  bash_binary = this->Rlocation(bash_binary, true);
+  if (GetBinaryPathWithoutExtension(bash_binary) == "bash") {
+    // Rlocation returns the original path if bash_binary is an absolute path.
+    bash_binary = this->Rlocation(bash_binary, true);
+  }
 
   if (DoesFilePathExist(bash_binary.c_str())) {
     wstring bash_bin_dir = GetParentDirFromPath(bash_binary);

--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -31,7 +31,7 @@ static constexpr const char* BASH_BIN_PATH = "bash_bin_path";
 ExitCode BashBinaryLauncher::Launch() {
   wstring bash_binary = this->GetLaunchInfoByKey(BASH_BIN_PATH);
 
-  if (GetBinaryPathWithoutExtension(bash_binary) == "bash") {
+  if (GetBinaryPathWithoutExtension(bash_binary) == L"bash") {
     // Rlocation returns the original path if bash_binary is an absolute path.
     bash_binary = this->Rlocation(bash_binary, true);
   }

--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -31,6 +31,8 @@ static constexpr const char* BASH_BIN_PATH = "bash_bin_path";
 ExitCode BashBinaryLauncher::Launch() {
   wstring bash_binary = this->GetLaunchInfoByKey(BASH_BIN_PATH);
 
+  // If bash_binary is already "bash" or "bash.exe", that means we want to
+  // rely on the shell binary in PATH, no need to do Rlocation.
   if (GetBinaryPathWithoutExtension(bash_binary) != L"bash") {
     // Rlocation returns the original path if bash_binary is an absolute path.
     bash_binary = this->Rlocation(bash_binary, true);

--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -30,6 +30,10 @@ static constexpr const char* BASH_BIN_PATH = "bash_bin_path";
 
 ExitCode BashBinaryLauncher::Launch() {
   wstring bash_binary = this->GetLaunchInfoByKey(BASH_BIN_PATH);
+
+  // Rlocation returns the original path if bash_binary is an absolute path.
+  bash_binary = this->Rlocation(bash_binary, true);
+
   if (DoesFilePathExist(bash_binary.c_str())) {
     wstring bash_bin_dir = GetParentDirFromPath(bash_binary);
     wstring path_env;

--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -31,7 +31,7 @@ static constexpr const char* BASH_BIN_PATH = "bash_bin_path";
 ExitCode BashBinaryLauncher::Launch() {
   wstring bash_binary = this->GetLaunchInfoByKey(BASH_BIN_PATH);
 
-  if (GetBinaryPathWithoutExtension(bash_binary) == L"bash") {
+  if (GetBinaryPathWithoutExtension(bash_binary) != L"bash") {
     // Rlocation returns the original path if bash_binary is an absolute path.
     bash_binary = this->Rlocation(bash_binary, true);
   }

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -31,11 +31,14 @@ static constexpr const char* WINDOWS_STYLE_ESCAPE_JVM_FLAGS = "escape_args";
 ExitCode PythonBinaryLauncher::Launch() {
   wstring python_binary = this->GetLaunchInfoByKey(PYTHON_BIN_PATH);
 
-  // The value of python_binary could be the following cases:
-  //   1. if --python_top or python toolchains are used, it should be the
-  //      runfile path of the Python binary.
-  //   2. if --python_path is used, it should be an absolute path to the Python binary.
-  //   3. if none of above are specified, it should be just "python".
+  // There are three kinds of values for `python_binary`:
+  // 1. An absolute path to a system interpreter. This is the case if `--python_path` is set by the
+  //    user, or if a `py_runtime` is used that has `interpreter_path` set.
+  // 2. A runfile path to an in-workspace interpreter. This is the case if a `py_runtime` is used
+  //    that has `interpreter` set.
+  // 3. The special constant, "python". This is the default case if neither of the above apply.
+  // Rlocation resolves runfiles paths to absolute paths, and if given an absolute path it leaves
+  // it alone, so it's suitable for cases 1 and 2.
   if (GetBinaryPathWithoutExtension(python_binary) != L"python") {
     // Rlocation returns the original path if python_binary is an absolute path.
     python_binary = this->Rlocation(python_binary, true);

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -30,6 +30,10 @@ static constexpr const char* WINDOWS_STYLE_ESCAPE_JVM_FLAGS = "escape_args";
 
 ExitCode PythonBinaryLauncher::Launch() {
   wstring python_binary = this->GetLaunchInfoByKey(PYTHON_BIN_PATH);
+
+  // Rlocation returns the original path if python_binary is an absolute path.
+  python_binary = this->Rlocation(python_binary, true);
+
   // If specified python binary path doesn't exist, then fall back to
   // python.exe and hope it's in PATH.
   if (!DoesFilePathExist(python_binary.c_str())) {

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -31,8 +31,10 @@ static constexpr const char* WINDOWS_STYLE_ESCAPE_JVM_FLAGS = "escape_args";
 ExitCode PythonBinaryLauncher::Launch() {
   wstring python_binary = this->GetLaunchInfoByKey(PYTHON_BIN_PATH);
 
-  // Rlocation returns the original path if python_binary is an absolute path.
-  python_binary = this->Rlocation(python_binary, true);
+  if (GetBinaryPathWithoutExtension(python_binary) == "python") {
+    // Rlocation returns the original path if python_binary is an absolute path.
+    python_binary = this->Rlocation(python_binary, true);
+  }
 
   // If specified python binary path doesn't exist, then fall back to
   // python.exe and hope it's in PATH.

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -31,8 +31,11 @@ static constexpr const char* WINDOWS_STYLE_ESCAPE_JVM_FLAGS = "escape_args";
 ExitCode PythonBinaryLauncher::Launch() {
   wstring python_binary = this->GetLaunchInfoByKey(PYTHON_BIN_PATH);
 
-  // If python binary is already "python" or "python.exe", that means we want to
-  // rely on the python binary in PATH, no need to do Rlocation.
+  // The value of python_binary could be the following cases:
+  //   1. if --python_top or python toolchains are used, it should be the
+  //      runfile path of the Python binary.
+  //   2. if --python_path is used, it should be an absolute path to the Python binary.
+  //   3. if none of above are specified, it should be just "python".
   if (GetBinaryPathWithoutExtension(python_binary) != L"python") {
     // Rlocation returns the original path if python_binary is an absolute path.
     python_binary = this->Rlocation(python_binary, true);

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -31,7 +31,7 @@ static constexpr const char* WINDOWS_STYLE_ESCAPE_JVM_FLAGS = "escape_args";
 ExitCode PythonBinaryLauncher::Launch() {
   wstring python_binary = this->GetLaunchInfoByKey(PYTHON_BIN_PATH);
 
-  if (GetBinaryPathWithoutExtension(python_binary) == "python") {
+  if (GetBinaryPathWithoutExtension(python_binary) == L"python") {
     // Rlocation returns the original path if python_binary is an absolute path.
     python_binary = this->Rlocation(python_binary, true);
   }

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -31,7 +31,7 @@ static constexpr const char* WINDOWS_STYLE_ESCAPE_JVM_FLAGS = "escape_args";
 ExitCode PythonBinaryLauncher::Launch() {
   wstring python_binary = this->GetLaunchInfoByKey(PYTHON_BIN_PATH);
 
-  if (GetBinaryPathWithoutExtension(python_binary) == L"python") {
+  if (GetBinaryPathWithoutExtension(python_binary) != L"python") {
     // Rlocation returns the original path if python_binary is an absolute path.
     python_binary = this->Rlocation(python_binary, true);
   }

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -31,6 +31,8 @@ static constexpr const char* WINDOWS_STYLE_ESCAPE_JVM_FLAGS = "escape_args";
 ExitCode PythonBinaryLauncher::Launch() {
   wstring python_binary = this->GetLaunchInfoByKey(PYTHON_BIN_PATH);
 
+  // If python binary is already "python" or "python.exe", that means we want to
+  // rely on the python binary in PATH, no need to do Rlocation.
   if (GetBinaryPathWithoutExtension(python_binary) != L"python") {
     // Rlocation returns the original path if python_binary is an absolute path.
     python_binary = this->Rlocation(python_binary, true);


### PR DESCRIPTION
Previously, we assume the python/bash binary path passed to the launcher is an absolute path specified by `--python_path` or `--shell_executable`, but this is not true when using python/shell toolchain. When using the python toolchain, the given python binary path will be a runfile path, we can use `Rlocation` to find the absolute path.

Fixes https://github.com/bazelbuild/bazel/issues/7947