### PR TITLE
Enable persistent workers for Desugar by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelStrategyModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelStrategyModule.java
@@ -70,6 +70,7 @@ public class BazelStrategyModule extends BlazeModule {
       builder.addStrategyByMnemonic("Javac", ImmutableList.of("worker"));
       builder.addStrategyByMnemonic("Closure", ImmutableList.of("worker"));
       builder.addStrategyByMnemonic("DexBuilder", ImmutableList.of("worker"));
+      builder.addStrategyByMnemonic("Desugar", ImmutableList.of("worker"));
 
       // The --spawn_strategy= flag is a bit special: If it's set to the empty string, we actually
       // have to pass a literal empty string to the builder to trigger the "use the strategy that


### PR DESCRIPTION
Default Desugar to use persistent workers as a sane default. Measured to reduce local build times by up to 20%.

RELNOTES: Android desugaring actions now use persistent workers by default. This has been measured to provide up to 20% reduction in build times. To disable it, use the `--strategy=Desugar=sandboxed` flag. See https://github.com/bazelbuild/bazel/issues/8342 and https://github.com/bazelbuild/bazel/issues/8427 for more details on local build speed optimization for Android apps.