### PR TITLE
Allow Starlark rules to be able to use the `exec_compatible_with`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkRuleFunctionsApi.java
@@ -280,7 +280,7 @@ public interface SkylarkRuleFunctionsApi<FileApiT extends FileApi> {
             type = Boolean.class,
             named = true,
             positional = false,
-            defaultValue = "False",
+            defaultValue = "True",
             disableWithFlag =
                 FlagIdentifier.INCOMPATIBLE_DISALLOW_RULE_EXECUTION_PLATFORM_CONSTRAINTS_ALLOWED,
             valueWhenDisabled = "True",


### PR DESCRIPTION
attribute by default.

Fixes #8451, part of #8134.