### PR TITLE
Split toolchains from cc_toolchains in cc_configure

### DIFF
--- a/tools/cpp/BUILD.toolchains.tpl
+++ b/tools/cpp/BUILD.toolchains.tpl
@@ -1,0 +1,20 @@
+load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
+toolchain(
+    name = "cc-toolchain-%{name}",
+    exec_compatible_with = HOST_CONSTRAINTS,
+    target_compatible_with = HOST_CONSTRAINTS,
+    toolchain = "@local_config_cc//:cc-compiler-%{name}",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+toolchain(
+    name = "cc-toolchain-armeabi-v7a",
+    exec_compatible_with = HOST_CONSTRAINTS,
+    target_compatible_with = [
+        "@bazel_tools//platforms:arm",
+        "@bazel_tools//platforms:android",
+    ],
+    toolchain = "@local_config_cc//:cc-compiler-armabi-v7a",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+

--- a/tools/cpp/BUILD.tpl
+++ b/tools/cpp/BUILD.tpl
@@ -18,7 +18,6 @@ package(default_visibility = ["//visibility:public"])
 
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 load(":armeabi_cc_toolchain_config.bzl", "armeabi_cc_toolchain_config")
-load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -93,14 +92,6 @@ cc_toolchain_config(
     supports_start_end_lib = %{supports_start_end_lib},
 )
 
-toolchain(
-    name = "cc-toolchain-%{name}",
-    exec_compatible_with = HOST_CONSTRAINTS,
-    target_compatible_with = HOST_CONSTRAINTS,
-    toolchain = ":cc-compiler-%{name}",
-    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
-)
-
 # Android tooling requires a default toolchain for the armeabi-v7a cpu.
 cc_toolchain(
     name = "cc-compiler-armeabi-v7a",
@@ -118,14 +109,3 @@ cc_toolchain(
 )
 
 armeabi_cc_toolchain_config(name = "stub_armeabi-v7a")
-
-toolchain(
-    name = "cc-toolchain-armeabi-v7a",
-    exec_compatible_with = HOST_CONSTRAINTS,
-    target_compatible_with = [
-        "@bazel_tools//platforms:arm",
-        "@bazel_tools//platforms:android",
-    ],
-    toolchain = ":cc-compiler-armabi-v7a",
-    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
-)

--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -22,26 +22,36 @@ load(
     "resolve_labels",
 )
 
+def cc_autoconf_toolchains_impl(repository_ctx, overriden_tools = dict()):
+    """Generate BUILD file with 'toolchain' targets for the local host C++ toolchain."""
+    print("Generating toolchains")
+    paths = resolve_labels(repository_ctx, [
+        "@bazel_tools//tools/cpp:BUILD.toolchains.tpl",
+    ])
+    env = repository_ctx.os.environ
+    cpu_value = get_cpu_value(repository_ctx)
+    if "BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN" in env and env["BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN"] == "1":
+        repository_ctx.file("BUILD", "# C++ toolchain autoconfiguration was disabled by BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN env variable.")
+    else:
+        repository_ctx.template(
+            "BUILD",
+            paths["@bazel_tools//tools/cpp:BUILD.toolchains.tpl"],
+            { "%{name}": cpu_value },
+        )
+
 cc_autoconf_toolchains = repository_rule(
     environ = [
         "BAZEL_USE_CPP_ONLY_TOOLCHAIN",
         "BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN",
     ],
-    implementation = cc_autoconf__toolchains_impl,
+    implementation = cc_autoconf_toolchains_impl,
 )
 
-def cc_autoconf__toolchains_impl(repository_ctx, overriden_tools = dict()):
-  """Generate BUILD file with 'toolchain' targets for the local host C++ toolchain."""
-    paths = resolve_labels(repository_ctx, [
-        "@bazel_tools//tools/cpp:BUILD.toolchains.tpl",
-    ])
-    env = repository_ctx.os.environ
-    if "BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN" in env and env["BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN"] == "1":
-        repository_ctx.file("BUILD", "# C++ toolchain autoconfiguration was disabled by BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN env variable.")
 
 
 def cc_autoconf_impl(repository_ctx, overriden_tools = dict()):
-  """Generate BUILD file with 'cc_toolchain' targets for the local host C++ toolchain."""
+    """Generate BUILD file with 'cc_toolchain' targets for the local host C++ toolchain."""
+    print("Generating cc toolchains")
     paths = resolve_labels(repository_ctx, [
         "@bazel_tools//tools/cpp:BUILD.static.freebsd",
         "@bazel_tools//tools/cpp:cc_toolchain_config.bzl",

--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -24,7 +24,6 @@ load(
 
 def cc_autoconf_toolchains_impl(repository_ctx, overriden_tools = dict()):
     """Generate BUILD file with 'toolchain' targets for the local host C++ toolchain."""
-    print("Generating toolchains")
     paths = resolve_labels(repository_ctx, [
         "@bazel_tools//tools/cpp:BUILD.toolchains.tpl",
     ])
@@ -32,6 +31,9 @@ def cc_autoconf_toolchains_impl(repository_ctx, overriden_tools = dict()):
     cpu_value = get_cpu_value(repository_ctx)
     if "BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN" in env and env["BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN"] == "1":
         repository_ctx.file("BUILD", "# C++ toolchain autoconfiguration was disabled by BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN env variable.")
+    elif (cpu_value == "darwin" and
+          ("BAZEL_USE_CPP_ONLY_TOOLCHAIN" not in env or env["BAZEL_USE_CPP_ONLY_TOOLCHAIN"] != "1")):
+        repository_ctx.symlink(paths["@bazel_tools//tools/osx/crosstool:BUILD.toolchains"], "BUILD")
     else:
         repository_ctx.template(
             "BUILD",
@@ -48,10 +50,8 @@ cc_autoconf_toolchains = repository_rule(
 )
 
 
-
 def cc_autoconf_impl(repository_ctx, overriden_tools = dict()):
     """Generate BUILD file with 'cc_toolchain' targets for the local host C++ toolchain."""
-    print("Generating cc toolchains")
     paths = resolve_labels(repository_ctx, [
         "@bazel_tools//tools/cpp:BUILD.static.freebsd",
         "@bazel_tools//tools/cpp:cc_toolchain_config.bzl",

--- a/tools/osx/crosstool/BUILD.toolchains
+++ b/tools/osx/crosstool/BUILD.toolchains
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+load(":osx_archs.bzl", "OSX_TOOLS_ARCHS", "OSX_TOOLS_CONSTRAINTS")
+
+[
+    toolchain(
+        name = "cc-toolchain-" + arch,
+        exec_compatible_with = [
+            # These only execute on macOS.
+            "@bazel_tools//platforms:osx",
+            "@bazel_tools//platforms:x86_64",
+        ],
+        target_compatible_with = OSX_TOOLS_CONSTRAINTS[arch],
+        toolchain = ":cc-compiler-" + arch,
+        toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+    )
+    for arch in OSX_TOOLS_ARCHS
+]

--- a/tools/osx/crosstool/BUILD.tpl
+++ b/tools/osx/crosstool/BUILD.tpl
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load(":osx_archs.bzl", "OSX_TOOLS_ARCHS", "OSX_TOOLS_CONSTRAINTS")
+load(":osx_archs.bzl", "OSX_TOOLS_ARCHS")
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 
 CC_TOOLCHAINS = [(
@@ -78,21 +78,6 @@ cc_toolchain_suite(
         name = (arch if arch != "armeabi-v7a" else "stub_armeabi-v7a"),
         compiler = "compiler",
         cpu = arch,
-    )
-    for arch in OSX_TOOLS_ARCHS
-]
-
-[
-    toolchain(
-        name = "cc-toolchain-" + arch,
-        exec_compatible_with = [
-            # These only execute on macOS.
-            "@bazel_tools//platforms:osx",
-            "@bazel_tools//platforms:x86_64",
-        ],
-        target_compatible_with = OSX_TOOLS_CONSTRAINTS[arch],
-        toolchain = ":cc-compiler-" + arch,
-        toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
     )
     for arch in OSX_TOOLS_ARCHS
 ]


### PR DESCRIPTION
This change modifies which part of cc_configure is executed unconditionally and which only on demand.

The root of the problem was the call `register_toolchains(@local_config_cc//:all)`. Because this was appended to the WORKSPACE file, each Bazel project executed the repository (and therefore tried to detect C++ toolchain and its capabilities) even when the C++ toolchain was not needed for the build.

This change split `@local_config_cc` into 2 repositories:

1. `@local_config_cc_toolchains` which contains only `toolchain` targets, and doesn't require C++ toolchain to be detected.
2. `@local_config_cc` which contains `cc_toolchain` targets, which do require C++ toolchain to be detected.

The point is that toolchain resolution has all the information needed to select the appropriate toolchain without autoconfiguration, therefore C++ toolchain will only be autoconfigured only after we already know it will be selected.

This cl is backwards incompatible for projects that relied on `@local_config_cc` containing `toolchain` targets. But because https://github.com/bazelbuild/bazel/issues/7260 is not yet flipped, there are not that many users of toolchains with C++ who manually instantiate `cc_autoconf` rule.

Fixes https://github.com/bazelbuild/bazel/issues/7751.
Progress towards https://github.com/bazelbuild/bazel/issues/7260.

RELNOTES: Repository containing autoconfigured C++ toolchain `@local_config_cc` has been split in 2 - see `local_config_cc_toolchains`.