### PR TITLE
Bash, runfiles lib v2: shorter init code

### DIFF
--- a/src/test/py/bazel/testdata/runfiles_test/bar/bar.sh
+++ b/src/test/py/bazel/testdata/runfiles_test/bar/bar.sh
@@ -13,27 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
-# --- begin runfiles.bash initialization ---
-if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-    if [[ -f "$0.runfiles_manifest" ]]; then
-      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
-    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
-      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-      export RUNFILES_DIR="$0.runfiles"
-    fi
-fi
-if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
-elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
-            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
-else
-  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
-  exit 1
-fi
-# --- end runfiles.bash initialization ---
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; } ; f=; set -e
+# --- end runfiles.bash initialization v2 ---
 
 echo "Hello Bash Bar!"
 echo "rloc=$(rlocation "foo_ws/bar/bar-sh-data.txt")"

--- a/src/test/py/bazel/testdata/runfiles_test/foo/foo.sh
+++ b/src/test/py/bazel/testdata/runfiles_test/foo/foo.sh
@@ -13,27 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
-# --- begin runfiles.bash initialization ---
-if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-    if [[ -f "$0.runfiles_manifest" ]]; then
-      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
-    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
-      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-      export RUNFILES_DIR="$0.runfiles"
-    fi
-fi
-if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
-elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
-            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
-else
-  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
-  exit 1
-fi
-# --- end runfiles.bash initialization ---
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; } ; f=; set -e
+# --- end runfiles.bash initialization v2 ---
 
 if ! type rlocation >&/dev/null; then
   echo >&2 "ERROR: rlocation is undefined"
@@ -42,16 +31,16 @@ fi
 
 case "$(uname -s | tr [:upper:] [:lower:])" in
 msys*|mingw*|cygwin*)
-  function is_windows() { true ; }
+  is_windows=true
   ;;
 *)
-  function is_windows() { false ; }
+  is_windows=false
   ;;
 esac
 
 function child_binary_name() {
   local lang=$1
-  if is_windows; then
+  if "$is_windows"; then
     echo "foo_ws/bar/bar-${lang}.exe"
   else
     echo "foo_ws/bar/bar-${lang}"
@@ -65,7 +54,7 @@ function main() {
   # Run a subprocess, propagate the runfiles envvar to it. The subprocess will
   # use this process's runfiles manifest or runfiles directory.
   runfiles_export_envvars
-  if is_windows; then
+  if "$is_windows"; then
     export SYSTEMROOT="${SYSTEMROOT:-}"
   fi
   for lang in py java sh cc; do

--- a/src/test/shell/bazel/help_test.sh
+++ b/src/test/shell/bazel/help_test.sh
@@ -16,27 +16,16 @@
 #
 # Test the help command.
 
-set -euo pipefail
-# --- begin runfiles.bash initialization ---
-if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-    if [[ -f "$0.runfiles_manifest" ]]; then
-      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
-    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
-      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-      export RUNFILES_DIR="$0.runfiles"
-    fi
-fi
-if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
-elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
-            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
-else
-  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
-  exit 1
-fi
-# --- end runfiles.bash initialization ---
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; } ; f=; set -e
+# --- end runfiles.bash initialization v2 ---
 
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }

--- a/tools/bash/runfiles/runfiles.bash
+++ b/tools/bash/runfiles/runfiles.bash
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Runfiles lookup library for Bazel-built Bash binaries and tests.
+# Runfiles lookup library for Bazel-built Bash binaries and tests, version 2.
+#
+# Version history:
+# - version 2: shorter init code
+# - version 1: original Bash runfiles library
 #
 # ENVIRONMENT:
 # - Use the example code provided below. It initializes the environment
@@ -35,33 +39,33 @@
 #     up the library's runtime location, thus we have a chicken-and-egg problem.
 #     Insert the following code snippet to the top of your main script:
 #
-#       # --- begin runfiles.bash initialization ---
-#       # Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
-#       set -euo pipefail
-#       if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-#         if [[ -f "$0.runfiles_manifest" ]]; then
-#           export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
-#         elif [[ -f "$0.runfiles/MANIFEST" ]]; then
-#           export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-#         elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-#           export RUNFILES_DIR="$0.runfiles"
-#         fi
-#       fi
-#       if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-#         source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
-#       elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-#         source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
-#                   "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
-#       else
-#         echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
-#         exit 1
-#       fi
-#       # --- end runfiles.bash initialization ---
+#       # --- begin runfiles.bash initialization v2 ---
+#       # Copy-pasted from the Bazel Bash runfiles library v2.
+#       set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+#       source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+#         source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+#         source "$0.runfiles/$f" 2>/dev/null || \
+#         source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+#         source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+#         { echo>&2 "ERROR: cannot find $f"; exit 1; } ; f=; set -e
+#       # --- end runfiles.bash initialization v2 ---
 #
-# 3.  Use rlocation to look up runfile paths:
+#
+# 3.  Use rlocation to look up runfile paths.
 #
 #       cat "$(rlocation my_workspace/path/to/my/data.txt)"
 #
+
+set -euo pipefail
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
 
 case "$(uname -s | tr [:upper:] [:lower:])" in
 msys*|mingw*|cygwin*)
@@ -84,7 +88,7 @@ function rlocation() {
       echo >&2 "INFO[runfiles.bash]: rlocation($1): absolute path, return"
     fi
     # If the path is absolute, print it as-is.
-    echo $1
+    echo "$1"
   elif [[ "$1" == ../* || "$1" == */.. || "$1" == ./* || "$1" == */./* || "$1" == "*/." || "$1" == *//* ]]; then
     if [[ "${RUNFILES_LIB_DEBUG:-}" == 1 ]]; then
       echo >&2 "ERROR[runfiles.bash]: rlocation($1): path is not normalized"


### PR DESCRIPTION
The Bash Runfiles Library is now at its version 2.

The new version:
- has a shorter init code (copy-pasted "stanza")
- has a long (more readable but equivalent)
  version of the new init code, which is suitable
  if the source file's line length is limited

The init code does the bare minimum to load the
runfiles library. Everything else is done in the
library itself (e.g. export RUNFILES_* envvars).

The rlocation() function is unchanged.

To demonstrate correctness, I updated:
- two mock binaries with the init code
- an actual test (help_test.sh) the init code

RELNOTES[NEW]: Bash, runfiles: the copy-pasted init code of the Bash runfiles library is now shorter, see `tools/bash/runfiles/runfiles.bash`. The rlocation() implementation is the same.