### PR TITLE
Windows: rewrite and move path normalization

### DIFF
--- a/src/main/cpp/util/path_platform.h
+++ b/src/main/cpp/util/path_platform.h
@@ -83,8 +83,7 @@ std::pair<std::wstring, std::wstring> SplitPathW(const std::wstring &path);
 
 bool IsRootDirectoryW(const std::wstring &path);
 
-bool TestOnly_NormalizeWindowsPath(const std::string &path,
-                                   std::string *result);
+std::string TestOnly_NormalizeWindowsPath(const std::string &path);
 
 // Converts 'path' to Windows style.
 //

--- a/src/test/cpp/util/path_windows_test.cc
+++ b/src/test/cpp/util/path_windows_test.cc
@@ -46,12 +46,7 @@ using std::unique_ptr;
 using std::wstring;
 
 TEST(PathWindowsTest, TestNormalizeWindowsPath) {
-#define ASSERT_NORMALIZE(x, y)                                          \
-  {                                                                     \
-    std::string result;                                                 \
-    EXPECT_TRUE(blaze_util::TestOnly_NormalizeWindowsPath(x, &result)); \
-    EXPECT_EQ(result, y);                                               \
-  }
+#define ASSERT_NORMALIZE(x, y) EXPECT_EQ(TestOnly_NormalizeWindowsPath(x), y);
 
   ASSERT_NORMALIZE("", "");
   ASSERT_NORMALIZE("a", "a");
@@ -115,6 +110,8 @@ TEST(PathWindowsTest, TestNormalizeWindowsPath) {
   ASSERT_NORMALIZE("c:/a/..", "c:\\");
   ASSERT_NORMALIZE("c:/a/../", "c:\\");
   ASSERT_NORMALIZE("c:/a/./../", "c:\\");
+  ASSERT_NORMALIZE("c:/../d:/e", "c:\\d:\\e");
+  ASSERT_NORMALIZE("c:/../d:/../e", "c:\\e");
 
   ASSERT_NORMALIZE("foo", "foo");
   ASSERT_NORMALIZE("foo/", "foo");


### PR DESCRIPTION
The new implementation:

- does not store substrings in the 'segments'
  vector, only indices
- compares parts of the original string without
  creating other string objects
- creates substrings only while merging remaining
  segments, thus creating at most as many strings
  (and potentially fewer) than the old
  implementation