### PR TITLE
Windows, JNI: merge lib-util and lib-file

### DIFF
--- a/src/main/cpp/BUILD
+++ b/src/main/cpp/BUILD
@@ -64,7 +64,6 @@ cc_library(
         "//src/conditions:windows": [
             "//src/main/native/windows:lib-file",
             "//src/main/native/windows:lib-process",
-            "//src/main/native/windows:lib-util",
         ],
         "//conditions:default": [],
     }),

--- a/src/main/native/windows/BUILD
+++ b/src/main/native/windows/BUILD
@@ -21,16 +21,22 @@ filegroup(
 
 cc_library(
     name = "lib-file",
-    srcs = ["file.cc"],
-    hdrs = ["file.h"],
+    srcs = [
+        "file.cc",
+        "util.cc",
+    ],
+    hdrs = [
+        "file.h",
+        "util.h",
+    ],
     visibility = [
         "//src/main/cpp:__subpackages__",
         "//src/main/tools:__pkg__",
         "//src/test/cpp:__subpackages__",
         "//src/test/native:__subpackages__",
+        "//src/tools/launcher/util:__pkg__",
         "//tools/test:__pkg__",
     ],
-    deps = [":lib-util"],
 )
 
 cc_library(
@@ -41,18 +47,7 @@ cc_library(
         "//src/main/cpp:__pkg__",
         "//tools/test:__pkg__",
     ],
-    deps = [":lib-util"],
-)
-
-cc_library(
-    name = "lib-util",
-    srcs = ["util.cc"],
-    hdrs = ["util.h"],
-    visibility = [
-        "//src/main/cpp:__pkg__",
-        "//src/tools/launcher/util:__pkg__",
-        "//tools/test:__pkg__",
-    ],
+    deps = [":lib-file"],
 )
 
 cc_binary(
@@ -74,7 +69,6 @@ cc_binary(
     deps = [
         ":lib-file",
         ":lib-process",
-        ":lib-util",
     ],
 )
 

--- a/src/test/shell/bazel/testdata/embedded_tools_srcs_deps
+++ b/src/test/shell/bazel/testdata/embedded_tools_srcs_deps
@@ -18,7 +18,6 @@
 //src/main/cpp/util:filesystem
 //src/main/native/windows:lib-file
 //src/main/native/windows:lib-process
-//src/main/native/windows:lib-util
 //src/main/cpp/util:strings
 //src/main/cpp/util:errors
 //src/main/cpp/util:port

--- a/src/tools/launcher/util/BUILD
+++ b/src/tools/launcher/util/BUILD
@@ -34,7 +34,7 @@ cc_test(
     ],
     deps = [
         ":util",
-        "//src/main/native/windows:lib-util",
+        "//src/main/native/windows:lib-file",
         "@bazel_tools//tools/cpp/runfiles",
         "@com_google_googletest//:gtest_main",
     ],

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -80,7 +80,6 @@ cc_library(
             "//src/main/cpp/util:strings",
             "//src/main/native/windows:lib-file",
             "//src/main/native/windows:lib-process",
-            "//src/main/native/windows:lib-util",
             "//src/tools/launcher/util",
             "//third_party/ijar:zip",
             "@bazel_tools//tools/cpp/runfiles",
@@ -103,7 +102,6 @@ cc_test(
     ] + select({
         "@bazel_tools//src/conditions:windows": [
             "//src/main/native/windows:lib-file",
-            "//src/main/native/windows:lib-util",
             "//third_party/ijar:zip",
         ],
         "//conditions:default": [],


### PR DESCRIPTION
They are mostly used together, and lib-util
contains a lot of path-related methods.

Also, the AsExecutablePathForCreateProcess method
is defind in util.cc but will need to call
functions defined in file.cc. Until now, lib-file
depended on lib-util, and without merging them
we'd either have a cyclic dependency or would have
to move most of util.cc into file.cc.