### PR TITLE
Windows, JNI: create process from relative path

### DIFF
--- a/src/main/native/windows/file.h
+++ b/src/main/native/windows/file.h
@@ -45,6 +45,15 @@ bool IsDevNull(const char_type* path) {
          (path[2] == 'L' || path[2] == 'l');
 }
 
+template <typename char_type>
+bool HasDriveSpecifierPrefix(const char_type* p) {
+  if (HasUncPrefix(p)) {
+    return iswalpha(p[4]) && p[5] == ':' && (p[6] == '\\' || p[6] == '/');
+  } else {
+    return iswalpha(p[0]) && p[1] == ':' && (p[2] == '\\' || p[2] == '/');
+  }
+}
+
 std::wstring AddUncPrefixMaybe(const std::wstring& path);
 
 std::wstring RemoveUncPrefixMaybe(const std::wstring& path);
@@ -183,6 +192,8 @@ int DeletePath(const wstring& path, wstring* error);
 //   "D:\\Bar".
 std::string Normalize(const std::string& p);
 std::wstring Normalize(const std::wstring& p);
+
+bool GetCwd(std::wstring* result, DWORD* err_code);
 
 }  // namespace windows
 }  // namespace bazel

--- a/src/main/native/windows/util.h
+++ b/src/main/native/windows/util.h
@@ -148,7 +148,7 @@ wstring AsShortPath(wstring path, wstring* result);
 // `path`, and if that succeeds and the result is at most MAX_PATH - 1 long (not
 // including null terminator), then that will be the result (plus quotes).
 // Otherwise this function fails and returns an error message.
-wstring AsExecutablePathForCreateProcess(const wstring& path, wstring* result);
+wstring AsExecutablePathForCreateProcess(wstring path, wstring* result);
 
 }  // namespace windows
 }  // namespace bazel

--- a/src/test/native/windows/util_test.cc
+++ b/src/test/native/windows/util_test.cc
@@ -256,7 +256,6 @@ TEST(WindowsUtilTest, TestAsExecutablePathForCreateProcessBadInputs) {
   ASSERT_SHORTENING_FAILS(L"\"cmd.exe\"", L"path should not be quoted");
   ASSERT_SHORTENING_FAILS(L"/dev/null", L"path is absolute without a drive");
   ASSERT_SHORTENING_FAILS(L"/usr/bin/bash", L"path is absolute without a");
-  ASSERT_SHORTENING_FAILS(L"foo\\bar.exe", L"path is not absolute");
   ASSERT_SHORTENING_FAILS(L"foo\\..\\bar.exe", L"path is not normalized");
   ASSERT_SHORTENING_FAILS(L"\\bar.exe", L"path is absolute");
 
@@ -266,6 +265,13 @@ TEST(WindowsUtilTest, TestAsExecutablePathForCreateProcessBadInputs) {
   }
   dummy += L".exe";
   ASSERT_SHORTENING_FAILS(dummy.c_str(), L"a file name but too long");
+
+  // Relative paths are fine, they are absolutized.
+  std::wstring rel(L"foo\\bar.exe");
+  std::wstring actual;
+  EXPECT_EQ(AsExecutablePathForCreateProcess(rel, &actual), L"");
+  EXPECT_GT(actual.size(), rel.size());
+  EXPECT_EQ(actual.rfind(rel), actual.size() - rel.size() - 1);
 }
 
 TEST(WindowsUtilTest, TestAsExecutablePathForCreateProcessConversions) {


### PR DESCRIPTION
The JNI library now supports creating processes
from a relative path.

The path is absolutized (relative to the current
directory) and normalized if necessary.

With this, we can "bazel run" tests with
--incompatible_windows_bashless_run_command and
--incompatible_windows_native_test_wrapper (but
not yet with
--noincompatible_windows_native_test_wrapper).