### PR TITLE
Flip --incompatible_windows_escape_python_args

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/python/PythonOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PythonOptions.java
@@ -256,7 +256,7 @@ public class PythonOptions extends FragmentOptions {
 
   @Option(
       name = "incompatible_windows_escape_python_args",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {
         OptionEffectTag.ACTION_COMMAND_LINES,


### PR DESCRIPTION
CI test results (Bazel@HEAD + Downstream):
https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1003

The flag affects Windows only, and on Windows only
two projects are broken: rules_foreign_cc and
rules_nodejs.

These are also broken on other platforms, and in
the previous build:
https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1002

Therefore I'm reasonably sure they are not broken
by this PR. That said, we can't completely be
sure because the tests didn't run.

See https://github.com/bazelbuild/bazel/issues/7974

Change-Id: I2cc09a4e9295495062dc4ac79b859dec6512b1b7