### PR TITLE
Fix adding bigger --max_idle_secs parameter when debugging Bazel in test

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/BuilderRunner.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/BuilderRunner.java
@@ -298,7 +298,7 @@ public final class BuilderRunner {
     if (enableDebug) {
       list.add("--host_jvm_debug");
       // 10 min for debug
-      this.flags.add("--max_idle_secs=600");
+      list.add("--max_idle_secs=600");
     }
     list.add(command);
     list.addAll(this.flags);


### PR DESCRIPTION
It should come before the command.