### PR TITLE
Use wrapped_clang for C++ link actions on Apple targets.

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -76,7 +76,14 @@ def configure_osx_toolchain(repository_ctx, overriden_tools):
         fail("BAZEL_USE_XCODE_TOOLCHAIN is set to 1 but Bazel couldn't find Xcode installed on the " +
              "system. Verify that 'xcode-select -p' is correct.")
     if xcode_toolchains:
-        cc = find_cc(repository_ctx, overriden_tools = {})
+        # For Xcode toolchains, there's no reason to use anything other than
+        # wrapped_clang, so that we still get the Bazel Xcode placeholder
+        # substitution and other behavior for actions that invoke this
+        # cc_wrapper.sh script. The wrapped_clang binary is already hardcoded
+        # into the Objective-C crosstool actions, anyway, so this ensures that
+        # the C++ actions behave consistently.
+        cc = repository_ctx.path("wrapped_clang")
+
         repository_ctx.template(
             "cc_wrapper.sh",
             paths["@bazel_tools//tools/cpp:osx_cc_wrapper.sh.tpl"],


### PR DESCRIPTION
The `cc_wrapper.sh` script doesn't perform substitution of Bazel placeholder strings like `__BAZEL_XCODE_DEVELOPER_DIR__` in command line arguments, so without this, the link command will fail if it contains those.

This is currently blocking https://github.com/bazelbuild/rules_swift/pull/243, which aims to clean up the logic in `swift_binary` by leveraging more of the `cc_common` APIs.