### PR TITLE
Flip `--incompatible_dont_enable_host_nonhost_crosstool_features`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -726,7 +726,7 @@ public class CppOptions extends FragmentOptions {
 
   @Option(
       name = "incompatible_dont_enable_host_nonhost_crosstool_features",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/cc_toolchain_config.bzl
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/cc_toolchain_config.bzl
@@ -522,7 +522,6 @@ _thin_lto_feature = feature(
             ],
         ),
     ],
-    requires = [feature_set(features = ["nonhost"])],
 )
 
 _simple_thin_lto_feature = feature(

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -1229,64 +1229,6 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
     assertThat(flags).containsNoneOf("-fastbuild", "-opt");
   }
 
-  private List<String> getHostAndTargetFlags(boolean useHost, boolean isDisabledByFlag)
-      throws Exception {
-    AnalysisMock.get()
-        .ccSupport()
-        .setupCcToolchainConfig(
-            mockToolsConfig,
-            CcToolchainConfig.builder()
-                .withFeatures(
-                    MockCcSupport.HOST_AND_NONHOST_CONFIGURATION_FEATURES,
-                    CppRuleClasses.SUPPORTS_PIC));
-    scratch.overwriteFile("mode/BUILD", "cc_library(name = 'a', srcs = ['a.cc'])");
-    useConfiguration(
-        "--cpu=k8",
-        isDisabledByFlag
-            ? "--incompatible_dont_enable_host_nonhost_crosstool_features"
-            : "--noincompatible_dont_enable_host_nonhost_crosstool_features");
-    ConfiguredTarget target;
-    String objectPath;
-    if (useHost) {
-      target = getHostConfiguredTarget("//mode:a");
-      objectPath = "_objs/a/a.o";
-    } else {
-      target = getConfiguredTarget("//mode:a");
-      objectPath = "_objs/a/a.pic.o";
-    }
-    Artifact objectArtifact = getBinArtifact(objectPath, target);
-    CppCompileAction action = (CppCompileAction) getGeneratingAction(objectArtifact);
-    assertThat(action).isNotNull();
-    return action.getCompilerOptions();
-  }
-
-  @Test
-  public void testHostAndNonHostFeatures() throws Exception {
-    useConfiguration();
-    List<String> flags;
-
-    flags = getHostAndTargetFlags(/* useHost= */ true, /* isDisabledByFlag= */ false);
-    assertThat(flags).contains("-host");
-    assertThat(flags).doesNotContain("-nonhost");
-
-    flags = getHostAndTargetFlags(/* useHost= */ false, /* isDisabledByFlag= */ false);
-    assertThat(flags).contains("-nonhost");
-    assertThat(flags).doesNotContain("-host");
-  }
-
-  @Test
-  public void testHostAndNonHostFeaturesDisabledByTheFlag() throws Exception {
-    List<String> flags;
-
-    flags = getHostAndTargetFlags(/* useHost= */ true, /* isDisabledByFlag= */ true);
-    assertThat(flags).doesNotContain("-host");
-    assertThat(flags).doesNotContain("-nonhost");
-
-    flags = getHostAndTargetFlags(/* useHost= */ false, /* isDisabledByFlag= */ true);
-    assertThat(flags).doesNotContain("-nonhost");
-    assertThat(flags).doesNotContain("-host");
-  }
-
   @Test
   public void testIncludePathsOutsideExecutionRoot() throws Exception {
     scratchRule(

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariablesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariablesTest.java
@@ -220,8 +220,7 @@ public class CompileBuildVariablesTest extends BuildViewTestCase {
                     "fission_flags_for_lto_backend",
                     CppRuleClasses.PER_OBJECT_DEBUG_INFO,
                     CppRuleClasses.SUPPORTS_START_END_LIB,
-                    CppRuleClasses.THIN_LTO,
-                    MockCcSupport.HOST_AND_NONHOST_CONFIGURATION_FEATURES));
+                    CppRuleClasses.THIN_LTO));
     useConfiguration("--fission=yes", "--features=thin_lto");
 
     scratch.file("x/BUILD", "cc_binary(name = 'bin', srcs = ['bin.cc'])");

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkBuildVariablesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/LinkBuildVariablesTest.java
@@ -217,7 +217,6 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
                 .withFeatures(
                     CppRuleClasses.THIN_LTO,
                     CppRuleClasses.SUPPORTS_PIC,
-                    MockCcSupport.HOST_AND_NONHOST_CONFIGURATION_FEATURES,
                     CppRuleClasses.SUPPORTS_INTERFACE_SHARED_LIBRARIES,
                     CppRuleClasses.SUPPORTS_DYNAMIC_LINKER,
                     CppRuleClasses.SUPPORTS_START_END_LIB));
@@ -343,7 +342,6 @@ public class LinkBuildVariablesTest extends LinkBuildVariablesTestCase {
             CcToolchainConfig.builder()
                 .withFeatures(
                     CppRuleClasses.THIN_LTO,
-                    MockCcSupport.HOST_AND_NONHOST_CONFIGURATION_FEATURES,
                     CppRuleClasses.SUPPORTS_DYNAMIC_LINKER,
                     CppRuleClasses.SUPPORTS_PIC,
                     CppRuleClasses.SUPPORTS_INTERFACE_SHARED_LIBRARIES,

--- a/tools/cpp/BUILD
+++ b/tools/cpp/BUILD
@@ -357,10 +357,10 @@ toolchain(
 
 cc_toolchain(
     name = "cc-compiler-x64_windows_msvc",
-    all_files = ":every-file-x64_windows",
+    all_files = ":empty",
     ar_files = ":empty",
     as_files = ":empty",
-    compiler_files = ":compile-x64_windows",
+    compiler_files = ":empty",
     dwp_files = ":empty",
     linker_files = ":empty",
     objcopy_files = ":empty",
@@ -389,24 +389,6 @@ toolchain(
     ],
     toolchain = ":cc-compiler-x64_windows_msvc",
     toolchain_type = ":toolchain_type",
-)
-
-filegroup(
-    name = "every-file-x64_windows",
-    srcs = [
-        ":compile-x64_windows",
-    ],
-)
-
-filegroup(
-    name = "compile-x64_windows",
-    srcs = glob(
-        [
-            "wrapper/bin/msvc_*",
-            "wrapper/bin/pydir/msvc*",
-        ],
-        allow_empty = True,
-    ),
 )
 
 filegroup(


### PR DESCRIPTION
RELNOTES: Incompatible flag `--incompatible_dont_enable_host_nonhost_crosstool_features` has been flipped. See https://github.com/bazelbuild/bazel/issues/7407 for more information.