### PR TITLE
Fix pkg_deb depends_file bug

### DIFF
--- a/tools/build_defs/pkg/pkg.bzl
+++ b/tools/build_defs/pkg/pkg.bzl
@@ -191,7 +191,7 @@ def _pkg_deb_impl(ctx):
         args += ["--built_using=" + ctx.attr.built_using]
 
     if ctx.attr.depends_file:
-        if ctx.file.depends:
+        if ctx.attr.depends:
             fail("Both depends and depends_file attributes were specified")
         args += ["--depends=@" + ctx.attr.depends_file.path]
         files += [ctx.file.depends_file]

--- a/tools/build_defs/pkg/pkg.bzl
+++ b/tools/build_defs/pkg/pkg.bzl
@@ -193,7 +193,7 @@ def _pkg_deb_impl(ctx):
     if ctx.attr.depends_file:
         if ctx.attr.depends:
             fail("Both depends and depends_file attributes were specified")
-        args += ["--depends=@" + ctx.attr.depends_file.path]
+        args += ["--depends=@" + ctx.file.depends_file.path]
         files += [ctx.file.depends_file]
     elif ctx.attr.depends:
         args += ["--depends=" + d for d in ctx.attr.depends]


### PR DESCRIPTION
At version 0.26.0 when depends_file attribute were to used, it generated an error:

file ".../tools/build_defs/pkg/pkg.bzl", line 188, in _pkg_deb_impl
		ctx.file.depends
No attribute 'depends' in file. Make sure there is a label type attribute marked as 'allow_single_file' with this name

This should fix the issue.