### PR TITLE
Fixed instructions for GCS remote cache

### DIFF
--- a/site/docs/remote-caching.md
+++ b/site/docs/remote-caching.md
@@ -165,7 +165,7 @@ to/from your GCS bucket.
 
 4. Connect to Cloud Storage by adding the following flags to your Bazel command:
    * Pass the following URL to Bazel by using the flag:
-       `--remote_cache=https://storage.googleapis.com/bucket-name`
+       `--remote_http_cache=https://storage.googleapis.com/bucket-name`
        where `bucket-name` is the name of your storage bucket.
    * Pass the authentication key using the flag: `--google_credentials=/path/to/your/secret-key.json`, or
      `--google_default_credentials` to use [Application Default Credentials].


### PR DESCRIPTION
Fix error `cannot find a NameResolver for https://storage.googleapis.com/<bucket_name>`
by switching from `--remote_cache` to `--remote_http_cache`.