### PR TITLE
Add host java toolchain testing with the tools at head.

### DIFF
--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -23,6 +23,7 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
 
 JAVA_TOOLCHAIN="$1"; shift
 add_to_bazelrc "build --java_toolchain=${JAVA_TOOLCHAIN}"
+add_to_bazelrc "build --host_java_toolchain=${JAVA_TOOLCHAIN}"
 
 JAVA_TOOLS_ZIP="$1"; shift
 if [[ "${JAVA_TOOLS_ZIP}" != "released" ]]; then


### PR DESCRIPTION
The sole purpose of this PR is to prove that testing with the host java_toolchain at head is required to discover issues.