### PR TITLE
Add testing for java_tools that embed javac12.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -496,6 +496,14 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "java_tools_langtools_javac12",
+    sha256 = "99b107105165a91df82cd7cf82a8efb930d803fb7de1663cf7f780142104cd14",
+    urls = [
+        "https://mirror.bazel.build/bazel_java_tools/jdk_langtools/langtools_jdk12.zip",
+    ],
+)
+
 load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
 
 skydoc_repositories()

--- a/src/BUILD
+++ b/src/BUILD
@@ -557,7 +557,7 @@ JAVA_TOOLS_DEPLOY_JARS = [
     "//conditions:default": [],
 })
 
-JAVA_VERSIONS = ("9", "10", "11")
+JAVA_VERSIONS = ("9", "10", "11", "12")
 
 [
     genrule(

--- a/src/BUILD
+++ b/src/BUILD
@@ -625,13 +625,6 @@ JAVA_VERSIONS = ("9", "10", "11", "12")
     for java_version in JAVA_VERSIONS
 ]
 
-JAVA_VERSIONS_TO_SOURCE_VERSION = {
-    "9": "8",
-    "10": "8",
-    "11": "8",
-    "12": "12"
-}
-
 [
     # The java_tools releases can have BUILD files that vary depending on the
     # javac version they embed. Currently the only difference is in the
@@ -641,9 +634,9 @@ JAVA_VERSIONS_TO_SOURCE_VERSION = {
         name = "create_java_tools_build_java" + java_version,
         srcs = ["//tools/jdk:BUILD.java_tools"],
         outs = ["remote_java_tools_java" + java_version + "/BUILD"],
-        cmd = "sed 's/JAVA_LANGUAGE_LEVEL/" + source_version + "/g' $< > $@",
+        cmd = "sed 's/JAVA_LANGUAGE_LEVEL/" + java_version + "/g' $< > $@",
     )
-    for (java_version, source_version) in JAVA_VERSIONS_TO_SOURCE_VERSION.items()
+    for java_version in JAVA_VERSIONS
 ]
 
 [

--- a/src/BUILD
+++ b/src/BUILD
@@ -625,19 +625,32 @@ JAVA_VERSIONS = ("9", "10", "11", "12")
     for java_version in JAVA_VERSIONS
 ]
 
-genrule(
-    name = "create_java_tools_build",
-    srcs = ["//tools/jdk:BUILD.java_tools"],
-    outs = ["remote_java_tools/BUILD"],
-    cmd = "cp $< $@",
-)
+JAVA_VERSIONS_TO_SOURCE_VERSION = {
+    "9": "8",
+    "10": "8",
+    "11": "8",
+    "12": "12"
+}
 
-genrule(
-    name = "java_tools_build_zip",
-    srcs = ["remote_java_tools/BUILD"],
-    outs = ["java_tools_build.zip"],
-    cmd = "zip -jX $@ $<",
-)
+[
+    genrule(
+        name = "create_java_tools_build_java" + java_version,
+        srcs = ["//tools/jdk:BUILD.java_tools"],
+        outs = ["remote_java_tools_java" + java_version + "/BUILD"],
+        cmd = "sed 's/JAVA_LANGUAGE_LEVEL/" + source_version + "/g' $< > $@",
+    )
+    for (java_version, source_version) in JAVA_VERSIONS_TO_SOURCE_VERSION.items()
+]
+
+[
+    genrule(
+        name = "java_tools_java" + java_version + "_build_zip",
+        srcs = ["remote_java_tools_java" + java_version + "/BUILD"],
+        outs = ["java_tools_java_" + java_version + "_build.zip"],
+        cmd = "zip -jX $@ $<",
+    )
+    for java_version in JAVA_VERSIONS
+]
 
 # Builds the remote Java tools archive. Not embedded or used in Bazel, but used
 # by the Java tools release process.
@@ -665,7 +678,7 @@ genrule(
         name = "java_tools_java" + java_version + "_zip",
         srcs = [
             "java_tools_java" + java_version + "_no_build.zip",
-            "java_tools_build.zip",
+            "java_tools_java_" + java_version + "_build.zip",
         ],
         outs = ["java_tools_java" + java_version + ".zip"],
         cmd = "$(location //src:merge_zip_files) - $@ $(SRCS)",

--- a/src/BUILD
+++ b/src/BUILD
@@ -633,6 +633,10 @@ JAVA_VERSIONS_TO_SOURCE_VERSION = {
 }
 
 [
+    # The java_tools releases can have BUILD files that vary depending on the
+    # javac version they embed. Currently the only difference is in the
+    # java_toolchain source version which has to be 12 for javac 12 to be able
+    # to build new Java 12 features.
     genrule(
         name = "create_java_tools_build_java" + java_version,
         srcs = ["//tools/jdk:BUILD.java_tools"],

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -147,6 +147,27 @@ sh_test(
 )
 
 sh_test(
+    name = "bazel_java12_test",
+    srcs = ["bazel_java12_test.sh"],
+    args = select({
+       "//src/conditions:darwin": ["@remote_java_tools_javac12_test_darwin//:toolchain"],
+       "//src/conditions:darwin_x86_64": ["@remote_java_tools_javac12_test_darwin//:toolchain"],
+       "//src/conditions:windows": ["@remote_java_tools_javac12_test_windows//:toolchain"],
+       "//src/conditions:linux_x86_64": ["@remote_java_tools_javac12_test_linux//:toolchain"],
+   }) + select({
+       "//src/conditions:darwin": ["@openjdk12_darwin_archive//:runtime"],
+       "//src/conditions:darwin_x86_64": ["@openjdk12_darwin_archive//:runtime"],
+       "//src/conditions:windows": ["@openjdk12_windows_archive//:runtime"],
+       "//src/conditions:linux_x86_64": ["@openjdk12_linux_archive//:runtime"],
+   }),
+    data = [
+        ":test-deps",
+        "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+sh_test(
     name = "bazel_java_test",
     # TODO(iirina): Investigate if the 'large' and 'eternal' values still apply.
     size = "large",

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -150,11 +150,13 @@ sh_test(
     name = "bazel_java12_test",
     srcs = ["bazel_java12_test.sh"],
     args = select({
+        # --java_toolchain and --host_java_toolchain values
        "//src/conditions:darwin": ["@remote_java_tools_javac12_test_darwin//:toolchain"],
        "//src/conditions:darwin_x86_64": ["@remote_java_tools_javac12_test_darwin//:toolchain"],
        "//src/conditions:windows": ["@remote_java_tools_javac12_test_windows//:toolchain"],
        "//src/conditions:linux_x86_64": ["@remote_java_tools_javac12_test_linux//:toolchain"],
    }) + select({
+       # --javabase and --host_javabase values
        "//src/conditions:darwin": ["@openjdk12_darwin_archive//:runtime"],
        "//src/conditions:darwin_x86_64": ["@openjdk12_darwin_archive//:runtime"],
        "//src/conditions:windows": ["@openjdk12_windows_archive//:runtime"],
@@ -406,8 +408,6 @@ sh_test(
     ],
 )
 
-JAVA_VERSIONS_RELEASED = ("9", "10", "11")
-
 # Test java coverage with the java_toolchain in the released java_tools versions.
 [
     sh_test(
@@ -436,7 +436,7 @@ JAVA_VERSIONS_RELEASED = ("9", "10", "11")
             "no_windows",
         ],
     )
-    for java_version in JAVA_VERSIONS_RELEASED
+    for java_version in JAVA_VERSIONS
 ]
 
 # Test java coverage with the java_toolchain in the java_tools zip built at head.

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -385,6 +385,8 @@ sh_test(
     ],
 )
 
+JAVA_VERSIONS_RELEASED = ("9", "10", "11")
+
 # Test java coverage with the java_toolchain in the released java_tools versions.
 [
     sh_test(
@@ -413,7 +415,7 @@ sh_test(
             "no_windows",
         ],
     )
-    for java_version in JAVA_VERSIONS
+    for java_version in JAVA_VERSIONS_RELEASED
 ]
 
 # Test java coverage with the java_toolchain in the java_tools zip built at head.

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -149,13 +149,12 @@ sh_test(
 sh_test(
     name = "bazel_java12_test",
     srcs = ["bazel_java12_test.sh"],
-    args = select({
+    args = [
         # --java_toolchain and --host_java_toolchain values
-       "//src/conditions:darwin": ["@remote_java_tools_javac12_test_darwin//:toolchain"],
-       "//src/conditions:darwin_x86_64": ["@remote_java_tools_javac12_test_darwin//:toolchain"],
-       "//src/conditions:windows": ["@remote_java_tools_javac12_test_windows//:toolchain"],
-       "//src/conditions:linux_x86_64": ["@remote_java_tools_javac12_test_linux//:toolchain"],
-   }) + select({
+        "@local_java_tools//:toolchain_jdk_12",
+        # java_tools zip to test
+        "src/java_tools_java12.zip",
+    ] + select({
        # --javabase and --host_javabase values
        "//src/conditions:darwin": ["@openjdk12_darwin_archive//:runtime"],
        "//src/conditions:darwin_x86_64": ["@openjdk12_darwin_archive//:runtime"],
@@ -164,6 +163,7 @@ sh_test(
    }),
     data = [
         ":test-deps",
+        "//src:java_tools_java12_zip",
         "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
         "@bazel_tools//tools/bash/runfiles",
     ],

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -190,7 +190,7 @@ sh_test(
     ],
 )
 
-JAVA_VERSIONS = ("9", "10", "11")
+JAVA_VERSIONS = ("9", "10", "11", "12")
 
 [
     sh_test(
@@ -246,7 +246,7 @@ JAVA_VERSIONS = ("9", "10", "11")
         # This test is only run by the java_tools binaries pipeline.
         tags = ["manual"],
     )
-    for java_version in ("9", "10", "11")
+    for java_version in JAVA_VERSIONS
 ]
 
 sh_test(

--- a/src/test/shell/bazel/bazel_java12_test.sh
+++ b/src/test/shell/bazel/bazel_java12_test.sh
@@ -111,4 +111,4 @@ EOF
   expect_log "Associated day number is 6"
 }
 
-run_suite "Tests Java 12 language new API changes"
+run_suite "Tests new Java 12 language features"

--- a/src/test/shell/bazel/bazel_java12_test.sh
+++ b/src/test/shell/bazel/bazel_java12_test.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Tests for Java 12 language level.
-#
+# Tests that bazel runs projects with Java 12 features.
 
 # --- begin runfiles.bash initialization ---
 if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then

--- a/src/test/shell/bazel/bazel_java12_test.sh
+++ b/src/test/shell/bazel/bazel_java12_test.sh
@@ -55,7 +55,21 @@ if "$is_windows"; then
 fi
 
 JAVA_TOOLCHAIN="$1"; shift
+JAVA_TOOLS_ZIP="$1"; shift
 JAVA_RUNTIME="$1"; shift
+
+echo "JAVA_TOOLS_ZIP=$JAVA_TOOLS_ZIP"
+
+
+JAVA_TOOLS_RLOCATION=$(rlocation io_bazel/$JAVA_TOOLS_ZIP)
+
+if "$is_windows"; then
+    JAVA_TOOLS_ZIP_FILE_URL="file:///${JAVA_TOOLS_RLOCATION}"
+else
+    JAVA_TOOLS_ZIP_FILE_URL="file://${JAVA_TOOLS_RLOCATION}"
+fi
+JAVA_TOOLS_ZIP_FILE_URL=${JAVA_TOOLS_ZIP_FILE_URL:-}
+
 add_to_bazelrc "build --java_toolchain=${JAVA_TOOLCHAIN}"
 add_to_bazelrc "build --host_java_toolchain=${JAVA_TOOLCHAIN}"
 add_to_bazelrc "build --javabase=${JAVA_RUNTIME}"
@@ -65,6 +79,11 @@ function set_up() {
     cat >>WORKSPACE <<EOF
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # java_tools versions only used to test Bazel with various JDK toolchains.
+
+http_archive(
+    name = "local_java_tools",
+    urls = ["${JAVA_TOOLS_ZIP_FILE_URL}"]
+)
 EOF
     cat $(rlocation io_bazel/src/test/shell/bazel/testdata/jdk_http_archives) >> WORKSPACE
 }

--- a/src/test/shell/bazel/bazel_java12_test.sh
+++ b/src/test/shell/bazel/bazel_java12_test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+#
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Tests for Java 12 language level.
+#
+
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+    if [[ -f "$0.runfiles_manifest" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+      export RUNFILES_DIR="$0.runfiles"
+    fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*|mingw*|cygwin*)
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+fi
+
+JAVA_TOOLCHAIN="$1"; shift
+JAVA_RUNTIME="$1"; shift
+add_to_bazelrc "build --java_toolchain=${JAVA_TOOLCHAIN}"
+add_to_bazelrc "build --host_java_toolchain=${JAVA_TOOLCHAIN}"
+add_to_bazelrc "build --javabase=${JAVA_RUNTIME}"
+add_to_bazelrc "build --host_javabase=${JAVA_RUNTIME}"
+
+function set_up() {
+    cat >>WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+# java_tools versions only used to test Bazel with various JDK toolchains.
+EOF
+    cat $(rlocation io_bazel/src/test/shell/bazel/testdata/jdk_http_archives) >> WORKSPACE
+}
+
+function test_java12_switch_statement() {
+  mkdir -p java/main
+  cat >java/main/BUILD <<EOF
+java_binary(
+    name = 'Javac12Example',
+    srcs = ['Javac12Example.java'],
+    main_class = 'Javac12Example',
+    javacopts = ["--enable-preview"],
+    jvm_flags = ["--enable-preview"],
+)
+EOF
+
+  cat >java/main/Javac12Example.java <<EOF
+public class Javac12Example {
+  enum Day {
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY,
+    SUNDAY
+  };
+
+  public static void main(String[] args) {
+    Day day = Day.MONDAY;
+    int numLetters = switch (day) {
+      case MONDAY, FRIDAY, SUNDAY -> 6;
+      case TUESDAY -> 7;
+      case THURSDAY, SATURDAY -> 8;
+      case WEDNESDAY -> 9;
+      default -> throw new IllegalStateException("Huh? " + day);
+    };
+    System.out.println("Associated day number is " + numLetters);
+  }
+}
+EOF
+  bazel run java/main:Javac12Example --test_output=all --verbose_failures &>"${TEST_log}"
+  expect_log "Associated day number is 6"
+}
+
+run_suite "Tests Java 12 language new API changes"

--- a/src/test/shell/bazel/testdata/jdk_http_archives
+++ b/src/test/shell/bazel/testdata/jdk_http_archives
@@ -1,3 +1,4 @@
+############################# Remote java_tools with embedded javac 9 ##############################
 http_archive(
     name = "remote_java_tools_javac9_test_linux",
     sha256 = "54c2fa7276fc109029b3d144ae6108f474b2fd49480b47473e7ec6eba45f0fe9",
@@ -20,6 +21,7 @@ http_archive(
     ],
 )
 
+############################# Remote java_tools with embedded javac 10 #############################
 http_archive(
     name = "remote_java_tools_javac10_test_linux",
     sha256 = "f345249e31ce344c0c382dcf9ef10823fa8eb8ba48f14587016c368f44106635",
@@ -42,6 +44,7 @@ http_archive(
     ],
 )
 
+############################# Remote java_tools with embedded javac 11 #############################
 http_archive(
     name = "remote_java_tools_javac11_test_linux",
     sha256 = "074d624fb34441df369afdfd454e75dba821d5d54932fcfee5ba598d17dc1b99",
@@ -64,6 +67,7 @@ http_archive(
     ],
 )
 
+############################# Remote java_tools with embedded javac 12 #############################
 http_archive(
     name = "remote_java_tools_javac12_test_linux",
     sha256 = "54d211b7238d3db3761c18524c5a5a87a2e8a959168a0e384c21b17f51662d8d",
@@ -84,8 +88,6 @@ http_archive(
         "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v1.0/java_tools_javac12_darwin-v1.0-rc2.zip",
     ],
 )
-
-
 
 ############################################## JDK 9 ###############################################
 http_archive(

--- a/src/test/shell/bazel/testdata/jdk_http_archives
+++ b/src/test/shell/bazel/testdata/jdk_http_archives
@@ -64,6 +64,11 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "remote_java_tools_javac12_test_linux",
+    urls = ["https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v1.0/java_tools_javac12_linux-v1.0-rc1.zip"],
+)
+
 ############################################## JDK 9 ###############################################
 http_archive(
     name = "openjdk9_linux_archive",

--- a/src/test/shell/bazel/testdata/jdk_http_archives
+++ b/src/test/shell/bazel/testdata/jdk_http_archives
@@ -71,21 +71,21 @@ http_archive(
 http_archive(
     name = "remote_java_tools_javac12_test_linux",
     sha256 = "54d211b7238d3db3761c18524c5a5a87a2e8a959168a0e384c21b17f51662d8d",
-    urls = ["https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v1.0/java_tools_javac12_linux-v1.0-rc2.zip"],
+    urls = ["https://mirror.bazel.build/bazel_java_tools/releases/javac12/v1.0/java_tools_javac12_linux-v1.0.zip"],
 )
 
 http_archive(
     name = "remote_java_tools_javac12_test_windows",
     sha256 = "314582cc8fd127ff164d2482f7b83fe77f4f1f0e12d712add67d3a2086c6a7e3",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v1.0/java_tools_javac12_windows-v1.0-rc2.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac12/v1.0/java_tools_javac12_windows-v1.0.zip",
     ],
 )
 http_archive(
     name = "remote_java_tools_javac12_test_darwin",
     sha256 = "add724f6381198cd25227bf93c00f0b07930255867b67c38e8c0411d0369c28f",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v1.0/java_tools_javac12_darwin-v1.0-rc2.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac12/v1.0/java_tools_javac12_darwin-v1.0.zip",
     ],
 )
 

--- a/src/test/shell/bazel/testdata/jdk_http_archives
+++ b/src/test/shell/bazel/testdata/jdk_http_archives
@@ -66,8 +66,26 @@ http_archive(
 
 http_archive(
     name = "remote_java_tools_javac12_test_linux",
-    urls = ["https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v1.0/java_tools_javac12_linux-v1.0-rc1.zip"],
+    sha256 = "54d211b7238d3db3761c18524c5a5a87a2e8a959168a0e384c21b17f51662d8d",
+    urls = ["https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v1.0/java_tools_javac12_linux-v1.0-rc2.zip"],
 )
+
+http_archive(
+    name = "remote_java_tools_javac12_test_windows",
+    sha256 = "314582cc8fd127ff164d2482f7b83fe77f4f1f0e12d712add67d3a2086c6a7e3",
+    urls = [
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v1.0/java_tools_javac12_windows-v1.0-rc2.zip",
+    ],
+)
+http_archive(
+    name = "remote_java_tools_javac12_test_darwin",
+    sha256 = "add724f6381198cd25227bf93c00f0b07930255867b67c38e8c0411d0369c28f",
+    urls = [
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v1.0/java_tools_javac12_darwin-v1.0-rc2.zip",
+    ],
+)
+
+
 
 ############################################## JDK 9 ###############################################
 http_archive(

--- a/src/test/shell/bazel/testdata/jdk_http_archives
+++ b/src/test/shell/bazel/testdata/jdk_http_archives
@@ -63,6 +63,8 @@ http_archive(
          "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v2.0/java_tools_javac11_darwin-v2.0.zip",
     ],
 )
+
+############################################## JDK 9 ###############################################
 http_archive(
     name = "openjdk9_linux_archive",
     build_file_content = "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
@@ -88,6 +90,8 @@ http_archive(
         "https://mirror.bazel.build/openjdk/azul-zulu-9.0.7.1-jdk9.0.7/zulu9.0.7.1-jdk9.0.7-win_x64.zip",
     ],
 )
+
+############################################## JDK 10 ##############################################
 http_archive(
     name = "openjdk10_linux_archive",
     build_file_content = "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
@@ -113,6 +117,8 @@ http_archive(
         "https://mirror.bazel.build/openjdk/azul-zulu10.2+3-jdk10.0.1/zulu10.2+3-jdk10.0.1-win_x64.zip",
     ],
 )
+
+############################################## JDK 11 ##############################################
 http_archive(
     name = "openjdk11_linux_archive",
     build_file_content = "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
@@ -135,5 +141,31 @@ http_archive(
     strip_prefix = "zulu11.31.11-ca-jdk11.0.3-win_x64",
     urls = [
         "https://mirror.bazel.build/openjdk/azul-zulu11.31.11-ca-jdk11.0.3/zulu11.31.11-ca-jdk11.0.3-win_x64.zip",
+    ],
+)
+
+############################################## JDK 12 ##############################################
+http_archive(
+    name = "openjdk12_linux_archive",
+    build_file_content = "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
+    strip_prefix = "zulu12.2.3-ca-jdk12.0.1-linux_x64",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu12.2.3-ca-jdk12.0.1/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz",
+    ],
+)
+http_archive(
+    name = "openjdk12_darwin_archive",
+    build_file_content = "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
+    strip_prefix = "zulu12.2.3-ca-jdk12.0.1-macosx_x64",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu12.2.3-ca-jdk12.0.1/zulu12.2.3-ca-jdk12.0.1-macosx_x64.tar.gz",
+    ],
+)
+http_archive(
+    name = "openjdk12_windows_archive",
+    build_file_content = "java_runtime(name = 'runtime', srcs =  glob(['**']), visibility = ['//visibility:public'])",
+    strip_prefix = "zulu12.2.3-ca-jdk12.0.1-win_x64",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu12.2.3-ca-jdk12.0.1/zulu12.2.3-ca-jdk12.0.1-win_x64.zip",
     ],
 )

--- a/src/upload_all_java_tools.sh
+++ b/src/upload_all_java_tools.sh
@@ -48,7 +48,7 @@ bazel_version=$(bazel info release | cut -d' ' -f2)
 
 # Passing the same commit_hash and timestamp to all targets to mark all the artifacts
 # uploaded on GCS with the same identifier.
-for java_version in 9 10 11; do
+for java_version in 9 10 11 12; do
 
     bazel build //src:java_tools_java${java_version}_zip
     zip_path=${PWD}/bazel-bin/src/java_tools_java${java_version}.zip

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -53,8 +53,8 @@ java_toolchain(
         "-parameters",
     ],
     singlejar = [":singlejar"],
-    source_version = "8",
-    target_version = "8",
+    source_version = "JAVA_LANGUAGE_LEVEL",
+    target_version = "JAVA_LANGUAGE_LEVEL",
     tools = [
         ":java_compiler_jar",
         ":jdk_compiler_jar",

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -62,6 +62,7 @@ java_toolchain(
     jacocorunner = ":jacoco_coverage_runner_filegroup"
 )
 
+# A toolchain that targets java JAVA_LANGUAGE_LEVEL.
 java_toolchain(
     name = "toolchain_jdk_JAVA_LANGUAGE_LEVEL",
     bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -53,6 +53,66 @@ java_toolchain(
         "-parameters",
     ],
     singlejar = [":singlejar"],
+    source_version = "8",
+    target_version = "8",
+    tools = [
+        ":java_compiler_jar",
+        ":jdk_compiler_jar",
+    ],
+    jacocorunner = ":jacoco_coverage_runner_filegroup"
+)
+
+java_toolchain(
+    name = "toolchain_jdk_JAVA_LANGUAGE_LEVEL",
+    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
+    compatible_javacopts = {
+        # Restrict protos to Java 7 so that they are compatible with Android.
+        "proto": [
+            "-source",
+            "7",
+            "-target",
+            "7",
+        ],
+    },
+    forcibly_disable_header_compilation = 0,
+    genclass = [":GenClass"],
+    header_compiler = [":Turbine"],
+    header_compiler_direct = [":TurbineDirect"],
+    ijar = [":ijar"],
+    javabuilder = [":JavaBuilder"],
+    javac = [":javac_jar"],
+    javac_supports_workers = 1,
+    jvm_opts = [
+        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
+        # G1 collector and having compact strings enabled.
+        "-XX:+UseParallelOldGC",
+        "-XX:-CompactStrings",
+        # Allow JavaBuilder to access internal javac APIs.
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+
+        # override the javac in the JDK.
+        "--patch-module=java.compiler=$(location :java_compiler_jar)",
+        "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
+
+        # quiet warnings from com.google.protobuf.UnsafeUtil,
+        # see: https://github.com/google/protobuf/issues/3781
+        # and: https://github.com/bazelbuild/bazel/issues/5599
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    ],
+    misc = [
+        "-XDskipDuplicateBridges=true",
+        "-g",
+        "-parameters",
+    ],
+    singlejar = [":singlejar"],
     source_version = "JAVA_LANGUAGE_LEVEL",
     target_version = "JAVA_LANGUAGE_LEVEL",
     tools = [


### PR DESCRIPTION
* Add a new java version (12) to all targets used to generate the java_tools zip release and to all java integration tests
* Add a new test for new java 12 features

`java_tools-javac12-v1.0` was released in https://github.com/bazelbuild/java_tools/issues/9.

This change doesn't upgrade the default value in Bazel to javac 12.