### PR TITLE
Add Scoot to list of Remote Execution services

### DIFF
--- a/site/docs/remote-execution.md
+++ b/site/docs/remote-execution.md
@@ -34,6 +34,7 @@ To run Bazel with remote execution, you can use one of the following:
     *   [Buildbarn](https://github.com/buildbarn)
     *   [Buildfarm](https://github.com/bazelbuild/bazel-buildfarm)
     *   [BuildGrid](https://gitlab.com/BuildGrid/buildgrid)
+    *   [Scoot](https://github.com/twitter/scoot)
 *   Hosted
     *   Remote Build Execution, which is a remote execution service from Google.
         Joining the


### PR DESCRIPTION
Add Scoot to the list of self-hosted remote execution services. Scoot is already on the list of servers in the remote-apis repo: https://github.com/bazelbuild/remote-apis/blob/master/README.md.
Scoot: https://github.com/twitter/scoot