### PR TITLE
Cherry picks for java_tools javac10 v3.2

### DIFF
--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -15,7 +15,7 @@ java_toolchain(
         ],
     },
     forcibly_disable_header_compilation = 0,
-    genclass = [":Genclass"],
+    genclass = [":GenClass"],
     header_compiler = [":Turbine"],
     header_compiler_direct = [":TurbineDirect"],
     ijar = [":ijar"],

--- a/tools/jdk/BUILD.java_tools.old
+++ b/tools/jdk/BUILD.java_tools.old
@@ -7,7 +7,7 @@ java_toolchain(
     source_version = "8",
     target_version = "8",
     forcibly_disable_header_compilation = 0,
-    genclass = [":Genclass"],
+    genclass = [":GenClass"],
     header_compiler = [":turbine"],
     header_compiler_direct = [":turbine_direct"],
     ijar = [":ijar"],


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/intellij/issues/845

This causes IntelliJ resolution to fail when there's a `java_plugin` in the build.

The filegroup is `GenClass`, not `Genclass`.

```
filegroup(
    name = "GenClass",
    srcs = ["java_tools/GenClass_deploy.jar"],
)
```

This will require a new java_tools release and a patch release to 0.26.0.

Closes #8490.

PiperOrigin-RevId: 250487423