### PR TITLE
Use native patch implementation in http_archive and git_repository

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -981,6 +981,7 @@ java_library(
         "//third_party:aether",
         "//third_party:apache_commons_compress",
         "//third_party:auto_value",
+        "//third_party:diffutils",
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party:maven",

--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -330,6 +330,7 @@ public class BazelRepositoryModule extends BlazeModule {
         outputVerificationRules =
             ImmutableSet.copyOf(repoOptions.experimentalVerifyRepositoryRules);
       }
+      skylarkRepositoryFunction.setUseNativePatch(repoOptions.useNativePatch);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -218,6 +218,24 @@ public final class WorkspaceRuleEvent implements ProgressLike {
     return new WorkspaceRuleEvent(result.build());
   }
 
+  /** Creates a new WorkspaceRuleEvent for a patch event. */
+  public static WorkspaceRuleEvent newPatchEvent(
+      String patchFile, Integer strip, String ruleLabel, Location location) {
+    WorkspaceLogProtos.PatchEvent e =
+        WorkspaceLogProtos.PatchEvent.newBuilder().setPatchFile(patchFile).setStrip(strip).build();
+
+    WorkspaceLogProtos.WorkspaceEvent.Builder result =
+        WorkspaceLogProtos.WorkspaceEvent.newBuilder();
+    result = result.setPatchEvent(e);
+    if (location != null) {
+      result = result.setLocation(location.print());
+    }
+    if (ruleLabel != null) {
+      result = result.setRule(ruleLabel);
+    }
+    return new WorkspaceRuleEvent(result.build());
+  }
+
   /** Creates a new WorkspaceRuleEvent for an os event. */
   public static WorkspaceRuleEvent newOsEvent(String ruleLabel, Location location) {
     OsEvent e = WorkspaceLogProtos.OsEvent.getDefaultInstance();

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto
@@ -94,6 +94,14 @@ message DeleteEvent {
   string path = 1;
 }
 
+// Information on "patch" event in repository_ctx.
+message PatchEvent {
+  // Path to the patch file
+  string patch_file = 1;
+  // Number of leading components to strip from file names
+  int32 strip = 2;
+}
+
 // Information on "os" event in repository_ctx.
 message OsEvent {
   // Takes no inputs
@@ -144,5 +152,6 @@ message WorkspaceEvent {
     ExtractEvent extract_event = 11;
     ReadEvent read_event = 12;
     DeleteEvent delete_event = 13;
+    PatchEvent patch_event = 14;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
@@ -1,0 +1,292 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository;
+
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.devtools.build.lib.vfs.Path;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import difflib.DiffUtils;
+import difflib.Patch;
+import difflib.PatchFailedException;
+
+public class PatchUtil {
+
+  private static Pattern chunkHeaderRe =
+      Pattern.compile("^@@\\s+-(?:(\\d+)(?:,(\\d+))?)\\s+\\+(?:(\\d+)(?:,(\\d+))?)\\s+@@$");
+
+  public enum Result {
+    COMPLETE,  // The entire chunk is read
+    CONTINUE,  // Should continue reading the chunk
+    ERROR,     // The chunk body doesn't match the chunk header's description
+  }
+
+  private static class ChunkHeader {
+    private int oldSize;
+    private int newSize;
+
+    public Result check(int oldLineCnt, int newLineCnt) {
+      if (oldLineCnt == oldSize && newLineCnt == newSize) {
+        return Result.COMPLETE;
+      }
+      if (oldLineCnt <= oldSize && newLineCnt <= newSize) {
+        return Result.CONTINUE;
+      }
+      return Result.ERROR;
+    }
+
+    ChunkHeader(String header) throws PatchFailedException {
+      Matcher m = chunkHeaderRe.matcher(header);
+      if (m.find()) {
+        oldSize = Integer.parseInt(m.group(2));
+        newSize = Integer.parseInt(m.group(4));
+      } else {
+        throw new PatchFailedException("Wrong chunk header: " + header);
+      }
+    }
+  }
+
+  private enum LineType {
+    OLD_FILE,
+    NEW_FILE,
+    CHUNK_HEAD,
+    CHUNK_ADD,
+    CHUNK_DEL,
+    CHUNK_EQL,
+    UNKNOWN
+  }
+
+  private static LineType getLineType(String line, boolean isReadingChunk) {
+    if (!isReadingChunk && line.startsWith("---")) {
+      return LineType.OLD_FILE;
+    }
+    if (!isReadingChunk && line.startsWith("+++")) {
+      return LineType.NEW_FILE;
+    }
+    if (line.startsWith("@@") && line.lastIndexOf("@@") != 0) {
+      int pos = line.indexOf("@@", 2);
+      Matcher m = chunkHeaderRe.matcher(line.substring(0, pos + 2));
+      if (m.find()) {
+        return LineType.CHUNK_HEAD;
+      } else {
+        return LineType.UNKNOWN;
+      }
+    }
+    if (isReadingChunk && line.startsWith("+")) {
+      return LineType.CHUNK_ADD;
+    }
+    if (isReadingChunk && line.startsWith("-")) {
+      return LineType.CHUNK_DEL;
+    }
+    if (isReadingChunk && (line.startsWith(" ") || line.isEmpty())) {
+      return LineType.CHUNK_EQL;
+    }
+    return LineType.UNKNOWN;
+  }
+
+  @VisibleForTesting
+  /**
+   * If file is not null and the file exists, return the file content as a list for String.
+   * Otherwise, return an empty list.
+   */
+  public static List<String> readFile(Path file) throws IOException {
+    List<String> content = new ArrayList<>();
+    if (file != null && file.exists()) {
+      BufferedReader reader = new BufferedReader(new InputStreamReader(file.getInputStream()));
+      String line;
+      while ((line = reader.readLine()) != null) {
+        content.add(line);
+      }
+      reader.close();
+    }
+    return content;
+  }
+
+  private static void writeFile(Path file, List<String> content) throws IOException {
+    BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(file.getOutputStream()));
+    for (String line : content) {
+      writer.write(line);
+      writer.write("\n");
+    }
+    writer.close();
+  }
+
+  private static void applyPatchToFile(List<String> patchContent, Path oldFile, Path newFile)
+      throws IOException, PatchFailedException {
+    // The oldFile could be <newFile>.orig, but the .orig may not exist, so in this case,
+    // we consider oldFile is the same as newFile.
+    if (oldFile != null && newFile != null) {
+      if (oldFile.getBaseName().equals(newFile.getBaseName().concat(".orig"))) {
+        oldFile = newFile;
+      }
+    }
+
+    List<String> oldContent = readFile(oldFile);
+    Patch<String> patch = DiffUtils.parseUnifiedDiff(patchContent);
+    List<String> newContent = DiffUtils.patch(oldContent, patch);
+
+    if (newContent.isEmpty() && newFile == null) {
+      oldFile.delete();
+      return;
+    }
+
+    if (newFile != null) {
+      writeFile(newFile, newContent);
+    }
+  }
+
+  /**
+   * Strip a number of leading components from a path
+   * @param path the original path
+   * @param strip the number of leading components to strip
+   * @return The stripped path
+   */
+  private static String stripPath(String path, int strip) {
+    int pos = 0;
+    while (pos < path.length() && strip > 0) {
+      if (path.charAt(pos) == '/') {
+        strip--;
+      }
+      pos++;
+    }
+    return path.substring(pos);
+  }
+
+  private static Path getFilePath(String line, int strip, Path outputDirectory) {
+    // The line could look like:
+    // --- a/foo/bar.txt   2019-05-27 17:19:37.054593200 +0200
+    // +++ b/foo/bar.txt   2019-05-27 17:19:37.054593200 +0200
+    // If strip is 1, we want get the file path as <outputDirectory>/foo/bar.txt
+    String file = null;
+    line = line.split("\t")[0];
+    if (line.length() > 4) {
+      if (line.substring(4).trim().equals("/dev/null")) {
+        return null;
+      }
+
+      file = stripPath(line.substring(4), strip);
+      if (!file.isEmpty()) {
+        return outputDirectory.getRelative(file);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Apply a patch file under a directory
+   * @param patchFile the patch file to apply
+   * @param strip the number of leading components to strip from file path in the patch file
+   * @param outputDirectory the repository directory to apply the patch file
+   */
+  public static void apply(Path patchFile, int strip, Path outputDirectory)
+      throws IOException, PatchFailedException {
+    List<String> patch = readFile(patchFile);
+    // Adding an extra line to make sure last chunk also gets applied.
+    patch.add("$");
+
+    boolean isReadingChunk = false;
+    List<String> patchContent = new ArrayList<>();
+    ChunkHeader header = null;
+    Path oldFile = null;
+    Path newFile = null;
+    int oldLineCount = 0;
+    int newLineCount = 0;
+    Result result;
+
+    for (int i = 0; i < patch.size(); i++) {
+      String line = patch.get(i);
+      switch (getLineType(line, isReadingChunk)) {
+        case OLD_FILE:
+          patchContent.add(line);
+          oldFile = getFilePath(line, strip, outputDirectory);
+          break;
+        case NEW_FILE:
+          patchContent.add(line);
+          newFile = getFilePath(line, strip, outputDirectory);
+          break;
+        case CHUNK_HEAD:
+          int pos = line.indexOf("@@", 2);
+          String headerStr = line.substring(0, pos + 2);
+          patchContent.add(headerStr);
+          header = new ChunkHeader(headerStr);
+          oldLineCount = 0;
+          newLineCount = 0;
+          isReadingChunk = true;
+          break;
+        case CHUNK_ADD:
+          newLineCount++;
+          patchContent.add(line);
+          result = header.check(oldLineCount, newLineCount);
+          if (result == Result.COMPLETE) {
+            isReadingChunk = false;
+          } else if (result == Result.ERROR) {
+            throw new PatchFailedException(
+                "Wrong chunk detected near line " + (i + 1) + ": " + line);
+          }
+          break;
+        case CHUNK_DEL:
+          oldLineCount++;
+          patchContent.add(line);
+          result = header.check(oldLineCount, newLineCount);
+          if (result == Result.COMPLETE) {
+            isReadingChunk = false;
+          } else if (result == Result.ERROR) {
+            throw new PatchFailedException(
+                "Wrong chunk detected near line " + (i + 1) + ": " + line);
+          }
+          break;
+        case CHUNK_EQL:
+          oldLineCount++;
+          newLineCount++;
+          patchContent.add(line);
+          result = header.check(oldLineCount, newLineCount);
+          if (result == Result.COMPLETE) {
+            isReadingChunk = false;
+          } else if (result == Result.ERROR) {
+            throw new PatchFailedException(
+                "Wrong chunk detected near line " + (i + 1) + ": " + line);
+          }
+          break;
+        case UNKNOWN:
+          if (!patchContent.isEmpty() && (oldFile != null || newFile != null)) {
+            result = header.check(oldLineCount, newLineCount);
+            // result will never be Result.Error here because it would have been throw in previous
+            // line already.
+            if (result == Result.CONTINUE) {
+              throw new PatchFailedException("Expecting more chunk line at line " + (i + 1));
+            }
+            applyPatchToFile(patchContent, oldFile, newFile);
+          }
+          patchContent.clear();
+          oldFile = null;
+          newFile = null;
+          oldLineCount = 0;
+          newLineCount = 0;
+          isReadingChunk = false;
+          break;
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
@@ -25,9 +25,13 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import difflib.Chunk;
+import difflib.Delta;
+import difflib.DeltaComparator;
 import difflib.DiffUtils;
 import difflib.Patch;
 import difflib.PatchFailedException;
@@ -40,7 +44,7 @@ public class PatchUtil {
   public enum Result {
     COMPLETE,  // The entire chunk is read
     CONTINUE,  // Should continue reading the chunk
-    ERROR,     // The chunk body doesn't match the chunk header's description
+    ERROR,     // The chunk body doesn't match the chunk header's size description
   }
 
   private static class ChunkHeader {
@@ -64,6 +68,75 @@ public class PatchUtil {
         newSize = Integer.parseInt(m.group(4));
       } else {
         throw new PatchFailedException("Wrong chunk header: " + header);
+      }
+    }
+  }
+
+  /**
+   * Sometimes the line number in patch file is not completely correct, but we might still be able
+   * to find a content match with an offset.
+   */
+  private static class OffsetPatch {
+    private List<Delta<String>> deltas;
+
+    public OffsetPatch(Patch<String> patch) {
+      this.deltas = patch.getDeltas();
+    }
+
+    public List<String> applyTo(List<String> target) throws PatchFailedException {
+      List<String> result = new ArrayList<>(target);
+      this.deltas.sort(DeltaComparator.INSTANCE);
+      ListIterator<Delta<String>> it = this.deltas.listIterator(this.deltas.size());
+
+      while(it.hasPrevious()) {
+        Delta<String> delta = it.previous();
+        applyTo(delta, result);
+      }
+
+      return result;
+    }
+
+    /**
+     * This function first tries to apply the Delta without any offset, if that fails, then
+     * it tries to apply the Delta with an offset, starting from 1, up to the total lines in
+     * the original content. For every offset, we try both forwards and backwards.
+     */
+    private void applyTo(Delta<String> delta, List<String> result) throws PatchFailedException {
+      PatchFailedException e = applyDelta(delta, result);
+      if (e == null) {
+        return;
+      }
+
+      Chunk<String> original = delta.getOriginal();
+      Chunk<String> revised = delta.getRevised();
+      int[] direction = {1, -1};
+      int maxOffset = result.size();
+      for (int i = 1; i < maxOffset; i++) {
+        for (int j = 0; j < 2; j++) {
+          int offset = i * direction[j];
+          if (offset + original.getPosition() < 0 || offset + revised.getPosition() < 0) {
+            continue;
+          }
+          delta.setOriginal(
+              new Chunk<>(original.getPosition() + offset, original.getLines()));
+          delta.setRevised(
+              new Chunk<>(revised.getPosition() + offset, revised.getLines()));
+          PatchFailedException exception = applyDelta(delta, result);
+          if (exception == null) {
+            return;
+          }
+        }
+      }
+
+      throw e;
+    }
+
+    private PatchFailedException applyDelta(Delta<String> delta, List<String> result) {
+      try {
+        delta.applyTo(result);
+        return null;
+      } catch (PatchFailedException e) {
+        return e;
       }
     }
   }
@@ -106,11 +179,11 @@ public class PatchUtil {
     return LineType.UNKNOWN;
   }
 
-  @VisibleForTesting
   /**
    * If file is not null and the file exists, return the file content as a list for String.
    * Otherwise, return an empty list.
    */
+  @VisibleForTesting
   public static List<String> readFile(Path file) throws IOException {
     List<String> content = new ArrayList<>();
     if (file != null && file.exists()) {
@@ -145,7 +218,7 @@ public class PatchUtil {
 
     List<String> oldContent = readFile(oldFile);
     Patch<String> patch = DiffUtils.parseUnifiedDiff(patchContent);
-    List<String> newContent = DiffUtils.patch(oldContent, patch);
+    List<String> newContent = new OffsetPatch(patch).applyTo(oldContent);
 
     if (newContent.isEmpty() && newFile == null) {
       oldFile.delete();

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java
@@ -134,7 +134,8 @@ public class PatchUtil {
         delta.applyTo(result);
         return null;
       } catch (PatchFailedException e) {
-        return e;
+        return new PatchFailedException(e.getMessage() +
+            "\nFailed to apply delta:\n    " + delta.toString());
       }
     }
   }
@@ -371,7 +372,8 @@ public class PatchUtil {
             isReadingChunk = false;
           } else if (result == Result.ERROR) {
             throw new PatchFailedException(
-                "Wrong chunk detected near line " + (i + 1) + ": " + line);
+                "Wrong chunk detected near line " + (i + 1) + ": " + line +
+                    ", does not expect an adding line here.");
           }
           break;
         case CHUNK_DEL:
@@ -382,7 +384,8 @@ public class PatchUtil {
             isReadingChunk = false;
           } else if (result == Result.ERROR) {
             throw new PatchFailedException(
-                "Wrong chunk detected near line " + (i + 1) + ": " + line);
+                "Wrong chunk detected near line " + (i + 1) + ": " + line +
+                    ", does not expect a deleting line here.");
           }
           break;
         case CHUNK_EQL:
@@ -394,7 +397,8 @@ public class PatchUtil {
             isReadingChunk = false;
           } else if (result == Result.ERROR) {
             throw new PatchFailedException(
-                "Wrong chunk detected near line " + (i + 1) + ": " + line);
+                "Wrong chunk detected near line " + (i + 1) + ": " + line +
+                    ", does not expect an equal line here.");
           }
           break;
         case RENAME_FROM:

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -133,6 +133,19 @@ public class RepositoryOptions extends OptionsBase {
       help = "If non-empty read the specified resolved file instead of the WORKSPACE file")
   public String experimentalResolvedFileInsteadOfWorkspace;
 
+  @Option(
+      name = "incompatible_use_native_patch",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+      metadataTags = {
+          OptionMetadataTag.INCOMPATIBLE_CHANGE,
+          OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+      },
+      help = "If enabled, Bazel's repository rules use a native implementation of patch on Windows, "
+          + "otherwise Bazel still calls patch command line tool for applying patch files.")
+  public boolean useNativePatch;
+
   /**
    * Converts from an equals-separated pair of strings into RepositoryName->PathFragment mapping.
    */

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.bazel.debug.WorkspaceRuleEvent;
 import com.google.devtools.build.lib.bazel.repository.DecompressorDescriptor;
@@ -40,6 +41,9 @@ import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction;
 import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
 import com.google.devtools.build.lib.rules.repository.WorkspaceAttributeMapper;
+import com.google.devtools.build.lib.shell.Command;
+import com.google.devtools.build.lib.shell.CommandException;
+import com.google.devtools.build.lib.shell.CommandResult;
 import com.google.devtools.build.lib.skylarkbuildapi.repository.SkylarkRepositoryContextApi;
 import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.EvalUtils;
@@ -66,6 +70,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -87,6 +92,7 @@ public class SkylarkRepositoryContext
   private final HttpDownloader httpDownloader;
   private final double timeoutScaling;
   private final Map<String, String> markerData;
+  private final boolean useNativePatch;
 
   /**
    * Create a new context (repository_ctx) object for a skylark repository rule ({@code rule}
@@ -101,7 +107,8 @@ public class SkylarkRepositoryContext
       Map<String, String> env,
       HttpDownloader httpDownloader,
       double timeoutScaling,
-      Map<String, String> markerData)
+      Map<String, String> markerData,
+      boolean useNativePatch)
       throws EvalException {
     this.rule = rule;
     this.packageLocator = packageLocator;
@@ -112,6 +119,7 @@ public class SkylarkRepositoryContext
     this.httpDownloader = httpDownloader;
     this.timeoutScaling = timeoutScaling;
     this.markerData = markerData;
+    this.useNativePatch = useNativePatch;
     WorkspaceAttributeMapper attrs = WorkspaceAttributeMapper.of(rule);
     ImmutableMap.Builder<String, Object> attrBuilder = new ImmutableMap.Builder<>();
     for (String name : attrs.getAttributeNames()) {
@@ -413,8 +421,26 @@ public class SkylarkRepositoryContext
             skylarkPath.toString(), strip, rule.getLabel().toString(), location);
     env.getListener().post(w);
     try {
-      PatchUtil.apply(skylarkPath.getPath(), strip, outputDirectory);
-    } catch (PatchFailedException e) {
+      if (useNativePatch) {
+        PatchUtil.apply(skylarkPath.getPath(), strip, outputDirectory);
+      } else {
+        Map<String, String> envBuilder = Maps.newLinkedHashMap();
+        envBuilder.putAll(osObject.getEnvironmentVariables());
+        Command command = new Command(
+            new String[] {"patch", "-p" + strip, "-i", skylarkPath.getPath().getPathString()},
+            envBuilder,
+            outputDirectory.getPathFile(),
+            Duration.ofSeconds(60));
+        CommandResult result = command.execute();
+        if (!result.getTerminationStatus().success()) {
+          throw new RepositoryFunctionException(
+              new EvalException(Location.BUILTIN,
+                  "Error applying patch " + skylarkPath.toString() + ": "
+                      + new String(result.getStderr())),
+              Transience.TRANSIENT);
+        }
+      }
+    } catch (CommandException | PatchFailedException e) {
       throw new RepositoryFunctionException(
           new EvalException(Location.BUILTIN,
               "Error applying patch " + skylarkPath.toString() + ": " + e.getLocalizedMessage()),

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
@@ -56,6 +56,7 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
 
   private final HttpDownloader httpDownloader;
   private double timeoutScaling = 1.0;
+  private boolean useNativePatch;
 
   public SkylarkRepositoryFunction(HttpDownloader httpDownloader) {
     this.httpDownloader = httpDownloader;
@@ -63,6 +64,10 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
 
   public void setTimeoutScaling(double timeoutScaling) {
     this.timeoutScaling = timeoutScaling;
+  }
+
+  public void setUseNativePatch(boolean useNativePatch) {
+    this.useNativePatch = useNativePatch;
   }
 
   @Nullable
@@ -140,7 +145,8 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
               clientEnvironment,
               httpDownloader,
               timeoutScaling,
-              markerData);
+              markerData,
+              useNativePatch);
 
       // Since restarting a repository function can be really expensive, we first ensure that
       // all label-arguments can be resolved to paths.

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/SkylarkRepositoryContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/SkylarkRepositoryContextApi.java
@@ -295,6 +295,31 @@ public interface SkylarkRepositoryContextApi<RepositoryFunctionExceptionT extend
       throws EvalException, RepositoryFunctionExceptionT, InterruptedException;
 
   @SkylarkCallable(
+      name = "patch",
+      doc =
+          "Apply a patch file to the external repository.",
+      useLocation = true,
+      parameters = {
+          @Param(
+              name = "patch_file",
+              allowedTypes = {
+                  @ParamType(type = String.class),
+                  @ParamType(type = Label.class),
+                  @ParamType(type = RepositoryPathApi.class)
+              },
+              doc =
+                  "Path of the patch file to apply."),
+          @Param(
+              name = "strip",
+              type = Integer.class,
+              named = true,
+              defaultValue = "0",
+              doc = "strip the specified number of leading components from file names."),
+      })
+  public void patch(Object patchFile, Integer strip, Location location)
+      throws EvalException, RepositoryFunctionExceptionT, InterruptedException;
+
+  @SkylarkCallable(
       name = "which",
       doc =
           "Returns the path of the corresponding program or None "

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/SkylarkRepositoryContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/SkylarkRepositoryContextApi.java
@@ -297,7 +297,11 @@ public interface SkylarkRepositoryContextApi<RepositoryFunctionExceptionT extend
   @SkylarkCallable(
       name = "patch",
       doc =
-          "Apply a patch file to the external repository.",
+          "Apply a patch file to the root directory of external repository. "
+              + "The patch file should be a standard "
+              + "[unified diff format](https://en.wikipedia.org/wiki/Diff#Unified_format) file. "
+              + "The native patch implementation doesn't support fuzz matching like the patch "
+              + "command line tool, so make sure your patch file content is correct.",
       useLocation = true,
       parameters = {
           @Param(

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
@@ -53,6 +53,7 @@ java_test(
         "//src/test/java/com/google/devtools/build/lib:packages_testutil",
         "//src/test/java/com/google/devtools/build/lib:test_runner",
         "//src/test/java/com/google/devtools/build/lib:testutil",
+        "//third_party:diffutils",
         "//third_party:guava",
         "//third_party:guava-testlib",
         "//third_party:jsr305",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/PatchUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/PatchUtilTest.java
@@ -1,0 +1,239 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.testutil.MoreAsserts.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.testutil.Scratch;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+
+import difflib.PatchFailedException;
+
+/**
+ * Tests for {@link PatchUtil}.
+ */
+@RunWith(JUnit4.class)
+public class PatchUtilTest {
+
+  private FileSystem fs;
+  private Scratch scratch;
+  private Path root;
+
+  @Before
+  public final void initializeFileSystemAndDirectories() throws Exception {
+    fs = new InMemoryFileSystem();
+    scratch = new Scratch(fs, "/root");
+    root = scratch.dir("/root");
+  }
+
+  @Test
+  public void testAddFile() throws IOException, PatchFailedException {
+    Path patchFile = scratch.file("/root/patchfile",
+        "diff --git a/newfile b/newfile",
+        "new file mode 100644",
+        "index 0000000..f742c88",
+        "--- /dev/null",
+        "+++ b/newfile",
+        "@@ -0,0 +1,2 @@",
+        "+I'm a new file",
+        "+hello, world",
+        "-- ",
+        "2.21.0.windows.1");
+    PatchUtil.apply(patchFile, 1, root);
+    Path newFile = root.getRelative("newfile");
+    ImmutableList<String> newFileContent = ImmutableList.of(
+        "I'm a new file",
+        "hello, world"
+    );
+    assertThat(PatchUtil.readFile(newFile)).containsExactlyElementsIn(newFileContent);
+  }
+
+  @Test
+  public void testDeleteFile() throws IOException, PatchFailedException {
+    Path oldFile = scratch.file("/root/oldfile",
+        "I'm an old file",
+        "bye, world"
+        );
+    Path patchFile = scratch.file("/root/patchfile",
+        "diff --git a/oldfile b/oldfile",
+        "deleted file mode 100644",
+        "index f742c88..0000000",
+        "--- a/oldfile",
+        "+++ /dev/null",
+        "@@ -1,2 +0,0 @@",
+        "-I'm an old file",
+        "-bye, world",
+        "-- ",
+        "2.21.0.windows.1");
+    PatchUtil.apply(patchFile, 1, root);
+    assertThat(oldFile.exists()).isFalse();
+  }
+
+  @Test
+  public void testGitFormatPatching() throws IOException, PatchFailedException {
+    Path foo = scratch.file("/root/foo.cc",
+        "#include <stdio.h>",
+        "",
+        "void main(){",
+        "  printf(\"Hello foo\");",
+        "}");
+    Path bar = scratch.file("/root/bar.cc",
+        "void lib(){",
+        "  printf(\"Hello bar\");",
+        "}");
+    Path patchFile = scratch.file("/root/patchfile",
+        "From d205551eab3350afdb380f90ef83442ffcc0e22b Mon Sep 17 00:00:00 2001",
+        "From: Yun Peng <pcloudy@google.com>",
+        "Date: Thu, 6 Jun 2019 11:34:08 +0200",
+        "Subject: [PATCH] 2",
+        "",
+        "---",
+        " bar.cc | 2 +-",
+        " foo.cc | 1 +",
+        " 2 files changed, 2 insertions(+), 1 deletion(-)",
+        "",
+        "diff --git a/bar.cc b/bar.cc",
+        "index e77137b..36dc9ab 100644",
+        "--- a/bar.cc",
+        "+++ b/bar.cc",
+        "@@ -1,3 +1,3 @@",
+        " void lib(){",
+        "-  printf(\"Hello bar\");",
+        "+  printf(\"Hello patch\");",
+        " }",
+        "diff --git a/foo.cc b/foo.cc",
+        "index f3008f9..ec4aaa0 100644",
+        "--- a/foo.cc",
+        "+++ b/foo.cc",
+        "@@ -2,4 +2,5 @@",
+        " ",
+        " void main(){",
+        "   printf(\"Hello foo\");",
+        "+  printf(\"Hello from patch\");",
+        " }",
+        "-- ",
+        "2.21.0.windows.1",
+        "",
+        "");
+    PatchUtil.apply(patchFile, 1, root);
+    ImmutableList<String> newFoo = ImmutableList.of(
+        "#include <stdio.h>",
+        "",
+        "void main(){",
+        "  printf(\"Hello foo\");",
+        "  printf(\"Hello from patch\");",
+        "}"
+    );
+    ImmutableList<String> newBar = ImmutableList.of(
+        "void lib(){",
+        "  printf(\"Hello patch\");",
+        "}"
+    );
+    assertThat(PatchUtil.readFile(foo)).containsExactlyElementsIn(newFoo);
+    assertThat(PatchUtil.readFile(bar)).containsExactlyElementsIn(newBar);
+  }
+
+  @Test
+  public void testChunkDoesNotMatch() throws IOException {
+    Path foo = scratch.file("/root/foo.cc",
+        "#include <stdio.h>",
+        "",
+        "void main(){",
+        "  printf(\"Hello foo\");",
+        "}");
+    Path patchFile = scratch.file("/root/patchfile",
+        "diff --git a/foo.cc b/foo.cc",
+        "index f3008f9..ec4aaa0 100644",
+        "--- a/foo.cc",
+        "+++ b/foo.cc",
+        "@@ -2,4 +2,5 @@",
+        " ",
+        " void main(){",
+        "   printf(\"Hello bar\");", // Should be "Hello foo"
+        "+  printf(\"Hello from patch\");",
+        " }");
+    PatchFailedException expected =
+        assertThrows(
+            PatchFailedException.class,
+            () -> PatchUtil.apply(patchFile, 1, root));
+    assertThat(expected).hasMessageThat()
+        .contains("Incorrect Chunk: the chunk content doesn't match the target");
+  }
+
+  @Test
+  public void testWrongChunkFormat1() throws IOException {
+    Path foo = scratch.file("/root/foo.cc",
+        "#include <stdio.h>",
+        "",
+        "void main(){",
+        "  printf(\"Hello foo\");",
+        "}");
+    Path patchFile = scratch.file("/root/patchfile",
+        "diff --git a/foo.cc b/foo.cc",
+        "index f3008f9..ec4aaa0 100644",
+        "--- a/foo.cc",
+        "+++ b/foo.cc",
+        "@@ -2,4 +2,5 @@",
+        " ",
+        " void main(){",
+        "   printf(\"Hello foo\");",
+        "+  printf(\"Hello from patch\");",
+        "+", // Adding this line will cause the chunk body not matching the header "@@ -2,4 +2,5 @@"
+        " }");
+    PatchFailedException expected =
+        assertThrows(
+            PatchFailedException.class,
+            () -> PatchUtil.apply(patchFile, 1, root));
+    assertThat(expected).hasMessageThat()
+        .contains("Wrong chunk detected near line 11:  }");
+  }
+
+  @Test
+  public void testWrongChunkFormat2() throws IOException {
+    Path foo = scratch.file("/root/foo.cc",
+        "#include <stdio.h>",
+        "",
+        "void main(){",
+        "  printf(\"Hello foo\");",
+        "}");
+    Path patchFile = scratch.file("/root/patchfile",
+        "diff --git a/foo.cc b/foo.cc",
+        "index f3008f9..ec4aaa0 100644",
+        "--- a/foo.cc",
+        "+++ b/foo.cc",
+        "@@ -2,4 +2,5 @@",
+        " ",
+        " void main(){",
+        "   printf(\"Hello foo\");",
+        "+  printf(\"Hello from patch\");");
+    PatchFailedException expected =
+        assertThrows(
+            PatchFailedException.class,
+            () -> PatchUtil.apply(patchFile, 1, root));
+    assertThat(expected).hasMessageThat()
+        .contains("Expecting more chunk line at line 10");
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/PatchUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/PatchUtilTest.java
@@ -396,7 +396,7 @@ public class PatchUtilTest {
             PatchFailedException.class,
             () -> PatchUtil.apply(patchFile, 1, root));
     assertThat(expected).hasMessageThat()
-        .contains("Wrong chunk detected near line 11:  }");
+        .contains("Wrong chunk detected near line 11:  }, does not expect an equal line here.");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
@@ -131,7 +131,8 @@ public class SkylarkRepositoryContextTest {
             ImmutableMap.of("FOO", "BAR"),
             downloader,
             1.0,
-            new HashMap<>());
+            new HashMap<>(),
+            false);
   }
 
   protected void setUpContexForRule(String name) throws Exception {

--- a/src/test/shell/bazel/external_patching_test.sh
+++ b/src/test/shell/bazel/external_patching_test.sh
@@ -691,7 +691,7 @@ sh_binary(
 )
 EOF
   # Building sh_binary doesn't need to execute Bash so we are fine here with a fake BAZEL_SH.
-  bazel build :foo.sh
+  bazel build --incompatible_use_native_patch :foo.sh
   foopath=`bazel info bazel-bin`/foo.sh
   grep -q 'New version' $foopath || fail "expected patch to be applied"
   grep env $foopath && fail "expected patch commands to be executed" || :

--- a/tools/build_defs/repo/git.bzl
+++ b/tools/build_defs/repo/git.bzl
@@ -99,11 +99,11 @@ _common_attrs = {
     "patches": attr.label_list(
         default = [],
         doc =
-            "A list of files that are to be applied as patches afer " +
+            "A list of files that are to be applied as patches after " +
             "extracting the archive.",
     ),
     "patch_tool": attr.string(
-        default = "patch",
+        default = "",
         doc = "The patch(1) utility to use.",
     ),
     "patch_args": attr.string_list(
@@ -115,7 +115,13 @@ _common_attrs = {
     ),
     "patch_cmds": attr.string_list(
         default = [],
-        doc = "Sequence of commands to be applied after patches are applied.",
+        doc = "Sequence of Bash commands to be applied on Linux/Macos after patches are applied.",
+    ),
+    "patch_cmds_win": attr.string_list(
+        default = [],
+        doc = "Sequence of Powershell commands to be applied on Windows after patches are " +
+              "applied. If this attribute is not set, patch_cmds will be executed on Windows, " +
+              "which requires Bash binary to exist.",
     ),
 }
 

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -188,11 +188,11 @@ following: `"zip"`, `"jar"`, `"war"`, `"tar"`, `"tar.gz"`, `"tgz"`,
     "patches": attr.label_list(
         default = [],
         doc =
-            "A list of files that are to be applied as patches afer " +
+            "A list of files that are to be applied as patches after " +
             "extracting the archive.",
     ),
     "patch_tool": attr.string(
-        default = "patch",
+        default = "",
         doc = "The patch(1) utility to use.",
     ),
     "patch_args": attr.string_list(
@@ -201,7 +201,13 @@ following: `"zip"`, `"jar"`, `"war"`, `"tar"`, `"tar.gz"`, `"tgz"`,
     ),
     "patch_cmds": attr.string_list(
         default = [],
-        doc = "Sequence of commands to be applied after patches are applied.",
+        doc = "Sequence of Bash commands to be applied on Linux/Macos after patches are applied.",
+    ),
+    "patch_cmds_win": attr.string_list(
+        default = [],
+        doc = "Sequence of Powershell commands to be applied on Windows after patches are " +
+              "applied. If this attribute is not set, patch_cmds will be executed on Windows, " +
+              "which requires Bash binary to exist.",
     ),
     "build_file": attr.label(
         allow_single_file = True,


### PR DESCRIPTION
When patch_args only contains -p<NUM> options, we use the native
implementation of patch. This will allow users to apply patch files
without installing patch command line tool (Helpfuly on Windows). When
users use options other than -p<NUM>, we fallback to the old behavior to
call patch tools through Bash.

Also added a new attribute patch_cmds_win, which allows users to
specifiy patch commands in powershell on Windows.

After this change, in most cases, Windows users no longer need to
install MSYS2 and patch tool to use http_archive and git_repository.