### PR TITLE
update rbe toolchains for bazel 0.26.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,15 +1,15 @@
 # Configuration to build and test Bazel itself on RBE.
-build:remote --host_javabase=@bazel_rbe_toolchains//configs/bazel_0.25.0/bazel-ubuntu1804/java:jdk
-build:remote --javabase=@bazel_rbe_toolchains//configs/bazel_0.25.0/bazel-ubuntu1804/java:jdk
+build:remote --host_javabase=@bazel_rbe_toolchains//configs/bazel_0.26.0/bazel-ubuntu1804/java:jdk
+build:remote --javabase=@bazel_rbe_toolchains//configs/bazel_0.26.0/bazel-ubuntu1804/java:jdk
 build:remote --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:remote --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:remote --crosstool_top=@bazel_rbe_toolchains//configs/bazel_0.25.0/bazel-ubuntu1804/cc:toolchain
+build:remote --crosstool_top=@bazel_rbe_toolchains//configs/bazel_0.26.0/bazel-ubuntu1804/cc:toolchain
 
-build:remote --extra_toolchains=@bazel_rbe_toolchains//configs/bazel_0.25.0/bazel-ubuntu1804/config:cc-toolchain
-build:remote --extra_execution_platforms=@bazel_rbe_toolchains//configs/bazel_0.25.0/bazel-ubuntu1804:default_platform
+build:remote --extra_toolchains=@bazel_rbe_toolchains//configs/bazel_0.26.0/bazel-ubuntu1804/config:cc-toolchain
+build:remote --extra_execution_platforms=@bazel_rbe_toolchains//configs/bazel_0.26.0/bazel-ubuntu1804:default_platform
 build:remote --extra_execution_platforms=//:rbe_highcpu_platform
-build:remote --host_platform=@bazel_rbe_toolchains//configs/bazel_0.25.0/bazel-ubuntu1804:default_platform
-build:remote --platforms=@bazel_rbe_toolchains//configs/bazel_0.25.0/bazel-ubuntu1804:default_platform
+build:remote --host_platform=@bazel_rbe_toolchains//configs/bazel_0.26.0/bazel-ubuntu1804:default_platform
+build:remote --platforms=@bazel_rbe_toolchains//configs/bazel_0.26.0/bazel-ubuntu1804:default_platform
 
  # TODO(ishikhman): Remove this flag after upgrading Bazel to 0.27.0
 build:remote --incompatible_list_based_execution_strategy_selection
@@ -17,9 +17,8 @@ build:remote --incompatible_list_based_execution_strategy_selection
 build:remote --define=EXECUTOR=remote
 
 build:remote --remote_instance_name=projects/bazel-untrusted/instances/default_instance
-build:remote --remote_executor=remotebuildexecution.googleapis.com
+build:remote --remote_executor=grpcs://remotebuildexecution.googleapis.com
 build:remote --remote_timeout=600
-build:remote --tls_enabled
 build:remote --google_default_credentials
 
 build:remote --jobs=100

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -317,11 +317,11 @@ http_archive(
 
 http_archive(
     name = "bazel_rbe_toolchains",
-    sha256 = "f575778fb1366718f5e1204200ecf35796c558998c15303945d351f0b42669e5",
-    strip_prefix = "bazel_rbe_toolchains-f50471a57cd05a313a953fa54756db6e8fd93673",
+    #sha256 = "",
+    strip_prefix = "bazel_rbe_toolchains-01529a65d21abdf71635ff0c2472043a567ecded",
     urls = [
-        "https://mirror.bazel.build/github.com/buchgr/bazel_rbe_toolchains/archive/f50471a57cd05a313a953fa54756db6e8fd93673.tar.gz",
-        "https://github.com/buchgr/bazel_rbe_toolchains/archive/f50471a57cd05a313a953fa54756db6e8fd93673.tar.gz",
+        "https://mirror.bazel.build/github.com/buchgr/bazel_rbe_toolchains/archive/01529a65d21abdf71635ff0c2472043a567ecded.tar.gz",
+        "https://github.com/buchgr/bazel_rbe_toolchains/archive/01529a65d21abdf71635ff0c2472043a567ecded.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Also fixes #8538, because the new docker image comes with python3-six.