### PR TITLE
Restore missingEdgeHook during a repository rule fetch failure to not suppress contextual console output

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeDependencyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeDependencyResolver.java
@@ -143,13 +143,14 @@ public final class SkyframeDependencyResolver extends DependencyResolver {
                   Event.error(
                       TargetUtils.getLocationMaybe(fromTarget),
                       String.format(
-                          "%s depends on %s in repository %s which failed to fetch",
+                          "%s depends on %s in repository %s which failed to fetch: "
+                              + e.getMessage(),
                           fromTarget.getLabel(),
                           label,
                           label.getPackageIdentifier().getRepository())));
-        } else {
-          rootCauses.add(new LoadingFailedCause(label, e.getMessage()));
+          continue;
         }
+        rootCauses.add(new LoadingFailedCause(label, e.getMessage()));
         missingEdgeHook(fromTarget, entry.getKey(), label, e);
         continue;
       }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeDependencyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeDependencyResolver.java
@@ -147,9 +147,9 @@ public final class SkyframeDependencyResolver extends DependencyResolver {
                           fromTarget.getLabel(),
                           label,
                           label.getPackageIdentifier().getRepository())));
-          continue;
+        } else {
+          rootCauses.add(new LoadingFailedCause(label, e.getMessage()));
         }
-        rootCauses.add(new LoadingFailedCause(label, e.getMessage()));
         missingEdgeHook(fromTarget, entry.getKey(), label, e);
         continue;
       }


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/6670#issuecomment-500037775