### PR TITLE
Cap the number of Android persistent resource processing workers at 2 to reduce OOM risks with no impact to build speed

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -930,6 +930,16 @@ public class AndroidConfiguration extends BuildConfiguration.Fragment
           "--strategy=AndroidAssetMerger=worker",
           "--strategy=AndroidResourceMerger=worker",
           "--strategy=AndroidCompiledResourceMerger=worker",
+          "--worker_max_instances=AaptPackage=2",
+          "--worker_max_instances=AndroidResourceParser=2",
+          "--worker_max_instances=AndroidResourceValidator=2",
+          "--worker_max_instances=AndroidResourceCompiler=2",
+          "--worker_max_instances=RClassGenerator=2",
+          "--worker_max_instances=AndroidResourceLink=2",
+          "--worker_max_instances=AndroidAapt2=2",
+          "--worker_max_instances=AndroidAssetMerger=2",
+          "--worker_max_instances=AndroidResourceMerger=2",
+          "--worker_max_instances=AndroidCompiledResourceMerger=2",
           // TODO(jingwen): ManifestMerger prints to stdout when there's a manifest merge
           // conflict. The worker protocol does not like this because it uses std i/o to
           // for communication. To get around this, re-configure manifest merger to *not*


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/8586 for context