### PR TITLE
improve remote execution error messages

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
+import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.runtime.BlazeModule;
 import com.google.devtools.build.lib.runtime.BuildEventArtifactUploaderFactory;
 import com.google.devtools.build.lib.runtime.Command;
@@ -228,9 +229,8 @@ public final class RemoteModule extends BlazeModule {
           capabilities = rsc.get(buildRequestId, invocationId);
         } catch (IOException e) {
           throw new AbruptExitException(
-              "Failed to query remote execution capabilities: " + e.getMessage(),
-              ExitCode.REMOTE_ERROR,
-              e);
+              "Failed to query remote execution capabilities: " + Utils.grpcAwareErrorMessage(e),
+              ExitCode.REMOTE_ERROR, e);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           return;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -51,6 +51,7 @@ import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.DigestUtil.ActionKey;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
+import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.remote.util.Utils.InMemoryOutput;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -192,7 +193,7 @@ final class RemoteSpawnCache implements SpawnCache {
       } catch (CacheNotFoundException e) {
         // Intentionally left blank
       } catch (IOException e) {
-        String errorMsg = e.getMessage();
+        String errorMsg = Utils.grpcAwareErrorMessage(e);
         if (isNullOrEmpty(errorMsg)) {
           errorMsg = e.getClass().getSimpleName();
         }
@@ -245,7 +246,7 @@ final class RemoteSpawnCache implements SpawnCache {
             remoteCache.upload(
                 actionKey, action, command, execRoot, files, context.getFileOutErr());
           } catch (IOException e) {
-            String errorMsg = e.getMessage();
+            String errorMsg = Utils.grpcAwareErrorMessage(e);
             if (isNullOrEmpty(errorMsg)) {
               errorMsg = e.getClass().getSimpleName();
             }

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -107,6 +107,16 @@ public class Utils {
     return !Collections.disjoint(outputs, topLevelOutputs);
   }
 
+  public static String grpcAwareErrorMessage(IOException e) {
+    io.grpc.Status errStatus = io.grpc.Status.fromThrowable(e);
+    if (!errStatus.getCode().equals(io.grpc.Status.UNKNOWN.getCode())) {
+      // If the error originated in the gRPC library then display it as "STATUS: error message"
+      // to the user
+      return String.format("%s: %s", errStatus.getCode().name(), errStatus.getDescription());
+    }
+    return e.getMessage();
+  }
+
   /** An in-memory output file. */
   public static final class InMemoryOutput {
     private final ActionInput output;

--- a/src/test/java/com/google/devtools/build/lib/remote/UtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/UtilsTest.java
@@ -1,0 +1,25 @@
+package com.google.devtools.build.lib.remote;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.build.lib.remote.util.Utils;
+import io.grpc.Status;
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for remote utility methods */
+@RunWith(JUnit4.class)
+public class UtilsTest {
+
+  @Test
+  public void testGrpcAwareErrorMessages() {
+    IOException ioError = new IOException("io error");
+    IOException wrappedGrpcError = new IOException("wrapped error",
+        Status.ABORTED.withDescription("grpc error").asRuntimeException());
+
+    assertThat(Utils.grpcAwareErrorMessage(ioError)).isEqualTo("io error");
+    assertThat(Utils.grpcAwareErrorMessage(wrappedGrpcError)).isEqualTo("ABORTED: grpc error");
+  }
+}


### PR DESCRIPTION
If the error originated in the gRPC library (it usually does) then
display the error as "STATUS CODE: error message" directly to the
user.

Before this change:

"java.io.IOException: io.grpc.StatusRuntimeException: UNAVAILABLE:
failed to dns resolve hostname"

After this change:

"UNAVAILABLE: failed to dns resolve hostname"