### PR TITLE
Fix broken debian packaging tests.

### DIFF
--- a/tools/build_defs/pkg/build_test.sh
+++ b/tools/build_defs/pkg/build_test.sh
@@ -218,11 +218,11 @@ function test_deb() {
 config
 control
 templates"
-  check_eq "$ctrl_listing abcd" "$(get_deb_ctl_listing test-deb.deb)"
+  check_eq "$ctrl_listing" "$(get_deb_ctl_listing test-deb.deb)"
   check_eq "-rw-r--r--" "$(get_deb_ctl_permission test-deb.deb conffiles)"
-  check_eq "-rw-r--r--" "$(get_deb_ctl_permission test-deb.deb config)"
+  check_eq "-rwxr-xr-x" "$(get_deb_ctl_permission test-deb.deb config)"
   check_eq "-rw-r--r--" "$(get_deb_ctl_permission test-deb.deb control)"
-  check_eq "-rw-r--r--" "$(get_deb_ctl_permission test-deb.deb templates)"
+  check_eq "-rwxr-xr-x" "$(get_deb_ctl_permission test-deb.deb templates)"
   local conffiles="/etc/nsswitch.conf
 /etc/other"
   check_eq "$conffiles" "$(get_deb_ctl_file test-deb.deb conffiles)"


### PR DESCRIPTION
One test was clearly wrong. It had some extra characters in the expected text.

Another 2 checks were failing becuase of permissions on files within the
debian package. I could argue that we should fix the code and write the
files in 644 mode rather then 755, but this package is now deprecated,
so I do not want to waste effort fixing it here. It will be addressed in
https://github.com/bazelbuild/rules_pkg/issues/40