### PR TITLE
Put deprecation warnings on pkg_deb and pkg_rpm.

### DIFF
--- a/tools/build_defs/pkg/pkg.bzl
+++ b/tools/build_defs/pkg/pkg.bzl
@@ -123,6 +123,12 @@ def _pkg_tar_impl(ctx):
 
 def _pkg_deb_impl(ctx):
     """The implementation for the pkg_deb rule."""
+
+    print("Deprecation warning: " + ctx.label.package + ":"
+          + ctx.label.name
+          + ": The built-in version of pkg_deb has been superceded by"
+          + " https://github.com/bazelbuild/rules_pkg/blob/master/pkg.")
+
     files = [ctx.file.data]
     args = [
         "--output=" + ctx.outputs.deb.path,

--- a/tools/build_defs/pkg/rpm.bzl
+++ b/tools/build_defs/pkg/rpm.bzl
@@ -20,6 +20,11 @@ spec_filetype = [".spec"]
 def _pkg_rpm_impl(ctx):
     """Implements to pkg_rpm rule."""
 
+    print("Deprecation warning: " + ctx.label.package + ":"
+          + ctx.label.name
+          + ": The built-in version of pkg_rpm has been superceded by"
+          + " https://github.com/bazelbuild/rules_pkg/blob/master/pkg.")
+
     files = []
     args = ["--name=" + ctx.label.name]
     if ctx.attr.rpmbuild_path:


### PR DESCRIPTION
The best we can have today is a print() style warning to point
you to rules_pkg.

Unfortunately, we can not do this with an incompatible flag until
--experimental_build_setting_api is turned on by default.
That change is staged as https://github.com/aiuto/bazel/pull/1

This exempts pkg_tar for the time being. That is used too heavily
to merit the warning. It may also have a different deprecation
time fram than pkg_deb and pkg_rpm. For that we can wait until
the build_settings_api is generally available.