### PR TITLE
tags propagation: Starlark rules part

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
@@ -18,11 +18,22 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.packages.Rule;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
  * Strings used to express requirements on action execution environments.
+ *
+ * If you are adding a new execution requirement, pay attention to the following:
+ * 1. If its name starts with one of the supported prefixes, then it can be also used as a tag on
+ * a target and will be propagated to the execution requirements, see for prefixes
+ * {@link com.google.devtools.build.lib.packages.TargetUtils#getExecutionInfo(Rule)}
+ *
+ * 2. If this is a potentially conflicting execution requirements, e.g. you are adding a pair
+ * 'requires-x' and 'block-x', you MUST take care of a potential conflict in the Executor that
+ * is using new execution requirements. As an example, see
+ * {@link Spawns#requiresNetwork(com.google.devtools.build.lib.actions.Spawn, boolean)}.
  */
 public class ExecutionRequirements {
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkActionFactory.java
@@ -545,7 +545,7 @@ public class SkylarkActionFactory implements SkylarkActionFactoryApi {
       builder.useDefaultShellEnvironment();
     }
 
-    Map<String, String> executionInfo =
+    ImmutableMap<String, String> executionInfo =
         TargetUtils.getFilteredExecutionInfo(executionRequirementsUnchecked, ruleContext.getRule());
     builder.setExecutionInfo(executionInfo);
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkActionFactory.java
@@ -544,15 +544,11 @@ public class SkylarkActionFactory implements SkylarkActionFactoryApi {
     if (EvalUtils.toBoolean(useDefaultShellEnv)) {
       builder.useDefaultShellEnvironment();
     }
-    if (executionRequirementsUnchecked != Runtime.NONE) {
-      builder.setExecutionInfo(
-          TargetUtils.filter(
-              SkylarkDict.castSkylarkDictOrNoneToDict(
-                  executionRequirementsUnchecked,
-                  String.class,
-                  String.class,
-                  "execution_requirements")));
-    }
+
+    Map<String, String> executionInfo =
+        TargetUtils.getFilteredExecutionInfo(executionRequirementsUnchecked, ruleContext.getRule());
+    builder.setExecutionInfo(executionInfo);
+
     if (inputManifestsUnchecked != Runtime.NONE) {
       for (RunfilesSupplier supplier : SkylarkList.castSkylarkListOrNoneToList(
           inputManifestsUnchecked, RunfilesSupplier.class, "runfiles suppliers")) {

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -244,9 +244,7 @@ public final class TargetUtils {
    */
   public static ImmutableMap<String, String> getFilteredExecutionInfo(Object executionRequirementsUnchecked,
       Rule rule) throws EvalException {
-    ImmutableMap.Builder<String, String> executionInfoBuilder = ImmutableMap.builder();
-    executionInfoBuilder.putAll(getExecutionInfo(rule));
-
+    Map<String, String> executionInfoBuilder = new HashMap<>();
     executionInfoBuilder.putAll(TargetUtils.filter(
         SkylarkDict.castSkylarkDictOrNoneToDict(
             executionRequirementsUnchecked,
@@ -254,7 +252,9 @@ public final class TargetUtils {
             String.class,
             "execution_requirements")));
 
-    return executionInfoBuilder.build();
+    getExecutionInfo(rule).forEach(executionInfoBuilder::putIfAbsent);
+
+    return ImmutableMap.copyOf(executionInfoBuilder);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -48,28 +48,14 @@ public final class TargetUtils {
   // some internal tags that we don't allow to be set on targets. We also don't want to
   // exhaustively enumerate all the legal values here. Right now, only a ~small set of tags is
   // recognized by Bazel.
-  private static final Predicate<String> LEGAL_EXEC_INFO_KEYS = new Predicate<String>() {
-    @Override
-    public boolean apply(String tag) {
-      return tag.startsWith("block-")
+  private static final Predicate<String> LEGAL_EXEC_INFO_KEYS =
+      tag -> tag.startsWith("block-")
           || tag.startsWith("requires-")
           || tag.startsWith("no-")
           || tag.startsWith("supports-")
           || tag.startsWith("disable-")
           || tag.equals("local")
           || tag.startsWith("cpu:");
-    }
-  };
-
-  // Not all the target level tags are propagated as execution requirements to the actions, because
-  // we do not want to propagate custom user's tags or create potential conflicts
-  // with execution requirements declared on the rules.
-  // See https://github.com/bazelbuild/bazel/issues/7766 for details.
-  private static final Predicate<String> TAGS_PROPAGATED_TO_EXEC_INFO =
-      tag -> tag.equals("no-remote")
-          || tag.equals("no-cache")
-          || tag.equals("no-sandbox");
-          // TODO(ishikhman): #7932 add new tags here as well (no-remote-exec and no-remote-cache)
 
   private TargetUtils() {} // Uninstantiable.
 
@@ -232,18 +218,14 @@ public final class TargetUtils {
   }
 
   /**
-   * Returns the execution info. These include execution requirement tags ('block-*', 'requires-*',
-   * 'no-*', 'supports-*', 'disable-*', 'local', and 'cpu:*') as keys with empty values.
+   * Returns the execution info from the tags declared on the target.
+   * These include only some tags {@link #LEGAL_EXEC_INFO_KEYS} as keys with empty values.
    */
   public static Map<String, String> getExecutionInfo(Rule rule) {
     // tags may contain duplicate values.
     Map<String, String> map = new HashMap<>();
     for (String tag :
         NonconfigurableAttributeMapper.of(rule).get(CONSTRAINTS_ATTR, Type.STRING_LIST)) {
-      // We don't want to pollute the execution info with random things, and we also need to reserve
-      // some internal tags that we don't allow to be set on targets. We also don't want to
-      // exhaustively enumerate all the legal values here. Right now, only a ~small set of tags is
-      // recognized by Bazel.
       if (LEGAL_EXEC_INFO_KEYS.apply(tag)) {
         map.put(tag, "");
       }
@@ -254,7 +236,7 @@ public final class TargetUtils {
   /**
    * Returns the execution info, obtained from the rule's tags and the execution requirements
    * provided. Only supported tags are included into the execution info, see {@link
-   * #LEGAL_EXEC_INFO_KEYS} and {@link #TAGS_PROPAGATED_TO_EXEC_INFO}.
+   * #LEGAL_EXEC_INFO_KEYS}.
    *
    * @param executionRequirementsUnchecked execution_requirements of a rule, expected to be of a
    * SkylarkDict<String, String> type, null or {@link com.google.devtools.build.lib.syntax.Runtime#NONE}
@@ -263,7 +245,7 @@ public final class TargetUtils {
   public static ImmutableMap<String, String> getFilteredExecutionInfo(Object executionRequirementsUnchecked,
       Rule rule) throws EvalException {
     ImmutableMap.Builder<String, String> executionInfoBuilder = ImmutableMap.builder();
-    executionInfoBuilder.putAll(getExecutionInfoFromTags(rule));
+    executionInfoBuilder.putAll(getExecutionInfo(rule));
 
     executionInfoBuilder.putAll(TargetUtils.filter(
         SkylarkDict.castSkylarkDictOrNoneToDict(
@@ -273,22 +255,6 @@ public final class TargetUtils {
             "execution_requirements")));
 
     return executionInfoBuilder.build();
-  }
-
-  /**
-   * Returns the execution info from the tags declared on the target.
-   * These include only some tags {@link #TAGS_PROPAGATED_TO_EXEC_INFO} as keys with empty values.
-   */
-  private static Map<String, String> getExecutionInfoFromTags(Rule rule) {
-    // tags may contain duplicate values.
-    ImmutableMap.Builder<String, String> map = ImmutableMap.builder();
-    for (String tag :
-        NonconfigurableAttributeMapper.of(rule).get(CONSTRAINTS_ATTR, Type.STRING_LIST)) {
-      if (TAGS_PROPAGATED_TO_EXEC_INFO.apply(tag)) {
-        map.put(tag, "");
-      }
-    }
-    return map.build();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -68,9 +68,8 @@ public final class TargetUtils {
   private static final Predicate<String> TAGS_PROPAGATED_TO_EXEC_INFO =
       tag -> tag.equals("no-remote")
           || tag.equals("no-cache")
-          || tag.equals("no-sandbox")
-          || tag.equals("no-remote-exec")
-          || tag.equals("no-remote-cache");
+          || tag.equals("no-sandbox");
+          // TODO(ishikhman): #7932 add new tags here as well (no-remote-exec and no-remote-cache)
 
   private TargetUtils() {} // Uninstantiable.
 

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.Location;
 import com.google.devtools.build.lib.syntax.EvalException;
-import com.google.devtools.build.lib.syntax.Runtime;
 import com.google.devtools.build.lib.syntax.SkylarkDict;
 import com.google.devtools.build.lib.syntax.Type;
 import com.google.devtools.build.lib.util.Pair;
@@ -254,9 +253,13 @@ public final class TargetUtils {
   }
 
   /**
-   * Returns the execution info, obtained from the rule's tags and the execution requirements provided.
-   * Only supported tags are included into the execution info,
-   * see {@link #LEGAL_EXEC_INFO_KEYS} and {@link #TAGS_PROPAGATED_TO_EXEC_INFO}.
+   * Returns the execution info, obtained from the rule's tags and the execution requirements
+   * provided. Only supported tags are included into the execution info, see {@link
+   * #LEGAL_EXEC_INFO_KEYS} and {@link #TAGS_PROPAGATED_TO_EXEC_INFO}.
+   *
+   * @param executionRequirementsUnchecked execution_requirements of a rule, expected to be of a
+   * SkylarkDict<String, String> type, null or {@link com.google.devtools.build.lib.syntax.Runtime#NONE}
+   * @param rule a rule instance to get tags from
    */
   public static ImmutableMap<String, String> getFilteredExecutionInfo(Object executionRequirementsUnchecked,
       Rule rule) throws EvalException {

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
@@ -115,6 +115,14 @@ public class SpawnActionTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testExecutionInfoCopied() {
+    SpawnAction copyFromWelcomeToDestination =
+        createCopyFromWelcomeToDestination(ImmutableMap.of());
+    Map<String, String> executionInfo = copyFromWelcomeToDestination.getExecutionInfo();
+    assertThat(executionInfo).containsExactlyEntriesIn(ImmutableMap.of("local", ""));
+  }
+
+  @Test
   public void testBuilder() throws Exception {
     Artifact input = getSourceArtifact("input");
     Artifact output = getBinArtifactWithNoOwner("output");

--- a/src/test/java/com/google/devtools/build/lib/packages/TargetUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/TargetUtilsTest.java
@@ -113,8 +113,9 @@ public class TargetUtilsTest extends PackageLoadingTestCase {
     Rule tag1 = (Rule) getTarget("//tests:tag1");
     Rule tag2 = (Rule) getTarget("//tests:tag2");
     Rule tag3 = (Rule) getTarget("//tests:tag3");
-    Rule tag4 = (Rule) getTarget("//tests:tag4");
-    Rule tag5 = (Rule) getTarget("//tests:tag5");
+    // TODO(ishikhman): uncomment after #7932
+    // Rule tag4 = (Rule) getTarget("//tests:tag4");
+    // Rule tag5 = (Rule) getTarget("//tests:tag5");
 
     Map<String, String> execInfo = TargetUtils.getFilteredExecutionInfo(null, tag1);
     assertThat(execInfo).containsExactly("no-cache", "");
@@ -125,11 +126,13 @@ public class TargetUtilsTest extends PackageLoadingTestCase {
     execInfo = TargetUtils.getFilteredExecutionInfo(null, tag3);
     assertThat(execInfo).containsExactly("no-sandbox", "");
 
-    execInfo = TargetUtils.getFilteredExecutionInfo(null, tag4);
-    assertThat(execInfo).containsExactly("no-remote-cache", "");
+    // TODO(ishikhman): uncomment after #7932
+    // execInfo = TargetUtils.getFilteredExecutionInfo(null, tag4);
+    // assertThat(execInfo).containsExactly("no-remote-cache", "");
 
-    execInfo = TargetUtils.getFilteredExecutionInfo(Runtime.NONE, tag5);
-    assertThat(execInfo).containsExactly("no-remote-exec", "", "no-sandbox", "");
+    // TODO(ishikhman): uncomment after #7932
+    // execInfo = TargetUtils.getFilteredExecutionInfo(Runtime.NONE, tag5);
+    // assertThat(execInfo).containsExactly("no-remote-exec", "", "no-sandbox", "");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/packages/TargetUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/TargetUtilsTest.java
@@ -155,9 +155,7 @@ public class TargetUtilsTest extends PackageLoadingTestCase {
   public void testExecutionInfo_withPrefixBlock() throws Exception {
     scratch.file(
         "tests/BUILD",
-        "sh_binary(name = 'with-prefix-block', srcs=['sh.sh'], tags=['block-some-feature', 'block-network', 'wrong-tag'])",
-        "sh_binary(name = 'with-prefix-cpu', srcs=['sh.sh'], tags=['cpu:123', 'wrong-tag'])",
-        "sh_binary(name = 'with-local-tag', srcs=['sh.sh'], tags=['local', 'some-tag'])"
+        "sh_binary(name = 'with-prefix-block', srcs=['sh.sh'], tags=['block-some-feature', 'block-network', 'wrong-tag'])"
     );
 
     Rule withBlockPrefix = (Rule) getTarget("//tests:with-prefix-block");

--- a/src/test/java/com/google/devtools/build/lib/packages/TargetUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/TargetUtilsTest.java
@@ -220,6 +220,20 @@ public class TargetUtilsTest extends PackageLoadingTestCase {
   }
 
   @Test
+  public void testFilteredExecutionInfo_withDuplicateTags() throws Exception {
+    scratch.file(
+        "tests/BUILD",
+        "sh_binary(name = 'tag1', srcs=['sh.sh'], tags=['supports-workers', 'no-cache'])"
+    );
+    Rule tag1 = (Rule) getTarget("//tests:tag1");
+    SkylarkDict<String, String> executionRequirementsUnchecked = SkylarkDict.of(null, "no-cache", "1");
+
+    Map<String, String> execInfo = TargetUtils.getFilteredExecutionInfo(executionRequirementsUnchecked, tag1);
+
+    assertThat(execInfo).containsExactly("no-cache", "1", "supports-workers", "");
+  }
+
+  @Test
   public void testFilteredExecutionInfo_WithNullUncheckedExecRequirements() throws Exception {
     scratch.file(
         "tests/BUILD",

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -667,6 +667,14 @@ sh_test(
 )
 
 sh_test(
+    name = "tags_propagation_skylark_test",
+    size = "large",
+    srcs = ["tag_propagation_skylark_test.sh"],
+    data = [":test-deps"],
+    tags = ["no_windows"],
+)
+
+sh_test(
     name = "disk_cache_test",
     size = "small",
     srcs = ["disk_cache_test.sh"],

--- a/src/test/shell/bazel/tag_propagation_skylark_test.sh
+++ b/src/test/shell/bazel/tag_propagation_skylark_test.sh
@@ -55,7 +55,7 @@ EOF
   bazel aquery '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
-  assert_contains "ExecutionInfo: {no-cache: '', no-remote: ''}" output1
+  assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: ''}" output1
 }
 
 # Test a basic skylark ctx.actions.run rule which has tags, that should be propagated
@@ -92,7 +92,7 @@ EOF
   bazel aquery '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
-  assert_contains "ExecutionInfo: {no-cache: '', no-remote: '', no-sandbox: ''}" output1
+  assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: '', no-sandbox: '', requires-network: ''}" output1
 }
 
 # Test a basic skylark ctx.actions.run rule which has tags, that should be propagated,
@@ -105,7 +105,7 @@ load(":skylark.bzl", "test_rule")
 test_rule(
     name = "test",
     out = "output.txt",
-    tags = ["no-cache", "no-remote", "no-sandbox", "requires-network", "local"]
+    tags = ["no-cache", "no-remote", "custom-tag-1", "requires-network", "local"]
 )
 EOF
 
@@ -131,7 +131,7 @@ EOF
   bazel aquery '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
-  assert_contains "ExecutionInfo: {no-cache: '', no-remote: '', no-sandbox: '', requires-x: ''}" output1
+  assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: '', requires-network: '', requires-x: ''}" output1
 }
 
 run_suite "tags propagation: skylark rule tests"

--- a/src/test/shell/bazel/tag_propagation_skylark_test.sh
+++ b/src/test/shell/bazel/tag_propagation_skylark_test.sh
@@ -114,7 +114,7 @@ def _test_impl(ctx):
   ctx.actions.run(
       outputs = [ctx.outputs.out],
       executable = 'dummy',
-      execution_requirements = {"requires-x": "", "custom-tag-whatever": ""})
+      execution_requirements = {"requires-x": "", "custom-tag-whatever": "", "no-cache": "1"})
   files_to_build = depset([ctx.outputs.out])
   return DefaultInfo(
       files = files_to_build,
@@ -131,7 +131,7 @@ EOF
   bazel aquery '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
-  assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: '', requires-network: '', requires-x: ''}" output1
+  assert_contains "ExecutionInfo: {local: '', no-cache: 1, no-remote: '', requires-network: '', requires-x: ''}" output1
 }
 
 run_suite "tags propagation: skylark rule tests"

--- a/src/test/shell/bazel/tag_propagation_skylark_test.sh
+++ b/src/test/shell/bazel/tag_propagation_skylark_test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests target's tags propagation with rules defined in Skylark.
+# Tests for https://github.com/bazelbuild/bazel/issues/7766
+
+# Load the test setup defined in the parent directory
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CURRENT_DIR}/../integration_test_setup.sh" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+# Test a basic skylark ctx.actions.run_shell rule which has tags, that should be propagated
+function test_tags_propagated_to_run_shell() {
+  mkdir -p test
+  cat << EOF >> test/BUILD
+load(":skylark.bzl", "test_rule")
+
+test_rule(
+    name = "test",
+    out = "output.txt",
+    tags = ["no-cache", "no-remote", "local"]
+)
+EOF
+
+  cat << 'EOF' >> test/skylark.bzl
+def _test_impl(ctx):
+  ctx.actions.run_shell(outputs = [ctx.outputs.out],
+                        command = ["touch", ctx.outputs.out.path])
+  files_to_build = depset([ctx.outputs.out])
+  return DefaultInfo(
+      files = files_to_build,
+  )
+
+test_rule = rule(
+    implementation=_test_impl,
+    attrs = {
+        "out": attr.output(mandatory = True),
+    },
+)
+EOF
+
+  bazel aquery '//test:test' > output1 2> $TEST_log \
+      || fail "should have generated output successfully"
+
+  assert_contains "ExecutionInfo: {no-cache: '', no-remote: ''}" output1
+}
+
+# Test a basic skylark ctx.actions.run rule which has tags, that should be propagated
+function test_tags_propagated_to_run() {
+  mkdir -p test
+  cat << EOF >> test/BUILD
+load(":skylark.bzl", "test_rule")
+
+test_rule(
+    name = "test",
+    out = "output.txt",
+    tags = ["no-cache", "no-remote", "no-sandbox", "requires-network", "local"]
+)
+EOF
+
+  cat << 'EOF' >> test/skylark.bzl
+def _test_impl(ctx):
+  ctx.actions.run(
+      outputs = [ctx.outputs.out],
+      executable = 'dummy')
+  files_to_build = depset([ctx.outputs.out])
+  return DefaultInfo(
+      files = files_to_build,
+  )
+
+test_rule = rule(
+    implementation=_test_impl,
+    attrs = {
+        "out": attr.output(mandatory = True),
+    },
+)
+EOF
+
+  bazel aquery '//test:test' > output1 2> $TEST_log \
+      || fail "should have generated output successfully"
+
+  assert_contains "ExecutionInfo: {no-cache: '', no-remote: '', no-sandbox: ''}" output1
+}
+
+# Test a basic skylark ctx.actions.run rule which has tags, that should be propagated,
+# when the rule also has execution_info
+function test_tags_propagated_to_run_with_exec_info_шт_кгду() {
+  mkdir -p test
+  cat << EOF >> test/BUILD
+load(":skylark.bzl", "test_rule")
+
+test_rule(
+    name = "test",
+    out = "output.txt",
+    tags = ["no-cache", "no-remote", "no-sandbox", "requires-network", "local"]
+)
+EOF
+
+  cat << 'EOF' >> test/skylark.bzl
+def _test_impl(ctx):
+  ctx.actions.run(
+      outputs = [ctx.outputs.out],
+      executable = 'dummy',
+      execution_requirements = {"requires-x": "", "custom-tag-whatever": ""})
+  files_to_build = depset([ctx.outputs.out])
+  return DefaultInfo(
+      files = files_to_build,
+  )
+
+test_rule = rule(
+    implementation=_test_impl,
+    attrs = {
+        "out": attr.output(mandatory = True),
+    },
+)
+EOF
+
+  bazel aquery '//test:test' > output1 2> $TEST_log \
+      || fail "should have generated output successfully"
+
+  assert_contains "ExecutionInfo: {no-cache: '', no-remote: '', no-sandbox: '', requires-x: ''}" output1
+}
+
+run_suite "tags propagation: skylark rule tests"

--- a/src/test/shell/bazel/tag_propagation_skylark_test.sh
+++ b/src/test/shell/bazel/tag_propagation_skylark_test.sh
@@ -97,7 +97,7 @@ EOF
 
 # Test a basic skylark ctx.actions.run rule which has tags, that should be propagated,
 # when the rule also has execution_info
-function test_tags_propagated_to_run_with_exec_info_шт_кгду() {
+function test_tags_propagated_to_run_with_exec_info_in_rule() {
   mkdir -p test
   cat << EOF >> test/BUILD
 load(":skylark.bzl", "test_rule")


### PR DESCRIPTION
Tags declared on targets are not propagated to actions and therefore are not taken into consideration by bazel. This causes some issues, for instance, target marked with a tag 'no-remote' will still be executed remotely.
As it was agreed in the design doc (see [doc](https://docs.google.com/document/d/1X2GtuuNT6UqYYOK5lJWQEdPjAgsbdB3nFjjmjso-XHo/edit#heading=h.5mcn15i0e1ch) and #7766 for details), set of tags to be propagated to actions as a first iteration.
This change is responsible for that first step for the Starlark Rules.

RELNOTES: tags 'no-remote', 'no-cache', 'no-remote-cache', 'no-remote-exec', 'no-sandbox' are propagated now to the actions from targets.

Closes #7766