### PR TITLE
Update toolchain resolution to not favor the host platform when no

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunction.java
@@ -397,10 +397,6 @@ public class ToolchainResolutionFunction implements SkyFunction {
               requiredToolchainTypes,
               platformKeys.executionPlatformKeys(),
               resolvedToolchains);
-    } else if (platformKeys.executionPlatformKeys().contains(platformKeys.hostPlatformKey())) {
-      // Fall back to the legacy behavior: use the host platform if it's available, otherwise the
-      // first execution platform.
-      selectedExecutionPlatformKey = Optional.of(platformKeys.hostPlatformKey());
     } else if (!platformKeys.executionPlatformKeys().isEmpty()) {
       // Just use the first execution platform.
       selectedExecutionPlatformKey = Optional.of(platformKeys.executionPlatformKeys().get(0));

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunctionTest.java
@@ -153,14 +153,10 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
 
     assertThat(unloadedToolchainContext.requiredToolchainTypes()).isEmpty();
 
-    // With no toolchains requested, should fall back to the host platform.
+    // Even with no toolchains requested, should still select the first execution platform.
     assertThat(unloadedToolchainContext.executionPlatform()).isNotNull();
     assertThat(unloadedToolchainContext.executionPlatform().label())
-        .isEqualTo(Label.parseAbsoluteUnchecked("//host:host"));
-
-    assertThat(unloadedToolchainContext.targetPlatform()).isNotNull();
-    assertThat(unloadedToolchainContext.targetPlatform().label())
-        .isEqualTo(Label.parseAbsoluteUnchecked("//platforms:linux"));
+        .isEqualTo(Label.parseAbsoluteUnchecked("//platforms:mac"));
   }
 
   @Test


### PR DESCRIPTION
toolchain types are required.

This makes the selection algorithms easier to understand, and will
correctly handle genrule and similar rules.

Fixes #8608.