### PR TITLE
Expose java toolchains for java 10 and 11 in @bazel_tools//tools/jdk

### DIFF
--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -17,8 +17,6 @@
 # Tests the java rules with the default values provided by Bazel.
 #
 
-add_to_bazelrc "build --javabase=@bazel_tools//tools/jdk:remote_jdk11"
-
 # --- begin runfiles.bash initialization ---
 if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
     if [[ -f "$0.runfiles_manifest" ]]; then
@@ -83,10 +81,74 @@ public class JavaBinary {
   }
 }
 EOF
-  bazel run java/main:JavaBinary --java_toolchain=//java/main:default_toolchain --verbose_failures -s &>"${TEST_log}"
+  bazel run java/main:JavaBinary --java_toolchain=//java/main:default_toolchain \
+      --javabase=@bazel_tools//tools/jdk:remote_jdk11 \
+      --verbose_failures -s &>"${TEST_log}"
   expect_log "Successfully executed JavaBinary!"
   javap -verbose -cp bazel-bin/java/main/JavaBinary.jar JavaBinary | grep major &>"${TEST_log}"
   expect_log "major version: 52"
+}
+
+function test_tools_jdk_toolchain_java10() {
+  mkdir -p java/main
+  cat >java/main/BUILD <<EOF
+java_binary(
+    name = 'JavaBinary',
+    srcs = ['JavaBinary.java'],
+    main_class = 'JavaBinary',
+)
+EOF
+
+   cat >java/main/JavaBinary.java <<EOF
+import java.util.ArrayList;
+public class JavaBinary {
+   public static void main(String[] args) {
+    var myList = new ArrayList<String>();
+    for (int i = 0; i < 3; i++) {
+      myList.add("myString" + i);
+    }
+
+    for (String string : myList) {
+      System.out.println(string);
+    }
+  }
+}
+EOF
+  bazel run java/main:JavaBinary --java_toolchain=@bazel_tools//tools/jdk:toolchain_java10 \
+      --javabase=@bazel_tools//tools/jdk:remote_jdk10 \
+      --verbose_failures -s &>"${TEST_log}"
+  expect_log "myString0"
+  expect_log "myString1"
+  expect_log "myString2"
+  javap -verbose -cp bazel-bin/java/main/JavaBinary.jar JavaBinary | grep major &>"${TEST_log}"
+  expect_log "major version: 54"
+}
+
+function test_tools_jdk_toolchain_java11() {
+  mkdir -p java/main
+  cat >java/main/BUILD <<EOF
+java_binary(
+    name = 'JavaBinary',
+    srcs = ['JavaBinary.java'],
+    main_class = 'JavaBinary',
+)
+EOF
+
+   cat >java/main/JavaBinary.java <<EOF
+public class JavaBinary {
+   public static void main(String[] args) {
+    // Java 11 new String methods.
+    String myString = "   strip_trailing_java11   ";
+    System.out.println(myString.stripLeading().stripTrailing());
+  }
+}
+EOF
+  bazel run java/main:JavaBinary --java_toolchain=@bazel_tools//tools/jdk:toolchain_java11 \
+      --javabase=@bazel_tools//tools/jdk:remote_jdk11 \
+      --verbose_failures -s &>"${TEST_log}"
+  expect_log "strip_trailing_java11"
+  javap -verbose -cp bazel-bin/java/main/JavaBinary.jar JavaBinary | grep major &>"${TEST_log}"
+  expect_log "major version: 55"
 }
 
 run_suite "Java integration tests with default Bazel values"

--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -17,6 +17,8 @@
 # Tests the java rules with the default values provided by Bazel.
 #
 
+set -euo pipefail
+
 # --- begin runfiles.bash initialization ---
 if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
     if [[ -f "$0.runfiles_manifest" ]]; then

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -378,7 +378,7 @@ default_java_toolchain(
     jvm_opts = [],
 )
 
-RELEASES = (8, 9)
+RELEASES = (8, 9, 10, 11)
 
 [
     default_java_toolchain(


### PR DESCRIPTION
The default java_toolchain in bazel supports language level 10 and 11.

RELNOTES: `@bazel_tools//tools/jdk:toolchain_java10` and `@bazel_tools//tools/jdk:toolchain_java11` are now available to enable java 10, respectively java 11 language level support.