### PR TITLE
Teach cc_configure about BAZEL_LINKLIBS env variable

### DIFF
--- a/tools/cpp/BUILD.tpl
+++ b/tools/cpp/BUILD.tpl
@@ -85,6 +85,7 @@ cc_toolchain_config(
     dbg_compile_flags = [%{dbg_compile_flags}],
     cxx_flags = [%{cxx_flags}],
     link_flags = [%{link_flags}],
+    link_libs = [%{link_libs}],
     opt_link_flags = [%{opt_link_flags}],
     unfiltered_compile_flags = [%{unfiltered_compile_flags}],
     coverage_compile_flags = [%{coverage_compile_flags}],

--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -126,6 +126,7 @@ cc_autoconf = repository_rule(
         "BAZEL_HOST_SYSTEM",
         "BAZEL_CXXOPTS",
         "BAZEL_LINKOPTS",
+        "BAZEL_LINKLIBS",
         "BAZEL_PYTHON",
         "BAZEL_SH",
         "BAZEL_TARGET_CPU",

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -342,6 +342,12 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
         "-lstdc++:-lm",
         False,
     ), ":")
+    link_libs = split_escaped(get_env_var(
+        repository_ctx,
+        "BAZEL_LINKLIBS",
+        "",
+        False,
+    ), ":")
     supports_gold_linker = _is_gold_supported(repository_ctx, cc)
     cc_path = repository_ctx.path(cc)
     if not str(cc_path).startswith(str(repository_ctx.path(".")) + "/"):
@@ -478,6 +484,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
                     "-pass-exit-codes",
                 )
             ) + link_opts),
+            "%{link_libs}": link_libs,
             "%{opt_compile_flags}": get_starlark_list(
                 [
                     # No debug symbols.

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -484,7 +484,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
                     "-pass-exit-codes",
                 )
             ) + link_opts),
-            "%{link_libs}": link_libs,
+            "%{link_libs}": get_starlark_list(link_libs),
             "%{opt_compile_flags}": get_starlark_list(
                 [
                     # No debug symbols.

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -854,6 +854,9 @@ def _impl(ctx):
                         iterate_over = "user_link_flags",
                         expand_if_available = "user_link_flags",
                     ),
+                    flag_group(
+                        flags = ctx.attr.link_libs,
+                    ),
                 ],
             ),
         ],
@@ -1191,6 +1194,7 @@ cc_toolchain_config = rule(
         "opt_compile_flags": attr.string_list(),
         "cxx_flags": attr.string_list(),
         "link_flags": attr.string_list(),
+        "link_libs": attr.string_list(),
         "opt_link_flags": attr.string_list(),
         "unfiltered_compile_flags": attr.string_list(),
         "coverage_compile_flags": attr.string_list(),

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -854,9 +854,7 @@ def _impl(ctx):
                         iterate_over = "user_link_flags",
                         expand_if_available = "user_link_flags",
                     ),
-                    flag_group(
-                        flags = ctx.attr.link_libs,
-                    ),
+                    ] + ([flag_group(flags = ctx.attr.link_libs)] if ctx.attr.link_libs else []),
                 ],
             ),
         ],


### PR DESCRIPTION
Using this variable is will be possible to specify system libraries that
should be added after default linker flags, after libraries to link, and
after user link flags (i.e. after --linkopt and `linkopts` rule attribute).

Flag separator is `:`, similarly to `BAZEL_LINKOPTS`. Escaping is done by
`%`.

Default value is empty string.

With this it's possible to force Bazel to statically link `libstdc++` by
using:

```
BAZEL_LINKOPTS=-static-libstdc++ BAZEL_LINKLIBS=-l%:libstdc++.a bazel build //foo
```

Fixes https://github.com/bazelbuild/bazel/issues/2840.
Relevant for https://github.com/bazelbuild/bazel/issues/8652.

RELNOTES: Bazel's C++ autoconfiguration now understands `BAZEL_LINKLIBS` environment variable to specify system libraries that should be appended to the link command line.
