### PR TITLE
remote: output files need to be writable. Fixes #8385

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -188,10 +188,9 @@ class RemoteActionInputFetcher implements ActionInputPrefetcher {
                   }
 
                   try {
-                    path.setReadable(true);
-                    path.setExecutable(true);
+                    path.chmod(0755);
                   } catch (IOException e) {
-                    logger.log(Level.WARNING, "Failed to chmod +xr on " + path, e);
+                    logger.log(Level.WARNING, "Failed to chmod 755 on " + path, e);
                   }
                 }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -197,6 +197,7 @@ public class RemoteActionInputFetcherTest {
         .isEqualTo("hello world");
     assertThat(a1.getPath().isExecutable()).isTrue();
     assertThat(a1.getPath().isReadable()).isTrue();
+    assertThat(a1.getPath().isWritable()).isTrue();
   }
 
   private Artifact createRemoteArtifact(


### PR DESCRIPTION
They need to be (over)writable by Bazel actions.