### PR TITLE
Allow passing extra HTTP headers to remote cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreFactory.java
@@ -88,13 +88,14 @@ public final class SimpleBlobStoreFactory {
               uri,
               options.remoteTimeout,
               options.remoteMaxConnections,
+              options.remoteHeaders,
               creds);
         } else {
           throw new Exception("Remote cache proxy unsupported: " + options.remoteProxy);
         }
       } else {
         return HttpBlobStore.create(
-            uri, options.remoteTimeout, options.remoteMaxConnections, creds);
+            uri, options.remoteTimeout, options.remoteMaxConnections, options.remoteHeaders, creds);
       }
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/AbstractHttpHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/AbstractHttpHandler.java
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /** Common functionality shared by concrete classes. */
 abstract class AbstractHttpHandler<T extends HttpObject> extends SimpleChannelInboundHandler<T>
@@ -39,9 +40,11 @@ abstract class AbstractHttpHandler<T extends HttpObject> extends SimpleChannelIn
       "bazel/" + BlazeVersionInfo.instance().getVersion();
 
   private final Credentials credentials;
+  private final List<Entry<String,String>> remoteHeaders;
 
-  public AbstractHttpHandler(Credentials credentials) {
+  public AbstractHttpHandler(Credentials credentials, List<Entry<String,String>> remoteHeaders) {
     this.credentials = credentials;
+    this.remoteHeaders = remoteHeaders;
   }
 
   protected ChannelPromise userPromise;
@@ -54,8 +57,8 @@ abstract class AbstractHttpHandler<T extends HttpObject> extends SimpleChannelIn
     userPromise = null;
   }
 
-  @SuppressWarnings("FutureReturnValueIgnored") 
-  protected void succeedAndResetUserPromise() {  
+  @SuppressWarnings("FutureReturnValueIgnored")
+  protected void succeedAndResetUserPromise() {
     userPromise.setSuccess();
     userPromise = null;
   }
@@ -79,6 +82,14 @@ abstract class AbstractHttpHandler<T extends HttpObject> extends SimpleChannelIn
       for (String value : entry.getValue()) {
         request.headers().add(name, value);
       }
+    }
+  }
+
+  protected void addExtraRemoteHeaders(HttpRequest request) {
+    for (Map.Entry<String,String> entry: this.remoteHeaders) {
+      String name  = entry.getKey();
+      String value = entry.getValue();
+      request.headers().add(name, value);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStore.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStore.java
@@ -65,6 +65,8 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -107,6 +109,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
   private final ChannelPool channelPool;
   private final URI uri;
   private final int timeoutSeconds;
+  private final List<Entry<String,String>> remoteHeaders;
   private final boolean useTls;
 
   private final Object closeLock = new Object();
@@ -123,7 +126,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
   private long lastRefreshTime;
 
   public static HttpBlobStore create(
-      URI uri, int timeoutSeconds, int remoteMaxConnections, @Nullable final Credentials creds)
+      URI uri, int timeoutSeconds, int remoteMaxConnections, List<Entry<String,String>> remoteHeaders, @Nullable final Credentials creds)
       throws Exception {
     return new HttpBlobStore(
         NioEventLoopGroup::new,
@@ -131,6 +134,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
         uri,
         timeoutSeconds,
         remoteMaxConnections,
+        remoteHeaders,
         creds,
         null);
   }
@@ -140,6 +144,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
       URI uri,
       int timeoutSeconds,
       int remoteMaxConnections,
+      List<Entry<String,String>> remoteHeaders,
       @Nullable final Credentials creds)
       throws Exception {
 
@@ -150,6 +155,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
           uri,
           timeoutSeconds,
           remoteMaxConnections,
+          remoteHeaders,
           creds,
           domainSocketAddress);
     } else if (Epoll.isAvailable()) {
@@ -159,6 +165,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
           uri,
           timeoutSeconds,
           remoteMaxConnections,
+          remoteHeaders,
           creds,
           domainSocketAddress);
     } else {
@@ -172,6 +179,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
       URI uri,
       int timeoutSeconds,
       int remoteMaxConnections,
+      List<Entry<String,String>> remoteHeaders,
       @Nullable final Credentials creds,
       @Nullable SocketAddress socketAddress)
       throws Exception {
@@ -237,6 +245,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
     }
     this.creds = creds;
     this.timeoutSeconds = timeoutSeconds;
+    this.remoteHeaders = remoteHeaders;
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
@@ -271,7 +280,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
                 p.addLast(new HttpRequestEncoder());
                 p.addLast(new ChunkedWriteHandler());
                 synchronized (credentialsLock) {
-                  p.addLast(new HttpUploadHandler(creds));
+                  p.addLast(new HttpUploadHandler(creds, remoteHeaders));
                 }
 
                 if (!ch.eventLoop().inEventLoop()) {
@@ -343,7 +352,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
                     new IdleTimeoutHandler(timeoutSeconds, ReadTimeoutException.INSTANCE));
                 p.addLast(new HttpClientCodec());
                 synchronized (credentialsLock) {
-                  p.addLast(new HttpDownloadHandler(creds));
+                  p.addLast(new HttpDownloadHandler(creds, remoteHeaders));
                 }
 
                 if (!ch.eventLoop().inEventLoop()) {

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpDownloadHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpDownloadHandler.java
@@ -36,6 +36,8 @@ import io.netty.util.internal.StringUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.List;
+import java.util.Map.Entry;
 
 /** ChannelHandler for downloads. */
 final class HttpDownloadHandler extends AbstractHttpHandler<HttpObject> {
@@ -50,8 +52,8 @@ final class HttpDownloadHandler extends AbstractHttpHandler<HttpObject> {
   /** the path header in the http request */
   private String path;
 
-  public HttpDownloadHandler(Credentials credentials) {
-    super(credentials);
+  public HttpDownloadHandler(Credentials credentials, List<Entry<String,String>> remoteHeaders) {
+    super(credentials, remoteHeaders);
   }
 
   @Override
@@ -136,6 +138,7 @@ final class HttpDownloadHandler extends AbstractHttpHandler<HttpObject> {
     path = constructPath(cmd.uri(), cmd.hash(), cmd.casDownload());
     HttpRequest request = buildRequest(path, constructHost(cmd.uri()));
     addCredentialHeaders(request, cmd.uri());
+    addExtraRemoteHeaders(request);
     addUserAgentHeader(request);
     ctx.writeAndFlush(request)
         .addListener(

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpUploadHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/http/HttpUploadHandler.java
@@ -32,6 +32,8 @@ import io.netty.handler.stream.ChunkedStream;
 import io.netty.handler.timeout.WriteTimeoutException;
 import io.netty.util.internal.StringUtil;
 import java.io.IOException;
+import java.util.List;
+import java.util.Map.Entry;
 
 /** ChannelHandler for uploads. */
 final class HttpUploadHandler extends AbstractHttpHandler<FullHttpResponse> {
@@ -41,8 +43,8 @@ final class HttpUploadHandler extends AbstractHttpHandler<FullHttpResponse> {
   /** the size of the data being uploaded in bytes */
   private long contentLength;
 
-  public HttpUploadHandler(Credentials credentials) {
-    super(credentials);
+  public HttpUploadHandler(Credentials credentials, List<Entry<String,String>> remoteHeaders) {
+    super(credentials, remoteHeaders);
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
@@ -92,6 +94,7 @@ final class HttpUploadHandler extends AbstractHttpHandler<FullHttpResponse> {
     contentLength = cmd.contentLength();
     HttpRequest request = buildRequest(path, constructHost(cmd.uri()), contentLength);
     addCredentialHeaders(request, cmd.uri());
+    addExtraRemoteHeaders(request);
     addUserAgentHeader(request);
     HttpChunkedInput body = buildBody(cmd);
     ctx.writeAndFlush(request)

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -17,12 +17,16 @@ package com.google.devtools.build.lib.remote.options;
 import com.google.common.base.Strings;
 import com.google.devtools.build.lib.util.OptionsUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsBase;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 /** Options for remote execution and distributed caching. */
 public final class RemoteOptions extends OptionsBase {
@@ -68,6 +72,19 @@ public final class RemoteOptions extends OptionsBase {
               + "If no schema is provided we'll default to grpc. "
               + "See https://docs.bazel.build/versions/master/remote-caching.html")
   public String remoteCache;
+
+  @Option(
+      name = "remote_header",
+      converter = Converters.AssignmentConverter.class,
+      defaultValue = "",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "Extra HTTP headers that will be passed to the remote_http_cache "
+              + "(e.g. --remote_header=Name=Value).",
+      allowMultiple = true)
+  public List<Entry<String, String>> remoteHeaders;
+
 
   @Option(
       name = "remote_timeout",

--- a/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStoreTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpBlobStoreTest.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.remote.blobstore.http;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -73,6 +74,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.IntFunction;
 import javax.annotation.Nullable;
 import org.junit.Test;
@@ -241,15 +243,16 @@ public class HttpBlobStoreTest {
       ServerChannel serverChannel, int timeoutSeconds, @Nullable final Credentials creds)
       throws Exception {
     SocketAddress socketAddress = serverChannel.localAddress();
+    List<Entry<String,String>> remoteHeaders = emptyList();
     if (socketAddress instanceof DomainSocketAddress) {
       DomainSocketAddress domainSocketAddress = (DomainSocketAddress) socketAddress;
       URI uri = new URI("http://localhost");
       return HttpBlobStore.create(
-          domainSocketAddress, uri, timeoutSeconds, /* remoteMaxConnections= */ 0, creds);
+          domainSocketAddress, uri, timeoutSeconds, /* remoteMaxConnections= */ 0, remoteHeaders, creds);
     } else if (socketAddress instanceof InetSocketAddress) {
       InetSocketAddress inetSocketAddress = (InetSocketAddress) socketAddress;
       URI uri = new URI("http://localhost:" + inetSocketAddress.getPort());
-      return HttpBlobStore.create(uri, timeoutSeconds, /* remoteMaxConnections= */ 0, creds);
+      return HttpBlobStore.create(uri, timeoutSeconds, /* remoteMaxConnections= */ 0, remoteHeaders, creds);
     } else {
       throw new IllegalStateException(
           "unsupported socket address class " + socketAddress.getClass());

--- a/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpDownloadHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpDownloadHandlerTest.java
@@ -37,6 +37,12 @@ import io.netty.handler.codec.http.LastHttpContent;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -54,7 +60,7 @@ public class HttpDownloadHandlerTest extends AbstractHttpHandlerTest {
    */
   @Test
   public void downloadShouldWork() throws IOException {
-    EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null));
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null, Collections.emptyList()));
     downloadShouldWork(true, ch);
     downloadShouldWork(false, ch);
   }
@@ -93,7 +99,7 @@ public class HttpDownloadHandlerTest extends AbstractHttpHandlerTest {
   /** Test that the handler correctly supports http error codes i.e. 404 (NOT FOUND). */
   @Test
   public void httpErrorsAreSupported() throws IOException {
-    EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null));
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null, Collections.emptyList()));
     ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
     DownloadCommand cmd = new DownloadCommand(CACHE_URI, true, "abcdef", out);
     ChannelPromise writePromise = ch.newPromise();
@@ -123,7 +129,7 @@ public class HttpDownloadHandlerTest extends AbstractHttpHandlerTest {
    */
   @Test
   public void httpErrorsWithContentAreSupported() throws IOException {
-    EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null));
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null, Collections.emptyList()));
     ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
     DownloadCommand cmd = new DownloadCommand(CACHE_URI, true, "abcdef", out);
     ChannelPromise writePromise = ch.newPromise();

--- a/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpUploadHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/blobstore/http/HttpUploadHandlerTest.java
@@ -33,6 +33,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import java.io.ByteArrayInputStream;
 import java.net.URI;
+import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -49,7 +50,7 @@ public class HttpUploadHandlerTest extends AbstractHttpHandlerTest {
    */
   @Test
   public void uploadsShouldWork() throws Exception {
-    EmbeddedChannel ch = new EmbeddedChannel(new HttpUploadHandler(null));
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpUploadHandler(null, Collections.emptyList()));
     HttpResponseStatus[] statuses = new HttpResponseStatus[] {HttpResponseStatus.OK,
         HttpResponseStatus.CREATED, HttpResponseStatus.ACCEPTED, HttpResponseStatus.NO_CONTENT};
 
@@ -86,7 +87,7 @@ public class HttpUploadHandlerTest extends AbstractHttpHandlerTest {
   /** Test that the handler correctly supports http error codes i.e. 404 (NOT FOUND). */
   @Test
   public void httpErrorsAreSupported() {
-    EmbeddedChannel ch = new EmbeddedChannel(new HttpUploadHandler(null));
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpUploadHandler(null, Collections.emptyList()));
     ByteArrayInputStream data = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5});
     ChannelPromise writePromise = ch.newPromise();
     ch.writeOneOutbound(new UploadCommand(CACHE_URI, true, "abcdef", data, 5), writePromise);
@@ -115,7 +116,7 @@ public class HttpUploadHandlerTest extends AbstractHttpHandlerTest {
    */
   @Test
   public void httpErrorsWithContentAreSupported() {
-    EmbeddedChannel ch = new EmbeddedChannel(new HttpUploadHandler(null));
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpUploadHandler(null, Collections.emptyList()));
     ByteArrayInputStream data = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5});
     ChannelPromise writePromise = ch.newPromise();
     ch.writeOneOutbound(new UploadCommand(CACHE_URI, true, "abcdef", data, 5), writePromise);


### PR DESCRIPTION
Fixes GitHub Issue #8245
https://github.com/bazelbuild/bazel/issues/8245