### PR TITLE
Always strip /external/<repo_name> from proto import path

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
@@ -324,6 +324,11 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
       if (protoRootFragment.startsWith(binOrGenfiles)) {
         protoRootFragment = protoRootFragment.relativeTo(binOrGenfiles);
       }
+      PathFragment repositoryPath = ruleContext.getLabel().getPackageIdentifier().getRepository()
+          .getPathUnderExecRoot();
+      if (protoRootFragment.startsWith(repositoryPath)) {
+        protoRootFragment = protoRootFragment.relativeTo(repositoryPath);
+      }
 
       String stripIncludePrefix =
           PathFragment.create("//").getRelative(protoRootFragment).toString();

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCommon.java
@@ -261,7 +261,7 @@ public class ProtoCommon {
     }
 
     if (stripImportPrefix == null) {
-      stripImportPrefix = PathFragment.EMPTY_FRAGMENT;
+      stripImportPrefix = PathFragment.create(ruleContext.getLabel().getWorkspaceRoot());
     } else if (stripImportPrefix.isAbsolute()) {
       stripImportPrefix =
           ruleContext

--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -1497,6 +1497,7 @@ java_test(
         ":guava_junit_truth",
         "//src/main/java/com/google/devtools/build/lib:build-base",
         "//src/main/java/com/google/devtools/build/lib:proto-rules",
+        "//src/main/java/com/google/devtools/build/lib:util",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/vfs",
     ],

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoLibraryTest.java
@@ -19,12 +19,14 @@ import static com.google.devtools.build.lib.actions.util.ActionsTestUtil.getFirs
 import static com.google.devtools.build.lib.actions.util.ActionsTestUtil.prettyArtifactNames;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.eventbus.EventBus;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.actions.SpawnAction;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.bazel.rules.cpp.proto.BazelCcProtoAspect;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.packages.AspectParameters;
 import com.google.devtools.build.lib.packages.util.Crosstool.CcToolchainConfig;
 import com.google.devtools.build.lib.rules.cpp.CcCompilationContext;
@@ -41,6 +43,7 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class CcProtoLibraryTest extends BuildViewTestCase {
+
   @Before
   public void setUp() throws Exception {
     mockToolsConfig.create("/protobuf/WORKSPACE");
@@ -242,5 +245,86 @@ public class CcProtoLibraryTest extends BuildViewTestCase {
     List<String> options = compilationSteps.get(0).getCompilerOptions();
     assertThat(options).doesNotContain("-fprofile-arcs");
     assertThat(options).doesNotContain("-ftest-coverage");
+  }
+
+  @Test
+  public void importPrefixWorksWithRepositories() throws Exception {
+    FileSystemUtils.appendIsoLatin1(
+        scratch.resolve("WORKSPACE"),
+        "local_repository(name = 'yolo_repo', path = '/yolo_repo')");
+    invalidatePackages();
+    scratch.file("/yolo_repo/WORKSPACE");
+    scratch.file("/yolo_repo/yolo_pkg/yolo.proto");
+    scratch.file(
+        "/yolo_repo/yolo_pkg/BUILD",
+        "proto_library(",
+        "  name = 'yolo_proto',",
+        "  srcs = ['yolo.proto'],",
+        "  import_prefix = 'bazel.build/yolo',",
+        ")",
+        "cc_proto_library(",
+        "  name = 'yolo_cc_proto',",
+        "  deps = [':yolo_proto'],",
+        ")");
+    assertThat(getTarget("@yolo_repo//yolo_pkg:yolo_cc_proto")).isNotNull();
+    assertThat(getProtoHeaderExecPath()).endsWith("_virtual_includes/yolo_proto/bazel.build/yolo/yolo_pkg/yolo.pb.h");
+  }
+
+  @Test
+  public void stripImportPrefixWorksWithRepositories() throws Exception {
+    FileSystemUtils.appendIsoLatin1(
+        scratch.resolve("WORKSPACE"),
+        "local_repository(name = 'yolo_repo', path = '/yolo_repo')");
+    invalidatePackages();
+
+    scratch.file("/yolo_repo/WORKSPACE");
+    scratch.file("/yolo_repo/yolo_pkg/yolo.proto");
+    scratch.file(
+        "/yolo_repo/yolo_pkg/BUILD",
+        "proto_library(",
+        "  name = 'yolo_proto',",
+        "  srcs = ['yolo.proto'],",
+        "  strip_import_prefix = '/yolo_pkg',",
+        ")",
+        "cc_proto_library(",
+        "  name = 'yolo_cc_proto',",
+        "  deps = [':yolo_proto'],",
+        ")");
+    assertThat(getTarget("@yolo_repo//yolo_pkg:yolo_cc_proto")).isNotNull();
+    assertThat(getProtoHeaderExecPath()).endsWith("_virtual_includes/yolo_proto/yolo.pb.h");
+  }
+
+  @Test
+  public void importPrefixAndStripImportPrefixWorksWithRepositories() throws Exception {
+    FileSystemUtils.appendIsoLatin1(
+        scratch.resolve("WORKSPACE"),
+        "local_repository(name = 'yolo_repo', path = '/yolo_repo')");
+    invalidatePackages();
+    scratch.file("/yolo_repo/WORKSPACE");
+    scratch.file("/yolo_repo/yolo_pkg/yolo.proto");
+    scratch.file(
+        "/yolo_repo/yolo_pkg/BUILD",
+        "proto_library(",
+        "  name = 'yolo_proto',",
+        "  srcs = ['yolo.proto'],",
+        "  import_prefix = 'bazel.build/yolo',",
+        "  strip_import_prefix = '/yolo_pkg'",
+        ")",
+        "cc_proto_library(",
+        "  name = 'yolo_cc_proto',",
+        "  deps = [':yolo_proto'],",
+        ")");
+    getTarget("@yolo_repo//yolo_pkg:yolo_cc_proto");
+
+    assertThat(getTarget("@yolo_repo//yolo_pkg:yolo_cc_proto")).isNotNull();
+    assertThat(getProtoHeaderExecPath()).endsWith("_virtual_includes/yolo_proto/bazel.build/yolo/yolo.pb.h");
+  }
+
+  private String getProtoHeaderExecPath() throws LabelSyntaxException {
+    ConfiguredTarget configuredTarget = getConfiguredTarget("@yolo_repo//yolo_pkg:yolo_cc_proto");
+    CcInfo ccInfo = configuredTarget.get(CcInfo.PROVIDER);
+    ImmutableList<Artifact> headers = ccInfo.getCcCompilationContext().getDeclaredIncludeSrcs()
+        .toList();
+    return Iterables.getOnlyElement(headers).getExecPathString();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/proto/BazelProtoLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/proto/BazelProtoLibraryTest.java
@@ -545,13 +545,55 @@ public class BazelProtoLibraryTest extends BuildViewTestCase {
     scratch.file(
         "main.proto",
         "syntax = 'proto3'';",
-        "import 'bazel.build/yolo/yolo_pkg/yolo.proto';");
+        "import 'yolo_pkg/yolo.proto';");
     scratch.file(
         "BUILD",
         "proto_library(",
         "  name = 'main_proto',",
         "  srcs = ['main.proto'],",
         "  deps = ['@yolo_repo//yolo_pkg_to_be_stripped/yolo_pkg:yolo_proto'],",
+        ")");
+
+    ConfiguredTarget main = getConfiguredTarget("//:main_proto");
+    ProtoInfo protoInfo = main.get(ProtoInfo.PROVIDER);
+    ImmutableList<Pair<Artifact, String>> importPaths = protoInfo
+        .getStrictImportableProtoSourcesImportPaths().toList();
+    assertThat(importPaths).isNotEmpty();
+    assertThat(importPaths.get(0).second).isEqualTo("yolo_pkg/yolo.proto");
+  }
+
+  @Test
+  public void testProtoSourceRootWithRelativeStripImportPrefixInExternalRepo() throws Exception {
+    if (!isThisBazel()) {
+      return;
+    }
+
+    FileSystemUtils.appendIsoLatin1(
+        scratch.resolve("WORKSPACE"),
+        "local_repository(name = 'yolo_repo', path = '/yolo_repo')");
+    invalidatePackages();
+
+    scratch.file("/yolo_repo/WORKSPACE");
+    scratch.file("/yolo_repo/yolo_pkg_to_be_stripped/yolo_pkg/yolo.proto");
+    scratch.file(
+        "/yolo_repo/BUILD",
+        "proto_library(",
+        "  name = 'yolo_proto',",
+        "  srcs = ['yolo_pkg_to_be_stripped/yolo_pkg/yolo.proto'],",
+        "  strip_import_prefix = 'yolo_pkg_to_be_stripped',",
+        "  visibility = ['//visibility:public'],",
+        ")");
+
+    scratch.file(
+        "main.proto",
+        "syntax = 'proto3'';",
+        "import 'yolo_pkg/yolo.proto';");
+    scratch.file(
+        "BUILD",
+        "proto_library(",
+        "  name = 'main_proto',",
+        "  srcs = ['main.proto'],",
+        "  deps = ['@yolo_repo//:yolo_proto'],",
         ")");
 
     ConfiguredTarget main = getConfiguredTarget("//:main_proto");

--- a/src/test/java/com/google/devtools/build/lib/rules/proto/BazelProtoLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/proto/BazelProtoLibraryTest.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.actions.FileWriteAction;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -431,6 +432,134 @@ public class BazelProtoLibraryTest extends BuildViewTestCase {
     reporter.removeHandler(failFastHandler);
     getConfiguredTarget("//third_party/a");
     assertContainsEvent("the 'proto_source_root' attribute is incompatible");
+  }
+
+
+  @Test
+  public void testProtoSourceRootWithImportPrefixInExternalRepo() throws Exception {
+    if (!isThisBazel()) {
+      return;
+    }
+
+    FileSystemUtils.appendIsoLatin1(
+        scratch.resolve("WORKSPACE"),
+        "local_repository(name = 'yolo_repo', path = '/yolo_repo')");
+    invalidatePackages();
+
+    scratch.file("/yolo_repo/WORKSPACE");
+    scratch.file("/yolo_repo/yolo_pkg/yolo.proto");
+    scratch.file(
+        "/yolo_repo/yolo_pkg/BUILD",
+        "proto_library(",
+        "  name = 'yolo_proto',",
+        "  srcs = ['yolo.proto'],",
+        "  import_prefix = 'bazel.build/yolo',",
+        "  visibility = ['//visibility:public'],",
+        ")");
+
+    scratch.file(
+        "main.proto",
+        "syntax = 'proto3'';",
+        "import 'bazel.build/yolo/yolo_pkg/yolo.proto';");
+    scratch.file(
+        "BUILD",
+        "proto_library(",
+        "  name = 'main_proto',",
+        "  srcs = ['main.proto'],",
+        "  deps = ['@yolo_repo//yolo_pkg:yolo_proto'],",
+        ")");
+
+    ConfiguredTarget main = getConfiguredTarget("//:main_proto");
+    ProtoInfo protoInfo = main.get(ProtoInfo.PROVIDER);
+    ImmutableList<Pair<Artifact, String>> importPaths = protoInfo
+        .getStrictImportableProtoSourcesImportPaths().toList();
+    assertThat(importPaths).isNotEmpty();
+    assertThat(importPaths.get(0).second).isEqualTo("bazel.build/yolo/yolo_pkg/yolo.proto");
+  }
+
+  @Test
+  public void testProtoSourceRootWithImportPrefixAndStripInExternalRepo() throws Exception {
+    if (!isThisBazel()) {
+      return;
+    }
+
+    FileSystemUtils.appendIsoLatin1(
+        scratch.resolve("WORKSPACE"),
+        "local_repository(name = 'yolo_repo', path = '/yolo_repo')");
+    invalidatePackages();
+
+    scratch.file("/yolo_repo/WORKSPACE");
+    scratch.file("/yolo_repo/yolo_pkg_to_be_stripped/yolo_pkg/yolo.proto");
+    scratch.file(
+        "/yolo_repo/yolo_pkg_to_be_stripped/yolo_pkg/BUILD",
+        "proto_library(",
+        "  name = 'yolo_proto',",
+        "  srcs = ['yolo.proto'],",
+        "  import_prefix = 'bazel.build/yolo',",
+        "  strip_import_prefix = '/yolo_pkg_to_be_stripped',",
+        "  visibility = ['//visibility:public'],",
+        ")");
+
+    scratch.file(
+        "main.proto",
+        "syntax = 'proto3'';",
+        "import 'bazel.build/yolo/yolo_pkg/yolo.proto';");
+    scratch.file(
+        "BUILD",
+        "proto_library(",
+        "  name = 'main_proto',",
+        "  srcs = ['main.proto'],",
+        "  deps = ['@yolo_repo//yolo_pkg_to_be_stripped/yolo_pkg:yolo_proto'],",
+        ")");
+
+    ConfiguredTarget main = getConfiguredTarget("//:main_proto");
+    ProtoInfo protoInfo = main.get(ProtoInfo.PROVIDER);
+    ImmutableList<Pair<Artifact, String>> importPaths = protoInfo
+        .getStrictImportableProtoSourcesImportPaths().toList();
+    assertThat(importPaths).isNotEmpty();
+    assertThat(importPaths.get(0).second).isEqualTo("bazel.build/yolo/yolo_pkg/yolo.proto");
+  }
+
+  @Test
+  public void testProtoSourceRootWithStripImportPrefixInExternalRepo() throws Exception {
+    if (!isThisBazel()) {
+      return;
+    }
+
+    FileSystemUtils.appendIsoLatin1(
+        scratch.resolve("WORKSPACE"),
+        "local_repository(name = 'yolo_repo', path = '/yolo_repo')");
+    invalidatePackages();
+
+    scratch.file("/yolo_repo/WORKSPACE");
+    scratch.file("/yolo_repo/yolo_pkg_to_be_stripped/yolo_pkg/yolo.proto");
+    scratch.file(
+        "/yolo_repo/yolo_pkg_to_be_stripped/yolo_pkg/BUILD",
+        "proto_library(",
+        "  name = 'yolo_proto',",
+        "  srcs = ['yolo.proto'],",
+        "  strip_import_prefix = '/yolo_pkg_to_be_stripped',",
+        "  visibility = ['//visibility:public'],",
+        ")");
+
+    scratch.file(
+        "main.proto",
+        "syntax = 'proto3'';",
+        "import 'bazel.build/yolo/yolo_pkg/yolo.proto';");
+    scratch.file(
+        "BUILD",
+        "proto_library(",
+        "  name = 'main_proto',",
+        "  srcs = ['main.proto'],",
+        "  deps = ['@yolo_repo//yolo_pkg_to_be_stripped/yolo_pkg:yolo_proto'],",
+        ")");
+
+    ConfiguredTarget main = getConfiguredTarget("//:main_proto");
+    ProtoInfo protoInfo = main.get(ProtoInfo.PROVIDER);
+    ImmutableList<Pair<Artifact, String>> importPaths = protoInfo
+        .getStrictImportableProtoSourcesImportPaths().toList();
+    assertThat(importPaths).isNotEmpty();
+    assertThat(importPaths.get(0).second).isEqualTo("yolo_pkg/yolo.proto");
   }
 
   @Test


### PR DESCRIPTION
Before this PR, when strip_import_prefix was not specified, and the proto target
was declared in an external repository, Bazel generated import path that leaked
`external/<repository_name>` path fragment. That path fragment is an
implementation detail of Bazel's execroot layout and should not be used in proto
source files.

This PR removes this path fragment from the import path.

Fixes https://github.com/bazelbuild/bazel/issues/8030.