### PR TITLE
Added HttpContentDecompressor to HttpBlobStore download pipeline

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -49,6 +49,7 @@ import io.netty.channel.pool.SimpleChannelPool;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestEncoder;
@@ -389,6 +390,7 @@ public final class HttpCacheClient implements RemoteCacheClient {
                     "timeout-handler",
                     new IdleTimeoutHandler(timeoutSeconds, ReadTimeoutException.INSTANCE));
                 p.addLast(new HttpClientCodec());
+                p.addLast("inflater", new HttpContentDecompressor());
                 synchronized (credentialsLock) {
                   p.addLast(new HttpDownloadHandler(creds, extraHttpHeaders));
                 }
@@ -419,6 +421,7 @@ public final class HttpCacheClient implements RemoteCacheClient {
       try {
         ch.pipeline().remove(IdleTimeoutHandler.class);
         ch.pipeline().remove(HttpClientCodec.class);
+        ch.pipeline().remove(HttpContentDecompressor.class);
         ch.pipeline().remove(HttpDownloadHandler.class);
       } catch (NoSuchElementException e) {
         // If the channel is in the process of closing but not yet closed, some handlers could have

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpDownloadHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpDownloadHandler.java
@@ -165,6 +165,7 @@ final class HttpDownloadHandler extends AbstractHttpHandler<HttpObject> {
     httpRequest.headers().set(HttpHeaderNames.HOST, host);
     httpRequest.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
     httpRequest.headers().set(HttpHeaderNames.ACCEPT, "*/*");
+    httpRequest.headers().set(HttpHeaderNames.ACCEPT_ENCODING, HttpHeaderValues.GZIP);
     return httpRequest;
   }
 

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -182,6 +182,9 @@ py_test(
     main = "remote/cache_decompression_test.py",
     srcs = ["remote/cache_decompression_test.py"],
     deps = [":test_base"],
+    tags = [
+        "no-sandbox", # This test sets up mock cache on localhost.
+    ],
 )
 
 py_test(

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -178,6 +178,13 @@ py_test(
 )
 
 py_test(
+    name = "bazel_remote_cache_decompression_test",
+    main = "remote/cache_decompression_test.py",
+    srcs = ["remote/cache_decompression_test.py"],
+    deps = [":test_base"],
+)
+
+py_test(
     name = "test_wrapper_test",
     srcs = select({
         "//src/conditions:windows": ["test_wrapper_test.py"],

--- a/src/test/py/bazel/remote/cache_decompression_test.py
+++ b/src/test/py/bazel/remote/cache_decompression_test.py
@@ -1,0 +1,124 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gzip
+import io
+import os
+import shutil
+import socket
+import stat
+import threading
+import unittest
+from src.test.py.bazel import test_base
+
+try:
+  from BaseHTTPServer import BaseHTTPRequestHandler
+except ImportError:
+  from http.server import BaseHTTPRequestHandler
+
+try:
+  from BaseHTTPServer import HTTPServer
+except ImportError:
+  from http.server import HTTPServer
+
+class MemoryStorageHandler(BaseHTTPRequestHandler):
+  protocol_version = 'HTTP/1.1'
+
+  def __init__(self, request, client_address, server):
+    BaseHTTPRequestHandler.__init__(self, request, client_address, server)
+
+  def do_PUT(self):
+    self.send_response(200)
+    self.end_headers()
+    self.server.storage[self.path] = self.rfile.read(int(self.headers['Content-Length']))
+    self.finish()
+
+  def do_GET(self):
+    if self.path in self.server.storage:
+      out = io.BytesIO()
+      with gzip.GzipFile(fileobj=out, mode='w') as f:
+        f.write(self.server.storage[self.path])
+      self.send_response(200)
+      self.send_header('Content-Length', str(len(out.getvalue())))
+      self.send_header('Content-Encoding', 'gzip')
+      self.end_headers()
+      self.wfile.write(out.getvalue())
+
+    else:
+      self.send_response(404)
+      self.end_headers()
+    self.finish()
+
+class CacheDecompressionTest(test_base.TestBase):
+
+  def setUp(self):
+    test_base.TestBase.setUp(self)
+    server_port = self.GetFreeTCPPort()
+    self.httpd = HTTPServer(('localhost', server_port), MemoryStorageHandler)
+    self.httpd.storage = {}
+    self.url = 'http://localhost:{}'.format(server_port)
+    self.background = threading.Thread(target=self.httpd.serve_forever)
+    self.background.start()
+
+  def tearDown(self):
+    self.httpd.shutdown()
+    self.background.join()
+    test_base.TestBase.tearDown(self)
+
+  def testDecompressionWorks(self):
+    content = ['Hello HTTP']
+    self.ScratchFile('WORKSPACE')
+    self.ScratchFile('input.txt', content)
+    self.ScratchFile('BUILD', [
+        'genrule(',
+        '    name = "genrule",',
+        '    cmd = "cp \\"$<\\" \\"$@\\"",',
+        '    srcs = ["//:input.txt"],',
+        '    outs = ["genrule.txt"],',
+        ')',
+    ])
+
+    exit_code, _, stderr = self.RunBazel(['build', '//:genrule.txt', '--remote_http_cache', self.url])
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertNotIn('INFO: 1 process: 1 remote cache hit.', stderr)
+    self.assertNotIn('HTTP version 1.1 is required', stderr)
+
+    exit_code, _, stderr = self.RunBazel(['clean', '--expunge'])
+    self.AssertExitCode(exit_code, 0, stderr)
+
+    exit_code, _, stderr = self.RunBazel(['build', '//:genrule.txt', '--remote_http_cache', self.url])
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertIn('INFO: 1 process: 1 remote cache hit.', stderr)
+    self.assertNotIn('HTTP version 1.1 is required', stderr)
+
+    exit_code, stdout, stderr = self.RunBazel(['info', 'bazel-genfiles'])
+    self.AssertExitCode(exit_code, 0, stderr)
+    bazel_genfiles = stdout[0]
+
+    self.AssertFileContentEqual(os.path.join(bazel_genfiles, 'genrule.txt'), content)
+
+  def GetFreeTCPPort(self):
+    tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    tcp.bind(('localhost', 0))
+    addr, port = tcp.getsockname()
+    tcp.close()
+    return port
+
+  def AssertFileContentEqual(self, file_path, entry):
+    with open(file_path, 'r') as f:
+      self.assertEqual(f.read().splitlines(), entry)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/src/test/py/bazel/remote/cache_decompression_test.py
+++ b/src/test/py/bazel/remote/cache_decompression_test.py
@@ -45,7 +45,7 @@ class MemoryStorageHandler(BaseHTTPRequestHandler):
     self.finish()
 
   def do_GET(self):
-    if self.path in self.server.storage:
+    if self.path in self.server.storage and 'gzip' in self.headers['Accept-Encoding']:
       out = io.BytesIO()
       with gzip.GzipFile(fileobj=out, mode='w') as f:
         f.write(self.server.storage[self.path])
@@ -89,7 +89,7 @@ class CacheDecompressionTest(test_base.TestBase):
         ')',
     ])
 
-    exit_code, _, stderr = self.RunBazel(['build', '//:genrule.txt', '--remote_http_cache', self.url])
+    exit_code, _, stderr = self.RunBazel(['build', '//:genrule.txt', '--remote_cache', self.url])
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertNotIn('INFO: 1 process: 1 remote cache hit.', stderr)
     self.assertNotIn('HTTP version 1.1 is required', stderr)
@@ -97,7 +97,7 @@ class CacheDecompressionTest(test_base.TestBase):
     exit_code, _, stderr = self.RunBazel(['clean', '--expunge'])
     self.AssertExitCode(exit_code, 0, stderr)
 
-    exit_code, _, stderr = self.RunBazel(['build', '//:genrule.txt', '--remote_http_cache', self.url])
+    exit_code, _, stderr = self.RunBazel(['build', '//:genrule.txt', '--remote_cache', self.url])
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertIn('INFO: 1 process: 1 remote cache hit.', stderr)
     self.assertNotIn('HTTP version 1.1 is required', stderr)


### PR DESCRIPTION
This patch enables accepting compressed data from remote cache.