### PR TITLE
Cap Android persistent workers' max instances at 1 for optimal performance and memory usage

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -897,14 +897,15 @@ public class AndroidConfiguration extends BuildConfiguration.Fragment
     public boolean oneVersionEnforcementUseTransitiveJarsForBinaryUnderTest;
 
     @Option(
-        name = "persistent_android_resource_processor",
+        name = "android_persistent_workers",
         defaultValue = "null",
+        oldName = "persistent_android_resource_processor",
         documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
         effectTags = {
           OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS,
           OptionEffectTag.EXECUTION,
         },
-        help = "Enable the persistent Android resource processor by using workers.",
+        help = "Enable persistent workers for Android build actions.",
         expansion = {
           "--internal_persistent_busybox_tools",
           // This implementation uses unique workers for each tool in the busybox.
@@ -918,13 +919,32 @@ public class AndroidConfiguration extends BuildConfiguration.Fragment
           "--strategy=AndroidAssetMerger=worker",
           "--strategy=AndroidResourceMerger=worker",
           "--strategy=AndroidCompiledResourceMerger=worker",
+          "--worker_max_instances=AaptPackage=2",
+          "--worker_max_instances=AndroidResourceParser=2",
+          "--worker_max_instances=AndroidResourceValidator=2",
+          "--worker_max_instances=AndroidResourceCompiler=2",
+          "--worker_max_instances=RClassGenerator=2",
+          "--worker_max_instances=AndroidResourceLink=2",
+          "--worker_max_instances=AndroidAapt2=2",
+          "--worker_max_instances=AndroidAssetMerger=2",
+          "--worker_max_instances=AndroidResourceMerger=2",
+          "--worker_max_instances=AndroidCompiledResourceMerger=2",
           // TODO(jingwen): ManifestMerger prints to stdout when there's a manifest merge
           // conflict. The worker protocol does not like this because it uses std i/o to
           // for communication. To get around this, re-configure manifest merger to *not*
           // use stdout for merge conflict warnings.
           // "--strategy=ManifestMerger=worker",
+          // Javac
+          "--strategy=Javac=worker",
+          "--worker_max_instances=Javac=2",
+          // DexBuilder
+          "--strategy=DexBuilder=worker",
+          "--worker_max_instances=DexBuilder=2",
+          // Desugar
+          "--strategy=Desugar=worker",
+          "--worker_max_instances=Desugar=2",
         })
-    public Void persistentResourceProcessor;
+    public Void androidPersistentWorkers;
 
     /**
      * We use this option to decide when to enable workers for busybox tools. This flag is also a

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -919,16 +919,18 @@ public class AndroidConfiguration extends BuildConfiguration.Fragment
           "--strategy=AndroidAssetMerger=worker",
           "--strategy=AndroidResourceMerger=worker",
           "--strategy=AndroidCompiledResourceMerger=worker",
-          "--worker_max_instances=AaptPackage=2",
-          "--worker_max_instances=AndroidResourceParser=2",
-          "--worker_max_instances=AndroidResourceValidator=2",
-          "--worker_max_instances=AndroidResourceCompiler=2",
-          "--worker_max_instances=RClassGenerator=2",
-          "--worker_max_instances=AndroidResourceLink=2",
-          "--worker_max_instances=AndroidAapt2=2",
-          "--worker_max_instances=AndroidAssetMerger=2",
-          "--worker_max_instances=AndroidResourceMerger=2",
-          "--worker_max_instances=AndroidCompiledResourceMerger=2",
+          // Use 1 worker for optimal performance. See benchmarks in
+          // https://github.com/bazelbuild/bazel/issues/8586#issuecomment-504638339
+          "--worker_max_instances=AaptPackage=1",
+          "--worker_max_instances=AndroidResourceParser=1",
+          "--worker_max_instances=AndroidResourceValidator=1",
+          "--worker_max_instances=AndroidResourceCompiler=1",
+          "--worker_max_instances=RClassGenerator=1",
+          "--worker_max_instances=AndroidResourceLink=1",
+          "--worker_max_instances=AndroidAapt2=1",
+          "--worker_max_instances=AndroidAssetMerger=1",
+          "--worker_max_instances=AndroidResourceMerger=1",
+          "--worker_max_instances=AndroidCompiledResourceMerger=1",
           // TODO(jingwen): ManifestMerger prints to stdout when there's a manifest merge
           // conflict. The worker protocol does not like this because it uses std i/o to
           // for communication. To get around this, re-configure manifest merger to *not*
@@ -936,13 +938,13 @@ public class AndroidConfiguration extends BuildConfiguration.Fragment
           // "--strategy=ManifestMerger=worker",
           // Javac
           "--strategy=Javac=worker",
-          "--worker_max_instances=Javac=2",
+          "--worker_max_instances=Javac=1",
           // DexBuilder
           "--strategy=DexBuilder=worker",
-          "--worker_max_instances=DexBuilder=2",
+          "--worker_max_instances=DexBuilder=1",
           // Desugar
           "--strategy=Desugar=worker",
-          "--worker_max_instances=Desugar=2",
+          "--worker_max_instances=Desugar=1",
         })
     public Void androidPersistentWorkers;
 

--- a/src/test/shell/bazel/android/resource_processing_integration_test.sh
+++ b/src/test/shell/bazel/android/resource_processing_integration_test.sh
@@ -93,22 +93,22 @@ function test_font_support() {
   assert_build //java/bazel:bin
 }
 
-function test_persistent_resource_processor_aapt() {
+function test_persistent_workers_aapt() {
   create_new_workspace
   setup_android_sdk_support
   create_android_binary
   setup_font_resources
 
-  assert_build //java/bazel:bin --persistent_android_resource_processor
+  assert_build //java/bazel:bin --android_persistent_workers
 }
 
-function test_persistent_resource_processor_aapt2() {
+function test_persistent_workers_aapt2() {
   create_new_workspace
   setup_android_sdk_support
   create_android_binary
   setup_font_resources
 
-  assert_build //java/bazel:bin --persistent_android_resource_processor --android_aapt=aapt2
+  assert_build //java/bazel:bin --android_persistent_workers --android_aapt=aapt2
 }
 
 run_suite "Resource processing integration tests"


### PR DESCRIPTION
The global default value for `--worker_max_instances` is 4. This change turns the default number of instances for Android-related persistent workers down to 1. See https://github.com/bazelbuild/bazel/issues/8586#issuecomment-504638339 for context and benchmarks.

This change reduces the risks of Android builds OOMing when using persistent workers, and makes the builds faster as well.

tl;dr: 10-20% faster builds, 55-65% lower memory usage.

Benchmark project: https://github.com/jin/simple_tree
Heap sizes: 5.47GiB -> 2.47GiB (Linux workstation), 2.25GiB -> 811MiB (MacBook Pro)
Build wall time: 30.998s -> 24.062s (Linux workstation), 75.949s -> 67.508s (MacBook Pro)

RELNOTES: Renamed `--persistent_android_resource_processor` to `--android_persistent_workers`. Reworked the flag's internals to make Android builds up to 20% faster and reduce JVM memory usage by up to 65%.