### PR TITLE
Add no-remote-cache and no-remote-exec execution requirements

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
@@ -28,11 +28,23 @@
   </li>
 
   <li><code>no-cache</code> keyword results in the action or test never being
-    cached.
+    cached (remotely or locally)
   </li>
 
-  <li><code>no-remote</code> keyword results in the action or test never being
+  <li><code>no-remote-cache</code> keyword results in the action or test never being
+    cached remotely (but it may be cached locally; it may also be executed remotely).
+    Note: for the purposes of this tag, the disk-cache is considered a local cache, whereas
+    the http and gRPC caches are considered remote.
+    If a combined cache is specified (i.e. a cache with local and remote components),
+    it's treated as a remote cache and disabled entirely.
+  </li>
+
+  <li><code>no-remote-exec</code> keyword results in the action or test never being
     executed remotely (but it may be cached remotely).
+  </li>
+
+  <li><code>no-remote</code> keyword prevents the action or test from being executed remotely
+    or cached remotely. This is equivalent to using both no-remote-cache and no-remote-exec.
   </li>
 
   <li><code>local</code> keyword precludes the action or test from being remotely cached,

--- a/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
@@ -176,14 +176,24 @@ public class ExecutionRequirements {
    */
   public static final String NO_CACHE = "no-cache";
 
+  /** Disables remote caching of a spawn. Note: does not disable remote execution */
+  public static final String NO_REMOTE_CACHE = "no-remote-cache";
+
+  /** Disables remote execution of a spawn. Note: does not disable remote caching */
+  public static final String NO_REMOTE_EXEC = "no-remote-exec";
+
+  /**
+  * Disables both remote execution and remote caching of a spawn.
+  * This is the equivalent of using no-remote-cache and no-remote-exec together.
+  */
+  public static final String NO_REMOTE = "no-remote";
+
   /** Disables local sandboxing of a spawn. */
   public static final String LEGACY_NOSANDBOX = "nosandbox";
 
   /** Disables local sandboxing of a spawn. */
   public static final String NO_SANDBOX = "no-sandbox";
 
-  /** Disables remote execution of a spawn. */
-  public static final String NO_REMOTE = "no-remote";
 
   /**
    * Enables networking for a spawn if possible (only if sandboxing is enabled and if the sandbox

--- a/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawns.java
@@ -33,6 +33,24 @@ public final class Spawns {
         && !spawn.getExecutionInfo().containsKey(ExecutionRequirements.LOCAL);
   }
 
+  /**
+   * Returns {@code true} if the result of {@code spawn} may be cached remotely.
+   */
+  public static boolean mayBeCachedRemotely(Spawn spawn) {
+    return mayBeCached(spawn)
+        && !spawn.getExecutionInfo().containsKey(ExecutionRequirements.NO_REMOTE)
+        && !spawn.getExecutionInfo().containsKey(ExecutionRequirements.NO_REMOTE_CACHE);
+  }
+
+  /**
+   * Returns {@code true} if {@code spawn} may be executed remotely.
+   */
+  public static boolean mayBeExecutedRemotely(Spawn spawn) {
+    return !spawn.getExecutionInfo().containsKey(ExecutionRequirements.LOCAL)
+        && !spawn.getExecutionInfo().containsKey(ExecutionRequirements.NO_REMOTE)
+        && !spawn.getExecutionInfo().containsKey(ExecutionRequirements.NO_REMOTE_EXEC);
+  }
+
   /** Returns whether a Spawn can be executed in a sandbox environment. */
   public static boolean mayBeSandboxed(Spawn spawn) {
     return !spawn.getExecutionInfo().containsKey(ExecutionRequirements.LEGACY_NOSANDBOX)
@@ -50,15 +68,6 @@ public final class Spawns {
     }
 
     return defaultSandboxDisallowNetwork;
-  }
-
-  /**
-   * Returns whether a Spawn claims to support being executed remotely according to its execution
-   * info tags.
-   */
-  public static boolean mayBeExecutedRemotely(Spawn spawn) {
-    return !spawn.getExecutionInfo().containsKey(ExecutionRequirements.LOCAL)
-        && !spawn.getExecutionInfo().containsKey(ExecutionRequirements.NO_REMOTE);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnCache.java
@@ -162,7 +162,8 @@ public interface SpawnCache extends ActionContext {
    * object is for the cache to store expensive intermediate values (such as the cache key) that are
    * needed both for the lookup and the subsequent store operation.
    *
-   * <p>The lookup must not succeed for non-cachable spawns. See {@link Spawns#mayBeCached()}.
+   * <p>The lookup must not succeed for non-cachable spawns. See {@link Spawns#mayBeCached()} and
+   * {@link Spawns#mayBeCachedRemotely}.
    *
    * <p>Note that cache stores may be disabled, in which case the returned {@link CacheHandle}
    * instance's {@link CacheHandle#store} is a no-op.

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -110,11 +110,11 @@ final class RemoteSpawnCache implements SpawnCache {
     this.topLevelOutputs = Preconditions.checkNotNull(topLevelOutputs, "topLevelOutputs");
   }
 
-
   @Override
   public CacheHandle lookup(Spawn spawn, SpawnExecutionContext context)
       throws InterruptedException, IOException, ExecException {
-    if (!Spawns.mayBeCached(spawn) || !Spawns.mayBeExecutedRemotely(spawn)) {
+    if (!Spawns.mayBeCached(spawn)
+        || (!Spawns.mayBeCachedRemotely(spawn) && isRemoteCache(options))) {
       return SpawnCache.NO_RESULT_NO_STORE;
     }
     boolean checkCache = options.remoteAcceptCached;
@@ -291,5 +291,9 @@ final class RemoteSpawnCache implements SpawnCache {
       reportedErrors.add(evt.getMessage());
       cmdlineReporter.handle(evt);
     }
+  }
+
+  private boolean isRemoteCache(RemoteOptions options) {
+    return !isNullOrEmpty(options.remoteCache);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -177,6 +177,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
     // Get the remote platform properties.
     Platform platform =
         parsePlatform(spawn.getExecutionPlatform(), remoteOptions.remoteDefaultPlatformProperties);
+
     Command command =
         buildCommand(
             spawn.getOutputFiles(), spawn.getArguments(), spawn.getEnvironment(), platform);


### PR DESCRIPTION
This resolves https://github.com/bazelbuild/bazel/issues/7932

It introduces two new execution requirements:
- `no-remote-exec`: disallows remote execution without preventing remote caching
- `no-remote-cache`: disallows remote caching without preventing remote execution or local caching

The current behavior of `no-remote` and `no-cache` remain unchanged. 