### PR TITLE
Make deps transitive in windows_dll_library

### DIFF
--- a/examples/windows/dll/windows_dll_library.bzl
+++ b/examples/windows/dll/windows_dll_library.bzl
@@ -16,6 +16,7 @@
 def windows_dll_library(
         name,
         srcs = [],
+        deps = [],
         hdrs = [],
         visibility = None,
         **kwargs):
@@ -28,6 +29,7 @@ def windows_dll_library(
     native.cc_binary(
         name = dll_name,
         srcs = srcs + hdrs,
+        deps = deps,
         linkshared = 1,
         **kwargs
     )
@@ -52,7 +54,7 @@ def windows_dll_library(
         name = name,
         hdrs = hdrs,
         visibility = visibility,
-        deps = [
+        deps = deps + [
             ":" + import_target_name,
         ],
     )


### PR DESCRIPTION
If cc_binary A depends on windows_dll_library B, which depends on windows_dll_library C. A should transitively depends on windows_dll_library C.