### PR TITLE
Add a Checksum class for plumbing HTTP downloader content checksums.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Checksum.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Checksum.java
@@ -1,0 +1,49 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.downloader;
+
+import com.google.common.hash.HashCode;
+import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
+
+/** The content checksum for an HTTP download, which knows its own type. */
+public class Checksum {
+  private final KeyType keyType;
+  private final HashCode hashCode;
+
+  private Checksum(KeyType keyType, HashCode hashCode) {
+    this.keyType = keyType;
+    this.hashCode = hashCode;
+  }
+
+  /** Constructs a new Checksum for a given key type and hash, in hex format. */
+  public static Checksum fromString(KeyType keyType, String hash) throws IllegalArgumentException {
+    if (!keyType.isValid(hash)) {
+      throw new IllegalArgumentException("Invalid " + keyType.toString() + " checksum '" + hash + "'");
+    }
+    return new Checksum(keyType, HashCode.fromString(hash));
+  }
+
+  public String toString() {
+    return hashCode.toString();
+  }
+
+  public HashCode getHashCode() {
+    return hashCode;
+  }
+
+  public KeyType getKeyType() {
+    return keyType;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HashInputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HashInputStream.java
@@ -42,10 +42,10 @@ final class HashInputStream extends InputStream {
   @Nullable private volatile HashCode actual;
 
   HashInputStream(
-      @WillCloseWhenClosed InputStream delegate, HashFunction function, HashCode code) {
+      @WillCloseWhenClosed InputStream delegate, Checksum checksum) {
     this.delegate = delegate;
-    this.hasher = function.newHasher();
-    this.code = code;
+    this.hasher = checksum.getKeyType().newHasher();
+    this.code = checksum.getHashCode();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexer.java
@@ -16,12 +16,14 @@ package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Ordering;
 import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
 import com.google.devtools.build.lib.bazel.repository.downloader.RetryingInputStream.Reconnector;
+import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.clock.Clock;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.events.Event;
@@ -95,8 +97,8 @@ final class HttpConnectorMultiplexer {
     this.sleeper = sleeper;
   }
 
-  public HttpStream connect(List<URL> urls, String sha256) throws IOException {
-    return connect(urls, sha256, ImmutableMap.<URI, Map<String, String>>of());
+  public HttpStream connect(List<URL> urls, Optional<Checksum> checksum) throws IOException {
+    return connect(urls, checksum, ImmutableMap.<URI, Map<String, String>>of());
   }
 
   /**
@@ -116,22 +118,21 @@ final class HttpConnectorMultiplexer {
    * and block until the connection can be renegotiated transparently right where it left off.
    *
    * @param urls mirrors by preference; each URL can be: file, http, or https
-   * @param sha256 hex checksum lazily checked on entire payload, or empty to disable
+   * @param checksum checksum lazily checked on entire payload, or empty to disable
    * @return an {@link InputStream} of response payload
    * @throws IOException if all mirrors are down and contains suppressed exception of each attempt
    * @throws InterruptedIOException if current thread is being cast into oblivion
    * @throws IllegalArgumentException if {@code urls} is empty or has an unsupported protocol
    */
   public HttpStream connect(
-      List<URL> urls, String sha256, Map<URI, Map<String, String>> authHeaders) throws IOException {
-    Preconditions.checkNotNull(sha256);
+      List<URL> urls, Optional<Checksum> checksum, Map<URI, Map<String, String>> authHeaders) throws IOException {
     HttpUtils.checkUrlsArgument(urls);
     if (Thread.interrupted()) {
       throw new InterruptedIOException();
     }
     // If there's only one URL then there's no need for us to run all our fancy thread stuff.
     if (urls.size() == 1) {
-      return establishConnection(urls.get(0), sha256, authHeaders);
+      return establishConnection(urls.get(0), checksum, authHeaders);
     }
     MutexConditionSharedMemory context = new MutexConditionSharedMemory();
     // The parent thread always holds the lock except when released by wait().
@@ -140,7 +141,7 @@ final class HttpConnectorMultiplexer {
       long now = clock.currentTimeMillis();
       long startAtTime = now;
       for (URL url : urls) {
-        context.jobs.add(new WorkItem(url, sha256, startAtTime, authHeaders));
+        context.jobs.add(new WorkItem(url, checksum, startAtTime, authHeaders));
         startAtTime += FAILOVER_DELAY_MS;
       }
       // Create the worker thread pool.
@@ -210,13 +211,13 @@ final class HttpConnectorMultiplexer {
 
   private static class WorkItem {
     final URL url;
-    final String sha256;
+    final Optional<Checksum> checksum;
     final long startAtTime;
     final Map<URI, Map<String, String>> authHeaders;
 
-    WorkItem(URL url, String sha256, long startAtTime, Map<URI, Map<String, String>> authHeaders) {
+    WorkItem(URL url, Optional<Checksum> checksum, long startAtTime, Map<URI, Map<String, String>> authHeaders) {
       this.url = url;
-      this.sha256 = sha256;
+      this.checksum = checksum;
       this.startAtTime = startAtTime;
       this.authHeaders = authHeaders;
     }
@@ -263,7 +264,7 @@ final class HttpConnectorMultiplexer {
         // Now we're actually going to attempt to connect to the remote server.
         HttpStream result;
         try {
-          result = establishConnection(work.url, work.sha256, work.authHeaders);
+          result = establishConnection(work.url, work.checksum, work.authHeaders);
         } catch (InterruptedIOException e) {
           // The parent thread got its result from another thread and killed this one.
           synchronized (context) {
@@ -307,7 +308,7 @@ final class HttpConnectorMultiplexer {
   }
 
   private HttpStream establishConnection(
-      final URL url, String sha256, Map<URI, Map<String, String>> additionalHeaders)
+      final URL url, Optional<Checksum> checksum, Map<URI, Map<String, String>> additionalHeaders)
       throws IOException {
     ImmutableMap<String, String> headers = REQUEST_HEADERS;
     try {
@@ -327,7 +328,7 @@ final class HttpConnectorMultiplexer {
     return httpStreamFactory.create(
         connection,
         url,
-        sha256,
+        checksum,
         new Reconnector() {
           @Override
           public URLConnection connect(Throwable cause, ImmutableMap<String, String> extraHeaders)

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -72,12 +72,12 @@ public class HttpDownloader {
   /**
    * Downloads file to disk and returns path.
    *
-   * <p>If the SHA256 checksum and path to the repository cache is specified, attempt to load the
+   * <p>If the checksum and path to the repository cache is specified, attempt to load the
    * file from the {@link RepositoryCache}. If it doesn't exist, proceed to download the file and
    * load it into the cache prior to returning the value.
    *
    * @param urls list of mirror URLs with identical content
-   * @param sha256 valid SHA256 hex checksum string which is checked, or empty to disable
+   * @param checksum valid checksum which is checked, or empty to disable
    * @param type extension, e.g. "tar.gz" to force on downloaded filename, or empty to not do this
    * @param output destination filename if {@code type} is <i>absent</i>, otherwise output directory
    * @param eventHandler CLI progress reporter
@@ -91,7 +91,7 @@ public class HttpDownloader {
   public Path download(
       List<URL> urls,
       Map<URI, Map<String, String>> authHeaders,
-      String sha256,
+      Optional<Checksum> checksum,
       String canonicalId,
       Optional<String> type,
       Path output,
@@ -116,14 +116,16 @@ public class HttpDownloader {
     }
     Path destination = getDownloadDestination(mainUrl, type, output);
 
-    // Is set to true if the value should be cached by the sha256 value provided
-    boolean isCachingByProvidedSha256 = false;
+    // Is set to true if the value should be cached by the checksum value provided
+    boolean isCachingByProvidedChecksum = false;
 
-    if (!sha256.isEmpty()) {
+    if (checksum.isPresent()) {
+      String cacheKey = checksum.get().toString();
+      KeyType cacheKeyType = checksum.get().getKeyType();
       try {
-        String currentSha256 =
-            RepositoryCache.getChecksum(KeyType.SHA256, destination);
-        if (currentSha256.equals(sha256)) {
+        String currentChecksum =
+            RepositoryCache.getChecksum(cacheKeyType, destination);
+        if (currentChecksum.equals(cacheKey)) {
           // No need to download.
           return destination;
         }
@@ -132,14 +134,14 @@ public class HttpDownloader {
       }
 
       if (repositoryCache.isEnabled()) {
-        isCachingByProvidedSha256 = true;
+        isCachingByProvidedChecksum = true;
 
         try {
           Path cachedDestination =
-              repositoryCache.get(sha256, destination, KeyType.SHA256, canonicalId);
+              repositoryCache.get(cacheKey, destination, cacheKeyType, canonicalId);
           if (cachedDestination != null) {
             // Cache hit!
-            eventHandler.post(new RepositoryCacheHitEvent(repo, sha256, mainUrl));
+            eventHandler.post(new RepositoryCacheHitEvent(repo, cacheKey, mainUrl));
             return cachedDestination;
           }
         } catch (IOException e) {
@@ -163,16 +165,16 @@ public class HttpDownloader {
           boolean match = false;
           Path candidate = dir.getRelative(destination.getBaseName());
           try {
-            match = RepositoryCache.getChecksum(KeyType.SHA256, candidate).equals(sha256);
+            match = RepositoryCache.getChecksum(cacheKeyType, candidate).equals(cacheKey);
           } catch (IOException e) {
             // Not finding anything in a distdir is a normal case, so handle it absolutely
             // quietly. In fact, it is not uncommon to specify a whole list of dist dirs,
             // with the asumption that only one will contain an entry.
           }
           if (match) {
-            if (isCachingByProvidedSha256) {
+            if (isCachingByProvidedChecksum) {
               try {
-                repositoryCache.put(sha256, candidate, KeyType.SHA256, canonicalId);
+                repositoryCache.put(cacheKey, candidate, cacheKeyType, canonicalId);
               } catch (IOException e) {
                 eventHandler.handle(
                     Event.warn("Failed to copy " + candidate + " to repository cache: " + e));
@@ -201,7 +203,7 @@ public class HttpDownloader {
     // Connect to the best mirror and download the file, while reporting progress to the CLI.
     semaphore.acquire();
     boolean success = false;
-    try (HttpStream payload = multiplexer.connect(urls, sha256, authHeaders);
+    try (HttpStream payload = multiplexer.connect(urls, checksum, authHeaders);
         OutputStream out = destination.getOutputStream()) {
       ByteStreams.copy(payload, out);
       success = true;
@@ -215,8 +217,8 @@ public class HttpDownloader {
       eventHandler.post(new FetchEvent(urls.get(0).toString(), success));
     }
 
-    if (isCachingByProvidedSha256) {
-      repositoryCache.put(sha256, destination, KeyType.SHA256, canonicalId);
+    if (isCachingByProvidedChecksum) {
+      repositoryCache.put(checksum.get().toString(), destination, checksum.get().getKeyType(), canonicalId);
     } else if (repositoryCache.isEnabled()) {
       String newSha256 = repositoryCache.put(destination, KeyType.SHA256, canonicalId);
       eventHandler.handle(Event.info("SHA256 (" + urls.get(0) + ") = " + newSha256));

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStream.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStream.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.hash.HashCode;
@@ -62,7 +63,7 @@ final class HttpStream extends FilterInputStream {
     HttpStream create(
         @WillCloseWhenClosed URLConnection connection,
         URL originalUrl,
-        String sha256,
+        Optional<Checksum> checksum,
         Reconnector reconnector)
             throws IOException {
       InputStream stream = new InterruptibleInputStream(connection.getInputStream());
@@ -89,8 +90,8 @@ final class HttpStream extends FilterInputStream {
           stream = new GZIPInputStream(stream, GZIP_BUFFER_BYTES);
         }
 
-        if (!sha256.isEmpty()) {
-          stream = new HashInputStream(stream, Hashing.sha256(), HashCode.fromString(sha256));
+        if (checksum.isPresent()) {
+          stream = new HashInputStream(stream, checksum.get());
           if (retrier != null) {
             retrier.disabled = true;
           }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.bazel.repository.DecompressorDescriptor;
 import com.google.devtools.build.lib.bazel.repository.DecompressorValue;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
+import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpUtils;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -474,6 +475,12 @@ public class SkylarkRepositoryContext
       warnAboutSha256Error(urls, sha256);
       sha256 = "";
     }
+    Optional<Checksum> checksum;
+    if (sha256.isEmpty()) {
+      checksum = Optional.absent();
+    } else {
+      checksum = Optional.of(Checksum.fromString(KeyType.SHA256, sha256));
+    }
     SkylarkPath outputPath = getPath("download()", output);
     WorkspaceRuleEvent w =
         WorkspaceRuleEvent.newDownloadEvent(
@@ -487,7 +494,7 @@ public class SkylarkRepositoryContext
           httpDownloader.download(
               urls,
               authHeaders,
-              sha256,
+              checksum,
               canonicalId,
               Optional.<String>absent(),
               outputPath.getPath(),
@@ -579,6 +586,12 @@ public class SkylarkRepositoryContext
       warnAboutSha256Error(urls, sha256);
       sha256 = "";
     }
+    Optional<Checksum> checksum;
+    if (sha256.isEmpty()) {
+      checksum = Optional.absent();
+    } else {
+      checksum = Optional.of(Checksum.fromString(KeyType.SHA256, sha256));
+    }
 
     WorkspaceRuleEvent w =
         WorkspaceRuleEvent.newDownloadAndExtractEvent(
@@ -601,7 +614,7 @@ public class SkylarkRepositoryContext
           httpDownloader.download(
               urls,
               authHeaders,
-              sha256,
+              checksum,
               canonicalId,
               Optional.of(type),
               outputPath.getPath(),

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
@@ -19,6 +19,7 @@ java_test(
     deps = [
         "//src/main/java/com/google/devtools/build/lib:events",
         "//src/main/java/com/google/devtools/build/lib:util",
+        "//src/main/java/com/google/devtools/build/lib/bazel/repository/cache",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/test/java/com/google/devtools/build/lib:foundations_testutil",
         "//src/test/java/com/google/devtools/build/lib:test_runner",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HashInputStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HashInputStreamTest.java
@@ -20,6 +20,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.common.io.CharStreams;
+import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
+import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -43,8 +45,7 @@ public class HashInputStreamTest {
         new InputStreamReader(
             new HashInputStream(
                 new ByteArrayInputStream("hello".getBytes(UTF_8)),
-                Hashing.sha1(),
-                HashCode.fromString("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d")),
+                Checksum.fromString(KeyType.SHA1, "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d")),
             UTF_8)) {
       assertThat(CharStreams.toString(reader)).isEqualTo("hello");
     }
@@ -58,8 +59,7 @@ public class HashInputStreamTest {
         new InputStreamReader(
             new HashInputStream(
                 new ByteArrayInputStream("hello".getBytes(UTF_8)),
-                Hashing.sha1(),
-                HashCode.fromString("0000000000000000000000000000000000000000")),
+                Checksum.fromString(KeyType.SHA1, "0000000000000000000000000000000000000000")),
             UTF_8)) {
       assertThat(CharStreams.toString(reader))
           .isNull(); // Only here to make @CheckReturnValue happy.

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerIntegrationTest.java
@@ -26,7 +26,10 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
+import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.util.Sleeper;
@@ -79,6 +82,9 @@ public class HttpConnectorMultiplexerIntegrationTest {
   private final HttpConnectorMultiplexer multiplexer =
       new HttpConnectorMultiplexer(eventHandler, connector, httpStreamFactory, clock, sleeper);
 
+  private final Optional<Checksum> HELLO_SHA256 = Optional.of(
+      Checksum.fromString(KeyType.SHA256, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"));
+
   @Before
   public void before() throws Exception {
     when(proxyHelper.createProxyIfNeeded(any(URL.class))).thenReturn(Proxy.NO_PROXY);
@@ -125,7 +131,7 @@ public class HttpConnectorMultiplexerIntegrationTest {
                   ImmutableList.of(
                       new URL(String.format("http://localhost:%d", server1.getLocalPort())),
                       new URL(String.format("http://localhost:%d", server2.getLocalPort()))),
-                  "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")) {
+                  HELLO_SHA256)) {
         assertThat(toByteArray(stream)).isEqualTo("hello".getBytes(US_ASCII));
       }
     }
@@ -190,7 +196,7 @@ public class HttpConnectorMultiplexerIntegrationTest {
                   ImmutableList.of(
                       new URL(String.format("http://localhost:%d", server1.getLocalPort())),
                       new URL(String.format("http://localhost:%d", server2.getLocalPort()))),
-                  "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")) {
+                  HELLO_SHA256)) {
         assertThat(toByteArray(stream)).isEqualTo("hello".getBytes(US_ASCII));
       }
     }
@@ -231,7 +237,7 @@ public class HttpConnectorMultiplexerIntegrationTest {
               new URL(String.format("http://localhost:%d", server1.getLocalPort())),
               new URL(String.format("http://localhost:%d", server2.getLocalPort())),
               new URL(String.format("http://localhost:%d", server3.getLocalPort()))),
-          "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9825");
+          HELLO_SHA256);
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerTest.java
@@ -33,9 +33,12 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
 import com.google.devtools.build.lib.bazel.repository.downloader.RetryingInputStream.Reconnector;
+import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.util.Sleeper;
@@ -69,6 +72,9 @@ public class HttpConnectorMultiplexerTest {
   private static final byte[] data2 = "second".getBytes(UTF_8);
   private static final byte[] data3 = "third".getBytes(UTF_8);
 
+  private static final Optional<Checksum> DUMMY_CHECKSUM = Optional.of(
+      Checksum.fromString(KeyType.SHA256, "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"));
+
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 
@@ -95,26 +101,26 @@ public class HttpConnectorMultiplexerTest {
     when(connector.connect(eq(URL2), any(ImmutableMap.class))).thenReturn(connection2);
     when(connector.connect(eq(URL3), any(ImmutableMap.class))).thenReturn(connection3);
     when(streamFactory
-            .create(same(connection1), any(URL.class), anyString(), any(Reconnector.class)))
+            .create(same(connection1), any(URL.class), any(Optional.class), any(Reconnector.class)))
         .thenReturn(stream1);
     when(streamFactory
-            .create(same(connection2), any(URL.class), anyString(), any(Reconnector.class)))
+            .create(same(connection2), any(URL.class), any(Optional.class), any(Reconnector.class)))
         .thenReturn(stream2);
     when(streamFactory
-            .create(same(connection3), any(URL.class), anyString(), any(Reconnector.class)))
+            .create(same(connection3), any(URL.class), any(Optional.class), any(Reconnector.class)))
         .thenReturn(stream3);
   }
 
   @Test
   public void emptyList_throwsIae() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    multiplexer.connect(ImmutableList.<URL>of(), "");
+    multiplexer.connect(ImmutableList.<URL>of(), null);
   }
 
   @Test
   public void ftpUrl_throwsIae() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    multiplexer.connect(asList(new URL("ftp://lol.example")), "");
+    multiplexer.connect(asList(new URL("ftp://lol.example")), null);
   }
 
   @Test
@@ -126,7 +132,7 @@ public class HttpConnectorMultiplexerTest {
           public void run() {
             Thread.currentThread().interrupt();
             try {
-              multiplexer.connect(asList(new URL("http://lol.example")), "");
+              multiplexer.connect(asList(new URL("http://lol.example")), null);
             } catch (InterruptedIOException ignored) {
               return;
             } catch (Exception ignored) {
@@ -143,10 +149,10 @@ public class HttpConnectorMultiplexerTest {
 
   @Test
   public void singleUrl_justCallsConnector() throws Exception {
-    assertThat(toByteArray(multiplexer.connect(asList(URL1), "abc"))).isEqualTo(data1);
+    assertThat(toByteArray(multiplexer.connect(asList(URL1), DUMMY_CHECKSUM))).isEqualTo(data1);
     verify(connector).connect(eq(URL1), any(ImmutableMap.class));
     verify(streamFactory)
-        .create(any(URLConnection.class), any(URL.class), eq("abc"), any(Reconnector.class));
+        .create(any(URLConnection.class), any(URL.class), eq(DUMMY_CHECKSUM), any(Reconnector.class));
     verifyNoMoreInteractions(sleeper, connector, streamFactory);
   }
 
@@ -154,7 +160,7 @@ public class HttpConnectorMultiplexerTest {
   public void multipleUrlsFail_throwsIOException() throws Exception {
     when(connector.connect(any(URL.class), any(ImmutableMap.class))).thenThrow(new IOException());
     IOException e =
-        assertThrows(IOException.class, () -> multiplexer.connect(asList(URL1, URL2, URL3), ""));
+        assertThrows(IOException.class, () -> multiplexer.connect(asList(URL1, URL2, URL3), null));
     assertThat(e).hasMessageThat().contains("All mirrors are down");
     verify(connector, times(3)).connect(any(URL.class), any(ImmutableMap.class));
     verify(sleeper, times(2)).sleepMillis(anyLong());
@@ -172,12 +178,12 @@ public class HttpConnectorMultiplexerTest {
           }
         }).when(sleeper).sleepMillis(anyLong());
     when(connector.connect(eq(URL1), any(ImmutableMap.class))).thenThrow(new IOException());
-    assertThat(toByteArray(multiplexer.connect(asList(URL1, URL2), "abc"))).isEqualTo(data2);
+    assertThat(toByteArray(multiplexer.connect(asList(URL1, URL2), DUMMY_CHECKSUM))).isEqualTo(data2);
     assertThat(clock.currentTimeMillis()).isEqualTo(1000L);
     verify(connector).connect(eq(URL1), any(ImmutableMap.class));
     verify(connector).connect(eq(URL2), any(ImmutableMap.class));
     verify(streamFactory)
-        .create(any(URLConnection.class), any(URL.class), eq("abc"), any(Reconnector.class));
+        .create(any(URLConnection.class), any(URL.class), eq(DUMMY_CHECKSUM), any(Reconnector.class));
     verify(sleeper).sleepMillis(anyLong());
     verifyNoMoreInteractions(sleeper, connector, streamFactory);
   }
@@ -204,7 +210,7 @@ public class HttpConnectorMultiplexerTest {
             return null;
           }
         }).when(sleeper).sleepMillis(anyLong());
-    assertThat(toByteArray(multiplexer.connect(asList(URL1, URL2), "abc"))).isEqualTo(data1);
+    assertThat(toByteArray(multiplexer.connect(asList(URL1, URL2), DUMMY_CHECKSUM))).isEqualTo(data1);
     assertThat(wasInterrupted.get()).isTrue();
   }
 
@@ -239,7 +245,7 @@ public class HttpConnectorMultiplexerTest {
           @Override
           public void run() {
             try {
-              multiplexer.connect(asList(URL1, URL2), "");
+              multiplexer.connect(asList(URL1, URL2), null);
             } catch (InterruptedIOException ignored) {
               return;
             } catch (Exception ignored) {


### PR DESCRIPTION
This is extracted from https://github.com/bazelbuild/bazel/pull/7208 ("Support subresource integrity format for `download()` checksums.")

I'm trying to revive that PR and rebase to master, but the replacement of `String sha256` through the HTTP downloader code is causing a lot of Git conflicts. I expect that portion of the change to require less discussion than the proposed content integrity changes, so I'm moving it to a separate PR to simplify review.

@dslomov or @aehlig, could one of you take a look? Once this is merged, I will rebase PR 7208 onto it.