### PR TITLE
Tests: print a warning if zip failed

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -356,8 +356,9 @@ fi
 if [[ -n "$TEST_UNDECLARED_OUTPUTS_ZIP" ]] && cd "$TEST_UNDECLARED_OUTPUTS_DIR"; then
   (
    shopt -s dotglob failglob
-   zip -qr "$TEST_UNDECLARED_OUTPUTS_ZIP" -- *
-  ) 2> /dev/null
+   zip -qr "$TEST_UNDECLARED_OUTPUTS_ZIP" -- * || \
+       echo >&2 "Could not create \"$TEST_UNDECLARED_OUTPUTS_ZIP\": zip not found or failed"
+  )
 fi
 
 exit $exitCode


### PR DESCRIPTION
If test-setup.sh fails to create the undeclared
outputs zip, then print a warning but carry on.
Failing to create this zip is a nuisance but not a
fatal error.

The warning is printed to the test log. If the
test fails, this is printed to the console too. If
the test passes, then the warning remains only in
the test log (Bazel prints no output for passing
tests).

Fixes https://github.com/bazelbuild/bazel/issues/8336

Change-Id: Iee8121d76e96445252d97142cef68c50afbb25b1