### PR TITLE
Windows: fix ijar compilation from ext.repo

### DIFF
--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -173,4 +173,36 @@ function test_java_tools_has_proguard() {
   expect_path_in_java_tools "java_tools/third_party/java/proguard/GPL.html"
 }
 
+function test_java_tools_singlejar_builds() {  
+  local java_tools_rlocation=$(rlocation io_bazel/src/java_tools_${JAVA_TOOLS_JAVA_VERSION}.zip)
+  local java_tools_zip_file_url="file://${java_tools_rlocation}"
+  if "$is_windows"; then
+    java_tools_zip_file_url="file:///${java_tools_rlocation}"
+  fi
+  cat >WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "local_java_tools",
+    urls = ["${java_tools_zip_file_url}"],
+)
+EOF
+  bazel build @local_java_tools//:singlejar_cc_bin || fail "singlejar failed to build"
+}
+
+function test_java_tools_ijar_builds() {
+  local java_tools_rlocation=$(rlocation io_bazel/src/java_tools_${JAVA_TOOLS_JAVA_VERSION}.zip)
+  local java_tools_zip_file_url="file://${java_tools_rlocation}"
+  if "$is_windows"; then
+    java_tools_zip_file_url="file:///${java_tools_rlocation}"
+  fi
+  cat >WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "local_java_tools",
+    urls = ["${java_tools_zip_file_url}"],
+)
+EOF
+  bazel build @local_java_tools//:ijar_cc_binary || fail "ijar failed to build"
+}
+
 run_suite "Java tools archive tests"

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -710,7 +710,10 @@ cc_library(
     name = "token_stream",
     hdrs = ["java_tools/src/tools/singlejar/token_stream.h"],
     strip_include_prefix = "java_tools",
-    deps = [":diag"],
+    deps = [
+        ":diag",
+        ":filesystem",
+    ],
 )
 
 filegroup(

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -473,16 +473,14 @@ cc_library(
 
 cc_library(
     name = "lib-file",
-    srcs = ["java_tools/src/main/native/windows/file.cc"],
-    hdrs = ["java_tools/src/main/native/windows/file.h"],
-    strip_include_prefix = "java_tools",
-    deps = [":lib-util"],
-)
-
-cc_library(
-    name = "lib-util",
-    srcs = ["java_tools/src/main/native/windows/util.cc"],
-    hdrs = ["java_tools/src/main/native/windows/util.h"],
+    srcs = [
+        "java_tools/src/main/native/windows/file.cc",
+        "java_tools/src/main/native/windows/util.cc",
+    ],
+    hdrs = [
+        "java_tools/src/main/native/windows/file.h",
+        "java_tools/src/main/native/windows/util.h",
+    ],
     strip_include_prefix = "java_tools",
 )
 


### PR DESCRIPTION
//src/main/native/windows:lib-file and
//src/main/native/windows:lib-util were merged
into one rule some time ago.

This commit merges the copies of those libraries
in tools/jdk/BUILD accordingly.

Fixes https://github.com/bazelbuild/bazel/issues/8614