### PR TITLE
Add fail_with_message and use it for @rules_cc

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/cc_configure.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/cc_configure.WORKSPACE
@@ -1,3 +1,13 @@
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe", "fail_with_message")
+
+maybe(
+    fail_with_message,
+    "rules_cc",
+    message = "Incompatible change `--incompatible_load_cc_rules_from_bzl` has been flipped, " +
+    "and your WORKSPACE file doesn't contain @rules_cc repository. " +
+    "See https://github.com/bazelbuild/bazel/issues/8743 for details.",
+)
+
 load("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_configure")
 
 cc_configure()

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -261,3 +261,13 @@ def use_netrc(netrc, urls):
                 "password": authforhost["password"],
             }
     return auth
+
+def _fail_with_message_impl(repository_ctx):
+    fail(repository_ctx.attr.message)
+
+fail_with_message = repository_rule(
+    implementation = _fail_with_message_impl,
+    attrs = {
+        "message": attr.string(doc = "Message to be shown when the repository is fetched."),
+    },
+)


### PR DESCRIPTION
Add `fail_with_message` rule into `@bazel_tools//tools/build_defs/repo:utils.bzl` and use it to initialize `rules_cc`. This will be used to show nice error message for people migrating for https://github.com/bazelbuild/bazel/issues/8743 who don't put `rules_cc` repository into their WORKSPACE file (as opposed to showing 'missing repository' error).

https://github.com/bazelbuild/bazel/issues/8743.
https://github.com/bazelbuild/bazel/issues/7643.