### PR TITLE
Do not re-compress during dev build.

### DIFF
--- a/src/package-bazel.sh
+++ b/src/package-bazel.sh
@@ -27,6 +27,12 @@ INSTALL_BASE_KEY=$4
 PLATFORMS_ARCHIVE=$5
 shift 4
 
+if [[ "$OUT" == *jdk_allmodules.zip ]]; then
+  DEV_BUILD=1
+else
+  DEV_BUILD=0
+fi
+
 TMP_DIR=${TMPDIR:-/tmp}
 PACKAGE_DIR="$(mktemp -d ${TMP_DIR%%/}/bazel.XXXXXXXX)"
 mkdir -p "${PACKAGE_DIR}"
@@ -34,28 +40,32 @@ trap "rm -fr ${PACKAGE_DIR}" EXIT
 
 cp $* ${PACKAGE_DIR}
 
-# Unpack the deploy jar for postprocessing and for "re-compressing" to save
-# ~10% of final binary size.
-unzip -q -d recompress ${DEPLOY_JAR}
-cd recompress
+if [[ $DEV_BUILD -eq 0 ]]; then
+  # Unpack the deploy jar for postprocessing and for "re-compressing" to save
+  # ~10% of final binary size.
+  unzip -q -d recompress ${DEPLOY_JAR}
+  cd recompress
 
-# Zero out timestamps and sort the entries to ensure determinism.
-find . -type f -print0 | xargs -0 touch -t 198001010000.00
-find . -type f | sort | zip -q0DX@ ../deploy-uncompressed.jar
+  # Zero out timestamps and sort the entries to ensure determinism.
+  find . -type f -print0 | xargs -0 touch -t 198001010000.00
+  find . -type f | sort | zip -q0DX@ ../deploy-uncompressed.jar
 
-# While we're in the deploy jar, grab the label and pack it into the final
-# packaged distribution zip where it can be used to quickly determine version
-# info.
-bazel_label="$(\
-  (grep '^build.label=' build-data.properties | cut -d'=' -f2- | tr -d '\n') \
-      || echo -n 'no_version')"
-echo -n "${bazel_label:-no_version}" > "${PACKAGE_DIR}/build-label.txt"
+  # While we're in the deploy jar, grab the label and pack it into the final
+  # packaged distribution zip where it can be used to quickly determine version
+  # info.
+  bazel_label="$(\
+    (grep '^build.label=' build-data.properties | cut -d'=' -f2- | tr -d '\n') \
+        || echo -n 'no_version')"
+  echo -n "${bazel_label:-no_version}" > "${PACKAGE_DIR}/build-label.txt"
 
-cd ..
+  cd ..
+
+  DEPLOY_JAR="deploy-uncompressed.jar"
+fi
 
 # The server jar needs to be the first binary we extract. This is how the Bazel
 # client knows what .jar to pass to the JVM.
-cp deploy-uncompressed.jar ${PACKAGE_DIR}/A-server.jar
+cp ${DEPLOY_JAR} ${PACKAGE_DIR}/A-server.jar
 cp ${INSTALL_BASE_KEY} ${PACKAGE_DIR}/install_base_key
 # The timestamp of embedded tools should already be zeroed out in the input zip
 touch -t 198001010000.00 ${PACKAGE_DIR}/*


### PR DESCRIPTION
Instead of building the target //src:bazel use //src:bazel-dev.

File I/O is much slower on Windows compared to Linux and the
recompressing step was causing a multi-minute slowdown on Windows.

This change should bring iteration times of simple changes for Bazel
developers down to significantly less than a minute.

RELNOTES: None