### PR TITLE
glob() now supports case-insensitive mode

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/GlobCache.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/GlobCache.java
@@ -255,7 +255,13 @@ public class GlobCache {
       }
       results.addAll(items);
     }
-    UnixGlob.removeExcludes(results, excludes);
+
+    // TODO(laszlocsomor): set `caseSensitive` from the value of
+    // `--incompatible_windows_case_insensitive_glob` or from FileSystem.isGlobCaseSensitive()
+    // See https://github.com/bazelbuild/bazel/issues/8767
+    final boolean caseSensitive = true;
+
+    UnixGlob.removeExcludes(results, excludes, caseSensitive);
     if (!allowEmpty && results.isEmpty()) {
       throw new BadGlobException(
           "all files in the glob have been excluded, but allow_empty is set to False.");

--- a/src/main/java/com/google/devtools/build/lib/skyframe/GlobFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/GlobFunction.java
@@ -43,7 +43,8 @@ import javax.annotation.Nullable;
  */
 public final class GlobFunction implements SkyFunction {
 
-  private final ConcurrentHashMap<String, Pattern> regexPatternCache = new ConcurrentHashMap<>();
+  private final UnixGlob.PatternCache regexPatternCache =
+      new UnixGlob.PatternCache(new ConcurrentHashMap<>(), new ConcurrentHashMap<>());
 
   private final boolean alwaysUseDirListing;
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/GlobFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/GlobFunction.java
@@ -156,6 +156,11 @@ public final class GlobFunction implements SkyFunction {
         }
       }
 
+      // TODO(laszlocsomor): set `caseSensitive` from the value of
+      // `--incompatible_windows_case_insensitive_glob` or from FileSystem.isGlobCaseSensitive()
+      // See https://github.com/bazelbuild/bazel/issues/8767
+      final boolean caseSensitive = true;
+
       // Now that we have the directory listing, we do three passes over it so as to maximize
       // skyframe batching:
       // (1) Process every dirent, keeping track of values we need to request if the dirent cannot
@@ -173,7 +178,7 @@ public final class GlobFunction implements SkyFunction {
       for (Dirent dirent : listingValue.getDirents()) {
         Dirent.Type direntType = dirent.getType();
         String fileName = dirent.getName();
-        if (!UnixGlob.matches(patternHead, fileName, regexPatternCache)) {
+        if (!UnixGlob.matches(patternHead, fileName, regexPatternCache, caseSensitive)) {
           continue;
         }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/GlobFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/GlobFunction.java
@@ -43,8 +43,11 @@ import javax.annotation.Nullable;
  */
 public final class GlobFunction implements SkyFunction {
 
-  private final UnixGlob.PatternCache regexPatternCache =
-      new UnixGlob.PatternCache(new ConcurrentHashMap<>(), new ConcurrentHashMap<>());
+  // TODO(laszlocsomor): we might need to create another regexPatternCache for case-insensitive
+  // glob() mode to avoid reading wrong cache results when the user changes the
+  // --incompatible_windows_case_ignoring_glob flag value between builds.
+  // See https://github.com/bazelbuild/bazel/issues/8767.
+  private final ConcurrentHashMap<String, Pattern> regexPatternCache = new ConcurrentHashMap<>();
 
   private final boolean alwaysUseDirListing;
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
@@ -1011,7 +1011,13 @@ public class PackageFunction implements SkyFunction {
         if (legacyIncludesToken != null) {
           matches.addAll(delegate.fetch(legacyIncludesToken));
         }
-        UnixGlob.removeExcludes(matches, excludes);
+
+        // TODO(laszlocsomor): set `caseSensitive` from the value of
+        // `--incompatible_windows_case_insensitive_glob` or from FileSystem.isGlobCaseSensitive()
+        // See https://github.com/bazelbuild/bazel/issues/8767
+        final boolean caseSensitive = true;
+
+        UnixGlob.removeExcludes(matches, excludes, caseSensitive);
         List<String> result = new ArrayList<>(matches);
         // Skyframe glob results are unsorted. And we used a LegacyGlobber that doesn't sort.
         // Therefore, we want to unconditionally sort here.

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -150,8 +150,6 @@ public abstract class FileSystem {
   // remove this method and all references to it and replace call sites with
   // isFilePathCaseSensitive().
   public boolean isGlobCaseSensitive() {
-    // TODO(laszlocsomor): as part of wiring up `--incompatible_windows_case_insensitive_glob`,
-    // override this in WindowsFileSystem.
     return true;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -138,6 +138,24 @@ public abstract class FileSystem {
   public abstract boolean isFilePathCaseSensitive();
 
   /**
+   * Returns true if glob() is case-sensitive.
+   *
+   * <p>When glob() is case-sensitive, it will only match (or exclude) file "Foo" if the include (or
+   * exclude) pattern uses the same upper-case and lower-case letters.
+   *
+   * <p>When glob() is case-insensitive (or case-ignoring), it will match (or exclude) the file
+   * "Foo" even if the include (or exclude) pattern uses a different casing, e.g. "foO").
+   */
+  // TODO(laszlocsomor): After `--incompatible_windows_case_insensitive_glob` is flipped to true,
+  // remove this method and all references to it and replace call sites with
+  // isFilePathCaseSensitive().
+  public boolean isGlobCaseSensitive() {
+    // TODO(laszlocsomor): as part of wiring up `--incompatible_windows_case_insensitive_glob`,
+    // override this in WindowsFileSystem.
+    return true;
+  }
+
+  /**
    * Returns the type of the file system path belongs to.
    *
    * <p>The string returned is obtained directly from the operating system, so

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -148,7 +148,7 @@ public abstract class FileSystem {
    */
   // TODO(laszlocsomor): After `--incompatible_windows_case_insensitive_glob` is flipped to true,
   // remove this method and all references to it and replace call sites with
-  // isFilePathCaseSensitive().
+  // isFilePathCaseSensitive(). See https://github.com/bazelbuild/bazel/issues/8767
   public boolean isGlobCaseSensitive() {
     return true;
   }

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -143,8 +143,8 @@ public abstract class FileSystem {
    * <p>When glob() is case-sensitive, it will only match (or exclude) file "Foo" if the include (or
    * exclude) pattern uses the same upper-case and lower-case letters.
    *
-   * <p>When glob() is case-insensitive (or case-ignoring), it will match (or exclude) the file
-   * "Foo" even if the include (or exclude) pattern uses a different casing, e.g. "foO").
+   * <p>When glob() is case-insensitive, it will match (or exclude) the file "Foo" even if the
+   * include (or exclude) pattern uses a different casing such as "foO".
    */
   // TODO(laszlocsomor): After `--incompatible_windows_case_insensitive_glob` is flipped to true,
   // remove this method and all references to it and replace call sites with

--- a/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
@@ -155,9 +155,9 @@ public final class UnixGlob {
     return null;
   }
 
-  /** Calls {@link #matches(String, String, Map) matches(pattern, str, null)} */
-  public static boolean matches(String pattern, String str) {
-    return matches(pattern, str, null);
+  /** Calls {@link #matches(String, String, Map) matches(pattern, str, null, boolean)} */
+  public static boolean matches(String pattern, String str, boolean caseSensitive) {
+    return matches(pattern, str, null, caseSensitive);
   }
 
   /**
@@ -169,14 +169,6 @@ public final class UnixGlob {
    * @param patternCache a cache from patterns to compiled Pattern objects, or {@code null} to skip
    *     caching
    */
-  public static boolean matches(String pattern, String str, Map<String, Pattern> patternCache) {
-    // TODO(laszlocsomor): set `caseSensitive` to OsPathPolicy.getFilePathOs().isCaseSensitive()
-    // after `--incompatible_windows_case_insensitive_glob` was flipped to true.
-    final boolean caseSensitive = true;
-    return matches(pattern, str, patternCache, caseSensitive);
-  }
-
-  @VisibleForTesting
   public static boolean matches(String pattern, String str, Map<String, Pattern> patternCache,
       boolean caseSensitive) {
     if (pattern.length() == 0 || str.length() == 0) {

--- a/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
@@ -883,14 +883,6 @@ public final class UnixGlob {
    * Filters out exclude patterns from a Set of paths. Common cases such as wildcard-free patterns
    * or suffix patterns are special-cased to make this function efficient.
    */
-  public static void removeExcludes(Set<String> paths, Collection<String> excludes) {
-    // TODO(laszlocsomor): set `caseSensitive` to OsPathPolicy.getFilePathOs().isCaseSensitive()
-    // after `--incompatible_windows_case_insensitive_glob` was flipped to true.
-    final boolean caseSensitive = true;
-    removeExcludes(paths, excludes, caseSensitive);
-  }
-
-  @VisibleForTesting
   public static void removeExcludes(Set<String> paths, Collection<String> excludes,
       boolean caseSensitive) {
     ArrayList<String> complexPatterns = new ArrayList<>(excludes.size());

--- a/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
@@ -169,7 +169,14 @@ public final class UnixGlob {
    * @param patternCache a cache from patterns to compiled Pattern objects, or {@code null} to skip
    *     caching
    */
-  public static boolean matches(String pattern, String str, Map<String, Pattern> patternCache) {
+  public static boolean matches(String pattern, String str, PatternCache patternCache) {
+    final boolean caseSensitive = OsPathPolicy.getFilePathOs().isCaseSensitive();
+    return matches(pattern, str, patternCache, caseSensitive);
+  }
+
+  @VisibleForTesting
+  public static boolean matches(String pattern, String str, PatternCache patternCache,
+      boolean caseSensitive) {
     if (pattern.length() == 0 || str.length() == 0) {
       return false;
     }
@@ -191,20 +198,21 @@ public final class UnixGlob {
 
     // Common case: *.xyz
     if (pattern.charAt(0) == '*' && pattern.lastIndexOf('*') == 0) {
-      return str.endsWith(pattern.substring(1));
+      return endsWithCase(str, pattern.substring(1), caseSensitive);
     }
     // Common case: xyz*
     int lastIndex = pattern.length() - 1;
     // The first clause of this if statement is unnecessary, but is an
     // optimization--charAt runs faster than indexOf.
     if (pattern.charAt(lastIndex) == '*' && pattern.indexOf('*') == lastIndex) {
-      return str.startsWith(pattern.substring(0, lastIndex));
+      return startsWithCase(str, pattern.substring(0, lastIndex), caseSensitive);
     }
 
     Pattern regex =
         patternCache == null
-            ? makePatternFromWildcard(pattern)
-            : patternCache.computeIfAbsent(pattern, p -> makePatternFromWildcard(p));
+            ? makePatternFromWildcard(pattern, caseSensitive)
+            : patternCache.get(caseSensitive).computeIfAbsent(
+                pattern, p -> makePatternFromWildcard(p, caseSensitive));
     return regex.matcher(str).matches();
   }
 
@@ -214,7 +222,7 @@ public final class UnixGlob {
    *
    * <p>e.g. "foo*bar?.java" -> "foo.*bar.\\.java"
    */
-  private static Pattern makePatternFromWildcard(String pattern) {
+  private static Pattern makePatternFromWildcard(String pattern, boolean caseSensitive) {
     StringBuilder regexp = new StringBuilder();
     for (int i = 0, len = pattern.length(); i < len; i++) {
       char c = pattern.charAt(i);
@@ -247,7 +255,14 @@ public final class UnixGlob {
           regexp.append(c);
           break;
         default:
-          regexp.append(c);
+          if (caseSensitive || !isAlphaAscii(c)) {
+            regexp.append(c);
+          } else {
+            regexp.append('[')
+                  .append(Character.toUpperCase(c))
+                  .append(Character.toLowerCase(c))
+                  .append(']');
+          }
           break;
       }
     }
@@ -478,7 +493,8 @@ public final class UnixGlob {
   private static final class GlobVisitor {
     // These collections are used across workers and must therefore be thread-safe.
     private final Collection<Path> results = Sets.newConcurrentHashSet();
-    private final ConcurrentHashMap<String, Pattern> cache = new ConcurrentHashMap<>();
+    private final PatternCache cache = new PatternCache(
+        new ConcurrentHashMap<>(), new ConcurrentHashMap<>());
 
     private final GlobFuture result;
     private final Executor executor;
@@ -558,7 +574,6 @@ public final class UnixGlob {
       if (baseStat == null || patterns.isEmpty()) {
         return Futures.immediateFuture(Collections.<Path>emptyList());
       }
-
       List<String[]> splitPatterns = checkAndSplitPatterns(patterns);
 
       // We do a dumb loop, even though it will likely duplicate logical work (note that the
@@ -567,6 +582,7 @@ public final class UnixGlob {
       // glob [*/*.java, sub/*.java, */*.txt]).
       pendingOps.incrementAndGet();
       try {
+        final boolean caseSensitive = base.getFileSystem().isGlobCaseSensitive();
         for (String[] splitPattern : splitPatterns) {
           int numRecursivePatterns = 0;
           for (String pattern : splitPattern) {
@@ -575,8 +591,10 @@ public final class UnixGlob {
             }
           }
           GlobTaskContext context = numRecursivePatterns > 1
-              ? new RecursiveGlobTaskContext(splitPattern, excludeDirectories, dirPred, syscalls)
-              : new GlobTaskContext(splitPattern, excludeDirectories, dirPred, syscalls);
+              ? new RecursiveGlobTaskContext(splitPattern, excludeDirectories, caseSensitive,
+                                             dirPred, syscalls)
+              : new GlobTaskContext(splitPattern, excludeDirectories, caseSensitive, dirPred,
+                                    syscalls);
           context.queueGlob(base, baseStat.isDirectory(), 0);
         }
       } finally {
@@ -685,16 +703,19 @@ public final class UnixGlob {
     private class GlobTaskContext {
       private final String[] patternParts;
       private final boolean excludeDirectories;
+      private final boolean caseSensitive;
       private final Predicate<Path> dirPred;
       private final FilesystemCalls syscalls;
 
       GlobTaskContext(
           String[] patternParts,
           boolean excludeDirectories,
+          boolean caseSensitive,
           Predicate<Path> dirPred,
           FilesystemCalls syscalls) {
         this.patternParts = patternParts;
         this.excludeDirectories = excludeDirectories;
+        this.caseSensitive = caseSensitive;
         this.dirPred = dirPred;
         this.syscalls = syscalls;
       }
@@ -744,9 +765,10 @@ public final class UnixGlob {
       private RecursiveGlobTaskContext(
           String[] patternParts,
           boolean excludeDirectories,
+          boolean caseSensitive,
           Predicate<Path> dirPred,
           FilesystemCalls syscalls) {
-        super(patternParts, excludeDirectories, dirPred, syscalls);
+        super(patternParts, excludeDirectories, caseSensitive, dirPred, syscalls);
       }
 
       @Override
@@ -820,7 +842,7 @@ public final class UnixGlob {
           // The file is a special file (fifo, etc.). No need to even match against the pattern.
           continue;
         }
-        if (matches(pattern, dent.getName(), cache)) {
+        if (matches(pattern, dent.getName(), cache, context.caseSensitive)) {
           Path child = base.getChild(dent.getName());
 
           if (childType == Dirent.Type.SYMLINK) {
@@ -869,11 +891,22 @@ public final class UnixGlob {
    * or suffix patterns are special-cased to make this function efficient.
    */
   public static void removeExcludes(Set<String> paths, Collection<String> excludes) {
+    final boolean caseSensitive = OsPathPolicy.getFilePathOs().isCaseSensitive();
+    removeExcludes(paths, excludes, caseSensitive);
+  }
+
+  @VisibleForTesting
+  public static void removeExcludes(Set<String> paths, Collection<String> excludes,
+      boolean caseSensitive) {
     ArrayList<String> complexPatterns = new ArrayList<>(excludes.size());
     Map<String, List<String>> starstarSlashStarHeadTailPairs = new HashMap<>();
     for (String exclude : excludes) {
       if (isWildcardFree(exclude)) {
-        paths.remove(exclude);
+        if (caseSensitive) {
+          paths.remove(exclude);
+        } else {
+          paths.removeIf(p -> p.equalsIgnoreCase(exclude));
+        }
         continue;
       }
       int patternPos = exclude.indexOf("**/*");
@@ -890,9 +923,9 @@ public final class UnixGlob {
     for (Map.Entry<String, List<String>> headTailPair : starstarSlashStarHeadTailPairs.entrySet()) {
       paths.removeIf(
           path -> {
-            if (path.startsWith(headTailPair.getKey())) {
+            if (startsWithCase(path, headTailPair.getKey(), caseSensitive)) {
               for (String tail : headTailPair.getValue()) {
-                if (path.endsWith(tail)) {
+                if (endsWithCase(path, tail, caseSensitive)) {
                   return true;
                 }
               }
@@ -904,12 +937,12 @@ public final class UnixGlob {
       return;
     }
     List<String[]> splitPatterns = checkAndSplitPatterns(complexPatterns);
-    HashMap<String, Pattern> patternCache = new HashMap<>();
+    PatternCache patternCache = new PatternCache(new HashMap<>(), new HashMap<>());
     paths.removeIf(
         path -> {
           String[] segments = Iterables.toArray(Splitter.on('/').split(path), String.class);
           for (String[] splitPattern : splitPatterns) {
-            if (matchesPattern(splitPattern, segments, 0, 0, patternCache)) {
+            if (matchesPattern(splitPattern, segments, 0, 0, patternCache, caseSensitive)) {
               return true;
             }
           }
@@ -919,24 +952,79 @@ public final class UnixGlob {
 
   /** Returns true if {@code pattern} matches {@code path} starting from the given segments. */
   private static boolean matchesPattern(
-      String[] pattern, String[] path, int i, int j, Map<String, Pattern> patternCache) {
+      String[] pattern, String[] path, int i, int j, PatternCache patternCache,
+      boolean caseSensitive) {
     if (i == pattern.length) {
       return j == path.length;
     }
     if (pattern[i].equals("**")) {
-      return matchesPattern(pattern, path, i + 1, j, patternCache)
-          || (j < path.length && matchesPattern(pattern, path, i, j + 1, patternCache));
+      return matchesPattern(pattern, path, i + 1, j, patternCache, caseSensitive)
+          || (j < path.length &&
+              matchesPattern(pattern, path, i, j + 1, patternCache, caseSensitive));
     }
     if (j == path.length) {
       return false;
     }
-    if (matches(pattern[i], path[j], patternCache)) {
-      return matchesPattern(pattern, path, i + 1, j + 1, patternCache);
+    if (matches(pattern[i], path[j], patternCache, caseSensitive)) {
+      return matchesPattern(pattern, path, i + 1, j + 1, patternCache, caseSensitive);
     }
     return false;
   }
 
   private static boolean isWildcardFree(String pattern) {
     return !pattern.contains("*") && !pattern.contains("?");
+  }
+
+  /**
+   * Glob pattern cache.
+   *
+   * <p>Has separate caches for case-sensitive and case-insensitive patterns.
+   */
+  public static final class PatternCache {
+    private final Map<String, Pattern> respectsCase;
+    private final Map<String, Pattern> ignoresCase;
+
+    public PatternCache(Map<String, Pattern> respectsCase, Map<String, Pattern> ignoresCase) {
+      this.respectsCase = respectsCase;
+      this.ignoresCase = ignoresCase;
+    }
+
+    public Map<String, Pattern> get(boolean caseSensitive) {
+      return caseSensitive ? respectsCase : ignoresCase;
+    }
+  }
+
+  @VisibleForTesting
+  static boolean startsWithCase(String s, String p, boolean caseSensitive) {
+//    if (p.isEmpty()) {
+//      return true;
+//    } else if (s.isEmpty()) {
+//      return false;
+//    }
+    if (caseSensitive) {
+      return s.startsWith(p);
+    } else {
+      return s.length() >= p.length() && s.regionMatches(true, 0, p, 0, p.length());
+    }
+  }
+
+  @VisibleForTesting
+  static boolean endsWithCase(String s, String p, boolean caseSensitive) {
+//    if (p.isEmpty()) {
+//      return true;
+//    } else if (s.isEmpty()) {
+//      return false;
+//    }
+    if (caseSensitive) {
+      return s.endsWith(p);
+    } else {
+      return s.length() >= p.length() &&
+             s.regionMatches(true, s.length() - p.length(), p, 0, p.length());
+    }
+  }
+
+  @VisibleForTesting
+  static boolean isAlphaAscii(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
@@ -170,7 +170,10 @@ public final class UnixGlob {
    *     caching
    */
   public static boolean matches(String pattern, String str, Map<String, Pattern> patternCache) {
-    return matches(pattern, str, patternCache, OsPathPolicy.getFilePathOs().isCaseSensitive());
+    // TODO(laszlocsomor): set `caseSensitive` to OsPathPolicy.getFilePathOs().isCaseSensitive()
+    // after `--incompatible_windows_case_insensitive_glob` was flipped to true.
+    final boolean caseSensitive = true;
+    return matches(pattern, str, patternCache, caseSensitive);
   }
 
   @VisibleForTesting
@@ -889,7 +892,10 @@ public final class UnixGlob {
    * or suffix patterns are special-cased to make this function efficient.
    */
   public static void removeExcludes(Set<String> paths, Collection<String> excludes) {
-    removeExcludes(paths, excludes, OsPathPolicy.getFilePathOs().isCaseSensitive());
+    // TODO(laszlocsomor): set `caseSensitive` to OsPathPolicy.getFilePathOs().isCaseSensitive()
+    // after `--incompatible_windows_case_insensitive_glob` was flipped to true.
+    final boolean caseSensitive = true;
+    removeExcludes(paths, excludes, caseSensitive);
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
@@ -170,8 +170,7 @@ public final class UnixGlob {
    *     caching
    */
   public static boolean matches(String pattern, String str, PatternCache patternCache) {
-    final boolean caseSensitive = OsPathPolicy.getFilePathOs().isCaseSensitive();
-    return matches(pattern, str, patternCache, caseSensitive);
+    return matches(pattern, str, patternCache, OsPathPolicy.getFilePathOs().isCaseSensitive());
   }
 
   @VisibleForTesting
@@ -891,8 +890,7 @@ public final class UnixGlob {
    * or suffix patterns are special-cased to make this function efficient.
    */
   public static void removeExcludes(Set<String> paths, Collection<String> excludes) {
-    final boolean caseSensitive = OsPathPolicy.getFilePathOs().isCaseSensitive();
-    removeExcludes(paths, excludes, caseSensitive);
+    removeExcludes(paths, excludes, OsPathPolicy.getFilePathOs().isCaseSensitive());
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
@@ -994,11 +994,6 @@ public final class UnixGlob {
 
   @VisibleForTesting
   static boolean startsWithCase(String s, String p, boolean caseSensitive) {
-//    if (p.isEmpty()) {
-//      return true;
-//    } else if (s.isEmpty()) {
-//      return false;
-//    }
     if (caseSensitive) {
       return s.startsWith(p);
     } else {
@@ -1008,11 +1003,6 @@ public final class UnixGlob {
 
   @VisibleForTesting
   static boolean endsWithCase(String s, String p, boolean caseSensitive) {
-//    if (p.isEmpty()) {
-//      return true;
-//    } else if (s.isEmpty()) {
-//      return false;
-//    }
     if (caseSensitive) {
       return s.endsWith(p);
     } else {

--- a/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/UnixGlob.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.vfs;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ascii;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -253,8 +254,8 @@ public final class UnixGlob {
             regexp.append(c);
           } else {
             regexp.append('[')
-                  .append(Character.toUpperCase(c))
-                  .append(Character.toLowerCase(c))
+                  .append(Ascii.toUpperCase(c))
+                  .append(Ascii.toLowerCase(c))
                   .append(']');
           }
           break;
@@ -892,7 +893,7 @@ public final class UnixGlob {
         if (caseSensitive) {
           paths.remove(exclude);
         } else {
-          paths.removeIf(p -> p.equalsIgnoreCase(exclude));
+          paths.removeIf(p -> Ascii.equalsIgnoreCase(p, exclude));
         }
         continue;
       }

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -108,7 +108,7 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   @Override
   public boolean isGlobCaseSensitive() {
     // TODO(laszlocsomor): as part of wiring up `--incompatible_windows_case_insensitive_glob`,
-    // return false here.
+    // return false here. See https://github.com/bazelbuild/bazel/issues/8767
     return true;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -106,6 +106,13 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   @Override
+  public boolean isGlobCaseSensitive() {
+    // TODO(laszlocsomor): as part of wiring up `--incompatible_windows_case_insensitive_glob`,
+    // return false here.
+    return true;
+  }
+
+  @Override
   protected boolean fileIsSymbolicLink(File file) {
     try {
       if (isSymlinkOrJunction(file)) {

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -107,8 +107,8 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
   @Override
   public boolean isGlobCaseSensitive() {
-    // TODO(laszlocsomor): as part of wiring up `--incompatible_windows_case_insensitive_glob`,
-    // return false here. See https://github.com/bazelbuild/bazel/issues/8767
+    // TODO(laszlocsomor): return the opposite of `--incompatible_windows_case_insensitive_glob`
+    // here. See https://github.com/bazelbuild/bazel/issues/8767
     return true;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -9,6 +9,7 @@ package(
 CROSS_PLATFORM_WINDOWS_TESTS = [
     "util/DependencySetWindowsTest.java",
     "vfs/PathFragmentWindowsTest.java",
+    "vfs/WindowsGlobTest.java",
     "vfs/WindowsPathTest.java",
 ]
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/GlobFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/GlobFunctionTest.java
@@ -544,7 +544,7 @@ public abstract class GlobFunctionTest {
 
   @Test
   public void testMatchesCallWithNoCache() {
-    assertThat(UnixGlob.matches("*a*b", "CaCb", null)).isTrue();
+    assertThat(UnixGlob.matches("*a*b", "CaCb", null, true)).isTrue();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/vfs/GlobTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/GlobTest.java
@@ -285,7 +285,7 @@ public class GlobTest {
 
   @Test
   public void testMatchesCallWithNoCache() {
-    assertThat(UnixGlob.matches("*a*b", "CaCb", null)).isTrue();
+    assertThat(UnixGlob.matches("*a*b", "CaCb", null, true)).isTrue();
   }
 
   @Test
@@ -297,11 +297,11 @@ public class GlobTest {
   public void testMatcherMethodRecursiveBelowDir() throws Exception {
     FileSystemUtils.createEmptyFile(tmpPath.getRelative("foo/file"));
     String pattern = "foo/**/*";
-    assertThat(UnixGlob.matches(pattern, "foo/bar")).isTrue();
-    assertThat(UnixGlob.matches(pattern, "foo/bar/baz")).isTrue();
-    assertThat(UnixGlob.matches(pattern, "foo")).isFalse();
-    assertThat(UnixGlob.matches(pattern, "foob")).isFalse();
-    assertThat(UnixGlob.matches("**/foo", "foo")).isTrue();
+    assertThat(UnixGlob.matches(pattern, "foo/bar", true)).isTrue();
+    assertThat(UnixGlob.matches(pattern, "foo/bar/baz", true)).isTrue();
+    assertThat(UnixGlob.matches(pattern, "foo", true)).isFalse();
+    assertThat(UnixGlob.matches(pattern, "foob", true)).isFalse();
+    assertThat(UnixGlob.matches("**/foo", "foo", true)).isTrue();
   }
 
   @Test
@@ -440,7 +440,7 @@ public class GlobTest {
 
   private Collection<String> removeExcludes(ImmutableList<String> paths, String... excludes) {
     HashSet<String> pathSet = new HashSet<>(paths);
-    UnixGlob.removeExcludes(pathSet, ImmutableList.copyOf(excludes));
+    UnixGlob.removeExcludes(pathSet, ImmutableList.copyOf(excludes), true);
     return pathSet;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/vfs/WindowsGlobTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/WindowsGlobTest.java
@@ -63,118 +63,22 @@ public class WindowsGlobTest {
     assertThat(matched).containsExactlyElementsIn(expected);
   }
 
-  private static final class MockPatternCache implements Map<String, Pattern> {
-    private final Map<String, Pattern> actual = new HashMap<>();
-    public Object lastPutKey;
-    public Object lastRemovedKey;
-
-    @Override
-    public int size() {
-      return actual.size();
-    }
-
-    @Override
-    public boolean isEmpty() {
-      return actual.isEmpty();
-    }
-
-    @Override
-    public boolean containsKey(Object key) {
-      return actual.containsKey(key);
-    }
-
-    @Override
-    public boolean containsValue(Object value) {
-      return actual.containsValue(value);
-    }
-
-    @Override
-    public Pattern get(Object key) {
-      return actual.get(key);
-    }
-
-    @Override
-    public Pattern put(String key, Pattern value) {
-      assertThat(actual.containsKey(key)).isFalse();
-      lastPutKey = key;
-      return actual.put(key, value);
-    }
-
-    @Override
-    public Pattern remove(Object key) {
-      lastRemovedKey = key;
-      return actual.remove(key);
-    }
-
-    @Override
-    public void putAll(Map<? extends String, ? extends Pattern> m) {
-      actual.putAll(m);
-    }
-
-    @Override
-    public void clear() {
-      actual.clear();
-    }
-
-    @Override
-    public Set<String> keySet() {
-      return actual.keySet();
-    }
-
-    @Override
-    public Collection<Pattern> values() {
-      return actual.values();
-    }
-
-    @Override
-    public Set<Map.Entry<String, Pattern>> entrySet() {
-      // entrySet() returns a mutable view. Let's not allow mutation outside of put()/remove().
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      return actual.equals(o);
-    }
-
-    @Override
-    public int hashCode() {
-      return actual.hashCode();
-    }
-  }
-
   @Test
-  public void testCaseSensitiveMatches() throws Exception {
-    MockPatternCache patternCache = new MockPatternCache();
-    assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", patternCache, true)).isTrue();
-    assertThat(patternCache.lastPutKey).isEqualTo("Foo/**");
-    assertThat(UnixGlob.matches("foo/**", "Foo/Bar/a.txt", patternCache, true)).isFalse();
-    assertThat(patternCache.lastPutKey).isEqualTo("foo/**");
-    assertThat(UnixGlob.matches("F*o*o/**", "Foo/Bar/a.txt", patternCache, true)).isTrue();
-    assertThat(patternCache.lastPutKey).isEqualTo("F*o*o/**");
-    assertThat(UnixGlob.matches("f*o*o/**", "Foo/Bar/a.txt", patternCache, true)).isFalse();
-    assertThat(patternCache.lastPutKey).isEqualTo("f*o*o/**");
-    // Test correct caching: this pattern should already be in the Map.
-    assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", patternCache, true)).isTrue();
-    assertThat(patternCache.lastPutKey).isEqualTo("f*o*o/**");
-    assertThat(patternCache.lastRemovedKey).isNull();
-  }
+  public void testMatches() throws Exception {
+    assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", null, true)).isTrue();
+    assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", null, false)).isTrue();
 
-  @Test
-  public void testCaseInsensitiveMatches() throws Exception {
-    MockPatternCache patternCache = new MockPatternCache();
-    assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
-    assertThat(patternCache.lastPutKey).isEqualTo("Foo/**");
-    assertThat(UnixGlob.matches("foo/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
-    assertThat(patternCache.lastPutKey).isEqualTo("foo/**");
-    assertThat(UnixGlob.matches("F*o*o/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
-    assertThat(patternCache.lastPutKey).isEqualTo("F*o*o/**");
-    assertThat(UnixGlob.matches("f*o*o/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
-    assertThat(patternCache.lastPutKey).isEqualTo("f*o*o/**");
-    // Test correct caching: this pattern should already be in the Map.
-    assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
-    assertThat(patternCache.lastPutKey).isEqualTo("f*o*o/**");
-    assertThat(patternCache.lastRemovedKey).isNull();
+    assertThat(UnixGlob.matches("foo/**", "Foo/Bar/a.txt", null, true)).isFalse();
+    assertThat(UnixGlob.matches("foo/**", "Foo/Bar/a.txt", null, false)).isTrue();
+
+    assertThat(UnixGlob.matches("F*o*o/**", "Foo/Bar/a.txt", null, true)).isTrue();
+    assertThat(UnixGlob.matches("F*o*o/**", "Foo/Bar/a.txt", null, false)).isTrue();
+
+    assertThat(UnixGlob.matches("f*o*o/**", "Foo/Bar/a.txt", null, true)).isFalse();
+    assertThat(UnixGlob.matches("f*o*o/**", "Foo/Bar/a.txt", null, false)).isTrue();
+
+    assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", null, true)).isTrue();
+    assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", null, false)).isTrue();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/vfs/WindowsGlobTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/WindowsGlobTest.java
@@ -73,21 +73,25 @@ public class WindowsGlobTest {
   }
 
   @Test
-  public void testMatches() throws Exception {
-    UnixGlob.PatternCache patternCache =
-        new UnixGlob.PatternCache(new HashMap<>(), new HashMap<>());
+  public void testCaseSensitiveMatches() throws Exception {
+    Map<String, Pattern> patternCache = new HashMap<>();
     // Test correct caching by executing the same checks twice.
     for (int i = 0; i < 2; i++) {
       assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", patternCache, true)).isTrue();
-      assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
-
       assertThat(UnixGlob.matches("foo/**", "Foo/Bar/a.txt", patternCache, true)).isFalse();
-      assertThat(UnixGlob.matches("foo/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
-
       assertThat(UnixGlob.matches("F*o*o/**", "Foo/Bar/a.txt", patternCache, true)).isTrue();
-      assertThat(UnixGlob.matches("F*o*o/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
-
       assertThat(UnixGlob.matches("f*o*o/**", "Foo/Bar/a.txt", patternCache, true)).isFalse();
+    }
+  }
+
+  @Test
+  public void testCaseInsensitiveMatches() throws Exception {
+    Map<String, Pattern> patternCache = new HashMap<>();
+    // Test correct caching by executing the same checks twice.
+    for (int i = 0; i < 2; i++) {
+      assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
+      assertThat(UnixGlob.matches("foo/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
+      assertThat(UnixGlob.matches("F*o*o/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
       assertThat(UnixGlob.matches("f*o*o/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/vfs/WindowsGlobTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/WindowsGlobTest.java
@@ -1,0 +1,345 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.vfs;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.clock.BlazeClock;
+import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests glob() on Windows (when glob is case-insensitive). */
+@RunWith(JUnit4.class)
+public class WindowsGlobTest {
+
+  private static Set<String> setOf(String... ee) {
+    return new HashSet<>(Arrays.asList(ee));
+  }
+
+  private Set<Path> resolvePaths(Path root, String... relativePaths) {
+    Set<Path> expectedFiles = new HashSet<>();
+    for (String expected : relativePaths) {
+      Path file = expected.equals(".") ? root : root.getRelative(expected);
+      expectedFiles.add(file);
+    }
+    return expectedFiles;
+  }
+
+  private void assertMatches(UnixGlob.FilesystemCalls fsCalls, Path root, String pattern,
+      String... expecteds) throws IOException {
+    AtomicReference<UnixGlob.FilesystemCalls> sysCalls = new AtomicReference<>(fsCalls);
+    assertThat(
+        new UnixGlob.Builder(root)
+            .addPattern(pattern)
+            .setFilesystemCalls(sysCalls)
+            .setExcludeDirectories(true)
+            .glob())
+        .containsExactlyElementsIn(resolvePaths(root, expecteds));
+  }
+
+  private static void assertExcludes(Collection<String> unfiltered, String exclusionPattern,
+                                     boolean caseSensitive, Collection<String> expected) {
+    Set<String> matched = new HashSet<>(unfiltered);
+    UnixGlob.removeExcludes(matched, ImmutableList.of(exclusionPattern), caseSensitive);
+    assertThat(matched).containsExactlyElementsIn(expected);
+  }
+
+  @Test
+  public void testMatches() throws Exception {
+    UnixGlob.PatternCache patternCache =
+        new UnixGlob.PatternCache(new HashMap<>(), new HashMap<>());
+    // Test correct caching by executing the same checks twice.
+    for (int i = 0; i < 2; i++) {
+      assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", patternCache, true)).isTrue();
+      assertThat(UnixGlob.matches("Foo/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
+
+      assertThat(UnixGlob.matches("foo/**", "Foo/Bar/a.txt", patternCache, true)).isFalse();
+      assertThat(UnixGlob.matches("foo/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
+
+      assertThat(UnixGlob.matches("F*o*o/**", "Foo/Bar/a.txt", patternCache, true)).isTrue();
+      assertThat(UnixGlob.matches("F*o*o/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
+
+      assertThat(UnixGlob.matches("f*o*o/**", "Foo/Bar/a.txt", patternCache, true)).isFalse();
+      assertThat(UnixGlob.matches("f*o*o/**", "Foo/Bar/a.txt", patternCache, false)).isTrue();
+    }
+  }
+
+  @Test
+  public void testExcludes() throws Exception {
+    assertExcludes(Arrays.asList("Foo/Bar/a.txt", "Foo/Bar/b.dat"), "Foo/**/*.dat", true,
+                   Arrays.asList("Foo/Bar/a.txt"));
+    assertExcludes(Arrays.asList("Foo/Bar/a.txt", "Foo/Bar/b.dat"), "Foo/**/*.dat", false,
+                   Arrays.asList("Foo/Bar/a.txt"));
+
+    assertExcludes(Arrays.asList("Foo/Bar/a.txt", "Foo/Bar/b.dat"), "foo/**/*.dat", true,
+                   Arrays.asList("Foo/Bar/a.txt", "Foo/Bar/b.dat"));
+    assertExcludes(Arrays.asList("Foo/Bar/a.txt", "Foo/Bar/b.dat"), "foo/**/*.dat", false,
+                   Arrays.asList("Foo/Bar/a.txt"));
+  }
+
+  private enum MockStat implements FileStatus {
+    FILE(true, false),
+    DIR(false, true),
+    UNKNOWN(false, false);
+
+    private final boolean isFile;
+    private final boolean isDir;
+
+    private MockStat(boolean isFile, boolean isDir) {
+      this.isFile = isFile;
+      this.isDir = isDir;
+    }
+
+    @Override public boolean isFile() { return isFile; }
+    @Override public boolean isDirectory() { return isDir; }
+    @Override public boolean isSymbolicLink() { return false; }
+    @Override public boolean isSpecialFile() { return false; }
+    @Override public long getSize() throws IOException { return 0; }
+
+    @Override
+    public long getLastModifiedTime() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getLastChangeTime() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getNodeId() throws IOException {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static FileSystem mockFs(boolean caseSensitive) throws IOException {
+    FileSystem fs = new InMemoryFileSystem(BlazeClock.instance()) {
+      @Override public boolean isFilePathCaseSensitive() { return caseSensitive; }
+      @Override public boolean isGlobCaseSensitive() { return isFilePathCaseSensitive(); }
+    };
+    fs.getPath("/globtmp/Foo/Bar").createDirectoryAndParents();
+    FileSystemUtils.writeContentAsLatin1(fs.getPath("/globtmp/Foo/Bar/a.txt"), "foo");
+    FileSystemUtils.writeContentAsLatin1(fs.getPath("/globtmp/Foo/Bar/b.dat"), "bar");
+    return fs;
+  }
+
+  private static Map<String, Collection<Dirent>> mockDirents(Path root) {
+    // Map keys must be Strings not Paths, lest they follow the host OS' case-sensitivity policy.
+    Map<String, Collection<Dirent>> d = root.getFileSystem().isGlobCaseSensitive()
+        ? new HashMap<>()
+        : new TreeMap<>((String x, String y) -> x.compareToIgnoreCase(y));
+    d.put(
+        root.getParentDirectory().toString(),
+        ImmutableList.of(new Dirent(root.getBaseName(), Dirent.Type.DIRECTORY)));
+    d.put(
+        root.toString(),
+        ImmutableList.of(new Dirent("Foo", Dirent.Type.DIRECTORY)));
+    d.put(
+        root.getRelative("Foo").toString(),
+        ImmutableList.of(new Dirent("Bar", Dirent.Type.DIRECTORY)));
+    d.put(
+        root.getRelative("Foo/Bar").toString(),
+        ImmutableList.of(
+            new Dirent("a.txt", Dirent.Type.FILE), new Dirent("b.dat", Dirent.Type.FILE)));
+    return d;
+  }
+
+  private static Map<String, FileStatus> mockStats(Path root) {
+    // Map keys must be Strings not Paths, lest they follow the host OS' case-sensitivity policy.
+    Map<String, FileStatus> d = root.getFileSystem().isGlobCaseSensitive()
+        ? new HashMap<>()
+        : new TreeMap<>((String x, String y) -> x.compareToIgnoreCase(y));
+    d.put(root.getParentDirectory().toString(), MockStat.DIR);
+    d.put(root.toString(), MockStat.DIR);
+    d.put(root.getRelative("Foo").toString(), MockStat.DIR);
+    d.put(root.getRelative("Foo/Bar").toString(), MockStat.DIR);
+    d.put(root.getRelative("Foo/Bar/a.txt").toString(), MockStat.FILE);
+    d.put(root.getRelative("Foo/Bar/b.dat").toString(), MockStat.FILE);
+    return d;
+  }
+
+  private static UnixGlob.FilesystemCalls mockFsCalls(Path root) {
+    return new UnixGlob.FilesystemCalls() {
+      private final Map<String, Collection<Dirent>> dirents = mockDirents(root);
+      private final Map<String, FileStatus> stats = mockStats(root);
+
+      @Override
+      public Collection<Dirent> readdir(Path path) throws IOException {
+        String p = path.toString();
+        if (path.getFileSystem().isGlobCaseSensitive()) {
+          if (dirents.containsKey(p)) {
+            return dirents.get(p);
+          }
+        } else {
+          for (String k : dirents.keySet()) {
+            return dirents.get(p);
+          }
+        }
+        throw new IOException(p.toString());
+      }
+
+      @Override
+      public FileStatus statIfFound(Path path, Symlinks symlinks) throws IOException {
+        String p = path.toString();
+        if (stats.containsKey(p)) {
+          return stats.get(p);
+        }
+        return MockStat.UNKNOWN;
+      }
+
+      @Override
+      public Dirent.Type getType(Path path, Symlinks symlinks) throws IOException {
+        String p = path.toString();
+        if (dirents.containsKey(p)) {
+          for (Dirent d : dirents.get(p)) {
+            if (d.getName().equals(path.getBaseName())) {
+              return d.getType();
+            }
+          }
+        }
+        throw new IOException();
+      }
+    };
+  }
+
+  @Test
+  public void testFoo() throws Exception {
+    FileSystem unixFs = mockFs(/* caseSensitive */ true);
+    FileSystem winFs = mockFs(/* caseSensitive */ false);
+
+    Path unixRoot = unixFs.getPath("/globtmp");
+    Path winRoot = winFs.getPath("/globtmp");
+
+    Path unixRoot2 = unixFs.getPath("/globTMP");
+    Path winRoot2 = winFs.getPath("/globTMP");
+
+    UnixGlob.FilesystemCalls unixFsCalls = mockFsCalls(unixRoot);
+    UnixGlob.FilesystemCalls winFsCalls = mockFsCalls(winRoot);
+
+    assertMatches(unixFsCalls, unixRoot, "Foo/*");
+    assertMatches(winFsCalls, winRoot, "Foo/*");
+
+    assertMatches(unixFsCalls, unixRoot, "Foo/*/*", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+    assertMatches(winFsCalls, winRoot, "Foo/*/*", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+
+    assertMatches(unixFsCalls, unixRoot, "Foo/**", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+    assertMatches(winFsCalls, winRoot, "Foo/**", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+
+    assertMatches(unixFsCalls, unixRoot, "foO/**");
+    assertMatches(winFsCalls, winRoot, "foO/**", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+
+    assertMatches(unixFsCalls, unixRoot, "foO/baR/*");
+    assertMatches(winFsCalls, winRoot, "foO/baR/*", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+
+    assertMatches(unixFsCalls, unixRoot2, "**");
+    assertMatches(winFsCalls, winRoot2, "**", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+
+    assertMatches(unixFsCalls, unixRoot2, "foO/**");
+    assertMatches(winFsCalls, winRoot2, "foO/**", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+
+    assertMatches(unixFsCalls, unixRoot2, "foO/baR/*");
+    assertMatches(winFsCalls, winRoot2, "foO/baR/*", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+
+    assertMatches(unixFsCalls, unixRoot, "foO/baR/**");
+    assertMatches(winFsCalls, winRoot, "foO/baR/**", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+
+    // A so-called "complex" first token with the right casing.
+    // The glob logic creates a regex for these.
+    assertMatches(unixFsCalls, unixRoot, "F*o*o/**", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+    assertMatches(winFsCalls, winRoot, "F*o*o/**", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+
+    // A "complex" first token with the wrong casing.
+    assertMatches(unixFsCalls, unixRoot, "f*o*O/**");
+    assertMatches(winFsCalls, winRoot, "f*o*O/**", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+
+    // A "complex" first pattern with the right casing, but wrongly-cased root.
+    assertMatches(unixFsCalls, unixRoot2, "F*o*o/**");
+    assertMatches(winFsCalls, winRoot2, "F*o*o/**", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+
+    // A "complex" first pattern with the wrong casing and wrongly-cased root.
+    assertMatches(unixFsCalls, unixRoot2, "f*o*O/**");
+    assertMatches(winFsCalls, winRoot2, "f*o*O/**", "Foo/Bar/a.txt", "Foo/Bar/b.dat");
+  }
+
+  @Test
+  public void testStartsWithCase() {
+    assertThat(UnixGlob.startsWithCase("", "", true)).isTrue();
+    assertThat(UnixGlob.startsWithCase("", "", false)).isTrue();
+
+    assertThat(UnixGlob.startsWithCase("Foo", "", true)).isTrue();
+    assertThat(UnixGlob.startsWithCase("Foo", "", false)).isTrue();
+
+    assertThat(UnixGlob.startsWithCase("", "Foo", true)).isFalse();
+    assertThat(UnixGlob.startsWithCase("", "Foo", false)).isFalse();
+
+    assertThat(UnixGlob.startsWithCase("Fo", "Foo", true)).isFalse();
+    assertThat(UnixGlob.startsWithCase("Fo", "Foo", false)).isFalse();
+
+    assertThat(UnixGlob.startsWithCase("Foo", "Foo", true)).isTrue();
+    assertThat(UnixGlob.startsWithCase("Foo", "Foo", false)).isTrue();
+
+    assertThat(UnixGlob.startsWithCase("Foox", "Foo", true)).isTrue();
+    assertThat(UnixGlob.startsWithCase("Foox", "Foo", false)).isTrue();
+
+    assertThat(UnixGlob.startsWithCase("xFoo", "Foo", true)).isFalse();
+    assertThat(UnixGlob.startsWithCase("xFoo", "Foo", false)).isFalse();
+
+    assertThat(UnixGlob.startsWithCase("Foox", "foO", true)).isFalse();
+    assertThat(UnixGlob.startsWithCase("Foox", "foO", false)).isTrue();
+  }
+
+  @Test
+  public void testEndsWithCase() {
+    assertThat(UnixGlob.endsWithCase("", "", true)).isTrue();
+    assertThat(UnixGlob.endsWithCase("", "", false)).isTrue();
+
+    assertThat(UnixGlob.endsWithCase("Foo", "", true)).isTrue();
+    assertThat(UnixGlob.endsWithCase("Foo", "", false)).isTrue();
+
+    assertThat(UnixGlob.endsWithCase("", "Foo", true)).isFalse();
+    assertThat(UnixGlob.endsWithCase("", "Foo", false)).isFalse();
+
+    assertThat(UnixGlob.endsWithCase("Fo", "Foo", true)).isFalse();
+    assertThat(UnixGlob.endsWithCase("Fo", "Foo", false)).isFalse();
+
+    assertThat(UnixGlob.endsWithCase("Foo", "Foo", true)).isTrue();
+    assertThat(UnixGlob.endsWithCase("Foo", "Foo", false)).isTrue();
+
+    assertThat(UnixGlob.endsWithCase("Foox", "Foo", true)).isFalse();
+    assertThat(UnixGlob.endsWithCase("Foox", "Foo", false)).isFalse();
+
+    assertThat(UnixGlob.endsWithCase("xFoo", "Foo", true)).isTrue();
+    assertThat(UnixGlob.endsWithCase("xFoo", "Foo", false)).isTrue();
+
+    assertThat(UnixGlob.endsWithCase("xFoo", "foO", true)).isFalse();
+    assertThat(UnixGlob.endsWithCase("xFoo", "foO", false)).isTrue();
+  }
+}


### PR DESCRIPTION
The behavior is triggered by
FileSystem.isGlobCaseSensitive() returning false.

None of the production FileSystem implementaitions
return false yet, only some test implementations.

Motivation is to support case-insensitive glob()
on Windows.

See https://github.com/bazelbuild/bazel/issues/8705 and https://github.com/bazelbuild/bazel/issues/8759.

Next we need to add an incompatible flag that
enables this behavior, and add a relevant bit to
the WindowsFileSystem. See https://github.com/bazelbuild/bazel/issues/8767

We must also warn the user somehow if enabling
this feature would change the result of some
globs. A potential approach would be to glob
case-sensitively and case-insensitively at the
same time and warn the user if the results are
different.