### PR TITLE
rule_test: apply "tags" to all rules in the macro

### DIFF
--- a/src/test/shell/bazel/rule_test_test.sh
+++ b/src/test/shell/bazel/rule_test_test.sh
@@ -178,8 +178,10 @@ EOF
 # Regression test for https://github.com/bazelbuild/bazel/issues/8723
 #
 # rule_test() is a macro that expands to a sh_test and _rule_test_rule.
-# Expect that rule_tags(..., tags) is applied to both rules, but rule_tags(..., visibility) is only
-# applied to the sh_test because _rule_test_rule should be private.
+# Expect that:
+# * test- and build-rule attributes (e.g. "tags") are applied to both rules,
+# * test-only attributes are applied only to the sh_rule,
+# * the build rule has its own visibility
 function test_kwargs_with_macro_rules() {
   create_new_workspace
   cat > BUILD <<'EOF'
@@ -199,6 +201,12 @@ rule_test(
     generates = ["x.out"],
     visibility = ["//foo:__pkg__"],
     tags = ["dont_build_me"],
+    args = ["x"],
+    flaky = False,
+    local = True,
+    shard_count = 2,
+    size = "small",
+    timeout = "short",
 )
 EOF
 

--- a/src/test/shell/bazel/rule_test_test.sh
+++ b/src/test/shell/bazel/rule_test_test.sh
@@ -202,6 +202,8 @@ rule_test(
 )
 EOF
 
+  bazel build //:all >& "$TEST_log" && fail "should have failed" || true
+
   bazel build --build_tag_filters=-dont_build_me //:all >& "$TEST_log" || fail "build failed"
 
   bazel query --output=label 'attr(tags, dont_build_me, //:all)' >& "$TEST_log" || fail "query failed"

--- a/tools/build_rules/test_rules.bzl
+++ b/tools/build_rules/test_rules.bzl
@@ -35,10 +35,25 @@ def _make_sh_test(name, **kwargs):
         **kwargs
     )
 
-def _merge_dicts(d1, d2):
+_TEST_ATTRS = {
+    "args": None,
+    "size": None,
+    "timeout": None,
+    "flaky": None,
+    "local": None,
+    "shard_count": None,
+}
+
+def _helper_rule_attrs(test_attrs, own_attrs):
     r = {}
-    r.update(d1)
-    r.update(d2)
+    r.update({k: v for k, v in test_attrs.items() if k not in _TEST_ATTRS})
+    r.update(own_attrs)
+    r.update(
+        dict(
+            testonly = 1,
+            visibility = ["//visibility:private"],
+        ),
+    )
     return r
 
 ### First, trivial tests that either always pass, always fail,
@@ -81,14 +96,12 @@ _successful_rule = rule(
 
 def successful_test(name, msg, **kwargs):
     _successful_rule(
-        **_merge_dicts(
+        **_helper_rule_attrs(
             kwargs,
             dict(
                 name = name + "_impl",
                 msg = msg,
                 out = name + "_impl.sh",
-                testonly = 1,
-                visibility = ["//visibility:private"],
             ),
         )
     )
@@ -132,14 +145,12 @@ _failed_rule = rule(
 
 def failed_test(name, msg, **kwargs):
     _failed_rule(
-        **_merge_dicts(
+        **_helper_rule_attrs(
             kwargs,
             dict(
                 name = name + "_impl",
                 msg = msg,
                 out = name + "_impl.sh",
-                testonly = 1,
-                visibility = ["//visibility:private"],
             ),
         )
     )
@@ -322,7 +333,7 @@ _rule_test_rule = rule(
 
 def rule_test(name, rule, generates = None, provides = None, **kwargs):
     _rule_test_rule(
-        **_merge_dicts(
+        **_helper_rule_attrs(
             kwargs,
             dict(
                 name = name + "_impl",
@@ -330,8 +341,6 @@ def rule_test(name, rule, generates = None, provides = None, **kwargs):
                 generates = generates,
                 provides = provides,
                 out = name + ".sh",
-                testonly = 1,
-                visibility = ["//visibility:private"],
             ),
         )
     )
@@ -393,7 +402,7 @@ _file_test_rule = rule(
 
 def file_test(name, file, content = None, regexp = None, matches = None, **kwargs):
     _file_test_rule(
-        **_merge_dicts(
+        **_helper_rule_attrs(
             kwargs,
             dict(
                 name = name + "_impl",
@@ -402,8 +411,6 @@ def file_test(name, file, content = None, regexp = None, matches = None, **kwarg
                 regexp = regexp or "",
                 matches = matches if (matches != None) else -1,
                 out = name + "_impl.sh",
-                testonly = 1,
-                visibility = ["//visibility:private"],
             ),
         )
     )

--- a/tools/build_rules/test_rules.bzl
+++ b/tools/build_rules/test_rules.bzl
@@ -35,6 +35,12 @@ def _make_sh_test(name, **kwargs):
         **kwargs
     )
 
+def _merge_dicts(d1, d2):
+    r = {}
+    r.update(d1)
+    r.update(d2)
+    return r
+
 ### First, trivial tests that either always pass, always fail,
 ### or sometimes pass depending on a trivial computation.
 
@@ -75,11 +81,16 @@ _successful_rule = rule(
 
 def successful_test(name, msg, **kwargs):
     _successful_rule(
-        name = name + "_impl",
-        msg = msg,
-        out = name + "_impl.sh",
-        testonly = 1,
-        visibility = ["//visibility:private"],
+        **_merge_dicts(
+            kwargs,
+            dict(
+                name = name + "_impl",
+                msg = msg,
+                out = name + "_impl.sh",
+                testonly = 1,
+                visibility = ["//visibility:private"],
+            ),
+        )
     )
 
     _make_sh_test(name, **kwargs)
@@ -121,11 +132,16 @@ _failed_rule = rule(
 
 def failed_test(name, msg, **kwargs):
     _failed_rule(
-        name = name + "_impl",
-        msg = msg,
-        out = name + "_impl.sh",
-        testonly = 1,
-        visibility = ["//visibility:private"],
+        **_merge_dicts(
+            kwargs,
+            dict(
+                name = name + "_impl",
+                msg = msg,
+                out = name + "_impl.sh",
+                testonly = 1,
+                visibility = ["//visibility:private"],
+            ),
+        )
     )
 
     _make_sh_test(name, **kwargs)
@@ -306,13 +322,18 @@ _rule_test_rule = rule(
 
 def rule_test(name, rule, generates = None, provides = None, **kwargs):
     _rule_test_rule(
-        name = name + "_impl",
-        rule = rule,
-        generates = generates,
-        provides = provides,
-        out = name + ".sh",
-        testonly = 1,
-        visibility = ["//visibility:private"],
+        **_merge_dicts(
+            kwargs,
+            dict(
+                name = name + "_impl",
+                rule = rule,
+                generates = generates,
+                provides = provides,
+                out = name + ".sh",
+                testonly = 1,
+                visibility = ["//visibility:private"],
+            ),
+        )
     )
 
     _make_sh_test(name, **kwargs)
@@ -372,14 +393,18 @@ _file_test_rule = rule(
 
 def file_test(name, file, content = None, regexp = None, matches = None, **kwargs):
     _file_test_rule(
-        name = name + "_impl",
-        file = file,
-        content = content or "",
-        regexp = regexp or "",
-        matches = matches if (matches != None) else -1,
-        out = name + "_impl.sh",
-        testonly = 1,
-        visibility = ["//visibility:private"],
+        **_merge_dicts(
+            kwargs,
+            dict(
+                name = name + "_impl",
+                file = file,
+                content = content or "",
+                regexp = regexp or "",
+                matches = matches if (matches != None) else -1,
+                out = name + "_impl.sh",
+                testonly = 1,
+                visibility = ["//visibility:private"],
+            ),
+        )
     )
-
     _make_sh_test(name, **kwargs)


### PR DESCRIPTION
RELNOTES: rule_test: fix Bazel 0.27 regression ("tags" attribute was ingored, https://github.com/bazelbuild/bazel/issues/8723

Fixes https://github.com/bazelbuild/bazel/issues/8723

Change-Id: I25ac338e4978084085b8c49d6d0a1c47d8dc4fd1