### PR TITLE
Make python repository import order deterministic

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
@@ -137,7 +137,10 @@ def CreateModuleSpace():
 # Returns repository roots to add to the import path.
 def GetRepositoriesImports(module_space, import_all):
   if import_all:
-    repo_dirs = [os.path.join(module_space, d) for d in os.listdir(module_space)]
+    repo_dirs = [
+        os.path.join(module_space, d)
+        for d in sorted(os.listdir(module_space))
+    ]
     return [d for d in repo_dirs if os.path.isdir(d)]
   return [os.path.join(module_space, "%workspace_name%")]
 


### PR DESCRIPTION
os.listdir returns in arbitary order. https://docs.python.org/3/library/os.html#os.listdir

If more than one repo has same top-level package name, the package imported can be inconsistent across machines. This could have unexpected outcome when the running py_binary or make the test flaky.