### PR TITLE
Windows: fix "insufficient resources" on Windows 7

### DIFF
--- a/src/main/native/windows/process.cc
+++ b/src/main/native/windows/process.cc
@@ -192,7 +192,7 @@ bool WaitableProcess::Create(const std::wstring& argv0,
       errmsg = L"Unrecoverable error: host OS is Windows 7 and subprocess"
         " got an inheritable console handle";
     } else {
-      errmsg = std::wstring(L"error: ") + ToString(err);
+      errmsg = GetLastErrorString(err) + L" (error: " + ToString(err) + L")";
     }
 
     *error = MakeErrorMessage(WSTR(__FILE__), __LINE__, L"CreateProcessW",

--- a/src/main/native/windows/process.cc
+++ b/src/main/native/windows/process.cc
@@ -50,14 +50,17 @@ static bool DupeHandle(HANDLE h, AutoHandle* out, std::wstring* error) {
 bool WaitableProcess::Create(const std::wstring& argv0,
                              const std::wstring& argv_rest, void* env,
                              const std::wstring& wcwd, std::wstring* error) {
-  AutoHandle dup_in, dup_out, dup_err;
-  if (!DupeHandle(GetStdHandle(STD_INPUT_HANDLE), &dup_in, error) ||
-      !DupeHandle(GetStdHandle(STD_OUTPUT_HANDLE), &dup_out, error) ||
-      !DupeHandle(GetStdHandle(STD_ERROR_HANDLE), &dup_err, error)) {
-    return false;
-  }
-  return Create(argv0, argv_rest, env, wcwd, dup_in, dup_out, dup_err, nullptr,
-                true, error);
+  // On Windows 7, the subprocess cannot inherit console handles via the
+  // attribute list (CreateProcessW fails with ERROR_NO_SYSTEM_RESOURCES).
+  // If we pass invalid handles here, the Create method creates an
+  // AutoAttributeList with 0 handles in it, and initializes the STARTUPINFOEXW
+  // without allowing handle inheritance. And in that case, the subprocess
+  // inherits this process' STD handles, which is exactly what we want, and it
+  // works on all supported Windows versions.
+  // Fixes https://github.com/bazelbuild/bazel/issues/8676
+  return Create(argv0, argv_rest, env, wcwd, INVALID_HANDLE_VALUE,
+                INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, nullptr, true,
+                error);
 }
 
 bool WaitableProcess::Create(const std::wstring& argv0,
@@ -150,8 +153,8 @@ bool WaitableProcess::Create(const std::wstring& argv0,
   static constexpr size_t kMaxCmdline = 32767;
 
   std::wstring cmd_sample = mutable_commandline.get();
-  if (cmd_sample.size() > 200) {
-    cmd_sample = cmd_sample.substr(0, 195) + L"(...)";
+  if (cmd_sample.size() > 500) {
+    cmd_sample = cmd_sample.substr(0, 495) + L"(...)";
   }
   if (wcsnlen_s(mutable_commandline.get(), kMaxCmdline) == kMaxCmdline) {
     std::wstringstream error_msg;
@@ -181,8 +184,18 @@ bool WaitableProcess::Create(const std::wstring& argv0,
           /* lpStartupInfo */ &info.StartupInfo,
           /* lpProcessInformation */ &process_info)) {
     DWORD err = GetLastError();
+
+    std::wstring errmsg;
+    if (err == ERROR_NO_SYSTEM_RESOURCES && !IsWindows8OrGreater() &&
+        attr_list->HasConsoleHandle()) {
+      errmsg = L"Unrecoverable error: host OS is Windows 7 and subprocess"
+        " got an inheritable console handle";
+    } else {
+      errmsg = std::wstring(L"error: ") + ToString(err);
+    }
+
     *error = MakeErrorMessage(WSTR(__FILE__), __LINE__, L"CreateProcessW",
-                              cmd_sample, err);
+                              cmd_sample, errmsg);
     return false;
   }
 

--- a/src/main/native/windows/process.cc
+++ b/src/main/native/windows/process.cc
@@ -52,11 +52,12 @@ bool WaitableProcess::Create(const std::wstring& argv0,
                              const std::wstring& wcwd, std::wstring* error) {
   // On Windows 7, the subprocess cannot inherit console handles via the
   // attribute list (CreateProcessW fails with ERROR_NO_SYSTEM_RESOURCES).
-  // If we pass invalid handles here, the Create method creates an
-  // AutoAttributeList with 0 handles in it, and initializes the STARTUPINFOEXW
-  // without allowing handle inheritance. And in that case, the subprocess
-  // inherits this process' STD handles, which is exactly what we want, and it
-  // works on all supported Windows versions.
+  // If we pass only invalid handles here, the Create method creates an
+  // AutoAttributeList with 0 handles and initializes the STARTUPINFOEXW as
+  // empty and disallowing handle inheritance. At the same time, CreateProcessW
+  // specifies neither CREATE_NEW_CONSOLE nor DETACHED_PROCESS, so the
+  // subprocess *does* inherit the console, which is exactly what we want, and
+  // it works on all supported Windows versions.
   // Fixes https://github.com/bazelbuild/bazel/issues/8676
   return Create(argv0, argv_rest, env, wcwd, INVALID_HANDLE_VALUE,
                 INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE, nullptr, true,

--- a/src/main/native/windows/util.h
+++ b/src/main/native/windows/util.h
@@ -81,6 +81,8 @@ class AutoAttributeList {
 
   void InitStartupInfoExW(STARTUPINFOEXW* startup_info) const;
 
+  bool HasConsoleHandle() const { return handles_.HasConsoleHandle(); }
+
  private:
   class StdHandles {
    public:
@@ -91,6 +93,15 @@ class AutoAttributeList {
     HANDLE StdIn() const { return stdin_h_; }
     HANDLE StdOut() const { return stdout_h_; }
     HANDLE StdErr() const { return stderr_h_; }
+
+    bool HasConsoleHandle() const {
+      for (size_t i = 0; i < valid_handles_; ++i) {
+        if (GetFileType(valid_handle_array_[i]) == FILE_TYPE_CHAR) {
+          return true;
+        }
+      }
+      return false;
+    }
 
    private:
     size_t valid_handles_;


### PR DESCRIPTION
On Windows 7, the subprocess cannot inherit
console handles via the attribute list
(CreateProcessW fails with
ERROR_NO_SYSTEM_RESOURCES).

However, if we:

- don't specify STARTF_USESTDHANDLES in
  STARTUPINFOW::dwFlags, and
- set CreateProcessW:bInheritHandles to FALSE,

then we disallow inheriting the current process'
open and inheritable handles.

However, if on top of that we also:

- don't specify CREATE_NEW_CONSOLE nor
  DETACHED_PROCESS in
  CreateProcessW:dwCreationFlags,

then, in this special case, the subprocess *does*
inherit the console handles, but nothing else
(i.e. none of the inheritable, open file handles
for example).

This is rather confusing, but seems to work and
do exactly what we need: for the subprocess to
inherit the console handles and nothing else.

https://github.com/bazelbuild/bazel/issues/8676