### PR TITLE
Windows: remove envvars from Chocolatey output

### DIFF
--- a/scripts/packages/chocolatey/tools/chocolateyinstall.ps1
+++ b/scripts/packages/chocolatey/tools/chocolateyinstall.ps1
@@ -20,10 +20,6 @@ Install-ChocolateyZipPackage -PackageName "$packageName" `
 write-host @"
 bazel installed to $packageDir
 
-You also need, in your environment variables (adjust paths for your system):
-  BAZEL_SH=c:\tools\msys64\usr\bin\bash.exe
-  BAZEL_PYTHON=c:\tools\python2\python.exe
-
 See also https://bazel.build/docs/windows.html
 "@
 


### PR DESCRIPTION
Chocolatey no longer says you must set BAZEL_SH
and BAZEL_PYTHON. Bazel works without setting
these envvars.