### PR TITLE
Explicitly mark globs with allow_empty

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -59,7 +59,10 @@ filegroup(
 
 filegroup(
     name = "bootstrap-derived-java-srcs",
-    srcs = glob(["derived/**/*.java"]),
+    srcs = glob(
+        ["derived/**/*.java"],
+        allow_empty = True,
+    ),
     visibility = ["//:__subpackages__"],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -646,6 +646,7 @@ java_library(
             "skyframe/*.java",
             "skyframe/actiongraph/*.java",
         ],
+        allow_empty = True,
         exclude = [
             "analysis/BuildInfo.java",
             "analysis/BuildVersionInfo.java",

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -19,6 +19,7 @@ java_library(
             "*.java",
             "transitions/*.java",
         ],
+        allow_empty = True,
         exclude = INTERFACE_SOURCES,
     ),
     deps = [

--- a/src/main/tools/jdk.BUILD
+++ b/src/main/tools/jdk.BUILD
@@ -38,54 +38,54 @@ filegroup(
 
 filegroup(
     name = "java",
-    deprecation = DEPRECATION_MESSAGE,
     srcs = select({
         ":windows": ["bin/java.exe"],
         "//conditions:default": ["bin/java"],
     }),
     data = [":jdk"],
+    deprecation = DEPRECATION_MESSAGE,
 )
 
 filegroup(
     name = "jar",
-    deprecation = DEPRECATION_MESSAGE,
     srcs = select({
         ":windows": ["bin/jar.exe"],
         "//conditions:default": ["bin/jar"],
     }),
     data = [":jdk"],
+    deprecation = DEPRECATION_MESSAGE,
 )
 
 filegroup(
-    deprecation = DEPRECATION_MESSAGE,
     name = "javac",
     srcs = select({
         ":windows": ["bin/javac.exe"],
         "//conditions:default": ["bin/javac"],
     }),
     data = [":jdk"],
+    deprecation = DEPRECATION_MESSAGE,
 )
 
 filegroup(
-    deprecation = DEPRECATION_MESSAGE,
     name = "javadoc",
     srcs = select({
         ":windows": ["bin/javadoc.exe"],
         "//conditions:default": ["bin/javadoc"],
     }),
     data = [":jdk"],
+    deprecation = DEPRECATION_MESSAGE,
 )
 
 filegroup(
-    deprecation = DEPRECATION_MESSAGE,
     name = "xjc",
     srcs = ["bin/xjc"],
+    deprecation = DEPRECATION_MESSAGE,
 )
 
 filegroup(
-    deprecation = DEPRECATION_MESSAGE,
     name = "wsimport",
     srcs = ["bin/wsimport"],
+    deprecation = DEPRECATION_MESSAGE,
 )
 
 BOOTCLASS_JARS = [
@@ -98,22 +98,28 @@ BOOTCLASS_JARS = [
 
 # TODO(cushon): this isn't compatible with JDK 9
 filegroup(
-    deprecation = DEPRECATION_MESSAGE,
     name = "bootclasspath",
     srcs = ["jre/lib/%s" % jar for jar in BOOTCLASS_JARS],
+    deprecation = DEPRECATION_MESSAGE,
 )
 
 # TODO(cushon): migrate to extclasspath and delete
 filegroup(
     name = "extdir",
+    srcs = glob(
+        ["jre/lib/ext/*.jar"],
+        allow_empty = True,
+    ),
     deprecation = DEPRECATION_MESSAGE,
-    srcs = glob(["jre/lib/ext/*.jar"]),
 )
 
 filegroup(
     name = "extclasspath",
+    srcs = glob(
+        ["jre/lib/ext/*.jar"],
+        allow_empty = True,
+    ),
     deprecation = DEPRECATION_MESSAGE,
-    srcs = glob(["jre/lib/ext/*.jar"]),
 )
 
 filegroup(
@@ -122,7 +128,11 @@ filegroup(
         # In some configurations, Java browser plugin is considered harmful and
         # common antivirus software blocks access to npjp2.dll interfering with Bazel,
         # so do not include it in JRE on Windows.
-        ":windows": glob(["jre/bin/**"], exclude = ["jre/bin/plugin2/**"]),
+        ":windows": glob(
+            ["jre/bin/**"],
+            allow_empty = True,
+            exclude = ["jre/bin/plugin2/**"],
+        ),
         "//conditions:default": glob(["jre/bin/**"]),
     }),
     deprecation = DEPRECATION_MESSAGE,
@@ -130,7 +140,10 @@ filegroup(
 
 filegroup(
     name = "jre-lib",
-    srcs = glob(["jre/lib/**"]),
+    srcs = glob(
+        ["jre/lib/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
@@ -191,9 +204,9 @@ filegroup(
 
 java_import(
     name = "langtools-neverlink",
+    deprecation = DEPRECATION_MESSAGE,
     jars = ["lib/tools.jar"],
     neverlink = 1,
-    deprecation = DEPRECATION_MESSAGE,
 )
 
 config_setting(

--- a/tools/build_rules/java_rules_skylark.bzl
+++ b/tools/build_rules/java_rules_skylark.bzl
@@ -62,7 +62,7 @@ def _java_library_impl(ctx):
     if ctx.files.srcjars:
         files += " @" + javalist_output
         for file in ctx.files.srcjars:
-            cmd += "%s tf %s | grep '\.java$' | sed 's|^|%s/|' >> %s\n" % (jar_path, file.path, java_output, javalist_output)
+            cmd += "%s tf %s | grep '\\.java$' | sed 's|^|%s/|' >> %s\n" % (jar_path, file.path, java_output, javalist_output)
             cmd += "unzip %s -d %s >/dev/null\n" % (file.path, java_output)
 
     if ctx.files.srcs or ctx.files.srcjars:


### PR DESCRIPTION
This is needed for Bazel 1.0 (see --incompatible_disallow_empty_glob).