### PR TITLE
Fix naming of flag --build_event_json_file_path_conversion.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BuildEventStreamOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BuildEventStreamOptions.java
@@ -85,8 +85,8 @@ public class BuildEventStreamOptions extends OptionsBase {
   public boolean buildEventBinaryFilePathConversion;
 
   @Option(
-      name = "experimental_build_event_json_file_path_conversion",
-      oldName = "build_event_json_file_path_conversion",
+      name = "build_event_json_file_path_conversion",
+      oldName = "experimental_build_event_json_file_path_conversion",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},


### PR DESCRIPTION
In https://github.com/bazelbuild/bazel/commit/1e0628d18c2e3defaddd935ffb41edbf3ef40339 (~two years ago) the `--experimental_build_event_` flags were renamed to remove the `experimental_` suffix. It looks like the change for `--build_event_json_file_path_conversion` was incorrect, it swapped the `name=` and `oldName=` lines. As a result, the public docs and output of `bazel help build` are confusing.

I believe this change is safe because Bazel accepts both the old and new names interchangeably.