### PR TITLE
Bootstrap: remove non-existent path from DIRS

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -44,7 +44,7 @@ if [ "$ERROR_PRONE_INDEX" -lt "$GUAVA_INDEX" ]; then
   LIBRARY_JARS="${LIBRARY_JARS_ARRAY[*]}"
 fi
 
-DIRS=$(echo src/{java_tools/singlejar/java/com/google/devtools/build/zip,main/java,tools/xcode-common/java/com/google/devtools/build/xcode/{common,util}} tools/java/runfiles third_party/java/dd_plist/java ${OUTPUT_DIR}/src)
+DIRS=$(echo src/{java_tools/singlejar/java/com/google/devtools/build/zip,main/java} tools/java/runfiles third_party/java/dd_plist/java ${OUTPUT_DIR}/src)
 EXCLUDE_FILES="src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/testing/*"
 # Exclude whole directories under the bazel src tree that bazel itself
 # doesn't depend on.
@@ -367,31 +367,6 @@ function build_jni() {
   fi
 }
 
-# Computes the value of the bazel.windows_unix_root JVM flag.
-# Prints the JVM flag verbatim on Windows, ready to be passed to the JVM.
-# Prints an empty string on other platforms.
-function windows_unix_root_jvm_flag() {
-  if [ "${PLATFORM}" != "windows" ]; then
-    echo ""
-    return
-  fi
-  [ -n "${BAZEL_SH}" ] || fail "\$BAZEL_SH is not defined"
-  if [ "$(basename "$BAZEL_SH")" = "bash.exe" ]; then
-    local result="$(dirname "$BAZEL_SH")"
-    if [ "$(basename "$result")" = "bin" ]; then
-      result="$(dirname "$result")"
-      if [ "$(basename "$result")" = "usr" ]; then
-        result="$(dirname "$result")"
-      fi
-      # Print the JVM flag. Replace backslashes with forward slashes so the JVM
-      # and the shell won't believe that backslashes are escaping characters.
-      echo "-Dbazel.windows_unix_root=${result//\\//}"
-      return
-    fi
-  fi
-  fail "\$BAZEL_SH=${BAZEL_SH}, must end with \"bin\\bash.exe\" or \"usr\\bin\\bash.exe\""
-}
-
 build_jni "${ARCHIVE_DIR}/_embedded_binaries"
 
 cp src/main/tools/jdk.BUILD ${ARCHIVE_DIR}/_embedded_binaries/jdk.BUILD
@@ -431,7 +406,6 @@ function run_bazel_jar() {
   "${JAVA_HOME}/bin/java" \
       -XX:+HeapDumpOnOutOfMemoryError -Xverify:none -Dfile.encoding=ISO-8859-1 \
       -XX:HeapDumpPath=${OUTPUT_DIR} \
-      $(windows_unix_root_jvm_flag) \
       -Djava.util.logging.config.file=${OUTPUT_DIR}/javalog.properties \
       ${JNI_FLAGS} \
       -jar ${ARCHIVE_DIR}/libblaze.jar \


### PR DESCRIPTION
This avoids a spurious error from "find".

Also remove the logic that computes the
--windows_unix_root flag, because that flag is no
longer necessary when building with MSVC.
(It's only required when building with MinGW GCC.)

Change-Id: I93fd7d5567280996acf3789823ef5e67236a976f