### PR TITLE
Fix test_host_xcodes on Xcode 11

### DIFF
--- a/src/test/shell/bazel/apple/bazel_apple_test.sh
+++ b/src/test/shell/bazel/apple/bazel_apple_test.sh
@@ -127,7 +127,7 @@ function test_host_xcodes() {
       | sed -E "s/Xcode (([0-9]|.)+).*/\1/")
   IOS_SDK=$(env -i xcodebuild -version -sdk | grep iphoneos \
       | sed -E "s/.*\(iphoneos(([0-9]|.)+)\).*/\1/")
-  MACOSX_SDK=$(env -i xcodebuild -version -sdk | grep macosx \
+  MACOSX_SDK=$(env -i xcodebuild -version -sdk | grep "(macosx" \
       | sed -E "s/.*\(macosx(([0-9]|.)+)\).*/\1/" | head -n 1)
 
   # Unfortunately xcodebuild -version doesn't always pad with trailing .0, so,


### PR DESCRIPTION
Xcode 11 includes a new DriverKit SDK that makes
`xcodebuild -version -sdk | grep macosx` now prints:

```
  DriverKit19.0.sdk - DriverKit 19.0 (driverkit.macosx19.0)
  MacOSX10.15.sdk - macOS 10.15 (macosx10.15)
```

This made the previous code for getting macOS SDK fails when runs with
Xcode 11 being selected.