### PR TITLE
Fix Bazel selects wrong Xcode 

### DIFF
--- a/src/test/shell/bazel/apple/bazel_apple_test.sh
+++ b/src/test/shell/bazel/apple/bazel_apple_test.sh
@@ -125,6 +125,8 @@ EOF
 function test_host_xcodes() {
   XCODE_VERSION=$(env -i xcodebuild -version | grep "Xcode" \
       | sed -E "s/Xcode (([0-9]|.)+).*/\1/")
+  XCODE_BUILD_VERSION=$(env -i xcodebuild -version | grep "Build version" \
+      | sed -E "s/Build version (([0-9]|.)+).*/\1/")
   IOS_SDK=$(env -i xcodebuild -version -sdk | grep iphoneos \
       | sed -E "s/.*\(iphoneos(([0-9]|.)+)\).*/\1/")
   MACOSX_SDK=$(env -i xcodebuild -version -sdk | grep macosx \
@@ -137,10 +139,12 @@ function test_host_xcodes() {
     XCODE_VERSION="${XCODE_VERSION}.0"
   fi
 
+  XCODE_VERSION_FULL="${XCODE_VERSION}.${XCODE_BUILD_VERSION}"
+
   bazel build @local_config_xcode//:host_xcodes >"${TEST_log}" 2>&1 \
      || fail "Expected host_xcodes to build"
 
-  bazel query "attr(version, $XCODE_VERSION, \
+  bazel query "attr(version, $XCODE_VERSION_FULL, \
       attr(default_ios_sdk_version, $IOS_SDK, \
       attr(default_macos_sdk_version, $MACOSX_SDK, \
       labels('versions', '@local_config_xcode//:host_xcodes'))))" \

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -198,6 +198,7 @@ def _darwin_build_file(repository_ctx):
         return VERSION_CONFIG_STUB + "\n# Error: " + xcodeloc_err + "\n"
 
     default_xcode_version = _search_string(xcodebuild_result.stdout, "Xcode ", "\n")
+    default_xcode_build_version = _search_string(xcodebuild_result.stdout, "Build version ", "\n")
     default_xcode_target = ""
     target_names = []
     buildcontents = ""
@@ -209,7 +210,7 @@ def _darwin_build_file(repository_ctx):
         target_name = "version%s" % version.replace(".", "_")
         buildcontents += _xcode_version_output(repository_ctx, target_name, version, aliases, developer_dir)
         target_names.append("':%s'" % target_name)
-        if (version == default_xcode_version or default_xcode_version in aliases):
+        if (version.startswith(default_xcode_version) and version.endswith(default_xcode_build_version)):
             default_xcode_target = target_name
     buildcontents += "xcode_config(name = 'host_xcodes',"
     if target_names:


### PR DESCRIPTION
when there are multiple copies of Xcode that have the same version but different build numbers (e.g. Xcode 11 beta, Xcode 11 beta 2, Xcode 11 beta 3) installed on the same machine.