### PR TITLE
Windows: fix string quoting in powershell scripts

### DIFF
--- a/scripts/packages/msi/make_msi_lib.ps1
+++ b/scripts/packages/msi/make_msi_lib.ps1
@@ -26,8 +26,8 @@ function Log-Info {
       [string]$msg
     )
     $basename = $PSCommandPath.Substring($PSCommandPath.LastIndexOfAny('/\') + 1)
-    $time = (Get-Date).ToString(.HH:mm:ss.)
-    Write-Host 'INFO[$basename $time] $msg'
+    $time = (Get-Date).ToString('HH:mm:ss')
+    Write-Host "INFO[$basename $time] $msg"
 }
 
 function Replace-Slashes {
@@ -66,26 +66,29 @@ function Get-UpgradeGuid {
     $d = @{}
     $result = $null
     foreach ($line in Get-Content -Path $Guids) {
-        $line = '$line'.Split('#')[0]
+        $line = "$line".Split('#')[0]
         if ($line) {
             $k, $v = $line.Split(' ', 2)
             # Ensure all version prefixes in the file are unique.
             if ($d.ContainsKey($k)) {
-                throw 'Duplicate relase prefix $k in $Guids'
+                throw "Duplicate relase prefix $k in $Guids"
             }
             else {
                 $d[$k] = $null
             }
+            if (! $v) {
+                throw "Null key '$v' in line '$line'"
+            }
             # Ensure all GUIDs in the file are unique. We can use the same
             # hashtable because the value domains are distinct.
             if ($d.ContainsKey($v)) {
-                throw 'Duplicate GUID $v in $Guids'
+                throw "Duplicate GUID $v in $Guids"
             }
             else {
                 $d[$v] = $null
             }
             if (! $result -and $release_name.StartsWith($k)) {
-                $result = '$v'
+                $result = "$v"
                 # Do not return yet, so we check that all GUIDs are unique.
             }
         }

--- a/scripts/packages/msi/make_msi_test.ps1
+++ b/scripts/packages/msi/make_msi_test.ps1
@@ -43,4 +43,4 @@ Assert-NotEqual $(Get-UpgradeGuid 0.28.0) $(Get-UpgradeGuid 0.29.0)
 Assert-NotEqual $(Get-UpgradeGuid 1.5.0) $(Get-UpgradeGuid 2.0.3rc1)
 
 
-Write-Host 'PASSED'
+Log-Info 'PASSED'


### PR DESCRIPTION
Use weak quoting (") instead of strong quoting (')
when variables must be expanded. (This is similar
behavior to Bash.)

See https://github.com/bazelbuild/bazel/issues/8813