### PR TITLE
Bazel client: warn if output paths have space

### DIFF
--- a/src/main/cpp/bazel_startup_options.cc
+++ b/src/main/cpp/bazel_startup_options.cc
@@ -135,6 +135,22 @@ void BazelStartupOptions::MaybeLogStartupOptionWarnings() const {
                             "ignored, since --ignore_all_rc_files is on.";
     }
   }
+  bool output_user_root_has_space =
+      output_user_root.find_first_of(' ') != std::string::npos;
+  if (output_user_root_has_space) {
+    BAZEL_LOG(WARNING) << "Output user root \"" << output_user_root
+      << "\" contains a space. This will probably break the build. "
+         "You should set a different --output_user_root.";
+  } else if (output_base.find_first_of(' ') != std::string::npos) {
+    // output_base is computed from output_user_root by default.
+    // If output_user_root was bad, don't check output_base: while output_base
+    // may also be bad, we already warned about output_user_root so there's no
+    // point in another warning.
+    BAZEL_LOG(WARNING) << "Output base \"" << output_base
+      << "\" contains a space. This will probably break the build. "
+         "You should not set --output_base and let Bazel use the default, or "
+         "set --output_base to a path without space.";
+  }
 }
 
 void BazelStartupOptions::AddExtraOptions(


### PR DESCRIPTION
Warn the user if output_user_root or output_base
have a space character, because that probably
breaks the build.

This is a warning and not a hard error, because
some Bazel functions ("bazel info" for example)
work fine with such paths.

Common causes for bad output paths are:
- user name having a space (on Windows)
- bad --output_user_root and/or --output_base
  value

Fixes https://github.com/bazelbuild/bazel/issues/7979