### PR TITLE
[sandbox] Run sandbox from common execroot

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -230,7 +230,11 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
       throws IOException {
     // We have to make the TEST_TMPDIR directory writable if it is specified.
     ImmutableSet.Builder<Path> writablePaths = ImmutableSet.builder();
-    writablePaths.add(sandboxExecRoot);
+
+    if (OS.getCurrent() != OS.WINDOWS) {
+      writablePaths.add(sandboxExecRoot);
+    }
+
     String testTmpdir = env.get("TEST_TMPDIR");
     if (testTmpdir != null) {
       addWritablePath(

--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -231,6 +231,8 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
     // We have to make the TEST_TMPDIR directory writable if it is specified.
     ImmutableSet.Builder<Path> writablePaths = ImmutableSet.builder();
 
+    // On Windows, sandboxExecRoot is actually the main execroot. We will specify
+    // exactly which output path is writable.
     if (OS.getCurrent() != OS.WINDOWS) {
       writablePaths.add(sandboxExecRoot);
     }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DummySandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DummySandboxedSpawn.java
@@ -1,0 +1,77 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.sandbox;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+import com.google.devtools.build.lib.exec.TreeDeleter;
+import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.FileSystemUtils.MoveResult;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+
+/**
+ * Implements detour-based sandboxed spawn.
+ */
+public class DummySandboxedSpawn implements SandboxedSpawn {
+
+  private final Path execRoot;
+  private final Map<String, String> environment;
+  private final List<String> arguments;
+
+  public DummySandboxedSpawn(
+      Path execRoot,
+      Map<String, String> environment,
+      List<String> arguments) {
+    this.execRoot = execRoot;
+    this.environment = environment;
+    this.arguments = arguments;
+  }
+
+  @Override
+  public Path getSandboxExecRoot() {
+    return execRoot;
+  }
+
+  @Override
+  public List<String> getArguments() {
+    return arguments;
+  }
+
+  @Override
+  public Map<String, String> getEnvironment() {
+    return environment;
+  }
+
+  @Override
+  public void createFileSystem() throws IOException {
+  }
+
+  @Override
+  public void copyOutputs(Path execRoot) throws IOException {
+  }
+
+  @Override
+  public void delete() {
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -368,8 +368,7 @@ public final class SandboxModule extends BlazeModule {
       SpawnRunner spawnRunner =
           withFallback(
               cmdEnv,
-              new WindowsSandboxedSpawnRunner(
-                  cmdEnv, sandboxBase, timeoutKillDelay, windowsSandboxPath, treeDeleter));
+              new WindowsSandboxedSpawnRunner(cmdEnv, timeoutKillDelay, windowsSandboxPath));
       spawnRunners.add(spawnRunner);
       builder.addActionContext(new WindowsSandboxedStrategy(cmdEnv.getExecRoot(), spawnRunner));
     }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxUtil.java
@@ -29,7 +29,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.logging.Logger;
 
 /** Utility functions for the {@code windows-sandbox}. */
@@ -105,6 +107,8 @@ public final class WindowsSandboxUtil {
     private Path stdoutPath;
     private Path stderrPath;
     private Set<Path> writableFilesAndDirectories = ImmutableSet.of();
+    private Map<PathFragment, Path> readableFilesAndDirectories = new TreeMap<>();
+    private Set<Path> inaccessiblePaths = ImmutableSet.of();
     private boolean useDebugMode = false;
     private List<String> commandArguments = ImmutableList.of();
 
@@ -153,6 +157,20 @@ public final class WindowsSandboxUtil {
       return this;
     }
 
+    /** Sets the files or directories to make readable for the sandboxed process, if any. */
+    public CommandLineBuilder setReadableFilesAndDirectories(
+        Map<PathFragment, Path> readableFilesAndDirectories) {
+      this.readableFilesAndDirectories = readableFilesAndDirectories;
+      return this;
+    }
+
+    /** Sets the files or directories to make inaccessible for the sandboxed process, if any. */
+    public CommandLineBuilder setInaccessiblePaths(
+        Set<Path> inaccessiblePaths) {
+      this.inaccessiblePaths = inaccessiblePaths;
+      return this;
+    }
+
     /** Sets whether to enable debug mode (e.g. to print debugging messages). */
     public CommandLineBuilder setUseDebugMode(boolean useDebugMode) {
       this.useDebugMode = useDebugMode;
@@ -186,6 +204,12 @@ public final class WindowsSandboxUtil {
       }
       for (Path writablePath : writableFilesAndDirectories) {
         commandLineBuilder.add("-w", writablePath.getPathString());
+      }
+      for (Path readablePath : readableFilesAndDirectories.values()) {
+        commandLineBuilder.add("-r", readablePath.getPathString());
+      }
+      for (Path writablePath : inaccessiblePaths) {
+        commandLineBuilder.add("-b", writablePath.getPathString());
       }
       if (useDebugMode) {
         commandLineBuilder.add("-D");

--- a/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxedSpawn.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxedSpawn.java
@@ -14,35 +14,24 @@
 
 package com.google.devtools.build.lib.sandbox;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterables;
-import com.google.devtools.build.lib.exec.TreeDeleter;
-import com.google.devtools.build.lib.sandbox.SandboxHelpers.SandboxOutputs;
-import com.google.devtools.build.lib.vfs.FileSystemUtils;
-import com.google.devtools.build.lib.vfs.FileSystemUtils.MoveResult;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.vfs.Path;
-import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Logger;
 
 /**
  * Implements detour-based sandboxed spawn.
  */
-public class DummySandboxedSpawn implements SandboxedSpawn {
+public class WindowsSandboxedSpawn implements SandboxedSpawn {
 
   private final Path execRoot;
-  private final Map<String, String> environment;
-  private final List<String> arguments;
+  private final ImmutableMap<String, String> environment;
+  private final ImmutableList<String> arguments;
 
-  public DummySandboxedSpawn(
+  public WindowsSandboxedSpawn(
       Path execRoot,
-      Map<String, String> environment,
-      List<String> arguments) {
+      ImmutableMap<String, String> environment,
+      ImmutableList<String> arguments) {
     this.execRoot = execRoot;
     this.environment = environment;
     this.arguments = arguments;
@@ -54,12 +43,12 @@ public class DummySandboxedSpawn implements SandboxedSpawn {
   }
 
   @Override
-  public List<String> getArguments() {
+  public ImmutableList<String> getArguments() {
     return arguments;
   }
 
   @Override
-  public Map<String, String> getEnvironment() {
+  public ImmutableMap<String, String> getEnvironment() {
     return environment;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/WindowsSandboxedSpawnRunner.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.sandbox;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ExecException;
@@ -60,9 +62,10 @@ final class WindowsSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
     Path tmpDir = createActionTemp(execRoot);
     Path commandTmpDir = tmpDir.getRelative("work");
     commandTmpDir.createDirectory();
-    Map<String, String> environment =
-        localEnvProvider.rewriteLocalEnv(
-            spawn.getEnvironment(), binTools, commandTmpDir.getPathString());
+    ImmutableMap<String, String> environment =
+        ImmutableMap.copyOf(
+            localEnvProvider.rewriteLocalEnv(
+                spawn.getEnvironment(), binTools, commandTmpDir.getPathString()));
 
     Map<PathFragment, Path> readablePaths =
         SandboxHelpers.processInputFiles(
@@ -93,7 +96,7 @@ final class WindowsSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
     Path statisticsPath = null;
 
-    SandboxedSpawn sandbox = new DummySandboxedSpawn(execRoot, environment, commandLineBuilder.build());
+    SandboxedSpawn sandbox = new WindowsSandboxedSpawn(execRoot, environment, commandLineBuilder.build());
 
     return runSpawn(spawn, sandbox, context, execRoot, timeout, statisticsPath);
   }


### PR DESCRIPTION
Make sandboxed process run under main execroot instead of unique sandboxed execroot. This way, we do not need to copy/symlink input files before execution and clean up sandbox base after execution.

Summary of how it works:

- `windows-sandbox` blocks all file access under current directory (main execroot).
- Declared input paths will be marked readable.
- Declared output paths will be marked writable.
- If sandboxed process tries to open file for read/write when the path is not marked with that permission, the operation will fail (e.g. `fopen` will return `nullptr`).