### PR TITLE
Undo breaking change of hiding android_common behind --experimental_google_legacy_api

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/android/AndroidBootstrap.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/android/AndroidBootstrap.java
@@ -54,10 +54,13 @@ public class AndroidBootstrap implements Bootstrap {
 
   @Override
   public void addBindingsToBuilder(ImmutableMap.Builder<String, Object> builder) {
-    builder.put(
-        "android_common",
-        FlagGuardedValue.onlyWhenExperimentalFlagIsTrue(
-            FlagIdentifier.EXPERIMENTAL_GOOGLE_LEGACY_API, androidCommon));
+    // TODO: Make an incompatible change flag to hide android_common behind
+    // --experimental_google_legacy_api.
+    // Rationale: android_common module contains commonly used functions used outside of
+    // the Android Starlark migration. Let's not break them without an incompatible
+    // change process.
+    builder.put("android_common", androidCommon);
+
     builder.put(
         ApkInfoApi.NAME,
         FlagGuardedValue.onlyWhenExperimentalFlagIsTrue(


### PR DESCRIPTION
This should be patched into 0.28.0 to fix https://github.com/bazelbuild/intellij/issues/976