### PR TITLE
C++ runfiles library test: cut unwanted dependency

### DIFF
--- a/tools/cpp/runfiles/BUILD
+++ b/tools/cpp/runfiles/BUILD
@@ -63,7 +63,6 @@ cc_test(
     visibility = ["//visibility:public"],
     deps = [
         ":runfiles",
-        "//src/main/cpp/util:filesystem",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/tools/cpp/runfiles/runfiles_test.cc
+++ b/tools/cpp/runfiles/runfiles_test.cc
@@ -24,8 +24,6 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "src/main/cpp/util/file.h"
-#include "src/main/cpp/util/path.h"
 
 #define RUNFILES_TEST_TOSTRING_HELPER(x) #x
 #define RUNFILES_TEST_TOSTRING(x) RUNFILES_TEST_TOSTRING_HELPER(x)
@@ -99,14 +97,14 @@ string RunfilesTest::GetTemp() {
 #ifdef _WIN32
   DWORD size = ::GetEnvironmentVariableA("TEST_TMPDIR", NULL, 0);
   if (size == 0) {
-    return std::move(string());  // unset or empty envvar
+    return string();  // unset or empty envvar
   }
   unique_ptr<char[]> value(new char[size]);
   ::GetEnvironmentVariableA("TEST_TMPDIR", value.get(), size);
-  return std::move(string(value.get()));
+  return value.get();
 #else
   char* result = getenv("TEST_TMPDIR");
-  return result != NULL ? std::move(string(result)) : std::move(string());
+  return result != NULL ? string(result) : string();
 #endif
 }
 
@@ -122,18 +120,22 @@ RunfilesTest::MockFile* RunfilesTest::MockFile::Create(
     return nullptr;
   }
 
-  string tmp(std::move(RunfilesTest::GetTemp()));
+  string tmp(RunfilesTest::GetTemp());
   if (tmp.empty()) {
     cerr << "WARNING: " << __FILE__ << "(" << __LINE__
          << "): $TEST_TMPDIR is empty" << endl;
     return nullptr;
   }
   string path(tmp + "/" + name);
-  string dirname = blaze_util::Dirname(path);
-  if (!blaze_util::MakeDirectories(dirname, 0777)) {
-    cerr << "WARNING: " << __FILE__ << "(" << __LINE__ << "): MakeDirectories("
-         << dirname << ") failed" << endl;
-    return nullptr;
+
+  string::size_type i = 0;
+  while ((i = name.find_first_of("/\\", i + 1)) != string::npos) {
+    string d = tmp + "\\" + name.substr(0, i);
+    if (!CreateDirectoryA(d.c_str(), NULL)) {
+      cerr << "ERROR: " << __FILE__ << "(" << __LINE__
+           << "): failed to create directory \"" << d << "\"" << endl;
+      return nullptr;
+    }
   }
 
   auto stm = std::ofstream(path);


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/8862