### PR TITLE
Make @local_config_platform//:host visible to everyone.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunction.java
@@ -127,6 +127,7 @@ public class LocalConfigPlatformFunction extends RepositoryFunction {
     return format(
         ImmutableList.of(
             "# DO NOT EDIT: automatically generated BUILD file for local_config_platform",
+            "package(default_visibility = ['//visibility:public'])",
             "load(':constraints.bzl', 'HOST_CONSTRAINTS')",
             "platform(name = 'host',",
             "  # Auto-detected host platform constraints.",


### PR DESCRIPTION
Making the target visible allows other platforms to inherit from it (e.g. java host platform).