### PR TITLE
Rename macro cc_* rules to avoid confusion

### DIFF
--- a/src/tools/launcher/BUILD
+++ b/src/tools/launcher/BUILD
@@ -1,4 +1,4 @@
-load(":win_rules.bzl", "cc_binary", "cc_library")
+load(":win_rules.bzl", "win_cc_binary", "win_cc_library")
 
 filegroup(
     name = "srcs",
@@ -6,7 +6,7 @@ filegroup(
     visibility = ["//src:__pkg__"],
 )
 
-cc_binary(
+win_cc_binary(
     name = "launcher",
     srcs = ["launcher_main.cc"],
     visibility = [
@@ -23,7 +23,7 @@ cc_binary(
     ],
 )
 
-cc_library(
+win_cc_library(
     name = "launcher_base",
     srcs = ["launcher.cc"],
     hdrs = ["launcher.h"],
@@ -34,21 +34,21 @@ cc_library(
     ],
 )
 
-cc_library(
+win_cc_library(
     name = "java_launcher",
     srcs = ["java_launcher.cc"],
     hdrs = ["java_launcher.h"],
     deps = [":launcher_base"],
 )
 
-cc_library(
+win_cc_library(
     name = "python_launcher",
     srcs = ["python_launcher.cc"],
     hdrs = ["python_launcher.h"],
     deps = [":launcher_base"],
 )
 
-cc_library(
+win_cc_library(
     name = "bash_launcher",
     srcs = ["bash_launcher.cc"],
     hdrs = ["bash_launcher.h"],

--- a/src/tools/launcher/dummy.cc
+++ b/src/tools/launcher/dummy.cc
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-int main() {}
+int main() { return 1; }

--- a/src/tools/launcher/util/BUILD
+++ b/src/tools/launcher/util/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//src/tools/launcher:__subpackages__"])
 
-load("//src/tools/launcher:win_rules.bzl", "cc_binary", "cc_library", "cc_test")
+load("//src/tools/launcher:win_rules.bzl", "win_cc_binary", "win_cc_library", "win_cc_test")
 
 filegroup(
     name = "srcs",
@@ -8,14 +8,14 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-cc_library(
+win_cc_library(
     name = "data_parser",
     srcs = ["data_parser.cc"],
     hdrs = ["data_parser.h"],
     deps = [":util"],
 )
 
-cc_library(
+win_cc_library(
     name = "util",
     srcs = ["launcher_util.cc"],
     hdrs = ["launcher_util.h"],
@@ -26,7 +26,7 @@ cc_library(
     deps = ["//src/main/cpp/util:filesystem"],
 )
 
-cc_test(
+win_cc_test(
     name = "util_test",
     srcs = ["launcher_util_test.cc"],
     data = [
@@ -40,7 +40,7 @@ cc_test(
     ],
 )
 
-cc_test(
+win_cc_test(
     name = "data_parser_test",
     srcs = ["data_parser_test.cc"],
     deps = [
@@ -49,7 +49,7 @@ cc_test(
     ],
 )
 
-cc_binary(
+win_cc_binary(
     name = "printarg",
     testonly = 1,
     srcs = ["printarg.cc"],

--- a/src/tools/launcher/win_rules.bzl
+++ b/src/tools/launcher/win_rules.bzl
@@ -19,7 +19,7 @@ only supports Java.
 
 load("@rules_cc//cc:defs.bzl", macro_cc_bin = "cc_binary", macro_cc_lib = "cc_library", macro_cc_test = "cc_test")
 
-def cc_library(srcs = [], hdrs = [], **kwargs):
+def win_cc_library(srcs = [], deps = [], hdrs = [], **kwargs):
     """Replace srcs and hdrs with a dummy.cc on non-Windows platforms."""
     macro_cc_lib(
         srcs = select({
@@ -30,25 +30,37 @@ def cc_library(srcs = [], hdrs = [], **kwargs):
             "//conditions:default": [],
             "//src/conditions:windows": hdrs,
         }),
+        deps = select({
+            "//conditions:default": [],
+            "//src/conditions:windows": deps,
+        }),
         **kwargs
     )
 
-def cc_binary(srcs = [], **kwargs):
+def win_cc_binary(srcs = [], deps = [], **kwargs):
     """Replace srcs with a dummy.cc on non-Windows platforms."""
     macro_cc_bin(
         srcs = select({
             "//conditions:default": ["dummy.cc"],
             "//src/conditions:windows": srcs,
         }),
+        deps = select({
+            "//conditions:default": [],
+            "//src/conditions:windows": deps,
+        }),
         **kwargs
     )
 
-def cc_test(srcs = [], **kwargs):
+def win_cc_test(srcs = [], deps = [], **kwargs):
     """Replace srcs with a dummy.cc on non-Windows platforms."""
     macro_cc_test(
         srcs = select({
             "//conditions:default": ["dummy.cc"],
             "//src/conditions:windows": srcs,
+        }),
+        deps = select({
+            "//conditions:default": [],
+            "//src/conditions:windows": deps,
         }),
         **kwargs
     )


### PR DESCRIPTION
Using the native rule names makes it look like
these are native rules. I spent half an hour
debugging why cc_binary behaved weirdly before
realizing it was overridden by a load().

Change-Id: I9cb562ef36cd4585b3a312202b72e90d5a54ccfa