### PR TITLE
Make incremental repository updates feature available without a flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
@@ -65,7 +65,7 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
 
   @Option(
       name = "experimental_allow_incremental_repository_updates",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
       effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
       metadataTags = {OptionMetadataTag.EXPERIMENTAL},

--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
@@ -1,4 +1,4 @@
-// Copyright 2017 The Bazel Authors. All rights reserved.
+// Copyright 2019 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 package com.google.devtools.build.lib.packages;
 
@@ -69,12 +70,8 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
       effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
       metadataTags = {OptionMetadataTag.EXPERIMENTAL},
       help =
-          "If used, it is possible to define a mapping between external repositories"
-              + " and some (mostly likely ignored by .bazelignore) directories."
-              + " The repository rule can read and update files in those directories,"
-              + " and the changes will be visible in the same build."
-              + " Use attribute 'managed_directories' of the global workspace()"
-              + " function in WORKSPACE file to define the mapping.")
+          "This flag will be removed in Bazel 1.0. Please do not use it.\n"
+              + "Incremental repository updates feature is now enabled without the flag.")
   public boolean experimentalAllowIncrementalRepositoryUpdates;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/WorkspaceGlobalsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/WorkspaceGlobalsApi.java
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 package com.google.devtools.build.lib.skylarkbuildapi;
 
@@ -52,9 +53,7 @@ public interface WorkspaceGlobalsApi {
             noneable = true,
             named = true,
             positional = false,
-            enableOnlyWithFlag = FlagIdentifier.EXPERIMENTAL_ALLOW_INCREMENTAL_REPOSITORY_UPDATES,
             defaultValue = "{}",
-            valueWhenDisabled = "{}",
             doc =
                 "Dict (strings to list of strings) for defining the mappings between external"
                     + " repositories and relative (to the workspace root) paths to directories"

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
@@ -1,4 +1,4 @@
-// Copyright 2017 The Bazel Authors. All rights reserved.
+// Copyright 2019 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 package com.google.devtools.build.lib.syntax;
 
@@ -243,7 +244,7 @@ public abstract class StarlarkSemantics {
           // <== Add new options here in alphabetic order ==>
           .experimentalBuildSettingApi(true)
           .experimentalCcSkylarkApiEnabledPackages(ImmutableList.of())
-          .experimentalAllowIncrementalRepositoryUpdates(false)
+          .experimentalAllowIncrementalRepositoryUpdates(true)
           .experimentalEnableAndroidMigrationApis(false)
           .experimentalGoogleLegacyApi(false)
           .experimentalJavaCommonCreateProviderEnabledPackages(ImmutableList.of())

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/manageddirs/ManagedDirectoriesBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/manageddirs/ManagedDirectoriesBlackBoxTest.java
@@ -92,27 +92,17 @@ public class ManagedDirectoriesBlackBoxTest extends AbstractBlackBoxTest {
     checkProjectFiles();
   }
 
-  @Test
-  public void testWithoutFlag() throws Exception {
-    generateProject();
-    ProcessResult result = context().bazel().shouldFail().build("//...");
-    assertThat(result.errString())
-        .contains(
-            "parameter 'managed_directories' is experimental and thus unavailable"
-                + " with the current flags.");
-  }
-
   private BuilderRunner bazel() {
     return bazel(false);
   }
 
   private BuilderRunner bazel(boolean watchFs) {
     currentDebugId = random.nextInt();
-    String[] flags =
-        watchFs
-            ? new String[] {"--experimental_allow_incremental_repository_updates", "--watchfs=true"}
-            : new String[] {"--experimental_allow_incremental_repository_updates"};
-    return context().bazel().withFlags(flags).withEnv("DEBUG_ID", String.valueOf(currentDebugId));
+    BuilderRunner bazel = context().bazel().withEnv("DEBUG_ID", String.valueOf(currentDebugId));
+    if (watchFs) {
+      bazel.withFlags("--watchfs=true");
+    }
+    return bazel;
   }
 
   @Test


### PR DESCRIPTION
- i.e. managed directories attribute can be used in workspace() function without --experimental_allow_incremental_repository_updates flag.
- we should remove the flag itself in a separate release, to give users the time for removing the usage of the flag from their Bazel config files.