### PR TITLE
explicitly point to @bazel_tools for //tools

### DIFF
--- a/tools/config/BUILD
+++ b/tools/config/BUILD
@@ -9,12 +9,12 @@ filegroup(
     name = "srcs",
     srcs = glob(["**"]),
     visibility = [
-        "//tools:__pkg__",
-        "//tools/build_defs:__pkg__",
+        "@bazel_tools//tools:__pkg__",
+        "@bazel_tools//tools/build_defs:__pkg__",
     ],
 )
 
 exports_files(
     ["common_settings.bzl"],
-    visibility = ["//tools:__subpackages__"],
+    visibility = ["@bazel_tools//tools:__subpackages__"],
 )


### PR DESCRIPTION
Explicitly point to @bazel_tools for //tools

This resolve ambiguity when this file is vendored into another source tree.