### PR TITLE
Add the worker strategy in the user manual

### DIFF
--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -821,6 +821,10 @@ The default is <code>armeabi-v7a</code>.
   </li>
 
   <li>
+    <code>worker</code> causes commands to be executed using a persistent worker, if available.
+  </li>
+
+  <li>
     <code>docker</code> causes commands to be executed inside a docker sandbox on the local machine.
     This requires that docker is installed.
   </li>


### PR DESCRIPTION
Add the `worker` strategy to the list of build strategy options, in the user manual.

Current docs: https://docs.bazel.build/versions/master/user-manual.html#flag--spawn_strategy