### PR TITLE
Use rules_pkg for rpm build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -630,3 +630,12 @@ load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 sass_repositories()
 
 register_execution_platforms("//:default_host_platform")  # buildozer: disable=positional-args
+
+# Tools for packaging 
+http_archive(
+    name = "rules_pkg",
+    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz",
+    sha256 = "5bdc04987af79bd27bc5b00fe30f59a858f77ffa0bd2d8143d5b31ad8b1bd71c",
+)
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -634,7 +634,10 @@ register_execution_platforms("//:default_host_platform")  # buildozer: disable=p
 # Tools for packaging 
 http_archive(
     name = "rules_pkg",
-    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/rules_pkg-0.2.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz",
+    ],
     sha256 = "5bdc04987af79bd27bc5b00fe30f59a858f77ffa0bd2d8143d5b31ad8b1bd71c",
 )
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")

--- a/scripts/packages/fedora/BUILD
+++ b/scripts/packages/fedora/BUILD
@@ -5,7 +5,7 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-load("//tools/build_defs/pkg:rpm.bzl", "pkg_rpm")
+load("@rules_pkg//:rpm.bzl", "pkg_rpm")
 
 pkg_rpm(
     name = "bazel",


### PR DESCRIPTION
Switch to rules_pkg for rpm distributions.

Before-after testing:
bazel build //scripts/packages/fedora:bazel
rpm2cpio bazel-bin/scripts/packages/fedora/bazel.rpm | cpio -ivt

On master branch at f6408d60c724b971ce684ece89b4000b54f81ccd
```
-rw-r--r--   1 root     root       321977 Jul 16 17:19 ./etc/bash_completion.d/bazel
-rw-r--r--   1 root     root            0 Jul 16 17:19 ./etc/bazel.bazelrc
-rwxr-xr-x   1 root     root         2746 Jul 16 17:19 ./usr/bin/bazel
-rwxr-xr-x   1 root     root     28910231 Jul 16 17:19 ./usr/bin/bazel-real
drwxr-xr-x   1 root     root            0 Jul 16 17:19 ./usr/lib/.build-id
drwxr-xr-x   1 root     root            0 Jul 16 17:19 ./usr/lib/.build-id/09
lrwxrwxrwx   1 root     root           30 Jul 16 17:19 ./usr/lib/.build-id/09/f10a27f1e5acd8047c84623dffaa5162d832fb -> ../../../../usr/bin/bazel-real
```

On this branch:
```
-rw-r--r--   1 root     root       321977 Jul 16 17:26 ./etc/bash_completion.d/bazel
-rw-r--r--   1 root     root            0 Jul 16 17:26 ./etc/bazel.bazelrc
-rwxr-xr-x   1 root     root         2746 Jul 16 17:26 ./usr/bin/bazel
-rwxr-xr-x   1 root     root     28910231 Jul 16 17:26 ./usr/bin/bazel-real
drwxr-xr-x   1 root     root            0 Jul 16 17:26 ./usr/lib/.build-id
drwxr-xr-x   1 root     root            0 Jul 16 17:26 ./usr/lib/.build-id/09
lrwxrwxrwx   1 root     root           30 Jul 16 17:26 ./usr/lib/.build-id/09/f10a27f1e5acd8047c84623dffaa5162d832fb -> ../../../../usr/bin/bazel-real

```

I can not vouch that the .build-id part is reasonable, but at least the content before and after are identical.