### PR TITLE
A flag --remote_default_platform_properties should invalidate the action cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
@@ -100,12 +100,12 @@ public interface ActionCache {
         Md5Digest usedClientEnvDigest,
         @Nullable List<String> files,
         Md5Digest md5Digest,
-        Md5Digest remoteDefaultPlatformDigest) {
+        Md5Digest remoteDefaultPlatformPropertiesDigest) {
       actionKey = key;
       this.usedClientEnvDigest = usedClientEnvDigest;
       this.files = files;
       this.md5Digest = md5Digest;
-      this.remoteDefaultPlatformPropertiesDigest = remoteDefaultPlatformDigest;
+      this.remoteDefaultPlatformPropertiesDigest = remoteDefaultPlatformPropertiesDigest;
       mdMap = null;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCache.java
@@ -374,12 +374,14 @@ public class CompactPersistentActionCache implements ActionCache {
       // + 5 bytes max for the file list length
       // + 5 bytes max for each file id
       // + 16 bytes for the environment digest
+      // + 16 bytes for the remote default platform properties digest
       int maxSize =
           VarInt.MAX_VARINT_SIZE
               + actionKeyBytes.length
               + Md5Digest.MD5_SIZE
               + VarInt.MAX_VARINT_SIZE
               + files.size() * VarInt.MAX_VARINT_SIZE
+              + Md5Digest.MD5_SIZE
               + Md5Digest.MD5_SIZE;
       ByteArrayOutputStream sink = new ByteArrayOutputStream(maxSize);
 
@@ -394,6 +396,7 @@ public class CompactPersistentActionCache implements ActionCache {
       }
 
       DigestUtils.write(entry.getUsedClientEnvDigest(), sink);
+      DigestUtils.write(entry.getRemoteDefaultPlatformPropertiesDigest(), sink);
 
       return sink.toByteArray();
     } catch (IOException e) {
@@ -433,11 +436,12 @@ public class CompactPersistentActionCache implements ActionCache {
       }
 
       Md5Digest usedClientEnvDigest = DigestUtils.read(source);
+      Md5Digest remoteDefaultPlatformPropertiesDigest = DigestUtils.read(source);
 
       if (source.remaining() > 0) {
         throw new IOException("serialized entry data has not been fully decoded");
       }
-      return new ActionCache.Entry(actionKey, usedClientEnvDigest, files, md5Digest);
+      return new ActionCache.Entry(actionKey, usedClientEnvDigest, files, md5Digest, remoteDefaultPlatformPropertiesDigest);
     } catch (BufferUnderflowException e) {
       throw new IOException("encoded entry data is incomplete", e);
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ActionExecutionFunction.java
@@ -138,6 +138,7 @@ public class ActionExecutionFunction implements SkyFunction {
       // the value of the flag changes. We are doing this conditionally only in Bazel if remote
       // execution is available in order to not introduce additional skyframe edges in Blaze.
       PrecomputedValue.REMOTE_OUTPUTS_MODE.get(env);
+      PrecomputedValue.REMOTE_DEFAULT_PLATFORM_PROPERTIES.get(env);
     }
 
     // Look up the parts of the environment that influence the action.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PrecomputedValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PrecomputedValue.java
@@ -110,7 +110,7 @@ public class PrecomputedValue implements SkyValue {
   public static final Precomputed<RemoteOutputsMode> REMOTE_OUTPUTS_MODE =
       new Precomputed<>(Key.create("remote_outputs_mode"));
 
-  public static final Precomputed<String> REMOTE_DEFAULT_PLATFORM_PROPERTIES =
+  public static final Precomputed<Map<String, String>> REMOTE_DEFAULT_PLATFORM_PROPERTIES =
       new Precomputed<>(Key.create("remote_default_platform_properties"));
 
   private final Object value;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PrecomputedValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PrecomputedValue.java
@@ -110,6 +110,9 @@ public class PrecomputedValue implements SkyValue {
   public static final Precomputed<RemoteOutputsMode> REMOTE_OUTPUTS_MODE =
       new Precomputed<>(Key.create("remote_outputs_mode"));
 
+  public static final Precomputed<String> REMOTE_DEFAULT_PLATFORM_PROPERTIES =
+      new Precomputed<>(Key.create("remote_default_platform_properties"));
+
   private final Object value;
 
   @AutoCodec.Instantiator

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -648,7 +648,7 @@ public final class SkyframeActionExecutor {
               action,
               resolvedCacheArtifacts,
               clientEnv,
-              this.options.getOptions(BuildRequestOptions.class).explanationPath != null
+              options.getOptions(BuildRequestOptions.class).explanationPath != null
                   ? reporter
                   : null,
               metadataHandler,

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -2673,6 +2673,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
             ? remoteOptions.remoteOutputsMode
             // If no value is specified then set it to some value so that it's not null.
             : RemoteOutputsMode.ALL);
+    setRemoteDefaultPlatformProperties(remoteOptions != null ? remoteOptions.remoteDefaultPlatformProperties : "");
     syncPackageLoading(
         packageCacheOptions,
         pathPackageLocator,
@@ -2711,6 +2712,10 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
 
     incrementalBuildMonitor = new SkyframeIncrementalBuildMonitor();
     invalidateTransientErrors();
+  }
+
+  private void setRemoteDefaultPlatformProperties(String remoteDefaultPlatformProperties) {
+    PrecomputedValue.REMOTE_DEFAULT_PLATFORM_PROPERTIES.set(injectable(), remoteDefaultPlatformProperties);
   }
 
   private void getActionEnvFromOptions(CoreOptions opt) {

--- a/src/main/protobuf/action_cache.proto
+++ b/src/main/protobuf/action_cache.proto
@@ -40,6 +40,7 @@ message ActionCacheStatistics {
     CORRUPTED_CACHE_ENTRY = 4;
     NOT_CACHED = 5;
     UNCONDITIONAL_EXECUTION = 6;
+    DIFFERENT_DEFAULT_PLATFORM = 7;
   }
 
   // Detailed information for a particular miss reason.

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -115,7 +115,7 @@ public class ActionCacheCheckerTest {
     }
   }
 
-  private void runActionWithPlatform(Action action, Map<String, String> clientEnv, Map<String, String> platform)
+  private void runAction(Action action, Map<String, String> clientEnv, Map<String, String> platform)
           throws Exception {
     MetadataHandler metadataHandler = new FakeMetadataHandler();
 
@@ -256,18 +256,18 @@ public class ActionCacheCheckerTest {
     Map<String, String> platform = new HashMap<>();
     platform.put("some-var", "1");
     // Not cached.
-    runActionWithPlatform(action, env, platform);
+    runAction(action, env, platform);
     // Cache hit because nothing changed.
-    runActionWithPlatform(action, env, platform);
+    runAction(action, env, platform);
     // Cache miss because platform changed to an empty from a previous value.
-    runActionWithPlatform(action, env, ImmutableSortedMap.of());
+    runAction(action, env, ImmutableSortedMap.of());
     // Cache hit with an empty platform.
-    runActionWithPlatform(action, env, ImmutableSortedMap.of());
+    runAction(action, env, ImmutableSortedMap.of());
     // Cache miss because platform changed to a value from an empty one.
-    runActionWithPlatform(action, env, ImmutableSortedMap.copyOf(platform));
+    runAction(action, env, ImmutableSortedMap.copyOf(platform));
     platform.put("another-var", "1234");
     // Cache miss because platform value changed.
-    runActionWithPlatform(action, env, ImmutableSortedMap.copyOf(platform));
+    runAction(action, env, ImmutableSortedMap.copyOf(platform));
 
     assertStatistics(
             2,


### PR DESCRIPTION
If the contents of this flag change then skyframe actions should also be invalidated.

Closes #8224