### PR TITLE
Add toolchain support for clang-cl on Windows

### DIFF
--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -247,7 +247,7 @@ example](https://github.com/bazelbuild/bazel/tree/master/examples/windows/dll).
           ],
       )
       ```
-      Then you can enable the Clang toolchain by either the following two ways:
+      Then you can enable the Clang toolchain by either of the following two ways:
       * Specify the following build flags:
       ```
       --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl --extra_execution_platforms=//:windows-clang-cl

--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -198,19 +198,19 @@ To build C++ targets with MSVC, you need:
     set BAZEL_WINSDK_FULL_VERSION=10.0.10240.0
     ```
 
-    If everything is set up, you can build a C++ target now!
+If everything is set up, you can build a C++ target now!
 
-    Try building a target from one of our [sample
-    projects](https://github.com/bazelbuild/bazel/tree/master/examples):
+Try building a target from one of our [sample
+projects](https://github.com/bazelbuild/bazel/tree/master/examples):
 
-    ```
-    C:\projects\bazel> bazel build //examples/cpp:hello-world
+```
+C:\projects\bazel> bazel build //examples/cpp:hello-world
 
-    C:\projects\bazel> bazel-bin\examples\cpp\hello-world.exe
-    ```
+C:\projects\bazel> bazel-bin\examples\cpp\hello-world.exe
+```
 
-    To build and use Dynamically Linked Libraries (DLL files), see [this
-    example](https://github.com/bazelbuild/bazel/tree/master/examples/windows/dll).
+To build and use Dynamically Linked Libraries (DLL files), see [this
+example](https://github.com/bazelbuild/bazel/tree/master/examples/windows/dll).
 
 ### Build C++ with Clang
 

--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -203,6 +203,8 @@ To build C++ targets, you need:
     From 0.29.0, Bazel supports building with LLVM's MSVC-compatible compiler driver (`clang-cl.exe`).
     To build with `clang-cl.exe`, you have to install **both** LLVM and Visual C++ Build tools.
     Because we still need to link to Visual C++ libraries.
+
+    To install LLVM, please visit http://releases.llvm.org/download.html.
     
     Bazel can automatically detect LLVM installation on your system, you can explicitly tell Bazel where LLVM is installed by `BAZEL_LLVM`.
     

--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -117,9 +117,9 @@ You can also tell Bazel where to find the Python binary and the C++ compiler:
   See the [Build C++ section](#build_cpp) below.
 
 <a name="build_cpp"></a>
-### Build C++
+### Build C++ with MSVC
 
-To build C++ targets, you need:
+To build C++ targets with MSVC, you need:
 
 *   The Visual C++ compiler.
 
@@ -198,67 +198,71 @@ To build C++ targets, you need:
     set BAZEL_WINSDK_FULL_VERSION=10.0.10240.0
     ```
 
-*   The Clang compiler
-    
-    From 0.29.0, Bazel supports building with LLVM's MSVC-compatible compiler driver (`clang-cl.exe`).
-    To build with `clang-cl.exe`, you have to install **both** LLVM and Visual C++ Build tools.
-    Because we still need to link to Visual C++ libraries.
+    If everything is set up, you can build a C++ target now!
 
-    To install LLVM, please visit http://releases.llvm.org/download.html.
-    
-    Bazel can automatically detect LLVM installation on your system, you can explicitly tell Bazel where LLVM is installed by `BAZEL_LLVM`.
-    
-    *   `BAZEL_LLVM` the LLVM installation directory
+    Try building a target from one of our [sample
+    projects](https://github.com/bazelbuild/bazel/tree/master/examples):
 
-        ```
-        set BAZEL_LLVM=C:\Program Files\LLVM
-        ```
-    
-    To use the Clang toolchain for building C++, there are two situations.
-    
-    * In Bazel 0.29.0: You can enable the Clang toolchain by a build flag `--compiler=clang-cl`. 
-      This is deprecated and will be removed in Bazel 1.0.
-    
-    * From Bazel 1.0: You have to add a platform target to your build file (eg. the top level BUILD file):
-        ```
-        platform(
+    ```
+    C:\projects\bazel> bazel build //examples/cpp:hello-world
+
+    C:\projects\bazel> bazel-bin\examples\cpp\hello-world.exe
+    ```
+
+    To build and use Dynamically Linked Libraries (DLL files), see [this
+    example](https://github.com/bazelbuild/bazel/tree/master/examples/windows/dll).
+
+### Build C++ with Clang
+
+  From 0.29.0, Bazel supports building with LLVM's MSVC-compatible compiler driver (`clang-cl.exe`).
+
+  **Requirement**: To build with Clang, you have to install **both**
+  [LLVM](http://releases.llvm.org/download.html) and Visual C++ Build tools, because although we use
+  `clang-cl.exe` as compiler, we still need to link to Visual C++ libraries.
+
+  Bazel can automatically detect LLVM installation on your system, or you can explicitly tell
+  Bazel where LLVM is installed by `BAZEL_LLVM`.
+
+  *   `BAZEL_LLVM` the LLVM installation directory
+
+      ```
+      set BAZEL_LLVM=C:\Program Files\LLVM
+      ```
+
+  To enable the Clang toolchain for building C++, there are several situations.
+
+  * In bazel 0.28 and older: Clang is not supported.
+
+  * In Bazel 0.29.0: You can enable the Clang toolchain by a build flag `--compiler=clang-cl`.
+    This is deprecated and will be removed in Bazel 1.0.
+
+  * From Bazel 1.0: You have to add a platform target to your build file (eg. the top level BUILD file):
+      ```
+      platform(
           name = "windows-clang-cl",
           constraint_values = [
-            "@platforms//cpu:x86_64",
-            "@platforms//os:windows",
-            "@bazel_tools//tools/cpp:clang-cl",
-          ]
-        )
-        ```
-        Then you can enable the Clang toolchain by specifying the following build flags:
-        ```
-        --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl --extra_execution_platforms=//:windows-clang-cl
-        ```
-        **or** registering the platform and toolchain in your WORKSPACE file:
-        ```
-        register_execution_platforms(
+              "@platforms//cpu:x86_64",
+              "@platforms//os:windows",
+              "@bazel_tools//tools/cpp:clang-cl",
+          ],
+      )
+      ```
+      Then you can enable the Clang toolchain by either the following two ways:
+      * Specify the following build flags:
+      ```
+      --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl --extra_execution_platforms=//:windows-clang-cl
+      ```
+      * Register the platform and toolchain in your WORKSPACE file:
+      ```
+      register_execution_platforms(
           ":windows-clang-cl"
-        )
-        
-        register_toolchains(
-            "@local_config_cc//:cc-toolchain-x64_windows-clang-cl",
-        )
-        ```
-     The reason we have those two ways is because [--incompatible_enable_cc_toolchain_resolution](https://github.com/bazelbuild/bazel/issues/7260) flag.
+      )
 
-If everything is set up, you can build a C++ target now!
-
-Try building a target from one of our [sample
-projects](https://github.com/bazelbuild/bazel/tree/master/examples):
-
-```
-C:\projects\bazel> bazel build //examples/cpp:hello-world
-
-C:\projects\bazel> bazel-bin\examples\cpp\hello-world.exe
-```
-
-To build and use Dynamically Linked Libraries (DLL files), see [this
-example](https://github.com/bazelbuild/bazel/tree/master/examples/windows/dll).
+      register_toolchains(
+          "@local_config_cc//:cc-toolchain-x64_windows-clang-cl",
+      )
+      ```
+   The reason we have those two ways is because [--incompatible_enable_cc_toolchain_resolution](https://github.com/bazelbuild/bazel/issues/7260) flag.
 
 ### Build Java
 

--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -262,7 +262,7 @@ example](https://github.com/bazelbuild/bazel/tree/master/examples/windows/dll).
           "@local_config_cc//:cc-toolchain-x64_windows-clang-cl",
       )
       ```
-   The reason we have those two ways is because [--incompatible_enable_cc_toolchain_resolution](https://github.com/bazelbuild/bazel/issues/7260) flag.
+      The reason we have those two ways is because [--incompatible_enable_cc_toolchain_resolution](https://github.com/bazelbuild/bazel/issues/7260) flag.
 
 ### Build Java
 

--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -198,6 +198,52 @@ To build C++ targets, you need:
     set BAZEL_WINSDK_FULL_VERSION=10.0.10240.0
     ```
 
+*   The Clang compiler
+    
+    From 0.29.0, Bazel supports building with LLVM's MSVC-compatible compiler driver (`clang-cl.exe`).
+    To build with `clang-cl.exe`, you have to install **both** LLVM and Visual C++ Build tools.
+    Because we still need to link to Visual C++ libraries.
+    
+    Bazel can automatically detect LLVM installation on your system, you can explicitly tell Bazel where LLVM is installed by `BAZEL_LLVM`.
+    
+    *   `BAZEL_LLVM` the LLVM installation directory
+
+        ```
+        set BAZEL_LLVM=C:\Program Files\LLVM
+        ```
+    
+    To use the Clang toolchain for building C++, there are two situations.
+    
+    * In Bazel 0.29.0: You can enable the Clang toolchain by a build flag `--compiler=clang-cl`. 
+      This is deprecated and will be removed in Bazel 1.0.
+    
+    * From Bazel 1.0: You have to add a platform target to your build file (eg. the top level BUILD file):
+        ```
+        platform(
+          name = "windows-clang-cl",
+          constraint_values = [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:windows",
+            "@bazel_tools//tools/cpp:clang-cl",
+          ]
+        )
+        ```
+        Then you can enable the Clang toolchain by specifying the following build flags:
+        ```
+        --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl --extra_execution_platforms=//:windows-clang-cl
+        ```
+        **or** registering the platform and toolchain in your WORKSPACE file:
+        ```
+        register_execution_platforms(
+          ":windows-clang-cl"
+        )
+        
+        register_toolchains(
+            "@local_config_cc//:cc-toolchain-x64_windows-clang-cl",
+        )
+        ```
+     The reason we have those two ways is because [--incompatible_enable_cc_toolchain_resolution](https://github.com/bazelbuild/bazel/issues/7260) flag.
+
 If everything is set up, you can build a C++ target now!
 
 Try building a target from one of our [sample

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -115,12 +115,12 @@ class TestBase(unittest.TestCase):
         actual_exit_code, lambda x: x != not_expected_exit_code,
         '(against expectations)', stderr_lines, stdout_lines)
 
-  def CreateWorkspaceWithDefaultRepos(self, path):
+  def CreateWorkspaceWithDefaultRepos(self, path, lines = []):
     rule_definition = [
         'load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")'
     ]
     rule_definition.extend(self.GetDefaultRepoRules())
-    self.ScratchFile(path, rule_definition)
+    self.ScratchFile(path, rule_definition + lines)
 
   def GetDefaultRepoRules(self):
     return self.GetCcRulesRepoRule()

--- a/tools/cpp/BUILD
+++ b/tools/cpp/BUILD
@@ -41,6 +41,11 @@ constraint_value(
 )
 
 constraint_value(
+    name = "clang-cl",
+    constraint_setting = ":cc_compiler",
+)
+
+constraint_value(
     name = "mingw",
     constraint_setting = ":cc_compiler",
 )

--- a/tools/cpp/BUILD.windows.tpl
+++ b/tools/cpp/BUILD.windows.tpl
@@ -35,6 +35,7 @@ cc_toolchain_suite(
         "x64_windows|msvc-cl": ":cc-compiler-x64_windows",
         "x64_windows|msys-gcc": ":cc-compiler-x64_windows_msys",
         "x64_windows|mingw-gcc": ":cc-compiler-x64_windows_mingw",
+        "x64_windows|clang-cl": ":cc-compiler-x64_windows-clang-cl",
         "x64_windows_msys": ":cc-compiler-x64_windows_msys",
         "x64_windows": ":cc-compiler-x64_windows",
         "armeabi-v7a": ":cc-compiler-armeabi-v7a",
@@ -179,6 +180,7 @@ cc_toolchain_config(
         "objdump": "wrapper/bin/msvc_nop.bat",
         "strip": "wrapper/bin/msvc_nop.bat",
     },
+    default_link_flags = ["/MACHINE:X64"],
     dbg_mode_debug_flag = "%{dbg_mode_debug_flag}",
     fastbuild_mode_debug_flag = "%{fastbuild_mode_debug_flag}",
 )
@@ -194,6 +196,72 @@ toolchain(
         "@platforms//os:windows",
     ],
     toolchain = ":cc-compiler-x64_windows",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+cc_toolchain(
+    name = "cc-compiler-x64_windows-clang-cl",
+    toolchain_identifier = "clang_cl_x64",
+    toolchain_config = ":clang_cl_x64",
+    all_files = ":empty",
+    ar_files = ":empty",
+    as_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 1,
+)
+
+cc_toolchain_config(
+    name = "clang_cl_x64",
+    cpu = "x64_windows",
+    compiler = "clang-cl",
+    host_system_name = "local",
+    target_system_name = "local",
+    target_libc = "msvcrt",
+    abi_version = "local",
+    abi_libc_version = "local",
+    toolchain_identifier = "clang_cl_x64",
+    msvc_env_tmp = "%{clang_cl_env_tmp}",
+    msvc_env_path = "%{clang_cl_env_path}",
+    msvc_env_include = "%{clang_cl_env_include}",
+    msvc_env_lib = "%{clang_cl_env_lib}",
+    msvc_cl_path = "%{clang_cl_cl_path}",
+    msvc_ml_path = "%{clang_cl_ml_path}",
+    msvc_link_path = "%{clang_cl_link_path}",
+    msvc_lib_path = "%{clang_cl_lib_path}",
+    cxx_builtin_include_directories = [%{clang_cl_cxx_builtin_include_directories}],
+    tool_paths = {
+        "ar": "%{clang_cl_lib_path}",
+        "ml": "%{clang_cl_ml_path}",
+        "cpp": "%{clang_cl_cl_path}",
+        "gcc": "%{clang_cl_cl_path}",
+        "gcov": "wrapper/bin/msvc_nop.bat",
+        "ld": "%{clang_cl_link_path}",
+        "nm": "wrapper/bin/msvc_nop.bat",
+        "objcopy": "wrapper/bin/msvc_nop.bat",
+        "objdump": "wrapper/bin/msvc_nop.bat",
+        "strip": "wrapper/bin/msvc_nop.bat",
+    },
+    default_link_flags = ["/MACHINE:X64", "/DEFAULTLIB:clang_rt.builtins-x86_64.lib"],
+    dbg_mode_debug_flag = "%{clang_cl_dbg_mode_debug_flag}",
+    fastbuild_mode_debug_flag = "%{clang_cl_fastbuild_mode_debug_flag}",
+)
+
+toolchain(
+    name = "cc-toolchain-x64_windows-clang-cl",
+    exec_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+        "@bazel_tools//tools/cpp:clang-cl",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+    ],
+    toolchain = ":cc-compiler-x64_windows-clang-cl",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 

--- a/tools/cpp/clang_installation_error.bat.tpl
+++ b/tools/cpp/clang_installation_error.bat.tpl
@@ -1,0 +1,24 @@
+:: Copyright 2017 The Bazel Authors. All rights reserved.
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::    http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+
+@echo OFF
+
+echo. 1>&2
+echo The target you are compiling requires the Clang compiler. 1>&2
+echo Bazel couldn't find a valid Clang installation on your machine. 1>&2
+%{clang_error_message}
+echo Please check your installation following https://docs.bazel.build/versions/master/windows.html#using 1>&2
+echo. 1>&2
+
+exit /b 1

--- a/tools/cpp/clang_installation_error.bat.tpl
+++ b/tools/cpp/clang_installation_error.bat.tpl
@@ -1,4 +1,4 @@
-:: Copyright 2017 The Bazel Authors. All rights reserved.
+:: Copyright 2019 The Bazel Authors. All rights reserved.
 ::
 :: Licensed under the Apache License, Version 2.0 (the "License");
 :: you may not use this file except in compliance with the License.


### PR DESCRIPTION
Previously we [added clang-cl.exe support](https://github.com/bazelbuild/bazel/pull/6553) through `USE_CLANG_CL` environment variable. That is a "hack" on the existing MSVC toolchain to make it use Clang tools. This change add proper toolchain support for `clang-cl.exe` on Windows.
Because `clang-cl.exe` is MSVC compatible, we can just reuse the MSVC toolchain definition.

After this change, to select the clang-cl toolchain on Windows, you can use:

-  Before Bazel 1.0, specify build flag `--compiler=clang-cl`, this is deprecated and will be disabled in Bazel 1.0. 
-  From Bazel 1.0 (or with `--incompatible_enable_cc_toolchain_resolution` flag). You have to add a platform target to your build file (eg. the top level BUILD file):
```
platform(
  name = "windows-clang-cl",
  constraint_values = [
    "@platforms//cpu:x86_64",
    "@platforms//os:windows",
    "@bazel_tools//tools/cpp:clang-cl",
  ]
)
```
Then you can tell Bazel to use the clang-cl toolchain by specifying build flags
```
--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl --extra_execution_platforms=//:windows-clang-cl
```
or registering the platform and toolchain in your WORKSPACE file:
```
register_execution_platforms(
  ":windows-clang-cl"
)

register_toolchains(
    "@local_config_cc//:cc-toolchain-x64_windows-clang-cl",
)
```
Related issue: [incompatible_enable_cc_toolchain_resolution: Turn on toolchain resolution for cc rules](https://github.com/bazelbuild/bazel/issues/7260)