### PR TITLE
Integrate Android NDK with toolchains

### DIFF
--- a/site/docs/android-ndk.md
+++ b/site/docs/android-ndk.md
@@ -255,6 +255,71 @@ cc_library(
 )
 ```
 
+## Integration with platforms and toolchains
+
+Bazel's configuration model is moving towards 
+[platforms](https://docs.bazel.build/versions/master/platforms.html) and 
+[toolchains](https://docs.bazel.build/versions/master/toolchains.html). If your
+build uses the `--platforms` flag to select for the architecture or operating system
+to build for, you will need to pass the `--extra_toolchains` flag to Bazel in
+order to use the NDK.
+
+For example, to integrate with the `android_arm64_cgo` toolchain provided by
+the Go rules, pass `--extra_toolchains=@androidndk//:all` in addition to the
+`--platforms` flag.
+
+```
+bazel build //my/cc:lib \
+  --platforms=@io_bazel_rules_go//go/toolchain:android_arm64_cgo \
+  --extra_toolchains=@androidndk//:all
+```
+
+By passing `--extra_toolchains=@androidndk//:all`, you're telling Bazel to look for
+these additional toolchains (for NDK 20) when resolving architecture and operating system 
+constraints:
+
+```python
+toolchain(
+  name = "x86-clang8.0.7-libcpp_toolchain",
+  toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+  target_compatible_with = [
+      "@bazel_tools//platforms:android", 
+      "@bazel_tools//platforms:x86_32"
+  ],
+  toolchain = "@androidndk//:x86-clang8.0.7-libcpp",
+)
+
+toolchain(
+  name = "x86_64-clang8.0.7-libcpp_toolchain",
+  toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+  target_compatible_with = [
+      "@bazel_tools//platforms:android", 
+      "@bazel_tools//platforms:x86_64"
+  ],
+  toolchain = "@androidndk//:x86_64-clang8.0.7-libcpp",
+)
+
+toolchain(
+  name = "arm-linux-androideabi-clang8.0.7-v7a-libcpp_toolchain",
+  toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+  target_compatible_with = [
+      "@bazel_tools//platforms:android", 
+      "@bazel_tools//platforms:arm"
+  ],
+  toolchain = "@androidndk//:arm-linux-androideabi-clang8.0.7-v7a-libcpp",
+)
+
+toolchain(
+  name = "aarch64-linux-android-clang8.0.7-libcpp_toolchain",
+  toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+  target_compatible_with = [
+      "@bazel_tools//platforms:android", 
+      "@bazel_tools//platforms:aarch64"
+  ],
+  toolchain = "@androidndk//:aarch64-linux-android-clang8.0.7-libcpp",
+)
+```
+
 ## How it works: introducing Android configuration transitions
 
 The `android_binary` rule can explicitly ask Bazel to build its dependencies in

--- a/site/docs/android-ndk.md
+++ b/site/docs/android-ndk.md
@@ -274,9 +274,15 @@ bazel build //my/cc:lib \
   --extra_toolchains=@androidndk//:all
 ```
 
-By passing `--extra_toolchains=@androidndk//:all`, you're telling Bazel to look for
-these additional toolchains (for NDK 20) when resolving architecture and operating system 
-constraints:
+You can also register them directly in the `WORKSPACE` file:
+
+```python
+android_ndk_repository(name = "androidndk")
+register_toolchains("@androidndk//:all")
+```
+
+By registering these toolchains, you're telling Bazel to look for these in the NDK BUILD file 
+(for NDK 20) when resolving architecture and operating system constraints:
 
 ```python
 toolchain(

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
@@ -56,7 +56,6 @@ import com.google.devtools.build.skyframe.SkyKey;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
@@ -56,6 +56,7 @@ import com.google.devtools.build.skyframe.SkyKey;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -201,12 +202,24 @@ public class AndroidNdkRepositoryFunction extends AndroidRepositoryFunction {
     return ccToolchainTemplate
         .replace("%toolchainName%", toolchain.getToolchainIdentifier())
         .replace("%cpu%", toolchain.getTargetCpu())
+        .replace("%platform_cpu%", getPlatformCpuLabel(toolchain.getTargetCpu()))
         .replace("%compiler%", toolchain.getCompiler())
         .replace("%version%", version)
         .replace("%dynamicRuntimeLibs%", toolchain.getDynamicRuntimesFilegroup())
         .replace("%staticRuntimeLibs%", toolchain.getStaticRuntimesFilegroup())
         .replace("%toolchainDirectory%", toolchainDirectory)
         .replace("%toolchainFileGlobs%", toolchainFileGlobs.toString().trim());
+  }
+
+  private static String getPlatformCpuLabel(String targetCpu) {
+    // Create a mapping of CcToolchain CPU values to platform arch constraint values
+    // in @bazel_tools//platforms
+    switch (targetCpu) {
+      case "x86": return "x86_32";
+      case "armeabi-v7a": return "arm";
+      case "arm64-v8a": return "aarch64";
+      default: return "x86_64";
+    }
   }
 
   private static String getTemplate(String templateFile) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_cc_toolchain_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_cc_toolchain_template.txt
@@ -26,6 +26,16 @@ cc_toolchain_config(
     version = "%version%",
 )
 
+toolchain(
+    name = "%toolchainName%_toolchain",
+    target_compatible_with = [
+        "@bazel_tools//platforms:android",
+        "@bazel_tools//platforms:%platform_cpu%",
+    ],
+    toolchain = "@androidndk//:%toolchainName%",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
 filegroup(
     name = "%toolchainName%-all_files",
     srcs = glob(["ndk/toolchains/%toolchainDirectory%/**"]) + glob([

--- a/src/test/shell/bazel/android/android_ndk_integration_test.sh
+++ b/src/test/shell/bazel/android/android_ndk_integration_test.sh
@@ -400,6 +400,44 @@ EOF
     --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
 }
 
+function test_platforms_and_toolchains() {
+  create_new_workspace
+  setup_android_ndk_support
+  cat > BUILD <<EOF
+cc_binary(
+    name = "foo",
+    srcs = ["foo.cc"],
+    linkopts = ["-ldl", "-lm"],
+)
+
+platform(
+    name = 'android_arm',
+    constraint_values = ['@bazel_tools//platforms:arm', '@bazel_tools//platforms:android'],
+    visibility = ['//visibility:public'])
+EOF
+  cat > foo.cc <<EOF
+#include <string>
+#include <jni.h>
+#include <android/log.h>
+#include <cstdio>
+#include <iostream>
+
+using namespace std;
+int main(){
+  string foo = "foo";
+  string bar = "bar";
+  string foobar = foo + bar;
+  return 0;
+}
+EOF
+  assert_build //:foo \
+    --cpu=armeabi-v7a \
+    --crosstool_top=@androidndk//:toolchain-libcpp \
+    --host_crosstool_top=@bazel_tools//tools/cpp:toolchain \
+    --platforms=//:android_arm \
+    --extra_toolchains=@androidndk//:all
+}
+
 function test_crosstool_libcpp_with_multiarch() {
   create_new_workspace
   setup_android_sdk_support


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/8871

Generates toolchains for the `cc_toolchain` targets in the `@androidndk` BUILD file:

```python
toolchain(
  name = "x86-clang8.0.7-libcpp_toolchain",
  toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
  target_compatible_with = [
      "@bazel_tools//platforms:android", 
      "@bazel_tools//platforms:x86_32"
  ],
  toolchain = "@androidndk//:x86-clang8.0.7-libcpp",
)
toolchain(
  name = "x86_64-clang8.0.7-libcpp_toolchain",
  toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
  target_compatible_with = [
      "@bazel_tools//platforms:android", 
      "@bazel_tools//platforms:x86_64"
  ],
  toolchain = "@androidndk//:x86_64-clang8.0.7-libcpp",
)
toolchain(
  name = "arm-linux-androideabi-clang8.0.7-v7a-libcpp_toolchain",
  toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
  target_compatible_with = [
      "@bazel_tools//platforms:android", 
      "@bazel_tools//platforms:arm"
  ],
  toolchain = "@androidndk//:arm-linux-androideabi-clang8.0.7-v7a-libcpp",
)
toolchain(
  name = "aarch64-linux-android-clang8.0.7-libcpp_toolchain",
  toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
  target_compatible_with = [
      "@bazel_tools//platforms:android", 
      "@bazel_tools//platforms:aarch64"
  ],
  toolchain = "@androidndk//:aarch64-linux-android-clang8.0.7-libcpp",
)
```

Users can use them by using the `--extra_toolchains=@androidndk//:all` flag or by registering them in the WORKSPACE with `register_toolchains("androidndk//:all")`.

RELNOTES: The Android NDK is now integrated with toolchains. To use them, pass the `--extra_toolchains=@androidndk//:all` flag or register them in your WORKSPACE with `register_toolchains("@androidndk//:all")`.