### PR TITLE
Use rules_pkg for the debian release packaging.

### DIFF
--- a/scripts/packages/debian/BUILD
+++ b/scripts/packages/debian/BUILD
@@ -4,7 +4,7 @@ filegroup(
     visibility = ["//scripts:__subpackages__"],
 )
 
-load("//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
+load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_deb")
 
 pkg_tar(
     name = "bazel-bin",


### PR DESCRIPTION
**Note**: `--host_force_python=PY2` is no longer required when using pkg_deb.

Before:

```
$ bazel build //scripts/packages/debian:bazel-debian  --host_force_python=PY2
...
Target //scripts/packages/debian:bazel-debian up-to-date:
  bazel-bin/scripts/packages/debian/bazel-debian.deb
  bazel-bin/scripts/packages/debian/bazel__amd64.deb
  bazel-bin/scripts/packages/debian/bazel__amd64.changes
$ dpkg -c bazel-bin/scripts/packages/debian/bazel-debian.deb
drwxr-xr-x 0/0               0 1999-12-31 19:00 ./
drwxr-xr-x 0/0               0 1999-12-31 19:00 ./usr/
drwxr-xr-x 0/0               0 1999-12-31 19:00 ./usr/bin/
-rwxr-xr-x 0/0            2746 1999-12-31 19:00 ./usr/bin/bazel
-rwxr-xr-x 0/0        48009086 1999-12-31 19:00 ./usr/bin/bazel-real
drwxr-xr-x 0/0               0 1999-12-31 19:00 ./etc/
drwxr-xr-x 0/0               0 1999-12-31 19:00 ./etc/bash_completion.d/
-rw-r--r-- 0/0          321977 1999-12-31 19:00 ./etc/bash_completion.d/bazel
-rw-r--r-- 0/0               0 1999-12-31 19:00 ./etc/bazel.bazelrc
```

After:
```
$ bazel build //scripts/packages/debian:bazel-debian
Target //scripts/packages/debian:bazel-debian up-to-date:
  bazel-bin/scripts/packages/debian/bazel-debian.deb
  bazel-bin/scripts/packages/debian/bazel__amd64.deb
  bazel-bin/scripts/packages/debian/bazel__amd64.changes
$ dpkg -c bazel-bin/scripts/packages/debian/bazel-debian.deb
drwxr-xr-x 0/0               0 1999-12-31 19:00 ./
drwxr-xr-x 0/0               0 1999-12-31 19:00 ./usr/
drwxr-xr-x 0/0               0 1999-12-31 19:00 ./usr/bin/
-rwxr-xr-x 0/0            2746 1999-12-31 19:00 ./usr/bin/bazel
-rwxr-xr-x 0/0        48009086 1999-12-31 19:00 ./usr/bin/bazel-real
drwxr-xr-x 0/0               0 1999-12-31 19:00 ./etc/
drwxr-xr-x 0/0               0 1999-12-31 19:00 ./etc/bash_completion.d/
-rw-r--r-- 0/0          321977 1999-12-31 19:00 ./etc/bash_completion.d/bazel
-rw-r--r-- 0/0               0 1999-12-31 19:00 ./etc/bazel.bazelrc
```

As identical as we can get.