### PR TITLE
Fix bazel run with --run_under does not work with targets in external workspace

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/RunUnderConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/RunUnderConverter.java
@@ -44,7 +44,7 @@ public class RunUnderConverter implements Converter<RunUnder> {
     final String runUnderCommand = runUnderList.get(0);
     ImmutableList<String> runUnderSuffix =
         ImmutableList.copyOf(runUnderList.subList(1, runUnderList.size()));
-    if (runUnderCommand.startsWith("//")) {
+    if (runUnderCommand.startsWith("//") || runUnderCommand.startsWith("@")) {
       try {
         final Label runUnderLabel = Label.parseAbsolute(runUnderCommand, ImmutableMap.of());
         return new RunUnderLabel(input, runUnderLabel, runUnderSuffix);


### PR DESCRIPTION
I tried to fix issue #7656 by adding a new condition to use RunUnderLabel. 