### PR TITLE
Add incompatible flag to forbid loading the native Protobuf rules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/proto/BazelProtoLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/BazelProtoLibrary.java
@@ -30,7 +30,9 @@ import com.google.devtools.build.lib.rules.proto.ProtoCompileActionBuilder.Servi
 public class BazelProtoLibrary implements RuleConfiguredTargetFactory {
 
   @Override
-  public ConfiguredTarget create(RuleContext ruleContext) throws ActionConflictException {
+  public ConfiguredTarget create(RuleContext ruleContext)
+      throws ActionConflictException, RuleErrorException {
+    ProtoCommon.checkRuleHasValidMigrationTag(ruleContext);
     ProtoInfo protoInfo =
         ProtoCommon.createProtoInfo(
             ruleContext,

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/BazelProtoLibraryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/BazelProtoLibraryRule.java
@@ -122,6 +122,10 @@ public final class BazelProtoLibraryRule implements RuleDefinition {
 
 /*<!-- #BLAZE_RULE (NAME = proto_library, TYPE = LIBRARY, FAMILY = Protocol Buffer) -->
 
+<p>Deprecated. Please use <a href="https://github.com/bazelbuild/rules_proto">
+   https://github.com/bazelbuild/rules_proto</a> instead.
+</p>
+
 <p>Use <code>proto_library</code> to define libraries of protocol buffers
    which may be used from multiple languages. A <code>proto_library</code> may be listed
    in the <code>deps</code> clause of supported rules, such as <code>java_proto_library</code>.

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCommon.java
@@ -48,6 +48,11 @@ public class ProtoCommon {
     throw new UnsupportedOperationException();
   }
 
+  // Keep in sync with the migration label in
+  // https://github.com/bazelbuild/rules_proto/blob/master/proto/defs.bzl.
+  private static final String PROTO_RULES_MIGRATION_LABEL =
+      "__PROTO_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__";
+
   /**
    * Gets the direct sources of a proto library. If protoSources is not empty, the value is just
    * protoSources. Otherwise, it's the combined sources of all direct dependencies of the given
@@ -479,9 +484,7 @@ public class ProtoCommon {
 
   private static boolean hasValidMigrationTag(RuleContext ruleContext) {
     return ruleContext
-        .attributes()
-        .get("tags", Type.STRING_LIST)
-        .contains("__PROTO_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__");
+        .attributes().get("tags", Type.STRING_LIST).contains(PROTO_RULES_MIGRATION_LABEL);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoConfiguration.java
@@ -199,11 +199,26 @@ public class ProtoConfiguration extends Fragment implements ProtoConfigurationAp
                 + "been superseded by the strip_import_prefix= and import_prefix= attributes")
     public boolean disableProtoSourceRoot;
 
+    @Option(
+        name = "incompatible_load_proto_rules_from_bzl",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+        metadataTags = {
+          OptionMetadataTag.INCOMPATIBLE_CHANGE,
+          OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+        },
+        help =
+            "If enabled, direct usage of the native Protobuf rules is disabled. Please use "
+                + "the Starlark rules instead https://github.com/bazelbuild/rules_proto")
+    public boolean loadProtoRulesFromBzl;
+
     @Override
     public FragmentOptions getHost() {
       Options host = (Options) super.getHost();
       host.disableLegacyProvider = disableLegacyProvider;
       host.disableProtoSourceRoot = disableProtoSourceRoot;
+      host.loadProtoRulesFromBzl = loadProtoRulesFromBzl;
       host.protoCompiler = protoCompiler;
       host.protocOpts = protocOpts;
       host.experimentalProtoExtraActions = experimentalProtoExtraActions;
@@ -318,5 +333,9 @@ public class ProtoConfiguration extends Fragment implements ProtoConfigurationAp
 
   public boolean generatedProtosInVirtualImports() {
     return options.generatedProtosInVirtualImports;
+  }
+
+  public boolean loadProtoRulesFromBzl() {
+    return options.loadProtoRulesFromBzl;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoConfiguration.java
@@ -210,7 +210,7 @@ public class ProtoConfiguration extends Fragment implements ProtoConfigurationAp
         },
         help =
             "If enabled, direct usage of the native Protobuf rules is disabled. Please use "
-                + "the Starlark rules instead https://github.com/bazelbuild/rules_proto")
+                + "the Starlark rules instead at https://github.com/bazelbuild/rules_proto")
     public boolean loadProtoRulesFromBzl;
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchain.java
@@ -37,6 +37,7 @@ public class ProtoLangToolchain implements RuleConfiguredTargetFactory {
   @Override
   public ConfiguredTarget create(RuleContext ruleContext)
       throws InterruptedException, RuleErrorException, ActionConflictException {
+    ProtoCommon.checkRuleHasValidMigrationTag(ruleContext);
     NestedSetBuilder<Artifact> blacklistedProtos = NestedSetBuilder.stableOrder();
     for (TransitiveInfoCollection protos :
         ruleContext.getPrerequisites("blacklisted_protos", TARGET)) {

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchainRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchainRule.java
@@ -90,6 +90,10 @@ public class ProtoLangToolchainRule implements RuleDefinition {
 
 /*<!-- #BLAZE_RULE (NAME = proto_lang_toolchain, TYPE = LIBRARY, FAMILY = Protocol Buffer) -->
 
+<p>Deprecated. Please <a href="https://github.com/bazelbuild/rules_proto">
+   https://github.com/bazelbuild/rules_proto</a> instead.
+</p>
+
 <p>
 Specifies how a LANG_proto_library rule (e.g., <code>java_proto_library</code>) should invoke the
 proto-compiler.

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchainRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchainRule.java
@@ -72,6 +72,7 @@ public class ProtoLangToolchainRule implements RuleDefinition {
                 .allowedFileTypes()
                 .mandatoryNativeProviders(
                     ImmutableList.<Class<? extends TransitiveInfoProvider>>of(FileProvider.class)))
+        .requiresConfigurationFragments(ProtoConfiguration.class)
         .advertiseProvider(ProtoLangToolchainProvider.class)
         .removeAttribute("data")
         .removeAttribute("deps")

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/ProtoInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/ProtoInfoApi.java
@@ -24,9 +24,11 @@ import com.google.devtools.build.lib.skylarkinterface.SkylarkModule;
     name = "ProtoInfo",
     doc = "Encapsulates information provided by <a href=\""
               + "../../be/protocol-buffer.html#proto_library\">proto_library.</a>"
+              + "<p>"
               + "Please consider using `load(\"@rules_proto//proto:defs.bzl\", \"ProtoInfo\")` "
               + "to load this symbol from <a href=\"https://github.com/bazelbuild/rules_proto.\">"
-              + "rules_proto</a>")
+              + "rules_proto</a>"
+              + "</p>")
 public interface ProtoInfoApi<FileT extends FileApi> extends StructApi {
   /** Provider class for {@link ProtoInfoApi} objects. */
   @SkylarkModule(name = "Provider", documented = false, doc = "")

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/ProtoInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/ProtoInfoApi.java
@@ -20,7 +20,13 @@ import com.google.devtools.build.lib.skylarkinterface.SkylarkCallable;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkModule;
 
 /** Info object propagating information about protocol buffer sources. */
-@SkylarkModule(name = "ProtoInfo", doc = "")
+@SkylarkModule(
+    name = "ProtoInfo",
+    doc = "Encapsulates information provided by <a href=\""
+              + "../../be/protocol-buffer.html#proto_library\">proto_library.</a>"
+              + "Please consider using `load(\"@rules_proto//proto:defs.bzl\", \"ProtoInfo\")` "
+              + "to load this symbol from <a href=\"https://github.com/bazelbuild/rules_proto.\">"
+              + "rules_proto</a>")
 public interface ProtoInfoApi<FileT extends FileApi> extends StructApi {
   /** Provider class for {@link ProtoInfoApi} objects. */
   @SkylarkModule(name = "Provider", documented = false, doc = "")

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/proto/ProtoModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/proto/ProtoModuleApi.java
@@ -21,5 +21,12 @@ import com.google.devtools.build.lib.skylarkinterface.SkylarkModule;
  *
  * <p>Currently just a placeholder so that we have a {@code proto_common} symbol.
  */
-@SkylarkModule(name = "proto_common", doc = "Utilities for protocol buffers")
+@SkylarkModule(
+    name = "proto_common",
+    doc = "Utilities for protocol buffers. "
+              + "<p>"
+              + "Please consider using `load(\"@rules_proto//proto:defs.bzl\", \"proto_common\")` "
+              + "to load this symbol from <a href=\"https://github.com/bazelbuild/rules_proto.\">"
+              + "rules_proto</a>"
+              + "</p>")
 public interface ProtoModuleApi {}

--- a/src/test/java/com/google/devtools/build/lib/rules/proto/BazelProtoLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/proto/BazelProtoLibraryTest.java
@@ -947,4 +947,48 @@ public class BazelProtoLibraryTest extends BuildViewTestCase {
   private Action getDescriptorWriteAction(String label) throws Exception {
     return getGeneratingAction(getDescriptorOutput(label));
   }
+
+  @Test
+  public void testMigrationLabel() throws Exception {
+    useConfiguration("--incompatible_load_proto_rules_from_bzl");
+    scratch.file(
+        "a/BUILD",
+        "proto_library(",
+        "    name = 'a',",
+        "    srcs = ['a.proto'],",
+        // Don't use |ProtoCommon.PROTO_RULES_MIGRATION_LABEL| here
+        // so we don't accidentally change it without breaking a local test.
+        "    tags = ['__PROTO_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__'],",
+        ")");
+
+    getConfiguredTarget("//a");
+  }
+
+  @Test
+  public void testMissingMigrationLabel() throws Exception {
+    useConfiguration("--incompatible_load_proto_rules_from_bzl");
+    scratch.file(
+        "a/BUILD",
+        "proto_library(",
+        "    name = 'a',",
+        "    srcs = ['a.proto'],",
+        ")");
+
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//a");
+    assertContainsEvent("The native Protobuf rules are deprecated.");
+  }
+
+  @Test
+  public void testMigrationLabelNotRequiredWhenDisabled() throws Exception {
+    useConfiguration("--noincompatible_load_proto_rules_from_bzl");
+    scratch.file(
+        "a/BUILD",
+        "proto_library(",
+        "    name = 'a',",
+        "    srcs = ['a.proto'],",
+        ")");
+
+    getConfiguredTarget("//a");
+  }
 }


### PR DESCRIPTION
RELNOTES: --incompatible_load_proto_rules_from_bzl was added to forbid loading the native proto rules directly. See more on tracking issue #8922