### PR TITLE
Augment recommendation in java_import_external to be consistent with maven_jar, rules_jvm_external naming style

### DIFF
--- a/tools/build_defs/repo/java.bzl
+++ b/tools/build_defs/repo/java.bzl
@@ -86,13 +86,12 @@ by those with terms most permissive to least:
 ### Naming
 
 Bazel repository names must match the following pattern: `[_0-9A-Za-z]+`. To
-choose an appropriate name based on a Maven group and artifact ID, we recommend
-an algorithm https://gist.github.com/jart/41bfd977b913c2301627162f1c038e55 which
-can be best explained by the following examples:
+choose an appropriate name based on a Maven group and artifact ID, replacing 
+illegal characters with underscores and leaving off the version. For example:
 
-- com.google.guava:guava becomes com_google_guava
-- commons-logging:commons-logging becomes commons_logging
-- junit:junit becomes junit
+- com.google.guava:guava:27.0-jre becomes com_google_guava_guava
+- commons-logging:commons-logging:1.2 becomes commons_logging_commons_logging
+- junit:junit:4.12 becomes junit_junit
 
 Adopting this naming convention will help maximize the chances that your
 codebase will be able to successfully interoperate with other Bazel codebases
@@ -104,7 +103,7 @@ Here is an example of a best practice definition of Google's Guava library:
 
 ```python
 java_import_external(
-    name = "com_google_guava",
+    name = "com_google_guava_guava",
     licenses = ["notice"],  # Apache 2.0
     jar_urls = [
         "http://bazel-mirror.storage.googleapis.com/repo1.maven.org/maven2/com/google/guava/guava/20.0/guava-20.0.jar",


### PR DESCRIPTION
maven_jar recommends the following: 

> Note that the maven_jar name is used as a repository name, so it is limited by the rules governing workspace names: it cannot contain dashes nor dots (see the documentation on workspace names for the exact specification). By convention, maven_jar names should match the artifact name, replacing illegal characters with underscores and leaving off the version. For example, a rule with artifact = "org.apache.commons:commons-lang3:3.4" should have name = "org_apache_commons_commons_lang3".

https://docs.bazel.build/versions/master/be/workspace.html#maven_jar_name

`rules_jvm_external` follows the same algorithm and generates the following for `com.google.guava:guava`:

```
@maven//:com_google_guava_guava

# with maven_install.generate_compat_repositories
@com_google_guava_guava//jar
@com_google_guava_guava//:com_google_guava_guava # or @com_google_guava_guava
```

This PR sets the recommendation in `java_import_external` to be aligned with `maven_jar` and `rules_jvm_external` to improve interoperability and lower migration friction.

Related: https://github.com/bazelbuild/bazel/issues/8908