### PR TITLE
convert rules using pkg_tar in //third_party to rules_pkg

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "srcs",

--- a/third_party/ijar/BUILD
+++ b/third_party/ijar/BUILD
@@ -7,7 +7,7 @@ package(
 
 licenses(["notice"])  # Apache 2.0
 
-load("//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 cc_library(
     name = "zip",


### PR DESCRIPTION
Part of the extraction of packaging rules from Bazel.
See https://docs.google.com/document/d/1GAbAiW0nVbxGlwsdXhFIcn3owlZJkMJiXBt-ttA9z_k/edit?ts=5cc6f473#