### PR TITLE
Add a prebuilt toolchain to java_tools.

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -257,6 +257,35 @@ JAVA_VERSIONS = ("9", "10", "11", "12")
 
 [
     sh_test(
+        name = "bazel_java_test_jdk" + java_version + "_prebuilt_toolchain_head",
+        size = "large",
+        timeout = "eternal",
+        srcs = ["bazel_java_test.sh"],
+        args = [
+            # --java_toolchain
+            "@local_java_tools//:prebuilt_toolchain",
+            # java_tools zip to test
+            "src/java_tools_java" + java_version + ".zip",
+            # --javabase value
+        ] + select({
+            "//src/conditions:darwin": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
+            "//src/conditions:darwin_x86_64": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
+            "//src/conditions:windows": ["@openjdk" + java_version + "_windows_archive//:runtime"],
+            "//src/conditions:linux_x86_64": ["@openjdk" + java_version + "_linux_archive//:runtime"],
+        }),
+        data = [
+            ":test-deps",
+            "//src:java_tools_java" + java_version + "_zip",
+            "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
+            "@bazel_tools//tools/bash/runfiles",
+        ],
+        exec_compatible_with = ["//:highcpu_machine"],
+    )
+    for java_version in JAVA_VERSIONS
+]
+
+[
+    sh_test(
         name = "bazel_java_test_local_java_tools_jdk" + java_version,
         size = "large",
         timeout = "eternal",

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -126,6 +126,66 @@ java_toolchain(
     ],
 )
 
+java_toolchain(
+    name = "prebuilt_toolchain",
+    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
+    compatible_javacopts = {
+        # Restrict protos to Java 7 so that they are compatible with Android.
+        "proto": [
+            "-source",
+            "7",
+            "-target",
+            "7",
+        ],
+    },
+    forcibly_disable_header_compilation = 0,
+    genclass = [":GenClass"],
+    header_compiler = [":Turbine"],
+    header_compiler_direct = [":TurbineDirect"],
+    ijar = [":ijar_prebuilt_binary"],
+    jacocorunner = ":jacoco_coverage_runner_filegroup",
+    javabuilder = [":JavaBuilder"],
+    javac = [":javac_jar"],
+    javac_supports_workers = 1,
+    jvm_opts = [
+        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
+        # G1 collector and having compact strings enabled.
+        "-XX:+UseParallelOldGC",
+        "-XX:-CompactStrings",
+        # Allow JavaBuilder to access internal javac APIs.
+        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+
+        # override the javac in the JDK.
+        "--patch-module=java.compiler=$(location :java_compiler_jar)",
+        "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
+
+        # quiet warnings from com.google.protobuf.UnsafeUtil,
+        # see: https://github.com/google/protobuf/issues/3781
+        # and: https://github.com/bazelbuild/bazel/issues/5599
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    ],
+    misc = [
+        "-XDskipDuplicateBridges=true",
+        "-g",
+        "-parameters",
+    ],
+    singlejar = [":prebuilt_singlejar"],
+    source_version = "8",
+    target_version = "8",
+    tools = [
+        ":java_compiler_jar",
+        ":jdk_compiler_jar",
+    ],
+)
+
 filegroup(
     name = "ExperimentalRunner",
     srcs = ["java_tools/ExperimentalRunner_deploy.jar"],
@@ -311,6 +371,15 @@ alias(
         ":darwin_x86_64": "java_tools/src/tools/singlejar/singlejar_local",
         ":windows": "java_tools/src/tools/singlejar/singlejar_local.exe",
         "//conditions:default": "singlejar_cc_bin",
+    }),
+)
+
+alias(
+    name = "prebuilt_singlejar",
+    actual = select({
+        ":darwin_x86_64": "java_tools/src/tools/singlejar/singlejar_local",
+        ":windows": "java_tools/src/tools/singlejar/singlejar_local.exe",
+        "//conditions:default": "java_tools/ijar/ijar",
     }),
 )
 

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -147,7 +147,7 @@ java_toolchain(
     genclass = [":GenClass"],
     header_compiler = [":Turbine"],
     header_compiler_direct = [":TurbineDirect"],
-    ijar = [":ijar_prebuilt_binary_alias"],
+    ijar = [":ijar_prebuilt_binary"],
     jacocorunner = ":jacoco_coverage_runner_filegroup",
     javabuilder = [":JavaBuilder"],
     javac = [":javac_jar"],
@@ -404,11 +404,6 @@ alias(
         ":windows": ":ijar_prebuilt_binary",
         "//conditions:default": ":ijar_cc_binary",
     }),
-)
-
-alias(
-    name = "ijar_prebuilt_binary_alias",
-    actual = ":ijar_prebuilt_binary",
 )
 
 filegroup(

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -126,6 +126,11 @@ java_toolchain(
     ],
 )
 
+# The new toolchain is using all the pre-built tools, including
+# singlejar and ijar, even on remote execution. This toolchain
+# should be used only when host and execution platform are the
+# same, otherwise the binaries will not work on the execution
+# platform.
 java_toolchain(
     name = "prebuilt_toolchain",
     bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -147,7 +147,7 @@ java_toolchain(
     genclass = [":GenClass"],
     header_compiler = [":Turbine"],
     header_compiler_direct = [":TurbineDirect"],
-    ijar = [":ijar_prebuilt_binary"],
+    ijar = [":ijar_prebuilt_binary_alias"],
     jacocorunner = ":jacoco_coverage_runner_filegroup",
     javabuilder = [":JavaBuilder"],
     javac = [":javac_jar"],
@@ -382,9 +382,8 @@ alias(
 alias(
     name = "prebuilt_singlejar",
     actual = select({
-        ":darwin_x86_64": "java_tools/src/tools/singlejar/singlejar_local",
         ":windows": "java_tools/src/tools/singlejar/singlejar_local.exe",
-        "//conditions:default": "java_tools/ijar/ijar",
+        "//conditions:default": "java_tools/src/tools/singlejar/singlejar_local",
     }),
 )
 
@@ -405,6 +404,11 @@ alias(
         ":windows": ":ijar_prebuilt_binary",
         "//conditions:default": ":ijar_cc_binary",
     }),
+)
+
+alias(
+    name = "ijar_prebuilt_binary_alias",
+    actual = ":ijar_prebuilt_binary",
 )
 
 filegroup(


### PR DESCRIPTION
The new toolchain is using all the pre-built tools, including singlejar and ijar, even on remote execution. This toolchain should be used only when host and execution platform are the same, otherwise the binaries will not work on the execution platform.