### PR TITLE
add expansion flags for builds without the bytes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -217,8 +217,10 @@ public final class RemoteOptions extends OptionsBase {
       converter = RemoteOutputsStrategyConverter.class,
       help =
           "If set to 'minimal' doesn't download any remote build outputs to the local machine, "
-              + "except the ones required by local actions. This option can significantly reduce"
-              + " build times if network bandwidth is a bottleneck.")
+              + "except the ones required by local actions. If set to 'toplevel' behaves like"
+              + "'minimal' except that it also downloads outputs of top level targets to the local "
+              + "machine. Both options can significantly reduce build times if network bandwidth "
+              + "is a bottleneck.")
   public RemoteOutputsMode remoteOutputsMode;
 
   /** Outputs strategy flag parser */
@@ -227,6 +229,36 @@ public final class RemoteOptions extends OptionsBase {
       super(RemoteOutputsMode.class, "download remote outputs");
     }
   }
+
+  @Option(
+      name = "experimental_remote_download_minimal",
+      defaultValue = "null",
+      expansion = {"--experimental_inmemory_jdeps_files", "--experimental_inmemory_dotd_files",
+          "--experimental_remote_download_outputs=minimal"},
+      category = "remote",
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      help =
+          "Does not download any remote build outputs to the local machine. This flag is a "
+              + "shortcut for three flags: --experimental_inmemory_jdeps_files, "
+              + "--experimental_inmemory_dotd_files and "
+              + "--experimental_remote_download_outputs=minimal.")
+  public Void remoteOutputsMinimal;
+
+  @Option(
+      name = "experimental_remote_download_toplevel",
+      defaultValue = "null",
+      expansion = {"--experimental_inmemory_jdeps_files", "--experimental_inmemory_dotd_files",
+          "--experimental_remote_download_outputs=toplevel"},
+      category = "remote",
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      help =
+          "Only downloads remote outputs of top level targets to the local machine. This flag is a "
+              + "shortcut for three flags: --experimental_inmemory_jdeps_files, "
+              + "--experimental_inmemory_dotd_files and "
+              + "--experimental_remote_download_outputs=toplevel.")
+  public Void remoteOutputsToplevel;
 
   @Option(
       name = "remote_result_cache_priority",

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -826,9 +826,7 @@ EOF
   bazel build \
     --genrule_strategy=remote \
     --remote_executor=grpc://localhost:${worker_port} \
-    --experimental_inmemory_jdeps_files \
-    --experimental_inmemory_dotd_files \
-    --experimental_remote_download_outputs=minimal \
+    --experimental_remote_download_minimal \
     //a:foobar || fail "Failed to build //a:foobar"
 
   (! [[ -f bazel-bin/a/foo.txt ]] && ! [[ -f bazel-bin/a/foobar.txt ]]) \
@@ -851,9 +849,7 @@ EOF
   bazel build \
     --spawn_strategy=remote \
     --remote_executor=grpc://localhost:${worker_port} \
-    --experimental_inmemory_jdeps_files \
-    --experimental_inmemory_dotd_files \
-    --experimental_remote_download_outputs=minimal \
+    --experimental_remote_download_minimal \
     //a:fail && fail "Expected test failure" || true
 
   [[ -f bazel-bin/a/fail.txt ]] \
@@ -884,9 +880,7 @@ EOF
   bazel build \
     --genrule_strategy=remote \
     --remote_executor=grpc://localhost:${worker_port} \
-    --experimental_inmemory_jdeps_files \
-    --experimental_inmemory_dotd_files \
-    --experimental_remote_download_outputs=minimal \
+    --experimental_remote_download_minimal \
     //a:remote || fail "Failed to build //a:remote"
 
   (! [[ -f bazel-bin/a/remote.txt ]]) \
@@ -895,9 +889,7 @@ EOF
   bazel build \
     --genrule_strategy=remote,local \
     --remote_executor=grpc://localhost:${worker_port} \
-    --experimental_inmemory_jdeps_files \
-    --experimental_inmemory_dotd_files \
-    --experimental_remote_download_outputs=minimal \
+    --experimental_remote_download_minimal \
     //a:local || fail "Failed to build //a:local"
 
   localtxt="bazel-bin/a/local.txt"
@@ -924,9 +916,7 @@ EOF
   bazel build \
     --genrule_strategy=remote \
     --remote_executor=grpc://localhost:${worker_port} \
-    --experimental_inmemory_jdeps_files \
-    --experimental_inmemory_dotd_files \
-    --experimental_remote_download_outputs=minimal \
+    --experimental_remote_download_minimal \
     //a:remote >& $TEST_log || fail "Failed to build //a:remote"
 
   expect_log "1 process: 1 remote"
@@ -934,8 +924,6 @@ EOF
   bazel build \
     --genrule_strategy=remote \
     --remote_executor=grpc://localhost:${worker_port} \
-    --experimental_inmemory_jdeps_files \
-    --experimental_inmemory_dotd_files \
     --experimental_remote_download_outputs=all \
     //a:remote >& $TEST_log || fail "Failed to build //a:remote"
 
@@ -991,9 +979,7 @@ EOF
   bazel build \
     --genrule_strategy=remote \
     --remote_executor=grpc://localhost:${worker_port} \
-    --experimental_inmemory_jdeps_files \
-    --experimental_inmemory_dotd_files \
-    --experimental_remote_download_outputs=minimal \
+    --experimental_remote_download_minimal \
     //a:substitute-buchgr >& $TEST_log || fail "Failed to build //a:substitute-buchgr"
 
   # The genrule //a:generate-template should run remotely and //a:substitute-buchgr
@@ -1031,9 +1017,7 @@ EOF
   bazel build \
     --genrule_strategy=remote \
     --remote_executor=grpc://localhost:${worker_port} \
-    --experimental_inmemory_jdeps_files \
-    --experimental_inmemory_dotd_files \
-    --experimental_remote_download_outputs=toplevel \
+    --experimental_remote_download_toplevel \
     //a:foobar || fail "Failed to build //a:foobar"
 
   (! [[ -f bazel-bin/a/foo.txt ]]) \
@@ -1049,9 +1033,7 @@ EOF
   bazel build \
     --genrule_strategy=remote \
     --remote_executor=grpc://localhost:${worker_port} \
-    --experimental_inmemory_jdeps_files \
-    --experimental_inmemory_dotd_files \
-    --experimental_remote_download_outputs=toplevel \
+    --experimental_remote_download_toplevel \
     //a:foobar >& $TEST_log || fail "Failed to build //a:foobar"
 
   expect_log "1 process: 1 remote cache hit"
@@ -1087,9 +1069,7 @@ EOF
 
   bazel test \
     --remote_executor=grpc://localhost:${worker_port} \
-    --experimental_inmemory_jdeps_files \
-    --experimental_inmemory_dotd_files \
-    --experimental_remote_download_outputs=minimal \
+    --experimental_remote_download_minimal \
     --build_event_text_file=$TEST_log \
     //a:foo //a:success_test || fail "Failed to test //a:foo //a:success_test"
 


### PR DESCRIPTION
this change is purely for convenience to make it easier to enable
builds without the bytes.