### PR TITLE
Fix building ijar_cc_binary and singlejar_cc_bin without sandbox by removing dependency on @bazel_tools//tools/cpp:malloc

### DIFF
--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -190,9 +190,6 @@ EOF
 }
 
 function test_java_tools_singlejar_builds() {
-  if "$is_windows"; then
-    echo "Skipping test on Windows." && return
-  fi
   local java_tools_rlocation=$(rlocation io_bazel/src/java_tools_${JAVA_TOOLS_JAVA_VERSION}.zip)
   local java_tools_zip_file_url="file://${java_tools_rlocation}"
   if "$is_windows"; then
@@ -209,9 +206,6 @@ EOF
 }
 
 function test_java_tools_ijar_builds() {
-  if "$is_windows"; then
-    echo "Skipping test on Windows." && return
-  fi
   local java_tools_rlocation=$(rlocation io_bazel/src/java_tools_${JAVA_TOOLS_JAVA_VERSION}.zip)
   local java_tools_zip_file_url="file://${java_tools_rlocation}"
   if "$is_windows"; then

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -341,12 +341,19 @@ filegroup(
     }),
 )
 
+cc_library(
+    name = "malloc",
+)
+
 cc_binary(
     name = "ijar_cc_binary",
     srcs = [
         "java_tools/ijar/classfile.cc",
         "java_tools/ijar/ijar.cc",
     ],
+    # Remove dependency on @bazel_tools//tools/cpp:malloc, which avoid /Iexternal/tools being used
+    # in compiling actions.
+    malloc = ":malloc",
     deps = [":zip"],
 )
 
@@ -569,6 +576,9 @@ cc_binary(
         "//conditions:default": [],
     }),
     linkstatic = 1,
+    # Remove dependency on @bazel_tools//tools/cpp:malloc, which avoid /Iexternal/tools being used
+    # in compiling actions.
+    malloc = ":malloc",
     visibility = ["//visibility:public"],
     deps = [
         ":options",


### PR DESCRIPTION
As @laszlocsomor [explained](https://github.com/bazelbuild/bazel/pull/8742#issuecomment-506745688
), building `ijar_cc_binary` and `singlejar_cc_bin` on Windows (where sandbox is not available yet) will have header conflict due to the same headers are shipped in both @bazel_tools and @local_java_tools. 

`ijar_cc_binary` and `singlejar_cc_bin` only declare headers in @local_java_tools as dependency, but it will search `external/bazel_tools` first because every cc targets depend on `@bazel_tools//tools/cpp:malloc` [implicitly](https://docs.bazel.build/versions/master/be/c-cpp.html#cc_binary).

This change remove the dependency on `@bazel_tools//tools/cpp:malloc` to avoid this confusion.

@lberki I believe cc targets depending on `@bazel_tools//tools/cpp:malloc` is a behavior that exists for a long time, is it still necessary? Looks like it's leaking `/Iexternal/tools` to all cc compilation and causing some header conflicts in non-sandboxed build. This is not the first time I've seen such error.
FYI @oquenchil 

This change replaces https://github.com/bazelbuild/bazel/pull/8945 and we no longer have to do a patch release for Bazel, just a new release for the java tools.


