### PR TITLE
Allow G1 in tools/jdk/BUILD.java_tools.

### DIFF
--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -27,10 +27,6 @@ java_toolchain(
     javac = [":javac_jar"],
     javac_supports_workers = 1,
     jvm_opts = [
-        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
-        # G1 collector and having compact strings enabled.
-        "-XX:+UseParallelOldGC",
-        "-XX:-CompactStrings",
         # Allow JavaBuilder to access internal javac APIs.
         "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
@@ -88,10 +84,6 @@ java_toolchain(
     javac = [":javac_jar"],
     javac_supports_workers = 1,
     jvm_opts = [
-        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance
-        # when using G1 collector and having compact strings enabled.
-        "-XX:+UseParallelOldGC",
-        "-XX:-CompactStrings",
         # Allow JavaBuilder to access internal javac APIs.
         "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
@@ -153,10 +145,6 @@ java_toolchain(
     javac = [":javac_jar"],
     javac_supports_workers = 1,
     jvm_opts = [
-        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
-        # G1 collector and having compact strings enabled.
-        "-XX:+UseParallelOldGC",
-        "-XX:-CompactStrings",
         # Allow JavaBuilder to access internal javac APIs.
         "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",


### PR DESCRIPTION
This is a followup to 01e6e05a35633df92cafc20b28eac15cd1aefa09. (I think BUILD.java_tools was introduced in between the creation of the PR for 01e6e05a35633df92cafc20b28eac15cd1aefa09 and its landing.)