### PR TITLE
Allow trailing commas in argument lists after *args and **kwargs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/Parser.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Parser.java
@@ -1271,28 +1271,25 @@ public class Parser {
   private <V extends Argument> ImmutableList<V>
       parseFunctionArguments(Supplier<V> parseArgument) {
     boolean hasArg = false;
-    boolean hasStar = false;
     boolean hasStarStar = false;
     ImmutableList.Builder<V> argumentsBuilder = ImmutableList.builder();
 
     while (token.kind != TokenKind.RPAREN && token.kind != TokenKind.EOF) {
+      if (hasArg) {
+        expect(TokenKind.COMMA);
+      }
+      if (token.kind == TokenKind.RPAREN) {
+        // list can end with a COMMA
+        break;
+      }
       if (hasStarStar) {
         reportError(lexer.createLocation(token.left, token.right),
             "unexpected tokens after kwarg");
         break;
       }
-      if (hasArg) {
-        expect(TokenKind.COMMA);
-      }
-      if (token.kind == TokenKind.RPAREN && !hasStar) {
-        // list can end with a COMMA if there is neither * nor **
-        break;
-      }
       V arg = parseArgument.get();
       hasArg = true;
-      if (arg.isStar()) {
-        hasStar = true;
-      } else if (arg.isStarStar()) {
+      if (arg.isStarStar()) {
         hasStarStar = true;
       }
       argumentsBuilder.add(arg);

--- a/src/test/java/com/google/devtools/build/lib/syntax/BaseFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/BaseFunctionTest.java
@@ -156,12 +156,23 @@ public class BaseFunctionTest extends EvaluationTestCase {
   }
 
   @Test
-  public void testCommaAfterArgsAndKwargs() throws Exception {
-    // Test that commas are not allowed in function definitions and calls
-    // after last *args or **kwargs expressions.
-    checkEvalErrorContains("syntax error at ')': expected identifier", "def foo(*args,): pass");
-    checkEvalErrorContains("unexpected tokens after kwarg", "def foo(**kwargs,): pass");
-    checkEvalErrorContains("syntax error at ')': expected expression", "foo(*args,)");
-    checkEvalErrorContains("unexpected tokens after kwarg", "foo(**kwargs,)");
+  public void testTrailingCommas() throws Exception {
+    // Test that trailing commas are allowed in function definitions and calls
+    // even after last *args or **kwargs expressions, like python3
+    eval(
+        "def f(*args, **kwargs): pass\n"
+            + "v1 = f(1,)\n"
+            + "v2 = f(*(1,2),)\n"
+            + "v3 = f(a=1,)\n"
+            + "v4 = f(**{\"a\": 1},)\n");
+
+    assertThat(Printer.repr(lookup("v1")))
+        .isEqualTo("None");
+    assertThat(Printer.repr(lookup("v2")))
+        .isEqualTo("None");
+    assertThat(Printer.repr(lookup("v3")))
+        .isEqualTo("None");
+    assertThat(Printer.repr(lookup("v4")))
+        .isEqualTo("None");
   }
 }


### PR DESCRIPTION
Related: https://github.com/bazelbuild/starlark/issues/26, https://github.com/bazelbuild/starlark/issues/27