### PR TITLE
Update java_tools tested versions.

### DIFF
--- a/src/create_java_tools_release.sh
+++ b/src/create_java_tools_release.sh
@@ -85,13 +85,15 @@ for platform in linux windows darwin; do
     # Copy the associated zip file that contains the sources of the release zip.
     gsutil -q cp "${gcs_bucket}/${rc_sources_url}" "${gcs_bucket}/${release_sources_artifact}"
   else
-    tmp_url=$(gsutil ls -lh ${gcs_bucket}/tmp/build/${commit_hash}/java${java_version}/java_tools_javac${java_version}_${platform}* | sort -k 2 | grep "gs" | cut -d " " -f 7)
+    tmp_url=$(gsutil ls -lh ${gcs_bucket}/tmp/build/${commit_hash}/java${java_version}/java_tools_javac${java_version}_${platform}* | sort -k 2 | grep gs -m 1 | awk '{print $4}')
+
+
     # Make the generated artifact a release candidate for the current platform.
     gsutil -q cp ${tmp_url} "${gcs_bucket}/${rc_url}"
     release_artifact="${rc_url}"
 
     # Copy the associated zip file that contains the sources of the release zip.
-    tmp_sources_url=$(gsutil ls -lh ${gcs_bucket}/tmp/sources/${commit_hash}/java${java_version}/java_tools_javac${java_version}_${platform}* | sort -k 2 | grep "gs" | cut -d " " -f 7)
+    tmp_sources_url=$(gsutil ls -lh ${gcs_bucket}/tmp/sources/${commit_hash}/java${java_version}/java_tools_javac${java_version}_${platform}* | sort -k 2 | grep gs -m 1 | awk '{print $4}')
     gsutil -q cp ${tmp_sources_url} ${gcs_bucket}/${rc_sources_url}
   fi
 

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1727,4 +1727,13 @@ EOF
   bazel build java/com/google/foo:my_skylark_rule >& "$TEST_log" || fail "Expected success"
 }
 
+# This test builds a simple java deploy jar using remote singlejar and ijar
+# targets which compile them from source.
+function test_build_hello_world_with_remote_embedded_tool_targets() {
+  write_hello_library_files
+
+  bazel build //java/main:main_deploy.jar --define EXECUTOR=remote \
+    &> $TEST_log || fail "build failed"
+}
+
 run_suite "Java integration tests"

--- a/src/test/shell/bazel/bazel_java_test_no_windows.sh
+++ b/src/test/shell/bazel/bazel_java_test_no_windows.sh
@@ -133,12 +133,3 @@ EOF
     bazel test --spawn_strategy=standalone --test_output=errors :check_runfiles
 }
 
-# This test builds a simple java deploy jar using remote singlejar and ijar
-# targets which compile them from source.
-# This test fails on Windows only when invoked from the java_tools binaries pipeline.
-function test_build_hello_world_with_remote_embedded_tool_targets() {
-  write_hello_library_files
-
-  bazel build //java/main:main_deploy.jar --define EXECUTOR=remote \
-    &> $TEST_log || fail "build failed"
-}

--- a/src/test/shell/bazel/testdata/jdk_http_archives
+++ b/src/test/shell/bazel/testdata/jdk_http_archives
@@ -24,23 +24,23 @@ http_archive(
 ################### Remote java_tools with embedded javac 10 ###################
 http_archive(
     name = "remote_java_tools_javac10_test_linux",
-    sha256 = "f345249e31ce344c0c382dcf9ef10823fa8eb8ba48f14587016c368f44106635",
+    sha256 = "52e03d400d978e9af6321786cdf477694c3838d7e78c2e5b926d0244670b6d3c",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac10/v4.0/java_tools_javac10_linux-v4.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac10/v5.0/java_tools_javac10_linux-v5.0-rc1.zip",
     ],
 )
 http_archive(
     name = "remote_java_tools_javac10_test_windows",
-    sha256 = "5db60de21bffd7d911a586c83523e9f03f838755d43f1155bcf345a71d6a79ef",
+    sha256 = "2e3fa82f5790917b56cec5f5d389ed5ff9592a00b5d66750a1f2b6387921d8be",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac10/v4.0/java_tools_javac10_windows-v4.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac10/v5.0/java_tools_javac10_windows-v5.0-rc1.zip",
     ],
 )
 http_archive(
     name = "remote_java_tools_javac10_test_darwin",
-    sha256 = "0b1d8969c87e5a020dbef470df25c9b1cba79b23e56f6b1438d0ad69f31a1b55",
+    sha256 = "d5503cc1700b3d544444302617ccc9b2c2780b7fa7bd013215da403148958c35",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac10/v4.0/java_tools_javac10_darwin-v4.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac10/v5.0/java_tools_javac10_darwin-v5.0-rc1.zip",
     ],
 )
 
@@ -70,22 +70,22 @@ http_archive(
 ################### Remote java_tools with embedded javac 12 ###################
 http_archive(
     name = "remote_java_tools_javac12_test_linux",
-    sha256 = "54d211b7238d3db3761c18524c5a5a87a2e8a959168a0e384c21b17f51662d8d",
-    urls = ["https://mirror.bazel.build/bazel_java_tools/releases/javac12/v1.0/java_tools_javac12_linux-v1.0.zip"],
+    sha256 = "fc199be2c7873b0792e00743679fedc1d249fa779c3fe7676111f8d7ced9f2b4",
+    urls = ["https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v2.0/java_tools_javac12_linux-v2.0-rc1.zip"],
 )
 
 http_archive(
     name = "remote_java_tools_javac12_test_windows",
-    sha256 = "314582cc8fd127ff164d2482f7b83fe77f4f1f0e12d712add67d3a2086c6a7e3",
+    sha256 = "cab191830609838e99c9adc5e9628e8c839305674c5a9ecf1eea4ba0f6c0b0aa",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac12/v1.0/java_tools_javac12_windows-v1.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v2.0/java_tools_javac12_windows-v2.0-rc1.zip",
     ],
 )
 http_archive(
     name = "remote_java_tools_javac12_test_darwin",
-    sha256 = "add724f6381198cd25227bf93c00f0b07930255867b67c38e8c0411d0369c28f",
+    sha256 = "d73ff1de1fc2d3ea8403d54099dd2247a2a87390107e7cf81e3a383b0c687341",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac12/v1.0/java_tools_javac12_darwin-v1.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v2.0/java_tools_javac12_darwin-v2.0-rc1.zip",
     ],
 )
 

--- a/src/test/shell/bazel/testdata/jdk_http_archives
+++ b/src/test/shell/bazel/testdata/jdk_http_archives
@@ -3,21 +3,21 @@ http_archive(
     name = "remote_java_tools_javac9_test_linux",
     sha256 = "0bf678d9815c7212564ecc99b3bd3643450c17657becb12a7bbedcf97ece740d",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac9/v3.0/java_tools_javac9_linux-v3.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac9/v3.0/java_tools_javac9_linux-v3.0.zip",
     ],
 )
 http_archive(
     name = "remote_java_tools_javac9_test_windows",
     sha256 = "9b7e8de98ed2d64ea20a7512f986028ca6375b0fce7637f8d05d1517e7890867",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac9/v3.0/java_tools_javac9_windows-v3.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac9/v3.0/java_tools_javac9_windows-v3.0.zip",
     ],
 )
 http_archive(
     name = "remote_java_tools_javac9_test_darwin",
     sha256 = "13a94ddf0c421332f0d3be1adbfc833e24a3a3715bab8f1152660f2df81e286a",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac9/v3.0/java_tools_javac9_darwin-v3.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac9/v3.0/java_tools_javac9_darwin-v3.0.zip",
     ],
 )
 
@@ -26,21 +26,21 @@ http_archive(
     name = "remote_java_tools_javac10_test_linux",
     sha256 = "52e03d400d978e9af6321786cdf477694c3838d7e78c2e5b926d0244670b6d3c",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac10/v5.0/java_tools_javac10_linux-v5.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac10/v5.0/java_tools_javac10_linux-v5.0.zip",
     ],
 )
 http_archive(
     name = "remote_java_tools_javac10_test_windows",
     sha256 = "2e3fa82f5790917b56cec5f5d389ed5ff9592a00b5d66750a1f2b6387921d8be",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac10/v5.0/java_tools_javac10_windows-v5.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac10/v5.0/java_tools_javac10_windows-v5.0.zip",
     ],
 )
 http_archive(
     name = "remote_java_tools_javac10_test_darwin",
     sha256 = "d5503cc1700b3d544444302617ccc9b2c2780b7fa7bd013215da403148958c35",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac10/v5.0/java_tools_javac10_darwin-v5.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac10/v5.0/java_tools_javac10_darwin-v5.0.zip",
     ],
 )
 
@@ -71,21 +71,21 @@ http_archive(
 http_archive(
     name = "remote_java_tools_javac12_test_linux",
     sha256 = "fc199be2c7873b0792e00743679fedc1d249fa779c3fe7676111f8d7ced9f2b4",
-    urls = ["https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v2.0/java_tools_javac12_linux-v2.0-rc1.zip"],
+    urls = ["https://mirror.bazel.build/bazel_java_tools/releases/javac12/v2.0/java_tools_javac12_linux-v2.0.zip"],
 )
 
 http_archive(
     name = "remote_java_tools_javac12_test_windows",
     sha256 = "cab191830609838e99c9adc5e9628e8c839305674c5a9ecf1eea4ba0f6c0b0aa",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v2.0/java_tools_javac12_windows-v2.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac12/v2.0/java_tools_javac12_windows-v2.0.zip",
     ],
 )
 http_archive(
     name = "remote_java_tools_javac12_test_darwin",
     sha256 = "d73ff1de1fc2d3ea8403d54099dd2247a2a87390107e7cf81e3a383b0c687341",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac12/v2.0/java_tools_javac12_darwin-v2.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac12/v2.0/java_tools_javac12_darwin-v2.0.zip",
     ],
 )
 

--- a/src/test/shell/bazel/testdata/jdk_http_archives
+++ b/src/test/shell/bazel/testdata/jdk_http_archives
@@ -1,23 +1,23 @@
 ################### Remote java_tools with embedded javac 9 ####################
 http_archive(
     name = "remote_java_tools_javac9_test_linux",
-    sha256 = "54c2fa7276fc109029b3d144ae6108f474b2fd49480b47473e7ec6eba45f0fe9",
+    sha256 = "0bf678d9815c7212564ecc99b3bd3643450c17657becb12a7bbedcf97ece740d",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac9/v2.0/java_tools_javac9_linux-v2.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac9/v3.0/java_tools_javac9_linux-v3.0-rc1.zip",
     ],
 )
 http_archive(
     name = "remote_java_tools_javac9_test_windows",
-    sha256 = "88a1b735f418ad9ef8dced55a509d990eca99f6a05c55347dfb05b91e6599a3a",
+    sha256 = "9b7e8de98ed2d64ea20a7512f986028ca6375b0fce7637f8d05d1517e7890867",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac9/v2.0/java_tools_javac9_windows-v2.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac9/v3.0/java_tools_javac9_windows-v3.0-rc1.zip",
     ],
 )
 http_archive(
     name = "remote_java_tools_javac9_test_darwin",
-    sha256 = "5181247a93e0ee250fa7418572aab571742466d45d23b924e45de839379b3372",
+    sha256 = "13a94ddf0c421332f0d3be1adbfc833e24a3a3715bab8f1152660f2df81e286a",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac9/v2.0/java_tools_javac9_darwin-v2.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac9/v3.0/java_tools_javac9_darwin-v3.0-rc1.zip",
     ],
 )
 


### PR DESCRIPTION
* Update the java_tools versions that we use in the java integration tests.
* Fix a flaky bug in the script that creates the java_tools release.
* Move a test from no_windows integration tests to all-platforms tests