### PR TITLE
Refactor merkletree implementation to be independent of ActionInput

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
@@ -1,0 +1,181 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.merkletree;
+
+import build.bazel.remote.execution.v2.Digest;
+import com.google.common.base.Preconditions;
+import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.ActionInputHelper;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.MetadataProvider;
+import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
+import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.DirectoryNode;
+import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.FileNode;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.vfs.Dirent;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.lib.vfs.Symlinks;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Builder for directory trees.
+ */
+class DirectoryTreeBuilder {
+
+  static DirectoryTree fromActionInputs(
+      SortedMap<PathFragment, ActionInput> inputs,
+      MetadataProvider metadataProvider,
+      Path execRoot,
+      DigestUtil digestUtil)
+      throws IOException {
+    Map<PathFragment, DirectoryNode> tree = new HashMap<>();
+    int numFiles = fromActionInputs(inputs, metadataProvider, execRoot, digestUtil, tree);
+    return new DirectoryTree(tree, numFiles);
+  }
+
+  private static int fromActionInputs(
+      SortedMap<PathFragment, ActionInput> inputs,
+      MetadataProvider metadataProvider,
+      Path execRoot,
+      DigestUtil digestUtil,
+      Map<PathFragment, DirectoryNode> tree)
+      throws IOException {
+    if (inputs.isEmpty()) {
+      return 0;
+    }
+
+    PathFragment dirname = null;
+    DirectoryNode dir = null;
+    int numFiles = inputs.size();
+    for (Map.Entry<PathFragment, ActionInput> e : inputs.entrySet()) {
+      // Path relative to the exec root
+      PathFragment path = e.getKey();
+      ActionInput input = e.getValue();
+      if (dirname == null || !path.getParentDirectory().equals(dirname)) {
+        dirname = path.getParentDirectory();
+        dir = tree.get(dirname);
+        if (dir == null) {
+          dir = new DirectoryNode(dirname.getBaseName());
+          tree.put(dirname, dir);
+          createParentDirectoriesIfNotExist(dirname, dir, tree);
+        }
+      }
+
+      if (input instanceof VirtualActionInput) {
+        VirtualActionInput virtualActionInput = (VirtualActionInput) input;
+        Digest d = digestUtil.compute(virtualActionInput);
+        dir.addChild(new FileNode(path.getBaseName(), virtualActionInput.getBytes(), d));
+        continue;
+      }
+
+      FileArtifactValue metadata =
+          Preconditions.checkNotNull(
+              metadataProvider.getMetadata(input),
+              "missing metadata for '%s'",
+              input.getExecPathString());
+      switch (metadata.getType()) {
+        case REGULAR_FILE:
+          Digest d = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());
+          dir.addChild(new FileNode(path.getBaseName(), ActionInputHelper.toInputPath(input, execRoot), d));
+          break;
+
+        case DIRECTORY:
+          SortedMap<PathFragment, ActionInput> directoryInputs = explodeDirectory(path, execRoot);
+          numFiles += fromActionInputs(directoryInputs, metadataProvider, execRoot,
+              digestUtil, tree);
+          break;
+
+        case SYMLINK:
+          throw new IllegalStateException(
+              String.format(
+                  "Encountered symlink input '%s', but all"
+                      + " symlinks should have been resolved by SkyFrame. This is a bug.",
+                  path));
+
+        case SPECIAL_FILE:
+          throw new IOException(
+              String.format(
+                  "The '%s' is a special input which is not supported"
+                      + " by remote caching and execution.",
+                  path));
+
+        case NONEXISTENT:
+          throw new IOException(String.format("The file type of '%s' is not supported.", path));
+      }
+    }
+    return numFiles;
+  }
+
+  private static SortedMap<PathFragment, ActionInput> explodeDirectory(
+      PathFragment dirname, Path execRoot) throws IOException {
+    SortedMap<PathFragment, ActionInput> inputs = new TreeMap<>();
+    explodeDirectory(dirname, inputs, execRoot);
+    return inputs;
+  }
+
+  private static void explodeDirectory(
+      PathFragment dirname, SortedMap<PathFragment, ActionInput> inputs, Path execRoot)
+      throws IOException {
+    Collection<Dirent> entries = execRoot.getRelative(dirname).readdir(Symlinks.FOLLOW);
+    for (Dirent entry : entries) {
+      String basename = entry.getName();
+      PathFragment path = dirname.getChild(basename);
+      switch (entry.getType()) {
+        case FILE:
+          inputs.put(path, ActionInputHelper.fromPath(path));
+          break;
+
+        case DIRECTORY:
+          explodeDirectory(path, inputs, execRoot);
+          break;
+
+        case SYMLINK:
+          throw new IllegalStateException(
+              String.format(
+                  "Encountered symlink input '%s', but all"
+                      + " symlinks should have been resolved by readdir. This is a bug.",
+                  path));
+
+        case UNKNOWN:
+          throw new IOException(String.format("The file type of '%s' is not supported.", path));
+      }
+    }
+  }
+
+  private static void createParentDirectoriesIfNotExist(
+      PathFragment dirname, DirectoryNode dir, Map<PathFragment, DirectoryNode> tree) {
+    PathFragment parentDirname = dirname.getParentDirectory();
+    DirectoryNode prevDir = dir;
+    while (parentDirname != null) {
+      DirectoryNode parentDir = tree.get(parentDirname);
+      if (parentDir != null) {
+        parentDir.addChild(prevDir);
+        break;
+      }
+
+      parentDir = new DirectoryNode(parentDirname.getBaseName());
+      parentDir.addChild(prevDir);
+      tree.put(parentDirname, parentDir);
+
+      parentDirname = parentDirname.getParentDirectory();
+      prevDir = parentDir;
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,16 +38,42 @@ import javax.annotation.Nullable;
 /** A merkle tree representation as defined by the remote execution api. */
 public class MerkleTree {
 
+  public static class PathOrBytes {
+
+    private final Path path;
+    private final ByteString bytes;
+
+    public PathOrBytes(Path path) {
+      this.path = Preconditions.checkNotNull(path, "path");
+      this.bytes = null;
+    }
+
+    public PathOrBytes(ByteString bytes) {
+      this.bytes = Preconditions.checkNotNull(bytes, "bytes");
+      this.path = null;
+    }
+
+    @Nullable
+    public Path getPath() {
+      return path;
+    }
+
+    @Nullable
+    public ByteString getBytes() {
+      return bytes;
+    }
+  }
+
   private final Map<Digest, Directory> digestDirectoryMap;
-  private final Map<Digest, ActionInput> digestActionInputMap;
+  private final Map<Digest, PathOrBytes> digestFileMap;
   private final Digest rootDigest;
 
   private MerkleTree(
       Map<Digest, Directory> digestDirectoryMap,
-      Map<Digest, ActionInput> digestActionInputMap,
+      Map<Digest, PathOrBytes> digestFileMap,
       Digest rootDigest) {
     this.digestDirectoryMap = digestDirectoryMap;
-    this.digestActionInputMap = digestActionInputMap;
+    this.digestFileMap = digestFileMap;
     this.rootDigest = rootDigest;
   }
 
@@ -61,8 +88,8 @@ public class MerkleTree {
   }
 
   @Nullable
-  public ActionInput getInputByDigest(Digest digest) {
-    return digestActionInputMap.get(digest);
+  public PathOrBytes getFileByDigest(Digest digest) {
+    return digestFileMap.get(digest);
   }
 
   /**
@@ -70,7 +97,7 @@ public class MerkleTree {
    * Directory} protobufs and {@link ActionInput} files.
    */
   public Iterable<Digest> getAllDigests() {
-    return Iterables.concat(digestDirectoryMap.keySet(), digestActionInputMap.keySet());
+    return Iterables.concat(digestDirectoryMap.keySet(), digestFileMap.keySet());
   }
 
   /**
@@ -91,29 +118,30 @@ public class MerkleTree {
       DigestUtil digestUtil)
       throws IOException {
     try (SilentCloseable c = Profiler.instance().profile("MerkleTree.build")) {
-      InputTree tree = InputTree.build(inputs, metadataProvider, execRoot, digestUtil);
+      DirectoryTree tree = DirectoryTreeBuilder.fromActionInputs(inputs, metadataProvider,
+          execRoot, digestUtil);
       return build(tree, digestUtil);
     }
   }
 
-  private static MerkleTree build(InputTree tree, DigestUtil digestUtil) {
+  private static MerkleTree build(DirectoryTree tree, DigestUtil digestUtil) {
     Preconditions.checkNotNull(tree);
     if (tree.isEmpty()) {
       return new MerkleTree(ImmutableMap.of(), ImmutableMap.of(), digestUtil.compute(new byte[0]));
     }
     Map<Digest, Directory> digestDirectoryMap =
         Maps.newHashMapWithExpectedSize(tree.numDirectories());
-    Map<Digest, ActionInput> digestActionInputMap =
+    Map<Digest, PathOrBytes> digestPathMap =
         Maps.newHashMapWithExpectedSize(tree.numFiles());
     Map<PathFragment, Digest> m = new HashMap<>();
     tree.visit(
         (dirname, files, dirs) -> {
           Directory.Builder b = Directory.newBuilder();
-          for (InputTree.FileNode file : files) {
+          for (DirectoryTree.FileNode file : files) {
             b.addFiles(buildProto(file));
-            digestActionInputMap.put(file.getDigest(), file.getActionInput());
+            digestPathMap.put(file.getDigest(), toPathOrBytes(file));
           }
-          for (InputTree.DirectoryNode dir : dirs) {
+          for (DirectoryTree.DirectoryNode dir : dirs) {
             PathFragment subDirname = dirname.getRelative(dir.getPathSegment());
             Digest protoDirDigest =
                 Preconditions.checkNotNull(m.remove(subDirname), "protoDirDigest was null");
@@ -125,10 +153,10 @@ public class MerkleTree {
           m.put(dirname, protoDirDigest);
         });
     return new MerkleTree(
-        digestDirectoryMap, digestActionInputMap, m.get(PathFragment.EMPTY_FRAGMENT));
+        digestDirectoryMap, digestPathMap, m.get(PathFragment.EMPTY_FRAGMENT));
   }
 
-  private static FileNode buildProto(InputTree.FileNode file) {
+  private static FileNode buildProto(DirectoryTree.FileNode file) {
     return FileNode.newBuilder()
         .setName(file.getPathSegment())
         .setDigest(file.getDigest())
@@ -136,10 +164,16 @@ public class MerkleTree {
         .build();
   }
 
-  private static DirectoryNode buildProto(InputTree.DirectoryNode dir, Digest protoDirDigest) {
+  private static DirectoryNode buildProto(DirectoryTree.DirectoryNode dir, Digest protoDirDigest) {
     return DirectoryNode.newBuilder()
         .setName(dir.getPathSegment())
         .setDigest(protoDirDigest)
         .build();
+  }
+
+  private static PathOrBytes toPathOrBytes(DirectoryTree.FileNode file) {
+    return file.getPath() != null
+        ? new PathOrBytes(file.getPath())
+        : new PathOrBytes(file.getBytes());
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeTest.java
@@ -126,10 +126,10 @@ public class MerkleTreeTest {
           digestUtil.computeAsUtf8("buzz"),
           digestUtil.computeAsUtf8("fizzbuzz")
         };
-    assertThat(tree.getInputByDigest(inputDigests[0])).isEqualTo(foo);
-    assertThat(tree.getInputByDigest(inputDigests[1])).isEqualTo(bar);
-    assertThat(tree.getInputByDigest(inputDigests[2])).isEqualTo(buzz);
-    assertThat(tree.getInputByDigest(inputDigests[3])).isEqualTo(fizzbuzz);
+    assertThat(tree.getFileByDigest(inputDigests[0]).getPath()).isEqualTo(foo.getPath());
+    assertThat(tree.getFileByDigest(inputDigests[1]).getPath()).isEqualTo(bar.getPath());
+    assertThat(tree.getFileByDigest(inputDigests[2]).getPath()).isEqualTo(buzz.getPath());
+    assertThat(tree.getFileByDigest(inputDigests[3]).getPath()).isEqualTo(fizzbuzz.getPath());
 
     Digest[] allDigests = Iterables.toArray(tree.getAllDigests(), Digest.class);
     assertThat(allDigests.length).isEqualTo(dirDigests.length + inputDigests.length);


### PR DESCRIPTION
This change splits up InputTree into DirectoryTree and
DirectoryTreeBuilder. It also replaces all uses of ActionInput in
the DirectoryTree and MerkleTree by either Path, ByteString or both.

This is part of a series of refactorings to make the remote package
be less dependent on execution phase constructs.