### PR TITLE
Enable sandboxing and remote caching for the "exclusive" tag

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
@@ -88,8 +88,9 @@
   <li><code>exclusive</code> keyword will force the test to be run in the
     &quot;exclusive&quot; mode, ensuring that no other tests are running at the
     same time. Such tests will be executed in serial fashion after all build
-    activity and non-exclusive tests have been completed. They will also always
-    run locally and thus without sandboxing.
+    activity and non-exclusive tests have been completed. Remote execution is
+    disabled for such tests because Bazel doesn't have control over what's
+    running on a remote machine.
   </li>
 
   <li><code>manual</code> keyword will force the test target to not be included in target pattern

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
@@ -88,8 +88,11 @@ public class TestTargetProperties {
 
     Map<String, String> executionInfo = Maps.newLinkedHashMap();
     executionInfo.putAll(TargetUtils.getExecutionInfo(rule));
-    if (TargetUtils.isLocalTestRule(rule) || TargetUtils.isExclusiveTestRule(rule)) {
+    if (TargetUtils.isLocalTestRule(rule)) {
       executionInfo.put(ExecutionRequirements.LOCAL, "");
+    }
+    if (TargetUtils.isExclusiveTestRule(rule)) {
+      executionInfo.put(ExecutionRequirements.NO_REMOTE_EXEC, "");
     }
 
     if (executionRequirements != null) {

--- a/src/test/java/com/google/devtools/build/lib/rules/test/TestTargetPropertiesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/test/TestTargetPropertiesTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.rules.test;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.test.TestProvider;
@@ -49,5 +50,23 @@ public class TestTargetPropertiesTest extends BuildViewTestCase {
             .getTestProperties()
             .getLocalResourceUsage(testAction.getOwner().getLabel(), false);
     assertThat(localResourceUsage.getCpuUsage()).isEqualTo(4.0);
+  }
+
+  @Test
+  public void testTestWithExclusiveDisablesRemoteExecution() throws Exception {
+    scratch.file("tests/test.sh", "#!/bin/bash", "exit 0");
+    scratch.file(
+        "tests/BUILD",
+        "sh_test(",
+        "  name = 'test',",
+        "  size = 'small',",
+        "  srcs = ['test.sh'],",
+        "  tags = ['exclusive'],",
+        ")");
+    ConfiguredTarget testTarget = getConfiguredTarget("//tests:test");
+    TestRunnerAction testAction =
+        (TestRunnerAction)
+            getGeneratingAction(TestProvider.getTestStatusArtifacts(testTarget).get(0));
+    assertThat(testAction.getExecutionInfo()).isEqualTo(ExecutionRequirements.NO_REMOTE_EXEC);
   }
 }

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1131,6 +1131,34 @@ EOF
   expect_log "uri:.*bytestream://localhost"
 }
 
+function test_exclusive_tag() {
+  # Test that the exclusive tag works with the remote cache.
+  mkdir -p a
+  cat > a/success.sh <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+  chmod 755 a/success.sh
+  cat > a/BUILD <<'EOF'
+sh_test(
+  name = "success_test",
+  srcs = ["success.sh"],
+  tags = ["exclusive"],
+)
+EOF
+
+  bazel test \
+    --remote_cache=grpc://localhost:${worker_port} \
+    //a:success_test || fail "Failed to test //a:success_test"
+
+  bazel test \
+    --remote_cache=grpc://localhost:${worker_port} \
+    --nocache_test_results \
+    //a:success_test >& $TEST_log || fail "Failed to test //a:success_test"
+
+  expect_log "remote cache hit"
+}
+
 # TODO(alpha): Add a test that fails remote execution when remote worker
 # supports sandbox.
 


### PR DESCRIPTION
There's no good reason why tests tagged with exclusive shouldn't
be able to use sandboxing and/or remote caching. The current
limitations have been kept from open sourcing Bazel and have
never been revisited since.

Remote execution will continue to be disabled because Bazel
can't control what else is running on a remote machine.