### PR TITLE
introduce --remote_default_exec_properties

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformUtils.java
@@ -15,7 +15,9 @@
 package com.google.devtools.build.lib.analysis.platform;
 
 import build.bazel.remote.execution.v2.Platform;
+import build.bazel.remote.execution.v2.Platform.Property;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Ordering;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -24,6 +26,7 @@ import com.google.protobuf.TextFormat.ParseException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
 import javax.annotation.Nullable;
 
 /** Utilities for accessing platform properties. */
@@ -33,12 +36,12 @@ public final class PlatformUtils {
   public static Platform getPlatformProto(
       @Nullable PlatformInfo executionPlatform, @Nullable RemoteOptions remoteOptions)
       throws UserExecException {
-    String defaultPlatformProperties = null;
+    SortedMap<String, String> defaultExecProperties = ImmutableSortedMap.of();
     if (remoteOptions != null) {
-      defaultPlatformProperties = remoteOptions.remoteDefaultPlatformProperties;
+      defaultExecProperties = remoteOptions.getRemoteDefaultExecProperties();
     }
 
-    if (executionPlatform == null && Strings.isNullOrEmpty(defaultPlatformProperties)) {
+    if (executionPlatform == null && defaultExecProperties.isEmpty()) {
       return null;
     }
 
@@ -61,16 +64,9 @@ public final class PlatformUtils {
                 executionPlatform.label()),
             e);
       }
-    } else if (!Strings.isNullOrEmpty(defaultPlatformProperties)) {
-      // Try and use the provided default value.
-      try {
-        TextFormat.getParser().merge(defaultPlatformProperties, platformBuilder);
-      } catch (ParseException e) {
-        throw new UserExecException(
-            String.format(
-                "Failed to parse --remote_default_platform_properties %s",
-                defaultPlatformProperties),
-            e);
+    } else {
+      for (Map.Entry<String, String> property : defaultExecProperties.entrySet()) {
+        platformBuilder.addProperties(Property.newBuilder().setName(property.getKey()).setValue(property.getValue()).build());
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/options/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/BUILD
@@ -11,8 +11,11 @@ java_library(
     srcs = glob(["*.java"]),
     deps = [
         "//src/main/java/com/google/devtools/build/lib:util",
+        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:guava",
+        "//third_party/protobuf:protobuf_java",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -328,7 +328,7 @@ public final class RemoteOptions extends OptionsBase {
 
   @Option(
       name = "remote_default_exec_properties",
-      defaultValue = "null",
+      defaultValue = "[]",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       converter = AssignmentConverter.class,
@@ -358,7 +358,7 @@ public final class RemoteOptions extends OptionsBase {
   }
 
   public SortedMap<String, String> getRemoteDefaultExecProperties() throws UserExecException {
-    boolean hasExecProperties = remoteDefaultExecProperties != null;
+    boolean hasExecProperties = !remoteDefaultExecProperties.isEmpty();
     boolean hasPlatformProperties = !remoteDefaultPlatformProperties.isEmpty();
 
     if (hasExecProperties && hasPlatformProperties) {

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -14,18 +14,27 @@
 
 package com.google.devtools.build.lib.remote.options;
 
+import build.bazel.remote.execution.v2.Platform;
+import build.bazel.remote.execution.v2.Platform.Property;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.util.OptionsUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.Converters;
+import com.google.devtools.common.options.Converters.AssignmentConverter;
 import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
 import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsBase;
+import com.google.protobuf.TextFormat;
+import com.google.protobuf.TextFormat.ParseException;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.SortedMap;
 
 /** Options for remote execution and distributed caching. */
 public final class RemoteOptions extends OptionsBase {
@@ -309,12 +318,24 @@ public final class RemoteOptions extends OptionsBase {
       defaultValue = "",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
+      deprecationWarning = "--remote_default_platform_properties has been deprecated in favor of --remote_default_exec_properties.",
       help =
           "Set the default platform properties to be set for the remote execution API, "
               + "if the execution platform does not already set remote_execution_properties. "
               + "This value will also be used if the host platform is selected as the execution "
               + "platform for remote execution.")
   public String remoteDefaultPlatformProperties;
+
+  @Option(
+      name = "remote_default_exec_properties",
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      converter = AssignmentConverter.class,
+      allowMultiple = true,
+      help = "Set the default exec properties to be used as the remote execution platform "
+              + "if an execution platform does not already set exec_properties.")
+  public List<Map.Entry<String, String>> remoteDefaultExecProperties;
 
   @Option(
       name = "remote_verify_downloads",
@@ -334,5 +355,41 @@ public final class RemoteOptions extends OptionsBase {
 
   public boolean isRemoteEnabled() {
     return !Strings.isNullOrEmpty(remoteCache) || !Strings.isNullOrEmpty(remoteExecutor);
+  }
+
+  public SortedMap<String, String> getRemoteDefaultExecProperties() throws UserExecException {
+    boolean hasExecProperties = remoteDefaultExecProperties != null;
+    boolean hasPlatformProperties = !remoteDefaultPlatformProperties.isEmpty();
+
+    if (hasExecProperties && hasPlatformProperties) {
+      throw new UserExecException("Setting both --remote_default_platform_properties and "
+          + "--remote_default_exec_properties is not allowed. Prefer setting "
+          + "--remote_default_exec_properties.");
+    }
+
+    if (hasExecProperties) {
+      return ImmutableSortedMap.<String, String>naturalOrder().putAll(remoteDefaultExecProperties).build();
+    } else if (hasPlatformProperties) {
+      // Try and use the provided default value.
+      final Platform platform;
+      try {
+        Platform.Builder builder = Platform.newBuilder();
+        TextFormat.getParser().merge(remoteDefaultPlatformProperties, builder);
+        platform = builder.build();
+      } catch (ParseException e) {
+        throw new UserExecException(
+            String.format(
+                "Failed to parse --remote_default_platform_properties %s",
+                remoteDefaultPlatformProperties), e);
+      }
+
+      ImmutableSortedMap.Builder<String, String> builder = ImmutableSortedMap.naturalOrder();
+      for (Property property : platform.getPropertiesList()) {
+        builder.put(property.getName(), property.getValue());
+      }
+      return builder.build();
+    }
+
+    return ImmutableSortedMap.of();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
@@ -61,7 +61,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
 
   // The name of the container image entry in the Platform proto
   // (see third_party/googleapis/devtools/remoteexecution/*/remote_execution.proto and
-  // remote_default_platform_properties in
+  // remote_default_exec_properties in
   // src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java)
   private static final String CONTAINER_IMAGE_ENTRY_NAME = "container-image";
   private static final String DOCKER_IMAGE_PREFIX = "docker://";

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/BUILD
@@ -26,6 +26,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis/platform:utils",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/remote/options",
+        "//src/main/java/com/google/devtools/common/options:options_internal",
         "//src/test/java/com/google/devtools/build/lib:analysis_testutil",
         "//src/test/java/com/google/devtools/build/lib:packages_testutil",
         "//src/test/java/com/google/devtools/build/lib:testutil",

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformUtilsTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import build.bazel.remote.execution.v2.Platform;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.common.options.Options;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,7 +28,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class PlatformUtilsTest {
   private static RemoteOptions remoteOptions() {
-    RemoteOptions remoteOptions = new RemoteOptions();
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     remoteOptions.remoteDefaultPlatformProperties =
         String.join(
             "\n",

--- a/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
@@ -49,6 +49,7 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import com.google.devtools.common.options.Options;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -290,7 +291,7 @@ public class AbstractSpawnStrategyTest {
 
   @Test
   public void testLogSpawn_DefaultPlatform_getsLogged() throws Exception {
-    RemoteOptions remoteOptions = new RemoteOptions();
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     remoteOptions.remoteDefaultPlatformProperties =
         String.join(
             "\n",
@@ -320,7 +321,7 @@ public class AbstractSpawnStrategyTest {
 
   @Test
   public void testLogSpawn_SpecifiedPlatform_overridesDefault() throws Exception {
-    RemoteOptions remoteOptions = new RemoteOptions();
+    RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     remoteOptions.remoteDefaultPlatformProperties =
         String.join(
             "\n",

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -10,6 +10,7 @@ filegroup(
         "//src/test/java/com/google/devtools/build/lib/remote/http:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/logging:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/merkletree:srcs",
+        "//src/test/java/com/google/devtools/build/lib/remote/options:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/util:srcs",
     ],
     visibility = ["//src/test/java/com/google/devtools/build/lib:__pkg__"],

--- a/src/test/java/com/google/devtools/build/lib/remote/options/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/options/BUILD
@@ -1,0 +1,25 @@
+package(
+    default_testonly = 1,
+    default_visibility = ["//src:__subpackages__"],
+)
+
+filegroup(
+    name = "srcs",
+    testonly = 0,
+    srcs = glob(["**"]),
+    visibility = ["//src/test/java/com/google/devtools/build/lib/remote:__pkg__"],
+)
+
+java_test(
+    name = "options",
+    srcs = glob(["*.java"]),
+    test_class = "com.google.devtools.build.lib.AllTests",
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
+        "//src/main/java/com/google/devtools/common/options",
+        "//src/test/java/com/google/devtools/build/lib:test_runner",
+        "//third_party:guava",
+        "//third_party:truth",
+    ],
+)

--- a/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/options/RemoteOptionsTest.java
@@ -1,0 +1,71 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.options;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.actions.UserExecException;
+import com.google.devtools.common.options.Options;
+import java.util.Arrays;
+import java.util.SortedMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for RemoteOptions. */
+@RunWith(JUnit4.class)
+public class RemoteOptionsTest {
+
+  @Test
+  public void testDefaultValueOfExecProperties() throws Exception {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    assertThat(options.getRemoteDefaultExecProperties()).isEmpty();
+  }
+
+  @Test
+  public void testRemoteDefaultExecProperties() throws Exception {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteDefaultExecProperties = Arrays.asList(Maps.immutableEntry("ISA", "x86-64"),
+        Maps.immutableEntry("OSFamily", "linux"));
+
+    SortedMap<String, String> properties = options.getRemoteDefaultExecProperties();
+    assertThat(properties).isEqualTo(ImmutableSortedMap.of("OSFamily", "linux", "ISA", "x86-64"));
+  }
+
+  @Test
+  public void testRemoteDefaultPlatformProperties() throws Exception {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteDefaultPlatformProperties = "properties:{name:\"ISA\" value:\"x86-64\"} properties:{name:\"OSFamily\" value:\"linux\"}";
+
+    SortedMap<String, String> properties = options.getRemoteDefaultExecProperties();
+    assertThat(properties).isEqualTo(ImmutableSortedMap.of("OSFamily", "linux", "ISA", "x86-64"));
+  }
+
+  @Test
+  public void testConflictingRemotePlatformAndExecProperties() {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.remoteDefaultExecProperties = Arrays.asList(Maps.immutableEntry("ISA", "x86-64"));
+    options.remoteDefaultPlatformProperties = "properties:{name:\"OSFamily\" value:\"linux\"}";
+
+    try {
+      options.getRemoteDefaultExecProperties();
+      fail("expected exception");
+    } catch (UserExecException e) {
+      // Intentionally left empty.
+    }
+  }
+}

--- a/src/test/shell/bazel/bazel_docker_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_docker_sandboxing_test.sh
@@ -19,7 +19,7 @@ source $(rlocation io_bazel/src/test/shell/integration_test_setup.sh) \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
 # Platform container is picked up if it specified.
-# --remote_default_platform_properties is ignored in this case
+# --remote_default_exec_properties is ignored in this case
 function test_platform_container() {
   mkdir -p t
   cat >t/BUILD <<'EOF'
@@ -43,13 +43,13 @@ EOF
     --extra_execution_platforms=//t:bad_docker \
     --experimental_enable_docker_sandbox --experimental_docker_verbose \
     --spawn_strategy=docker \
-    --remote_default_platform_properties="properties:{name:\"container-image\" value:\"docker://bad_flag_container\"}"\
+    --remote_default_exec_properties="container-image=docker://bad_flag_container" \
     //t:echo \
     &> $TEST_log && fail "Expected build to fail, it succeded"
   grep "bad_platform_container" $TEST_log || fail "Wrong container was chosen"
 }
 
-# If platform container is not specified, --remote_default_platform_properties
+# If platform container is not specified, --remote_default_exec_properties
 # are picked up
 function test_flag_container() {
   mkdir -p t
@@ -64,7 +64,7 @@ EOF
   bazel build  \
     --experimental_enable_docker_sandbox --experimental_docker_verbose \
     --spawn_strategy=docker \
-    --remote_default_platform_properties="properties:{name:\"container-image\" value:\"docker://bad_flag_container\"}"\
+    --remote_default_exec_properties="container-image=docker://bad_flag_container" \
     //t:echo \
     &> $TEST_log && fail "Expected build to fail, it succeded"
   grep "bad_flag_container" $TEST_log || fail "Wrong container was chosen"

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1131,6 +1131,33 @@ EOF
   expect_log "uri:.*bytestream://localhost"
 }
 
+function test_remote_exec_properties() {
+  # Test that setting remote exec properties works.
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = "foo",
+  srcs = [],
+  outs = ["foo.txt"],
+  cmd = "echo \"foo\" > \"$@\"",
+)
+EOF
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_default_exec_properties=OSFamily=linux \
+    //a:foo || fail "Failed to build //a:foo"
+
+  bazel clean
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --remote_default_exec_properties=OSFamily=windows \
+    //a:foo >& $TEST_log || fail "Failed to build //a:foo"
+
+  expect_not_log "remote cache hit"
+}
+
 # TODO(alpha): Add a test that fails remote execution when remote worker
 # supports sandbox.
 

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -83,7 +83,7 @@ final class ExecutionServer extends ExecutionImplBase {
 
   // The name of the container image entry in the Platform proto
   // (see third_party/googleapis/devtools/remoteexecution/*/remote_execution.proto and
-  // remote_default_platform_properties in
+  // remote_default_exec_properties in
   // src/main/java/com/google/devtools/build/lib/remote/RemoteOptions.java)
   private static final String CONTAINER_IMAGE_ENTRY_NAME = "container-image";
   private static final String DOCKER_IMAGE_PREFIX = "docker://";


### PR DESCRIPTION
`--remote_default_exec_properties` serves the same purpose as
`--remote_default_platform properties` but is easier to use in that it
doesn't require the user to specify a text protobuf on the command line.

Use it like:
```
bazel build :foo --remote_cache=host:port \
  --remote_default_exec_properties=OSFamily=linux \
  --remote_default_exec_properties=ISA=x86-64 \
  --remote_default_exec_properties=ContainerImage=docker://...
```
The naming is also inline with the newly introduced `exec_properties`
attribute.

RELNOTES: --remote_default_platform_properties has been deprecated in favor
of --remote_default_exec_properties.