### PR TITLE
WIP: Android platforms and platform mappings in the NDK

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
@@ -398,6 +398,10 @@ public class AndroidNdkRepositoryFunction extends AndroidRepositoryFunction {
             .replaceAll(
                 "%big_conditional_populating_variables%",
                 Joiner.on("\n" + "    ").join(bigConditional.build())));
+
+    writeFile(outputDirectory,
+        "platform_mappings",
+        getTemplate("android_ndk_platform_mappings.txt"));
     return RepositoryDirectoryValue.builder().setPath(outputDirectory);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_build_file_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_build_file_template.txt
@@ -17,6 +17,8 @@
 
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 
+exports_files(["platform_mappings"])
+
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -32,6 +34,46 @@ cc_library(
 alias(
     name = "default_crosstool",
     actual = "%defaultCrosstool%",
+)
+
+# Platform definitions for Android.
+# The constraints are on OS and Architecture. Currently, there are
+# no constraints on API levels. There is also no constraint on the STL
+# as Android NDK ships with libcpp only.
+#
+# Keep consistent with Android NDK supported architectures.
+# See https://docs.bazel.build/versions/master/android-ndk.html#integration-with-platforms-and-toolchains
+# for more information.
+platform(
+    name = "android_x86_64",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "android_x86",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:x86",
+    ],
+)
+
+platform(
+    name = "android_arm",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:arm",
+    ],
+)
+
+platform(
+    name = "android_aarch64",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:aarch64",
+    ],
 )
 
 ################################################################

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_platform_mappings.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_platform_mappings.txt
@@ -1,0 +1,13 @@
+platforms:
+  @androidsdk//:android_arm
+    --android_cpu=armeabi-v7a
+    --fat_apk_cpu=armeabi-v7a
+  @androidsdk//:android_x86_64
+    --android_cpu=x86_64
+    --fat_apk_cpu=x86_64
+
+flags:
+  --fat_apk_cpu=armeabi-v7a
+    @androidsdk//:android_arm
+  --fat_apk_cpu=x86_64
+    @androidsdk//:android_x86_64


### PR DESCRIPTION
```
$ cat platform_mappings 
platforms:
  @androidndk//:android_arm
    --crosstool_top=@androidndk//:default_crosstool
    --cpu=armeabi-v7a
    --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
    --fat_apk_cpu=arm
  @androidndk//:android_aarch64
    --crosstool_top=@androidndk//:default_crosstool
    --cpu=arm64-v8a
    --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
    --fat_apk_cpu=arm64-v8a
  @androidndk//:android_x86
    --crosstool_top=@androidndk//:default_crosstool
    --cpu=x86
    --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
    --fat_apk_cpu=x86
  @androidndk//:android_x86_64
    --crosstool_top=@androidndk//:default_crosstool
    --cpu=x86_64
    --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
    --fat_apk_cpu=x86_64


$ gbazel build :app --platforms=@androidndk//:android_x86_64 --extra_toolchains=@androidndk//:all
INFO: Build options --android_cpu, --fat_apk_cpu, and --platforms have changed, discarding analysis cache.
INFO: Analyzed target //app/src/main:app (59 packages loaded, 7018 targets configured).
INFO: Found 1 target...
Target //app/src/main:app up-to-date:
  bazel-bin/app/src/main/app_deploy.jar
  bazel-bin/app/src/main/app_unsigned.apk
  bazel-bin/app/src/main/app.apk
INFO: Elapsed time: 15.003s, Critical Path: 5.68s
INFO: 10 processes: 9 linux-sandbox, 1 worker.
INFO: Build completed successfully, 11 total actions

$ zipinfo -1 bazel-bin/app/src/main/app.apk | grep lib/
lib/x86_64/libapp.so
```

TODO / Open questions:

* It would be nice to be able to ship `platform_mappings` with `@androidndk`. But `--platform_mappings` only accept a path to the file, not a label like `@androidndk//:platform_mappings`.
* How to represent `--fat_apk_cpu` transitions in platform mappings?

If we try to pass multiple target platforms to `--platforms`, Bazel hard crashes with `platform_mappings` not supporting multiple target platforms:

```
$ gbazel build //app/src/main:app --platforms=@androidndk//:android_aarch64,@androidndk//:android_x86_64 --extra_toolchains=@androidndk//:all
Starting local Bazel server and connecting to it...
Internal error thrown during build. Printing stack trace: java.lang.IllegalArgumentException: Platform mapping only supports a single target platform but found [@androidndk//:android_aarch64, @androidndk//:android_x86_64]
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:216)
	at com.google.devtools.build.lib.skyframe.PlatformMappingValue.computeMapping(PlatformMappingValue.java:213)
	at com.google.devtools.build.lib.skyframe.PlatformMappingValue.lambda$map$0(PlatformMappingValue.java:191)
	at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4875)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3527)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2276)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2154)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2044)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3951)
	at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4870)
	at com.google.devtools.build.lib.skyframe.PlatformMappingValue.map(PlatformMappingValue.java:191)
	at com.google.devtools.build.lib.skyframe.BuildConfigurationValue.keyWithPlatformMapping(BuildConfigurationValue.java:90)
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.toConfigurationKey(SkyframeExecutor.java:2158)
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.getConfigurations(SkyframeExecutor.java:1927)
	at com.google.devtools.build.lib.skyframe.SkyframeExecutor.createConfigurations(SkyframeExecutor.java:1505)
	at com.google.devtools.build.lib.analysis.BuildView.update(BuildView.java:247)
	at com.google.devtools.build.lib.buildtool.AnalysisPhaseRunner.runAnalysisPhase(AnalysisPhaseRunner.java:198)
	at com.google.devtools.build.lib.buildtool.AnalysisPhaseRunner.execute(AnalysisPhaseRunner.java:110)
	at com.google.devtools.build.lib.buildtool.BuildTool.buildTargets(BuildTool.java:141)
	at com.google.devtools.build.lib.buildtool.BuildTool.processRequest(BuildTool.java:268)
	at com.google.devtools.build.lib.runtime.commands.BuildCommand.exec(BuildCommand.java:99)
	at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.execExclusively(BlazeCommandDispatcher.java:518)
	at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.exec(BlazeCommandDispatcher.java:192)
	at com.google.devtools.build.lib.server.GrpcServerImpl.executeCommand(GrpcServerImpl.java:573)
	at com.google.devtools.build.lib.server.GrpcServerImpl.lambda$run$2(GrpcServerImpl.java:624)
	at java.base/java.lang.Thread.run(Unknown Source)

INFO: Elapsed time: 2.867s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (1 packages loaded)
```