### PR TITLE
Don't crash if the server returns a long response on uploading.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpBlobStore.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpBlobStore.java
@@ -277,8 +277,11 @@ public final class HttpBlobStore implements SimpleBlobStore {
                     "timeout-handler",
                     new IdleTimeoutHandler(timeoutSeconds, WriteTimeoutException.INSTANCE));
                 p.addLast(new HttpResponseDecoder());
-                // The 10KiB limit was chosen at random. We only expect HTTP servers to respond with
-                // an error message in the body and that should always be less than 10KiB.
+                // The 10KiB limit was chosen arbitrarily. We only expect HTTP servers to respond
+                // with an error message in the body, and that should always be less than 10KiB. If
+                // the response is larger than 10KiB, HttpUploadHandler will catch the
+                // TooLongFrameException that HttpObjectAggregator throws and convert it to an
+                // IOException.
                 p.addLast(new HttpObjectAggregator(10 * 1024));
                 p.addLast(new HttpRequestEncoder());
                 p.addLast(new ChunkedWriteHandler());

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpUploadHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpUploadHandler.java
@@ -19,6 +19,7 @@ import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableList;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpChunkedInput;
@@ -121,6 +122,8 @@ final class HttpUploadHandler extends AbstractHttpHandler<FullHttpResponse> {
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable t) {
     if (t instanceof WriteTimeoutException) {
       super.exceptionCaught(ctx, new UploadTimeoutException(path, contentLength));
+    } else if (t instanceof TooLongFrameException) {
+      super.exceptionCaught(ctx, new IOException(t));
     } else {
       super.exceptionCaught(ctx, t);
     }

--- a/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -18,6 +18,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/remote/http",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/test/java/com/google/devtools/build/lib:test_runner",
+        "//src/test/java/com/google/devtools/build/lib:testutil",
         "//third_party:api_client",
         "//third_party:auth",
         "//third_party:guava",


### PR DESCRIPTION
HttpObjectAggregator raises runtime error TooLongFrameException if the response body exceeds the aggregation limit. We need to turn this exception into an IOException, so it doesn't crash Bazel.