### PR TITLE
Fallback to next urls if download fails in HttpDownloader 

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
@@ -21,6 +21,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib:util",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/cache",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/test/java/com/google/devtools/build/lib:foundations_testutil",
         "//src/test/java/com/google/devtools/build/lib:test_runner",
         "//src/test/java/com/google/devtools/build/lib:testutil",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloaderTestSuite.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloaderTestSuite.java
@@ -25,6 +25,7 @@ import org.junit.runners.Suite.SuiteClasses;
   HttpConnectorMultiplexerIntegrationTest.class,
   HttpConnectorMultiplexerTest.class,
   HttpConnectorTest.class,
+  HttpDownloaderTest.class,
   HttpStreamTest.class,
   HttpUtilsTest.class,
   ProgressInputStreamTest.class,

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnectorMultiplexerIntegrationTest.java
@@ -73,7 +73,7 @@ public class HttpConnectorMultiplexerIntegrationTest {
   private final Sleeper sleeper = mock(Sleeper.class);
   private final Locale locale = Locale.US;
   private final HttpConnector connector =
-      new HttpConnector(locale, eventHandler, proxyHelper, sleeper);
+      new HttpConnector(locale, eventHandler, proxyHelper, sleeper, 0.1f);
   private final ProgressInputStream.Factory progressInputStreamFactory =
       new ProgressInputStream.Factory(locale, clock, eventHandler);
   private final HttpStream.Factory httpStreamFactory =
@@ -102,7 +102,7 @@ public class HttpConnectorMultiplexerIntegrationTest {
     try (ServerSocket server1 = new ServerSocket(0, 1, InetAddress.getByName(null));
         ServerSocket server2 = new ServerSocket(0, 1, InetAddress.getByName(null))) {
       for (final ServerSocket server : asList(server1, server2)) {
-        @SuppressWarnings("unused") 
+        @SuppressWarnings("unused")
         Future<?> possiblyIgnoredError =
             executor.submit(
                 new Callable<Object>() {
@@ -239,6 +239,50 @@ public class HttpConnectorMultiplexerIntegrationTest {
               new URL(String.format("http://localhost:%d", server2.getLocalPort())),
               new URL(String.format("http://localhost:%d", server3.getLocalPort()))),
           HELLO_SHA256);
+    }
+  }
+
+  @Test
+  public void firstUrlSocketTimeout_secondOk() throws Exception {
+    final Phaser phaser = new Phaser(3);
+    try (ServerSocket server1 = new ServerSocket(0, 1, InetAddress.getByName(null));
+        ServerSocket server2 = new ServerSocket(0, 1, InetAddress.getByName(null))) {
+
+      @SuppressWarnings("unused")
+      Future<?> possiblyIgnoredError = executor.submit(() -> {
+        phaser.arriveAndAwaitAdvance();
+        try (Socket socket = server1.accept()) {
+          // Do nothing to cause SocketTimeoutException on client side.
+        }
+        return null;
+      });
+
+      @SuppressWarnings("unused")
+      Future<?> possiblyIgnoredError2 = executor.submit(() -> {
+                  phaser.arriveAndAwaitAdvance();
+                  try (Socket socket = server2.accept()) {
+                    readHttpRequest(socket.getInputStream());
+                    sendLines(
+                        socket,
+                        "HTTP/1.1 200 OK",
+                        "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                        "Connection: close",
+                        "",
+                        "hello");
+                  }
+                return null;
+              });
+
+      phaser.arriveAndAwaitAdvance();
+      phaser.arriveAndDeregister();
+      try (HttpStream stream =
+          multiplexer.connect(
+              ImmutableList.of(
+                  new URL(String.format("http://localhost:%d", server1.getLocalPort())),
+                  new URL(String.format("http://localhost:%d", server2.getLocalPort()))),
+              HELLO_SHA256)) {
+        assertThat(toByteArray(stream)).isEqualTo("hello".getBytes(US_ASCII));
+      }
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -1,26 +1,38 @@
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.bazel.repository.downloader.DownloaderTestUtils.sendLines;
 import static com.google.devtools.build.lib.bazel.repository.downloader.HttpParser.readHttpRequest;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.base.Optional;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.DigestHashFunction.DefaultHashFunctionNotSetException;
+import com.google.devtools.build.lib.vfs.JavaIoFileSystem;
 import com.google.devtools.build.lib.vfs.Path;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.concurrent.Callable;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -30,57 +42,276 @@ public class HttpDownloaderTest {
   @Rule
   public final TemporaryFolder workingDir = new TemporaryFolder();
 
+  @Rule
+  public final Timeout timeout = new Timeout(30, SECONDS);
+
   private final RepositoryCache repositoryCache = mock(RepositoryCache.class);
   private final HttpDownloader httpDownloader = new HttpDownloader(repositoryCache);
 
-  private final ExecutorService executor = Executors.newFixedThreadPool(1);
+  private final ExecutorService executor = Executors.newFixedThreadPool(2);
   private final ExtendedEventHandler eventHandler = mock(ExtendedEventHandler.class);
+  private final JavaIoFileSystem fs;
 
-  @Test
-  public void name() {
+  public HttpDownloaderTest() throws DefaultHashFunctionNotSetException {
+    try {
+      DigestHashFunction.setDefault(DigestHashFunction.SHA256);
+    } catch (DigestHashFunction.DefaultAlreadySetException e) {
+      // Do nothing.
+    }
+    fs = new JavaIoFileSystem();
 
+    // Scale timeouts down to make tests fast.
+    httpDownloader.setTimeoutScaling(0.1f);
+  }
+
+  @After
+  public void after() {
+    executor.shutdown();
   }
 
   @Test
-  public void downloadFrom1UrlOk() throws IOException, InterruptedException {
+  public void downloadFrom1UrlOk()
+      throws IOException, InterruptedException {
     try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
       Future<?> possiblyIgnoredError =
-          executor.submit(
-              new Callable<Object>() {
-                @Override
-                public Object call() throws Exception {
-                  try (Socket socket = server.accept()) {
-                    readHttpRequest(socket.getInputStream());
-                    sendLines(
-                        socket,
-                        "HTTP/1.1 200 OK",
-                        "Date: Fri, 31 Dec 1999 23:59:59 GMT",
-                        "Connection: close",
-                        "Content-Type: text/plain",
-                        "Content-Length: 5",
-                        "",
-                        "hello");
-                  }
-                  return null;
-                }
-              });
+          executor.submit(() -> {
+            try (Socket socket = server.accept()) {
+              readHttpRequest(socket.getInputStream());
+              sendLines(
+                  socket,
+                  "HTTP/1.1 200 OK",
+                  "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                  "Connection: close",
+                  "Content-Type: text/plain",
+                  "Content-Length: 5",
+                  "",
+                  "hello");
+            }
+            return null;
+          });
 
-      Path outputFile = Path.getFileSystemForSerialization()
-          .getPath(workingDir.newFile().getAbsolutePath());
-
-      httpDownloader.download(
+      Path resultingFile = httpDownloader.download(
           Collections.singletonList(
               new URL(String.format("http://localhost:%d/foo", server.getLocalPort()))),
           Collections.emptyMap(),
           Optional.absent(),
           "testCanonicalId",
           Optional.absent(),
-          outputFile,
+          fs.getPath(workingDir.newFile().getAbsolutePath()),
           eventHandler,
           Collections.emptyMap(),
           "testRepo"
       );
+
+      assertThat(new String(readFile(resultingFile), UTF_8)).isEqualTo("hello");
+    }
+  }
+
+  @Test
+  public void downloadFrom2UrlsFirstOk()
+      throws IOException, InterruptedException {
+    try (
+        ServerSocket server1 = new ServerSocket(0, 1, InetAddress.getByName(null));
+        ServerSocket server2 = new ServerSocket(0, 1, InetAddress.getByName(null))) {
+      Future<?> possiblyIgnoredError =
+          executor.submit(() -> {
+            while (!executor.isShutdown()) {
+              try (Socket socket = server1.accept()) {
+                readHttpRequest(socket.getInputStream());
+                sendLines(
+                    socket,
+                    "HTTP/1.1 200 OK",
+                    "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                    "Connection: close",
+                    "Content-Type: text/plain",
+                    "",
+                    "content1");
+              }
+            }
+            return null;
+          });
+
+      Future<?> possiblyIgnoredError2 =
+          executor.submit(() -> {
+            while (!executor.isShutdown()) {
+              try (Socket socket = server2.accept()) {
+                readHttpRequest(socket.getInputStream());
+                sendLines(
+                    socket,
+                    "HTTP/1.1 200 OK",
+                    "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                    "Connection: close",
+                    "Content-Type: text/plain",
+                    "",
+                    "content2");
+              }
+            }
+            return null;
+          });
+
+      final List<URL> urls = new ArrayList<>(2);
+      urls.add(new URL(String.format("http://localhost:%d/foo", server1.getLocalPort())));
+      urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
+
+      Path resultingFile = httpDownloader.download(
+          urls,
+          Collections.emptyMap(),
+          Optional.absent(),
+          "testCanonicalId",
+          Optional.absent(),
+          fs.getPath(workingDir.newFile().getAbsolutePath()),
+          eventHandler,
+          Collections.emptyMap(),
+          "testRepo"
+      );
+
+      assertThat(new String(readFile(resultingFile), UTF_8)).isEqualTo("content1");
+    }
+  }
+
+  @Test
+  public void downloadFrom2UrlsFirstSocketTimeoutOnBodyReadSecondOk()
+      throws IOException, InterruptedException {
+    try (
+        ServerSocket server1 = new ServerSocket(0, 1, InetAddress.getByName(null));
+        ServerSocket server2 = new ServerSocket(0, 1, InetAddress.getByName(null))) {
+      Future<?> possiblyIgnoredError =
+          executor.submit(() -> {
+            Socket socket = server1.accept();
+            readHttpRequest(socket.getInputStream());
+
+            sendLines(
+                socket,
+                "HTTP/1.1 200 OK",
+                "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                "Connection: close",
+                "Content-Type: text/plain",
+                "",
+                "content1"
+            );
+
+            // Never close the socket to cause SocketTimeoutException during body read on client side.
+            return null;
+          });
+
+      Future<?> possiblyIgnoredError2 =
+          executor.submit(() -> {
+            while (!executor.isShutdown()) {
+              try (Socket socket = server2.accept()) {
+                readHttpRequest(socket.getInputStream());
+                sendLines(
+                    socket,
+                    "HTTP/1.1 200 OK",
+                    "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                    "Connection: close",
+                    "Content-Type: text/plain",
+                    "",
+                    "content2");
+              }
+            }
+            return null;
+          });
+
+      final List<URL> urls = new ArrayList<>(2);
+      urls.add(new URL(String.format("http://localhost:%d/foo", server1.getLocalPort())));
+      urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
+
+      Path resultingFile = httpDownloader.download(
+          urls,
+          Collections.emptyMap(),
+          Optional.absent(),
+          "testCanonicalId",
+          Optional.absent(),
+          fs.getPath(workingDir.newFile().getAbsolutePath()),
+          eventHandler,
+          Collections.emptyMap(),
+          "testRepo"
+      );
+
+      assertThat(new String(readFile(resultingFile), UTF_8)).isEqualTo("content2");
+    }
+  }
+
+  @Test
+  public void downloadFrom2UrlsBothSocketTimeoutDuringBodyRead()
+      throws IOException, InterruptedException {
+    try (
+        ServerSocket server1 = new ServerSocket(0, 1, InetAddress.getByName(null));
+        ServerSocket server2 = new ServerSocket(0, 1, InetAddress.getByName(null))) {
+      Future<?> possiblyIgnoredError =
+          executor.submit(() -> {
+            Socket socket = server1.accept();
+            readHttpRequest(socket.getInputStream());
+
+            sendLines(
+                socket,
+                "HTTP/1.1 200 OK",
+                "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                "Connection: close",
+                "Content-Type: text/plain",
+                "",
+                "content1"
+            );
+
+            // Never close the socket to cause SocketTimeoutException during body read on client side.
+            return null;
+          });
+
+      Future<?> possiblyIgnoredError2 =
+          executor.submit(() -> {
+            Socket socket = server1.accept();
+            readHttpRequest(socket.getInputStream());
+
+            sendLines(
+                socket,
+                "HTTP/1.1 200 OK",
+                "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                "Connection: close",
+                "Content-Type: text/plain",
+                "",
+                "content2"
+            );
+
+            // Never close the socket to cause SocketTimeoutException during body read on client side.
+            return null;
+          });
+
+      final List<URL> urls = new ArrayList<>(2);
+      urls.add(new URL(String.format("http://localhost:%d/foo", server1.getLocalPort())));
+      urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
+
+      Path outputFile = fs.getPath(workingDir.newFile().getAbsolutePath());
+      try {
+        httpDownloader.download(
+            urls,
+            Collections.emptyMap(),
+            Optional.absent(),
+            "testCanonicalId",
+            Optional.absent(),
+            outputFile,
+            eventHandler,
+            Collections.emptyMap(),
+            "testRepo"
+        );
+        fail("Should have thrown");
+      } catch (IOException expected) {
+        assertThat(expected.getSuppressed()).hasLength(2);
+
+        for (Throwable suppressed : expected.getSuppressed()) {
+          assertThat(suppressed).isInstanceOf(IOException.class);
+          assertThat(suppressed).hasCauseThat().isInstanceOf(SocketTimeoutException.class);
+        }
+      }
+    }
+  }
+
+  private byte[] readFile(Path path) throws IOException {
+    final byte[] data = new byte[(int) path.getFileSize()];
+
+    try (DataInputStream stream = new DataInputStream(path.getInputStream())) {
+      stream.readFully(data);
     }
 
+    return data;
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -1,0 +1,86 @@
+package com.google.devtools.build.lib.bazel.repository.downloader;
+
+import static com.google.devtools.build.lib.bazel.repository.downloader.DownloaderTestUtils.sendLines;
+import static com.google.devtools.build.lib.bazel.repository.downloader.HttpParser.readHttpRequest;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.base.Optional;
+import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.vfs.Path;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URL;
+import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class HttpDownloaderTest {
+
+  @Rule
+  public final TemporaryFolder workingDir = new TemporaryFolder();
+
+  private final RepositoryCache repositoryCache = mock(RepositoryCache.class);
+  private final HttpDownloader httpDownloader = new HttpDownloader(repositoryCache);
+
+  private final ExecutorService executor = Executors.newFixedThreadPool(1);
+  private final ExtendedEventHandler eventHandler = mock(ExtendedEventHandler.class);
+
+  @Test
+  public void name() {
+
+  }
+
+  @Test
+  public void downloadFrom1UrlOk() throws IOException, InterruptedException {
+    try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName(null))) {
+      Future<?> possiblyIgnoredError =
+          executor.submit(
+              new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                  try (Socket socket = server.accept()) {
+                    readHttpRequest(socket.getInputStream());
+                    sendLines(
+                        socket,
+                        "HTTP/1.1 200 OK",
+                        "Date: Fri, 31 Dec 1999 23:59:59 GMT",
+                        "Connection: close",
+                        "Content-Type: text/plain",
+                        "Content-Length: 5",
+                        "",
+                        "hello");
+                  }
+                  return null;
+                }
+              });
+
+      Path outputFile = Path.getFileSystemForSerialization()
+          .getPath(workingDir.newFile().getAbsolutePath());
+
+      httpDownloader.download(
+          Collections.singletonList(
+              new URL(String.format("http://localhost:%d/foo", server.getLocalPort()))),
+          Collections.emptyMap(),
+          Optional.absent(),
+          "testCanonicalId",
+          Optional.absent(),
+          outputFile,
+          eventHandler,
+          Collections.emptyMap(),
+          "testRepo"
+      );
+    }
+
+  }
+}


### PR DESCRIPTION
Fixes #8974.

`HttpDownloader` never retried `IOException` that could have occurred during `ByteStreams.copy(payload, out)`, HttpConnector would have retried connection phase errors but not payload ones.

This chageset adds fallback to next url(s) if present for both payload read errors and connection errors and adds (completely) missing tests for `HttpDownloader`.

Note, that this PR technically disables questionable `HttpConnectorMultiplexer` optimization that attempts to connect to multiple urls at the same time (by starting threads that race with each other) and picking the one that connected faster. There is a way to keep that optimization while falling back to next urls, but it would require all exceptions to contain url that caused it so that `HttpDownloader` could retry download on other urls. I think making `HttpDownloader` more reliable and actually using provided `urls` as fallback is much more important than mentioned optimization.

