### PR TITLE
Track suppressed exceptions in AbstractRemoteActionCache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -231,9 +231,17 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
         // Wait for all downloads to finish.
         getFromFuture(download);
       } catch (IOException e) {
-        downloadException = downloadException == null ? e : downloadException;
+        if (downloadException == null) {
+          downloadException = e;
+        } else {
+          downloadException.addSuppressed(e);
+        }
       } catch (InterruptedException e) {
-        interruptedException = interruptedException == null ? e : interruptedException;
+        if (interruptedException == null) {
+          interruptedException = e;
+        } else {
+          interruptedException.addSuppressed(e);
+        }
       }
     }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -711,14 +711,11 @@ public class AbstractRemoteActionCacheTests {
             () ->
                 cache.download(
                     result, execRoot, new FileOutErr(stdout, stderr), outputFilesLocker));
+
     assertThat(e.getSuppressed()).hasLength(1);
     assertThat(e.getSuppressed()[0]).isInstanceOf(IOException.class);
     assertThat(e.getSuppressed()[0]).hasMessageThat().isEqualTo("file3 failed");
-    assertThat(cache.getNumSuccessfulDownloads()).isEqualTo(1);
-    assertThat(cache.getNumFailedDownloads()).isEqualTo(2);
-    assertThat(cache.getDownloadQueueSize()).isEqualTo(3);
     assertThat(Throwables.getRootCause(e)).hasMessageThat().isEqualTo("file2 failed");
-    verify(outputFilesLocker, never()).lock();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -623,6 +623,7 @@ public class AbstractRemoteActionCacheTests {
         assertThrows(
             IOException.class,
             () -> cache.download(result.build(), execRoot, null, outputFilesLocker));
+    assertThat(expected.getSuppressed()).isEmpty();
     assertThat(expected).hasMessageThat().contains("dir/link");
     assertThat(expected).hasMessageThat().contains("/foo");
     assertThat(expected).hasMessageThat().contains("absolute path");
@@ -679,10 +680,44 @@ public class AbstractRemoteActionCacheTests {
             () ->
                 cache.download(
                     result, execRoot, new FileOutErr(stdout, stderr), outputFilesLocker));
+    assertThat(e.getSuppressed()).isEmpty();
     assertThat(cache.getNumSuccessfulDownloads()).isEqualTo(2);
     assertThat(cache.getNumFailedDownloads()).isEqualTo(1);
     assertThat(cache.getDownloadQueueSize()).isEqualTo(3);
     assertThat(Throwables.getRootCause(e)).hasMessageThat().isEqualTo("download failed");
+    verify(outputFilesLocker, never()).lock();
+  }
+
+  @Test
+  public void downloadWithMultipleErrorsAddsThemAsSuppressed() throws Exception {
+    Path stdout = fs.getPath("/execroot/stdout");
+    Path stderr = fs.getPath("/execroot/stderr");
+
+    DefaultRemoteActionCache cache = newTestCache();
+    Digest digest1 = cache.addContents("file1");
+    Digest digest2 = cache.addException("file2", new IOException("file2 failed"));
+    Digest digest3 = cache.addException("file3", new IOException("file3 failed"));
+
+    ActionResult result =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            .addOutputFiles(OutputFile.newBuilder().setPath("file1").setDigest(digest1))
+            .addOutputFiles(OutputFile.newBuilder().setPath("file2").setDigest(digest2))
+            .addOutputFiles(OutputFile.newBuilder().setPath("file3").setDigest(digest3))
+            .build();
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () ->
+                cache.download(
+                    result, execRoot, new FileOutErr(stdout, stderr), outputFilesLocker));
+    assertThat(e.getSuppressed()).hasLength(1);
+    assertThat(e.getSuppressed()[0]).isInstanceOf(IOException.class);
+    assertThat(e.getSuppressed()[0]).hasMessageThat().isEqualTo("file3 failed");
+    assertThat(cache.getNumSuccessfulDownloads()).isEqualTo(1);
+    assertThat(cache.getNumFailedDownloads()).isEqualTo(2);
+    assertThat(cache.getDownloadQueueSize()).isEqualTo(3);
+    assertThat(Throwables.getRootCause(e)).hasMessageThat().isEqualTo("file2 failed");
     verify(outputFilesLocker, never()).lock();
   }
 


### PR DESCRIPTION
Adds tracking of suppressed exceptions in `AbstractRemoteActionCache` similarly to how Bazel tracks them in other places, like `HttpConnector` https://github.com/bazelbuild/bazel/blob/a9cdc3dd2355d1de382e40f7b4692e345ab310d0/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java#L222