### PR TITLE
Add load() statements for Python rules in third_party

### DIFF
--- a/third_party/def_parser/BUILD
+++ b/third_party/def_parser/BUILD
@@ -1,3 +1,7 @@
+# Needed for #9006. Consider replacing label with @rules_python as per #9029 if
+# merging from upstream becomes an issue.
+load("//tools/python:private/defs.bzl", "py_test")
+
 licenses(["notice"])  # 3-clause BSD
 
 package(

--- a/third_party/protobuf/3.6.1/BUILD
+++ b/third_party/protobuf/3.6.1/BUILD
@@ -21,6 +21,8 @@ config_setting(
 
 load(":protobuf.bzl", "py_proto_library")
 load(":compiler_config_setting.bzl", "create_compiler_config_setting")
+# Needed for #9006. Hopefully a future upstream version will include this line.
+load("@rules_python//python:defs.bzl", "py_library")
 
 filegroup(
     name = "srcs",

--- a/third_party/protobuf/3.6.1/protobuf.bzl
+++ b/third_party/protobuf/3.6.1/protobuf.bzl
@@ -1,3 +1,6 @@
+# Needed for #9006. Hopefully a future upstream version will include this line.
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
 def _GetPath(ctx, path):
     if ctx.label.workspace_root:
         return ctx.label.workspace_root + "/" + path
@@ -383,7 +386,7 @@ def py_proto_library(
     if default_runtime and not default_runtime in py_libs + deps:
         py_libs = py_libs + [default_runtime]
 
-    native.py_library(
+    py_library(
         name = name,
         srcs = outs + py_extra_srcs,
         deps = py_libs + deps,
@@ -406,7 +409,7 @@ def internal_protobuf_py_tests(
     """
     for m in modules:
         s = "python/google/protobuf/internal/%s.py" % m
-        native.py_test(
+        py_test(
             name = "py_%s" % m,
             srcs = [s],
             main = s,

--- a/third_party/protobuf/3.6.1/six.BUILD
+++ b/third_party/protobuf/3.6.1/six.BUILD
@@ -1,3 +1,6 @@
+# Needed for #9006. Hopefully a future upstream version will include this line.
+load("@rules_python//python:defs.bzl", "py_library")
+
 genrule(
   name = "copy_six",
   srcs = ["six-1.10.0/six.py"],

--- a/third_party/protobuf/README.md
+++ b/third_party/protobuf/README.md
@@ -43,6 +43,11 @@ You will create and merge the following Pull Requests.
     copy the `licenses` declaration and the `srcs` filegroup to the corresponding file under
     `third_party/protobuf/<new_proto>`.
 
+1.  Modify the new protobuf to be compatible with #9006 (until upstream protobuf migrates):
+    In the `BUILD`, `protobuf.bzl`, and `six.BUILD` files under `third_party/protobuf/<new_proto>`,
+    copy the line that loads from `@rules_python` along with its explanatory comment, from the
+    corresponding files in the old proto directory. (See also #9019.)
+
 1.  In `third_party/protobuf/<new_proto>/BUILD`, in the `srcs` filegroup rule, update the version
     number referring to the newly added `srcs` rules.
 

--- a/third_party/py/abseil/BUILD
+++ b/third_party/py/abseil/BUILD
@@ -1,3 +1,7 @@
+# Needed for #9006. Consider replacing label with @rules_python as per #9029 if
+# merging from upstream becomes an issue.
+load("//tools/python:private/defs.bzl", "py_library")
+
 licenses(["notice"])
 
 filegroup(

--- a/third_party/py/concurrent/BUILD
+++ b/third_party/py/concurrent/BUILD
@@ -1,3 +1,7 @@
+# Needed for #9006. Consider replacing label with @rules_python as per #9029 if
+# merging from upstream becomes an issue.
+load("//tools/python:private/defs.bzl", "py_library")
+
 licenses(["notice"])
 
 filegroup(

--- a/third_party/py/gflags/BUILD
+++ b/third_party/py/gflags/BUILD
@@ -1,3 +1,7 @@
+# Needed for #9006. Consider replacing label with @rules_python as per #9029 if
+# merging from upstream becomes an issue.
+load("//tools/python:private/defs.bzl", "py_library")
+
 licenses(["notice"])
 
 filegroup(

--- a/third_party/py/mock/BUILD
+++ b/third_party/py/mock/BUILD
@@ -1,3 +1,7 @@
+# Needed for #9006. Consider replacing label with @rules_python as per #9029 if
+# merging from upstream becomes an issue.
+load("//tools/python:private/defs.bzl", "py_library")
+
 licenses(["notice"])
 
 filegroup(

--- a/third_party/py/six/BUILD
+++ b/third_party/py/six/BUILD
@@ -1,3 +1,8 @@
+# Needed for #9006. We can't easily replace this label with a @rules_python
+# label (#9029) because this file is used in both @io_bazel and @bazel_tools,
+# the latter of which can't reference other repos.
+load("//tools/python:private/defs.bzl", "py_library")
+
 licenses(["notice"])
 
 filegroup(


### PR DESCRIPTION
This PR is necessary to unblock #9006, which blocks the next Bazel release. However, I'm running into some trouble getting the load paths to work. Note that this PR depends on cl/260716838 which is as of this writing in-flight.

The trouble with load paths is that this makes third_party packages load a bzl underneath `//tools`, This works for some third_party packages, but six and protobuf get turned into local external repos by Bazel's own WORKSPACE file, which causes the labels to resolve relative to `@six` and `@com_google_protobuf` respectively.

I can sort of fix this by qualifying the label with `@io_bazel`, except that this breaks six's use inside of `@bazel_tools`, which cannot access `@io_bazel`.

So my ideas are

- Add some kind of repository renaming to the generation of `@bazel_tools`, to rewrite `@io_bazel` as `@bazel_tools` or the main repo name. This seems ugly and like it will confuse future debugging.

- Use labels that are not qualified by repo name and therefore work both within `@io_bazel` and `@bazel_tools`. Add some kind of rewriting step to the repo rules that produce `@six` and `@com_google_protobuf` within Bazel's WORKSPACE.

- Don't add a dependency on the `//tools/...` bzl at all, but instead inline that file into each third_party package that needs it.

Finally, I want to say I've never modified third_party before so I don't know what our practices are regarding hand-crafted changes to vendored sources. I'm happy to tweak things by adding explanatory comments, but this change is somewhat time-sensitive (cut date is supposed to be August 1).