### PR TITLE
update docs to reflect new default "python_version"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPyRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPyRuleClasses.java
@@ -180,7 +180,7 @@ public final class BazelPyRuleClasses {
                           + " to the configuration"))
           /* <!-- #BLAZE_RULE($base_py_binary).ATTRIBUTE(python_version) -->
           Whether to build this target (and its transitive <code>deps</code>) for Python 2 or Python
-          3. Valid values are <code>"PY2"</code> (the default) and <code>"PY3"</code>.
+          3. Valid values are <code>"PY2"</code> and <code>"PY3"</code> (the default).
 
           <p>Under the old semantics
           (<code>--incompatible_allow_python_version_transitions=false</code>), the Python version


### PR DESCRIPTION
Since [0.25.0](https://github.com/bazelbuild/bazel/blob/master/CHANGELOG.md#release-0250-2019-05-01) (commit: 33e571939085dd158422e1b3503cfc738e0a3165), the default `python_version` for python rules is `"PY3"`, yet the docs still indicate that it is `"PY2"`. This is an update to make it more clear.