### PR TITLE
Refactor SimpleBlobStore#put

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
@@ -92,7 +92,7 @@ public final class SimpleBlobStoreActionCache extends AbstractRemoteActionCache 
     upload(result, actionKey, action, command, execRoot, files, /* uploadAction= */ true);
     if (outErr.getErrorPath().exists()) {
       Digest stdErrDigest = digestUtil.compute(outErr.getErrorPath());
-      uploadFile(stdErrDigest, outErr.getOutputPath());
+      uploadFile(stdErrDigest, outErr.getErrorPath());
       result.setStderrDigest(stdErrDigest);
     }
     if (outErr.getOutputPath().exists()) {

--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
@@ -21,6 +21,7 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.DirectoryNode;
 import build.bazel.remote.execution.v2.FileNode;
+import com.google.common.base.Throwables;
 import com.google.common.hash.HashingOutputStream;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -38,14 +39,13 @@ import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 
 /**
@@ -57,17 +57,12 @@ import javax.annotation.Nullable;
  */
 @ThreadSafe
 public final class SimpleBlobStoreActionCache extends AbstractRemoteActionCache {
-  private static final int MAX_BLOB_SIZE_FOR_INLINE = 10 * 1024;
-
   private final SimpleBlobStore blobStore;
-
-  private final ConcurrentHashMap<String, Boolean> storedBlobs;
 
   public SimpleBlobStoreActionCache(
       RemoteOptions options, SimpleBlobStore blobStore, DigestUtil digestUtil) {
     super(options, digestUtil);
     this.blobStore = blobStore;
-    this.storedBlobs = new ConcurrentHashMap<>();
   }
 
   public void downloadTree(Digest rootDigest, Path rootLocation)
@@ -84,13 +79,6 @@ public final class SimpleBlobStoreActionCache extends AbstractRemoteActionCache 
     }
   }
 
-  private Digest uploadFileContents(Path file) throws IOException, InterruptedException {
-    Digest digest = digestUtil.compute(file);
-    try (InputStream in = file.getInputStream()) {
-      return uploadStream(digest, in);
-    }
-  }
-
   @Override
   public void upload(
       DigestUtil.ActionKey actionKey,
@@ -103,12 +91,14 @@ public final class SimpleBlobStoreActionCache extends AbstractRemoteActionCache 
     ActionResult.Builder result = ActionResult.newBuilder();
     upload(result, actionKey, action, command, execRoot, files, /* uploadAction= */ true);
     if (outErr.getErrorPath().exists()) {
-      Digest stderr = uploadFileContents(outErr.getErrorPath());
-      result.setStderrDigest(stderr);
+      Digest stdErrDigest = digestUtil.compute(outErr.getErrorPath());
+      uploadFile(stdErrDigest, outErr.getOutputPath());
+      result.setStderrDigest(stdErrDigest);
     }
     if (outErr.getOutputPath().exists()) {
-      Digest stdout = uploadFileContents(outErr.getOutputPath());
-      result.setStdoutDigest(stdout);
+      Digest stdoutDigest = digestUtil.compute(outErr.getOutputPath());
+      uploadFile(stdoutDigest, outErr.getOutputPath());
+      result.setStdoutDigest(stdoutDigest);
     }
     blobStore.putActionResult(actionKey.getDigest().getHash(), result.build().toByteArray());
   }
@@ -135,54 +125,30 @@ public final class SimpleBlobStoreActionCache extends AbstractRemoteActionCache 
     }
 
     for (Map.Entry<Digest, Path> entry : manifest.getDigestToFile().entrySet()) {
-      try (InputStream in = entry.getValue().getInputStream()) {
-        uploadStream(entry.getKey(), in);
-      }
+      uploadFile(entry.getKey(), entry.getValue());
     }
 
     for (Map.Entry<Digest, Chunker> entry : manifest.getDigestToChunkers().entrySet()) {
-      uploadBlob(entry.getValue().next().getData().toByteArray(), entry.getKey());
+      uploadBlob(entry.getKey(), entry.getValue().next().getData());
     }
   }
 
-  public void uploadOutErr(ActionResult.Builder result, byte[] stdout, byte[] stderr)
-      throws IOException, InterruptedException {
-    if (stdout.length <= MAX_BLOB_SIZE_FOR_INLINE) {
-      result.setStdoutRaw(ByteString.copyFrom(stdout));
-    } else if (stdout.length > 0) {
-      result.setStdoutDigest(uploadBlob(stdout));
-    }
-    if (stderr.length <= MAX_BLOB_SIZE_FOR_INLINE) {
-      result.setStderrRaw(ByteString.copyFrom(stderr));
-    } else if (stderr.length > 0) {
-      result.setStderrDigest(uploadBlob(stderr));
+  public void uploadFile(Digest digest, Path file) throws IOException, InterruptedException {
+    try {
+      blobStore.uploadFile(digest, file).get();
+    } catch (ExecutionException e) {
+      Throwables.propagateIfPossible(e.getCause(), IOException.class, InterruptedException.class);
+      throw new IOException(String.format("Uploading of file '%s' failed: %s", file.getPathString(), e.getCause()));
     }
   }
 
-  public Digest uploadBlob(byte[] blob) throws IOException, InterruptedException {
-    return uploadBlob(blob, digestUtil.compute(blob));
-  }
-
-  private Digest uploadBlob(byte[] blob, Digest digest) throws IOException, InterruptedException {
-    try (InputStream in = new ByteArrayInputStream(blob)) {
-      return uploadStream(digest, in);
+  public void uploadBlob(Digest digest, ByteString data) throws IOException, InterruptedException {
+    try {
+      blobStore.uploadBlob(digest, data).get();
+    } catch (ExecutionException e) {
+      Throwables.propagateIfPossible(e.getCause(), IOException.class, InterruptedException.class);
+      throw new IOException(String.format("Uploading of blob with digest '%s' failed: %s", digest, e.getCause()));
     }
-  }
-
-  public Digest uploadStream(Digest digest, InputStream in)
-      throws IOException, InterruptedException {
-    final String hash = digest.getHash();
-
-    if (storedBlobs.putIfAbsent(hash, true) == null) {
-      try {
-        blobStore.put(hash, digest.getSizeBytes(), in);
-      } catch (Exception e) {
-        storedBlobs.remove(hash);
-        throw e;
-      }
-    }
-
-    return digest;
   }
 
   public boolean containsKey(Digest digest) throws IOException, InterruptedException {
@@ -256,5 +222,9 @@ public final class SimpleBlobStoreActionCache extends AbstractRemoteActionCache 
         },
         MoreExecutors.directExecutor());
     return outerF;
+  }
+
+  public DigestUtil getDigestUtil() {
+    return digestUtil;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/BUILD
@@ -16,5 +16,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:guava",
+        "//third_party/protobuf:protobuf_java",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/remote/common/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BUILD
@@ -12,5 +12,8 @@ java_library(
     tags = ["bazel"],
     deps = [
         "//third_party:guava",
+        "//third_party/protobuf:protobuf_java",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/remote/common/SimpleBlobStore.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/SimpleBlobStore.java
@@ -14,9 +14,11 @@
 
 package com.google.devtools.build.lib.remote.common;
 
+import build.bazel.remote.execution.v2.Digest;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.protobuf.ByteString;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
@@ -50,16 +52,25 @@ public interface SimpleBlobStore {
    */
   ListenableFuture<Boolean> getActionResult(String actionKey, OutputStream out);
 
-  /**
-   * Uploads a BLOB (as {@code in}) with length {@code length} indexed by {@code key} to the CAS.
-   *
-   * <p>The caller is responsible to close {@code in}.
-   */
-  void put(String key, long length, InputStream in) throws IOException, InterruptedException;
-
   /** Uploads a bytearray BLOB (as {@code in}) indexed by {@code key} to the Action Cache. */
   void putActionResult(String actionKey, byte[] in) throws IOException, InterruptedException;
 
   /** Close resources associated with the blob store. */
   void close();
+
+  /**
+   * Uploads a file.
+   *
+   * @param digest the digest of the file.
+   * @param file the file to upload.
+   */
+  ListenableFuture<Void> uploadFile(Digest digest, Path file);
+
+  /**
+   * Uploads a BLOB.
+   *
+   * @param digest the digest of the blob.
+   * @param data the blob to upload.
+   */
+  ListenableFuture<Void> uploadBlob(Digest digest, ByteString data);
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
@@ -16,5 +16,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:guava",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+        "//third_party/protobuf:protobuf_java",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/OnDiskBlobStore.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/OnDiskBlobStore.java
@@ -13,11 +13,14 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.disk;
 
+import build.bazel.remote.execution.v2.Digest;
 import com.google.common.io.ByteStreams;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.remote.common.SimpleBlobStore;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.protobuf.ByteString;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -66,8 +69,42 @@ public class OnDiskBlobStore implements SimpleBlobStore {
   }
 
   @Override
-  public void put(String key, long length, InputStream in)
-      throws IOException, InterruptedException {
+  public void putActionResult(String key, byte[] in) throws IOException {
+    saveFile(getDiskKey(key, /* actionResult= */ true), new ByteArrayInputStream(in));
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public ListenableFuture<Void> uploadFile(Digest digest, Path file) {
+    try (InputStream in = file.getInputStream()) {
+      saveFile(digest.getHash(), in);
+    } catch (IOException e) {
+      return Futures.immediateFailedFuture(e);
+    }
+    return Futures.immediateFuture(null);
+  }
+
+  @Override
+  public ListenableFuture<Void> uploadBlob(Digest digest, ByteString data) {
+    try (InputStream in = data.newInput()) {
+      saveFile(digest.getHash(), in);
+    } catch (IOException e) {
+      return Futures.immediateFailedFuture(e);
+    }
+    return Futures.immediateFuture(null);
+  }
+
+  protected Path toPath(String key, boolean actionResult) {
+    return root.getChild(getDiskKey(key, actionResult));
+  }
+
+  private String getDiskKey(String key, boolean actionResult) {
+    return actionResult ? OnDiskBlobStore.ACTION_KEY_PREFIX + key : key;
+  }
+
+  private void saveFile(String key, InputStream in) throws IOException {
     Path target = toPath(key, /* actionResult= */ false);
     if (target.exists()) {
       return;
@@ -81,21 +118,5 @@ public class OnDiskBlobStore implements SimpleBlobStore {
     // TODO(ulfjack): Fsync temp here before we rename it to avoid data loss in the case of machine
     // crashes (the OS may reorder the writes and the rename).
     temp.renameTo(target);
-  }
-
-  @Override
-  public void putActionResult(String key, byte[] in) throws IOException, InterruptedException {
-    put(getDiskKey(key, /* actionResult= */ true), in.length, new ByteArrayInputStream(in));
-  }
-
-  @Override
-  public void close() {}
-
-  protected Path toPath(String key, boolean actionResult) {
-    return root.getChild(getDiskKey(key, actionResult));
-  }
-
-  private String getDiskKey(String key, boolean actionResult) {
-    return actionResult ? OnDiskBlobStore.ACTION_KEY_PREFIX + key : key;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/http/AbstractHttpHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/AbstractHttpHandler.java
@@ -103,7 +103,7 @@ abstract class AbstractHttpHandler<T extends HttpObject> extends SimpleChannelIn
     if (!uri.getPath().endsWith("/")) {
       builder.append("/");
     }
-    builder.append(isCas ? "cas/" : "ac/");
+    builder.append(isCas ? HttpBlobStore.CAS_PREFIX : HttpBlobStore.AC_PREFIX);
     builder.append(hash);
     return builder.toString();
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -22,5 +22,8 @@ java_library(
         "//third_party:auth",
         "//third_party:guava",
         "//third_party:netty",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+        "//third_party/protobuf:protobuf_java",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpBlobStore.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpBlobStore.java
@@ -106,6 +106,9 @@ import javax.net.ssl.SSLEngine;
  * <p>The implementation currently does not support transfer encoding chunked.
  */
 public final class HttpBlobStore implements SimpleBlobStore {
+
+  public static final String AC_PREFIX = "ac/";
+  public static final String CAS_PREFIX = "cas/";
   private static final Pattern INVALID_TOKEN_ERROR =
       Pattern.compile("\\s*error\\s*=\\s*\"?invalid_token\"?");
 
@@ -554,7 +557,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
     UploadCommand upload = new UploadCommand(uri, casUpload, key, wrappedIn, length);
     Channel ch = null;
     boolean success = false;
-    if (storedBlobs.putIfAbsent((casUpload ? "cas/" : "ac/") + key, true) == null) {
+    if (storedBlobs.putIfAbsent((casUpload ? CAS_PREFIX : AC_PREFIX) + key, true) == null) {
       try {
         ch = acquireUploadChannel();
         ChannelFuture uploadFuture = ch.writeAndFlush(upload);

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -43,6 +43,9 @@ public class Utils {
     try {
       return f.get();
     } catch (ExecutionException e) {
+      if (e.getCause() instanceof InterruptedException) {
+        throw (InterruptedException) e.getCause();
+      }
       if (e.getCause() instanceof IOException) {
         throw (IOException) e.getCause();
       }

--- a/src/test/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCacheTest.java
@@ -284,39 +284,6 @@ public class SimpleBlobStoreActionCacheTest {
   }
 
   @Test
-  public void testUploadBlob() throws Exception {
-    final Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
-
-    final ConcurrentMap<String, byte[]> map = new ConcurrentHashMap<>();
-    final SimpleBlobStoreActionCache client = newClient(map);
-
-    byte[] bytes = "abcdefg".getBytes(UTF_8);
-    assertThat(client.uploadBlob(bytes)).isEqualTo(digest);
-    assertThat(map.keySet()).containsExactly(digest.getHash());
-    assertThat(map.entrySet()).hasSize(1);
-    assertThat(map.get(digest.getHash())).isEqualTo(bytes);
-  }
-
-  @Test
-  public void testUploadBlobAtMostOnce() throws Exception {
-    final Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
-
-    final ConcurrentMap<String, byte[]> map = new ConcurrentHashMap<>();
-    final SimpleBlobStoreActionCache client = newClient(map);
-
-    byte[] bytes = "abcdefg".getBytes(UTF_8);
-    assertThat(client.uploadBlob(bytes)).isEqualTo(digest);
-    assertThat(map.keySet()).containsExactly(digest.getHash());
-    assertThat(map.entrySet()).hasSize(1);
-    assertThat(map.get(digest.getHash())).isEqualTo(bytes);
-
-    // Blob store does not get upload more than once during a single build.
-    map.remove(digest.getHash());
-    assertThat(client.uploadBlob(bytes)).isEqualTo(digest);
-    assertThat(map.entrySet()).hasSize(0);
-  }
-
-  @Test
   public void testUploadDirectory() throws Exception {
     final Digest fooDigest =
         fakeFileCache.createScratchInput(ActionInputHelper.fromPath("a/foo"), "xyz");

--- a/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -25,5 +25,7 @@ java_test(
         "//third_party:mockito",
         "//third_party:netty",
         "//third_party:truth",
+        "//third_party/protobuf:protobuf_java",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -17,8 +17,10 @@ java_test(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/remote/http",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/test/java/com/google/devtools/build/lib:test_runner",
         "//src/test/java/com/google/devtools/build/lib:testutil",
+        "//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http",
         "//third_party:api_client",
         "//third_party:auth",
         "//third_party:guava",
@@ -26,6 +28,6 @@ java_test(
         "//third_party:netty",
         "//third_party:truth",
         "//third_party/protobuf:protobuf_java",
-        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/tools/remote/BUILD
+++ b/src/tools/remote/BUILD
@@ -2,7 +2,7 @@ filegroup(
     name = "srcs",
     srcs = glob(["**"]) + [
         "//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker:srcs",
-        "//src/tools/remote/src/test/java/com/google/devtools/build/remote/worker:srcs",
+        "//src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/http:srcs",
     ],
     visibility = ["//src:__pkg__"],
 )

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
@@ -1,6 +1,6 @@
 filegroup(
     name = "srcs",
-    srcs = glob(["**"]),
+    srcs = glob(["**"]) + ["//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http:srcs"],
     visibility = ["//src/tools/remote:__pkg__"],
 )
 
@@ -29,6 +29,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/shell",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/common/options",
+        "//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http",
         "//third_party:guava",
         "//third_party:netty",
         "//third_party/grpc:grpc-jar",

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ByteStreamServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ByteStreamServer.java
@@ -232,9 +232,7 @@ final class ByteStreamServer extends ByteStreamImplBase {
 
         try {
           Digest d = digestUtil.compute(temp);
-          try (InputStream in = temp.getInputStream()) {
-            cache.uploadStream(d, in);
-          }
+          cache.uploadFile(d, temp);
           try {
             temp.delete();
           } catch (IOException e) {

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CasServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CasServer.java
@@ -65,7 +65,8 @@ final class CasServer extends ContentAddressableStorageImplBase {
     for (BatchUpdateBlobsRequest.Request r : request.getRequestsList()) {
       BatchUpdateBlobsResponse.Response.Builder resp = batchResponse.addResponsesBuilder();
       try {
-        Digest digest = cache.uploadBlob(r.getData().toByteArray());
+        Digest digest = cache.getDigestUtil().compute(r.getData().toByteArray());
+        cache.uploadBlob(digest, r.getData());
         if (!r.getDigest().equals(digest)) {
           String err =
               "Upload digest " + r.getDigest() + " did not match data digest: " + digest;

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -51,6 +51,7 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.util.Durations;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
@@ -340,8 +341,17 @@ final class ExecutionServer extends ExecutionImplBase {
       }
     }
     byte[] stdout = cmdResult.getStdout();
+    if (stdout.length > 0) {
+      Digest stdoutDigest = digestUtil.compute(stdout);
+      cache.uploadBlob(stdoutDigest, ByteString.copyFrom(stdout));
+      result.setStdoutDigest(stdoutDigest);
+    }
     byte[] stderr = cmdResult.getStderr();
-    cache.uploadOutErr(result, stdout, stderr);
+    if (stderr.length > 0) {
+      Digest stderrDigest = digestUtil.compute(stderr);
+      result.setStderrDigest(stderrDigest);
+    }
+
     ActionResult finalResult = result.setExitCode(exitCode).build();
     resp.setResult(finalResult);
     if (errStatus != null) {

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
@@ -51,6 +51,7 @@ import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.JavaIoFileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.devtools.build.remote.worker.http.HttpCacheServerInitializer;
 import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingException;
 import io.grpc.Server;

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/BUILD
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/BUILD
@@ -1,0 +1,18 @@
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker:__pkg__"],
+)
+
+java_library(
+    name = "http",
+    srcs = glob(["*.java"]),
+    visibility = [
+        "//src/test/java/com/google/devtools/build/lib/remote/http:__pkg__",
+        "//src/tools/remote:__subpackages__",
+    ],
+    deps = [
+        "//third_party:guava",
+        "//third_party:netty",
+    ],
+)

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/HttpCacheServerHandler.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/HttpCacheServerHandler.java
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.devtools.build.remote.worker;
+package com.google.devtools.build.remote.worker.http;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
@@ -40,8 +41,18 @@ import java.util.regex.Pattern;
 @Sharable
 public class HttpCacheServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
 
-  final ConcurrentMap<String, byte[]> cache = new ConcurrentHashMap<>();
   private static final Pattern URI_PATTERN = Pattern.compile("^/?(.*/)?(ac/|cas/)([a-f0-9]{64})$");
+
+  private final ConcurrentMap<String, byte[]> cache;
+
+  @VisibleForTesting
+  public HttpCacheServerHandler(ConcurrentMap<String, byte[]> cache) {
+    this.cache = Preconditions.checkNotNull(cache);
+  }
+
+  HttpCacheServerHandler() {
+    this(new ConcurrentHashMap<>());
+  }
 
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/HttpCacheServerInitializer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/HttpCacheServerInitializer.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.devtools.build.remote.worker;
+package com.google.devtools.build.remote.worker.http;
 
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;

--- a/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/http/BUILD
+++ b/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/http/BUILD
@@ -11,11 +11,12 @@ filegroup(
 )
 
 java_test(
-    name = "worker",
+    name = "http",
     srcs = glob(["*.java"]),
-    test_class = "com.google.devtools.build.remote.worker.HttpCacheServerHandlerTest",
+    test_class = "com.google.devtools.build.remote.worker.http.HttpCacheServerHandlerTest",
     deps = [
         "//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker",
+        "//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http",
         "//third_party:junit4",
         "//third_party:truth",
     ],

--- a/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/http/HttpCacheServerHandlerTest.java
+++ b/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/http/HttpCacheServerHandlerTest.java
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.devtools.build.remote.worker;
+package com.google.devtools.build.remote.worker.http;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.devtools.build.remote.worker.http.HttpCacheServerHandler;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;


### PR DESCRIPTION
Split it into `SimpleBlobStore#uploadFile` and `SimpleBlobStore#uploadBlob`.
The return type changes to `ListenableFuture<Void>` but all
implementations are still blocking for now.

This is a refactoring towards the larger goal of removing `SimpleBlobStoreActionCache`
and making GrpcRemoteCache a SimpleBlobStore implementation.