### PR TITLE
Introduce flag to conditionally disable BES artifact upload

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEvent.java
@@ -53,10 +53,18 @@ public interface BuildEvent extends ChainableEvent, ExtendedEventHandler.Postabl
 
     public final Path path;
     public final LocalFileType type;
+    public final boolean shouldUploadArtifacts; /** whether the local file should be uploaded to the BEP */
 
     public LocalFile(Path path, LocalFileType type) {
       this.path = Preconditions.checkNotNull(path);
       this.type = Preconditions.checkNotNull(type);
+      this.shouldUploadArtifacts = true;
+    }
+
+    public LocalFile(Path path, LocalFileType type, boolean shouldUploadArtifacts) {
+      this.path = Preconditions.checkNotNull(path);
+      this.type = Preconditions.checkNotNull(type);
+      this.shouldUploadArtifacts = shouldUploadArtifacts;
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventProtocolOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventProtocolOptions.java
@@ -48,4 +48,14 @@ public class BuildEventProtocolOptions extends OptionsBase {
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help = "If true, expand Filesets in the BEP when presenting output files.")
   public boolean expandFilesets;
+
+
+  @Option(
+          name = "bep_disable_artifact_upload",
+          defaultValue = "false",
+          documentationCategory = OptionDocumentationCategory.REMOTE,
+          effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+          help = "Entirely disables the upload of artifacts from the BES")
+  public boolean bepDisableArtifactUpload;
+
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -87,7 +87,7 @@ import javax.annotation.Nullable;
 
 /** A cache for storing artifacts (input and output) as well as the output of running an action. */
 @ThreadSafety.ThreadSafe
-public abstract class AbstractRemoteActionCache implements AutoCloseable {
+public abstract class AbstractRemoteActionCache implements AutoCloseable, CasDigestLookup  {
 
   /** See {@link SpawnExecutionContext#lockOutputFiles()}. */
   @FunctionalInterface
@@ -147,7 +147,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
    */
   protected abstract ListenableFuture<Void> uploadBlob(Digest digest, ByteString data);
 
-  protected abstract ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests)
+  public abstract ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests)
       throws IOException, InterruptedException;
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
@@ -91,7 +91,7 @@ class ByteStreamBuildEventArtifactUploader implements BuildEventArtifactUploader
                 }
                 DigestUtil digestUtil = new DigestUtil(file.getFileSystem().getDigestFunction());
                 Digest digest = digestUtil.compute(file);
-                if (isRemoteFile(file)) {
+                if (isRemoteFile(file) || !files.get(file).shouldUploadArtifacts) {
                   return Futures.immediateFuture(new PathDigestPair(file, digest));
                 }
                 Chunker chunker = Chunker.builder().setInput(digest.getSizeBytes(), file).build();

--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
@@ -26,15 +26,21 @@ import com.google.devtools.build.lib.buildeventstream.BuildEvent.LocalFile;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
 import com.google.devtools.build.lib.buildeventstream.PathConverter;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.Path;
 import io.grpc.Context;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Collection;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -48,20 +54,25 @@ class ByteStreamBuildEventArtifactUploader implements BuildEventArtifactUploader
   private final String remoteServerInstanceName;
 
   private final AtomicBoolean shutdown = new AtomicBoolean();
+  private final String remoteInstanceName;
+  private final CasDigestLookup digestLookup;
 
   ByteStreamBuildEventArtifactUploader(
       ByteStreamUploader uploader,
       String remoteServerName,
       Context ctx,
       @Nullable String remoteInstanceName,
-      int maxUploadThreads) {
+      int maxUploadThreads,
+      CasDigestLookup digestLookup) {
     this.uploader = Preconditions.checkNotNull(uploader);
     String remoteServerInstanceName = Preconditions.checkNotNull(remoteServerName);
-    if (!Strings.isNullOrEmpty(remoteInstanceName)) {
-      remoteServerInstanceName += "/" + remoteInstanceName;
+    this.remoteInstanceName = remoteInstanceName;
+    if (!Strings.isNullOrEmpty(this.remoteInstanceName)) {
+      remoteServerInstanceName += "/" + this.remoteInstanceName;
     }
     this.ctx = ctx;
     this.remoteServerInstanceName = remoteServerInstanceName;
+    this.digestLookup = digestLookup;
     // Limit the maximum threads number to 1000 (chosen arbitrarily)
     this.uploadExecutor =
         MoreExecutors.listeningDecorator(
@@ -78,42 +89,109 @@ class ByteStreamBuildEventArtifactUploader implements BuildEventArtifactUploader
     if (files.isEmpty()) {
       return Futures.immediateFuture(PathConverter.NO_CONVERSION);
     }
-    List<ListenableFuture<PathDigestPair>> uploads = new ArrayList<>(files.size());
 
-      for (Path file : files.keySet()) {
-      ListenableFuture<Boolean> isDirectoryFuture = uploadExecutor.submit(() -> file.isDirectory());
-      ListenableFuture<PathDigestPair> digestFuture =
-          Futures.transformAsync(
-              isDirectoryFuture,
-              isDirectory -> {
-                if (isDirectory) {
-                  return Futures.immediateFuture(new PathDigestPair(file, null));
-                }
+    // create futures for non-uploads:
+    //  - directories should not be uploaded to CAS, and have no path
+    //  - remote files should not be uploaded to CAS, but have a path
+    List<ListenableFuture<Pair<Path, PathDigestPair>>> futures = files.keySet().stream()
+        .map(file -> Futures.transformAsync(
+            uploadExecutor.submit(() -> file.isDirectory()),
+            isDirectory -> {
+              Pair<Path, PathDigestPair> pair;
+              if (isDirectory) {
+                pair = new Pair<>(file, new PathDigestPair(file, null));
+              } else if (isRemoteFile(file) || !files.get(file).shouldUploadArtifacts) {
                 DigestUtil digestUtil = new DigestUtil(file.getFileSystem().getDigestFunction());
-                Digest digest = digestUtil.compute(file);
-                if (isRemoteFile(file) || !files.get(file).shouldUploadArtifacts) {
-                  return Futures.immediateFuture(new PathDigestPair(file, digest));
-                }
-                Chunker chunker = Chunker.builder().setInput(digest.getSizeBytes(), file).build();
-                final ListenableFuture<Void> upload;
-                Context prevCtx = ctx.attach();
-                try {
-                  upload =
-                      uploader.uploadBlobAsync(
-                          HashCode.fromString(digest.getHash()), chunker, /* forceUpload=*/ false);
-                } finally {
-                  ctx.detach(prevCtx);
-                }
-                return Futures.transform(
-                    upload, unused -> new PathDigestPair(file, digest), uploadExecutor);
-              },
-              MoreExecutors.directExecutor());
-      uploads.add(digestFuture);
-      }
+                pair = new Pair<>(file, new PathDigestPair(file, digestUtil.compute(file)));
+              } else {
+                pair = new Pair<>(file, null); // we potentially need to upload this
+              }
+              return Futures.immediateFuture(pair);
+            },
+            MoreExecutors.directExecutor()
+        ))
+        .collect(Collectors.toList());
+
+    // perform missing blob check and upload missing items
+    ListenableFuture<List<PathDigestPair>> pathDigestPairFuture = Futures.transformAsync(
+        Futures.allAsList(futures),
+        this::uploadMissingFiles,
+        MoreExecutors.directExecutor()
+    );
+
     return Futures.transform(
-        Futures.allAsList(uploads),
+        pathDigestPairFuture,
         pathDigestPairs -> new PathConverterImpl(remoteServerInstanceName, pathDigestPairs),
         MoreExecutors.directExecutor());
+  }
+
+  private ListenableFuture<List<PathDigestPair>> uploadMissingFiles(List<Pair<Path, PathDigestPair>> pairs)
+      throws IOException, InterruptedException {
+    List<ListenableFuture<PathDigestPair>> pathDigestFutures = new ArrayList<>(pairs.size());
+    Map<Digest, List<Path>> toUpload = new HashMap<>();
+
+    // mark all entries without a PathDigestPair for upload
+    for (Pair<Path, PathDigestPair> pathPair : pairs) {
+      Path path = pathPair.first;
+      if (pathPair.second == null) {
+        DigestUtil digestUtil = new DigestUtil(path.getFileSystem().getDigestFunction());
+        Digest digest = digestUtil.compute(path);
+        if (!toUpload.containsKey(digest)) {
+          toUpload.put(digest, new LinkedList<>());
+        }
+        toUpload.get(digest).add(path);
+      } else {
+        pathDigestFutures.add(Futures.immediateFuture(pathPair.second));
+      }
+    }
+
+    Context prevContext = ctx.attach();
+    ImmutableSet<Digest> missingDigests = digestLookup.getMissingDigests(toUpload.keySet());
+    ctx.detach(prevContext);
+
+    // new hashset because removeAll mutates the map
+    Set<Digest> cachedDigests = new HashSet<>(toUpload.keySet());
+    cachedDigests.removeAll(missingDigests);
+
+    List<ListenableFuture<PathDigestPair>> cachedPairFutures = new ArrayList<>();
+
+    // if not on the CAS, add the result of the upload
+    for (Digest digest : missingDigests) {
+      for (Path path : toUpload.get(digest)) {
+        cachedPairFutures.add(uploadFile(path, digest));
+      }
+    }
+
+    // otherwise, if cached, just add the file
+    for (Digest digest : cachedDigests) {
+      for (Path path : toUpload.get(digest)) {
+        cachedPairFutures.add(Futures.immediateFuture(new PathDigestPair(path, digest)));
+      }
+    }
+
+    return Futures.transform(
+        Futures.allAsList(
+            Futures.allAsList(pathDigestFutures), Futures.allAsList(cachedPairFutures)),
+        futureLists -> futureLists.stream()
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList()),
+        MoreExecutors.directExecutor()
+    );
+  }
+
+  private ListenableFuture<PathDigestPair> uploadFile(Path file, Digest digest) {
+    Chunker chunker = Chunker.builder().setInput(digest.getSizeBytes(), file).build();
+    final ListenableFuture<Void> upload;
+    Context prevCtx = ctx.attach();
+    try {
+      upload =
+          uploader.uploadBlobAsync(
+              HashCode.fromString(digest.getHash()), chunker, /* forceUpload=*/ false);
+    } finally {
+      ctx.detach(prevCtx);
+    }
+
+    return Futures.transform(upload, unused -> new PathDigestPair(file, digest), uploadExecutor);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderFactory.java
@@ -30,14 +30,16 @@ class ByteStreamBuildEventArtifactUploaderFactory implements
   private final String remoteServerName;
   private final Context ctx;
   @Nullable private final String remoteInstanceName;
+  private final CasDigestLookup digestLookup;
 
   ByteStreamBuildEventArtifactUploaderFactory(
       ByteStreamUploader uploader, String remoteServerName, Context ctx,
-      @Nullable String remoteInstanceName) {
+      @Nullable String remoteInstanceName, CasDigestLookup digestLookup) {
     this.uploader = uploader;
     this.remoteServerName = remoteServerName;
     this.ctx = ctx;
     this.remoteInstanceName = remoteInstanceName;
+    this.digestLookup = digestLookup;
   }
 
   @Override
@@ -47,6 +49,7 @@ class ByteStreamBuildEventArtifactUploaderFactory implements
         remoteServerName,
         ctx,
         remoteInstanceName,
-        env.getOptions().getOptions(RemoteOptions.class).buildEventUploadMaxThreads);
+        env.getOptions().getOptions(RemoteOptions.class).buildEventUploadMaxThreads,
+        digestLookup);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/CasDigestLookup.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/CasDigestLookup.java
@@ -1,0 +1,11 @@
+package com.google.devtools.build.lib.remote;
+
+import build.bazel.remote.execution.v2.Digest;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+
+/** A simple interface for lookup of CAS digests. */
+public interface CasDigestLookup {
+  ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests)
+      throws IOException, InterruptedException;
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -267,7 +267,8 @@ public final class RemoteModule extends BlazeModule {
                 uploader,
                 cacheChannel.authority(),
                 requestContext,
-                remoteOptions.remoteInstanceName));
+                remoteOptions.remoteInstanceName,
+                cache));
       }
 
       if (enableBlobStoreCache) {

--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
@@ -82,7 +82,7 @@ public class SimpleBlobStoreActionCache extends AbstractRemoteActionCache {
   }
 
   @Override
-  protected ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests) {
+  public ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests) {
     return ImmutableSet.copyOf(digests);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -1168,7 +1168,7 @@ public class AbstractRemoteActionCacheTests {
     }
 
     @Override
-    protected ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests) {
+    public ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests) {
       throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -244,7 +244,7 @@ public class RemoteActionInputFetcherTest {
     }
 
     @Override
-    protected ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests) {
+    public ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests) {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Issue #8673 describes a pain point with the BES when dealing with large output artifacts from RE. This patch introduces a flag to the bazel CLI that conditionally disables BES upload for targets marked with `no-remote` or `no-cache` (even without builds without the bytes).

When the flag `--bep_disable_artifact_upload` is provided, the BES artifact uploader will respect the tags when determining which outputs should be sent to the BES, and ignore files referenced by any events if the target that triggered that event is tagged with either of the aforementioned tags.

This significantly reduces build times in some cases, but is contingent on being able to mark all the offending targets as no-cache or no-remote. I understand that this may not be ideal for all use cases. Some potential solutions:

1) make the flag enable or disable the functionality for _all_ targets, not just those with specific tags (this is the functionality present in the first commit in this patchset)
2) make the tags that enable this functionality configurable
3) introduce a new tag that controls this functionality

Criticisms or opinions welcome.