### PR TITLE
Refactor GrpcRemoteCache to use uploadFile and uploadBlob.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -134,6 +134,28 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
       throws ExecException, IOException, InterruptedException;
 
   /**
+   * Uploads a file
+   *
+   * <p>Any errors are being propagated via the returned future. If the future completes without
+   * errors the upload was successful.
+   *
+   * @param digest the digest of the file.
+   * @param file the file to upload.
+   */
+  protected abstract ListenableFuture<Void> uploadFile(Digest digest, Path file);
+
+  /**
+   * Uploads a BLOB.
+   *
+   * <p>Any errors are being propagated via the returned future. If the future completes without
+   * errors the upload was successful
+   *
+   * @param digest the digest of the blob.
+   * @param data the blob to upload.
+   */
+  protected abstract ListenableFuture<Void> uploadBlob(Digest digest, ByteString data);
+
+  /**
    * Downloads a blob with a content hash {@code digest} to {@code out}.
    *
    * @return a future that completes after the download completes (succeeds / fails).
@@ -641,7 +663,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
     private final boolean allowSymlinks;
     private final boolean uploadSymlinks;
     private final Map<Digest, Path> digestToFile = new HashMap<>();
-    private final Map<Digest, Chunker> digestToChunkers = new HashMap<>();
+    private final Map<Digest, ByteString> digestToBlobs = new HashMap<>();
     private Digest stderrDigest;
     private Digest stdoutDigest;
 
@@ -731,16 +753,11 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
      * Adds an action and command protos to upload. They need to be uploaded as part of the action
      * result.
      */
-    public void addAction(DigestUtil.ActionKey actionKey, Action action, Command command)
-        throws IOException {
-      byte[] actionBlob = action.toByteArray();
-      digestToChunkers.put(
-          actionKey.getDigest(),
-          Chunker.builder().setInput(actionBlob).setChunkSize(actionBlob.length).build());
-      byte[] commandBlob = command.toByteArray();
-      digestToChunkers.put(
-          action.getCommandDigest(),
-          Chunker.builder().setInput(commandBlob).setChunkSize(commandBlob.length).build());
+    public void addAction(DigestUtil.ActionKey actionKey, Action action, Command command) {
+      ByteString actionBlob = action.toByteString();
+      digestToBlobs.put(actionKey.getDigest(), actionBlob);
+      ByteString commandBlob = command.toByteString();
+      digestToBlobs.put(action.getCommandDigest(), commandBlob);
     }
 
     /** Map of digests to file paths to upload. */
@@ -751,10 +768,10 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
     /**
      * Map of digests to chunkers to upload. When the file is a regular, non-directory file it is
      * transmitted through {@link #getDigestToFile()}. When it is a directory, it is transmitted as
-     * a {@link Tree} protobuf message through {@link #getDigestToChunkers()}.
+     * a {@link Tree} protobuf message through {@link #getDigestToBlobs()}.
      */
-    public Map<Digest, Chunker> getDigestToChunkers() {
-      return digestToChunkers;
+    public Map<Digest, ByteString> getDigestToBlobs() {
+      return digestToBlobs;
     }
 
     @Nullable
@@ -796,9 +813,8 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
       Directory root = computeDirectory(dir, tree);
       tree.setRoot(root);
 
-      byte[] blob = tree.build().toByteArray();
-      Digest digest = digestUtil.compute(blob);
-      Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(blob.length).build();
+      ByteString data = tree.build().toByteString();
+      Digest digest = digestUtil.compute(data.toByteArray());
 
       if (result != null) {
         result
@@ -807,7 +823,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
             .setTreeDigest(digest);
       }
 
-      digestToChunkers.put(digest, chunker);
+      digestToBlobs.put(digest, data);
     }
 
     private Directory computeDirectory(Path path, Tree.Builder tree)

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
@@ -38,6 +38,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
@@ -401,6 +402,18 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
     }
   }
 
+  @Override
+  protected ListenableFuture<Void> uploadFile(Digest digest, Path path) {
+    return uploader.uploadBlobAsync(HashCode.fromString(digest.getHash()),
+        Chunker.builder().setInput(digest.getSizeBytes(), path).build(), /* forceUpload= */ true);
+  }
+
+  @Override
+  protected ListenableFuture<Void> uploadBlob(Digest digest, ByteString data) {
+    return uploader.uploadBlobAsync(HashCode.fromString(digest.getHash()),
+        Chunker.builder().setInput(data.toByteArray()).build(), /* forceUpload= */ true);
+  }
+
   void upload(
       Path execRoot,
       ActionKey actionKey,
@@ -421,33 +434,29 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
     manifest.setStdoutStderr(outErr);
     manifest.addAction(actionKey, action, command);
 
-    Map<HashCode, Chunker> filesToUpload = Maps.newHashMap();
-
     Map<Digest, Path> digestToFile = manifest.getDigestToFile();
-    Map<Digest, Chunker> digestToChunkers = manifest.getDigestToChunkers();
+    Map<Digest, ByteString> digestToBlobs = manifest.getDigestToBlobs();
     Collection<Digest> digests = new ArrayList<>();
     digests.addAll(digestToFile.keySet());
-    digests.addAll(digestToChunkers.keySet());
+    digests.addAll(digestToBlobs.keySet());
 
     ImmutableSet<Digest> digestsToUpload = getMissingDigests(digests);
+    ImmutableList.Builder<ListenableFuture<Void>> uploads = ImmutableList.builder();
     for (Digest digest : digestsToUpload) {
-      Chunker chunker;
       Path file = digestToFile.get(digest);
       if (file != null) {
-        chunker = Chunker.builder().setInput(digest.getSizeBytes(), file).build();
+        uploads.add(uploadFile(digest, file));
       } else {
-        chunker = digestToChunkers.get(digest);
-        if (chunker == null) {
+        ByteString blob = digestToBlobs.get(digest);
+        if (blob == null) {
           String message = "FindMissingBlobs call returned an unknown digest: " + digest;
           throw new IOException(message);
         }
+        uploads.add(uploadBlob(digest, blob));
       }
-      filesToUpload.put(HashCode.fromString(digest.getHash()), chunker);
     }
 
-    if (!filesToUpload.isEmpty()) {
-      uploader.uploadBlobs(filesToUpload, /*forceUpload=*/true);
-    }
+    waitForUploads(uploads.build());
 
     if (manifest.getStderrDigest() != null) {
       result.setStderrDigest(manifest.getStderrDigest());
@@ -456,7 +465,27 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
       result.setStdoutDigest(manifest.getStdoutDigest());
     }
   }
-  
+
+
+  private void waitForUploads(List<ListenableFuture<Void>> uploads) throws IOException,
+      InterruptedException {
+    try {
+      for (ListenableFuture<Void> upload : uploads) {
+        upload.get();
+      }
+    } catch (ExecutionException e) {
+      // TODO(buchgr): Add support for cancellation and factor this method out to be shared
+      // between ByteStreamUploader as well.
+      Throwable cause = e.getCause();
+      Throwables.throwIfInstanceOf(cause, IOException.class);
+      Throwables.throwIfInstanceOf(cause, InterruptedException.class);
+      if (cause != null) {
+        throw new IOException(cause);
+      }
+      throw new IOException(e);
+    }
+  }
+
   // Execution Cache API
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
@@ -21,7 +21,6 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.DirectoryNode;
 import build.bazel.remote.execution.v2.FileNode;
-import com.google.common.base.Throwables;
 import com.google.common.hash.HashingOutputStream;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -44,7 +43,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 
 /**
@@ -91,12 +89,12 @@ public final class SimpleBlobStoreActionCache extends AbstractRemoteActionCache 
     upload(result, actionKey, action, command, execRoot, files, /* uploadAction= */ true);
     if (outErr.getErrorPath().exists()) {
       Digest stdErrDigest = digestUtil.compute(outErr.getErrorPath());
-      uploadFile(stdErrDigest, outErr.getErrorPath());
+      getFromFuture(uploadFile(stdErrDigest, outErr.getErrorPath()));
       result.setStderrDigest(stdErrDigest);
     }
     if (outErr.getOutputPath().exists()) {
       Digest stdoutDigest = digestUtil.compute(outErr.getOutputPath());
-      uploadFile(stdoutDigest, outErr.getOutputPath());
+      getFromFuture(uploadFile(stdoutDigest, outErr.getOutputPath()));
       result.setStdoutDigest(stdoutDigest);
     }
     blobStore.putActionResult(actionKey.getDigest().getHash(), result.build().toByteArray());
@@ -124,32 +122,22 @@ public final class SimpleBlobStoreActionCache extends AbstractRemoteActionCache 
     }
 
     for (Map.Entry<Digest, Path> entry : manifest.getDigestToFile().entrySet()) {
-      uploadFile(entry.getKey(), entry.getValue());
+      getFromFuture(uploadFile(entry.getKey(), entry.getValue()));
     }
 
-    for (Map.Entry<Digest, Chunker> entry : manifest.getDigestToChunkers().entrySet()) {
-      uploadBlob(entry.getKey(), entry.getValue().next().getData());
+    for (Map.Entry<Digest, ByteString> entry : manifest.getDigestToBlobs().entrySet()) {
+      uploadBlob(entry.getKey(), entry.getValue());
     }
   }
 
-  public void uploadFile(Digest digest, Path file) throws IOException, InterruptedException {
-    try {
-      blobStore.uploadFile(digest, file).get();
-    } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, InterruptedException.class);
-      throw new IOException(
-          String.format("Uploading of file '%s' failed: %s", file.getPathString(), e.getCause()));
-    }
+  @Override
+  public ListenableFuture<Void> uploadFile(Digest digest, Path file) {
+    return blobStore.uploadFile(digest, file);
   }
 
-  public void uploadBlob(Digest digest, ByteString data) throws IOException, InterruptedException {
-    try {
-      blobStore.uploadBlob(digest, data).get();
-    } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause(), IOException.class, InterruptedException.class);
-      throw new IOException(
-          String.format("Uploading of blob with digest '%s' failed: %s", digest, e.getCause()));
-    }
+  @Override
+  public ListenableFuture<Void> uploadBlob(Digest digest, ByteString data) {
+    return blobStore.uploadBlob(digest, data);
   }
 
   public boolean containsKey(Digest digest) throws IOException, InterruptedException {

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -1168,6 +1168,16 @@ public class AbstractRemoteActionCacheTests {
     }
 
     @Override
+    protected ListenableFuture<Void> uploadFile(Digest digest, Path path) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected ListenableFuture<Void> uploadBlob(Digest digest, ByteString data) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected ListenableFuture<Void> downloadBlob(Digest digest, OutputStream out) {
       SettableFuture<Void> result = SettableFuture.create();
       ListenableFuture<byte[]> downloadResult = downloadResults.get(digest);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -243,6 +243,16 @@ public class RemoteActionInputFetcherTest {
     }
 
     @Override
+    protected ListenableFuture<Void> uploadFile(Digest digest, Path path) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected ListenableFuture<Void> uploadBlob(Digest digest, ByteString data) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected ListenableFuture<Void> downloadBlob(Digest digest, OutputStream out) {
       ByteString data = cacheEntries.get(digest);
       if (data == null) {

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ByteStreamServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ByteStreamServer.java
@@ -231,7 +231,7 @@ final class ByteStreamServer extends ByteStreamImplBase {
 
         try {
           Digest d = digestUtil.compute(temp);
-          cache.uploadFile(d, temp);
+          getFromFuture(cache.uploadFile(d, temp));
           try {
             temp.delete();
           } catch (IOException e) {


### PR DESCRIPTION
The methods have the same signature as the ones in SimpleBlobStore. This gets us one step closer to merging AbstractRemoteActionCache and SimpleBlobStoreActionCache.