### PR TITLE
Add stub @rules_python to third_party/

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -35,6 +35,7 @@ filegroup(
         "//third_party/py/gflags:srcs",
         "//third_party/py/mock:srcs",
         "//third_party/py/six:srcs",
+        "//third_party/rules_python:srcs",
         "//third_party/zlib:srcs",
         "//third_party/nanopb:srcs",
         "//third_party/def_parser:srcs",

--- a/third_party/rules_python/BUILD
+++ b/third_party/rules_python/BUILD
@@ -1,5 +1,5 @@
 filegroup(
     name = "srcs",
     srcs = glob(["**"]) + ["//third_party/rules_python/python:srcs"],
-    visibility = ["//visibility:public"],
+    visibility = ["//third_party:__pkg__"],
 )

--- a/third_party/rules_python/BUILD
+++ b/third_party/rules_python/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]) + ["//third_party/rules_python/python:srcs"],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/rules_python/python/BUILD
+++ b/third_party/rules_python/python/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/third_party/rules_python/python/BUILD
+++ b/third_party/rules_python/python/BUILD
@@ -1,5 +1,5 @@
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
-    visibility = ["//visibility:public"],
+    visibility = ["//third_party/rules_python:__pkg__"],
 )

--- a/third_party/rules_python/python/defs.bzl
+++ b/third_party/rules_python/python/defs.bzl
@@ -1,0 +1,36 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This file is selectively copied from //tools/python:private/defs.bzl."""
+
+_MIGRATION_TAG = "__PYTHON_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
+
+def _add_tags(attrs):
+    if "tags" in attrs and attrs["tags"] != None:
+        attrs["tags"] += [_MIGRATION_TAG]
+    else:
+        attrs["tags"] = [_MIGRATION_TAG]
+    return attrs
+
+def py_library(**attrs):
+    native.py_library(**_add_tags(attrs))
+
+def py_binary(**attrs):
+    native.py_binary(**_add_tags(attrs))
+
+def py_test(**attrs):
+    native.py_test(**_add_tags(attrs))
+
+def py_runtime(**attrs):
+    native.py_runtime(**_add_tags(attrs))

--- a/third_party/rules_python/rules_python.WORKSPACE
+++ b/third_party/rules_python/rules_python.WORKSPACE
@@ -1,0 +1,7 @@
+# A stub version of bazelbuild/rules_python that contains only the defs.bzl
+# file, which is needed to access native Python rules under
+# --incompatible_load_python_rules_from_bzl (#9006).
+#
+# TODO(#9029): Maybe replace this with the real thing.
+
+workspace(name = "rules_python")


### PR DESCRIPTION
This stub contains only one relevant file, @rules_python//python:defs.bzl,
which mimics the file at the same path in bazelbuild/rules_python. Having this
repo gives us a way to inject this defs.bzl file into our protobuf dependency,
which is loaded as a separate (local) external repo and therefore cannot access
the existing //tools/python:private/defs.bzl in Bazel's own workspace. It also
means we'll be compatible with the future upstream migration to fix protobuf
for #9006.

A separate PR will add this to the Bazel root WORKSPACE file (since
third_party/ must be updated in a separate commit).

Break-out of #9019. Work toward #9006.

RELNOTES: None