### PR TITLE
Flip the default value for incompatible_auto_configure_host_platform.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
@@ -169,7 +169,7 @@ public class PlatformOptions extends FragmentOptions {
 
   @Option(
       name = "incompatible_auto_configure_host_platform",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {


### PR DESCRIPTION
Part of #7081 and 6849.

DO NOT SUBMIT.

RELNOTES: Make --incompatible_auto_configure_host_platform on by
default.