### PR TITLE
Remove worker log by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
@@ -114,7 +114,7 @@ final class WorkerFactory extends BaseKeyedPooledObjectFactory<WorkerKey, Worker
     boolean hashMatches =
         key.getWorkerFilesCombinedHash().equals(worker.getWorkerFilesCombinedHash());
 
-    if (reporter != null && !hashMatches) {
+    if (workerOptions.workerVerbose && reporter != null && !hashMatches) {
       StringBuilder msg = new StringBuilder();
       msg.append(
           String.format(


### PR DESCRIPTION
This hash change log doesn't seem actionable by the user, so we might as
well only enable it for the verbose mode.