### PR TITLE
made --incompatible_tags_propagation to be true by default (only star…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
@@ -175,7 +175,7 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
 
   @Option(
       name = "incompatible_allow_tags_propagation",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
       effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
       metadataTags = {

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
@@ -301,7 +301,7 @@ public abstract class StarlarkSemantics {
           .incompatibleDisallowSplitEmptySeparator(false)
           .incompatibleDisallowDictLookupUnhashableKeys(false)
           .incompatibleDisablePartitionDefaultParameter(false)
-          .incompatibleAllowTagsPropagation(false)
+          .incompatibleAllowTagsPropagation(true)
           .incompatibleAssignmentIdentifiersHaveLocalScope(false)
           .incompatibleDisallowHashingFrozenMutables(false)
           .build();

--- a/src/test/shell/bazel/tags_propagation_skylark_test.sh
+++ b/src/test/shell/bazel/tags_propagation_skylark_test.sh
@@ -52,7 +52,7 @@ test_rule = rule(
 )
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+  bazel aquery '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
   assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: ''}" output1
@@ -89,7 +89,7 @@ test_rule = rule(
 )
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+  bazel aquery '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
   assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: '', no-sandbox: '', requires-network: ''}" output1
@@ -128,7 +128,7 @@ test_rule = rule(
 )
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+  bazel aquery '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
   assert_contains "ExecutionInfo: {local: '', no-cache: 1, no-remote: '', requires-network: '', requires-x: ''}" output1


### PR DESCRIPTION
`--incompatible_allow_tags_propagation` flag protects the tags propagation from targets to actions.

RELNOTES: bazel will take tags specified on target level, filter them based on prefix and propagate to the actions, that are created for the target. Propagated prefixes: "block-", "requires-", "no-", "supports-", "disable-", "local", "cpu:". Only Starlark rules affected. See #8830 for details.