### PR TITLE
Accept hpp files as objc headers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcRuleClasses.java
@@ -306,7 +306,7 @@ public class ObjcRuleClasses {
   /**
    * Header files, which are not compiled directly, but may be included/imported from source files.
    */
-  static final FileType HEADERS = FileType.of(".h", ".inc");
+  static final FileType HEADERS = FileType.of(".h", ".inc", ".hpp");
 
   /**
    * Files allowed in the srcs attribute. This includes private headers.


### PR DESCRIPTION
hpp is a valid objc++ file extension. It should be accepted.