### PR TITLE
Fix incorrect stdout/stderr in remote action cache. Fixes #9072

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -665,11 +665,11 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
     public void setStdoutStderr(FileOutErr outErr) throws IOException {
       if (outErr.getErrorPath().exists()) {
         stderrDigest = digestUtil.compute(outErr.getErrorPath());
-        addFile(stderrDigest, outErr.getErrorPath());
+        digestToFile.put(stderrDigest, outErr.getErrorPath());
       }
       if (outErr.getOutputPath().exists()) {
         stdoutDigest = digestUtil.compute(outErr.getOutputPath());
-        addFile(stdoutDigest, outErr.getOutputPath());
+        digestToFile.put(stdoutDigest, outErr.getOutputPath());
       }
     }
 


### PR DESCRIPTION
Commit a6b5b0540 introduced a bug where the stdout/test.log of
an action was incorrectly added as an output file to the
ActionResult protobuf. Fortunately, we found the bug on Windows
because one cannot delete a file while it's still being open.

PAIR=pcloudy