### PR TITLE
Add rules_java load statements.

### DIFF
--- a/examples/java-native/src/main/java/com/example/myproject/BUILD
+++ b/examples/java-native/src/main/java/com/example/myproject/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_binary(

--- a/examples/java-native/src/test/java/com/example/myproject/BUILD
+++ b/examples/java-native/src/test/java/com/example/myproject/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "hello",
     srcs = ["TestHello.java"],

--- a/src/java_tools/buildjar/BUILD
+++ b/src/java_tools/buildjar/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_toolchain")
+
 # Description:
 # JavaBuilder and java tools used by Bazel
 package(default_visibility = [":buildjar_package_group"])

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 # Description:
 #   The Java library builders, which are used by Bazel to compile Java
 #   source code.
@@ -148,7 +150,7 @@ java_library(
 ## Bootstrapping using Skylark rules
 #
 
-load("//tools/build_rules:java_rules_skylark.bzl", "bootstrap_java_library", "bootstrap_java_binary")
+load("//tools/build_rules:java_rules_skylark.bzl", "bootstrap_java_binary", "bootstrap_java_library")
 
 bootstrap_java_library(
     name = "skylark-deps",

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/genclass/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/genclass/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(default_visibility = ["//src/java_tools/buildjar:buildjar_package_group"])
 
 filegroup(

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src/java_tools/buildjar:buildjar_package_group"])
 
 filegroup(

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 # Description:
 #   Plugins for the Java library builders, which are used by Bazel to
 #   compile Java source code.

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/statistics/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/statistics/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/src/java_tools/buildjar/java/com/google/devtools/build/java/bazel/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/java/bazel/BUILD
@@ -3,6 +3,8 @@
 #
 # This is not the source code for javac itself.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src/java_tools/buildjar:buildjar_package_group"],
 )

--- a/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+
 package(default_visibility = ["//src/java_tools/buildjar:buildjar_package_group"])
 
 java_binary(

--- a/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/javac/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/javac/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(default_visibility = ["//src/java_tools/buildjar:buildjar_package_group"])
 
 java_binary(

--- a/src/java_tools/buildjar/javatests/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/javatests/com/google/devtools/build/buildjar/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(default_visibility = ["//src/java_tools/buildjar:buildjar_package_group"])
 
 filegroup(

--- a/src/java_tools/buildjar/javatests/com/google/devtools/build/java/turbine/javac/BUILD
+++ b/src/java_tools/buildjar/javatests/com/google/devtools/build/java/turbine/javac/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(default_visibility = ["//src/java_tools/buildjar:buildjar_package_group"])
 
 java_library(

--- a/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/BUILD
+++ b/src/java_tools/import_deps_checker/java/com/google/devtools/build/importdeps/BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   A checker to check the completeness of the deps of java_import or aar_import targets.
 
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/java_tools/import_deps_checker/javatests/com/google/devtools/build/importdeps/BUILD
+++ b/src/java_tools/import_deps_checker/javatests/com/google/devtools/build/importdeps/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
+
 # Description:
 #   Tests for the checker to check the completeness of the deps of java_import or aar_import targets.
 package(

--- a/src/java_tools/import_deps_checker/javatests/com/google/devtools/build/importdeps/testdata/BUILD
+++ b/src/java_tools/import_deps_checker/javatests/com/google/devtools/build/importdeps/testdata/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import", "java_library")
+
 # Description:
 #   Test data for testing dependency checking.
 package(

--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/junit4/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/junit4/BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   JUnit 4.x extensions
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_testonly = 1,
     default_visibility = ["//visibility:public"],

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(default_visibility = [
     "//src/java_tools/junitrunner:junitrunner_package_group",
 ])

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/internal/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/internal/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = [
     "//src/java_tools/junitrunner:junitrunner_package_group",
 ])

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = [
     "//src/java_tools/junitrunner:junitrunner_package_group",
 ])

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/model/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/model/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = [
     "//src/java_tools/junitrunner:junitrunner_package_group",
 ])

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/sharding/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/sharding/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = [
     "//src/java_tools/junitrunner:junitrunner_package_group",
 ])

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/sharding/api/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/sharding/api/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = [
     "//src/java_tools/junitrunner:junitrunner_package_group",
 ])

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/sharding/testing/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/sharding/testing/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = [
     "//src/java_tools/junitrunner:junitrunner_package_group",
 ])

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/util/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/util/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = [
     "//src/java_tools/junitrunner:junitrunner_package_group",
 ])

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/junit4/runner/BUILD
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/junit4/runner/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(default_visibility = [
     "//src/java_tools/junitrunner:junitrunner_package_group",
 ])

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/BUILD
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
+
 package(default_visibility = [
     "//src/java_tools/junitrunner:junitrunner_package_group",
 ])

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/testbed/BUILD
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/testbed/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = [
     "//src/java_tools/junitrunner:junitrunner_package_group",
 ])

--- a/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/BUILD
+++ b/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 # Description:
 #   SingleJar combines multiple zip files and additional files
 #   into a single zip file.
@@ -69,7 +71,7 @@ java_binary(
 # Bootstrapping using Skylark rules
 #
 
-load("//tools/build_rules:java_rules_skylark.bzl", "bootstrap_java_library", "bootstrap_java_binary")
+load("//tools/build_rules:java_rules_skylark.bzl", "bootstrap_java_binary", "bootstrap_java_library")
 
 bootstrap_java_library(
     name = "skylark-deps",

--- a/src/java_tools/singlejar/java/com/google/devtools/build/zip/BUILD
+++ b/src/java_tools/singlejar/java/com/google/devtools/build/zip/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 # Description:
 #   Zip provides a library for reading and writing zip files, allowing more
 #   advanced manipulation than the JDK equivalents by providing detailed zip

--- a/src/java_tools/singlejar/javatests/com/google/devtools/build/singlejar/BUILD
+++ b/src/java_tools/singlejar/javatests/com/google/devtools/build/singlejar/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 # Description:
 #   Tests for SingleJar
 package(default_visibility = ["//src/java_tools/singlejar:singlejar_package_group"])

--- a/src/java_tools/singlejar/javatests/com/google/devtools/build/zip/BUILD
+++ b/src/java_tools/singlejar/javatests/com/google/devtools/build/zip/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 # Description:
 #   Tests for Zip
 package(default_visibility = ["//src/java_tools/singlejar:singlejar_package_group"])

--- a/src/main/java/com/google/devtools/build/docgen/BUILD
+++ b/src/main/java/com/google/devtools/build/docgen/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 # Description:
 #   Documentation generator for Bazel
 package(

--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 # Description:
 #   Main Java code for Bazel
 package(

--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/actionsketch/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actionsketch/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/annotations/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/annotations/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0
 
 package(

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/annotations/processor/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/annotations/processor/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_plugin")
+
 # Description:
 #   A preprocessor for skylark annotations.
 package(default_visibility = ["//src:__subpackages__"])

--- a/src/main/java/com/google/devtools/build/lib/authandtls/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_proto_library")
+
 # Description:
 #   Debugging helpers and modules
 package(

--- a/src/main/java/com/google/devtools/build/lib/bazel/execlog/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/execlog/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/cache/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/client/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_proto_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 load("//tools/build_rules:utilities.bzl", "java_library_srcs")

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/causes/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/causes/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/clock/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/clock/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/cmdline/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/collect/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/collect/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/collect/compacthashmap/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/collect/compacthashmap/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/collect/compacthashset/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/collect/compacthashset/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/collect/nestedset/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/collect/nestedset/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/concurrent/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/concurrent/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/dynamic/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/dynamic/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/exec/local/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/graph/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/graph/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/includescanning/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/lib/metrics/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/metrics/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/lib/network/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/network/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/lib/outputfilter/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/outputfilter/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/lib/profiler/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/profiler/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/profiler/callcounts/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/profiler/callcounts/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/profiler/memory/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/profiler/memory/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/query2/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/query2/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/remote/blobstore/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/blobstore/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/remote/common/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/remote/logging/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/logging/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/remote/options/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/cpp/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/cpp/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/swift/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/swift/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/config/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/genquery/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/genquery/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/java/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/shell/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/shell/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/packages/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/packages/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/trimming/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/trimming/BUILD
@@ -1,5 +1,7 @@
 # Classes which provide support for automatically trimming configuration to avoid wasted work during a build.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/BUILD
@@ -6,6 +6,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/android/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/android/BUILD
@@ -6,6 +6,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/apple/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/apple/BUILD
@@ -6,6 +6,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/config/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/config/BUILD
@@ -6,6 +6,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/BUILD
@@ -6,6 +6,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/go/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/go/BUILD
@@ -6,6 +6,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/java/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/java/BUILD
@@ -6,6 +6,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/platform/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/platform/BUILD
@@ -6,6 +6,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/proto/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/proto/BUILD
@@ -6,6 +6,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/python/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/python/BUILD
@@ -6,6 +6,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/repository/BUILD
@@ -6,6 +6,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/stubs/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/stubs/BUILD
@@ -5,6 +5,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/test/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/test/BUILD
@@ -6,6 +6,8 @@
 #   those which contain pure-Skylark concepts, such as the interpreter or
 #   annotation interfaces).
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0

--- a/src/main/java/com/google/devtools/build/lib/skylarkdebug/module/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkdebug/module/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/skylarkdebug/proto/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkdebug/proto/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_proto_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 load("//tools/build_rules:utilities.bzl", "java_library_srcs")

--- a/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkdebug/server/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/skylarkinterface/processor/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skylarkinterface/processor/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_plugin")
+
 # Description:
 #   A preprocessor for skylarkinterface annotations.
 package(default_visibility = [

--- a/src/main/java/com/google/devtools/build/lib/ssd/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/ssd/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/standalone/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/standalone/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/supplier/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/supplier/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 java_library(

--- a/src/main/java/com/google/devtools/build/lib/unsafe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/unsafe/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/lib/vfs/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/vfs/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/windows/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/windows/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/windows/jni/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/windows/jni/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/lib/worker/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/worker/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 filegroup(

--- a/src/main/java/com/google/devtools/build/skydoc/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/BUILD
@@ -6,6 +6,8 @@
 # Usage:
 # skydoc <target_file> <output_file>
 
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/android/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/android/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/apple/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/apple/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/config/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/config/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/cpp/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/cpp/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/java/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/java/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/platform/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/platform/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/proto/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/proto/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/python/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/python/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/repository/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/repository/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/test/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/test/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/renderer/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/renderer/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/rendering/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/rendering/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/main/java/com/google/devtools/build/skydoc/rendering/proto/BUILD
+++ b/src/main/java/com/google/devtools/build/skydoc/rendering/proto/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_proto_library")
+
 package(
     default_visibility = [
         "//src/main/java/com/google/devtools/build/skydoc:__subpackages__",

--- a/src/main/java/com/google/devtools/build/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/skyframe/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 # Description:
 #   Skyframe Java code
 package(

--- a/src/main/java/com/google/devtools/common/options/BUILD
+++ b/src/main/java/com/google/devtools/common/options/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 # Description:
 #   A devtools-common options parser.
 #   Open-sourced as part of Bazel.

--- a/src/main/java/com/google/devtools/common/options/processor/BUILD
+++ b/src/main/java/com/google/devtools/common/options/processor/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_plugin")
+
 # Description:
 #   A preprocessor for the annotations used in the options parser.
 package(default_visibility = ["//src:__subpackages__"])

--- a/src/main/java/com/google/devtools/common/options/testing/BUILD
+++ b/src/main/java/com/google/devtools/common/options/testing/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 # Description:
 #   Testing tools for the devtools-common options parser.
 package(

--- a/src/main/java/com/google/devtools/starlark/BUILD
+++ b/src/main/java/com/google/devtools/starlark/BUILD
@@ -1,6 +1,8 @@
 # The Starlark interpreter
 # Open-sourced as part of Bazel.
 
+load("@rules_java//java:defs.bzl", "java_binary")
+
 package(default_visibility = ["//src:__subpackages__"])
 
 java_binary(

--- a/src/main/protobuf/BUILD
+++ b/src/main/protobuf/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 load("//tools/build_rules:genproto.bzl", "cc_grpc_library")

--- a/src/test/java/com/google/devtools/build/android/BUILD
+++ b/src/test/java/com/google/devtools/build/android/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]) + [

--- a/src/test/java/com/google/devtools/build/android/desugar/BUILD
+++ b/src/test/java/com/google/devtools/build/android/desugar/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_import", "java_library", "java_test")
+
 # Description:
 #   Tests for the Java 8 desugaring tool for Android.
 package(

--- a/src/test/java/com/google/devtools/build/android/desugar/classes_for_testing_type_inference/BUILD
+++ b/src/test/java/com/google/devtools/build/android/desugar/classes_for_testing_type_inference/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import")
+
 # Description:
 #   Tests for the extension classes for desugaring try-with-resources for Android.
 package(

--- a/src/test/java/com/google/devtools/build/android/desugar/dependencies/BUILD
+++ b/src/test/java/com/google/devtools/build/android/desugar/dependencies/BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   Tests for the dependency tracking helper library for desugar.
 
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
 )

--- a/src/test/java/com/google/devtools/build/android/desugar/io/BUILD
+++ b/src/test/java/com/google/devtools/build/android/desugar/io/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 # Description:
 #   Tests for the Java 8 desugaring tool for Android.
 package(

--- a/src/test/java/com/google/devtools/build/android/desugar/runtime/BUILD
+++ b/src/test/java/com/google/devtools/build/android/desugar/runtime/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 # Description:
 #   Tests for the extension classes for desugaring try-with-resources for Android.
 package(

--- a/src/test/java/com/google/devtools/build/android/desugar/scan/BUILD
+++ b/src/test/java/com/google/devtools/build/android/desugar/scan/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 # Description:
 #   Tests for the Java 8 desugaring tool for Android.
 package(

--- a/src/test/java/com/google/devtools/build/android/dexer/BUILD
+++ b/src/test/java/com/google/devtools/build/android/dexer/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/android/idlclass/BUILD
+++ b/src/test/java/com/google/devtools/build/android/idlclass/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/android/junctions/BUILD
+++ b/src/test/java/com/google/devtools/build/android/junctions/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/android/resources/BUILD
+++ b/src/test/java/com/google/devtools/build/android/resources/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/android/ziputils/BUILD
+++ b/src/test/java/com/google/devtools/build/android/ziputils/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/docgen/BUILD
+++ b/src/test/java/com/google/devtools/build/docgen/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
+
 package(
     default_visibility = [
         ":__subpackages__",

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -69,6 +69,7 @@ public final class BazelAnalysisMock extends AnalysisMock {
   public List<String> getWorkspaceContents(MockToolsConfig config) {
     String bazelToolWorkspace = config.getPath("/bazel_tools_workspace").getPathString();
     String bazelPlatformsWorkspace = config.getPath("/platforms").getPathString();
+    String rulesJavaWorkspace = config.getPath("/rules_java_workspace").getPathString();
     String localConfigPlatformWorkspace =
         config.getPath("/local_config_platform_workspace").getPathString();
 
@@ -78,6 +79,9 @@ public final class BazelAnalysisMock extends AnalysisMock {
             "local_repository(name = 'platforms', path = '" + bazelPlatformsWorkspace + "')",
             "local_repository(name = 'local_config_xcode', path = '/local_config_xcode')",
             "local_repository(name = 'com_google_protobuf', path = '/protobuf')",
+            "local_repository(name = 'rules_java', path = '" + rulesJavaWorkspace + "')",
+            "register_toolchains('@rules_java//java/toolchains/runtime:all')",
+            "register_toolchains('@rules_java//java/toolchains/javac:all')",
             "bind(name = 'android/sdk', actual='@bazel_tools//tools/android:sdk')",
             "register_toolchains('@bazel_tools//tools/cpp:all')",
             "register_toolchains('@bazel_tools//tools/jdk:all')",
@@ -283,6 +287,41 @@ public final class BazelAnalysisMock extends AnalysisMock {
     config.create("/bazel_tools_workspace/objcproto/empty.m");
     config.create("/bazel_tools_workspace/objcproto/empty.cc");
     config.create("/bazel_tools_workspace/objcproto/well_known_type.proto");
+
+    config.create("/rules_java_workspace/WORKSPACE", "workspace(name = 'rules_java')");
+    config.create("/rules_java_workspace/java/BUILD");
+    config.create("/rules_java_workspace/java/defs.bzl",
+        "def java_binary(**attrs):",
+        "    native.java_binary(**attrs)",
+        "def java_library(**attrs):",
+        "    native.java_library(**attrs)",
+        "def java_import(**attrs):",
+        "    native.java_import(**attrs)"
+    );
+    config.create("/rules_java_workspace/java/repositories.bzl",
+        "def rules_java_dependencies():",
+        "    pass",
+        "def rules_java_toolchains():",
+        "    pass");
+
+    config.create(
+        "/rules_java_workspace/java/toolchains/runtime/BUILD",
+        "toolchain_type(name = 'toolchain_type')",
+        "toolchain(",
+        "    name = 'local_jdk',",
+        "    toolchain = '@bazel_tools//tools/jdk:jdk',",
+        "    toolchain_type = '@rules_java//java/toolchains/runtime:toolchain_type',",
+        "    )"
+    );
+    config.create(
+        "/rules_java_workspace/java/toolchains/javac/BUILD",
+        "toolchain_type(name = 'toolchain_type')",
+        "toolchain(",
+        "    name = 'javac_toolchain',",
+        "    toolchain = '@bazel_tools//tools/jdk:toolchain',",
+        "    toolchain_type = '@rules_java//java/toolchains/javac:toolchain_type',",
+        "    )"
+    );
 
     MockPlatformSupport.setup(config);
     ccSupport().setup(config);

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/analysis/skylark/annotations/processor/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/skylark/annotations/processor/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])  # Apache 2.0
 
 filegroup(

--- a/src/test/java/com/google/devtools/build/lib/analysis/whitelisting/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/whitelisting/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/bazel/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = True,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/bazel/debug/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/debug/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/bazel/execlog/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/execlog/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/cache/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/cache/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/blackbox/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_testonly = 1,
     default_visibility = [

--- a/src/test/java/com/google/devtools/build/lib/blackbox/bazel/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/bazel/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package_group(
     name = "tests",
     packages = [

--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 java_library(
     name = "deps",
     testonly = 1,

--- a/src/test/java/com/google/devtools/build/lib/blackbox/junit/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/junit/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 java_test(
     name = "TimeoutTestWatcherTest",
     srcs = [

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 filegroup(
     name = "srcs",
     testonly = 0,

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(default_testonly = 1)
 
 filegroup(

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/buildeventstream/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildeventstream/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildeventstream/transports/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/outputfilter/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/outputfilter/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/profiler/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/profiler/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/profiler/callcounts/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/profiler/callcounts/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src/test/java/com/google/devtools/build/lib:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/profiler/memory/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/profiler/memory/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])  # Apache 2.0
 
 filegroup(

--- a/src/test/java/com/google/devtools/build/lib/query2/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/query2/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_testonly = 1,
     default_visibility = [

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/remote/logging/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/logging/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/remote/util/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/rules/android/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/rules/apple/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/apple/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/rules/config/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/config/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/rules/python/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/python/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = True,
 )

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/shell/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/shell/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = [

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/skyframe/packages/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/packages/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/skyframe/serialization/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/serialization/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/skyframe/trimming/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/trimming/BUILD
@@ -1,5 +1,7 @@
 # Tests for the trimming support classes.
 
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
 )

--- a/src/test/java/com/google/devtools/build/lib/skylark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skylark/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/skylarkdebug/server/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skylarkdebug/server/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/skylarkinterface/processor/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skylarkinterface/processor/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])  # Apache 2.0
 
 filegroup(

--- a/src/test/java/com/google/devtools/build/lib/supplier/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/supplier/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/build/lib/unsafe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/unsafe/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )

--- a/src/test/java/com/google/devtools/build/skydoc/BUILD
+++ b/src/test/java/com/google/devtools/build/skydoc/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_test")
 load(":skydoc_test.bzl", "skydoc_test")
 
 package(

--- a/src/test/java/com/google/devtools/build/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/skyframe/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/test/java/com/google/devtools/common/options/BUILD
+++ b/src/test/java/com/google/devtools/common/options/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]) + [

--- a/src/test/java/com/google/devtools/common/options/processor/BUILD
+++ b/src/test/java/com/google/devtools/common/options/processor/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 filegroup(
     name = "srcs",
     srcs = glob(

--- a/src/test/java/com/google/devtools/common/options/testing/BUILD
+++ b/src/test/java/com/google/devtools/common/options/testing/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 # Description:
 #   Tests of the testing tools for the devtools-common options parser.
 package(

--- a/src/test/starlark/BUILD
+++ b/src/test/starlark/BUILD
@@ -1,7 +1,7 @@
 load(
     "//tools/build_rules:test_rules.bzl",
-    "rule_test",
     "file_test",
+    "rule_test",
 )
 load("//tools/python:private/defs.bzl", "py_test")
 

--- a/src/tools/android/java/com/google/devtools/build/android/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/BUILD
@@ -1,5 +1,7 @@
 # Actions for Android rules.
 
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 filegroup(

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   Tool for desugaring Java constructs not supported by Android tools or devices.
 
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 filegroup(
     name = "embedded_tools",
     srcs = ["BUILD.tools"],

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/dependencies/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/dependencies/BUILD
@@ -2,6 +2,8 @@
 #   Dependency tracking helper library for desugar that we package separately
 #   for the benefit of desugar users who want to compile the tool from source.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(
     default_visibility = [
         "//src/test/java/com/google/devtools/build/android/desugar:__subpackages__",

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/io/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/io/BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   Tool for desugaring Java constructs not supported by Android tools or devices.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 java_library(
     name = "io",
     srcs = glob(["*.java"]),

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/runtime/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/runtime/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 # Description:
 #   This is the extension package to support desugaring try-with-resources statements.
 package(

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/scan/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/scan/BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   Tools for scanning bytecode for references to other classes and emitting Proguard-style keeps.
 
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 filegroup(
     name = "embedded_tools",
     srcs = ["BUILD.tools"],

--- a/src/tools/android/java/com/google/devtools/build/android/dexer/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/dexer/BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   Collection of dex utilities used in the bazel android actions.
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),

--- a/src/tools/android/java/com/google/devtools/build/android/idlclass/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/idlclass/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 filegroup(
     name = "embedded_tools",
     srcs = ["BUILD.tools"],

--- a/src/tools/android/java/com/google/devtools/build/android/junctions/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/junctions/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:private"])
 
 package_group(

--- a/src/tools/android/java/com/google/devtools/build/android/proto/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/proto/BUILD
@@ -1,5 +1,7 @@
 # Protos of the Actions for Android rules.
 
+load("@rules_java//java:defs.bzl", "java_proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_proto//proto:defs.bzl", "proto_library")

--- a/src/tools/android/java/com/google/devtools/build/android/resources/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/resources/BUILD
@@ -1,6 +1,8 @@
 # Description:
 #   Tools for android resource processing
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = [
     "//src/test/java/com/google/devtools/build/android:__subpackages__",
     "//src/tools/android/java/com/google/devtools/build/android:__pkg__",

--- a/src/tools/android/java/com/google/devtools/build/android/ziputils/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/ziputils/BUILD
@@ -1,5 +1,7 @@
 # Low level zip archive processing library.
 
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(
     default_visibility = [
         "//src/test/java/com/google/devtools/build/android/ziputils:__pkg__",

--- a/src/tools/execlog/BUILD
+++ b/src/tools/execlog/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]) + [

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/BUILD
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),

--- a/src/tools/execlog/test/main/java/com/google/devtools/build/execlog/BUILD
+++ b/src/tools/execlog/test/main/java/com/google/devtools/build/execlog/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/src/tools/package_printer/java/com/google/devtools/build/packageprinter/BUILD
+++ b/src/tools/package_printer/java/com/google/devtools/build/packageprinter/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 licenses(["notice"])  # Apache 2.0
 
 filegroup(

--- a/src/tools/remote/BUILD
+++ b/src/tools/remote/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]) + [

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),

--- a/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/BUILD
+++ b/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src/tools/remote:__pkg__"],

--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 # Description:
 #   singlejar C++ implementation.
 package(default_visibility = ["//src:__subpackages__"])

--- a/src/tools/skylark/java/com/google/devtools/skylark/common/BUILD
+++ b/src/tools/skylark/java/com/google/devtools/skylark/common/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 java_library(
     name = "common",
     srcs = glob(["**/*.java"]),

--- a/src/tools/workspacelog/BUILD
+++ b/src/tools/workspacelog/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]) + [

--- a/src/tools/workspacelog/src/main/java/com/google/devtools/build/workspacelog/BUILD
+++ b/src/tools/workspacelog/src/main/java/com/google/devtools/build/workspacelog/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),

--- a/src/tools/workspacelog/test/main/java/com/google/devtools/build/workspacelog/BUILD
+++ b/src/tools/workspacelog/test/main/java/com/google/devtools/build/workspacelog/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 package(
     default_testonly = 1,
     default_visibility = ["//src:__subpackages__"],

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import", "java_library", "java_plugin")
+
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_pkg//:pkg.bzl", "pkg_tar")

--- a/third_party/allocation_instrumenter/BUILD
+++ b/third_party/allocation_instrumenter/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0

--- a/third_party/aws-sdk-auth-lite/BUILD
+++ b/third_party/aws-sdk-auth-lite/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  #  Apache-2 license
 
 filegroup(

--- a/third_party/checker_framework_dataflow/BUILD
+++ b/third_party/checker_framework_dataflow/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["restricted"])  # GNU GPL v2 with Classpath exception

--- a/third_party/checker_framework_javacutil/BUILD
+++ b/third_party/checker_framework_javacutil/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["restricted"])  # GNU GPL v2 with Classpath exception

--- a/third_party/googleapis/BUILD.bazel
+++ b/third_party/googleapis/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
@@ -254,6 +256,7 @@ proto_library(
     name = "google_api_auth_proto",
     srcs = ["google/api/auth.proto"],
     deps = [
-       ":google_api_annotations_proto",
-       "@com_google_protobuf//:descriptor_proto"],
+        ":google_api_annotations_proto",
+        "@com_google_protobuf//:descriptor_proto",
+    ],
 )

--- a/third_party/grpc/BUILD
+++ b/third_party/grpc/BUILD
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:defs.bzl", "java_import")
+
 licenses(["notice"])  # Apache v2
 
 package(

--- a/third_party/grpc/build_defs.bzl
+++ b/third_party/grpc/build_defs.bzl
@@ -3,6 +3,8 @@ You need to load the rules in your BUILD file for use, like:
 load("//third_party/grpc:build_defs.bzl", "java_grpc_library")
 """
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 def _path_ignoring_repository(f):
     if (len(f.owner.workspace_root) == 0):
         return f.short_path
@@ -102,7 +104,7 @@ def java_grpc_library(name, srcs, deps, enable_deprecated = None, visibility = N
         ],
         **kwargs
     )
-    native.java_library(
+    java_library(
         name = name,
         srcs = [gensource_name],
         visibility = visibility,

--- a/third_party/ijar/test/BUILD
+++ b/third_party/ijar/test/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
+
 package(default_visibility = ["//visibility:__pkg__"])
 
 licenses(["notice"])  # Apache License 2.0

--- a/third_party/jarjar/BUILD
+++ b/third_party/jarjar/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_import")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0

--- a/third_party/java/android_databinding/BUILD
+++ b/third_party/java/android_databinding/BUILD
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:defs.bzl", "java_import")
+
 licenses(["notice"])  # Apache License 2.0
 
 exports_files(["LICENSE"])

--- a/third_party/java/aosp_gradle_core/BUILD
+++ b/third_party/java/aosp_gradle_core/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0

--- a/third_party/java/apkbuilder/BUILD
+++ b/third_party/java/apkbuilder/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+
 licenses(["notice"])  # Apache 2.0
 
 filegroup(

--- a/third_party/java/dd_plist/BUILD
+++ b/third_party/java/dd_plist/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # MIT

--- a/third_party/java/jacoco/BUILD
+++ b/third_party/java/jacoco/BUILD
@@ -3,6 +3,8 @@
 #
 # http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.3/jacoco-0.8.3.zip
 
+load("@rules_java//java:defs.bzl", "java_import")
+
 licenses(["reciprocal"])  # EPL 1.0 (Eclipse Public License)
 
 exports_files(["LICENSE"])

--- a/third_party/java/javapoet/BUILD
+++ b/third_party/java/javapoet/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import")
+
 licenses(["notice"])  # Apache License 2.0
 
 exports_files(["LICENSE"])
@@ -15,4 +17,3 @@ java_import(
     name = "javapoet",
     jars = ["javapoet-1.8.0.jar"],
 )
-

--- a/third_party/java/jcommander/BUILD
+++ b/third_party/java/jcommander/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])

--- a/third_party/java/jdk/langtools/BUILD
+++ b/third_party/java/jdk/langtools/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["restricted"])  # GNU GPL v2 with Classpath exception

--- a/third_party/jaxb/BUILD
+++ b/third_party/jaxb/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import")
+
 licenses(["reciprocal"])  #  CDDL License
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/jformatstring/BUILD
+++ b/third_party/jformatstring/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["restricted"])  # GNU GPL v2 with Classpath exception

--- a/third_party/pprof/BUILD
+++ b/third_party/pprof/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0

--- a/third_party/protobuf/3.6.1/BUILD
+++ b/third_party/protobuf/3.6.1/BUILD
@@ -1,5 +1,7 @@
 # Bazel (http://bazel.io/) BUILD file for Protobuf.
 
+load("@rules_java//java:defs.bzl", "java_import")
+
 licenses(["notice"])
 
 exports_files(["LICENSE"])
@@ -21,6 +23,7 @@ config_setting(
 
 load(":protobuf.bzl", "py_proto_library")
 load(":compiler_config_setting.bzl", "create_compiler_config_setting")
+
 # Needed for #9006. Hopefully a future upstream version will include this line.
 load("@rules_python//python:defs.bzl", "py_library")
 
@@ -81,12 +84,12 @@ create_compiler_config_setting(
 
 MSVC_COPTS = [
     "/DHAVE_PTHREAD",
-    "/wd4018", # -Wno-sign-compare
-    "/wd4514", # -Wno-unused-function
+    "/wd4018",  # -Wno-sign-compare
+    "/wd4514",  # -Wno-unused-function
 ]
 
 COPTS = select({
-    ":msvc" : MSVC_COPTS,
+    ":msvc": MSVC_COPTS,
     "//conditions:default": [
         "-DHAVE_PTHREAD",
         "-Wall",
@@ -110,16 +113,19 @@ config_setting(
 LINK_OPTS = select({
     ":android": [],
     ":msvc": [],
-    "//conditions:default": ["-lpthread", "-lm"],
+    "//conditions:default": [
+        "-lpthread",
+        "-lm",
+    ],
 })
 
 load(
     ":protobuf.bzl",
     "cc_proto_library",
-    "py_proto_library",
     "internal_copied_filegroup",
     "internal_gen_well_known_protos_java",
     "internal_protobuf_py_tests",
+    "py_proto_library",
 )
 
 cc_library(
@@ -247,18 +253,33 @@ objc_library(
 # Map of all well known protos.
 # name => (include path, imports)
 WELL_KNOWN_PROTO_MAP = {
-    "any" : ("src/google/protobuf/any.proto", []),
-    "api" : ("src/google/protobuf/api.proto", ["source_context", "type"]),
-    "compiler_plugin" : ("src/google/protobuf/compiler/plugin.proto", ["descriptor"]),
-    "descriptor" : ("src/google/protobuf/descriptor.proto", []),
-    "duration" : ("src/google/protobuf/duration.proto", []),
-    "empty" : ("src/google/protobuf/empty.proto", []),
-    "field_mask" : ("src/google/protobuf/field_mask.proto", []),
-    "source_context" : ("src/google/protobuf/source_context.proto", []),
-    "struct" : ("src/google/protobuf/struct.proto", []),
-    "timestamp" : ("src/google/protobuf/timestamp.proto", []),
-    "type" : ("src/google/protobuf/type.proto", ["any", "source_context"]),
-    "wrappers" : ("src/google/protobuf/wrappers.proto", []),
+    "any": ("src/google/protobuf/any.proto", []),
+    "api": (
+        "src/google/protobuf/api.proto",
+        [
+            "source_context",
+            "type",
+        ],
+    ),
+    "compiler_plugin": (
+        "src/google/protobuf/compiler/plugin.proto",
+        ["descriptor"],
+    ),
+    "descriptor": ("src/google/protobuf/descriptor.proto", []),
+    "duration": ("src/google/protobuf/duration.proto", []),
+    "empty": ("src/google/protobuf/empty.proto", []),
+    "field_mask": ("src/google/protobuf/field_mask.proto", []),
+    "source_context": ("src/google/protobuf/source_context.proto", []),
+    "struct": ("src/google/protobuf/struct.proto", []),
+    "timestamp": ("src/google/protobuf/timestamp.proto", []),
+    "type": (
+        "src/google/protobuf/type.proto",
+        [
+            "any",
+            "source_context",
+        ],
+    ),
+    "wrappers": ("src/google/protobuf/wrappers.proto", []),
 }
 
 WELL_KNOWN_PROTOS = [value[0] for value in WELL_KNOWN_PROTO_MAP.values()]
@@ -295,9 +316,9 @@ cc_proto_library(
     name = proto[0] + "_proto",
     srcs = [proto[1][0]],
     strip_import_prefix = "src",
-    deps = [dep + "_proto" for dep in proto[1][1]],
     visibility = ["//visibility:public"],
-    ) for proto in WELL_KNOWN_PROTO_MAP.items()]
+    deps = [dep + "_proto" for dep in proto[1][1]],
+) for proto in WELL_KNOWN_PROTO_MAP.items()]
 
 ################################################################################
 # Protocol Buffers Compiler
@@ -508,11 +529,14 @@ cc_binary(
 cc_test(
     name = "win32_test",
     srcs = ["src/google/protobuf/stubs/io_win32_unittest.cc"],
+    tags = [
+        "manual",
+        "windows",
+    ],
     deps = [
         ":protobuf_lite",
         "//external:gtest_main",
     ],
-    tags = ["manual", "windows"],
 )
 
 cc_test(
@@ -722,11 +746,11 @@ py_proto_library(
     }),
     default_runtime = "",
     protoc = ":protoc",
+    py_extra_srcs = glob(["python/**/__init__.py"]),
     py_libs = [
         ":python_srcs",
         "//external:six",
     ],
-    py_extra_srcs = glob(["python/**/__init__.py"]),
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )
@@ -817,10 +841,10 @@ internal_protobuf_py_tests(
 
 proto_lang_toolchain(
     name = "cc_toolchain",
+    blacklisted_protos = [proto + "_proto" for proto in WELL_KNOWN_PROTO_MAP.keys()],
     command_line = "--cpp_out=$(OUT)",
     runtime = ":protobuf",
     visibility = ["//visibility:public"],
-    blacklisted_protos = [proto + "_proto" for proto in WELL_KNOWN_PROTO_MAP.keys()],
 )
 
 proto_lang_toolchain(

--- a/third_party/protobuf/3.6.1/examples/BUILD
+++ b/third_party/protobuf/3.6.1/examples/BUILD
@@ -4,6 +4,8 @@
 # the WORKSPACE file in the same directory with this BUILD file for an
 # example.
 
+load("@rules_java//java:defs.bzl", "java_binary", "java_lite_proto_library", "java_proto_library")
+
 # For each .proto file, a proto_library target should be defined. This target
 # is not bound to any particular language. Instead, it defines the dependency
 # graph of the .proto files (i.e., proto imports) and serves as the provider

--- a/third_party/remoteapis/BUILD.bazel
+++ b/third_party/remoteapis/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
@@ -14,8 +16,8 @@ filegroup(
 )
 
 JAVA_LIBRARY_PROTOS = [
-  "build_bazel_semver_semver",
-  "build_bazel_remote_execution_v2_remote_execution",
+    "build_bazel_semver_semver",
+    "build_bazel_remote_execution_v2_remote_execution",
 ]
 
 [java_library_srcs(
@@ -26,8 +28,9 @@ JAVA_LIBRARY_PROTOS = [
 # for bootstrapping
 filegroup(
     name = "dist_jars",
-    srcs = [":" + proto + "_java_proto_srcs" for proto in JAVA_LIBRARY_PROTOS]
-    + [":build_bazel_remote_execution_v2_remote_execution_java_grpc_srcs"],
+    srcs = [":" + proto + "_java_proto_srcs" for proto in JAVA_LIBRARY_PROTOS] + [
+        ":build_bazel_remote_execution_v2_remote_execution_java_grpc_srcs",
+    ],
     visibility = ["@//src:__pkg__"],
 )
 

--- a/tools/android/android_sdk_repository_template.bzl
+++ b/tools/android/android_sdk_repository_template.bzl
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:defs.bzl", "java_binary", "java_import")
+
 def create_config_setting_rule():
     """Create config_setting rule for windows.
 
@@ -86,7 +88,7 @@ def create_android_sdk_rules(
         if api_level >= 23:
             # Android 23 removed most of org.apache.http from android.jar and moved it
             # to a separate jar.
-            native.java_import(
+            java_import(
                 name = "org_apache_http_legacy-%d" % api_level,
                 jars = ["platforms/android-%d/optional/org.apache.http.legacy.jar" % api_level],
             )
@@ -94,7 +96,7 @@ def create_android_sdk_rules(
         if api_level >= 28:
             # Android 28 removed most of android.test from android.jar and moved it
             # to separate jars.
-            native.java_import(
+            java_import(
                 name = "legacy_test-%d" % api_level,
                 jars = [
                     "platforms/android-%d/optional/android.test.base.jar" % api_level,
@@ -148,8 +150,7 @@ def create_android_sdk_rules(
         name = "sdk",
         actual = ":sdk-%d" % default_api_level,
     )
-
-    native.java_binary(
+    java_binary(
         name = "apksigner",
         main_class = "com.android.apksigner.ApkSignerTool",
         runtime_deps = ["build-tools/%s/lib/apksigner.jar" % build_tools_directory],
@@ -248,20 +249,17 @@ def create_android_sdk_rules(
         srcs = ["main_dex_list_creator.sh"],
         data = [":main_dex_list_creator_java"],
     )
-
-    native.java_binary(
+    java_binary(
         name = "main_dex_list_creator_java",
         main_class = "com.android.multidex.ClassReferenceListBuilder",
         runtime_deps = [":dx_jar_import"],
     )
-
-    native.java_binary(
+    java_binary(
         name = "dx_binary",
         main_class = "com.android.dx.command.Main",
         runtime_deps = [":dx_jar_import"],
     )
-
-    native.java_import(
+    java_import(
         name = "dx_jar_import",
         jars = ["build-tools/%s/lib/dx.jar" % build_tools_directory],
     )

--- a/tools/j2objc/BUILD
+++ b/tools/j2objc/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
 
 package(default_visibility = ["//visibility:public"])

--- a/tools/java/runfiles/BUILD
+++ b/tools/java/runfiles/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:private"])
 
 filegroup(

--- a/tools/java/runfiles/testing/BUILD
+++ b/tools/java/runfiles/testing/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(default_visibility = ["//visibility:private"])
 
 filegroup(

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_import", "java_runtime", "java_toolchain")
 load(
     "//tools/jdk:default_java_toolchain.bzl",
     "JDK8_JVM_OPTS",

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:defs.bzl", "java_toolchain")
+
 """Bazel rules for creating Java toolchains."""
 
 JDK8_JVM_OPTS = [
@@ -84,8 +86,7 @@ def default_java_toolchain(name, **kwargs):
 
     toolchain_args = dict(DEFAULT_TOOLCHAIN_CONFIGURATION)
     toolchain_args.update(kwargs)
-
-    native.java_toolchain(
+    java_toolchain(
         name = name,
         **toolchain_args
     )

--- a/tools/jdk/remote_java_tools_aliases.bzl
+++ b/tools/jdk/remote_java_tools_aliases.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:defs.bzl", "java_import")
+
 """A collection of macros that retrieve targets from the remote java tools."""
 
 def _get_args(target, attr, **kwargs):
@@ -38,4 +40,4 @@ def remote_java_tools_filegroup(name, target, **kwargs):
 
 def remote_java_tools_java_import(name, target, **kwargs):
     args = _get_args(target, "jars", **kwargs)
-    native.java_import(name = name, **args)
+    java_import(name = name, **args)

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(
     default_visibility = [
         "//tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator:__pkg__",

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BUILD
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0


### PR DESCRIPTION
Migrate bazel to use the Java rules from the rules_java repository.

Progress on #8746.