### PR TITLE
Cycle remote execute/wait on unresponsive end

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
@@ -129,49 +129,53 @@ class GrpcRemoteExecutor {
     try {
       return retrier.execute(
           () -> {
-            final Iterator<Operation> replies;
-            if (waitExecution.get()) {
-              WaitExecutionRequest wr =
-                  WaitExecutionRequest.newBuilder().setName(operation.get().getName()).build();
-              replies = execBlockingStub().waitExecution(wr);
-            } else {
-              replies = execBlockingStub().execute(request);
-            }
-            try {
-              while (replies.hasNext()) {
-                Operation o = replies.next();
-                operation.set(o);
-                waitExecution.set(!operation.get().getDone());
-                ExecuteResponse r = getOperationResponse(o);
-                if (r != null) {
-                  return r;
-                }
+            for (;;) {
+              final Iterator<Operation> replies;
+              if (waitExecution.get()) {
+                WaitExecutionRequest wr =
+                    WaitExecutionRequest.newBuilder().setName(operation.get().getName()).build();
+                replies = execBlockingStub().waitExecution(wr);
+              } else {
+                replies = execBlockingStub().execute(request);
               }
-            } catch (StatusRuntimeException e) {
-              if (e.getStatus().getCode() == Code.NOT_FOUND) {
-                // Operation was lost on the server. Retry Execute.
-                waitExecution.set(false);
-              }
-              throw e;
-            } finally {
-              // The blocking streaming call closes correctly only when trailers and a Status
-              // are received from the server so that onClose() is called on this call's
-              // CallListener. Under normal circumstances (no cancel/errors), these are
-              // guaranteed to be sent by the server only if replies.hasNext() has been called
-              // after all replies from the stream have been consumed.
               try {
                 while (replies.hasNext()) {
-                  replies.next();
+                  Operation o = replies.next();
+                  operation.set(o);
+                  waitExecution.set(!operation.get().getDone());
+                  ExecuteResponse r = getOperationResponse(o);
+                  if (r != null) {
+                    return r;
+                  }
                 }
               } catch (StatusRuntimeException e) {
-                // Cleanup: ignore exceptions, because the meaningful errors have already been
-                // propagated.
+                if (e.getStatus().getCode() == Code.NOT_FOUND) {
+                  // Operation was lost on the server. Retry Execute.
+                  waitExecution.set(false);
+                }
+                throw e;
+              } finally {
+                // The blocking streaming call closes correctly only when trailers and a Status
+                // are received from the server so that onClose() is called on this call's
+                // CallListener. Under normal circumstances (no cancel/errors), these are
+                // guaranteed to be sent by the server only if replies.hasNext() has been called
+                // after all replies from the stream have been consumed.
+                try {
+                  while (replies.hasNext()) {
+                    replies.next();
+                  }
+                } catch (StatusRuntimeException e) {
+                  // Cleanup: ignore exceptions, because the meaningful errors have already been
+                  // propagated.
+                }
+              }
+              if (!waitExecution.get()) {
+                throw new IOException(
+                    String.format(
+                        "Remote server error: execution request for %s terminated with no result.",
+                        operation.get().getName()));
               }
             }
-            throw new IOException(
-                String.format(
-                    "Remote server error: execution request for %s terminated with no result.",
-                    operation.get().getName()));
           });
     } catch (StatusRuntimeException e) {
       throw new IOException(e);

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
@@ -1191,4 +1191,85 @@ public class GrpcRemoteExecutionClientTest {
     assertThat(numCacheUploads.get()).isEqualTo(2);
     assertThat(numExecuteCalls.get()).isEqualTo(2);
   }
+
+  @Test
+  public void execWaitsOnUnfinishedCompletion() throws Exception {
+    serviceRegistry.addService(
+        new ActionCacheImplBase() {
+          @Override
+          public void getActionResult(
+              GetActionResultRequest request, StreamObserver<ActionResult> responseObserver) {
+            responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
+          }
+        });
+
+    final String opName = "operations/xyz";
+    final Digest resultDigest = DIGEST_UTIL.compute("bla".getBytes(UTF_8));
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+            responseObserver.onNext(
+                ReadResponse.newBuilder().setData(ByteString.copyFromUtf8("bla")).build());
+            responseObserver.onCompleted();
+          }
+        });
+    final ActionResult actionResult =
+        ActionResult.newBuilder()
+            .setStdoutRaw(ByteString.copyFromUtf8("stdout"))
+            .setStderrRaw(ByteString.copyFromUtf8("stderr"))
+            .addOutputFiles(OutputFile.newBuilder().setPath("foo").setDigest(resultDigest).build())
+            .build();
+    final Operation unfinishedOperation = Operation.newBuilder()
+        .setName(opName)
+        .build();
+    final Operation completeOperation = unfinishedOperation.toBuilder()
+        .setDone(true)
+        .setResponse(Any.pack(ExecuteResponse.newBuilder().setResult(actionResult).build()))
+        .build();
+    final WaitExecutionRequest waitExecutionRequest = WaitExecutionRequest.newBuilder()
+        .setName(opName)
+        .build();
+    ExecutionImplBase mockExecutionImpl = Mockito.mock(ExecutionImplBase.class);
+    // Flow of this test:
+    // - call execute, get an unfinished Operation, then the stream completes
+    // - call waitExecute, get an unfinished Operation, then the stream completes
+    // - call waitExecute, get a finished Operation
+    Mockito.doAnswer(answerWith(unfinishedOperation, Status.OK))
+        .when(mockExecutionImpl)
+        .execute(
+            ArgumentMatchers.<ExecuteRequest>any(),
+            ArgumentMatchers.<StreamObserver<Operation>>any());
+    Mockito.doAnswer(answerWith(unfinishedOperation, Status.OK))
+        .doAnswer(answerWith(completeOperation, Status.OK))
+        .when(mockExecutionImpl)
+        .waitExecution(
+            ArgumentMatchers.eq(waitExecutionRequest),
+            ArgumentMatchers.<StreamObserver<Operation>>any());
+    serviceRegistry.addService(mockExecutionImpl);
+
+    serviceRegistry.addService(
+        new ContentAddressableStorageImplBase() {
+
+          @Override
+          public void findMissingBlobs(
+              FindMissingBlobsRequest request,
+              StreamObserver<FindMissingBlobsResponse> responseObserver) {
+            responseObserver.onNext(FindMissingBlobsResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+          }
+        });
+
+    FakeSpawnExecutionContext policy =
+        new FakeSpawnExecutionContext(simpleSpawn, fakeFileCache, execRoot, outErr);
+
+    SpawnResult result = client.exec(simpleSpawn, policy);
+    assertThat(result.setupSuccess()).isTrue();
+    assertThat(result.exitCode()).isEqualTo(0);
+    assertThat(result.isCacheHit()).isFalse();
+    Mockito.verify(mockExecutionImpl, Mockito.times(1))
+        .execute(Mockito.any(ExecuteRequest.class), Mockito.any(StreamObserver.class));
+    Mockito.verify(mockExecutionImpl, Mockito.times(2))
+        .waitExecution(Mockito.eq(waitExecutionRequest), Mockito.any(StreamObserver.class));
+  }
 }


### PR DESCRIPTION
If an execute/waitExecution stream ends, it can be the result of a
server termination. Ignore this state and rewait for the execution
assuming we are configured to do so.

Fixes #8605

Change-Id: Ib68063795e0482b9a67c2565263cb58098f4c8b6