### PR TITLE
Protobuf spec for a remote repository cache.

### DIFF
--- a/src/main/protobuf/BUILD
+++ b/src/main/protobuf/BUILD
@@ -190,6 +190,30 @@ java_library_srcs(
     deps = [":remote_execution_log_java_proto"],
 )
 
+proto_library(
+    name = "remote_repository_cache_proto",
+    srcs = ["remote_repository_cache.proto"],
+    deps = [
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_proto",
+    ],
+)
+
+java_proto_library(
+    name = "remote_repository_cache_java_proto",
+    deps = [":remote_repository_cache_proto"],
+)
+
+java_grpc_library(
+    name = "remote_repository_cache_java_grpc",
+    srcs = [":remote_repository_cache_proto"],
+    deps = [":remote_repository_cache_java_proto"],
+)
+
+java_library_srcs(
+    name = "remote_repository_cache_java_proto_srcs",
+    deps = [":remote_repository_cache_java_proto"],
+)
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),

--- a/src/main/protobuf/remote_repository_cache.proto
+++ b/src/main/protobuf/remote_repository_cache.proto
@@ -1,0 +1,73 @@
+// Copyright 2019 The Bazel Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package bazel_repository_cache;
+
+import "build/bazel/remote/execution/v2/remote_execution.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "RemoteRepositoryCacheProto";
+option java_package = "com.google.devtools.build.lib.remote.repositorycache";
+
+// The repository cache API is used to download and cache external repositories.
+// Once downloaded, the repository content can be fetched from the
+// [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage]
+// by digest.
+service RepositoryCache {
+  // Ensure that a single file is available in the CAS.
+  //
+  // Errors:
+  // * `INVALID_ARGUMENT`: One or more request fields are invalid.
+  // * `NOT_FOUND`: The cache could not find content for the given request.
+  // * `RESOURCE_EXHAUSTED`: There is insufficient CAS capacity to store the
+  //   downloaded content.
+  // * `FAILED_PRECONDITION`: The cache found content at the given URLs that it
+  //   believes is valid content, but it did not match the content integrity
+  //   checksum.
+  //
+  // Repository caches may, but are not required to, verify content integrity.
+  // The client is expected to perform its own content integrity validation if
+  // the cache is not trusted to do so.
+  rpc ResolveFile(ResolveFileRequest) returns (ResolveFileResponse);
+}
+
+// A request message for
+// [RepositoryCache.ResolveFile][bazel_repository_cache.RepositoryCache.ResolveFile].
+message ResolveFileRequest {
+  // The instance of the execution system to operate against. A server may
+  // support multiple instances of the execution system (with their own workers,
+  // storage, caches, etc.). The server MAY require use of this field to select
+  // between them in an implementation-defined fashion, otherwise it can be
+  // omitted.
+  string instance_name = 1;
+
+  // List of mirror URLs referencing the same file.
+  repeated string urls = 2;
+
+  // Expected checksum of the file downloaded, in Subresource Integrity format.
+  string integrity = 3;
+
+  // If set, restrict cache hits to those cases where the file was added to the
+  // cache with the same canonical id
+  string canonical_id = 4;
+}
+
+// A response message for
+// [RepositoryCache.ResolveFile][bazel_repository_cache.RepositoryCache.ResolveFile].
+message ResolveFileResponse {
+  // The blob digest of the downloaded file.
+  build.bazel.remote.execution.v2.Digest digest = 1;
+}


### PR DESCRIPTION
(extracted from https://github.com/bazelbuild/bazel/pull/8782)

This API is currently a proposal under review: https://docs.google.com/document/d/1aagKnM8kRmMvLqSXasShsI-NYOBZYtgNrbYWLPwBoBg/edit

Mailing list thread: https://groups.google.com/forum/#!topic/remote-execution-apis/Gyzvz7WkQPE

Discussion on the doc is mostly focused on whether it should be expanded to support non-file caching, such as the output of a Git clone. Since it seems like the core functionality of "download and cache a single file" is not controversial, I'd like to start work on that part.

The spec currently describes two RPCs, `ResolveFile` and `ResolveDirectory`. Since Bazel does not currently support downloading directories as part of a repository rule, I've left that RPC out of this PR.

cc @aehlig @buchgr @dslomov @EricBurnett @ulfjack