### PR TITLE
Enable the flag incompatible_disallow_rule_execution_platform_constraints_allowed

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
@@ -386,7 +386,7 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
 
   @Option(
       name = "incompatible_disallow_rule_execution_platform_constraints_allowed",
-      defaultValue = "False",
+      defaultValue = "True",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
       effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
       metadataTags = {

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
@@ -276,7 +276,7 @@ public abstract class StarlarkSemantics {
           .incompatibleDisallowLegacyJavaProvider(false)
           .incompatibleDisallowLegacyJavaInfo(false)
           .incompatibleDisallowOldStyleArgsAdd(true)
-          .incompatibleDisallowRuleExecutionPlatformConstraintsAllowed(false)
+          .incompatibleDisallowRuleExecutionPlatformConstraintsAllowed(true)
           .incompatibleDisallowStructProviderSyntax(false)
           .incompatibleDisallowUnverifiedHttpDownloads(true)
           .incompatibleExpandDirectories(true)

--- a/src/test/shell/bazel/toolchain_test.sh
+++ b/src/test/shell/bazel/toolchain_test.sh
@@ -1003,7 +1003,6 @@ sample_rule = rule(
   implementation = _impl,
   attrs = {},
   toolchains = ['//toolchain:test_toolchain'],
-  execution_platform_constraints_allowed = True,
 )
 EOF
 
@@ -1074,7 +1073,6 @@ sample_rule = rule(
     '//platforms:value2',
   ],
   toolchains = ['//toolchain:test_toolchain'],
-  execution_platform_constraints_allowed = True,
 )
 EOF
 
@@ -1453,7 +1451,6 @@ sample_rule = rule(
   attrs = {
     "dep": attr.label(cfg = 'exec'),
   },
-  execution_platform_constraints_allowed = True,
 )
 
 def _display_platform_impl(ctx):


### PR DESCRIPTION
--incompatible_disallow_rule_execution_platform_constraints_allowed.

RELNOTES: Enable incompatible_disallow_rule_execution_platform_constraints_allowed by default (https://github.com/bazelbuild/bazel/issues/8136).