### PR TITLE
Build setting rules shouldn't be able to use toolchain resolution.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -853,6 +853,10 @@ public class RuleClass {
           attrBuilder.allowedRuleClasses(ANY_RULE);
         }
         this.add(attrBuilder);
+
+        // Build setting rules should opt out of toolchain resolution, since they form part of the
+        // configuration.
+        this.useToolchainResolution(false);
       }
 
       return new RuleClass(


### PR DESCRIPTION
They are part of the configuration, this would lead to cycles.

Fixes #9099.