### PR TITLE
Clear COMPREPLY if there are no completions

### DIFF
--- a/scripts/bazel-complete-template.bash
+++ b/scripts/bazel-complete-template.bash
@@ -429,6 +429,10 @@ _bazel__to_compreply() {
   while IFS="" read -r reply; do
     COMPREPLY+=("${reply}")
   done < <(echo "${replies}")
+  # Null may be set despite there being no completions
+  if [ ${#COMPREPLY[@]} -eq 1] && [ -z ${COMPREPLY[0]} ]; then
+    COMPREPLY=()
+  fi
 }
 
 _bazel__complete() {


### PR DESCRIPTION
Checks COMPREPLY after filling it to reset it to () if it only contains a null entry, allowing fall-through to other completions configured through bash.

Per the [bash manual][1], after a bash completion function runs, "possible completions are retrieved from the value of the COMPREPLY array variable." However, the bazel completion function includes a null first element in COMPREPLY if no completions are found. This prevents it from falling through and allowing other default behaviors - it does not play nice in the shell. This is done in _bazel__to_compreply().

For example:

    complete -o nospace -o default -F _bazel__complete

This command should allow any command to use bazel completions (if available), and then fall-through to default completions. Typing `vim l<TAB>` should give me completions of files beginning with l (assuming no bazel completions begin that way). In its current state, by including a null entry in COMPREPLY, the fallthrough enabled by '-o default' is currently prevented.

Fixes #9112

[1]: https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html