### PR TITLE
Improve performance of string.replace

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -491,6 +491,7 @@ java_library(
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:jsr305",
+        "//third_party:apache_commons_lang",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -491,7 +491,6 @@ java_library(
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:jsr305",
-        "//third_party:apache_commons_lang",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
@@ -286,9 +286,23 @@ public final class StringModule {
   public String replace(
       String self, String oldString, String newString, Object maxSplitO)
       throws EvalException {
-    int maxSplit = -1;
-    if (maxSplitO != Runtime.NONE && (Integer) maxSplitO >= 0) {
-      maxSplit = (Integer) maxSplitO;
+    int maxSplit = Integer.MAX_VALUE;
+    if (maxSplitO != Runtime.NONE) {
+      maxSplit = Math.max(0, (Integer) maxSplitO);
+    }
+    if (oldString.equals("")) {
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < self.length(); i++) {
+        if (maxSplit > 0) {
+          sb.append(newString);
+          maxSplit--;
+        }
+        sb.append(self.charAt(i));
+      }
+      if (maxSplit > 0) {
+        sb.append(newString);
+      }
+      return sb.toString();
     }
     return StringUtils.replace(self, oldString, newString, maxSplit);
   }

--- a/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Skylark String module.
@@ -290,21 +289,25 @@ public final class StringModule {
     if (maxSplitO != Runtime.NONE) {
       maxSplit = Math.max(0, (Integer) maxSplitO);
     }
-    if (oldString.equals("")) {
-      StringBuilder sb = new StringBuilder();
-      for (int i = 0; i < self.length(); i++) {
-        if (maxSplit > 0) {
-          sb.append(newString);
-          maxSplit--;
-        }
-        sb.append(self.charAt(i));
-      }
-      if (maxSplit > 0) {
+    StringBuilder sb = new StringBuilder();
+    int start = 0;
+    for (int i = 0; i < maxSplit; i++) {
+      if (oldString.isEmpty()) {
         sb.append(newString);
+        if (start < self.length()) {
+          sb.append(self.charAt(start++));
+        } else {
+          break;
+        }
+      } else {
+        int end = self.indexOf(oldString, start);
+        if (end < 0) break;
+        sb.append(self, start, end).append(newString);
+        start = end + oldString.length();
       }
-      return sb.toString();
     }
-    return StringUtils.replace(self, oldString, newString, maxSplit);
+    sb.append(self, start, self.length());
+    return sb.toString();
   }
 
   @SkylarkCallable(

--- a/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Skylark String module.
@@ -281,25 +282,15 @@ public final class StringModule {
             // TODO(cparsons): This parameter should be positional-only.
             legacyNamed = true,
             doc = "The maximum number of replacements.")
-      },
-      useLocation = true)
+      })
   public String replace(
-      String self, String oldString, String newString, Object maxSplitO, Location loc)
+      String self, String oldString, String newString, Object maxSplitO)
       throws EvalException {
-    StringBuffer sb = new StringBuffer();
-    Integer maxSplit =
-        Type.INTEGER.convertOptional(
-            maxSplitO, "'maxsplit' argument of 'replace'", /*label*/ null, Integer.MAX_VALUE);
-    try {
-      Matcher m = Pattern.compile(oldString, Pattern.LITERAL).matcher(self);
-      for (int i = 0; i < maxSplit && m.find(); i++) {
-        m.appendReplacement(sb, Matcher.quoteReplacement(newString));
-      }
-      m.appendTail(sb);
-    } catch (IllegalStateException e) {
-      throw new EvalException(loc, e.getMessage() + " in call to replace");
+    int maxSplit = -1;
+    if (maxSplitO != Runtime.NONE && (Integer) maxSplitO >= 0) {
+      maxSplit = (Integer) maxSplitO;
     }
-    return sb.toString();
+    return StringUtils.replace(self, oldString, newString, maxSplit);
   }
 
   @SkylarkCallable(

--- a/src/test/starlark/testdata/string_misc.sky
+++ b/src/test/starlark/testdata/string_misc.sky
@@ -41,6 +41,9 @@ assert_eq('b$()n$()n$()'.replace('$()', '$($())'), "b$($())n$($())n$($())")
 assert_eq('b\\n\\n\\'.replace('\\', '$()'), "b$()n$()n$()")
 
 assert_eq('banana'.replace('a', 'e', 2), "benena")
+assert_eq('banana'.replace('a', 'e', 0), "banana")
+assert_eq('banana'.replace('a', 'e', -1), "benene")
+assert_eq('banana'.replace('a', 'e', -10), "benene")
 
 # index, rindex
 assert_eq('banana'.index('na'), 2)

--- a/src/test/starlark/testdata/string_misc.sky
+++ b/src/test/starlark/testdata/string_misc.sky
@@ -42,8 +42,17 @@ assert_eq('b\\n\\n\\'.replace('\\', '$()'), "b$()n$()n$()")
 
 assert_eq('banana'.replace('a', 'e', 2), "benena")
 assert_eq('banana'.replace('a', 'e', 0), "banana")
-assert_eq('banana'.replace('a', 'e', -1), "benene")
-assert_eq('banana'.replace('a', 'e', -10), "benene")
+assert_eq('banana'.replace('a', 'e', -1), "banana")
+assert_eq('banana'.replace('a', 'e', -10), "banana")
+
+assert_eq('banana'.replace('', '-'), "-b-a-n-a-n-a-")
+assert_eq('banana'.replace('', '-', -2), "banana")
+assert_eq('banana'.replace('', '-', 2), "-b-anana")
+assert_eq('banana'.replace('', '-', 0), "banana")
+
+assert_eq('banana'.replace('', ''), "banana")
+assert_eq('banana'.replace('a', ''), "bnn")
+assert_eq('banana'.replace('a', '', 2), "bnna")
 
 # index, rindex
 assert_eq('banana'.index('na'), 2)


### PR DESCRIPTION
This PR improves the performance, in terms of time, of `replace` method by replacing regex by linear scanning which is much faster.
Using the benchmark [here](https://github.com/Quarz0/starlark/blob/benchmark_runner/benchmark_suite/data/string_replace.star), the results obtained on my local machine were as follows:
```
=== data/string_replace.star ===
                   Time (MS)  Memory (KB)
java               10777.098    89340.000    # Before
java                1728.092   184904.000    # After
go                    10.259     4496.000
rust                6615.044     4500.000
python3               50.873     5640.000
```

~~This also fixes the case where `maxsplits` is a negative value. According to the [spec](https://github.com/bazelbuild/starlark/blob/master/spec.md#stringreplace), a negative value for the number of splits should be ignored and this is also what python and the Go implementation do.~~
```python
# Before
"abc".replace("a", "z", -1)    # "abc"
# After
"abc".replace("a", "z", -1)    # "zbc"
```