### PR TITLE
Fix Android builds with aapt2 on Windows

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/BusyBoxActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/BusyBoxActionBuilder.java
@@ -223,21 +223,15 @@ public final class BusyBoxActionBuilder {
   /**
    * Adds an efficient flag and inputs based on transitive values.
    *
-   * <p>Each value will be separated on the command line by the host-specific path separator.
+   * <p>Each value will be separated on the command line by the ':' character, the option parser's
+   * PathListConverter delimiter.
    *
    * <p>Unlike other transitive input methods in this class, this method adds the values to both the
    * command line and the list of inputs.
    */
   public BusyBoxActionBuilder addTransitiveVectoredInput(
       @CompileTimeConstant String arg, NestedSet<Artifact> values) {
-    commandLine.addExecPaths(
-        arg,
-        VectorArg.join(
-                dataContext
-                    .getActionConstructionContext()
-                    .getConfiguration()
-                    .getHostPathSeparator())
-            .each(values));
+    commandLine.addExecPaths(arg, VectorArg.join(":").each(values));
     inputs.addTransitive(values);
     return this;
   }

--- a/src/tools/android/java/com/google/devtools/build/android/aapt2/ProtoApk.java
+++ b/src/tools/android/java/com/google/devtools/build/android/aapt2/ProtoApk.java
@@ -43,11 +43,8 @@ import com.google.common.io.ByteStreams;
 import com.google.common.xml.XmlEscapers;
 import com.google.devtools.build.android.AndroidResourceOutputs.UniqueZipBuilder;
 import com.google.protobuf.ByteString;
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
+
+import java.io.*;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -226,7 +223,17 @@ public class ProtoApk implements Closeable {
 
   /** The apk as path. */
   public Path asApkPath() {
-    return Paths.get(uri.toString().substring("jar:".length() + 1));
+    String pathString = uri.toString().substring("jar:".length() + 1);
+
+    // On Windows, the fully qualified URI looks like:
+    // jar:////C:/Users/user/AppData/Local/Temp/android_resources_tmp12318742536955859612/linked/bin.-pb.apk
+    //
+    // We want "C:/Users...".
+    if (pathString.startsWith("///")) {
+      pathString = pathString.substring("///".length());
+    }
+
+    return Paths.get(pathString);
   }
 
   /** Thrown when errors occur during proto apk processing. */


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/9102

This will require a new android_tools release. Let's also follow up by adding some pure `android_binary` builds for presubmit, perhaps using the example app.