### PR TITLE
Client, refactor: simplify nullary flag handling

### DIFF
--- a/src/main/cpp/bazel_startup_options.cc
+++ b/src/main/cpp/bazel_startup_options.cc
@@ -29,10 +29,10 @@ BazelStartupOptions::BazelStartupOptions(
       use_workspace_rc(true),
       use_home_rc(true),
       use_master_bazelrc_(true) {
-  RegisterNullaryStartupFlag("home_rc");
-  RegisterNullaryStartupFlag("master_bazelrc");
-  RegisterNullaryStartupFlag("system_rc");
-  RegisterNullaryStartupFlag("workspace_rc");
+  RegisterNullaryStartupFlagNoRc("home_rc", &use_home_rc);
+  RegisterNullaryStartupFlagNoRc("master_bazelrc", &use_master_bazelrc_);
+  RegisterNullaryStartupFlagNoRc("system_rc", &use_system_rc);
+  RegisterNullaryStartupFlagNoRc("workspace_rc", &use_workspace_rc);
   RegisterUnaryStartupFlag("bazelrc");
 }
 
@@ -48,62 +48,6 @@ blaze_exit_code::ExitCode BazelStartupOptions::ProcessArgExtra(
       return blaze_exit_code::BAD_ARGV;
     }
     user_bazelrc_ = *value;
-  } else if (GetNullaryOption(arg, "--system_rc")) {
-    if (!rcfile.empty()) {
-      *error = "Can't specify --system_rc in .bazelrc file.";
-      return blaze_exit_code::BAD_ARGV;
-    }
-    use_system_rc = true;
-    option_sources["system_rc"] = rcfile;
-  } else if (GetNullaryOption(arg, "--nosystem_rc")) {
-    if (!rcfile.empty()) {
-      *error = "Can't specify --nosystem_rc in .bazelrc file.";
-      return blaze_exit_code::BAD_ARGV;
-    }
-    use_system_rc = false;
-    option_sources["system_rc"] = rcfile;
-  } else if (GetNullaryOption(arg, "--workspace_rc")) {
-    if (!rcfile.empty()) {
-      *error = "Can't specify --workspace_rc in .bazelrc file.";
-      return blaze_exit_code::BAD_ARGV;
-    }
-    use_workspace_rc = true;
-    option_sources["workspace_rc"] = rcfile;
-  } else if (GetNullaryOption(arg, "--noworkspace_rc")) {
-    if (!rcfile.empty()) {
-      *error = "Can't specify --noworkspace_rc in .bazelrc file.";
-      return blaze_exit_code::BAD_ARGV;
-    }
-    use_workspace_rc = false;
-    option_sources["workspace_rc"] = rcfile;
-  } else if (GetNullaryOption(arg, "--home_rc")) {
-    if (!rcfile.empty()) {
-      *error = "Can't specify --home_rc in .bazelrc file.";
-      return blaze_exit_code::BAD_ARGV;
-    }
-    use_home_rc = true;
-    option_sources["home_rc"] = rcfile;
-  } else if (GetNullaryOption(arg, "--nohome_rc")) {
-    if (!rcfile.empty()) {
-      *error = "Can't specify --nohome_rc in .bazelrc file.";
-      return blaze_exit_code::BAD_ARGV;
-    }
-    use_home_rc = false;
-    option_sources["home_rc"] = rcfile;
-  } else if (GetNullaryOption(arg, "--master_bazelrc")) {
-    if (!rcfile.empty()) {
-      *error = "Can't specify --master_bazelrc in .bazelrc file.";
-      return blaze_exit_code::BAD_ARGV;
-    }
-    use_master_bazelrc_ = true;
-    option_sources["blazerc"] = rcfile;
-  } else if (GetNullaryOption(arg, "--nomaster_bazelrc")) {
-    if (!rcfile.empty()) {
-      *error = "Can't specify --nomaster_bazelrc in .bazelrc file.";
-      return blaze_exit_code::BAD_ARGV;
-    }
-    use_master_bazelrc_ = false;
-    option_sources["blazerc"] = rcfile;
   } else {
     *is_processed = false;
     return blaze_exit_code::SUCCESS;

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -36,9 +36,17 @@ namespace blaze {
 using std::string;
 using std::vector;
 
-void StartupOptions::RegisterNullaryStartupFlag(const std::string &flag_name) {
-  valid_nullary_startup_flags_.insert(std::string("--") + flag_name);
-  valid_nullary_startup_flags_.insert(std::string("--no") + flag_name);
+void StartupOptions::RegisterNullaryStartupFlag(const std::string &flag_name,
+                                                bool* flag_value) {
+  all_nullary_startup_flags_[std::string("--") + flag_name] = flag_value;
+  all_nullary_startup_flags_[std::string("--no") + flag_name] = flag_value;
+}
+
+void StartupOptions::RegisterNullaryStartupFlagNoRc(
+    const std::string& flag_name, bool* flag_value) {
+  RegisterNullaryStartupFlag(flag_name, flag_value);
+  no_rc_nullary_startup_flags_.insert(std::string("--") + flag_name);
+  no_rc_nullary_startup_flags_.insert(std::string("--no") + flag_name);
 }
 
 void StartupOptions::RegisterUnaryStartupFlag(const std::string &flag_name) {
@@ -105,22 +113,23 @@ StartupOptions::StartupOptions(const string &product_name,
   // IMPORTANT: Before modifying the statements below please contact a Bazel
   // core team member that knows the internal procedure for adding/deprecating
   // startup flags.
-  RegisterNullaryStartupFlag("batch");
-  RegisterNullaryStartupFlag("batch_cpu_scheduling");
-  RegisterNullaryStartupFlag("block_for_lock");
-  RegisterNullaryStartupFlag("client_debug");
-  RegisterNullaryStartupFlag("deep_execroot");
-  RegisterNullaryStartupFlag("expand_configs_in_place");
-  RegisterNullaryStartupFlag("experimental_oom_more_eagerly");
-  RegisterNullaryStartupFlag("fatal_event_bus_exceptions");
-  RegisterNullaryStartupFlag("host_jvm_debug");
-  RegisterNullaryStartupFlag("idle_server_tasks");
-  RegisterNullaryStartupFlag("incompatible_enable_execution_transition");
-  RegisterNullaryStartupFlag("shutdown_on_low_sys_mem");
-  RegisterNullaryStartupFlag("ignore_all_rc_files");
-  RegisterNullaryStartupFlag("unlimit_coredumps");
-  RegisterNullaryStartupFlag("watchfs");
-  RegisterNullaryStartupFlag("write_command_log");
+  RegisterNullaryStartupFlag("batch", &batch);
+  RegisterNullaryStartupFlag("batch_cpu_scheduling", &batch_cpu_scheduling);
+  RegisterNullaryStartupFlag("block_for_lock", &block_for_lock);
+  RegisterNullaryStartupFlag("client_debug", &client_debug);
+  RegisterNullaryStartupFlag("deep_execroot", &deep_execroot);
+  RegisterNullaryStartupFlag("expand_configs_in_place", &expand_configs_in_place);
+  RegisterNullaryStartupFlag("experimental_oom_more_eagerly", &oom_more_eagerly);
+  RegisterNullaryStartupFlag("fatal_event_bus_exceptions", &fatal_event_bus_exceptions);
+  RegisterNullaryStartupFlag("host_jvm_debug", &host_jvm_debug);  // --no was not supported
+  RegisterNullaryStartupFlag("idle_server_tasks", &idle_server_tasks);
+  RegisterNullaryStartupFlag("incompatible_enable_execution_transition",
+      &incompatible_enable_execution_transition);
+  RegisterNullaryStartupFlag("shutdown_on_low_sys_mem", &shutdown_on_low_sys_mem);
+  RegisterNullaryStartupFlagNoRc("ignore_all_rc_files", &ignore_all_rc_files);
+  RegisterNullaryStartupFlag("unlimit_coredumps", &unlimit_coredumps);
+  RegisterNullaryStartupFlag("watchfs", &watchfs);
+  RegisterNullaryStartupFlag("write_command_log", &write_command_log);
   RegisterUnaryStartupFlag("command_port");
   RegisterUnaryStartupFlag("connect_timeout_secs");
   RegisterUnaryStartupFlag("digest_function");
@@ -160,12 +169,12 @@ bool StartupOptions::IsUnary(const string &arg) const {
 bool StartupOptions::IsNullary(const string &arg) const {
   std::string::size_type i = arg.find_first_of('=');
   if (i == std::string::npos) {
-    return valid_nullary_startup_flags_.find(arg) !=
-           valid_nullary_startup_flags_.end();
+    return all_nullary_startup_flags_.find(arg) !=
+           all_nullary_startup_flags_.end();
   } else {
     std::string f = arg.substr(0, i);
-    if (valid_nullary_startup_flags_.find(f) !=
-        valid_nullary_startup_flags_.end()) {
+    if (all_nullary_startup_flags_.find(f) !=
+        all_nullary_startup_flags_.end()) {
       BAZEL_DIE(blaze_exit_code::BAD_ARGV)
           << "In argument '" << arg << "': option '" << f
           << "' does not take a value.";
@@ -192,6 +201,22 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
   const char* next_arg = next_argstr.empty() ? NULL : next_argstr.c_str();
   const char* value = NULL;
 
+  if (IsNullary(argstr)) {
+    bool* target = all_nullary_startup_flags_[argstr];
+    bool enabled = (argstr.compare(0, 4, "--no") != 0);
+    if (no_rc_nullary_startup_flags_.find(argstr) !=
+        no_rc_nullary_startup_flags_.end()) {
+      if (!rcfile.empty()) {
+        *error = std::string("Can't specify ") + argstr + " in the .bazelrc file.";
+        return blaze_exit_code::BAD_ARGV;
+      }
+    }
+    *target = enabled;
+    option_sources[argstr.substr(enabled ? 2 : 4)] = rcfile;
+    *is_space_separated = false;
+    return blaze_exit_code::SUCCESS;
+  }
+
   if ((value = GetUnaryOption(arg, next_arg, "--output_base")) != NULL) {
     output_base = blaze::AbsolutePathFromFlag(value);
     option_sources["output_base"] = rcfile;
@@ -207,21 +232,6 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
                                      "--server_jvm_out")) != NULL) {
     server_jvm_out = blaze::AbsolutePathFromFlag(value);
     option_sources["server_jvm_out"] = rcfile;
-  } else if (GetNullaryOption(arg, "--deep_execroot")) {
-    deep_execroot = true;
-    option_sources["deep_execroot"] = rcfile;
-  } else if (GetNullaryOption(arg, "--nodeep_execroot")) {
-    deep_execroot = false;
-    option_sources["deep_execroot"] = rcfile;
-  } else if (GetNullaryOption(arg, "--block_for_lock")) {
-    block_for_lock = true;
-    option_sources["block_for_lock"] = rcfile;
-  } else if (GetNullaryOption(arg, "--noblock_for_lock")) {
-    block_for_lock = false;
-    option_sources["block_for_lock"] = rcfile;
-  } else if (GetNullaryOption(arg, "--host_jvm_debug")) {
-    host_jvm_debug = true;
-    option_sources["host_jvm_debug"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--host_jvm_profile")) !=
              NULL) {
     host_jvm_profile = value;
@@ -236,38 +246,6 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
              NULL) {
     host_jvm_args.push_back(value);
     option_sources["host_jvm_args"] = rcfile;  // NB: This is incorrect
-  } else if (GetNullaryOption(arg, "--ignore_all_rc_files")) {
-    if (!rcfile.empty()) {
-      *error = "Can't specify --ignore_all_rc_files in an rc file.";
-      return blaze_exit_code::BAD_ARGV;
-    }
-    ignore_all_rc_files = true;
-    option_sources["ignore_all_rc_files"] = rcfile;
-  } else if (GetNullaryOption(arg, "--noignore_all_rc_files")) {
-    if (!rcfile.empty()) {
-      *error = "Can't specify --noignore_all_rc_files in an rc file.";
-      return blaze_exit_code::BAD_ARGV;
-    }
-    ignore_all_rc_files = false;
-    option_sources["ignore_all_rc_files"] = rcfile;
-  } else if (GetNullaryOption(arg, "--batch")) {
-    batch = true;
-    option_sources["batch"] = rcfile;
-  } else if (GetNullaryOption(arg, "--nobatch")) {
-    batch = false;
-    option_sources["batch"] = rcfile;
-  } else if (GetNullaryOption(arg, "--batch_cpu_scheduling")) {
-    batch_cpu_scheduling = true;
-    option_sources["batch_cpu_scheduling"] = rcfile;
-  } else if (GetNullaryOption(arg, "--nobatch_cpu_scheduling")) {
-    batch_cpu_scheduling = false;
-    option_sources["batch_cpu_scheduling"] = rcfile;
-  } else if (GetNullaryOption(arg, "--fatal_event_bus_exceptions")) {
-    fatal_event_bus_exceptions = true;
-    option_sources["fatal_event_bus_exceptions"] = rcfile;
-  } else if (GetNullaryOption(arg, "--nofatal_event_bus_exceptions")) {
-    fatal_event_bus_exceptions = false;
-    option_sources["fatal_event_bus_exceptions"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--io_nice_level")) !=
              NULL) {
     if (!blaze_util::safe_strto32(value, &io_nice_level) ||
@@ -317,18 +295,6 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
       return blaze_exit_code::BAD_ARGV;
     }
     option_sources["macos_qos_class"] = rcfile;
-  } else if (GetNullaryOption(arg, "--shutdown_on_low_sys_mem")) {
-    shutdown_on_low_sys_mem = true;
-    option_sources["shutdown_on_low_sys_mem"] = rcfile;
-  } else if (GetNullaryOption(arg, "--noshutdown_on_low_sys_mem")) {
-    shutdown_on_low_sys_mem = false;
-    option_sources["shutdown_on_low_sys_mem"] = rcfile;
-  } else if (GetNullaryOption(arg, "--experimental_oom_more_eagerly")) {
-    oom_more_eagerly = true;
-    option_sources["experimental_oom_more_eagerly"] = rcfile;
-  } else if (GetNullaryOption(arg, "--noexperimental_oom_more_eagerly")) {
-    oom_more_eagerly = false;
-    option_sources["experimental_oom_more_eagerly"] = rcfile;
   } else if ((value = GetUnaryOption(
                   arg, next_arg,
                   "--experimental_oom_more_eagerly_threshold")) != NULL) {
@@ -342,36 +308,6 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
       return blaze_exit_code::BAD_ARGV;
     }
     option_sources["experimental_oom_more_eagerly_threshold"] = rcfile;
-  } else if (GetNullaryOption(arg, "--write_command_log")) {
-    write_command_log = true;
-    option_sources["write_command_log"] = rcfile;
-  } else if (GetNullaryOption(arg, "--nowrite_command_log")) {
-    write_command_log = false;
-    option_sources["write_command_log"] = rcfile;
-  } else if (GetNullaryOption(arg, "--watchfs")) {
-    watchfs = true;
-    option_sources["watchfs"] = rcfile;
-  } else if (GetNullaryOption(arg, "--nowatchfs")) {
-    watchfs = false;
-    option_sources["watchfs"] = rcfile;
-  } else if (GetNullaryOption(arg, "--client_debug")) {
-    client_debug = true;
-    option_sources["client_debug"] = rcfile;
-  } else if (GetNullaryOption(arg, "--noclient_debug")) {
-    client_debug = false;
-    option_sources["client_debug"] = rcfile;
-  } else if (GetNullaryOption(arg, "--expand_configs_in_place")) {
-    expand_configs_in_place = true;
-    option_sources["expand_configs_in_place"] = rcfile;
-  } else if (GetNullaryOption(arg, "--noexpand_configs_in_place")) {
-    expand_configs_in_place = false;
-    option_sources["expand_configs_in_place"] = rcfile;
-  } else if (GetNullaryOption(arg, "--idle_server_tasks")) {
-    idle_server_tasks = true;
-    option_sources["idle_server_tasks"] = rcfile;
-  } else if (GetNullaryOption(arg, "--noidle_server_tasks")) {
-    idle_server_tasks = false;
-    option_sources["idle_server_tasks"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg,
                                      "--connect_timeout_secs")) != NULL) {
     if (!blaze_util::safe_strto32(value, &connect_timeout_secs) ||
@@ -409,20 +345,6 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
           "multiple times.";
       return blaze_exit_code::BAD_ARGV;
     }
-  } else if (GetNullaryOption(arg, "--unlimit_coredumps")) {
-    unlimit_coredumps = true;
-    option_sources["unlimit_coredumps"] = rcfile;
-  } else if (GetNullaryOption(arg, "--nounlimit_coredumps")) {
-    unlimit_coredumps = false;
-    option_sources["unlimit_coredumps"] = rcfile;
-  } else if (GetNullaryOption(arg,
-                              "--incompatible_enable_execution_transition")) {
-    incompatible_enable_execution_transition = true;
-    option_sources["incompatible_enable_execution_transition"] = rcfile;
-  } else if (GetNullaryOption(arg,
-                              "--noincompatible_enable_execution_transition")) {
-    incompatible_enable_execution_transition = false;
-    option_sources["incompatible_enable_execution_transition"] = rcfile;
   } else {
     bool extra_argument_processed;
     blaze_exit_code::ExitCode process_extra_arg_exit_code = ProcessArgExtra(

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -118,15 +118,20 @@ StartupOptions::StartupOptions(const string &product_name,
   RegisterNullaryStartupFlag("block_for_lock", &block_for_lock);
   RegisterNullaryStartupFlag("client_debug", &client_debug);
   RegisterNullaryStartupFlag("deep_execroot", &deep_execroot);
-  RegisterNullaryStartupFlag("expand_configs_in_place", &expand_configs_in_place);
-  RegisterNullaryStartupFlag("experimental_oom_more_eagerly", &oom_more_eagerly);
-  RegisterNullaryStartupFlag("fatal_event_bus_exceptions", &fatal_event_bus_exceptions);
-  RegisterNullaryStartupFlag("host_jvm_debug", &host_jvm_debug);  // --no was not supported
+  RegisterNullaryStartupFlag("expand_configs_in_place",
+                             &expand_configs_in_place);
+  RegisterNullaryStartupFlag("experimental_oom_more_eagerly",
+                             &oom_more_eagerly);
+  RegisterNullaryStartupFlag("fatal_event_bus_exceptions",
+                             &fatal_event_bus_exceptions);
+  RegisterNullaryStartupFlag("host_jvm_debug", &host_jvm_debug);
   RegisterNullaryStartupFlag("idle_server_tasks", &idle_server_tasks);
   RegisterNullaryStartupFlag("incompatible_enable_execution_transition",
-      &incompatible_enable_execution_transition);
-  RegisterNullaryStartupFlag("shutdown_on_low_sys_mem", &shutdown_on_low_sys_mem);
-  RegisterNullaryStartupFlagNoRc("ignore_all_rc_files", &ignore_all_rc_files);
+                             &incompatible_enable_execution_transition);
+  RegisterNullaryStartupFlag("shutdown_on_low_sys_mem",
+                             &shutdown_on_low_sys_mem);
+  RegisterNullaryStartupFlagNoRc("ignore_all_rc_files",
+                             &ignore_all_rc_files);
   RegisterNullaryStartupFlag("unlimit_coredumps", &unlimit_coredumps);
   RegisterNullaryStartupFlag("watchfs", &watchfs);
   RegisterNullaryStartupFlag("write_command_log", &write_command_log);
@@ -202,16 +207,22 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
   const char* value = NULL;
 
   if (IsNullary(argstr)) {
+    // 'argstr' is either "--foo" or "--nofoo", and 'target' is the pointer to
+    // the bool storing the flag's value.
     bool* target = all_nullary_startup_flags_[argstr];
+    // 'enabled' is true if 'argstr' is "--foo", and false if it's "--nofoo".
     bool enabled = (argstr.compare(0, 4, "--no") != 0);
     if (no_rc_nullary_startup_flags_.find(argstr) !=
         no_rc_nullary_startup_flags_.end()) {
+      // no_rc_nullary_startup_flags_ are forbidden in .bazelrc files.
       if (!rcfile.empty()) {
-        *error = std::string("Can't specify ") + argstr + " in the .bazelrc file.";
+        *error = std::string("Can't specify ") + argstr +
+                     " in the .bazelrc file.";
         return blaze_exit_code::BAD_ARGV;
       }
     }
     *target = enabled;
+    // Use the key "foo" for 'argstr' of "--foo" / "--nofoo".
     option_sources[argstr.substr(enabled ? 2 : 4)] = rcfile;
     *is_space_separated = false;
     return blaze_exit_code::SUCCESS;

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -277,7 +278,10 @@ class StartupOptions {
 
   void RegisterUnaryStartupFlag(const std::string& flag_name);
 
-  void RegisterNullaryStartupFlag(const std::string& flag_name);
+  void RegisterNullaryStartupFlag(const std::string& flag_name, bool* value);
+
+  void RegisterNullaryStartupFlagNoRc(const std::string& flag_name,
+                                      bool* value);
 
  private:
   // Parses a single argument, either from the command line or from the .blazerc
@@ -309,10 +313,15 @@ class StartupOptions {
 
   // Startup flags that don't expect a value, e.g. "master_bazelrc".
   // Valid uses are "--master_bazelrc" are "--nomaster_bazelrc".
-  std::unordered_set<std::string> valid_nullary_startup_flags_;
+  // Keys are positive and negative flag names (e.g. "--master_bazelrc" and
+  // "--nomaster_bazelrc"), values are pointers to the boolean to mutate.
+  std::unordered_map<std::string, bool*> all_nullary_startup_flags_;
+  std::unordered_set<std::string> no_rc_nullary_startup_flags_;
 
   // Startup flags that expect a value, e.g. "bazelrc".
   // Valid uses are "--bazelrc=foo" and "--bazelrc foo".
+  // Keys are flag names (e.g. "--bazelrc"), values are pointers to the string
+  // to mutate.
   std::unordered_set<std::string> valid_unary_startup_flags_;
 };
 

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -18,6 +18,7 @@
 #include <sys/qos.h>
 #endif
 
+#include <functional>
 #include <map>
 #include <string>
 #include <unordered_map>
@@ -289,6 +290,11 @@ class StartupOptions {
   void RegisterNullaryStartupFlagNoRc(const std::string& flag_name,
                                       bool* value);
 
+  typedef std::function<void(bool)> SpecialNullaryFlagHandler;
+
+  void RegisterSpecialNullaryStartupFlag(const std::string &flag_name,
+                                         SpecialNullaryFlagHandler handler);
+
  private:
   // Parses a single argument, either from the command line or from the .blazerc
   // "startup" options.
@@ -327,6 +333,14 @@ class StartupOptions {
   // Contains positive and negative names (e.g. "--master_bazelrc" and
   // "--nomaster_bazelrc") of flags that must not appear in .bazelrc files.
   std::unordered_set<std::string> no_rc_nullary_startup_flags_;
+
+  // Subset of 'all_nullary_startup_flags_'.
+  // Contains positive and negative names (e.g. "--master_bazelrc" and
+  // "--nomaster_bazelrc") of flags that have a special handler.
+  // Can be used for tri-state flags where omitting the flag completely means
+  // leaving the tri-state as "auto".
+  std::unordered_map<std::string, SpecialNullaryFlagHandler>
+      special_nullary_startup_flags_;
 
   // Startup flags that expect a value, e.g. "bazelrc".
   // Valid uses are "--bazelrc=foo" and "--bazelrc foo".

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -278,8 +278,14 @@ class StartupOptions {
 
   void RegisterUnaryStartupFlag(const std::string& flag_name);
 
+  // Register a nullary startup flag.
+  // Both '--flag_name' and '--noflag_name' will be registered as valid nullary
+  // flags. 'value' is the pointer to the boolean that will receive the flag's
+  // value.
   void RegisterNullaryStartupFlag(const std::string& flag_name, bool* value);
 
+  // Same as RegisterNullaryStartupFlag, but these flags are forbidden in
+  // .bazelrc files.
   void RegisterNullaryStartupFlagNoRc(const std::string& flag_name,
                                       bool* value);
 
@@ -316,6 +322,10 @@ class StartupOptions {
   // Keys are positive and negative flag names (e.g. "--master_bazelrc" and
   // "--nomaster_bazelrc"), values are pointers to the boolean to mutate.
   std::unordered_map<std::string, bool*> all_nullary_startup_flags_;
+
+  // Subset of 'all_nullary_startup_flags_'.
+  // Contains positive and negative names (e.g. "--master_bazelrc" and
+  // "--nomaster_bazelrc") of flags that must not appear in .bazelrc files.
   std::unordered_set<std::string> no_rc_nullary_startup_flags_;
 
   // Startup flags that expect a value, e.g. "bazelrc".


### PR DESCRIPTION
Nullary startup flags (e.g. --[no]master_bazelrc)
are registered with
StartupOptions::RegisterNullaryStartupOption.

Important change: `--host_jvm_debug` now supports
the negative flag (`--nohost_jvm_debug`).
I suspect the missing support was a bug resulting
from the code duplication this PR eliminates.

Until now, nullary flags also had their special
handling logic, even though the logic was always
the same.

Now, nullary flags are registered together with
their member variable's pointer, and there's only
one code path to handle all. Startup flags
forbidden in .bazelrc files are handled specially.

Until now, we searched the handler code linearly
via a long if-elseif-elseif-... chain, so parsing
N flags out of M possible flags performed O(N*M)
string comparisons.

Now, we look up the nullary flag names from a
std::unordered_map, which has O(1) lookup
complexity, reducing the total complexity to O(M).

Also a drive-by improvement in blaze.cc: use
std::unique_ptr instead of manual new/delete.

Change-Id: Ie3dcba4ae6afa959e84657b7ff9bb8f4c87777fd