### PR TITLE
Improve performance of string methods count and split

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
@@ -27,11 +27,11 @@ import com.google.devtools.build.lib.skylarkinterface.SkylarkModuleCategory;
 import com.google.devtools.build.lib.syntax.SkylarkList.MutableList;
 import com.google.devtools.build.lib.syntax.SkylarkList.Tuple;
 import com.google.devtools.build.lib.syntax.Type.ConversionException;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Collections;
 
 /**
  * Skylark String module.
@@ -336,7 +336,7 @@ public final class StringModule {
     if (maxSplitO != Runtime.NONE) {
       maxSplit = (Integer) maxSplitO;
     }
-    List<String> res = new ArrayList<>();
+    ArrayList<String> res = new ArrayList<>();
     int start = 0;
     while (true) {
       int end = self.indexOf(sep, start);
@@ -347,7 +347,7 @@ public final class StringModule {
       res.add(self.substring(start, end));
       start = end + sep.length();
     }
-    return MutableList.copyOf(env, res);
+    return MutableList.wrapUnsafe(env, res);
   }
 
   @SkylarkCallable(
@@ -385,18 +385,19 @@ public final class StringModule {
     if (maxSplitO != Runtime.NONE) {
       maxSplit = (Integer) maxSplitO;
     }
-    ArrayDeque<String> res = new ArrayDeque<>();
-    int end = self.length() - 1;
+    ArrayList<String> res = new ArrayList<>();
+    int end = self.length();
     while (true) {
-      int start = self.lastIndexOf(sep, end);
+      int start = self.lastIndexOf(sep, end - 1);
       if (start < 0 || maxSplit-- == 0) {
-        res.addFirst(self.substring(0, Math.max(0, end + 1)));
+        res.add(self.substring(0, end));
         break;
       }
-      res.addFirst(self.substring(start + sep.length(), end + 1));
-      end = start - 1;
+      res.add(self.substring(start + sep.length(), end));
+      end = start;
     }
-    return MutableList.copyOf(env, res);
+    Collections.reverse(res);
+    return MutableList.wrapUnsafe(env, res);
   }
 
   @SkylarkCallable(

--- a/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
@@ -332,12 +332,22 @@ public final class StringModule {
     if (sep.isEmpty()) {
       throw new EvalException(loc, "Empty separator");
     }
-    int maxSplit =
-        Type.INTEGER.convertOptional(maxSplitO, "'split' argument of 'split'", /*label*/ null, -2);
-    // + 1 because the last result is the remainder. The default is -2 so that after +1,
-    // it becomes -1.
-    String[] ss = Pattern.compile(sep, Pattern.LITERAL).split(self, maxSplit + 1);
-    return MutableList.of(env, ss);
+    int maxSplit = Integer.MAX_VALUE;
+    if (maxSplitO != Runtime.NONE) {
+      maxSplit = (Integer) maxSplitO;
+    }
+    List<String> res = new ArrayList<>();
+    int start = 0;
+    while (true) {
+      int end = self.indexOf(sep, start);
+      if (end < 0 || maxSplit-- == 0) {
+        res.add(self.substring(start));
+        break;
+      }
+      res.add(self.substring(start, end));
+      start = end + sep.length();
+    }
+    return MutableList.copyOf(env, res);
   }
 
   @SkylarkCallable(
@@ -368,58 +378,25 @@ public final class StringModule {
   public MutableList<String> rsplit(
       String self, String sep, Object maxSplitO, Location loc, Environment env)
       throws EvalException {
-    int maxSplit = Type.INTEGER.convertOptional(maxSplitO, "'split' argument of 'split'", null, -1);
-    try {
-      return stringRSplit(self, sep, maxSplit, env);
-    } catch (IllegalArgumentException ex) {
-      throw new EvalException(loc, ex);
+    if (sep.isEmpty()) {
+      throw new EvalException(loc, "Empty separator");
     }
-  }
-
-  /**
-   * Splits the given string into a list of words, using {@code separator} as a delimiter.
-   *
-   * <p>At most {@code maxSplits} will be performed, going from right to left.
-   *
-   * @param input The input string.
-   * @param separator The separator string.
-   * @param maxSplits The maximum number of splits. Negative values mean unlimited splits.
-   * @return A list of words
-   * @throws IllegalArgumentException
-   */
-  private static MutableList<String> stringRSplit(
-      String input, String separator, int maxSplits, Environment env) {
-    if (separator.isEmpty()) {
-      throw new IllegalArgumentException("Empty separator");
+    int maxSplit = Integer.MAX_VALUE;
+    if (maxSplitO != Runtime.NONE) {
+      maxSplit = (Integer) maxSplitO;
     }
-
-    if (maxSplits <= 0) {
-      maxSplits = Integer.MAX_VALUE;
+    ArrayDeque<String> res = new ArrayDeque<>();
+    int end = self.length() - 1;
+    while (true) {
+      int start = self.lastIndexOf(sep, end);
+      if (start < 0 || maxSplit-- == 0) {
+        res.addFirst(self.substring(0, Math.max(0, end + 1)));
+        break;
+      }
+      res.addFirst(self.substring(start + sep.length(), end + 1));
+      end = start - 1;
     }
-
-    ArrayDeque<String> result = new ArrayDeque<>();
-    String[] parts = input.split(Pattern.quote(separator), -1);
-    int sepLen = separator.length();
-    int remainingLength = input.length();
-    int splitsSoFar = 0;
-
-    // Copies parts from the array into the final list, starting at the end (because
-    // it's rsplit), as long as fewer than maxSplits splits are performed. The
-    // last spot in the list is reserved for the remaining string, whose length
-    // has to be tracked throughout the loop.
-    for (int pos = parts.length - 1; (pos >= 0) && (splitsSoFar < maxSplits); --pos) {
-      String current = parts[pos];
-      result.addFirst(current);
-
-      ++splitsSoFar;
-      remainingLength -= sepLen + current.length();
-    }
-
-    if (splitsSoFar == maxSplits && remainingLength >= 0)   {
-      result.addFirst(input.substring(0, remainingLength));
-    }
-
-    return MutableList.copyOf(env, result);
+    return MutableList.copyOf(env, res);
   }
 
   @SkylarkCallable(
@@ -975,10 +952,10 @@ public final class StringModule {
       return str.length() + 1;
     }
     int count = 0;
-    int index = -1;
-    while ((index = str.indexOf(sub)) >= 0) {
+    int index = 0;
+    while ((index = str.indexOf(sub, index)) >= 0) {
       count++;
-      str = str.substring(index + sub.length());
+      index += sub.length();
     }
     return count;
   }

--- a/src/test/starlark/testdata/string_split.sky
+++ b/src/test/starlark/testdata/string_split.sky
@@ -48,3 +48,9 @@ assert_eq('ogooglo'.rsplit('o', 5), ['', 'g', '', 'gl', ''])
 assert_eq('google'.rsplit('google'), ['', ''])
 assert_eq('google'.rsplit('google', 1), ['', ''])
 assert_eq('google'.rsplit('google', 2), ['', ''])
+
+# zero/negative split
+assert_eq('a-b-c'.split('-', 0), ['a-b-c'])
+assert_eq('a-b-c'.rsplit('-', 0), ['a-b-c'])
+assert_eq('a-b-c'.split('-', -1), ['a', 'b', 'c'])
+assert_eq('a-b-c'.rsplit('-', -2), ['a', 'b', 'c'])


### PR DESCRIPTION
The following 2 benchmark results show the performance improvements of this change:

- `string.count` [benchmark](https://github.com/Quarz0/starlark/blob/benchmark_runner/benchmark_suite/data/string_count.star):
```
=== data/string_count.star ===
          Time (MS)  Memory (KB)
java       8802.588   756580.000    # before
java       4831.417    99908.000    # after
go          702.808     8320.000
python3    2298.714     7560.000
```

- `string.split/rsplit` [benchmark](https://github.com/Quarz0/starlark/blob/benchmark_runner/benchmark_suite/data/string_split.star):
```
=== data/string_split.star ===
          Time (MS)  Memory (KB)
java      10451.067   746772.000    # before
java       4317.741   742340.000    # after
go         8855.651    11380.000
python3    1478.717    11852.000
```
