### PR TITLE
Windows: export generated DEF file from cc_library via 'def_file' output group

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -70,6 +70,9 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
   /** A string constant for the name of dynamic library output group. */
   public static final String DYNAMIC_LIBRARY_OUTPUT_GROUP_NAME = "dynamic_library";
 
+  /** A string constant for the name of Windows def file output group. */
+  public static final String DEF_FILE_OUTPUT_GROUP_NAME = "def_file";
+
   private final CppSemantics semantics;
 
   protected CcLibrary(CppSemantics semantics) {
@@ -307,28 +310,32 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
         // If user specifies a custom DEF file, then we use it.
         Artifact defFile = common.getWinDefFile();
 
+        Artifact defParser = common.getDefParser();
+        Artifact generatedDefFile = null;
+        if (defParser != null) {
+          try {
+            generatedDefFile =
+                CppHelper.createDefFileActions(
+                    ruleContext,
+                    defParser,
+                    ccCompilationOutputs.getObjectFiles(false),
+                    ccToolchain
+                        .getFeatures()
+                        .getArtifactNameForCategory(
+                            ArtifactCategory.DYNAMIC_LIBRARY, ruleContext.getLabel().getName()));
+            targetBuilder.addOutputGroup(DEF_FILE_OUTPUT_GROUP_NAME, generatedDefFile);
+          } catch (EvalException e) {
+            ruleContext.throwWithRuleError(e.getMessage());
+            throw new IllegalStateException("Should not be reached");
+          }
+        }
+
         // If no DEF file is specified and the windows_export_all_symbols feature is enabled, parse
         // object files to generate DEF file and use it to export symbols - if we have a parser.
         // Otherwise, use no DEF file.
         if (defFile == null
             && CppHelper.shouldUseGeneratedDefFile(ruleContext, featureConfiguration)) {
-          Artifact defParser = common.getDefParser();
-          if (defParser != null) {
-            try {
-              defFile =
-                  CppHelper.createDefFileActions(
-                      ruleContext,
-                      defParser,
-                      ccCompilationOutputs.getObjectFiles(false),
-                      ccToolchain
-                          .getFeatures()
-                          .getArtifactNameForCategory(
-                              ArtifactCategory.DYNAMIC_LIBRARY, ruleContext.getLabel().getName()));
-            } catch (EvalException e) {
-              ruleContext.throwWithRuleError(e.getMessage());
-              throw new IllegalStateException("Should not be reached");
-            }
-          }
+          defFile = generatedDefFile;
         }
 
         if (defFile != null) {

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -505,6 +505,46 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertFileContentContains(def_file, 'hello_B')
     self.AssertFileContentContains(def_file, 'hello_C')
 
+  def testUsingDefFileGeneratedFromCcLibrary(self):
+    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
+    self.ScratchFile('lib_A.cc', ['void hello_A() {}'])
+    self.ScratchFile('lib_B.cc', ['void hello_B() {}'])
+    self.ScratchFile('BUILD', [
+      'cc_library(',
+      '  name = "lib_A",',
+      '  srcs = ["lib_A.cc"],',
+      ')',
+      '',
+      'cc_library(',
+      '  name = "lib_B",',
+      '  srcs = ["lib_B.cc"],',
+      '  deps = [":lib_A"]',
+      ')',
+      '',
+      'filegroup(',
+      '  name = "lib_B_symbols",',
+      '  srcs = [":lib_B"],',
+      '  output_group = "def_file",',
+      ')',
+      '',
+      'cc_binary(',
+      '  name = "lib.dll",',
+      '  deps = [":lib_B"],',
+      '  win_def_file = ":lib_B_symbols",',
+      '  linkshared = 1,',
+      ')',
+    ])
+    # Test specifying DEF file in cc_binary
+    bazel_bin = self.getBazelInfo('bazel-bin')
+    exit_code, _, stderr = self.RunBazel(['build', '//:lib.dll', '-s'])
+    self.AssertExitCode(exit_code, 0, stderr)
+    def_file = bazel_bin + '/lib_B.gen.def'
+    self.assertTrue(os.path.exists(def_file))
+    # hello_A should not be exported
+    self.AssertFileContentNotContains(def_file, 'hello_A')
+    # hello_B should be exported
+    self.AssertFileContentContains(def_file, 'hello_B')
+
   def testWinDefFileAttribute(self):
     self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('lib.cc', ['void hello() {}'])


### PR DESCRIPTION
We already have 'def_file' output group for cc_binary, but it's
generated from all transitive dependencies. This could easily go over
the 64K symbol limit in DLL on Windows. The def file generated from cc_library
will only contain symbols from the library's own sources, which can
be used in win_def_file attribute in cc_binary to export symbols
during linking DLL.

RELNOTES[NEW]: Users can now get generated def file from cc_library via
"def_file" output group on Windows.