### PR TITLE
Remove reference to CriticalPathComputer so that garbage can be cleaned up after a build.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BuildSummaryStatsModule.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BuildSummaryStatsModule.java
@@ -166,7 +166,10 @@ public class BuildSummaryStatsModule extends BlazeModule {
       event.getResult().getBuildToolLogCollection()
           .addDirectValue("process stats", spawnSummary.getBytes(StandardCharsets.UTF_8));
     } finally {
-      criticalPathComputer = null;
+      if (criticalPathComputer != null) {
+        eventBus.unregister(criticalPathComputer);
+        criticalPathComputer = null;
+      }
     }
   }
 }


### PR DESCRIPTION

RELNOTES: None.