### PR TITLE
Ext.repos: improve error message for missing path

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
@@ -265,9 +265,12 @@ public class AndroidNdkRepositoryFunction extends AndroidRepositoryFunction {
     prepareLocalRepositorySymlinkTree(rule, outputDirectory);
     WorkspaceAttributeMapper attributes = WorkspaceAttributeMapper.of(rule);
     PathFragment pathFragment;
+    String userDefinedPath = null;
     if (attributes.isAttributeValueExplicitlySpecified("path")) {
-      pathFragment = getTargetPath(rule, directories.getWorkspace());
+      userDefinedPath = getPathAttr(rule);
+      pathFragment = getTargetPath(userDefinedPath, directories.getWorkspace());
     } else if (environ.get(PATH_ENV_VAR) != null) {
+      userDefinedPath = environ.get(PATH_ENV_VAR);
       pathFragment = getAndroidNdkHomeEnvironmentVar(directories.getWorkspace(), environ);
     } else {
       throw new RepositoryFunctionException(
@@ -286,7 +289,7 @@ public class AndroidNdkRepositoryFunction extends AndroidRepositoryFunction {
     }
 
     Path ndkHome = directories.getOutputBase().getFileSystem().getPath(pathFragment);
-    if (!symlinkLocalRepositoryContents(ndkSymlinkTreeDirectory, ndkHome)) {
+    if (!symlinkLocalRepositoryContents(ndkSymlinkTreeDirectory, ndkHome, userDefinedPath)) {
       return null;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
@@ -97,9 +97,12 @@ public class AndroidSdkRepositoryFunction extends AndroidRepositoryFunction {
     WorkspaceAttributeMapper attributes = WorkspaceAttributeMapper.of(rule);
     FileSystem fs = directories.getOutputBase().getFileSystem();
     Path androidSdkPath;
+    String userDefinedPath = null;
     if (attributes.isAttributeValueExplicitlySpecified("path")) {
-      androidSdkPath = fs.getPath(getTargetPath(rule, directories.getWorkspace()));
+      userDefinedPath = getPathAttr(rule);
+      androidSdkPath = fs.getPath(getTargetPath(userDefinedPath, directories.getWorkspace()));
     } else if (environ.get(PATH_ENV_VAR) != null) {
+      userDefinedPath = environ.get(PATH_ENV_VAR);
       androidSdkPath =
           fs.getPath(getAndroidHomeEnvironmentVar(directories.getWorkspace(), environ));
     } else {
@@ -111,7 +114,7 @@ public class AndroidSdkRepositoryFunction extends AndroidRepositoryFunction {
           Transience.PERSISTENT);
     }
 
-    if (!symlinkLocalRepositoryContents(outputDirectory, androidSdkPath)) {
+    if (!symlinkLocalRepositoryContents(outputDirectory, androidSdkPath, userDefinedPath)) {
       return null;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryFunction.java
@@ -62,7 +62,8 @@ public class NewLocalRepositoryFunction extends RepositoryFunction {
       return null;
     }
 
-    PathFragment pathFragment = getTargetPath(rule, directories.getWorkspace());
+    String userDefinedPath = getPathAttr(rule);
+    PathFragment pathFragment = getTargetPath(userDefinedPath, directories.getWorkspace());
 
     FileSystem fs = directories.getOutputBase().getFileSystem();
     Path path = fs.getPath(pathFragment);
@@ -79,18 +80,20 @@ public class NewLocalRepositoryFunction extends RepositoryFunction {
       if (!dirFileValue.exists()) {
         throw new RepositoryFunctionException(
             new IOException(
-                "Expected directory at "
-                    + dirPath.asPath().getPathString()
-                    + " but it does not exist."),
+                String.format(
+                    "The repository's path is \"%s\" (absolute: \"%s\") "
+                        + "but this directory does not exist.",
+                    userDefinedPath, dirPath.asPath().getPathString())),
             Transience.PERSISTENT);
       }
       if (!dirFileValue.isDirectory()) {
         // Someone tried to create a local repository from a file.
         throw new RepositoryFunctionException(
             new IOException(
-                "Expected directory at "
-                    + dirPath.asPath().getPathString()
-                    + " but it is not a directory."),
+                String.format(
+                    "The repository's path is \"%s\" (absolute: \"%s\") "
+                        + "but this is not a directory.",
+                    userDefinedPath, dirPath.asPath().getPathString())),
             Transience.PERSISTENT);
       }
     } catch (IOException e) {
@@ -137,7 +140,7 @@ public class NewLocalRepositoryFunction extends RepositoryFunction {
     }
 
     // Link x/y/z to /some/path/to/y/z.
-    if (!symlinkLocalRepositoryContents(outputDirectory, path)) {
+    if (!symlinkLocalRepositoryContents(outputDirectory, path, userDefinedPath)) {
       return null;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -149,7 +149,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
 
     if (Preconditions.checkNotNull(overrides).containsKey(repositoryName)) {
       DigestWriter.clearMarkerFile(directories, repositoryName);
-      return setupOverride(overrides.get(repositoryName), env, repoRoot);
+      return setupOverride(overrides.get(repositoryName), env, repoRoot, repositoryName.strippedName());
     }
 
     Rule rule;
@@ -330,11 +330,11 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
   }
 
   private RepositoryDirectoryValue setupOverride(
-      PathFragment sourcePath, Environment env, Path repoRoot)
+      PathFragment sourcePath, Environment env, Path repoRoot, String pathAttr)
       throws RepositoryFunctionException, InterruptedException {
     setupRepositoryRoot(repoRoot);
     RepositoryDirectoryValue.Builder directoryValue =
-        LocalRepositoryFunction.symlink(repoRoot, sourcePath, env);
+        LocalRepositoryFunction.symlink(repoRoot, sourcePath, pathAttr, env);
     if (directoryValue == null) {
       return null;
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -439,17 +439,19 @@ public abstract class RepositoryFunction {
     return writeFile(repositoryDirectory, "BUILD.bazel", contents);
   }
 
-  @VisibleForTesting
-  protected static PathFragment getTargetPath(Rule rule, Path workspace)
-      throws RepositoryFunctionException {
+  protected static String getPathAttr(Rule rule) throws RepositoryFunctionException {
     WorkspaceAttributeMapper mapper = WorkspaceAttributeMapper.of(rule);
-    String path;
     try {
-      path = mapper.get("path", Type.STRING);
+      return mapper.get("path", Type.STRING);
     } catch (EvalException e) {
       throw new RepositoryFunctionException(e, Transience.PERSISTENT);
     }
-    PathFragment pathFragment = PathFragment.create(path);
+  }
+
+  @VisibleForTesting
+  protected static PathFragment getTargetPath(String userDefinedPath, Path workspace)
+      throws RepositoryFunctionException {
+    PathFragment pathFragment = PathFragment.create(userDefinedPath);
     return workspace.getRelative(pathFragment).asFragment();
   }
 
@@ -467,7 +469,7 @@ public abstract class RepositoryFunction {
    * </pre>
    */
   public static boolean symlinkLocalRepositoryContents(
-      Path repositoryDirectory, Path targetDirectory)
+      Path repositoryDirectory, Path targetDirectory, String userDefinedPath)
       throws RepositoryFunctionException {
     try {
       FileSystemUtils.createDirectoryAndParents(repositoryDirectory);
@@ -476,7 +478,13 @@ public abstract class RepositoryFunction {
         createSymbolicLink(symlinkPath, target);
       }
     } catch (IOException e) {
-      throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+      throw new RepositoryFunctionException(
+          new IOException(
+              String.format(
+                  "The repository's path is \"%s\" (absolute: \"%s\") "
+                      + "but a symlink could not be created for it, because: %s",
+                  userDefinedPath, targetDirectory, e.getMessage())),
+          Transience.TRANSIENT);
     }
 
     return true;

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryFunctionTest.java
@@ -82,7 +82,9 @@ public class RepositoryFunctionTest extends BuildViewTestCase {
             "    name = 'z',",
             "    path = 'a/b/c',",
             ")");
-    assertThat(TestingRepositoryFunction.getTargetPath(rule, rootDirectory))
+    assertThat(
+            TestingRepositoryFunction.getTargetPath(
+                TestingRepositoryFunction.getPathAttr(rule), rootDirectory))
         .isEqualTo(rootDirectory.getRelative("a/b/c").asFragment());
   }
 
@@ -92,7 +94,9 @@ public class RepositoryFunctionTest extends BuildViewTestCase {
         "    name = 'w',",
         "    path = '/a/b/c',",
         ")");
-    assertThat(TestingRepositoryFunction.getTargetPath(rule, rootDirectory))
+    assertThat(
+            TestingRepositoryFunction.getTargetPath(
+                TestingRepositoryFunction.getPathAttr(rule), rootDirectory))
         .isEqualTo(PathFragment.create("/a/b/c"));
   }
 

--- a/src/test/shell/bazel/local_repository_test.sh
+++ b/src/test/shell/bazel/local_repository_test.sh
@@ -517,6 +517,53 @@ eof
   expect_log "@foo4b.* path is \"./fake\" (absolute: \"[^\"]*workspace/fake\").*symlink could not be created"
 }
 
+function test_path_looking_like_home_directory_is_reported_as_user_defined_it() {
+  cat >WORKSPACE <<eof
+local_repository(name = "foo1", path = "~/missing")
+
+new_local_repository(name = "foo2", path = "~/missing", build_file_content = "")
+
+android_sdk_repository(name = "foo3a", path = "~/missing")
+
+android_sdk_repository(name = "foo3b")
+
+android_ndk_repository(name = "foo4a", path = "~/missing")
+
+android_ndk_repository(name = "foo4b")
+eof
+
+  # All repositories can be used as a kind of marker and be queried, even if they can't be fetched.
+  for repo in foo1 foo2 foo3a foo3b foo4a foo4b; do
+    bazel query "//external:$repo" >& "$TEST_log" || fail "Expected success"
+  done
+
+  # Fetching the repositories should attempt to create symlinks to their directory.
+  # Although "~/missing" looks like a path under the home directory, "~/" is only a Bash shorthand
+  # that Bazel does not resolve, and instead treats "~/missing" as a relative path under the
+  # workspace. Assert that the error message clarifies this.
+  bazel query @foo1//:* >& "$TEST_log" && fail "Expected failure" || true
+  expect_log "@foo1.* path is \"~/missing\" (absolute: \"[^\"]*workspace/~/missing\").*does not exist"
+
+  bazel query @foo2//:* >& "$TEST_log" && fail "Expected failure" || true
+  expect_log "@foo2.* path is \"~/missing\" (absolute: \"[^\"]*workspace/~/missing\").*does not exist"
+
+  bazel query @foo3a//:* >& "$TEST_log" && fail "Expected failure" || true
+  expect_log "@foo3a.* path is \"~/missing\" (absolute: \"[^\"]*workspace/~/missing\").*symlink could not be created"
+
+  # Since "~/" is a Bash shorthand for "$HOME" and setting an envvar is a Bash command, ANDROID_HOME
+  # will actually be expanded to the full path of the home directory.
+  HOME=/fake_home ANDROID_HOME=~/fake bazel query @foo3b//:* >& "$TEST_log" && fail "Expected failure" || true
+  expect_log "@foo3b.* path is \"/fake_home/fake\" (absolute: \"/fake_home/fake\").*symlink could not be created"
+
+  bazel query @foo4a//:* >& "$TEST_log" && fail "Expected failure" || true
+  expect_log "@foo4a.* path is \"~/missing\" (absolute: \"[^\"]*workspace/~/missing\").*symlink could not be created"
+
+  # Since "~/" is a Bash shorthand for "$HOME" and setting an envvar is a Bash command,
+  # ANDROID_NDK_HOME will actually be expanded to the full path of the home directory.
+  HOME=/fake_home ANDROID_NDK_HOME=~/fake bazel query @foo4b//:* >& "$TEST_log" && fail "Expected failure" || true
+  expect_log "@foo4b.* path is \"/fake_home/fake\" (absolute: \"/fake_home/fake\").*symlink could not be created"
+}
+
 function test_overlaid_build_file() {
   local mutant=$TEST_TMPDIR/mutant
   mkdir $mutant

--- a/src/test/shell/bazel/local_repository_test.sh
+++ b/src/test/shell/bazel/local_repository_test.sh
@@ -476,6 +476,47 @@ EOF
 }
 
 
+function test_missing_path_reported_as_user_defined_it() {
+  cat >WORKSPACE <<eof
+local_repository(name = "foo1", path = "./missing")
+
+new_local_repository(name = "foo2", path = "./missing", build_file_content = "")
+
+android_sdk_repository(name = "foo3a", path = "./missing")
+
+android_sdk_repository(name = "foo3b")
+
+android_ndk_repository(name = "foo4a", path = "./missing")
+
+android_ndk_repository(name = "foo4b")
+eof
+
+  # All repositories can be used as a kind of marker and be queried, even if they can't be fetched.
+  for repo in foo1 foo2 foo3a foo3b foo4a foo4b; do
+    bazel query "//external:$repo" >& "$TEST_log" || fail "Expected success"
+  done
+
+  # Fetching the repositories should attempt to create symlinks to their directory.
+  # Since the directories don't exist, we expect failure.
+  bazel query @foo1//:* >& "$TEST_log" && fail "Expected failure" || true
+  expect_log "@foo1.* path is \"./missing\" (absolute: \"[^\"]*workspace/missing\").*does not exist"
+
+  bazel query @foo2//:* >& "$TEST_log" && fail "Expected failure" || true
+  expect_log "@foo2.* path is \"./missing\" (absolute: \"[^\"]*workspace/missing\").*does not exist"
+
+  bazel query @foo3a//:* >& "$TEST_log" && fail "Expected failure" || true
+  expect_log "@foo3a.* path is \"./missing\" (absolute: \"[^\"]*workspace/missing\").*symlink could not be created"
+
+  ANDROID_HOME=./fake bazel query @foo3b//:* >& "$TEST_log" && fail "Expected failure" || true
+  expect_log "@foo3b.* path is \"./fake\" (absolute: \"[^\"]*workspace/fake\").*symlink could not be created"
+
+  bazel query @foo4a//:* >& "$TEST_log" && fail "Expected failure" || true
+  expect_log "@foo4a.* path is \"./missing\" (absolute: \"[^\"]*workspace/missing\").*symlink could not be created"
+
+  ANDROID_NDK_HOME=./fake bazel query @foo4b//:* >& "$TEST_log" && fail "Expected failure" || true
+  expect_log "@foo4b.* path is \"./fake\" (absolute: \"[^\"]*workspace/fake\").*symlink could not be created"
+}
+
 function test_overlaid_build_file() {
   local mutant=$TEST_TMPDIR/mutant
   mkdir $mutant
@@ -1065,7 +1106,7 @@ local_repository(
 )
 EOF
   bazel build @r//... &> $TEST_log && fail "Build succeeded unexpectedly"
-  expect_log "must be an existing directory"
+  expect_log "(absolute: \"$TEST_TMPDIR/r\") but this directory does not exist"
 }
 
 # Regression test for #2841.


### PR DESCRIPTION
If Bazel fails to fetch a local repository because
the user-defined "path" is wrong, the error now
references that user-defined path, not the
Bazel-computed absolute path.

Example:

    local_repository(
        name = "foo",
        path = "./bar",
    )

For Bazel this means "bar" under the workspace
directory. If that does not exist, then Bazel
reports an error.

Until now, this error referenced "bar" by the
computed absolute path, which is sometimes
confusing.

Now Bazel reports the path as it was defined in
the WORKSPACE file, or as defined by the ANDROID_*
envvars.

Affected rules:
- local_repository
- new_local_repository
- android_sdk_repository
- android_ndk_repository

Fixes https://github.com/bazelbuild/bazel/issues/9139

Change-Id: I6df8708c65ce593d8b60b806bfe6c6522da1a51f