### PR TITLE
 Pull upload(ActionResult) into super class

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -29,6 +29,7 @@ import build.bazel.remote.execution.v2.SymlinkNode;
 import build.bazel.remote.execution.v2.Tree;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -79,6 +80,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -120,20 +122,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
   abstract ActionResult getCachedActionResult(ActionKey actionKey)
       throws IOException, InterruptedException;
 
-  /**
-   * Upload the result of a locally executed action to the remote cache.
-   *
-   * @throws IOException if there was an error uploading to the remote cache
-   * @throws ExecException if uploading any of the action outputs is not supported
-   */
-  abstract void upload(
-      SimpleBlobStore.ActionKey actionKey,
-      Action action,
-      Command command,
-      Path execRoot,
-      Collection<Path> files,
-      FileOutErr outErr)
-      throws ExecException, IOException, InterruptedException;
+  protected abstract void setCachedActionResult(ActionKey actionKey, ActionResult action) throws IOException, InterruptedException;
 
   /**
    * Uploads a file
@@ -156,6 +145,114 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
    * @param data the blob to upload.
    */
   protected abstract ListenableFuture<Void> uploadBlob(Digest digest, ByteString data);
+
+  protected abstract ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests) throws IOException, InterruptedException;
+
+  /**
+   * Upload the result of a locally executed action to the remote cache.
+   *
+   * @throws IOException if there was an error uploading to the remote cache
+   * @throws ExecException if uploading any of the action outputs is not supported
+   */
+  public ActionResult upload(
+      ActionKey actionKey,
+      Action action,
+      Command command,
+      Path execRoot,
+      Collection<Path> outputs,
+      FileOutErr outErr,
+      int exitCode)
+      throws ExecException, IOException, InterruptedException {
+    ActionResult.Builder resultBuilder = ActionResult.newBuilder();
+    uploadOutputs(execRoot, actionKey, action, command, outputs, outErr, resultBuilder);
+    resultBuilder.setExitCode(exitCode);
+    ActionResult result = resultBuilder.build();
+    if (exitCode == 0 && !action.getDoNotCache()) {
+      setCachedActionResult(actionKey, result);
+    }
+    return result;
+  }
+
+  public ActionResult upload(
+      ActionKey actionKey,
+      Action action,
+      Command command,
+      Path execRoot,
+      Collection<Path> outputs,
+      FileOutErr outErr) throws ExecException, IOException, InterruptedException {
+    return upload(actionKey, action, command, execRoot, outputs, outErr, /* exitCode= */ 0);
+  }
+
+  private void uploadOutputs(
+      Path execRoot,
+      ActionKey actionKey,
+      Action action,
+      Command command,
+      Collection<Path> files,
+      FileOutErr outErr,
+      ActionResult.Builder result)
+      throws ExecException, IOException, InterruptedException {
+    UploadManifest manifest =
+        new UploadManifest(
+            digestUtil,
+            result,
+            execRoot,
+            options.incompatibleRemoteSymlinks,
+            options.allowSymlinkUpload);
+    manifest.addFiles(files);
+    manifest.setStdoutStderr(outErr);
+    manifest.addAction(actionKey, action, command);
+
+    Map<Digest, Path> digestToFile = manifest.getDigestToFile();
+    Map<Digest, ByteString> digestToBlobs = manifest.getDigestToBlobs();
+    Collection<Digest> digests = new ArrayList<>();
+    digests.addAll(digestToFile.keySet());
+    digests.addAll(digestToBlobs.keySet());
+
+    ImmutableSet<Digest> digestsToUpload = getMissingDigests(digests);
+    ImmutableList.Builder<ListenableFuture<Void>> uploads = ImmutableList.builder();
+    for (Digest digest : digestsToUpload) {
+      Path file = digestToFile.get(digest);
+      if (file != null) {
+        uploads.add(uploadFile(digest, file));
+      } else {
+        ByteString blob = digestToBlobs.get(digest);
+        if (blob == null) {
+          String message = "FindMissingBlobs call returned an unknown digest: " + digest;
+          throw new IOException(message);
+        }
+        uploads.add(uploadBlob(digest, blob));
+      }
+    }
+
+    waitForUploads(uploads.build());
+
+    if (manifest.getStderrDigest() != null) {
+      result.setStderrDigest(manifest.getStderrDigest());
+    }
+    if (manifest.getStdoutDigest() != null) {
+      result.setStdoutDigest(manifest.getStdoutDigest());
+    }
+  }
+
+  private static void waitForUploads(List<ListenableFuture<Void>> uploads)
+      throws IOException, InterruptedException {
+    try {
+      for (ListenableFuture<Void> upload : uploads) {
+        upload.get();
+      }
+    } catch (ExecutionException e) {
+      // TODO(buchgr): Add support for cancellation and factor this method out to be shared
+      // between ByteStreamUploader as well.
+      Throwable cause = e.getCause();
+      Throwables.throwIfInstanceOf(cause, IOException.class);
+      Throwables.throwIfInstanceOf(cause, InterruptedException.class);
+      if (cause != null) {
+        throw new IOException(cause);
+      }
+      throw new IOException(e);
+    }
+  }
 
   /**
    * Downloads a blob with a content hash {@code digest} to {@code out}.

--- a/src/main/java/com/google/devtools/build/lib/util/ExitCode.java
+++ b/src/main/java/com/google/devtools/build/lib/util/ExitCode.java
@@ -1,4 +1,4 @@
-// Copyright 2014 The Bazel Authors. All rights reserved.
+  // Copyright 2014 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -38,6 +38,7 @@ import build.bazel.remote.execution.v2.Tree;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -1150,20 +1151,12 @@ public class AbstractRemoteActionCacheTests {
 
     @Nullable
     @Override
-    ActionResult getCachedActionResult(ActionKey actionKey)
-        throws IOException, InterruptedException {
+    ActionResult getCachedActionResult(ActionKey actionKey) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    void upload(
-        ActionKey actionKey,
-        Action action,
-        Command command,
-        Path execRoot,
-        Collection<Path> files,
-        FileOutErr outErr)
-        throws ExecException, IOException, InterruptedException {
+    protected void setCachedActionResult(ActionKey actionKey, ActionResult action) {
       throw new UnsupportedOperationException();
     }
 
@@ -1175,6 +1168,11 @@ public class AbstractRemoteActionCacheTests {
     @Override
     protected ListenableFuture<Void> uploadBlob(Digest digest, ByteString data) {
       throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests) {
+      return null;
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteCacheTest.java
@@ -530,6 +530,16 @@ public class GrpcRemoteCacheTest {
             responseObserver.onCompleted();
           }
         });
+    serviceRegistry.addService(
+        new ActionCacheImplBase() {
+          @Override
+          public void updateActionResult(UpdateActionResultRequest request,
+              StreamObserver<ActionResult> responseObserver) {
+            responseObserver.onNext(request.getActionResult());
+            responseObserver.onCompleted();
+          }
+        }
+    );
 
     ActionResult result = uploadDirectory(client, ImmutableList.<Path>of(fooFile, barDir));
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
@@ -558,6 +568,16 @@ public class GrpcRemoteCacheTest {
             responseObserver.onCompleted();
           }
         });
+    serviceRegistry.addService(
+        new ActionCacheImplBase() {
+          @Override
+          public void updateActionResult(UpdateActionResultRequest request,
+              StreamObserver<ActionResult> responseObserver) {
+            responseObserver.onNext(request.getActionResult());
+            responseObserver.onCompleted();
+          }
+        }
+    );
 
     ActionResult result = uploadDirectory(client, ImmutableList.<Path>of(barDir));
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
@@ -608,6 +628,16 @@ public class GrpcRemoteCacheTest {
             responseObserver.onCompleted();
           }
         });
+    serviceRegistry.addService(
+        new ActionCacheImplBase() {
+          @Override
+          public void updateActionResult(UpdateActionResultRequest request,
+              StreamObserver<ActionResult> responseObserver) {
+            responseObserver.onNext(request.getActionResult());
+            responseObserver.onCompleted();
+          }
+        }
+    );
 
     ActionResult result = uploadDirectory(client, ImmutableList.of(barDir));
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
@@ -617,12 +647,10 @@ public class GrpcRemoteCacheTest {
 
   private ActionResult uploadDirectory(GrpcRemoteCache client, List<Path> outputs)
       throws Exception {
-    ActionResult.Builder result = ActionResult.newBuilder();
     Action action = Action.getDefaultInstance();
     ActionKey actionKey = DIGEST_UTIL.computeActionKey(action);
     Command cmd = Command.getDefaultInstance();
-    client.upload(execRoot, actionKey, action, cmd, outputs, outErr, result);
-    return result.build();
+    return client.upload(actionKey, action, cmd, execRoot, outputs, outErr);
   }
 
   @Test
@@ -662,16 +690,24 @@ public class GrpcRemoteCacheTest {
             responseObserver.onCompleted();
           }
         });
+    serviceRegistry.addService(
+        new ActionCacheImplBase() {
+          @Override
+          public void updateActionResult(UpdateActionResultRequest request,
+              StreamObserver<ActionResult> responseObserver) {
+            responseObserver.onNext(request.getActionResult());
+            responseObserver.onCompleted();
+          }
+        }
+    );
 
-    ActionResult.Builder result = ActionResult.newBuilder();
-    client.upload(
-        execRoot,
+    ActionResult result = client.upload(
         DIGEST_UTIL.asActionKey(actionDigest),
         action,
         command,
-        ImmutableList.<Path>of(fooFile, barFile),
-        outErr,
-        result);
+        execRoot,
+        ImmutableList.of(fooFile, barFile),
+        outErr);
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
     expectedResult.setStdoutDigest(stdoutDigest);
     expectedResult.setStderrDigest(stderrDigest);
@@ -681,7 +717,7 @@ public class GrpcRemoteCacheTest {
         .setPath("bar")
         .setDigest(barDigest)
         .setIsExecutable(true);
-    assertThat(result.build()).isEqualTo(expectedResult.build());
+    assertThat(result).isEqualTo(expectedResult.build());
   }
 
   @Test
@@ -711,19 +747,27 @@ public class GrpcRemoteCacheTest {
             responseObserver.onCompleted();
           }
         });
+    serviceRegistry.addService(
+        new ActionCacheImplBase() {
+          @Override
+          public void updateActionResult(UpdateActionResultRequest request,
+              StreamObserver<ActionResult> responseObserver) {
+            responseObserver.onNext(request.getActionResult());
+            responseObserver.onCompleted();
+          }
+        }
+    );
 
     RemoteOptions options = Options.getDefaults(RemoteOptions.class);
     options.maxOutboundMessageSize = 80; // Enough for one digest, but not two.
     final GrpcRemoteCache client = newClient(options);
-    ActionResult.Builder result = ActionResult.newBuilder();
-    client.upload(
-        execRoot,
+    ActionResult result = client.upload(
         DIGEST_UTIL.asActionKey(actionDigest),
         action,
         command,
-        ImmutableList.<Path>of(fooFile, barFile),
-        outErr,
-        result);
+        execRoot,
+        ImmutableList.of(fooFile, barFile),
+        outErr);
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
     expectedResult.addOutputFilesBuilder().setPath("a/foo").setDigest(fooDigest);
     expectedResult
@@ -731,7 +775,7 @@ public class GrpcRemoteCacheTest {
         .setPath("bar")
         .setDigest(barDigest)
         .setIsExecutable(true);
-    assertThat(result.build()).isEqualTo(expectedResult.build());
+    assertThat(result).isEqualTo(expectedResult.build());
     assertThat(numGetMissingCalls.get()).isEqualTo(4);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -22,6 +22,7 @@ import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Digest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.HashCode;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -232,13 +233,7 @@ public class RemoteActionInputFetcherTest {
     }
 
     @Override
-    void upload(
-        ActionKey actionKey,
-        Action action,
-        Command command,
-        Path execRoot,
-        Collection<Path> files,
-        FileOutErr outErr) {
+    protected void setCachedActionResult(ActionKey actionKey, ActionResult action) {
       throw new UnsupportedOperationException();
     }
 
@@ -250,6 +245,11 @@ public class RemoteActionInputFetcherTest {
     @Override
     protected ListenableFuture<Void> uploadBlob(Digest digest, ByteString data) {
       throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests) {
+      return null;
     }
 
     @Override

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/BUILD
@@ -16,6 +16,7 @@ java_library(
     visibility = ["//src/tools/remote:__subpackages__"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib:build-base",
+        "//src/main/java/com/google/devtools/build/lib:io",
         "//src/main/java/com/google/devtools/build/lib:os_util",
         "//src/main/java/com/google/devtools/build/lib:packages-internal",
         "//src/main/java/com/google/devtools/build/lib:process_util",


### PR DESCRIPTION
Remove the custom upload(ActionResult) implementations from SimpleBlobStoreActionCache and GrpcRemoteCache.

This is a big step towards merging SimpleBlobStoreActionCache and GrpcRemoteCache.

(this is rebased on top of https://github.com/bazelbuild/bazel/pull/9039)