### PR TITLE
Windows: Ignore workspace name differences while doing header checking

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1241,11 +1241,10 @@ public class CppCompileAction extends AbstractAction
     ShowIncludesFilter showIncludesFilterForStdout;
     ShowIncludesFilter showIncludesFilterForStderr;
     if (featureConfiguration.isEnabled(CppRuleClasses.PARSE_SHOWINCLUDES)) {
-      String workspaceName = actionExecutionContext.getExecRoot().getBaseName();
       showIncludesFilterForStdout =
-          new ShowIncludesFilter(getSourceFile().getFilename(), workspaceName);
+          new ShowIncludesFilter(getSourceFile().getFilename());
       showIncludesFilterForStderr =
-          new ShowIncludesFilter(getSourceFile().getFilename(), workspaceName);
+          new ShowIncludesFilter(getSourceFile().getFilename());
       FileOutErr originalOutErr = actionExecutionContext.getFileOutErr();
       FileOutErr tempOutErr = originalOutErr.childOutErr();
       spawnContext = actionExecutionContext.withFileOutErr(tempOutErr);

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilter.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilter.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * A Class for filtering the output of /showIncludes from MSVC compiler.
@@ -40,11 +42,9 @@ public class ShowIncludesFilter {
 
   private FilterShowIncludesOutputStream filterShowIncludesOutputStream;
   private final String sourceFileName;
-  private final String workspaceName;
 
-  public ShowIncludesFilter(String sourceFileName, String workspaceName) {
+  public ShowIncludesFilter(String sourceFileName) {
     this.sourceFileName = sourceFileName;
-    this.workspaceName = workspaceName;
   }
 
   /**
@@ -149,13 +149,13 @@ public class ShowIncludesFilter {
                 StandardCharsets.UTF_8) // Spanish
             );
     private final String sourceFileName;
-    private final String execRootSuffix;
+    private final static Pattern EXECROOT_HEADER_PATTERN =
+        Pattern.compile(".*execroot\\\\[^\\\\]*\\\\(?<headerPath>.*)");
 
     public FilterShowIncludesOutputStream(
-        OutputStream out, String sourceFileName, String workspaceName) {
+        OutputStream out, String sourceFileName) {
       super(out);
       this.sourceFileName = sourceFileName;
-      this.execRootSuffix = "execroot\\" + workspaceName + "\\";
     }
 
     @Override
@@ -167,9 +167,9 @@ public class ShowIncludesFilter {
         for (String prefix : SHOW_INCLUDES_PREFIXES) {
           if (line.startsWith(prefix)) {
             line = line.substring(prefix.length()).trim();
-            int index = line.indexOf(execRootSuffix);
-            if (index != -1) {
-              line = line.substring(index + execRootSuffix.length());
+            Matcher m = EXECROOT_HEADER_PATTERN.matcher(line);
+            if (m.matches()) {
+              line = m.group("headerPath");
             }
             dependencies.add(line);
             prefixMatched = true;
@@ -214,7 +214,7 @@ public class ShowIncludesFilter {
 
   public FilterOutputStream getFilteredOutputStream(OutputStream outputStream) {
     filterShowIncludesOutputStream =
-        new FilterShowIncludesOutputStream(outputStream, sourceFileName, workspaceName);
+        new FilterShowIncludesOutputStream(outputStream, sourceFileName);
     return filterShowIncludesOutputStream;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilterTest.java
@@ -38,7 +38,7 @@ public class ShowIncludesFilterTest {
 
   @Before
   public void setUpOutputStreams() throws IOException {
-    showIncludesFilter = new ShowIncludesFilter("foo.cpp", "__main__");
+    showIncludesFilter = new ShowIncludesFilter("foo.cpp");
     output = new ByteArrayOutputStream();
     filterOutputStream = showIncludesFilter.getFilteredOutputStream(output);
     fs = new InMemoryFileSystem();
@@ -93,17 +93,31 @@ public class ShowIncludesFilterTest {
   }
 
   @Test
-  public void testMatchAllOfNotePrefixWithAbsolutePath() throws IOException {
+  public void testFindHeaderFromAbsolutePathUnderExecroot() throws IOException {
     // "Note: including file:" is the prefix
     filterOutputStream.write(
-        getBytes("Note: including file: C:\\tmp\\xxxx\\execroot\\__main__\\bar.h"));
+        getBytes("Note: including file: C:\\tmp\\xxxx\\execroot\\__main__\\foo\\bar\\bar.h"));
     filterOutputStream.flush();
     // flush to output should not work, waiting for newline
     assertThat(output.toString()).isEmpty();
     filterOutputStream.write(getBytes("\n"));
     // It's a match, output should be filtered, dependency on bar.h should be found.
     assertThat(output.toString()).isEmpty();
-    assertThat(showIncludesFilter.getDependencies()).contains("bar.h");
+    assertThat(showIncludesFilter.getDependencies()).contains("foo\\bar\\bar.h");
+  }
+
+  @Test
+  public void testFindHeaderFromAbsolutePathOutsideExecroot() throws IOException {
+    // "Note: including file:" is the prefix
+    filterOutputStream.write(
+        getBytes("Note: including file: C:\\system\\foo\\bar\\bar.h"));
+    filterOutputStream.flush();
+    // flush to output should not work, waiting for newline
+    assertThat(output.toString()).isEmpty();
+    filterOutputStream.write(getBytes("\n"));
+    // It's a match, output should be filtered, dependency on bar.h should be found.
+    assertThat(output.toString()).isEmpty();
+    assertThat(showIncludesFilter.getDependencies()).contains("C:\\system\\foo\\bar\\bar.h");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/ShowIncludesFilterTest.java
@@ -93,6 +93,7 @@ public class ShowIncludesFilterTest {
   }
 
   @Test
+  // Regression tests for https://github.com/bazelbuild/bazel/issues/9172
   public void testFindHeaderFromAbsolutePathUnderExecroot() throws IOException {
     // "Note: including file:" is the prefix
     filterOutputStream.write(

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -285,7 +285,7 @@ class TestBase(unittest.TestCase):
       os.chmod(abspath, stat.S_IRWXU)
     return abspath
 
-  def RunBazel(self, args, env_remove=None, env_add=None):
+  def RunBazel(self, args, env_remove=None, env_add=None, cwd=None):
     """Runs "bazel <args>", waits for it to exit.
 
     Args:
@@ -301,7 +301,7 @@ class TestBase(unittest.TestCase):
         self.Rlocation('io_bazel/src/bazel'),
         '--bazelrc=' + self._test_bazelrc,
         '--nomaster_bazelrc',
-    ] + args, env_remove, env_add)
+    ] + args, env_remove, env_add, False, cwd)
 
   def StartRemoteWorker(self):
     """Runs a "local remote worker" to run remote builds and tests on.
@@ -370,7 +370,7 @@ class TestBase(unittest.TestCase):
       print('--------------------------')
       print('\n'.join(stderr_lines))
 
-  def RunProgram(self, args, env_remove=None, env_add=None, shell=False):
+  def RunProgram(self, args, env_remove=None, env_add=None, shell=False, cwd=None):
     """Runs a program (args[0]), waits for it to exit.
 
     Args:
@@ -390,7 +390,7 @@ class TestBase(unittest.TestCase):
             args,
             stdout=stdout,
             stderr=stderr,
-            cwd=self._test_cwd,
+            cwd=(cwd if cwd else self._test_cwd),
             env=self._EnvMap(env_remove, env_add),
             shell=shell)
         exit_code = proc.wait()


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/9172