### PR TITLE
Remove defaults from Apple device types and versions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class ObjcCommandLineOptions extends FragmentOptions {
   @Option(
     name = "ios_simulator_version",
-    defaultValue = "9.3",
+    defaultValue = "null",
     converter = DottedVersionConverter.class,
     documentationCategory = OptionDocumentationCategory.TESTING,
     effectTags = {OptionEffectTag.TEST_RUNNER},
@@ -42,7 +42,7 @@ public class ObjcCommandLineOptions extends FragmentOptions {
 
   @Option(
     name = "ios_simulator_device",
-    defaultValue = "iPhone 5s",
+    defaultValue = "null",
     documentationCategory = OptionDocumentationCategory.TESTING,
     effectTags = {OptionEffectTag.TEST_RUNNER},
     help =
@@ -54,7 +54,7 @@ public class ObjcCommandLineOptions extends FragmentOptions {
 
   @Option(
     name = "watchos_simulator_version",
-    defaultValue = "2.0",
+    defaultValue = "null",
     converter = DottedVersionConverter.class,
     documentationCategory = OptionDocumentationCategory.TESTING,
     effectTags = {OptionEffectTag.TEST_RUNNER},
@@ -64,7 +64,7 @@ public class ObjcCommandLineOptions extends FragmentOptions {
 
   @Option(
     name = "watchos_simulator_device",
-    defaultValue = "Apple Watch - 38mm",
+    defaultValue = "null",
     documentationCategory = OptionDocumentationCategory.TESTING,
     effectTags = {OptionEffectTag.TEST_RUNNER},
     help =
@@ -76,7 +76,7 @@ public class ObjcCommandLineOptions extends FragmentOptions {
 
   @Option(
     name = "tvos_simulator_version",
-    defaultValue = "9.0",
+    defaultValue = "null",
     converter = DottedVersionConverter.class,
     documentationCategory = OptionDocumentationCategory.TESTING,
     effectTags = {OptionEffectTag.TEST_RUNNER},
@@ -86,7 +86,7 @@ public class ObjcCommandLineOptions extends FragmentOptions {
 
   @Option(
     name = "tvos_simulator_device",
-    defaultValue = "Apple TV 1080p",
+    defaultValue = "null",
     documentationCategory = OptionDocumentationCategory.TESTING,
     effectTags = {OptionEffectTag.TEST_RUNNER},
     help =

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcConfiguration.java
@@ -73,21 +73,12 @@ public class ObjcConfiguration extends BuildConfiguration.Fragment
   private final boolean strictObjcModuleMaps;
 
   ObjcConfiguration(ObjcCommandLineOptions objcOptions, CoreOptions options) {
-    this.iosSimulatorDevice =
-        Preconditions.checkNotNull(objcOptions.iosSimulatorDevice, "iosSimulatorDevice");
-    this.iosSimulatorVersion =
-        Preconditions.checkNotNull(DottedVersion.maybeUnwrap(objcOptions.iosSimulatorVersion),
-            "iosSimulatorVersion");
-    this.watchosSimulatorDevice =
-        Preconditions.checkNotNull(objcOptions.watchosSimulatorDevice, "watchosSimulatorDevice");
-    this.watchosSimulatorVersion =
-        Preconditions.checkNotNull(DottedVersion.maybeUnwrap(objcOptions.watchosSimulatorVersion),
-            "watchosSimulatorVersion");
-    this.tvosSimulatorDevice =
-        Preconditions.checkNotNull(objcOptions.tvosSimulatorDevice, "tvosSimulatorDevice");
-    this.tvosSimulatorVersion =
-        Preconditions.checkNotNull(DottedVersion.maybeUnwrap(objcOptions.tvosSimulatorVersion),
-            "tvosSimulatorVersion");
+    this.iosSimulatorDevice = objcOptions.iosSimulatorDevice;
+    this.iosSimulatorVersion = DottedVersion.maybeUnwrap(objcOptions.iosSimulatorVersion);
+    this.watchosSimulatorDevice = objcOptions.watchosSimulatorDevice;
+    this.watchosSimulatorVersion = DottedVersion.maybeUnwrap(objcOptions.watchosSimulatorVersion);
+    this.tvosSimulatorDevice = objcOptions.tvosSimulatorDevice;
+    this.tvosSimulatorVersion = DottedVersion.maybeUnwrap(objcOptions.tvosSimulatorVersion);
     this.generateLinkmap = objcOptions.generateLinkmap;
     this.runMemleaks = objcOptions.runMemleaks;
     this.copts = ImmutableList.copyOf(objcOptions.copts);

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/apple/ObjcConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/apple/ObjcConfigurationApi.java
@@ -31,16 +31,16 @@ import javax.annotation.Nullable;
 )
 public interface ObjcConfigurationApi<ApplePlatformTypeApiT extends ApplePlatformTypeApi> {
 
-  @SkylarkCallable(name = "ios_simulator_device", structField = true,
+  @SkylarkCallable(name = "ios_simulator_device", structField = true, allowReturnNones = true,
       doc = "The type of device (e.g. 'iPhone 6') to use when running on the simulator.")
   public String getIosSimulatorDevice();
 
-  @SkylarkCallable(name = "ios_simulator_version", structField = true,
+  @SkylarkCallable(name = "ios_simulator_version", structField = true, allowReturnNones = true,
       doc = "The SDK version of the iOS simulator to use when running on the simulator.")
   public DottedVersionApi<?> getIosSimulatorVersion();
 
   @SkylarkCallable(
-      name = "simulator_device_for_platform_type",
+      name = "simulator_device_for_platform_type", allowReturnNones = true,
       doc = "The type of device (e.g., 'iPhone 6' to simulate when running on the simulator.",
       parameters = {
         @Param(
@@ -55,7 +55,7 @@ public interface ObjcConfigurationApi<ApplePlatformTypeApiT extends ApplePlatfor
   public String getSimulatorDeviceForPlatformType(ApplePlatformTypeApiT platformType);
 
   @SkylarkCallable(
-      name = "simulator_version_for_platform_type",
+      name = "simulator_version_for_platform_type", allowReturnNones = true,
       doc = "The SDK version of the simulator to use when running on the simulator.",
       parameters = {
         @Param(


### PR DESCRIPTION
These defaults are very prone to getting out of date, which makes these
fields detrimental to rule implementations. In the case of rules_apple
we'd like to make the tests default to these versions, if a version
isn't passed as part of the test target, unfortunately we cannot
differentiate between the user didn't pass a value, and these old
versions. Overall these defaults aren't very helpful because with each
Xcode update old versions no longer run on developer machines unless
they install the old simulator versions manually.