### PR TITLE
renamed 'incompatible_allow_tags_propagation' to 'experimental_..'

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkActionFactory.java
@@ -628,7 +628,7 @@ public class SkylarkActionFactory implements SkylarkActionFactoryApi {
         TargetUtils.getFilteredExecutionInfo(
             executionRequirementsUnchecked,
             ruleContext.getRule(),
-            starlarkSemantics.incompatibleAllowTagsPropagation());
+            starlarkSemantics.experimentalAllowTagsPropagation());
     builder.setExecutionInfo(executionInfo);
 
     if (inputManifestsUnchecked != Runtime.NONE) {

--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
@@ -161,19 +161,19 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
   public boolean incompatibleBzlDisallowLoadAfterStatement;
 
   @Option(
-      name = "incompatible_allow_tags_propagation",
+      name = "experimental_allow_tags_propagation",
+      oldName = "incompatible_allow_tags_propagation",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
       effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
       metadataTags = {
-        OptionMetadataTag.INCOMPATIBLE_CHANGE,
-        OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+        OptionMetadataTag.EXPERIMENTAL,
       },
       help =
           "If set to true, tags will be propagated from a target to the actions' execution"
               + " requirements; otherwise tags are not propagated. See"
               + " https://github.com/bazelbuild/bazel/issues/8830 for details.")
-  public boolean incompatibleAllowTagsPropagation;
+  public boolean experimentalAllowTagsPropagation;
 
   @Option(
       name = "incompatible_depset_union",
@@ -655,6 +655,7 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
             // <== Add new options here in alphabetic order ==>
             .experimentalAllowIncrementalRepositoryUpdates(
                 experimentalAllowIncrementalRepositoryUpdates)
+            .experimentalAllowTagsPropagation(experimentalAllowTagsPropagation)
             .experimentalBuildSettingApi(experimentalBuildSettingApi)
             .experimentalCcSkylarkApiEnabledPackages(experimentalCcSkylarkApiEnabledPackages)
             .experimentalEnableAndroidMigrationApis(experimentalEnableAndroidMigrationApis)
@@ -700,7 +701,6 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
             .incompatibleRestrictStringEscapes(incompatibleRestrictStringEscapes)
             .incompatibleDisallowDictLookupUnhashableKeys(
                 incompatibleDisallowDictLookupUnhashableKeys)
-            .incompatibleAllowTagsPropagation(incompatibleAllowTagsPropagation)
             .incompatibleDisallowHashingFrozenMutables(incompatibleDisallowHashingFrozenMutables)
             .build();
     return INTERNER.intern(semantics);

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -243,12 +243,12 @@ public final class TargetUtils {
    *     {@code SkylarkDict<String, String>} type, null or {@link
    *     com.google.devtools.build.lib.syntax.Runtime#NONE}
    * @param rule a rule instance to get tags from
-   * @param incompatibleAllowTagsPropagation if set to true, tags will be propagated from a target
+   * @param allowTagsPropagation if set to true, tags will be propagated from a target
    *     to the actions' execution requirements, for more details {@see
-   *     SkylarkSematicOptions#incompatibleAllowTagsPropagation}
+   *     SkylarkSematicOptions#experimentalAllowTagsPropagation}
    */
   public static ImmutableMap<String, String> getFilteredExecutionInfo(
-      Object executionRequirementsUnchecked, Rule rule, boolean incompatibleAllowTagsPropagation)
+      Object executionRequirementsUnchecked, Rule rule, boolean allowTagsPropagation)
       throws EvalException {
     Map<String, String> checkedExecutionRequirements =
         TargetUtils.filter(
@@ -262,7 +262,7 @@ public final class TargetUtils {
     // adding filtered execution requirements to the execution info map
     executionInfoBuilder.putAll(checkedExecutionRequirements);
 
-    if (incompatibleAllowTagsPropagation) {
+    if (allowTagsPropagation) {
       Map<String, String> checkedTags = getExecutionInfo(rule);
       // merging filtered tags to the execution info map avoiding duplicates
       checkedTags.forEach(executionInfoBuilder::putIfAbsent);

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
@@ -60,7 +60,7 @@ public abstract class StarlarkSemantics {
     INCOMPATIBLE_OBJC_FRAMEWORK_CLEANUP(StarlarkSemantics::incompatibleObjcFrameworkCleanup),
     INCOMPATIBLE_DISALLOW_RULE_EXECUTION_PLATFORM_CONSTRAINTS_ALLOWED(
         StarlarkSemantics::incompatibleDisallowRuleExecutionPlatformConstraintsAllowed),
-    INCOMPATIBLE_ALLOW_TAGS_PROPAGATION(StarlarkSemantics::incompatibleAllowTagsPropagation),
+    INCOMPATIBLE_ALLOW_TAGS_PROPAGATION(StarlarkSemantics::experimentalAllowTagsPropagation),
     NONE(null);
 
     // Using a Function here makes the enum definitions far cleaner, and, since this is
@@ -207,7 +207,7 @@ public abstract class StarlarkSemantics {
 
   public abstract boolean incompatibleDisallowDictLookupUnhashableKeys();
 
-  public abstract boolean incompatibleAllowTagsPropagation();
+  public abstract boolean experimentalAllowTagsPropagation();
 
   public abstract boolean incompatibleDisallowHashingFrozenMutables();
 
@@ -244,6 +244,7 @@ public abstract class StarlarkSemantics {
   public static final StarlarkSemantics DEFAULT_SEMANTICS =
       builder()
           // <== Add new options here in alphabetic order ==>
+          .experimentalAllowTagsPropagation(false)
           .experimentalBuildSettingApi(true)
           .experimentalCcSkylarkApiEnabledPackages(ImmutableList.of())
           .experimentalAllowIncrementalRepositoryUpdates(true)
@@ -286,7 +287,6 @@ public abstract class StarlarkSemantics {
           .incompatibleDepsetForLibrariesToLinkGetter(true)
           .incompatibleRestrictStringEscapes(false)
           .incompatibleDisallowDictLookupUnhashableKeys(false)
-          .incompatibleAllowTagsPropagation(false)
           .incompatibleDisallowHashingFrozenMutables(false)
           .build();
 
@@ -311,7 +311,7 @@ public abstract class StarlarkSemantics {
 
     public abstract Builder experimentalStarlarkUnusedInputsList(boolean value);
 
-    public abstract Builder incompatibleAllowTagsPropagation(boolean value);
+    public abstract Builder experimentalAllowTagsPropagation(boolean value);
 
     public abstract Builder incompatibleBzlDisallowLoadAfterStatement(boolean value);
 

--- a/src/test/java/com/google/devtools/build/lib/packages/SkylarkSemanticsConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/SkylarkSemanticsConsistencyTest.java
@@ -183,7 +183,7 @@ public class SkylarkSemanticsConsistencyTest {
         .experimentalPlatformsApi(rand.nextBoolean())
         .experimentalStarlarkConfigTransitions(rand.nextBoolean())
         .experimentalStarlarkUnusedInputsList(rand.nextBoolean())
-        .incompatibleAllowTagsPropagation(rand.nextBoolean())
+        .experimentalAllowTagsPropagation(rand.nextBoolean())
         .incompatibleBzlDisallowLoadAfterStatement(rand.nextBoolean())
         .incompatibleDepsetForLibrariesToLinkGetter(rand.nextBoolean())
         .incompatibleDepsetIsNotIterable(rand.nextBoolean())

--- a/src/test/shell/bazel/tags_propagation_skylark_test.sh
+++ b/src/test/shell/bazel/tags_propagation_skylark_test.sh
@@ -52,7 +52,7 @@ test_rule = rule(
 )
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+  bazel aquery --experimental_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
   assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: ''}" output1
@@ -89,7 +89,7 @@ test_rule = rule(
 )
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+  bazel aquery --experimental_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
   assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: '', no-sandbox: '', requires-network: ''}" output1
@@ -128,14 +128,14 @@ test_rule = rule(
 )
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+  bazel aquery --experimental_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
   assert_contains "ExecutionInfo: {local: '', no-cache: 1, no-remote: '', requires-network: '', requires-x: ''}" output1
 }
 
 # Test a basic skylark ctx.actions.run rule which has tags, that should not be propagated
-# as --incompatible_allow_tags_propagation flag set to false
+# as --experimental_allow_tags_propagation flag set to false
 function test_tags_not_propagated_to_run_when_incompatible_flag_off() {
   mkdir -p test
   cat << EOF >> test/BUILD
@@ -166,7 +166,7 @@ test_rule = rule(
 )
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation=false '//test:test' > output1 2> $TEST_log \
+  bazel aquery --experimental_allow_tags_propagation=false '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
   assert_not_contains "ExecutionInfo: {}" output1


### PR DESCRIPTION
renamed `--incompatible_allow_tags_propagation` to `--experimental_allow_tags_propagation`

RELNOTES: use `--experimental_allow_tags_propagation` to propagate tags to actions from target or rules. Tags that can be propagated should have one of the following prefixed: `no-`, `requires-`, `supports-`, `block-`, `disable-`, `cpu:`. See #8830 for details

Note: this is only 'starlark' rules part. Native rules change will come as a seperate change under the same flag.