### PR TITLE
Refactor SimpleBlobStore#get(ActionResult)(...)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteCache.java
@@ -49,6 +49,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ProgressiveBackoff;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.SimpleBlobStore.ActionKey;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -254,6 +255,10 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
     uploader.uploadBlobs(inputsToUpload, /* forceUpload= */ true);
   }
 
+  private String digestToString(Digest digest) {
+    return digest.getHash() + "/" + digest.getSizeBytes();
+  }
+
   @Override
   protected ListenableFuture<Void> downloadBlob(Digest digest, OutputStream out) {
     if (digest.getSizeBytes() == 0) {
@@ -263,7 +268,7 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
     if (!options.remoteInstanceName.isEmpty()) {
       resourceName += options.remoteInstanceName + "/";
     }
-    resourceName += "blobs/" + digestUtil.toString(digest);
+    resourceName += "blobs/" + digestToString(digest);
 
     @Nullable Supplier<HashCode> hashSupplier = null;
     if (options.remoteVerifyDownloads) {
@@ -348,7 +353,7 @@ public class GrpcRemoteCache extends AbstractRemoteActionCache {
               public void onError(Throwable t) {
                 Status status = Status.fromThrowable(t);
                 if (status.getCode() == Status.Code.NOT_FOUND) {
-                  future.setException(new CacheNotFoundException(digest, digestUtil));
+                  future.setException(new CacheNotFoundException(digest));
                 } else {
                   future.setException(t);
                 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.vfs.Path;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -42,6 +42,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.exec.ExecutorBuilder;
 import com.google.devtools.build.lib.packages.TargetUtils;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.logging.LoggingInterceptor;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -45,6 +45,7 @@ import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.SimpleBlobStore.ActionKey;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -56,6 +56,7 @@ import com.google.devtools.build.lib.exec.SpawnRunner;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.SimpleBlobStore.ActionKey;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;

--- a/src/main/java/com/google/devtools/build/lib/remote/common/CacheNotFoundException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/CacheNotFoundException.java
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.devtools.build.lib.remote;
+package com.google.devtools.build.lib.remote.common;
 
 import build.bazel.remote.execution.v2.Digest;
-import com.google.devtools.build.lib.remote.util.DigestUtil;
 import java.io.IOException;
 
 /**
@@ -25,8 +24,8 @@ import java.io.IOException;
 public final class CacheNotFoundException extends IOException {
   private final Digest missingDigest;
 
-  CacheNotFoundException(Digest missingDigest, DigestUtil digestUtil) {
-    super("Missing digest: " + digestUtil.toString(missingDigest));
+  public CacheNotFoundException(Digest missingDigest) {
+    super("Missing digest: " + missingDigest.getHash() + "/" + missingDigest.getSizeBytes());
     this.missingDigest = missingDigest;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/http/DownloadCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/DownloadCommand.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.http;
 
+import build.bazel.remote.execution.v2.Digest;
 import com.google.common.base.Preconditions;
 import java.io.OutputStream;
 import java.net.URI;
@@ -22,13 +23,13 @@ final class DownloadCommand {
 
   private final URI uri;
   private final boolean casDownload;
-  private final String hash;
+  private final Digest digest;
   private final OutputStream out;
 
-  protected DownloadCommand(URI uri, boolean casDownload, String hash, OutputStream out) {
+  protected DownloadCommand(URI uri, boolean casDownload, Digest digest, OutputStream out) {
     this.uri = Preconditions.checkNotNull(uri);
     this.casDownload = casDownload;
-    this.hash = Preconditions.checkNotNull(hash);
+    this.digest = Preconditions.checkNotNull(digest);
     this.out = Preconditions.checkNotNull(out);
   }
 
@@ -40,8 +41,8 @@ final class DownloadCommand {
     return casDownload;
   }
 
-  public String hash() {
-    return hash;
+  public Digest digest() {
+    return digest;
   }
 
   public OutputStream out() {

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpDownloadHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpDownloadHandler.java
@@ -136,7 +136,7 @@ final class HttpDownloadHandler extends AbstractHttpHandler<HttpObject> {
     }
     DownloadCommand cmd = (DownloadCommand) msg;
     out = cmd.out();
-    path = constructPath(cmd.uri(), cmd.hash(), cmd.casDownload());
+    path = constructPath(cmd.uri(), cmd.digest().getHash(), cmd.casDownload());
     HttpRequest request = buildRequest(path, constructHost(cmd.uri()));
     addCredentialHeaders(request, cmd.uri());
     addExtraRemoteHeaders(request);

--- a/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/DigestUtil.java
@@ -116,7 +116,7 @@ public class DigestUtil {
     return new HashingOutputStream(hashFn.getHashFunction(), out);
   }
 
-  public String toString(Digest digest) {
+  public static String toString(Digest digest) {
     return digest.getHash() + "/" + digest.getSizeBytes();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -54,6 +54,7 @@ import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.AbstractRemoteActionCache.OutputFilesLocker;
 import com.google.devtools.build.lib.remote.AbstractRemoteActionCache.UploadManifest;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.SimpleBlobStore.ActionKey;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
@@ -1179,7 +1180,7 @@ public class AbstractRemoteActionCacheTests {
       Futures.addCallback(
           downloadResult != null
               ? downloadResult
-              : Futures.immediateFailedFuture(new CacheNotFoundException(digest, digestUtil)),
+              : Futures.immediateFailedFuture(new CacheNotFoundException(digest)),
           new FutureCallback<byte[]>() {
             @Override
             public void onSuccess(byte[] bytes) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.clock.JavaClock;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.SimpleBlobStore.ActionKey;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
@@ -252,7 +253,7 @@ public class RemoteActionInputFetcherTest {
     protected ListenableFuture<Void> downloadBlob(Digest digest, OutputStream out) {
       ByteString data = cacheEntries.get(digest);
       if (data == null) {
-        return Futures.immediateFailedFuture(new CacheNotFoundException(digest, digestUtil));
+        return Futures.immediateFailedFuture(new CacheNotFoundException(digest));
       }
       try {
         data.writeTo(out);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -57,6 +57,7 @@ import com.google.devtools.build.lib.exec.SpawnInputExpander;
 import com.google.devtools.build.lib.exec.SpawnRunner.ProgressStatus;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.exec.util.FakeOwner;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.SimpleBlobStore.ActionKey;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
@@ -595,7 +596,7 @@ public class RemoteSpawnCacheTest {
                 return actionResult;
               }
             });
-    doThrow(new CacheNotFoundException(digest, digestUtil))
+    doThrow(new CacheNotFoundException(digest))
         .when(remoteCache)
         .download(eq(actionResult), eq(execRoot), eq(outErr), any());
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -63,6 +63,7 @@ import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.SpawnRunner;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.exec.util.FakeOwner;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.SimpleBlobStore.ActionKey;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
@@ -613,7 +614,7 @@ public class RemoteSpawnRunnerTest {
 
     ActionResult cachedResult = ActionResult.newBuilder().setExitCode(0).build();
     when(cache.getCachedActionResult(any(ActionKey.class))).thenReturn(cachedResult);
-    Exception downloadFailure = new CacheNotFoundException(Digest.getDefaultInstance(), digestUtil);
+    Exception downloadFailure = new CacheNotFoundException(Digest.getDefaultInstance());
     doThrow(downloadFailure)
         .when(cache)
         .download(eq(cachedResult), any(Path.class), any(FileOutErr.class), any());
@@ -650,7 +651,7 @@ public class RemoteSpawnRunnerTest {
     when(executor.executeRemotely(any(ExecuteRequest.class)))
         .thenReturn(cachedResponse)
         .thenReturn(executedResponse);
-    Exception downloadFailure = new CacheNotFoundException(Digest.getDefaultInstance(), digestUtil);
+    Exception downloadFailure = new CacheNotFoundException(Digest.getDefaultInstance());
     doThrow(downloadFailure)
         .when(cache)
         .download(eq(cachedResult), any(Path.class), any(FileOutErr.class), any());

--- a/src/test/java/com/google/devtools/build/lib/remote/http/AbstractHttpHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/AbstractHttpHandlerTest.java
@@ -18,6 +18,9 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import build.bazel.remote.execution.v2.Digest;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -35,12 +38,14 @@ import org.mockito.Mockito;
 @RunWith(JUnit4.class)
 public abstract class AbstractHttpHandlerTest {
 
+  private static final DigestUtil DIGEST_UTIL = new DigestUtil(DigestHashFunction.SHA256);
+  private static final Digest DIGEST = DIGEST_UTIL.computeAsUtf8("foo");
+
   @Test
   public void basicAuthShouldWork() throws Exception {
     URI uri = new URI("http://user:password@does.not.exist/foo");
     EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null, ImmutableList.of()));
-    ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
-    DownloadCommand cmd = new DownloadCommand(uri, true, "abcdef", new ByteArrayOutputStream());
+    DownloadCommand cmd = new DownloadCommand(uri, true, DIGEST, new ByteArrayOutputStream());
     ChannelPromise writePromise = ch.newPromise();
     ch.writeOneOutbound(cmd, writePromise);
 
@@ -53,8 +58,7 @@ public abstract class AbstractHttpHandlerTest {
   public void basicAuthShouldNotEnabled() throws Exception {
     URI uri = new URI("http://does.not.exist/foo");
     EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null, ImmutableList.of()));
-    ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
-    DownloadCommand cmd = new DownloadCommand(uri, true, "abcdef", new ByteArrayOutputStream());
+    DownloadCommand cmd = new DownloadCommand(uri, true, DIGEST, new ByteArrayOutputStream());
     ChannelPromise writePromise = ch.newPromise();
     ch.writeOneOutbound(cmd, writePromise);
 
@@ -66,8 +70,7 @@ public abstract class AbstractHttpHandlerTest {
   public void hostDoesntIncludePortHttp() throws Exception {
     URI uri = new URI("http://does.not.exist/foo");
     EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null, ImmutableList.of()));
-    ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
-    DownloadCommand cmd = new DownloadCommand(uri, true, "abcdef", new ByteArrayOutputStream());
+    DownloadCommand cmd = new DownloadCommand(uri, true, DIGEST, new ByteArrayOutputStream());
     ChannelPromise writePromise = ch.newPromise();
     ch.writeOneOutbound(cmd, writePromise);
 
@@ -79,8 +82,7 @@ public abstract class AbstractHttpHandlerTest {
   public void hostDoesntIncludePortHttps() throws Exception {
     URI uri = new URI("https://does.not.exist/foo");
     EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null, ImmutableList.of()));
-    ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
-    DownloadCommand cmd = new DownloadCommand(uri, true, "abcdef", new ByteArrayOutputStream());
+    DownloadCommand cmd = new DownloadCommand(uri, true, DIGEST, new ByteArrayOutputStream());
     ChannelPromise writePromise = ch.newPromise();
     ch.writeOneOutbound(cmd, writePromise);
 
@@ -92,8 +94,7 @@ public abstract class AbstractHttpHandlerTest {
   public void hostDoesIncludePort() throws Exception {
     URI uri = new URI("http://does.not.exist:8080/foo");
     EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null, ImmutableList.of()));
-    ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
-    DownloadCommand cmd = new DownloadCommand(uri, true, "abcdef", new ByteArrayOutputStream());
+    DownloadCommand cmd = new DownloadCommand(uri, true, DIGEST, new ByteArrayOutputStream());
     ChannelPromise writePromise = ch.newPromise();
     ch.writeOneOutbound(cmd, writePromise);
 
@@ -108,7 +109,7 @@ public abstract class AbstractHttpHandlerTest {
         new EmbeddedChannel(new HttpDownloadHandler(/* credentials= */ null, ImmutableList.of()));
     DownloadCommand cmd =
         new DownloadCommand(
-            uri, /* casDownload= */ true, /* hash= */ "abcdef", new ByteArrayOutputStream());
+            uri, /* casDownload= */ true, DIGEST, new ByteArrayOutputStream());
     ChannelPromise writePromise = ch.newPromise();
     ch.writeOneOutbound(cmd, writePromise);
 
@@ -127,7 +128,7 @@ public abstract class AbstractHttpHandlerTest {
         new EmbeddedChannel(new HttpDownloadHandler(/* credentials= */ null, remoteHeaders));
     DownloadCommand cmd =
         new DownloadCommand(
-            uri, /* casDownload= */ true, /* hash= */ "abcdef", new ByteArrayOutputStream());
+            uri, /* casDownload= */ true, DIGEST, new ByteArrayOutputStream());
     ChannelPromise writePromise = ch.newPromise();
     ch.writeOneOutbound(cmd, writePromise);
 
@@ -147,7 +148,7 @@ public abstract class AbstractHttpHandlerTest {
         new EmbeddedChannel(new HttpDownloadHandler(/* credentials= */ null, remoteHeaders));
     DownloadCommand cmd =
         new DownloadCommand(
-            uri, /* casDownload= */ true, /* hash= */ "abcdef", new ByteArrayOutputStream());
+            uri, /* casDownload= */ true, DIGEST, new ByteArrayOutputStream());
     ChannelPromise writePromise = ch.newPromise();
     ch.writeOneOutbound(cmd, writePromise);
 

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpBlobStoreTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpBlobStoreTest.java
@@ -97,6 +97,7 @@ import org.mockito.Mockito;
 public class HttpBlobStoreTest {
 
   private static final DigestUtil DIGEST_UTIL = new DigestUtil(DigestHashFunction.SHA256);
+  private static final Digest DIGEST = DIGEST_UTIL.computeAsUtf8("foo");
 
   private static ServerChannel createServer(
       Class<? extends ServerChannel> serverChannelClass,
@@ -308,7 +309,7 @@ public class HttpBlobStoreTest {
 
     Credentials credentials = newCredentials();
     HttpBlobStore blobStore = createHttpBlobStore(server, /* timeoutSeconds= */ 1, credentials);
-    getFromFuture(blobStore.get("key", new ByteArrayOutputStream()));
+    getFromFuture(blobStore.downloadBlob(DIGEST, new ByteArrayOutputStream()));
 
     fail("Exception expected");
   }
@@ -353,7 +354,7 @@ public class HttpBlobStoreTest {
 
       Credentials credentials = newCredentials();
       HttpBlobStore blobStore = createHttpBlobStore(server, /* timeoutSeconds= */ 1, credentials);
-      getFromFuture(blobStore.get("key", new ByteArrayOutputStream()));
+      getFromFuture(blobStore.downloadBlob(DIGEST, new ByteArrayOutputStream()));
       fail("Exception expected");
     } finally {
       testServer.stop(server);
@@ -415,7 +416,7 @@ public class HttpBlobStoreTest {
       Credentials credentials = newCredentials();
       HttpBlobStore blobStore = createHttpBlobStore(server, /* timeoutSeconds= */ 1, credentials);
       ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
-      getFromFuture(blobStore.get("key", out));
+      getFromFuture(blobStore.downloadBlob(DIGEST, out));
       assertThat(out.toString(Charsets.US_ASCII.name())).isEqualTo("File Contents");
       verify(credentials, times(1)).refresh();
       verify(credentials, times(2)).getRequestMetadata(any(URI.class));
@@ -471,7 +472,7 @@ public class HttpBlobStoreTest {
 
       Credentials credentials = newCredentials();
       HttpBlobStore blobStore = createHttpBlobStore(server, /* timeoutSeconds= */ 1, credentials);
-      getFromFuture(blobStore.get("key", new ByteArrayOutputStream()));
+      getFromFuture(blobStore.downloadBlob(DIGEST, new ByteArrayOutputStream()));
       fail("Exception expected.");
     } catch (Exception e) {
       assertThat(e).isInstanceOf(HttpException.class);

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ByteStreamServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ByteStreamServer.java
@@ -24,7 +24,7 @@ import com.google.bytestream.ByteStreamProto.ReadRequest;
 import com.google.bytestream.ByteStreamProto.ReadResponse;
 import com.google.bytestream.ByteStreamProto.WriteRequest;
 import com.google.bytestream.ByteStreamProto.WriteResponse;
-import com.google.devtools.build.lib.remote.CacheNotFoundException;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.Chunker;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -37,7 +37,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.devtools.build.lib.actions.ExecException;
-import com.google.devtools.build.lib.remote.CacheNotFoundException;
+import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.ExecutionStatusException;
 import com.google.devtools.build.lib.remote.SimpleBlobStoreActionCache;
 import com.google.devtools.build.lib.remote.common.SimpleBlobStore.ActionKey;

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreActionCache.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/OnDiskBlobStoreActionCache.java
@@ -28,6 +28,6 @@ class OnDiskBlobStoreActionCache extends SimpleBlobStoreActionCache {
   }
 
   public boolean containsKey(Digest digest) {
-    return ((OnDiskBlobStore) blobStore).contains(digest.getHash());
+    return ((OnDiskBlobStore) blobStore).contains(digest);
   }
 }


### PR DESCRIPTION
The change update methods signatures to be compatible with those in
AbstractRemoteActionCache:
  1) Future<Boolean> get(String, OutputStream) -> Future<Void> downloadBlob(Digest, OutputStream)
  2) Future<Boolean> getActionResult(String, OutputStream) -> Future<ActionResult> downloadActionResult(ActionKey)

The refactoring uncovered a bug in CombinedDiskHttpBlobStore. We did not
close the output stream *before* moving a file to the disk cache, thus
potentially moving a corrupted file to the disk cache as any errors
would only be reported afterwards.