### PR TITLE
Stop lexer from scanning characters in ints if first token in not a zero

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/Lexer.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Lexer.java
@@ -673,6 +673,8 @@ final class Lexer {
         case 'd': case 'D':
         case 'e': case 'E':
         case 'f': case 'F':
+          if (buffer[oldPos] != '0')
+            return bufferSlice(oldPos, pos);
         case '0': case '1':
         case '2': case '3':
         case '4': case '5':

--- a/src/main/java/com/google/devtools/build/lib/syntax/Lexer.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Lexer.java
@@ -667,27 +667,32 @@ final class Lexer {
       switch (c) {
         case 'X': case 'x': // for hexadecimal prefix
         case 'O': case 'o': // for octal prefix
+          if (buffer[oldPos] != '0' || pos != oldPos + 1) {
+            // 'x' and 'o' can only appear as a second token after '0'
+            return bufferSlice(oldPos, pos);
+          }
+          break;
         case 'a': case 'A':
         case 'b': case 'B':
         case 'c': case 'C':
         case 'd': case 'D':
         case 'e': case 'E':
         case 'f': case 'F':
-          if (buffer[oldPos] != '0') {
-            // a number not starting with zero must be decimal
-            // and can only contain digits
+          if (buffer[oldPos] != '0' || Character.toLowerCase(buffer[oldPos + 1]) != 'x') {
+            // not hexadecimal, cannot contain letters
             return bufferSlice(oldPos, pos);
           }
+          break;
         case '0': case '1':
         case '2': case '3':
         case '4': case '5':
         case '6': case '7':
         case '8': case '9':
-          pos++;
           break;
         default:
           return bufferSlice(oldPos, pos);
       }
+      pos++;
     }
     // TODO(bazel-team): (2009) to do roundtripping when we evaluate the integer
     // constants, we must save the actual text of the tokens, not just their

--- a/src/main/java/com/google/devtools/build/lib/syntax/Lexer.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Lexer.java
@@ -673,8 +673,11 @@ final class Lexer {
         case 'd': case 'D':
         case 'e': case 'E':
         case 'f': case 'F':
-          if (buffer[oldPos] != '0')
+          if (buffer[oldPos] != '0') {
+            // a number not starting with zero must be decimal
+            // and can only contain digits
             return bufferSlice(oldPos, pos);
+          }
         case '0': case '1':
         case '2': case '3':
         case '4': case '5':

--- a/src/test/java/com/google/devtools/build/lib/syntax/LexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/LexerTest.java
@@ -182,6 +182,17 @@ public class LexerTest {
   }
 
   @Test
+  public void testNoWhiteSpaceBetweenTokens() throws Exception {
+    assertThat(names(tokens("6or()"))).isEqualTo("INT OR LPAREN RPAREN NEWLINE EOF");
+    assertThat(names(tokens("0in(''and[])")))
+        .isEqualTo("INT IN LPAREN STRING AND LBRACKET RBRACKET RPAREN NEWLINE EOF");
+
+    assertThat(values(tokens("0or()"))).isEqualTo("INT(0) IDENTIFIER(r) LPAREN RPAREN NEWLINE EOF");
+    assertThat(lastError.toString())
+        .isEqualTo("/some/path.txt:1: invalid base-8 integer constant: 0o");
+  }
+
+  @Test
   public void testNonAsciiIdentifiers() throws Exception {
     tokens("ümlaut");
     assertThat(lastError.toString()).contains("invalid character: 'ü'");
@@ -237,13 +248,13 @@ public class LexerTest {
 
     assertThat(values(tokens("1.2.345"))).isEqualTo("INT(1) DOT INT(2) DOT INT(345) NEWLINE EOF");
 
-    assertThat(values(tokens("1.23E10"))).isEqualTo("INT(1) DOT INT(0) NEWLINE EOF");
+    assertThat(values(tokens("1.0E10"))).isEqualTo("INT(1) DOT INT(0) NEWLINE EOF");
     assertThat(lastError.toString())
-        .isEqualTo("/some/path.txt:1: invalid base-10 integer constant: 23E10");
+        .isEqualTo("/some/path.txt:1: invalid base-8 integer constant: 0E10");
 
-    assertThat(values(tokens("1.23E-10"))).isEqualTo("INT(1) DOT INT(0) MINUS INT(10) NEWLINE EOF");
+    assertThat(values(tokens("1.03E-10"))).isEqualTo("INT(1) DOT INT(0) MINUS INT(10) NEWLINE EOF");
     assertThat(lastError.toString())
-        .isEqualTo("/some/path.txt:1: invalid base-10 integer constant: 23E");
+        .isEqualTo("/some/path.txt:1: invalid base-8 integer constant: 03E");
 
     assertThat(values(tokens(". 123"))).isEqualTo("DOT INT(123) NEWLINE EOF");
     assertThat(values(tokens(".123"))).isEqualTo("DOT INT(123) NEWLINE EOF");

--- a/src/test/java/com/google/devtools/build/lib/syntax/LexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/LexerTest.java
@@ -184,6 +184,8 @@ public class LexerTest {
   @Test
   public void testNoWhiteSpaceBetweenTokens() throws Exception {
     assertThat(names(tokens("6or()"))).isEqualTo("INT OR LPAREN RPAREN NEWLINE EOF");
+    assertThat(names(tokens("0and()"))).isEqualTo("INT AND LPAREN RPAREN NEWLINE EOF");
+    assertThat(names(tokens("0o1or()"))).isEqualTo("INT OR LPAREN RPAREN NEWLINE EOF");
     assertThat(names(tokens("0in(''and[])")))
         .isEqualTo("INT IN LPAREN STRING AND LBRACKET RBRACKET RPAREN NEWLINE EOF");
 
@@ -245,16 +247,9 @@ public class LexerTest {
   @Test
   public void testIntegersAndDot() throws Exception {
     assertThat(values(tokens("1.2345"))).isEqualTo("INT(1) DOT INT(2345) NEWLINE EOF");
-
     assertThat(values(tokens("1.2.345"))).isEqualTo("INT(1) DOT INT(2) DOT INT(345) NEWLINE EOF");
-
-    assertThat(values(tokens("1.0E10"))).isEqualTo("INT(1) DOT INT(0) NEWLINE EOF");
-    assertThat(lastError.toString())
-        .isEqualTo("/some/path.txt:1: invalid base-8 integer constant: 0E10");
-
-    assertThat(values(tokens("1.03E-10"))).isEqualTo("INT(1) DOT INT(0) MINUS INT(10) NEWLINE EOF");
-    assertThat(lastError.toString())
-        .isEqualTo("/some/path.txt:1: invalid base-8 integer constant: 03E");
+    assertThat(values(tokens("1.23E10"))).isEqualTo("INT(1) DOT INT(23) IDENTIFIER(E10) NEWLINE EOF");
+    assertThat(values(tokens("1.23E-10"))).isEqualTo("INT(1) DOT INT(23) IDENTIFIER(E) MINUS INT(10) NEWLINE EOF");
 
     assertThat(values(tokens(". 123"))).isEqualTo("DOT INT(123) NEWLINE EOF");
     assertThat(values(tokens(".123"))).isEqualTo("DOT INT(123) NEWLINE EOF");


### PR DESCRIPTION
If the first token of a number is not '0', then the lexer should not scan any characters because the number should be a decimal.
This solves some cases where omitting whitespace between tokens produced errors. For example
```
# Before
6in() # False
6or() # invalid base-10 integer constant: 6o

# After
6in() # False
6or() # 6
```
The first example works correctly in both cases since the token 'i' never advances the buffer, while 'o' can appear in integers.