### PR TITLE
Enable unpacking of dicts into positional args

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/EvalUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/EvalUtils.java
@@ -381,6 +381,9 @@ public final class EvalUtils {
     } else if (o instanceof Iterable) {
       return (Iterable<?>) o;
     } else if (o instanceof Map) {
+      if (o instanceof SkylarkDict) {
+        return ((SkylarkDict) o).keySet();
+      }
       return toCollection(o, loc, env);
     } else {
       throw new EvalException(loc,

--- a/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -841,12 +842,15 @@ public final class FuncallExpression extends Expression {
       if (arg.isPositional()) {
         posargs.add(value);
       } else if (arg.isStar()) { // expand the starArg
-        if (!(value instanceof Iterable)) {
+        Collection<?> items;
+        try {
+          items = EvalUtils.toCollection(value, getLocation(), env);
+        } catch (EvalException e) {
           throw new EvalException(
               getLocation(),
               "argument after * must be an iterable, not " + EvalUtils.getDataTypeName(value));
         }
-        for (Object starArgUnit : (Iterable<Object>) value) {
+        for (Object starArgUnit : items) {
           posargs.add(starArgUnit);
         }
       } else if (arg.isStarStar()) { // expand the kwargs

--- a/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/FuncallExpression.java
@@ -842,9 +842,9 @@ public final class FuncallExpression extends Expression {
       if (arg.isPositional()) {
         posargs.add(value);
       } else if (arg.isStar()) { // expand the starArg
-        Collection<?> items;
+        Iterable<?> items;
         try {
-          items = EvalUtils.toCollection(value, getLocation(), env);
+          items = EvalUtils.toIterable(value, getLocation(), env);
         } catch (EvalException e) {
           throw new EvalException(
               getLocation(),

--- a/src/test/java/com/google/devtools/build/lib/syntax/SkylarkEvaluationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/SkylarkEvaluationTest.java
@@ -1252,19 +1252,6 @@ public class SkylarkEvaluationTest extends EvaluationTest {
   }
 
   @Test
-  public void testPositionalArgTypes() throws Exception {
-    new SkylarkTest().setUp(
-        "def foo(*args): return args",
-        "a = {'one': 1}",
-        "b = (1, 2)",
-        "c = [3, 4]")
-        .testStatement("str(foo(*a))", "(\"one\",)")
-        .testStatement("str(foo(*b))", "(1, 2)")
-        .testStatement("str(foo(*c))", "(3, 4)")
-        .testIfErrorContains("argument after * must be an iterable, not int", "foo(*2)");
-  }
-
-  @Test
   public void testNoJavaCallsWithoutSkylark() throws Exception {
     new SkylarkTest().testIfExactError("type 'int' has no method to_string()", "s = 3.to_string()");
   }

--- a/src/test/java/com/google/devtools/build/lib/syntax/SkylarkEvaluationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/SkylarkEvaluationTest.java
@@ -1252,6 +1252,19 @@ public class SkylarkEvaluationTest extends EvaluationTest {
   }
 
   @Test
+  public void testPositionalArgTypes() throws Exception {
+    new SkylarkTest().setUp(
+        "def foo(*args): return args",
+        "a = {'one': 1}",
+        "b = (1, 2)",
+        "c = [3, 4]")
+        .testStatement("str(foo(*a))", "(\"one\",)")
+        .testStatement("str(foo(*b))", "(1, 2)")
+        .testStatement("str(foo(*c))", "(3, 4)")
+        .testIfErrorContains("argument after * must be an iterable, not int", "foo(*2)");
+  }
+
+  @Test
   public void testNoJavaCallsWithoutSkylark() throws Exception {
     new SkylarkTest().testIfExactError("type 'int' has no method to_string()", "s = 3.to_string()");
   }

--- a/src/test/starlark/testdata/function.sky
+++ b/src/test/starlark/testdata/function.sky
@@ -58,3 +58,19 @@ getattr("", "abc") ### object of type 'string' has no attribute 'abc'
 ---
 x = getattr("", "pop", "clear")
 x() ### 'string' object is not callable
+---
+
+# positional args
+
+def foo(*args):
+    return args
+
+a = {'one': 1}
+b = (1, 2)
+c = [3, 4]
+
+assert_eq(foo(*a), ('one',))
+assert_eq(foo(*b), (1, 2))
+assert_eq(foo(*c), (3, 4))
+
+foo(*2) ### argument after * must be an iterable, not int


### PR DESCRIPTION
```python
def varargs(*args): return args
x15 = {"one": 1}

# Before
varargs(*x15) # argument after * must be an iterable, not dict
# After
varargs(*x15) # ("one",)
```