### PR TITLE
Use rules_android in Android tutorial

### DIFF
--- a/site/docs/tutorial/android-app.md
+++ b/site/docs/tutorial/android-app.md
@@ -116,7 +116,7 @@ RULES_ANDROID_VERSION = "b60d84e5635233d2d8fc905041576bd44cefbb94"
 RULES_ANDROID_SHA = "d7cdd6e6aced08e152ff14074ea6cde98d6329d7fe1c5cd578a1e4edb4b3e4c9"
 
 http_archive(
-    name = "build_bazel_rules_android",
+    name = "rules_android",
     urls = [
         "https://github.com/bazelbuild/rules_android/archive/%s.zip" % RULES_ANDROID_VERSION,
     ],
@@ -135,7 +135,7 @@ file so that Bazel knows where to find them.
 Add the following lines to your `WORKSPACE` file:
 
 ```python
-load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
+load("@rules_android//android:rules.bzl", "android_sdk_repository")
 
 android_sdk_repository(name = "androidsdk")
 ```
@@ -260,7 +260,7 @@ and declare a new `android_library` target:
 `src/main/java/com/example/bazel/BUILD`:
 
 ```python
-load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("@rules_android//android:rules.bzl", "android_library")
 
 package(
     default_visibility = ["//src:__subpackages__"],
@@ -293,7 +293,7 @@ and declare a new `android_binary` target:
 `src/main/BUILD`:
 
 ```python
-load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("@rules_android//android:rules.bzl", "android_binary")
 
 android_binary(
     name = "app",

--- a/site/docs/tutorial/android-app.md
+++ b/site/docs/tutorial/android-app.md
@@ -105,16 +105,37 @@ If Bazel prints the path of the current directory, you're good to go! If the
 ERROR: The 'info' command is only supported from within a workspace.
 ```
 
-## Integrate with the Android SDK
+## Integrate with the Bazel Android Rules
+
+Android-specific Bazel rules are defined in a separate repository: https://github.com/bazelbuild/rules_android
+
+Add the following lines to your `WORKSPACE` file:
+
+```python
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "build_bazel_rules_android",
+    urls = [
+        "https://github.com/bazelbuild/rules_android/archive/b60d84e5635233d2d8fc905041576bd44cefbb94.zip",
+    ],
+    strip_prefix = "rules_android-b60d84e5635233d2d8fc905041576bd44cefbb94",
+    sha256 = "d7cdd6e6aced08e152ff14074ea6cde98d6329d7fe1c5cd578a1e4edb4b3e4c9"
+)
+```
+
+This will allow you load Android rules required for the build.
 
 Bazel needs to run the Android SDK [build
 tools](https://developer.android.com/tools/revisions/build-tools.html) to build
 the app. This means that you need to add some information to your `WORKSPACE`
 file so that Bazel knows where to find them.
 
-Add the following line to your `WORKSPACE` file:
+Add the following lines to your `WORKSPACE` file:
 
 ```python
+load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
+
 android_sdk_repository(name = "androidsdk")
 ```
 
@@ -238,6 +259,8 @@ and declare a new `android_library` target:
 `src/main/java/com/example/bazel/BUILD`:
 
 ```python
+load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )
@@ -269,6 +292,8 @@ and declare a new `android_binary` target:
 `src/main/BUILD`:
 
 ```python
+load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+
 android_binary(
     name = "app",
     manifest = "AndroidManifest.xml",
@@ -381,7 +406,7 @@ you:
     for the app and a `WORKSPACE` file that identifies the top level of the
     workspace directory.
 *   Updated the `WORKSPACE` file to contain references to the required
-    external dependencies, like the Android SDK.
+    external dependencies, like the Bazel Android rules and Android SDK.
 *   Created a `BUILD` file.
 *   Built the app with Bazel.
 *   Deployed and ran the app on an Android emulator or physical device.

--- a/site/docs/tutorial/android-app.md
+++ b/site/docs/tutorial/android-app.md
@@ -112,15 +112,16 @@ Android-specific Bazel rules are defined in a separate repository: https://githu
 Add the following lines to your `WORKSPACE` file:
 
 ```python
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+RULES_ANDROID_VERSION = "b60d84e5635233d2d8fc905041576bd44cefbb94"
+RULES_ANDROID_SHA = "d7cdd6e6aced08e152ff14074ea6cde98d6329d7fe1c5cd578a1e4edb4b3e4c9"
 
 http_archive(
     name = "build_bazel_rules_android",
     urls = [
-        "https://github.com/bazelbuild/rules_android/archive/b60d84e5635233d2d8fc905041576bd44cefbb94.zip",
+        "https://github.com/bazelbuild/rules_android/archive/%s.zip" % RULES_ANDROID_VERSION,
     ],
-    strip_prefix = "rules_android-b60d84e5635233d2d8fc905041576bd44cefbb94",
-    sha256 = "d7cdd6e6aced08e152ff14074ea6cde98d6329d7fe1c5cd578a1e4edb4b3e4c9"
+    strip_prefix = "rules_android-%s" % RULES_ANDROID_VERSION,
+    sha256 = RULES_ANDROID_SHA,
 )
 ```
 


### PR DESCRIPTION
This change updates [Bazel Android Tutorial](https://docs.bazel.build/versions/master/tutorial/android-app.html) to use [rules_android](https://github.com/bazelbuild/rules_android) so that users aren't exposed to the deprecated native rules and are better prepared for the future use of [rules_android](https://github.com/bazelbuild/rules_android).

Caveat: I had to use commit instead of a tag for [rules_android](https://github.com/bazelbuild/rules_android) since it hasn't been released in a while even though it gets changed.