### PR TITLE
Handle negative count arg in string.replace

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
@@ -508,6 +508,18 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
       help = "If set to true, the command parameter of actions.run_shell will only accept string")
   public boolean incompatibleRunShellCommandString;
 
+  @Option(
+      name = "incompatible_string_replace_count",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
+      metadataTags = {
+        OptionMetadataTag.INCOMPATIBLE_CHANGE,
+        OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+      },
+      help = "If set to true, a negative count in string.replace() will be ignored")
+  public boolean incompatibleStringReplaceCount;
+
   /** Used in an integration test to confirm that flags are visible to the interpreter. */
   @Option(
       name = "internal_skylark_flag_test_canary",
@@ -652,6 +664,7 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
             .incompatibleNoRuleOutputsParam(incompatibleNoRuleOutputsParam)
             .incompatibleNoSupportToolsInActionInputs(incompatibleNoSupportToolsInActionInputs)
             .incompatibleRunShellCommandString(incompatibleRunShellCommandString)
+            .incompatibleStringReplaceCount(incompatibleStringReplaceCount)
             .incompatibleVisibilityPrivateAttributesAtDefinition(
                 incompatibleVisibilityPrivateAttributesAtDefinition)
             .internalSkylarkFlagTestCanary(internalSkylarkFlagTestCanary)

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
@@ -257,6 +257,8 @@ public abstract class StarlarkSemantics {
 
   public abstract boolean incompatibleRunShellCommandString();
 
+  public abstract boolean incompatibleStringReplaceCount();
+
   public abstract boolean incompatibleVisibilityPrivateAttributesAtDefinition();
 
   public abstract boolean internalSkylarkFlagTestCanary();
@@ -343,6 +345,7 @@ public abstract class StarlarkSemantics {
           .incompatibleNoRuleOutputsParam(false)
           .incompatibleNoSupportToolsInActionInputs(true)
           .incompatibleRunShellCommandString(false)
+          .incompatibleStringReplaceCount(false)
           .incompatibleVisibilityPrivateAttributesAtDefinition(false)
           .internalSkylarkFlagTestCanary(false)
           .incompatibleDoNotSplitLinkingCmdline(true)
@@ -421,6 +424,8 @@ public abstract class StarlarkSemantics {
     public abstract Builder incompatibleNoSupportToolsInActionInputs(boolean value);
 
     public abstract Builder incompatibleRunShellCommandString(boolean value);
+
+    public abstract Builder incompatibleStringReplaceCount(boolean value);
 
     public abstract Builder incompatibleVisibilityPrivateAttributesAtDefinition(boolean value);
 

--- a/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
@@ -279,14 +279,24 @@ final class StringModule implements StarlarkValue {
             type = Integer.class,
             noneable = true,
             defaultValue = "None",
-            doc = "The maximum number of replacements. A negative value is ignored.")
-      })
-  public String replace(String self, String oldString, String newString, Object count)
+            doc = "The maximum number of replacements. A negative value is ignored (if --incompatible_string_replace_count is true).")
+      },
+      useStarlarkThread = true)
+  public String replace(String self, String oldString, String newString, Object count, StarlarkThread thread)
       throws EvalException {
     int maxReplaces = Integer.MAX_VALUE;
-    if (count != Starlark.NONE && (Integer) count >= 0) {
-      maxReplaces = (Integer) count;
+
+    StarlarkSemantics semantics = thread.getSemantics();
+    if (semantics.incompatibleStringReplaceCount()) {
+      if (count != Starlark.NONE && (Integer) count >= 0) {
+        maxReplaces = (Integer) count;
+      }
+    } else {
+      if (count != Starlark.NONE) {
+        maxReplaces = Math.max(0, (Integer) count);
+      }
     }
+
     StringBuilder sb = new StringBuilder();
     int start = 0;
     for (int i = 0; i < maxReplaces; i++) {

--- a/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
@@ -274,16 +274,17 @@ final class StringModule implements StarlarkValue {
             type = String.class,
             doc = "The string to replace with."),
         @Param(
-            name = "count",
+            // TODO(#8147): rename param to "count" once it's positional-only.
+            name = "maxsplit",
             type = Integer.class,
             noneable = true,
             defaultValue = "None",
-            doc = "The maximum number of replacements.")
+            doc = "The maximum number of replacements. A negative value is ignored.")
       })
   public String replace(String self, String oldString, String newString, Object count)
       throws EvalException {
     int maxReplaces = Integer.MAX_VALUE;
-    if (count != Starlark.NONE && (Integer) count > -1) {
+    if (count != Starlark.NONE && (Integer) count >= 0) {
       maxReplaces = (Integer) count;
     }
     StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StringModule.java
@@ -274,21 +274,21 @@ final class StringModule implements StarlarkValue {
             type = String.class,
             doc = "The string to replace with."),
         @Param(
-            name = "maxsplit",
+            name = "count",
             type = Integer.class,
             noneable = true,
             defaultValue = "None",
             doc = "The maximum number of replacements.")
       })
-  public String replace(String self, String oldString, String newString, Object maxSplitO)
+  public String replace(String self, String oldString, String newString, Object count)
       throws EvalException {
-    int maxSplit = Integer.MAX_VALUE;
-    if (maxSplitO != Starlark.NONE) {
-      maxSplit = Math.max(0, (Integer) maxSplitO);
+    int maxReplaces = Integer.MAX_VALUE;
+    if (count != Starlark.NONE && (Integer) count > -1) {
+      maxReplaces = (Integer) count;
     }
     StringBuilder sb = new StringBuilder();
     int start = 0;
-    for (int i = 0; i < maxSplit; i++) {
+    for (int i = 0; i < maxReplaces; i++) {
       if (oldString.isEmpty()) {
         sb.append(newString);
         if (start < self.length()) {

--- a/src/test/java/com/google/devtools/build/lib/packages/SkylarkSemanticsConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/SkylarkSemanticsConsistencyTest.java
@@ -156,6 +156,7 @@ public class SkylarkSemanticsConsistencyTest {
         "--incompatible_no_rule_outputs_param=" + rand.nextBoolean(),
         "--incompatible_no_support_tools_in_action_inputs=" + rand.nextBoolean(),
         "--incompatible_run_shell_command_string=" + rand.nextBoolean(),
+        "--incompatible_string_replace_count=" + rand.nextBoolean(),
         "--incompatible_visibility_private_attributes_at_definition=" + rand.nextBoolean(),
         "--incompatible_require_linker_input_cc_api=" + rand.nextBoolean(),
         "--incompatible_restrict_string_escapes=" + rand.nextBoolean(),
@@ -207,6 +208,7 @@ public class SkylarkSemanticsConsistencyTest {
         .incompatibleNoRuleOutputsParam(rand.nextBoolean())
         .incompatibleNoSupportToolsInActionInputs(rand.nextBoolean())
         .incompatibleRunShellCommandString(rand.nextBoolean())
+        .incompatibleStringReplaceCount(rand.nextBoolean())
         .incompatibleVisibilityPrivateAttributesAtDefinition(rand.nextBoolean())
         .incompatibleRequireLinkerInputCcApi(rand.nextBoolean())
         .incompatibleRestrictStringEscapes(rand.nextBoolean())

--- a/src/test/java/com/google/devtools/build/lib/syntax/StringModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/StringModuleTest.java
@@ -1,0 +1,52 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.syntax;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.build.lib.syntax.util.EvaluationTestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for SkylarkStringModule.
+ */
+@RunWith(JUnit4.class)
+public class StringModuleTest extends EvaluationTestCase {
+
+  @Test
+  public void testReplace() throws Exception {
+      // Test that the behaviour is the same for the basic case both before
+      // and after the incompatible change.
+      new Scenario("--incompatible_string_replace_count=false")
+        .testEval("\"banana\".replace(\"a\", \"o\")", "\"bonono\"")
+        .testEval("\"banana\".replace(\"a\", \"o\", 2)", "\"bonona\"")
+        .testEval("\"banana\".replace(\"a\", \"o\", 0)", "\"banana\"");
+
+      new Scenario("--incompatible_string_replace_count=true")
+        .testEval("\"banana\".replace(\"a\", \"o\")", "\"bonono\"")
+        .testEval("\"banana\".replace(\"a\", \"o\", 2)", "\"bonona\"")
+        .testEval("\"banana\".replace(\"a\", \"o\", 0)", "\"banana\"");
+  }
+
+  @Test
+  public void testReplaceIncompatibleChange() throws Exception {
+      new Scenario("--incompatible_string_replace_count=false")
+        .testEval("\"banana\".replace(\"a\", \"o\", -2)", "\"banana\"");
+
+      new Scenario("--incompatible_string_replace_count=true")
+        .testEval("\"banana\".replace(\"a\", \"o\", -2)", "\"bonono\"");
+  }
+}

--- a/src/test/starlark/testdata/string_misc.sky
+++ b/src/test/starlark/testdata/string_misc.sky
@@ -43,17 +43,6 @@ assert_eq('b\\n\\n\\'.replace('\\', '$()'), "b$()n$()n$()")
 
 assert_eq('banana'.replace('a', 'e', 2), "benena")
 assert_eq('banana'.replace('a', 'e', 0), "banana")
-assert_eq('banana'.replace('a', 'e', -1), "benene")
-assert_eq('banana'.replace('a', 'e', -10), "benene")
-
-assert_eq('banana'.replace('', '-'), "-b-a-n-a-n-a-")
-assert_eq('banana'.replace('', '-', -2), "-b-a-n-a-n-a-")
-assert_eq('banana'.replace('', '-', 2), "-b-anana")
-assert_eq('banana'.replace('', '-', 0), "banana")
-
-assert_eq('banana'.replace('', ''), "banana")
-assert_eq('banana'.replace('a', ''), "bnn")
-assert_eq('banana'.replace('a', '', 2), "bnna")
 
 # index, rindex
 assert_eq('banana'.index('na'), 2)

--- a/src/test/starlark/testdata/string_misc.sky
+++ b/src/test/starlark/testdata/string_misc.sky
@@ -43,11 +43,11 @@ assert_eq('b\\n\\n\\'.replace('\\', '$()'), "b$()n$()n$()")
 
 assert_eq('banana'.replace('a', 'e', 2), "benena")
 assert_eq('banana'.replace('a', 'e', 0), "banana")
-assert_eq('banana'.replace('a', 'e', -1), "banana")
-assert_eq('banana'.replace('a', 'e', -10), "banana")
+assert_eq('banana'.replace('a', 'e', -1), "benene")
+assert_eq('banana'.replace('a', 'e', -10), "benene")
 
 assert_eq('banana'.replace('', '-'), "-b-a-n-a-n-a-")
-assert_eq('banana'.replace('', '-', -2), "banana")
+assert_eq('banana'.replace('', '-', -2), "-b-a-n-a-n-a-")
 assert_eq('banana'.replace('', '-', 2), "-b-anana")
 assert_eq('banana'.replace('', '-', 0), "banana")
 


### PR DESCRIPTION
Also update the name of the argument to be "count" instead of "maxsplit",
to match the Starlark spec.

This fixes #9181