### PR TITLE
Wire up --incompatible_disallow_unverified_http_downloads for maven_server

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunction.java
@@ -152,8 +152,7 @@ public class MavenJarFunction extends RepositoryFunction {
               null,
               "Plain HTTP URLs are not allowed without checksums in the maven_jar rule. Please "
                   + String.format("use HTTPS for the maven_server rule for %s ", serverUrl)
-                  + "or add a sha1 checksum to the maven_jar rule. To "
-                  + "disable this check, pass "
+                  + "or add a sha1 checksum to the maven_jar rule. To disable this check, pass "
                   + "--incompatible_disallow_unverified_http_downloads=false to your build"),
           Transience.PERSISTENT);
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenServerFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenServerFunction.java
@@ -52,9 +52,7 @@ import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
 import org.apache.maven.settings.building.SettingsBuildingException;
 import org.apache.maven.settings.building.SettingsBuildingResult;
 
-/**
- * Implementation of maven_repository.
- */
+/** Implementation of maven_server. */
 public class MavenServerFunction implements SkyFunction {
   public static final SkyFunctionName NAME =
       SkyFunctionName.createHermetic("MAVEN_SERVER_FUNCTION");

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunctionTest.java
@@ -152,7 +152,7 @@ public class MavenJarFunctionTest extends BuildViewTestCase {
 
     try {
       jarFunction.validateServerUrl(
-          rule, TEST_SERVER.getUrl(), /*disallowUnverifieDHttpDownloads=*/ true);
+          rule, TEST_SERVER.getUrl(), /*disallowUnverifiedHttpDownloads=*/ true);
     } catch (RepositoryFunctionException expected) {
       assertThat(expected.getMessage())
           .contains("Plain HTTP URLs are not allowed without checksums");

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunctionTest.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.packages.Rule;
+import com.google.devtools.build.lib.rules.repository.RepositoryFunction.RepositoryFunctionException;
 import com.google.devtools.build.lib.rules.repository.WorkspaceAttributeMapper;
 import java.io.IOException;
 import org.apache.maven.settings.Server;
@@ -133,6 +134,28 @@ public class MavenJarFunctionTest extends BuildViewTestCase {
       fail("Expected failure to fetch artifact because of nonexistent server.");
     } catch (IOException expected) {
       assertThat(expected.getMessage()).contains("Failed to fetch Maven dependency:");
+    }
+  }
+
+  @Test
+  public void testValidateHttpServerUrlWithNoChecksum() throws Exception {
+    Rule rule =
+        scratchRule(
+            "external",
+            "foo",
+            "maven_jar(",
+            "    name = 'foo',",
+            "    artifact = 'x:y:z:1.1',",
+            ")");
+    MavenDownloader downloader = new MavenDownloader(Mockito.mock(RepositoryCache.class));
+    MavenJarFunction jarFunction = new MavenJarFunction(downloader);
+
+    try {
+      jarFunction.validateServerUrl(
+          rule, TEST_SERVER.getUrl(), /*disallowUnverifieDHttpDownloads=*/ true);
+    } catch (RepositoryFunctionException expected) {
+      assertThat(expected.getMessage())
+          .contains("Plain HTTP URLs are not allowed without checksums");
     }
   }
 }


### PR DESCRIPTION
Force usage of either HTTPS or HTTP w/ SHA-1. Note that SHA-1 is still susceptible to collision attacks, but this should reduce the exploitable surface of the current implementation that allows plain HTTP without checksums.

Also see https://github.com/bazelbuild/bazel/issues/6799#issuecomment-524382068

