### PR TITLE
Add sha256 and sha256_src attributes to maven_jar

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenDownloader.java
@@ -198,7 +198,7 @@ public class MavenDownloader extends HttpDownloader {
   }
 
   @Nullable
-  private String retrieveChecksum(
+  private static String retrieveChecksum(
       String name, String attribute, KeyType keyType, WorkspaceAttributeMapper mapper)
       throws EvalException, IOException {
     String checksum =
@@ -207,12 +207,12 @@ public class MavenDownloader extends HttpDownloader {
             : null;
     if (checksum != null && !keyType.isValid(checksum)) {
       throw new IOException(
-          "Invalid " + keyType.toString()+ " for maven_jar " + name + ": '" + checksum + "'");
+          "Invalid " + keyType + " for maven_jar " + name + ": '" + checksum + "'");
     }
     return checksum;
   }
 
-  private Path getDownloadDestination(Path outputDirectory, Artifact artifact) {
+  private static Path getDownloadDestination(Path outputDirectory, Artifact artifact) {
     String groupIdPath = artifact.getGroupId().replace('.', '/');
     String artifactId = artifact.getArtifactId();
     String classifier = artifact.getClassifier();
@@ -230,7 +230,7 @@ public class MavenDownloader extends HttpDownloader {
     return outputDirectory.getRelative(joiner.toString());
   }
 
-  private Artifact srcjarCoords(Artifact jar) {
+  private static Artifact srcjarCoords(Artifact jar) {
     return new DefaultArtifact(
         jar.getGroupId(), jar.getArtifactId(), "sources", jar.getExtension(), jar.getVersion());
   }
@@ -238,7 +238,7 @@ public class MavenDownloader extends HttpDownloader {
   /*
    * Set up request for and resolve (retrieve to local repo) artifact
    */
-  private Artifact downloadArtifact(
+  private static Artifact downloadArtifact(
       Artifact artifact,
       RemoteRepository repository,
       RepositorySystemSession session,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunction.java
@@ -138,7 +138,8 @@ public class MavenJarFunction extends RepositoryFunction {
     return createOutputTree(rule, outputDir, serverValue, env.getListener());
   }
 
-  private void validateShaAttributes(Rule rule, String sha1, String sha256) throws RepositoryFunctionException {
+  private static void validateShaAttributes(
+      Rule rule, String sha1, String sha256) throws RepositoryFunctionException {
     if (WorkspaceAttributeMapper.of(rule).isAttributeValueExplicitlySpecified(sha1)
         && WorkspaceAttributeMapper.of(rule).isAttributeValueExplicitlySpecified(sha256)) {
       throw new RepositoryFunctionException(

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/MavenJarRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/MavenJarRule.java
@@ -55,6 +55,20 @@ public class MavenJarRule implements RuleDefinition {
         <p>Either this or <code>repository</code> can be specified.</p>
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("server", Type.STRING))
+        /* <!-- #BLAZE_RULE(maven_jar).ATTRIBUTE(sha256) -->
+        A SHA-256 hash of the desired jar.
+
+        <p>If the downloaded jar does not match this hash, Bazel will error out. It is a security
+        risk to download a file without verifying cryptographic secure hash.</p>
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(attr("sha256", Type.STRING))
+        /* <!-- #BLAZE_RULE(maven_jar).ATTRIBUTE(sha256_src) -->
+        A SHA-256 hash of the desired jar source file.
+
+        <p>If the downloaded source jar does not match this hash, Bazel will error out. It is a
+        security risk to download a file without verifying cryptographic secure hash.</p>
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(attr("sha256_src", Type.STRING))
         /* <!-- #BLAZE_RULE(maven_jar).ATTRIBUTE(sha1) -->
         A SHA-1 hash of the desired jar.
 
@@ -62,14 +76,16 @@ public class MavenJarRule implements RuleDefinition {
         risk to download a file without verifying cryptographic secure hash. <b>Note that SHA-1 is
         no longer considered a secure cryptographic hash function</b>, but specifying the hash is
         still marginally better than no check at all. This attribute is kept here for legacy support
-        purposes. Please migrate to <a href="https://github.com/bazelbuild/rules_jvm_external/">
-        <code>rules_jvm_external</code></a> and pin your Maven artifacts with their SHA-256
-        checksums.</p>
+        purposes. Please either use the 'sha256' attribute or migrate to
+        <a href="https://github.com/bazelbuild/rules_jvm_external/"><code>rules_jvm_external</code>
+        </a> and pin your Maven artifacts with their SHA-256 checksums.</p>
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("sha1", Type.STRING))
         /* <!-- #BLAZE_RULE(maven_jar).ATTRIBUTE(sha1_src) -->
-        A SHA-1 hash of the desired jar source file.
+        A SHA-1 hash of the desired jar source file. Please consider using 'sha256_src' instead.
 
+        <p>If the downloaded source jar does not match this hash, Bazel will error out. It is a
+        security risk to download a file without verifying cryptographic secure hash.</p>
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("sha1_src", Type.STRING))
         .setWorkspaceOnly()

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/MavenJarFunctionTest.java
@@ -57,6 +57,7 @@ public class MavenJarFunctionTest extends BuildViewTestCase {
     try {
       downloader.download(
           "foo",
+          rule.getLocation(),
           WorkspaceAttributeMapper.of(rule),
           scratch.dir("/whatever"),
           TEST_SERVER,
@@ -80,6 +81,7 @@ public class MavenJarFunctionTest extends BuildViewTestCase {
     try {
       downloader.download(
           "foo",
+          rule.getLocation(),
           WorkspaceAttributeMapper.of(rule),
           scratch.dir("/whatever"),
           TEST_SERVER,
@@ -102,6 +104,7 @@ public class MavenJarFunctionTest extends BuildViewTestCase {
     try {
       downloader.download(
           "foo",
+          rule.getLocation(),
           WorkspaceAttributeMapper.of(rule),
           scratch.dir("/whatever"),
           TEST_SERVER,
@@ -126,6 +129,7 @@ public class MavenJarFunctionTest extends BuildViewTestCase {
     try {
       downloader.download(
           "foo",
+          rule.getLocation(),
           WorkspaceAttributeMapper.of(rule),
           scratch.dir("/whatever"),
           TEST_SERVER,
@@ -135,4 +139,53 @@ public class MavenJarFunctionTest extends BuildViewTestCase {
       assertThat(expected.getMessage()).contains("Failed to fetch Maven dependency:");
     }
   }
+
+  @Test
+  public void testInvalidSha256() throws Exception {
+    Rule rule = scratchRule("external", "foo",
+        "maven_jar(",
+        "    name = 'foo',",
+        "    artifact = 'x:y:z:1.1',",
+        "    sha256 = '12345',",
+        ")");
+    MavenDownloader downloader = new MavenDownloader(Mockito.mock(RepositoryCache.class));
+    try {
+      downloader.download(
+          "foo",
+          rule.getLocation(),
+          WorkspaceAttributeMapper.of(rule),
+          scratch.dir("/whatever"),
+          TEST_SERVER,
+          extendedEventHandler);
+      fail("Invalid sha256 should have thrown.");
+    } catch (IOException expected) {
+      assertThat(expected.getMessage()).contains("Invalid SHA-256 for maven_jar foo");
+    }
+  }
+
+
+  @Test
+  public void testValidSha256() throws Exception {
+    Rule rule = scratchRule("external", "foo",
+        "maven_jar(",
+        "    name = 'foo',",
+        "    artifact = 'x:y:z:1.1',",
+        "    sha256 = '766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7',",
+        ")");
+    MavenDownloader downloader = new MavenDownloader(Mockito.mock(RepositoryCache.class));
+    try {
+      downloader.download(
+          "foo",
+          rule.getLocation(),
+          WorkspaceAttributeMapper.of(rule),
+          scratch.dir("/whatever"),
+          TEST_SERVER,
+          extendedEventHandler);
+      fail("Expected failure to fetch artifact because of nonexistent server and not due to "
+          + "the existence of a valid SHA256");
+    } catch (IOException expected) {
+      assertThat(expected.getMessage()).contains("Failed to fetch Maven dependency:");
+    }
+  }
+
 }

--- a/src/test/shell/bazel/remote_helpers.sh
+++ b/src/test/shell/bazel/remote_helpers.sh
@@ -87,6 +87,7 @@ EOF
   ${bazel_javabase}/bin/jar cf $test_jar carnivore/Mongoose.class
   ${bazel_javabase}/bin/jar cf $test_srcjar carnivore/Mongoose.java
   sha256=$(sha256sum $test_jar | cut -f 1 -d ' ')
+  sha256_src=$(sha256sum $test_srcjar | cut -f 1 -d ' ')
   # OS X doesn't have sha1sum, so use openssl.
   sha1=$(openssl sha1 $test_jar | cut -f 2 -d ' ')
   sha1_src=$(openssl sha1 $test_srcjar | cut -f 2 -d ' ')


### PR DESCRIPTION
..and print warnings if sha256 or sha256_src aren't used, like this:

> `WARNING: /usr/local/google/home/jingwen/code/copybara/WORKSPACE:192:1: maven_jar rule @junit//jar: Not using a checksum to verify the integrity of the artifact or the usage of SHA-1 is not secure (see https://shattered.io) and can result in an non-reproducible build. Please specify the SHA-256 checksum with: sha256 = "90a8e1603eeca48e7e879f3afbc9560715322985f39a274f6f6070b43f9d06fe",`

> `WARNING: /usr/local/google/home/jingwen/code/copybara/WORKSPACE:192:1: maven_jar rule @junit//jar: Not using a checksum to verify the integrity of the artifact or the usage of SHA-1 is not secure (see https://shattered.io) and can result in an non-reproducible build. Please specify the SHA-256 checksum with: sha256_src = "694f4694a51f67dadea4d2045742d38fb4efb92d82d42744b15e26ce653bcd3e",`

The warning message is designed to be copy paste-able directly into the WORKSPACE file. 

https://github.com/bazelbuild/bazel/issues/6799
https://github.com/bazelbuild/bazel/issues/8880

RELNOTES: Added `sha256` and `sha256_src` attributes to `maven_jar`. Please consider migrating to SHA-256 as SHA-1 has been deemed cryptographically insecure ([https://shattered.io]()). Or, use [`rules_jvm_external`](https://github.com/bazelbuild/rules_jvm_external) to manage your transitive Maven dependencies with artifact pinning and SHA-256 verification support.