### PR TITLE
bazelrc: support --enable_platform_specific_config

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Multiset;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
@@ -330,10 +329,9 @@ public final class BlazeOptionHandler {
       return false;
     }
 
-    Multiset<String> keys = commandToRcArgs.keys();
     for (String commandName : getCommandNamesToParse(commandAnnotation)) {
       String defaultConfigDef = commandName + ":" + OS.getCurrent().getCanonicalName();
-      if (keys.contains(defaultConfigDef)) {
+      if (commandToRcArgs.containsKey(defaultConfigDef)) {
         return true;
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -18,13 +18,16 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multiset;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.runtime.commands.ProjectFileSupport;
 import com.google.devtools.build.lib.runtime.proto.InvocationPolicyOuterClass.InvocationPolicy;
 import com.google.devtools.build.lib.util.ExitCode;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.common.options.InvocationPolicyEnforcer;
@@ -316,6 +319,28 @@ public final class BlazeOptionHandler {
   }
 
   /**
+   * If --enable_platform_specific_config is true and the corresponding config definition exists,
+   * we should enable the platform specific config.
+   */
+  private boolean shouldEnablePlatformSpecificConfig(
+      OptionValueDescription enablePlatformSpecificConfigDescription,
+      ListMultimap<String, RcChunkOfArgs> commandToRcArgs) {
+    if (enablePlatformSpecificConfigDescription == null ||
+        !(boolean) enablePlatformSpecificConfigDescription.getValue()) {
+      return false;
+    }
+
+    Multiset<String> keys = commandToRcArgs.keys();
+    for (String commandName : getCommandNamesToParse(commandAnnotation)) {
+      String defaultConfigDef = commandName + ":" + OS.getCurrent().getCanonicalName();
+      if (keys.contains(defaultConfigDef)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Expand the values of --config according to the definitions provided in the rc files and the
    * applicable command.
    */
@@ -325,23 +350,30 @@ public final class BlazeOptionHandler {
 
     OptionValueDescription configValueDescription =
         optionsParser.getOptionValueDescription("config");
-    if (configValueDescription == null || configValueDescription.getCanonicalInstances() == null) {
-      // No --config values were set, we can avoid this whole thing.
-      return;
+    if (configValueDescription != null && configValueDescription.getCanonicalInstances() != null) {
+      // Find the base set of configs. This does not include the config options that might be
+      // recursively included.
+      ImmutableList<ParsedOptionDescription> configInstances =
+          ImmutableList.copyOf(configValueDescription.getCanonicalInstances());
+
+      // Expand the configs that are mentioned in the input. Flatten these expansions before parsing
+      // them, to preserve order.
+      for (ParsedOptionDescription configInstance : configInstances) {
+        String configValueToExpand = (String) configInstance.getConvertedValue();
+        List<String> expansion = getExpansion(eventHandler, commandToRcArgs, configValueToExpand);
+        optionsParser.parseArgsAsExpansionOfOption(
+            configInstance, String.format("expanded from --%s", configValueToExpand), expansion);
+      }
     }
 
-    // Find the base set of configs. This does not include the config options that might be
-    // recursively incuded.
-    ImmutableList<ParsedOptionDescription> configInstances =
-        ImmutableList.copyOf(configValueDescription.getCanonicalInstances());
-
-    // Expand the configs that are mentioned in the input. Flatten these expansions before parsing
-    // them, to preserve order.
-    for (ParsedOptionDescription configInstance : configInstances) {
-      String configValueToExpand = (String) configInstance.getConvertedValue();
-      List<String> expansion = getExpansion(eventHandler, commandToRcArgs, configValueToExpand);
+    OptionValueDescription enablePlatformSpecificConfigDescription =
+        optionsParser.getOptionValueDescription("enable_platform_specific_config");
+    if (shouldEnablePlatformSpecificConfig(enablePlatformSpecificConfigDescription, commandToRcArgs)) {
+      List<String> expansion = getExpansion(eventHandler, commandToRcArgs, OS.getCurrent().getCanonicalName());
       optionsParser.parseArgsAsExpansionOfOption(
-          configInstance, String.format("expanded from --%s", configValueToExpand), expansion);
+          Iterables.getOnlyElement(enablePlatformSpecificConfigDescription.getCanonicalInstances()),
+          String.format("enabled by --enable_platform_specific_config"),
+          expansion);
     }
 
     // At this point, we've expanded everything, identify duplicates, if any, to warn about

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -57,6 +57,19 @@ public class CommonCommandOptions extends OptionsBase {
   public Void allIncompatibleChanges;
 
   @Option(
+      name = "enable_platform_specific_config",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "When the value of this flag is true, a host platform specific config section will be "
+              + "enabled if it exists. Bazel recognizes your host platform as linux, osx, windows "
+              + "or freebsd. It's equivalent to add --config=linux on Linux platforms and "
+              + "--config=windows on Windows, etc."
+  )
+  public boolean enablePlatformSpecificConfig;
+
+  @Option(
     name = "config",
     defaultValue = "",
     documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -62,9 +62,10 @@ public class CommonCommandOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
-          "When the value of this flag is true, a host platform specific config section will be "
-              + "enabled if it exists. Bazel recognizes your host platform as linux, osx, windows "
-              + "or freebsd. It's equivalent to add --config=linux on Linux platforms and "
+          "If true, Bazel picks up host-OS-specific config lines from bazelrc files. For example, "
+              + "if the host OS is Linux and you run bazel build, Bazel picks up lines starting "
+              + "with build:linux. Supported OS identifiers are linux, osx, windows, and freebsd. "
+              + "Enabling this flag is equivalent to using --config=linux on Linux, "
               + "--config=windows on Windows, etc."
   )
   public boolean enablePlatformSpecificConfig;

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
@@ -332,6 +332,9 @@ public class BlazeOptionHandlerTest {
 
   @Test
   public void testExpandConfigOptions_withPlatformSpecificConfigEnabledInConfig() throws Exception {
+    // --enable_platform_specific_config itself will affect the selecting of config sections.
+    // Because Bazel expands config sections recursively, we want to make sure it's fine to enable
+    // --enable_platform_specific_config via another config section.
     parser.parse("--config=platform_config");
     optionHandler.expandConfigOptions(eventHandler, structuredArgsForDifferentPlatforms());
     switch (OS.getCurrent()) {


### PR DESCRIPTION
When the value of this flag is true, a host platform specific config
section will be enabled if it exists. Bazel recognizes your host
platform as linux, osx, windows or freebsd. It's equivalent to add
--config=linux on Linux platforms and --config=windows on Windows, etc.

Fixes https://github.com/bazelbuild/bazel/issues/5055

RELNOTES[NEW]: Platform-specific bazelrc: with --enable_platform_specific_config you can 
enable flags in bazelrc according to your host platform.
GOOGLE: