### PR TITLE
Client: convert self_path to Path

### DIFF
--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -148,7 +148,7 @@ std::string GetJavaBinaryUnderJavabase();
 // CreateProcessW.
 //
 // This function does not return on success.
-void ExecuteServerJvm(const std::string& exe,
+void ExecuteServerJvm(const blaze_util::Path& exe,
                       const std::vector<std::string>& server_jvm_args);
 
 // Execute the "bazel run" request in the current directory.
@@ -157,7 +157,7 @@ void ExecuteServerJvm(const std::string& exe,
 // CreateProcessW.
 //
 // This function does not return on success.
-void ExecuteRunRequest(const std::string& exe,
+void ExecuteRunRequest(const blaze_util::Path& exe,
                        const std::vector<std::string>& run_request_args);
 
 class BlazeServerStartup {
@@ -174,7 +174,7 @@ class BlazeServerStartup {
 // both as a symlink (for legacy reasons) and as a file, and returned to the
 // caller.
 int ExecuteDaemon(
-    const std::string& exe, const std::vector<std::string>& args_vector,
+    const blaze_util::Path& exe, const std::vector<std::string>& args_vector,
     const std::map<std::string, EnvVarValue>& env,
     const blaze_util::Path& daemon_output, const bool daemon_output_append,
     const std::string& binaries_dir, const blaze_util::Path& server_dir,

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -278,9 +278,9 @@ class CharPP {
   char** charpp_;
 };
 
-static void ExecuteProgram(const string& exe,
+static void ExecuteProgram(const blaze_util::Path& exe,
                            const vector<string>& args_vector) {
-  BAZEL_LOG(INFO) << "Invoking binary " << exe << " in "
+  BAZEL_LOG(INFO) << "Invoking binary " << exe.AsPrintablePath() << " in "
                   << blaze_util::GetCwd();
 
   // TODO(jmmv): This execution does not respect any settings we might apply
@@ -289,15 +289,15 @@ static void ExecuteProgram(const string& exe,
   // priority of Bazel on macOS from a QoS perspective, this could have
   // adverse scheduling effects on any tools invoked via ExecuteProgram.
   CharPP argv(args_vector);
-  execv(exe.c_str(), argv.get());
+  execv(exe.AsNativePath().c_str(), argv.get());
 }
 
-void ExecuteServerJvm(const string& exe,
+void ExecuteServerJvm(const blaze_util::Path& exe,
                       const std::vector<string>& server_jvm_args) {
   ExecuteProgram(exe, server_jvm_args);
 }
 
-void ExecuteRunRequest(const string& exe,
+void ExecuteRunRequest(const blaze_util::Path& exe,
                        const std::vector<string>& run_request_args) {
   ExecuteProgram(exe, run_request_args);
 }
@@ -357,7 +357,8 @@ int ConfigureDaemonProcess(posix_spawnattr_t* attrp,
 void WriteSystemSpecificProcessIdentifier(const blaze_util::Path& server_dir,
                                           pid_t server_pid);
 
-int ExecuteDaemon(const string& exe, const std::vector<string>& args_vector,
+int ExecuteDaemon(const blaze_util::Path& exe,
+                  const std::vector<string>& args_vector,
                   const std::map<string, EnvVarValue>& env,
                   const blaze_util::Path& daemon_output,
                   const bool daemon_output_append, const string& binaries_dir,
@@ -374,7 +375,7 @@ int ExecuteDaemon(const string& exe, const std::vector<string>& args_vector,
     daemonize_args.push_back("-a");
   }
   daemonize_args.push_back("--");
-  daemonize_args.push_back(exe);
+  daemonize_args.push_back(exe.AsNativePath());
   std::copy(args_vector.begin(), args_vector.end(),
             std::back_inserter(daemonize_args));
 

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -658,6 +658,7 @@ int ExecuteDaemon(const blaze_util::Path& exe,
           /* bInheritHandle */ TRUE,
           /* dwOptions */ DUPLICATE_SAME_ACCESS)) {
     std::string error = GetLastErrorString();
+    BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "ExecuteDaemon(" << exe.AsPrintablePath() << "): DuplicateHandle("
         << daemon_output.AsPrintablePath() << ") failed: " << error;
   }

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -482,17 +482,18 @@ static const int MAX_CMDLINE_LENGTH = 32768;
 struct CmdLine {
   WCHAR cmdline[MAX_CMDLINE_LENGTH];
 };
-static void CreateCommandLine(CmdLine* result, const string& exe,
+static void CreateCommandLine(CmdLine* result, const blaze_util::Path& exe,
                               const std::vector<std::wstring>& wargs_vector) {
   std::wstringstream cmdline;
   string short_exe;
-  if (!exe.empty()) {
+  if (!exe.IsEmpty()) {
     string error;
-    if (!blaze_util::AsShortWindowsPath(exe, &short_exe, &error)) {
+    wstring wshort_exe;
+    if (!blaze_util::AsShortWindowsPath(exe.AsNativePath(), &wshort_exe, &error)) {
       BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-          << "CreateCommandLine: AsShortWindowsPath(" << exe << "): " << error;
+          << "CreateCommandLine: AsShortWindowsPath(" << exe.AsPrintablePath()
+          << "): " << error;
     }
-    wstring wshort_exe = blaze_util::CstringToWstring(short_exe.c_str()).get();
     cmdline << L'\"' << wshort_exe << L'\"';
   }
 
@@ -615,7 +616,8 @@ class ProcessHandleBlazeServerStartup : public BlazeServerStartup {
   AutoHandle proc;
 };
 
-int ExecuteDaemon(const string& exe, const std::vector<string>& args_vector,
+int ExecuteDaemon(const blaze_util::Path& exe,
+                  const std::vector<string>& args_vector,
                   const std::map<string, EnvVarValue>& env,
                   const blaze_util::Path& daemon_output,
                   const bool daemon_out_append, const string& binaries_dir,
@@ -631,7 +633,7 @@ int ExecuteDaemon(const string& exe, const std::vector<string>& args_vector,
   if (!devnull.IsValid()) {
     std::string error = GetLastErrorString();
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "ExecuteDaemon(" << exe << "): CreateFileA(NUL) failed: " << error;
+        << "ExecuteDaemon(" << exe.AsPrintablePath() << "): CreateFileA(NUL) failed: " << error;
   }
 
   AutoHandle stdout_file(CreateJvmOutputFile(
@@ -639,7 +641,7 @@ int ExecuteDaemon(const string& exe, const std::vector<string>& args_vector,
   if (!stdout_file.IsValid()) {
     std::string error = GetLastErrorString();
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "ExecuteDaemon(" << exe << "): CreateJvmOutputFile("
+        << "ExecuteDaemon(" << exe.AsPrintablePath() << "): CreateJvmOutputFile("
         << daemon_output.AsPrintablePath() << ") failed: " << error;
   }
   HANDLE stderr_handle;
@@ -656,8 +658,7 @@ int ExecuteDaemon(const string& exe, const std::vector<string>& args_vector,
           /* bInheritHandle */ TRUE,
           /* dwOptions */ DUPLICATE_SAME_ACCESS)) {
     std::string error = GetLastErrorString();
-    BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "ExecuteDaemon(" << exe << "): DuplicateHandle("
+        << "ExecuteDaemon(" << exe.AsPrintablePath() << "): DuplicateHandle("
         << daemon_output.AsPrintablePath() << ") failed: " << error;
   }
   AutoHandle stderr_file(stderr_handle);
@@ -668,7 +669,7 @@ int ExecuteDaemon(const string& exe, const std::vector<string>& args_vector,
   if (!AutoAttributeList::Create(devnull, stdout_file, stderr_handle,
                                  &lpAttributeList, &werror)) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "ExecuteDaemon(" << exe << "): attribute list creation failed: "
+        << "ExecuteDaemon(" << exe.AsPrintablePath() << "): attribute list creation failed: "
         << blaze_util::WstringToString(werror);
   }
 
@@ -706,9 +707,10 @@ int ExecuteDaemon(const string& exe, const std::vector<string>& args_vector,
   }
 
   if (!ok) {
+    string err = GetLastErrorString();
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "ExecuteDaemon(" << exe << "): CreateProcess(" << cmdline.cmdline
-        << ") failed: " << GetLastErrorString();
+        << "ExecuteDaemon(" << exe.AsPrintablePath() << "): CreateProcess("
+        << cmdline.cmdline << ") failed: " << err;
   }
 
   WriteProcessStartupTime(server_dir, processInfo.hProcess);
@@ -734,33 +736,32 @@ int ExecuteDaemon(const string& exe, const std::vector<string>& args_vector,
 // Run the given program in the current working directory, using the given
 // argument vector, wait for it to finish, then exit ourselves with the exitcode
 // of that program.
-static void ExecuteProgram(const string& exe,
+static void ExecuteProgram(const blaze_util::Path& exe,
                            const std::vector<std::wstring>& wargs_vector) {
-  std::wstring wexe = blaze_util::CstringToWstring(exe.c_str()).get();
-
   CmdLine cmdline;
-  CreateCommandLine(&cmdline, "", wargs_vector);
+  CreateCommandLine(&cmdline, blaze_util::Path(), wargs_vector);
 
   bazel::windows::WaitableProcess proc;
   std::wstring werror;
-  if (!proc.Create(wexe, cmdline.cmdline, nullptr, L"", &werror) ||
+  if (!proc.Create(exe.AsNativePath(), cmdline.cmdline, nullptr, L"",
+                   &werror) ||
       proc.WaitFor(-1, nullptr, &werror) !=
           bazel::windows::WaitableProcess::kWaitSuccess) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "ExecuteProgram(" << exe
+        << "ExecuteProgram(" << exe.AsPrintablePath()
         << ") failed: " << blaze_util::WstringToCstring(werror.c_str()).get();
   }
   werror.clear();
   int x = proc.GetExitCode(&werror);
   if (!werror.empty()) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "ExecuteProgram(" << exe
+        << "ExecuteProgram(" << exe.AsPrintablePath()
         << ") failed: " << blaze_util::WstringToCstring(werror.c_str()).get();
   }
   exit(x);
 }
 
-void ExecuteServerJvm(const string& exe,
+void ExecuteServerJvm(const blaze_util::Path& exe,
                       const std::vector<string>& server_jvm_args) {
   std::vector<std::wstring> wargs;
   wargs.reserve(server_jvm_args.size());
@@ -773,7 +774,7 @@ void ExecuteServerJvm(const string& exe,
   ExecuteProgram(exe, wargs);
 }
 
-void ExecuteRunRequest(const string& exe,
+void ExecuteRunRequest(const blaze_util::Path& exe,
                        const std::vector<string>& run_request_args) {
   std::vector<std::wstring> wargs;
   wargs.reserve(run_request_args.size());

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -559,8 +559,8 @@ blaze_exit_code::ExitCode StartupOptions::SanityCheckJavabase(
   return BadServerJavabaseError(javabase_type, option_sources);
 }
 
-string StartupOptions::GetExe(const string &jvm, const string &jar_path) const {
-  return jvm;
+blaze_util::Path StartupOptions::GetExe(const string &jvm, const string &jar_path) const {
+  return blaze_util::Path(jvm);
 }
 
 void StartupOptions::AddJVMArgumentPrefix(const string &javabase,

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -84,7 +84,7 @@ class StartupOptions {
 
   // Returns the executable used to start the Blaze server, typically the given
   // JVM.
-  virtual std::string GetExe(const std::string &jvm,
+  virtual blaze_util::Path GetExe(const std::string &jvm,
                              const std::string &jar_path) const;
 
   // Adds JVM prefix flags to be set. These will be added before all other

--- a/src/main/cpp/util/path_platform.h
+++ b/src/main/cpp/util/path_platform.h
@@ -168,6 +168,8 @@ bool AsAbsoluteWindowsPath(const std::wstring &path, std::wstring *result,
 // existing segments and leaving the rest unshortened.
 bool AsShortWindowsPath(const std::string &path, std::string *result,
                         std::string *error);
+bool AsShortWindowsPath(const std::wstring &path, std::wstring *result,
+                        std::string *error);
 
 #else
 

--- a/src/main/cpp/util/path_windows.cc
+++ b/src/main/cpp/util/path_windows.cc
@@ -350,8 +350,20 @@ bool AsAbsoluteWindowsPath(const std::wstring& path, std::wstring* result,
 
 bool AsShortWindowsPath(const std::string& path, std::string* result,
                         std::string* error) {
+  std::wstring wresult;
+  if (AsShortWindowsPath(CstringToWstring(path.c_str()).get(), &wresult,
+                         error)) {
+    *result = WstringToString(wresult);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool AsShortWindowsPath(const std::wstring& path, std::wstring* result,
+                        std::string* error) {
   if (IsDevNull(path.c_str())) {
-    result->assign("NUL");
+    *result = L"NUL";
     return true;
   }
 
@@ -401,7 +413,8 @@ bool AsShortWindowsPath(const std::string& path, std::string* result,
       if (error) {
         std::string last_error = GetLastErrorString();
         std::stringstream msg;
-        msg << "AsShortWindowsPath(" << path << "): GetShortPathNameW("
+        msg << "AsShortWindowsPath(" << WstringToString(path)
+            << "): GetShortPathNameW("
             << WstringToString(wpath) << ") failed: " << last_error;
         *error = msg.str();
       }
@@ -411,8 +424,8 @@ bool AsShortWindowsPath(const std::string& path, std::string* result,
     wresult = std::wstring(RemoveUncPrefixMaybe(wshort.get())) + wsuffix;
   }
 
-  result->assign(WstringToCstring(wresult.c_str()).get());
-  ToLower(result);
+  std::transform(wresult.begin(), wresult.end(), wresult.begin(), towlower);
+  *result = wresult;
   return true;
 }
 


### PR DESCRIPTION
Benefits of a Path abstraction instead of raw
strings:
- type safety
- no need to convert paths on Windows all the time
- no need to check if paths are absolute