### PR TITLE
Delete sys.path[0] in Python stub

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
@@ -2,6 +2,10 @@
 
 from __future__ import print_function
 
+import sys
+
+del sys.path[0]
+
 import os
 import re
 import tempfile

--- a/src/test/py/bazel/py_test.py
+++ b/src/test/py/bazel/py_test.py
@@ -115,6 +115,8 @@ class TestInitPyFiles(test_base.TestBase):
         os.path.exists('bazel-bin/src/a/a.runfiles/__main__/src/a/__init__.py'))
 
 
+@unittest.skipIf(test_base.TestBase.IsWindows(),
+                 "https://github.com/bazelbuild/bazel/issues/5087")
 class PyRemoteTest(test_base.TestBase):
 
   _worker_port = None

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
 import locale
 import os
 import shutil
@@ -326,15 +325,7 @@ class TestBase(unittest.TestCase):
     else:
       worker_path = tempfile.mkdtemp(dir=self._tests_root)
       worker_exe = self.Rlocation('io_bazel/src/tools/remote/worker')
-    # We would always use 'cas', but on Windows where we create this under
-    # %TEMP%, we need to make sure that different test targets use different
-    # values of this so tests running in parallel don't try to use the same CAS
-    # directory.  We use a truncated hash to keep the name short while
-    # hopefully retaining uniqueness between targets.
-    test_target = TestBase.GetEnv('TEST_TARGET', '')
-    cas_name = 'cas-' + hashlib.sha256(test_target.encode()).hexdigest()[:5]
-    self._cas_path = os.path.join(worker_path, cas_name)
-    os.mkdir(self._cas_path)
+    self._cas_path = tempfile.mkdtemp(prefix='cas', dir=worker_path)
 
     # Get an open port. Unfortunately this seems to be the best option in
     # Python.

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -325,7 +325,8 @@ class TestBase(unittest.TestCase):
     else:
       worker_path = tempfile.mkdtemp(dir=self._tests_root)
       worker_exe = self.Rlocation('io_bazel/src/tools/remote/worker')
-    self._cas_path = tempfile.mkdtemp(prefix='cas', dir=worker_path)
+    self._cas_path = os.path.join(worker_path, 'cas')
+    os.mkdir(self._cas_path)
 
     # Get an open port. Unfortunately this seems to be the best option in
     # Python.

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 import locale
 import os
 import shutil
@@ -325,7 +326,14 @@ class TestBase(unittest.TestCase):
     else:
       worker_path = tempfile.mkdtemp(dir=self._tests_root)
       worker_exe = self.Rlocation('io_bazel/src/tools/remote/worker')
-    self._cas_path = os.path.join(worker_path, 'cas')
+    # We would always use 'cas', but on Windows where we create this under
+    # %TEMP%, we need to make sure that different test targets use different
+    # values of this so tests running in parallel don't try to use the same CAS
+    # directory.  We use a truncated hash to keep the name short while
+    # hopefully retaining uniqueness between targets.
+    test_target = TestBase.GetEnv('TEST_TARGET', '')
+    cas_name = 'cas-' + hashlib.sha256(test_target.encode()).hexdigest()[:5]
+    self._cas_path = os.path.join(worker_path, cas_name)
     os.mkdir(self._cas_path)
 
     # Get an open port. Unfortunately this seems to be the best option in

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -336,7 +336,8 @@ class TestBase(unittest.TestCase):
 
     env_add = {}
     try:
-      env['RUNFILES_MANIFEST_FILE'] = TestBase.GetEnv('RUNFILES_MANIFEST_FILE')
+      env_add['RUNFILES_MANIFEST_FILE'] = TestBase.GetEnv(
+          'RUNFILES_MANIFEST_FILE')
     except EnvVarUndefinedError:
       pass
 


### PR DESCRIPTION
Fixes #9239.  Implements the proposed solution of deleting `sys.path[0]` before importing any other modules in the Python stub.  Also adds tests to ensure this does not regress in the future.  As part of adding tests, the existing functionality for remote tests in `TestBase` is modified to work on non-Windows.