### PR TITLE
Update remote Android tools

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,7 +126,7 @@ distdir_tar(
         "c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz",
         "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz",
         "0.16.2.zip",
-        "android_tools_pkg-0.9.tar.gz",
+        "android_tools_pkg-0.10.tar.gz",
         # bazelbuild/platforms
         "441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip",
         # bazelbuild/rules_java
@@ -151,7 +151,7 @@ distdir_tar(
         "c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz": "e6a76586b264f30679688f65f7e71ac112d1446681010a13bf22d9ca071f34b7",
         "8ccf4f1c351928b55d5dddf3672e3667f6978d60.tar.gz": "d868ce50d592ef4aad7dec4dd32ae68d2151261913450fac8390b3fd474bb898",
         "0.16.2.zip": "9b72bb0aea72d7cbcfc82a01b1e25bf3d85f791e790ddec16c65e2d906382ee0",
-        "android_tools_pkg-0.9.tar.gz": "23011efa92c7566ad0bcea69a90c9efeec1e96e73d865eb88a6dc934fe47db9b", # built at 43fc06881c9ec39712fbfa557b7df1137e3aeec3
+        "android_tools_pkg-0.10.tar.gz": "9c5081f93276fefb3db7ca61cc1225ff6d1913e7e315568265bb1a728265a9b1", # built at c91a9535302f13521a8875c384ff0b87639ce149
         # bazelbuild/platforms
         "441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip": "a07fe5e75964361885db725039c2ba673f0ee0313d971ae4f50c9b18cd28b0b5",
         # bazelbuild/rules_java
@@ -198,8 +198,8 @@ distdir_tar(
             "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
             "https://github.com/bazelbuild/rules_nodejs/archive/0.16.2.zip",
         ],
-        "android_tools_pkg-0.9.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.9.tar.gz",
+        "android_tools_pkg-0.10.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.10.tar.gz",
         ],
         # bazelbuild/platforms
         "441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip": [
@@ -508,7 +508,7 @@ distdir_tar(
         "zulu11.31.15-ca-jdk11.0.3-linux_aarch64.tar.gz",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip",
-        "android_tools_pkg-0.9.tar.gz",
+        "android_tools_pkg-0.10.tar.gz",
         # bazelbuild/platforms
         "441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip",
         # bazelbuild/rules_java
@@ -539,7 +539,7 @@ distdir_tar(
         "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz": "f3f44b6235508e87b760bf37a49e186cc1fa4e9cd28384c4dbf5a33991921e08",
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": "059f8e3484bf07b63a8f2820d5f528f473eff1befdb1896ee4f8ff06be3b8d8f",
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": "e1f5b4ce1b9148140fae2fcfb8a96d1c9b7eac5b8df0e13fbcad9b8561284880",
-        "android_tools_pkg-0.9.tar.gz": "23011efa92c7566ad0bcea69a90c9efeec1e96e73d865eb88a6dc934fe47db9b", # built at 43fc06881c9ec39712fbfa557b7df1137e3aeec3
+        "android_tools_pkg-0.10.tar.gz": "9c5081f93276fefb3db7ca61cc1225ff6d1913e7e315568265bb1a728265a9b1", # built at c91a9535302f13521a8875c384ff0b87639ce149
         # bazelbuild/platforms
         "441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip": "a07fe5e75964361885db725039c2ba673f0ee0313d971ae4f50c9b18cd28b0b5",
         # bazelbuild/rules_java
@@ -569,8 +569,8 @@ distdir_tar(
         "zulu11.31.15-ca-jdk11.0.3-linux_aarch64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.31.15-ca-jdk11.0.3/zulu11.31.15-ca-jdk11.0.3-linux_aarch64.tar.gz"],
         "zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-macosx_x64.zip"],
         "zulu11.29.3-ca-jdk11.0.2-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.29.3-ca-jdk11.0.2/zulu11.29.3-ca-jdk11.0.2-win_x64.zip"],
-        "android_tools_pkg-0.9.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.9.tar.gz",
+        "android_tools_pkg-0.10.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.10.tar.gz",
         ],
         # bazelbuild/platforms
         "441afe1bfdadd6236988e9cac159df6b5a9f5a98.zip": [

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "android_tools",
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.9.tar.gz",
-    sha256 = "23011efa92c7566ad0bcea69a90c9efeec1e96e73d865eb88a6dc934fe47db9b", # built at 43fc06881c9ec39712fbfa557b7df1137e3aeec3
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.10.tar.gz",
+    sha256 = "9c5081f93276fefb3db7ca61cc1225ff6d1913e7e315568265bb1a728265a9b1", # built at c91a9535302f13521a8875c384ff0b87639ce149
 )
 

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -31,7 +31,7 @@
 set -euo pipefail
 
 # The version of android_tools.tar.gz
-VERSION="0.9"
+VERSION="0.10"
 VERSIONED_FILENAME="android_tools_pkg-$VERSION.tar.gz"
 
 # Create a temp directory to hold the versioned tarball, and clean it up when the script exits.


### PR DESCRIPTION
This integrates cl/264926247 so that Bazel can omit the
"--useCompiledResourcesForMerge" argument when invoking RPBB