### PR TITLE
ubuntu install via apt docs: ensure that curl is installed

### DIFF
--- a/site/docs/install-ubuntu.md
+++ b/site/docs/install-ubuntu.md
@@ -86,6 +86,7 @@ sudo apt-get install openjdk-11-jdk
 
 ```bash
 echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
+sudo apt-get install curl
 curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
 ```
 


### PR DESCRIPTION
Curl isn't installed as part of ubuntu's base system (eg inside
containers), we should recommend that users install it before use.