### PR TITLE
WindowsFileSystem.readSymbolicLink: Map IOException to NotASymlinkException

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -36,10 +36,9 @@ import java.nio.file.attribute.DosFileAttributes;
 public class WindowsFileSystem extends JavaIoFileSystem {
 
   public static final LinkOption[] NO_OPTIONS = new LinkOption[0];
-  public static final LinkOption[] NO_FOLLOW = new LinkOption[] { LinkOption.NOFOLLOW_LINKS };
+  public static final LinkOption[] NO_FOLLOW = new LinkOption[] {LinkOption.NOFOLLOW_LINKS};
 
-  public WindowsFileSystem() throws DefaultHashFunctionNotSetException {
-  }
+  public WindowsFileSystem() throws DefaultHashFunctionNotSetException {}
 
   public WindowsFileSystem(DigestHashFunction hashFunction) {
     super(hashFunction);
@@ -47,10 +46,8 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
   @Override
   public String getFileSystemType(Path path) {
-    // TODO(laszlocsomor): implement this properly, i.e. actually query this
-    // information from
-    // somewhere (java.nio.Filesystem? System.getProperty? implement JNI method and
-    // use WinAPI?).
+    // TODO(laszlocsomor): implement this properly, i.e. actually query this information from
+    // somewhere (java.nio.Filesystem? System.getProperty? implement JNI method and use WinAPI?).
     return "ntfs";
   }
 
@@ -70,8 +67,10 @@ public class WindowsFileSystem extends JavaIoFileSystem {
 
   @Override
   protected void createSymbolicLink(Path linkPath, PathFragment targetFragment) throws IOException {
-    Path targetPath = targetFragment.isAbsolute() ? getPath(targetFragment)
-        : linkPath.getParentDirectory().getRelative(targetFragment);
+    Path targetPath =
+        targetFragment.isAbsolute()
+            ? getPath(targetFragment)
+            : linkPath.getParentDirectory().getRelative(targetFragment);
     try {
       java.nio.file.Path link = getIoFile(linkPath).toPath();
       java.nio.file.Path target = getIoFile(targetPath).toPath();
@@ -137,49 +136,50 @@ public class WindowsFileSystem extends JavaIoFileSystem {
     }
 
     final boolean isSymbolicLink = !followSymlinks && fileIsSymbolicLink(file);
-    FileStatus status = new FileStatus() {
-      @Override
-      public boolean isFile() {
-        return attributes.isRegularFile() || (isSpecialFile() && !isDirectory());
-      }
+    FileStatus status =
+        new FileStatus() {
+          @Override
+          public boolean isFile() {
+            return attributes.isRegularFile() || (isSpecialFile() && !isDirectory());
+          }
 
-      @Override
-      public boolean isSpecialFile() {
-        return attributes.isOther();
-      }
+          @Override
+          public boolean isSpecialFile() {
+            return attributes.isOther();
+          }
 
-      @Override
-      public boolean isDirectory() {
-        return attributes.isDirectory();
-      }
+          @Override
+          public boolean isDirectory() {
+            return attributes.isDirectory();
+          }
 
-      @Override
-      public boolean isSymbolicLink() {
-        return isSymbolicLink;
-      }
+          @Override
+          public boolean isSymbolicLink() {
+            return isSymbolicLink;
+          }
 
-      @Override
-      public long getSize() throws IOException {
-        return attributes.size();
-      }
+          @Override
+          public long getSize() throws IOException {
+            return attributes.size();
+          }
 
-      @Override
-      public long getLastModifiedTime() throws IOException {
-        return attributes.lastModifiedTime().toMillis();
-      }
+          @Override
+          public long getLastModifiedTime() throws IOException {
+            return attributes.lastModifiedTime().toMillis();
+          }
 
-      @Override
-      public long getLastChangeTime() {
-        // This is the best we can do with Java NIO...
-        return attributes.lastModifiedTime().toMillis();
-      }
+          @Override
+          public long getLastChangeTime() {
+            // This is the best we can do with Java NIO...
+            return attributes.lastModifiedTime().toMillis();
+          }
 
-      @Override
-      public long getNodeId() {
-        // TODO(bazel-team): Consider making use of attributes.fileKey().
-        return -1;
-      }
-    };
+          @Override
+          public long getNodeId() {
+            // TODO(bazel-team): Consider making use of attributes.fileKey().
+            return -1;
+          }
+        };
 
     return status;
   }
@@ -199,36 +199,32 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   }
 
   /**
-   * Returns true if the path refers to a directory junction, directory symlink,
-   * or regular symlink.
+   * Returns true if the path refers to a directory junction, directory symlink, or regular symlink.
    *
-   * <p>
-   * Directory junctions are symbolic links created with "mklink /J" where the
-   * target is a directory or another directory junction. Directory junctions can
-   * be created without any user privileges.
+   * <p>Directory junctions are symbolic links created with "mklink /J" where the target is a
+   * directory or another directory junction. Directory junctions can be created without any user
+   * privileges.
    *
-   * <p>
-   * Directory symlinks are symbolic links created with "mklink /D" where the
-   * target is a directory or another directory symlink. Note that directory
-   * symlinks can only be created by Administrators.
+   * <p>Directory symlinks are symbolic links created with "mklink /D" where the target is a
+   * directory or another directory symlink. Note that directory symlinks can only be created by
+   * Administrators.
    *
-   * <p>
-   * Normal symlinks are symbolic links created with "mklink". Normal symlinks
-   * should not point at directories, because even though "mklink" can create the
-   * link, it will not be a functional one (the linked directory's contents cannot
-   * be listed). Only Administrators may create regular symlinks.
+   * <p>Normal symlinks are symbolic links created with "mklink". Normal symlinks should not point
+   * at directories, because even though "mklink" can create the link, it will not be a functional
+   * one (the linked directory's contents cannot be listed). Only Administrators may create regular
+   * symlinks.
    *
-   * <p>
-   * This method returns true for all three types as long as their target is a
-   * directory (even if they are dangling), though only directory junctions and
-   * directory symlinks are useful.
+   * <p>This method returns true for all three types as long as their target is a directory (even if
+   * they are dangling), though only directory junctions and directory symlinks are useful.
    */
   @VisibleForTesting
   static boolean isSymlinkOrJunction(File file) throws IOException {
     return WindowsFileOperations.isSymlinkOrJunction(file.getPath());
   }
 
-  private static DosFileAttributes getAttribs(File file, boolean followSymlinks) throws IOException {
-    return Files.readAttributes(file.toPath(), DosFileAttributes.class, symlinkOpts(followSymlinks));
+  private static DosFileAttributes getAttribs(File file, boolean followSymlinks)
+      throws IOException {
+    return Files.readAttributes(
+        file.toPath(), DosFileAttributes.class, symlinkOpts(followSymlinks));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsFileSystem.java
@@ -92,11 +92,14 @@ public class WindowsFileSystem extends JavaIoFileSystem {
   @Override
   protected PathFragment readSymbolicLink(Path path) throws IOException {
     java.nio.file.Path nioPath = getNioPath(path);
-    try {
-      return PathFragment.create(WindowsFileOperations.readSymlinkOrJunction(nioPath.toString()));
-    } catch (IOException e) {
-      throw e.getMessage().endsWith("path is not a link") ? new NotASymlinkException(path) : e;
+    WindowsFileOperations.ReadSymlinkOrJunctionResult result = WindowsFileOperations.readSymlinkOrJunction(nioPath.toString());
+    if (result.getStatus() == WindowsFileOperations.ReadSymlinkOrJunctionResult.Status.OK) {
+      return PathFragment.create(result.getResult());
     }
+    if (result.getStatus() == WindowsFileOperations.ReadSymlinkOrJunctionResult.Status.NOT_A_LINK) {
+      throw new NotASymlinkException(path);
+    }
+    throw new IOException(result.getResult());
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/jni/WindowsFileOperations.java
@@ -42,6 +42,30 @@ public class WindowsFileOperations {
     // Prevent construction
   }
 
+  public static class ReadSymlinkOrJunctionResult {
+    public enum Status {
+      OK,
+      NOT_A_LINK,
+      ERROR
+    }
+
+    private String result;
+    private Status status;
+
+    public ReadSymlinkOrJunctionResult(Status s, String r) {
+      this.status = s;
+      this.result = r;
+    }
+
+    public String getResult() {
+      return result;
+    }
+    public Status getStatus() {
+      return status;
+    }
+  }
+
+
   private static final int MAX_PATH = 260;
 
   // Keep IS_SYMLINK_OR_JUNCTION_* values in sync with src/main/native/windows/file.cc.
@@ -183,13 +207,13 @@ public class WindowsFileOperations {
         String.format("Cannot create junction (name=%s, target=%s): %s", name, target, error[0]));
   }
 
-  public static String readSymlinkOrJunction(String name) throws IOException {
+  public static ReadSymlinkOrJunctionResult readSymlinkOrJunction(String name) {
     WindowsJniLoader.loadJni();
     String[] target = new String[] {null};
     String[] error = new String[] {null};
     switch (nativeReadSymlinkOrJunction(asLongPath(name), target, error)) {
       case READ_SYMLINK_OR_JUNCTION_SUCCESS:
-        return removeUncPrefixAndUseSlashes(target[0]);
+        return new ReadSymlinkOrJunctionResult(ReadSymlinkOrJunctionResult.Status.OK, removeUncPrefixAndUseSlashes(target[0]));
       case READ_SYMLINK_OR_JUNCTION_ACCESS_DENIED:
         error[0] = "access is denied";
         break;
@@ -197,8 +221,7 @@ public class WindowsFileOperations {
         error[0] = "path does not exist";
         break;
       case READ_SYMLINK_OR_JUNCTION_NOT_A_LINK:
-        error[0] = "path is not a link";
-        break;
+        return new ReadSymlinkOrJunctionResult(ReadSymlinkOrJunctionResult.Status.NOT_A_LINK, "path is not a link");
       case READ_SYMLINK_OR_JUNCTION_UNKNOWN_LINK_TYPE:
         error[0] = "unknown link type";
         break;
@@ -207,7 +230,7 @@ public class WindowsFileOperations {
         // 'error[0]'.
         break;
     }
-    throw new IOException(String.format("Cannot read link (name=%s): %s", name, error[0]));
+    return new ReadSymlinkOrJunctionResult(ReadSymlinkOrJunctionResult.Status.ERROR, String.format("Cannot read link (name=%s): %s", name, error[0]));
   }
 
   public static boolean deletePath(String path) throws IOException {

--- a/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/windows/WindowsFileSystemTest.java
@@ -357,14 +357,14 @@ public class WindowsFileSystemTest {
       testUtil.createVfsPath(fs, "dir\\hello.txt").readSymbolicLink();
       fail("expected exception");
     } catch (IOException expected) {
-      assertThat(expected).hasMessageThat().matches(".*path is not a link");
+      assertThat(expected).hasMessageThat().matches(".*is not a symlink");
     }
 
     try {
       dirPath.readSymbolicLink();
       fail("expected exception");
     } catch (IOException expected) {
-      assertThat(expected).hasMessageThat().matches(".*path is not a link");
+      assertThat(expected).hasMessageThat().matches(".*is not a symlink");
     }
 
     assertThat(juncPath.readSymbolicLink()).isEqualTo(dirPath.asFragment());

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -91,6 +91,23 @@ py_test(
 )
 
 py_test(
+    name = "bazel_windows_symlinks_test",
+    size = "medium",
+    srcs = select({
+        "//src/conditions:windows": ["bazel_windows_symlinks_test.py"],
+        "//conditions:default": ["empty_test.py"],
+    }),
+    main = select({
+        "//src/conditions:windows": "bazel_windows_symlinks_test.py",
+        "//conditions:default": "empty_test.py",
+    }),
+    deps = select({
+        "//src/conditions:windows": [":test_base"],
+        "//conditions:default": [],
+    }),
+)
+
+py_test(
     name = "windows_remote_test",
     size = "medium",
     srcs = select({

--- a/src/test/py/bazel/bazel_windows_symlinks_test.py
+++ b/src/test/py/bazel/bazel_windows_symlinks_test.py
@@ -1,0 +1,41 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from src.test.py.bazel import test_base
+
+
+class BazelWindowsTest(test_base.TestBase):
+
+    def createProjectFiles(self):
+        self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
+        self.ScratchFile(
+            'foo/BUILD', ['genrule(name="x", srcs=[":sample"], outs=["link"], cmd="python -c \\"import os; os.symlink(os.path.join(os.getcwd(), \'$<\'),\'$@\')\\"",)'])
+        self.ScratchFile('foo/sample', [
+            'sample',
+        ])
+
+    def testWindowsSymlinkedOutput(self):
+        self.createProjectFiles()
+
+        exit_code, _, stderr = self.RunBazel([
+            '--batch', 'build',
+            '//foo:x',
+        ])
+        self.AssertExitCode(exit_code, 0, stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test/py/bazel/bazel_windows_symlinks_test.py
+++ b/src/test/py/bazel/bazel_windows_symlinks_test.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The Bazel Authors. All rights reserved.
+# Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,12 +17,17 @@ import unittest
 from src.test.py.bazel import test_base
 
 
-class BazelWindowsTest(test_base.TestBase):
+class BazelWindowsSymlinksTest(test_base.TestBase):
 
     def createProjectFiles(self):
         self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
-        self.ScratchFile(
-            'foo/BUILD', ['genrule(name="x", srcs=[":sample"], outs=["link"], cmd="python -c \\"import os; os.symlink(os.path.join(os.getcwd(), \'$<\'),\'$@\')\\"",)'])
+        self.ScratchFile('foo/BUILD', [
+               'py_binary(name="symlinker", srcs=[":symlinker.py"])',
+               'genrule(name="x",srcs=[":sample"],outs=["link"],cmd="$(location symlinker) $< $@",tools=[":symlinker"])'
+        ])
+        self.ScratchFile('foo/symlinker.py', [
+            'import os; import sys; os.symlink(os.path.join(os.getcwd(), sys.argv[1]), sys.argv[2])',
+        ])
         self.ScratchFile('foo/sample', [
             'sample',
         ])

--- a/src/test/py/bazel/bazel_windows_symlinks_test.py
+++ b/src/test/py/bazel/bazel_windows_symlinks_test.py
@@ -22,11 +22,7 @@ class BazelWindowsSymlinksTest(test_base.TestBase):
     def createProjectFiles(self):
         self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
         self.ScratchFile('foo/BUILD', [
-               'py_binary(name="symlinker", srcs=[":symlinker.py"])',
-               'genrule(name="x",srcs=[":sample"],outs=["link"],cmd="$(location symlinker) $< $@",tools=[":symlinker"])'
-        ])
-        self.ScratchFile('foo/symlinker.py', [
-            'import os; import sys; os.symlink(os.path.join(os.getcwd(), sys.argv[1]), sys.argv[2])',
+               'genrule(name="x",srcs=[":sample"],outs=["link"],cmd="IN=$< OUT=$@ OUT2=$${OUT//\\//\\\\\\\\\\\\} IN2=$${IN//\\//\\\\\\\\\\\\} cmd.exe /C \\"mklink %OUT2% %cd%\\\\%IN2%\\"")'
         ])
         self.ScratchFile('foo/sample', [
             'sample',


### PR DESCRIPTION
Fixes symbolic link outputs on Windows.

FileSystem.resolveOneLink expects that readSymbolicLink throws NotASymlinkException when the provided path is valid but is not a symbol link. UnixFileSystem.readSymbolicLink throws the exception when necessary, but WindowsFileSystem.readSymbolicLink - doesn't (throws IOException instead).

The PR fixes WindowsFileSystem.readSymbolicLink. It's implemented in the same way as Unix implementation.