### PR TITLE
Add additional Github urls for the java_tools zips.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -220,6 +220,7 @@ http_archive(
     sha256 = "b644b1eb3743376ce3aeb0cc6a15374ca5676bf872cc653c3633751c8226e060",
     urls = [
         "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v5.0/java_tools_javac11_linux-v5.0.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/javac11-v5.0/java_tools_javac11_linux-v5.0.zip",
     ],
 )
 
@@ -228,6 +229,7 @@ http_archive(
     sha256 = "116fef8a385873bfda5fa76e831959aa0ad0b12ca9a880bd0fc7252413ed7c1f",
     urls = [
         "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v5.0/java_tools_javac11_windows-v5.0.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/javac11-v5.0/java_tools_javac11_windows-v5.0.zip",
     ],
 )
 
@@ -236,6 +238,7 @@ http_archive(
     sha256 = "dfa0e6b6320325eb28023ed754022d985d462b4db468394be305a82f55e7dafa",
     urls = [
         "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v5.0/java_tools_javac11_darwin-v5.0.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/javac11-v5.0/java_tools_javac11_darwin-v5.0.zip",
     ],
 )
 


### PR DESCRIPTION
As of java_tools javac11-v4.0 the releases are also uploaded on Github under [the java_tools repository](https://github.com/bazelbuild/java_tools/releases).

Add the additional Github urls to make downloading the archives more reliable. Users have reported `connection reset` errors from the mirror.bazel urls (for example https://github.com/bazelbuild/rules_scala/issues/798#issuecomment-525577628).