### PR TITLE
propagated for cc_library and cc_binary

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -102,8 +102,6 @@ import com.google.devtools.build.lib.util.OrderedSetMultimap;
 import com.google.devtools.build.lib.util.StringUtil;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
-
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -112,6 +110,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * The totality of data available during the analysis of a rule.

--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -125,6 +125,15 @@ import javax.annotation.Nullable;
 public final class RuleContext extends TargetContext
     implements ActionConstructionContext, ActionRegistry, RuleErrorConsumer {
 
+  public boolean isAllowTagsPropagation() {
+    try {
+      return this.getAnalysisEnvironment().getSkylarkSemantics().experimentalAllowTagsPropagation();
+    } catch (InterruptedException e) {
+      // fallback to false if value of experimentalAllowTagsPropagation cannot be fetched
+      return false;
+    }
+  }
+
   /**
    * The configured version of FilesetEntry.
    */
@@ -550,6 +559,40 @@ public final class RuleContext extends TargetContext
 
   @Override
   public void registerAction(ActionAnalysisMetadata... action) {
+//List<ActionAnalysisMetadata> newList = new ArrayList<>();
+//    try {
+//        if (this.getAnalysisEnvironment() == null
+//                || this.getAnalysisEnvironment().getSkylarkSemantics() == null
+//                || !this.getAnalysisEnvironment().getSkylarkSemantics().experimentalAllowTagsPropagation()) {
+//            getAnalysisEnvironment().registerAction(action);
+//            return;
+//      }
+//      for (ActionAnalysisMetadata metadata : action) {
+//        if (metadata instanceof ExecutionInfoSpecifier && !(metadata instanceof StarlarkAction)) {
+//          ExecutionInfoSpecifier executionInfoSpecifier = (ExecutionInfoSpecifier) metadata;
+//          ImmutableMap<String, String> filteredExecutionInfo = TargetUtils.getFilteredExecutionInfo(
+//                  executionInfoSpecifier.getExecutionInfo(),
+//                  rule,
+//                  this.getAnalysisEnvironment().getSkylarkSemantics().experimentalAllowTagsPropagation());
+//
+//          Map<String, String> executionInfoBuilder = new HashMap<>();
+//          // in case something was already in action.executionInfo - we copy it to the final Map
+//          executionInfoBuilder.putAll(executionInfoSpecifier.getExecutionInfo());
+//          // adding filtered execution requirements to the execution info map
+//          executionInfoBuilder.putAll(filteredExecutionInfo);
+//
+//          ActionAnalysisMetadata updatedAction = executionInfoSpecifier.addExecutionInfo(ImmutableMap.copyOf(executionInfoBuilder));
+//          newList.add(updatedAction);
+//        } else {
+//          newList.add(metadata);
+//        }
+//      }
+//    } catch (InterruptedException e) {
+//      // todo: what?
+//      e.printStackTrace();
+//      throw new RuntimeException("Something horrible happened!");
+//    }
+//    getAnalysisEnvironment().registerAction(newList.toArray(new ActionAnalysisMetadata[0]));
     getAnalysisEnvironment().registerAction(action);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -126,9 +126,10 @@ import java.util.stream.Collectors;
 public final class RuleContext extends TargetContext
     implements ActionConstructionContext, ActionRegistry, RuleErrorConsumer {
 
-    public boolean isAllowTagsPropagation() throws InterruptedException {
-        return this.getAnalysisEnvironment().getSkylarkSemantics().experimentalAllowTagsPropagation();
-    }
+  @Override
+  public boolean isAllowTagsPropagation() throws InterruptedException {
+    return this.getAnalysisEnvironment().getSkylarkSemantics().experimentalAllowTagsPropagation();
+  }
 
   /**
    * The configured version of FilesetEntry.

--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -559,40 +559,6 @@ public final class RuleContext extends TargetContext
 
   @Override
   public void registerAction(ActionAnalysisMetadata... action) {
-//List<ActionAnalysisMetadata> newList = new ArrayList<>();
-//    try {
-//        if (this.getAnalysisEnvironment() == null
-//                || this.getAnalysisEnvironment().getSkylarkSemantics() == null
-//                || !this.getAnalysisEnvironment().getSkylarkSemantics().experimentalAllowTagsPropagation()) {
-//            getAnalysisEnvironment().registerAction(action);
-//            return;
-//      }
-//      for (ActionAnalysisMetadata metadata : action) {
-//        if (metadata instanceof ExecutionInfoSpecifier && !(metadata instanceof StarlarkAction)) {
-//          ExecutionInfoSpecifier executionInfoSpecifier = (ExecutionInfoSpecifier) metadata;
-//          ImmutableMap<String, String> filteredExecutionInfo = TargetUtils.getFilteredExecutionInfo(
-//                  executionInfoSpecifier.getExecutionInfo(),
-//                  rule,
-//                  this.getAnalysisEnvironment().getSkylarkSemantics().experimentalAllowTagsPropagation());
-//
-//          Map<String, String> executionInfoBuilder = new HashMap<>();
-//          // in case something was already in action.executionInfo - we copy it to the final Map
-//          executionInfoBuilder.putAll(executionInfoSpecifier.getExecutionInfo());
-//          // adding filtered execution requirements to the execution info map
-//          executionInfoBuilder.putAll(filteredExecutionInfo);
-//
-//          ActionAnalysisMetadata updatedAction = executionInfoSpecifier.addExecutionInfo(ImmutableMap.copyOf(executionInfoBuilder));
-//          newList.add(updatedAction);
-//        } else {
-//          newList.add(metadata);
-//        }
-//      }
-//    } catch (InterruptedException e) {
-//      // todo: what?
-//      e.printStackTrace();
-//      throw new RuntimeException("Something horrible happened!");
-//    }
-//    getAnalysisEnvironment().registerAction(newList.toArray(new ActionAnalysisMetadata[0]));
     getAnalysisEnvironment().registerAction(action);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -102,6 +102,8 @@ import com.google.devtools.build.lib.util.OrderedSetMultimap;
 import com.google.devtools.build.lib.util.StringUtil;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
+
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -110,7 +112,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
 /**
  * The totality of data available during the analysis of a rule.
@@ -125,14 +126,9 @@ import javax.annotation.Nullable;
 public final class RuleContext extends TargetContext
     implements ActionConstructionContext, ActionRegistry, RuleErrorConsumer {
 
-  public boolean isAllowTagsPropagation() {
-    try {
-      return this.getAnalysisEnvironment().getSkylarkSemantics().experimentalAllowTagsPropagation();
-    } catch (InterruptedException e) {
-      // fallback to false if value of experimentalAllowTagsPropagation cannot be fetched
-      return false;
+    public boolean isAllowTagsPropagation() throws InterruptedException {
+        return this.getAnalysisEnvironment().getSkylarkSemantics().experimentalAllowTagsPropagation();
     }
-  }
 
   /**
    * The configured version of FilesetEntry.

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/ActionConstructionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/ActionConstructionContext.java
@@ -36,6 +36,8 @@ import javax.annotation.Nullable;
  */
 public interface ActionConstructionContext {
 
+  boolean isAllowTagsPropagation() throws InterruptedException;
+
   /** Returns the bin directory for constructed actions. */
   ArtifactRoot getBinDirectory();
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcModule.java
@@ -84,7 +84,7 @@ public class BazelCcModule extends CcModule
       boolean disallowNopicOutputs,
       Location location,
       Environment environment)
-      throws EvalException {
+          throws EvalException, InterruptedException {
     return compile(
         skylarkActionFactoryApi,
         skylarkFeatureConfiguration,

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -28,11 +28,8 @@ import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.SkylarkDict;
 import com.google.devtools.build.lib.syntax.Type;
 import com.google.devtools.build.lib.util.Pair;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
 import javax.annotation.Nullable;
 
 /**
@@ -232,6 +229,21 @@ public final class TargetUtils {
       }
     }
     return ImmutableMap.copyOf(map);
+  }
+
+  /**
+   * TODO(ishikhman) : update doc
+   * Returns the execution info from the tags declared on the target. These include only some tags
+   * {@link #legalExecInfoKeys} as keys with empty values.
+   * @param rule
+   * @param allowTagsPropagation
+   */
+  public static Map<String, String> getExecutionInfo(Rule rule, boolean allowTagsPropagation) {
+    if (allowTagsPropagation){
+      return getExecutionInfo(rule);
+    } else {
+      return Collections.emptyMap();
+    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -27,7 +27,12 @@ import com.google.devtools.build.lib.syntax.Type;
 import com.google.devtools.build.lib.util.Pair;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static com.google.devtools.build.lib.packages.BuildType.TRISTATE;
 import static com.google.devtools.build.lib.syntax.Type.BOOLEAN;
@@ -229,23 +234,6 @@ public final class TargetUtils {
       }
     }
     return ImmutableMap.copyOf(map);
-  }
-
-  /**
-   * Returns the execution info from the tags declared on the target. These include only some tags
-   * {@link #legalExecInfoKeys} as keys with empty values.
-   *
-   * @param rule a rule instance to get tags from
-   * @param allowTagsPropagation if set to true, tags will be propagated from a target to the
-   *        actions' execution requirements, for more details {@see
-   *        SkylarkSematicOptions#experimentalAllowTagsPropagation}
-   */
-  public static Map<String, String> getExecutionInfo(Rule rule, boolean allowTagsPropagation) {
-    if (allowTagsPropagation){
-      return getExecutionInfo(rule);
-    } else {
-      return Collections.emptyMap();
-    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -14,9 +14,6 @@
 
 package com.google.devtools.build.lib.packages;
 
-import static com.google.devtools.build.lib.packages.BuildType.TRISTATE;
-import static com.google.devtools.build.lib.syntax.Type.BOOLEAN;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
@@ -29,8 +26,11 @@ import com.google.devtools.build.lib.syntax.SkylarkDict;
 import com.google.devtools.build.lib.syntax.Type;
 import com.google.devtools.build.lib.util.Pair;
 
-import java.util.*;
 import javax.annotation.Nullable;
+import java.util.*;
+
+import static com.google.devtools.build.lib.packages.BuildType.TRISTATE;
+import static com.google.devtools.build.lib.syntax.Type.BOOLEAN;
 
 /**
  * Utility functions over Targets that don't really belong in the base {@link
@@ -232,11 +232,13 @@ public final class TargetUtils {
   }
 
   /**
-   * TODO(ishikhman) : update doc
    * Returns the execution info from the tags declared on the target. These include only some tags
    * {@link #legalExecInfoKeys} as keys with empty values.
-   * @param rule
-   * @param allowTagsPropagation
+   *
+   * @param rule a rule instance to get tags from
+   * @param allowTagsPropagation if set to true, tags will be propagated from a target to the
+   *        actions' execution requirements, for more details {@see
+   *        SkylarkSematicOptions#experimentalAllowTagsPropagation}
    */
   public static Map<String, String> getExecutionInfo(Rule rule, boolean allowTagsPropagation) {
     if (allowTagsPropagation){

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -14,6 +14,9 @@
 
 package com.google.devtools.build.lib.packages;
 
+import static com.google.devtools.build.lib.packages.BuildType.TRISTATE;
+import static com.google.devtools.build.lib.syntax.Type.BOOLEAN;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
@@ -25,17 +28,12 @@ import com.google.devtools.build.lib.syntax.EvalException;
 import com.google.devtools.build.lib.syntax.SkylarkDict;
 import com.google.devtools.build.lib.syntax.Type;
 import com.google.devtools.build.lib.util.Pair;
-
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.devtools.build.lib.packages.BuildType.TRISTATE;
-import static com.google.devtools.build.lib.syntax.Type.BOOLEAN;
+import javax.annotation.Nullable;
 
 /**
  * Utility functions over Targets that don't really belong in the base {@link
@@ -234,6 +232,18 @@ public final class TargetUtils {
       }
     }
     return ImmutableMap.copyOf(map);
+  }
+
+  /**
+   * Returns the execution info from the tags declared on the target if tags propagation is allowed.
+   * These include only some tags {@link #legalExecInfoKeys} as keys with empty values.
+   */
+  public static ImmutableMap<String, String> getExecutionInfo(Rule rule, boolean allowTagsPropagation) {
+    if (allowTagsPropagation) {
+      return ImmutableMap.copyOf(getExecutionInfo(rule));
+    } else {
+      return ImmutableMap.of();
+    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
@@ -353,7 +353,7 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
                 featureConfiguration,
                 ccToolchain,
                 fdoContext,
-                ruleContext.getRule())
+                TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
             .fromCommon(common, /* additionalCopts= */ ImmutableList.of())
             .addPrivateHeaders(common.getPrivateHeaders())
             .addSources(common.getSources())
@@ -410,7 +410,7 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
                   ruleContext.getConfiguration(),
                   cppConfiguration,
                   ruleContext.getSymbolGenerator(),
-                  ruleContext.getRule())
+                  TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
               .fromCommon(ruleContext, common)
               .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
               .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
@@ -717,7 +717,7 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
                 ruleContext.getConfiguration(),
                 cppConfiguration,
                 ruleContext.getSymbolGenerator(),
-                ruleContext.getRule())
+                TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
             .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
             .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
             .setTestOrTestOnlyTarget(ruleContext.isTestTarget() || ruleContext.isTestOnlyTarget())

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
@@ -352,7 +352,7 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
                 semantics,
                 featureConfiguration,
                 ccToolchain,
-                fdoContext)
+                fdoContext, ruleContext)
             .fromCommon(common, /* additionalCopts= */ ImmutableList.of())
             .addPrivateHeaders(common.getPrivateHeaders())
             .addSources(common.getSources())

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
@@ -352,7 +352,8 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
                 semantics,
                 featureConfiguration,
                 ccToolchain,
-                fdoContext, ruleContext)
+                fdoContext,
+                ruleContext.getRule())
             .fromCommon(common, /* additionalCopts= */ ImmutableList.of())
             .addPrivateHeaders(common.getPrivateHeaders())
             .addSources(common.getSources())
@@ -409,7 +410,7 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
                   ruleContext.getConfiguration(),
                   cppConfiguration,
                   ruleContext.getSymbolGenerator(),
-                  ruleContext)
+                  ruleContext.getRule())
               .fromCommon(ruleContext, common)
               .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
               .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
@@ -715,7 +716,8 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
                 fdoContext,
                 ruleContext.getConfiguration(),
                 cppConfiguration,
-                ruleContext.getSymbolGenerator(), ruleContext)
+                ruleContext.getSymbolGenerator(),
+                ruleContext.getRule())
             .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
             .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
             .setTestOrTestOnlyTarget(ruleContext.isTestTarget() || ruleContext.isTestOnlyTarget())

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
@@ -408,7 +408,8 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
                   fdoContext,
                   ruleContext.getConfiguration(),
                   cppConfiguration,
-                  ruleContext.getSymbolGenerator())
+                  ruleContext.getSymbolGenerator(),
+                  ruleContext)
               .fromCommon(ruleContext, common)
               .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
               .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
@@ -714,7 +715,7 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
                 fdoContext,
                 ruleContext.getConfiguration(),
                 cppConfiguration,
-                ruleContext.getSymbolGenerator())
+                ruleContext.getSymbolGenerator(), ruleContext)
             .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
             .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
             .setTestOrTestOnlyTarget(ruleContext.isTestTarget() || ruleContext.isTestOnlyTarget())

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -223,7 +223,7 @@ public final class CcCompilationHelper {
 
   private final CppSemantics semantics;
   private final BuildConfiguration configuration;
-  private RuleContext ruleContext;
+  @Nullable private final RuleContext ruleContext;
   private final CppConfiguration cppConfiguration;
 
   private final List<Artifact> publicHeaders = new ArrayList<>();
@@ -288,7 +288,7 @@ public final class CcCompilationHelper {
           CcToolchainProvider ccToolchain,
           FdoContext fdoContext,
           BuildConfiguration buildConfiguration,
-          RuleContext ruleContext) {
+          @Nullable RuleContext ruleContext) {
     this.semantics = Preconditions.checkNotNull(semantics);
     this.featureConfiguration = Preconditions.checkNotNull(featureConfiguration);
     this.sourceCategory = Preconditions.checkNotNull(sourceCategory);
@@ -1554,7 +1554,9 @@ public final class CcCompilationHelper {
     builder.setCcCompilationContext(ccCompilationContext);
     builder.setCoptsFilter(coptsFilter);
     builder.setFeatureConfiguration(featureConfiguration);
-    builder.addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()));
+    if (ruleContext != null) {
+      builder.addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()));
+    }
     return builder;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -42,6 +42,7 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.BuildType;
+import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
 import com.google.devtools.build.lib.packages.RuleErrorConsumer;
 import com.google.devtools.build.lib.packages.TargetUtils;
@@ -223,7 +224,7 @@ public final class CcCompilationHelper {
 
   private final CppSemantics semantics;
   private final BuildConfiguration configuration;
-  @Nullable private final RuleContext ruleContext;
+  private final Rule rule;
   private final CppConfiguration cppConfiguration;
 
   private final List<Artifact> publicHeaders = new ArrayList<>();
@@ -288,7 +289,7 @@ public final class CcCompilationHelper {
           CcToolchainProvider ccToolchain,
           FdoContext fdoContext,
           BuildConfiguration buildConfiguration,
-          @Nullable RuleContext ruleContext) {
+          Rule rule) {
     this.semantics = Preconditions.checkNotNull(semantics);
     this.featureConfiguration = Preconditions.checkNotNull(featureConfiguration);
     this.sourceCategory = Preconditions.checkNotNull(sourceCategory);
@@ -307,7 +308,7 @@ public final class CcCompilationHelper {
     this.actionRegistry = Preconditions.checkNotNull(actionRegistry);
     this.label = Preconditions.checkNotNull(label);
     this.grepIncludes = grepIncludes;
-    this.ruleContext = ruleContext;
+    this.rule = rule;
   }
 
   /** Creates a CcCompilationHelper for cpp source files. */
@@ -320,7 +321,7 @@ public final class CcCompilationHelper {
           FeatureConfiguration featureConfiguration,
           CcToolchainProvider ccToolchain,
           FdoContext fdoContext,
-          RuleContext ruleContext) {
+          Rule rule) {
     this(
         actionRegistry,
         actionConstructionContext,
@@ -332,7 +333,7 @@ public final class CcCompilationHelper {
         ccToolchain,
         fdoContext,
         actionConstructionContext.getConfiguration(),
-            ruleContext);
+            rule);
   }
 
   /** Sets fields that overlap for cc_library and cc_binary rules. */
@@ -1554,8 +1555,8 @@ public final class CcCompilationHelper {
     builder.setCcCompilationContext(ccCompilationContext);
     builder.setCoptsFilter(coptsFilter);
     builder.setFeatureConfiguration(featureConfiguration);
-    if (ruleContext != null && ruleContext.isAllowTagsPropagation()) {
-      builder.addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule()));
+    if (actionConstructionContext.isAllowTagsPropagation()) {
+      builder.addExecutionInfo(TargetUtils.getExecutionInfo(rule));
     }
     return builder;
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -699,7 +699,7 @@ public final class CcCompilationHelper {
    *
    * @throws RuleErrorException
    */
-  public CompilationInfo compile() throws RuleErrorException {
+  public CompilationInfo compile() throws RuleErrorException, InterruptedException {
 
     if (!generatePicAction && !generateNoPicAction) {
       ruleErrorConsumer.ruleError("Either PIC or no PIC actions have to be created.");
@@ -1239,7 +1239,7 @@ public final class CcCompilationHelper {
    * file. It takes into account fake-ness, coverage, and PIC, in addition to using the settings
    * specified on the current object. This method should only be called once.
    */
-  private CcCompilationOutputs createCcCompileActions() throws RuleErrorException {
+  private CcCompilationOutputs createCcCompileActions() throws RuleErrorException, InterruptedException {
     CcCompilationOutputs.Builder result = CcCompilationOutputs.builder();
     Preconditions.checkNotNull(ccCompilationContext);
 
@@ -1546,7 +1546,7 @@ public final class CcCompilationHelper {
    * Returns a {@code CppCompileActionBuilder} with the common fields for a C++ compile action being
    * initialized.
    */
-  private CppCompileActionBuilder initializeCompileAction(Artifact sourceArtifact) {
+  private CppCompileActionBuilder initializeCompileAction(Artifact sourceArtifact) throws InterruptedException {
     CppCompileActionBuilder builder =
         new CppCompileActionBuilder(
             actionConstructionContext, grepIncludes, ccToolchain, configuration);
@@ -1554,15 +1554,15 @@ public final class CcCompilationHelper {
     builder.setCcCompilationContext(ccCompilationContext);
     builder.setCoptsFilter(coptsFilter);
     builder.setFeatureConfiguration(featureConfiguration);
-    if (ruleContext != null) {
-      builder.addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()));
+    if (ruleContext != null && ruleContext.isAllowTagsPropagation()) {
+      builder.addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule()));
     }
     return builder;
   }
 
   private void createModuleCodegenAction(
       CcCompilationOutputs.Builder result, Label sourceLabel, Artifact module)
-      throws RuleErrorException {
+          throws RuleErrorException, InterruptedException {
     if (fake) {
       // We can't currently foresee a situation where we'd want nocompile tests for module codegen.
       // If we find one, support needs to be added here.
@@ -1678,7 +1678,7 @@ public final class CcCompilationHelper {
   }
 
   private Collection<Artifact> createModuleAction(
-      CcCompilationOutputs.Builder result, CppModuleMap cppModuleMap) throws RuleErrorException {
+      CcCompilationOutputs.Builder result, CppModuleMap cppModuleMap) throws RuleErrorException, InterruptedException {
     Artifact moduleMapArtifact = cppModuleMap.getArtifact();
     CppCompileActionBuilder builder = initializeCompileAction(moduleMapArtifact);
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -296,7 +296,6 @@ public final class CcCompilationHelper {
     this.fdoContext = Preconditions.checkNotNull(fdoContext);
     this.actionConstructionContext = Preconditions.checkNotNull(actionConstructionContext);
     this.configuration = buildConfiguration;
-    this.ruleContext = ruleContext;
     this.cppConfiguration = configuration.getFragment(CppConfiguration.class);
     setGenerateNoPicAction(
         !ccToolchain.usePicForDynamicLibraries(cppConfiguration, featureConfiguration)
@@ -1555,7 +1554,7 @@ public final class CcCompilationHelper {
     builder.setCcCompilationContext(ccCompilationContext);
     builder.setCoptsFilter(coptsFilter);
     builder.setFeatureConfiguration(featureConfiguration);
-    builder.addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule()));
+    builder.addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()));
     return builder;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcImport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcImport.java
@@ -160,7 +160,7 @@ public abstract class CcImport implements RuleConfiguredTargetFactory {
                 semantics,
                 featureConfiguration,
                 ccToolchain,
-                ccToolchain.getFdoContext())
+                ccToolchain.getFdoContext(), ruleContext)
             .addPublicHeaders(common.getHeaders())
             .setHeadersCheckingMode(HeadersCheckingMode.STRICT)
             .setCodeCoverageEnabled(CcCompilationHelper.isCodeCoverageEnabled(ruleContext))

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcImport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcImport.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.analysis.RunfilesProvider;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget.Mode;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.rules.cpp.CcCompilationHelper.CompilationInfo;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.FeatureConfiguration;
 import com.google.devtools.build.lib.rules.cpp.CppConfiguration.HeadersCheckingMode;
@@ -161,7 +162,7 @@ public abstract class CcImport implements RuleConfiguredTargetFactory {
                 featureConfiguration,
                 ccToolchain,
                 ccToolchain.getFdoContext(),
-                ruleContext.getRule())
+                TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
             .addPublicHeaders(common.getHeaders())
             .setHeadersCheckingMode(HeadersCheckingMode.STRICT)
             .setCodeCoverageEnabled(CcCompilationHelper.isCodeCoverageEnabled(ruleContext))

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcImport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcImport.java
@@ -160,7 +160,8 @@ public abstract class CcImport implements RuleConfiguredTargetFactory {
                 semantics,
                 featureConfiguration,
                 ccToolchain,
-                ccToolchain.getFdoContext(), ruleContext)
+                ccToolchain.getFdoContext(),
+                ruleContext.getRule())
             .addPublicHeaders(common.getHeaders())
             .setHeadersCheckingMode(HeadersCheckingMode.STRICT)
             .setCodeCoverageEnabled(CcCompilationHelper.isCodeCoverageEnabled(ruleContext))

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -184,7 +184,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
                 fdoContext,
                 ruleContext.getConfiguration(),
                 ruleContext.getFragment(CppConfiguration.class),
-                ruleContext.getSymbolGenerator())
+                ruleContext.getSymbolGenerator(), ruleContext)
             .fromCommon(ruleContext, common)
             .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
             .setTestOrTestOnlyTarget(ruleContext.isTestOnlyTarget())

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -157,7 +157,8 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
                 semantics,
                 featureConfiguration,
                 ccToolchain,
-                fdoContext)
+                fdoContext,
+                ruleContext)
             .fromCommon(common, additionalCopts)
             .addSources(common.getSources())
             .addPrivateHeaders(common.getPrivateHeaders())

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -43,6 +43,7 @@ import com.google.devtools.build.lib.packages.AttributeMap;
 import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction;
 import com.google.devtools.build.lib.packages.RawAttributeMapper;
+import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.rules.cpp.CcCommon.CcFlagsSupplier;
 import com.google.devtools.build.lib.rules.cpp.CcCompilationHelper.CompilationInfo;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.FeatureConfiguration;
@@ -158,7 +159,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
                 featureConfiguration,
                 ccToolchain,
                 fdoContext,
-                ruleContext.getRule())
+                TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
             .fromCommon(common, additionalCopts)
             .addSources(common.getSources())
             .addPrivateHeaders(common.getPrivateHeaders())
@@ -185,7 +186,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
                 ruleContext.getConfiguration(),
                 ruleContext.getFragment(CppConfiguration.class),
                 ruleContext.getSymbolGenerator(),
-                ruleContext.getRule())
+                TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
             .fromCommon(ruleContext, common)
             .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
             .setTestOrTestOnlyTarget(ruleContext.isTestOnlyTarget())

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -158,7 +158,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
                 featureConfiguration,
                 ccToolchain,
                 fdoContext,
-                ruleContext)
+                ruleContext.getRule())
             .fromCommon(common, additionalCopts)
             .addSources(common.getSources())
             .addPrivateHeaders(common.getPrivateHeaders())
@@ -184,7 +184,8 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
                 fdoContext,
                 ruleContext.getConfiguration(),
                 ruleContext.getFragment(CppConfiguration.class),
-                ruleContext.getSymbolGenerator(), ruleContext)
+                ruleContext.getSymbolGenerator(),
+                ruleContext.getRule())
             .fromCommon(ruleContext, common)
             .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
             .setTestOrTestOnlyTarget(ruleContext.isTestOnlyTarget())

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
@@ -143,7 +143,7 @@ public final class CcLinkingHelper {
    * @param ccToolchain the C++ toolchain provider for the build
    * @param fdoContext the C++ FDO optimization support provider for the build
    * @param configuration the configuration that gives the directory of output artifacts
-   * @param ruleContext
+   * @param ruleContext the data available during the analysis of a rule
    */
   public CcLinkingHelper(
           RuleErrorConsumer ruleErrorConsumer,
@@ -821,7 +821,7 @@ public final class CcLinkingHelper {
   }
 
   private CppLinkActionBuilder newLinkActionBuilder(
-      Artifact outputArtifact, LinkTargetType linkType) {
+      Artifact outputArtifact, LinkTargetType linkType) throws InterruptedException {
     CppLinkActionBuilder builder = new CppLinkActionBuilder(
             ruleErrorConsumer,
             actionConstructionContext,
@@ -843,8 +843,8 @@ public final class CcLinkingHelper {
                             : ccToolchain.getLinkerFiles())
             .setLinkArtifactFactory(linkArtifactFactory)
             .setUseTestOnlyFlags(useTestOnlyFlags);
-    if (ruleContext != null) {
-      builder.addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()));
+    if (ruleContext != null && ruleContext.isAllowTagsPropagation()) {
+      builder.addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule()));
     }
     return builder;
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
+import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
 import com.google.devtools.build.lib.packages.RuleErrorConsumer;
 import com.google.devtools.build.lib.packages.TargetUtils;
@@ -126,7 +127,7 @@ public final class CcLinkingHelper {
   private final ActionRegistry actionRegistry;
   private final RuleErrorConsumer ruleErrorConsumer;
   private final SymbolGenerator<?> symbolGenerator;
-  @Nullable private final RuleContext ruleContext;
+  private final Rule rule;
 
   private Artifact grepIncludes;
   private boolean isStampingEnabled;
@@ -143,7 +144,7 @@ public final class CcLinkingHelper {
    * @param ccToolchain the C++ toolchain provider for the build
    * @param fdoContext the C++ FDO optimization support provider for the build
    * @param configuration the configuration that gives the directory of output artifacts
-   * @param ruleContext the data available during the analysis of a rule
+   * @param rule the data associated with a rule
    */
   public CcLinkingHelper(
           RuleErrorConsumer ruleErrorConsumer,
@@ -157,7 +158,7 @@ public final class CcLinkingHelper {
           BuildConfiguration configuration,
           CppConfiguration cppConfiguration,
           SymbolGenerator<?> symbolGenerator,
-          @Nullable RuleContext ruleContext) {
+          Rule rule) {
     this.semantics = Preconditions.checkNotNull(semantics);
     this.featureConfiguration = Preconditions.checkNotNull(featureConfiguration);
     this.ccToolchain = Preconditions.checkNotNull(ccToolchain);
@@ -169,7 +170,7 @@ public final class CcLinkingHelper {
     this.actionRegistry = actionRegistry;
     this.actionConstructionContext = actionConstructionContext;
     this.symbolGenerator = symbolGenerator;
-    this.ruleContext = ruleContext;
+    this.rule = rule;
   }
 
   /** Sets fields that overlap for cc_library and cc_binary rules. */
@@ -843,8 +844,8 @@ public final class CcLinkingHelper {
                             : ccToolchain.getLinkerFiles())
             .setLinkArtifactFactory(linkArtifactFactory)
             .setUseTestOnlyFlags(useTestOnlyFlags);
-    if (ruleContext != null && ruleContext.isAllowTagsPropagation()) {
-      builder.addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule()));
+    if (actionConstructionContext.isAllowTagsPropagation()) {
+      builder.addExecutionInfo(TargetUtils.getExecutionInfo(rule));
     }
     return builder;
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
@@ -842,7 +842,7 @@ public final class CcLinkingHelper {
                 : ccToolchain.getLinkerFiles())
         .setLinkArtifactFactory(linkArtifactFactory)
         .setUseTestOnlyFlags(useTestOnlyFlags)
-        .addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule()));
+        .addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
 import com.google.devtools.build.lib.packages.RuleErrorConsumer;
+import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.rules.cpp.CcLinkingContext.Linkstamp;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.FeatureConfiguration;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainVariables.VariablesExtension;
@@ -124,6 +125,7 @@ public final class CcLinkingHelper {
   private final ActionRegistry actionRegistry;
   private final RuleErrorConsumer ruleErrorConsumer;
   private final SymbolGenerator<?> symbolGenerator;
+  private RuleContext ruleContext;
 
   private Artifact grepIncludes;
   private boolean isStampingEnabled;
@@ -131,8 +133,7 @@ public final class CcLinkingHelper {
 
   /**
    * Creates a CcLinkingHelper that outputs artifacts in a given configuration.
-   *
-   * @param ruleErrorConsumer the RuleErrorConsumer
+   *  @param ruleErrorConsumer the RuleErrorConsumer
    * @param label the Label of the rule being built
    * @param actionRegistry the ActionRegistry of the rule being built
    * @param actionConstructionContext the ActionConstructionContext of the rule being built
@@ -141,19 +142,21 @@ public final class CcLinkingHelper {
    * @param ccToolchain the C++ toolchain provider for the build
    * @param fdoContext the C++ FDO optimization support provider for the build
    * @param configuration the configuration that gives the directory of output artifacts
+   * @param ruleContext
    */
   public CcLinkingHelper(
-      RuleErrorConsumer ruleErrorConsumer,
-      Label label,
-      ActionRegistry actionRegistry,
-      ActionConstructionContext actionConstructionContext,
-      CppSemantics semantics,
-      FeatureConfiguration featureConfiguration,
-      CcToolchainProvider ccToolchain,
-      FdoContext fdoContext,
-      BuildConfiguration configuration,
-      CppConfiguration cppConfiguration,
-      SymbolGenerator<?> symbolGenerator) {
+          RuleErrorConsumer ruleErrorConsumer,
+          Label label,
+          ActionRegistry actionRegistry,
+          ActionConstructionContext actionConstructionContext,
+          CppSemantics semantics,
+          FeatureConfiguration featureConfiguration,
+          CcToolchainProvider ccToolchain,
+          FdoContext fdoContext,
+          BuildConfiguration configuration,
+          CppConfiguration cppConfiguration,
+          SymbolGenerator<?> symbolGenerator,
+          RuleContext ruleContext) {
     this.semantics = Preconditions.checkNotNull(semantics);
     this.featureConfiguration = Preconditions.checkNotNull(featureConfiguration);
     this.ccToolchain = Preconditions.checkNotNull(ccToolchain);
@@ -165,6 +168,7 @@ public final class CcLinkingHelper {
     this.actionRegistry = actionRegistry;
     this.actionConstructionContext = actionConstructionContext;
     this.symbolGenerator = symbolGenerator;
+    this.ruleContext = ruleContext;
   }
 
   /** Sets fields that overlap for cc_library and cc_binary rules. */
@@ -837,7 +841,8 @@ public final class CcLinkingHelper {
                 ? ccToolchain.getArFiles()
                 : ccToolchain.getLinkerFiles())
         .setLinkArtifactFactory(linkArtifactFactory)
-        .setUseTestOnlyFlags(useTestOnlyFlags);
+        .setUseTestOnlyFlags(useTestOnlyFlags)
+        .addExecutionInfo(TargetUtils.getExecutionInfo(ruleContext.getRule()));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -1433,7 +1433,7 @@ public abstract class CcModule
                     .getConfiguration()
                     .getFragment(CppConfiguration.class),
                 ((BazelStarlarkContext) starlarkContext).getSymbolGenerator(),
-                /* ruleContext= */ null)
+                actions.getRuleContext().getRule())
             .setGrepIncludes(convertFromNoneable(grepIncludes, /* defaultValue= */ null))
             .addNonCodeLinkerInputs(additionalInputs)
             .setShouldCreateStaticLibraries(!disallowStaticLibraries)
@@ -1528,7 +1528,7 @@ public abstract class CcModule
       SkylarkList<Artifact> headersForClifDoNotUseThisParam,
       Location location,
       @Nullable Environment environment)
-      throws EvalException {
+          throws EvalException, InterruptedException {
     if (environment != null) {
       CcCommon.checkLocationWhitelisted(
           environment.getSemantics(),
@@ -1573,7 +1573,8 @@ public abstract class CcModule
                 getSemantics(),
                 featureConfiguration.getFeatureConfiguration(),
                 ccToolchainProvider,
-                fdoContext, null)
+                fdoContext,
+                actions.getRuleContext().getRule())
             .addPublicHeaders(publicHeaders)
             .addPrivateHeaders(privateHeaders)
             .addSources(sources)
@@ -1682,7 +1683,7 @@ public abstract class CcModule
                 actions.getActionConstructionContext().getConfiguration(),
                 cppConfiguration,
                 ((BazelStarlarkContext) starlarkContext).getSymbolGenerator(),
-                /* ruleContext= */ null)
+                actions.getRuleContext().getRule())
             .setGrepIncludes(convertFromNoneable(grepIncludes, /* defaultValue= */ null))
             .setLinkingMode(linkDepsStatically ? LinkingMode.STATIC : LinkingMode.DYNAMIC)
             .addNonCodeLinkerInputs(additionalInputs)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -1432,7 +1432,8 @@ public abstract class CcModule
                     .getActionConstructionContext()
                     .getConfiguration()
                     .getFragment(CppConfiguration.class),
-                ((BazelStarlarkContext) starlarkContext).getSymbolGenerator(), null)
+                ((BazelStarlarkContext) starlarkContext).getSymbolGenerator(),
+                /* ruleContext= */ null)
             .setGrepIncludes(convertFromNoneable(grepIncludes, /* defaultValue= */ null))
             .addNonCodeLinkerInputs(additionalInputs)
             .setShouldCreateStaticLibraries(!disallowStaticLibraries)
@@ -1680,7 +1681,8 @@ public abstract class CcModule
                 fdoContext,
                 actions.getActionConstructionContext().getConfiguration(),
                 cppConfiguration,
-                ((BazelStarlarkContext) starlarkContext).getSymbolGenerator(), null)
+                ((BazelStarlarkContext) starlarkContext).getSymbolGenerator(),
+                /* ruleContext= */ null)
             .setGrepIncludes(convertFromNoneable(grepIncludes, /* defaultValue= */ null))
             .setLinkingMode(linkDepsStatically ? LinkingMode.STATIC : LinkingMode.DYNAMIC)
             .addNonCodeLinkerInputs(additionalInputs)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -1432,7 +1432,7 @@ public abstract class CcModule
                     .getActionConstructionContext()
                     .getConfiguration()
                     .getFragment(CppConfiguration.class),
-                ((BazelStarlarkContext) starlarkContext).getSymbolGenerator())
+                ((BazelStarlarkContext) starlarkContext).getSymbolGenerator(), null)
             .setGrepIncludes(convertFromNoneable(grepIncludes, /* defaultValue= */ null))
             .addNonCodeLinkerInputs(additionalInputs)
             .setShouldCreateStaticLibraries(!disallowStaticLibraries)
@@ -1680,7 +1680,7 @@ public abstract class CcModule
                 fdoContext,
                 actions.getActionConstructionContext().getConfiguration(),
                 cppConfiguration,
-                ((BazelStarlarkContext) starlarkContext).getSymbolGenerator())
+                ((BazelStarlarkContext) starlarkContext).getSymbolGenerator(), null)
             .setGrepIncludes(convertFromNoneable(grepIncludes, /* defaultValue= */ null))
             .setLinkingMode(linkDepsStatically ? LinkingMode.STATIC : LinkingMode.DYNAMIC)
             .addNonCodeLinkerInputs(additionalInputs)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -1572,7 +1572,7 @@ public abstract class CcModule
                 getSemantics(),
                 featureConfiguration.getFeatureConfiguration(),
                 ccToolchainProvider,
-                fdoContext)
+                fdoContext, null)
             .addPublicHeaders(publicHeaders)
             .addPrivateHeaders(privateHeaders)
             .addSources(sources)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.events.Location;
 import com.google.devtools.build.lib.packages.Provider;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
 import com.google.devtools.build.lib.packages.SkylarkInfo;
+import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.rules.cpp.CcCompilationHelper.CompilationInfo;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.ActionConfig;
 import com.google.devtools.build.lib.rules.cpp.CcToolchainFeatures.ArtifactNamePattern;
@@ -1433,7 +1434,7 @@ public abstract class CcModule
                     .getConfiguration()
                     .getFragment(CppConfiguration.class),
                 ((BazelStarlarkContext) starlarkContext).getSymbolGenerator(),
-                actions.getRuleContext().getRule())
+                TargetUtils.getExecutionInfo(actions.getRuleContext().getRule(), actions.getRuleContext().isAllowTagsPropagation()))
             .setGrepIncludes(convertFromNoneable(grepIncludes, /* defaultValue= */ null))
             .addNonCodeLinkerInputs(additionalInputs)
             .setShouldCreateStaticLibraries(!disallowStaticLibraries)
@@ -1574,7 +1575,7 @@ public abstract class CcModule
                 featureConfiguration.getFeatureConfiguration(),
                 ccToolchainProvider,
                 fdoContext,
-                actions.getRuleContext().getRule())
+                TargetUtils.getExecutionInfo(actions.getRuleContext().getRule(), actions.getRuleContext().isAllowTagsPropagation()))
             .addPublicHeaders(publicHeaders)
             .addPrivateHeaders(privateHeaders)
             .addSources(sources)
@@ -1683,7 +1684,7 @@ public abstract class CcModule
                 actions.getActionConstructionContext().getConfiguration(),
                 cppConfiguration,
                 ((BazelStarlarkContext) starlarkContext).getSymbolGenerator(),
-                actions.getRuleContext().getRule())
+                TargetUtils.getExecutionInfo(actions.getRuleContext().getRule(), actions.getRuleContext().isAllowTagsPropagation()))
             .setGrepIncludes(convertFromNoneable(grepIncludes, /* defaultValue= */ null))
             .setLinkingMode(linkDepsStatically ? LinkingMode.STATIC : LinkingMode.DYNAMIC)
             .addNonCodeLinkerInputs(additionalInputs)

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java
@@ -148,6 +148,7 @@ public class CppLinkActionBuilder {
   //  of them.
   private boolean isTestOrTestOnlyTarget;
   private boolean isStampingEnabled;
+  private Map<String, String> executionInfo = new LinkedHashMap<>();
 
   /**
    * Creates a builder that builds {@link CppLinkAction}s.
@@ -1022,15 +1023,15 @@ public class CppLinkActionBuilder {
     // If the crosstool uses action_configs to configure cc compilation, collect execution info
     // from there, otherwise, use no execution info.
     // TODO(b/27903698): Assert that the crosstool has an action_config for this action.
-    Map<String, String> executionRequirements = new LinkedHashMap<>();
+//    Map<String, String> executionRequirements = new LinkedHashMap<>();
 
     if (featureConfiguration.actionIsConfigured(getActionName())) {
       for (String req : featureConfiguration.getToolRequirementsForAction(getActionName())) {
-        executionRequirements.put(req, "");
+        executionInfo.put(req, "");
       }
     }
     configuration.modifyExecutionInfo(
-        executionRequirements, CppLinkAction.getMnemonic(mnemonic, isLtoIndexing));
+            executionInfo, CppLinkAction.getMnemonic(mnemonic, isLtoIndexing));
 
     if (!isLtoIndexing) {
       for (Map.Entry<Linkstamp, Artifact> linkstampEntry : linkstampMap.entrySet()) {
@@ -1092,7 +1093,7 @@ public class CppLinkActionBuilder {
         linkCommandLine,
         configuration.getActionEnvironment(),
         toolchainEnv,
-        ImmutableMap.copyOf(executionRequirements),
+        ImmutableMap.copyOf(executionInfo),
         toolchain.getToolPathFragment(Tool.LD, ruleErrorConsumer),
         toolchain.getHostSystemName(),
         toolchain.getTargetCpu());
@@ -1580,6 +1581,11 @@ public class CppLinkActionBuilder {
   /** Adds an extra output artifact to the link action. */
   public CppLinkActionBuilder addActionOutput(Artifact output) {
     this.linkActionOutputs.add(output);
+    return this;
+  }
+
+  public CppLinkActionBuilder addExecutionInfo(Map<String, String> executionInfo) {
+    this.executionInfo.putAll(executionInfo);
     return this;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java
@@ -148,7 +148,7 @@ public class CppLinkActionBuilder {
   //  of them.
   private boolean isTestOrTestOnlyTarget;
   private boolean isStampingEnabled;
-  private Map<String, String> executionInfo = new LinkedHashMap<>();
+  private final Map<String, String> executionInfo = new LinkedHashMap<>();
 
   /**
    * Creates a builder that builds {@link CppLinkAction}s.
@@ -1023,7 +1023,6 @@ public class CppLinkActionBuilder {
     // If the crosstool uses action_configs to configure cc compilation, collect execution info
     // from there, otherwise, use no execution info.
     // TODO(b/27903698): Assert that the crosstool has an action_config for this action.
-//    Map<String, String> executionRequirements = new LinkedHashMap<>();
 
     if (featureConfiguration.actionIsConfigured(getActionName())) {
       for (String req : featureConfiguration.getToolRequirementsForAction(getActionName())) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
@@ -311,7 +311,8 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
                   cppSemantics,
                   featureConfiguration,
                   toolchain,
-                  toolchain.getFdoContext(), ruleContext)
+                  toolchain.getFdoContext(),
+                  ruleContext.getRule())
               .addCcCompilationContexts(CppHelper.getCompilationContextsFromDeps(deps))
               .addCcCompilationContexts(
                   ImmutableList.of(CcCompilationHelper.getStlCcCompilationContext(ruleContext)));
@@ -358,7 +359,8 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
                   toolchain.getFdoContext(),
                   ruleContext.getConfiguration(),
                   ruleContext.getFragment(CppConfiguration.class),
-                  ruleContext.getSymbolGenerator(), ruleContext)
+                  ruleContext.getSymbolGenerator(),
+                  ruleContext.getRule())
               .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
               .setTestOrTestOnlyTarget(ruleContext.isTestOnlyTarget());
       helper.addCcLinkingContexts(CppHelper.getLinkingContextsFromDeps(deps));

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
@@ -358,7 +358,7 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
                   toolchain.getFdoContext(),
                   ruleContext.getConfiguration(),
                   ruleContext.getFragment(CppConfiguration.class),
-                  ruleContext.getSymbolGenerator())
+                  ruleContext.getSymbolGenerator(), ruleContext)
               .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
               .setTestOrTestOnlyTarget(ruleContext.isTestOnlyTarget());
       helper.addCcLinkingContexts(CppHelper.getLinkingContextsFromDeps(deps));

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
@@ -311,7 +311,7 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
                   cppSemantics,
                   featureConfiguration,
                   toolchain,
-                  toolchain.getFdoContext())
+                  toolchain.getFdoContext(), ruleContext)
               .addCcCompilationContexts(CppHelper.getCompilationContextsFromDeps(deps))
               .addCcCompilationContexts(
                   ImmutableList.of(CcCompilationHelper.getStlCcCompilationContext(ruleContext)));

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.packages.AspectParameters;
 import com.google.devtools.build.lib.packages.Attribute.LabelLateBoundDefault;
 import com.google.devtools.build.lib.packages.NativeAspectClass;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
+import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.rules.cpp.AspectLegalCppSemantics;
 import com.google.devtools.build.lib.rules.cpp.CcCommon;
 import com.google.devtools.build.lib.rules.cpp.CcCompilationHelper;
@@ -300,7 +301,7 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
     }
 
     private CcCompilationHelper initializeCompilationHelper(
-        FeatureConfiguration featureConfiguration, List<TransitiveInfoCollection> deps) {
+        FeatureConfiguration featureConfiguration, List<TransitiveInfoCollection> deps) throws InterruptedException {
       CcToolchainProvider toolchain = ccToolchain(ruleContext);
       CcCompilationHelper helper =
           new CcCompilationHelper(
@@ -312,7 +313,7 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
                   featureConfiguration,
                   toolchain,
                   toolchain.getFdoContext(),
-                  ruleContext.getRule())
+                  TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
               .addCcCompilationContexts(CppHelper.getCompilationContextsFromDeps(deps))
               .addCcCompilationContexts(
                   ImmutableList.of(CcCompilationHelper.getStlCcCompilationContext(ruleContext)));
@@ -345,7 +346,7 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
     }
 
     private CcLinkingHelper initializeLinkingHelper(
-        FeatureConfiguration featureConfiguration, ImmutableList<TransitiveInfoCollection> deps) {
+        FeatureConfiguration featureConfiguration, ImmutableList<TransitiveInfoCollection> deps) throws InterruptedException {
       CcToolchainProvider toolchain = ccToolchain(ruleContext);
       CcLinkingHelper helper =
           new CcLinkingHelper(
@@ -360,7 +361,7 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
                   ruleContext.getConfiguration(),
                   ruleContext.getFragment(CppConfiguration.class),
                   ruleContext.getSymbolGenerator(),
-                  ruleContext.getRule())
+                  TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
               .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
               .setTestOrTestOnlyTarget(ruleContext.isTestOnlyTarget());
       helper.addCcLinkingContexts(CppHelper.getLinkingContextsFromDeps(deps));

--- a/src/main/java/com/google/devtools/build/lib/rules/nativedeps/NativeDepsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/nativedeps/NativeDepsHelper.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.analysis.actions.SymlinkAction;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
+import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.rules.cpp.CcCommon;
 import com.google.devtools.build.lib.rules.cpp.CcCompilationOutputs;
 import com.google.devtools.build.lib.rules.cpp.CcInfo;
@@ -248,7 +249,7 @@ public abstract class NativeDepsHelper {
             configuration,
             ruleContext.getFragment(CppConfiguration.class),
             ruleContext.getSymbolGenerator(),
-            ruleContext.getRule())
+            TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
         .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
         .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
         .setTestOrTestOnlyTarget(ruleContext.isTestTarget() || ruleContext.isTestOnlyTarget())

--- a/src/main/java/com/google/devtools/build/lib/rules/nativedeps/NativeDepsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/nativedeps/NativeDepsHelper.java
@@ -247,7 +247,8 @@ public abstract class NativeDepsHelper {
             fdoContext,
             configuration,
             ruleContext.getFragment(CppConfiguration.class),
-            ruleContext.getSymbolGenerator(), ruleContext)
+            ruleContext.getSymbolGenerator(),
+            ruleContext.getRule())
         .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
         .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
         .setTestOrTestOnlyTarget(ruleContext.isTestTarget() || ruleContext.isTestOnlyTarget())

--- a/src/main/java/com/google/devtools/build/lib/rules/nativedeps/NativeDepsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/nativedeps/NativeDepsHelper.java
@@ -247,7 +247,7 @@ public abstract class NativeDepsHelper {
             fdoContext,
             configuration,
             ruleContext.getFragment(CppConfiguration.class),
-            ruleContext.getSymbolGenerator())
+            ruleContext.getSymbolGenerator(), ruleContext)
         .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
         .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
         .setTestOrTestOnlyTarget(ruleContext.isTestTarget() || ruleContext.isTestOnlyTarget())

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
@@ -85,6 +85,7 @@ import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.packages.BuildType;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.SafeImplicitOutputsFunction;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
+import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.rules.apple.AppleCommandLineOptions.AppleBitcodeMode;
 import com.google.devtools.build.lib.rules.apple.AppleConfiguration;
 import com.google.devtools.build.lib.rules.apple.XcodeConfig;
@@ -305,7 +306,7 @@ public class CompilationSupport {
                 ccToolchain,
                 fdoContext,
                 buildConfiguration,
-                ruleContext.getRule())
+                TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
             .addSources(sources)
             .addPrivateHeaders(privateHdrs)
             .addDefines(objcProvider.get(DEFINE))
@@ -426,7 +427,7 @@ public class CompilationSupport {
                 buildConfiguration,
                 ruleContext.getFragment(CppConfiguration.class),
                 ruleContext.getSymbolGenerator(),
-                ruleContext.getRule())
+                TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
             .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
             .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
             .setTestOrTestOnlyTarget(ruleContext.isTestTarget() || ruleContext.isTestOnlyTarget())

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
@@ -292,7 +292,7 @@ public class CompilationSupport {
       ObjcCppSemantics semantics,
       String purpose,
       boolean generateModuleMap)
-      throws RuleErrorException {
+          throws RuleErrorException, InterruptedException {
     CcCompilationHelper result =
         new CcCompilationHelper(
                 ruleContext,
@@ -305,7 +305,7 @@ public class CompilationSupport {
                 ccToolchain,
                 fdoContext,
                 buildConfiguration,
-                ruleContext)
+                ruleContext.getRule())
             .addSources(sources)
             .addPrivateHeaders(privateHdrs)
             .addDefines(objcProvider.get(DEFINE))
@@ -425,7 +425,8 @@ public class CompilationSupport {
                 fdoContext,
                 buildConfiguration,
                 ruleContext.getFragment(CppConfiguration.class),
-                ruleContext.getSymbolGenerator(), ruleContext)
+                ruleContext.getSymbolGenerator(),
+                ruleContext.getRule())
             .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
             .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
             .setTestOrTestOnlyTarget(ruleContext.isTestTarget() || ruleContext.isTestOnlyTarget())

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
@@ -304,7 +304,8 @@ public class CompilationSupport {
                 CcCompilationHelper.SourceCategory.CC_AND_OBJC,
                 ccToolchain,
                 fdoContext,
-                buildConfiguration)
+                buildConfiguration,
+                ruleContext)
             .addSources(sources)
             .addPrivateHeaders(privateHdrs)
             .addDefines(objcProvider.get(DEFINE))

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
@@ -425,7 +425,7 @@ public class CompilationSupport {
                 fdoContext,
                 buildConfiguration,
                 ruleContext.getFragment(CppConfiguration.class),
-                ruleContext.getSymbolGenerator())
+                ruleContext.getSymbolGenerator(), ruleContext)
             .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
             .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
             .setTestOrTestOnlyTarget(ruleContext.isTestTarget() || ruleContext.isTestOnlyTarget())

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -768,6 +768,14 @@ sh_test(
 )
 
 sh_test(
+    name = "tags_propagation_native_test",
+    size = "large",
+    srcs = ["tags_propagation_native_test.sh"],
+    data = [":test-deps"],
+    tags = ["no_windows"],
+)
+
+sh_test(
     name = "disk_cache_test",
     size = "small",
     srcs = ["disk_cache_test.sh"],

--- a/src/test/shell/bazel/tags_propagation_native_test.sh
+++ b/src/test/shell/bazel/tags_propagation_native_test.sh
@@ -94,30 +94,6 @@ EOF
   assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: ''}" output1
 }
 
-function test_java_tags_propagated() {
-  mkdir -p test
-  cat > test/BUILD <<EOF
-package(default_visibility = ["//visibility:public"])
-java_library(
-  name = 'test',
-  srcs = [ 'Hello.java' ],
-  tags = ["no-cache", "no-remote", "local"]
-)
-EOF
-  cat > test/Hello.java <<EOF
-public class Main {
-    public static void main(String[] args) {
-        System.out.println("Hello there");
-    }
-}
-EOF
-
-  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
-      || fail "should have generated output successfully"
-
-  assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: ''}" output1
-}
-
 # Test a native test rule rule which has tags, that should be propagated (independent of flags)
 function test_test_rules_tags_propagated() {
   mkdir -p test

--- a/src/test/shell/bazel/tags_propagation_native_test.sh
+++ b/src/test/shell/bazel/tags_propagation_native_test.sh
@@ -40,7 +40,7 @@ EOF
 int main() { std::cout << "Hello test!" << std::endl; return 0; }
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+  bazel aquery --experimental_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
   if [[  "${PLATFORM}" = "darwin"  ]]; then
@@ -66,7 +66,7 @@ EOF
 int main() { std::cout << "Hello test!" << std::endl; return 0; }
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+  bazel aquery --experimental_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
   if [[  "${PLATFORM}" = "darwin"  ]]; then
@@ -88,7 +88,7 @@ genrule(
 )
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+  bazel aquery --experimental_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
   assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: ''}" output1
@@ -110,7 +110,7 @@ EOF
 int main() { std::cout << "Hello test!" << std::endl; return 0; }
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation=false '//test:test' > output1 2> $TEST_log \
+  bazel aquery --experimental_allow_tags_propagation=false '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
  if [[  "${PLATFORM}" = "darwin"  ]]; then
@@ -121,7 +121,7 @@ EOF
 }
 
 # Test a basic native rule which has tags, that should not be propagated
-# as --incompatible_allow_tags_propagation flag set to false
+# as --experimental_allow_tags_propagation flag set to false
 function test_cc_library_tags_not_propagated_when_incompatible_flag_off() {
   mkdir -p test
   cat > test/BUILD <<EOF
@@ -137,7 +137,7 @@ EOF
 int main() { std::cout << "Hello test!" << std::endl; return 0; }
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation=false '//test:test' > output1 2> $TEST_log \
+  bazel aquery --experimental_allow_tags_propagation=false '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
 
@@ -148,7 +148,7 @@ EOF
   fi
 }
 
-function test_cc_binary_tags_not_propagated() {
+function test_cc_binary_tags_not_propagated_when_incompatible_flag_off() {
 
  mkdir -p test
   cat > test/BUILD <<EOF
@@ -164,7 +164,7 @@ EOF
 int main() { std::cout << "Hello test!" << std::endl; return 0; }
 EOF
 
-  bazel aquery --incompatible_allow_tags_propagation=false '//test:test' > output1 2> $TEST_log \
+  bazel aquery --experimental_allow_tags_propagation=false '//test:test' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
   if [[  "${PLATFORM}" = "darwin"  ]]; then

--- a/src/test/shell/bazel/tags_propagation_native_test.sh
+++ b/src/test/shell/bazel/tags_propagation_native_test.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+#
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests target's tags propagation with rules defined in Skylark.
+# Tests for https://github.com/bazelbuild/bazel/issues/7766
+
+# Load the test setup defined in the parent directory
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CURRENT_DIR}/../integration_test_setup.sh" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
+
+# Test a basic native rule which has tags, that should be propagated
+function test_cc_library_tags_propagated() {
+  mkdir -p test
+  cat > test/BUILD <<EOF
+package(default_visibility = ["//visibility:public"])
+cc_library(
+  name = 'test',
+  srcs = [ 'test.cc' ],
+  tags = ["no-cache", "no-remote", "local"]
+)
+EOF
+  cat > test/test.cc <<EOF
+#include <iostream>
+int main() { std::cout << "Hello test!" << std::endl; return 0; }
+EOF
+
+  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+      || fail "should have generated output successfully"
+
+  if [[  "${PLATFORM}" = "darwin"  ]]; then
+    assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: '', requires-darwin: ''}" output1
+  else
+    assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: ''}" output1
+  fi
+}
+
+function test_cc_binary_tags_propagated() {
+
+ mkdir -p test
+  cat > test/BUILD <<EOF
+package(default_visibility = ["//visibility:public"])
+cc_binary(
+  name = "test",
+  srcs = ["test.cc"],
+  tags = ["no-cache", "no-remote", "local"]
+)
+EOF
+  cat > test/test.cc <<EOF
+#include <iostream>
+int main() { std::cout << "Hello test!" << std::endl; return 0; }
+EOF
+
+  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+      || fail "should have generated output successfully"
+
+  if [[  "${PLATFORM}" = "darwin"  ]]; then
+    assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: '', requires-darwin: ''}" output1
+  else
+    assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: ''}" output1
+  fi
+}
+
+function test_genrule_tags_propagated() {
+  mkdir -p test
+  cat > test/BUILD <<EOF
+package(default_visibility = ["//visibility:public"])
+genrule(
+  name = 'test',
+  outs = [ 'test.out' ],
+  cmd = "echo hello > \$@",
+  tags = ["no-cache", "no-remote", "local"]
+)
+EOF
+
+  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+      || fail "should have generated output successfully"
+
+  assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: ''}" output1
+}
+
+function test_java_tags_propagated() {
+  mkdir -p test
+  cat > test/BUILD <<EOF
+package(default_visibility = ["//visibility:public"])
+java_library(
+  name = 'test',
+  srcs = [ 'Hello.java' ],
+  tags = ["no-cache", "no-remote", "local"]
+)
+EOF
+  cat > test/Hello.java <<EOF
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello there");
+    }
+}
+EOF
+
+  bazel aquery --incompatible_allow_tags_propagation '//test:test' > output1 2> $TEST_log \
+      || fail "should have generated output successfully"
+
+  assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: ''}" output1
+}
+
+# Test a native test rule rule which has tags, that should be propagated (independent of flags)
+function test_test_rules_tags_propagated() {
+  mkdir -p test
+  cat > test/BUILD <<EOF
+package(default_visibility = ["//visibility:public"])
+cc_test(
+  name = 'test',
+  srcs = [ 'test.cc' ],
+  tags = ["no-cache", "no-remote", "local"]
+)
+EOF
+  cat > test/test.cc <<EOF
+#include <iostream>
+int main() { std::cout << "Hello test!" << std::endl; return 0; }
+EOF
+
+  bazel aquery --incompatible_allow_tags_propagation=false '//test:test' > output1 2> $TEST_log \
+      || fail "should have generated output successfully"
+
+ if [[  "${PLATFORM}" = "darwin"  ]]; then
+    assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: '', requires-darwin: ''}" output1
+  else
+    assert_contains "ExecutionInfo: {local: '', no-cache: '', no-remote: ''}" output1
+  fi
+}
+
+# Test a basic native rule which has tags, that should not be propagated
+# as --incompatible_allow_tags_propagation flag set to false
+function test_tags_not_propagated_when_incompatible_flag_off() {
+  mkdir -p test
+  cat > test/BUILD <<EOF
+package(default_visibility = ["//visibility:public"])
+cc_library(
+  name = 'test',
+  srcs = [ 'test.cc' ],
+  tags = ["no-cache", "no-remote", "local"]
+)
+EOF
+  cat > test/test.cc <<EOF
+#include <iostream>
+int main() { std::cout << "Hello test!" << std::endl; return 0; }
+EOF
+
+  bazel aquery --incompatible_allow_tags_propagation=false '//test:test' > output1 2> $TEST_log \
+      || fail "should have generated output successfully"
+
+
+ if [[  "${PLATFORM}" = "darwin"  ]]; then
+    assert_contains "ExecutionInfo: {requires-darwin: ''}" output1
+  else
+    assert_not_contains "ExecutionInfo: {" output1
+  fi
+}
+
+run_suite "tags propagation: skylark rule tests"


### PR DESCRIPTION
Part of #8830 

RELNOTES[NEW]: tags: use `--experimental_allow_tags_propagation` flag to propagate tags to the action's execution requirements from cc_library or cc_binary targets. Such tags should start with: `no-`, `requires-`, `supports-`, `block-`, `disable-`, `cpu:`. See #8830 for details.