### PR TITLE
Client: convert more members and functions to Path

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -348,7 +348,7 @@ string GetEmbeddedBinariesRoot(const string &install_base) {
 
 // Returns the JVM command argument array.
 static vector<string> GetServerExeArgs(
-    const string &jvm_path,
+    const blaze_util::Path &jvm_path,
     const string &server_jar_path,
     const vector<string> &archive_contents,
     const string &install_md5,
@@ -362,15 +362,15 @@ static vector<string> GetServerExeArgs(
   result.push_back(
       startup_options.GetLowercaseProductName() +
       "(" + workspace_layout.GetPrettyWorkspaceName(workspace) + ")");
-  startup_options.AddJVMArgumentPrefix(
-      blaze_util::Dirname(blaze_util::Dirname(jvm_path)), &result);
+  startup_options.AddJVMArgumentPrefix(jvm_path.GetParent().GetParent(),
+                                       &result);
 
   result.push_back("-XX:+HeapDumpOnOutOfMemoryError");
   result.push_back("-XX:HeapDumpPath=" +
                    startup_options.output_base.AsJvmArgument());
 
   // TODO(b/109998449): only assume JDK >= 9 for embedded JDKs
-  if (!startup_options.GetEmbeddedJavabase().empty()) {
+  if (!startup_options.GetEmbeddedJavabase().IsEmpty()) {
     // quiet warnings from com.google.protobuf.UnsafeUtil,
     // see: https://github.com/google/protobuf/issues/3781
     result.push_back("--add-opens=java.base/java.nio=ALL-UNNAMED");
@@ -399,14 +399,14 @@ static vector<string> GetServerExeArgs(
   set<string> java_library_paths;
   std::stringstream java_library_path;
   java_library_path << "-Djava.library.path=";
-  string real_install_dir =
-      GetEmbeddedBinariesRoot(startup_options.install_base);
+  blaze_util::Path real_install_dir =
+      blaze_util::Path(GetEmbeddedBinariesRoot(startup_options.install_base));
 
   bool first = true;
   for (const auto &it : archive_contents) {
     if (IsSharedLibrary(it)) {
-      string libpath(blaze_util::PathAsJvmFlag(
-          blaze_util::JoinPath(real_install_dir, blaze_util::Dirname(it))));
+      string libpath(
+          real_install_dir.GetRelative(blaze_util::Dirname(it)).AsJvmArgument());
       // Only add the library path if it's not added yet.
       if (java_library_paths.find(libpath) == java_library_paths.end()) {
         java_library_paths.insert(libpath);
@@ -537,9 +537,10 @@ static vector<string> GetServerExeArgs(
   // These flags are passed to the java process only for Blaze reporting
   // purposes; the real interpretation of the jvm flags occurs when we set up
   // the java command line.
-  if (!startup_options.GetExplicitServerJavabase().empty()) {
-    result.push_back("--server_javabase=" +
-                     startup_options.GetExplicitServerJavabase());
+  if (!startup_options.GetExplicitServerJavabase().IsEmpty()) {
+    result.push_back(
+        "--server_javabase=" +
+        startup_options.GetExplicitServerJavabase().AsCommandLineArgument());
   }
   if (startup_options.host_jvm_debug) {
     result.push_back("--host_jvm_debug");
@@ -1233,7 +1234,8 @@ static ATTRIBUTE_NORETURN void RunClientServerMode(
     // Check for the case when the workspace directory deleted and then gets
     // recreated while the server is running
 
-    string server_cwd = GetProcessCWD(server->ProcessInfo().server_pid_);
+    blaze_util::Path server_cwd =
+        GetProcessCWD(server->ProcessInfo().server_pid_);
     // If server_cwd is empty, GetProcessCWD failed. This notably occurs when
     // running under Docker because then readlink(/proc/[pid]/cwd) returns
     // EPERM.
@@ -1245,14 +1247,14 @@ static ATTRIBUTE_NORETURN void RunClientServerMode(
     // cases, it's better to assume that everything is alright if we can't get
     // the cwd.
 
-    if (!server_cwd.empty() &&
-        (server_cwd != workspace ||                         // changed
-         server_cwd.find(" (deleted)") != string::npos)) {  // deleted.
+    if (!server_cwd.IsEmpty() &&
+        (server_cwd != blaze_util::Path(workspace) || // changed
+         server_cwd.Contains(" (deleted)"))) {  // deleted.
       // There's a distant possibility that the two paths look the same yet are
       // actually different because the two processes have different mount
       // tables.
-      BAZEL_LOG(INFO) << "Server's cwd moved or deleted (" << server_cwd
-                      << ").";
+      BAZEL_LOG(INFO) << "Server's cwd moved or deleted ("
+                      << server_cwd.AsPrintablePath() << ").";
       server->KillRunningServer();
     } else {
       break;
@@ -1513,7 +1515,7 @@ static void RunLauncher(const string &self_path,
 
   EnsureCorrectRunningVersion(startup_options, logging_info, blaze_server);
 
-  const string jvm_path = startup_options.GetJvm();
+  const blaze_util::Path jvm_path = startup_options.GetJvm();
   const string server_jar_path = GetServerJarPath(archive_contents);
   const vector<string> server_exe_args = GetServerExeArgs(
       jvm_path,

--- a/src/main/cpp/blaze_util_darwin.cc
+++ b/src/main/cpp/blaze_util_darwin.cc
@@ -151,13 +151,13 @@ void SetScheduling(bool batch_cpu_scheduling, int io_nice_level) {
   // stubbed out so we can compile for Darwin.
 }
 
-string GetProcessCWD(int pid) {
+blaze_util::Path GetProcessCWD(int pid) {
   struct proc_vnodepathinfo info = {};
   if (proc_pidinfo(
           pid, PROC_PIDVNODEPATHINFO, 0, &info, sizeof(info)) != sizeof(info)) {
-    return "";
+    return blaze_util::Path();
   }
-  return string(info.pvi_cdir.vip_path);
+  return blaze_util::Path(string(info.pvi_cdir.vip_path));
 }
 
 bool IsSharedLibrary(const string &filename) {

--- a/src/main/cpp/blaze_util_freebsd.cc
+++ b/src/main/cpp/blaze_util_freebsd.cc
@@ -106,8 +106,10 @@ void SetScheduling(bool batch_cpu_scheduling, int io_nice_level) {
   // Stubbed out so we can compile for FreeBSD.
 }
 
-string GetProcessCWD(int pid) {
-  if (kill(pid, 0) < 0) return "";
+blaze_util::Path GetProcessCWD(int pid) {
+  if (kill(pid, 0) < 0) {
+    return blaze_util::Path();
+  }
   auto procstat = procstat_open_sysctl();
   unsigned int n;
   auto p = procstat_getprocs(procstat, KERN_PROC_PID, pid, &n);
@@ -133,7 +135,7 @@ string GetProcessCWD(int pid) {
     procstat_freeprocs(procstat, p);
   }
   procstat_close(procstat);
-  return cwd;
+  return blaze_util::Path(cwd);
 }
 
 bool IsSharedLibrary(const string &filename) {

--- a/src/main/cpp/blaze_util_linux.cc
+++ b/src/main/cpp/blaze_util_linux.cc
@@ -116,15 +116,15 @@ void SetScheduling(bool batch_cpu_scheduling, int io_nice_level) {
   }
 }
 
-string GetProcessCWD(int pid) {
+blaze_util::Path GetProcessCWD(int pid) {
   char server_cwd[PATH_MAX] = {};
   if (readlink(
           ("/proc/" + ToString(pid) + "/cwd").c_str(),
           server_cwd, sizeof(server_cwd)) < 0) {
-    return "";
+    return blaze_util::Path();
   }
 
-  return string(server_cwd);
+  return blaze_util::Path(string(server_cwd));
 }
 
 bool IsSharedLibrary(const string &filename) {

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -130,7 +130,7 @@ uint64_t GetMillisecondsMonotonic();
 void SetScheduling(bool batch_cpu_scheduling, int io_nice_level);
 
 // Returns the cwd for a process.
-std::string GetProcessCWD(int pid);
+blaze_util::Path GetProcessCWD(int pid);
 
 bool IsSharedLibrary(const std::string& filename);
 

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -448,10 +448,10 @@ void SetScheduling(bool batch_cpu_scheduling, int io_nice_level) {
   // TODO(bazel-team): There should be a similar function on Windows.
 }
 
-string GetProcessCWD(int pid) {
+blaze_util::Path GetProcessCWD(int pid) {
   // TODO(bazel-team) 2016-11-18: decide whether we need this on Windows and
   // implement or delete.
-  return "";
+  return blaze_util::Path();
 }
 
 bool IsSharedLibrary(const string &filename) {

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -274,7 +274,8 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
              NULL) {
     // TODO(bazel-team): Consider examining the javabase and re-execing in case
     // of architecture mismatch.
-    explicit_server_javabase_ = blaze::AbsolutePathFromFlag(value);
+    explicit_server_javabase_ =
+        blaze_util::Path(blaze::AbsolutePathFromFlag(value));
     option_sources["server_javabase"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--host_jvm_args")) !=
              NULL) {
@@ -434,65 +435,64 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArgs(
   return blaze_exit_code::SUCCESS;
 }
 
-string StartupOptions::GetSystemJavabase() const {
-  return blaze::GetSystemJavabase();
+blaze_util::Path StartupOptions::GetSystemJavabase() const {
+  return blaze_util::Path(blaze::GetSystemJavabase());
 }
 
-string StartupOptions::GetEmbeddedJavabase() const {
-  string bundled_jre_path = blaze_util::JoinPath(
-      install_base, "_embedded_binaries/embedded_tools/jdk");
-  if (blaze_util::CanExecuteFile(blaze_util::JoinPath(
-          bundled_jre_path, GetJavaBinaryUnderJavabase()))) {
+blaze_util::Path StartupOptions::GetEmbeddedJavabase() const {
+  blaze_util::Path bundled_jre_path = blaze_util::Path(blaze_util::JoinPath(
+      install_base, "_embedded_binaries/embedded_tools/jdk"));
+  if (blaze_util::CanExecuteFile(
+        bundled_jre_path.GetRelative(GetJavaBinaryUnderJavabase()))) {
     return bundled_jre_path;
   }
-  return "";
+  return blaze_util::Path();
 }
 
-std::pair<string, StartupOptions::JavabaseType>
+std::pair<blaze_util::Path, StartupOptions::JavabaseType>
 StartupOptions::GetServerJavabaseAndType() const {
   // 1) Allow overriding the server_javabase via --server_javabase.
-  if (!explicit_server_javabase_.empty()) {
-    return std::pair<string, JavabaseType>(explicit_server_javabase_,
+  if (!explicit_server_javabase_.IsEmpty()) {
+    return std::pair<blaze_util::Path, JavabaseType>(explicit_server_javabase_,
                                            JavabaseType::EXPLICIT);
   }
-  if (default_server_javabase_.first.empty()) {
-    string bundled_jre_path = GetEmbeddedJavabase();
-    if (!bundled_jre_path.empty()) {
+  if (default_server_javabase_.first.IsEmpty()) {
+    blaze_util::Path bundled_jre_path = GetEmbeddedJavabase();
+    if (!bundled_jre_path.IsEmpty()) {
       // 2) Use a bundled JVM if we have one.
-      default_server_javabase_ = std::pair<string, JavabaseType>(
+      default_server_javabase_ = std::pair<blaze_util::Path, JavabaseType>(
           bundled_jre_path, JavabaseType::EMBEDDED);
     } else {
       // 3) Otherwise fall back to using the default system JVM.
-      string system_javabase = GetSystemJavabase();
-      if (system_javabase.empty()) {
+      blaze_util::Path system_javabase = GetSystemJavabase();
+      if (system_javabase.IsEmpty()) {
         BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
             << "Could not find system javabase. Ensure JAVA_HOME is set, or "
                "javac is on your PATH.";
       }
-      default_server_javabase_ = std::pair<string, JavabaseType>(
+      default_server_javabase_ = std::pair<blaze_util::Path, JavabaseType>(
           system_javabase, JavabaseType::SYSTEM);
     }
   }
   return default_server_javabase_;
 }
 
-string StartupOptions::GetServerJavabase() const {
+blaze_util::Path StartupOptions::GetServerJavabase() const {
   return GetServerJavabaseAndType().first;
 }
 
-string StartupOptions::GetExplicitServerJavabase() const {
+blaze_util::Path StartupOptions::GetExplicitServerJavabase() const {
   return explicit_server_javabase_;
 }
 
-string StartupOptions::GetJvm() const {
+blaze_util::Path StartupOptions::GetJvm() const {
   auto javabase_and_type = GetServerJavabaseAndType();
   blaze_exit_code::ExitCode sanity_check_code =
       SanityCheckJavabase(javabase_and_type.first, javabase_and_type.second);
   if (sanity_check_code != blaze_exit_code::SUCCESS) {
     exit(sanity_check_code);
   }
-  return blaze_util::JoinPath(javabase_and_type.first,
-                              GetJavaBinaryUnderJavabase());
+  return javabase_and_type.first.GetRelative(GetJavaBinaryUnderJavabase());
 }
 
 // Prints an appropriate error message and returns an appropriate error exit
@@ -526,58 +526,54 @@ static blaze_exit_code::ExitCode BadServerJavabaseError(
 }
 
 blaze_exit_code::ExitCode StartupOptions::SanityCheckJavabase(
-    const std::string &javabase,
+    const blaze_util::Path &javabase,
     StartupOptions::JavabaseType javabase_type) const {
-  std::string java_program =
-      blaze_util::JoinPath(javabase, GetJavaBinaryUnderJavabase());
+  blaze_util::Path java_program =
+      javabase.GetRelative(GetJavaBinaryUnderJavabase());
   if (!blaze_util::CanExecuteFile(java_program)) {
     if (!blaze_util::PathExists(java_program)) {
-      BAZEL_LOG(ERROR) << "Couldn't find java at '" << java_program << "'.";
+      BAZEL_LOG(ERROR) << "Couldn't find java at '"
+                       << java_program.AsPrintablePath() << "'.";
     } else {
-      BAZEL_LOG(ERROR) << "Java at '" << java_program
-                       << "' exists but is not executable: "
-                       << blaze_util::GetLastErrorString();
+      string err = blaze_util::GetLastErrorString();
+      BAZEL_LOG(ERROR) << "Java at '" << java_program.AsPrintablePath()
+                       << "' exists but is not executable: " << err;
     }
     return BadServerJavabaseError(javabase_type, option_sources);
   }
-  // If the full JDK is installed
-  string jdk_rt_jar = blaze_util::JoinPath(javabase, "jre/lib/rt.jar");
-  // If just the JRE is installed
-  string jre_rt_jar = blaze_util::JoinPath(javabase, "lib/rt.jar");
-  // rt.jar does not exist in java 9+ so check for java instead
-  string jre_java = blaze_util::JoinPath(javabase, "bin/java");
-  string jre_java_exe = blaze_util::JoinPath(javabase, "bin/java.exe");
-  if (blaze_util::CanReadFile(jdk_rt_jar) ||
-      blaze_util::CanReadFile(jre_rt_jar) ||
-      blaze_util::CanReadFile(jre_java) ||
-      blaze_util::CanReadFile(jre_java_exe)) {
+  if (// If the full JDK is installed
+      blaze_util::CanReadFile(javabase.GetRelative("jre/lib/rt.jar")) ||
+      // If just the JRE is installed
+      blaze_util::CanReadFile(javabase.GetRelative("lib/rt.jar")) ||
+      // rt.jar does not exist in java 9+ so check for java instead
+      blaze_util::CanReadFile(javabase.GetRelative("bin/java")) ||
+      blaze_util::CanReadFile(javabase.GetRelative("bin/java.exe"))) {
     return blaze_exit_code::SUCCESS;
   }
   BAZEL_LOG(ERROR) << "Problem with java installation: couldn't find/access "
                       "rt.jar or java in "
-                   << javabase;
+                   << javabase.AsPrintablePath();
   return BadServerJavabaseError(javabase_type, option_sources);
 }
 
-blaze_util::Path StartupOptions::GetExe(const string &jvm,
+blaze_util::Path StartupOptions::GetExe(const blaze_util::Path &jvm,
                                         const string &jar_path) const {
-  return blaze_util::Path(jvm);
+  return jvm;
 }
 
-void StartupOptions::AddJVMArgumentPrefix(const string &javabase,
+void StartupOptions::AddJVMArgumentPrefix(const blaze_util::Path &javabase,
     std::vector<string> *result) const {
 }
 
-void StartupOptions::AddJVMArgumentSuffix(const string &real_install_dir,
-                                          const string &jar_path,
+void StartupOptions::AddJVMArgumentSuffix(
+    const blaze_util::Path &real_install_dir, const string &jar_path,
     std::vector<string> *result) const {
   result->push_back("-jar");
-  result->push_back(blaze_util::PathAsJvmFlag(
-      blaze_util::JoinPath(real_install_dir, jar_path)));
+  result->push_back(real_install_dir.GetRelative(jar_path).AsJvmArgument());
 }
 
 blaze_exit_code::ExitCode StartupOptions::AddJVMArguments(
-    const string &server_javabase, std::vector<string> *result,
+    const blaze_util::Path &server_javabase, std::vector<string> *result,
     const vector<string> &user_options, string *error) const {
   AddJVMLoggingArguments(result);
 
@@ -631,7 +627,7 @@ void StartupOptions::AddJVMLoggingArguments(std::vector<string> *result) const {
 }
 
 blaze_exit_code::ExitCode StartupOptions::AddJVMMemoryArguments(
-    const string &, std::vector<string> *, const vector<string> &,
+    const blaze_util::Path &, std::vector<string> *, const vector<string> &,
     string *) const {
   return blaze_exit_code::SUCCESS;
 }

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -80,21 +80,21 @@ class StartupOptions {
 
   // Returns the path to the JVM. This should be called after parsing
   // the startup options.
-  virtual std::string GetJvm() const;
+  virtual blaze_util::Path GetJvm() const;
 
   // Returns the executable used to start the Blaze server, typically the given
   // JVM.
-  virtual blaze_util::Path GetExe(const std::string &jvm,
+  virtual blaze_util::Path GetExe(const blaze_util::Path &jvm,
                                   const std::string &jar_path) const;
 
   // Adds JVM prefix flags to be set. These will be added before all other
   // JVM flags.
-  virtual void AddJVMArgumentPrefix(const std::string &javabase,
+  virtual void AddJVMArgumentPrefix(const blaze_util::Path &javabase,
                                     std::vector<std::string> *result) const;
 
   // Adds JVM suffix flags. These will be added after all other JVM flags, and
   // just before the Blaze server startup flags.
-  virtual void AddJVMArgumentSuffix(const std::string &real_install_dir,
+  virtual void AddJVMArgumentSuffix(const blaze_util::Path &real_install_dir,
                                     const std::string &jar_path,
                                     std::vector<std::string> *result) const;
 
@@ -103,7 +103,7 @@ class StartupOptions {
   // Returns the exit code after this operation. "error" will be set to a
   // descriptive string for any value other than blaze_exit_code::SUCCESS.
   blaze_exit_code::ExitCode AddJVMArguments(
-      const std::string &server_javabase, std::vector<std::string> *result,
+      const blaze_util::Path &server_javabase, std::vector<std::string> *result,
       const std::vector<std::string> &user_options, std::string *error) const;
 
   // Checks whether the argument is a valid nullary option.
@@ -191,7 +191,7 @@ class StartupOptions {
   std::map<std::string, std::string> option_sources;
 
   // Returns the embedded JDK, or an empty string.
-  std::string GetEmbeddedJavabase() const;
+  blaze_util::Path GetEmbeddedJavabase() const;
 
   // The source of truth for the server javabase.
   enum class JavabaseType {
@@ -206,15 +206,15 @@ class StartupOptions {
 
   // Returns the server javabase and its source of truth. This should be called
   // after parsing the --server_javabase option.
-  std::pair<std::string, JavabaseType> GetServerJavabaseAndType() const;
+  std::pair<blaze_util::Path, JavabaseType> GetServerJavabaseAndType() const;
 
   // Returns the server javabase. This should be called after parsing the
   // --server_javabase option.
-  std::string GetServerJavabase() const;
+  blaze_util::Path GetServerJavabase() const;
 
   // Returns the explicit value of the --server_javabase startup option or the
   // empty string if it was not specified on the command line.
-  std::string GetExplicitServerJavabase() const;
+  blaze_util::Path GetExplicitServerJavabase() const;
 
   // Port to start up the gRPC command server on. If 0, let the kernel choose.
   int command_port;
@@ -281,13 +281,13 @@ class StartupOptions {
   // message and returns an appropriate exit code with which the client should
   // terminate.
   blaze_exit_code::ExitCode SanityCheckJavabase(
-      const std::string &javabase,
+      const blaze_util::Path &javabase,
       StartupOptions::JavabaseType javabase_type) const;
 
   // Returns the absolute path to the user's local JDK install, to be used as
   // the default target javabase and as a fall-back host_javabase. This is not
   // the embedded JDK.
-  virtual std::string GetSystemJavabase() const;
+  virtual blaze_util::Path GetSystemJavabase() const;
 
   // Adds JVM logging-related flags for Bazel.
   //
@@ -300,7 +300,7 @@ class StartupOptions {
   // This is called by StartupOptions::AddJVMArguments and is a separate method
   // so that subclasses of StartupOptions can override it.
   virtual blaze_exit_code::ExitCode AddJVMMemoryArguments(
-      const std::string &server_javabase, std::vector<std::string> *result,
+      const blaze_util::Path &server_javabase, std::vector<std::string> *result,
       const std::vector<std::string> &user_options, std::string *error) const;
 
   virtual std::string GetRcFileBaseName() const = 0;
@@ -358,11 +358,11 @@ class StartupOptions {
                                        std::string *error);
 
   // The server javabase as provided on the commandline.
-  std::string explicit_server_javabase_;
+  blaze_util::Path explicit_server_javabase_;
 
   // The default server javabase to be used and its source of truth (computed
   // lazily). Not guarded by a mutex - StartupOptions is not thread-safe.
-  mutable std::pair<std::string, JavabaseType> default_server_javabase_;
+  mutable std::pair<blaze_util::Path, JavabaseType> default_server_javabase_;
 
   // Startup flags that don't expect a value, e.g. "master_bazelrc".
   // Valid uses are "--master_bazelrc" are "--nomaster_bazelrc".

--- a/src/main/cpp/util/file_platform.h
+++ b/src/main/cpp/util/file_platform.h
@@ -164,10 +164,12 @@ std::string MakeCanonical(const char *path);
 // Returns true if `path` exists, is a file or symlink to one, and is readable.
 // Follows symlinks.
 bool CanReadFile(const std::string &path);
+bool CanReadFile(const Path &path);
 
 // Returns true if `path` exists, is a file or symlink to one, and is writable.
 // Follows symlinks.
 bool CanExecuteFile(const std::string &path);
+bool CanExecuteFile(const Path &path);
 
 // Returns true if `path` exists, is a directory or symlink/junction to one, and
 // is both readable and writable.

--- a/src/main/cpp/util/file_posix.cc
+++ b/src/main/cpp/util/file_posix.cc
@@ -316,8 +316,16 @@ bool CanReadFile(const std::string &path) {
   return !IsDirectory(path) && CanAccess(path, true, false, false);
 }
 
+bool CanReadFile(const Path &path) {
+  return CanReadFile(path.AsNativePath());
+}
+
 bool CanExecuteFile(const std::string &path) {
   return !IsDirectory(path) && CanAccess(path, false, false, true);
+}
+
+bool CanExecuteFile(const Path &path) {
+  return CanExecuteFile(path.AsNativePath());
 }
 
 bool CanAccessDirectory(const std::string &path) {

--- a/src/main/cpp/util/file_windows.cc
+++ b/src/main/cpp/util/file_windows.cc
@@ -520,30 +520,25 @@ static bool CanReadFileW(const wstring& path) {
 }
 
 bool CanReadFile(const std::string& path) {
-  wstring wpath;
-  string error;
-  if (!AsAbsoluteWindowsPath(path, &wpath, &error)) {
-    BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "CanReadFile(" << path
-        << "): AsAbsoluteWindowsPath failed: " << error;
-    return false;
-  }
-  return CanReadFileW(wpath);
+  return CanReadFile(Path(path));
+}
+
+bool CanReadFile(const Path& path) {
+  return CanReadFileW(path.AsNativePath());
 }
 
 bool CanExecuteFile(const std::string& path) {
-  wstring wpath;
-  string error;
-  if (!AsAbsoluteWindowsPath(path, &wpath, &error)) {
-    BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "CanExecuteFile(" << path
-        << "): AsAbsoluteWindowsPath failed: " << error;
+  return CanExecuteFile(Path(path));
+}
+
+bool CanExecuteFile(const Path &path) {
+  std::wstring p = path.AsNativePath();
+  if (p.size() < 4) {
     return false;
   }
-  return CanReadFileW(wpath) && (ends_with(wpath, wstring(L".exe")) ||
-                                 ends_with(wpath, wstring(L".com")) ||
-                                 ends_with(wpath, wstring(L".cmd")) ||
-                                 ends_with(wpath, wstring(L".bat")));
+  std::wstring ext = p.substr(p.size() - 4);
+  return CanReadFileW(p) &&
+         (ext == L".exe" || ext == L".com" || ext == L".cmd" || ext == L".bat");
 }
 
 bool CanAccessDirectory(const std::string& path) {

--- a/src/main/cpp/util/path_platform.h
+++ b/src/main/cpp/util/path_platform.h
@@ -25,18 +25,41 @@ class Path {
  public:
   Path() {}
   explicit Path(const std::string &path);
+  bool operator==(const Path& o) const { return path_ == o.path_; }
+  bool operator!=(const Path& o) const { return path_ != o.path_; }
   bool IsEmpty() const { return path_.empty(); }
   bool IsNull() const;
   bool Contains(const char c) const;
+  bool Contains(const std::string &s) const;
   Path GetRelative(const std::string &r) const;
+
+  // Returns the canonical form (like realpath(2)) of this path.
+  // All symlinks in the path are resolved.
+  // If canonicalization fails, returns an empty Path.
   Path Canonicalize() const;
+
+  Path GetParent() const;
+
+  // Returns a printable string representing this path.
+  // Only use when printing user messages, do not pass to filesystem API
+  // functions.
   std::string AsPrintablePath() const;
+
+  // Returns a string representation of this path that's safe to pass on the
+  // command line as a JVM argument.
   std::string AsJvmArgument() const;
+
+  // Returns a string representation of this path, safe to pass to the Bazel
+  // server.
   std::string AsCommandLineArgument() const;
 
 #if defined(_WIN32) || defined(__CYGWIN__)
+  // Returns a platform-native, absolute, normalized path.
+  // Use this to pass paths to filesystem API functions.
   const std::wstring AsNativePath() const { return path_; }
 #else
+  // Returns a platform-native, absolute, normalized path.
+  // Use this to pass paths to filesystem API functions.
   const std::string AsNativePath() const { return path_; }
 #endif
 

--- a/src/main/cpp/util/path_posix.cc
+++ b/src/main/cpp/util/path_posix.cc
@@ -143,11 +143,17 @@ bool Path::Contains(const char c) const {
   return path_.find_first_of(c) != std::string::npos;
 }
 
+bool Path::Contains(const std::string &s) const {
+  return path_.find(s) != std::string::npos;
+}
+
 Path Path::GetRelative(const std::string &r) const {
   return Path(JoinPath(path_, r));
 }
 
 Path Path::Canonicalize() const { return Path(MakeCanonical(path_.c_str())); }
+
+Path Path::GetParent() const { return Path(SplitPath(path_).first); }
 
 std::string Path::AsPrintablePath() const { return path_; }
 

--- a/src/main/cpp/util/path_windows.cc
+++ b/src/main/cpp/util/path_windows.cc
@@ -507,10 +507,18 @@ Path Path::Canonicalize() const {
   return Path(MakeCanonical(WstringToString(path_).c_str()));
 }
 
+Path Path::GetParent() const {
+  return Path(SplitPathW(path_).first);
+}
+
 bool Path::IsNull() const { return path_ == L"NUL"; }
 
 bool Path::Contains(const char c) const {
   return path_.find_first_of(c) != std::wstring::npos;
+}
+
+bool Path::Contains(const std::string& s) const {
+  return path_.find(CstringToWstring(s.c_str()).get()) != std::wstring::npos;
 }
 
 std::string Path::AsPrintablePath() const {


### PR DESCRIPTION
Convert server_exe and server_cwd from raw strings
to Path.

Converts jvm-related functions to accept / return
Path.

Benefits of a Path abstraction instead of raw
strings:
- type safety
- no need to convert paths on Windows all the time
- no need to check if paths are absolute