### PR TITLE
Tags propagation for java rules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileActionBuilder.java
@@ -372,7 +372,9 @@ public class JavaHeaderCompileActionBuilder {
               /* commandLineLimits= */ ruleContext.getConfiguration().getCommandLineLimits(),
               /* isShellCommand= */ false,
               /* env= */ actionEnvironment,
-              /* executionInfo= */ getExecutionInfo(executionInfo),
+              /* executionInfo= */ addTags(ruleContext
+                  .getConfiguration()
+                  .modifiedExecutionInfo(executionInfo, "Turbine")),
               /* progressMessage= */ progressMessage,
               /* runfilesSupplier= */ CompositeRunfilesSupplier.fromSuppliers(runfilesSuppliers),
               /* mnemonic= */ "Turbine",
@@ -455,7 +457,9 @@ public class JavaHeaderCompileActionBuilder {
             /* commandLineLimits= */ ruleContext.getConfiguration().getCommandLineLimits(),
             /* isShellCommand= */ false,
             /* env= */ actionEnvironment,
-            /* executionInfo= */ getExecutionInfo(executionInfo),
+            /* executionInfo= */ addTags(ruleContext
+                .getConfiguration()
+                .modifiedExecutionInfo(executionInfo, "JavacTurbine")),
             /* progressMessage= */ progressMessage,
             /* runfilesSupplier= */ CompositeRunfilesSupplier.fromSuppliers(runfilesSuppliers),
             /* mnemonic= */ "JavacTurbine",
@@ -471,12 +475,6 @@ public class JavaHeaderCompileActionBuilder {
     executionInfoBuilder.putAll(TargetUtils.getExecutionInfo(ruleContext.getRule(), ruleContext.isAllowTagsPropagation()));
 
     return ImmutableMap.copyOf(executionInfoBuilder);
-  }
-
-  private ImmutableMap<String, String> getExecutionInfo(ImmutableMap<String, String> execInfo) throws InterruptedException {
-    return addTags(ruleContext.getConfiguration()
-            .modifiedExecutionInfo(execInfo, "JavacTurbine"));
-
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfoBuildHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfoBuildHelper.java
@@ -292,7 +292,7 @@ final class JavaInfoBuildHelper {
       JavaSemantics javaSemantics,
       Location location,
       Environment environment)
-      throws EvalException {
+          throws EvalException, InterruptedException {
 
     if (sourceJars.isEmpty()
         && sourceFiles.isEmpty()

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaLibraryHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaLibraryHelper.java
@@ -182,7 +182,7 @@ public final class JavaLibraryHelper {
       JavaRuntimeInfo hostJavabase,
       JavaRuleOutputJarsProvider.Builder outputJarsBuilder,
       boolean createOutputSourceJar,
-      @Nullable Artifact outputSourceJar) {
+      @Nullable Artifact outputSourceJar) throws InterruptedException {
     return build(
         semantics,
         javaToolchainProvider,
@@ -204,7 +204,7 @@ public final class JavaLibraryHelper {
       @Nullable Artifact outputSourceJar,
       @Nullable JavaInfo.Builder javaInfoBuilder,
       Iterable<JavaGenJarsProvider> transitiveJavaGenJars,
-      ImmutableList<Artifact> additionalJavaBaseInputs) {
+      ImmutableList<Artifact> additionalJavaBaseInputs) throws InterruptedException {
 
     Preconditions.checkState(output != null, "must have an output file; use setOutput()");
     Preconditions.checkState(

--- a/src/main/java/com/google/devtools/build/lib/rules/java/proto/JavaLiteProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/proto/JavaLiteProtoAspect.java
@@ -172,7 +172,7 @@ public class JavaLiteProtoAspect extends NativeAspectClass implements Configured
                   "exports", RuleConfiguredTarget.Mode.TARGET, JavaCompilationArgsProvider.class));
     }
 
-    void addProviders(ConfiguredAspect.Builder aspect) {
+    void addProviders(ConfiguredAspect.Builder aspect) throws InterruptedException {
       JavaInfo.Builder javaInfo = JavaInfo.Builder.create();
       // Represents the result of compiling the code generated for this proto, including all of its
       // dependencies.

--- a/src/main/java/com/google/devtools/build/lib/rules/java/proto/JavaProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/proto/JavaProtoAspect.java
@@ -192,7 +192,7 @@ public class JavaProtoAspect extends NativeAspectClass implements ConfiguredAspe
                     JavaCompilationArgsProvider.class));
     }
 
-    void addProviders(ConfiguredAspect.Builder aspect) {
+    void addProviders(ConfiguredAspect.Builder aspect) throws InterruptedException {
       // Represents the result of compiling the code generated for this proto, including all of its
       // dependencies.
       JavaInfo.Builder javaInfo = JavaInfo.Builder.create();

--- a/src/main/java/com/google/devtools/build/lib/rules/java/proto/JavaProtoAspectCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/proto/JavaProtoAspectCommon.java
@@ -108,7 +108,7 @@ public class JavaProtoAspectCommon {
       String injectingRuleKind,
       Artifact sourceJar,
       Artifact outputJar,
-      JavaCompilationArgsProvider dep) {
+      JavaCompilationArgsProvider dep) throws InterruptedException {
     JavaLibraryHelper helper =
         new JavaLibraryHelper(ruleContext)
             .setInjectingRuleKind(injectingRuleKind)


### PR DESCRIPTION
Part of #8830

RELNOTES[NEW]: tags: use --experimental_allow_tags_propagation flag to propagate tags to the action's execution requirements from java targets. Such tags should start with: no-, requires-, supports-, block-, disable-, cpu:. See #8830 for details.