### PR TITLE
Make --workspace_status_command work with "Builds without the Bytes".

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -74,7 +74,7 @@ class RemoteActionFileSystem extends DelegateFileSystem {
   @Override
   public boolean delete(Path path) throws IOException {
     RemoteFileArtifactValue m = getRemoteInputMetadata(path);
-    if (m != null) {
+    if (m == null) {
       return super.delete(path);
     }
     return true;

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionFileSystemTest.java
@@ -126,6 +126,35 @@ public class RemoteActionFileSystemTest {
     verifyNoMoreInteractions(inputFetcher);
   }
 
+  @Test
+  public void testDeleteRemoteFile() throws Exception {
+    // arrange
+    ActionInputMap inputs = new ActionInputMap(1);
+    Artifact remoteArtifact = createRemoteArtifact("remote-file", "remote contents", inputs);
+    FileSystem actionFs = newRemoteActionFileSystem(inputs);
+
+    // act
+    boolean success = actionFs.delete(actionFs.getPath(remoteArtifact.getPath().getPathString()));
+
+    // assert
+    assertThat(success).isTrue();
+  }
+
+  @Test
+  public void testDeleteLocalFile() throws Exception {
+    // arrange
+    ActionInputMap inputs = new ActionInputMap(0);
+    FileSystem actionFs = newRemoteActionFileSystem(inputs);
+    Path filePath = actionFs.getPath(execRoot.getPathString()).getChild("local-file");
+    FileSystemUtils.writeContent(filePath, StandardCharsets.UTF_8, "local contents");
+
+    // act
+    boolean success = actionFs.delete(actionFs.getPath(filePath.getPathString()));
+
+    // assert
+    assertThat(success).isTrue();
+  }
+
   private FileSystem newRemoteActionFileSystem(ActionInputMap inputs) {
     return new RemoteActionFileSystem(
         fs,

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1158,6 +1158,43 @@ EOF
   expect_not_log "remote cache hit"
 }
 
+function test_downloads_minimal_stable_status() {
+  # Regression test for #8385
+
+  mkdir -p a
+  cat > a/BUILD <<'EOF'
+genrule(
+  name = "foo",
+  srcs = [],
+  outs = ["foo.txt"],
+  cmd = "echo \"foo\" > \"$@\"",
+)
+EOF
+
+cat > status.sh << 'EOF'
+#!/bin/sh
+echo "STABLE_FOO 1"
+EOF
+chmod +x status.sh
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --experimental_remote_download_minimal \
+    --workspace_status_command=status.sh \
+    //a:foo || "Failed to build //a:foo"
+
+cat > status.sh << 'EOF'
+#!/bin/sh
+echo "STABLE_FOO 2"
+EOF
+
+  bazel build \
+    --remote_executor=grpc://localhost:${worker_port} \
+    --experimental_remote_download_minimal \
+    --workspace_status_command=status.sh \
+    //a:foo || "Failed to build //a:foo"
+}
+
 # TODO(alpha): Add a test that fails remote execution when remote worker
 # supports sandbox.
 


### PR DESCRIPTION
Fixes #8385

Due to a typo in delete() stable-status.txt would not get deleted
between builds. More details in #8385.

Thanks @emfree for the debugging work and pointing out the root cause!