### PR TITLE
Remove flogger dependency from Starlark

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/collect/nestedset/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/collect/nestedset/BUILD
@@ -29,7 +29,6 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization:constants",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//third_party:auto_value",
-        "//third_party:flogger",
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party/protobuf:protobuf_java",

--- a/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSet.java
+++ b/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSet.java
@@ -18,7 +18,6 @@ import static java.util.stream.Collectors.joining;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.build.lib.bugreport.BugReport;
@@ -36,6 +35,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
@@ -46,7 +47,7 @@ import javax.annotation.Nullable;
 @SuppressWarnings("unchecked")
 @AutoCodec
 public final class NestedSet<E> implements Iterable<E> {
-  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+  private static final Logger logger = Logger.getLogger(NestedSet.class.getName());
 
   /**
    * Order and size of set packed into one int.
@@ -377,7 +378,7 @@ public final class NestedSet<E> implements Iterable<E> {
         try {
           return Arrays.toString(Futures.getDone(future));
         } catch (ExecutionException e) {
-          logger.atSevere().withCause(e).log("Error getting %s", future);
+          logger.log(Level.SEVERE, "Error getting " + future, e);
           // Don't rethrow, since we may be in the process of trying to construct an error message.
           return "Future " + future + " with error: " + e.getCause().getMessage();
         }

--- a/src/main/java/com/google/devtools/build/lib/profiler/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/profiler/BUILD
@@ -12,6 +12,9 @@ java_library(
     name = "profiler",
     srcs = glob([
         "*.java",
+    ], exclude = [
+        # Not used anywhere, but adds dependency to flogger
+        "GoogleAutoProfilerUtils.java",
     ]),
     visibility = ["//visibility:public"],
     deps = [
@@ -20,7 +23,6 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/collect",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/common/options",
-        "//third_party:flogger",
         "//third_party:gson",
         "//third_party:guava",
         "//third_party:jsr305",


### PR DESCRIPTION
The only place where Starlark dependency uses flogger is `NestedSet`
handling of futures.

Removing flogger removes 140K dependencies (size of three flogger
jars) from Starlark.

```
% bazel run //src/main/java/com/google/devtools/starlark:Starlark -- -c 'print("1")'
...
1
```

```
% bazel query 'deps(//src/main/java/com/google/devtools/starlark:Starlark)' | grep flogger | wc -l
...
0
```

This diff also removes `GoogleAutoProfilerUtils.java` from `profiler`
library, because this file is not used anywhere, but depends on
`flogger`.