### PR TITLE
WIP: Client: GetAllFilesUnder and Dumper now use Path

### DIFF
--- a/src/main/cpp/archive_utils.cc
+++ b/src/main/cpp/archive_utils.cc
@@ -140,7 +140,7 @@ class NoteAllFilesZipProcessor : public PureZipExtractorProcessor {
 // A PureZipExtractorProcessor to extract the files from the blaze zip.
 class ExtractBlazeZipProcessor : public PureZipExtractorProcessor {
  public:
-  explicit ExtractBlazeZipProcessor(const string &output_dir,
+  explicit ExtractBlazeZipProcessor(const blaze_util::Path &output_dir,
                                     blaze::embedded_binaries::Dumper *dumper)
       : output_dir_(output_dir), dumper_(dumper) {}
 
@@ -157,11 +157,11 @@ class ExtractBlazeZipProcessor : public PureZipExtractorProcessor {
                const devtools_ijar::u4 attr,
                const devtools_ijar::u1 *data,
                const size_t size) override {
-    dumper_->Dump(data, size, blaze_util::JoinPath(output_dir_, filename));
+    dumper_->Dump(data, size, output_dir_.GetRelative(filename));
   }
 
  private:
-  const string output_dir_;
+  const blaze_util::Path output_dir_;
   blaze::embedded_binaries::Dumper *dumper_;
 };
 
@@ -230,7 +230,7 @@ void DetermineArchiveContents(
 void ExtractArchiveOrDie(const string &archive_path,
                          const string &product_name,
                          const string &expected_install_md5,
-                         const string &output_dir) {
+                         const blaze_util::Path &output_dir) {
   std::string install_md5;
   GetInstallKeyFileProcessor install_key_processor(&install_md5);
 
@@ -247,7 +247,7 @@ void ExtractArchiveOrDie(const string &archive_path,
                                   &install_key_processor});
   if (!blaze_util::MakeDirectories(output_dir, 0777)) {
     BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
-        << "couldn't create '" << output_dir
+        << "couldn't create '" << output_dir.AsPrintablePath()
         << "': " << blaze_util::GetLastErrorString();
   }
 

--- a/src/main/cpp/archive_utils.h
+++ b/src/main/cpp/archive_utils.h
@@ -33,7 +33,7 @@ void DetermineArchiveContents(const std::string &archive_path,
 void ExtractArchiveOrDie(const std::string &archive_path,
                          const std::string &product_name,
                          const std::string &expected_install_md5,
-                         const std::string &output_dir);
+                         const blaze_util::Path &output_dir);
 
 // Retrieves the build label (version string) from `archive_path` into
 // `build_label`.

--- a/src/main/cpp/archive_utils.h
+++ b/src/main/cpp/archive_utils.h
@@ -18,6 +18,11 @@
 #include <string>
 #include <vector>
 
+namespace blaze_util {
+// Forward-declare Path without including the full header file.
+class Path;
+}
+
 namespace blaze {
 
 // Determines the contents of the archive, storing the names of the contained

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -44,7 +44,7 @@ class Dumper {
   // If writing fails, this method sets a flag in the `Dumper`, and `Finish`
   // will return false. Subsequent `Dump` calls will have no effect.
   virtual void Dump(const void* data, const size_t size,
-                    const std::string& path) = 0;
+                    const blaze_util::Path& path) = 0;
 
   // Finishes dumping data.
   //

--- a/src/main/cpp/util/file.cc
+++ b/src/main/cpp/util/file.cc
@@ -95,11 +95,11 @@ bool WriteFile(const std::string &content, const Path &path,
 
 class DirectoryTreeWalker : public DirectoryEntryConsumer {
  public:
-  DirectoryTreeWalker(vector<string> *files,
+  DirectoryTreeWalker(vector<Path> *files,
                       _ForEachDirectoryEntry walk_entries)
       : _files(files), _walk_entries(walk_entries) {}
 
-  void Consume(const string &path, bool follow_directory) override {
+  void Consume(const Path &path, bool follow_directory) override {
     if (follow_directory) {
       Walk(path);
     } else {
@@ -107,19 +107,19 @@ class DirectoryTreeWalker : public DirectoryEntryConsumer {
     }
   }
 
-  void Walk(const string &path) { _walk_entries(path, this); }
+  void Walk(const Path &path) { _walk_entries(path, this); }
 
  private:
-  vector<string> *_files;
+  vector<Path> *_files;
   _ForEachDirectoryEntry _walk_entries;
 };
 
-void GetAllFilesUnder(const string &path, vector<string> *result) {
+void GetAllFilesUnder(const Path &path, vector<Path> *result) {
   _GetAllFilesUnder(path, result, &ForEachDirectoryEntry);
 }
 
-void _GetAllFilesUnder(const string &path,
-                       vector<string> *result,
+void _GetAllFilesUnder(const Path &path,
+                       vector<Path> *result,
                        _ForEachDirectoryEntry walk_entries) {
   DirectoryTreeWalker(result, walk_entries).Walk(path);
 }

--- a/src/main/cpp/util/file.h
+++ b/src/main/cpp/util/file.h
@@ -73,18 +73,16 @@ bool WriteFile(const std::string &content, const Path &path,
 // Populates `result` with the full paths of the files. Every entry will have
 // `path` as its prefix. If `path` is a file, `result` contains just this
 // file.
-void GetAllFilesUnder(const std::string &path,
-                      std::vector<std::string> *result);
+void GetAllFilesUnder(const Path &path, std::vector<Path> *result);
 
 class DirectoryEntryConsumer;
 
 // Visible for testing only.
-typedef void (*_ForEachDirectoryEntry)(const std::string &path,
+typedef void (*_ForEachDirectoryEntry)(const Path &path,
                                        DirectoryEntryConsumer *consume);
 
 // Visible for testing only.
-void _GetAllFilesUnder(const std::string &path,
-                       std::vector<std::string> *result,
+void _GetAllFilesUnder(const Path &path, std::vector<Path> *result,
                        _ForEachDirectoryEntry walk_entries);
 
 }  // namespace blaze_util

--- a/src/main/cpp/util/file_platform.h
+++ b/src/main/cpp/util/file_platform.h
@@ -143,7 +143,7 @@ int RenameDirectory(const std::string &old_name, const std::string &new_name);
 // Reads which directory a symlink points to. Puts the target of the symlink
 // in ``result`` and returns if the operation was successful. Will not work on
 // symlinks that don't point to directories on Windows.
-bool ReadDirectorySymlink(const blaze_util::Path &symlink, std::string *result);
+bool ReadDirectorySymlink(const Path &symlink, std::string *result);
 
 // Unlinks the file given by 'file_path'.
 // Returns true on success. In case of failure sets errno.
@@ -208,7 +208,7 @@ class DirectoryEntryConsumer {
   // `name` is the full path of the entry.
   // `is_directory` is true if this entry is a directory (but false if this is a
   // symlink pointing to a directory).
-  virtual void Consume(const std::string &name, bool is_directory) = 0;
+  virtual void Consume(const Path &name, bool is_directory) = 0;
 };
 
 // Executes a function for each entry in a directory (except "." and "..").
@@ -217,8 +217,7 @@ class DirectoryEntryConsumer {
 // false otherwise.
 //
 // See DirectoryEntryConsumer for more details.
-void ForEachDirectoryEntry(const std::string &path,
-                           DirectoryEntryConsumer *consume);
+void ForEachDirectoryEntry(const Path &path, DirectoryEntryConsumer *consume);
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 std::wstring GetCwdW();

--- a/src/main/cpp/util/file_posix.cc
+++ b/src/main/cpp/util/file_posix.cc
@@ -451,12 +451,12 @@ bool ChangeDirectory(const string& path) {
   return chdir(path.c_str()) == 0;
 }
 
-void ForEachDirectoryEntry(const string &path,
+void ForEachDirectoryEntry(const blaze_util::Path &path,
                            DirectoryEntryConsumer *consume) {
   DIR *dir;
   struct dirent *ent;
 
-  if ((dir = opendir(path.c_str())) == NULL) {
+  if ((dir = opendir(path.AsNativePath().c_str())) == NULL) {
     // This is not a directory or it cannot be opened.
     return;
   }
@@ -466,7 +466,7 @@ void ForEachDirectoryEntry(const string &path,
       continue;
     }
 
-    string filename(blaze_util::JoinPath(path, ent->d_name));
+    blaze_util::Path filename = path.GetRelative(ent->d_name);
     bool is_directory;
 // 'd_type' field isn't part of the POSIX spec.
 #ifdef _DIRENT_HAVE_D_TYPE
@@ -476,9 +476,9 @@ void ForEachDirectoryEntry(const string &path,
 #endif
       {
         struct stat buf;
-        if (lstat(filename.c_str(), &buf) == -1) {
+        if (lstat(filename.AsNativePath().c_str(), &buf) == -1) {
           BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
-              << "stat failed for filename '" << filename
+              << "stat failed for filename '" << filename.AsPrintablePath()
               << "': " << GetLastErrorString();
         }
         is_directory = S_ISDIR(buf.st_mode);

--- a/src/main/cpp/util/path_platform.h
+++ b/src/main/cpp/util/path_platform.h
@@ -55,6 +55,9 @@ class Path {
   std::string AsCommandLineArgument() const;
 
 #if defined(_WIN32) || defined(__CYGWIN__)
+  static Path FromUnchecked(const std::wstring& p);
+  Path GetRelative(const std::wstring &r) const;
+
   // Returns a platform-native, absolute, normalized path.
   // Use this to pass paths to filesystem API functions.
   const std::wstring AsNativePath() const { return path_; }

--- a/src/main/cpp/util/path_windows.cc
+++ b/src/main/cpp/util/path_windows.cc
@@ -488,6 +488,10 @@ Path::Path(const std::string& path) {
 }
 
 Path Path::GetRelative(const std::string& r) const {
+  return GetRelative(CstringToWstring(r.c_str()).get());
+}
+
+Path Path::GetRelative(const std::wstring &r) const {
   if (r.empty()) {
     return *this;
   } else if (IsDevNull(r.c_str())) {
@@ -497,9 +501,7 @@ Path Path::GetRelative(const std::string& r) const {
   } else {
     std::string error;
     std::wstring new_path;
-    if (!AsAbsoluteWindowsPath(
-            path_ + L"\\" + CstringToWstring(r.c_str()).get(), &new_path,
-            &error)) {
+    if (!AsAbsoluteWindowsPath(path_ + L"\\" + r, &new_path, &error)) {
       BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
           << "Path::GetRelative failed: " << error;
     }

--- a/src/test/cpp/option_processor_test.cc
+++ b/src/test/cpp/option_processor_test.cc
@@ -51,9 +51,10 @@ class OptionProcessorTest : public ::testing::Test {
     // but it intentionally skips directories. As a consequence, there may be
     // empty directories from test to test. Remove this once
     // blaze_util::DeleteDirectories(path) exists.
-    std::vector<std::string> files_in_workspace;
-    blaze_util::GetAllFilesUnder(workspace_, &files_in_workspace);
-    for (const std::string& file : files_in_workspace) {
+    std::vector<blaze_util::Path> files_in_workspace;
+    blaze_util::GetAllFilesUnder(blaze_util::Path(workspace_),
+                                 &files_in_workspace);
+    for (const auto& file : files_in_workspace) {
       blaze_util::UnlinkPath(file);
     }
   }

--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -79,17 +79,17 @@ class RcFileTest : public ::testing::Test {
     // and other rc-related directories, but it intentionally skips directories.
     // As a consequence, there may be empty directories from test to test.
     // Remove this once blaze_util::DeleteDirectories(path) exists.
-    std::vector<std::string> files;
-    blaze_util::GetAllFilesUnder(workspace_, &files);
-    for (const std::string& file : files) {
+    std::vector<blaze_util::Path> files;
+    blaze_util::GetAllFilesUnder(blaze_util::Path(workspace_), &files);
+    for (const auto& file : files) {
       blaze_util::UnlinkPath(file);
     }
-    blaze_util::GetAllFilesUnder(cwd_, &files);
-    for (const std::string& file : files) {
+    blaze_util::GetAllFilesUnder(blaze_util::Path(cwd_), &files);
+    for (const auto& file : files) {
       blaze_util::UnlinkPath(file);
     }
-    blaze_util::GetAllFilesUnder(binary_dir_, &files);
-    for (const std::string& file : files) {
+    blaze_util::GetAllFilesUnder(blaze_util::Path(binary_dir_), &files);
+    for (const auto& file : files) {
       blaze_util::UnlinkPath(file);
     }
   }

--- a/src/test/cpp/workspace_layout_test.cc
+++ b/src/test/cpp/workspace_layout_test.cc
@@ -43,9 +43,10 @@ class WorkspaceLayoutTest : public ::testing::Test {
     // but it intentionally skips directories. As a consequence, there may be
     // empty directories from test to test. Remove this once
     // blaze_util::DeleteDirectories(path) exists.
-    std::vector<std::string> files_in_workspace;
-    blaze_util::GetAllFilesUnder(build_root_, &files_in_workspace);
-    for (const std::string& file : files_in_workspace) {
+    std::vector<blaze_util::Path> files_in_workspace;
+    blaze_util::GetAllFilesUnder(blaze_util::Path(build_root_),
+                                 &files_in_workspace);
+    for (const auto& file : files_in_workspace) {
       blaze_util::UnlinkPath(file);
     }
   }


### PR DESCRIPTION
Benefits of a Path abstraction instead of raw
strings:
- type safety
- no need to convert paths on Windows all the time
- no need to check if paths are absolute

Change-Id: Ic82d223e68952ee8d063e2722fa5d113c8759e8a