### PR TITLE
Migrate from .java provider to JavaInfo

### DIFF
--- a/src/java_tools/import_deps_checker/javatests/com/google/devtools/build/importdeps/tests.bzl
+++ b/src/java_tools/import_deps_checker/javatests/com/google/devtools/build/importdeps/tests.bzl
@@ -22,7 +22,7 @@ def _compile_time_jars(ctx):
 
 compile_time_jars = rule(
     attrs = {
-        "deps": attr.label_list(providers = ["java"]),
+        "deps": attr.label_list(providers = [JavaInfo]),
     },
     implementation = _compile_time_jars,
 )

--- a/tools/build_rules/utilities.bzl
+++ b/tools/build_rules/utilities.bzl
@@ -27,7 +27,7 @@ _java_library_srcs = rule(
         "deps": attr.label_list(
             mandatory = True,
             allow_empty = False,
-            providers = ["java"],
+            providers = [JavaInfo],
         ),
     },
 )


### PR DESCRIPTION
Old legacy java provider is deprecated.

Fixes #9288.