### PR TITLE
Fix loading of configuration conditions to correctly report errors for

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/analysis/ConfigurableAttributesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/ConfigurableAttributesTest.java
@@ -494,6 +494,22 @@ public class ConfigurableAttributesTest extends BuildViewTestCase {
     assertContainsEvent("//foo:fake is not a valid configuration key for //foo:g");
   }
 
+  @Test
+  public void configKeyNonexistentTarget_otherPackage() throws Exception {
+    reporter.removeHandler(failFastHandler); // Expect errors.
+    scratch.file("bar/BUILD");
+    scratch.file(
+        "foo/BUILD",
+        "genrule(",
+        "    name = 'g',",
+        "    outs = ['g.out'],",
+        "    cmd = select({'//bar:fake': ''})",
+        ")");
+    assertThat(getConfiguredTarget("//foo:g")).isNull();
+    assertContainsEvent(
+        "While resolving configuation keys for //foo:g: no such target '//bar:fake'");
+  }
+
   /**
    * Tests config keys with multiple requirements.
    */


### PR DESCRIPTION
config dependencies.

Example error message:
```
ERROR: While resolving configuation keys for //:alias: no such target '//configs:config_baaar': target 'config_baaar' not declared in package 'configs' (did you mean 'config_bar'?) defined by /usr/local/google/home/jcater/repos/demo/configs/BUILD.bazel
```

Fixes #9292.