### PR TITLE
WIP: Have remote_outputs=toplevel download runfiles. Fixes #8899

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -49,7 +49,7 @@ final class RemoteActionContextProvider extends ActionContextProvider {
   private final DigestUtil digestUtil;
   @Nullable private final Path logDir;
   private final AtomicReference<SpawnRunner> fallbackRunner = new AtomicReference<>();
-  private ImmutableSet<ActionInput> topLevelOutputs = ImmutableSet.of();
+  private ImmutableSet<ActionInput> filesToDownload = ImmutableSet.of();
 
   private RemoteActionContextProvider(
       CommandEnvironment env,
@@ -103,7 +103,7 @@ final class RemoteActionContextProvider extends ActionContextProvider {
               commandId,
               env.getReporter(),
               digestUtil,
-              topLevelOutputs);
+              filesToDownload);
       return ImmutableList.of(spawnCache);
     } else {
       RemoteSpawnRunner spawnRunner =
@@ -121,7 +121,7 @@ final class RemoteActionContextProvider extends ActionContextProvider {
               retrier,
               digestUtil,
               logDir,
-              topLevelOutputs);
+              filesToDownload);
       return ImmutableList.of(new RemoteSpawnStrategy(env.getExecRoot(), spawnRunner));
     }
   }
@@ -171,8 +171,8 @@ final class RemoteActionContextProvider extends ActionContextProvider {
     return cache;
   }
 
-  void setTopLevelOutputs(ImmutableSet<ActionInput> topLevelOutputs) {
-    this.topLevelOutputs = Preconditions.checkNotNull(topLevelOutputs, "topLevelOutputs");
+  void setFilesToDownload(ImmutableSet<ActionInput> topLevelOutputs) {
+    this.filesToDownload = Preconditions.checkNotNull(topLevelOutputs, "filesToDownload");
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOutputsMode.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOutputsMode.java
@@ -27,9 +27,9 @@ public enum RemoteOutputsMode {
   MINIMAL,
 
   /**
-   * Downloads outputs of top level targets, but generally not intermediate outputs. The only
-   * intermediate outputs to be downloaded are .d and .jdeps files for C++ and Java compilation
-   * actions.
+   * Downloads outputs of top level targets. Top level targets are targets specified on the command
+   * line. If a top level target has runfile dependencies it will also download those. Intermediate
+   * outputs are generally not downloaded (See {@link #MINIMAL}.
    */
   TOPLEVEL;
 

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -101,12 +101,12 @@ public class Utils {
   }
 
   /** Returns {@code true} if outputs contains one or more top level outputs. */
-  public static boolean hasTopLevelOutputs(
-      Collection<? extends ActionInput> outputs, ImmutableSet<ActionInput> topLevelOutputs) {
-    if (topLevelOutputs.isEmpty()) {
+  public static boolean hasFilesToDownload(
+      Collection<? extends ActionInput> outputs, ImmutableSet<ActionInput> filesToDownload) {
+    if (filesToDownload.isEmpty()) {
       return false;
     }
-    return !Collections.disjoint(outputs, topLevelOutputs);
+    return !Collections.disjoint(outputs, filesToDownload);
   }
 
   public static String grpcAwareErrorMessage(IOException e) {


### PR DESCRIPTION
This change makes it so that when building a binary remotely and
having --experimental_remote_download_toplevel set the runfiles of the
binary will also be downloaded. This applies also to building a test
target. However, when executing a test remotely with bazel test neither
the test binary nor its runfiles are downloaded. Instead Bazel fetches
the test result: test.xml and test.log

This change also enables bazel run to be used with
--experimental_remote_download_toplevel.