### PR TITLE
Make --experimental_remote_download_outputs none experimental

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -235,7 +235,8 @@ public final class RemoteOptions extends OptionsBase {
   public boolean allowSymlinkUpload;
 
   @Option(
-      name = "experimental_remote_download_outputs",
+      name = "remote_download_outputs",
+      oldName = "experimental_remote_download_outputs",
       defaultValue = "all",
       category = "remote",
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
@@ -257,7 +258,8 @@ public final class RemoteOptions extends OptionsBase {
   }
 
   @Option(
-      name = "experimental_remote_download_minimal",
+      name = "remote_download_minimal",
+      oldName = "experimental_remote_download_minimal",
       defaultValue = "null",
       expansion = {
         "--experimental_inmemory_jdeps_files",
@@ -275,7 +277,8 @@ public final class RemoteOptions extends OptionsBase {
   public Void remoteOutputsMinimal;
 
   @Option(
-      name = "experimental_remote_download_toplevel",
+      name = "remote_download_toplevel",
+      oldName = "experimental_remote_download_toplevel",
       defaultValue = "null",
       expansion = {
         "--experimental_inmemory_jdeps_files",


### PR DESCRIPTION
Enough people are using and reported good results so that I believe it's
time to mark this feature none experimental and here to stay.

Minimal mode can be enabled via --remote_download_minimal. Toplevel
mode can be enabled via --remote_download_toplevel.