### PR TITLE
Modify cpp-use-cases.md to fix build_file

### DIFF
--- a/site/docs/cpp-use-cases.md
+++ b/site/docs/cpp-use-cases.md
@@ -173,7 +173,7 @@ http_archive(
     name = "gtest",
     url = "https://github.com/google/googletest/archive/release-1.7.0.zip",
     sha256 = "b58cb7547a28b2c718d1e38aee18a3659c9e3ff52440297e965f5edffe34b6d0",
-    build_file = "gtest.BUILD",
+    build_file = "@//:gtest.BUILD",
     strip_prefix = "googletest-release-1.7.0",
 )
 ```
@@ -262,4 +262,3 @@ cc_library(
 ```
 
 This way, other C++ targets in your workspace can depend on this rule.
-


### PR DESCRIPTION
The build_file parameter for `gtest.BUILD` after the `strip_prefix` process was wrongly configured without the preceding `@//:`, which leads it to not discover the `gtest.BUILD` file and thus fail the build

Resolves #9312 