### PR TITLE
Disable runfile tree building when --remote_download_minimal

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -262,6 +262,7 @@ public final class RemoteOptions extends OptionsBase {
       oldName = "experimental_remote_download_minimal",
       defaultValue = "null",
       expansion = {
+        "--nobuild_runfile_links",
         "--experimental_inmemory_jdeps_files",
         "--experimental_inmemory_dotd_files",
         "--experimental_remote_download_outputs=minimal"


### PR DESCRIPTION
Since we don't download any outputs there's no point in building the runfile tree. After this change there should no longer be dangling symlinks in the output base. It can also improve performance if symlink tree creation is slow.