### PR TITLE
Call FindMissingBlobs before BES artifact upload. Fixes #8673, #7630

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -85,18 +85,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
-/**
- * A cache for storing artifacts (input and output) as well as the output of running an action.
- */
+/** A cache for storing artifacts (input and output) as well as the output of running an action. */
 @ThreadSafety.ThreadSafe
-public abstract class AbstractRemoteActionCache implements AutoCloseable {
+public abstract class AbstractRemoteActionCache implements MissingDigestsFinder, AutoCloseable {
 
-  /**
-   * See {@link SpawnExecutionContext#lockOutputFiles()}.
-   */
+  /** See {@link SpawnExecutionContext#lockOutputFiles()}. */
   @FunctionalInterface
   interface OutputFilesLocker {
-
     void lock() throws InterruptedException;
   }
 
@@ -151,9 +146,6 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
    * @param data the blob to upload.
    */
   protected abstract ListenableFuture<Void> uploadBlob(Digest digest, ByteString data);
-
-  protected abstract ListenableFuture<ImmutableSet<Digest>> getMissingDigests(
-      Iterable<Digest> digests) throws IOException, InterruptedException;
 
   /**
    * Upload the result of a locally executed action to the remote cache.
@@ -217,7 +209,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
     digests.addAll(digestToFile.keySet());
     digests.addAll(digestToBlobs.keySet());
 
-    ImmutableSet<Digest> digestsToUpload = Utils.getFromFuture(getMissingDigests(digests));
+    ImmutableSet<Digest> digestsToUpload = Utils.getFromFuture(findMissingDigests(digests));
     ImmutableList.Builder<ListenableFuture<Void>> uploads = ImmutableList.builder();
     for (Digest digest : digestsToUpload) {
       Path file = digestToFile.get(digest);
@@ -273,7 +265,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
    * Downloads a blob with content hash {@code digest} and stores its content in memory.
    *
    * @return a future that completes after the download completes (succeeds / fails). If successful,
-   * the content is stored in the future's {@code byte[]}.
+   *     the content is stored in the future's {@code byte[]}.
    */
   public ListenableFuture<byte[]> downloadBlob(Digest digest) {
     if (digest.getSizeBytes() == 0) {
@@ -309,7 +301,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
    * <p>In case of failure, this method deletes any output files it might have already created.
    *
    * @param outputFilesLocker ensures that we are the only ones writing to the output files when
-   * using the dynamic spawn strategy.
+   *     using the dynamic spawn strategy.
    * @throws IOException in case of a cache miss or if the remote cache is unavailable.
    * @throws ExecException in case clean up after a failed download failed.
    */
@@ -483,9 +475,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
     }
   }
 
-  /**
-   * Download a file (that is not a directory). The content is fetched from the digest.
-   */
+  /** Download a file (that is not a directory). The content is fetched from the digest. */
   public ListenableFuture<Void> downloadFile(Path path, Digest digest) throws IOException {
     Preconditions.checkNotNull(path.getParentDirectory()).createDirectoryAndParents();
     if (digest.getSizeBytes() == 0) {
@@ -562,13 +552,13 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
    * @param result the action result metadata of a successfully executed action (exit code = 0).
    * @param outputs the action's declared output files
    * @param inMemoryOutputPath the path of an output file whose contents should be returned in
-   * memory by this method.
+   *     memory by this method.
    * @param outErr stdout and stderr of this action
    * @param execRoot the execution root
    * @param metadataInjector the action's metadata injector that allows this method to inject
-   * metadata about an action output instead of downloading the output
+   *     metadata about an action output instead of downloading the output
    * @param outputFilesLocker ensures that we are the only ones writing to the output files when
-   * using the dynamic spawn strategy.
+   *     using the dynamic spawn strategy.
    * @throws IOException in case of failure
    * @throws InterruptedException in case of receiving an interrupt
    */
@@ -764,11 +754,8 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
     return new ActionResultMetadata(files.build(), symlinks.build(), directories.build());
   }
 
-  /**
-   * UploadManifest adds output metadata to a {@link ActionResult}.
-   */
+  /** UploadManifest adds output metadata to a {@link ActionResult}. */
   static class UploadManifest {
-
     private final DigestUtil digestUtil;
     private final ActionResult.Builder result;
     private final Path execRoot;
@@ -870,9 +857,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
       digestToBlobs.put(action.getCommandDigest(), command.toByteString());
     }
 
-    /**
-     * Map of digests to file paths to upload.
-     */
+    /** Map of digests to file paths to upload. */
     public Map<Digest, Path> getDigestToFile() {
       return digestToFile;
     }
@@ -1014,9 +999,7 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
     }
   }
 
-  /**
-   * Release resources associated with the cache. The cache may not be used after calling this.
-   */
+  /** Release resources associated with the cache. The cache may not be used after calling this. */
   @Override
   public abstract void close();
 
@@ -1071,13 +1054,10 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
     }
   }
 
-  /**
-   * In-memory representation of action result metadata.
-   */
+  /** In-memory representation of action result metadata. */
   static class ActionResultMetadata {
 
     static class SymlinkMetadata {
-
       private final Path path;
       private final PathFragment target;
 
@@ -1096,7 +1076,6 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
     }
 
     static class FileMetadata {
-
       private final Path path;
       private final Digest digest;
       private final boolean isExecutable;
@@ -1121,7 +1100,6 @@ public abstract class AbstractRemoteActionCache implements AutoCloseable {
     }
 
     static class DirectoryMetadata {
-
       private final ImmutableList<FileMetadata> files;
       private final ImmutableList<SymlinkMetadata> symlinks;
 

--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
@@ -16,7 +16,9 @@ package com.google.devtools.build.lib.remote;
 import build.bazel.remote.execution.v2.Digest;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.hash.HashCode;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -25,11 +27,14 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent.LocalFile;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
 import com.google.devtools.build.lib.buildeventstream.PathConverter;
+import com.google.devtools.build.lib.collect.ImmutableIterable;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.vfs.Path;
 import io.grpc.Context;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,11 +51,13 @@ class ByteStreamBuildEventArtifactUploader implements BuildEventArtifactUploader
   private final Context ctx;
   private final ByteStreamUploader uploader;
   private final String remoteServerInstanceName;
+  private final MissingDigestsFinder missingDigestsFinder;
 
   private final AtomicBoolean shutdown = new AtomicBoolean();
 
   ByteStreamBuildEventArtifactUploader(
       ByteStreamUploader uploader,
+      MissingDigestsFinder missingDigestsFinder,
       String remoteServerName,
       Context ctx,
       @Nullable String remoteInstanceName,
@@ -66,11 +73,136 @@ class ByteStreamBuildEventArtifactUploader implements BuildEventArtifactUploader
     this.uploadExecutor =
         MoreExecutors.listeningDecorator(
             Executors.newFixedThreadPool(Math.min(maxUploadThreads, 1000)));
+    this.missingDigestsFinder = missingDigestsFinder;
   }
 
+  /** Returns {@code true} if Bazel knows that the file is stored on a remote system. */
   private static boolean isRemoteFile(Path file) {
     return file.getFileSystem() instanceof RemoteActionFileSystem
         && ((RemoteActionFileSystem) file.getFileSystem()).isRemote(file);
+  }
+
+  private static final class PathMetadata {
+
+    private final Path path;
+    private final Digest digest;
+    private final boolean directory;
+    private final boolean remote;
+
+    PathMetadata(Path path, Digest digest, boolean directory, boolean remote) {
+      this.path = path;
+      this.digest = digest;
+      this.directory = directory;
+      this.remote = remote;
+    }
+
+    public Path getPath() {
+      return path;
+    }
+
+    public Digest getDigest() {
+      return digest;
+    }
+
+    public boolean isDirectory() {
+      return directory;
+    }
+
+    public boolean isRemote() {
+      return remote;
+    }
+  }
+
+  /**
+   * Collects metadata for {@code file}. Depending on the underlying filesystem used this method
+   * might do I/O.
+   */
+  private static PathMetadata readPathMetadata(Path file) throws IOException {
+    if (file.isDirectory()) {
+      return new PathMetadata(file, /* digest= */ null, /* directory= */ true, /* remote= */ false);
+    }
+    DigestUtil digestUtil = new DigestUtil(file.getFileSystem().getDigestFunction());
+    Digest digest = digestUtil.compute(file);
+    return new PathMetadata(file, digest, /* directory= */ false, isRemoteFile(file));
+  }
+
+  private List<PathMetadata> processQueryResult(ImmutableSet<Digest> missingDigests,
+      List<PathMetadata> filesToQuery) {
+    List<PathMetadata> allPaths = new ArrayList<>(filesToQuery.size());
+    for (PathMetadata file : filesToQuery) {
+      if (missingDigests.contains(file.getDigest())) {
+        allPaths.add(file);
+      } else {
+        PathMetadata remotePathMetadata =
+            new PathMetadata(file.getPath(), file.getDigest(), file.isDirectory(),
+                /* remote= */ true);
+        allPaths.add(remotePathMetadata);
+      }
+    }
+    return allPaths;
+  }
+
+  /**
+   * For files where {@link PathMetadata#isRemote()} returns {@code false} this method checks if
+   * the remote cache already contains the file. If so {@link PathMetadata#isRemote()} is set to
+   * {@code true}.
+   */
+  private ListenableFuture<ImmutableIterable<PathMetadata>> queryRemoteCache(
+      ImmutableList<ListenableFuture<PathMetadata>> allPaths) throws Exception {
+    List<PathMetadata> knownRemotePaths = new ArrayList<>(allPaths.size());
+    List<PathMetadata> filesToQuery = new ArrayList<>();
+    Set<Digest> digestsToQuery = new HashSet<>();
+    for (ListenableFuture<PathMetadata> pathMetadataFuture : allPaths) {
+      // This line is guaranteed to not block, as this code is only called after all futures in
+      // allPaths have completed.
+      PathMetadata pathMetadata = pathMetadataFuture.get();
+      if (pathMetadata.isRemote() || pathMetadata.isDirectory()) {
+        knownRemotePaths.add(pathMetadata);
+      } else {
+        filesToQuery.add(pathMetadata);
+        digestsToQuery.add(pathMetadata.getDigest());
+      }
+    }
+    if (digestsToQuery.isEmpty()) {
+      return Futures.immediateFuture(ImmutableIterable.from(knownRemotePaths));
+    }
+    return Futures.transform(
+        ctx.call(() -> missingDigestsFinder.findMissingDigests(digestsToQuery)),
+        (missingDigests) -> {
+          List<PathMetadata> filesToQueryUpdated = processQueryResult(missingDigests, filesToQuery);
+          return ImmutableIterable.from(Iterables.concat(knownRemotePaths, filesToQueryUpdated));
+        }, MoreExecutors.directExecutor());
+  }
+
+  /**
+   * Uploads any files from {@code allPaths} where {@link PathMetadata#isRemote()} returns
+   * {@code false}.
+   */
+  private ListenableFuture<List<PathMetadata>> uploadLocalFiles(
+      ImmutableIterable<PathMetadata> allPaths) {
+    ImmutableList.Builder<ListenableFuture<PathMetadata>> allPathsUploaded =
+        ImmutableList.builder();
+    for (PathMetadata path : allPaths) {
+      if (!path.isRemote() && !path.isDirectory()) {
+        Chunker chunker = Chunker.builder()
+            .setInput(path.getDigest().getSizeBytes(), path.getPath())
+            .build();
+        final ListenableFuture<Void> upload;
+        Context prevCtx = ctx.attach();
+        try {
+          upload =
+              uploader.uploadBlobAsync(
+                  HashCode.fromString(path.getDigest().getHash()), chunker,
+                  /* forceUpload=*/ false);
+        } finally {
+          ctx.detach(prevCtx);
+        }
+        allPathsUploaded.add(Futures.transform(upload, unused -> path, uploadExecutor));
+      } else {
+        allPathsUploaded.add(Futures.immediateFuture(path));
+      }
+    }
+    return Futures.allAsList(allPathsUploaded.build());
   }
 
   @Override
@@ -78,41 +210,27 @@ class ByteStreamBuildEventArtifactUploader implements BuildEventArtifactUploader
     if (files.isEmpty()) {
       return Futures.immediateFuture(PathConverter.NO_CONVERSION);
     }
-    List<ListenableFuture<PathDigestPair>> uploads = new ArrayList<>(files.size());
+    // Collect metadata about each path
+    ImmutableList.Builder<ListenableFuture<PathMetadata>> allPathMetadata = ImmutableList.builder();
+    for (Path file : files.keySet()) {
+      ListenableFuture<PathMetadata> pathMetadata =
+          uploadExecutor.submit(() -> readPathMetadata(file));
+      allPathMetadata.add(pathMetadata);
+    }
 
-      for (Path file : files.keySet()) {
-      ListenableFuture<Boolean> isDirectoryFuture = uploadExecutor.submit(() -> file.isDirectory());
-      ListenableFuture<PathDigestPair> digestFuture =
-          Futures.transformAsync(
-              isDirectoryFuture,
-              isDirectory -> {
-                if (isDirectory) {
-                  return Futures.immediateFuture(new PathDigestPair(file, null));
-                }
-                DigestUtil digestUtil = new DigestUtil(file.getFileSystem().getDigestFunction());
-                Digest digest = digestUtil.compute(file);
-                if (isRemoteFile(file)) {
-                  return Futures.immediateFuture(new PathDigestPair(file, digest));
-                }
-                Chunker chunker = Chunker.builder().setInput(digest.getSizeBytes(), file).build();
-                final ListenableFuture<Void> upload;
-                Context prevCtx = ctx.attach();
-                try {
-                  upload =
-                      uploader.uploadBlobAsync(
-                          HashCode.fromString(digest.getHash()), chunker, /* forceUpload=*/ false);
-                } finally {
-                  ctx.detach(prevCtx);
-                }
-                return Futures.transform(
-                    upload, unused -> new PathDigestPair(file, digest), uploadExecutor);
-              },
-              MoreExecutors.directExecutor());
-      uploads.add(digestFuture);
-      }
-    return Futures.transform(
-        Futures.allAsList(uploads),
-        pathDigestPairs -> new PathConverterImpl(remoteServerInstanceName, pathDigestPairs),
+    // Query the remote cache to check which files need to be uploaded
+    ImmutableList<ListenableFuture<PathMetadata>> allPaths = allPathMetadata.build();
+    ListenableFuture<ImmutableIterable<PathMetadata>> allPathsUpdatedMetadata =
+        Futures.whenAllSucceed(allPaths).callAsync(() -> queryRemoteCache(allPaths),
+            MoreExecutors.directExecutor());
+
+    // Upload local files (if any)
+    ListenableFuture<List<PathMetadata>> allPathsMetadata =
+        Futures.transformAsync(allPathsUpdatedMetadata,
+            (paths) -> uploadLocalFiles(paths), MoreExecutors.directExecutor());
+
+    return Futures.transform(allPathsMetadata,
+        (metadata) -> new PathConverterImpl(remoteServerInstanceName, metadata),
         MoreExecutors.directExecutor());
   }
 
@@ -135,12 +253,12 @@ class ByteStreamBuildEventArtifactUploader implements BuildEventArtifactUploader
     private final Map<Path, Digest> pathToDigest;
     private final Set<Path> skippedPaths;
 
-    PathConverterImpl(String remoteServerInstanceName, List<PathDigestPair> uploads) {
+    PathConverterImpl(String remoteServerInstanceName, List<PathMetadata> uploads) {
       Preconditions.checkNotNull(uploads);
       this.remoteServerInstanceName = remoteServerInstanceName;
       pathToDigest = new HashMap<>(uploads.size());
       ImmutableSet.Builder<Path> skippedPaths = ImmutableSet.builder();
-      for (PathDigestPair pair : uploads) {
+      for (PathMetadata pair : uploads) {
         Path path = pair.getPath();
         Digest digest = pair.getDigest();
         if (digest != null) {
@@ -167,25 +285,6 @@ class ByteStreamBuildEventArtifactUploader implements BuildEventArtifactUploader
       return String.format(
           "bytestream://%s/blobs/%s/%d",
           remoteServerInstanceName, digest.getHash(), digest.getSizeBytes());
-    }
-  }
-
-  private static class PathDigestPair {
-
-    private final Path path;
-    private final Digest digest;
-
-    PathDigestPair(Path path, Digest digest) {
-      this.path = path;
-      this.digest = digest;
-    }
-
-    public Path getPath() {
-      return path;
-    }
-
-    public Digest getDigest() {
-      return digest;
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderFactory.java
@@ -29,12 +29,14 @@ class ByteStreamBuildEventArtifactUploaderFactory implements
   private final ByteStreamUploader uploader;
   private final String remoteServerName;
   private final Context ctx;
+  private final MissingDigestsFinder missingDigestsFinder;
   @Nullable private final String remoteInstanceName;
 
-  ByteStreamBuildEventArtifactUploaderFactory(
-      ByteStreamUploader uploader, String remoteServerName, Context ctx,
+  ByteStreamBuildEventArtifactUploaderFactory(ByteStreamUploader uploader,
+      MissingDigestsFinder missingDigestsFinder, String remoteServerName, Context ctx,
       @Nullable String remoteInstanceName) {
     this.uploader = uploader;
+    this.missingDigestsFinder = missingDigestsFinder;
     this.remoteServerName = remoteServerName;
     this.ctx = ctx;
     this.remoteInstanceName = remoteInstanceName;
@@ -44,6 +46,7 @@ class ByteStreamBuildEventArtifactUploaderFactory implements
   public BuildEventArtifactUploader create(CommandEnvironment env) {
     return new ByteStreamBuildEventArtifactUploader(
         uploader.retain(),
+        missingDigestsFinder,
         remoteServerName,
         ctx,
         remoteInstanceName,

--- a/src/main/java/com/google/devtools/build/lib/remote/MissingDigestsFinder.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/MissingDigestsFinder.java
@@ -1,0 +1,30 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import build.bazel.remote.execution.v2.Digest;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
+
+/** Supports querying a remote cache whether it contains a list of blobs. */
+interface MissingDigestsFinder {
+
+  /**
+   * Returns a set of digests that the remote cache does not know about. The returned set is
+   * guaranteed to be a subset of {@code digests}.
+   *
+   * @param digests The list of digests to look for.
+   */
+  ListenableFuture<ImmutableSet<Digest>> findMissingDigests(Iterable<Digest> digests);
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -269,6 +269,7 @@ public final class RemoteModule extends BlazeModule {
         buildEventArtifactUploaderFactoryDelegate.init(
             new ByteStreamBuildEventArtifactUploaderFactory(
                 uploader,
+                cache,
                 cacheChannel.authority(),
                 requestContext,
                 remoteOptions.remoteInstanceName));

--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
@@ -82,7 +82,7 @@ public class SimpleBlobStoreActionCache extends AbstractRemoteActionCache {
   }
 
   @Override
-  protected ListenableFuture<ImmutableSet<Digest>> getMissingDigests(Iterable<Digest> digests) {
+  public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(Iterable<Digest> digests) {
     return Futures.immediateFuture(ImmutableSet.copyOf(digests));
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/SimpleBlobStoreActionCache.java
@@ -82,8 +82,8 @@ public class SimpleBlobStoreActionCache extends AbstractRemoteActionCache {
   }
 
   @Override
-  protected ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests) {
-    return ImmutableSet.copyOf(digests);
+  protected ListenableFuture<ImmutableSet<Digest>> getMissingDigests(Iterable<Digest> digests) {
+    return Futures.immediateFuture(ImmutableSet.copyOf(digests));
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -1168,7 +1168,7 @@ public class AbstractRemoteActionCacheTests {
     }
 
     @Override
-    protected ListenableFuture<ImmutableSet<Digest>> getMissingDigests(Iterable<Digest> digests) {
+    public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(Iterable<Digest> digests) {
       throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCacheTests.java
@@ -1168,7 +1168,7 @@ public class AbstractRemoteActionCacheTests {
     }
 
     @Override
-    protected ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests) {
+    protected ListenableFuture<ImmutableSet<Digest>> getMissingDigests(Iterable<Digest> digests) {
       throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -244,7 +244,7 @@ public class RemoteActionInputFetcherTest {
     }
 
     @Override
-    protected ImmutableSet<Digest> getMissingDigests(Iterable<Digest> digests) {
+    protected ListenableFuture<ImmutableSet<Digest>> getMissingDigests(Iterable<Digest> digests) {
       throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -244,7 +244,7 @@ public class RemoteActionInputFetcherTest {
     }
 
     @Override
-    protected ListenableFuture<ImmutableSet<Digest>> getMissingDigests(Iterable<Digest> digests) {
+    public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(Iterable<Digest> digests) {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Bazel unconditionally uploads files referenced by BEP events to the remote cache. This change makes it so that Bazel calls FindMissingBlobs() before uploading a file.

This should drastically improve BES performance for when files already exist remotely (i.e. when using remote execution).

A side effect of this change is that it also moves calls to potentially blocking Path#getDigest() on the thread pool.