### PR TITLE
Add docs to ctx.actions.declare_directory pointing to Args.add_all()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkActionFactoryApi.java
@@ -80,8 +80,11 @@ public interface SkylarkActionFactoryApi extends SkylarkValue {
   @SkylarkCallable(
       name = "declare_directory",
       doc =
-          "Declares that rule or aspect create a directory with the given name, in the "
-              + "current package. You must create an action that generates the directory.",
+          "Declares that the rule or aspect creates a directory with the given name, in the "
+              + "current package. You must create an action that generates the directory. "
+              + "The contents of the directory are not directly accessible from Starlark, "
+              + "but can be expanded in an action command with "
+              + "<a href=\"actions.html#add_all\"><code>Args.add_all()</code></a>.",
       parameters = {
         @Param(
             name = "filename",

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkActionFactoryApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/SkylarkActionFactoryApi.java
@@ -84,7 +84,7 @@ public interface SkylarkActionFactoryApi extends SkylarkValue {
               + "current package. You must create an action that generates the directory. "
               + "The contents of the directory are not directly accessible from Starlark, "
               + "but can be expanded in an action command with "
-              + "<a href=\"actions.html#add_all\"><code>Args.add_all()</code></a>.",
+              + "<a href=\"Args.html#add_all\"><code>Args.add_all()</code></a>.",
       parameters = {
         @Param(
             name = "filename",


### PR DESCRIPTION
A common use-case is to expand the generated directory in an action command.
This adds a link to declare_directory command, pointing to Args.add_all().