### PR TITLE
Implement GetTree in remote worker

### DIFF
--- a/src/tools/remote/BUILD
+++ b/src/tools/remote/BUILD
@@ -4,6 +4,7 @@ filegroup(
     name = "srcs",
     srcs = glob(["**"]) + [
         "//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker:srcs",
+        "//src/tools/remote/src/test/java/com/google/devtools/build/remote/worker:srcs",
         "//src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/http:srcs",
     ],
     visibility = ["//src:__pkg__"],

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CasServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/CasServer.java
@@ -15,18 +15,33 @@
 package com.google.devtools.build.remote.worker;
 
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static java.util.logging.Level.WARNING;
 
 import build.bazel.remote.execution.v2.BatchUpdateBlobsRequest;
 import build.bazel.remote.execution.v2.BatchUpdateBlobsResponse;
 import build.bazel.remote.execution.v2.ContentAddressableStorageGrpc.ContentAddressableStorageImplBase;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.Directory;
+import build.bazel.remote.execution.v2.DirectoryNode;
 import build.bazel.remote.execution.v2.FindMissingBlobsRequest;
 import build.bazel.remote.execution.v2.FindMissingBlobsResponse;
+import build.bazel.remote.execution.v2.GetTreeRequest;
+import build.bazel.remote.execution.v2.GetTreeResponse;
+import com.google.devtools.build.lib.remote.CacheNotFoundException;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.Code;
+import io.grpc.Context;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
 
 /** A basic implementation of a {@link ContentAddressableStorageImplBase} service. */
 final class CasServer extends ContentAddressableStorageImplBase {
+  private static final Logger logger = Logger.getLogger(CasServer.class.getName());
   static final long MAX_BATCH_SIZE_BYTES = 1024 * 1024 * 4;
   private final OnDiskBlobStoreActionCache cache;
 
@@ -70,5 +85,63 @@ final class CasServer extends ContentAddressableStorageImplBase {
     }
     responseObserver.onNext(batchResponse.build());
     responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getTree(GetTreeRequest request, StreamObserver<GetTreeResponse> responseObserver) {
+    // Directories are returned in depth-first order.  We store all previously-traversed digests so
+    // identical subtrees having the same digest will only be traversed and returned once.
+    Set<Digest> seenDigests = new HashSet<>();
+    Deque<Digest> pendingDigests = new ArrayDeque<>();
+    seenDigests.add(request.getRootDigest());
+    pendingDigests.push(request.getRootDigest());
+    // The page token is implemented as the previous directory's digest.  If the client passes a
+    // page token, we still do the complete traversal internally, but we skip sending the results to
+    // the client until we see the page token's digest.
+    boolean skipping = !request.getPageToken().isEmpty();
+    while (!pendingDigests.isEmpty() && !Context.current().isCancelled()) {
+      Digest digest = pendingDigests.pop();
+      byte[] directoryBytes;
+      try {
+        directoryBytes = getFromFuture(cache.downloadBlob(digest));
+      } catch (CacheNotFoundException e) {
+        responseObserver.onError(StatusUtils.notFoundError(digest));
+        return;
+      } catch (Exception e) {
+        logger.log(WARNING, "Read request failed.", e);
+        responseObserver.onError(StatusUtils.internalError(e));
+        return;
+      }
+      Directory directory;
+      try {
+        directory = Directory.parseFrom(directoryBytes);
+      } catch (InvalidProtocolBufferException e) {
+        logger.log(WARNING, "Failed to parse directory in tree.", e);
+        responseObserver.onError(StatusUtils.internalError(e));
+        return;
+      }
+      for (DirectoryNode directoryNode : directory.getDirectoriesList()) {
+        if (!seenDigests.contains(directoryNode.getDigest())) {
+          seenDigests.add(directoryNode.getDigest());
+          pendingDigests.push(directoryNode.getDigest());
+        }
+      }
+      GetTreeResponse response =
+          GetTreeResponse.newBuilder()
+              .addDirectories(directory)
+              .setNextPageToken(pendingDigests.isEmpty() ? "" : digest.getHash())
+              .build();
+      if (!skipping) {
+        responseObserver.onNext(response);
+      }
+      if (request.getPageToken().equals(digest.getHash())) {
+        skipping = false;
+      }
+    }
+    if (Context.current().isCancelled()) {
+      responseObserver.onError(Status.CANCELLED.asException());
+    } else {
+      responseObserver.onCompleted();
+    }
   }
 }

--- a/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/BUILD
+++ b/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/BUILD
@@ -1,0 +1,30 @@
+package(
+    default_testonly = 1,
+    default_visibility = ["//src/tools/remote:__pkg__"],
+)
+
+filegroup(
+    name = "srcs",
+    testonly = 0,
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/remote:__pkg__"],
+)
+
+java_test(
+    name = "worker",
+    srcs = glob(["*.java"]),
+    test_class = "com.google.devtools.build.remote.worker.CasServerTest",
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/remote",
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
+        "//src/main/java/com/google/devtools/build/lib/remote/util",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs",
+        "//src/tools/remote/src/main/java/com/google/devtools/build/remote/worker",
+        "//third_party:junit4",
+        "//third_party:truth",
+        "//third_party/grpc:grpc-jar",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+    ],
+)

--- a/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/CasServerTest.java
+++ b/src/tools/remote/src/test/java/com/google/devtools/build/remote/worker/CasServerTest.java
@@ -1,0 +1,118 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.remote.worker;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+
+import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.Directory;
+import build.bazel.remote.execution.v2.DirectoryNode;
+import build.bazel.remote.execution.v2.GetTreeRequest;
+import build.bazel.remote.execution.v2.GetTreeResponse;
+import com.google.devtools.build.lib.remote.SimpleBlobStoreActionCache;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
+import com.google.devtools.build.lib.vfs.FileSystem;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link com.google.devtools.build.remote.worker.CasServer} */
+@RunWith(JUnit4.class)
+public class CasServerTest {
+  private Digest uploadDirectory(
+      SimpleBlobStoreActionCache cache, DigestUtil digestUtil, Directory directory)
+      throws IOException, InterruptedException {
+    Digest digest = digestUtil.compute(directory);
+    getFromFuture(cache.uploadBlob(digest, directory.toByteString()));
+    return digest;
+  }
+
+  @Test
+  public void testGetTree() throws IOException, InterruptedException {
+    FileSystem fileSystem = new InMemoryFileSystem();
+    Path cacheDir = fileSystem.getPath("/cache");
+    cacheDir.createDirectory();
+    DigestUtil digestUtil = new DigestUtil(DigestHashFunction.DEFAULT_HASH_FOR_TESTS);
+    OnDiskBlobStoreActionCache cache =
+        new OnDiskBlobStoreActionCache(new RemoteOptions(), cacheDir, digestUtil);
+    CasServer casServer = new CasServer(cache);
+
+    // Fake directory structure:
+    // root
+    // - foo
+    //   - bar
+    //     - baz
+    // - quux
+    Directory emptyDir = Directory.newBuilder().build();
+    Digest emptyDirDigest = uploadDirectory(cache, digestUtil, emptyDir);
+    Directory barDir =
+        Directory.newBuilder()
+            .addDirectories(
+                DirectoryNode.newBuilder().setName("baz").setDigest(emptyDirDigest).build())
+            .build();
+    Digest barDigest = uploadDirectory(cache, digestUtil, barDir);
+    Directory fooDir =
+        Directory.newBuilder()
+            .addDirectories(DirectoryNode.newBuilder().setName("bar").setDigest(barDigest).build())
+            .build();
+    Digest fooDigest = uploadDirectory(cache, digestUtil, fooDir);
+    Directory rootDir =
+        Directory.newBuilder()
+            .addDirectories(DirectoryNode.newBuilder().setName("foo").setDigest(fooDigest).build())
+            .addDirectories(
+                DirectoryNode.newBuilder().setName("quux").setDigest(emptyDirDigest).build())
+            .build();
+    Digest rootDigest = uploadDirectory(cache, digestUtil, rootDir);
+
+    GetTreeRequest request = GetTreeRequest.newBuilder().setRootDigest(rootDigest).build();
+    GetTreeResponse.Builder fullResponseBuilder = GetTreeResponse.newBuilder();
+    AtomicBoolean completed = new AtomicBoolean(false);
+    AtomicBoolean hadError = new AtomicBoolean(false);
+    StreamObserver<GetTreeResponse> responseObserver =
+        new StreamObserver<GetTreeResponse>() {
+          @Override
+          public void onNext(GetTreeResponse response) {
+            fullResponseBuilder.mergeFrom(response);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            hadError.set(true);
+          }
+
+          @Override
+          public void onCompleted() {
+            completed.set(true);
+          }
+        };
+
+    casServer.getTree(request, responseObserver);
+
+    assertThat(completed.get()).isTrue();
+    assertThat(hadError.get()).isFalse();
+    GetTreeResponse fullResponse = fullResponseBuilder.build();
+    assertThat(fullResponse.getNextPageToken()).isEmpty();
+    assertThat(fullResponse.getDirectoriesList())
+        .containsExactly(rootDir, fooDir, barDir, emptyDir);
+  }
+}


### PR DESCRIPTION
This is not the most high-performance implementation available, but it
should be sufficient for testing purposes.

Fixes #9328.