### PR TITLE
Fix destructive mv of bazel internal files

### DIFF
--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -61,7 +61,7 @@ genrule(
     cmd = "\n".join([
         "tmpdir=$$(mktemp -d $${TMPDIR:-/tmp}/tmp.XXXXXXXX)",
         "trap \"rm -fr $${tmpdir}\" EXIT",
-        "mv $(SRCS) $${tmpdir}/bazel.exe",
+        "cp $(SRCS) $${tmpdir}/bazel.exe",
         "touch -t 198001010000.00 $${tmpdir}/bazel.exe",
         "zip -jq $@ $${tmpdir}/bazel.exe",
     ]),


### PR DESCRIPTION
The genrule was moving a $SRC.  In some sandboxes, ths is a permission
problem.  On Debian Stretch, this results in the following error:

ERROR: /home/austin/local/bazel2/scripts/packages/BUILD:57:2: Executing
genrule //scripts/packages:zip-bazel-exe_nojdk failed (Exit 1) bash
failed: error executing command /bin/bash -c ... (remaining 1
argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
touch: cannot touch '/tmp/tmp.EhwgH9R4/bazel.exe': Permission denied

So let's copy instead.