### PR TITLE
updated documentation to clarify TLS support 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceOptions.java
@@ -34,6 +34,8 @@ public class BuildEventServiceOptions extends OptionsBase {
     help =
         "Specifies the build event service (BES) backend endpoint as HOST or HOST:PORT. "
             + "Disabled by default."
+            + "The supported schemas are grpc and grpcs (grpc with TLS enabled). "
+            + "If no schema is provided bazel'll default to grpcs. Specify grpc:// schema to disable TLS."
   )
   public String besBackend;
 

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -31,6 +31,7 @@ import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.protobuf.TextFormat;
 import com.google.protobuf.TextFormat.ParseException;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -66,7 +67,10 @@ public final class RemoteOptions extends OptionsBase {
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
-      help = "HOST or HOST:PORT of a remote execution endpoint.")
+      help =
+          "HOST or HOST:PORT of a remote execution endpoint."
+              + "The supported schemas are grpc and grpcs (grpc with TLS enabled). "
+              + "If no schema is provided bazel'll default to grpcs. Specify grpc:// schema to disable TLS.")
   public String remoteExecutor;
 
   @Option(
@@ -76,8 +80,8 @@ public final class RemoteOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
-          "A URI of a caching endpoint. The supported schemas are http(s) and grpc. "
-              + "If no schema is provided we'll default to grpc. "
+          "A URI of a caching endpoint. The supported schemas are http, https, grpc and grpcs (grpc with TLS enabled). "
+              + "If no schema is provided bazel'll default to grpcs. Specify grpc:// or http:// schema to disable TLS."
               + "See https://docs.bazel.build/versions/master/remote-caching.html")
   public String remoteCache;
 


### PR DESCRIPTION
updated documentation to clarify TLS support for --remote_cache, --remote_executor and --bes_backend

Follow-up of #8061