### PR TITLE
Fix noremote_upload_local_results behavior in combined blobstore

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
@@ -47,11 +47,12 @@ public final class RemoteCacheClientFactory {
       PathFragment diskCachePath,
       boolean remoteVerifyDownloads,
       DigestUtil digestUtil,
-      RemoteCacheClient remoteCacheClient)
+      RemoteCacheClient remoteCacheClient,
+      RemoteOptions options)
       throws IOException {
     DiskCacheClient diskCacheClient =
         createDiskCache(workingDirectory, diskCachePath, remoteVerifyDownloads, digestUtil);
-    return new DiskAndRemoteCacheClient(diskCacheClient, remoteCacheClient);
+    return new DiskAndRemoteCacheClient(diskCacheClient, remoteCacheClient, options);
   }
 
   public static ReferenceCountedChannel createGrpcChannel(
@@ -159,7 +160,7 @@ public final class RemoteCacheClientFactory {
 
     RemoteCacheClient httpCache = createHttp(options, cred, digestUtil);
     return createDiskAndRemoteClient(
-        workingDirectory, diskCachePath, options.remoteVerifyDownloads, digestUtil, httpCache);
+        workingDirectory, diskCachePath, options.remoteVerifyDownloads, digestUtil, httpCache, options);
   }
 
   public static boolean isDiskCache(RemoteOptions options) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -298,7 +298,8 @@ public final class RemoteModule extends BlazeModule {
                   remoteOptions.diskCache,
                   remoteOptions.remoteVerifyDownloads,
                   digestUtil,
-                  cacheClient);
+                  cacheClient,
+                  remoteOptions);
         }
 
         RemoteCache remoteCache = new RemoteCache(cacheClient, remoteOptions, digestUtil);

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
@@ -14,6 +14,7 @@ java_library(
     tags = ["bazel"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
@@ -37,17 +38,21 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
 
   private final RemoteCacheClient remoteCache;
   private final DiskCacheClient diskCache;
+  private final RemoteOptions options;
 
-  public DiskAndRemoteCacheClient(DiskCacheClient diskCache, RemoteCacheClient remoteCache) {
+  public DiskAndRemoteCacheClient(DiskCacheClient diskCache, RemoteCacheClient remoteCache, RemoteOptions options) {
     this.diskCache = Preconditions.checkNotNull(diskCache);
     this.remoteCache = Preconditions.checkNotNull(remoteCache);
+    this.options = options;
   }
 
   @Override
   public void uploadActionResult(ActionKey actionKey, ActionResult actionResult)
       throws IOException, InterruptedException {
     diskCache.uploadActionResult(actionKey, actionResult);
-    remoteCache.uploadActionResult(actionKey, actionResult);
+    if (!options.incompatibleRemoteResultsIgnoreDisk || options.remoteUploadLocalResults) {
+      remoteCache.uploadActionResult(actionKey, actionResult);
+    }
   }
 
   @Override
@@ -60,7 +65,9 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
   public ListenableFuture<Void> uploadFile(Digest digest, Path file) {
     try {
       diskCache.uploadFile(digest, file).get();
-      remoteCache.uploadFile(digest, file).get();
+      if (!options.incompatibleRemoteResultsIgnoreDisk || options.remoteUploadLocalResults) {
+        remoteCache.uploadFile(digest, file).get();
+      }
     } catch (ExecutionException e) {
       return Futures.immediateFailedFuture(e.getCause());
     } catch (InterruptedException e) {
@@ -73,7 +80,9 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
   public ListenableFuture<Void> uploadBlob(Digest digest, ByteString data) {
     try {
       diskCache.uploadBlob(digest, data).get();
-      remoteCache.uploadBlob(digest, data).get();
+      if (!options.incompatibleRemoteResultsIgnoreDisk || options.remoteUploadLocalResults) {
+        remoteCache.uploadBlob(digest, data).get();
+      }
     } catch (ExecutionException e) {
       return Futures.immediateFailedFuture(e.getCause());
     } catch (InterruptedException e) {
@@ -130,22 +139,26 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
       return Futures.immediateFailedFuture(e);
     }
 
-    ListenableFuture<Void> download =
-        closeStreamOnError(remoteCache.downloadBlob(digest, tempOut), tempOut);
-    ListenableFuture<Void> saveToDiskAndTarget =
-        Futures.transformAsync(
-            download,
-            (unused) -> {
-              try {
-                tempOut.close();
-                diskCache.captureFile(tempPath, digest, /* isActionCache= */ false);
-              } catch (IOException e) {
-                return Futures.immediateFailedFuture(e);
-              }
-              return diskCache.downloadBlob(digest, out);
-            },
-            MoreExecutors.directExecutor());
-    return saveToDiskAndTarget;
+    if (!options.incompatibleRemoteResultsIgnoreDisk || options.remoteAcceptCached) {
+      ListenableFuture<Void> download =
+          closeStreamOnError(remoteCache.downloadBlob(digest, tempOut), tempOut);
+      ListenableFuture<Void> saveToDiskAndTarget =
+          Futures.transformAsync(
+              download,
+              (unused) -> {
+                try {
+                  tempOut.close();
+                  diskCache.captureFile(tempPath, digest, /* isActionCache= */ false);
+                } catch (IOException e) {
+                  return Futures.immediateFailedFuture(e);
+                }
+                return diskCache.downloadBlob(digest, out);
+              },
+              MoreExecutors.directExecutor());
+      return saveToDiskAndTarget;
+    } else {
+      return Futures.immediateFuture(null);
+    }
   }
 
   @Override
@@ -154,16 +167,20 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
       return diskCache.downloadActionResult(actionKey);
     }
 
-    return Futures.transformAsync(
-        remoteCache.downloadActionResult(actionKey),
-        (actionResult) -> {
-          if (actionResult == null) {
-            return Futures.immediateFuture(null);
-          } else {
-            diskCache.uploadActionResult(actionKey, actionResult);
-            return Futures.immediateFuture(actionResult);
-          }
-        },
-        MoreExecutors.directExecutor());
+    if (!options.incompatibleRemoteResultsIgnoreDisk || options.remoteAcceptCached) {
+      return Futures.transformAsync(
+          remoteCache.downloadActionResult(actionKey),
+          (actionResult) -> {
+            if (actionResult == null) {
+              return Futures.immediateFuture(null);
+            } else {
+              diskCache.uploadActionResult(actionKey, actionResult);
+              return Futures.immediateFuture(actionResult);
+            }
+          },
+          MoreExecutors.directExecutor());
+    } else {
+      return Futures.immediateFuture(null);
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -144,6 +144,25 @@ public final class RemoteOptions extends OptionsBase {
   public boolean remoteUploadLocalResults;
 
   @Option(
+      name = "incompatible_remote_results_ignore_disk",
+      defaultValue = "false",
+      category = "remote",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      metadataTags = {
+        OptionMetadataTag.INCOMPATIBLE_CHANGE,
+        OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+      },
+      help =
+          "If set to true, --noremote_upload_local_results and --noremote_accept_cached "
+              + "will not apply to the disk cache. "
+              + "If a combined cache is used:"
+              + "\n\t--noremote_upload_local_results will cause results to be written to the disk cache, but not uploaded to the remote cache."
+              + "\n\t--noremote_accept_cached will result in Bazel checking for results in the disk cache, but not in the remote cache."
+              + "\nSee #8216 for details.")
+  public boolean incompatibleRemoteResultsIgnoreDisk;
+
+  @Option(
       name = "remote_instance_name",
       defaultValue = "",
       documentationCategory = OptionDocumentationCategory.REMOTE,

--- a/src/test/shell/bazel/remote/remote_execution_http_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_http_test.sh
@@ -364,6 +364,10 @@ EOF
 function test_genrule_combined_disk_http_cache() {
   # Test for the combined disk and http cache.
   # Built items should be pushed to both the disk and http cache.
+  # If --noremote_upload_local_results flag is set,
+  # built items should only be pushed to the disk cache.
+  # If --noremote_accept_cached flag is set,
+  # built items should only be checked from the disk cache.
   # If an item is missing on disk cache, but present on http cache,
   # then bazel should copy it from http cache to disk cache on fetch.
 
@@ -383,10 +387,66 @@ EOF
   rm -rf $cache
   mkdir $cache
 
-  # Build and push to disk and http cache
-  bazel build $disk_flags $http_flags //a:test \
+  # Build and push to disk cache but not http cache
+  bazel build $disk_flags $http_flags --incompatible_remote_results_ignore_disk=true --noremote_upload_local_results //a:test \
     || fail "Failed to build //a:test with combined disk http cache"
   cp -f bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected
+
+  # Fetch from disk cache
+  bazel clean
+  bazel build $disk_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_upload_local_results &> $TEST_log \
+    || fail "Failed to fetch //a:test from disk cache"
+  expect_log "1 remote cache hit" "Fetch from disk cache failed"
+  diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
+    || fail "Disk cache generated different result"
+
+  # No cache result from http cache, rebuild target
+  bazel clean
+  bazel build $http_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_upload_local_results &> $TEST_log \
+    || fail "Failed to build //a:test"
+  expect_not_log "1 remote cache hit" "Should not get cache hit from http cache"
+  expect_log "1 linux-sandbox" "Rebuild target failed"
+  diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
+    || fail "Rebuilt target generated different result"
+
+  rm -rf $cache
+  mkdir $cache
+
+  # No cache result from http cache, rebuild target, and upload result to http cache
+  bazel clean
+  bazel build $http_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_accept_cached &> $TEST_log \
+    || fail "Failed to build //a:test"
+  expect_not_log "1 remote cache hit" "Should not get cache hit from http cache"
+  expect_log "1 linux-sandbox" "Rebuild target failed"
+  diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
+    || fail "Rebuilt target generated different result"
+
+  # No cache result from http cache, rebuild target, and upload result to disk cache
+  bazel clean
+  bazel build $disk_flags $http_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_accept_cached &> $TEST_log \
+    || fail "Failed to build //a:test"
+  expect_not_log "1 remote cache hit" "Should not get cache hit from http cache"
+  expect_log "1 linux-sandbox" "Rebuild target failed"
+  diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
+    || fail "Rebuilt target generated different result"
+
+  # Fetch from disk cache
+  bazel clean
+  bazel build $disk_flags $http_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_accept_cached &> $TEST_log \
+    || fail "Failed to build //a:test"
+  expect_log "1 remote cache hit" "Fetch from disk cache failed"
+  diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
+    || fail "Disk cache generated different result"
+
+  rm -rf $cache
+  mkdir $cache
+
+  # Build and push to disk cache and http cache
+  bazel clean
+  bazel build $disk_flags $http_flags //a:test \
+    || fail "Failed to build //a:test with combined disk http cache"
+  diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
+    || fail "Built target generated different result"
 
   # Fetch from disk cache
   bazel clean

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1514,6 +1514,10 @@ EOF
 function test_genrule_combined_disk_grpc_cache() {
   # Test for the combined disk and grpc cache.
   # Built items should be pushed to both the disk and grpc cache.
+  # If --noremote_upload_local_results flag is set,
+  # built items should only be pushed to the disk cache.
+  # If --noremote_accept_cached flag is set,
+  # built items should only be checked from the disk cache.
   # If an item is missing on disk cache, but present on grpc cache,
   # then bazel should copy it from grpc cache to disk cache on fetch.
 
@@ -1533,10 +1537,66 @@ EOF
   rm -rf $cache
   mkdir $cache
 
-  # Build and push to disk and grpc cache
-  bazel build $disk_flags $grpc_flags //a:test \
+  # Build and push to disk cache but not grpc cache
+  bazel build $disk_flags $grpc_flags --incompatible_remote_results_ignore_disk=true --noremote_upload_local_results //a:test \
     || fail "Failed to build //a:test with combined disk grpc cache"
   cp -f bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected
+
+  # Fetch from disk cache
+  bazel clean
+  bazel build $disk_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_upload_local_results &> $TEST_log \
+    || fail "Failed to fetch //a:test from disk cache"
+  expect_log "1 remote cache hit" "Fetch from disk cache failed"
+  diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
+    || fail "Disk cache generated different result"
+
+  # No cache result from grpc cache, rebuild target
+  bazel clean
+  bazel build $grpc_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_upload_local_results &> $TEST_log \
+    || fail "Failed to build //a:test"
+  expect_not_log "1 remote cache hit" "Should not get cache hit from grpc cache"
+  expect_log "1 linux-sandbox" "Rebuild target failed"
+  diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
+    || fail "Rebuilt target generated different result"
+
+  rm -rf $cache
+  mkdir $cache
+
+  # No cache result from grpc cache, rebuild target, and upload result to grpc cache
+  bazel clean
+  bazel build $grpc_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_accept_cached &> $TEST_log \
+    || fail "Failed to build //a:test"
+  expect_not_log "1 remote cache hit" "Should not get cache hit from grpc cache"
+  expect_log "1 linux-sandbox" "Rebuild target failed"
+  diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
+    || fail "Rebuilt target generated different result"
+
+  # No cache result from grpc cache, rebuild target, and upload result to disk cache
+  bazel clean
+  bazel build $disk_flags $grpc_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_accept_cached &> $TEST_log \
+    || fail "Failed to build //a:test"
+  expect_not_log "1 remote cache hit" "Should not get cache hit from grpc cache"
+  expect_log "1 linux-sandbox" "Rebuild target failed"
+  diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
+    || fail "Rebuilt target generated different result"
+
+  # Fetch from disk cache
+  bazel clean
+  bazel build $disk_flags $grpc_flags //a:test --incompatible_remote_results_ignore_disk=true --noremote_accept_cached &> $TEST_log \
+    || fail "Failed to build //a:test"
+  expect_log "1 remote cache hit" "Fetch from disk cache failed"
+  diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
+    || fail "Disk cache generated different result"
+
+  rm -rf $cache
+  mkdir $cache
+
+  # Build and push to disk cache and grpc cache
+  bazel clean
+  bazel build $disk_flags $grpc_flags //a:test \
+    || fail "Failed to build //a:test with combined disk grpc cache"
+  diff bazel-genfiles/a/test.txt ${TEST_TMPDIR}/test_expected \
+    || fail "Built target generated different result"
 
   # Fetch from disk cache
   bazel clean


### PR DESCRIPTION
Disable the upload action to remote cache when `--noremote_upload_local_results` is set.

This problem would only happen in `CombinedDiskHttpBlobStore` at this moment when users want read/write permission to disk cache but only read permission to remote cache.

Once the GrpcCache refactoring (making GrpcCache a SimpleBlobStore implementation) is done, `CombinedDiskHttpBlobStore` should be renamed to `CombinedDiskRemoteBlobStore`. Then this fix will apply to both GrpcCache and HttpCache.

Fix https://github.com/bazelbuild/bazel/issues/8216