### PR TITLE
fix build for Power

### DIFF
--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -11,6 +11,12 @@ filegroup(
 )
 
 config_setting(
+    name = "linux_ppc",
+    values = {"cpu": "ppc"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "linux_x86_64",
     values = {"cpu": "k8"},
     visibility = ["//visibility:public"],

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -528,6 +528,7 @@ UNNECESSARY_DYNAMIC_LIBRARIES = select({
     # The .so file is an x86 one, so we can just remove it if the CPU is not x86
     "//src/conditions:arm": "*.so *.jnilib *.dll",
     "//src/conditions:linux_aarch64": "*.so *.jnilib *.dll",
+    "//src/conditions:linux_ppc": "*.so *.jnilib *.dll",
     # Play it safe -- better have a big binary than a slow binary
     # zip -d does require an argument. Supply something bogus.
     "//conditions:default": "*.bogusextension",


### PR DESCRIPTION
The zip -d flag will error if it doesn't find that extension.
This is a fix for Power, but doesn't fix the default case.

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>