### PR TITLE
change bash-completion .deb package dependency to suggests

### DIFF
--- a/scripts/packages/debian/BUILD
+++ b/scripts/packages/debian/BUILD
@@ -79,7 +79,6 @@ pkg_deb(
         # Keep in sync with Depends section in ./control
         "g++",
         "zlib1g-dev",
-        "bash-completion",
         "unzip",
         "python",
     ],
@@ -90,6 +89,7 @@ pkg_deb(
     suggests = [
         # Keep in sync with Suggests section in ./control
         "google-jdk | java8-sdk-headless | java8-jdk | java8-sdk | oracle-java8-installer",
+        "bash-completion",
     ],
     version_file = ":version.txt",
     visibility = ["//scripts/packages:__pkg__"],

--- a/scripts/packages/debian/control
+++ b/scripts/packages/debian/control
@@ -10,8 +10,8 @@ Section: contrib/devel
 Priority: optional
 Architecture: amd64
 # Keep in sync with :bazel-debian in ./BUILD
-Depends: g++, zlib1g-dev, bash-completion, unzip, python
-Suggests: google-jdk | java8-sdk-headless | java8-jdk | java8-sdk | oracle-java8-installer
+Depends: g++, zlib1g-dev, unzip, python
+Suggests: google-jdk | java8-sdk-headless | java8-jdk | java8-sdk | oracle-java8-installer, bash-completion
 Description: Bazel is a tool that automates software builds and tests.
  Supported build tasks include running compilers and linkers to produce
  executable programs and libraries, and assembling deployable packages


### PR DESCRIPTION
bash-completion is not a hard dependency for bazel on debian-based
installs. By moving bash-completion to a "Suggests" dependency, users
who do not want bash-completion installed can simply uninstall that
package.

Resolves #9348.