### PR TITLE
Add explicit --sdk argument to xcrun calls

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -398,7 +398,7 @@ cp $OUTPUT_DIR/libblaze.jar ${ARCHIVE_DIR}
 # TODO(b/28965185): Remove when xcode-locator is no longer required in embedded_binaries.
 log "Compiling xcode-locator..."
 if [[ $PLATFORM == "darwin" ]]; then
-  run /usr/bin/xcrun clang -fobjc-arc -framework CoreServices -framework Foundation -o ${ARCHIVE_DIR}/_embedded_binaries/xcode-locator tools/osx/xcode_locator.m
+  run /usr/bin/xcrun --sdk macosx clang -fobjc-arc -framework CoreServices -framework Foundation -o ${ARCHIVE_DIR}/_embedded_binaries/xcode-locator tools/osx/xcode_locator.m
 else
   cp tools/osx/xcode_locator_stub.sh ${ARCHIVE_DIR}/_embedded_binaries/xcode-locator
 fi

--- a/src/tools/xcode/realpath/BUILD
+++ b/src/tools/xcode/realpath/BUILD
@@ -5,7 +5,7 @@ genrule(
     name = "realpath_genrule",
     srcs = ["realpath.c"],
     outs = ["realpath"],
-    cmd = "/usr/bin/xcrun clang -o $@ $<",
+    cmd = "/usr/bin/xcrun --sdk macosx clang -o $@ $<",
     output_to_bindir = 1,
     visibility = ["//visibility:public"],
 )

--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -108,6 +108,8 @@ def configure_osx_toolchain(repository_ctx, overriden_tools):
             "env",
             "-i",
             "xcrun",
+            "--sdk",
+            "macosx",
             "clang",
             "-std=c++11",
             "-lc++",

--- a/tools/osx/BUILD
+++ b/tools/osx/BUILD
@@ -18,7 +18,7 @@ exports_files([
 ])
 
 DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
-  /usr/bin/xcrun clang -fobjc-arc -framework CoreServices \
+  /usr/bin/xcrun --sdk macosx clang -fobjc-arc -framework CoreServices \
       -framework Foundation -o $@ $<
 """
 

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -117,6 +117,8 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
         "env",
         "-i",
         "xcrun",
+        "--sdk",
+        "macosx",
         "clang",
         "-fobjc-arc",
         "-framework",


### PR DESCRIPTION
Xcode 11 (and possibly earlier versions) has a bug where, when you don't
pass `-sdk macosx`, it can either pick the global
`/Library/Developer/CommandLineTools` SDK path, or the SDK path bundled
within Xcode itself. This seems to depend on if you have other versions
of Xcode installed, and which versions of the command line tools you
have installed. Passing `-sdk macosx` seems to always force it to pick
the Xcode bundled version, which is what we prefer. This fixes issues
with remote cache misses caused by these tools not being the same
because of this difference. At least 2 apple bugs have been filed
about this FB7147521 FB7253366

You can see which path it's picking by running:

```
env -i xcrun -l -n clang
```