### PR TITLE
Prevent action-cache duplicate suppression

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/AbstractRemoteActionCache.java
@@ -354,13 +354,13 @@ public abstract class AbstractRemoteActionCache implements MissingDigestsFinder,
       } catch (IOException e) {
         if (downloadException == null) {
           downloadException = e;
-        } else {
+        } else if (e != downloadException) {
           downloadException.addSuppressed(e);
         }
       } catch (InterruptedException e) {
         if (interruptedException == null) {
           interruptedException = e;
-        } else {
+        } else if (e != interruptedException) {
           interruptedException.addSuppressed(e);
         }
       }


### PR DESCRIPTION
Exceptions that are reused between download futures must not be added to
the suppression of themselves.

Fixes #9362