### PR TITLE
Improve package loading error message on directories without BUILD files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
@@ -113,10 +113,12 @@ public class PackageLookupFunction implements SkyFunction {
    */
   public static String explainNoBuildFileValue(PackageIdentifier packageKey, Environment env)
       throws InterruptedException {
+    String educationalMessage = "A BUILD file marks a directory as a Bazel package. However, ";
     if (packageKey.getRepository().isMain()) {
       PathPackageLocator pkgLocator = PrecomputedValue.PATH_PACKAGE_LOCATOR.get(env);
       StringBuilder message = new StringBuilder();
-      message.append("BUILD file not found in any of the following directories.");
+      message.append(educationalMessage);
+      message.append("there are no BUILD files found in any of the following directories:");
       for (Root root : pkgLocator.getPathEntries()) {
         message
             .append("\n - ")
@@ -124,7 +126,8 @@ public class PackageLookupFunction implements SkyFunction {
       }
       return message.toString();
     } else {
-      return "BUILD file not found in directory '"
+      return educationalMessage
+          + "there is no BUILD file found in the directory '"
           + packageKey.getPackageFragment()
           + "' of external repository "
           + packageKey.getRepository();

--- a/src/test/java/com/google/devtools/build/lib/analysis/AnalysisFailureReportingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/AnalysisFailureReportingTest.java
@@ -92,7 +92,8 @@ public class AnalysisFailureReportingTest extends AnalysisTestCase {
         .containsExactly(
             new LoadingFailedCause(
                 causeLabel,
-                "no such package 'bar': BUILD file not found in any of the following directories.\n"
+                "no such package 'bar': A BUILD file marks a directory as a Bazel package. "
+                    + "However, there are no BUILD files in any of the following directories:\n"
                     + " - /workspace/bar"));
   }
 


### PR DESCRIPTION
Let's inform the user that BUILD files turn directories into packages.

Fixes https://github.com/bazelbuild/bazel/pull/9364