### PR TITLE
Provide jdk:current_host_java_runtime in runfiles

### DIFF
--- a/tools/jdk/java_toolchain_alias.bzl
+++ b/tools/jdk/java_toolchain_alias.bzl
@@ -46,10 +46,14 @@ java_runtime_alias = rule(
 def _java_host_runtime_alias(ctx):
     """An experimental implementation of java_host_runtime_alias using toolchain resolution."""
     runtime = ctx.attr._runtime
+    toolchain = runtime[java_common.JavaRuntimeInfo]
     return [
-        runtime[java_common.JavaRuntimeInfo],
+        toolchain,
         runtime[platform_common.TemplateVariableInfo],
-        runtime[DefaultInfo],
+        DefaultInfo(
+            runfiles = ctx.runfiles(transitive_files = toolchain.files),
+            files = toolchain.files,
+        ),
     ]
 
 java_host_runtime_alias = rule(


### PR DESCRIPTION
Closes #9391.

While jdk:current_java_runtime is provided in runfiles,
jdk:current_host_java_runtime is not. With this change it is possible
to access the location of host java runtime.

Change-Id: Iac0949ff8b64c33d57a8324de28d75f8bc8c7fc4