### PR TITLE
Fix framework_search_paths var name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
@@ -21,7 +21,7 @@ import static com.google.devtools.build.lib.rules.objc.ObjcProvider.DEFINE;
 import static com.google.devtools.build.lib.rules.objc.ObjcProvider.DYNAMIC_FRAMEWORK_DIR;
 import static com.google.devtools.build.lib.rules.objc.ObjcProvider.DYNAMIC_FRAMEWORK_FILE;
 import static com.google.devtools.build.lib.rules.objc.ObjcProvider.FORCE_LOAD_LIBRARY;
-import static com.google.devtools.build.lib.rules.objc.ObjcProvider.FRAMEWORK_SEARCH_PATH_ONLY;
+import static com.google.devtools.build.lib.rules.objc.ObjcProvider.FRAMEWORK_SEARCH_PATHS;
 import static com.google.devtools.build.lib.rules.objc.ObjcProvider.FRAMEWORK_SUFFIX;
 import static com.google.devtools.build.lib.rules.objc.ObjcProvider.HEADER;
 import static com.google.devtools.build.lib.rules.objc.ObjcProvider.IMPORTED_LIBRARY;
@@ -691,7 +691,7 @@ public class CompilationSupport {
         // include "foo" as a search path.
         .addAll(uniqueParentDirectories(provider.getStaticFrameworkDirs()))
         .addAll(uniqueParentDirectories(provider.get(DYNAMIC_FRAMEWORK_DIR)))
-        .addAll(uniqueParentDirectories(provider.get(FRAMEWORK_SEARCH_PATH_ONLY)))
+        .addAll(uniqueParentDirectories(provider.get(FRAMEWORK_SEARCH_PATHS)))
         .build();
   }
 
@@ -706,7 +706,7 @@ public class CompilationSupport {
     }
     ImmutableList.Builder<PathFragment> searchPaths = new ImmutableList.Builder<>();
     return searchPaths
-        .addAll(uniqueParentDirectories(provider.get(FRAMEWORK_SEARCH_PATH_ONLY)))
+        .addAll(uniqueParentDirectories(provider.get(FRAMEWORK_SEARCH_PATHS)))
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommon.java
@@ -368,7 +368,7 @@ public final class ObjcCommon {
           objcProvider.addTransitiveAndPropagate(ObjcProvider.DYNAMIC_FRAMEWORK_FILE, provider);
           objcProvider.addTransitiveAndPropagate(ObjcProvider.STATIC_FRAMEWORK_FILE, provider);
         } else {
-          objcProvider.addTransitiveAndPropagate(ObjcProvider.FRAMEWORK_SEARCH_PATH_ONLY, provider);
+          objcProvider.addTransitiveAndPropagate(ObjcProvider.FRAMEWORK_SEARCH_PATHS, provider);
           objcProvider.addTransitiveAndPropagate(ObjcProvider.HEADER, provider);
         }
         objcProvider.addTransitiveAndPropagate(ObjcProvider.MERGE_ZIP, provider);

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcProvider.java
@@ -241,7 +241,7 @@ public final class ObjcProvider extends Info implements ObjcProviderApi<Artifact
    * each compile action, but do not cause -framework (link framework) arguments to be added to
    * link actions.
    */
-  public static final Key<PathFragment> FRAMEWORK_SEARCH_PATH_ONLY =
+  public static final Key<PathFragment> FRAMEWORK_SEARCH_PATHS =
       new Key<>(LINK_ORDER, "framework_search_paths", PathFragment.class);
 
   /** The static library files of user-specified static frameworks. */
@@ -358,7 +358,7 @@ public final class ObjcProvider extends Info implements ObjcProviderApi<Artifact
           DYNAMIC_FRAMEWORK_DIR,
           DYNAMIC_FRAMEWORK_FILE,
           EXPORTED_DEBUG_ARTIFACTS,
-          FRAMEWORK_SEARCH_PATH_ONLY,
+          FRAMEWORK_SEARCH_PATHS,
           FORCE_LOAD_LIBRARY,
           HEADER,
           IMPORTED_LIBRARY,
@@ -423,7 +423,7 @@ public final class ObjcProvider extends Info implements ObjcProviderApi<Artifact
   @Override
   public SkylarkNestedSet frameworkSearchPathOnly() {
     return ObjcProviderSkylarkConverters.convertPathFragmentsToSkylark(
-        get(FRAMEWORK_SEARCH_PATH_ONLY));
+        get(FRAMEWORK_SEARCH_PATHS));
   }
 
   @Override
@@ -594,7 +594,7 @@ public final class ObjcProvider extends Info implements ObjcProviderApi<Artifact
           DYNAMIC_FRAMEWORK_FILE,
           FLAG,
           MERGE_ZIP,
-          FRAMEWORK_SEARCH_PATH_ONLY,
+          FRAMEWORK_SEARCH_PATHS,
           HEADER,
           INCLUDE,
           INCLUDE_SYSTEM,


### PR DESCRIPTION
In the documentation this is showing up incorrectly because of the
variable name.