### PR TITLE
Create new DefaultInfo for java_host_runtime_alias instead of propagating the same object.

### DIFF
--- a/tools/jdk/java_toolchain_alias.bzl
+++ b/tools/jdk/java_toolchain_alias.bzl
@@ -49,9 +49,12 @@ def _java_host_runtime_alias(ctx):
     return [
         runtime[java_common.JavaRuntimeInfo],
         runtime[platform_common.TemplateVariableInfo],
+        # Create a new DefaultInfo instead of propagating runtime[DefaultInfo]
+        # directly.
         DefaultInfo(
-            runfiles = ctx.runfiles(transitive_files = runtime.files),
-            files = runtime.files,
+            files = runtime[DefaultInfo].files,
+            data_runfiles = runtime[DefaultInfo].data_runfiles,
+            default_runfiles = runtime[DefaultInfo].default_runfiles,
         ),
     ]
 

--- a/tools/jdk/java_toolchain_alias.bzl
+++ b/tools/jdk/java_toolchain_alias.bzl
@@ -49,7 +49,10 @@ def _java_host_runtime_alias(ctx):
     return [
         runtime[java_common.JavaRuntimeInfo],
         runtime[platform_common.TemplateVariableInfo],
-        runtime[DefaultInfo],
+        DefaultInfo(
+            runfiles = ctx.runfiles(transitive_files = runtime.files),
+            files = runtime.files,
+        ),
     ]
 
 java_host_runtime_alias = rule(


### PR DESCRIPTION
Fixes #9391.