### PR TITLE
Specify 2.7 instead of 2 for python version

### DIFF
--- a/tools/python/utils.bzl
+++ b/tools/python/utils.bzl
@@ -21,7 +21,7 @@ file is less likely to cause bootstrapping issues.
 
 def _expand_pyversion_template_impl(ctx):
     for output, version, strict in [
-        (ctx.outputs.out2, "2", "1"),
+        (ctx.outputs.out2, "2.7", "1"),
         (ctx.outputs.out3, "3", "1"),
         (ctx.outputs.out2_nonstrict, "2", "0"),
         (ctx.outputs.out3_nonstrict, "3", "0"),


### PR DESCRIPTION
This changes the python setup to prefer an executable named `python2.7`
over `python2`. This fixes an issue on macOS where it doesn't ship with
a `python2` executable, but you can install one from homebrew, but
really you'd prefer to be using the system `python2.7` binary. I assume
that this isn't a huge issue because bazel likely doesn't support
versions of python before 2.7.

Follow up to https://github.com/bazelbuild/bazel/commit/3a4be3c93813987a27a97dade3f9ebbc5770e349