### PR TITLE
Add explicit version minimums for macOS tools

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -398,7 +398,7 @@ cp $OUTPUT_DIR/libblaze.jar ${ARCHIVE_DIR}
 # TODO(b/28965185): Remove when xcode-locator is no longer required in embedded_binaries.
 log "Compiling xcode-locator..."
 if [[ $PLATFORM == "darwin" ]]; then
-  run /usr/bin/xcrun --sdk macosx clang -fobjc-arc -framework CoreServices -framework Foundation -o ${ARCHIVE_DIR}/_embedded_binaries/xcode-locator tools/osx/xcode_locator.m
+  run /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.9 -fobjc-arc -framework CoreServices -framework Foundation -o ${ARCHIVE_DIR}/_embedded_binaries/xcode-locator tools/osx/xcode_locator.m
 else
   cp tools/osx/xcode_locator_stub.sh ${ARCHIVE_DIR}/_embedded_binaries/xcode-locator
 fi

--- a/src/tools/xcode/realpath/BUILD
+++ b/src/tools/xcode/realpath/BUILD
@@ -5,7 +5,7 @@ genrule(
     name = "realpath_genrule",
     srcs = ["realpath.c"],
     outs = ["realpath"],
-    cmd = "/usr/bin/xcrun --sdk macosx clang -o $@ $<",
+    cmd = "/usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.9 -o $@ $<",
     output_to_bindir = 1,
     visibility = ["//visibility:public"],
 )

--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -111,6 +111,7 @@ def configure_osx_toolchain(repository_ctx, overriden_tools):
             "--sdk",
             "macosx",
             "clang",
+            "-mmacosx-version-min=10.9",
             "-std=c++11",
             "-lc++",
             "-o",

--- a/tools/osx/BUILD
+++ b/tools/osx/BUILD
@@ -18,7 +18,7 @@ exports_files([
 ])
 
 DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
-  /usr/bin/xcrun --sdk macosx clang -fobjc-arc -framework CoreServices \
+  /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.9 -fobjc-arc -framework CoreServices \
       -framework Foundation -o $@ $<
 """
 

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -120,6 +120,7 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
         "--sdk",
         "macosx",
         "clang",
+        "-mmacosx-version-min=10.9",
         "-fobjc-arc",
         "-framework",
         "CoreServices",


### PR DESCRIPTION
This is a follow up to https://github.com/bazelbuild/bazel/pull/9371
which helps maintain cache hits across different macOS versions. By
default when you compile something on macOS with clang the minimum OS
version is set to the current OS version. This means if you have
developers on multiple OS versions they may not get cache hits.

10.9 was chosen to match rules_apple https://github.com/bazelbuild/rules_apple/commit/86ce42562e784cc5cbd17aeb5f5a5334c856ba9b