### PR TITLE
Update deprecated flag value

### DIFF
--- a/site/docs/remote-caching.md
+++ b/site/docs/remote-caching.md
@@ -247,7 +247,7 @@ Use the following flags to:
 
 ```
 build --remote_cache=http://replace-with-your.host:port
-build --spawn_strategy=standalone
+build --spawn_strategy=local
 ```
 
 Using the remote cache with sandboxing enabled is the default. Use the
@@ -266,7 +266,7 @@ disabled.
 ```
 build --remote_cache=http://replace-with-your.host:port
 build --remote_upload_local_results=false
-build --spawn_strategy=standalone
+build --spawn_strategy=local
 ```
 
 Using the remote cache with sandboxing enabled is experimental. Use the


### PR DESCRIPTION
According to the User Manual, `standalone` is a deprecated value for the `--spawn_strategy` flag. This update the Remote Caching page to use the new value `local` instead.