### PR TITLE
Bazel client: fix string conversion functions

### DIFF
--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -389,7 +389,7 @@ string GetSelfPath() {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "GetSelfPath: GetModuleFileNameW: " << GetLastErrorString();
   }
-  return string(blaze_util::WstringToCstring(buffer).get());
+  return blaze_util::WstringToCstring(buffer);
 }
 
 string GetOutputRoot() {
@@ -418,7 +418,7 @@ string GetHomeDir() {
   // is the same as %USERPROFILE%, but it does not require the envvar to be set.
   if (SUCCEEDED(::SHGetKnownFolderPath(FOLDERID_Profile, KF_FLAG_DEFAULT, NULL,
                                        &wpath))) {
-    string result = string(blaze_util::WstringToCstring(wpath).get());
+    string result = blaze_util::WstringToCstring(wpath);
     ::CoTaskMemFree(wpath);
     return result;
   }
@@ -515,7 +515,7 @@ static void CreateCommandLine(CmdLine* result, const blaze_util::Path& exe,
     BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
         << "Command line too long (" << cmdline_str.size() << " > "
         << MAX_CMDLINE_LENGTH
-        << "): " << blaze_util::WstringToCstring(cmdline_str.c_str()).get();
+        << "): " << blaze_util::WstringToCstring(cmdline_str);
   }
 
   // Copy command line into a mutable buffer.
@@ -675,7 +675,7 @@ int ExecuteDaemon(const blaze_util::Path& exe,
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "ExecuteDaemon(" << exe.AsPrintablePath()
         << "): attribute list creation failed: "
-        << blaze_util::WstringToString(werror);
+        << blaze_util::WstringToCstring(werror);
   }
 
   PROCESS_INFORMATION processInfo = {0};
@@ -685,7 +685,7 @@ int ExecuteDaemon(const blaze_util::Path& exe,
   std::vector<std::wstring> wesc_args_vector;
   wesc_args_vector.reserve(args_vector.size());
   for (const string& a : args_vector) {
-    std::wstring wa = blaze_util::CstringToWstring(a.c_str()).get();
+    std::wstring wa = blaze_util::CstringToWstring(a);
     std::wstring wesc = bazel::windows::WindowsEscapeArg(wa);
     wesc_args_vector.push_back(wesc);
   }
@@ -755,14 +755,14 @@ static void ExecuteProgram(const blaze_util::Path& exe,
           bazel::windows::WaitableProcess::kWaitSuccess) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "ExecuteProgram(" << exe.AsPrintablePath()
-        << ") failed: " << blaze_util::WstringToCstring(werror.c_str()).get();
+        << ") failed: " << blaze_util::WstringToCstring(werror);
   }
   werror.clear();
   int x = proc.GetExitCode(&werror);
   if (!werror.empty()) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "ExecuteProgram(" << exe.AsPrintablePath()
-        << ") failed: " << blaze_util::WstringToCstring(werror.c_str()).get();
+        << ") failed: " << blaze_util::WstringToCstring(werror);
   }
   exit(x);
 }
@@ -772,7 +772,7 @@ void ExecuteServerJvm(const blaze_util::Path& exe,
   std::vector<std::wstring> wargs;
   wargs.reserve(server_jvm_args.size());
   for (const string& a : server_jvm_args) {
-    std::wstring wa = blaze_util::CstringToWstring(a.c_str()).get();
+    std::wstring wa = blaze_util::CstringToWstring(a);
     std::wstring wesc = bazel::windows::WindowsEscapeArg(wa);
     wargs.push_back(wesc);
   }
@@ -786,7 +786,7 @@ void ExecuteRunRequest(const blaze_util::Path& exe,
   wargs.reserve(run_request_args.size());
   std::wstringstream joined;
   for (const string& a : run_request_args) {
-    std::wstring wa = blaze_util::CstringToWstring(a.c_str()).get();
+    std::wstring wa = blaze_util::CstringToWstring(a);
     // The arguments are already escaped (Bash-style or Windows-style, depending
     // on --[no]incompatible_windows_bashless_run_command).
     wargs.push_back(wa);
@@ -812,7 +812,7 @@ bool SymlinkDirectories(const string& posix_target,
   wstring werror;
   if (CreateJunction(name.AsNativePath(), target, &werror) !=
       CreateJunctionResult::kSuccess) {
-    string error(blaze_util::WstringToCstring(werror.c_str()).get());
+    string error(blaze_util::WstringToCstring(werror));
     BAZEL_LOG(ERROR) << "SymlinkDirectories(" << posix_target << ", "
                      << name.AsPrintablePath()
                      << "): CreateJunction: " << error;
@@ -1163,7 +1163,7 @@ string GetUserName() {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "GetUserNameW failed: " << GetLastErrorString();
   }
-  return string(blaze_util::WstringToCstring(buffer).get());
+  return blaze_util::WstringToCstring(buffer);
 }
 
 bool IsEmacsTerminal() {

--- a/src/main/cpp/util/file_windows.cc
+++ b/src/main/cpp/util/file_windows.cc
@@ -443,7 +443,7 @@ bool ReadDirectorySymlink(const blaze_util::Path& name, string* result) {
   if (!RealPath(name.AsNativePath().c_str(), &result_ptr)) {
     return false;
   }
-  *result = WstringToCstring(RemoveUncPrefixMaybe(result_ptr.get())).get();
+  *result = WstringToCstring(RemoveUncPrefixMaybe(result_ptr.get()));
   return true;
 }
 
@@ -490,7 +490,7 @@ string MakeCanonical(const char* path) {
     *p_to++ = towlower(*p_from++);
   }
   *p_to = 0;
-  return string(WstringToCstring(lcase_realpath.get()).get());
+  return WstringToCstring(lcase_realpath.get());
 }
 
 static bool CanReadFileW(const wstring& path) {
@@ -600,7 +600,7 @@ bool MakeDirectoriesW(const wstring& path, unsigned int mode) {
   std::string error;
   if (!AsAbsoluteWindowsPath(path, &abs_path, &error)) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "MakeDirectoriesW(" << blaze_util::WstringToString(path)
+        << "MakeDirectoriesW(" << blaze_util::WstringToCstring(path)
         << "): " << error;
   }
   if (IsRootDirectoryW(abs_path) || IsDirectoryW(abs_path)) {
@@ -611,7 +611,7 @@ bool MakeDirectoriesW(const wstring& path, unsigned int mode) {
     // Since `abs_path` is not a root directory, there should have been at least
     // one directory above it.
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "MakeDirectoriesW(" << blaze_util::WstringToString(abs_path)
+        << "MakeDirectoriesW(" << blaze_util::WstringToCstring(abs_path)
         << ") could not find dirname: " << GetLastErrorString();
   }
   return MakeDirectoriesW(parent, mode) &&
@@ -674,8 +674,7 @@ std::wstring GetCwdW() {
 }
 
 string GetCwd() {
-  return string(
-      WstringToCstring(RemoveUncPrefixMaybe(GetCwdW().c_str())).get());
+  return WstringToCstring(RemoveUncPrefixMaybe(GetCwdW().c_str()));
 }
 
 bool ChangeDirectory(const string& path) {
@@ -717,9 +716,10 @@ void ForEachDirectoryEntryW(const wstring& path,
   }
   string error;
   if (!AsWindowsPath(path, &wpath, &error)) {
+    std::string err = GetLastErrorString();
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
-        << "ForEachDirectoryEntryW(" << path
-        << "): AsWindowsPath failed: " << GetLastErrorString();
+        << "ForEachDirectoryEntryW(" << WstringToCstring(path)
+        << "): AsWindowsPath failed: " << err;
   }
 
   static const wstring kUncPrefix(L"\\\\?\\");
@@ -794,7 +794,7 @@ void ForEachDirectoryEntry(const string &path,
   do {
     if (kDot != metadata.cFileName && kDotDot != metadata.cFileName) {
       wstring wname = wpath + metadata.cFileName;
-      string name(WstringToCstring(/* omit prefix */ 4 + wname.c_str()).get());
+      string name(WstringToCstring(/* omit prefix */ 4 + wname.c_str()));
       bool is_dir = (metadata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
       bool is_junc =
           (metadata.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;

--- a/src/main/cpp/util/logging.cc
+++ b/src/main/cpp/util/logging.cc
@@ -70,11 +70,6 @@ DECLARE_STREAM_OPERATOR(double)
 DECLARE_STREAM_OPERATOR(long double)
 DECLARE_STREAM_OPERATOR(void*)
 
-LogMessage& LogMessage::operator<<(const std::wstring& wstr) {
-  message_ << WstringToString(wstr);
-  return *this;
-}
-
 #undef DECLARE_STREAM_OPERATOR
 
 void LogMessage::Finish() {

--- a/src/main/cpp/util/logging.h
+++ b/src/main/cpp/util/logging.h
@@ -53,7 +53,6 @@ class LogMessage {
              int exit_code);
 
   LogMessage& operator<<(const std::string& value);
-  LogMessage& operator<<(const std::wstring& wstr);
   LogMessage& operator<<(const char* value);
   LogMessage& operator<<(char value);
   LogMessage& operator<<(bool value);

--- a/src/main/cpp/util/path_windows.cc
+++ b/src/main/cpp/util/path_windows.cc
@@ -88,8 +88,7 @@ std::string MakeAbsolute(const std::string& path) {
         << "): AsAbsoluteWindowsPath failed: " << error;
   }
   std::transform(wpath.begin(), wpath.end(), wpath.begin(), ::towlower);
-  return std::string(
-      WstringToCstring(RemoveUncPrefixMaybe(wpath.c_str())).get());
+  return WstringToCstring(RemoveUncPrefixMaybe(wpath.c_str()));
 }
 
 std::string MakeAbsoluteAndResolveEnvvars(const std::string& path) {
@@ -302,8 +301,7 @@ bool AsWindowsPath(const std::string& path, std::string* result,
 
 bool AsWindowsPath(const std::string& path, std::wstring* result,
                    std::string* error) {
-  return AsWindowsPathImpl(std::wstring(CstringToWstring(path.c_str()).get()),
-                           result, error);
+  return AsWindowsPathImpl(CstringToWstring(path), result, error);
 }
 
 bool AsWindowsPath(const std::wstring& path, std::wstring* result,
@@ -339,8 +337,7 @@ static bool AsAbsoluteWindowsPathImpl(const std::wstring& path,
 
 bool AsAbsoluteWindowsPath(const std::string& path, std::wstring* result,
                            std::string* error) {
-  return AsAbsoluteWindowsPathImpl(CstringToWstring(path.c_str()).get(), result,
-                                   error);
+  return AsAbsoluteWindowsPathImpl(CstringToWstring(path), result, error);
 }
 
 bool AsAbsoluteWindowsPath(const std::wstring& path, std::wstring* result,
@@ -351,9 +348,8 @@ bool AsAbsoluteWindowsPath(const std::wstring& path, std::wstring* result,
 bool AsShortWindowsPath(const std::string& path, std::string* result,
                         std::string* error) {
   std::wstring wresult;
-  if (AsShortWindowsPath(CstringToWstring(path.c_str()).get(), &wresult,
-                         error)) {
-    *result = WstringToString(wresult);
+  if (AsShortWindowsPath(CstringToWstring(path), &wresult, error)) {
+    *result = WstringToCstring(wresult);
     return true;
   } else {
     return false;
@@ -413,8 +409,8 @@ bool AsShortWindowsPath(const std::wstring& path, std::wstring* result,
       if (error) {
         std::string last_error = GetLastErrorString();
         std::stringstream msg;
-        msg << "AsShortWindowsPath(" << WstringToString(path)
-            << "): GetShortPathNameW(" << WstringToString(wpath)
+        msg << "AsShortWindowsPath(" << WstringToCstring(path)
+            << "): GetShortPathNameW(" << WstringToCstring(wpath)
             << ") failed: " << last_error;
         *error = msg.str();
       }
@@ -498,8 +494,7 @@ Path Path::GetRelative(const std::string& r) const {
     std::string error;
     std::wstring new_path;
     if (!AsAbsoluteWindowsPath(
-            path_ + L"\\" + CstringToWstring(r.c_str()).get(), &new_path,
-            &error)) {
+            path_ + L"\\" + CstringToWstring(r), &new_path, &error)) {
       BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
           << "Path::GetRelative failed: " << error;
     }
@@ -508,7 +503,7 @@ Path Path::GetRelative(const std::string& r) const {
 }
 
 Path Path::Canonicalize() const {
-  return Path(MakeCanonical(WstringToString(path_).c_str()));
+  return Path(MakeCanonical(WstringToCstring(path_).c_str()));
 }
 
 Path Path::GetParent() const { return Path(SplitPathW(path_).first); }
@@ -520,11 +515,11 @@ bool Path::Contains(const char c) const {
 }
 
 bool Path::Contains(const std::string& s) const {
-  return path_.find(CstringToWstring(s.c_str()).get()) != std::wstring::npos;
+  return path_.find(CstringToWstring(s)) != std::wstring::npos;
 }
 
 std::string Path::AsPrintablePath() const {
-  return WstringToCstring(RemoveUncPrefixMaybe(path_.c_str())).get();
+  return WstringToCstring(RemoveUncPrefixMaybe(path_.c_str()));
 }
 
 std::string Path::AsJvmArgument() const {

--- a/src/main/cpp/util/strings.cc
+++ b/src/main/cpp/util/strings.cc
@@ -289,40 +289,6 @@ string AsLower(const string &str) {
   return string(result.get());
 }
 
-template <typename U, typename V>
-static unique_ptr<V[]> UstringToVstring(
-    const U *input, size_t (*convert)(V *output, const U *input, size_t len),
-    const char *fmtStringU) {
-  size_t size = convert(nullptr, input, 0) + 1;
-  if (size == (size_t)-1) {
-    fprintf(stderr, "UstringToVstring: invalid input \"");
-    fprintf(stderr, fmtStringU, input);
-    fprintf(stderr, "\"\n");
-    exit(blaze_exit_code::INTERNAL_ERROR);
-    return unique_ptr<V[]>(nullptr);  // formally return, though unreachable
-  }
-  unique_ptr<V[]> result(new V[size]);
-  convert(result.get(), input, size);
-  result.get()[size - 1] = 0;
-  return std::move(result);
-}
-
-unique_ptr<char[]> WstringToCstring(const wchar_t *input) {
-  return UstringToVstring<wchar_t, char>(input, wcstombs, "%ls");
-}
-
-std::string WstringToString(const std::wstring &input) {
-  return string(WstringToCstring(input.c_str()).get());
-}
-
-unique_ptr<wchar_t[]> CstringToWstring(const char *input) {
-  return UstringToVstring<char, wchar_t>(input, mbstowcs, "%s");
-}
-
-std::wstring CstringToWstring(const std::string &input) {
-  return wstring(CstringToWstring(input.c_str()).get());
-}
-
 #if defined(_WIN32) || defined(__CYGWIN__)
 
 template <typename U, typename V>
@@ -372,9 +338,9 @@ static int ConvertWcsToMbs(const bool use_utf8, const std::wstring &input,
                              output, output_size, NULL, NULL);
 }
 
-static int ConvertMbsToWcs(const bool use_utf8, const std::string &input,
+static int ConvertMbsToWcs(const bool /* unused */, const std::string &input,
                            wchar_t *output, const size_t output_size) {
-  return MultiByteToWideChar(use_utf8 ? CP_UTF8 : CP_ACP, 0, input.c_str(), -1,
+  return MultiByteToWideChar(CP_UTF8, 0, input.c_str(), -1,
                              output, output_size);
 }
 
@@ -388,14 +354,34 @@ bool WcsToUtf8(const std::wstring &input, std::string *output,
   return UStrToVStr(input, output, true, ConvertWcsToMbs, win32_error);
 }
 
-bool AcpToWcs(const std::string &input, std::wstring *output,
-              uint32_t *win32_error) {
-  return UStrToVStr(input, output, false, ConvertMbsToWcs, win32_error);
-}
-
 bool Utf8ToWcs(const std::string &input, std::wstring *output,
                uint32_t *win32_error) {
-  return UStrToVStr(input, output, true, ConvertMbsToWcs, win32_error);
+  return UStrToVStr(input, output, /* unused */ true, ConvertMbsToWcs,
+                    win32_error);
+}
+
+std::string WstringToCstring(const std::wstring &input) {
+  std::string result;
+  uint32_t err;
+  if (!WcsToUtf8(input, &result, &err)) {
+    fprintf(stderr,
+            "WstringToCstring: failed with error %d (0x%08x), "
+            "invalid input \"%ls\"\n", err, err, input.c_str());
+    exit(blaze_exit_code::INTERNAL_ERROR);
+  }
+  return result;
+}
+
+std::wstring CstringToWstring(const std::string &input) {
+  std::wstring result;
+  uint32_t err;
+  if (!Utf8ToWcs(input, &result, &err)) {
+    fprintf(stderr,
+            "CstringToWstring: failed with error %d (0x%08x), "
+            "invalid input \"%s\"\n", err, err, input.c_str());
+    exit(blaze_exit_code::INTERNAL_ERROR);
+  }
+  return result;
 }
 
 #endif  // defined(_WIN32) || defined(__CYGWIN__)

--- a/src/main/cpp/util/strings.h
+++ b/src/main/cpp/util/strings.h
@@ -107,30 +107,6 @@ void ToLower(std::string *str);
 
 std::string AsLower(const std::string &str);
 
-// Convert a wchar_t string to a char string. Useful when consuming results of
-// widechar Windows API functions.
-// TODO(laszlocsomor): audit usages of WstringToCstring and replace with
-// WcsToAcp or WcsToUtf8 appropriately. WstringToCstring does not specify the
-// output encoding.
-//
-// Deprecated. Use WcsToAcp or WcsToUtf8.
-std::unique_ptr<char[]> WstringToCstring(const wchar_t *input);
-
-// Deprecated. Use WcsToAcp or WcsToUtf8.
-std::string WstringToString(const std::wstring &input);
-
-// Convert a char string to a wchar_t string. Useful when passing arguments to
-// widechar Windows API functions.
-// TODO(laszlocsomor): audit usages of CstringToWstring and replace with
-// AcpToWcs or Utf8ToWcs appropriately. CstringToWstring does not specify the
-// input encoding.
-//
-// Deprecated. Use AcpToWcs or Utf8ToWcs.
-std::unique_ptr<wchar_t[]> CstringToWstring(const char *input);
-
-// Deprecated. Use AcpToWcs or Utf8ToWcs.
-std::wstring CstringToWstring(const std::string &input);
-
 #if defined(_WIN32) || defined(__CYGWIN__)
 // Convert UTF-16 string to ASCII (using the Active Code Page).
 bool WcsToAcp(const std::wstring &input, std::string *output,
@@ -140,13 +116,15 @@ bool WcsToAcp(const std::wstring &input, std::string *output,
 bool WcsToUtf8(const std::wstring &input, std::string *output,
                uint32_t *error = nullptr);
 
-// Convert ASCII string (using the Active Code Page) to UTF-16 string.
-bool AcpToWcs(const std::string &input, std::wstring *output,
-              uint32_t *error = nullptr);
-
 // Convert UTF-8 string to UTF-16.
 bool Utf8ToWcs(const std::string &input, std::wstring *output,
                uint32_t *error = nullptr);
+
+// Deprecated. Use WcsToAcp or WcsToUtf8.
+std::string WstringToCstring(const std::wstring &input);
+
+// Deprecated. Use AcpToWcs or Utf8ToWcs.
+std::wstring CstringToWstring(const std::string &input);
 #endif  // defined(_WIN32) || defined(__CYGWIN__)
 
 }  // namespace blaze_util

--- a/src/test/cpp/blaze_util_windows_test.cc
+++ b/src/test/cpp/blaze_util_windows_test.cc
@@ -46,11 +46,11 @@ using std::wstring;
         ::GetEnvironmentVariableA(blaze_util::AsLower(key).c_str(), NULL, 0), \
         (DWORD)0);                                                            \
     ASSERT_EQ(::GetEnvironmentVariableW(                                      \
-                  blaze_util::CstringToWstring(key).get(), NULL, 0),          \
+                  blaze_util::CstringToWstring(key).c_str(), NULL, 0),        \
               (DWORD)0);                                                      \
     ASSERT_EQ(::GetEnvironmentVariableW(blaze_util::CstringToWstring(         \
-                                            blaze_util::AsLower(key).c_str()) \
-                                            .get(),                           \
+                                            blaze_util::AsLower(key))         \
+                                            .c_str(),                         \
                                         NULL, 0),                             \
               (DWORD)0);                                                      \
   }
@@ -82,8 +82,8 @@ using std::wstring;
     ASSERT_EQ(string(buf.get()), expected);                                  \
                                                                              \
     /* Assert that GetEnvironmentVariableW can retrieve the value. */        \
-    wstring wkey(blaze_util::CstringToWstring(key.c_str()).get());           \
-    wstring wexpected(blaze_util::CstringToWstring(expected.c_str()).get()); \
+    wstring wkey(blaze_util::CstringToWstring(key));                         \
+    wstring wexpected(blaze_util::CstringToWstring(expected));               \
     size = ::GetEnvironmentVariableW(wkey.c_str(), NULL, 0);                 \
     ASSERT_GT(size, (DWORD)0);                                               \
     unique_ptr<WCHAR[]> wbuf(new WCHAR[size]);                               \
@@ -92,7 +92,7 @@ using std::wstring;
     ASSERT_EQ(wstring(wbuf.get()), wexpected);                               \
                                                                              \
     /* Assert that widechar envvar keys are case-insensitive. */             \
-    wstring wlkey(blaze_util::CstringToWstring(lkey.c_str()).get());         \
+    wstring wlkey(blaze_util::CstringToWstring(lkey));                       \
     ASSERT_EQ(::GetEnvironmentVariableW(wlkey.c_str(), wbuf.get(), size),    \
               size - 1);                                                     \
     ASSERT_EQ(wstring(wbuf.get()), wexpected);                               \

--- a/src/test/cpp/util/path_windows_test.cc
+++ b/src/test/cpp/util/path_windows_test.cc
@@ -199,7 +199,7 @@ TEST(PathWindowsTest, TestAsAbsoluteWindowsPath) {
   ASSERT_EQ(L"\\\\?\\c:\\non-existent", actual);
 
   WCHAR cwd[MAX_PATH];
-  wstring cwdw(CstringToWstring(GetCwd().c_str()).get());
+  wstring cwdw(CstringToWstring(GetCwd()));
   wstring expected =
       wstring(L"\\\\?\\") + cwdw +
       ((cwdw.back() == L'\\') ? L"non-existent" : L"\\non-existent");

--- a/src/test/cpp/util/strings_test.cc
+++ b/src/test/cpp/util/strings_test.cc
@@ -303,16 +303,6 @@ TEST(BlazeUtil, StringPrintf) {
   EXPECT_EQ("a b", out);
 }
 
-TEST(BlazeUtil, CstringToWstringTest) {
-  unique_ptr<wchar_t[]> actual = CstringToWstring("hello world");
-  EXPECT_EQ(0, wcscmp(actual.get(), L"hello world"));
-}
-
-TEST(BlazeUtil, WstringToCstringTest) {
-  unique_ptr<char[]> actual = WstringToCstring(L"hello world");
-  EXPECT_EQ(0, strcmp(actual.get(), "hello world"));
-}
-
 TEST(BlazeUtil, EndsWithTest) {
   ASSERT_TRUE(ends_with("", ""));
   ASSERT_TRUE(ends_with(L"", L""));

--- a/src/test/cpp/util/strings_windows_test.cc
+++ b/src/test/cpp/util/strings_windows_test.cc
@@ -46,13 +46,6 @@ static const wchar_t kUtf16Cyrillic[] = {
     0x0,
 };
 
-TEST(BlazeUtil, WcsToAcpTest) {
-  std::string actual;
-  uint32_t win32_err;
-  ASSERT_TRUE(WcsToAcp(kUtf16Latin, &actual, &win32_err));
-  ASSERT_TRUE(actual == kAsciiLatin);
-}
-
 TEST(BlazeUtil, WcsToUtf8Test) {
   std::string actual;
   uint32_t win32_err;
@@ -62,13 +55,6 @@ TEST(BlazeUtil, WcsToUtf8Test) {
   ASSERT_TRUE(actual == kUtf8Cyrillic);
 }
 
-TEST(BlazeUtil, AcpToWcsTest) {
-  std::wstring actual;
-  uint32_t win32_err;
-  ASSERT_TRUE(AcpToWcs(kAsciiLatin, &actual, &win32_err));
-  ASSERT_TRUE(actual == kUtf16Latin);
-}
-
 TEST(BlazeUtil, Utf8ToWcsTest) {
   std::wstring actual;
   uint32_t win32_err;
@@ -76,6 +62,18 @@ TEST(BlazeUtil, Utf8ToWcsTest) {
   ASSERT_TRUE(actual == kUtf16Latin);
   ASSERT_TRUE(Utf8ToWcs(kUtf8Cyrillic, &actual, &win32_err));
   ASSERT_TRUE(actual == kUtf16Cyrillic);
+}
+
+TEST(BlazeUtil, Utf8ToUtf16) {
+  EXPECT_EQ(CstringToWstring("Hello"), L"Hello");
+  EXPECT_EQ(CstringToWstring(kAsciiLatin), kUtf16Latin);
+  EXPECT_EQ(CstringToWstring(kUtf8Cyrillic), kUtf16Cyrillic);
+}
+
+TEST(BlazeUtil, Utf16ToUtf8) {
+  EXPECT_EQ(WstringToCstring(L"Hello"), "Hello");
+  EXPECT_EQ(WstringToCstring(kUtf16Latin), kAsciiLatin);
+  EXPECT_EQ(WstringToCstring(kUtf16Cyrillic), kUtf8Cyrillic);
 }
 
 }  // namespace blaze_util

--- a/src/tools/launcher/util/data_parser_test.cc
+++ b/src/tools/launcher/util/data_parser_test.cc
@@ -102,7 +102,7 @@ class LaunchDataParserTest : public ::testing::Test {
     if (item == parsed_launch_info->end()) {
       return "Cannot find key: " + key;
     }
-    return blaze_util::WstringToString(item->second);
+    return blaze_util::WstringToCstring(item->second);
   }
 
   string test_tmpdir;

--- a/third_party/ijar/mapped_file_windows.cc
+++ b/third_party/ijar/mapped_file_windows.cc
@@ -58,7 +58,7 @@ MappedInputFile::MappedInputFile(const char* name) {
   if (file == INVALID_HANDLE_VALUE) {
     string errormsg = blaze_util::GetLastErrorString();
     BAZEL_DIE(255) << "MappedInputFile(" << name << "): CreateFileW("
-                   << blaze_util::WstringToString(wname)
+                   << blaze_util::WstringToCstring(wname)
                    << ") failed: " << errormsg;
   }
 
@@ -148,7 +148,7 @@ MappedOutputFile::MappedOutputFile(const char* name, size_t estimated_size) {
   if (file == INVALID_HANDLE_VALUE) {
     string errormsg = blaze_util::GetLastErrorString();
     BAZEL_DIE(255) << "MappedOutputFile(" << name << "): CreateFileW("
-                   << blaze_util::WstringToString(wname)
+                   << blaze_util::WstringToCstring(wname)
                    << ") failed: " << errormsg;
   }
 


### PR DESCRIPTION
The string conversion functions now work for
non-ASCII input:

- Fixed WstringToCstring (UTF-16 to UTF-8) and
  CstringToWstring (UTF-8 to UTF-16) converters
- Added tests to cover non-ASCII conversion
- Removed unused functions
- Moved all string conversion logic to
  Windows-specific code path, because it's not
  needed on any other platform

Step towards fixing https://github.com/bazelbuild/bazel/issues/7819