### PR TITLE
Remove dead link in functions doc ToC

### DIFF
--- a/site/docs/external.md
+++ b/site/docs/external.md
@@ -80,7 +80,7 @@ local_repository(
 
 If your coworker has a target `//foo:bar`, your project can refer to it as
 `@coworkers_project//foo:bar`. External project names must be
-[valid workspace names](be/functions.html#workspace), so `_` (valid) is used to
+[valid workspace names](skylark/lib/globals.html#workspace), so `_` (valid) is used to
 replace `-` (invalid) in the name `coworkers_project`.
 
 <a name="non-bazel-projects"></a>

--- a/src/main/java/com/google/devtools/build/docgen/templates/be/functions.vm
+++ b/src/main/java/com/google/devtools/build/docgen/templates/be/functions.vm
@@ -19,7 +19,6 @@ title: Functions
     <li><a href="#exports_files">exports_files</a></li>
     <li><a href="#glob">glob</a></li>
     <li><a href="#select">select</a></li>
-    <li><a href="#workspace">workspace</a></li>
   </ul>
 </div>
 #end

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/MavenJarRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/workspace/MavenJarRule.java
@@ -110,7 +110,7 @@ public class MavenJarRule implements RuleDefinition {
 
 <p>Note that the maven_jar name is used as a repository name, so it is limited by the rules
 governing workspace names: it cannot contain dashes nor dots (see
-<a href="http://bazel.build/docs/be/functions.html#workspace">the documentation on workspace
+<a href="http://bazel.build/docs/skylark/lib/globals.html#workspace">the documentation on workspace
 names</a> for the exact specification). By convention, maven_jar names should match the artifact
 name, replacing illegal characters with underscores and leaving off the version.  For example, a
 rule with <code>artifact = "org.apache.commons:commons-lang3:3.4"</code> should have


### PR DESCRIPTION
In b970b2488a55e476f8773a837698c77ecaf2d18e the docs for workspace were removed from this page in favour of the API reference docs.

CC @aehlig 