### PR TITLE
toolchain_vanilla: Unset source and target language level versions

### DIFF
--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -379,6 +379,8 @@ default_java_toolchain(
     forcibly_disable_header_compilation = True,
     javabuilder = [":vanillajavabuilder"],
     jvm_opts = [],
+    source_version = "",
+    target_version = "",
 )
 
 RELEASES = (8, 9, 10, 11)


### PR DESCRIPTION
Closes #9415.

The main feature of toolchain_vanilla definition is to support newer
Java language versions that the embedded JDK, e.g.: at the time of this
CL, toolchain_java could be used to support building with JDK 13 and
produce byte code major version 57, using the combination of absolute
javabase and toolchain_vanilla:

  $ bazel build --define=ABSOLUTE_JAVABASE=/use/local/bin/jdk-13 \
    --javabase=@bazel_tools//tools/jdk:absolute_javabase \
    --host_javabase=@bazel_tools//tools/jdk:absolute_javabase \
    --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla \
    --java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla \
    :gerrit

Unfortunately, 6ef6d879ab69225d54ecab3db847fb4eff33bbeb sets source and
target language levels to Java 8 to restore backwards compatibility,
to fix a regression, that was introduced during bump of remote JDK
version to Java 11, in bad5a2beb9f8441d97b88d5c4323055e710f72e8.

This change restores the neutrality of toolchain_vanilla declaration by
unsetting source and target language level versions. So that the bazel
invocation in the example above produces byte code major version 57
(Java 13), and not 52 (Java 8) as it is the case before this change.

Change-Id: I1f471c987487b81bc149d1ad4368eee149004d79