### PR TITLE
Indent BEP text proto output by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/TextFormatFileTransport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/TextFormatFileTransport.java
@@ -46,6 +46,10 @@ public final class TextFormatFileTransport extends FileTransport {
   @Override
   protected byte[] serializeEvent(BuildEventStreamProtos.BuildEvent buildEvent) {
     String protoTextRepresentation = TextFormat.printToString(buildEvent);
-    return ("event {\n" + protoTextRepresentation + "}\n\n").getBytes(Charsets.UTF_8);
+    return (
+        "event {\n"
+        + protoTextRepresentation.replaceAll("(?m)^", "  ") // indent by 2 spaces
+        + "}\n\n"
+    ).getBytes(Charsets.UTF_8);
   }
 }


### PR DESCRIPTION
This makes the BEP text file print:

```
event {
  id {
    build_metrics {
    }
  }
  build_metrics {
    action_summary {
      actions_created: 3
      actions_executed: 2
    }
    memory_metrics {
    }
    target_metrics {
      targets_loaded: 6
      targets_configured: 6
    }
    package_metrics {
      packages_loaded: 4
    }
  }
}
```

instead of

```
event {
id {
  build_metrics {
  }
}
build_metrics {
  action_summary {
    actions_created: 3
    actions_executed: 2
  }
  memory_metrics {
  }
  target_metrics {
    targets_loaded: 6
    targets_configured: 6
  }
  package_metrics {
    packages_loaded: 4
  }
}
}
```

which can be hard to read for large proto structures.