### PR TITLE
Remove unused device_debug_entitlements.plist

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/packages/util/MockObjcSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/MockObjcSupport.java
@@ -82,7 +82,6 @@ public final class MockObjcSupport {
     for (String tool :
         ImmutableSet.of(
             "objc_dummy.mm",
-            "device_debug_entitlements.plist",
             "gcov",
             "realpath",
             "testrunner",

--- a/tools/objc/device_debug_entitlements.plist
+++ b/tools/objc/device_debug_entitlements.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>get-task-allow</key>
-	<true/>
-</dict>
-</plist>


### PR DESCRIPTION
I assume this was previously used with `--device_debug_entitlements` but
now that flag only surfaces a starlark value.