### PR TITLE
bazel syntax: Implement comprension scopes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkThread.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkThread.java
@@ -1077,6 +1077,19 @@ public final class StarlarkThread implements Freezable {
     return this;
   }
 
+  // Used only for Eval.evalComprehension..
+  void updateInternal(String name, @Nullable Object value) {
+    try {
+      if (value != null) {
+        lexicalFrame.put(this, name, value);
+      } else {
+        lexicalFrame.remove(this, name);
+      }
+    } catch (MutabilityException ex) {
+      throw new IllegalStateException(ex);
+    }
+  }
+
   /**
    * Initializes a binding in this StarlarkThread. It is an error if the variable is already bound.
    * This is not for end-users, and will throw an AssertionError in case of conflict.

--- a/src/test/java/com/google/devtools/build/lib/syntax/EvaluationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/EvaluationTest.java
@@ -570,6 +570,15 @@ public class EvaluationTest extends EvaluationTestCase {
   }
 
   @Test
+  public void testListComprehensionScope() throws Exception {
+    // Test list comprenesion creates a scope, so outer variables kept unchanged
+    new BuildTest()
+        .setUp("x = 1", "l = [x * 3 for x in [2]]", "y = x")
+        .testEval("y", "1")
+        .testEval("l", "[6]");
+  }
+
+  @Test
   public void testInOperator() throws Exception {
     newTest()
         .testStatement("'b' in ['a', 'b']", Boolean.TRUE)

--- a/src/test/java/com/google/devtools/build/lib/syntax/SkylarkEvaluationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/SkylarkEvaluationTest.java
@@ -2188,19 +2188,6 @@ public class SkylarkEvaluationTest extends EvaluationTest {
   }
 
   @Test
-  public void testListComprehensionsDoNotLeakVariables() throws Exception {
-    checkEvalErrorContains(
-        // TODO(laurentlb): This happens because the variable gets undefined after the list
-        // comprehension. We should do better.
-        "local variable 'a' is referenced before assignment.",
-        "def foo():",
-        "  a = 10",
-        "  b = [a for a in range(3)]",
-        "  return a",
-        "x = foo()");
-  }
-
-  @Test
   public void testListComprehensionsShadowGlobalVariable() throws Exception {
     eval("a = 18", "def foo():", "  b = [a for a in range(3)]", "  return a", "x = foo()");
     assertThat(lookup("x")).isEqualTo(18);


### PR DESCRIPTION
Fix this program taken from Starlark spec:

```
x = 1
_ = [x for x in [2]]            # new variable x is local to the comprehension
print(x)                        # 1
```

Before this commit it resulted in

```
Traceback (most recent call last):
	File "", line 3
		print(x)
	File "", line 3, in print
		x
global variable 'x' is referenced before assignment.
```

Fixes issue #9438