### PR TITLE
bazel syntax: Implement indexed local variables

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/BuiltinFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BuiltinFunction.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.syntax;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.events.Location;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
@@ -56,7 +57,7 @@ public class BuiltinFunction extends BaseFunction {
   // Builtins cannot create or modify variable bindings. So it's sufficient to use a shared
   // instance.
   private static final LexicalFrame SHARED_LEXICAL_FRAME_FOR_BUILTIN_FUNCTION_CALLS =
-      LexicalFrame.create(Mutability.IMMUTABLE);
+      LexicalFrame.create(Mutability.IMMUTABLE, ImmutableMap.of());
 
   // The underlying invoke() method.
   @Nullable private Method invokeMethod;

--- a/src/main/java/com/google/devtools/build/lib/syntax/DefStatement.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/DefStatement.java
@@ -13,8 +13,11 @@
 // limitations under the License.
 package com.google.devtools.build.lib.syntax;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import javax.annotation.Nullable;
 
 /** Syntax node for a 'def' statement, which defines a function. */
 public final class DefStatement extends Statement {
@@ -23,6 +26,10 @@ public final class DefStatement extends Statement {
   private final FunctionSignature.WithValues<Expression, Expression> signature;
   private final ImmutableList<Statement> statements;
   private final ImmutableList<Parameter<Expression, Expression>> parameters;
+
+  /** Initialized during verification */
+  @Nullable
+  private ImmutableMap<String, Integer> localNameToIndex;
 
   DefStatement(
       Identifier identifier,
@@ -33,6 +40,17 @@ public final class DefStatement extends Statement {
     this.parameters = ImmutableList.copyOf(parameters);
     this.signature = signature;
     this.statements = ImmutableList.copyOf(statements);
+  }
+
+  void setLocalNameToIndex(
+      ImmutableMap<String, Integer> localNameToIndex) {
+    Preconditions.checkState(this.localNameToIndex == null);
+    this.localNameToIndex = localNameToIndex;
+  }
+
+  ImmutableMap<String, Integer> getLocalNameToIndex() {
+    Preconditions.checkState(localNameToIndex != null);
+    return localNameToIndex;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/syntax/Identifier.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Identifier.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.syntax;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.syntax.ValidationEnvironment.Scope;
 import java.io.IOException;
 import javax.annotation.Nullable;
 
@@ -27,10 +28,14 @@ import javax.annotation.Nullable;
  */
 public final class Identifier extends Expression {
 
+  /** Unset of non-local scope */
+  static final int LOCAL_INDEX_UNDEFINED = -131719;
+
   private final String name;
   // The scope of the variable. The value is set when the AST has been analysed by
   // ValidationEnvironment.
   @Nullable private ValidationEnvironment.Scope scope;
+  private int localScopeIndex = LOCAL_INDEX_UNDEFINED;
 
   // TODO(adonovan): lock down, after removing last use in skyframe serialization.
   public Identifier(String name) {
@@ -52,14 +57,19 @@ public final class Identifier extends Expression {
     return scope;
   }
 
+  public int getLocalScopeIndex() {
+    return localScopeIndex;
+  }
+
   @Override
   public void prettyPrint(Appendable buffer) throws IOException {
     buffer.append(name);
   }
 
-  void setScope(ValidationEnvironment.Scope scope) {
+  void setScope(ValidationEnvironment.Scope scope, int varindex) {
     Preconditions.checkState(this.scope == null);
     this.scope = scope;
+    this.localScopeIndex = varindex;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkThread.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkThread.java
@@ -1077,6 +1077,19 @@ public final class StarlarkThread implements Freezable {
     return this;
   }
 
+  // Used only for Eval.evalComprehension..
+  void updateInternal(String name, @Nullable Object value) {
+    try {
+      if (value != null) {
+        lexicalFrame.put(this, name, value);
+      } else {
+        lexicalFrame.remove(this, name);
+      }
+    } catch (MutabilityException ex) {
+      throw new IllegalStateException(ex);
+    }
+  }
+
   /**
    * Initializes a binding in this StarlarkThread. It is an error if the variable is already bound.
    * This is not for end-users, and will throw an AssertionError in case of conflict.

--- a/src/main/java/com/google/devtools/build/skydoc/SkydocMain.java
+++ b/src/main/java/com/google/devtools/build/skydoc/SkydocMain.java
@@ -69,6 +69,7 @@ import com.google.devtools.build.lib.syntax.StarlarkThread.Extension;
 import com.google.devtools.build.lib.syntax.StarlarkThread.GlobalFrame;
 import com.google.devtools.build.lib.syntax.Statement;
 import com.google.devtools.build.lib.syntax.StringLiteral;
+import com.google.devtools.build.lib.syntax.ValidationEnvironment;
 import com.google.devtools.build.skydoc.fakebuildapi.FakeActionsInfoProvider;
 import com.google.devtools.build.skydoc.fakebuildapi.FakeBuildApiGlobals;
 import com.google.devtools.build.skydoc.fakebuildapi.FakeConfigApi;
@@ -503,6 +504,10 @@ public class SkydocMain {
             eventHandler,
             globalFrame(ruleInfoList, providerInfoList, aspectInfoList),
             imports);
+
+    if (!ValidationEnvironment.validateFile(buildFileAST, thread, false, eventHandler)) {
+      throw new StarlarkEvaluationException("Starlark evaluation error");
+    }
 
     if (!buildFileAST.exec(thread, eventHandler)) {
       throw new StarlarkEvaluationException("Starlark evaluation error");

--- a/src/test/java/com/google/devtools/build/lib/syntax/EvaluationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/EvaluationTest.java
@@ -570,6 +570,15 @@ public class EvaluationTest extends EvaluationTestCase {
   }
 
   @Test
+  public void testListComprehensionScope() throws Exception {
+    // Test list comprenesion creates a scope, so outer variables kept unchanged
+    new BuildTest()
+        .setUp("x = 1", "l = [x * 3 for x in [2]]", "y = x")
+        .testEval("y", "1")
+        .testEval("l", "[6]");
+  }
+
+  @Test
   public void testInOperator() throws Exception {
     newTest()
         .testStatement("'b' in ['a', 'b']", Boolean.TRUE)

--- a/src/test/java/com/google/devtools/build/lib/syntax/SkylarkEvaluationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/SkylarkEvaluationTest.java
@@ -2188,19 +2188,6 @@ public class SkylarkEvaluationTest extends EvaluationTest {
   }
 
   @Test
-  public void testListComprehensionsDoNotLeakVariables() throws Exception {
-    checkEvalErrorContains(
-        // TODO(laurentlb): This happens because the variable gets undefined after the list
-        // comprehension. We should do better.
-        "local variable 'a' is referenced before assignment.",
-        "def foo():",
-        "  a = 10",
-        "  b = [a for a in range(3)]",
-        "  return a",
-        "x = foo()");
-  }
-
-  @Test
   public void testListComprehensionsShadowGlobalVariable() throws Exception {
     eval("a = 18", "def foo():", "  b = [a for a in range(3)]", "  return a", "x = foo()");
     assertThat(lookup("x")).isEqualTo(18);

--- a/src/test/java/com/google/devtools/build/skydoc/testdata/filter_rules_test/input.bzl
+++ b/src/test/java/com/google/devtools/build/skydoc/testdata/filter_rules_test/input.bzl
@@ -1,6 +1,6 @@
 load(
     ":testdata/filter_rules_test/dep.bzl",
-    "my_rule_impl",
+    my_rule_impl_imported = "my_rule_impl",
     dep_rule = "my_rule",
 )
 


### PR DESCRIPTION
Speed-up Starlark evaluation by replacing by-name access with
by-index access for local scope variables.

`LexicalFrame` variables is now represented as a pair of:
* `Object[] locals`
* `Map<String, Integer>` when by name access is needed

`ValidationEnvironment` now assigns a variable index for each local
variable.

Similar optimization is possible for `GlobalFrame`, but it's harder
to implement because the global frame is much more complicated. It is
also not that important for global scope.

Tested with this command:

```
bazel build //src/main/java/com/google/devtools/starlark:Starlark && \
time bazel run //src/main/java/com/google/devtools/starlark:Starlark -- `pwd`/bubble_sort.sky
```

where `bubble_sort.sky` is:

```
def bubble_sort(array):
    array = list(array)
    for i in range(len(array)):
        for j in range((len(array) - i) - 1):
            if array[j] > array[j + 1]:
                array[j], array[j + 1] = array[j + 1], array[j]
    return array

def bench():
    for i in range(1000):
        for j in range(1000):
            if [2, 3, 4, 5, 6, 7, 9] != bubble_sort([9, 3, 5, 4, 7, 2, 6]):
                fail()

bench()
print("$")
```

The program runs in about 18 seconds with this patch and in about 19
seconds without it (hard to say more precisely because of high
variability).

**Note**, github does not have stacked reviews, have a look at top commit only please,
the ones below are #9440, #9445.

**Note**, [similar change in starlark-rust](https://github.com/google/starlark-rust/commit/8b5c6a628389a1c61c6d7b7739c8e85310844178).

@adonovan ?