### PR TITLE
Add python zip file to a output group

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.actions.ParamFileInfo;
 import com.google.devtools.build.lib.actions.ParameterFile;
 import com.google.devtools.build.lib.analysis.AnalysisUtils;
 import com.google.devtools.build.lib.analysis.FilesToRunProvider;
+import com.google.devtools.build.lib.analysis.RuleConfiguredTargetBuilder;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.analysis.RunfilesProvider;
@@ -279,20 +280,20 @@ public class BazelPythonSemantics implements PythonSemantics {
 
   @Override
   public void postInitExecutable(
-      RuleContext ruleContext, RunfilesSupport runfilesSupport, PyCommon common) {
-    if (ruleContext.getFragment(PythonConfiguration.class).buildPythonZip()) {
-      FilesToRunProvider zipper = ruleContext.getExecutablePrerequisite("$zipper", Mode.HOST);
-      Artifact executable = common.getExecutable();
-      if (!ruleContext.hasErrors()) {
-        createPythonZipAction(
-            ruleContext,
-            executable,
-            common.getPythonZipArtifact(executable),
-            getPythonIntermediateStubArtifact(ruleContext, executable),
-            zipper,
-            runfilesSupport);
-      }
+      RuleContext ruleContext, RunfilesSupport runfilesSupport, PyCommon common, RuleConfiguredTargetBuilder builder) {
+    FilesToRunProvider zipper = ruleContext.getExecutablePrerequisite("$zipper", Mode.HOST);
+    Artifact executable = common.getExecutable();
+    Artifact zipFile = common.getPythonZipArtifact(executable);
+    if (!ruleContext.hasErrors()) {
+      createPythonZipAction(
+          ruleContext,
+          executable,
+          zipFile,
+          getPythonIntermediateStubArtifact(ruleContext, executable),
+          zipper,
+          runfilesSupport);
     }
+    builder.addOutputGroup("python_zip_file", zipFile);
   }
 
   private static boolean isUnderWorkspace(PathFragment path) {

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PyExecutable.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PyExecutable.java
@@ -107,7 +107,7 @@ public abstract class PyExecutable implements RuleConfiguredTargetFactory {
         new RuleConfiguredTargetBuilder(ruleContext);
     common.addCommonTransitiveInfoProviders(builder, common.getFilesToBuild());
 
-    semantics.postInitExecutable(ruleContext, runfilesSupport, common);
+    semantics.postInitExecutable(ruleContext, runfilesSupport, common, builder);
 
     return builder
         .setFilesToBuild(common.getFilesToBuild())

--- a/src/main/java/com/google/devtools/build/lib/rules/python/PythonSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/python/PythonSemantics.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.rules.python;
 
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.analysis.RuleConfiguredTargetBuilder;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.analysis.RunfilesSupport;
@@ -80,7 +81,7 @@ public interface PythonSemantics {
    *
    * @throws InterruptedException
    */
-  void postInitExecutable(RuleContext ruleContext, RunfilesSupport runfilesSupport, PyCommon common)
+  void postInitExecutable(RuleContext ruleContext, RunfilesSupport runfilesSupport, PyCommon common, RuleConfiguredTargetBuilder builder)
       throws InterruptedException, RuleErrorException;
 
   CcInfo buildCcInfoProvider(Iterable<? extends TransitiveInfoCollection> deps);

--- a/src/test/shell/integration/python_test.sh
+++ b/src/test/shell/integration/python_test.sh
@@ -139,4 +139,16 @@ EOF
   [ ! -e "bazel-bin/py-tool${EXE_EXT}.runfiles" ] || fail "py_binary runfiles tree built"
 }
 
+function test_get_python_zip_file_via_output_group() {
+  touch foo.py
+  cat > BUILD <<'EOF'
+py_binary(
+  name = 'foo',
+  srcs = ['foo.py'],
+)
+EOF
+  bazel build :foo --output_groups=python_zip_file
+  [[ -f "bazel-bin/foo.zip" ]] || fail "failed to get python zip file via output group"
+}
+
 run_suite "Tests for the Python rules"


### PR DESCRIPTION
After this change, users can get the python zip file of a certain
target without using `--build_python_zip` by

`bazel build //foo:bar --output_groups=python_zip_file`

or
```
filegroup(
  name = "bar_zip",
  srcs = ["//foo:bar"],
  output_group = "python_zip_file",
)
```

Fixes https://github.com/bazelbuild/bazel/issues/3530