### PR TITLE
Cherry pick for java_tools javac11-v5.1

### DIFF
--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -36,6 +36,10 @@ java_toolchain(
     javac = [":javac_jar"],
     javac_supports_workers = 1,
     jvm_opts = [
+        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
+        # G1 collector and having compact strings enabled.
+        "-XX:+UseParallelOldGC",
+        "-XX:-CompactStrings",
         # Allow JavaBuilder to access internal javac APIs.
         "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
@@ -93,6 +97,10 @@ java_toolchain(
     javac = [":javac_jar"],
     javac_supports_workers = 1,
     jvm_opts = [
+        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance
+        # when using G1 collector and having compact strings enabled.
+        "-XX:+UseParallelOldGC",
+        "-XX:-CompactStrings",
         # Allow JavaBuilder to access internal javac APIs.
         "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
@@ -154,6 +162,10 @@ java_toolchain(
     javac = [":javac_jar"],
     javac_supports_workers = 1,
     jvm_opts = [
+        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
+        # G1 collector and having compact strings enabled.
+        "-XX:+UseParallelOldGC",
+        "-XX:-CompactStrings",
         # Allow JavaBuilder to access internal javac APIs.
         "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",


### PR DESCRIPTION
The purpose of this PR is solely for cutting a java_tools patch release candidate.
Base commit: f1bbe586fd305714f5240dfb90fcf8664b22f415
Cherry-pick: 51421724b6038844838a74886e894df16b1bcaf1
