### PR TITLE
JavacOptions: Fix incompatibility of -target and -parameters options

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/JavacOptions.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/JavacOptions.java
@@ -17,13 +17,11 @@ package com.google.devtools.build.buildjar.javac;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Ints;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -232,8 +230,8 @@ public final class JavacOptions {
   /**
    * Normalizer for {@code -source}, {@code -target}, and {@code --release} options. If both {@code
    * -source} and {@code --release} are specified, {@code --release} wins. If {@code -parameters}
-   * option is passed, but target option is 7 or lower, filter out {@code -parameters} option, as
-   * it is not compatbile with Java language level 7.
+   * option is passed, but target option is 7 or lower, filter out {@code -parameters} option, as it
+   * is not compatbile with Java language level 7.
    */
   public static class ReleaseOptionNormalizer implements JavacOptionNormalizer {
 
@@ -280,11 +278,11 @@ public final class JavacOptions {
 
     @Override
     public void normalize(List<String> normalized) {
-      String releaseOrTarget = null;
+      int targetedJavaVersion = 8;
       if (release != null) {
         normalized.add("--release");
         normalized.add(release);
-        releaseOrTarget = release;
+        targetedJavaVersion = Integer.parseInt(release);
       } else {
         if (source != null) {
           normalized.add("-source");
@@ -293,11 +291,11 @@ public final class JavacOptions {
         if (target != null) {
           normalized.add("-target");
           normalized.add(target);
-          releaseOrTarget = target;
+          targetedJavaVersion = Integer.parseInt(target);
         }
       }
       // Put -parameters option back if no target option was provided or at least target 8.
-      if (parameters && Optional.ofNullable(releaseOrTarget).map(Ints::tryParse).orElse(8) >= 8) {
+      if (parameters && targetedJavaVersion >= 8) {
         normalized.add("-parameters");
       }
     }


### PR DESCRIPTION
Closes #8772.

Java compiler -target 7 (and lower) and -parameters options are mutually
exclusive. Starting from version 11 the javac is issuing this warning:

  warning: -parameters is not supported for target value 1.7. Use 1.8 or later.

and is spamming the build log. This is particularly annoying, because
the major project in distributed Java ecosystem Google Protobuf is
targeting java language level 7, so that this spam affects everyone in
the wild. But the scope of the problem is unrelated to Protobuf and
every attempt to pass -target 7 javac option to the java_library rule
ends up in the above spam.

To rectify extend ReleaseOptionNormalizer and filter out -parameters
option from the command line if java language level is 7 or lower.

Test Plan:

* Build new java_tools with:

  $ bazel build //src:java_tools_java11.zip

* Switch to using custom version of java_tools, e.g.:

  http_archive(
    name = "local_java_tools",
    urls = ["file:///tmp/java_tools_java11.zip"],
  )

* Build java source with custom java tools toolchain:

cat A.java:

class A {}

cat BUILD:

java_library(
    name = "a",
    srcs = ["A.java"],
    javacopts = [
        "-source 7",
        "-target 7",
    ],
)

  $ bazel build \
    --host_java_toolchain=@local_java_tools//:toolchain \
    --java_toolchain=@local_java_tools//:toolchain \
    :a

and confirm that there is no build warning.

* Retry the build without custom java tools and confirm that the warning
is reported:

  $ bazel build :a
  warning: -parameters is not supported for target value 1.7. Use 1.8 or later.

Change-Id: Ibec6dd14d8d4a395a6de3128cd15ccec52752d4b