### PR TITLE
Support remote execution and BES reporting via unix domain sockets.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -18,6 +18,7 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import io.grpc.CallCredentials;
 import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
@@ -25,6 +26,13 @@ import io.grpc.auth.MoreCallCredentials;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollDomainSocketChannel;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.handler.ssl.SslContext;
 import java.io.File;
 import java.io.FileInputStream;
@@ -42,7 +50,7 @@ public final class GoogleAuthUtils {
    *
    * @throws IOException in case the channel can't be constructed.
    */
-  public static ManagedChannel newChannel(String target, AuthAndTLSOptions options,
+  public static ManagedChannel newChannel(String target, String proxy, AuthAndTLSOptions options,
       ClientInterceptor... interceptors)
       throws IOException {
     Preconditions.checkNotNull(target);
@@ -56,10 +64,9 @@ public final class GoogleAuthUtils {
 
     try {
       NettyChannelBuilder builder =
-          NettyChannelBuilder.forTarget(targetUrl)
+          newNettyChannelBuilder(targetUrl, proxy)
               .negotiationType(
                   isTlsEnabled(target) ? NegotiationType.TLS : NegotiationType.PLAINTEXT)
-              .defaultLoadBalancingPolicy("round_robin")
               .intercept(interceptors);
       if (sslContext != null) {
         builder.sslContext(sslContext);
@@ -110,6 +117,34 @@ public final class GoogleAuthUtils {
         throw new IOException(message, e);
       }
     }
+  }
+
+  private static NettyChannelBuilder newNettyChannelBuilder(String targetUrl, String proxy) throws IOException {
+    if (Strings.isNullOrEmpty(proxy)) {
+      return NettyChannelBuilder.forTarget(targetUrl)
+          .defaultLoadBalancingPolicy("round_robin");
+    }
+
+    if (!proxy.startsWith("unix:")) {
+      throw new IOException("Remote proxy unsupported: " + proxy);
+    }
+
+    DomainSocketAddress address = new DomainSocketAddress(proxy.replaceFirst("^unix:", ""));
+    NettyChannelBuilder builder =
+        NettyChannelBuilder.forAddress(address)
+            .overrideAuthority(targetUrl);
+    if (KQueue.isAvailable()) {
+      return builder
+          .channelType(KQueueDomainSocketChannel.class)
+          .eventLoopGroup(new KQueueEventLoopGroup());
+    }
+    if (Epoll.isAvailable()) {
+      return builder
+          .channelType(EpollDomainSocketChannel.class)
+          .eventLoopGroup(new EpollEventLoopGroup());
+    }
+
+    throw new IOException("Unix domain sockets are unsupported on this platform");
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
@@ -69,7 +69,7 @@ public class BazelBuildEventServiceModule
   @VisibleForTesting
   protected ManagedChannel newGrpcChannel(
       BuildEventServiceOptions besOptions, AuthAndTLSOptions authAndTLSOptions) throws IOException {
-    return GoogleAuthUtils.newChannel(besOptions.besBackend, authAndTLSOptions);
+    return GoogleAuthUtils.newChannel(besOptions.besBackend, besOptions.besProxy, authAndTLSOptions);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceOptions.java
@@ -138,6 +138,16 @@ public class BuildEventServiceOptions extends OptionsBase {
               + "or should end the invocation immediately and finish the upload in the background.")
   public BesUploadMode besUploadMode;
 
+  @Option(
+      name = "bes_proxy",
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "Connect to the Build Event Service through a proxy. Currently this flag can only be used to "
+              + "configure a Unix domain socket (unix:/path/to/socket).")
+  public String besProxy;
+
   /** Determines the mode that will be used to upload data to the Build Event Service. */
   public enum BesUploadMode {
     /** Block at the end of the build waiting for the upload to complete */

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -200,6 +200,7 @@ public final class RemoteModule extends BlazeModule {
             new ReferenceCountedChannel(
                 GoogleAuthUtils.newChannel(
                     remoteOptions.remoteExecutor,
+                    remoteOptions.remoteProxy,
                     authAndTlsOptions,
                     interceptors.toArray(new ClientInterceptor[0])));
       }
@@ -218,6 +219,7 @@ public final class RemoteModule extends BlazeModule {
               new ReferenceCountedChannel(
                   GoogleAuthUtils.newChannel(
                       remoteOptions.remoteCache,
+                      remoteOptions.remoteProxy,
                       authAndTlsOptions,
                       interceptors.toArray(new ClientInterceptor[0])));
         } else {  // Assume --remote_cache is equal to --remote_executor by default.

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -47,7 +47,7 @@ public final class RemoteOptions extends OptionsBase {
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "Connect to the remote cache through a proxy. Currently this flag can only be used to "
-              + "configure a Unix domain socket (unix:/path/to/socket) for the HTTP cache.")
+              + "configure a Unix domain socket (unix:/path/to/socket).")
   public String remoteProxy;
 
   @Option(

--- a/src/test/shell/bazel/remote/BUILD
+++ b/src/test/shell/bazel/remote/BUILD
@@ -12,6 +12,7 @@ sh_test(
     timeout = "eternal",
     srcs = ["remote_execution_test.sh"],
     data = [
+        ":uds_proxy.py",
         "//src/test/shell/bazel:test-deps",
         "//src/tools/remote:worker",
     ],

--- a/src/test/shell/bazel/remote/uds_proxy.py
+++ b/src/test/shell/bazel/remote/uds_proxy.py
@@ -1,0 +1,62 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import os
+import select
+import socket
+import sys
+import threading
+
+
+def main(argv=None):
+  if argv is None:
+    argv = sys.argv[1:]
+
+  srv_address = argv[0]
+  dst_host, dst_port = argv[1].split(":")
+  dst_address = (dst_host, int(dst_port))
+
+  srv_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+  srv_sock.bind(srv_address)
+  srv_sock.listen(64)
+  while True:
+    src_sock, src_address = srv_sock.accept()
+    proxy_thread = threading.Thread(target=proxy, args=[src_sock, dst_address])
+    proxy_thread.daemon = True
+    proxy_thread.start()
+
+
+def proxy(src_sock, dst_address):
+  with contextlib.closing(src_sock):
+    src_sock.settimeout(None)
+    dst_sock = socket.create_connection(dst_address)
+    with contextlib.closing(dst_sock):
+      dst_sock.settimeout(None)
+
+      while True:
+        readable, _, _ = select.select([src_sock, dst_sock], [], [])
+        if src_sock in readable:
+          data = src_sock.recv(4096)
+          if not data:
+            return
+          dst_sock.sendall(data)
+        if dst_sock in readable:
+          data = dst_sock.recv(4096)
+          if data:
+            src_sock.sendall(data)
+
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
This extends the existing `--remote_proxy` flag to also apply to gRPC channels created for `--remote_executor` and `--remote_cache`. It also adds a `--bes_proxy` flag, which applies to gRPC channels created by BES.

Logic in `newNettyChannelBuilder()` was derived from the existing unix socket setup in `HttpBlobStore`.