### PR TITLE
Chocolatey: Remove strict MSYS2 version requirement

### DIFF
--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -76,7 +76,7 @@ Supply like `--params="/option:'value' ..."` ([see docs for --params](https://gi
     </dependencies>-->
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.0.7"/>
-      <dependency id="msys2" version="[20160719.1.0,20160719.1.1]"/>
+      <dependency id="msys2" version="20160719.1.0"/>
       <dependency id="vcredist140" version="14.20.27508.1"/>
     </dependencies>
     <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->


### PR DESCRIPTION
The version given is very old and I don't see a reason why Bazel should depend on this exact version of MSYS2.

On Bazel's CI we just test against the latest MSYS2 version available from Chocolatey and it works fine, so one could argue that this old version is actually a very untested environment.

Users are also complaining about this (I guess because it prevents their MSYS2 version from being upgraded?): https://chocolatey.org/packages/bazel#comment-4643886227