### PR TITLE
Windows: Allow building DLL without any symbol exported

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
@@ -459,7 +459,7 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
                   ruleContext, defParser, objectFiles.build(), binary.getFilename());
         }
         customDefFile = common.getWinDefFile();
-        trivialDefFile = CppHelper.createTrivialDefFileAction(ruleContext, binary.getFilename());
+        trivialDefFile = CppHelper.createTrivialDLLDefFileAction(ruleContext, binary.getFilename());
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
@@ -430,7 +430,6 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
     CcLinkingContext depsCcLinkingContext = collectCcLinkingContext(ruleContext);
 
     Artifact generatedDefFile = null;
-    Artifact customDefFile;
     Artifact winDefFile = null;
     if (isLinkShared(ruleContext)) {
       if (featureConfiguration.isEnabled(CppRuleClasses.TARGETS_WINDOWS)) {
@@ -458,8 +457,7 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
               CppHelper.createDefFileActions(
                   ruleContext, defParser, objectFiles.build(), binary.getFilename());
         }
-        customDefFile = common.getWinDefFile();
-        winDefFile = CppHelper.getWindowsDefFileForLinking(ruleContext, customDefFile, generatedDefFile, featureConfiguration);
+        winDefFile = CppHelper.getWindowsDefFileForLinking(ruleContext, common.getWinDefFile(), generatedDefFile, featureConfiguration);
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
@@ -459,7 +459,7 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
                   ruleContext, defParser, objectFiles.build(), binary.getFilename());
         }
         customDefFile = common.getWinDefFile();
-        trivialDefFile = CppHelper.createTrivialDLLDefFileAction(ruleContext, binary.getFilename());
+        trivialDefFile = CppHelper.createTrivialDefFileAction(ruleContext);
       }
     }
 
@@ -833,7 +833,7 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
     // 3. Otherwise, we use a trivial DEF file to ensure the import library will be generated.
     if (customDefFile != null) {
       ccLinkingHelper.setDefFile(customDefFile);
-    } else if (CppHelper.shouldUseGeneratedDefFile(ruleContext, featureConfiguration)) {
+    } else if (generatedDefFile != null && CppHelper.shouldUseGeneratedDefFile(ruleContext, featureConfiguration)) {
       ccLinkingHelper.setDefFile(generatedDefFile);
     } else {
       ccLinkingHelper.setDefFile(trivialDefFile);

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -331,7 +331,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
                     dllName);
             targetBuilder.addOutputGroup(DEF_FILE_OUTPUT_GROUP_NAME, generatedDefFile);
           }
-          trivialDefFile = CppHelper.createTrivialDefFileAction(ruleContext, dllName);
+          trivialDefFile = CppHelper.createTrivialDLLDefFileAction(ruleContext, dllName);
         } catch (EvalException e) {
           throw ruleContext.throwWithRuleError(e.getMessage());
         }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -311,12 +311,10 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
     if (ruleContext.getRule().getImplicitOutputsFunction() != ImplicitOutputsFunction.NONE
         || !ccCompilationOutputs.isEmpty()) {
       if (featureConfiguration.isEnabled(CppRuleClasses.TARGETS_WINDOWS)) {
-        // If user specifies a custom DEF file, then we use it.
         Artifact customDefFile = common.getWinDefFile();
         Artifact generatedDefFile = null;
-        Artifact trivialDefFile = CppHelper.createTrivialDefFileAction(ruleContext);
-        Artifact defParser = common.getDefParser();
 
+        Artifact defParser = common.getDefParser();
         if (defParser != null) {
           try {
             generatedDefFile =
@@ -333,18 +331,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
             throw ruleContext.throwWithRuleError(e.getMessage());
           }
         }
-
-        // 1. If a custom DEF file is specified in win_def_file attribute, use it.
-        // 2. If the windows_export_all_symbols feature is enabled, parse object files to
-        //    generate DEF file and use it to export symbols - if we have a parser.
-        // 3. Otherwise, we use a trivial DEF file to ensure the import library will be generated.
-        if (customDefFile != null) {
-          linkingHelper.setDefFile(customDefFile);
-        } else if (generatedDefFile != null && CppHelper.shouldUseGeneratedDefFile(ruleContext, featureConfiguration)) {
-          linkingHelper.setDefFile(generatedDefFile);
-        } else {
-          linkingHelper.setDefFile(trivialDefFile);
-        }
+        linkingHelper.setDefFile(CppHelper.getWindowsDefFileForLinking(ruleContext, customDefFile, generatedDefFile, featureConfiguration));
       }
       ccLinkingOutputs = linkingHelper.link(ccCompilationOutputs);
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -47,6 +47,7 @@ import com.google.devtools.build.lib.analysis.StaticallyLinkedMarkerProvider;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.actions.ActionConstructionContext;
 import com.google.devtools.build.lib.analysis.actions.CustomCommandLine;
+import com.google.devtools.build.lib.analysis.actions.FileWriteAction;
 import com.google.devtools.build.lib.analysis.actions.SpawnAction;
 import com.google.devtools.build.lib.analysis.actions.SymlinkAction;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
@@ -884,6 +885,26 @@ public class CppHelper {
             .build(ruleContext));
     return defFile;
   }
+
+  /**
+   * Create action for generating trivial DEF file without any exports, should only be used when
+   * targeting Windows.
+   *
+   * @param dllName The DLL name to be written into the DEF file, it specifies which DLL is required
+   *     at runtime
+   * @return The DEF file artifact.
+   */
+  public static Artifact createTrivialDefFileAction(RuleContext ruleContext, String dllName) {
+    Artifact trivialDefFile =
+        ruleContext.getBinArtifact(
+            ruleContext.getLabel().getName()
+                + ".gen.trivial"
+                + Iterables.getOnlyElement(CppFileTypes.WINDOWS_DEF_FILE.getExtensions()));
+    ruleContext.registerAction(FileWriteAction.create(ruleContext, trivialDefFile,
+        "LIBRARY " + dllName + "\n", false));
+    return trivialDefFile;
+  }
+
 
   /**
    * Returns true if the build implied by the given config and toolchain uses --start-lib/--end-lib

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -897,7 +897,7 @@ public class CppHelper {
     Artifact trivialDefFile =
         ruleContext.getBinArtifact(
             ruleContext.getLabel().getName()
-                + ".gen.trivial"
+                + ".gen.empty"
                 + Iterables.getOnlyElement(CppFileTypes.WINDOWS_DEF_FILE.getExtensions()));
     ruleContext.registerAction(FileWriteAction.create(ruleContext, trivialDefFile, "", false));
     return trivialDefFile;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -890,18 +890,15 @@ public class CppHelper {
    * Create action for generating trivial DEF file without any exports, should only be used when
    * targeting Windows.
    *
-   * @param dllName The DLL name to be written into the DEF file, it specifies which DLL is required
-   *     at runtime
-   * @return The DEF file artifact.
+   * @return The artifact of an empty DEF file.
    */
-  public static Artifact createTrivialDLLDefFileAction(RuleContext ruleContext, String dllName) {
+  public static Artifact createTrivialDefFileAction(RuleContext ruleContext) {
     Artifact trivialDefFile =
         ruleContext.getBinArtifact(
             ruleContext.getLabel().getName()
                 + ".gen.trivial"
                 + Iterables.getOnlyElement(CppFileTypes.WINDOWS_DEF_FILE.getExtensions()));
-    ruleContext.registerAction(FileWriteAction.create(ruleContext, trivialDefFile,
-        "LIBRARY " + dllName + "\n", false));
+    ruleContext.registerAction(FileWriteAction.create(ruleContext, trivialDefFile, "", false));
     return trivialDefFile;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -894,7 +894,7 @@ public class CppHelper {
    *     at runtime
    * @return The DEF file artifact.
    */
-  public static Artifact createTrivialDefFileAction(RuleContext ruleContext, String dllName) {
+  public static Artifact createTrivialDLLDefFileAction(RuleContext ruleContext, String dllName) {
     Artifact trivialDefFile =
         ruleContext.getBinArtifact(
             ruleContext.getLabel().getName()

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -893,7 +893,7 @@ public class CppHelper {
    *
    * @return The artifact of an empty DEF file.
    */
-  public static Artifact createEmptyDefFileAction(RuleContext ruleContext) {
+  private static Artifact createEmptyDefFileAction(RuleContext ruleContext) {
     Artifact trivialDefFile =
         ruleContext.getBinArtifact(
             ruleContext.getLabel().getName()

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -138,17 +138,15 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
 
     # TODO(pcloudy): change suffixes to .lib and .dll after making DLL
-    # extensions correct on
-    # Windows.
+    # extensions correct on Windows.
     import_library = os.path.join(bazel_bin, 'A.if.lib')
     shared_library = os.path.join(bazel_bin, 'A.dll')
-    def_file = os.path.join(bazel_bin, 'A.gen.def')
-    trivial_def_file = os.path.join(bazel_bin, 'A.gen.trivial.def')
+    empty_def_file = os.path.join(bazel_bin, 'A.gen.empty.def')
 
     self.assertTrue(os.path.exists(import_library))
     self.assertTrue(os.path.exists(shared_library))
-    # A trivial DEF file should be generated for //:A
-    self.assertTrue(os.path.exists(trivial_def_file))
+    # An empty DEF file should be generated for //:A
+    self.assertTrue(os.path.exists(empty_def_file))
 
   def testBuildDynamicLibraryWithExportSymbolFeature(self):
     self.createProjectFiles()
@@ -161,8 +159,7 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
 
     # TODO(pcloudy): change suffixes to .lib and .dll after making DLL
-    # extensions correct on
-    # Windows.
+    # extensions correct on Windows.
     import_library = os.path.join(bazel_bin, 'B.if.lib')
     shared_library = os.path.join(bazel_bin, 'B.dll')
     def_file = os.path.join(bazel_bin, 'B.gen.def')
@@ -180,12 +177,12 @@ class BazelWindowsCppTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
     import_library = os.path.join(bazel_bin, 'B.if.lib')
     shared_library = os.path.join(bazel_bin, 'B.dll')
-    trivial_def_file = os.path.join(bazel_bin, 'B.gen.trivial.def')
+    empty_def_file = os.path.join(bazel_bin, 'B.gen.empty.def')
     self.assertTrue(os.path.exists(import_library))
     self.assertTrue(os.path.exists(shared_library))
-    # A trivial DEF file should be generated for //:B
-    self.assertTrue(os.path.exists(trivial_def_file))
-    self.AssertFileContentNotContains(trivial_def_file, 'hello_B')
+    # An empty DEF file should be generated for //:B
+    self.assertTrue(os.path.exists(empty_def_file))
+    self.AssertFileContentNotContains(empty_def_file, 'hello_B')
 
   def testBuildCcBinaryWithDependenciesDynamicallyLinked(self):
     self.createProjectFiles()
@@ -204,7 +201,7 @@ class BazelWindowsCppTest(test_base.TestBase):
     # a_shared_library
     self.assertTrue(os.path.exists(os.path.join(bazel_bin, 'A.dll')))
     # a_def_file
-    self.assertTrue(os.path.exists(os.path.join(bazel_bin, 'A.gen.trivial.def')))
+    self.assertTrue(os.path.exists(os.path.join(bazel_bin, 'A.gen.empty.def')))
     # b_import_library
     self.assertTrue(os.path.exists(os.path.join(bazel_bin, 'B.if.lib')))
     # b_shared_library
@@ -533,9 +530,9 @@ class BazelWindowsCppTest(test_base.TestBase):
 
     # Although windows_export_all_symbols is not specified for this target,
     # we should still be able to build a DLL without any symbol exported.
-    trivial_def_file = os.path.join(bazel_bin, 'A.dll.gen.trivial.def')
-    self.assertTrue(os.path.exists(trivial_def_file))
-    self.AssertFileContentNotContains(trivial_def_file, 'hello_A')
+    empty_def_file = os.path.join(bazel_bin, 'A.dll.gen.empty.def')
+    self.assertTrue(os.path.exists(empty_def_file))
+    self.AssertFileContentNotContains(empty_def_file, 'hello_A')
 
   def testUsingDefFileGeneratedFromCcLibrary(self):
     self.CreateWorkspaceWithDefaultRepos('WORKSPACE')

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -517,7 +517,7 @@ class BazelWindowsCppTest(test_base.TestBase):
   def testBuildSharedLibraryWithoutAnySymbolExported(self):
     self.createProjectFiles()
     self.ScratchFile(
-      'lib/BUILD',
+      'BUILD',
       [
         'cc_binary(',
         '  name = "A.dll",',
@@ -528,12 +528,12 @@ class BazelWindowsCppTest(test_base.TestBase):
       ])
     bazel_bin = self.getBazelInfo('bazel-bin')
 
-    exit_code, _, stderr = self.RunBazel(['build', '//lib:A.dll'])
+    exit_code, _, stderr = self.RunBazel(['build', '//:A.dll'])
     self.AssertExitCode(exit_code, 0, stderr)
 
     # Although windows_export_all_symbols is not specified for this target,
     # we should still be able to build a DLL without any symbol exported.
-    trivial_def_file = os.path.join(bazel_bin, 'lib/A.dll.gen.trivial.def')
+    trivial_def_file = os.path.join(bazel_bin, 'A.dll.gen.trivial.def')
     self.assertTrue(os.path.exists(trivial_def_file))
     self.AssertFileContentNotContains(trivial_def_file, 'hello_A')
 


### PR DESCRIPTION
Previously, when building a DLL without any symbol exported, the action
will fail because the import library won't be generated by the linker.
In this change, we use a trivial DEF file to make sure the linker always
generate the import library when linking a DLL.

Fixes https://github.com/bazelbuild/bazel/issues/4561