### PR TITLE
Hide sidebar item 'Building With Platforms'

### DIFF
--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -168,7 +168,11 @@ nav: docs
                      <li><a href="/versions/{{ current_version }}/remote-caching-debug.html">Debugging Remote Cache Hit Rate for Local Execution</a></li>
                   </ul>
               </li>
+              
+              {% if major_version == "master" or major_version >= 1 %}
               <li><a href="/versions/{{ current_version }}/platforms-intro.html">Building With Platforms</a></li>
+              {% endif %}
+            
              </ul>
 
            {% if major_version == 0 %}


### PR DESCRIPTION
While researching on Bazel I noticed a broken link in the documentation for item 'Building With Platforms' on the bazel website.
According to PR #9446 this item should not appear before Bazel 1.0.
This is why I added version conditionals so this item will appear only for the intended versions of the documentation.