### PR TITLE
Python: Look for which before attempting to look for python

### DIFF
--- a/tools/python/pywrapper_template.txt
+++ b/tools/python/pywrapper_template.txt
@@ -44,6 +44,11 @@ die() {
 #     https://github.com/bazelbuild/bazel/issues/8414
 #     https://github.com/bazelbuild/bazel/issues/8415
 
+# Check if `which` is present first
+if ! which --help >/dev/null 2>&1; then
+  die "which utility not found."
+fi
+
 # Try the "python%VERSION%" command name first, then fall back on "python".
 PYTHON_BIN="$(PATH="$PATH" which python%VERSION% 2> /dev/null)"
 USED_FALLBACK="0"


### PR DESCRIPTION
If the system does not have `which`, looking for python executables
will fail, and the error message will not help, because it was
`which` that was not found, not python.