### PR TITLE
Fix broken link to "Building with Platforms" (not available before 1.1)

### DIFF
--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -168,7 +168,9 @@ nav: docs
                      <li><a href="/versions/{{ current_version }}/remote-caching-debug.html">Debugging Remote Cache Hit Rate for Local Execution</a></li>
                   </ul>
               </li>
-              <li><a href="/versions/{{ current_version }}/platforms-intro.html">Building With Platforms</a></li>
+              {% if major_version == "master" or (major_version > 0 and minor_version > 0) %}
+              <li><a href="/versions/master/platforms-intro.html">Building With Platforms</a></li>
+              {% endif %}
              </ul>
 
            {% if major_version == 0 %}

--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -168,7 +168,7 @@ nav: docs
                      <li><a href="/versions/{{ current_version }}/remote-caching-debug.html">Debugging Remote Cache Hit Rate for Local Execution</a></li>
                   </ul>
               </li>
-              {% if major_version == "master" or (major_version > 0 and minor_version > 0) %}
+              {% if major_version == "master" or major_version > 1 or major_version == 1 and minor_version >= 1 %}
               <li><a href="/versions/master/platforms-intro.html">Building With Platforms</a></li>
               {% endif %}
              </ul>


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel-website/issues/211

Notes:
* Liquid's boolean evaluator doesn't support parentheses
* Operator evaluation order is right-to-left: https://help.shopify.com/en/themes/liquid/basics/operators#order-of-operations
