### PR TITLE
NOT FOR REVIEW: Add --protocopt=--include_source_info by default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCompileActionBuilder.java
@@ -533,6 +533,8 @@ public class ProtoCompileActionBuilder {
       }
     }
 
+    cmdLine.addAll(ImmutableList.of("--include_source_info"));
+
     cmdLine.addAll(protocOpts);
 
     // Add include maps


### PR DESCRIPTION
See #9337

Note: This is not for review.