### PR TITLE
Fix chocolatey package name for package-fix-notation

### DIFF
--- a/scripts/packages/chocolatey/build.ps1
+++ b/scripts/packages/chocolatey/build.ps1
@@ -33,7 +33,7 @@ if ($fixPackage -eq $true) {
   if ($mode -eq "release") {
     $prefix = "."
   }
-  $tvPackageFixVersion = "$($prefix)$((get-date).tostring("yyyyMMdd_hhmmss"))"
+  $tvPackageFixVersion = "$($prefix)$((get-date).tostring("yyyyMMdd"))"
 }
 remove-item -force -ErrorAction SilentlyContinue "./*.nupkg"
 remove-item -force -ErrorAction SilentlyContinue "./bazel.nuspec"


### PR DESCRIPTION
See https://chocolatey.org/docs/create-packages#package-fix-version-notation - _HHmm suffix results in 502 bad gateway

See also https://twitter.com/gep13/status/1181815547983536128

cc @meteorcloudy and @philwo 