### PR TITLE
Add tool for dumping remote execution grpc log

### DIFF
--- a/src/main/protobuf/BUILD
+++ b/src/main/protobuf/BUILD
@@ -182,6 +182,11 @@ proto_library(
     ],
 )
 
+cc_proto_library(
+    name = "remote_execution_log_cc_proto",
+    deps = [":remote_execution_log_proto"],
+)
+
 java_proto_library(
     name = "remote_execution_log_java_proto",
     deps = [":remote_execution_log_proto"],

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -30,6 +30,7 @@ filegroup(
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:srcs",
         "//tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator:srcs",
         "//tools/python:srcs",
+        "//tools/remote_execution_log_dump:srcs",
         "//tools/runfiles:srcs",
         "//tools/sh:srcs",
         "//tools/whitelists:srcs",

--- a/tools/remote_execution_log_dump/BUILD
+++ b/tools/remote_execution_log_dump/BUILD
@@ -1,0 +1,12 @@
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+)
+
+cc_binary(
+    name = "remote_execution_log_dump",
+    srcs = ["remote_execution_log_dump.cpp"],
+    deps = [
+        "//src/main/protobuf:remote_execution_log_cc_proto",
+    ],
+)

--- a/tools/remote_execution_log_dump/remote_execution_log_dump.cpp
+++ b/tools/remote_execution_log_dump/remote_execution_log_dump.cpp
@@ -1,0 +1,29 @@
+#include <fcntl.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/util/delimited_message_util.h>
+#include <iostream>
+#include "src/main/protobuf/remote_execution_log.pb.h"
+
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    std::cerr << "error: usage: " << argv[0] << " GRPC_LOG" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  auto filepath = argv[1];
+  auto fp = open(filepath, O_RDONLY);
+  if (fp == -1) {
+    std::cerr << "error: failed to open '" << filepath
+              << "' for reading with code " << errno << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  remote_logging::LogEntry entry;
+  google::protobuf::io::FileInputStream file_input_stream(fp);
+  while (google::protobuf::util::ParseDelimitedFromZeroCopyStream(
+      &entry, &file_input_stream, nullptr)) {
+    std::cout << entry.DebugString() << std::endl;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This is a small script for dumping a human readable version of the log
produced by `--experimental_remote_grpc_log`.

Usage:

```sh
$ bazel run tools/remote_execution_log_dump path/to/log
metadata {
  tool_details {
    tool_name: "bazel"
    tool_version: "1.0.0"
  }
  action_id: "capabilities"
  tool_invocation_id: "..."
  correlated_invocations_id: "..."
}
...
```