### PR TITLE
Support flag overrides of config settings in external repositories.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -653,6 +653,7 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
         OptionsParser.builder()
             .optionsData(optionsData)
             .skippedPrefix("--//")
+            .skippedPrefix("--@")
             .allowResidue(annotation.allowResidue())
             .build();
     return parser;

--- a/src/main/java/com/google/devtools/common/options/OptionsParser.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParser.java
@@ -183,7 +183,7 @@ public class OptionsParser implements OptionsParsingResult {
     }
 
     /** Any flags with this prefix will be skipped during processing. */
-    public Builder skippedPrefix(@Nullable String skippedPrefix) {
+    public Builder skippedPrefix(String skippedPrefix) {
       this.implBuilder.skippedPrefix(skippedPrefix);
       return this;
     }

--- a/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
@@ -47,7 +47,7 @@ class OptionsParserImpl {
   static final class Builder {
     private OptionsData optionsData;
     private ArgsPreProcessor argsPreProcessor = args -> args;
-    @Nullable private String skippedPrefix;
+    private ArrayList<String> skippedPrefixes = new ArrayList<>();
     private boolean ignoreInternalOptions = true;
 
     /** Set the {@link OptionsData} to be used in this instance. */
@@ -63,8 +63,8 @@ class OptionsParserImpl {
     }
 
     /** Any flags with this prefix will be skipped during processing. */
-    public Builder skippedPrefix(@Nullable String skippedPrefix) {
-      this.skippedPrefix = skippedPrefix;
+    public Builder skippedPrefix(String skippedPrefix) {
+      this.skippedPrefixes.add(skippedPrefix);
       return this;
     }
 
@@ -77,7 +77,7 @@ class OptionsParserImpl {
     /** Returns a newly-initialized {@link OptionsParserImpl}. */
     public OptionsParserImpl build() {
       return new OptionsParserImpl(
-          this.optionsData, this.argsPreProcessor, this.skippedPrefix, this.ignoreInternalOptions);
+          this.optionsData, this.argsPreProcessor, this.skippedPrefixes, this.ignoreInternalOptions);
     }
   }
 
@@ -124,17 +124,17 @@ class OptionsParserImpl {
 
   private final List<String> warnings = new ArrayList<>();
   private final ArgsPreProcessor argsPreProcessor;
-  @Nullable private final String skippedPrefix;
+  private final List<String> skippedPrefixes;
   private final boolean ignoreInternalOptions;
 
   OptionsParserImpl(
       OptionsData optionsData,
       ArgsPreProcessor argsPreProcessor,
-      @Nullable String skippedPrefix,
+      List<String> skippedPrefixes,
       boolean ignoreInternalOptions) {
     this.optionsData = optionsData;
     this.argsPreProcessor = argsPreProcessor;
-    this.skippedPrefix = skippedPrefix;
+    this.skippedPrefixes = skippedPrefixes;
     this.ignoreInternalOptions = ignoreInternalOptions;
   }
 
@@ -145,10 +145,13 @@ class OptionsParserImpl {
 
   /** Returns a {@link Builder} that is configured the same as this parser. */
   Builder toBuilder() {
-    return builder()
+    Builder builder = builder()
         .optionsData(optionsData)
-        .argsPreProcessor(argsPreProcessor)
-        .skippedPrefix(skippedPrefix);
+        .argsPreProcessor(argsPreProcessor);
+    for (String skippedPrefix : skippedPrefixes) {
+      builder.skippedPrefix(skippedPrefix);
+    }
+    return builder;
   }
 
   /** Implements {@link OptionsParser#asCompleteListOfParsedOptions()}. */
@@ -350,7 +353,7 @@ class OptionsParserImpl {
         continue; // not an option arg
       }
 
-      if (skippedPrefix != null && arg.startsWith(skippedPrefix)) {
+      if (skippedPrefixes.stream().anyMatch(prefix -> arg.startsWith(prefix))) {
         unparsedArgs.add(arg);
         continue;
       }

--- a/src/test/java/com/google/devtools/build/lib/skylark/StarlarkOptionsParsingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skylark/StarlarkOptionsParsingTest.java
@@ -161,6 +161,19 @@ public class StarlarkOptionsParsingTest extends SkylarkTestCase {
     assertThat(result.getResidue()).isEmpty();
   }
 
+  // test --@workspace//flag=value
+  @Test
+  public void testFlagNameWithWorkspace() throws Exception {
+    writeBasicIntFlag();
+    rewriteWorkspace("workspace(name = 'starlark_options_test')");
+
+    OptionsParsingResult result = parseStarlarkOptions("--@starlark_options_test//test:my_int_setting=666");
+
+    assertThat(result.getStarlarkOptions()).hasSize(1);
+    assertThat(result.getStarlarkOptions().get("@starlark_options_test//test:my_int_setting")).isEqualTo(666);
+    assertThat(result.getResidue()).isEmpty();
+  }
+
   // test --fake_flag=value
   @Test
   public void testBadFlag_equalsForm() throws Exception {


### PR DESCRIPTION
The user-defined flags documented at https://docs.bazel.build/versions/1.0.0/skylark/config.html can't currently be set across repositories with `--@some_repo//:some_flag`. It looks like this is just a simple oversight in the flag parser, and after changing it to accept `--@` as a Starlark flag prefix the rest of the functionality is working.

Fixes https://github.com/bazelbuild/bazel/issues/10039