### PR TITLE
Update "six" library from 1.10.0 to 1.12.0

### DIFF
--- a/third_party/py/six/CHANGES
+++ b/third_party/py/six/CHANGES
@@ -3,6 +3,38 @@ Changelog for six
 
 This file lists the changes in each six version.
 
+1.12.0
+------
+
+- Issue #259, pull request #260: `six.add_metaclass` now preserves
+  `__qualname__` from the original class.
+
+- Pull request #204: Add `six.ensure_binary`, `six.ensure_text`, and
+  `six.ensure_str`.
+
+1.11.0
+------
+
+- Pull request #178: `with_metaclass` now properly proxies `__prepare__` to the
+  underlying metaclass.
+
+- Pull request #191: Allow `with_metaclass` to work with metaclasses implemented
+  in C.
+
+- Pull request #203: Add parse_http_list and parse_keqv_list to moved
+  urllib.request.
+
+- Pull request #172 and issue #171: Add unquote_to_bytes to moved urllib.parse.
+
+- Pull request #167: Add `six.moves.getoutput`.
+
+- Pull request #80: Add `six.moves.urllib_parse.splitvalue`.
+
+- Pull request #75: Add `six.moves.email_mime_image`.
+
+- Pull request #72: Avoid creating reference cycles through tracebacks in
+  `reraise`.
+
 1.10.0
 ------
 

--- a/third_party/py/six/LICENSE
+++ b/third_party/py/six/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2015 Benjamin Peterson
+Copyright (c) 2010-2018 Benjamin Peterson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/third_party/py/six/PKG-INFO
+++ b/third_party/py/six/PKG-INFO
@@ -1,12 +1,28 @@
-Metadata-Version: 1.1
+Metadata-Version: 1.2
 Name: six
-Version: 1.10.0
+Version: 1.12.0
 Summary: Python 2 and 3 compatibility utilities
-Home-page: http://pypi.python.org/pypi/six/
+Home-page: https://github.com/benjaminp/six
 Author: Benjamin Peterson
 Author-email: benjamin@python.org
 License: MIT
-Description: Six is a Python 2 and 3 compatibility library.  It provides utility functions
+Description: .. image:: https://img.shields.io/pypi/v/six.svg
+           :target: https://pypi.org/project/six/
+           :alt: six on PyPI
+        
+        .. image:: https://travis-ci.org/benjaminp/six.svg?branch=master
+           :target: https://travis-ci.org/benjaminp/six
+           :alt: six on TravisCI
+        
+        .. image:: https://readthedocs.org/projects/six/badge/?version=latest
+           :target: https://six.readthedocs.io/
+           :alt: six's documentation on Read the Docs
+        
+        .. image:: https://img.shields.io/badge/license-MIT-green.svg
+           :target: https://github.com/benjaminp/six/blob/master/LICENSE
+           :alt: MIT License badge
+        
+        Six is a Python 2 and 3 compatibility library.  It provides utility functions
         for smoothing over the differences between the Python versions with the goal of
         writing Python code that is compatible on both Python versions.  See the
         documentation for more information on what is provided.
@@ -15,18 +31,20 @@ Description: Six is a Python 2 and 3 compatibility library.  It provides utility
         file, so it can be easily copied into your project. (The copyright and license
         notice must be retained.)
         
-        Online documentation is at https://pythonhosted.org/six/.
+        Online documentation is at https://six.readthedocs.io/.
         
-        Bugs can be reported to https://bitbucket.org/gutworth/six.  The code can also
+        Bugs can be reported to https://github.com/benjaminp/six.  The code can also
         be found there.
         
         For questions about six or porting in general, email the python-porting mailing
         list: https://mail.python.org/mailman/listinfo/python-porting
         
 Platform: UNKNOWN
+Classifier: Development Status :: 5 - Production/Stable
 Classifier: Programming Language :: Python :: 2
 Classifier: Programming Language :: Python :: 3
 Classifier: Intended Audience :: Developers
 Classifier: License :: OSI Approved :: MIT License
 Classifier: Topic :: Software Development :: Libraries
 Classifier: Topic :: Utilities
+Requires-Python: >=2.6, !=3.0.*, !=3.1.*

--- a/third_party/py/six/README.md
+++ b/third_party/py/six/README.md
@@ -1,6 +1,6 @@
 [six](https://pythonhosted.org/six/)
 ------
 
-* Version: 1.10.0
+* Version: 1.12.0
 * License: MIT
-* From: [https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz](https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz)
+* From: [https://pypi.python.org/packages/source/s/six/six-1.12.0.tar.gz](https://pypi.python.org/packages/source/s/six/six-1.12.0.tar.gz)

--- a/third_party/py/six/README.rst
+++ b/third_party/py/six/README.rst
@@ -1,0 +1,32 @@
+.. image:: https://img.shields.io/pypi/v/six.svg
+   :target: https://pypi.org/project/six/
+   :alt: six on PyPI
+
+.. image:: https://travis-ci.org/benjaminp/six.svg?branch=master
+   :target: https://travis-ci.org/benjaminp/six
+   :alt: six on TravisCI
+
+.. image:: https://readthedocs.org/projects/six/badge/?version=latest
+   :target: https://six.readthedocs.io/
+   :alt: six's documentation on Read the Docs
+
+.. image:: https://img.shields.io/badge/license-MIT-green.svg
+   :target: https://github.com/benjaminp/six/blob/master/LICENSE
+   :alt: MIT License badge
+
+Six is a Python 2 and 3 compatibility library.  It provides utility functions
+for smoothing over the differences between the Python versions with the goal of
+writing Python code that is compatible on both Python versions.  See the
+documentation for more information on what is provided.
+
+Six supports every Python version since 2.6.  It is contained in only one Python
+file, so it can be easily copied into your project. (The copyright and license
+notice must be retained.)
+
+Online documentation is at https://six.readthedocs.io/.
+
+Bugs can be reported to https://github.com/benjaminp/six.  The code can also
+be found there.
+
+For questions about six or porting in general, email the python-porting mailing
+list: https://mail.python.org/mailman/listinfo/python-porting

--- a/third_party/py/six/documentation/conf.py
+++ b/third_party/py/six/documentation/conf.py
@@ -33,7 +33,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"six"
-copyright = u"2010-2015, Benjamin Peterson"
+copyright = u"2010-2018, Benjamin Peterson"
 
 sys.path.append(os.path.abspath(os.path.join(".", "..")))
 from six import __version__ as six_version

--- a/third_party/py/six/documentation/index.rst
+++ b/third_party/py/six/documentation/index.rst
@@ -13,8 +13,8 @@ Python 3.  It is intended to support codebases that work on both Python 2 and 3
 without modification.  six consists of only one Python file, so it is painless
 to copy into a project.
 
-Six can be downloaded on `PyPi <http://pypi.python.org/pypi/six/>`_.  Its bug
-tracker and code hosting is on `BitBucket <http://bitbucket.org/gutworth/six>`_.
+Six can be downloaded on `PyPI <https://pypi.org/project/six/>`_.  Its bug
+tracker and code hosting is on `GitHub <https://github.com/benjaminp/six>`_.
 
 The name, "six", comes from the fact that 2*3 equals 6.  Why not addition?
 Multiplication is more powerful, and, anyway, "five" has already been snatched
@@ -50,8 +50,9 @@ Six provides constants that may differ between Python versions.  Ones ending
 
 .. data:: class_types
 
-   Possible class types.  In Python 2, this encompasses old-style and new-style
-   classes.  In Python 3, this is just new-styles.
+   Possible class types.  In Python 2, this encompasses old-style
+   :data:`py2:types.ClassType` and new-style ``type`` classes.  In Python 3,
+   this is just ``type``.
 
 
 .. data:: integer_types
@@ -104,7 +105,7 @@ Here's example usage of the module::
 Object model compatibility
 >>>>>>>>>>>>>>>>>>>>>>>>>>
 
-Python 3 renamed the attributes of several intepreter data structures.  The
+Python 3 renamed the attributes of several interpreter data structures.  The
 following accessors are available.  Note that the recommended way to inspect
 functions and methods is the stdlib :mod:`py3:inspect` module.
 
@@ -164,7 +165,9 @@ functions and methods is the stdlib :mod:`py3:inspect` module.
 
    Get the next item of iterator *it*.  :exc:`py3:StopIteration` is raised if
    the iterator is exhausted.  This is a replacement for calling ``it.next()``
-   in Python 2 and ``next(it)`` in Python 3.
+   in Python 2 and ``next(it)`` in Python 3.  Python 2.6 and above have a
+   builtin ``next`` function, so six's version is only necessary for Python 2.5
+   compatibility.
 
 
 .. function:: callable(obj)
@@ -345,7 +348,7 @@ Python 2 and 3.
    on Python 3 or ::
 
        class MyClass(object):
-           __metaclass__ = MyMeta
+           __metaclass__ = Meta
 
    on Python 2.
 
@@ -361,7 +364,7 @@ Binary and text data
 >>>>>>>>>>>>>>>>>>>>
 
 Python 3 enforces the distinction between byte strings and text strings far more
-rigoriously than Python 2 does; binary data cannot be automatically coerced to
+rigorously than Python 2 does; binary data cannot be automatically coerced to
 or from text data.  six provides several functions to assist in classifying
 string data in all Python versions.
 
@@ -369,14 +372,14 @@ string data in all Python versions.
 .. function:: b(data)
 
    A "fake" bytes literal.  *data* should always be a normal string literal.  In
-   Python 2, :func:`b` returns a 8-bit string.  In Python 3, *data* is encoded
+   Python 2, :func:`b` returns an 8-bit string.  In Python 3, *data* is encoded
    with the latin-1 encoding to bytes.
 
 
    .. note::
 
       Since all Python versions 2.6 and after support the ``b`` prefix,
-      :func:`b`, code without 2.5 support doesn't need :func:`b`.
+      code without 2.5 support doesn't need :func:`b`.
 
 
 .. function:: u(text)
@@ -431,9 +434,27 @@ string data in all Python versions.
    a bytes object iterator in Python 3.
 
 
+.. function:: ensure_binary(s, encoding='utf-8', errors='strict')
+
+   Coerce *s* to :data:`binary_type`. *encoding*, *errors* are the same as
+   :meth:`py3:str.encode`
+
+
+.. function:: ensure_str(s, encoding='utf-8', errors='strict')
+
+   Coerce *s* to ``str``. ``encoding``, ``errors`` are the same
+   :meth:`py3:str.encode`
+
+
+.. function:: ensure_text(s, encoding='utf-8', errors='strict')
+
+   Coerce *s* to :data:`text_type`. *encoding*, *errors* are the same as
+   :meth:`py3:str.encode`
+
+
 .. data:: StringIO
 
-   This is an fake file object for textual data.  It's an alias for
+   This is a fake file object for textual data.  It's an alias for
    :class:`py2:StringIO.StringIO` in Python 2 and :class:`py3:io.StringIO` in
    Python 3.
 
@@ -501,7 +522,7 @@ Python 2 or 3, write::
    from six.moves import html_parser
 
 Similarly, to get the function to reload modules, which was moved from the
-builtin module to the ``imp`` module, use::
+builtin module to the ``importlib`` module, use::
 
    from six.moves import reload_module
 
@@ -509,7 +530,7 @@ For the most part, :mod:`six.moves` aliases are the names of the modules in
 Python 3.  When the new Python 3 name is a package, the components of the name
 are separated by underscores.  For example, ``html.parser`` becomes
 ``html_parser``.  In some cases where several modules have been combined, the
-Python 2 name is retained.  This is so the appropiate modules can be found when
+Python 2 name is retained.  This is so the appropriate modules can be found when
 running on Python 2.  For example, ``BaseHTTPServer`` which is in
 ``http.server`` in Python 3 is aliased as ``BaseHTTPServer``.
 
@@ -530,14 +551,14 @@ functionality; its structure mimics the structure of the Python 3
 
      from six.moves.cPickle import loads
 
-   work, six places special proxy objects in in :data:`py3:sys.modules`. These
+   work, six places special proxy objects in :data:`py3:sys.modules`. These
    proxies lazily load the underlying module when an attribute is fetched. This
    will fail if the underlying module is not available in the Python
    interpreter. For example, ``sys.modules["six.moves.winreg"].LoadKey`` would
    fail on any non-Windows platform. Unfortunately, some applications try to
    load attributes on every module in :data:`py3:sys.modules`. six mitigates
    this problem for some applications by pretending attributes on unimportable
-   modules don't exist. This hack doesn't work in every case, though. If you are
+   modules do not exist. This hack does not work in every case, though. If you are
    encountering problems with the lazy modules and don't use any from imports
    directly from ``six.moves`` modules, you can workaround the issue by removing
    the six proxy modules::
@@ -548,139 +569,143 @@ functionality; its structure mimics the structure of the Python 3
 
 Supported renames:
 
-+------------------------------+-------------------------------------+-------------------------------------+
-| Name                         | Python 2 name                       | Python 3 name                       |
-+==============================+=====================================+=====================================+
-| ``builtins``                 | :mod:`py2:__builtin__`              | :mod:`py3:builtins`                 |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``configparser``             | :mod:`py2:ConfigParser`             | :mod:`py3:configparser`             |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``copyreg``                  | :mod:`py2:copy_reg`                 | :mod:`py3:copyreg`                  |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``cPickle``                  | :mod:`py2:cPickle`                  | :mod:`py3:pickle`                   |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``cStringIO``                | :func:`py2:cStringIO.StringIO`      | :class:`py3:io.StringIO`            |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``dbm_gnu``                  | :func:`py2:gdbm`                    | :class:`py3:dbm.gnu`                |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``_dummy_thread``            | :mod:`py2:dummy_thread`             | :mod:`py3:_dummy_thread`            |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``email_mime_multipart``     | :mod:`py2:email.MIMEMultipart`      | :mod:`py3:email.mime.multipart`     |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``email_mime_nonmultipart``  | :mod:`py2:email.MIMENonMultipart`   | :mod:`py3:email.mime.nonmultipart`  |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``email_mime_text``          | :mod:`py2:email.MIMEText`           | :mod:`py3:email.mime.text`          |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``email_mime_base``          | :mod:`py2:email.MIMEBase`           | :mod:`py3:email.mime.base`          |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``filter``                   | :func:`py2:itertools.ifilter`       | :func:`py3:filter`                  |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``filterfalse``              | :func:`py2:itertools.ifilterfalse`  | :func:`py3:itertools.filterfalse`   |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``getcwd``                   | :func:`py2:os.getcwdu`              | :func:`py3:os.getcwd`               |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``getcwdb``                  | :func:`py2:os.getcwd`               | :func:`py3:os.getcwdb`              |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``http_cookiejar``           | :mod:`py2:cookielib`                | :mod:`py3:http.cookiejar`           |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``http_cookies``             | :mod:`py2:Cookie`                   | :mod:`py3:http.cookies`             |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``html_entities``            | :mod:`py2:htmlentitydefs`           | :mod:`py3:html.entities`            |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``html_parser``              | :mod:`py2:HTMLParser`               | :mod:`py3:html.parser`              |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``http_client``              | :mod:`py2:httplib`                  | :mod:`py3:http.client`              |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``BaseHTTPServer``           | :mod:`py2:BaseHTTPServer`           | :mod:`py3:http.server`              |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``CGIHTTPServer``            | :mod:`py2:CGIHTTPServer`            | :mod:`py3:http.server`              |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``SimpleHTTPServer``         | :mod:`py2:SimpleHTTPServer`         | :mod:`py3:http.server`              |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``input``                    | :func:`py2:raw_input`               | :func:`py3:input`                   |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``intern``                   | :func:`py2:intern`                  | :func:`py3:sys.intern`              |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``map``                      | :func:`py2:itertools.imap`          | :func:`py3:map`                     |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``queue``                    | :mod:`py2:Queue`                    | :mod:`py3:queue`                    |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``range``                    | :func:`py2:xrange`                  | :func:`py3:range`                   |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``reduce``                   | :func:`py2:reduce`                  | :func:`py3:functools.reduce`        |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``reload_module``            | :func:`py2:reload`                  | :func:`py3:imp.reload`,             |
-|                              |                                     | :func:`py3:importlib.reload`        |
-|                              |                                     | on Python 3.4+                      |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``reprlib``                  | :mod:`py2:repr`                     | :mod:`py3:reprlib`                  |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``shlex_quote``              | :mod:`py2:pipes.quote`              | :mod:`py3:shlex.quote`              |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``socketserver``             | :mod:`py2:SocketServer`             | :mod:`py3:socketserver`             |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``_thread``                  | :mod:`py2:thread`                   | :mod:`py3:_thread`                  |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter``                  | :mod:`py2:Tkinter`                  | :mod:`py3:tkinter`                  |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_dialog``           | :mod:`py2:Dialog`                   | :mod:`py3:tkinter.dialog`           |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_filedialog``       | :mod:`py2:FileDialog`               | :mod:`py3:tkinter.FileDialog`       |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_scrolledtext``     | :mod:`py2:ScrolledText`             | :mod:`py3:tkinter.scrolledtext`     |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_simpledialog``     | :mod:`py2:SimpleDialog`             | :mod:`py3:tkinter.simpledialog`     |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_ttk``              | :mod:`py2:ttk`                      | :mod:`py3:tkinter.ttk`              |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_tix``              | :mod:`py2:Tix`                      | :mod:`py3:tkinter.tix`              |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_constants``        | :mod:`py2:Tkconstants`              | :mod:`py3:tkinter.constants`        |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_dnd``              | :mod:`py2:Tkdnd`                    | :mod:`py3:tkinter.dnd`              |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_colorchooser``     | :mod:`py2:tkColorChooser`           | :mod:`py3:tkinter.colorchooser`     |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_commondialog``     | :mod:`py2:tkCommonDialog`           | :mod:`py3:tkinter.commondialog`     |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_tkfiledialog``     | :mod:`py2:tkFileDialog`             | :mod:`py3:tkinter.filedialog`       |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_font``             | :mod:`py2:tkFont`                   | :mod:`py3:tkinter.font`             |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_messagebox``       | :mod:`py2:tkMessageBox`             | :mod:`py3:tkinter.messagebox`       |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``tkinter_tksimpledialog``   | :mod:`py2:tkSimpleDialog`           | :mod:`py3:tkinter.simpledialog`     |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``urllib.parse``             | See :mod:`six.moves.urllib.parse`   | :mod:`py3:urllib.parse`             |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``urllib.error``             | See :mod:`six.moves.urllib.error`   | :mod:`py3:urllib.error`             |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``urllib.request``           | See :mod:`six.moves.urllib.request` | :mod:`py3:urllib.request`           |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``urllib.response``          | See :mod:`six.moves.urllib.response`| :mod:`py3:urllib.response`          |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``urllib.robotparser``       | :mod:`py2:robotparser`              | :mod:`py3:urllib.robotparser`       |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``urllib_robotparser``       | :mod:`py2:robotparser`              | :mod:`py3:urllib.robotparser`       |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``UserDict``                 | :class:`py2:UserDict.UserDict`      | :class:`py3:collections.UserDict`   |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``UserList``                 | :class:`py2:UserList.UserList`      | :class:`py3:collections.UserList`   |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``UserString``               | :class:`py2:UserString.UserString`  | :class:`py3:collections.UserString` |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``winreg``                   | :mod:`py2:_winreg`                  | :mod:`py3:winreg`                   |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``xmlrpc_client``            | :mod:`py2:xmlrpclib`                | :mod:`py3:xmlrpc.client`            |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``xmlrpc_server``            | :mod:`py2:SimpleXMLRPCServer`       | :mod:`py3:xmlrpc.server`            |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``xrange``                   | :func:`py2:xrange`                  | :func:`py3:range`                   |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``zip``                      | :func:`py2:itertools.izip`          | :func:`py3:zip`                     |
-+------------------------------+-------------------------------------+-------------------------------------+
-| ``zip_longest``              | :func:`py2:itertools.izip_longest`  | :func:`py3:itertools.zip_longest`   |
-+------------------------------+-------------------------------------+-------------------------------------+
++------------------------------+-------------------------------------+---------------------------------------+
+| Name                         | Python 2 name                       | Python 3 name                         |
++==============================+=====================================+=======================================+
+| ``builtins``                 | :mod:`py2:__builtin__`              | :mod:`py3:builtins`                   |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``configparser``             | :mod:`py2:ConfigParser`             | :mod:`py3:configparser`               |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``copyreg``                  | :mod:`py2:copy_reg`                 | :mod:`py3:copyreg`                    |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``cPickle``                  | :mod:`py2:cPickle`                  | :mod:`py3:pickle`                     |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``cStringIO``                | :func:`py2:cStringIO.StringIO`      | :class:`py3:io.StringIO`              |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``dbm_gnu``                  | :func:`py2:gdbm`                    | :class:`py3:dbm.gnu`                  |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``_dummy_thread``            | :mod:`py2:dummy_thread`             | :mod:`py3:_dummy_thread`              |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``email_mime_base``          | :mod:`py2:email.MIMEBase`           | :mod:`py3:email.mime.base`            |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``email_mime_image``         | :mod:`py2:email.MIMEImage`          | :mod:`py3:email.mime.image`           |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``email_mime_multipart``     | :mod:`py2:email.MIMEMultipart`      | :mod:`py3:email.mime.multipart`       |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``email_mime_nonmultipart``  | :mod:`py2:email.MIMENonMultipart`   | :mod:`py3:email.mime.nonmultipart`    |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``email_mime_text``          | :mod:`py2:email.MIMEText`           | :mod:`py3:email.mime.text`            |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``filter``                   | :func:`py2:itertools.ifilter`       | :func:`py3:filter`                    |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``filterfalse``              | :func:`py2:itertools.ifilterfalse`  | :func:`py3:itertools.filterfalse`     |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``getcwd``                   | :func:`py2:os.getcwdu`              | :func:`py3:os.getcwd`                 |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``getcwdb``                  | :func:`py2:os.getcwd`               | :func:`py3:os.getcwdb`                |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``getoutput``                | :func:`py2:commands.getoutput`      | :func:`py3:subprocess.getoutput`      |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``http_cookiejar``           | :mod:`py2:cookielib`                | :mod:`py3:http.cookiejar`             |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``http_cookies``             | :mod:`py2:Cookie`                   | :mod:`py3:http.cookies`               |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``html_entities``            | :mod:`py2:htmlentitydefs`           | :mod:`py3:html.entities`              |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``html_parser``              | :mod:`py2:HTMLParser`               | :mod:`py3:html.parser`                |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``http_client``              | :mod:`py2:httplib`                  | :mod:`py3:http.client`                |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``BaseHTTPServer``           | :mod:`py2:BaseHTTPServer`           | :mod:`py3:http.server`                |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``CGIHTTPServer``            | :mod:`py2:CGIHTTPServer`            | :mod:`py3:http.server`                |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``SimpleHTTPServer``         | :mod:`py2:SimpleHTTPServer`         | :mod:`py3:http.server`                |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``input``                    | :func:`py2:raw_input`               | :func:`py3:input`                     |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``intern``                   | :func:`py2:intern`                  | :func:`py3:sys.intern`                |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``map``                      | :func:`py2:itertools.imap`          | :func:`py3:map`                       |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``queue``                    | :mod:`py2:Queue`                    | :mod:`py3:queue`                      |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``range``                    | :func:`py2:xrange`                  | :func:`py3:range`                     |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``reduce``                   | :func:`py2:reduce`                  | :func:`py3:functools.reduce`          |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``reload_module``            | :func:`py2:reload`                  | :func:`py3:imp.reload`,               |
+|                              |                                     | :func:`py3:importlib.reload`          |
+|                              |                                     | on Python 3.4+                        |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``reprlib``                  | :mod:`py2:repr`                     | :mod:`py3:reprlib`                    |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``shlex_quote``              | :mod:`py2:pipes.quote`              | :mod:`py3:shlex.quote`                |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``socketserver``             | :mod:`py2:SocketServer`             | :mod:`py3:socketserver`               |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``_thread``                  | :mod:`py2:thread`                   | :mod:`py3:_thread`                    |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter``                  | :mod:`py2:Tkinter`                  | :mod:`py3:tkinter`                    |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_dialog``           | :mod:`py2:Dialog`                   | :mod:`py3:tkinter.dialog`             |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_filedialog``       | :mod:`py2:FileDialog`               | :mod:`py3:tkinter.FileDialog`         |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_scrolledtext``     | :mod:`py2:ScrolledText`             | :mod:`py3:tkinter.scrolledtext`       |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_simpledialog``     | :mod:`py2:SimpleDialog`             | :mod:`py3:tkinter.simpledialog`       |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_ttk``              | :mod:`py2:ttk`                      | :mod:`py3:tkinter.ttk`                |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_tix``              | :mod:`py2:Tix`                      | :mod:`py3:tkinter.tix`                |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_constants``        | :mod:`py2:Tkconstants`              | :mod:`py3:tkinter.constants`          |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_dnd``              | :mod:`py2:Tkdnd`                    | :mod:`py3:tkinter.dnd`                |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_colorchooser``     | :mod:`py2:tkColorChooser`           | :mod:`py3:tkinter.colorchooser`       |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_commondialog``     | :mod:`py2:tkCommonDialog`           | :mod:`py3:tkinter.commondialog`       |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_tkfiledialog``     | :mod:`py2:tkFileDialog`             | :mod:`py3:tkinter.filedialog`         |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_font``             | :mod:`py2:tkFont`                   | :mod:`py3:tkinter.font`               |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_messagebox``       | :mod:`py2:tkMessageBox`             | :mod:`py3:tkinter.messagebox`         |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``tkinter_tksimpledialog``   | :mod:`py2:tkSimpleDialog`           | :mod:`py3:tkinter.simpledialog`       |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``urllib.parse``             | See :mod:`six.moves.urllib.parse`   | :mod:`py3:urllib.parse`               |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``urllib.error``             | See :mod:`six.moves.urllib.error`   | :mod:`py3:urllib.error`               |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``urllib.request``           | See :mod:`six.moves.urllib.request` | :mod:`py3:urllib.request`             |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``urllib.response``          | See :mod:`six.moves.urllib.response`| :mod:`py3:urllib.response`            |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``urllib.robotparser``       | :mod:`py2:robotparser`              | :mod:`py3:urllib.robotparser`         |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``urllib_robotparser``       | :mod:`py2:robotparser`              | :mod:`py3:urllib.robotparser`         |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``UserDict``                 | :class:`py2:UserDict.UserDict`      | :class:`py3:collections.UserDict`     |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``UserList``                 | :class:`py2:UserList.UserList`      | :class:`py3:collections.UserList`     |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``UserString``               | :class:`py2:UserString.UserString`  | :class:`py3:collections.UserString`   |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``winreg``                   | :mod:`py2:_winreg`                  | :mod:`py3:winreg`                     |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``xmlrpc_client``            | :mod:`py2:xmlrpclib`                | :mod:`py3:xmlrpc.client`              |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``xmlrpc_server``            | :mod:`py2:SimpleXMLRPCServer`       | :mod:`py3:xmlrpc.server`              |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``xrange``                   | :func:`py2:xrange`                  | :func:`py3:range`                     |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``zip``                      | :func:`py2:itertools.izip`          | :func:`py3:zip`                       |
++------------------------------+-------------------------------------+---------------------------------------+
+| ``zip_longest``              | :func:`py2:itertools.izip_longest`  | :func:`py3:itertools.zip_longest`     |
++------------------------------+-------------------------------------+---------------------------------------+
 
 urllib parse
 <<<<<<<<<<<<
@@ -715,7 +740,8 @@ and :mod:`py2:urllib`:
 * :func:`py2:urllib.quote_plus`
 * :func:`py2:urllib.splittag`
 * :func:`py2:urllib.splituser`
-* :func:`py2:urllib.unquote`
+* :func:`py2:urllib.splitvalue`
+* :func:`py2:urllib.unquote` (also exposed as :func:`py3:urllib.parse.unquote_to_bytes`)
 * :func:`py2:urllib.unquote_plus`
 * :func:`py2:urllib.urlencode`
 
@@ -762,6 +788,8 @@ and :mod:`py2:urllib2`:
 * :func:`py2:urllib2.urlopen`
 * :func:`py2:urllib2.install_opener`
 * :func:`py2:urllib2.build_opener`
+* :func:`py2:urllib2.parse_http_list`
+* :func:`py2:urllib2.parse_keqv_list`
 * :class:`py2:urllib2.Request`
 * :class:`py2:urllib2.OpenerDirector`
 * :class:`py2:urllib2.HTTPDefaultErrorHandler`

--- a/third_party/py/six/setup.cfg
+++ b/third_party/py/six/setup.cfg
@@ -1,11 +1,14 @@
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [flake8]
 max-line-length = 100
 ignore = F821
 
-[pytest]
+[metadata]
+license_file = LICENSE
+
+[tool:pytest]
 minversion = 2.2.0
 pep8ignore = 
 	documentation/*.py ALL
@@ -16,7 +19,6 @@ flakes-ignore =
 	six.py UndefinedName
 
 [egg_info]
-tag_date = 0
-tag_svn_revision = 0
 tag_build = 
+tag_date = 0
 

--- a/third_party/py/six/setup.py
+++ b/third_party/py/six/setup.py
@@ -1,5 +1,28 @@
+# Copyright (c) 2010-2018 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from __future__ import with_statement
 
+# Six is a dependency of setuptools, so using setuptools creates a
+# circular dependency when building a Python stack from source. We
+# therefore allow falling back to distutils to install six.
 try:
     from setuptools import setup
 except ImportError:
@@ -8,6 +31,7 @@ except ImportError:
 import six
 
 six_classifiers = [
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 3",
     "Intended Audience :: Developers",
@@ -16,17 +40,19 @@ six_classifiers = [
     "Topic :: Utilities",
 ]
 
-with open("README", "r") as fp:
+with open("README.rst", "r") as fp:
     six_long_description = fp.read()
 
 setup(name="six",
       version=six.__version__,
       author="Benjamin Peterson",
       author_email="benjamin@python.org",
-      url="http://pypi.python.org/pypi/six/",
+      url="https://github.com/benjaminp/six",
+      tests_require=["pytest"],
       py_modules=["six"],
       description="Python 2 and 3 compatibility utilities",
       long_description=six_long_description,
       license="MIT",
-      classifiers=six_classifiers
+      classifiers=six_classifiers,
+      python_requires=">=2.6, !=3.0.*, !=3.1.*",
       )

--- a/third_party/py/six/six.egg-info/PKG-INFO
+++ b/third_party/py/six/six.egg-info/PKG-INFO
@@ -1,12 +1,28 @@
-Metadata-Version: 1.1
+Metadata-Version: 1.2
 Name: six
-Version: 1.10.0
+Version: 1.12.0
 Summary: Python 2 and 3 compatibility utilities
-Home-page: http://pypi.python.org/pypi/six/
+Home-page: https://github.com/benjaminp/six
 Author: Benjamin Peterson
 Author-email: benjamin@python.org
 License: MIT
-Description: Six is a Python 2 and 3 compatibility library.  It provides utility functions
+Description: .. image:: https://img.shields.io/pypi/v/six.svg
+           :target: https://pypi.org/project/six/
+           :alt: six on PyPI
+        
+        .. image:: https://travis-ci.org/benjaminp/six.svg?branch=master
+           :target: https://travis-ci.org/benjaminp/six
+           :alt: six on TravisCI
+        
+        .. image:: https://readthedocs.org/projects/six/badge/?version=latest
+           :target: https://six.readthedocs.io/
+           :alt: six's documentation on Read the Docs
+        
+        .. image:: https://img.shields.io/badge/license-MIT-green.svg
+           :target: https://github.com/benjaminp/six/blob/master/LICENSE
+           :alt: MIT License badge
+        
+        Six is a Python 2 and 3 compatibility library.  It provides utility functions
         for smoothing over the differences between the Python versions with the goal of
         writing Python code that is compatible on both Python versions.  See the
         documentation for more information on what is provided.
@@ -15,18 +31,20 @@ Description: Six is a Python 2 and 3 compatibility library.  It provides utility
         file, so it can be easily copied into your project. (The copyright and license
         notice must be retained.)
         
-        Online documentation is at https://pythonhosted.org/six/.
+        Online documentation is at https://six.readthedocs.io/.
         
-        Bugs can be reported to https://bitbucket.org/gutworth/six.  The code can also
+        Bugs can be reported to https://github.com/benjaminp/six.  The code can also
         be found there.
         
         For questions about six or porting in general, email the python-porting mailing
         list: https://mail.python.org/mailman/listinfo/python-porting
         
 Platform: UNKNOWN
+Classifier: Development Status :: 5 - Production/Stable
 Classifier: Programming Language :: Python :: 2
 Classifier: Programming Language :: Python :: 3
 Classifier: Intended Audience :: Developers
 Classifier: License :: OSI Approved :: MIT License
 Classifier: Topic :: Software Development :: Libraries
 Classifier: Topic :: Utilities
+Requires-Python: >=2.6, !=3.0.*, !=3.1.*

--- a/third_party/py/six/six.egg-info/SOURCES.txt
+++ b/third_party/py/six/six.egg-info/SOURCES.txt
@@ -1,7 +1,7 @@
 CHANGES
 LICENSE
 MANIFEST.in
-README
+README.rst
 setup.cfg
 setup.py
 six.py

--- a/third_party/py/six/six.py
+++ b/third_party/py/six/six.py
@@ -1,6 +1,4 @@
-"""Utilities for writing code that runs on Python 2 and 3"""
-
-# Copyright (c) 2010-2015 Benjamin Peterson
+# Copyright (c) 2010-2018 Benjamin Peterson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""Utilities for writing code that runs on Python 2 and 3"""
+
 from __future__ import absolute_import
 
 import functools
@@ -29,7 +29,7 @@ import sys
 import types
 
 __author__ = "Benjamin Peterson <benjamin@python.org>"
-__version__ = "1.10.0"
+__version__ = "1.12.0"
 
 
 # Useful for very coarse version differentiation.
@@ -241,6 +241,7 @@ _moved_attributes = [
     MovedAttribute("map", "itertools", "builtins", "imap", "map"),
     MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
     MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
+    MovedAttribute("getoutput", "commands", "subprocess"),
     MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
     MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
     MovedAttribute("reduce", "__builtin__", "functools"),
@@ -262,10 +263,11 @@ _moved_attributes = [
     MovedModule("html_entities", "htmlentitydefs", "html.entities"),
     MovedModule("html_parser", "HTMLParser", "html.parser"),
     MovedModule("http_client", "httplib", "http.client"),
+    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
+    MovedModule("email_mime_image", "email.MIMEImage", "email.mime.image"),
     MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
     MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
     MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
-    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
     MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
     MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
     MovedModule("SimpleHTTPServer", "SimpleHTTPServer", "http.server"),
@@ -337,10 +339,12 @@ _urllib_parse_moved_attributes = [
     MovedAttribute("quote_plus", "urllib", "urllib.parse"),
     MovedAttribute("unquote", "urllib", "urllib.parse"),
     MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_to_bytes", "urllib", "urllib.parse", "unquote", "unquote_to_bytes"),
     MovedAttribute("urlencode", "urllib", "urllib.parse"),
     MovedAttribute("splitquery", "urllib", "urllib.parse"),
     MovedAttribute("splittag", "urllib", "urllib.parse"),
     MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("splitvalue", "urllib", "urllib.parse"),
     MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
     MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
     MovedAttribute("uses_params", "urlparse", "urllib.parse"),
@@ -416,6 +420,8 @@ _urllib_request_moved_attributes = [
     MovedAttribute("URLopener", "urllib", "urllib.request"),
     MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
     MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+    MovedAttribute("parse_http_list", "urllib2", "urllib.request"),
+    MovedAttribute("parse_keqv_list", "urllib2", "urllib.request"),
 ]
 for attr in _urllib_request_moved_attributes:
     setattr(Module_six_moves_urllib_request, attr.name, attr)
@@ -679,11 +685,15 @@ if PY3:
     exec_ = getattr(moves.builtins, "exec")
 
     def reraise(tp, value, tb=None):
-        if value is None:
-            value = tp()
-        if value.__traceback__ is not tb:
-            raise value.with_traceback(tb)
-        raise value
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
 
 else:
     def exec_(_code_, _globs_=None, _locs_=None):
@@ -699,19 +709,28 @@ else:
         exec("""exec _code_ in _globs_, _locs_""")
 
     exec_("""def reraise(tp, value, tb=None):
-    raise tp, value, tb
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
 """)
 
 
 if sys.version_info[:2] == (3, 2):
     exec_("""def raise_from(value, from_value):
-    if from_value is None:
-        raise value
-    raise value from from_value
+    try:
+        if from_value is None:
+            raise value
+        raise value from from_value
+    finally:
+        value = None
 """)
 elif sys.version_info[:2] > (3, 2):
     exec_("""def raise_from(value, from_value):
-    raise value from from_value
+    try:
+        raise value from from_value
+    finally:
+        value = None
 """)
 else:
     def raise_from(value, from_value):
@@ -802,10 +821,14 @@ def with_metaclass(meta, *bases):
     # This requires a bit of explanation: the basic idea is to make a dummy
     # metaclass for one level of class instantiation that replaces itself with
     # the actual metaclass.
-    class metaclass(meta):
+    class metaclass(type):
 
         def __new__(cls, name, this_bases, d):
             return meta(name, bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
     return type.__new__(metaclass, 'temporary_class', (), {})
 
 
@@ -821,8 +844,69 @@ def add_metaclass(metaclass):
                 orig_vars.pop(slots_var)
         orig_vars.pop('__dict__', None)
         orig_vars.pop('__weakref__', None)
+        if hasattr(cls, '__qualname__'):
+            orig_vars['__qualname__'] = cls.__qualname__
         return metaclass(cls.__name__, cls.__bases__, orig_vars)
     return wrapper
+
+
+def ensure_binary(s, encoding='utf-8', errors='strict'):
+    """Coerce **s** to six.binary_type.
+
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+
+    For Python 3:
+      - `str` -> encoded to `bytes`
+      - `bytes` -> `bytes`
+    """
+    if isinstance(s, text_type):
+        return s.encode(encoding, errors)
+    elif isinstance(s, binary_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
+
+def ensure_str(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to `str`.
+
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
+    if PY2 and isinstance(s, text_type):
+        s = s.encode(encoding, errors)
+    elif PY3 and isinstance(s, binary_type):
+        s = s.decode(encoding, errors)
+    return s
+
+
+def ensure_text(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to six.text_type.
+
+    For Python 2:
+      - `unicode` -> `unicode`
+      - `str` -> `unicode`
+
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if isinstance(s, binary_type):
+        return s.decode(encoding, errors)
+    elif isinstance(s, text_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
 
 
 def python_2_unicode_compatible(klass):


### PR DESCRIPTION
The newer version has features we need to easily
migrate our .py scripts from PY2 to PY3 syntax.

Change-Id: Ifee50f35ef63796911de1de1459332ae174b77d0