### PR TITLE
Remove redundant trailing slash in clone command

### DIFF
--- a/site/docs/tutorial/cpp.md
+++ b/site/docs/tutorial/cpp.md
@@ -38,7 +38,7 @@ you don't have it installed already. Then, retrieve the sample project from
 Bazel's GitHub repository:
 
 ```
-git clone https://github.com/bazelbuild/examples/
+git clone https://github.com/bazelbuild/examples
 ```
 
 The sample project for this tutorial is in the `examples/cpp-tutorial` directory

--- a/site/docs/tutorial/java.md
+++ b/site/docs/tutorial/java.md
@@ -58,7 +58,7 @@ you don't have it installed already.
 Retrieve the sample project from Bazel's GitHub repository:
 
 ```sh
-git clone https://github.com/bazelbuild/examples/
+git clone https://github.com/bazelbuild/examples
 ```
 
 The sample project for this tutorial is in the `examples/java-tutorial`


### PR DESCRIPTION
If you e.g. would have this settings in your `.gitconfig`:

```
# Enforce SSH
[url "ssh://git@github.com/"]
  insteadOf = https://github.com/
```

You would end up with this error following the current clone command documented:

```
Cloning into 'examples'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Removing the trailing slash would resolve this issue.