### PR TITLE
Rename FileSystem#createChannel() into createReadableByteChannel()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionFileSystem.java
@@ -89,9 +89,9 @@ class RemoteActionFileSystem extends DelegateFileSystem {
   }
 
   @Override
-  protected ReadableByteChannel createChannel(Path path) throws IOException {
+  protected ReadableByteChannel createReadableByteChannel(Path path) throws IOException {
     downloadFileIfRemote(path);
-    return super.createChannel(path);
+    return super.createReadableByteChannel(path);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/AbstractFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/AbstractFileSystem.java
@@ -14,6 +14,8 @@
 //
 package com.google.devtools.build.lib.vfs;
 
+import static java.nio.file.StandardOpenOption.READ;
+
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
@@ -26,6 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
+import java.util.EnumSet;
 
 /** This class implements the FileSystem interface using direct calls to the UNIX filesystem. */
 @ThreadSafe
@@ -78,7 +81,7 @@ public abstract class AbstractFileSystem extends FileSystem {
   }
 
   @Override
-  protected ReadableByteChannel createChannel(Path path) throws IOException {
+  protected ReadableByteChannel createReadableByteChannel(Path path) throws IOException {
     final String name = path.toString();
     if (profiler.isActive()
         && (profiler.isProfiling(ProfilerTask.VFS_READ)
@@ -86,7 +89,7 @@ public abstract class AbstractFileSystem extends FileSystem {
       long startTime = Profiler.nanoTimeMaybe();
       try {
         // Currently, we do not proxy ReadableByteChannel for profiling.
-        return Files.newByteChannel(java.nio.file.Paths.get(name));
+        return Files.newByteChannel(java.nio.file.Paths.get(name), EnumSet.of(READ));
       } finally {
         profiler.logSimpleTask(startTime, ProfilerTask.VFS_OPEN, name);
       }

--- a/src/main/java/com/google/devtools/build/lib/vfs/DelegateFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/DelegateFileSystem.java
@@ -175,8 +175,8 @@ public abstract class DelegateFileSystem extends FileSystem {
   }
 
   @Override
-  protected ReadableByteChannel createChannel(Path path) throws IOException {
-    return delegateFs.createChannel(toDelegatePath(path));
+  protected ReadableByteChannel createReadableByteChannel(Path path) throws IOException {
+    return delegateFs.createReadableByteChannel(toDelegatePath(path));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -706,7 +706,7 @@ public abstract class FileSystem {
    *
    * @throws IOException if there was an error opening the file for reading
    */
-  protected ReadableByteChannel createChannel(Path path) throws IOException {
+  protected ReadableByteChannel createReadableByteChannel(Path path) throws IOException {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -867,7 +867,7 @@ public class Path
    * @throws IOException if the file was not found or could not be opened for reading
    */
   public ReadableByteChannel createChannel() throws IOException {
-    return fileSystem.createChannel(this);
+    return fileSystem.createReadableByteChannel(this);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/vfs/Path.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/Path.java
@@ -866,7 +866,7 @@ public class Path
    *
    * @throws IOException if the file was not found or could not be opened for reading
    */
-  public ReadableByteChannel createChannel() throws IOException {
+  public ReadableByteChannel createReadableByteChannel() throws IOException {
     return fileSystem.createReadableByteChannel(this);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/FileInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/FileInfo.java
@@ -54,7 +54,7 @@ public abstract class FileInfo extends InMemoryContentInfo {
 
   public abstract InputStream getInputStream() throws IOException;
 
-  public ReadableByteChannel createChannel() throws IOException {
+  public ReadableByteChannel createReadableByteChannel() throws IOException {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileInfo.java
@@ -69,7 +69,7 @@ public class InMemoryFileInfo extends FileInfo {
   }
 
   @Override
-  public ReadableByteChannel createChannel() {
+  public ReadableByteChannel createReadableByteChannel() {
     return new ReadableByteChannel() {
       private int offset = 0;
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
@@ -725,7 +725,7 @@ public class InMemoryFileSystem extends AbstractFileSystemWithCustomStat {
         throw Error.EACCES.exception(path);
       }
       Preconditions.checkState(status instanceof FileInfo);
-      return ((FileInfo) status).createChannel();
+      return ((FileInfo) status).createReadableByteChannel();
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/inmemoryfs/InMemoryFileSystem.java
@@ -715,7 +715,7 @@ public class InMemoryFileSystem extends AbstractFileSystemWithCustomStat {
   }
 
   @Override
-  protected ReadableByteChannel createChannel(Path path) throws IOException {
+  protected ReadableByteChannel createReadableByteChannel(Path path) throws IOException {
     synchronized (this) {
       InMemoryContentInfo status = inodeStat(path, true);
       if (status.isDirectory()) {

--- a/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/FileSystemTest.java
@@ -1063,7 +1063,7 @@ public abstract class FileSystemTest {
       outStream.write(new byte[] {1});
     }
 
-    try (ReadableByteChannel channel = xFile.createChannel()) {
+    try (ReadableByteChannel channel = xFile.createReadableByteChannel()) {
       ByteBuffer buffer = ByteBuffer.allocate(2);
       int numRead = readFromChannel(channel, buffer, 1);
       assertThat(numRead).isEqualTo(1);
@@ -1094,7 +1094,7 @@ public abstract class FileSystemTest {
       outStream.write(bytes);
     }
 
-    try (ReadableByteChannel channel = xFile.createChannel()) {
+    try (ReadableByteChannel channel = xFile.createReadableByteChannel()) {
       ByteBuffer buffer = ByteBuffer.allocate(bytes.length);
       int numRead = readFromChannel(channel, buffer, bytes.length);
       assertThat(numRead).isEqualTo(bytes.length);


### PR DESCRIPTION
- as it is more correct and the channel is read-only
- also, explicitly specify the READ open option