### PR TITLE
Bump minimum build-tools version to 29.0.2

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
@@ -55,7 +55,7 @@ public class AndroidSdkRepositoryFunction extends AndroidRepositoryFunction {
   private static final PathFragment BUILD_TOOLS_DIR = PathFragment.create("build-tools");
   private static final PathFragment PLATFORMS_DIR = PathFragment.create("platforms");
   private static final PathFragment SYSTEM_IMAGES_DIR = PathFragment.create("system-images");
-  private static final Revision MIN_BUILD_TOOLS_REVISION = new Revision(26, 0, 1);
+  private static final Revision MIN_BUILD_TOOLS_REVISION = new Revision(29, 0, 2);
   private static final String PATH_ENV_VAR = "ANDROID_HOME";
   private static final ImmutableList<String> PATH_ENV_VAR_AS_LIST = ImmutableList.of(PATH_ENV_VAR);
   private static final ImmutableList<String> LOCAL_MAVEN_REPOSITORIES =


### PR DESCRIPTION
This is technically a breaking change, but it fixes issues seen in certain Android builds with aapt2. 

https://github.com/bazelbuild/bazel/issues/10079