### PR TITLE
Avoid breaking toolchain resolution if platform has defaulted constraint.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
@@ -185,12 +185,26 @@ public abstract class ConstraintCollection
       return true;
     }
 
-    // Then, check the parent, directly to ignore defaults.
+    // Then, check the parent.
     if (parent() != null) {
       return parent().has(constraint);
     }
 
     return constraint.hasDefaultConstraintValue();
+  }
+
+  public boolean hasWithoutDefault(ConstraintSettingInfo constraint) {
+    // First, check locally.
+    if (constraints().containsKey(constraint)) {
+      return true;
+    }
+
+    // Then, check the parent, directly to ignore defaults.
+    if (parent() != null) {
+      return parent().hasWithoutDefault(constraint);
+    }
+
+    return false;
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/ToolchainTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/ToolchainTestCase.java
@@ -44,8 +44,10 @@ public abstract class ToolchainTestCase extends SkylarkTestCase {
   public PlatformInfo macPlatform;
 
   public ConstraintSettingInfo setting;
+  public ConstraintSettingInfo defaultedSetting;
   public ConstraintValueInfo linuxConstraint;
   public ConstraintValueInfo macConstraint;
+  public ConstraintValueInfo defaultedConstraint;
 
   public Label testToolchainTypeLabel;
   public ToolchainTypeInfo testToolchainType;
@@ -101,28 +103,38 @@ public abstract class ToolchainTestCase extends SkylarkTestCase {
         "constraint_value(name = 'linux',",
         "    constraint_setting = ':os')",
         "constraint_value(name = 'mac',",
-        "    constraint_setting = ':os')");
+        "    constraint_setting = ':os')",
+        "constraint_setting(name = 'setting_with_default',",
+        "    default_constraint_value = ':default_value')",
+        "constraint_value(name = 'default_value',",
+        "    constraint_setting = ':setting_with_default')",
+        "constraint_value(name = 'non_default_value',",
+        "    constraint_setting = ':setting_with_default')");
 
     scratch.file(
         "platforms/BUILD",
         "platform(name = 'linux',",
-        "    constraint_values = ['//constraints:linux'])",
+        "    constraint_values = ['//constraints:linux', '//constraints:non_default_value'])",
         "platform(name = 'mac',",
-        "    constraint_values = ['//constraints:mac'])");
+        "    constraint_values = ['//constraints:mac', '//constraints:non_default_value'])");
 
     setting = ConstraintSettingInfo.create(makeLabel("//constraints:os"));
     linuxConstraint = ConstraintValueInfo.create(setting, makeLabel("//constraints:linux"));
     macConstraint = ConstraintValueInfo.create(setting, makeLabel("//constraints:mac"));
+    defaultedSetting = ConstraintSettingInfo.create(makeLabel("//constraints:setting_with_default"));
+    defaultedConstraint = ConstraintValueInfo.create(defaultedSetting, makeLabel("//constraints:non_default_value"));
 
     linuxPlatform =
         PlatformInfo.builder()
             .setLabel(makeLabel("//platforms:linux"))
             .addConstraint(linuxConstraint)
+            .addConstraint(defaultedConstraint)
             .build();
     macPlatform =
         PlatformInfo.builder()
             .setLabel(makeLabel("//platforms:mac"))
             .addConstraint(macConstraint)
+            .addConstraint(defaultedConstraint)
             .build();
   }
 


### PR DESCRIPTION
### Summary
See https://github.com/bazelbuild/bazel/issues/8778 and https://github.com/bazelbuild/bazel/issues/8274 for context / motivation. In summary, the presence of a `constraint_setting` with `default_constraint_value` in a Platform's constraints will cause toolchain resolution to break for all toolchains that do not explicitly set that constraint value. This makes `default_constraint_value` dangerous because setting it can break other rulesets composed into the same top-level workspace.

cc @jayconrod @m3rcuriel @katre

### Test Plan
I updated the unit test `SingleToolchainResolutionFunction`, verified it failed, then altered the implementation to pass. I also built `//src:bazel` and ran it with a test workspace to verify the end result worked as expected.

Test workspace:
```
$ cat WORKSPACE
register_toolchains("//:my_toolchain")
$ cat BUILD
load(":rules.bzl", "my_toolchain_info", "my_rule")

my_rule(name = "hello")
toolchain_type(name = "my_toolchain_type")
my_toolchain_info(name = "my_toolchain_info")
toolchain(
    name = "my_toolchain",
    toolchain = "//:my_toolchain_info",
    toolchain_type = "//:my_toolchain_type",
)

constraint_setting(
    name = "setting",
    default_constraint_value = ":value_a",
)
constraint_value(
    name = "value_a",
    constraint_setting = ":setting",
)
constraint_value(
    name = "value_b",
    constraint_setting = ":setting",
)
platform(
    name = "platform_a",
    constraint_values = ["//:value_a"],
)
platform(
    name = "platform_b",
    constraint_values = ["//:value_b"],
)

$ cat rules.bzl
def _my_toolchain_info(ctx):
    return platform_common.ToolchainInfo()

my_toolchain_info = rule(_my_toolchain_info)

def _my_rule(ctx):
    pass

my_rule = rule(_my_rule, toolchains = ["//:my_toolchain_type"])
```