### PR TITLE
Allow user-specific `user.bazelrc` per "Best Practices for Bazel"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,4 +42,5 @@ build:ubuntu1604_java8 --config=remote_shared
 # Alias
 build:remote --config=ubuntu1604_java8
 
-
+# User-specific .bazelrc
+try-import user.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 /.sass-cache
 # Bazelisk version file
 .bazelversion
+# User-specific .bazelrc
+user.bazelrc


### PR DESCRIPTION
https://docs.bazel.build/versions/master/best-practices.html describes allowing a user-specific `user.bazelrc` in a workspace, but Bazel itself doesn't do this. This makes it a bit annoying to set flags every time.