### PR TITLE
Fix python zip file name when target name has dot (.)

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
@@ -131,14 +131,6 @@ public class BazelPythonSemantics implements PythonSemantics {
     return result;
   }
 
-  /**
-   * Returns an artifact next to the executable file with ".temp" suffix. Used only if we're
-   * building a zip.
-   */
-  public Artifact getPythonIntermediateStubArtifact(RuleContext ruleContext, Artifact executable) {
-    return ruleContext.getRelatedArtifact(executable.getRootRelativePath(), ".temp");
-  }
-
   private static String boolToLiteral(boolean value) {
     return value ? "True" : "False";
   }
@@ -308,7 +300,7 @@ public class BazelPythonSemantics implements PythonSemantics {
 
     if (!ruleContext.hasErrors()) {
       // Create the stub file that's needed by the python zip file.
-      Artifact stubFileForZipFile = getPythonIntermediateStubArtifact(ruleContext, executable);
+      Artifact stubFileForZipFile = common.getPythonIntermediateStubArtifact(executable);
       createStubFile(ruleContext, stubFileForZipFile, common, /* isForZipFile= */ true);
 
       createPythonZipAction(

--- a/src/test/shell/integration/python_test.sh
+++ b/src/test/shell/integration/python_test.sh
@@ -139,4 +139,20 @@ EOF
   [ ! -e "bazel-bin/py-tool${EXE_EXT}.runfiles" ] || fail "py_binary runfiles tree built"
 }
 
+function test_building_zip_file_with_target_name_with_dot() {
+  touch bin.py
+  chmod u+x bin.py
+  cat > BUILD <<'EOF'
+py_binary(
+  name = "bin.v1",  # .v1 should not be treated as extension and removed accidentally
+  srcs = ["bin.py"],
+  main = "bin.py",
+)
+EOF
+
+  bazel build --build_python_zip :bin.v1
+  [ -d "bazel-bin/bin.v1.temp" ] || fail "Stub file for python zip file not built"
+  [ -d "bazel-bin/bin.v1.zip" ] || fail "Python zip file not built"
+}
+
 run_suite "Tests for the Python rules"


### PR DESCRIPTION
To fix https://buildkite.com/bazel/bazel-at-head-plus-disabled/builds/351#26e616ad-56b1-4d78-b64c-fcb3c5c66f41/436-470

When building python zip file on linux and mac, we accidentally remove the last segment when a python target name has dot (.).
For example, `create_tensorflow.python_api_2_keras_python_api_gen_compat_v2 -> create_tensorflow`

This commit replace the usage of `ruleContext.getDerivedArtifact` with a custom implementation to fix this problem.