### PR TITLE
Attempt to git fetch only specified commit

### DIFF
--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -21,8 +21,8 @@ _GitRepoInfo = provider(
         "shallow": "Defines the depth of a fetch. Either empty, --depth=1, or --shallow-since=<>",
         "reset_ref": """Reference to use for resetting the git repository.
 Either commit hash, tag or branch.""",
-        "fetch_ref": """Reference for fetching. Can be empty (HEAD), tag or branch.
-Can not be a commit hash, since typically it is forbidden by git servers.""",
+        "fetch_ref": """Reference for fetching.
+Either commit hash, tag or branch.""",
         "remote": "URL of the git repository to fetch from.",
         "init_submodules": """If True, submodules update command will be called after fetching
 and resetting to the specified reference.""",
@@ -49,20 +49,17 @@ def git_repo(ctx, directory):
         if ctx.attr.branch:
             fail("shallow_since not allowed if a branch is specified; --depth=1 will be used for branches")
 
-    shallow = "--depth=1"
-    if ctx.attr.commit:
-        # We can not use the commit value in --shallow-since;
-        # And since we are fetching HEAD in this case, we can not use --depth=1
-        shallow = ""
-
     # Use shallow-since if given
     if ctx.attr.shallow_since:
         shallow = "--shallow-since=%s" % ctx.attr.shallow_since
+    else:
+        shallow = "--depth=1"
 
     reset_ref = ""
     fetch_ref = ""
     if ctx.attr.commit:
         reset_ref = ctx.attr.commit
+        fetch_ref = ctx.attr.commit
     elif ctx.attr.tag:
         reset_ref = "tags/" + ctx.attr.tag
         fetch_ref = "tags/" + ctx.attr.tag + ":tags/" + ctx.attr.tag
@@ -118,15 +115,19 @@ def add_origin(ctx, git_repo, remote):
     _git(ctx, git_repo, "remote", "add", "origin", remote)
 
 def fetch(ctx, git_repo):
-    if not git_repo.fetch_ref:
-        # We need to explicitly specify to fetch all branches and tags, otherwise only
-        # HEAD-reachable is fetched.
+    args = ["fetch", "origin", git_repo.fetch_ref]
+    st = _git_maybe_shallow(ctx, git_repo, *args)
+    if st.return_code == 0:
+        return
+    if ctx.attr.commit:
+        # Perhaps uploadpack.allowReachableSHA1InWant or similar is not enabled on the server;
+        # fall back to fetching all branches, tags, and history.
         # The semantics of --tags flag of git-fetch have changed in Git 1.9, from 1.9 it means
         # "everything that is already specified and all tags"; before 1.9, it used to mean
         # "ignore what is specified and fetch all tags".
         # The arguments below work correctly for both before 1.9 and after 1.9,
         # as we directly specify the list of references to fetch.
-        _git_maybe_shallow(
+        _git(
             ctx,
             git_repo,
             "fetch",
@@ -135,7 +136,7 @@ def fetch(ctx, git_repo):
             "refs/tags/*:refs/tags/*",
         )
     else:
-        _git_maybe_shallow(ctx, git_repo, "fetch", "origin", git_repo.fetch_ref)
+        _error(ctx.name, ["git"] + args, st.stderr)
 
 def reset(ctx, git_repo):
     _git(ctx, git_repo, "reset", "--hard", git_repo.reset_ref)
@@ -165,10 +166,8 @@ def _git_maybe_shallow(ctx, git_repo, command, *args):
     if git_repo.shallow:
         st = _execute(ctx, git_repo, start + [git_repo.shallow] + args_list)
         if st.return_code == 0:
-            return
-    st = _execute(ctx, git_repo, start + args_list)
-    if st.return_code != 0:
-        _error(ctx.name, start + args_list, st.stderr)
+            return st
+    return _execute(ctx, git_repo, start + args_list)
 
 def _execute(ctx, git_repo, args):
     return ctx.execute(


### PR DESCRIPTION
The Git server config setting uploadpack.allowReachableSHA1InWant and friends allow git fetch to request a particular commit, which is more efficient than fetching all refs and then checking out the commit locally. Attempt to do this, and fall back to fetching everything if it fails.

Resolves #8969