### PR TITLE
Enable PIC for cc regardless of compilation_mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 # User-specific .bazelrc
 user.bazelrc
 
+/third_party

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -539,8 +539,7 @@ public class CppHelper {
       CppConfiguration cppConfiguration,
       FeatureConfiguration featureConfiguration) {
     return cppConfiguration.forcePic()
-        || (toolchain.usePicForDynamicLibraries(cppConfiguration, featureConfiguration)
-            && cppConfiguration.getCompilationMode() != CompilationMode.OPT);
+        || toolchain.usePicForDynamicLibraries(cppConfiguration, featureConfiguration);
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainTest.java
@@ -178,7 +178,7 @@ public class CcToolchainTest extends BuildViewTestCase {
             mockToolsConfig, CcToolchainConfig.builder().withFeatures(CppRuleClasses.SUPPORTS_PIC));
     invalidatePackages();
     assertThat(usePicForBinariesWithConfiguration("--cpu=k8")).isTrue();
-    assertThat(usePicForBinariesWithConfiguration("--cpu=k8", "-c", "opt")).isFalse();
+    assertThat(usePicForBinariesWithConfiguration("--cpu=k8", "-c", "opt")).isTrue();
   }
 
   private boolean usePicForBinariesWithConfiguration(String... configuration) throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/SkylarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/SkylarkCcCommonTest.java
@@ -5111,7 +5111,7 @@ public class SkylarkCcCommonTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testCreatePicAndNoPic() throws Exception {
+  public void testCreateOnlyPicWithOpt() throws Exception {
     getAnalysisMock()
         .ccSupport()
         .setupCcToolchainConfig(
@@ -5121,7 +5121,7 @@ public class SkylarkCcCommonTest extends BuildViewTestCase {
     assertThat(getConfiguredTarget("//foo:bin")).isNotNull();
     ConfiguredTarget target = getConfiguredTarget("//foo:skylark_lib");
     assertThat(getFilenamesToBuild(target)).contains("skylark_lib.pic.o");
-    assertThat(getFilenamesToBuild(target)).contains("skylark_lib.o");
+    assertThat(getFilenamesToBuild(target)).doesNotContain("skylark_lib.o");
   }
 
   @Test
@@ -5532,7 +5532,7 @@ public class SkylarkCcCommonTest extends BuildViewTestCase {
     SkylarkInfo fooInfo =
         (SkylarkInfo) getConfiguredTarget("//foo:foo").get(SkylarkProviderIdentifier.forKey(key));
 
-    assertThat(fooLibrary.getObjectFiles()).isEqualTo(fooInfo.getValue("objects"));
+    assertThat(fooLibrary.getObjectFiles()).isNull();
     assertThat(fooLibrary.getPicObjectFiles()).isEqualTo(fooInfo.getValue("pic_objects"));
   }
 

--- a/src/test/shell/bazel/bazel_thinlto_test.sh
+++ b/src/test/shell/bazel/bazel_thinlto_test.sh
@@ -95,8 +95,8 @@ function test_bazel_thinlto() {
   grep -q "action 'LTO Backend Compile" $TEST_log \
     || fail "LTO Actions missing"
 
-  if [[ ! -e bazel-bin/hello/hello.lto/hello/_objs/hello/hello.o.thinlto.bc ]] \
-    || [[ ! -e bazel-bin/hello/hello.lto/hello/_objs/hello_lib/hellolib.o.thinlto.bc ]]; then
+  if [[ ! -e bazel-bin/hello/hello.lto/hello/_objs/hello/hello.pic.o.thinlto.bc ]] \
+    || [[ ! -e bazel-bin/hello/hello.lto/hello/_objs/hello_lib/hellolib.pic.o.thinlto.bc ]]; then
     fail "bitcode files were not generated"
   fi
 }


### PR DESCRIPTION
If the feature for supports_pic is enabled, this should be enabled for
all compilation modes.