### PR TITLE
Fix typo in j2objc URL

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,7 +41,7 @@ http_archive(
     sha256 = "8d3403b5b7db57e347c943d214577f6879e5b175c2b59b7e075c0b6453330e9b",
     strip_prefix = "j2objc-2.5",
     urls = [
-        "https://miirror.bazel.build/github.com/google/j2objc/releases/download/2.5/j2objc-2.5.zip",
+        "https://mirror.bazel.build/github.com/google/j2objc/releases/download/2.5/j2objc-2.5.zip",
         "https://github.com/google/j2objc/releases/download/2.5/j2objc-2.5.zip",
     ],
 )


### PR DESCRIPTION
Fix the mirror download URL for j2objc.