### PR TITLE
Migrate CoverageOutputGenerator for incompatible_load_java_rules_from_bzl

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD.remote
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD.remote
@@ -1,4 +1,5 @@
 package(default_visibility = ["//visibility:public"])
+load("@rules_java//java:defs.bzl", "java_binary", "java_import")
 
 java_import(
   name = "all_lcov_merger_lib",

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD.tools
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD.tools
@@ -1,4 +1,5 @@
 package(default_visibility = ["//visibility:public"])
+load("@rules_java//java:defs.bzl", "java_binary", "java_import")
 
 java_import(
   name = "all_lcov_merger_lib",


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/8741