### PR TITLE
Correct references to --compilationMode

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/J2ObjcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/J2ObjcLibrary.java
@@ -40,7 +40,7 @@ import java.util.List;
 public class J2ObjcLibrary implements RuleConfiguredTargetFactory {
 
   public static final String NO_ENTRY_CLASS_ERROR_MSG =
-      "Entry classes must be specified when flag --compilationMode=opt is on in order to"
+      "Entry classes must be specified when flag --compilation_mode=opt is on in order to"
           + " perform J2ObjC dead code stripping.";
 
   public static final ImmutableList<String> J2OBJC_SUPPORTED_RULES =

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
@@ -156,7 +156,7 @@ public class ObjcCommandLineOptions extends FragmentOptions {
     effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
     help =
         "Whether to perform symbol and dead-code strippings on linked binaries. Binary "
-            + "strippings will be performed if both this flag and --compilationMode=opt are "
+            + "strippings will be performed if both this flag and --compilation_mode=opt are "
             + "specified."
   )
   public boolean enableBinaryStripping;


### PR DESCRIPTION
Replaces two references to `--compilationMode` with  `--compilation_mode`.