### PR TITLE
Add cc_library option to ensure include_prefix behaves the same regardless of library path

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java
@@ -447,6 +447,19 @@ public class BazelCppRuleClasses {
           prefix is added.
           <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
           .add(attr("include_prefix", STRING))
+          /* <!-- #BLAZE_RULE($cc_library).ATTRIBUTE(always_create_virtual_includes) -->
+          Set to ensure that include_prefix behaves the same when it mirrors the
+          workspace directory tree as when it does not.
+
+          <p>Without this, if include_prefix is the relative path from the workspace
+          root to the library directory, it is treated differently. Specifically
+          its public headers aren't in a place findable by <code>\<include_prefix/header\></code>
+
+          <p>When this is set, -isystem is always set in such a way that dependent
+          code can find this library's headers, prefixed with <code>include_prefix</code>
+
+          <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+          .add(attr("always_create_virtual_includes", BOOLEAN))
           /* <!-- #BLAZE_RULE($cc_library).ATTRIBUTE(textual_hdrs) -->
            The list of header files published by
            this library to be textually included by sources in dependent rules.

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -266,6 +266,7 @@ public final class CcCompilationHelper {
   private boolean isCodeCoverageEnabled = true;
   private String stripIncludePrefix = null;
   private String includePrefix = null;
+  private boolean alwaysCreateVirtualIncludes = false;
 
   private CcCompilationContext ccCompilationContext;
 
@@ -858,7 +859,8 @@ public final class CcCompilationHelper {
         includePath = prefix.getRelative(includePath);
       }
 
-      if (!originalHeader.getExecPath().equals(includePath)) {
+      if (alwaysCreateVirtualIncludes ||
+          !originalHeader.getExecPath().equals(includePath)) {
         Artifact virtualHeader =
             actionConstructionContext.getUniqueDirectoryArtifact(
                 "_virtual_includes",
@@ -1052,6 +1054,14 @@ public final class CcCompilationHelper {
   /** Don't generate a module map for this target if a custom module map is provided. */
   public CcCompilationHelper doNotGenerateModuleMap() {
     generateModuleMap = false;
+    return this;
+  }
+
+  /** Ensure that include_prefix works the same for paths that mirror the workspace
+   *  directory and those that don't.
+   */
+  public CcCompilationHelper setAlwaysCreateVirtualIncludes() {
+    alwaysCreateVirtualIncludes = true;
     return this;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -216,6 +216,10 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
       }
     }
 
+    if (ruleContext.attributes().get("always_create_virtual_includes", Type.BOOLEAN)) {
+      compilationHelper.setAlwaysCreateVirtualIncludes();
+    }
+
     if (ruleContext.getRule().isAttrDefined("srcs", BuildType.LABEL_LIST)) {
       ruleContext.checkSrcsSamePackage(true);
     }


### PR DESCRIPTION
Currently include_prefix behaves differently (at least for system includes) when include_prefix matches the path of the library within a larger project.

If you have a library located at path foo/bar (with BUILD file at foo/bar/BUILD), and an include file named Log.h, currently if you specify an include_prefix of "foo/bar", then dependent code cannot do the following and have it work:

#include <foo/bar/Log.h>

Log.h in that case will not be found by the dependent code. If you switch the <> to "", it will be found (because Bazel currently sticks in an "-iquote ." argument to the compile command line). Furthermore, if you change the include_prefix to be "foobar", and change the includes to be:

#include <foobar/Log.h>

it will be also be found.

In cases where it's not possible to change the #include in dependent source code, then the only WAR I've found so far is to put "-isystem ." in the copts of all dependent code, but that's not a really great solution.

This code change allows cc_library rules to opt-in to having include_prefix always treated the same, regardless of library path.

It's possible that this feature: https://docs.google.com/document/d/1PKTDhE9rHzd0WQJY2czjg_vPT28fufGcl2Gain6mUaI/edit?pli=1#heading=h.9grrl7f2c55j
will address the issue as well, but it's not clear what the status of that is, and what the timeline for adoption would be.
