### PR TITLE
Use bzl files from rules_cc repo in unit tests

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -132,7 +132,7 @@ distdir_tar(
         # bazelbuild/rules_java
         "7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
         # bazelbuild/rules_cc
-        "0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+        "fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
         # bazelbuild/bazel-toolchains
         "0.28.3.tar.gz",
         # bazelbuild/rules_pkg
@@ -157,7 +157,7 @@ distdir_tar(
         # bazelbuild/rules_java
         "7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip": "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
         # bazelbuild/rules_cc
-        "0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip": "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
+        "fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip": "3cb64a6454df7e2c1a060c851822f60808531b9ecc19f4e831e0060f5d43d27a",
         # bazelbuild/bazel-toolchains
         "0.28.3.tar.gz": "d8c2f20deb2f6143bac792d210db1a4872102d81529fe0ea3476c1696addd7ff",
         # bazelbuild/rules_pkg
@@ -212,9 +212,9 @@ distdir_tar(
             "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
         ],
         # bazelbuild/rules_cc
-        "0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip": [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
-            "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+        "fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
+            "https://github.com/bazelbuild/rules_cc/archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
         ],
         # bazelbuild/bazel-toolchains
         "0.28.3.tar.gz": [
@@ -453,11 +453,11 @@ http_archive(
 
 http_archive(
     name = "rules_cc",
-    sha256 = "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
-    strip_prefix = "rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c",
+    sha256 = "3cb64a6454df7e2c1a060c851822f60808531b9ecc19f4e831e0060f5d43d27a",
+    strip_prefix = "rules_cc-fe8f0a4cf9f49dfca982620b98220f7ad883fb21",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
-        "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
+        "https://github.com/bazelbuild/rules_cc/archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
     ],
 )
 
@@ -512,7 +512,7 @@ distdir_tar(
         # bazelbuild/rules_java
         "7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
         # bazelbuild/rules_cc
-        "0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+        "fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
         # bazelbuild/rules_proto
         "97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
     ],
@@ -543,7 +543,7 @@ distdir_tar(
         # bazelbuild/rules_java
         "7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip": "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
         # bazelbuild/rules_cc
-        "0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip": "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
+        "fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip": "3cb64a6454df7e2c1a060c851822f60808531b9ecc19f4e831e0060f5d43d27a",
         # bazelbuild/rules_proto
         "97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz": "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
     },
@@ -581,9 +581,9 @@ distdir_tar(
             "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
         ],
         # bazelbuild/rules_cc
-        "0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip": [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
-            "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+        "fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip": [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
+            "https://github.com/bazelbuild/rules_cc/archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
         ],
         # bazelbuild/rules_proto
         "97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz": [

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -272,12 +272,12 @@ maybe(
 maybe(
     http_archive,
     "rules_cc",
-    sha256 = "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
+    sha256 = "3cb64a6454df7e2c1a060c851822f60808531b9ecc19f4e831e0060f5d43d27a",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
-        "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
+        "https://github.com/bazelbuild/rules_cc/archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
     ],
-    strip_prefix = "rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c",
+    strip_prefix = "rules_cc-fe8f0a4cf9f49dfca982620b98220f7ad883fb21",
 )
 
 # Needed only because of java_tools.

--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -940,7 +940,7 @@ java_library(
         "//src/test/java/com/google/devtools/build/lib/packages/util/mock:android_cc_toolchain_config.bzl",
         "//src/test/java/com/google/devtools/build/lib/packages/util/mock:osx_cc_toolchain_config.bzl",
         "//tools/build_defs/cc:action_names.bzl",
-        "//tools/cpp:cc_toolchain_config_lib.bzl",
+        "@rules_cc//cc:srcs",
         "//tools/python:srcs",
     ],
     deps = [

--- a/src/test/java/com/google/devtools/build/lib/blackbox/framework/BlackBoxTestEnvironment.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/framework/BlackBoxTestEnvironment.java
@@ -81,13 +81,13 @@ public abstract class BlackBoxTestEnvironment {
             "load('@bazel_tools//tools/build_defs/repo:http.bzl', 'http_archive')",
             "http_archive(",
             "    name = 'rules_cc',",
-            "    sha256 = '36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89',",
-            "    strip_prefix = 'rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c',",
+            "    sha256 = '3cb64a6454df7e2c1a060c851822f60808531b9ecc19f4e831e0060f5d43d27a',",
+            "    strip_prefix = 'rules_cc-fe8f0a4cf9f49dfca982620b98220f7ad883fb21',",
             "    urls = [",
             "        'https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/"
-                + "0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip',",
+                + "fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip',",
             "        'https://github.com/bazelbuild/rules_cc/archive/"
-                + "0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip',",
+                + "fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip',",
             "    ],",
             ")",
             "http_archive(",

--- a/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockCcSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockCcSupport.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.packages.util;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.testutil.TestConstants;
 import java.io.IOException;
 
 /**
@@ -77,13 +78,31 @@ public final class BazelMockCcSupport extends MockCcSupport {
 
   private void setupRulesCc(MockToolsConfig config) throws IOException {
     for (String path : ImmutableList.of(
+        "cc/BUILD",
         "cc/defs.bzl",
         "cc/action_names.bzl",
         "cc/cc_toolchain_config_lib.bzl",
         "cc/find_cc_toolchain.bzl",
-        "cc/toolchain_utils.bzl")) {
-      config.create("/rules_cc_workspace/" + path, ResourceLoader.readFromResources("external/rules_cc/" + path));
+        "cc/toolchain_utils.bzl"
+        )) {
+      try {
+        config.create(TestConstants.RULES_CC_REPOSITORY_SCRATCH + path,
+            ResourceLoader.readFromResources(TestConstants.RULES_CC_REPOSITORY_EXECROOT  + path));
+      } catch (Exception e) {
+        throw new RuntimeException("Couldn't read rules_cc file from " + path, e);
+      }
     }
+
+    config.overwrite(
+        TestConstants.TOOLS_REPOSITORY_SCRATCH + "tools/cpp/cc_toolchain_config_lib.bzl",
+        ResourceLoader.readFromResources(
+            TestConstants.RULES_CC_REPOSITORY_EXECROOT + "cc/cc_toolchain_config_lib.bzl"));
+    config.overwrite(
+        TestConstants.TOOLS_REPOSITORY_SCRATCH + "tools/build_defs/cc/action_names.bzl",
+        ResourceLoader.readFromResources(
+            TestConstants.RULES_CC_REPOSITORY_EXECROOT + "cc/action_names.bzl"));
+    config.create(TestConstants.TOOLS_REPOSITORY_SCRATCH + "tools/build_defs/cc/BUILD");
+    config.append(TestConstants.TOOLS_REPOSITORY_SCRATCH + "tools/cpp/BUILD", "");
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockCcSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockCcSupport.java
@@ -71,7 +71,19 @@ public final class BazelMockCcSupport extends MockCcSupport {
   @Override
   public void setup(MockToolsConfig config) throws IOException {
     writeMacroFile(config);
+    setupRulesCc(config);
     setupCcToolchainConfig(config);
+  }
+
+  private void setupRulesCc(MockToolsConfig config) throws IOException {
+    for (String path : ImmutableList.of(
+        "cc/defs.bzl",
+        "cc/action_names.bzl",
+        "cc/cc_toolchain_config_lib.bzl",
+        "cc/find_cc_toolchain.bzl",
+        "cc/toolchain_utils.bzl")) {
+      config.create("/rules_cc_workspace/" + path, ResourceLoader.readFromResources("external/rules_cc/" + path));
+    }
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/packages/util/Crosstool.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/Crosstool.java
@@ -497,16 +497,6 @@ public final class Crosstool {
     config.create(crosstoolTop + "/mock_version/x86/bin/ld");
     config.overwrite(crosstoolTop + "/BUILD", build);
     config.overwrite(crosstoolTop + "/cc_toolchain_config.bzl", ccToolchainConfigFileContents);
-    config.overwrite(
-        TestConstants.TOOLS_REPOSITORY_SCRATCH + "tools/cpp/cc_toolchain_config_lib.bzl",
-        ResourceLoader.readFromResources(
-            TestConstants.BAZEL_REPO_PATH + "tools/cpp/cc_toolchain_config_lib.bzl"));
-    config.overwrite(
-        TestConstants.TOOLS_REPOSITORY_SCRATCH + "tools/build_defs/cc/action_names.bzl",
-        ResourceLoader.readFromResources(
-            TestConstants.BAZEL_REPO_PATH + "tools/build_defs/cc/action_names.bzl"));
-    config.create(TestConstants.TOOLS_REPOSITORY_SCRATCH + "tools/build_defs/cc/BUILD");
-    config.append(TestConstants.TOOLS_REPOSITORY_SCRATCH + "tools/cpp/BUILD", "");
     config.create(crosstoolTop + "/crosstool.cppmap", "module crosstool {}");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -22,9 +22,7 @@ java_test(
         ],
     ) + ["proto/CcProtoLibraryTest.java"],
     resources = [
-        "//tools/build_defs/cc:action_names.bzl",
-        "//tools/cpp:cc_toolchain_config_lib.bzl",
-        "//tools/cpp:lib_cc_configure",
+        "@rules_cc//cc:srcs",
     ],
     shard_count = 5,
     tags = ["rules"],

--- a/src/test/java/com/google/devtools/build/lib/testutil/TestConstants.java
+++ b/src/test/java/com/google/devtools/build/lib/testutil/TestConstants.java
@@ -105,8 +105,16 @@ public class TestConstants {
   public static final String TOOLS_REPOSITORY = "@bazel_tools";
   /** The file path in which to create files so that they end up under {@link #TOOLS_REPOSITORY}. */
   public static final String TOOLS_REPOSITORY_SCRATCH = "/bazel_tools_workspace/";
+
   /** The output file path prefix for tool file dependencies. */
   public static final String TOOLS_REPOSITORY_PATH_PREFIX = "external/bazel_tools/";
+
+  /** Repository label prefix for rules_cc. */
+  public static final String RULES_CC_REPOSITORY = "@rules_cc";
+  /** The file path in which to create files so that they end up under {@link #RULES_CC_REPOSITORY}. */
+  public static final String RULES_CC_REPOSITORY_SCRATCH = "/rules_cc_workspace/";
+  /** The directory in which rules_cc repo resides in execroot. */
+  public static final String RULES_CC_REPOSITORY_EXECROOT = "external/rules_cc/";
 
   public static final ImmutableList<String> DOCS_RULES_PATHS = ImmutableList.of(
       "src/main/java/com/google/devtools/build/lib/rules");

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -138,12 +138,12 @@ class TestBase(unittest.TestCase):
     return self.GetCcRulesRepoRule()
 
   def GetCcRulesRepoRule(self):
-    sha256 = '36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89'
-    strip_pfx = 'rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c'
+    sha256 = '3cb64a6454df7e2c1a060c851822f60808531b9ecc19f4e831e0060f5d43d27a'
+    strip_pfx = 'rules_cc-fe8f0a4cf9f49dfca982620b98220f7ad883fb21'
     url1 = ('https://mirror.bazel.build/github.com/bazelbuild/rules_cc/'
-            'archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip')
+            'archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip')
     url2 = ('https://github.com/bazelbuild/rules_cc/'
-            'archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip')
+            'archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip')
     return [
         'http_archive(',
         '    name = "rules_cc",',

--- a/src/test/py/bazel/testdata/runfiles_test/WORKSPACE.mock
+++ b/src/test/py/bazel/testdata/runfiles_test/WORKSPACE.mock
@@ -4,10 +4,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
   name = "rules_cc",
-  sha256 = "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
-  strip_prefix = "rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c",
+  sha256 = "3cb64a6454df7e2c1a060c851822f60808531b9ecc19f4e831e0060f5d43d27a",
+  strip_prefix = "rules_cc-fe8f0a4cf9f49dfca982620b98220f7ad883fb21",
   urls = [
-      "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
-      "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+      "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
+      "https://github.com/bazelbuild/rules_cc/archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
   ],
 )

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -458,11 +458,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_cc",
-    sha256 = "36fa66d4d49debd71d05fba55c1353b522e8caef4a20f8080a3d17cdda001d89",
-    strip_prefix = "rules_cc-0d5f3f2768c6ca2faca0079a997a97ce22997a0c",
+    sha256 = "3cb64a6454df7e2c1a060c851822f60808531b9ecc19f4e831e0060f5d43d27a",
+    strip_prefix = "rules_cc-fe8f0a4cf9f49dfca982620b98220f7ad883fb21",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
-        "https://github.com/bazelbuild/rules_cc/archive/0d5f3f2768c6ca2faca0079a997a97ce22997a0c.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
+        "https://github.com/bazelbuild/rules_cc/archive/fe8f0a4cf9f49dfca982620b98220f7ad883fb21.zip",
     ],
 )
 EOF


### PR DESCRIPTION
This is in preparation for incompatible_use_cc_configure_from_rules_cc (https://github.com/bazelbuild/bazel/issues/10134). This PR updates the rules_cc pin in the WORKSPACE file (which also affects which version Bazel bundles in the binary) to get the right files.