### PR TITLE
Move retry logic to where it's being used.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -42,7 +42,6 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.exec.ExecutorBuilder;
 import com.google.devtools.build.lib.packages.TargetUtils;
-import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.logging.LoggingInterceptor;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -64,20 +63,13 @@ import com.google.devtools.build.lib.vfs.OutputService;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsParsingResult;
-import com.google.protobuf.Any;
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.rpc.PreconditionFailure;
-import com.google.rpc.PreconditionFailure.Violation;
 import io.grpc.CallCredentials;
 import io.grpc.ClientInterceptor;
 import io.grpc.Context;
-import io.grpc.Status.Code;
-import io.grpc.protobuf.StatusProto;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -104,39 +96,6 @@ public final class RemoteModule extends BlazeModule {
     builder.addBuildEventArtifactUploaderFactory(
         buildEventArtifactUploaderFactoryDelegate, "remote");
   }
-
-  private static final String VIOLATION_TYPE_MISSING = "MISSING";
-
-  private static final Predicate<? super Exception> RETRIABLE_EXEC_ERRORS =
-      e -> {
-        if (e instanceof CacheNotFoundException || e.getCause() instanceof CacheNotFoundException) {
-          return true;
-        }
-        if (!RemoteRetrierUtils.causedByStatus(e, Code.FAILED_PRECONDITION)) {
-          return false;
-        }
-        com.google.rpc.Status status = StatusProto.fromThrowable(e);
-        if (status == null || status.getDetailsCount() == 0) {
-          return false;
-        }
-        for (Any details : status.getDetailsList()) {
-          PreconditionFailure f;
-          try {
-            f = details.unpack(PreconditionFailure.class);
-          } catch (InvalidProtocolBufferException protoEx) {
-            return false;
-          }
-          if (f.getViolationsCount() == 0) {
-            return false; // Generally shouldn't happen
-          }
-          for (Violation v : f.getViolationsList()) {
-            if (!v.getType().equals(VIOLATION_TYPE_MISSING)) {
-              return false;
-            }
-          }
-        }
-        return true; // if *all* > 0 violations have type MISSING
-      };
 
   /** Returns whether remote execution should be available. */
   public static boolean shouldEnableRemoteExecution(RemoteOptions options) {
@@ -251,7 +210,6 @@ public final class RemoteModule extends BlazeModule {
         }
         checkClientServerCompatibility(
             capabilities, remoteOptions, digestUtil.getDigestFunction(), env.getReporter());
-        executeRetrier = createExecuteRetrier(remoteOptions, retryScheduler);
         ByteStreamUploader uploader =
             new ByteStreamUploader(
                 remoteOptions.remoteInstanceName,
@@ -281,7 +239,6 @@ public final class RemoteModule extends BlazeModule {
       }
 
       if (enableBlobStoreCache) {
-        executeRetrier = null;
         cacheClient =
             RemoteCacheClientFactory.create(
                 remoteOptions,
@@ -311,12 +268,12 @@ public final class RemoteModule extends BlazeModule {
             new RemoteExecutionCache((GrpcCacheClient) cacheClient, remoteOptions, digestUtil);
         actionContextProvider =
             RemoteActionContextProvider.createForRemoteExecution(
-                env, remoteCache, executor, executeRetrier, digestUtil, logDir);
+                env, remoteCache, executor, retryScheduler, digestUtil, logDir);
       } else if (cacheClient != null) {
         RemoteCache remoteCache = new RemoteCache(cacheClient, remoteOptions, digestUtil);
         actionContextProvider =
             RemoteActionContextProvider.createForRemoteCaching(
-                env, remoteCache, executeRetrier, digestUtil);
+                env, remoteCache, retryScheduler, digestUtil);
       }
     } catch (IOException e) {
       env.getReporter().handle(Event.error(e.getMessage()));
@@ -532,17 +489,6 @@ public final class RemoteModule extends BlazeModule {
     return "build".equals(command.name())
         ? ImmutableList.of(RemoteOptions.class, AuthAndTLSOptions.class)
         : ImmutableList.of();
-  }
-
-  static RemoteRetrier createExecuteRetrier(
-      RemoteOptions options, ListeningScheduledExecutorService retryService) {
-    return new RemoteRetrier(
-        options.remoteMaxRetryAttempts > 0
-            ? () -> new Retrier.ZeroBackoff(options.remoteMaxRetryAttempts)
-            : () -> Retrier.RETRIES_DISABLED,
-        RemoteModule.RETRIABLE_EXEC_ERRORS,
-        retryService,
-        Retrier.ALLOW_ALL_CALLS);
   }
 
   private static class BuildEventArtifactUploaderFactoryDelegate

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
@@ -239,7 +239,7 @@ public class GrpcRemoteExecutionClientTest {
             "command-id",
             remoteCache,
             executor,
-            RemoteModule.createExecuteRetrier(remoteOptions, retryService),
+            retryService,
             DIGEST_UTIL,
             logDir,
             /* filesToDownload= */ ImmutableSet.of());

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -146,7 +146,6 @@ public class RemoteSpawnRunnerTest {
     outErr = new FileOutErr(stdout, stderr);
 
     remoteOptions = Options.getDefaults(RemoteOptions.class);
-    retrier = RemoteModule.createExecuteRetrier(remoteOptions, retryService);
   }
 
   @AfterClass
@@ -817,7 +816,7 @@ public class RemoteSpawnRunnerTest {
             "command-id",
             cache,
             executor,
-            retrier,
+            retryService,
             digestUtil,
             logDir,
             /* filesToDownload= */ ImmutableSet.of());
@@ -1014,7 +1013,7 @@ public class RemoteSpawnRunnerTest {
         "command-id",
         cache,
         executor,
-        retrier,
+        retryService,
         digestUtil,
         logDir,
         topLevelOutputs);


### PR DESCRIPTION
Simple refactoring that moves the retry logic from the
RemoteModule to the RemoteSpawnRunner where it's actually
being used.