### PR TITLE
Refactor remote package initialization.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -51,11 +51,10 @@ public final class GoogleAuthUtils {
    * @throws IOException in case the channel can't be constructed.
    */
   public static ManagedChannel newChannel(
-      String target, String proxy, AuthAndTLSOptions options, ClientInterceptor... interceptors)
+      String target, String proxy, AuthAndTLSOptions options, @Nullable ClientInterceptor interceptor)
       throws IOException {
     Preconditions.checkNotNull(target);
     Preconditions.checkNotNull(options);
-    Preconditions.checkNotNull(interceptors);
 
     final SslContext sslContext =
         isTlsEnabled(target) ? createSSlContext(options.tlsCertificate) : null;
@@ -66,8 +65,10 @@ public final class GoogleAuthUtils {
       NettyChannelBuilder builder =
           newNettyChannelBuilder(targetUrl, proxy)
               .negotiationType(
-                  isTlsEnabled(target) ? NegotiationType.TLS : NegotiationType.PLAINTEXT)
-              .intercept(interceptors);
+                  isTlsEnabled(target) ? NegotiationType.TLS : NegotiationType.PLAINTEXT);
+      if (interceptor != null) {
+        builder.intercept(interceptor);
+      }
       if (sslContext != null) {
         builder.sslContext(sslContext);
         if (options.tlsAuthorityOverride != null) {

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
@@ -70,7 +70,7 @@ public class BazelBuildEventServiceModule
   protected ManagedChannel newGrpcChannel(
       BuildEventServiceOptions besOptions, AuthAndTLSOptions authAndTLSOptions) throws IOException {
     return GoogleAuthUtils.newChannel(
-        besOptions.besBackend, besOptions.besProxy, authAndTLSOptions);
+        besOptions.besBackend, besOptions.besProxy, authAndTLSOptions, /* interceptor= */ null);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -46,7 +46,7 @@ final class RemoteActionContextProvider extends ActionContextProvider {
   private final CommandEnvironment env;
   private final RemoteCache cache;
   @Nullable private final GrpcRemoteExecutor executor;
-  private final ListeningScheduledExecutorService retryScheduler;
+  @Nullable private final ListeningScheduledExecutorService retryScheduler;
   private final DigestUtil digestUtil;
   @Nullable private final Path logDir;
   private final AtomicReference<SpawnRunner> fallbackRunner = new AtomicReference<>();

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
@@ -18,6 +18,8 @@ import com.google.auth.Credentials;
 import com.google.common.base.Ascii;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
+import com.google.devtools.build.lib.authandtls.GoogleAuthUtils;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.disk.CombinedDiskHttpCacheClient;
 import com.google.devtools.build.lib.remote.disk.DiskCacheClient;
@@ -26,6 +28,7 @@ import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import io.grpc.ClientInterceptor;
 import io.netty.channel.unix.DomainSocketAddress;
 import java.io.IOException;
 import java.net.URI;
@@ -39,17 +42,20 @@ public final class RemoteCacheClientFactory {
 
   private RemoteCacheClientFactory() {}
 
-  public static RemoteCacheClient create(
-      RemoteOptions options,
-      @Nullable Credentials creds,
-      Path workingDirectory,
-      DigestUtil digestUtil)
-      throws IOException {
+  public static ReferenceCountedChannel createGrpcChannel(String target, String proxyUri,
+      AuthAndTLSOptions authOptions, @Nullable ClientInterceptor interceptor) throws IOException {
+    return new ReferenceCountedChannel(
+        GoogleAuthUtils.newChannel(target, proxyUri, authOptions,
+            interceptor));
+  }
+
+  public static RemoteCacheClient create(RemoteOptions options, @Nullable Credentials creds,
+      Path workingDirectory, DigestUtil digestUtil) throws IOException {
     Preconditions.checkNotNull(workingDirectory, "workingDirectory");
-    if (isHttpUrlOptions(options) && isDiskCache(options)) {
+    if (isHttpCache(options) && isDiskCache(options)) {
       return createCombinedCache(workingDirectory, options.diskCache, options, creds, digestUtil);
     }
-    if (isHttpUrlOptions(options)) {
+    if (isHttpCache(options)) {
       return createHttp(options, creds, digestUtil);
     }
     if (isDiskCache(options)) {
@@ -62,7 +68,7 @@ public final class RemoteCacheClientFactory {
   }
 
   public static boolean isRemoteCacheOptions(RemoteOptions options) {
-    return isHttpUrlOptions(options) || isDiskCache(options);
+    return isHttpCache(options) || isDiskCache(options);
   }
 
   private static RemoteCacheClient createHttp(
@@ -138,11 +144,11 @@ public final class RemoteCacheClientFactory {
     return new CombinedDiskHttpCacheClient(diskCache, httpCache);
   }
 
-  private static boolean isDiskCache(RemoteOptions options) {
+  public static boolean isDiskCache(RemoteOptions options) {
     return options.diskCache != null && !options.diskCache.isEmpty();
   }
 
-  private static boolean isHttpUrlOptions(RemoteOptions options) {
+  public static boolean isHttpCache(RemoteOptions options) {
     return options.remoteCache != null
         && (Ascii.toLowerCase(options.remoteCache).startsWith("http://")
             || Ascii.toLowerCase(options.remoteCache).startsWith("https://"));


### PR DESCRIPTION
Over time RemoteModule#beforeCommand has grown quite complex. In that
it was hard to tell what the control flow was for a particular
configuration. This change simplifies it.