### PR TITLE
Remove --incompatible_use_native_patch

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -334,7 +334,6 @@ public class BazelRepositoryModule extends BlazeModule {
         outputVerificationRules =
             ImmutableSet.copyOf(repoOptions.experimentalVerifyRepositoryRules);
       }
-      skylarkRepositoryFunction.setUseNativePatch(repoOptions.useNativePatch);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -133,20 +133,6 @@ public class RepositoryOptions extends OptionsBase {
       help = "If non-empty read the specified resolved file instead of the WORKSPACE file")
   public String experimentalResolvedFileInsteadOfWorkspace;
 
-  @Option(
-      name = "incompatible_use_native_patch",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
-      effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
-      metadataTags = {
-        OptionMetadataTag.INCOMPATIBLE_CHANGE,
-        OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
-      },
-      help =
-          "If enabled, Bazel's repository rules use a native implementation of patch, "
-              + "otherwise Bazel still calls patch command line tool for applying patch files.")
-  public boolean useNativePatch;
-
   /**
    * Converts from an equals-separated pair of strings into RepositoryName->PathFragment mapping.
    */

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
@@ -57,7 +57,6 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
 
   private final HttpDownloader httpDownloader;
   private double timeoutScaling = 1.0;
-  private boolean useNativePatch;
 
   public SkylarkRepositoryFunction(HttpDownloader httpDownloader) {
     this.httpDownloader = httpDownloader;
@@ -65,10 +64,6 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
 
   public void setTimeoutScaling(double timeoutScaling) {
     this.timeoutScaling = timeoutScaling;
-  }
-
-  public void setUseNativePatch(boolean useNativePatch) {
-    this.useNativePatch = useNativePatch;
   }
 
   @Nullable
@@ -150,8 +145,7 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
               httpDownloader,
               directories.getEmbeddedBinariesRoot(),
               timeoutScaling,
-              markerData,
-              useNativePatch);
+              markerData);
 
       // Since restarting a repository function can be really expensive, we first ensure that
       // all label-arguments can be resolved to paths.

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -385,6 +385,19 @@ public class BazelRulesModule extends BlazeModule {
         help = "This option is deprecated and has no effect.")
     public boolean incompatibleDisableLateBoundOptionDefaults;
 
+    @Option(
+        name = "incompatible_use_native_patch",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {
+            OptionMetadataTag.DEPRECATED,
+            OptionMetadataTag.INCOMPATIBLE_CHANGE,
+            OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+        },
+        help = "This option is deprecated and has no effect.")
+    public boolean useNativePatch;
+
     @Deprecated
     @Option(
         name = "ui",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
@@ -132,8 +132,7 @@ public class SkylarkRepositoryContextTest {
             downloader,
             null,
             1.0,
-            new HashMap<>(),
-            true);
+            new HashMap<>());
   }
 
   protected void setUpContexForRule(String name) throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/PatchApiBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/PatchApiBlackBoxTest.java
@@ -124,8 +124,7 @@ public class PatchApiBlackBoxTest extends AbstractBlackBoxTest {
   @Test
   public void testPatchApiUsingNativePatch() throws Exception {
     setUpPatchTestRepo(null, null, true);
-    BuilderRunner bazel =
-        WorkspaceTestUtils.bazel(context()).withFlags("--incompatible_use_native_patch");
+    BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     bazel.build("@test//:foo");
     assertFooIsPatched(bazel);
   }
@@ -134,39 +133,17 @@ public class PatchApiBlackBoxTest extends AbstractBlackBoxTest {
   public void testPatchApiUsingNativePatchFailed() throws Exception {
     // Using -p2 should cause an error
     setUpPatchTestRepo(ImmutableList.of("-p2"), null, true);
-    BuilderRunner bazel =
-        WorkspaceTestUtils.bazel(context())
-            .withFlags("--incompatible_use_native_patch")
-            .shouldFail();
+    BuilderRunner bazel = WorkspaceTestUtils.bazel(context()).shouldFail();
     ProcessResult result = bazel.build("@test//:foo");
     assertThat(result.errString())
         .contains("Cannot determine file name with strip = 2 at line 4:\n--- a/foo.sh");
   }
 
   @Test
-  public void testPatchApiUsingPatchTool() throws Exception {
-    setUpPatchTestRepo(null, null, true);
-    BuilderRunner bazel =
-        WorkspaceTestUtils.bazel(context()).withFlags("--noincompatible_use_native_patch");
-    if (isWindows()) {
-      // On Windows, we expect no patch tool in PATH after removing MSYS paths from PATH env var.
-      bazel.shouldFail();
-    }
-    ProcessResult result = bazel.build("@test//:foo");
-    if (isWindows()) {
-      assertThat(result.errString()).contains("CreateProcessW(\"patch\" -p1 -i");
-      assertThat(result.errString()).contains("The system cannot find the file specified.");
-    } else {
-      assertFooIsPatched(bazel);
-    }
-  }
-
-  @Test
   public void testFallBackToPatchToolDueToPatchArgs() throws Exception {
     // Native patch doesn't support -b argument, should fallback to patch command line tool.
     setUpPatchTestRepo(ImmutableList.of("-p1", "-b"), null, true);
-    BuilderRunner bazel =
-        WorkspaceTestUtils.bazel(context()).withFlags("--incompatible_use_native_patch");
+    BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     if (isWindows()) {
       // On Windows, we expect no patch tool in PATH after removing MSYS paths from PATH env var.
       bazel.shouldFail();
@@ -188,8 +165,7 @@ public class PatchApiBlackBoxTest extends AbstractBlackBoxTest {
   public void testFallBackToPatchToolWhenItIsSpecified() throws Exception {
     // Should fallback to the specified patch tool.
     setUpPatchTestRepo(null, "patch", true);
-    BuilderRunner bazel =
-        WorkspaceTestUtils.bazel(context()).withFlags("--incompatible_use_native_patch");
+    BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     if (isWindows()) {
       // On Windows, we expect no patch tool in PATH after removing MSYS paths from PATH env var.
       bazel.shouldFail();
@@ -207,8 +183,7 @@ public class PatchApiBlackBoxTest extends AbstractBlackBoxTest {
   @Test
   public void testFallBackToPatchCmdsWhenPatchCmdsWinNotSpecified() throws Exception {
     setUpPatchTestRepo(null, null, false);
-    BuilderRunner bazel =
-        WorkspaceTestUtils.bazel(context()).withFlags("--incompatible_use_native_patch");
+    BuilderRunner bazel = WorkspaceTestUtils.bazel(context());
     if (isWindows()) {
       // On Windows, we expect no bash tool in PATH after removing MSYS paths from PATH env var.
       bazel.shouldFail();


### PR DESCRIPTION
This flag is already flipped in Bazel 1.0, now it can be removed.

Related https://github.com/bazelbuild/bazel/issues/8316