### PR TITLE
Hardcode path to dirname on macOS

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -83,7 +83,7 @@ def configure_osx_toolchain(repository_ctx, overriden_tools):
         # the C++ actions behave consistently.
         cc = repository_ctx.path("wrapped_clang")
 
-        cc_path = '"$(dirname "$0")"/wrapped_clang'
+        cc_path = '"$(/usr/bin/dirname "$0")"/wrapped_clang'
         repository_ctx.template(
             "cc_wrapper.sh",
             paths["@bazel_tools//tools/cpp:osx_cc_wrapper.sh.tpl"],


### PR DESCRIPTION
It seems that some repos have customized PATH so this isn't available.
This should fix that.