### PR TITLE
Enable combined disk cache for grpc caching protocol.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
 import com.google.devtools.build.lib.authandtls.GoogleAuthUtils;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
-import com.google.devtools.build.lib.remote.disk.CombinedDiskHttpCacheClient;
+import com.google.devtools.build.lib.remote.disk.DiskAndRemoteCacheClient;
 import com.google.devtools.build.lib.remote.disk.DiskCacheClient;
 import com.google.devtools.build.lib.remote.http.HttpCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -42,6 +42,14 @@ public final class RemoteCacheClientFactory {
 
   private RemoteCacheClientFactory() {}
 
+  public static RemoteCacheClient createDiskAndRemoteClient(Path workingDirectory,
+      PathFragment diskCachePath, boolean remoteVerifyDownloads, DigestUtil digestUtil,
+      RemoteCacheClient remoteCacheClient) throws IOException {
+    DiskCacheClient diskCacheClient =
+        createDiskCache(workingDirectory, diskCachePath, remoteVerifyDownloads, digestUtil);
+    return new DiskAndRemoteCacheClient(diskCacheClient, remoteCacheClient);
+  }
+
   public static ReferenceCountedChannel createGrpcChannel(
       String target,
       String proxyUri,
@@ -60,7 +68,7 @@ public final class RemoteCacheClientFactory {
       throws IOException {
     Preconditions.checkNotNull(workingDirectory, "workingDirectory");
     if (isHttpCache(options) && isDiskCache(options)) {
-      return createCombinedCache(workingDirectory, options.diskCache, options, creds, digestUtil);
+      return createDiskAndHttpCache(workingDirectory, options.diskCache, options, creds, digestUtil);
     }
     if (isHttpCache(options)) {
       return createHttp(options, creds, digestUtil);
@@ -117,7 +125,7 @@ public final class RemoteCacheClientFactory {
     }
   }
 
-  private static RemoteCacheClient createDiskCache(
+  private static DiskCacheClient createDiskCache(
       Path workingDirectory,
       PathFragment diskCachePath,
       boolean verifyDownloads,
@@ -131,7 +139,7 @@ public final class RemoteCacheClientFactory {
     return new DiskCacheClient(cacheDir, verifyDownloads, digestUtil);
   }
 
-  private static RemoteCacheClient createCombinedCache(
+  private static RemoteCacheClient createDiskAndHttpCache(
       Path workingDirectory,
       PathFragment diskCachePath,
       RemoteOptions options,
@@ -147,8 +155,8 @@ public final class RemoteCacheClientFactory {
     DiskCacheClient diskCache =
         new DiskCacheClient(cacheDir, options.remoteVerifyDownloads, digestUtil);
     RemoteCacheClient httpCache = createHttp(options, cred, digestUtil);
-
-    return new CombinedDiskHttpCacheClient(diskCache, httpCache);
+    return createDiskAndRemoteClient(workingDirectory, diskCachePath, options.remoteVerifyDownloads,
+        digestUtil, httpCache);
   }
 
   public static boolean isDiskCache(RemoteOptions options) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -21,6 +21,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree.PathOrBytes;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -39,8 +40,9 @@ import java.util.concurrent.ExecutionException;
 /** A {@link RemoteCache} with additional functionality needed for remote execution. */
 public class RemoteExecutionCache extends RemoteCache {
 
-  public RemoteExecutionCache(
-      GrpcCacheClient protocolImpl, RemoteOptions options, DigestUtil digestUtil) {
+  public RemoteExecutionCache(RemoteCacheClient protocolImpl,
+      RemoteOptions options,
+      DigestUtil digestUtil) {
     super(protocolImpl, options, digestUtil);
   }
 
@@ -86,7 +88,7 @@ public class RemoteExecutionCache extends RemoteCache {
    * end-point from the executor itself, so the functionality lives here.
    */
   public void ensureInputsPresent(
-      MerkleTree merkleTree, Map<Digest, Message> additionalInputs, Path execRoot)
+      MerkleTree merkleTree, Map<Digest, Message> additionalInputs)
       throws IOException, InterruptedException {
     Iterable<Digest> allDigests =
         Iterables.concat(merkleTree.getAllDigests(), additionalInputs.keySet());

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -279,7 +279,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
                 Map<Digest, Message> additionalInputs = Maps.newHashMapWithExpectedSize(2);
                 additionalInputs.put(actionKey.getDigest(), action);
                 additionalInputs.put(commandHash, command);
-                remoteCache.ensureInputsPresent(merkleTree, additionalInputs, execRoot);
+                remoteCache.ensureInputsPresent(merkleTree, additionalInputs);
               }
               ExecuteResponse reply;
               try (SilentCloseable c = prof.profile(REMOTE_EXECUTION, "execute remotely")) {

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
@@ -33,12 +33,12 @@ import java.util.concurrent.ExecutionException;
  * a remote blob store. If a blob isn't found in the first store, the second store is used, and the
  * blob added to the first. Put puts the blob on both stores.
  */
-public final class CombinedDiskHttpCacheClient implements RemoteCacheClient {
+public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
 
   private final RemoteCacheClient remoteCache;
   private final DiskCacheClient diskCache;
 
-  public CombinedDiskHttpCacheClient(DiskCacheClient diskCache, RemoteCacheClient remoteCache) {
+  public DiskAndRemoteCacheClient(DiskCacheClient diskCache, RemoteCacheClient remoteCache) {
     this.diskCache = Preconditions.checkNotNull(diskCache);
     this.remoteCache = Preconditions.checkNotNull(remoteCache);
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -137,6 +137,8 @@ public class DiskCacheClient implements RemoteCacheClient {
 
   @Override
   public ListenableFuture<ImmutableSet<Digest>> findMissingDigests(Iterable<Digest> digests) {
+    // Both upload and download check if the file exists before doing I/O. So we don't
+    // have to do it here.
     return Futures.immediateFuture(ImmutableSet.copyOf(digests));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -298,7 +298,7 @@ public class GrpcCacheClientTest {
         });
 
     // Upload all missing inputs (that is, the virtual action input from above)
-    client.ensureInputsPresent(merkleTree, ImmutableMap.of(), execRoot);
+    client.ensureInputsPresent(merkleTree, ImmutableMap.of());
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactoryTest.java
@@ -19,7 +19,7 @@ import static com.google.devtools.build.lib.testutil.MoreAsserts.assertThrows;
 
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
-import com.google.devtools.build.lib.remote.disk.CombinedDiskHttpCacheClient;
+import com.google.devtools.build.lib.remote.disk.DiskAndRemoteCacheClient;
 import com.google.devtools.build.lib.remote.disk.DiskCacheClient;
 import com.google.devtools.build.lib.remote.http.HttpCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -62,7 +62,7 @@ public class RemoteCacheClientFactoryTest {
         RemoteCacheClientFactory.create(
             remoteOptions, /* creds= */ null, workingDirectory, digestUtil);
 
-    assertThat(blobStore).isInstanceOf(CombinedDiskHttpCacheClient.class);
+    assertThat(blobStore).isInstanceOf(DiskAndRemoteCacheClient.class);
   }
 
   @Test
@@ -75,7 +75,7 @@ public class RemoteCacheClientFactoryTest {
         RemoteCacheClientFactory.create(
             remoteOptions, /* creds= */ null, workingDirectory, digestUtil);
 
-    assertThat(blobStore).isInstanceOf(CombinedDiskHttpCacheClient.class);
+    assertThat(blobStore).isInstanceOf(DiskAndRemoteCacheClient.class);
     assertThat(workingDirectory.exists()).isTrue();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -211,7 +211,7 @@ public class RemoteSpawnRunnerTest {
     runner.exec(spawn, policy);
 
     verify(localRunner).exec(spawn, policy);
-    verify(cache).ensureInputsPresent(any(), any(), eq(execRoot));
+    verify(cache).ensureInputsPresent(any(), any());
     verifyNoMoreInteractions(cache);
   }
 


### PR DESCRIPTION
This change enables the combined disk cache for the gRPC
protocol too.

$ bazel build src:bazel --disk_cache=/path/to/dir
--remote_cache=grpcs://...

It does not yet also enable it for remote execution as
this will need a bit more work. In particular it will
require some refactorings around RemoteCacheClient#findMissingBlobs
as when used with remote execution findMissingBlobs() should
only check the remote cache and not the local disk cache. Else,
it could happen that an input file is missing from the local
cache but not from the remote cache in which case Bazel would
attempt to upload the file again.

RELNOTES: The --disk_cache flag can now also be used together
with the gRPC remote cache.