### PR TITLE
Don't claim cc_toolchain.ar_files and cc_toolchain.as_files are unused.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainRule.java
@@ -224,22 +224,15 @@ public final class CcToolchainRule implements RuleDefinition {
                 .cfg(HostTransition.createFactory())
                 .mandatory())
         /* <!-- #BLAZE_RULE(cc_toolchain).ATTRIBUTE(as_files) -->
-        Currently unused (<a href="https://github.com/bazelbuild/bazel/issues/6928">#6928</a>).
-
         <p>Collection of all cc_toolchain artifacts required for assembly actions.</p>
         <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
         .add(attr("as_files", LABEL).legacyAllowAnyFileType().cfg(HostTransition.createFactory()))
         /* <!-- #BLAZE_RULE(cc_toolchain).ATTRIBUTE(ar_files) -->
-        Currently unused (<a href="https://github.com/bazelbuild/bazel/issues/6928">#6928</a>).
-
         <p>Collection of all cc_toolchain artifacts required for archiving actions.</p>
         <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
         .add(attr("ar_files", LABEL).legacyAllowAnyFileType().cfg(HostTransition.createFactory()))
         /* <!-- #BLAZE_RULE(cc_toolchain).ATTRIBUTE(linker_files) -->
         Collection of all cc_toolchain artifacts required for linking actions.
-
-        <p>Currently also used for archiving actions
-         (<a href="https://github.com/bazelbuild/bazel/issues/6928">#6928</a>).</p>
         <!-- #END_BLAZE_RULE.ATTRIBUTE -->*/
         .add(
             attr("linker_files", LABEL)


### PR DESCRIPTION
Using these attributes is the the default behavior since https://github.com/bazelbuild/bazel/commit/030ca7fb98c56bfc63f5dc9e61e6a89c4b274293.

Fixes https://github.com/bazelbuild/bazel/issues/6928.