### PR TITLE
Document what create_linking_context_from_compilation_outputs returns

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/CcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/CcModuleApi.java
@@ -995,7 +995,8 @@ public interface CcModuleApi<
       doc =
           "Should be used for creating library rules that can propagate information downstream in"
               + " order to be linked later by a top level rule that does transitive linking to"
-              + " create an executable or dynamic library.",
+              + " create an executable or dynamic library. Returns tuple of "
+              + "(<code>CcLinkingContext</code>, <code>CcLinkingOutputs</code>).",
       useLocation = true,
       useStarlarkThread = true,
       parameters = {


### PR DESCRIPTION
It's just a tuple, so document what's actually in the tuple, like
cc_common.compile.