### PR TITLE
docs: fix #zsh link

### DIFF
--- a/site/docs/completion.md
+++ b/site/docs/completion.md
@@ -65,7 +65,7 @@ If you installed Bazel:
             source /path/to/bazel-complete.bash
             ```
 
-<h2 name="zsh">Zsh completion</h2>
+<h2 id="zsh">Zsh completion</h2>
 
 Bazel also comes with a Zsh completion script. To install it:
 


### PR DESCRIPTION
This modification allows `https://docs.bazel.build/versions/master/completion.html#zsh` linked in [Installing on Ubuntu](https://docs.bazel.build/versions/master/install-ubuntu.html) and [Installing on macOS](https://docs.bazel.build/versions/master/install-os-x.html) to work.