### PR TITLE
Use homebrew-core install/upgrade option

### DIFF
--- a/site/docs/install-os-x.md
+++ b/site/docs/install-os-x.md
@@ -103,15 +103,6 @@ https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
 ### Step 2: Install Bazel via Homebrew
 
-* `bazelbuild/tap/bazel` is maintained by the Bazel team, and installs the
-  official Bazel binary package (see above).
-* The default [homebrew/core formula](https://formulae.brew.sh/formula/bazel)
-  is maintained by the community, and compiles Bazel from source or installs a
-  binary pre-compiled by the Homebrew project.
-
-If you previously installed Bazel from homebrew/core, you can switch to the
-`bazelbuild` tap by uninstalling the existing package: `brew uninstall bazel`.
-
 Install the `bazelbuild/tap` Bazel package via Homebrew as follows:
 
 ```bash

--- a/site/docs/install-os-x.md
+++ b/site/docs/install-os-x.md
@@ -101,9 +101,7 @@ Install Homebrew (a one-time step):
 https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
 
-### Step 2: Install the Bazel Homebrew package
-
-Please note that there are two different Bazel packages ("formulae"):
+### Step 2: Install Bazel via Homebrew
 
 * `bazelbuild/tap/bazel` is maintained by the Bazel team, and installs the
   official Bazel binary package (see above).
@@ -117,8 +115,7 @@ If you previously installed Bazel from homebrew/core, you can switch to the
 Install the `bazelbuild/tap` Bazel package via Homebrew as follows:
 
 ```bash
-brew tap bazelbuild/tap
-brew install bazelbuild/tap/bazel
+brew install bazel
 ```
 
 All set! You can confirm Bazel is installed successfully by running the following command:
@@ -130,5 +127,5 @@ bazel --version
 Once installed, you can upgrade to a newer version of Bazel using the following command:
 
 ```bash
-brew upgrade bazelbuild/tap/bazel
+brew upgrade bazel
 ```

--- a/site/docs/install-os-x.md
+++ b/site/docs/install-os-x.md
@@ -103,20 +103,20 @@ https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
 ### Step 2: Install Bazel via Homebrew
 
-Install the `bazelbuild/tap` Bazel package via Homebrew as follows:
+Install the Bazel package via Homebrew as follows:
 
 ```bash
-brew install bazel
+$ brew install bazel
 ```
 
 All set! You can confirm Bazel is installed successfully by running the following command:
 
 ```bash
-bazel --version
+$ bazel --version
 ```
 
 Once installed, you can upgrade to a newer version of Bazel using the following command:
 
 ```bash
-brew upgrade bazel
+$ brew upgrade bazel
 ```


### PR DESCRIPTION
The bazel formula is actively maintained in homebrew-core, so it would be nice to mention as default option in the README. :)