### PR TITLE
Support .bazelignore file for external repo

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
@@ -112,7 +112,10 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
     }
 
     BlacklistedPackagePrefixesValue blacklistedPackagesValue =
-        (BlacklistedPackagePrefixesValue) env.getValue(BlacklistedPackagePrefixesValue.key());
+        (BlacklistedPackagePrefixesValue)
+            env.getValue(
+                BlacklistedPackagePrefixesValue.key(
+                    rule.getPackage().getPackageIdentifier().getRepository()));
     if (env.valuesMissing()) {
       return null;
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
@@ -114,8 +114,8 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
     BlacklistedPackagePrefixesValue blacklistedPackagesValue =
         (BlacklistedPackagePrefixesValue)
             env.getValue(
-                BlacklistedPackagePrefixesValue.key(
-                    rule.getPackage().getPackageIdentifier().getRepository()));
+                BlacklistedPackagePrefixesValue.key());
+
     if (env.valuesMissing()) {
       return null;
     }

--- a/src/main/java/com/google/devtools/build/lib/cmdline/TargetPattern.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/TargetPattern.java
@@ -65,7 +65,6 @@ public abstract class TargetPattern implements Serializable {
   private final Type type;
   private final String originalPattern;
   private final String offset;
-  private final RepositoryName repository;
 
   /**
    * Returns a parser with no offset. Note that the Parser class is immutable, so this method may
@@ -118,13 +117,11 @@ public abstract class TargetPattern implements Serializable {
     return SLASH_JOINER.join(pieces);
   }
 
-  private TargetPattern(
-      Type type, String originalPattern, String offset, RepositoryName repository) {
+  private TargetPattern(Type type, String originalPattern, String offset) {
     // Don't allow inheritance outside this class.
     this.type = type;
     this.originalPattern = Preconditions.checkNotNull(originalPattern);
     this.offset = Preconditions.checkNotNull(offset);
-    this.repository = repository;
   }
 
   /**
@@ -303,9 +300,8 @@ public abstract class TargetPattern implements Serializable {
     throw new IllegalStateException();
   }
 
-  public RepositoryName getRepository() {
-    return this.repository;
-  }
+  /** Returns the repository name of the target path. */
+  public abstract RepositoryName getRepository();
 
   /**
    * Returns {@code true} iff this pattern has type {@code Type.TARGETS_BELOW_DIRECTORY} or
@@ -321,7 +317,7 @@ public abstract class TargetPattern implements Serializable {
 
     private SingleTarget(
         String targetName, PackageIdentifier directory, String originalPattern, String offset) {
-      super(Type.SINGLE_TARGET, originalPattern, offset, directory.getRepository());
+      super(Type.SINGLE_TARGET, originalPattern, offset);
       this.targetName = Preconditions.checkNotNull(targetName);
       this.directory = Preconditions.checkNotNull(directory);
     }
@@ -344,6 +340,11 @@ public abstract class TargetPattern implements Serializable {
     @Override
     public PackageIdentifier getDirectoryForTargetOrTargetsInPackage() {
       return directory;
+    }
+
+    @Override
+    public RepositoryName getRepository() {
+      return directory.getRepository();
     }
 
     @Override
@@ -379,7 +380,7 @@ public abstract class TargetPattern implements Serializable {
     private final String path;
 
     private InterpretPathAsTarget(String path, String originalPattern, String offset) {
-      super(Type.PATH_AS_TARGET, originalPattern, offset, null);
+      super(Type.PATH_AS_TARGET, originalPattern, offset);
       this.path = normalize(Preconditions.checkNotNull(path));
     }
 
@@ -426,6 +427,11 @@ public abstract class TargetPattern implements Serializable {
     }
 
     @Override
+    public RepositoryName getRepository() {
+      return RepositoryName.MAIN;
+    }
+
+    @Override
     public boolean getRulesOnly() {
       return false;
     }
@@ -459,7 +465,7 @@ public abstract class TargetPattern implements Serializable {
     private TargetsInPackage(String originalPattern, String offset,
         PackageIdentifier packageIdentifier, String suffix, boolean wasOriginallyAbsolute,
         boolean rulesOnly, boolean checkWildcardConflict) {
-      super(Type.TARGETS_IN_PACKAGE, originalPattern, offset, packageIdentifier.getRepository());
+      super(Type.TARGETS_IN_PACKAGE, originalPattern, offset);
       Preconditions.checkArgument(!packageIdentifier.getRepository().isDefault());
       this.packageIdentifier = packageIdentifier;
       this.suffix = Preconditions.checkNotNull(suffix);
@@ -495,6 +501,11 @@ public abstract class TargetPattern implements Serializable {
     @Override
     public PackageIdentifier getDirectoryForTargetOrTargetsInPackage() {
       return packageIdentifier;
+    }
+
+    @Override
+    public RepositoryName getRepository() {
+      return packageIdentifier.getRepository();
     }
 
     @Override
@@ -569,7 +580,7 @@ public abstract class TargetPattern implements Serializable {
 
     private TargetsBelowDirectory(
         String originalPattern, String offset, PackageIdentifier directory, boolean rulesOnly) {
-      super(Type.TARGETS_BELOW_DIRECTORY, originalPattern, offset, directory.getRepository());
+      super(Type.TARGETS_BELOW_DIRECTORY, originalPattern, offset);
       Preconditions.checkArgument(!directory.getRepository().isDefault());
       this.directory = Preconditions.checkNotNull(directory);
       this.rulesOnly = rulesOnly;
@@ -626,6 +637,11 @@ public abstract class TargetPattern implements Serializable {
     @Override
     public PackageIdentifier getDirectoryForTargetsUnderDirectory() {
       return directory;
+    }
+
+    @Override
+    public RepositoryName getRepository() {
+      return directory.getRepository();
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/cmdline/TargetPattern.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/TargetPattern.java
@@ -65,6 +65,7 @@ public abstract class TargetPattern implements Serializable {
   private final Type type;
   private final String originalPattern;
   private final String offset;
+  private final RepositoryName repository;
 
   /**
    * Returns a parser with no offset. Note that the Parser class is immutable, so this method may
@@ -117,11 +118,13 @@ public abstract class TargetPattern implements Serializable {
     return SLASH_JOINER.join(pieces);
   }
 
-  private TargetPattern(Type type, String originalPattern, String offset) {
+  private TargetPattern(
+      Type type, String originalPattern, String offset, RepositoryName repository) {
     // Don't allow inheritance outside this class.
     this.type = type;
     this.originalPattern = Preconditions.checkNotNull(originalPattern);
     this.offset = Preconditions.checkNotNull(offset);
+    this.repository = repository;
   }
 
   /**
@@ -300,6 +303,10 @@ public abstract class TargetPattern implements Serializable {
     throw new IllegalStateException();
   }
 
+  public RepositoryName getRepository() {
+    return this.repository;
+  }
+
   /**
    * Returns {@code true} iff this pattern has type {@code Type.TARGETS_BELOW_DIRECTORY} or
    * {@code Type.TARGETS_IN_PACKAGE} and the target pattern suffix specified it should match
@@ -314,7 +321,7 @@ public abstract class TargetPattern implements Serializable {
 
     private SingleTarget(
         String targetName, PackageIdentifier directory, String originalPattern, String offset) {
-      super(Type.SINGLE_TARGET, originalPattern, offset);
+      super(Type.SINGLE_TARGET, originalPattern, offset, directory.getRepository());
       this.targetName = Preconditions.checkNotNull(targetName);
       this.directory = Preconditions.checkNotNull(directory);
     }
@@ -372,7 +379,7 @@ public abstract class TargetPattern implements Serializable {
     private final String path;
 
     private InterpretPathAsTarget(String path, String originalPattern, String offset) {
-      super(Type.PATH_AS_TARGET, originalPattern, offset);
+      super(Type.PATH_AS_TARGET, originalPattern, offset, null);
       this.path = normalize(Preconditions.checkNotNull(path));
     }
 
@@ -452,7 +459,7 @@ public abstract class TargetPattern implements Serializable {
     private TargetsInPackage(String originalPattern, String offset,
         PackageIdentifier packageIdentifier, String suffix, boolean wasOriginallyAbsolute,
         boolean rulesOnly, boolean checkWildcardConflict) {
-      super(Type.TARGETS_IN_PACKAGE, originalPattern, offset);
+      super(Type.TARGETS_IN_PACKAGE, originalPattern, offset, packageIdentifier.getRepository());
       Preconditions.checkArgument(!packageIdentifier.getRepository().isDefault());
       this.packageIdentifier = packageIdentifier;
       this.suffix = Preconditions.checkNotNull(suffix);
@@ -562,7 +569,7 @@ public abstract class TargetPattern implements Serializable {
 
     private TargetsBelowDirectory(
         String originalPattern, String offset, PackageIdentifier directory, boolean rulesOnly) {
-      super(Type.TARGETS_BELOW_DIRECTORY, originalPattern, offset);
+      super(Type.TARGETS_BELOW_DIRECTORY, originalPattern, offset, directory.getRepository());
       Preconditions.checkArgument(!directory.getRepository().isDefault());
       this.directory = Preconditions.checkNotNull(directory);
       this.rulesOnly = rulesOnly;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BlacklistedPackagePrefixesValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BlacklistedPackagePrefixesValue.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.skyframe.AbstractSkyKey;
 import com.google.devtools.build.skyframe.SkyFunctionName;
+import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 
 /** An immutable set of package name prefixes that should be blacklisted. */
@@ -29,18 +30,25 @@ import com.google.devtools.build.skyframe.SkyValue;
 public class BlacklistedPackagePrefixesValue implements SkyValue {
   private final ImmutableSet<PathFragment> patterns;
 
+  @AutoCodec.VisibleForSerialization @AutoCodec
+  static final SkyKey BLACKLIST_KEY = () -> SkyFunctions.BLACKLISTED_PACKAGE_PREFIXES;
+
   public BlacklistedPackagePrefixesValue(ImmutableSet<PathFragment> patterns) {
     this.patterns = Preconditions.checkNotNull(patterns);
   }
 
   /** Creates a key from the main repository. */
-  public static Key key() {
-    return Key.create(RepositoryName.MAIN);
+  public static SkyKey key() {
+    return BLACKLIST_KEY;
   }
 
   /** Creates a key from the given repository name. */
-  public static Key key(RepositoryName repository) {
-    return Key.create(repository);
+  public static SkyKey key(RepositoryName repository) {
+    if (repository.isMain()) {
+      return BLACKLIST_KEY;
+    } else {
+      return Key.create(repository);
+    }
   }
 
   public ImmutableSet<PathFragment> getPatterns() {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/GlobFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/GlobFunction.java
@@ -57,7 +57,8 @@ public final class GlobFunction implements SkyFunction {
     GlobDescriptor glob = (GlobDescriptor) skyKey.argument();
 
     BlacklistedPackagePrefixesValue blacklistedPackagePrefixes =
-        (BlacklistedPackagePrefixesValue) env.getValue(BlacklistedPackagePrefixesValue.key());
+        (BlacklistedPackagePrefixesValue)
+            env.getValue(BlacklistedPackagePrefixesValue.key(glob.getPackageId().getRepository()));
     if (env.valuesMissing()) {
       return null;
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/GlobFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/GlobFunction.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.actions.InconsistentFilesystemException;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.vfs.Dirent;
@@ -56,9 +57,10 @@ public final class GlobFunction implements SkyFunction {
       throws GlobFunctionException, InterruptedException {
     GlobDescriptor glob = (GlobDescriptor) skyKey.argument();
 
+    RepositoryName repositoryName = glob.getPackageId().getRepository();
     BlacklistedPackagePrefixesValue blacklistedPackagePrefixes =
         (BlacklistedPackagePrefixesValue)
-            env.getValue(BlacklistedPackagePrefixesValue.key(glob.getPackageId().getRepository()));
+            env.getValue(BlacklistedPackagePrefixesValue.key(repositoryName));
     if (env.valuesMissing()) {
       return null;
     }
@@ -80,7 +82,7 @@ public final class GlobFunction implements SkyFunction {
               env.getValue(
                   PackageLookupValue.key(
                       PackageIdentifier.create(
-                          glob.getPackageId().getRepository(),
+                          repositoryName,
                           glob.getPackageId().getPackageFragment().getRelative(globSubdir))));
       if (globSubdirPkgLookupValue == null) {
         return null;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
@@ -412,7 +412,8 @@ public class PackageFunction implements SkyFunction {
     RuleVisibility defaultVisibility = PrecomputedValue.DEFAULT_VISIBILITY.get(env);
     StarlarkSemantics starlarkSemantics = PrecomputedValue.STARLARK_SEMANTICS.get(env);
     BlacklistedPackagePrefixesValue blacklistedPackagePrefixes =
-        (BlacklistedPackagePrefixesValue) env.getValue(BlacklistedPackagePrefixesValue.key());
+        (BlacklistedPackagePrefixesValue)
+            env.getValue(BlacklistedPackagePrefixesValue.key(packageId.getRepository()));
     if (env.valuesMissing()) {
       return null;
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
@@ -92,8 +92,7 @@ public class PackageLookupFunction implements SkyFunction {
 
     // Check .bazelignore file under main repository.
     BlacklistedPackagePrefixesValue blacklistedPatternsValue =
-        (BlacklistedPackagePrefixesValue)
-            env.getValue(BlacklistedPackagePrefixesValue.key(packageKey.getRepository()));
+        (BlacklistedPackagePrefixesValue) env.getValue(BlacklistedPackagePrefixesValue.key());
     if (blacklistedPatternsValue == null) {
       return null;
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfPatternFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfPatternFunction.java
@@ -83,18 +83,13 @@ public class PrepareDepsOfPatternFunction implements SkyFunction {
 
     TargetPattern parsedPattern = patternKey.getParsedPattern();
 
-    ImmutableSet<PathFragment> blacklistedPatterns;
-    if (parsedPattern.getRepository() == null) {
-      blacklistedPatterns = ImmutableSet.of();
-    } else {
-      BlacklistedPackagePrefixesValue blacklist =
-          (BlacklistedPackagePrefixesValue)
-              env.getValue(BlacklistedPackagePrefixesValue.key(parsedPattern.getRepository()));
-      if (blacklist == null) {
-        return null;
-      }
-      blacklistedPatterns = blacklist.getPatterns();
+    BlacklistedPackagePrefixesValue blacklist =
+        (BlacklistedPackagePrefixesValue)
+            env.getValue(BlacklistedPackagePrefixesValue.key(parsedPattern.getRepository()));
+    if (blacklist == null) {
+      return null;
     }
+    ImmutableSet<PathFragment> blacklistedPatterns = blacklist.getPatterns();
 
     // This SkyFunction is used to load the universe, so we want both the blacklisted directories
     // from the global blacklist and the excluded directories from the TargetPatternKey itself to be

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfPatternFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PrepareDepsOfPatternFunction.java
@@ -83,18 +83,26 @@ public class PrepareDepsOfPatternFunction implements SkyFunction {
 
     TargetPattern parsedPattern = patternKey.getParsedPattern();
 
-    BlacklistedPackagePrefixesValue blacklist =
-        (BlacklistedPackagePrefixesValue) env.getValue(BlacklistedPackagePrefixesValue.key());
-    if (blacklist == null) {
-      return null;
+    ImmutableSet<PathFragment> blacklistedPatterns;
+    if (parsedPattern.getRepository() == null) {
+      blacklistedPatterns = ImmutableSet.of();
+    } else {
+      BlacklistedPackagePrefixesValue blacklist =
+          (BlacklistedPackagePrefixesValue)
+              env.getValue(BlacklistedPackagePrefixesValue.key(parsedPattern.getRepository()));
+      if (blacklist == null) {
+        return null;
+      }
+      blacklistedPatterns = blacklist.getPatterns();
     }
+
     // This SkyFunction is used to load the universe, so we want both the blacklisted directories
     // from the global blacklist and the excluded directories from the TargetPatternKey itself to be
     // embedded in the SkyKeys created and used by the DepsOfPatternPreparer. The
     // DepsOfPatternPreparer ignores excludedSubdirectories and embeds blacklistedSubdirectories in
     // the SkyKeys it creates and uses.
     ImmutableSet<PathFragment> blacklistedSubdirectories =
-        patternKey.getAllSubdirectoriesToExclude(blacklist.getPatterns());
+        patternKey.getAllSubdirectoriesToExclude(blacklistedPatterns);
     ImmutableSet<PathFragment> excludedSubdirectories = ImmutableSet.of();
 
     DepsOfPatternPreparer preparer =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -505,9 +505,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
         SkyFunctions.COLLECT_PACKAGES_UNDER_DIRECTORY,
         newCollectPackagesUnderDirectoryFunction(directories));
     map.put(
-        SkyFunctions.BLACKLISTED_PACKAGE_PREFIXES,
-        new BlacklistedPackagePrefixesFunction(
-            hardcodedBlacklistedPackagePrefixes, additionalBlacklistedPackagePrefixesFile));
+        SkyFunctions.BLACKLISTED_PACKAGE_PREFIXES, newBlacklistedPackagePrefixesFunction());
     map.put(SkyFunctions.TESTS_IN_SUITE, new TestExpansionFunction());
     map.put(SkyFunctions.TEST_SUITE_EXPANSION, new TestsForTargetPatternFunction());
     map.put(SkyFunctions.TARGET_PATTERN_PHASE, new TargetPatternPhaseFunction());
@@ -634,6 +632,11 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
 
   protected SkyFunction newGlobFunction() {
     return new GlobFunction(/*alwaysUseDirListing=*/ false);
+  }
+
+  protected SkyFunction newBlacklistedPackagePrefixesFunction() {
+    return new BlacklistedPackagePrefixesFunction(
+        hardcodedBlacklistedPackagePrefixes, additionalBlacklistedPackagePrefixesFile);
   }
 
   protected SkyFunction newCollectPackagesUnderDirectoryFunction(BlazeDirectories directories) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/TargetPatternFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TargetPatternFunction.java
@@ -48,18 +48,13 @@ public class TargetPatternFunction implements SkyFunction {
         ((TargetPatternValue.TargetPatternKey) key.argument());
     TargetPattern parsedPattern = patternKey.getParsedPattern();
 
-    ImmutableSet<PathFragment> blacklistedPatterns;
-    if (parsedPattern.getRepository() == null) {
-      blacklistedPatterns = ImmutableSet.of();
-    } else {
-      BlacklistedPackagePrefixesValue blacklist =
-          (BlacklistedPackagePrefixesValue)
-              env.getValue(BlacklistedPackagePrefixesValue.key(parsedPattern.getRepository()));
-      if (blacklist == null) {
-        return null;
-      }
-      blacklistedPatterns = blacklist.getPatterns();
+    BlacklistedPackagePrefixesValue blacklist =
+        (BlacklistedPackagePrefixesValue)
+            env.getValue(BlacklistedPackagePrefixesValue.key(parsedPattern.getRepository()));
+    if (blacklist == null) {
+      return null;
     }
+    ImmutableSet<PathFragment> blacklistedPatterns = blacklist.getPatterns();
 
     ResolvedTargets<Target> resolvedTargets;
     try {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/TargetPatternFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TargetPatternFunction.java
@@ -44,13 +44,23 @@ public class TargetPatternFunction implements SkyFunction {
   @Override
   public SkyValue compute(SkyKey key, Environment env) throws TargetPatternFunctionException,
       InterruptedException {
-    BlacklistedPackagePrefixesValue blacklisted =
-        (BlacklistedPackagePrefixesValue) env.getValue(BlacklistedPackagePrefixesValue.key());
-    if (env.valuesMissing()) {
-      return null;
-    }
     TargetPatternValue.TargetPatternKey patternKey =
         ((TargetPatternValue.TargetPatternKey) key.argument());
+    TargetPattern parsedPattern = patternKey.getParsedPattern();
+
+    ImmutableSet<PathFragment> blacklistedPatterns;
+    if (parsedPattern.getRepository() == null) {
+      blacklistedPatterns = ImmutableSet.of();
+    } else {
+      BlacklistedPackagePrefixesValue blacklist =
+          (BlacklistedPackagePrefixesValue)
+              env.getValue(BlacklistedPackagePrefixesValue.key(parsedPattern.getRepository()));
+      if (blacklist == null) {
+        return null;
+      }
+      blacklistedPatterns = blacklist.getPatterns();
+    }
+
     ResolvedTargets<Target> resolvedTargets;
     try {
       EnvironmentBackedRecursivePackageProvider provider =
@@ -61,7 +71,6 @@ public class TargetPatternFunction implements SkyFunction {
               env.getListener(),
               patternKey.getPolicy(),
               MultisetSemaphore.<PackageIdentifier>unbounded());
-      TargetPattern parsedPattern = patternKey.getParsedPattern();
       ImmutableSet<PathFragment> excludedSubdirectories = patternKey.getExcludedSubdirectories();
       ResolvedTargets.Builder<Target> resolvedTargetsBuilder = ResolvedTargets.builder();
       BatchCallback<Target, RuntimeException> callback =
@@ -75,7 +84,7 @@ public class TargetPatternFunction implements SkyFunction {
           };
       parsedPattern.eval(
           resolver,
-          blacklisted.getPatterns(),
+          blacklistedPatterns,
           excludedSubdirectories,
           callback,
           // The exception type here has to match the one on the BatchCallback. Since the callback


### PR DESCRIPTION
RELNOTES[NEW]:
Similar to the [.bazelignore](https://docs.bazel.build/versions/master/guide.html#.bazelignore) in the main repository, a `.bazelignore` file in external repository will cause the specified directories to be ignored by Bazel. Bazel won't try to identify any packages under the directories, but the files can still be referenced in other BUILD files.

Fixes https://github.com/bazelbuild/bazel/issues/10234
Fixes https://github.com/bazelbuild/bazel/issues/9080