### PR TITLE
Add --incompatible_remove_enabled_toolchain_types flag.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
@@ -493,6 +493,20 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
   public boolean incompatibleRemapMainRepo;
 
   @Option(
+      name = "incompatible_remove_enabled_toolchain_types",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
+      metadataTags = {
+        OptionMetadataTag.INCOMPATIBLE_CHANGE,
+        OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+      },
+      help =
+          "If set to true, the platform configuration fragment cannot access the (deprecated) list"
+              + " of enabled toolchain types.")
+  public boolean incompatibleRemoveEnabledToolchainTypes;
+
+  @Option(
       name = "incompatible_remove_native_maven_jar",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
@@ -643,6 +657,7 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
             .incompatibleNoSupportToolsInActionInputs(incompatibleNoSupportToolsInActionInputs)
             .incompatibleNoTargetOutputGroup(incompatibleNoTargetOutputGroup)
             .incompatibleRemapMainRepo(incompatibleRemapMainRepo)
+            .incompatibleRemoveEnabledToolchainTypes(incompatibleRemoveEnabledToolchainTypes)
             .incompatibleRemoveNativeMavenJar(incompatibleRemoveNativeMavenJar)
             .incompatibleRestrictNamedParams(incompatibleRestrictNamedParams)
             .incompatibleRunShellCommandString(incompatibleRunShellCommandString)

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/platform/PlatformConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/platform/PlatformConfigurationApi.java
@@ -20,6 +20,7 @@ import com.google.devtools.build.lib.skylarkinterface.SkylarkCallable;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkModule;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkModuleCategory;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkValue;
+import com.google.devtools.build.lib.syntax.StarlarkSemantics.FlagIdentifier;
 import java.util.List;
 
 /** The platform configuration. */
@@ -46,6 +47,7 @@ public interface PlatformConfigurationApi extends SkylarkValue {
   @SkylarkCallable(
       name = "enabled_toolchain_types",
       structField = true,
+      disableWithFlag = FlagIdentifier.INCOMPATIBLE_REMOVE_ENABLE_TOOLCHAIN_TYPES,
       doc = "The set of toolchain types enabled for platform-based toolchain selection.")
   List<Label> getEnabledToolchainTypes();
 }

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
@@ -66,6 +66,8 @@ public abstract class StarlarkSemantics {
     INCOMPATIBLE_NO_TARGET_OUTPUT_GROUP(StarlarkSemantics::incompatibleNoTargetOutputGroup),
     INCOMPATIBLE_NO_ATTR_LICENSE(StarlarkSemantics::incompatibleNoAttrLicense),
     INCOMPATIBLE_ALLOW_TAGS_PROPAGATION(StarlarkSemantics::experimentalAllowTagsPropagation),
+    INCOMPATIBLE_REMOVE_ENABLE_TOOLCHAIN_TYPES(
+        StarlarkSemantics::incompatibleRemoveEnabledToolchainTypes),
     NONE(null);
 
     // Using a Function here makes the enum definitions far cleaner, and, since this is
@@ -184,6 +186,8 @@ public abstract class StarlarkSemantics {
 
   public abstract boolean incompatibleRemapMainRepo();
 
+  public abstract boolean incompatibleRemoveEnabledToolchainTypes();
+
   public abstract boolean incompatibleRemoveNativeMavenJar();
 
   public abstract boolean incompatibleRestrictNamedParams();
@@ -270,6 +274,7 @@ public abstract class StarlarkSemantics {
           .incompatibleNoSupportToolsInActionInputs(true)
           .incompatibleNoTargetOutputGroup(true)
           .incompatibleRemapMainRepo(true)
+          .incompatibleRemoveEnabledToolchainTypes(false)
           .incompatibleRemoveNativeMavenJar(true)
           .incompatibleRunShellCommandString(false)
           .incompatibleRestrictNamedParams(true)
@@ -346,6 +351,8 @@ public abstract class StarlarkSemantics {
     public abstract Builder incompatibleNoTargetOutputGroup(boolean value);
 
     public abstract Builder incompatibleRemapMainRepo(boolean value);
+
+    public abstract Builder incompatibleRemoveEnabledToolchainTypes(boolean value);
 
     public abstract Builder incompatibleRemoveNativeMavenJar(boolean value);
 

--- a/src/test/java/com/google/devtools/build/lib/packages/SkylarkSemanticsConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/SkylarkSemanticsConsistencyTest.java
@@ -152,6 +152,7 @@ public class SkylarkSemanticsConsistencyTest {
         "--incompatible_no_support_tools_in_action_inputs=" + rand.nextBoolean(),
         "--incompatible_no_target_output_group=" + rand.nextBoolean(),
         "--incompatible_remap_main_repo=" + rand.nextBoolean(),
+        "--incompatible_remove_enabled_toolchain_types=" + rand.nextBoolean(),
         "--incompatible_remove_native_maven_jar=" + rand.nextBoolean(),
         "--incompatible_restrict_named_params=" + rand.nextBoolean(),
         "--incompatible_run_shell_command_string=" + rand.nextBoolean(),
@@ -202,6 +203,7 @@ public class SkylarkSemanticsConsistencyTest {
         .incompatibleNoSupportToolsInActionInputs(rand.nextBoolean())
         .incompatibleNoTargetOutputGroup(rand.nextBoolean())
         .incompatibleRemapMainRepo(rand.nextBoolean())
+        .incompatibleRemoveEnabledToolchainTypes(rand.nextBoolean())
         .incompatibleRemoveNativeMavenJar(rand.nextBoolean())
         .incompatibleRestrictNamedParams(rand.nextBoolean())
         .incompatibleRunShellCommandString(rand.nextBoolean())

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/PlatformConfigurationApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/PlatformConfigurationApiTest.java
@@ -14,15 +14,15 @@
 package com.google.devtools.build.lib.rules.platform;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.testutil.MoreAsserts.assertThrows;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.SkylarkProvider.SkylarkKey;
 import com.google.devtools.build.lib.packages.StructImpl;
-import com.google.devtools.build.lib.skylarkbuildapi.platform.PlatformConfigurationApi;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -35,42 +35,66 @@ public class PlatformConfigurationApiTest extends BuildViewTestCase {
   public void testHostPlatform() throws Exception {
     scratch.file("platforms/BUILD", "platform(name = 'test_platform')");
 
-    useConfiguration("--host_platform=//platforms:test_platform");
-    ruleBuilder().build();
     scratch.file(
-        "foo/BUILD",
-        "load(':extension.bzl', 'my_rule')",
-        "my_rule(",
-        "  name = 'my_skylark_rule',",
+        "verify/verify.bzl",
+        "result = provider()",
+        "def _impl(ctx):",
+        "  platformConfig = ctx.fragments.platform",
+        "  host_platform = platformConfig.host_platform",
+        "  return [result(",
+        "    host_platform = host_platform,",
+        "  )]",
+        "verify = rule(",
+        "  implementation = _impl,",
+        "  fragments = ['platform'],",
         ")");
-    assertNoEvents();
+    scratch.file("verify/BUILD", "load(':verify.bzl', 'verify')", "verify(name = 'verify')");
 
-    PlatformConfigurationApi platformConfiguration = fetchPlatformConfiguration();
-    assertThat(platformConfiguration).isNotNull();
-    assertThat(platformConfiguration.getHostPlatform())
-        .isEqualTo(Label.parseAbsoluteUnchecked("//platforms:test_platform"));
+    useConfiguration("--host_platform=//platforms:test_platform");
+
+    ConfiguredTarget myRuleTarget = getConfiguredTarget("//verify:verify");
+    StructImpl info =
+        (StructImpl)
+            myRuleTarget.get(
+                new SkylarkKey(
+                    Label.parseAbsolute("//verify:verify.bzl", ImmutableMap.of()), "result"));
+
+    @SuppressWarnings("unchecked")
+    Label hostPlatform = (Label) info.getValue("host_platform");
+    assertThat(hostPlatform).isEqualTo(Label.parseAbsoluteUnchecked("//platforms:test_platform"));
   }
 
   @Test
   public void testTargetPlatform_single() throws Exception {
     scratch.file("platforms/BUILD", "platform(name = 'test_platform')");
 
-    useConfiguration("--platforms=//platforms:test_platform");
-    ruleBuilder().build();
     scratch.file(
-        "foo/BUILD",
-        "load(':extension.bzl', 'my_rule')",
-        "my_rule(",
-        "  name = 'my_skylark_rule',",
+        "verify/verify.bzl",
+        "result = provider()",
+        "def _impl(ctx):",
+        "  platformConfig = ctx.fragments.platform",
+        "  target_platform = platformConfig.platform",
+        "  return [result(",
+        "    target_platform = target_platform,",
+        "  )]",
+        "verify = rule(",
+        "  implementation = _impl,",
+        "  fragments = ['platform'],",
         ")");
-    assertNoEvents();
+    scratch.file("verify/BUILD", "load(':verify.bzl', 'verify')", "verify(name = 'verify')");
 
-    PlatformConfigurationApi platformConfiguration = fetchPlatformConfiguration();
-    assertThat(platformConfiguration).isNotNull();
-    assertThat(platformConfiguration.getTargetPlatform())
-        .isEqualTo(Label.parseAbsoluteUnchecked("//platforms:test_platform"));
-    assertThat(platformConfiguration.getTargetPlatforms())
-        .containsExactly(Label.parseAbsoluteUnchecked("//platforms:test_platform"));
+    useConfiguration("--platforms=//platforms:test_platform");
+
+    ConfiguredTarget myRuleTarget = getConfiguredTarget("//verify:verify");
+    StructImpl info =
+        (StructImpl)
+            myRuleTarget.get(
+                new SkylarkKey(
+                    Label.parseAbsolute("//verify:verify.bzl", ImmutableMap.of()), "result"));
+
+    @SuppressWarnings("unchecked")
+    Label targetPlatform = (Label) info.getValue("target_platform");
+    assertThat(targetPlatform).isEqualTo(Label.parseAbsoluteUnchecked("//platforms:test_platform"));
   }
 
   @Test
@@ -81,54 +105,73 @@ public class PlatformConfigurationApiTest extends BuildViewTestCase {
         "toolchain_type(name = 'test_toolchain_type2')",
         "toolchain_type(name = 'test_toolchain_type3')");
 
+    scratch.file(
+        "verify/verify.bzl",
+        "result = provider()",
+        "def _impl(ctx):",
+        "  platformConfig = ctx.fragments.platform",
+        "  enabled_toolchain_types = platformConfig.enabled_toolchain_types",
+        "  return [result(",
+        "    enabled_toolchain_types = enabled_toolchain_types,",
+        "  )]",
+        "verify = rule(",
+        "  implementation = _impl,",
+        "  fragments = ['platform'],",
+        ")");
+    scratch.file("verify/BUILD", "load(':verify.bzl', 'verify')", "verify(name = 'verify',", ")");
+
+    setSkylarkSemanticsOptions("--incompatible_remove_enabled_toolchain_types=false");
     useConfiguration(
         "--enabled_toolchain_types="
             + "//toolchains:test_toolchain_type1,//toolchains:test_toolchain_type3");
-    ruleBuilder().build();
-    scratch.file(
-        "foo/BUILD",
-        "load(':extension.bzl', 'my_rule')",
-        "my_rule(",
-        "  name = 'my_skylark_rule',",
-        ")");
-    assertNoEvents();
 
-    PlatformConfigurationApi platformConfiguration = fetchPlatformConfiguration();
-    assertThat(platformConfiguration).isNotNull();
-    assertThat(platformConfiguration.getEnabledToolchainTypes())
+    ConfiguredTarget myRuleTarget = getConfiguredTarget("//verify:verify");
+    StructImpl info =
+        (StructImpl)
+            myRuleTarget.get(
+                new SkylarkKey(
+                    Label.parseAbsolute("//verify:verify.bzl", ImmutableMap.of()), "result"));
+
+    @SuppressWarnings("unchecked")
+    List<Label> enabledToolchainTypes = (List<Label>) info.getValue("enabled_toolchain_types");
+    assertThat(enabledToolchainTypes)
         .containsExactly(
             Label.parseAbsoluteUnchecked("//toolchains:test_toolchain_type1"),
             Label.parseAbsoluteUnchecked("//toolchains:test_toolchain_type3"));
   }
 
-  private RuleBuilder ruleBuilder() {
-    return new RuleBuilder();
-  }
+  @Test
+  public void testEnabledToolchainTypes_disabled() throws Exception {
+    scratch.file(
+        "toolchains/BUILD",
+        "toolchain_type(name = 'test_toolchain_type1')",
+        "toolchain_type(name = 'test_toolchain_type2')",
+        "toolchain_type(name = 'test_toolchain_type3')");
 
-  private class RuleBuilder {
-    private void build() throws Exception {
-      ImmutableList.Builder<String> lines = ImmutableList.builder();
-      lines.add(
-          "result = provider()",
-          "def _impl(ctx):",
-          "  platformConfig = ctx.fragments.platform",
-          "  return [result(property = platformConfig)]");
-      lines.add("my_rule = rule(", "  implementation = _impl,", "  fragments = ['platform'],", ")");
+    scratch.file(
+        "verify/verify.bzl",
+        "result = provider()",
+        "def _impl(ctx):",
+        "  platformConfig = ctx.fragments.platform",
+        "  enabled_toolchain_types = platformConfig.enabled_toolchain_types",
+        "  return [result(",
+        "    enabled_toolchain_types = enabled_toolchain_types,",
+        "  )]",
+        "verify = rule(",
+        "  implementation = _impl,",
+        "  fragments = ['platform'],",
+        ")");
+    scratch.file("verify/BUILD", "load(':verify.bzl', 'verify')", "verify(name = 'verify',", ")");
 
-      scratch.file("foo/extension.bzl", lines.build().toArray(new String[] {}));
-    }
-  }
+    setSkylarkSemanticsOptions("--incompatible_remove_enabled_toolchain_types");
+    useConfiguration(
+        "--enabled_toolchain_types="
+            + "//toolchains:test_toolchain_type1,//toolchains:test_toolchain_type3");
 
-  private PlatformConfigurationApi fetchPlatformConfiguration() throws Exception {
-    ConfiguredTarget myRuleTarget = getConfiguredTarget("//foo:my_skylark_rule");
-    StructImpl info =
-        (StructImpl)
-            myRuleTarget.get(
-                new SkylarkKey(
-                    Label.parseAbsolute("//foo:extension.bzl", ImmutableMap.of()), "result"));
-
-    @SuppressWarnings("unchecked")
-    PlatformConfigurationApi javaInfo = (PlatformConfigurationApi) info.getValue("property");
-    return javaInfo;
+    AssertionError error =
+        assertThrows(AssertionError.class, () -> getConfiguredTarget("//verify:verify"));
+    assertThat(error)
+        .hasMessageThat()
+        .contains("object of type 'platform' has no field 'enabled_toolchain_types'");
   }
 }


### PR DESCRIPTION
This removes the "enabled_toolchain_types" field on the platform
configuration fragment in Starlark.

Part of #10262.