### PR TITLE
docs: fix ios-app tutorial

### DIFF
--- a/site/docs/tutorial/ios-app.md
+++ b/site/docs/tutorial/ios-app.md
@@ -104,12 +104,24 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.4.0",
+    tag = "0.19.0",
 )
+git_repository(
+    name = "build_bazel_rules_swift",
+    remote = "https://github.com/bazelbuild/rules_swift.git",
+	tag = "0.13.0",
+)
+
+git_repository(
+    name = "build_bazel_apple_support",
+    remote = "https://github.com/bazelbuild/apple_support.git",
+	tag = "0.7.2",
+)
+
 git_repository(
     name = "bazel_skylib",
     remote = "https://github.com/bazelbuild/bazel-skylib.git",
-    tag = "0.3.1",
+    tag = "0.9.0",
 )
 ```
 
@@ -174,7 +186,6 @@ objc_library(
          "UrlGet/main.m",
     ],
     hdrs = glob(["UrlGet/*.h"]),
-    xibs = ["UrlGet/UrlGetViewController.xib"],
 )
 ```
 
@@ -198,6 +209,7 @@ ios_application(
     ],
     minimum_os_version = "9.0",
     infoplists = [":UrlGet/UrlGet-Info.plist"],
+    launch_storyboard = "UrlGet/UrlGetViewController.xib",
     visibility = ["//visibility:public"],
     deps = [":UrlGetClasses"],
 )

--- a/site/docs/tutorial/ios-app.md
+++ b/site/docs/tutorial/ios-app.md
@@ -186,6 +186,7 @@ objc_library(
          "UrlGet/main.m",
     ],
     hdrs = glob(["UrlGet/*.h"]),
+    data = ["UrlGet/UrlGetViewController.xib"],
 )
 ```
 
@@ -209,7 +210,6 @@ ios_application(
     ],
     minimum_os_version = "9.0",
     infoplists = [":UrlGet/UrlGet-Info.plist"],
-    launch_storyboard = "UrlGet/UrlGetViewController.xib",
     visibility = ["//visibility:public"],
     deps = [":UrlGetClasses"],
 )


### PR DESCRIPTION
The patch allows `bazel build //ios-app:ios-app` work well following "Create a BUILD file" instructions in [Introduction to Bazel: Building an iOS App](https://docs.bazel.build/versions/master/tutorial/ios-app.html).