### PR TITLE
Support .bazelversion and $USE_BAZEL_VERSION in Bazel's wrapper script.

### DIFF
--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -41,6 +41,14 @@ filegroup(
     }),
 )
 
+filegroup(
+    name = "wrapper",
+    srcs = ["bazel.sh"],
+    visibility = [
+        "//src/test/shell/bazel:__subpackages__",
+    ]
+)
+
 sh_binary(
     name = "package-info-generator",
     srcs = ["package_info_generator.sh"],

--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015 The Bazel Authors. All rights reserved.
+# Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,10 +16,37 @@
 
 set -eu
 
-# This is a script which is installed instead of the real Bazel binary.
-# It looks for a tools/bazel executable next to the containing WORKSPACE
-# file and runs that. If that's not found, it runs the real Bazel binary which
-# is installed next to this script as bazel-real.
+# This is a script which can be installed as your "bazel" binary instead of the
+# real Bazel binary. When called, it tries to determine and run the correct
+# Bazel version for a given project and forwards all arguments to it.
+#
+# You can specify which Bazel version to use using these methods:
+# 1. Set $USE_BAZEL_VERSION to a version number
+#    (e.g. export USE_BAZEL_VERSION=0.29.1).
+# 2. Add a .bazelversion file that contains a version number next to your
+#    WORKSPACE file.
+# 3. Otherwise, the latest Bazel version will be used.
+#
+# This wrapper only recognizes Bazel versions installed next to itself, thus
+# if you install this wrapper as /usr/bin/bazel, you'll have to install binaries
+# for individual Bazel binaries as e.g. /usr/bin/bazel-0.29.1.
+#
+# In addition, if an executable called "tools/bazel" is found in the current
+# workspace, this script will not directly execute Bazel, but instead store
+# the path to the real Bazel executable in the environment variable BAZEL_REAL
+# and then execute the "tools/bazel" wrapper script.
+#
+# In contrast to Bazelisk, this script does not download anything from the
+# internet and instead relies on the local system to provide Bazel binaries.
+
+function color() {
+      # Usage: color "31;5" "string"
+      # Some valid values for color:
+      # - 5 blink, 1 strong, 4 underlined
+      # - fg: 31 red,  32 green, 33 yellow, 34 blue, 35 purple, 36 cyan, 37 white
+      # - bg: 40 black, 41 red, 44 blue, 45 purple
+      printf '\033[%sm%s\033[0m\n' "$@"
+}
 
 # `readlink -f` that works on OSX too.
 function get_realpath() {
@@ -61,29 +88,77 @@ function get_realpath() {
     fi
 }
 
-BAZEL_REAL="$(dirname "$(get_realpath "${BASH_SOURCE[0]}")")/bazel-real"
-export BAZEL_REAL
-
-WORKSPACE_DIR="${PWD}"
-while [[ "${WORKSPACE_DIR}" != / ]]; do
-    if [[ -e "${WORKSPACE_DIR}/WORKSPACE" ]]; then
-      break;
+function get_workspace_root() {
+  workspace_dir="${PWD}"
+  while [[ "${workspace_dir}" != / ]]; do
+    if [[ -e "${workspace_dir}/WORKSPACE" ]]; then
+      readonly workspace_dir
+      return
     fi
-    WORKSPACE_DIR="$(dirname "${WORKSPACE_DIR}")"
-done
-readonly WORKSPACE_DIR
+    workspace_dir="$(dirname "${workspace_dir}")"
+  done
+  readonly workspace_dir=""
+}
 
-if [[ -e "${WORKSPACE_DIR}/WORKSPACE" ]]; then
-  readonly WRAPPER="${WORKSPACE_DIR}/tools/bazel"
+get_workspace_root
 
-  if [[ -x "${WRAPPER}" && ! -d "${WRAPPER}" ]]; then
-    exec -a "$0" "${WRAPPER}" "$@"
+readonly wrapper_dir="$(dirname "$(get_realpath "${BASH_SOURCE[0]}")")"
+
+function get_bazel_version() {
+  if [[ -n ${USE_BAZEL_VERSION:-} ]]; then
+    readonly reason="specified in \$USE_BAZEL_VERSION"
+    readonly bazel_version="bazel-${USE_BAZEL_VERSION}"
+  elif [[ -e "${workspace_dir}/.bazelversion" ]]; then
+    readonly reason="specified in ${workspace_dir}/.bazelversion"
+    read -r bazel_version < "${workspace_dir}/.bazelversion"
+    readonly bazel_version="bazel-${bazel_version}"
+  elif [[ -x "${wrapper_dir}/bazel-real" ]]; then
+    readonly reason="automatically selected bazel-real"
+    readonly bazel_version="bazel-real"
+  else
+    readonly reason="automatically selected latest available version"
+    readonly bazel_version="$(basename $(find -H "${wrapper_dir}" -maxdepth 1 -name 'bazel-[0-9]*' -type f | sort -V | tail -n 1) 2>/dev/null)"
   fi
+}
+
+get_bazel_version
+
+if [[ -z $bazel_version ]]; then
+  (color "31" "ERROR: No installed Bazel version found, cannot continue."
+  echo ""
+  echo "Workspace root is: ${workspace_dir:-<empty>}"
+  echo "Selected Bazel version is: ${bazel_version:-<empty>} (${reason:-<empty>})"
+  echo ""
+  echo "You can specify which Bazel version to use using these methods:"
+  echo "1. Set \$USE_BAZEL_VERSION to a version number (e.g. export USE_BAZEL_VERSION=0.29.1)."
+  echo "2. Add a .bazelversion file that contains a version number next to your WORKSPACE file."
+  echo "3. Otherwise, the latest Bazel version installed as ${wrapper_dir}/bazel-* will be used."
+  echo ""
+  echo "For case 1 and 2, a binary called \"bazel-\$version\" (e.g. \"bazel-0.29.1\") must be present in ${wrapper_dir}."
+  echo ""
+  echo "You might be able to install specific Bazel versions via apt-get:"
+  echo "  $ apt-get update && apt-get install bazel-0.29.1") >&2
+  exit 1
 fi
 
-if [[ ! -x "${BAZEL_REAL}" ]]; then
-    echo "Failed to find underlying Bazel executable at ${BAZEL_REAL}" >&2
-    exit 1
+BAZEL_REAL="${wrapper_dir}/${bazel_version}"
+
+if [[ ! -x $BAZEL_REAL ]]; then
+  (color "31" "ERROR: Required Bazel binary \"${bazel_version}\" (${reason}) not found in ${wrapper_dir}."
+  echo ""
+  echo "Workspace root is: ${workspace_dir:-<empty>}"
+  echo "Bazel version is: ${bazel_version:-<empty>} (${reason:-<empty>})"
+  echo "Bazel binary is: ${BAZEL_REAL:-<empty>}"
+  echo ""
+  echo "If this is an officially released Bazel version, you might be able to install it:"
+  echo "  $ apt-get update && apt-get install ${bazel_version}") >&2
+  exit 1
+fi
+
+readonly wrapper="${workspace_dir}/tools/bazel"
+if [[ -x "$wrapper" ]]; then
+  export BAZEL_REAL
+  exec -a "$0" "${wrapper}" "$@"
 fi
 
 exec -a "$0" "${BAZEL_REAL}" "$@"

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -145,6 +145,19 @@ sh_test(
 )
 
 sh_test(
+    name = "bazel_wrapper_test",
+    srcs = ["bazel_wrapper_test.sh"],
+    data = [
+        ":test-deps",
+        "//scripts/packages:wrapper",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+    tags = [
+        "no_windows",  # wrapper is not used on Windows
+    ],
+)
+
+sh_test(
     name = "bazel_java_test_no_windows",
     size = "large",
     timeout = "eternal",

--- a/src/test/shell/bazel/bazel_wrapper_test.sh
+++ b/src/test/shell/bazel/bazel_wrapper_test.sh
@@ -60,9 +60,9 @@ EOF
 
 setup_mock() {
   # Setup a mock workspace.
-  mkdir workspace workspace/subdir
-  touch workspace/{BUILD,WORKSPACE}
-  touch workspace/subdir/BUILD
+  mkdir ws ws/subdir
+  touch ws/{BUILD,WORKSPACE}
+  touch ws/subdir/BUILD
 
   # Setup a mock "/usr/bin" folder with the wrapper and some "Bazel" binaries.
   mkdir bin
@@ -72,7 +72,7 @@ setup_mock() {
   mock_bazel "bin/bazel-1.0.1"
   mock_bazel "bin/bazel-real"
 
-  cd workspace
+  cd ws
 }
 
 test_use_bazel_version_envvar() {

--- a/src/test/shell/bazel/bazel_wrapper_test.sh
+++ b/src/test/shell/bazel/bazel_wrapper_test.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+#
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# An end-to-end test for the wrapper used by our installer and distro packages.
+
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+    if [[ -f "$0.runfiles_manifest" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+      export RUNFILES_DIR="$0.runfiles"
+    fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+set -e
+
+wrapper=$(rlocation io_bazel/scripts/packages/bazel.sh)
+
+mock_bazel() {
+  cat > "$1" <<'EOF'
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Hello from $(basename $0)!"
+echo "My args: $@"
+
+exit 0
+EOF
+  chmod +x "$1"
+}
+
+setup_mock() {
+  # Setup a mock workspace.
+  mkdir workspace workspace/subdir
+  touch workspace/{BUILD,WORKSPACE}
+  touch workspace/subdir/BUILD
+
+  # Setup a mock "/usr/bin" folder with the wrapper and some "Bazel" binaries.
+  mkdir bin
+  cp "$wrapper" "bin/bazel"
+  chmod +x "bin/bazel"
+  mock_bazel "bin/bazel-0.29.1"
+  mock_bazel "bin/bazel-1.0.1"
+  mock_bazel "bin/bazel-real"
+
+  cd workspace
+}
+
+test_use_bazel_version_envvar() {
+  setup_mock
+
+  USE_BAZEL_VERSION="0.29.1" ../bin/bazel version &> "$TEST_log"
+  expect_log "Hello from bazel-0.29.1"
+  expect_log "My args: version"
+}
+
+test_bazelversion_file() {
+  setup_mock
+
+  echo "1.0.1" > .bazelversion
+
+  ../bin/bazel info &> "$TEST_log"
+  expect_log "Hello from bazel-1.0.1"
+  expect_log "My args: info"
+
+  cd subdir
+  ../../bin/bazel build //src:bazel &> "$TEST_log"
+  expect_log "Hello from bazel-1.0.1"
+  expect_log "My args: build //src:bazel"
+}
+
+test_uses_bazelreal() {
+  setup_mock
+
+  ../bin/bazel &> "$TEST_log"
+  expect_log "Hello from bazel-real"
+  expect_log "My args:"
+}
+
+test_uses_latest_version() {
+  setup_mock
+
+  rm ../bin/bazel-real
+  ../bin/bazel &> "$TEST_log"
+  expect_log "Hello from bazel-1.0.1"
+
+  rm ../bin/bazel-1.0.1
+  ../bin/bazel &> "$TEST_log"
+  expect_log "Hello from bazel-0.29.1"
+}
+
+test_error_message_for_no_available_bazel_version() {
+  setup_mock
+
+  rm ../bin/bazel-*
+  if ../bin/bazel &> "$TEST_log"; then
+    fail "Bazel wrapper should have failed"
+  fi
+  expect_log "No installed Bazel version found, cannot continue"
+}
+
+test_error_message_for_required_bazel_not_found() {
+  setup_mock
+
+  if USE_BAZEL_VERSION="foobar" ../bin/bazel &> "$TEST_log"; then
+    fail "Bazel wrapper should have failed"
+  fi
+  expect_log "ERROR: Required Bazel binary \"bazel-foobar\" (specified in \$USE_BAZEL_VERSION) not found"
+}
+
+test_delegates_to_wrapper_if_present() {
+  setup_mock
+
+  mkdir tools
+  cat > tools/bazel <<'EOF'
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Hello from the wrapper tools/bazel!"
+echo "BAZEL_REAL = ${BAZEL_REAL}"
+echo "My args: $@"
+
+exit 0
+EOF
+  chmod +x tools/bazel
+
+  USE_BAZEL_VERSION="0.29.1" ../bin/bazel build //src:bazel &> "$TEST_log"
+  expect_log "Hello from the wrapper tools/bazel!"
+  expect_log "BAZEL_REAL = .*/bin/bazel-0.29.1"
+  expect_log "My args: build //src:bazel"
+}
+
+run_suite "Integration tests for scripts/packages/bazel.sh."


### PR DESCRIPTION
This will allow users to install multiple versions of Bazel and have the
wrapper automatically determine and run the correct version for each
project.