### PR TITLE
Allow a bootstrap build of Bazel on OpenBSD to succeed.

### DIFF
--- a/scripts/bootstrap/buildenv.sh
+++ b/scripts/bootstrap/buildenv.sh
@@ -93,6 +93,11 @@ freebsd)
   JAVA_HOME="${JAVA_HOME:-/usr/local/openjdk8}"
   ;;
 
+openbsd)
+  # JAVA_HOME must point to a Java installation.
+  JAVA_HOME="${JAVA_HOME:-/usr/local/jdk-1.8.0}"
+  ;;
+
 darwin)
   if [[ -z "$JAVA_HOME" ]]; then
     JAVA_HOME="$(/usr/libexec/java_home -v ${JAVA_VERSION}+ 2> /dev/null)" \

--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -20,6 +20,7 @@ filegroup(
             ":zip-bazel-exe_nojdk",
         ],
         "//src/conditions:freebsd": [],
+        "//src/conditions:openbsd": [],
         "//src/conditions:darwin": [
             ":with-jdk/install.sh",
             ":without-jdk/install.sh",

--- a/scripts/packages/template_bin.sh
+++ b/scripts/packages/template_bin.sh
@@ -115,6 +115,10 @@ if [ -z "${JAVA_HOME-}" ]; then
       JAVA_HOME="/usr/local/openjdk8"
       BASHRC="~/.bashrc"
       ;;
+    openbsd)
+      JAVA_HOME="/usr/local/jdk-1.8.0"
+      BASHRC="~/.bashrc"
+      ;;
     darwin)
       JAVA_HOME="$(/usr/libexec/java_home -v ${JAVA_VERSION}+ 2> /dev/null)" || true
       BASHRC="~/.bash_profile"

--- a/src/BUILD
+++ b/src/BUILD
@@ -7,7 +7,9 @@ load(":rule_size_test.bzl", "rule_size_test")
 exports_files(["jdeps_modules.golden"])
 
 # Keep only the first 32 chars (a hex md5sum) and no trailing newline.
-md5_cmd = "set -e -o pipefail && echo $(SRCS) | sort | xargs %s | %s | head -c 32 > $@"
+# Avoid using the `head` tool's `-c` option, since it does not exist on OpenBSD;
+# here we use `dd` instead.
+md5_cmd = "set -e -o pipefail && echo $(SRCS) | sort | xargs %s | %s | dd bs=32 count=1 > $@"
 
 # TODO(bazel-team): find a better way to handle dylib extensions.
 filegroup(
@@ -40,6 +42,7 @@ filegroup(
         "//src/conditions:darwin": md5_cmd % ("/sbin/md5", "/sbin/md5"),
         "//src/conditions:darwin_x86_64": md5_cmd % ("/sbin/md5", "/sbin/md5"),
         "//src/conditions:freebsd": md5_cmd % ("/sbin/md5", "/sbin/md5"),
+        "//src/conditions:openbsd": md5_cmd % ("/bin/md5", "/bin/md5"),
         "//conditions:default": md5_cmd % ("md5sum", "md5sum"),
     }),
 ) for suffix, embedded_tools_target in {
@@ -354,8 +357,8 @@ filegroup(
         ],
     }),
     outs = ["package" + suffix + ".zip"],
-    cmd = "$(location :package-bazel.sh) $@ " + ("" if embed else "''") + " $(SRCS)",
-    tools = ["package-bazel.sh"],
+    cmd = "$(location :package_bazel_on_host_platform) $@ " + ("" if embed else "''") + " $(SRCS)",
+    tools = [":package_bazel_on_host_platform"],
 ) for suffix, embed in [
     ("_jdk_allmodules", True),
     ("_jdk_minimal", True),
@@ -363,6 +366,16 @@ filegroup(
     ("_notools", False),
     ("_nojdk", True),
 ]]
+
+genrule(
+    name = "package_bazel_on_host_platform",
+    srcs = ["package-bazel.sh"],
+    outs = ["package-bazel-on-host-platform.sh"],
+    cmd = select({
+        "//src/conditions:openbsd": "cat $(SRCS) | sed -e 's@#!/bin/bash@#!/usr/local/bin/bash@' > $@",
+        "//conditions:default": "cp $(SRCS) $@",
+    }),
+)
 
 genrule(
     name = "platforms_archive",

--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -47,6 +47,12 @@ config_setting(
 )
 
 config_setting(
+    name = "openbsd",
+    values = {"cpu": "openbsd"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "windows",
     values = {"cpu": "x64_windows"},
     visibility = ["//visibility:public"],

--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -5,6 +5,12 @@ config_setting(
 )
 
 config_setting(
+    name = "openbsd",
+    values = {"cpu": "openbsd"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "darwin",
     values = {"cpu": "darwin"},
     visibility = ["//visibility:public"],

--- a/src/main/cpp/BUILD
+++ b/src/main/cpp/BUILD
@@ -32,6 +32,10 @@ cc_library(
             "blaze_util_freebsd.cc",
             "blaze_util_posix.cc",
         ],
+        "//src/conditions:openbsd": [
+            "blaze_util_openbsd.cc",
+            "blaze_util_posix.cc",
+        ],
         "//src/conditions:windows": [
             "blaze_util_windows.cc",
         ],
@@ -52,6 +56,8 @@ cc_library(
             "-framework CoreFoundation",
         ],
         "//src/conditions:freebsd": [
+        ],
+        "//src/conditions:openbsd": [
         ],
         "//src/conditions:windows": WIN_LINK_OPTS,
         "//conditions:default": [
@@ -113,6 +119,8 @@ cc_binary(
         "//src/conditions:freebsd": [
             "-lprocstat",
             "-lm",
+        ],
+        "//src/conditions:openbsd": [
         ],
         "//src/conditions:windows": [
         ],

--- a/src/main/cpp/blaze_util_openbsd.cc
+++ b/src/main/cpp/blaze_util_openbsd.cc
@@ -1,0 +1,168 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>  // errno, ENAMETOOLONG
+#include <limits.h>
+#include <pwd.h>
+#include <signal.h>
+#include <spawn.h>
+#include <stdlib.h>
+#include <string.h>  // strerror
+#include <sys/mount.h>
+#include <sys/param.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "src/main/cpp/blaze_util.h"
+#include "src/main/cpp/blaze_util_platform.h"
+#include "src/main/cpp/util/errors.h"
+#include "src/main/cpp/util/exit_code.h"
+#include "src/main/cpp/util/file.h"
+#include "src/main/cpp/util/logging.h"
+#include "src/main/cpp/util/path.h"
+#include "src/main/cpp/util/port.h"
+#include "src/main/cpp/util/strings.h"
+
+namespace blaze {
+
+using blaze_util::GetLastErrorString;
+using std::string;
+
+string GetOutputRoot() {
+  char buf[2048];
+  struct passwd pwbuf;
+  struct passwd *pw = NULL;
+  int uid = getuid();
+  int r = getpwuid_r(uid, &pwbuf, buf, 2048, &pw);
+  if (r != -1 && pw != NULL) {
+    return blaze_util::JoinPath(pw->pw_dir, ".cache/bazel");
+  } else {
+    return "/tmp";
+  }
+}
+
+void WarnFilesystemType(const blaze_util::Path &output_base) {
+  struct statfs buf = {};
+  if (statfs(output_base.AsNativePath().c_str(), &buf) < 0) {
+    BAZEL_LOG(WARNING) << "couldn't get file system type information for '"
+                       << output_base.AsPrintablePath()
+                       << "': " << strerror(errno);
+    return;
+  }
+
+  if (strcmp(buf.f_fstypename, "nfs") == 0) {
+    BAZEL_LOG(WARNING) << "Output base '" << output_base.AsPrintablePath()
+                       << "' is on NFS. This may lead to surprising failures "
+                          "and undetermined behavior.";
+  }
+}
+
+// OpenBSD does not provide an API for a running process to find the path of
+// its own executable, so we try to figure out the path by inspecting argv[0].
+// In theory this is inadequate, since the parent process can set argv[0] to
+// anything, but in practice this is good enough.
+string GetSelfPath(const string& argv0) {
+  // TODO(aldersondrive): Add a new --bazel_executable_path startup option
+  // only on platforms that need it), and inspect it here. If it's set, use its
+  // value instead of applying the heuristics below.
+
+  // If argv[0] starts with a slash, it's an absolute path. Use it.
+  if (argv0.length() > 0 && argv0[0] == '/') {
+    return argv0;
+  }
+
+  // Otherwise, if argv[0] contains a slash, then it's a relative path. Prepend
+  // the current directory to form an absolute path.
+  if (argv0.length() > 0 && argv0.find('/') != string::npos) {
+    char buf[PATH_MAX];
+    if (getcwd(buf, sizeof(buf)) == nullptr) {
+      BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR) << "getcwd failed";
+    }
+    return string(buf) + "/" + argv0;
+  }
+
+  // TODO(aldersondrive): Try to find the executable by inspecting the PATH.
+
+  // None of the above worked. Give up.
+  BAZEL_DIE(blaze_exit_code::BAD_ARGV)
+      << "Unable to determine the location of this Bazel executable. "
+         "Currently, argv[0] must be an absolute or relative path to the "
+         "executable.";
+  return "";  // Never executed. Needed so compiler does not complain.
+}
+
+uint64_t GetMillisecondsMonotonic() {
+  struct timespec ts = {};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1000LL + (ts.tv_nsec / 1000000LL);
+}
+
+void SetScheduling(bool batch_cpu_scheduling, int io_nice_level) {
+  // Stubbed out so we can compile for OpenBSD.
+}
+
+blaze_util::Path GetProcessCWD(int pid) {
+  // OpenBSD does not support looking up the working directory of another
+  // process.
+  return blaze_util::Path("");
+}
+
+bool IsSharedLibrary(const string &filename) {
+  return blaze_util::ends_with(filename, ".so");
+}
+
+string GetSystemJavabase() {
+  // If JAVA_HOME is defined, then use it as default.
+  string javahome = GetPathEnv("JAVA_HOME");
+
+  if (!javahome.empty()) {
+    string javac = blaze_util::JoinPath(javahome, "bin/javac");
+    if (access(javac.c_str(), X_OK) == 0) {
+      return javahome;
+    }
+    BAZEL_LOG(WARNING)
+        << "Ignoring JAVA_HOME, because it must point to a JDK, not a JRE.";
+  }
+
+  return "/usr/local/jdk-1.8.0";
+}
+
+int ConfigureDaemonProcess(posix_spawnattr_t *attrp,
+                           const StartupOptions &options) {
+  // No interesting platform-specific details to configure on this platform.
+  return 0;
+}
+
+void WriteSystemSpecificProcessIdentifier(const blaze_util::Path &server_dir,
+                                          pid_t server_pid) {}
+
+bool VerifyServerProcess(int pid, const blaze_util::Path &output_base) {
+  // TODO(lberki): This only checks for the process's existence, not whether
+  // its start time matches. Therefore this might accidentally kill an
+  // unrelated process if the server died and the PID got reused.
+  return killpg(pid, 0) == 0;
+}
+
+// Not supported.
+void ExcludePathFromBackup(const blaze_util::Path &path) {}
+
+int32_t GetExplicitSystemLimit(const int resource) {
+  return -1;
+}
+
+}  // namespace blaze

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -106,9 +106,13 @@ void SigPrintf(const char *format, ...);
 
 std::string GetProcessIdAsString();
 
-// Get an absolute path to the binary being executed that is guaranteed to be
+// Gets an absolute path to the binary being executed that is guaranteed to be
 // readable.
+#if defined(CAN_FIND_OWN_EXECUTABLE_PATH)
 std::string GetSelfPath();
+#else
+std::string GetSelfPath(const std::string& argv0);
+#endif
 
 // Returns the directory Bazel can use to store output.
 std::string GetOutputRoot();
@@ -129,7 +133,8 @@ uint64_t GetMillisecondsMonotonic();
 // on Linux, so it should only be called when necessary.
 void SetScheduling(bool batch_cpu_scheduling, int io_nice_level);
 
-// Returns the cwd for a process.
+// Returns the cwd for a process, or an empty string if the directory is
+// unknown.
 blaze_util::Path GetProcessCWD(int pid);
 
 bool IsSharedLibrary(const std::string& filename);

--- a/src/main/cpp/util/port.h
+++ b/src/main/cpp/util/port.h
@@ -71,6 +71,21 @@
 #endif
 
 
+// CAN_FIND_OWN_EXECUTABLE_PATH
+//
+// Indicates that a running process can find a path to its own executable.
+#if !defined(__OpenBSD__)
+#define CAN_FIND_OWN_EXECUTABLE_PATH
+#endif
+
+// HAVE_EMULTIHOP
+//
+// Indicates that errno.h defines EMULTIHOP.
+#if !defined(__OpenBSD__)
+#define HAVE_EMULTIHOP
+#endif
+
+
 // Linux I/O priorities support is available only in later versions of glibc.
 // Therefore, we include some of the needed definitions here.  May need to
 // be removed once we switch to a new version of glibc

--- a/src/main/java/com/google/devtools/build/lib/analysis/ShellConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ShellConfiguration.java
@@ -36,6 +36,7 @@ public class ShellConfiguration extends BuildConfiguration.Fragment {
       ImmutableMap.<OS, PathFragment>builder()
           .put(OS.WINDOWS, PathFragment.create("c:/tools/msys64/usr/bin/bash.exe"))
           .put(OS.FREEBSD, PathFragment.create("/usr/local/bin/bash"))
+          .put(OS.OPENBSD, PathFragment.create("/usr/local/bin/bash"))
           .build();
 
   private final PathFragment shellExecutable;

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
@@ -37,6 +37,8 @@ public class AutoCpuConverter implements Converter<String> {
           return "darwin";
         case FREEBSD:
           return "freebsd";
+        case OPENBSD:
+          return "openbsd";
         case WINDOWS:
           switch (CPU.getCurrent()) {
             case X86_64:
@@ -81,6 +83,8 @@ public class AutoCpuConverter implements Converter<String> {
       return Pair.of(CPU.getCurrent(), OS.DARWIN);
     } else if (input.startsWith("freebsd")) {
       return Pair.of(CPU.getCurrent(), OS.FREEBSD);
+    } else if (input.startsWith("openbsd")) {
+      return Pair.of(CPU.getCurrent(), OS.OPENBSD);
     } else if (input.startsWith("x64_windows")) {
       return Pair.of(CPU.getCurrent(), OS.WINDOWS);
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunction.java
@@ -129,6 +129,8 @@ public class LocalConfigPlatformFunction extends RepositoryFunction {
         return "@platforms//os:osx";
       case FREEBSD:
         return "@platforms//os:freebsd";
+      case OPENBSD:
+        return "@platforms//os:openbsd";
       case LINUX:
         return "@platforms//os:linux";
       case WINDOWS:

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -45,6 +45,11 @@ bind(
 )
 
 bind(
+    name = "jni_md_header-openbsd",
+    actual = "@local_jdk//:jni_md_header-openbsd",
+)
+
+bind(
     name = "java",
     actual = "@local_jdk//:java",
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
@@ -235,13 +235,14 @@ public class BazelPythonSemantics implements PythonSemantics {
 
       if (OS.getCurrent() != OS.WINDOWS) {
         PathFragment shExecutable = ShToolchain.getPathOrError(ruleContext);
+        String pythonExecutableName = OS.getCurrent() == OS.OPENBSD ? "python3" : "python";
         ruleContext.registerAction(
             new SpawnAction.Builder()
                 .addInput(zipFile)
                 .addOutput(executable)
                 .setShellCommand(
                     shExecutable,
-                    "echo '#!/usr/bin/env python' | cat - "
+                    "echo '#!/usr/bin/env " + pythonExecutableName + "' | cat - "
                         + zipFile.getExecPathString()
                         + " > "
                         + executable.getExecPathString())

--- a/src/main/java/com/google/devtools/build/lib/platform/JniLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/platform/JniLoader.java
@@ -28,6 +28,7 @@ class JniLoader {
       switch (OS.getCurrent()) {
         case LINUX:
         case FREEBSD:
+        case OPENBSD:
         case UNKNOWN:
         case DARWIN:
           UnixJniLoader.loadJni();

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
@@ -1573,7 +1573,7 @@ public class CppActionConfigs {
   }
 
   private static String ifLinux(CppPlatform platform, String... lines) {
-    // Platform `LINUX` also includes FreeBSD.
+    // Platform `LINUX` also includes FreeBSD and OpenBSD.
     return ifTrue(platform == CppPlatform.LINUX, lines);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -327,6 +327,8 @@ public final class BlazeOptionHandler {
         return "windows";
       case FREEBSD:
         return "freebsd";
+      case OPENBSD:
+        return "openbsd";
       default:
         return OS.getCurrent().getCanonicalName();
     }

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -65,8 +65,8 @@ public class CommonCommandOptions extends OptionsBase {
       help =
           "If true, Bazel picks up host-OS-specific config lines from bazelrc files. For example, "
               + "if the host OS is Linux and you run bazel build, Bazel picks up lines starting "
-              + "with build:linux. Supported OS identifiers are linux, macos, windows, and "
-              + "freebsd. Enabling this flag is equivalent to using --config=linux on Linux, "
+              + "with build:linux. Supported OS identifiers are linux, macos, windows, freebsd, "
+              + "and openbsd. Enabling this flag is equivalent to using --config=linux on Linux, "
               + "--config=windows on Windows, etc.")
   public boolean enablePlatformSpecificConfig;
 

--- a/src/main/java/com/google/devtools/build/lib/util/OS.java
+++ b/src/main/java/com/google/devtools/build/lib/util/OS.java
@@ -21,11 +21,12 @@ import java.util.EnumSet;
 public enum OS {
   DARWIN("osx", "Mac OS X"),
   FREEBSD("freebsd", "FreeBSD"),
+  OPENBSD("openbsd", "OpenBSD"),
   LINUX("linux", "Linux"),
   WINDOWS("windows", "Windows"),
   UNKNOWN("unknown", "");
 
-  private static final EnumSet<OS> POSIX_COMPATIBLE = EnumSet.of(DARWIN, FREEBSD, LINUX);
+  private static final EnumSet<OS> POSIX_COMPATIBLE = EnumSet.of(DARWIN, FREEBSD, OPENBSD, LINUX);
 
   private final String canonicalName;
   private final String detectionName;

--- a/src/main/java/com/google/devtools/build/lib/vfs/OsPathPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/OsPathPolicy.java
@@ -87,6 +87,7 @@ public interface OsPathPolicy {
     switch (OS.getCurrent()) {
       case LINUX:
       case FREEBSD:
+      case OPENBSD:
       case UNKNOWN:
         return UnixOsPathPolicy.INSTANCE;
       case DARWIN:

--- a/src/main/native/BUILD
+++ b/src/main/native/BUILD
@@ -6,6 +6,7 @@ genrule(
         "//src/conditions:darwin": ["//tools/jdk:jni_md_header-darwin"],
         "//src/conditions:darwin_x86_64": ["//tools/jdk:jni_md_header-darwin"],
         "//src/conditions:freebsd": ["//tools/jdk:jni_md_header-freebsd"],
+        "//src/conditions:openbsd": ["//tools/jdk:jni_md_header-openbsd"],
         "//src/conditions:windows": ["//tools/jdk:jni_md_header-windows"],
         "//conditions:default": ["//tools/jdk:jni_md_header-linux"],
     }),
@@ -34,6 +35,7 @@ filegroup(
             "fsevents.cc",
         ],
         "//src/conditions:freebsd": ["unix_jni_freebsd.cc"],
+        "//src/conditions:openbsd": ["unix_jni_openbsd.cc"],
         "//conditions:default": ["unix_jni_linux.cc"],
     }),
 )

--- a/src/main/native/unix_jni.cc
+++ b/src/main/native/unix_jni.cc
@@ -85,7 +85,9 @@ void PostException(JNIEnv *env, int error_number, const std::string& message) {
     case ENAMETOOLONG:  // File name too long
     case ENODATA:    // No data available
     case EINVAL:     // Invalid argument
+#if defined(HAVE_EMULTIHOP)
     case EMULTIHOP:  // Multihop attempted
+#endif
     case ENOLINK:    // Link has been severed
     case EIO:        // I/O error
     case EAGAIN:     // Try again

--- a/src/main/native/unix_jni.h
+++ b/src/main/native/unix_jni.h
@@ -33,7 +33,7 @@ namespace blaze_jni {
       } \
     } while (0)
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 // stat64 is deprecated on OS X/BSD.
 typedef struct stat portable_stat_struct;
 #define portable_stat ::stat
@@ -44,7 +44,7 @@ typedef struct stat64 portable_stat_struct;
 #define portable_lstat ::lstat64
 #endif
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #define ENODATA ENOATTR
 #endif
 

--- a/src/main/native/unix_jni_openbsd.cc
+++ b/src/main/native/unix_jni_openbsd.cc
@@ -1,0 +1,118 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/main/native/unix_jni.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+
+#include <string>
+
+namespace blaze_jni {
+
+using std::string;
+
+// See unix_jni.h.
+string ErrorMessage(int error_number) {
+  char buf[1024] = "";
+  if (strerror_r(error_number, buf, sizeof buf) < 0) {
+    snprintf(buf, sizeof buf, "strerror_r(%d): errno %d", error_number, errno);
+  }
+
+  return string(buf);
+}
+
+int portable_fstatat(int dirfd, char *name, portable_stat_struct *statbuf,
+                     int flags) {
+  return fstatat(dirfd, name, statbuf, flags);
+}
+
+int StatSeconds(const portable_stat_struct &statbuf, StatTimes t) {
+  switch (t) {
+    case STAT_ATIME:
+      return statbuf.st_atime;
+    case STAT_CTIME:
+      return statbuf.st_ctime;
+    case STAT_MTIME:
+      return statbuf.st_mtime;
+    default:
+      CHECK(false);
+  }
+}
+
+int StatNanoSeconds(const portable_stat_struct &statbuf, StatTimes t) {
+  switch (t) {
+    case STAT_ATIME:
+      return statbuf.st_atimespec.tv_nsec;
+    case STAT_CTIME:
+      return statbuf.st_ctimespec.tv_nsec;
+    case STAT_MTIME:
+      return statbuf.st_mtimespec.tv_nsec;
+    default:
+      CHECK(false);
+  }
+}
+
+ssize_t portable_getxattr(const char *path, const char *name, void *value,
+                          size_t size, bool *attr_not_found) {
+  *attr_not_found = true;
+  return -1;
+}
+
+ssize_t portable_lgetxattr(const char *path, const char *name, void *value,
+                           size_t size, bool *attr_not_found) {
+  *attr_not_found = true;
+  return -1;
+}
+
+int portable_sysctlbyname(const char *name_chars, long *mibp, size_t *sizep) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int portable_push_disable_sleep() {
+  // Currently not supported.
+  // https://wiki.freebsd.org/SuspendResume
+  return -1;
+}
+
+int portable_pop_disable_sleep() {
+  // Currently not supported.
+  // https://wiki.freebsd.org/SuspendResume
+  return -1;
+}
+
+int portable_suspend_count() {
+  // Currently not implemented.
+  return 0;
+}
+
+int portable_memory_pressure_warning_count() {
+  // Currently not implemented.
+  return 0;
+}
+
+int portable_memory_pressure_critical_count() {
+  // Currently not implemented.
+  return 0;
+}
+
+}  // namespace blaze_jni

--- a/src/main/tools/BUILD
+++ b/src/main/tools/BUILD
@@ -67,6 +67,7 @@ cc_binary(
         "//src/conditions:darwin": ["dummy-sandbox.c"],
         "//src/conditions:darwin_x86_64": ["dummy-sandbox.c"],
         "//src/conditions:freebsd": ["dummy-sandbox.c"],
+        "//src/conditions:openbsd": ["dummy-sandbox.c"],
         "//src/conditions:windows": ["dummy-sandbox.c"],
         "//conditions:default": [
             "linux-sandbox.cc",
@@ -82,6 +83,7 @@ cc_binary(
         "//src/conditions:darwin": [],
         "//src/conditions:darwin_x86_64": [],
         "//src/conditions:freebsd": [],
+        "//src/conditions:openbsd": [],
         "//src/conditions:windows": [],
         "//conditions:default": [
             ":logging",

--- a/src/main/tools/jdk.BUILD
+++ b/src/main/tools/jdk.BUILD
@@ -33,6 +33,12 @@ filegroup(
 )
 
 filegroup(
+    name = "jni_md_header-openbsd",
+    srcs = ["include/openbsd/jni_md.h"],
+    deprecation = DEPRECATION_MESSAGE,
+)
+
+filegroup(
     name = "jni_md_header-windows",
     srcs = ["include/win32/jni_md.h"],
     deprecation = DEPRECATION_MESSAGE,

--- a/src/main/tools/process-wrapper-legacy.h
+++ b/src/main/tools/process-wrapper-legacy.h
@@ -21,7 +21,7 @@
 // The process-wrapper implementation that was used until and including Bazel
 // 0.4.5. Waits for the wrapped process to exit and then kills its process
 // group. Works on all POSIX operating systems (tested on Linux, macOS,
-// FreeBSD).
+// FreeBSD, and OpenBSD).
 //
 // Caveats:
 // - Killing just the process group of the spawned child means that daemons or

--- a/src/test/java/com/google/devtools/build/lib/analysis/ShellConfigurationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/ShellConfigurationTest.java
@@ -34,6 +34,8 @@ public class ShellConfigurationTest extends BuildViewTestCase {
         .isEqualTo(PathFragment.create("/bin/bash"));
     assertThat(determineShellExecutable(OS.FREEBSD, null))
         .isEqualTo(PathFragment.create("/usr/local/bin/bash"));
+    assertThat(determineShellExecutable(OS.OPENBSD, null))
+        .isEqualTo(PathFragment.create("/usr/local/bin/bash"));
     assertThat(determineShellExecutable(OS.WINDOWS, null))
         .isEqualTo(PathFragment.create("c:/tools/msys64/usr/bin/bash.exe"));
   }
@@ -44,6 +46,8 @@ public class ShellConfigurationTest extends BuildViewTestCase {
     assertThat(determineShellExecutable(OS.LINUX, binBash))
         .isEqualTo(PathFragment.create("/bin/bash"));
     assertThat(determineShellExecutable(OS.FREEBSD, binBash))
+        .isEqualTo(PathFragment.create("/bin/bash"));
+    assertThat(determineShellExecutable(OS.OPENBSD, binBash))
         .isEqualTo(PathFragment.create("/bin/bash"));
     assertThat(determineShellExecutable(OS.WINDOWS, binBash))
         .isEqualTo(PathFragment.create("/bin/bash"));

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunctionTest.java
@@ -84,6 +84,7 @@ public class LocalConfigPlatformFunctionTest {
           new Object[] {OS.LINUX, "@platforms//os:linux"},
           new Object[] {OS.DARWIN, "@platforms//os:osx"},
           new Object[] {OS.FREEBSD, "@platforms//os:freebsd"},
+          new Object[] {OS.OPENBSD, "@platforms//os:openbsd"},
           new Object[] {OS.WINDOWS, "@platforms//os:windows"});
     }
 

--- a/src/test/java/com/google/devtools/build/lib/packages/util/MockPlatformSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/MockPlatformSupport.java
@@ -84,6 +84,10 @@ public class MockPlatformSupport {
         "constraint_value(",
         "    name = 'freebsd',",
         "    constraint_setting = ':os',",
+        ")"
+        "constraint_value(",
+        "    name = 'openbsd',",
+        "    constraint_setting = ':os',",
         ")");
     String basePlatform;
     if (TestConstants.LOCAL_CONFIG_PLATFORM_PATH != null) {

--- a/src/test/java/com/google/devtools/build/lib/packages/util/MockPlatformSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/MockPlatformSupport.java
@@ -84,7 +84,7 @@ public class MockPlatformSupport {
         "constraint_value(",
         "    name = 'freebsd',",
         "    constraint_setting = ':os',",
-        ")"
+        ")",
         "constraint_value(",
         "    name = 'openbsd',",
         "    constraint_setting = ':os',",

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
@@ -163,6 +163,7 @@ public class BlazeOptionHandlerTest {
     structuredArgs.put("c0:windows", new RcChunkOfArgs("rc1", ImmutableList.of("command_windows")));
     structuredArgs.put("c0:macos", new RcChunkOfArgs("rc1", ImmutableList.of("command_macos")));
     structuredArgs.put("c0:freebsd", new RcChunkOfArgs("rc1", ImmutableList.of("command_freebsd")));
+    structuredArgs.put("c0:openbsd", new RcChunkOfArgs("rc1", ImmutableList.of("command_openbsd")));
     structuredArgs.put(
         "c0:platform_config",
         new RcChunkOfArgs("rc1", ImmutableList.of("--enable_platform_specific_config")));
@@ -328,6 +329,9 @@ public class BlazeOptionHandlerTest {
       case FREEBSD:
         assertThat(parser.getResidue()).containsExactly("command_freebsd");
         break;
+      case OPENBSD:
+        assertThat(parser.getResidue()).containsExactly("command_openbsd");
+        break;
       default:
         assertThat(parser.getResidue()).isEmpty();
     }
@@ -352,6 +356,9 @@ public class BlazeOptionHandlerTest {
         break;
       case FREEBSD:
         assertThat(parser.getResidue()).containsExactly("command_freebsd");
+        break;
+      case OPENBSD:
+        assertThat(parser.getResidue()).containsExactly("command_openbsd");
         break;
       default:
         assertThat(parser.getResidue()).isEmpty();

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -97,7 +97,7 @@ EOF
 
 function test_remote_grpc_via_unix_socket() {
   case "$PLATFORM" in
-  darwin|freebsd|linux)
+  darwin|freebsd|openbsd|linux)
     ;;
   *)
     return 0

--- a/src/test/shell/shell_utils.sh
+++ b/src/test/shell/shell_utils.sh
@@ -110,7 +110,7 @@ function get_real_path() {
 function md5_file() {
   if [ $# -gt 0 ]; then
     local result=""
-    if [[ ${PLATFORM} == "darwin" ]] || [[ ${PLATFORM} == "freebsd" ]]; then
+    if [[ ${PLATFORM} == "darwin" ]] || [[ ${PLATFORM} == "freebsd" ]] || [[ ${PLATFORM} == "openbsd" ]]; then
       result=$(md5 -q $@ || echo)
     else
       result=$(md5sum $@ | awk '{print $1}' || echo)

--- a/src/test/shell/unittest.bash
+++ b/src/test/shell/unittest.bash
@@ -734,9 +734,14 @@ if [ "$UNAME" = "linux" ] || [[ "$UNAME" =~ msys_nt* ]]; then
     function timestamp() {
       echo $(($(date +%s%N)/1000000))
     }
+elif [[ "$UNAME" = "openbsd" ]]; then
+    function timestamp() {
+      # OpenBSD does not have %N, so python is the best we can do.
+      python3 -c 'import time; print(int(round(time.time() * 1000)))'
+    }
 else
     function timestamp() {
-      # OS X and FreeBSD do not have %N so python is the best we can do
+      # OS X and FreeBSD do not have %N, so python is the best we can do.
       python -c 'import time; print(int(round(time.time() * 1000)))'
     }
 fi

--- a/src/tools/singlejar/diag.h
+++ b/src/tools/singlejar/diag.h
@@ -19,7 +19,7 @@
  * Various useful diagnostics functions from Linux err.h file, wrapped
  * for portability.
  */
-#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 
 #include <err.h>
 #define diag_err(...) err(__VA_ARGS__)

--- a/src/tools/singlejar/mapped_file_posix.inc
+++ b/src/tools/singlejar/mapped_file_posix.inc
@@ -24,8 +24,8 @@
 
 #include "src/tools/singlejar/diag.h"
 
-// The implementation is 64-bit Linux or OSX specific.
-#if !((defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)) && \
+// The implementation is specific to 64-bit Linux / OS X / BSD.
+#if !((defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)) && \
       __SIZEOF_POINTER__ == 8)
 #error This code for 64 bit Unix.
 #endif

--- a/src/tools/singlejar/zip_headers.h
+++ b/src/tools/singlejar/zip_headers.h
@@ -27,7 +27,7 @@
 
 #if defined(__linux__)
 #include <endian.h>
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <sys/endian.h>
 #elif defined(__APPLE__) || defined(_WIN32)
 // Hopefully OSX and Windows will keep running solely on little endian CPUs, so:

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -527,6 +527,7 @@ UNNECESSARY_DYNAMIC_LIBRARIES = select({
     "//src/conditions:arm": "*.so *.jnilib *.dll",
     "//src/conditions:linux_aarch64": "*.so *.jnilib *.dll",
     "//src/conditions:linux_ppc": "*.so *.jnilib *.dll",
+    "//src/conditions:openbsd": "*.so *.jnilib *.dll",
     # Play it safe -- better have a big binary than a slow binary
     # zip -d does require an argument. Supply something bogus.
     "//conditions:default": "*.bogusextension",
@@ -706,6 +707,11 @@ config_setting(
 config_setting(
     name = "freebsd",
     values = {"host_cpu": "freebsd"},
+)
+
+config_setting(
+    name = "openbsd",
+    values = {"host_cpu": "openbsd"},
 )
 
 config_setting(

--- a/tools/cpp/BUILD.static.openbsd
+++ b/tools/cpp/BUILD.static.openbsd
@@ -1,0 +1,112 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This becomes the BUILD file for @local_config_cc// under OpenBSD.
+
+package(default_visibility = ["//visibility:public"])
+
+load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+load("@rules_cc//cc:defs.bzl", "cc_toolchain_suite", "cc_toolchain", "cc_library")
+
+cc_library(
+    name = "malloc",
+)
+
+filegroup(
+    name = "empty",
+    srcs = [],
+)
+
+# Hardcoded toolchain, legacy behaviour.
+cc_toolchain_suite(
+    name = "toolchain",
+    toolchains = {
+        "armeabi-v7a|compiler": ":cc-compiler-armeabi-v7a",
+        "openbsd|compiler": ":cc-compiler-openbsd",
+        "armeabi-v7a": ":cc-compiler-armeabi-v7a",
+        "openbsd": ":cc-compiler-openbsd",
+    },
+)
+
+cc_toolchain(
+    name = "cc-compiler-openbsd",
+    toolchain_identifier = "local_openbsd",
+    toolchain_config = ":local_openbsd",
+    all_files = ":empty",
+    ar_files = ":empty",
+    as_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 0,
+)
+
+cc_toolchain_config(
+    name = "local_openbsd",
+    cpu = "openbsd",
+)
+
+toolchain(
+    name = "cc-toolchain-openbsd",
+    exec_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:openbsd",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:openbsd",
+    ],
+    toolchain = ":cc-compiler-openbsd",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+cc_toolchain(
+    name = "cc-compiler-armeabi-v7a",
+    toolchain_identifier = "stub_armeabi-v7a",
+    toolchain_config = ":stub_armeabi-v7a",
+    all_files = ":empty",
+    ar_files = ":empty",
+    as_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 0,
+)
+
+cc_toolchain_config(
+    name = "stub_armeabi-v7a",
+    cpu = "armeabi-v7a",
+)
+
+toolchain(
+    name = "cc-toolchain-armeabi-v7a",
+    exec_compatible_with = [
+        "@platforms//cpu:arm",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:arm",
+        "@platforms//os:android",
+    ],
+    toolchain = ":cc-compiler-armeabi-v7a",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+filegroup(
+    name = "link_dynamic_library",
+    srcs = ["link_dynamic_library.sh"],
+)

--- a/tools/cpp/BUILD.tpl
+++ b/tools/cpp/BUILD.tpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This becomes the BUILD file for @local_config_cc// under non-FreeBSD unixes.
+# This becomes the BUILD file for @local_config_cc// under non-BSD unixes.
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -108,12 +108,24 @@ def cc_autoconf_impl(repository_ctx, overriden_tools = dict()):
             "@bazel_tools//tools/cpp:freebsd_cc_toolchain_config.bzl",
         ])
 
-        # This is defaulting to a static crosstool, we should eventually
-        # autoconfigure this platform too.  Theorically, FreeBSD should be
-        # straightforward to add but we cannot run it in a docker container so
+        # This is defaulting to a static crosstool. We should eventually
+        # autoconfigure this platform too. Theorically, FreeBSD should be
+        # straightforward to add but we cannot run it in a Docker container so
         # skipping until we have proper tests for FreeBSD.
         repository_ctx.symlink(paths["@bazel_tools//tools/cpp:freebsd_cc_toolchain_config.bzl"], "cc_toolchain_config.bzl")
         repository_ctx.symlink(paths["@bazel_tools//tools/cpp:BUILD.static.freebsd"], "BUILD")
+    elif cpu_value == "openbsd":
+        paths = resolve_labels(repository_ctx, [
+            "@bazel_tools//tools/cpp:BUILD.static.openbsd",
+            "@bazel_tools//tools/cpp:openbsd_cc_toolchain_config.bzl",
+        ])
+
+        # This is defaulting to a static crosstool. We should eventually
+        # autoconfigure this platform too. Theorically, OpenBSD should be
+        # straightforward to add but we cannot run it in a Docker container so
+        # skipping until we have proper tests for OpenBSD.
+        repository_ctx.symlink(paths["@bazel_tools//tools/cpp:openbsd_cc_toolchain_config.bzl"], "cc_toolchain_config.bzl")
+        repository_ctx.symlink(paths["@bazel_tools//tools/cpp:BUILD.static.openbsd"], "BUILD")
     elif cpu_value == "x64_windows":
         # TODO(ibiryukov): overriden_tools are only supported in configure_unix_toolchain.
         # We might want to add that to Windows too(at least for msys toolchain).

--- a/tools/cpp/cc_toolchain_config.bzl
+++ b/tools/cpp/cc_toolchain_config.bzl
@@ -98,6 +98,8 @@ def _impl(ctx):
         toolchain_identifier = "local_darwin"
     elif (ctx.attr.cpu == "freebsd"):
         toolchain_identifier = "local_freebsd"
+    elif (ctx.attr.cpu == "openbsd"):
+        toolchain_identifier = "local_openbsd"
     elif (ctx.attr.cpu == "local"):
         toolchain_identifier = "local_linux"
     elif (ctx.attr.cpu == "x64_windows" and ctx.attr.compiler == "windows_clang"):
@@ -119,6 +121,7 @@ def _impl(ctx):
         host_system_name = "armeabi-v7a"
     elif (ctx.attr.cpu == "darwin" or
           ctx.attr.cpu == "freebsd" or
+          ctx.attr.cpu == "openbsd" or
           ctx.attr.cpu == "local" or
           ctx.attr.cpu == "x64_windows" or
           ctx.attr.cpu == "x64_windows_msvc"):
@@ -130,6 +133,7 @@ def _impl(ctx):
         target_system_name = "armeabi-v7a"
     elif (ctx.attr.cpu == "darwin" or
           ctx.attr.cpu == "freebsd" or
+          ctx.attr.cpu == "openbsd" or
           ctx.attr.cpu == "local" or
           ctx.attr.cpu == "x64_windows" or
           ctx.attr.cpu == "x64_windows_msvc"):
@@ -143,6 +147,8 @@ def _impl(ctx):
         target_cpu = "darwin"
     elif (ctx.attr.cpu == "freebsd"):
         target_cpu = "freebsd"
+    elif (ctx.attr.cpu == "openbsd"):
+        target_cpu = "openbsd"
     elif (ctx.attr.cpu == "local"):
         target_cpu = "local"
     elif (ctx.attr.cpu == "x64_windows"):
@@ -155,6 +161,7 @@ def _impl(ctx):
     if (ctx.attr.cpu == "armeabi-v7a"):
         target_libc = "armeabi-v7a"
     elif (ctx.attr.cpu == "freebsd" or
+          ctx.attr.cpu == "openbsd" or
           ctx.attr.cpu == "local" or
           ctx.attr.cpu == "x64_windows"):
         target_libc = "local"
@@ -170,6 +177,7 @@ def _impl(ctx):
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin" or
           ctx.attr.cpu == "freebsd" or
+          ctx.attr.cpu == "openbsd" or
           ctx.attr.cpu == "local"):
         compiler = "compiler"
     elif (ctx.attr.cpu == "x64_windows" and ctx.attr.compiler == "windows_clang"):
@@ -187,6 +195,7 @@ def _impl(ctx):
         abi_version = "armeabi-v7a"
     elif (ctx.attr.cpu == "darwin" or
           ctx.attr.cpu == "freebsd" or
+          ctx.attr.cpu == "openbsd" or
           ctx.attr.cpu == "local" or
           ctx.attr.cpu == "x64_windows" or
           ctx.attr.cpu == "x64_windows_msvc"):
@@ -198,6 +207,7 @@ def _impl(ctx):
         abi_libc_version = "armeabi-v7a"
     elif (ctx.attr.cpu == "darwin" or
           ctx.attr.cpu == "freebsd" or
+          ctx.attr.cpu == "openbsd" or
           ctx.attr.cpu == "local" or
           ctx.attr.cpu == "x64_windows" or
           ctx.attr.cpu == "x64_windows_msvc"):
@@ -211,6 +221,7 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "darwin" or
         ctx.attr.cpu == "freebsd" or
+        ctx.attr.cpu == "openbsd" or
         ctx.attr.cpu == "local"):
         objcopy_embed_data_action = action_config(
             action_name = "objcopy_embed_data",
@@ -274,6 +285,7 @@ def _impl(ctx):
         action_configs = [c_compile_action, cpp_compile_action]
     elif (ctx.attr.cpu == "darwin" or
           ctx.attr.cpu == "freebsd" or
+          ctx.attr.cpu == "openbsd" or
           ctx.attr.cpu == "local" or
           ctx.attr.cpu == "x64_windows"):
         action_configs = [objcopy_embed_data_action]
@@ -348,7 +360,7 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "freebsd"):
+    elif (ctx.attr.cpu == "freebsd" or ctx.atr.cpu == "openbsd"):
         default_link_flags_feature = feature(
             name = "default_link_flags",
             enabled = True,
@@ -417,7 +429,8 @@ def _impl(ctx):
         )
 
     if (ctx.attr.cpu == "darwin" or
-        ctx.attr.cpu == "freebsd"):
+        ctx.attr.cpu == "freebsd" or
+        ctx.attr.cpu == "openbsd"):
         unfiltered_compile_flags_feature = feature(
             name = "unfiltered_compile_flags",
             enabled = True,
@@ -685,7 +698,7 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "freebsd"):
+    elif (ctx.attr.cpu == "freebsd" or ctx.attr.cpu == "openbsd"):
         default_compile_flags_feature = feature(
             name = "default_compile_flags",
             enabled = True,
@@ -941,6 +954,7 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "darwin" or
         ctx.attr.cpu == "freebsd" or
+        ctx.attr.cpu == "openbsd" or
         ctx.attr.cpu == "local"):
         user_compile_flags_feature = feature(
             name = "user_compile_flags",
@@ -996,6 +1010,7 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "darwin" or
         ctx.attr.cpu == "freebsd" or
+        ctx.attr.cpu == "openbsd" or
         ctx.attr.cpu == "local"):
         sysroot_feature = feature(
             name = "sysroot",
@@ -1152,6 +1167,7 @@ def _impl(ctx):
             unfiltered_compile_flags_feature,
         ]
     elif (ctx.attr.cpu == "freebsd" or
+          ctx.attr.cpu == "openbsd" or
           ctx.attr.cpu == "local"):
         features = [
             default_compile_flags_feature,
@@ -1196,7 +1212,7 @@ def _impl(ctx):
         cxx_builtin_include_directories = []
     elif (ctx.attr.cpu == "darwin"):
         cxx_builtin_include_directories = ["/"]
-    elif (ctx.attr.cpu == "freebsd"):
+    elif (ctx.attr.cpu == "freebsd" or ctx.attr.cpu == "openbsd"):
         cxx_builtin_include_directories = ["/usr/lib/clang", "/usr/local/include", "/usr/include"]
     elif (ctx.attr.cpu == "local" or
           ctx.attr.cpu == "x64_windows" and ctx.attr.compiler == "windows_clang"):
@@ -1289,6 +1305,20 @@ def _impl(ctx):
             tool_path(name = "compat-ld", path = "/usr/bin/ld"),
             tool_path(name = "cpp", path = "/usr/bin/cpp"),
             tool_path(name = "dwp", path = "/usr/bin/dwp"),
+            tool_path(name = "gcc", path = "/usr/bin/clang"),
+            tool_path(name = "gcov", path = "/usr/bin/gcov"),
+            tool_path(name = "ld", path = "/usr/bin/ld"),
+            tool_path(name = "nm", path = "/usr/bin/nm"),
+            tool_path(name = "objcopy", path = "/usr/bin/objcopy"),
+            tool_path(name = "objdump", path = "/usr/bin/objdump"),
+            tool_path(name = "strip", path = "/usr/bin/strip"),
+        ]
+    elif (ctx.attr.cpu == "openbsd"):
+        tool_paths = [
+            tool_path(name = "ar", path = "/usr/bin/ar"),
+            tool_path(name = "compat-ld", path = "/usr/bin/ld"),
+            tool_path(name = "cpp", path = "/usr/bin/cpp"),
+            tool_path(name = "dwp", path = "/usr/bin/false"),
             tool_path(name = "gcc", path = "/usr/bin/clang"),
             tool_path(name = "gcov", path = "/usr/bin/gcov"),
             tool_path(name = "ld", path = "/usr/bin/ld"),

--- a/tools/cpp/lib_cc_configure.bzl
+++ b/tools/cpp/lib_cc_configure.bzl
@@ -184,6 +184,8 @@ def get_cpu_value(repository_ctx):
         return "darwin"
     if os_name.find("freebsd") != -1:
         return "freebsd"
+    if os_name.find("openbsd") != -1:
+        return "openbsd"
     if os_name.find("windows") != -1:
         return "x64_windows"
 

--- a/tools/cpp/openbsd_cc_toolchain_config.bzl
+++ b/tools/cpp/openbsd_cc_toolchain_config.bzl
@@ -1,0 +1,307 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A Starlark cc_toolchain configuration rule for openbsd."""
+
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "action_config",
+    "feature",
+    "flag_group",
+    "flag_set",
+    "tool",
+    "tool_path",
+    "with_feature_set",
+)
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+all_compile_actions = [
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.clif_match,
+    ACTION_NAMES.lto_backend,
+]
+
+all_cpp_compile_actions = [
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.clif_match,
+]
+
+all_link_actions = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+def _impl(ctx):
+    cpu = ctx.attr.cpu
+    compiler = "compiler"
+    toolchain_identifier = "local_openbsd" if cpu == "openbsd" else "stub_armeabi-v7a"
+    host_system_name = "local" if cpu == "openbsd" else "armeabi-v7a"
+    target_system_name = "local" if cpu == "openbsd" else "armeabi-v7a"
+    target_libc = "local" if cpu == "openbsd" else "armeabi-v7a"
+    abi_version = "local" if cpu == "openbsd" else "armeabi-v7a"
+    abi_libc_version = "local" if cpu == "openbsd" else "armeabi-v7a"
+
+    objcopy_embed_data_action = action_config(
+        action_name = "objcopy_embed_data",
+        enabled = True,
+        tools = [tool(path = "/usr/bin/objcopy")],
+    )
+
+    action_configs = [objcopy_embed_data_action] if cpu == "openbsd" else []
+
+    default_link_flags_feature = feature(
+        name = "default_link_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-lstdc++",
+                            "-Wl,-z,relro,-z,now",
+                            "-no-canonical-prefixes",
+                        ],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [flag_group(flags = ["-Wl,--gc-sections"])],
+                with_features = [with_feature_set(features = ["opt"])],
+            ),
+        ],
+    )
+
+    unfiltered_compile_flags_feature = feature(
+        name = "unfiltered_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-no-canonical-prefixes",
+                            "-Wno-builtin-macro-redefined",
+                            "-D__DATE__=\"redacted\"",
+                            "-D__TIMESTAMP__=\"redacted\"",
+                            "-D__TIME__=\"redacted\"",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    supports_pic_feature = feature(name = "supports_pic", enabled = True)
+
+    default_compile_flags_feature = feature(
+        name = "default_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-U_FORTIFY_SOURCE",
+                            "-D_FORTIFY_SOURCE=1",
+                            "-fstack-protector",
+                            "-Wall",
+                            "-fno-omit-frame-pointer",
+                        ],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [flag_group(flags = ["-g"])],
+                with_features = [with_feature_set(features = ["dbg"])],
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-g0",
+                            "-O2",
+                            "-DNDEBUG",
+                            "-ffunction-sections",
+                            "-fdata-sections",
+                        ],
+                    ),
+                ],
+                with_features = [with_feature_set(features = ["opt"])],
+            ),
+            flag_set(
+                actions = all_cpp_compile_actions + [ACTION_NAMES.lto_backend],
+                flag_groups = [flag_group(flags = ["-std=c++0x"])],
+            ),
+        ],
+    )
+
+    opt_feature = feature(name = "opt")
+
+    supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = True)
+
+    objcopy_embed_flags_feature = feature(
+        name = "objcopy_embed_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = ["objcopy_embed_data"],
+                flag_groups = [flag_group(flags = ["-I", "binary"])],
+            ),
+        ],
+    )
+
+    dbg_feature = feature(name = "dbg")
+
+    user_compile_flags_feature = feature(
+        name = "user_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{user_compile_flags}"],
+                        iterate_over = "user_compile_flags",
+                        expand_if_available = "user_compile_flags",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    sysroot_feature = feature(
+        name = "sysroot",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.lto_backend,
+                ] + all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["--sysroot=%{sysroot}"],
+                        expand_if_available = "sysroot",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    if cpu == "openbsd":
+        features = [
+            default_compile_flags_feature,
+            default_link_flags_feature,
+            supports_dynamic_linker_feature,
+            supports_pic_feature,
+            objcopy_embed_flags_feature,
+            opt_feature,
+            dbg_feature,
+            user_compile_flags_feature,
+            sysroot_feature,
+            unfiltered_compile_flags_feature,
+        ]
+    else:
+        features = [supports_dynamic_linker_feature, supports_pic_feature]
+
+    if (cpu == "openbsd"):
+        cxx_builtin_include_directories = ["/usr/lib/clang", "/usr/local/include", "/usr/include"]
+    else:
+        cxx_builtin_include_directories = []
+
+    if cpu == "openbsd":
+        tool_paths = [
+            tool_path(name = "ar", path = "/usr/bin/ar"),
+            tool_path(name = "compat-ld", path = "/usr/bin/ld"),
+            tool_path(name = "cpp", path = "/usr/bin/cpp"),
+            tool_path(name = "dwp", path = "/usr/bin/false"),
+            tool_path(name = "gcc", path = "/usr/bin/clang"),
+            tool_path(name = "gcov", path = "/usr/bin/gcov"),
+            tool_path(name = "ld", path = "/usr/bin/ld"),
+            tool_path(name = "nm", path = "/usr/bin/nm"),
+            tool_path(name = "objcopy", path = "/usr/bin/objcopy"),
+            tool_path(name = "objdump", path = "/usr/bin/objdump"),
+            tool_path(name = "strip", path = "/usr/bin/strip"),
+        ]
+    else:
+        tool_paths = [
+            tool_path(name = "ar", path = "/bin/false"),
+            tool_path(name = "compat-ld", path = "/bin/false"),
+            tool_path(name = "cpp", path = "/bin/false"),
+            tool_path(name = "dwp", path = "/bin/false"),
+            tool_path(name = "gcc", path = "/bin/false"),
+            tool_path(name = "gcov", path = "/bin/false"),
+            tool_path(name = "ld", path = "/bin/false"),
+            tool_path(name = "nm", path = "/bin/false"),
+            tool_path(name = "objcopy", path = "/bin/false"),
+            tool_path(name = "objdump", path = "/bin/false"),
+            tool_path(name = "strip", path = "/bin/false"),
+        ]
+
+    out = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(out, "Fake executable")
+    return [
+        cc_common.create_cc_toolchain_config_info(
+            ctx = ctx,
+            features = features,
+            action_configs = action_configs,
+            cxx_builtin_include_directories = cxx_builtin_include_directories,
+            toolchain_identifier = toolchain_identifier,
+            host_system_name = host_system_name,
+            target_system_name = target_system_name,
+            target_cpu = cpu,
+            target_libc = target_libc,
+            compiler = compiler,
+            abi_version = abi_version,
+            abi_libc_version = abi_libc_version,
+            tool_paths = tool_paths,
+        ),
+        DefaultInfo(
+            executable = out,
+        ),
+    ]
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {
+        "cpu": attr.string(mandatory = True),
+    },
+    provides = [CcToolchainConfigInfo],
+    executable = True,
+)

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -116,6 +116,11 @@ java_runtime_files(
     srcs = ["include/freebsd/jni_md.h"],
 )
 
+java_runtime_files(
+    name = "jni_md_header-openbsd",
+    srcs = ["include/openbsd/jni_md.h"],
+)
+
 alias(
     name = "java",
     actual = "@local_jdk//:java",

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -62,7 +62,7 @@ DEFAULT_TOOLCHAIN_CONFIGURATION = {
     ],
     "javac_supports_workers": 1,
     "jvm_opts": select({
-        "//src/conditions:openbsd": JDK8_JVM_OPTS,
+        "@bazel_tools//src/conditions:openbsd": JDK8_JVM_OPTS,
         "//conditions:default": JDK9_JVM_OPTS,
     }),
     "misc": DEFAULT_JAVACOPTS,

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -61,7 +61,10 @@ DEFAULT_TOOLCHAIN_CONFIGURATION = {
         "@bazel_tools//tools/jdk:jdk_compiler_jar",
     ],
     "javac_supports_workers": 1,
-    "jvm_opts": JDK9_JVM_OPTS,
+    "jvm_opts": select({
+        "//src/conditions:openbsd": JDK8_JVM_OPTS,
+        "//conditions:default": JDK9_JVM_OPTS,
+    }),
     "misc": DEFAULT_JAVACOPTS,
     "singlejar": ["@bazel_tools//tools/jdk:singlejar"],
     "bootclasspath": ["@bazel_tools//tools/jdk:platformclasspath"],

--- a/tools/platforms/BUILD
+++ b/tools/platforms/BUILD
@@ -74,6 +74,11 @@ alias(
 )
 
 alias(
+    name = "openbsd",
+    actual = "@platforms//os:openbsd",
+)
+
+alias(
     name = "android",
     actual = "@platforms//os:android",
 )
@@ -109,6 +114,7 @@ platform(
     os_constraints = [
         "@platforms//os:osx",
         "@platforms//os:freebsd",
+        "@platforms//os:openbsd",
         "@platforms//os:linux",
         "@platforms//os:windows",
     ],
@@ -129,6 +135,7 @@ platform(
     os_constraints = [
         "@platforms//os:osx",
         "@platforms//os:freebsd",
+        "@platforms//os:openbsd",
         "@platforms//os:linux",
         "@platforms//os:windows",
     ],

--- a/tools/platforms/BUILD.tools
+++ b/tools/platforms/BUILD.tools
@@ -62,6 +62,11 @@ alias(
 )
 
 alias(
+    name = "openbsd",
+    actual = "@platforms//os:openbsd",
+)
+
+alias(
     name = "android",
     actual = "@platforms//os:android",
 )
@@ -97,6 +102,7 @@ platform(
     os_constraints = [
         "@platforms//os:osx",
         "@platforms//os:freebsd",
+        "@platforms//os:openbsd",
         "@platforms//os:linux",
         "@platforms//os:windows",
     ],
@@ -117,6 +123,7 @@ platform(
     os_constraints = [
         "@platforms//os:osx",
         "@platforms//os:freebsd",
+        "@platforms//os:openbsd",
         "@platforms//os:linux",
         "@platforms//os:windows",
     ],


### PR DESCRIPTION
Tested on OpenBSD 6.6-current (amd64 architecture), as follows:

```
# Create a 'dist' tarball. Here, `bbazel` is a binary left over from the
# porting work leading up to this patch.
cd ~/git/aldersondrive_bazel
/home/me/bin/bbazel build --host_javabase=@local_jdk//:jdk :bazel-distfile

# Perform a bootstrap build based on the tarball.
rm -rf ~/test_bootstrap
mkdir ~/test_bootstrap
cd ~/test_bootstrap
unzip ~/git/aldersondrive_bazel/bazel-bin/bazel-distfile.zip
EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" JAVA_HOME="/usr/local/jdk-1.8.0" BAZEL_JAVAC_OPTS="-J-Xmx2g -J-Xms200m" bash ./compile.sh
```

The resulting Bazel binary appeared to work in some simple testing involving cc_library, cc_binary, java_library, and java_binary.

Known issues/limitations:

- For the above to work, I had to add `python` to my PATH. (On OpenBSD, the Python binary is called `python3`.)

```
ln -s /usr/local/bin/python3 ~/bin/python
```

- Building a java_binary's deploy JAR fails because the `singlejar` tool fails to build. I intend to look into this issue next.

```
In file included from external/remote_java_tools_linux/java_tools/src/tools/singlejar/input_jar.cc:15:
In file included from bazel-out/host/bin/external/remote_java_tools_linux/_virtual_includes/input_jar/src/tools/singlejar/input_jar.h:27:
bazel-out/host/bin/external/remote_java_tools_linux/_virtual_includes/diag/src/tools/singlejar/diag.h:54:2: error: Unknown platform
#error Unknown platform
 ^
```

- Running Bazel requires a `--host_javabase=@local_jdk//:jdk` flag.

- Sandboxing is unsupported.

This change is part of the OpenBSD port in https://github.com/bazelbuild/bazel/issues/10250.