### PR TITLE
Adds explicit support for comments in bazelignore file

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/BlacklistedPackagePrefixesFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BlacklistedPackagePrefixesFunction.java
@@ -127,7 +127,7 @@ public class BlacklistedPackagePrefixesFunction implements SkyFunction {
 
     @Override
     public boolean processLine(String line) throws IOException {
-      if (!line.isEmpty()) {
+      if (!line.isEmpty() && !line.startsWith("#")) {
         fragments.add(PathFragment.create(line));
       }
       return true;

--- a/src/test/shell/bazel/bazelignore_test.sh
+++ b/src/test/shell/bazel/bazelignore_test.sh
@@ -25,6 +25,27 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
 
 set -e
 
+test_ignores_comment_lines() {
+    rm -rf work && mkdir work && cd work
+    create_workspace_with_default_repos WORKSPACE
+    mkdir -p ignoreme
+    echo Not a valid BUILD file > ignoreme/BUILD
+    mkdir -p '#foo/bar'
+    cat > '#foo/bar/BUILD' <<'EOI'
+genrule(
+  name = "out",
+  outs = ["out.txt"],
+  cmd = "echo Hello World > $@",
+)
+EOI
+    cat > .bazelignore <<'EOI'
+# Some comment
+#foo/bar
+ignoreme
+EOI
+    bazel build '//#foo/bar/...' || fail "Could not build valid target"
+}
+
 test_does_not_glob_into_ignored_directory() {
     rm -rf work && mkdir work && cd work
     create_workspace_with_default_repos WORKSPACE


### PR DESCRIPTION
This adds explicit support for comments in the `.bazelignore` file, by removing all lines starting with `#`.