### PR TITLE
Update release process of apt repo

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -262,7 +262,8 @@ function merge_previous_dists() {
 
 # Create a debian package with version in package name and add it to the repo
 function add_versioned_deb_pkg() {
-  local deb_pkg_name="$1"
+  local distribution="$1"
+  local deb_pkg_name="$2"
   # Extract the original package
   mkdir -p deb-output
   dpkg-deb -R "${deb_pkg_name}" deb-output
@@ -339,7 +340,7 @@ EOF
   reprepro -C jdk1.8 includedeb "${distribution}" "${deb_pkg_name}"
   reprepro -C jdk1.8 includedsc "${distribution}" "${deb_dsc_name}"
 
-  add_versioned_deb_pkg "${deb_pkg_name}"
+  add_versioned_deb_pkg "${distribution}" "${deb_pkg_name}"
 
   merge_previous_dists "${distribution}"
 

--- a/scripts/packages/debian/BUILD
+++ b/scripts/packages/debian/BUILD
@@ -69,7 +69,7 @@ genrule(
 pkg_deb(
     name = "bazel-debian",
     architecture = "amd64",
-    built_using = "bazel (HEAD)",
+    built_using = "bazel",
     conffiles = [
         "etc/bash_completion.d/bazel",
         "etc/bazel.bazelrc",
@@ -80,7 +80,6 @@ pkg_deb(
         "g++",
         "zlib1g-dev",
         "unzip",
-        "python",
     ],
     description_file = "description",
     homepage = "http://bazel.build",


### PR DESCRIPTION
With the new release process, Bazel APT repo will now support
installing Bazel at a specific version.
Users can run "apt-get install bazel=1.0.0", can call "bazel" from command line.

We also publish side-by-side packages named "bazel-<version>", which
made it possible to install multiple Bazel versions at the same time.
Users can run "apt-get install bazel-1.0.0", then call "bazel-1.0.0" from command line.
This will support https://github.com/bazelbuild/bazel/pull/10272