### PR TITLE
Test remote execution and test.xml generation

### DIFF
--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1324,6 +1324,48 @@ EOF
     //a:foo || "Failed to build //a:foo"
 }
 
+function test_testxml_download_toplevel() {
+  # Test that a test action generating its own test.xml file works with
+  # --remote_download_toplevel.
+  mkdir -p a
+
+  cat > a/test.sh <<'EOF'
+#!/bin/sh
+
+cat > $XML_OUTPUT_FILE <<EOF2
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="test" tests="1" failures="0" errors="0">
+    <testcase name="test_case" status="run">
+      <system-out>test_case succeeded.</system-out>
+    </testcase>
+  </testsuite>
+</testsuites>
+EOF2
+EOF
+
+  chmod +x a/test.sh
+
+  cat > a/BUILD <<EOF
+sh_test(
+  name = 'test',
+  srcs = [ 'test.sh' ],
+)
+EOF
+
+  bazel test \
+      --remote_executor=grpc://localhost:${worker_port} \
+      --remote_download_toplevel \
+      //a:test \
+      || fail "Failed to run //a:test with remote execution"
+
+  testxml=bazel-testlogs/a/test/test.xml
+  [ -e $testxml ] || fail "Expected to find XML output"
+  cat $testxml > $TEST_log
+  expect_log 'test_case succeeded.'
+}
+
+
 function test_tag_no_remote_cache() {
   mkdir -p a
   cat > a/BUILD <<'EOF'


### PR DESCRIPTION
Add a test case that verifies that --remote_download_toplevel works
for test actions that generate their own test.xml file.

Related #10106