### PR TITLE
Remove builtin directory file on macOS

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -19,7 +19,6 @@ load(
     "@bazel_tools//tools/cpp:lib_cc_configure.bzl",
     "escape_string",
     "resolve_labels",
-    "write_builtin_include_directory_paths",
 )
 load(
     "@bazel_tools//tools/cpp:unix_cc_configure.bzl",
@@ -140,7 +139,6 @@ def configure_osx_toolchain(repository_ctx, overriden_tools):
                  error_msg)
 
         escaped_include_paths = _get_escaped_xcode_cxx_inc_directories(repository_ctx, cc, xcode_toolchains)
-        write_builtin_include_directory_paths(repository_ctx, cc, escaped_include_paths)
         escaped_cxx_include_directories = []
         for path in escaped_include_paths:
             escaped_cxx_include_directories.append(("        \"%s\"," % path))

--- a/tools/osx/crosstool/BUILD.tpl
+++ b/tools/osx/crosstool/BUILD.tpl
@@ -47,7 +47,6 @@ cc_toolchain_suite(
     filegroup(
         name = "osx_tools_" + arch,
         srcs = [
-            ":builtin_include_directory_paths",
             ":cc_wrapper",
             ":libtool",
             ":make_hashed_objlist.py",


### PR DESCRIPTION
On macOS the paths produced in this file are specific to Xcode paths.
Since Xcode versions are already managed by `local_config_xcode`, having
this duplicates that validation, and also breaks caching.

This fixes https://github.com/bazelbuild/bazel/issues/10187