### PR TITLE
HttpStream: Enable retries during 32KB precheck

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStream.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStream.java
@@ -90,9 +90,6 @@ final class HttpStream extends FilterInputStream {
 
         if (checksum.isPresent()) {
           stream = new HashInputStream(stream, checksum.get());
-          if (retrier != null) {
-            retrier.disabled = true;
-          }
           byte[] buffer = new byte[PRECHECK_BYTES];
           int read = 0;
           while (read < PRECHECK_BYTES) {
@@ -108,9 +105,6 @@ final class HttpStream extends FilterInputStream {
             stream = ByteStreams.limit(new ByteArrayInputStream(buffer), read);
           } else {
             stream = new SequenceInputStream(new ByteArrayInputStream(buffer), stream);
-            if (retrier != null) {
-              retrier.disabled = false;
-            }
           }
         }
       } catch (Exception e) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/RetryingInputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/RetryingInputStream.java
@@ -45,7 +45,6 @@ class RetryingInputStream extends InputStream {
             throws IOException;
   }
 
-  volatile boolean disabled;
   private volatile InputStream delegate;
   private final Reconnector reconnector;
   private final AtomicLong toto = new AtomicLong();
@@ -98,9 +97,6 @@ class RetryingInputStream extends InputStream {
   }
 
   private void tryAgainIfPossible(IOException cause) throws IOException {
-    if (disabled) {
-      throw cause;
-    }
     if (cause instanceof InterruptedIOException && !(cause instanceof SocketTimeoutException)) {
       throw cause;
     }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStreamTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URL;
@@ -148,10 +149,14 @@ public class HttpStreamTest {
     when(connection.getHeaderField("Accept-Ranges")).thenReturn("bytes");
     thrown.expect(SocketTimeoutException.class);
 
+    Field field = RetryingInputStream.class.getDeclaredField("MAX_RESUMES");
+    field.setAccessible(true);
+    int maxResumes = (int) field.get(null);
+
     try {
       streamFactory.create(connection, AURL, GOOD_CHECKSUM, reconnector);
     } catch (Exception e) {
-      assertThat(nRetries).isGreaterThan(3);  // RetryingInputStream.MAX_RESUMES
+      assertThat(nRetries).isGreaterThan(maxResumes);
       throw e;
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStreamTest.java
@@ -20,6 +20,8 @@ import static com.google.devtools.build.lib.bazel.repository.downloader.Download
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,6 +37,7 @@ import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -77,8 +80,12 @@ public class HttpStreamTest {
   private final ProgressInputStream.Factory progress = mock(ProgressInputStream.Factory.class);
   private final HttpStream.Factory streamFactory = new HttpStream.Factory(progress);
 
+  private int nRetries;
+
   @Before
   public void before() throws Exception {
+    nRetries = 0;
+
     when(connection.getInputStream()).thenReturn(new ByteArrayInputStream(data));
     when(progress.create(any(InputStream.class), any(), any(URL.class)))
         .thenAnswer(
@@ -102,6 +109,50 @@ public class HttpStreamTest {
   public void smallDataWithValidChecksum_readsOk() throws Exception {
     try (HttpStream stream = streamFactory.create(connection, AURL, GOOD_CHECKSUM, reconnector)) {
       assertThat(toByteArray(stream)).isEqualTo(data);
+    }
+  }
+
+  @Test
+  public void smallDataWithValidChecksum_timesOutInCreateRetriesOk() throws Exception {
+    InputStream inputStream = mock(ByteArrayInputStream.class);
+    InputStream realInputStream = new ByteArrayInputStream(data);
+
+    doAnswer((Answer<Integer>) invocation -> {
+      Object[] args = invocation.getArguments();
+      Object mock = invocation.getMock();
+
+      if (nRetries++ == 0) {
+        throw new SocketTimeoutException();
+      } else {
+        return realInputStream.read((byte[])args[0], (int)args[1], (int)args[2]);
+      }
+    }).when(inputStream).read(any(), anyInt(), anyInt());
+    when(reconnector.connect(any(), any())).thenReturn(connection);
+    when(connection.getInputStream()).thenReturn(inputStream);
+    when(connection.getHeaderField("Accept-Ranges")).thenReturn("bytes");
+    try (HttpStream stream = streamFactory.create(connection, AURL, GOOD_CHECKSUM, reconnector)) {
+      assertThat(toByteArray(stream)).isEqualTo(data);
+    }
+  }
+
+  @Test
+  public void smallDataWithValidChecksum_timesOutInCreateRepeatedly() throws Exception {
+    InputStream inputStream = mock(ByteArrayInputStream.class);
+
+    doAnswer((Answer<Integer>) invocation -> {
+      ++nRetries;
+      throw new SocketTimeoutException();
+    }).when(inputStream).read(any(), anyInt(), anyInt());
+    when(reconnector.connect(any(), any())).thenReturn(connection);
+    when(connection.getInputStream()).thenReturn(inputStream);
+    when(connection.getHeaderField("Accept-Ranges")).thenReturn("bytes");
+    thrown.expect(SocketTimeoutException.class);
+
+    try {
+      streamFactory.create(connection, AURL, GOOD_CHECKSUM, reconnector);
+    } catch (Exception e) {
+      assertThat(nRetries).isGreaterThan(3);  // RetryingInputStream.MAX_RESUMES
+      throw e;
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/RetryingInputStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/RetryingInputStreamTest.java
@@ -78,14 +78,6 @@ public class RetryingInputStreamTest {
   }
 
   @Test
-  public void readThrowsExceptionWhenDisabled_passesThrough() throws Exception {
-    stream.disabled = true;
-    when(delegate.read()).thenThrow(new IOException());
-    assertThrows(IOException.class, () -> stream.read());
-    verify(delegate).read();
-  }
-
-  @Test
   public void readInterrupted_alwaysPassesThrough() throws Exception {
     when(delegate.read()).thenThrow(new InterruptedIOException());
     assertThrows(InterruptedIOException.class, () -> stream.read());


### PR DESCRIPTION
HttpStream performs a 32KB precheck transfer during creation to evade captive
portals and slow mirrors.  (Note: This occurs after having established a
connection to a remote server and that server replying with a HTTP 200 or 206.)
For reasons unknown (no code comment), retries were disabled during precheck, so
if our upstream server flaked *even once*, we'd throw a SocketTimeoutException
and no longer consider this mirror.

This commit removes the code which disables/re-enables retries during the
precheck phase.  It also includes some new test cases to confirm that transfers
are adequately retried.

NB: I am not a Java developer. <img src="https://i.kym-cdn.com/entries/icons/original/000/008/342/ihave.jpg" alt="I have no idea what I'm doing."/>

Closes #10294.