### PR TITLE
Allow building the Bazel C++ code on OpenBSD.

### DIFF
--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -47,6 +47,12 @@ config_setting(
 )
 
 config_setting(
+    name = "openbsd",
+    values = {"cpu": "openbsd"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "windows",
     values = {"cpu": "x64_windows"},
     visibility = ["//visibility:public"],

--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -5,6 +5,12 @@ config_setting(
 )
 
 config_setting(
+    name = "openbsd",
+    values = {"cpu": "openbsd"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "darwin",
     values = {"cpu": "darwin"},
     visibility = ["//visibility:public"],

--- a/src/main/cpp/BUILD
+++ b/src/main/cpp/BUILD
@@ -32,6 +32,10 @@ cc_library(
             "blaze_util_freebsd.cc",
             "blaze_util_posix.cc",
         ],
+        "//src/conditions:openbsd": [
+            "blaze_util_openbsd.cc",
+            "blaze_util_posix.cc",
+        ],
         "//src/conditions:windows": [
             "blaze_util_windows.cc",
         ],
@@ -52,6 +56,8 @@ cc_library(
             "-framework CoreFoundation",
         ],
         "//src/conditions:freebsd": [
+        ],
+        "//src/conditions:openbsd": [
         ],
         "//src/conditions:windows": WIN_LINK_OPTS,
         "//conditions:default": [
@@ -113,6 +119,8 @@ cc_binary(
         "//src/conditions:freebsd": [
             "-lprocstat",
             "-lm",
+        ],
+        "//src/conditions:openbsd": [
         ],
         "//src/conditions:windows": [
         ],

--- a/src/main/cpp/blaze_util_openbsd.cc
+++ b/src/main/cpp/blaze_util_openbsd.cc
@@ -1,0 +1,168 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>  // errno, ENAMETOOLONG
+#include <limits.h>
+#include <pwd.h>
+#include <signal.h>
+#include <spawn.h>
+#include <stdlib.h>
+#include <string.h>  // strerror
+#include <sys/mount.h>
+#include <sys/param.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "src/main/cpp/blaze_util.h"
+#include "src/main/cpp/blaze_util_platform.h"
+#include "src/main/cpp/util/errors.h"
+#include "src/main/cpp/util/exit_code.h"
+#include "src/main/cpp/util/file.h"
+#include "src/main/cpp/util/logging.h"
+#include "src/main/cpp/util/path.h"
+#include "src/main/cpp/util/port.h"
+#include "src/main/cpp/util/strings.h"
+
+namespace blaze {
+
+using blaze_util::GetLastErrorString;
+using std::string;
+
+string GetOutputRoot() {
+  char buf[2048];
+  struct passwd pwbuf;
+  struct passwd *pw = NULL;
+  int uid = getuid();
+  int r = getpwuid_r(uid, &pwbuf, buf, 2048, &pw);
+  if (r != -1 && pw != NULL) {
+    return blaze_util::JoinPath(pw->pw_dir, ".cache/bazel");
+  } else {
+    return "/tmp";
+  }
+}
+
+void WarnFilesystemType(const blaze_util::Path &output_base) {
+  struct statfs buf = {};
+  if (statfs(output_base.AsNativePath().c_str(), &buf) < 0) {
+    BAZEL_LOG(WARNING) << "couldn't get file system type information for '"
+                       << output_base.AsPrintablePath()
+                       << "': " << strerror(errno);
+    return;
+  }
+
+  if (strcmp(buf.f_fstypename, "nfs") == 0) {
+    BAZEL_LOG(WARNING) << "Output base '" << output_base.AsPrintablePath()
+                       << "' is on NFS. This may lead to surprising failures "
+                          "and undetermined behavior.";
+  }
+}
+
+// OpenBSD does not provide an API for a running process to find the path of
+// its own executable, so we try to figure out the path by inspecting argv[0].
+// In theory this is inadequate, since the parent process can set argv[0] to
+// anything, but in practice this is good enough.
+string GetSelfPath(const string& argv0) {
+  // TODO(aldersondrive): Add a new --bazel_executable_path startup option
+  // only on platforms that need it), and inspect it here. If it's set, use its
+  // value instead of applying the heuristics below.
+
+  // If argv[0] starts with a slash, it's an absolute path. Use it.
+  if (argv0.length() > 0 && argv0[0] == '/') {
+    return argv0;
+  }
+
+  // Otherwise, if argv[0] contains a slash, then it's a relative path. Prepend
+  // the current directory to form an absolute path.
+  if (argv0.length() > 0 && argv0.find('/') != string::npos) {
+    char buf[PATH_MAX];
+    if (getcwd(buf, sizeof(buf)) == nullptr) {
+      BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR) << "getcwd failed";
+    }
+    return string(buf) + "/" + argv0;
+  }
+
+  // TODO(aldersondrive): Try to find the executable by inspecting the PATH.
+
+  // None of the above worked. Give up.
+  BAZEL_DIE(blaze_exit_code::BAD_ARGV)
+      << "Unable to determine the location of this Bazel executable. "
+         "Currently, argv[0] must be an absolute or relative path to the "
+         "executable.";
+  return "";  // Never executed. Needed so compiler does not complain.
+}
+
+uint64_t GetMillisecondsMonotonic() {
+  struct timespec ts = {};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1000LL + (ts.tv_nsec / 1000000LL);
+}
+
+void SetScheduling(bool batch_cpu_scheduling, int io_nice_level) {
+  // Stubbed out so we can compile for OpenBSD.
+}
+
+blaze_util::Path GetProcessCWD(int pid) {
+  // OpenBSD does not support looking up the working directory of another
+  // process.
+  return blaze_util::Path("");
+}
+
+bool IsSharedLibrary(const string &filename) {
+  return blaze_util::ends_with(filename, ".so");
+}
+
+string GetSystemJavabase() {
+  // If JAVA_HOME is defined, then use it as default.
+  string javahome = GetPathEnv("JAVA_HOME");
+
+  if (!javahome.empty()) {
+    string javac = blaze_util::JoinPath(javahome, "bin/javac");
+    if (access(javac.c_str(), X_OK) == 0) {
+      return javahome;
+    }
+    BAZEL_LOG(WARNING)
+        << "Ignoring JAVA_HOME, because it must point to a JDK, not a JRE.";
+  }
+
+  return "/usr/local/jdk-1.8.0";
+}
+
+int ConfigureDaemonProcess(posix_spawnattr_t *attrp,
+                           const StartupOptions &options) {
+  // No interesting platform-specific details to configure on this platform.
+  return 0;
+}
+
+void WriteSystemSpecificProcessIdentifier(const blaze_util::Path &server_dir,
+                                          pid_t server_pid) {}
+
+bool VerifyServerProcess(int pid, const blaze_util::Path &output_base) {
+  // TODO(lberki): This only checks for the process's existence, not whether
+  // its start time matches. Therefore this might accidentally kill an
+  // unrelated process if the server died and the PID got reused.
+  return killpg(pid, 0) == 0;
+}
+
+// Not supported.
+void ExcludePathFromBackup(const blaze_util::Path &path) {}
+
+int32_t GetExplicitSystemLimit(const int resource) {
+  return -1;
+}
+
+}  // namespace blaze

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -106,9 +106,13 @@ void SigPrintf(const char *format, ...);
 
 std::string GetProcessIdAsString();
 
-// Get an absolute path to the binary being executed that is guaranteed to be
+// Gets an absolute path to the binary being executed that is guaranteed to be
 // readable.
+#if defined(CAN_FIND_OWN_EXECUTABLE_PATH)
 std::string GetSelfPath();
+#else
+std::string GetSelfPath(const std::string& argv0);
+#endif
 
 // Returns the directory Bazel can use to store output.
 std::string GetOutputRoot();
@@ -129,7 +133,8 @@ uint64_t GetMillisecondsMonotonic();
 // on Linux, so it should only be called when necessary.
 void SetScheduling(bool batch_cpu_scheduling, int io_nice_level);
 
-// Returns the cwd for a process.
+// Returns the cwd for a process, or an empty string if the directory is
+// unknown.
 blaze_util::Path GetProcessCWD(int pid);
 
 bool IsSharedLibrary(const std::string& filename);

--- a/src/main/cpp/util/port.h
+++ b/src/main/cpp/util/port.h
@@ -71,6 +71,21 @@
 #endif
 
 
+// CAN_FIND_OWN_EXECUTABLE_PATH
+//
+// Indicates that a running process can find a path to its own executable.
+#if !defined(__OpenBSD__)
+#define CAN_FIND_OWN_EXECUTABLE_PATH
+#endif
+
+// HAVE_EMULTIHOP
+//
+// Indicates that errno.h defines EMULTIHOP.
+#if !defined(__OpenBSD__)
+#define HAVE_EMULTIHOP
+#endif
+
+
 // Linux I/O priorities support is available only in later versions of glibc.
 // Therefore, we include some of the needed definitions here.  May need to
 // be removed once we switch to a new version of glibc

--- a/src/main/cpp/util/port.h
+++ b/src/main/cpp/util/port.h
@@ -74,15 +74,12 @@
 // CAN_FIND_OWN_EXECUTABLE_PATH
 //
 // Indicates that a running process can find a path to its own executable.
-#if !defined(__OpenBSD__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW32__)
 #define CAN_FIND_OWN_EXECUTABLE_PATH
-#endif
-
-// HAVE_EMULTIHOP
-//
-// Indicates that errno.h defines EMULTIHOP.
-#if !defined(__OpenBSD__)
-#define HAVE_EMULTIHOP
+#elif defined(__OpenBSD__)
+// Not supported on this platform.
+#else
+#error Unrecognized platform.
 #endif
 
 

--- a/src/main/native/BUILD
+++ b/src/main/native/BUILD
@@ -6,6 +6,7 @@ genrule(
         "//src/conditions:darwin": ["//tools/jdk:jni_md_header-darwin"],
         "//src/conditions:darwin_x86_64": ["//tools/jdk:jni_md_header-darwin"],
         "//src/conditions:freebsd": ["//tools/jdk:jni_md_header-freebsd"],
+        "//src/conditions:openbsd": ["//tools/jdk:jni_md_header-openbsd"],
         "//src/conditions:windows": ["//tools/jdk:jni_md_header-windows"],
         "//conditions:default": ["//tools/jdk:jni_md_header-linux"],
     }),
@@ -34,6 +35,7 @@ filegroup(
             "fsevents.cc",
         ],
         "//src/conditions:freebsd": ["unix_jni_freebsd.cc"],
+        "//src/conditions:openbsd": ["unix_jni_openbsd.cc"],
         "//conditions:default": ["unix_jni_linux.cc"],
     }),
 )

--- a/src/main/native/unix_jni.cc
+++ b/src/main/native/unix_jni.cc
@@ -85,7 +85,7 @@ void PostException(JNIEnv *env, int error_number, const std::string& message) {
     case ENAMETOOLONG:  // File name too long
     case ENODATA:    // No data available
     case EINVAL:     // Invalid argument
-#if defined(HAVE_EMULTIHOP)
+#if defined(EMULTIHOP)
     case EMULTIHOP:  // Multihop attempted
 #endif
     case ENOLINK:    // Link has been severed

--- a/src/main/native/unix_jni.cc
+++ b/src/main/native/unix_jni.cc
@@ -85,7 +85,9 @@ void PostException(JNIEnv *env, int error_number, const std::string& message) {
     case ENAMETOOLONG:  // File name too long
     case ENODATA:    // No data available
     case EINVAL:     // Invalid argument
+#if defined(HAVE_EMULTIHOP)
     case EMULTIHOP:  // Multihop attempted
+#endif
     case ENOLINK:    // Link has been severed
     case EIO:        // I/O error
     case EAGAIN:     // Try again

--- a/src/main/native/unix_jni.h
+++ b/src/main/native/unix_jni.h
@@ -33,7 +33,7 @@ namespace blaze_jni {
       } \
     } while (0)
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 // stat64 is deprecated on OS X/BSD.
 typedef struct stat portable_stat_struct;
 #define portable_stat ::stat
@@ -44,7 +44,7 @@ typedef struct stat64 portable_stat_struct;
 #define portable_lstat ::lstat64
 #endif
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #define ENODATA ENOATTR
 #endif
 

--- a/src/main/native/unix_jni_openbsd.cc
+++ b/src/main/native/unix_jni_openbsd.cc
@@ -1,0 +1,118 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/main/native/unix_jni.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+
+#include <string>
+
+namespace blaze_jni {
+
+using std::string;
+
+// See unix_jni.h.
+string ErrorMessage(int error_number) {
+  char buf[1024] = "";
+  if (strerror_r(error_number, buf, sizeof buf) < 0) {
+    snprintf(buf, sizeof buf, "strerror_r(%d): errno %d", error_number, errno);
+  }
+
+  return string(buf);
+}
+
+int portable_fstatat(int dirfd, char *name, portable_stat_struct *statbuf,
+                     int flags) {
+  return fstatat(dirfd, name, statbuf, flags);
+}
+
+int StatSeconds(const portable_stat_struct &statbuf, StatTimes t) {
+  switch (t) {
+    case STAT_ATIME:
+      return statbuf.st_atime;
+    case STAT_CTIME:
+      return statbuf.st_ctime;
+    case STAT_MTIME:
+      return statbuf.st_mtime;
+    default:
+      CHECK(false);
+  }
+}
+
+int StatNanoSeconds(const portable_stat_struct &statbuf, StatTimes t) {
+  switch (t) {
+    case STAT_ATIME:
+      return statbuf.st_atimespec.tv_nsec;
+    case STAT_CTIME:
+      return statbuf.st_ctimespec.tv_nsec;
+    case STAT_MTIME:
+      return statbuf.st_mtimespec.tv_nsec;
+    default:
+      CHECK(false);
+  }
+}
+
+ssize_t portable_getxattr(const char *path, const char *name, void *value,
+                          size_t size, bool *attr_not_found) {
+  *attr_not_found = true;
+  return -1;
+}
+
+ssize_t portable_lgetxattr(const char *path, const char *name, void *value,
+                           size_t size, bool *attr_not_found) {
+  *attr_not_found = true;
+  return -1;
+}
+
+int portable_sysctlbyname(const char *name_chars, long *mibp, size_t *sizep) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int portable_push_disable_sleep() {
+  // Currently not supported.
+  // https://wiki.freebsd.org/SuspendResume
+  return -1;
+}
+
+int portable_pop_disable_sleep() {
+  // Currently not supported.
+  // https://wiki.freebsd.org/SuspendResume
+  return -1;
+}
+
+int portable_suspend_count() {
+  // Currently not implemented.
+  return 0;
+}
+
+int portable_memory_pressure_warning_count() {
+  // Currently not implemented.
+  return 0;
+}
+
+int portable_memory_pressure_critical_count() {
+  // Currently not implemented.
+  return 0;
+}
+
+}  // namespace blaze_jni


### PR DESCRIPTION
This PR is smaller than it appears, because the *_openbsd.cc files are largely copy/pasted from the corresponding *_freebsd.cc files. The GitHub web UI does not show this similarity, AFAIK. You could try:

```
diff src/main/cpp/blaze_util_freebsd.cc src/main/cpp/blaze_util_openbsd.cc
diff src/main/native/unix_jni_freebsd.cc src/main/native/unix_jni_openbsd.cc
```

This change, split out of the larger PR https://github.com/bazelbuild/bazel/pull/10274, is part of the OpenBSD port in https://github.com/bazelbuild/bazel/issues/10250.