### PR TITLE
Fix VS15 toolchain configure: hide output from VsDevCmd.bat

### DIFF
--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -157,7 +157,7 @@ def find_vc_path(repository_ctx):
         repository_ctx.file(
             "get_vc_dir.bat",
             "@echo off\n" +
-            "call \"" + script + "\"\n" +
+            "call \"" + script + "\" > NUL\n" +
             "echo %VCINSTALLDIR%",
             True,
         )


### PR DESCRIPTION
VsDevCmd.bat outputs header
```
**********************************************************************
** Visual Studio 2019 Developer Command Prompt v16.3.10
** Copyright (c) 2019 Microsoft Corporation
**********************************************************************
```
which interferes with 
```
echo %VCINSTALLDIR%
```
and doesn't allow to configure VS toolchain.