### PR TITLE
Add @repo//jar:file target to java_import_external and jvm_maven_import_external

### DIFF
--- a/tools/build_defs/repo/jvm.bzl
+++ b/tools/build_defs/repo/jvm.bzl
@@ -123,6 +123,10 @@ def _jvm_import_external(repository_ctx):
         "    actual = \"@%s\"," % repository_ctx.name,
         ")",
         "",
+        "filegroup(",
+        "    name = \"file\",",
+        "    srcs = [\"//:%s\"]," % path,
+        ")",
     ]))
 
 def _should_fetch_sources_in_current_env(repository_ctx):


### PR DESCRIPTION
This adds compatibility between maven_jar and the Starlark rules' API, and helps with migration from maven_jar as seen in https://github.com/bazelbuild/rules_scala/pull/871