### PR TITLE
Chocolatey: Remove msys2 dependency

### DIFF
--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -76,7 +76,6 @@ Supply like `--params="/option:'value' ..."` ([see docs for --params](https://gi
     </dependencies>-->
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.0.7"/>
-      <dependency id="msys2" version="20160719.1.0"/>
       <dependency id="vcredist140" version="14.20.27508.1"/>
     </dependencies>
     <!-- chocolatey-uninstall.extension - If supporting 0.9.9.x (or below) and including a chocolateyUninstall.ps1 file to uninstall an EXE/MSI, you probably want to include chocolatey-uninstall.extension as a dependency. Please verify whether you are using a helper function from that package. -->


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/10003#issuecomment-541465220 suggests it's no longer necessary and hasn't been for a while.

I pushed 1.1.0, 1.2.0 and 1.2.1 with this change to chocolatey; https://chocolatey.org/packages/bazel#dependencies.

cc @laszlocsomor @meteorcloudy 