### PR TITLE
zipper: Don't assume argument file ends with '\n'

### DIFF
--- a/third_party/ijar/zip_main.cc
+++ b/third_party/ijar/zip_main.cc
@@ -251,11 +251,12 @@ char **read_filelist(char *filename) {
   }
 
   size_t sizeof_array = sizeof(char *) * (nb_entries + 1);
-  void *result = malloc(sizeof_array + file_stat.total_size);
+  void *result = malloc(sizeof_array + file_stat.total_size + 1);
   // copy the content
   char **filelist = static_cast<char **>(result);
   char *content = static_cast<char *>(result) + sizeof_array;
   memcpy(content, data, file_stat.total_size);
+  content[file_stat.total_size] = '\0';
   free(data);
   // Create the corresponding array
   int j = 1;


### PR DESCRIPTION
Resolves #10350.

Testing Done:
```console
$ touch foo bar
$ echo foo > args.txt
$ echo -n bar >> args.txt
$ valgrind zipper Cc foo.zip @args.txt
```