### PR TITLE
Starlark Docs: Python Diffs: Strings aren't iterable

### DIFF
--- a/site/docs/skylark/language.md
+++ b/site/docs/skylark/language.md
@@ -132,6 +132,8 @@ not defined across value types. In short: `5 < 'foo'` will throw an error and
 * Strings are represented with double-quotes (e.g. when you call
   [repr](lib/globals.html#repr)).
 
+* Strings aren't iterable.
+
 The following Python features are not supported:
 
 * implicit string concatenation (use explicit `+` operator).


### PR DESCRIPTION
Per https://github.com/bazelbuild/starlark/blob/master/design.md#strings-are-not-iterable

This is commonly encountered e.g. when validating inputs against externally-imposed naming conventions, particularly since regexps aren't supported either.