### PR TITLE
VFS: add RootedPathAndCasing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/vfs/RootedPathAndCasing.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/RootedPathAndCasing.java
@@ -1,0 +1,78 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.vfs;
+
+import com.google.common.base.Preconditions;
+import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * A {@link RootedPath} and its String representation.
+ *
+ * <p>This object stores not just a path but also the particular casing of it. On case-sensitive
+ * filesystems, the paths "foo/Bar.txt" and "FOO/bar.TXT" are different files, but on
+ * case-insensitive (or case-ignoring) they refer to the same file.
+ *
+ * <p>The {@code RootedPathAndCasing} class therefore allows comparing equal {@link RootedPath}s
+ * that might use different casing.
+ */
+@AutoCodec
+public final class RootedPathAndCasing implements Serializable {
+  private final RootedPath path;
+  private final String casing;
+  private final int hash;
+
+  /** Constructs a {@link RootedPath} from a {@link Root} and path fragment relative to the root. */
+  @AutoCodec.Instantiator
+  @AutoCodec.VisibleForSerialization
+  RootedPathAndCasing(RootedPath path, String casing) {
+    this.path = Preconditions.checkNotNull(path);
+    this.casing = Preconditions.checkNotNull(casing);
+    this.hash = Objects.hash(path, casing);
+  }
+
+  public static RootedPathAndCasing create(RootedPath path) {
+    return new RootedPathAndCasing(path, path.getRootRelativePath().getPathString());
+  }
+
+  public RootedPath getPath() {
+    return path;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof RootedPathAndCasing)) {
+      return false;
+    }
+    RootedPathAndCasing other = (RootedPathAndCasing) obj;
+    return hash == other.hash  // fast track for unequal objects
+        && Objects.equals(path, other.path)
+        && Objects.equals(casing, other.casing);
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    return "[" + path.getRoot() + "]/[" + casing + "]";
+  }
+}
+

--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -12,6 +12,7 @@ package(
 CROSS_PLATFORM_WINDOWS_TESTS = [
     "util/DependencySetWindowsTest.java",
     "vfs/PathFragmentWindowsTest.java",
+    "vfs/RootedPathAndCasingTest.java",
     "vfs/WindowsPathTest.java",
 ]
 
@@ -485,8 +486,8 @@ java_test(
     ],
 )
 
-# Tests that test Windows-specific functionality that run on other operating
-# systems
+# Tests that exercise Windows-specific (or case-insensitive-filesystem specific) functionality.
+# These don't need to run on Windows, they merely use Windows- and case-insensitive path semantics.
 java_test(
     name = "windows_test",
     srcs = CROSS_PLATFORM_WINDOWS_TESTS + ["vfs/PathAbstractTest.java"],

--- a/src/test/java/com/google/devtools/build/lib/vfs/RootedPathAndCasingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/RootedPathAndCasingTest.java
@@ -1,0 +1,89 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.vfs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.build.lib.clock.BlazeClock;
+import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link RootedPathAndCasing}. */
+@RunWith(JUnit4.class)
+public class RootedPathAndCasingTest {
+  private FileSystem filesystem;
+  private Path root;
+
+  @Before
+  public final void initializeFileSystem() throws Exception  {
+    filesystem = new InMemoryFileSystem(BlazeClock.instance());
+    root = filesystem.getPath("c:/");
+  }
+
+  @Test
+  public void testSanityCheckFilesystemIsCaseInsensitive() {
+    Path p1 = root.getRelative("Foo/Bar");
+    Path p2 = root.getRelative("FOO/BAR");
+    Path p3 = root.getRelative("control");
+    assertThat(p1).isNotSameInstanceAs(p2);
+    assertThat(p1).isNotSameInstanceAs(p3);
+    assertThat(p2).isNotSameInstanceAs(p3);
+    assertThat(p1).isEqualTo(p2);
+    assertThat(p1).isNotEqualTo(p3);
+  }
+
+  @Test
+  public void testEqualsAndHashCodeContract() {
+    PathFragment pf1 = PathFragment.create("Foo/Bar");
+    PathFragment pf2 = PathFragment.create("FOO/baR");
+    PathFragment pf3 = PathFragment.create("FOO/baR");
+    assertThat(pf1).isNotSameInstanceAs(pf2);
+    assertThat(pf2).isNotSameInstanceAs(pf3);
+    assertThat(pf1).isEqualTo(pf2);
+    assertThat(pf1).isEqualTo(pf3);
+
+    RootedPath rp1 = RootedPath.toRootedPath(Root.fromPath(root), pf1);
+    RootedPath rp2 = RootedPath.toRootedPath(Root.fromPath(root), pf2);
+    RootedPath rp3 = RootedPath.toRootedPath(Root.fromPath(root), pf3);
+    assertThat(rp1).isNotSameInstanceAs(rp2);
+    assertThat(rp2).isNotSameInstanceAs(rp3);
+    assertThat(rp1).isEqualTo(rp2);
+    assertThat(rp1).isEqualTo(rp3);
+    assertThat(rp1.hashCode()).isEqualTo(rp2.hashCode());
+    assertThat(rp1.hashCode()).isEqualTo(rp3.hashCode());
+
+    RootedPathAndCasing rpac1 = RootedPathAndCasing.create(rp1);
+    RootedPathAndCasing rpac2 = RootedPathAndCasing.create(rp2);
+    RootedPathAndCasing rpac3 = RootedPathAndCasing.create(rp3);
+    assertThat(rpac1).isNotSameInstanceAs(rpac2);
+    assertThat(rpac2).isNotSameInstanceAs(rpac3);
+    assertThat(rpac1).isNotEqualTo(rpac2);
+    assertThat(rpac2).isEqualTo(rpac3);
+    assertThat(rpac1.hashCode()).isNotEqualTo(rpac2.hashCode());
+    assertThat(rpac2.hashCode()).isEqualTo(rpac3.hashCode());
+  }
+
+  @Test
+  public void testToStringRespectsCasing() {
+    RootedPath rp1 = RootedPath.toRootedPath(Root.fromPath(root), PathFragment.create("Foo/Bar"));
+    RootedPath rp2 = RootedPath.toRootedPath(Root.fromPath(root), PathFragment.create("FOO/baR"));
+    RootedPathAndCasing rpac1 = RootedPathAndCasing.create(rp1);
+    RootedPathAndCasing rpac2 = RootedPathAndCasing.create(rp2);
+    assertThat(rpac1.toString()).contains("Foo/Bar");
+    assertThat(rpac2.toString()).contains("FOO/baR");
+  }
+}


### PR DESCRIPTION
This class stores a RootedPath and the String
value of its relative part.

This class allows distinguishing RootedPaths on
case-insensitive filesystems, if two RootedPaths
refer to the same file but use different casing.

The motivation is to support validating package
path casing. (See issue #8799.) My plan is to add
a new SkyFunction called PathCasingLookupFunction,
which validates that a certain RootedPath is
correctly cased. The SkyKey can't just take a
RootedPath, because on Windows the path semantics
dictate that RootedPath objects are compared
without regard to casing. Thus we must also store
the particular casing in the SkyKey, and so we
need the RootedPathWithCasing class.

The class only compares the casing of the relative
parts, not of the root parts. Reason is, this
class will be used to validate the casing of
package paths, which are always relative to the
package root whose casing we needn't worry about.

See https://github.com/bazelbuild/bazel/issues/8799