### PR TITLE
Add aliases for :lcov_merger and :coverage_report_generator targets

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD.remote
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD.remote
@@ -12,3 +12,13 @@ java_binary(
   main_class = "com.google.devtools.coverageoutputgenerator.Main",
   runtime_deps = [":all_lcov_merger_lib"],
 )
+
+alias(
+  name = "lcov_merger",
+  actual = "Main",
+)
+
+alias(
+  name = "coverage_report_generator",
+  actual = "Main",
+)


### PR DESCRIPTION
Currently, the coverage tool setup is smeared across @bazel_tools//tools/test/BUILD, @bazel_tools//tools/test/CoverageOutputGenerator/.../BUILD (both shipped inside Bazel), and @remote_coverage_tools//, which is separately uploaded as a zipped repository. The second BUILD file contains java_* rules which are actually used. The remote_coverage_tools repository contains a copy of the java_* rules, but they are never used, and the java_import in the former directly references the deploy jar in the latter.

Instead, the plan is to only ship @bazel_tools//tools/test/BUILD in Bazel, and use alias rules to point to the @remote_coverage_tools repository. There, we define two rules (:lcov_merger and :coverage_report_generator), which fully define the implementation. This allows the repository to be swapped out for another repository with a different implementation using --override_repository, which facilitates independent work on the merger and generator.

The underlying problem is that the merger currently does not work with remote execution, and there is no workaround because all the relevant parts are hard-coded in Bazel, which requires a Bazel release to fix. By making the coverage tools self-contained, we make it easier to solve such problems in the future.

This should not cause any problems for the existing workaround described in #4685.

Progress on #4685.

Change-Id: I26758db573a1966b40169314d4aec61eff83f83b