### PR TITLE
Refactor GetProcessCWD to return a unique_ptr.

### DIFF
--- a/src/main/cpp/blaze_util_bsd.cc
+++ b/src/main/cpp/blaze_util_bsd.cc
@@ -154,10 +154,10 @@ void SetScheduling(bool batch_cpu_scheduling, int io_nice_level) {
   // Stubbed out so we can compile.
 }
 
-blaze_util::Path GetProcessCWD(int pid) {
+std::unique_ptr<blaze_util::Path> GetProcessCWD(int pid) {
 #if defined(HAVE_PROCSTAT)
   if (kill(pid, 0) < 0) {
-    return blaze_util::Path();
+    return nullptr;
   }
   auto procstat = procstat_open_sysctl();
   unsigned int n;
@@ -184,9 +184,9 @@ blaze_util::Path GetProcessCWD(int pid) {
     procstat_freeprocs(procstat, p);
   }
   procstat_close(procstat);
-  return blaze_util::Path(cwd);
+  return std::unique_ptr<blaze_util::Path>(new blaze_util::Path(cwd));
 #else
-  return blaze_util::Path("");
+  return nullptr;
 #endif
 }
 

--- a/src/main/cpp/blaze_util_darwin.cc
+++ b/src/main/cpp/blaze_util_darwin.cc
@@ -151,13 +151,14 @@ void SetScheduling(bool batch_cpu_scheduling, int io_nice_level) {
   // stubbed out so we can compile for Darwin.
 }
 
-blaze_util::Path GetProcessCWD(int pid) {
+std::unique_ptr<blaze_util::Path> GetProcessCWD(int pid) {
   struct proc_vnodepathinfo info = {};
   if (proc_pidinfo(
           pid, PROC_PIDVNODEPATHINFO, 0, &info, sizeof(info)) != sizeof(info)) {
-    return blaze_util::Path();
+    return nullptr;
   }
-  return blaze_util::Path(string(info.pvi_cdir.vip_path));
+  return std::unique_ptr<blaze_util::Path>(
+      new blaze_util::Path(string(info.pvi_cdir.vip_path)));
 }
 
 bool IsSharedLibrary(const string &filename) {

--- a/src/main/cpp/blaze_util_linux.cc
+++ b/src/main/cpp/blaze_util_linux.cc
@@ -116,7 +116,7 @@ void SetScheduling(bool batch_cpu_scheduling, int io_nice_level) {
   }
 }
 
-blaze_util::Path GetProcessCWD(int pid) {
+std::unique_ptr<blaze_util::Path> GetProcessCWD(int pid) {
   char server_cwd[PATH_MAX] = {};
   if (readlink(
           ("/proc/" + ToString(pid) + "/cwd").c_str(),

--- a/src/main/cpp/blaze_util_linux.cc
+++ b/src/main/cpp/blaze_util_linux.cc
@@ -121,10 +121,11 @@ blaze_util::Path GetProcessCWD(int pid) {
   if (readlink(
           ("/proc/" + ToString(pid) + "/cwd").c_str(),
           server_cwd, sizeof(server_cwd)) < 0) {
-    return blaze_util::Path();
+    return nullptr;
   }
 
-  return blaze_util::Path(string(server_cwd));
+  return std::unique_ptr<blaze_util::Path>(
+      new blaze_util::Path(string(server_cwd)));
 }
 
 bool IsSharedLibrary(const string &filename) {

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -17,6 +17,7 @@
 
 #include <cinttypes>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -129,13 +130,9 @@ uint64_t GetMillisecondsMonotonic();
 // on Linux, so it should only be called when necessary.
 void SetScheduling(bool batch_cpu_scheduling, int io_nice_level);
 
-// Returns the cwd of the specified process, or an empty string if the
-// directory is unknown.
-//
-// TODO(aldersondrive): Change the return type to
-// std::unique_ptr<blaze_util::Path>, so that we can return nullptr instead of
-// relying on callers to recognize the empty string as special.
-blaze_util::Path GetProcessCWD(int pid);
+// Returns the current working directory of the specified process, or nullptr
+// if the directory is unknown.
+std::unique_ptr<blaze_util::Path> GetProcessCWD(int pid);
 
 bool IsSharedLibrary(const std::string& filename);
 

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -454,10 +454,10 @@ void SetScheduling(bool batch_cpu_scheduling, int io_nice_level) {
   // TODO(bazel-team): There should be a similar function on Windows.
 }
 
-blaze_util::Path GetProcessCWD(int pid) {
+std::unique_ptr<blaze_util::Path> GetProcessCWD(int pid) {
   // TODO(bazel-team) 2016-11-18: decide whether we need this on Windows and
   // implement or delete.
-  return blaze_util::Path();
+  return nullptr;
 }
 
 bool IsSharedLibrary(const string &filename) {


### PR DESCRIPTION
This way we can use `nullptr`, rather than a sentinel value (the empty string), to indicate that the directory is unknown.

This change resolves a TODO. It was originally requested by @jmmv.

`std::make_unique` and `absl::make_unique` seem to be unavailable, so I've made do with `std::unique_ptr<blaze_util::Path>(new blaze_util::Path(...))`.