### PR TITLE
Allow building the Bazel server for OpenBSD.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/ShellConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ShellConfiguration.java
@@ -36,6 +36,7 @@ public class ShellConfiguration extends BuildConfiguration.Fragment {
       ImmutableMap.<OS, PathFragment>builder()
           .put(OS.WINDOWS, PathFragment.create("c:/tools/msys64/usr/bin/bash.exe"))
           .put(OS.FREEBSD, PathFragment.create("/usr/local/bin/bash"))
+          .put(OS.OPENBSD, PathFragment.create("/usr/local/bin/bash"))
           .build();
 
   private final PathFragment shellExecutable;

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
@@ -37,6 +37,8 @@ public class AutoCpuConverter implements Converter<String> {
           return "darwin";
         case FREEBSD:
           return "freebsd";
+        case OPENBSD:
+          return "openbsd";
         case WINDOWS:
           switch (CPU.getCurrent()) {
             case X86_64:
@@ -81,6 +83,8 @@ public class AutoCpuConverter implements Converter<String> {
       return Pair.of(CPU.getCurrent(), OS.DARWIN);
     } else if (input.startsWith("freebsd")) {
       return Pair.of(CPU.getCurrent(), OS.FREEBSD);
+    } else if (input.startsWith("openbsd")) {
+      return Pair.of(CPU.getCurrent(), OS.OPENBSD);
     } else if (input.startsWith("x64_windows")) {
       return Pair.of(CPU.getCurrent(), OS.WINDOWS);
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunction.java
@@ -129,6 +129,8 @@ public class LocalConfigPlatformFunction extends RepositoryFunction {
         return "@platforms//os:osx";
       case FREEBSD:
         return "@platforms//os:freebsd";
+      case OPENBSD:
+        return "@platforms//os:openbsd";
       case LINUX:
         return "@platforms//os:linux";
       case WINDOWS:

--- a/src/main/java/com/google/devtools/build/lib/platform/JniLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/platform/JniLoader.java
@@ -28,6 +28,7 @@ class JniLoader {
       switch (OS.getCurrent()) {
         case LINUX:
         case FREEBSD:
+        case OPENBSD:
         case UNKNOWN:
         case DARWIN:
           UnixJniLoader.loadJni();

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java
@@ -1573,7 +1573,7 @@ public class CppActionConfigs {
   }
 
   private static String ifLinux(CppPlatform platform, String... lines) {
-    // Platform `LINUX` also includes FreeBSD.
+    // Platform `LINUX` also includes FreeBSD and OpenBSD.
     return ifTrue(platform == CppPlatform.LINUX, lines);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeOptionHandler.java
@@ -326,6 +326,8 @@ public final class BlazeOptionHandler {
         return "windows";
       case FREEBSD:
         return "freebsd";
+      case OPENBSD:
+        return "openbsd";
       default:
         return OS.getCurrent().getCanonicalName();
     }

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -65,8 +65,8 @@ public class CommonCommandOptions extends OptionsBase {
       help =
           "If true, Bazel picks up host-OS-specific config lines from bazelrc files. For example, "
               + "if the host OS is Linux and you run bazel build, Bazel picks up lines starting "
-              + "with build:linux. Supported OS identifiers are linux, macos, windows, and "
-              + "freebsd. Enabling this flag is equivalent to using --config=linux on Linux, "
+              + "with build:linux. Supported OS identifiers are linux, macos, windows, freebsd, "
+              + "and openbsd. Enabling this flag is equivalent to using --config=linux on Linux, "
               + "--config=windows on Windows, etc.")
   public boolean enablePlatformSpecificConfig;
 

--- a/src/main/java/com/google/devtools/build/lib/util/OS.java
+++ b/src/main/java/com/google/devtools/build/lib/util/OS.java
@@ -21,11 +21,12 @@ import java.util.EnumSet;
 public enum OS {
   DARWIN("osx", "Mac OS X"),
   FREEBSD("freebsd", "FreeBSD"),
+  OPENBSD("openbsd", "OpenBSD"),
   LINUX("linux", "Linux"),
   WINDOWS("windows", "Windows"),
   UNKNOWN("unknown", "");
 
-  private static final EnumSet<OS> POSIX_COMPATIBLE = EnumSet.of(DARWIN, FREEBSD, LINUX);
+  private static final EnumSet<OS> POSIX_COMPATIBLE = EnumSet.of(DARWIN, FREEBSD, OPENBSD, LINUX);
 
   private final String canonicalName;
   private final String detectionName;

--- a/src/main/java/com/google/devtools/build/lib/vfs/OsPathPolicy.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/OsPathPolicy.java
@@ -87,6 +87,7 @@ public interface OsPathPolicy {
     switch (OS.getCurrent()) {
       case LINUX:
       case FREEBSD:
+      case OPENBSD:
       case UNKNOWN:
         return UnixOsPathPolicy.INSTANCE;
       case DARWIN:

--- a/src/test/java/com/google/devtools/build/lib/analysis/ShellConfigurationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/ShellConfigurationTest.java
@@ -34,6 +34,8 @@ public class ShellConfigurationTest extends BuildViewTestCase {
         .isEqualTo(PathFragment.create("/bin/bash"));
     assertThat(determineShellExecutable(OS.FREEBSD, null))
         .isEqualTo(PathFragment.create("/usr/local/bin/bash"));
+    assertThat(determineShellExecutable(OS.OPENBSD, null))
+        .isEqualTo(PathFragment.create("/usr/local/bin/bash"));
     assertThat(determineShellExecutable(OS.WINDOWS, null))
         .isEqualTo(PathFragment.create("c:/tools/msys64/usr/bin/bash.exe"));
   }
@@ -44,6 +46,8 @@ public class ShellConfigurationTest extends BuildViewTestCase {
     assertThat(determineShellExecutable(OS.LINUX, binBash))
         .isEqualTo(PathFragment.create("/bin/bash"));
     assertThat(determineShellExecutable(OS.FREEBSD, binBash))
+        .isEqualTo(PathFragment.create("/bin/bash"));
+    assertThat(determineShellExecutable(OS.OPENBSD, binBash))
         .isEqualTo(PathFragment.create("/bin/bash"));
     assertThat(determineShellExecutable(OS.WINDOWS, binBash))
         .isEqualTo(PathFragment.create("/bin/bash"));

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/LocalConfigPlatformFunctionTest.java
@@ -84,6 +84,7 @@ public class LocalConfigPlatformFunctionTest {
           new Object[] {OS.LINUX, "@platforms//os:linux"},
           new Object[] {OS.DARWIN, "@platforms//os:osx"},
           new Object[] {OS.FREEBSD, "@platforms//os:freebsd"},
+          new Object[] {OS.OPENBSD, "@platforms//os:openbsd"},
           new Object[] {OS.WINDOWS, "@platforms//os:windows"});
     }
 

--- a/src/test/java/com/google/devtools/build/lib/packages/util/MockPlatformSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/MockPlatformSupport.java
@@ -84,6 +84,10 @@ public class MockPlatformSupport {
         "constraint_value(",
         "    name = 'freebsd',",
         "    constraint_setting = ':os',",
+        ")",
+        "constraint_value(",
+        "    name = 'openbsd',",
+        "    constraint_setting = ':os',",
         ")");
     String basePlatform;
     if (TestConstants.LOCAL_CONFIG_PLATFORM_PATH != null) {

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeOptionHandlerTest.java
@@ -163,6 +163,7 @@ public class BlazeOptionHandlerTest {
     structuredArgs.put("c0:windows", new RcChunkOfArgs("rc1", ImmutableList.of("command_windows")));
     structuredArgs.put("c0:macos", new RcChunkOfArgs("rc1", ImmutableList.of("command_macos")));
     structuredArgs.put("c0:freebsd", new RcChunkOfArgs("rc1", ImmutableList.of("command_freebsd")));
+    structuredArgs.put("c0:openbsd", new RcChunkOfArgs("rc1", ImmutableList.of("command_openbsd")));
     structuredArgs.put(
         "c0:platform_config",
         new RcChunkOfArgs("rc1", ImmutableList.of("--enable_platform_specific_config")));
@@ -328,6 +329,9 @@ public class BlazeOptionHandlerTest {
       case FREEBSD:
         assertThat(parser.getResidue()).containsExactly("command_freebsd");
         break;
+      case OPENBSD:
+        assertThat(parser.getResidue()).containsExactly("command_openbsd");
+        break;
       default:
         assertThat(parser.getResidue()).isEmpty();
     }
@@ -352,6 +356,9 @@ public class BlazeOptionHandlerTest {
         break;
       case FREEBSD:
         assertThat(parser.getResidue()).containsExactly("command_freebsd");
+        break;
+      case OPENBSD:
+        assertThat(parser.getResidue()).containsExactly("command_openbsd");
         break;
       default:
         assertThat(parser.getResidue()).isEmpty();

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -116,6 +116,11 @@ java_runtime_files(
     srcs = ["include/freebsd/jni_md.h"],
 )
 
+java_runtime_files(
+    name = "jni_md_header-openbsd",
+    srcs = ["include/openbsd/jni_md.h"],
+)
+
 alias(
     name = "java",
     actual = "@local_jdk//:java",


### PR DESCRIPTION
This change, split out of the larger PR https://github.com/bazelbuild/bazel/pull/10274, is part of the OpenBSD port in https://github.com/bazelbuild/bazel/issues/10250.