### PR TITLE
Fix small mix-up in toolchain documentation

### DIFF
--- a/site/docs/cc-toolchain-config-reference.md
+++ b/site/docs/cc-toolchain-config-reference.md
@@ -750,7 +750,7 @@ The following is a reference of `CcToolchainConfigInfo` build variables.
    <td>compile</td>
    <td>Sequence of <code>-iquote</code> includes -
        directories in which the compiler searches for headers included using
-       <code>#include&lt;foo.h&gt;</code>.
+       <code>#include "foo.h"</code>.
    </td>
   </tr>
   <tr>
@@ -759,7 +759,7 @@ The following is a reference of `CcToolchainConfigInfo` build variables.
    <td>compile</td>
    <td>Sequence of <code>-isystem</code> includes -
        directories in which the compiler searches for headers included using
-       <code>#include "foo.h"</code>.
+       <code>#include&lt;foo.h&gt;</code>.
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
The description of the CcToolchainConfigInfo build variables `quote_include_paths` and `system_include_paths` has been mixed up according to my understanding.