### PR TITLE
Include reportGeneratorExec's runfiles as action inputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -895,6 +895,7 @@ java_library(
         ":util",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:localhost_capacity",
+        "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -895,7 +895,6 @@ java_library(
         ":util",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:localhost_capacity",
-        "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
@@ -44,8 +44,6 @@ import com.google.devtools.build.lib.analysis.test.CoverageReportActionFactory.C
 import com.google.devtools.build.lib.analysis.test.TestProvider;
 import com.google.devtools.build.lib.analysis.test.TestProvider.TestParams;
 import com.google.devtools.build.lib.analysis.test.TestRunnerAction;
-import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
-import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
@@ -247,13 +245,10 @@ public final class CoverageReportActionBuilder {
     args = CoverageArgs.createCopyWithCoverageDirAndLcovOutput(args, coverageDir, lcovOutput);
     ImmutableList<String> actionArgs = argsFunc.apply(args);
 
-    NestedSetBuilder<Artifact> inputsBuilder = NestedSetBuilder.stableOrder();
-    Iterable<Artifact> inputs = inputsBuilder
+    ImmutableList<Artifact> inputs = ImmutableList.<Artifact>builder()
         .addAll(args.coverageArtifacts())
         .add(reportGeneratorExec)
-        .addTransitive(
-            NestedSetBuilder.create(Order.STABLE_ORDER,
-                                    args.reportGenerator().getRunfilesSupport().getRunfilesMiddleman()))
+        .add(args.reportGenerator().getRunfilesSupport().getRunfilesMiddleman())
         .add(args.lcovArtifact())
         .build();
     return new CoverageReportAction(

--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.FilesToRunProvider;
+import com.google.devtools.build.lib.analysis.RunfilesSupport;
 import com.google.devtools.build.lib.analysis.actions.FileWriteAction;
 import com.google.devtools.build.lib.analysis.test.CoverageReportActionFactory.CoverageReportActionsWrapper;
 import com.google.devtools.build.lib.analysis.test.TestProvider;
@@ -242,18 +243,20 @@ public final class CoverageReportActionBuilder {
     Artifact lcovOutput = args.factory().getDerivedArtifact(
         coverageDir.getRelative("_coverage_report.dat"), root, args.artifactOwner());
     Artifact reportGeneratorExec = args.reportGenerator().getExecutable();
+    RunfilesSupport runfilesSupport = args.reportGenerator().getRunfilesSupport();
     args = CoverageArgs.createCopyWithCoverageDirAndLcovOutput(args, coverageDir, lcovOutput);
     ImmutableList<String> actionArgs = argsFunc.apply(args);
 
-    ImmutableList<Artifact> inputs = ImmutableList.<Artifact>builder()
+    ImmutableList.Builder<Artifact> inputsBuilder = ImmutableList.<Artifact>builder()
         .addAll(args.coverageArtifacts())
         .add(reportGeneratorExec)
-        .add(args.reportGenerator().getRunfilesSupport().getRunfilesMiddleman())
-        .add(args.lcovArtifact())
-        .build();
+        .add(args.lcovArtifact());
+    if (runfilesSupport != null) {
+      inputsBuilder.add(runfilesSupport.getRunfilesMiddleman());
+    }
     return new CoverageReportAction(
         ACTION_OWNER,
-        inputs,
+        inputsBuilder.build(),
         ImmutableList.of(lcovOutput),
         actionArgs,
         locationFunc.apply(args),

--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
@@ -44,6 +44,8 @@ import com.google.devtools.build.lib.analysis.test.CoverageReportActionFactory.C
 import com.google.devtools.build.lib.analysis.test.TestProvider;
 import com.google.devtools.build.lib.analysis.test.TestProvider.TestParams;
 import com.google.devtools.build.lib.analysis.test.TestRunnerAction;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
@@ -245,9 +247,13 @@ public final class CoverageReportActionBuilder {
     args = CoverageArgs.createCopyWithCoverageDirAndLcovOutput(args, coverageDir, lcovOutput);
     ImmutableList<String> actionArgs = argsFunc.apply(args);
 
-    ImmutableList<Artifact> inputs = ImmutableList.<Artifact>builder()
+    NestedSetBuilder<Artifact> inputsBuilder = NestedSetBuilder.stableOrder();
+    Iterable<Artifact> inputs = inputsBuilder
         .addAll(args.coverageArtifacts())
         .add(reportGeneratorExec)
+        .addTransitive(
+            NestedSetBuilder.create(Order.STABLE_ORDER,
+                                    args.reportGenerator().getRunfilesSupport().getRunfilesMiddleman()))
         .add(args.lcovArtifact())
         .build();
     return new CoverageReportAction(


### PR DESCRIPTION
The combination of `--coverage_report_generator` with `--disk_cache` led to
a `java.lang.IllegalStateException` in `ActionMetadataHandler.getMetadata`,
seemingly because `CoverageReportActionBuilder`'s report generator
can have an (until now) undeclared runfiles tree.  Fix that by declaring the
latter.

Resolves #10401.