### PR TITLE
Repoint --coverage_report_generator default to CoverageOutputGenerator

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -216,7 +216,7 @@ public class TestConfiguration extends Fragment {
     @Option(
         name = "coverage_report_generator",
         converter = LabelConverter.class,
-        defaultValue = "@bazel_tools//tools/test:coverage_report_generator",
+        defaultValue = "@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main",
         documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
         effectTags = {
             OptionEffectTag.CHANGES_INPUTS,
@@ -226,7 +226,7 @@ public class TestConfiguration extends Fragment {
         help =
             "Location of the binary that is used to generate coverage reports. This must "
                 + "currently be a filegroup that contains a single file, the binary. Defaults to "
-                + "'//tools/test:coverage_report_generator'."
+                + "'@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main'."
     )
     public Label coverageReportGenerator;
 


### PR DESCRIPTION
From https://github.com/bazelbuild/bazel/issues/6450#issuecomment-514933269:

> The default value of the --coverage_report_generator flag is broken and we
> didn't get to fixing it. It should be an easy change though, PRs are always
> welcome. :)

This change does that, but using
`@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main`.
(`CoverageOutputGenerator` supersedes `LcovMerger` per #7412.)

Resolves #6450.