### PR TITLE
Pass execution_requirements through sha256 run

### DIFF
--- a/tools/build_defs/hash/hash.bzl
+++ b/tools/build_defs/hash/hash.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Functions for producing the hash of an artifact."""
 
-def sha256(ctx, artifact):
+def sha256(ctx, artifact, execution_requirements = None):
     """Create an action to compute the SHA-256 of an artifact."""
     out = ctx.actions.declare_file(artifact.basename + ".sha256")
     ctx.actions.run(
@@ -22,6 +22,7 @@ def sha256(ctx, artifact):
         inputs = [artifact],
         outputs = [out],
         mnemonic = "SHA256",
+        execution_requirements = execution_requirements,
         # This is necessary until the interpreter used by py_binary is more
         # configurable. As a workaround, let users override $PATH with
         # --action_env for this rule.


### PR DESCRIPTION
Make execution_requirements specifiable by callers of sha256 to enable
propagation of common.tags and control resultant action behavior