### PR TITLE
Python coverage: experimental first steps

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPyTestRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPyTestRule.java
@@ -57,6 +57,7 @@ public final class BazelPyTestRule implements RuleDefinition {
             attr("$launcher", LABEL)
                 .cfg(HostTransition.createFactory())
                 .value(env.getToolsLabel("//tools/launcher:launcher")))
+        .add(attr(":lcov_merger", LABEL).value(BaseRuleClasses.getCoverageOutputGeneratorLabel()))
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
@@ -307,7 +307,26 @@ def Main():
   program = python_program = FindPythonBinary(module_space)
   if python_program is None:
     raise AssertionError('Could not find python binary: ' + PYTHON_BINARY)
-  args = [python_program, main_filename] + args
+
+  cov_tool = os.environ.get('PYTHON_COVERAGE')
+  if cov_tool:
+    # Inhibit infinite recursion:
+    del os.environ['PYTHON_COVERAGE']
+    if not os.path.exists(cov_tool):
+      raise EnvironmentError('Python coverage tool %s not found.' % cov_tool)
+    args = [python_program, cov_tool, 'run', '-a', '--branch', main_filename] + args
+    # coverage library expects sys.path[0] to contain the library, and replaces
+    # it with the directory of the program it starts. Our actual sys.path[0] is
+    # the runfiles directory, which must not be replaced.
+    # CoverageScript.do_execute() undoes this sys.path[0] setting.
+    #
+    # Update sys.path such that python finds the coverage package. The coverage
+    # entry point is coverage.coverage_main, so we need to do twice the dirname.
+    new_env['PYTHONPATH'] = \
+        new_env['PYTHONPATH'] + ':' + os.path.dirname(os.path.dirname(cov_tool))
+    new_env['PYTHON_LCOV_FILE'] = os.environ.get('COVERAGE_DIR') + '/pylcov.dat'
+  else:
+    args = [python_program, main_filename] + args
 
   os.environ.update(new_env)
 


### PR DESCRIPTION
- Add lcov_merger as an attribute to the py_test rule so that it does
  not immediately fall over
- Add a small section to python_stub_template.txt to perform minimal
  setup for coverage integration

I was able to get this to work manually by using a modified version of
coverage.py, see:
https://github.com/nedbat/coveragepy/pull/863

Note that the patch does not work out of the box.

It's basically ~impossible to add integration tests until we get a
working version of coverage.py, but this is the minimum change required
in Bazel to get a basic working version.