### PR TITLE
Properly break down sandboxed spawns.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -80,10 +80,7 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
     try (ResourceHandle ignored =
         resourceManager.acquireResources(owner, spawn.getLocalResources())) {
       context.report(ProgressStatus.EXECUTING, getName());
-      SandboxedSpawn sandbox;
-      try (SilentCloseable c = Profiler.instance().profile("SandboxedSpawn.prepareSpawn")) {
-        sandbox = prepareSpawn(spawn, context);
-      }
+      SandboxedSpawn sandbox = prepareSpawn(spawn, context);
       return runSpawn(spawn, sandbox, context);
     } catch (IOException e) {
       throw new UserExecException("I/O exception during sandboxed execution", e);
@@ -102,14 +99,21 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
       Spawn originalSpawn, SandboxedSpawn sandbox, SpawnExecutionContext context)
       throws IOException, InterruptedException {
     try {
-      sandbox.createFileSystem();
+      try (SilentCloseable c = Profiler.instance().profile("sandbox.createFileSystem")) {
+        sandbox.createFileSystem();
+      }
       FileOutErr outErr = context.getFileOutErr();
-      context.prefetchInputs();
+      try (SilentCloseable c = Profiler.instance().profile("context.prefetchInputs")) {
+        context.prefetchInputs();
+      }
 
-      SpawnResult result = run(originalSpawn, sandbox, context.getTimeout(), outErr);
+      SpawnResult result;
+      try (SilentCloseable c = Profiler.instance().profile("subprocess.run")) {
+        result = run(originalSpawn, sandbox, context.getTimeout(), outErr);
+      }
 
       context.lockOutputFiles();
-      try {
+      try (SilentCloseable c = Profiler.instance().profile("sandbox.copyOutputs")) {
         // We copy the outputs even when the command failed.
         sandbox.copyOutputs(execRoot);
       } catch (IOException e) {
@@ -118,7 +122,9 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
       return result;
     } finally {
       if (!sandboxOptions.sandboxDebug) {
-        sandbox.delete();
+        try (SilentCloseable c = Profiler.instance().profile("sandbox.delete")) {
+          sandbox.delete();
+        }
       }
     }
   }


### PR DESCRIPTION
The previous attempt only accounted for the object creation but not the
actual sandbox setup.

Fix #10404.

RELNOTES: None