### PR TITLE
Fix cc toolchain autodetection to not error when

### DIFF
--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -909,4 +909,27 @@ EOF
       fail "bazel build should've passed with --features=compiler_param_file"
 }
 
+function test_disable_cc_toolchain_detection() {
+  cat > ok.cc <<EOF
+#include <stdio.h>
+int main() {
+  printf("Hello\n");
+}
+EOF
+
+  cat > BUILD <<EOF
+cc_binary(
+  name = "ok",
+  srcs = ["ok.cc"],
+)
+EOF
+
+  # This only shows reliably for query due to ordering issues in how Bazel shows
+  # errors.
+  BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel query 'deps(//:ok)' &>"$TEST_log" || \
+    fail "Should pass with fake toolchain"
+  expect_not_log "An error occurred during the fetch of repository 'local_config_cc'"
+  expect_log "@local_config_cc//:empty"
+}
+
 run_suite "cc_integration_test"

--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -101,7 +101,7 @@ def cc_autoconf_impl(repository_ctx, overriden_tools = dict()):
             "@bazel_tools//tools/cpp:empty_cc_toolchain_config.bzl",
         ])
         repository_ctx.symlink(paths["@bazel_tools//tools/cpp:empty_cc_toolchain_config.bzl"], "cc_toolchain_config.bzl")
-        repository_ctx.symlink(paths("@bazel_tools//tools/cpp:BUILD.empty"), "BUILD")
+        repository_ctx.symlink(paths["@bazel_tools//tools/cpp:BUILD.empty"], "BUILD")
     elif cpu_value == "freebsd":
         paths = resolve_labels(repository_ctx, [
             "@bazel_tools//tools/cpp:BUILD.static.freebsd",


### PR DESCRIPTION
BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN is set.

Also add a test to prevent regression in the future.

Fixes #10439.