### PR TITLE
Extend http downloader to add support for non-standard authorization headers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -79,8 +79,11 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.*;
-import java.util.function.Function;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
@@ -1087,17 +1090,21 @@ public class SkylarkRepositoryContext
                               + " without a pattern being provided");
             }
 
-            String pattern = (String) authMap.get("pattern");
-            String result = "";
+            String result = (String) authMap.get("pattern");
 
             for (String component : Arrays.asList("password", "login")) {
               String demarcatedComponent = "<" + component + ">";
 
-              if (pattern.contains(demarcatedComponent) && !authMap.containsKey(component)) {
-                throw new EvalException(null, "Auth pattern contains " + demarcatedComponent + " but it was not provided in auth dict.");
+              if (result.contains(demarcatedComponent)) {
+                if (!authMap.containsKey(component)) {
+                  throw new EvalException(null, "Auth pattern contains " + demarcatedComponent + " but it was not provided in auth dict.");
+                }
+              } else {
+                // component isn't in the pattern, ignore it
+                continue;
               }
 
-              result = pattern.replaceAll(demarcatedComponent, (String)authMap.get(component));
+              result = result.replaceAll(demarcatedComponent, (String)authMap.get(component));
             }
 
             headers.put(

--- a/src/test/shell/bazel/testing_server.py
+++ b/src/test/shell/bazel/testing_server.py
@@ -44,7 +44,7 @@ class Handler(BaseHTTPRequestHandler):
   simulate_timeout = False
   filename = None
   redirect = None
-  valid_header = b'Basic ' + base64.b64encode('foo:bar'.encode('ascii'))
+  valid_headers = [b'Basic ' + base64.b64encode('foo:bar'.encode('ascii')), b'Bearer TOKEN']
 
   def do_HEAD(self):  # pylint: disable=invalid-name
     self.send_response(200)
@@ -84,12 +84,13 @@ class Handler(BaseHTTPRequestHandler):
       return
 
     auth_header = self.headers.get('Authorization', '').encode('ascii')
-    if auth_header == self.valid_header:
+    
+    if auth_header in self.valid_headers:
       self.do_HEAD()
       self.serve_file()
     else:
       self.do_AUTHHEAD()
-      self.wfile.write(b'Login required.')
+      self.wfile.write(b'Login required.' + str(auth_header))
 
   def serve_file(self):
     path_to_serve = self.path[1:]

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -223,7 +223,7 @@ machine storage.cloudprovider.com
         password RANDOM-TOKEN
 ```
 
-The final HTTP request would have:
+The final HTTP request would have the following header:
 
 ```
 Authorization: Bearer RANDOM-TOKEN
@@ -448,7 +448,7 @@ machine storage.cloudprovider.com
         password RANDOM-TOKEN
 ```
 
-The final HTTP request would have:
+The final HTTP request would have the following header:
 
 ```
 Authorization: Bearer RANDOM-TOKEN
@@ -510,41 +510,40 @@ unless it was added to the cache by a request with the same canonical id.
     "auth_patterns": attr.string_dict(
         doc = """An optional dict mapping host names to custom authorization patterns.
 
-    If a URL's host name is present in this dict the value will be used as a pattern when
-    generating the authorization header for the http request. This enables the use of custom
-    authorization schemes used in a lot of common cloud storage providers.
+If a URL's host name is present in this dict the value will be used as a pattern when
+generating the authorization header for the http request. This enables the use of custom
+authorization schemes used in a lot of common cloud storage providers.
 
-    The pattern currently supports 2 tokens: `<login>` and `<password>`, which are replaced with
-    their equivalent value in the netrc file for the same host name. After formatting, the result
-    is set as the value for the `Authorization` field of the HTTP request.
+The pattern currently supports 2 tokens: `<login>` and `<password>`, which are replaced with
+their equivalent value in the netrc file for the same host name. After formatting, the result
+is set as the value for the `Authorization` field of the HTTP request.
 
-    Example WORKSPACE and netrc for a http download to an oauth2 enabled API using a bearer token:
+Example WORKSPACE and netrc for a http download to an oauth2 enabled API using a bearer token:
 
-    ```python
-    http_jar(
-        name = "custom-artifact",
-        url = "https://storage.cloudprovider.com/custom-bucket/custom-artifact.jar",
-        sha256 = "...",
-        netrc = "/home/testuser/workspace/netrc",
-        auth_patterns = {
-            "storage.cloudprovider.com": "Bearer <password>"
-        }
-    )
+```python
+http_jar(
+    name = "custom-artifact",
+    url = "https://storage.cloudprovider.com/custom-bucket/custom-artifact.jar",
+    sha256 = "...",
+    netrc = "/home/testuser/workspace/netrc",
+    auth_patterns = {
+        "storage.cloudprovider.com": "Bearer <password>"
+    }
+)
 
-    netrc:
+netrc:
 
-    ```
-    machine storage.cloudprovider.com
-            password RANDOM-TOKEN
-    ```
+```
+machine storage.cloudprovider.com
+        password RANDOM-TOKEN
+```
 
-    The final HTTP request would have:
+The final HTTP request would have the following header:
 
-    ```
-    Authorization: Bearer RANDOM-TOKEN
-    ```
-
-    """,
+```
+Authorization: Bearer RANDOM-TOKEN
+```
+""",
     ),
 }
 

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -43,16 +43,16 @@ def _get_auth(ctx, urls):
     """Given the list of URLs obtain the correct auth dict."""
     if ctx.attr.netrc:
         netrc = read_netrc(ctx, ctx.attr.netrc)
-        return use_netrc(netrc, urls)
+        return use_netrc(netrc, urls, ctx.attr.auth_patterns)
 
     if "HOME" in ctx.os.environ:
         if not ctx.os.name.startswith("windows"):
             netrcfile = "%s/.netrc" % (ctx.os.environ["HOME"],)
             if ctx.execute(["test", "-f", netrcfile]).return_code == 0:
                 netrc = read_netrc(ctx, netrcfile)
-                return use_netrc(netrc, urls)
+                return use_netrc(netrc, urls, ctx.attr.auth_patterns)
 
-        # TODO: Search at a similarly canonical place for Windows as well
+    # TODO: Search at a similarly canonical place for Windows as well
 
     return {}
 
@@ -191,6 +191,45 @@ easier but should be set before shipping.""",
     ),
     "netrc": attr.string(
         doc = "Location of the .netrc file to use for authentication",
+    ),
+    "auth_patterns": attr.string_dict(
+        doc = """An optional dict mapping host names to custom authorization patterns.
+
+If a URL's host name is present in this dict the value will be used as a pattern when
+generating the authorization header for the http request. This enables the use of custom
+authorization schemes used in a lot of common cloud storage providers.
+
+The pattern currently supports 2 tokens: `<login>` and `<password>`, which are replaced with
+their equivalent value in the netrc file for the same host name. After formatting, the result
+is set as the value for the `Authorization` field of the HTTP request.
+
+Example WORKSPACE and netrc for a http download to an oauth2 enabled API using a bearer token:
+
+```python
+http_jar(
+    name = "custom-artifact",
+    url = "https://storage.cloudprovider.com/custom-bucket/custom-artifact.jar",
+    sha256 = "...",
+    netrc = "/home/testuser/workspace/netrc",
+    auth_patterns = {
+        "storage.cloudprovider.com": "Bearer <password>"
+    }
+)
+
+netrc:
+
+```
+machine storage.cloudprovider.com
+        password RANDOM-TOKEN
+```
+
+The final HTTP request would have:
+
+```
+Authorization: Bearer RANDOM-TOKEN
+```
+
+""",
     ),
     "canonical_id": attr.string(
         doc = """A canonical id of the archive downloaded.
@@ -378,6 +417,45 @@ Authentication is not supported.""",
     "netrc": attr.string(
         doc = "Location of the .netrc file to use for authentication",
     ),
+    "auth_patterns": attr.string_dict(
+        doc = """An optional dict mapping host names to custom authorization patterns.
+
+If a URL's host name is present in this dict the value will be used as a pattern when
+generating the authorization header for the http request. This enables the use of custom
+authorization schemes used in a lot of common cloud storage providers.
+
+The pattern currently supports 2 tokens: `<login>` and `<password>`, which are replaced with
+their equivalent value in the netrc file for the same host name. After formatting, the result
+is set as the value for the `Authorization` field of the HTTP request.
+
+Example WORKSPACE and netrc for a http download to an oauth2 enabled API using a bearer token:
+
+```python
+http_jar(
+    name = "custom-artifact",
+    url = "https://storage.cloudprovider.com/custom-bucket/custom-artifact.jar",
+    sha256 = "...",
+    netrc = "/home/testuser/workspace/netrc",
+    auth_patterns = {
+        "storage.cloudprovider.com": "Bearer <password>"
+    }
+)
+
+netrc:
+
+```
+machine storage.cloudprovider.com
+        password RANDOM-TOKEN
+```
+
+The final HTTP request would have:
+
+```
+Authorization: Bearer RANDOM-TOKEN
+```
+
+""",
+    ),
 }
 
 http_file = repository_rule(
@@ -428,6 +506,45 @@ unless it was added to the cache by a request with the same canonical id.
     ),
     "netrc": attr.string(
         doc = "Location of the .netrc file to use for authentication",
+    ),
+    "auth_patterns": attr.string_dict(
+        doc = """An optional dict mapping host names to custom authorization patterns.
+
+    If a URL's host name is present in this dict the value will be used as a pattern when
+    generating the authorization header for the http request. This enables the use of custom
+    authorization schemes used in a lot of common cloud storage providers.
+
+    The pattern currently supports 2 tokens: `<login>` and `<password>`, which are replaced with
+    their equivalent value in the netrc file for the same host name. After formatting, the result
+    is set as the value for the `Authorization` field of the HTTP request.
+
+    Example WORKSPACE and netrc for a http download to an oauth2 enabled API using a bearer token:
+
+    ```python
+    http_jar(
+        name = "custom-artifact",
+        url = "https://storage.cloudprovider.com/custom-bucket/custom-artifact.jar",
+        sha256 = "...",
+        netrc = "/home/testuser/workspace/netrc",
+        auth_patterns = {
+            "storage.cloudprovider.com": "Bearer <password>"
+        }
+    )
+
+    netrc:
+
+    ```
+    machine storage.cloudprovider.com
+            password RANDOM-TOKEN
+    ```
+
+    The final HTTP request would have:
+
+    ```
+    Authorization: Bearer RANDOM-TOKEN
+    ```
+
+    """,
     ),
 }
 

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -289,13 +289,14 @@ def read_netrc(ctx, filename):
         netrc[currentmachinename] = currentmachine
     return netrc
 
-def use_netrc(netrc, urls):
+def use_netrc(netrc, urls, patterns):
     """compute an auth dict from a parsed netrc file and a list of URLs
 
     Args:
       netrc: a netrc file already parsed to a dict, e.g., as obtained from
         read_netrc
       urls: a list of URLs.
+      patterns: optional dict of url to authorization patterns
 
     Returns:
       dict suitable as auth argument for ctx.download; more precisely, the dict
@@ -316,10 +317,24 @@ def use_netrc(netrc, urls):
         if not host in netrc:
             continue
         authforhost = netrc[host]
-        if "login" in authforhost and "password" in authforhost:
+        if host in patterns:
+            auth_dict = {
+                "type": "pattern",
+                "pattern": patterns[host],
+            }
+
+            if "login" in authforhost:
+                auth_dict["login"] = authforhost["login"]
+
+            if "password" in authforhost:
+                auth_dict["password"] = authforhost["password"]
+
+            auth[url] = auth_dict
+        elif "login" in authforhost and "password" in authforhost:
             auth[url] = {
                 "type": "basic",
                 "login": authforhost["login"],
                 "password": authforhost["password"],
             }
+
     return auth

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -301,8 +301,8 @@ def use_netrc(netrc, urls, patterns):
     Returns:
       dict suitable as auth argument for ctx.download; more precisely, the dict
       will map all URLs where the netrc file provides login and password to a
-      dict containing the corresponding login and passwored, as well as the
-      mapping of "type" to "basic"
+      dict containing the corresponding login, password and optional authorization pattern,
+      as well as the mapping of "type" to "basic" or "pattern".
     """
     auth = {}
     for url in urls:


### PR DESCRIPTION
In order to leverage downloading from certain cloud storage providers that don't support basic authentication, this PR extends the existing authentication mechanism in bazel to forward an oauth2 token to the request header.

Sample netrc

```
machine storage.googleapis.com
        oauth2-token aaabbbbccccdddd
```

See https://github.com/bazelbuild/bazel/issues/10442