### PR TITLE
Fix rendering of < and > in HTML docs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/BazelCcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/BazelCcModuleApi.java
@@ -136,7 +136,7 @@ public interface BazelCcModuleApi<
             name = "system_includes",
             doc =
                 "Search paths for header files referenced by angle brackets, e.g. #include"
-                    + " <foo/bar/header.h>. They can be either relative to the exec root or"
+                    + " &lt;foo/bar/header.h&gt;. They can be either relative to the exec root or"
                     + " absolute. Usually passed with -isystem. Propagated to dependents "
                     + "transitively.",
             positional = false,

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/CcCompilationContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/CcCompilationContextApi.java
@@ -56,7 +56,7 @@ public interface CcCompilationContextApi extends StarlarkValue {
       name = "system_includes",
       doc =
           "Returns the set of search paths (as strings) for header files referenced by angle"
-              + " brackets, e.g. #include <foo/bar/header.h>. They can be either relative to the"
+              + " brackets, e.g. #include &lt;foo/bar/header.h&gt;. They can be either relative to the"
               + " exec root or absolute. Usually passed with -isystem.",
       structField = true)
   Depset getSkylarkSystemIncludeDirs();


### PR DESCRIPTION
Without escaping, they make it in directly into the output HTML, which
doesn't render correctly.