### PR TITLE
Allow empty_globs in Android SDK BUILD globs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
@@ -37,7 +37,10 @@ alias(
 
 filegroup(
     name = "emulator_x86_bios",
-    srcs = glob(["emulator/lib/pc-bios/*"]),
+    srcs = glob(
+        ["emulator/lib/pc-bios/*"],
+	allow_empty = True,
+    ),
 )
 
 alias(
@@ -47,7 +50,10 @@ alias(
 
 filegroup(
     name = "emulator_shared_libs",
-    srcs = glob(["emulator/lib64/**"]),
+    srcs = glob(
+        ["emulator/lib64/**"],
+	allow_empty = True,
+    ),
 )
 
 filegroup(
@@ -70,4 +76,4 @@ create_system_images_filegroups(
 )
 
 exports_files([
-%exported_files%] + glob(["system-images/**"]))
+%exported_files%] + glob(["system-images/**"], allow_empty = True))

--- a/tools/android/android_sdk_repository_template.bzl
+++ b/tools/android/android_sdk_repository_template.bzl
@@ -63,7 +63,10 @@ def create_android_sdk_rules(
         "build-tools/%s/aidl.exe" % build_tools_directory,
         "build-tools/%s/zipalign.exe" % build_tools_directory,
         "platform-tools/adb.exe",
-    ] + native.glob(["build-tools/%s/aapt2.exe" % build_tools_directory])
+    ] + native.glob(
+        ["build-tools/%s/aapt2.exe" % build_tools_directory],
+        allow_empty = True,
+    )
 
     linux_only_files = [
         "build-tools/%s/aapt" % build_tools_directory,
@@ -73,6 +76,7 @@ def create_android_sdk_rules(
     ] + native.glob(
         ["extras", "build-tools/%s/aapt2" % build_tools_directory],
         exclude_directories = 0,
+        allow_empty = True,
     )
 
     # This filegroup is used to pass the minimal contents of the SDK to the


### PR DESCRIPTION
Some of these globs are OS-specific, leading to empty files. We also do
not require Android SDKs to contain certain components like emulators.

Enable allow_empty for these globs to be compatible with
--incompatible_disallow_empty_glob