### PR TITLE
DottedVersion.Option implements StarlarkValue

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/DottedVersion.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/DottedVersion.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.skylarkbuildapi.apple.DottedVersionApi;
 import com.google.devtools.build.lib.syntax.Printer;
+import com.google.devtools.build.lib.syntax.StarlarkValue;
 import java.util.ArrayList;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -89,7 +90,7 @@ public final class DottedVersion implements DottedVersionApi<DottedVersion> {
    * directory names)</p>
    * */
   @Immutable
-  public static final class Option {
+  public static final class Option implements StarlarkValue {
     private final DottedVersion version;
 
     private Option(DottedVersion version) {
@@ -103,6 +104,11 @@ public final class DottedVersion implements DottedVersionApi<DottedVersion> {
     @Override
     public int hashCode() {
       return version.stringRepresentation.hashCode();
+    }
+
+    @Override
+    public void repr(Printer printer) {
+      printer.append(version.stringRepresentation);
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/syntax/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/syntax/BUILD
@@ -32,6 +32,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/packages:starlark_semantics_options",
+        "//src/main/java/com/google/devtools/build/lib/rules/apple",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/testutils",
         "//src/main/java/com/google/devtools/build/lib/skylarkinterface",
         "//src/main/java/com/google/devtools/build/lib/util",

--- a/src/test/java/com/google/devtools/build/lib/syntax/StarlarkEvaluationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/StarlarkEvaluationTest.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.NativeInfo;
 import com.google.devtools.build.lib.packages.NativeProvider;
 import com.google.devtools.build.lib.packages.StructProvider;
+import com.google.devtools.build.lib.rules.apple.DottedVersion;
 import com.google.devtools.build.lib.skylarkinterface.Param;
 import com.google.devtools.build.lib.skylarkinterface.ParamType;
 import com.google.devtools.build.lib.skylarkinterface.SkylarkCallable;
@@ -1438,6 +1439,14 @@ public final class StarlarkEvaluationTest extends EvaluationTestCase {
         .contains(
             "invalid Starlark value: class"
                 + " com.google.devtools.build.lib.collect.nestedset.NestedSet");
+  }
+
+  @Test
+  public void testDottedVersionSkylarkValue() throws Exception {
+    new Scenario()
+        .update("version", DottedVersion.option(DottedVersion.fromStringUnchecked("1.0")))
+        .setUp("x = 'ok' if str(version) == '1.0' else 'fail'")
+        .testLookup("x", "ok");
   }
 
   @Test


### PR DESCRIPTION
As of 2.0, it is not possible to transition on these values anymore, since `DottedVersion` does implement StarlarkValue, but `DottedVersion.Option` does not.