### PR TITLE
Add an "explain" subcommand to "bazel help"

### DIFF
--- a/src/main/protobuf/bazel_flags.proto
+++ b/src/main/protobuf/bazel_flags.proto
@@ -35,6 +35,8 @@ message FlagInfo {
   optional string abbreviation = 5;
   // True if a flag is allowed to occur multiple times in a single arg list.
   optional bool allows_multiple = 6 [default = false];
+  // The default value of this flag as an unparsed string.
+  optional string default_value = 7;
 }
 
 message FlagCollection {

--- a/src/test/shell/bazel/help_test.sh
+++ b/src/test/shell/bazel/help_test.sh
@@ -35,4 +35,13 @@ function test_info_keys() {
   expect_log_once "default-package-path"
 }
 
+function test_help_explain() {
+  bazel help explain -- build //... --compilation_mode opt -k >& $TEST_log || fail "help failed"
+
+  expect_log_once "--compilation_mode \[\-c\] (default: fastbuild)"
+  expect_log_once "Specify the mode the binary will be built in. Values: 'fastbuild', 'dbg', 'opt'."
+  expect_log_once "--keep_going \[\-k\] (default: false)"
+  expect_log_once "Continue as much as possible after an error."
+}
+
 run_suite "'help' command tests"


### PR DESCRIPTION
e.g.

```
$ bazel help explain -- --host_jvm_debug build //... -c -k -s
Starting local Bazel server and connecting to it...
--compilation_mode [-c] (default: fastbuild)
    Specify the mode the binary will be built in. Values: 'fastbuild', 'dbg', 'opt'.
--host_jvm_debug (default: null)
    Convenience option to add some additional JVM startup flags, which cause the JVM to wait during startup until you connect from a JDWP-compliant debugger (like Eclipse) to port 5005.
--subcommands [-s] (default: false)
    Display the subcommands executed during a build.
--keep_going [-k] (default: false)
    Continue as much as possible after an error.  While the target that failed and those that depend on it cannot be analyzed, other prerequisites of these targets can be.
```

RELNOTES[NEW]: Added `bazel help explain -- <command>` subcommand to print descriptions of the flags used in the command.