### PR TITLE
Update the error thrown by Bazel

### DIFF
--- a/site/docs/tutorial/cc-toolchain-config.md
+++ b/site/docs/tutorial/cc-toolchain-config.md
@@ -139,7 +139,7 @@ using an older release of Bazel, look for the "Configuring CROSSTOOL" tutorial.
 4.  Run the build again. Bazel throws the following error:
 
     ```
-    Rule '//toolchain:asmjs_toolchain_config' does not exist
+    Rule '//toolchain:asmjs_toolchain' does not exist
     ```
 
     Now you need to define `cc_toolchain` targets for every value in the


### PR DESCRIPTION
Hello,

The error message thrown by Bazel in step 4 should be updated.
The label of the toolchain specified in step 3 is **//toolchain:asmjs_toolchain** and not **//toolchain:asmjs_toolchain_config**.
Therefore the error message should be 
```
    Rule '//toolchain:asmjs_toolchain' does not exist
```
Kind regards,
George