### PR TITLE
Refactor in BuildView: move progress counters

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
@@ -46,6 +46,7 @@ import com.google.devtools.build.lib.skyframe.BuildConfigurationValue;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
 import com.google.devtools.build.lib.skyframe.TargetPatternPhaseValue;
 import com.google.devtools.build.lib.util.AbruptExitException;
+import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.util.RegexFilter;
 import com.google.devtools.common.options.OptionsParsingException;
 import java.util.Collection;
@@ -221,13 +222,15 @@ public final class AnalysisPhaseRunner {
             env.getReporter(),
             env.getEventBus());
 
+    Pair<Integer, Integer> tcal = view.getTargetsConfiguredAndLoaded();
+
     // TODO(bazel-team): Merge these into one event.
     env.getEventBus()
         .post(
             new AnalysisPhaseCompleteEvent(
                 analysisResult.getTargetsToBuild(),
-                view.getTargetsLoaded(),
-                view.getTargetsConfigured(),
+                /* targetsLoaded */ tcal.second.intValue(),
+                /* targetsConfigured */ tcal.first.intValue(),
                 timer.stop().elapsed(TimeUnit.MILLISECONDS),
                 view.getAndClearPkgManagerStatistics(),
                 view.getActionsConstructed(),


### PR DESCRIPTION
Move the progress counters (e.g. number of
evaluated actions) into the SkyframeBuildView's
progressReceiver, because this reflects the
ownership of these counters more cleanly, since
the progressReceiver is the only object that
mutates them.

In SkyframeBuildView, merge
resetEvaluatedConfiguredTargetKeysSet() and
resetEvaluationActionCount() into just
resetProgressReceiver(), because the two calls
must go together, and because the new name
expresses the purpose of these methods better.

In BuildView, merge getTargetsConfigured and
getTargetsLoaded() into just
getTargetsConfiguredAndLoaded(), because the two
calls always go together, both used to call
SkyframeBuildView.getEvaluatedTargetKeys() which
created a new ImmutableSet for both. Now we only
create that set once.

Change-Id: If8d6518abdbb854974d9589329e66f711413264a