### PR TITLE
"Stream" action cache digest computations.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.actions.ActionAnalysisMetadata.MiddlemanTyp
 import com.google.devtools.build.lib.actions.cache.ActionCache;
 import com.google.devtools.build.lib.actions.cache.DigestUtils;
 import com.google.devtools.build.lib.actions.cache.MetadataHandler;
+import com.google.devtools.build.lib.actions.cache.OrderIndependentHasher;
 import com.google.devtools.build.lib.actions.cache.Protos.ActionCacheStatistics.MissReason;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -43,11 +44,11 @@ import javax.annotation.Nullable;
  * Checks whether an {@link Action} needs to be executed, or whether it has not changed since it was
  * last stored in the action cache. Must be informed of the new Action data after execution as well.
  *
- * <p>The fingerprint, input files names, and metadata (either mtimes or MD5sums) of each action are
- * cached in the action cache to avoid unnecessary rebuilds. Middleman artifacts are handled
- * specially, avoiding the need to create actual files corresponding to the middleman artifacts.
- * Instead of that, results of MiddlemanAction dependency checks are cached internally and then
- * reused whenever an input middleman artifact is encountered.
+ * <p>The fingerprint, input files names, and metadata (either mtimes or content digests) of each
+ * action are cached in the action cache to avoid unnecessary rebuilds. Middleman artifacts are
+ * handled specially, avoiding the need to create actual files corresponding to the middleman
+ * artifacts. Instead of that, results of MiddlemanAction dependency checks are cached internally
+ * and then reused whenever an input middleman artifact is encountered.
  *
  * <p>While instances of this class hold references to action and metadata cache instances, they are
  * otherwise lightweight, and should be constructed anew and discarded for each build request.
@@ -149,16 +150,17 @@ public class ActionCacheChecker {
       NestedSet<Artifact> actionInputs,
       MetadataHandler metadataHandler,
       boolean checkOutput) {
-    Map<String, FileArtifactValue> mdMap = new HashMap<>();
+    OrderIndependentHasher hasher = new OrderIndependentHasher();
     if (checkOutput) {
       for (Artifact artifact : action.getOutputs()) {
-        mdMap.put(artifact.getExecPathString(), getMetadataMaybe(metadataHandler, artifact));
+        hasher.addArtifact(
+            artifact.getExecPathString(), getMetadataMaybe(metadataHandler, artifact));
       }
     }
     for (Artifact artifact : actionInputs.toList()) {
-      mdMap.put(artifact.getExecPathString(), getMetadataMaybe(metadataHandler, artifact));
+      hasher.addArtifact(artifact.getExecPathString(), getMetadataMaybe(metadataHandler, artifact));
     }
-    return !Arrays.equals(DigestUtils.fromMetadata(mdMap), entry.getFileDigest());
+    return !Arrays.equals(hasher.finish(), entry.getFileDigest());
   }
 
   private void reportCommand(EventHandler handler, Action action) {
@@ -340,7 +342,6 @@ public class ActionCacheChecker {
       return true;
     }
 
-    entry.getFileDigest();
     actionCache.accountHit();
     return false;
   }
@@ -384,8 +385,8 @@ public class ActionCacheChecker {
     }
     Map<String, String> usedEnvironment =
         computeUsedEnv(action, clientEnv, remoteDefaultPlatformProperties);
-    ActionCache.Entry entry =
-        new ActionCache.Entry(
+    ActionCache.Entry.Builder entry =
+        new ActionCache.Entry.Builder(
             action.getKey(actionKeyContext), usedEnvironment, action.discoversInputs());
     for (Artifact output : action.getOutputs()) {
       // Remove old records from the cache if they used different key.
@@ -406,8 +407,7 @@ public class ActionCacheChecker {
     for (Artifact input : action.getInputs().toList()) {
       entry.addFile(input.getExecPath(), getMetadataMaybe(metadataHandler, input));
     }
-    entry.getFileDigest();
-    actionCache.put(key, entry);
+    actionCache.put(key, entry.build());
   }
 
   @Nullable
@@ -513,10 +513,12 @@ public class ActionCacheChecker {
       // Compute the aggregated middleman digest.
       // Since we never validate action key for middlemen, we should not store
       // it in the cache entry and just use empty string instead.
-      entry = new ActionCache.Entry("", ImmutableMap.<String, String>of(), false);
+      ActionCache.Entry.Builder entryBuilder =
+          new ActionCache.Entry.Builder("", ImmutableMap.<String, String>of(), false);
       for (Artifact input : action.getInputs().toList()) {
-        entry.addFile(input.getExecPath(), getMetadataMaybe(metadataHandler, input));
+        entryBuilder.addFile(input.getExecPath(), getMetadataMaybe(metadataHandler, input));
       }
+      entry = entryBuilder.build();
     }
 
     metadataHandler.setDigestForVirtualArtifact(middleman, entry.getFileDigest());

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/ActionCache.java
@@ -14,9 +14,7 @@
 
 package com.google.devtools.build.lib.actions.cache;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.BaseEncoding;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
@@ -26,10 +24,8 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadCompatible;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -64,57 +60,26 @@ public interface ActionCache {
   void remove(String key);
 
   /**
-   * An entry in the ActionCache that contains all action input and output
-   * artifact paths and their metadata plus action key itself.
-   *
-   * Cache entry operates under assumption that once it is fully initialized
-   * and getFileDigest() method is called, it becomes logically immutable (all methods
-   * will continue to return same result regardless of internal data transformations).
+   * An entry in the ActionCache that contains the action key, input digest, and environment digest.
+   * For input-discovering actions, it also contains the paths of the action's inputs and outputs.
    */
   final class Entry {
     /** Unique instance to represent a corrupted cache entry. */
-    public static final ActionCache.Entry CORRUPTED =
-        new ActionCache.Entry(null, ImmutableMap.<String, String>of(), false);
+    public static final ActionCache.Entry CORRUPTED = new ActionCache.Entry(null, null, null, null);
 
     private final String actionKey;
     @Nullable
     // Null iff the corresponding action does not do input discovery.
     private final List<String> files;
-    // If null, digest is non-null and the entry is immutable.
-    private Map<String, FileArtifactValue> mdMap;
-    private byte[] digest;
+
+    private final byte[] digest;
     private final byte[] usedClientEnvDigest;
 
-    public Entry(String key, Map<String, String> usedClientEnv, boolean discoversInputs) {
-      actionKey = key;
-      this.usedClientEnvDigest = DigestUtils.fromEnv(usedClientEnv);
-      files = discoversInputs ? new ArrayList<String>() : null;
-      mdMap = new HashMap<>();
-    }
-
-    public Entry(
-        String key, byte[] usedClientEnvDigest, @Nullable List<String> files, byte[] digest) {
+    Entry(String key, byte[] usedClientEnvDigest, @Nullable List<String> files, byte[] digest) {
       actionKey = key;
       this.usedClientEnvDigest = usedClientEnvDigest;
       this.files = files;
       this.digest = digest;
-      mdMap = null;
-    }
-
-    /**
-     * Adds the artifact, specified by the executable relative path and its metadata into the cache
-     * entry.
-     */
-    public void addFile(PathFragment relativePath, FileArtifactValue md) {
-      Preconditions.checkState(mdMap != null);
-      Preconditions.checkState(!isCorrupted());
-      Preconditions.checkState(digest == null);
-
-      String execPath = relativePath.getPathString();
-      if (discoversInputs()) {
-        files.add(execPath);
-      }
-      mdMap.put(execPath, md);
     }
 
     /**
@@ -129,17 +94,8 @@ public interface ActionCache {
       return usedClientEnvDigest;
     }
 
-    /**
-     * Returns the combined digest of the action's inputs and outputs.
-     *
-     * <p>This may compress the data into a more compact representation, and makes the object
-     * immutable.
-     */
+    /** Returns the combined digest of the action's inputs and outputs. */
     public byte[] getFileDigest() {
-      if (digest == null) {
-        digest = DigestUtils.fromMetadata(mdMap);
-        mdMap = null;
-      }
       return digest;
     }
 
@@ -177,11 +133,7 @@ public interface ActionCache {
           .append(formatDigest(usedClientEnvDigest))
           .append("\n");
       builder.append("      digestKey = ");
-      if (digest == null) {
-        builder.append(formatDigest(DigestUtils.fromMetadata(mdMap))).append(" (from mdMap)\n");
-      } else {
-        builder.append(formatDigest(digest)).append("\n");
-      }
+      builder.append(formatDigest(digest)).append("\n");
 
       if (discoversInputs()) {
         List<String> fileInfo = Lists.newArrayListWithCapacity(files.size());
@@ -192,6 +144,40 @@ public interface ActionCache {
         }
       }
       return builder.toString();
+    }
+
+    public static final class Builder {
+      private final String actionKey;
+      private final byte[] usedClientEnvDigest;
+      private final ImmutableList.Builder<String> files;
+      private final OrderIndependentHasher hasher = new OrderIndependentHasher();
+
+      public Builder(String key, Map<String, String> usedClientEnv, boolean discoversInputs) {
+        actionKey = key;
+        this.usedClientEnvDigest = DigestUtils.fromEnv(usedClientEnv);
+        files = discoversInputs ? ImmutableList.<String>builder() : null;
+      }
+
+      /**
+       * Add the artifact, specified by the executable relative path and its metadata into the cache
+       * entry. It is not allowed to call addFile with the same arguments twice; doing so may cause
+       * incorrect builds.
+       */
+      public void addFile(PathFragment relativePath, FileArtifactValue md) {
+        String execPath = relativePath.getPathString();
+        if (files != null) {
+          files.add(execPath);
+        }
+        hasher.addArtifact(execPath, md);
+      }
+
+      public Entry build() {
+        return new Entry(
+            actionKey,
+            usedClientEnvDigest,
+            (files != null) ? files.build() : null,
+            hasher.finish());
+      }
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/actions/cache/OrderIndependentHasher.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/OrderIndependentHasher.java
@@ -1,0 +1,51 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.actions.cache;
+
+import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.util.Fingerprint;
+import javax.annotation.Nullable;
+
+/** Utility class for combining a set of (path, metadata) pairs into a single digest. */
+public final class OrderIndependentHasher {
+  private final Fingerprint fp = new Fingerprint();
+  private final byte[] tmp = new byte[fp.getDigestLength()];
+  private final byte[] digest = new byte[fp.getDigestLength()];
+
+  /**
+   * Add a artifact's path and metadata to the digest. This method must never be called twice with
+   * the same arguments.
+   */
+  public void addArtifact(String execPath, @Nullable FileArtifactValue md) {
+    fp.addString(execPath);
+    if (md == null) {
+      // Move along, nothing to see here.
+    } else if (md.getDigest() != null) {
+      fp.addBytes(md.getDigest());
+    } else {
+      // Use the timestamp if the digest is not present, but not both. Modifying a timestamp while
+      // keeping the contents of a file the same should not cause rebuilds.
+      fp.addLong(md.getModifiedTime());
+    }
+    fp.digestAndReset(tmp, 0, tmp.length);
+    for (int i = 0; i < digest.length; i++) {
+      digest[i] ^= tmp[i];
+    }
+  }
+
+  /** Return the final combined digest. */
+  public byte[] finish() {
+    return digest;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/skyframe/TreeArtifactValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TreeArtifactValue.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.HasDigest;
-import com.google.devtools.build.lib.actions.cache.DigestUtils;
+import com.google.devtools.build.lib.actions.cache.OrderIndependentHasher;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.vfs.Dirent;
 import com.google.devtools.build.lib.vfs.Dirent.Type;
@@ -47,9 +47,7 @@ public class TreeArtifactValue implements HasDigest, SkyValue {
 
   private static final TreeArtifactValue EMPTY =
       new TreeArtifactValue(
-          DigestUtils.fromMetadata(ImmutableMap.of()),
-          ImmutableSortedMap.of(),
-          /* remote= */ false);
+          new OrderIndependentHasher().finish(), ImmutableSortedMap.of(), /* remote= */ false);
 
   private final byte[] digest;
   private final ImmutableSortedMap<TreeFileArtifact, FileArtifactValue> childData;
@@ -73,6 +71,7 @@ public class TreeArtifactValue implements HasDigest, SkyValue {
     if (childFileValues.isEmpty()) {
       return EMPTY;
     }
+    OrderIndependentHasher hasher = new OrderIndependentHasher();
     Map<String, FileArtifactValue> digestBuilder =
         Maps.newHashMapWithExpectedSize(childFileValues.size());
     boolean remote = true;
@@ -81,12 +80,10 @@ public class TreeArtifactValue implements HasDigest, SkyValue {
       // TODO(buchgr): Enforce that all children in a tree artifact are either remote or local
       // once b/70354083 is fixed.
       remote = remote && value.isRemote();
-      digestBuilder.put(e.getKey().getParentRelativePath().getPathString(), value);
+      hasher.addArtifact(e.getKey().getParentRelativePath().getPathString(), value);
     }
     return new TreeArtifactValue(
-        DigestUtils.fromMetadata(digestBuilder),
-        ImmutableSortedMap.copyOf(childFileValues),
-        remote);
+        hasher.finish(), ImmutableSortedMap.copyOf(childFileValues), remote);
   }
 
   FileArtifactValue getSelfData() {

--- a/src/main/java/com/google/devtools/build/lib/util/Fingerprint.java
+++ b/src/main/java/com/google/devtools/build/lib/util/Fingerprint.java
@@ -59,6 +59,11 @@ public final class Fingerprint implements Consumer<String> {
     this(DigestHashFunction.SHA256);
   }
 
+  /** Return the length of the fingerprint in bytes. */
+  public int getDigestLength() {
+    return messageDigest.getDigestLength();
+  }
+
   /**
    * Completes the hash computation by doing final operations and resets the underlying state,
    * allowing this instance to be used again.

--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -600,6 +600,7 @@ java_test(
     name = "actions_test",
     srcs = glob([
         "actions/*.java",
+        "actions/cache/*.java",
     ]),
     test_class = "com.google.devtools.build.lib.AllTests",
     deps = [

--- a/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/cache/CompactPersistentActionCacheTest.java
@@ -17,11 +17,9 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.testutil.Scratch;
 import com.google.devtools.build.lib.vfs.Path;
-import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
@@ -137,27 +135,13 @@ public class CompactPersistentActionCacheTest {
     assertFullSave();
   }
 
-  // Regression test to check that CompactActionCacheEntry.toString does not mutate the object.
-  // Mutations may result in IllegalStateException.
-  @Test
-  public void testEntryToStringIsIdempotent() throws Exception {
-    ActionCache.Entry entry =
-        new ActionCache.Entry("actionKey", ImmutableMap.<String, String>of(), false);
-    entry.toString();
-    entry.addFile(
-        PathFragment.create("foo/bar"), FileArtifactValue.createForDirectoryWithMtime(1234));
-    entry.toString();
-    entry.getFileDigest();
-    entry.toString();
-  }
-
   private void assertToStringIsntTooBig(int numRecords) throws Exception {
     for (int i = 0; i < numRecords; i++) {
       putKey(Integer.toString(i));
     }
     String val = cache.toString();
     assertThat(val).startsWith("Action cache (" + numRecords + " records):\n");
-    assertWithMessage(val).that(val.length()).isAtMost(2000);
+    assertWithMessage(val).that(val.length()).isAtMost(2500);
     // Cache was too big to print out fully.
     if (numRecords > 10) {
       assertThat(val).endsWith("...");
@@ -198,8 +182,9 @@ public class CompactPersistentActionCacheTest {
 
   private void putKey(String key, ActionCache ac, boolean discoversInputs) {
     ActionCache.Entry entry =
-        new ActionCache.Entry(key, ImmutableMap.<String, String>of("k", "v"), discoversInputs);
-    entry.getFileDigest();
+        new ActionCache.Entry.Builder(
+                key, ImmutableMap.<String, String>of("k", "v"), discoversInputs)
+            .build();
     ac.put(key, entry);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactMetadataTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TreeArtifactMetadataTest.java
@@ -37,11 +37,12 @@ import com.google.devtools.build.lib.actions.BasicActionLookupValue;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.MissingInputFileException;
 import com.google.devtools.build.lib.actions.MutableActionGraph.ActionConflictException;
-import com.google.devtools.build.lib.actions.cache.DigestUtils;
+import com.google.devtools.build.lib.actions.cache.OrderIndependentHasher;
 import com.google.devtools.build.lib.actions.util.TestAction.DummyAction;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.events.NullEventHandler;
+import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.vfs.FileStatus;
 import com.google.devtools.build.lib.vfs.FileStatusWithDigestAdapter;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
@@ -111,24 +112,25 @@ public class TreeArtifactMetadataTest extends ArtifactFunctionTestCase {
     // Assertions about digest. As of this writing this logic is essentially the same
     // as that in TreeArtifact, but it's good practice to unit test anyway to guard against
     // breaking changes.
+    OrderIndependentHasher hasher = new OrderIndependentHasher();
     Map<String, FileArtifactValue> digestBuilder = new HashMap<>();
     for (PathFragment child : children) {
       FileArtifactValue subdigest =
           FileArtifactValue.createForTesting(tree.getPath().getRelative(child));
-      digestBuilder.put(child.getPathString(), subdigest);
+      hasher.addArtifact(child.getPathString(), subdigest);
     }
-    assertThat(DigestUtils.fromMetadata(digestBuilder)).isEqualTo(value.getDigest());
+    assertThat(hasher.finish()).isEqualTo(value.getDigest());
     return value;
   }
 
   @Test
   public void testEmptyTreeArtifacts() throws Exception {
     TreeArtifactValue value = doTestTreeArtifacts(ImmutableList.<PathFragment>of());
-    // Additional test, only for this test method: we expect the FileArtifactValue is equal to
-    // the digest [0]
+    // Additional test, only for this test method: we expect the FileArtifactValue's digest is an
+    // array of zeros.
     assertThat(value.getMetadata().getDigest()).isEqualTo(value.getDigest());
     // Java zero-fills arrays.
-    assertThat(value.getDigest()).isEqualTo(new byte[1]);
+    assertThat(value.getDigest()).isEqualTo(new byte[new Fingerprint().getDigestLength()]);
   }
 
   @Test


### PR DESCRIPTION
Now that ActionAnalysisMetadata.getInputs() returns a NestedSet, we don't need allocate an intermediate (path -> metadata) map during action digest computation. Encapsulate the logic for this in a OrderIndependentHasher class. This class also caches fingerprints and digest arrays to avoid allocations.

Update the size constant in CompactPersistentActionCacheTest.testToStringIsntToBig because the digests are all 32 byte arrays instead of 1 byte arrays.

Additionally, fix ActionCache.Entry so it's stateless and immutable by making a builder class for it. Delete CompactPersistentActionCacheTest.testEntryToStringIsIdempotent because the property it wants to proven by the type system.