### PR TITLE
Remove tests of actions with duplicate inputs.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/skyframe/ParallelBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ParallelBuilderTest.java
@@ -637,19 +637,6 @@ public class ParallelBuilderTest extends TimestampBuilderTestCase {
     assertThat(e).hasMessageThat().isEqualTo(CYCLE_MSG);
   }
 
-  @Test
-  public void testDuplicatedInput() throws Exception {
-    // <null> -> [action] -> foo
-    // (foo, foo) -> [action] -> bar
-    Artifact foo = createDerivedArtifact("foo");
-    Artifact bar = createDerivedArtifact("bar");
-    registerAction(new TestAction(TestAction.NO_EFFECT, emptyNestedSet, ImmutableSet.of(foo)));
-    registerAction(
-        new TestAction(TestAction.NO_EFFECT, asNestedSet(foo, foo), ImmutableSet.of(bar)));
-    buildArtifacts(bar);
-  }
-
-
   // Regression test for bug #735765, "ParallelBuilder still issues new jobs
   // after one has failed, without --keep-going."  The incorrect behaviour is
   // that, when the first job fails, while no new jobs are added to the queue

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TimestampBuilderMediumTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TimestampBuilderMediumTest.java
@@ -285,40 +285,6 @@ public class TimestampBuilderMediumTest extends TimestampBuilderTestCase {
     assertThat(button2.pressed).isTrue(); // name changed. must rebuild.
   }
 
-  @Test
-  public void testDuplicateInputs() throws Exception {
-    // (/hello,/hello) -> [action] -> /goodbye
-
-    Artifact hello = createSourceArtifact("hello");
-    FileSystemUtils.createDirectoryAndParents(hello.getPath().getParentDirectory());
-    FileSystemUtils.writeContentAsLatin1(hello.getPath(), "hello");
-    Artifact goodbye = createDerivedArtifact("goodbye");
-    Button button = createActionButton(asNestedSet(hello, hello), ImmutableSet.of(goodbye));
-
-    button.pressed = false;
-    buildArtifacts(persistentBuilder(cache), goodbye);
-    assertThat(button.pressed).isTrue(); // built
-
-    button.pressed = false;
-    buildArtifacts(persistentBuilder(cache), goodbye);
-    assertThat(button.pressed).isFalse(); // not rebuilt
-
-    FileSystemUtils.writeContentAsLatin1(hello.getPath(), "hello2");
-
-    button.pressed = false;
-    buildArtifacts(persistentBuilder(cache), goodbye);
-    assertThat(button.pressed).isTrue(); // rebuilt
-
-    button.pressed = false;
-    buildArtifacts(persistentBuilder(cache), goodbye);
-    assertThat(button.pressed).isFalse(); // not rebuilt
-
-    // Creating a new persistent cache does not cause a rebuild
-    cache.save();
-    buildArtifacts(persistentBuilder(createCache()), goodbye);
-    assertThat(button.pressed).isFalse(); // not rebuilt
-  }
-
   /**
    * Tests that changing timestamp of the input file without changing it content
    * does not cause action reexecution when metadata cache uses file digests in


### PR DESCRIPTION
Since all actions store their inputs as NestedSets now, these tests proved nothing except that NestedSetBuilder deduplicates its inputs.

@ulfjack 