### PR TITLE
Put HTTP portions of external downloads behind an interface.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.bazel.repository.LocalConfigPlatformRule;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions;
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.RepositoryOverride;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
+import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import com.google.devtools.build.lib.bazel.repository.skylark.SkylarkRepositoryFunction;
 import com.google.devtools.build.lib.bazel.repository.skylark.SkylarkRepositoryModule;
@@ -95,7 +96,8 @@ public class BazelRepositoryModule extends BlazeModule {
   private final AtomicBoolean isFetch = new AtomicBoolean(false);
   private final SkylarkRepositoryFunction skylarkRepositoryFunction;
   private final RepositoryCache repositoryCache = new RepositoryCache();
-  private final HttpDownloader httpDownloader = new HttpDownloader(repositoryCache);
+  private final HttpDownloader httpDownloader = new HttpDownloader();
+  private final DownloadManager downloadManager = new DownloadManager(repositoryCache, httpDownloader);
   private final MutableSupplier<Map<String, String>> clientEnvironmentSupplier =
       new MutableSupplier<>();
   private ImmutableMap<RepositoryName, PathFragment> overrides = ImmutableMap.of();
@@ -108,7 +110,7 @@ public class BazelRepositoryModule extends BlazeModule {
   private final ManagedDirectoriesKnowledgeImpl managedDirectoriesKnowledge;
 
   public BazelRepositoryModule() {
-    this.skylarkRepositoryFunction = new SkylarkRepositoryFunction(httpDownloader);
+    this.skylarkRepositoryFunction = new SkylarkRepositoryFunction(downloadManager);
     this.repositoryHandlers = repositoryRules();
     ManagedDirectoriesListener listener =
         repositoryNamesWithManagedDirs -> {
@@ -259,7 +261,7 @@ public class BazelRepositoryModule extends BlazeModule {
       }
 
       if (repoOptions.experimentalDistdir != null) {
-        httpDownloader.setDistdir(
+        downloadManager.setDistdir(
             repoOptions
                 .experimentalDistdir
                 .stream()
@@ -270,7 +272,7 @@ public class BazelRepositoryModule extends BlazeModule {
                             : env.getBlazeWorkspace().getWorkspace().getRelative(path))
                 .collect(Collectors.toList()));
       } else {
-        httpDownloader.setDistdir(ImmutableList.<Path>of());
+        downloadManager.setDistdir(ImmutableList.<Path>of());
       }
 
       if (repoOptions.httpTimeoutScaling > 0) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -1,0 +1,271 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.downloader;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
+import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
+import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCacheHitEvent;
+import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Bazel file downloader.
+ *
+ * <p>This class uses a {@link Downloader} to download files from external mirrors and
+ * writes them to disk.
+ */
+public class DownloadManager {
+
+  private final RepositoryCache repositoryCache;
+  private List<Path> distdir = ImmutableList.of();
+  private final Downloader downloader;
+
+  public DownloadManager(RepositoryCache repositoryCache, Downloader downloader) {
+    this.repositoryCache = repositoryCache;
+    this.downloader = downloader;
+  }
+
+  public void setDistdir(List<Path> distdir) {
+    this.distdir = ImmutableList.copyOf(distdir);
+  }
+
+  /**
+   * Downloads file to disk and returns path.
+   *
+   * <p>If the checksum and path to the repository cache is specified, attempt to load the file from
+   * the {@link RepositoryCache}. If it doesn't exist, proceed to download the file and load it into
+   * the cache prior to returning the value.
+   *
+   * @param urls list of mirror URLs with identical content
+   * @param checksum valid checksum which is checked, or absent to disable
+   * @param type extension, e.g. "tar.gz" to force on downloaded filename, or empty to not do this
+   * @param output destination filename if {@code type} is <i>absent</i>, otherwise output directory
+   * @param eventHandler CLI progress reporter
+   * @param clientEnv environment variables in shell issuing this command
+   * @param repo the name of the external repository for which the file was fetched; used only for
+   *     reporting
+   * @throws IllegalArgumentException on parameter badness, which should be checked beforehand
+   * @throws IOException if download was attempted and ended up failing
+   * @throws InterruptedException if this thread is being cast into oblivion
+   */
+  public Path download(
+      List<URL> urls,
+      Map<URI, Map<String, String>> authHeaders,
+      Optional<Checksum> checksum,
+      String canonicalId,
+      Optional<String> type,
+      Path output,
+      ExtendedEventHandler eventHandler,
+      Map<String, String> clientEnv,
+      String repo)
+      throws IOException, InterruptedException {
+    if (Thread.interrupted()) {
+      throw new InterruptedException();
+    }
+
+    URL mainUrl; // The "main" URL for this request
+    // Used for reporting only and determining the file name only.
+    if (urls.isEmpty()) {
+      if (type.isPresent() && !Strings.isNullOrEmpty(type.get())) {
+        mainUrl = new URL("http://nonexistent.example.org/cacheprobe." + type.get());
+      } else {
+        mainUrl = new URL("http://nonexistent.example.org/cacheprobe");
+      }
+    } else {
+      mainUrl = urls.get(0);
+    }
+    Path destination = getDownloadDestination(mainUrl, type, output);
+    ImmutableSet<String> candidateFileNames = getCandidateFileNames(mainUrl, destination);
+
+    // Is set to true if the value should be cached by the checksum value provided
+    boolean isCachingByProvidedChecksum = false;
+
+    if (checksum.isPresent()) {
+      String cacheKey = checksum.get().toString();
+      KeyType cacheKeyType = checksum.get().getKeyType();
+      try {
+        eventHandler.post(
+            new CacheProgress(mainUrl.toString(), "Checking in " + cacheKeyType + " cache"));
+        String currentChecksum = RepositoryCache.getChecksum(cacheKeyType, destination);
+        if (currentChecksum.equals(cacheKey)) {
+          // No need to download.
+          return destination;
+        }
+      } catch (IOException e) {
+        // Ignore error trying to hash. We'll attempt to retrieve from cache or just download again.
+      } finally {
+        eventHandler.post(new CacheProgress(mainUrl.toString()));
+      }
+
+      if (repositoryCache.isEnabled()) {
+        isCachingByProvidedChecksum = true;
+
+        try {
+          Path cachedDestination =
+              repositoryCache.get(cacheKey, destination, cacheKeyType, canonicalId);
+          if (cachedDestination != null) {
+            // Cache hit!
+            eventHandler.post(new RepositoryCacheHitEvent(repo, cacheKey, mainUrl));
+            return cachedDestination;
+          }
+        } catch (IOException e) {
+          // Ignore error trying to get. We'll just download again.
+        }
+      }
+
+      if (urls.isEmpty()) {
+        throw new IOException("Cache miss and no url specified");
+      }
+
+      for (Path dir : distdir) {
+        if (!dir.exists()) {
+          // This is not a warning (and probably we even should drop the message); it is
+          // perfectly fine to have a common rc-file pointing to a volume that is sometimes,
+          // but not always mounted.
+          eventHandler.handle(Event.info("non-existent distir " + dir));
+        } else if (!dir.isDirectory()) {
+          eventHandler.handle(Event.warn("distdir " + dir + " is not a directory"));
+        } else {
+          for (String name : candidateFileNames) {
+            boolean match = false;
+            Path candidate = dir.getRelative(name);
+            try {
+              eventHandler.post(
+                  new CacheProgress(
+                      mainUrl.toString(), "Checking " + cacheKeyType + " of " + candidate));
+              match = RepositoryCache.getChecksum(cacheKeyType, candidate).equals(cacheKey);
+            } catch (IOException e) {
+              // Not finding anything in a distdir is a normal case, so handle it absolutely
+              // quietly. In fact, it is common to specify a whole list of dist dirs,
+              // with the assumption that only one will contain an entry.
+            } finally {
+              eventHandler.post(new CacheProgress(mainUrl.toString()));
+            }
+            if (match) {
+              if (isCachingByProvidedChecksum) {
+                try {
+                  repositoryCache.put(cacheKey, candidate, cacheKeyType, canonicalId);
+                } catch (IOException e) {
+                  eventHandler.handle(
+                      Event.warn("Failed to copy " + candidate + " to repository cache: " + e));
+                }
+              }
+              FileSystemUtils.createDirectoryAndParents(destination.getParentDirectory());
+              FileSystemUtils.copyFile(candidate, destination);
+              return destination;
+            }
+          }
+        }
+      }
+    }
+
+    try {
+      downloader.download(
+          urls, authHeaders, checksum, canonicalId, destination, eventHandler, clientEnv);
+    } catch (InterruptedIOException e) {
+      throw new InterruptedException(e.getMessage());
+    }
+
+    if (isCachingByProvidedChecksum) {
+      repositoryCache.put(
+          checksum.get().toString(), destination, checksum.get().getKeyType(), canonicalId);
+    } else if (repositoryCache.isEnabled()) {
+      String newSha256 = repositoryCache.put(destination, KeyType.SHA256, canonicalId);
+      eventHandler.handle(Event.info("SHA256 (" + urls.get(0) + ") = " + newSha256));
+    }
+
+    return destination;
+  }
+
+  private Path getDownloadDestination(URL url, Optional<String> type, Path output) {
+    if (!type.isPresent()) {
+      return output;
+    }
+    String basename =
+        MoreObjects.firstNonNull(
+            Strings.emptyToNull(PathFragment.create(url.getPath()).getBaseName()),
+            "temp");
+    if (!type.get().isEmpty()) {
+      String suffix = "." + type.get();
+      if (!basename.endsWith(suffix)) {
+        basename += suffix;
+      }
+    }
+    return output.getRelative(basename);
+  }
+
+  /**
+   * Deterimine the list of filenames to look for in the distdirs. Note that an output name may be
+   * specified that is unrelated to the primary URL. This happens, e.g., when the paramter output is
+   * specified in ctx.download.
+   */
+  private static ImmutableSet<String> getCandidateFileNames(URL url, Path destination) {
+    String urlBaseName = PathFragment.create(url.getPath()).getBaseName();
+    if (!Strings.isNullOrEmpty(urlBaseName) && !urlBaseName.equals(destination.getBaseName())) {
+      return ImmutableSet.of(urlBaseName, destination.getBaseName());
+    } else {
+      return ImmutableSet.of(destination.getBaseName());
+    }
+  }
+
+  private static class CacheProgress implements ExtendedEventHandler.FetchProgress {
+    private final String originalUrl;
+    private final String progress;
+    private final boolean isFinished;
+
+    CacheProgress(String originalUrl, String progress) {
+      this.originalUrl = originalUrl;
+      this.progress = progress;
+      this.isFinished = false;
+    }
+
+    CacheProgress(String originalUrl) {
+      this.originalUrl = originalUrl;
+      this.progress = "";
+      this.isFinished = true;
+    }
+
+    @Override
+    public String getResourceIdentifier() {
+      return originalUrl;
+    }
+
+    @Override
+    public String getProgress() {
+      return progress;
+    }
+
+    @Override
+    public boolean isFinished() {
+      return isFinished;
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Downloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Downloader.java
@@ -1,0 +1,49 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.repository.downloader;
+
+import com.google.common.base.Optional;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.vfs.Path;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+public interface Downloader {
+  /**
+   * Downloads a file and writes it to the specified output path.
+   *
+   * <p>On failure the output file will be in an undefined state, and may
+   * or may not exist. The caller is responsible for cleaning up outputs of
+   * failed downloads.
+   *
+   * @param urls list of mirror URLs with identical content
+   * @param checksum valid checksum which is checked, or absent to disable
+   * @param output path to the destination file to write
+   * @throws IOException if download was attempted and ended up failing
+   * @throws InterruptedException if this thread is being cast into oblivion
+   */
+  void download(
+      List<URL> urls,
+      Map<URI, Map<String, String>> authHeaders,
+      Optional<Checksum> checksum,
+      String canonicalId,
+      Path output,
+      ExtendedEventHandler eventHandler,
+      Map<String, String> clientEnv)
+      throws IOException, InterruptedException;
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -14,16 +14,10 @@
 
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.io.ByteStreams;
-import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
-import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
-import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCacheHitEvent;
 import com.google.devtools.build.lib.buildeventstream.FetchEvent;
 import com.google.devtools.build.lib.clock.Clock;
 import com.google.devtools.build.lib.clock.JavaClock;
@@ -31,9 +25,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.util.JavaSleeper;
 import com.google.devtools.build.lib.util.Sleeper;
-import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
-import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
@@ -48,162 +40,34 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 
 /**
- * Bazel file downloader.
+ * HTTP implementation of {@link Downloader}.
  *
  * <p>This class uses {@link HttpConnectorMultiplexer} to connect to HTTP mirrors and then reads the
  * file to disk.
  */
-public class HttpDownloader {
-
+public class HttpDownloader implements Downloader {
   private static final int MAX_PARALLEL_DOWNLOADS = 8;
   private static final Semaphore semaphore = new Semaphore(MAX_PARALLEL_DOWNLOADS, true);
 
-  protected final RepositoryCache repositoryCache;
-  private List<Path> distdir = ImmutableList.of();
   private float timeoutScaling = 1.0f;
 
-  public HttpDownloader(RepositoryCache repositoryCache) {
-    this.repositoryCache = repositoryCache;
-  }
-
-  public void setDistdir(List<Path> distdir) {
-    this.distdir = ImmutableList.copyOf(distdir);
+  public HttpDownloader() {
   }
 
   public void setTimeoutScaling(float timeoutScaling) {
     this.timeoutScaling = timeoutScaling;
   }
 
-  /**
-   * Downloads file to disk and returns path.
-   *
-   * <p>If the checksum and path to the repository cache is specified, attempt to load the file from
-   * the {@link RepositoryCache}. If it doesn't exist, proceed to download the file and load it into
-   * the cache prior to returning the value.
-   *
-   * @param urls list of mirror URLs with identical content
-   * @param checksum valid checksum which is checked, or empty to disable
-   * @param type extension, e.g. "tar.gz" to force on downloaded filename, or empty to not do this
-   * @param output destination filename if {@code type} is <i>absent</i>, otherwise output directory
-   * @param eventHandler CLI progress reporter
-   * @param clientEnv environment variables in shell issuing this command
-   * @param repo the name of the external repository for which the file was fetched; used only for
-   *     reporting
-   * @throws IllegalArgumentException on parameter badness, which should be checked beforehand
-   * @throws IOException if download was attempted and ended up failing
-   * @throws InterruptedException if this thread is being cast into oblivion
-   */
-  public Path download(
+  @Override
+  public void download(
       List<URL> urls,
       Map<URI, Map<String, String>> authHeaders,
       Optional<Checksum> checksum,
       String canonicalId,
-      Optional<String> type,
-      Path output,
+      Path destination,
       ExtendedEventHandler eventHandler,
-      Map<String, String> clientEnv,
-      String repo)
+      Map<String, String> clientEnv)
       throws IOException, InterruptedException {
-    if (Thread.interrupted()) {
-      throw new InterruptedException();
-    }
-
-    URL mainUrl; // The "main" URL for this request
-    // Used for reporting only and determining the file name only.
-    if (urls.isEmpty()) {
-      if (type.isPresent() && !Strings.isNullOrEmpty(type.get())) {
-        mainUrl = new URL("http://nonexistent.example.org/cacheprobe." + type.get());
-      } else {
-        mainUrl = new URL("http://nonexistent.example.org/cacheprobe");
-      }
-    } else {
-      mainUrl = urls.get(0);
-    }
-    Path destination = getDownloadDestination(mainUrl, type, output);
-    ImmutableSet<String> candidateFileNames = getCandidateFileNames(mainUrl, destination);
-
-    // Is set to true if the value should be cached by the checksum value provided
-    boolean isCachingByProvidedChecksum = false;
-
-    if (checksum.isPresent()) {
-      String cacheKey = checksum.get().toString();
-      KeyType cacheKeyType = checksum.get().getKeyType();
-      try {
-        eventHandler.post(
-            new CacheProgress(mainUrl.toString(), "Checking in " + cacheKeyType + " cache"));
-        String currentChecksum = RepositoryCache.getChecksum(cacheKeyType, destination);
-        if (currentChecksum.equals(cacheKey)) {
-          // No need to download.
-          return destination;
-        }
-      } catch (IOException e) {
-        // Ignore error trying to hash. We'll attempt to retrieve from cache or just download again.
-      } finally {
-        eventHandler.post(new CacheProgress(mainUrl.toString()));
-      }
-
-      if (repositoryCache.isEnabled()) {
-        isCachingByProvidedChecksum = true;
-
-        try {
-          Path cachedDestination =
-              repositoryCache.get(cacheKey, destination, cacheKeyType, canonicalId);
-          if (cachedDestination != null) {
-            // Cache hit!
-            eventHandler.post(new RepositoryCacheHitEvent(repo, cacheKey, mainUrl));
-            return cachedDestination;
-          }
-        } catch (IOException e) {
-          // Ignore error trying to get. We'll just download again.
-        }
-      }
-
-      if (urls.isEmpty()) {
-        throw new IOException("Cache miss and no url specified");
-      }
-
-      for (Path dir : distdir) {
-        if (!dir.exists()) {
-          // This is not a warning (and probably we even should drop the message); it is
-          // perfectly fine to have a common rc-file pointing to a volume that is sometimes,
-          // but not always mounted.
-          eventHandler.handle(Event.info("non-existent distir " + dir));
-        } else if (!dir.isDirectory()) {
-          eventHandler.handle(Event.warn("distdir " + dir + " is not a directory"));
-        } else {
-          for (String name : candidateFileNames) {
-            boolean match = false;
-            Path candidate = dir.getRelative(name);
-            try {
-              eventHandler.post(
-                  new CacheProgress(
-                      mainUrl.toString(), "Checking " + cacheKeyType + " of " + candidate));
-              match = RepositoryCache.getChecksum(cacheKeyType, candidate).equals(cacheKey);
-            } catch (IOException e) {
-              // Not finding anything in a distdir is a normal case, so handle it absolutely
-              // quietly. In fact, it is common to specify a whole list of dist dirs,
-              // with the assumption that only one will contain an entry.
-            } finally {
-              eventHandler.post(new CacheProgress(mainUrl.toString()));
-            }
-            if (match) {
-              if (isCachingByProvidedChecksum) {
-                try {
-                  repositoryCache.put(cacheKey, candidate, cacheKeyType, canonicalId);
-                } catch (IOException e) {
-                  eventHandler.handle(
-                      Event.warn("Failed to copy " + candidate + " to repository cache: " + e));
-                }
-              }
-              FileSystemUtils.createDirectoryAndParents(destination.getParentDirectory());
-              FileSystemUtils.copyFile(candidate, destination);
-              return destination;
-            }
-          }
-        }
-      }
-    }
-
     Clock clock = new JavaClock();
     Sleeper sleeper = new JavaSleeper();
     Locale locale = Locale.getDefault();
@@ -270,80 +134,6 @@ public class HttpDownloader {
       }
 
       throw exception;
-    }
-
-    if (isCachingByProvidedChecksum) {
-      repositoryCache.put(
-          checksum.get().toString(), destination, checksum.get().getKeyType(), canonicalId);
-    } else if (repositoryCache.isEnabled()) {
-      String newSha256 = repositoryCache.put(destination, KeyType.SHA256, canonicalId);
-      eventHandler.handle(Event.info("SHA256 (" + urls.get(0) + ") = " + newSha256));
-    }
-
-    return destination;
-  }
-
-  private Path getDownloadDestination(URL url, Optional<String> type, Path output) {
-    if (!type.isPresent()) {
-      return output;
-    }
-    String basename =
-        MoreObjects.firstNonNull(
-            Strings.emptyToNull(PathFragment.create(url.getPath()).getBaseName()),
-            "temp");
-    if (!type.get().isEmpty()) {
-      String suffix = "." + type.get();
-      if (!basename.endsWith(suffix)) {
-        basename += suffix;
-      }
-    }
-    return output.getRelative(basename);
-  }
-
-  /**
-   * Deterimine the list of filenames to look for in the distdirs. Note that an output name may be
-   * specified that is unrelated to the primary URL. This happens, e.g., when the paramter output is
-   * specified in ctx.download.
-   */
-  private static ImmutableSet<String> getCandidateFileNames(URL url, Path destination) {
-    String urlBaseName = PathFragment.create(url.getPath()).getBaseName();
-    if (!Strings.isNullOrEmpty(urlBaseName) && !urlBaseName.equals(destination.getBaseName())) {
-      return ImmutableSet.of(urlBaseName, destination.getBaseName());
-    } else {
-      return ImmutableSet.of(destination.getBaseName());
-    }
-  }
-
-  private static class CacheProgress implements ExtendedEventHandler.FetchProgress {
-    private final String originalUrl;
-    private final String progress;
-    private final boolean isFinished;
-
-    CacheProgress(String originalUrl, String progress) {
-      this.originalUrl = originalUrl;
-      this.progress = progress;
-      this.isFinished = false;
-    }
-
-    CacheProgress(String originalUrl) {
-      this.originalUrl = originalUrl;
-      this.progress = "";
-      this.isFinished = true;
-    }
-
-    @Override
-    public String getResourceIdentifier() {
-      return originalUrl;
-    }
-
-    @Override
-    public String getProgress() {
-      return progress;
-    }
-
-    @Override
-    public boolean isFinished() {
-      return isFinished;
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -30,7 +30,7 @@ import com.google.devtools.build.lib.bazel.repository.PatchUtil;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
 import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
-import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
+import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpUtils;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.ExtendedEventHandler.FetchProgress;
@@ -99,7 +99,7 @@ public class SkylarkRepositoryContext
   private final SkylarkOS osObject;
   private final ImmutableSet<PathFragment> blacklistedPatterns;
   private final Environment env;
-  private final HttpDownloader httpDownloader;
+  private final DownloadManager downloadManager;
   private final double timeoutScaling;
   private final Map<String, String> markerData;
   private final StarlarkSemantics starlarkSemantics;
@@ -116,7 +116,7 @@ public class SkylarkRepositoryContext
       ImmutableSet<PathFragment> blacklistedPatterns,
       Environment environment,
       Map<String, String> env,
-      HttpDownloader httpDownloader,
+      DownloadManager downloadManager,
       Path embeddedBinariesRoot,
       double timeoutScaling,
       Map<String, String> markerData,
@@ -130,7 +130,7 @@ public class SkylarkRepositoryContext
     this.blacklistedPatterns = blacklistedPatterns;
     this.env = environment;
     this.osObject = new SkylarkOS(env);
-    this.httpDownloader = httpDownloader;
+    this.downloadManager = downloadManager;
     this.timeoutScaling = timeoutScaling;
     this.markerData = markerData;
     WorkspaceAttributeMapper attrs = WorkspaceAttributeMapper.of(rule);
@@ -664,7 +664,7 @@ public class SkylarkRepositoryContext
       checkInOutputDirectory("write", outputPath);
       makeDirectories(outputPath.getPath());
       downloadedPath =
-          httpDownloader.download(
+          downloadManager.download(
               urls,
               authHeaders,
               checksum,
@@ -786,7 +786,7 @@ public class SkylarkRepositoryContext
     try (SilentCloseable c =
         Profiler.instance().profile("fetching: " + rule.getLabel().toString())) {
       downloadedPath =
-          httpDownloader.download(
+          downloadManager.download(
               urls,
               authHeaders,
               checksum,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryFunction.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.bazel.repository.RepositoryResolvedEvent;
-import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
+import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.packages.BazelStarlarkContext;
 import com.google.devtools.build.lib.packages.Rule;
@@ -57,12 +57,12 @@ import javax.annotation.Nullable;
  */
 public class SkylarkRepositoryFunction extends RepositoryFunction {
 
-  private final HttpDownloader httpDownloader;
+  private final DownloadManager downloadManager;
   private double timeoutScaling = 1.0;
   @Nullable private RepositoryRemoteExecutor repositoryRemoteExecutor;
 
-  public SkylarkRepositoryFunction(HttpDownloader httpDownloader) {
-    this.httpDownloader = httpDownloader;
+  public SkylarkRepositoryFunction(DownloadManager downloadManager) {
+    this.downloadManager = downloadManager;
   }
 
   public void setTimeoutScaling(double timeoutScaling) {
@@ -146,7 +146,7 @@ public class SkylarkRepositoryFunction extends RepositoryFunction {
               blacklistedPatterns,
               env,
               clientEnvironment,
-              httpDownloader,
+              downloadManager,
               directories.getEmbeddedBinariesRoot(),
               timeoutScaling,
               markerData,

--- a/src/main/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoader.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.bazel.BazelRepositoryModule;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
+import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import com.google.devtools.build.lib.bazel.repository.skylark.SkylarkRepositoryFunction;
 import com.google.devtools.build.lib.bazel.rules.BazelRulesModule;
@@ -92,7 +93,8 @@ public class BazelPackageLoader extends AbstractPackageLoader {
     public BazelPackageLoader buildImpl() {
       // Set up SkyFunctions and PrecomputedValues needed to make local repositories work correctly.
       RepositoryCache repositoryCache = new RepositoryCache();
-      HttpDownloader httpDownloader = new HttpDownloader(repositoryCache);
+      HttpDownloader httpDownloader = new HttpDownloader();
+      DownloadManager downloadManager = new DownloadManager(repositoryCache, httpDownloader);
       addExtraSkyFunctions(
           ImmutableMap.<SkyFunctionName, SkyFunction>builder()
               .put(
@@ -109,7 +111,7 @@ public class BazelPackageLoader extends AbstractPackageLoader {
                   SkyFunctions.REPOSITORY_DIRECTORY,
                   new RepositoryDelegatorFunction(
                       BazelRepositoryModule.repositoryRules(),
-                      new SkylarkRepositoryFunction(httpDownloader),
+                      new SkylarkRepositoryFunction(downloadManager),
                       isFetch,
                       ImmutableMap::of,
                       directories,

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloaderTest.java
@@ -58,7 +58,8 @@ public class HttpDownloaderTest {
   @Rule public final Timeout timeout = new Timeout(30, SECONDS);
 
   private final RepositoryCache repositoryCache = mock(RepositoryCache.class);
-  private final HttpDownloader httpDownloader = new HttpDownloader(repositoryCache);
+  private final HttpDownloader httpDownloader = new HttpDownloader();
+  private final DownloadManager downloadManager = new DownloadManager(repositoryCache, httpDownloader);
 
   private final ExecutorService executor = Executors.newFixedThreadPool(2);
   private final ExtendedEventHandler eventHandler = mock(ExtendedEventHandler.class);
@@ -104,7 +105,7 @@ public class HttpDownloaderTest {
               });
 
       Path resultingFile =
-          httpDownloader.download(
+          downloadManager.download(
               Collections.singletonList(
                   new URL(String.format("http://localhost:%d/foo", server.getLocalPort()))),
               Collections.emptyMap(),
@@ -169,7 +170,7 @@ public class HttpDownloaderTest {
       urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
 
       Path resultingFile =
-          httpDownloader.download(
+          downloadManager.download(
               urls,
               Collections.emptyMap(),
               Optional.absent(),
@@ -235,7 +236,7 @@ public class HttpDownloaderTest {
       urls.add(new URL(String.format("http://localhost:%d/foo", server2.getLocalPort())));
 
       Path resultingFile =
-          httpDownloader.download(
+          downloadManager.download(
               urls,
               Collections.emptyMap(),
               Optional.absent(),
@@ -303,7 +304,7 @@ public class HttpDownloaderTest {
 
       Path outputFile = fs.getPath(workingDir.newFile().getAbsolutePath());
       try {
-        httpDownloader.download(
+        downloadManager.download(
             urls,
             Collections.emptyMap(),
             Optional.absent(),

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharStreams;
-import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
+import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.events.Location;
 import com.google.devtools.build.lib.packages.Attribute;
@@ -125,7 +125,7 @@ public final class SkylarkRepositoryContextTest {
     Rule rule =
         WorkspaceFactoryHelper.createAndAddRepositoryRule(
             packageBuilder, buildRuleClass(attributes), null, kwargs, Location.BUILTIN);
-    HttpDownloader downloader = Mockito.mock(HttpDownloader.class);
+    DownloadManager downloader = Mockito.mock(DownloadManager.class);
     SkyFunction.Environment environment = Mockito.mock(SkyFunction.Environment.class);
     when(environment.getListener()).thenReturn(listener);
     PathPackageLocator packageLocator =

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryIntegrationTest.java
@@ -24,7 +24,7 @@ import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
-import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
+import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.packages.BuildFileContainsErrorsException;
 import com.google.devtools.build.lib.packages.NoSuchPackageException;
 import com.google.devtools.build.lib.rules.repository.LocalRepositoryFunction;
@@ -71,7 +71,7 @@ public class SkylarkRepositoryIntegrationTest extends BuildViewTestCase {
         BlazeDirectories directories) {
       // Add both the local repository and the skylark repository functions
       // The RepositoryCache mock injected with the SkylarkRepositoryFunction
-      HttpDownloader downloader = Mockito.mock(HttpDownloader.class);
+      DownloadManager downloader = Mockito.mock(DownloadManager.class);
       RepositoryFunction localRepositoryFunction = new LocalRepositoryFunction();
       SkylarkRepositoryFunction skylarkRepositoryFunction =
           new SkylarkRepositoryFunction(downloader);

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -28,7 +28,7 @@ import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.ServerDirectories;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
-import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
+import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.skylark.SkylarkRepositoryFunction;
 import com.google.devtools.build.lib.bazel.repository.skylark.SkylarkRepositoryModule;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
@@ -116,7 +116,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
             /* defaultSystemJavabase= */ null,
             TestConstants.PRODUCT_NAME);
     managedDirectoriesKnowledge = new TestManagedDirectoriesKnowledge();
-    HttpDownloader downloader = Mockito.mock(HttpDownloader.class);
+    DownloadManager downloader = Mockito.mock(DownloadManager.class);
     RepositoryFunction localRepositoryFunction = new LocalRepositoryFunction();
     testSkylarkRepositoryFunction =
         new TestSkylarkRepositoryFunction(rootPath, downloader, managedDirectoriesKnowledge);
@@ -384,7 +384,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
 
     private TestSkylarkRepositoryFunction(
         Path workspaceRoot,
-        HttpDownloader downloader,
+        DownloadManager downloader,
         TestManagedDirectoriesKnowledge managedDirectoriesKnowledge) {
       super(downloader);
       this.workspaceRoot = workspaceRoot;


### PR DESCRIPTION
This PR is in preparation for a remote implementation of external downloads. It is intended to have no behavior changes, and to split the current `HttpDownloader` logic into:
* `HttpDownloader`, which does the actual download with all the fancy concurrency and error handling.
* `DownloadManager`, which interacts with `RepositoryCache` and the distdirs. It doesn't know about HTTP any more, instead going through a `Downloader` interface.

A future PR will implement a `Downloader` in terms of the bazelbuild/remote-apis protocol and put it behind an `--experimental_remote_downloader` flag.

R: @buchgr @dslomov 
CC: @sstriker