### PR TITLE
Add PostGCMemoryUseRecorderModule to the default Bazel modules.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/Bazel.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/Bazel.java
@@ -67,6 +67,9 @@ public final class Bazel {
           com.google.devtools.build.lib.buildeventservice.BazelBuildEventServiceModule.class,
           com.google.devtools.build.lib.profiler.callcounts.CallcountsModule.class,
           com.google.devtools.build.lib.profiler.memory.AllocationTrackerModule.class,
+          com.google.devtools.build.lib.metrics.PostGCMemoryUseRecorder
+              .PostGCMemoryUseRecorderModule.class,
+          com.google.devtools.build.lib.metrics.PostGCMemoryUseRecorder.GcAfterBuildModule.class,
           com.google.devtools.build.lib.metrics.MetricsModule.class,
           BazelBuiltinCommandModule.class);
 


### PR DESCRIPTION
RELNOTES: None