### PR TITLE
Make --verbose_failures work again

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
@@ -208,7 +208,7 @@ public interface SpawnResult {
   }
 
   String getDetailMessage(
-      String messagePrefix, String message, boolean catastrophe, boolean forciblyRunRemotely);
+      String messagePrefix, String message, boolean verboseFailures, boolean catastrophe, boolean forciblyRunRemotely);
 
   /** Returns a file path to the action metadata log. */
   Optional<MetadataLog> getActionMetadataLog();
@@ -336,11 +336,13 @@ public interface SpawnResult {
 
     @Override
     public String getDetailMessage(
-        String messagePrefix, String message, boolean catastrophe, boolean forciblyRunRemotely) {
+        String messagePrefix, String message, boolean verboseFailures, boolean catastrophe, boolean forciblyRunRemotely) {
       TerminationStatus status = new TerminationStatus(
           exitCode(), status() == Status.TIMEOUT);
       String reason = " (" + status.toShortString() + ")"; // e.g " (Exit 1)"
-      String explanation = status.exited() ? "" : ": " + message;
+      // Include the command line as error message if --verbose_failures is enabled or
+      // the command line didn't exit normally.
+      String explanation = verboseFailures || !status.exited() ? ": " + message : "";
 
       if (!status().isConsideredUserError()) {
         String errorDetail = status().name().toLowerCase(Locale.US)

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnExecException.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnExecException.java
@@ -65,16 +65,9 @@ public class SpawnExecException extends ExecException {
     if (messagePrefix == null) {
       messagePrefix = action.describe();
     }
-    // Note: we intentionally do not include the ExecException here, unless verboseFailures is true,
-    // because it creates unwieldy and useless messages. If users need more info, they can run with
-    // --verbose_failures.
     String message =
-        result.getDetailMessage(messagePrefix, getMessage(), isCatastrophic(), forciblyRunRemotely);
-    if (verboseFailures) {
-      return new ActionExecutionException(message + ": " + getMessage(), this, action, isCatastrophic(), getExitCode());
-    } else {
-      return new ActionExecutionException(message, action, isCatastrophic(), getExitCode());
-    }
+        result.getDetailMessage(messagePrefix, getMessage(), verboseFailures, isCatastrophic(), forciblyRunRemotely);
+    return new ActionExecutionException(message + ": " + getMessage(), this, action, isCatastrophic(), getExitCode());
   }
 
   /** Return exit code depending on the spawn result. */

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnExecException.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnExecException.java
@@ -37,7 +37,7 @@ public class SpawnExecException extends ExecException {
     super(message, result.isCatastrophe());
     checkArgument(
         !Status.SUCCESS.equals(result.status()),
-        "Can't create exception with successful" + " spawn result.");
+        "Can't create exception with successful spawn result.");
     this.result = Preconditions.checkNotNull(result);
     this.forciblyRunRemotely = forciblyRunRemotely;
   }
@@ -71,7 +71,7 @@ public class SpawnExecException extends ExecException {
     String message =
         result.getDetailMessage(messagePrefix, getMessage(), isCatastrophic(), forciblyRunRemotely);
     if (verboseFailures) {
-      return new ActionExecutionException(message, this, action, isCatastrophic(), getExitCode());
+      return new ActionExecutionException(message + ": " + getMessage(), this, action, isCatastrophic(), getExitCode());
     } else {
       return new ActionExecutionException(message, action, isCatastrophic(), getExitCode());
     }

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnExecException.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnExecException.java
@@ -67,7 +67,7 @@ public class SpawnExecException extends ExecException {
     }
     String message =
         result.getDetailMessage(messagePrefix, getMessage(), verboseFailures, isCatastrophic(), forciblyRunRemotely);
-    return new ActionExecutionException(message + ": " + getMessage(), this, action, isCatastrophic(), getExitCode());
+    return new ActionExecutionException(message, this, action, isCatastrophic(), getExitCode());
   }
 
   /** Return exit code depending on the spawn result. */

--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -1301,7 +1301,6 @@ java_test(
     name = "standalone-tests",
     srcs = glob(["standalone/*.java"]),
     data = [":embedded_scripts"],
-    tags = ["no_windows"],
     test_class = "com.google.devtools.build.lib.AllTests",
     deps = [
         ":actions_testutil",

--- a/src/test/java/com/google/devtools/build/lib/actions/SpawnResultTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/SpawnResultTest.java
@@ -41,7 +41,7 @@ public final class SpawnResultTest {
             .setExitCode(1)
             .setRunnerName("test")
             .build();
-    assertThat(r.getDetailMessage("", "", false, false))
+    assertThat(r.getDetailMessage("", "", false, false, false))
         .contains("(failed due to timeout after 5.00 seconds.)");
   }
 
@@ -53,7 +53,7 @@ public final class SpawnResultTest {
             .setExitCode(1)
             .setRunnerName("test")
             .build();
-    assertThat(r.getDetailMessage("", "", false, false))
+    assertThat(r.getDetailMessage("", "", false, false, false))
         .contains("(failed due to timeout.)");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -761,7 +761,7 @@ public class RemoteSpawnRunnerTest {
 
     SpawnResult result = runner.exec(spawn, policy);
     assertThat(result.exitCode()).isEqualTo(ExitCode.REMOTE_ERROR.getNumericExitCode());
-    assertThat(result.getDetailMessage("", "", false, false)).contains("reasons");
+    assertThat(result.getDetailMessage("", "", false,false, false)).contains("reasons");
   }
 
   @Test
@@ -780,7 +780,7 @@ public class RemoteSpawnRunnerTest {
 
     SpawnResult result = runner.exec(spawn, policy);
     assertThat(result.exitCode()).isEqualTo(ExitCode.REMOTE_ERROR.getNumericExitCode());
-    assertThat(result.getDetailMessage("", "", false, false)).contains("reasons");
+    assertThat(result.getDetailMessage("", "", false,false, false)).contains("reasons");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/standalone/StandaloneSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/standalone/StandaloneSpawnStrategyTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionContext.LostInputsCheck;
+import com.google.devtools.build.lib.actions.ActionExecutionException;
 import com.google.devtools.build.lib.actions.ActionInputPrefetcher;
 import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.Artifact;
@@ -63,6 +64,7 @@ import com.google.devtools.common.options.Options;
 import com.google.devtools.common.options.OptionsParser;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -178,7 +180,9 @@ public class StandaloneSpawnStrategyTest {
     Spawn spawn = createSpawn(getTrueCommand());
     executor.getContext(SpawnActionContext.class).exec(spawn, createContext());
 
-    assertThat(out()).isEmpty();
+    if (OS.getCurrent() != OS.WINDOWS) {
+      assertThat(out()).isEmpty();
+    }
     assertThat(err()).isEmpty();
   }
 
@@ -205,34 +209,56 @@ public class StandaloneSpawnStrategyTest {
   }
 
   @Test
-  public void testBinFalseYieldsException() throws Exception {
+  public void testBinFalseYieldsException() {
     ExecException e = assertThrows(ExecException.class, () -> run(createSpawn(getFalseCommand())));
     assertWithMessage("got: " + e.getMessage())
-        .that(e.getMessage().startsWith("false failed: error executing command"))
+        .that(e.getMessage().contains("failed: error executing command"))
         .isTrue();
   }
 
   private static String getFalseCommand() {
+    if (OS.getCurrent() == OS.WINDOWS) {
+      // No false command on Windows, with use help.exe as an alternative,
+      // the caveat is that the command will have some output to stdout.
+      // Default exit code of help is 1
+      return "C:/windows/system32/help.exe";
+    }
     return OS.getCurrent() == OS.DARWIN ? "/usr/bin/false" : "/bin/false";
   }
 
   private static String getTrueCommand() {
+    if (OS.getCurrent() == OS.WINDOWS) {
+      // No false command on Windows, with use whoami.exe as an alternative,
+      // the caveat is that the command will have some output to stdout.
+      // Default exit code of help is 0
+      return "C:/windows/system32/whoami.exe";
+    }
     return OS.getCurrent() == OS.DARWIN ? "/usr/bin/true" : "/bin/true";
   }
 
   @Test
   public void testBinEchoPrintsArguments() throws Exception {
-    Spawn spawn = createSpawn("/bin/echo", "Hello,", "world.");
+    Spawn spawn;
+    if (OS.getCurrent() == OS.WINDOWS) {
+      spawn = createSpawn("C:/windows/system32/cmd.exe", "/c", "echo", "Hello,", "world.");
+    } else {
+      spawn = createSpawn("/bin/echo", "Hello,", "world.");
+    }
     run(spawn);
-    assertThat(out()).isEqualTo("Hello, world.\n");
+    assertThat(out()).isEqualTo("Hello, world." + System.lineSeparator());
     assertThat(err()).isEmpty();
   }
 
   @Test
   public void testCommandRunsInWorkingDir() throws Exception {
-    Spawn spawn = createSpawn("/bin/pwd");
+    Spawn spawn;
+    if (OS.getCurrent() == OS.WINDOWS) {
+      spawn = createSpawn("C:/windows/system32/cmd.exe", "/c", "cd");
+    } else {
+      spawn = createSpawn("/bin/pwd");
+    }
     run(spawn);
-    assertThat(out()).isEqualTo(executor.getExecRoot() + "\n");
+    assertThat(out().replace('\\', '/')).isEqualTo(executor.getExecRoot() + System.lineSeparator());
   }
 
   @Test
@@ -246,21 +272,48 @@ public class StandaloneSpawnStrategyTest {
     Spawn spawn =
         new SimpleSpawn(
             new ActionsTestUtil.NullAction(),
-            ImmutableList.of("/usr/bin/env"),
+            OS.getCurrent() == OS.WINDOWS ? ImmutableList.of("C:/windows/system32/cmd.exe", "/c", "set") : ImmutableList.of("/usr/bin/env"),
             /*environment=*/ ImmutableMap.of("foo", "bar", "baz", "boo"),
             /*executionInfo=*/ ImmutableMap.of(),
             /*inputs=*/ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
             /*outputs=*/ ImmutableSet.of(),
             ResourceSet.ZERO);
     run(spawn);
-    assertThat(Sets.newHashSet(out().split("\n"))).isEqualTo(Sets.newHashSet("foo=bar", "baz=boo"));
+    HashSet environment = Sets.newHashSet(out().split(System.lineSeparator()));
+    if (OS.getCurrent() == OS.WINDOWS) {
+      // On Windows, we have some other env vars (eg. SystemRoot) as default.
+      assertThat(environment).contains("foo=bar");
+      assertThat(environment).contains("baz=boo");
+    } else {
+      assertThat(environment).isEqualTo(Sets.newHashSet("foo=bar", "baz=boo"));
+    }
   }
 
   @Test
   public void testStandardError() throws Exception {
-    Spawn spawn = createSpawn("/bin/sh", "-c", "echo Oops! >&2");
+    Spawn spawn;
+    if (OS.getCurrent() == OS.WINDOWS) {
+      spawn = createSpawn("C:/windows/system32/cmd.exe", "/c", "echo Oops!>&2");
+    } else {
+      spawn = createSpawn("/bin/sh", "-c", "echo Oops! >&2");
+    }
     run(spawn);
-    assertThat(err()).isEqualTo("Oops!\n");
+    assertThat(err()).isEqualTo("Oops!" + System.lineSeparator());
     assertThat(out()).isEmpty();
+  }
+
+  @Test
+  /**
+   * Regression test for https://github.com/bazelbuild/bazel/issues/10572
+   * Make sure we do have the command line executed in the error message of ActionExecutionException
+   * when --verbose_failures is enabled.
+   */
+  public void testVerboseFailures() {
+    ExecException e = assertThrows(ExecException.class, () -> run(createSpawn(getFalseCommand())));
+    ActionExecutionException actionExecutionException =
+        e.toActionExecutionException("", /* verbose_failures= */ true, null);
+    assertWithMessage("got: " + actionExecutionException.getMessage())
+        .that(actionExecutionException.getMessage().contains("failed: error executing command"))
+        .isTrue();
   }
 }


### PR DESCRIPTION
--verbose_failures is broken since Bazel 0.28.0, Bazel won't print the
failing command for local execution even --verbose_failures is enabled.

This change fixes the problem and adds a test for it.

Fixes https://github.com/bazelbuild/bazel/issues/10572