### PR TITLE
Explicitly pass architecture for arm64_32 in osx crosstool

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -337,8 +337,7 @@ def _impl(ctx):
     else:
         cpp_header_parsing_action = None
 
-    if (ctx.attr.cpu == "armeabi-v7a" or
-        ctx.attr.cpu == "watchos_arm64_32"):
+    if (ctx.attr.cpu == "armeabi-v7a"):
         objc_compile_action = action_config(
             action_name = ACTION_NAMES.objc_compile,
             flag_sets = [
@@ -367,6 +366,38 @@ def _impl(ctx):
                 tool(
                     path = "wrapped_clang",
                     execution_requirements = execution_requirements,
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "watchos_arm64_32"):
+        objc_compile_action = action_config(
+            action_name = ACTION_NAMES.objc_compile,
+            flag_sets = [
+                flag_set(
+                    flag_groups = [flag_group(flags = ["-arch", "arm64_32"])],
+                ),
+            ],
+            implies = [
+                "compiler_input_flags",
+                "compiler_output_flags",
+                "objc_actions",
+                "apply_default_compiler_flags",
+                "apply_default_warnings",
+                "framework_paths",
+                "preprocessor_defines",
+                "include_system_dirs",
+                "version_min",
+                "objc_arc",
+                "no_objc_arc",
+                "apple_env",
+                "user_compile_flags",
+                "sysroot",
+                "unfiltered_compile_flags",
+            ],
+            tools = [
+                tool(
+                    path = "wrapped_clang",
+                    execution_requirements = ["requires-darwin"],
                 ),
             ],
         )
@@ -603,8 +634,7 @@ def _impl(ctx):
     else:
         objc_compile_action = None
 
-    if (ctx.attr.cpu == "armeabi-v7a" or
-        ctx.attr.cpu == "watchos_arm64_32"):
+    if (ctx.attr.cpu == "armeabi-v7a"):
         objcpp_executable_action = action_config(
             action_name = "objc++-executable",
             flag_sets = [
@@ -663,6 +693,68 @@ def _impl(ctx):
                 tool(
                     path = "wrapped_clang_pp",
                     execution_requirements = execution_requirements,
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "watchos_arm64_32"):
+        objcpp_executable_action = action_config(
+            action_name = "objc++-executable",
+            flag_sets = [
+                flag_set(
+                    flag_groups = [
+                        flag_group(flags = ["-stdlib=libc++", "-std=gnu++11"]),
+                        flag_group(flags = ["-arch", "arm64_32"]),
+                        flag_group(
+                            flags = [
+                                "-Xlinker",
+                                "-objc_abi_version",
+                                "-Xlinker",
+                                "2",
+                                "-fobjc-link-runtime",
+                                "-ObjC",
+                            ],
+                        ),
+                        flag_group(
+                            flags = ["-framework", "%{framework_names}"],
+                            iterate_over = "framework_names",
+                        ),
+                        flag_group(
+                            flags = ["-weak_framework", "%{weak_framework_names}"],
+                            iterate_over = "weak_framework_names",
+                        ),
+                        flag_group(
+                            flags = ["-l%{library_names}"],
+                            iterate_over = "library_names",
+                        ),
+                        flag_group(flags = ["-filelist", "%{filelist}"]),
+                        flag_group(flags = ["-o", "%{linked_binary}"]),
+                        flag_group(
+                            flags = ["-force_load", "%{force_load_exec_paths}"],
+                            iterate_over = "force_load_exec_paths",
+                        ),
+                        flag_group(
+                            flags = ["%{dep_linkopts}"],
+                            iterate_over = "dep_linkopts",
+                        ),
+                        flag_group(
+                            flags = ["-Wl,%{attr_linkopts}"],
+                            iterate_over = "attr_linkopts",
+                        ),
+                    ],
+                ),
+            ],
+            implies = [
+                "include_system_dirs",
+                "framework_paths",
+                "version_min",
+                "strip_debug_symbols",
+                "apple_env",
+                "apply_implicit_frameworks",
+            ],
+            tools = [
+                tool(
+                    path = "wrapped_clang_pp",
+                    execution_requirements = ["requires-darwin"],
                 ),
             ],
         )
@@ -1250,8 +1342,7 @@ def _impl(ctx):
     else:
         cpp_compile_action = None
 
-    if (ctx.attr.cpu == "armeabi-v7a" or
-        ctx.attr.cpu == "watchos_arm64_32"):
+    if (ctx.attr.cpu == "armeabi-v7a"):
         objcpp_compile_action = action_config(
             action_name = ACTION_NAMES.objcpp_compile,
             flag_sets = [
@@ -1288,6 +1379,46 @@ def _impl(ctx):
                 tool(
                     path = "wrapped_clang",
                     execution_requirements = execution_requirements,
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "watchos_arm64_32"):
+        objcpp_compile_action = action_config(
+            action_name = ACTION_NAMES.objcpp_compile,
+            flag_sets = [
+                flag_set(
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-arch",
+                                "arm64_32",
+                                "-stdlib=libc++",
+                                "-std=gnu++11",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+            implies = [
+                "compiler_input_flags",
+                "compiler_output_flags",
+                "apply_default_compiler_flags",
+                "apply_default_warnings",
+                "framework_paths",
+                "preprocessor_defines",
+                "include_system_dirs",
+                "version_min",
+                "objc_arc",
+                "no_objc_arc",
+                "apple_env",
+                "user_compile_flags",
+                "sysroot",
+                "unfiltered_compile_flags",
+            ],
+            tools = [
+                tool(
+                    path = "wrapped_clang",
+                    execution_requirements = ["requires-darwin"],
                 ),
             ],
         )
@@ -1663,8 +1794,7 @@ def _impl(ctx):
     else:
         preprocess_assemble_action = None
 
-    if (ctx.attr.cpu == "armeabi-v7a" or
-        ctx.attr.cpu == "watchos_arm64_32"):
+    if (ctx.attr.cpu == "armeabi-v7a"):
         objc_archive_action = action_config(
             action_name = "objc-archive",
             flag_sets = [
@@ -1692,6 +1822,37 @@ def _impl(ctx):
                 tool(
                     path = "libtool",
                     execution_requirements = execution_requirements,
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "watchos_arm64_32"):
+        objc_archive_action = action_config(
+            action_name = "objc-archive",
+            flag_sets = [
+                flag_set(
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-no_warning_for_no_symbols",
+                                "-static",
+                                "-filelist",
+                                "%{obj_list_path}",
+                                "-arch_only",
+                                "arm64_32",
+                                "-syslibroot",
+                                "%{sdk_dir}",
+                                "-o",
+                                "%{archive_path}",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+            implies = ["apple_env"],
+            tools = [
+                tool(
+                    path = "libtool",
+                    execution_requirements = ["requires-darwin"],
                 ),
             ],
         )
@@ -1889,8 +2050,7 @@ def _impl(ctx):
     else:
         objc_archive_action = None
 
-    if (ctx.attr.cpu == "armeabi-v7a" or
-        ctx.attr.cpu == "watchos_arm64_32"):
+    if (ctx.attr.cpu == "armeabi-v7a"):
         objc_executable_action = action_config(
             action_name = "objc-executable",
             flag_sets = [
@@ -1953,6 +2113,72 @@ def _impl(ctx):
                 tool(
                     path = "wrapped_clang",
                     execution_requirements = execution_requirements,
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "watchos_arm64_32"):
+        objc_executable_action = action_config(
+            action_name = "objc-executable",
+            flag_sets = [
+                flag_set(
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-Xlinker",
+                                "-objc_abi_version",
+                                "-Xlinker",
+                                "2",
+                                "-fobjc-link-runtime",
+                                "-ObjC",
+                            ],
+                        ),
+                    ],
+                    with_features = [with_feature_set(not_features = ["kernel_extension"])],
+                ),
+                flag_set(
+                    flag_groups = [
+                        flag_group(flags = ["-arch", "arm64_32"]),
+                        flag_group(
+                            flags = ["-framework", "%{framework_names}"],
+                            iterate_over = "framework_names",
+                        ),
+                        flag_group(
+                            flags = ["-weak_framework", "%{weak_framework_names}"],
+                            iterate_over = "weak_framework_names",
+                        ),
+                        flag_group(
+                            flags = ["-l%{library_names}"],
+                            iterate_over = "library_names",
+                        ),
+                        flag_group(flags = ["-filelist", "%{filelist}"]),
+                        flag_group(flags = ["-o", "%{linked_binary}"]),
+                        flag_group(
+                            flags = ["-force_load", "%{force_load_exec_paths}"],
+                            iterate_over = "force_load_exec_paths",
+                        ),
+                        flag_group(
+                            flags = ["%{dep_linkopts}"],
+                            iterate_over = "dep_linkopts",
+                        ),
+                        flag_group(
+                            flags = ["-Wl,%{attr_linkopts}"],
+                            iterate_over = "attr_linkopts",
+                        ),
+                    ],
+                ),
+            ],
+            implies = [
+                "include_system_dirs",
+                "framework_paths",
+                "version_min",
+                "strip_debug_symbols",
+                "apple_env",
+                "apply_implicit_frameworks",
+            ],
+            tools = [
+                tool(
+                    path = "wrapped_clang",
+                    execution_requirements = ["requires-darwin"],
                 ),
             ],
         )
@@ -2572,8 +2798,7 @@ def _impl(ctx):
     else:
         cpp_link_nodeps_dynamic_library_action = None
 
-    if (ctx.attr.cpu == "armeabi-v7a" or
-        ctx.attr.cpu == "watchos_arm64_32"):
+    if (ctx.attr.cpu == "armeabi-v7a"):
         objc_fully_link_action = action_config(
             action_name = "objc-fully-link",
             flag_sets = [
@@ -2611,6 +2836,47 @@ def _impl(ctx):
                 tool(
                     path = "libtool",
                     execution_requirements = execution_requirements,
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "watchos_arm64_32"):
+        objc_fully_link_action = action_config(
+            action_name = "objc-fully-link",
+            flag_sets = [
+                flag_set(
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-no_warning_for_no_symbols",
+                                "-static",
+                                "-arch_only",
+                                "arm64_32",
+                                "-syslibroot",
+                                "%{sdk_dir}",
+                                "-o",
+                                "%{fully_linked_archive_path}",
+                            ],
+                        ),
+                        flag_group(
+                            flags = ["%{objc_library_exec_paths}"],
+                            iterate_over = "objc_library_exec_paths",
+                        ),
+                        flag_group(
+                            flags = ["%{cc_library_exec_paths}"],
+                            iterate_over = "cc_library_exec_paths",
+                        ),
+                        flag_group(
+                            flags = ["%{imported_library_exec_paths}"],
+                            iterate_over = "imported_library_exec_paths",
+                        ),
+                    ],
+                ),
+            ],
+            implies = ["apple_env"],
+            tools = [
+                tool(
+                    path = "libtool",
+                    execution_requirements = ["requires-darwin"],
                 ),
             ],
         )


### PR DESCRIPTION
The `<architecture>` placeholder is not replaced with the correct architecture, which is making clang fail with `clang: error: invalid arch name '-arch <architecture>'`. 

Fixes #10582.