### PR TITLE
Optimize //src:bazel-dev / package-bazel.sh to reduce incremental build times by 60%

### DIFF
--- a/scripts/bazel-dev.sh
+++ b/scripts/bazel-dev.sh
@@ -37,7 +37,7 @@ BAZEL_DIR=${BAZEL_DIR:-$HOME/os-bazel}
 BAZEL_BINARY=${BAZEL_BINARY:-$(which bazel)}
 
 # The location of the resulting binary.
-BAZEL_DEV="$BAZEL_DIR/bazel-bin/src/bazel"
+BAZEL_DEV="$BAZEL_DIR/bazel-bin/src/bazel-dev"
 
 # First, check whether a rebuild is needed.
 REBUILD=0
@@ -56,7 +56,7 @@ if [ "$REBUILD" == 1 ]; then
   (
     cd "$BAZEL_DIR"
     result=0
-    ${BAZEL_BINARY} build //src:bazel || result=$?
+    ${BAZEL_BINARY} build //src:bazel-dev || result=$?
     if [[ $result != 0 ]]; then
       echo -e "\033[31mError building dev version of bazel.\033[0m"
       exit $result

--- a/site/docs/install-compile-source.md
+++ b/site/docs/install-compile-source.md
@@ -16,7 +16,9 @@ To build Bazel from source, you can do one of the following:
 
 TL;DR:
 
-1.  [Get the latest Bazel release](https://github.com/bazelbuild/bazel/releases)
+1.  Get the latest Bazel release from the
+    [GitHub release page](https://github.com/bazelbuild/bazel/releases) or with 
+    [Bazelisk](https://github.com/bazelbuild/bazelisk).
 
 2.  [Download Bazel's sources from GitHub](https://github.com/bazelbuild/bazel/archive/master.zip)
     and extract somewhere.
@@ -26,10 +28,11 @@ TL;DR:
     [for Unix-like systems](#bootstrap-unix-prereq) or
     [for Windows](#bootstrap-windows-prereq))
 
-4.  Build Bazel using Bazel: `bazel build //src:bazel`
-    (or `bazel build //src:bazel-dev.exe` on Windows)
+4.  Build a development build of Bazel using Bazel: 
+     `bazel build //src:bazel-dev` (or `bazel build //src:bazel-dev.exe` on
+    Windows)
 
-5.  The resulting binary is at `bazel-bin/src/bazel`
+5.  The resulting binary is at `bazel-bin/src/bazel-dev`
     (or `bazel-bin\src\bazel-dev.exe` on Windows). You can copy it wherever you
     like and use immediately without further installation.
 
@@ -88,7 +91,7 @@ Unix-like systems</h3>
 
 ([Scroll down](#build-bazel-on-windows) for instructions for Windows.)
 
-**Goal**: Run Bazel to build a custom Bazel binary (`bazel-bin/src/bazel`).
+**Goal**: Run Bazel to build a custom Bazel binary (`bazel-bin/src/bazel-dev`).
 
 **Instructions**:
 
@@ -102,9 +105,12 @@ Unix-like systems</h3>
 
 3.  Build Bazel from source:
 
-        bazel build //src:bazel
+        bazel build //src:bazel-dev
+        
+    Alternatively you can run `bazel build //src:bazel --compilation_mode=opt` 
+    to yield a smaller binary but it's slower to build.
 
-4.  The output will be at `bazel-bin/src/bazel`
+4.  The output will be at `bazel-bin/src/bazel-dev` (or `bazel-bin/src/bazel`).
 
 <h3 id="build-bazel-on-windows">4. Build Bazel on Windows</h3>
 
@@ -128,10 +134,11 @@ Unix-like systems.)
 
         bazel build //src:bazel-dev.exe
 
-    Alternatively you can build `//src:bazel.exe` -- that yields a smaller
-    binary but it's slower to build.
+    Alternatively you can run `bazel build //src:bazel.exe 
+    --compilation_mode=opt` to yield a smaller binary but it's slower to build.
 
-4.  The output will be at `bazel-bin\src\bazel-dev.exe`
+4.  The output will be at `bazel-bin\src\bazel-dev.exe` (or 
+    `bazel-bin\src\bazel.exe`).
 
 <h3 id="build-bazel-install">5. Install the built binary</h3>
 

--- a/site/docs/install-compile-source.md
+++ b/site/docs/install-compile-source.md
@@ -29,7 +29,7 @@ TL;DR:
     [for Windows](#bootstrap-windows-prereq))
 
 4.  Build a development build of Bazel using Bazel: 
-     `bazel build //src:bazel-dev` (or `bazel build //src:bazel-dev.exe` on
+    `bazel build //src:bazel-dev` (or `bazel build //src:bazel-dev.exe` on
     Windows)
 
 5.  The resulting binary is at `bazel-bin/src/bazel-dev`

--- a/src/BUILD
+++ b/src/BUILD
@@ -332,13 +332,6 @@ filegroup(
     "_nojdk",
 ]]
 
-config_setting(
-    name = "fastbuild",
-    values = {
-        "compilation_mode": "fastbuild",
-    },
-)
-
 [genrule(
     name = "package-zip" + suffix,
     srcs = ([":embedded_tools" + suffix + ".zip"] if embed else []) + [
@@ -361,12 +354,7 @@ config_setting(
         ],
     }),
     outs = ["package" + suffix + ".zip"],
-    cmd = "$(location :package-bazel.sh) $@" +
-          select({
-              ":fastbuild": " fastbuild ",
-              "//conditions:default": " opt ",
-          }) +
-          ("" if embed else "''") + " $(SRCS)",
+    cmd = "$(location :package-bazel.sh) $@ " + ("" if embed else "''") + " $(SRCS)",
     tools = ["package-bazel.sh"],
 ) for suffix, embed in [
     ("_jdk_allmodules", True),

--- a/src/BUILD
+++ b/src/BUILD
@@ -332,6 +332,13 @@ filegroup(
     "_nojdk",
 ]]
 
+config_setting(
+    name = "fastbuild",
+    values = {
+        "compilation_mode": "fastbuild",
+    },
+)
+
 [genrule(
     name = "package-zip" + suffix,
     srcs = ([":embedded_tools" + suffix + ".zip"] if embed else []) + [
@@ -354,7 +361,12 @@ filegroup(
         ],
     }),
     outs = ["package" + suffix + ".zip"],
-    cmd = "$(location :package-bazel.sh) $@ " + ("" if embed else "''") + " $(SRCS)",
+    cmd = "$(location :package-bazel.sh) $@" +
+          select({
+              ":fastbuild": " fastbuild ",
+              "//conditions:default": " opt ",
+          }) +
+          ("" if embed else "''") + " $(SRCS)",
     tools = ["package-bazel.sh"],
 ) for suffix, embed in [
     ("_jdk_allmodules", True),

--- a/src/package-bazel.sh
+++ b/src/package-bazel.sh
@@ -21,11 +21,12 @@ set -euo pipefail
 
 WORKDIR=$(pwd)
 OUT=$1
-EMBEDDED_TOOLS=$2
-DEPLOY_JAR=$3
-INSTALL_BASE_KEY=$4
-PLATFORMS_ARCHIVE=$5
-shift 5
+COMPILATION_MODE=$2
+EMBEDDED_TOOLS=$3
+DEPLOY_JAR=$4
+INSTALL_BASE_KEY=$5
+PLATFORMS_ARCHIVE=$6
+shift 6
 
 if [[ "$OUT" == *jdk_allmodules.zip ]]; then
   DEV_BUILD=1
@@ -100,6 +101,12 @@ cp $INSTALL_BASE_KEY $PACKAGE_DIR/install_base_key
 # Zero timestamps.
 (cd $PACKAGE_DIR; xargs touch -t 198001010000.00) < files.list
 
-# Create output zip with compression.
-(cd $PACKAGE_DIR; zip -q9DX@ $WORKDIR/$OUT) < files.list
+if [ "$COMPILATION_MODE" = "opt" ]; then
+  # Create output zip with highest compression, but slow.
+  (cd $PACKAGE_DIR; zip -q9DX@ $WORKDIR/$OUT) < files.list
+else
+  # Create output zip with lowest compression, but fast.
+  (cd $PACKAGE_DIR; zip -q1DX@ $WORKDIR/$OUT) < files.list
+fi
+
 

--- a/src/package-bazel.sh
+++ b/src/package-bazel.sh
@@ -21,12 +21,11 @@ set -euo pipefail
 
 WORKDIR=$(pwd)
 OUT=$1
-COMPILATION_MODE=$2
-EMBEDDED_TOOLS=$3
-DEPLOY_JAR=$4
-INSTALL_BASE_KEY=$5
-PLATFORMS_ARCHIVE=$6
-shift 6
+EMBEDDED_TOOLS=$2
+DEPLOY_JAR=$3
+INSTALL_BASE_KEY=$4
+PLATFORMS_ARCHIVE=$5
+shift 5
 
 if [[ "$OUT" == *jdk_allmodules.zip ]]; then
   DEV_BUILD=1
@@ -101,12 +100,13 @@ cp $INSTALL_BASE_KEY $PACKAGE_DIR/install_base_key
 # Zero timestamps.
 (cd $PACKAGE_DIR; xargs touch -t 198001010000.00) < files.list
 
-if [ "$COMPILATION_MODE" = "opt" ]; then
-  # Create output zip with highest compression, but slow.
-  (cd $PACKAGE_DIR; zip -q9DX@ $WORKDIR/$OUT) < files.list
-else
+if [[ "$DEV_BUILD" -eq 1 ]]; then
   # Create output zip with lowest compression, but fast.
-  (cd $PACKAGE_DIR; zip -q1DX@ $WORKDIR/$OUT) < files.list
+  ZIP_ARGS="-q1DX@"
+else
+  # Create output zip with highest compression, but slow.
+  ZIP_ARGS="-q9DX@"
 fi
+(cd $PACKAGE_DIR; zip $ZIP_ARGS $WORKDIR/$OUT) < files.list
 
 


### PR DESCRIPTION
Cuts incremental build times of the package-bazel step in //src:bazel-dev by over 60%.

On a trivial change to package-bazel.sh:

```
jingwen@jingwen1:~/bazel$ bazel build //src:bazel 
INFO: Analyzed target //src:bazel (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //src:bazel up-to-date:
  bazel-bin/src/bazel
INFO: Elapsed time: 5.651s, Critical Path: 5.21s
INFO: 1 process: 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions
```

with `-c opt`:

```
jingwen@jingwen1:~/bazel$ bazel build //src:bazel -c opt
INFO: Analyzed target //src:bazel (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //src:bazel up-to-date:
  bazel-bin/src/bazel
INFO: Elapsed time: 14.577s, Critical Path: 14.18s
INFO: 1 process: 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions
```

This uses the `--compilation_mode` config setting. Since the default of `-c` is `fastbuild`, this will increase the size of the regular `bazel build //src:bazel` build, but is a no-op change for `bazel build -c opt //src:bazel` release-type builds.

Alternatively, we could reuse the `DEV_BUILD` variable that is set by building `//src:bazel-dev` instead of `//src:bazel`. The implication is that folks building `//src:bazel` would have to remember to build `//src:bazel-dev` to take advantage of the faster incremental build, instead of getting it for free.

RELNOTES: Reduced the packaging time (`package-bazel.sh`) for the `//src:bazel-dev` Bazel development build target from 14s to 6s. Use `//src:bazel-dev` if you're iterating rapidly on a local Bazel changes, and use `//src:bazel --compilation_mode=opt` for release builds.