### PR TITLE
A few FilesystemValueChecker improvements.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
@@ -113,7 +113,7 @@ public class FilesystemValueChecker {
    */
   public ImmutableBatchDirtyResult getNewAndOldValues(
       Map<SkyKey, SkyValue> valuesMap,
-      Iterable<SkyKey> keys,
+      Collection<SkyKey> keys,
       SkyValueDirtinessChecker dirtinessChecker)
       throws InterruptedException {
     return getDirtyValues(new MapBackedValueFetcher(valuesMap), keys,
@@ -124,9 +124,11 @@ public class FilesystemValueChecker {
    * Returns a {@link Differencer.DiffWithDelta} containing keys that are dirty according to the
    * passed-in {@code dirtinessChecker}.
    */
-  public Differencer.DiffWithDelta getNewAndOldValues(WalkableGraph walkableGraph,
-      Iterable<SkyKey> keys, SkyValueDirtinessChecker dirtinessChecker)
-          throws InterruptedException {
+  public Differencer.DiffWithDelta getNewAndOldValues(
+      WalkableGraph walkableGraph,
+      Collection<SkyKey> keys,
+      SkyValueDirtinessChecker dirtinessChecker)
+      throws InterruptedException {
     return getDirtyValues(new WalkableGraphBackedValueFetcher(walkableGraph), keys,
         dirtinessChecker, /*checkMissingValues=*/true);
   }
@@ -484,7 +486,7 @@ public class FilesystemValueChecker {
 
   private ImmutableBatchDirtyResult getDirtyValues(
       ValueFetcher fetcher,
-      Iterable<SkyKey> keys,
+      Collection<SkyKey> keys,
       final SkyValueDirtinessChecker checker,
       final boolean checkMissingValues)
       throws InterruptedException {
@@ -495,7 +497,6 @@ public class FilesystemValueChecker {
 
     ThrowableRecordingRunnableWrapper wrapper =
         new ThrowableRecordingRunnableWrapper("FilesystemValueChecker#getDirtyValues");
-    final AtomicInteger numKeysScanned = new AtomicInteger(0);
     final AtomicInteger numKeysChecked = new AtomicInteger(0);
     MutableBatchDirtyResult batchResult = new MutableBatchDirtyResult(numKeysChecked);
     ElapsedTimeReceiver elapsedTimeReceiver =
@@ -506,12 +507,11 @@ public class FilesystemValueChecker {
                     "Spent %d ms checking %d filesystem nodes (%d scanned)",
                     TimeUnit.MILLISECONDS.convert(elapsedTimeNanos, TimeUnit.NANOSECONDS),
                     numKeysChecked.get(),
-                    numKeysScanned.get()));
+                    keys.size()));
           }
         };
     try (AutoProfiler prof = AutoProfiler.create(elapsedTimeReceiver)) {
       for (final SkyKey key : keys) {
-        numKeysScanned.incrementAndGet();
         if (!checker.applies(key)) {
           continue;
         }


### PR DESCRIPTION
- Pass possibly-modified keys around as a Collection rather than an Iterable.
- Remove an atomic that counted the possibly-modified keys.
- Use a lambda in getDiff.