### PR TITLE
Rollforward of commit 4162cc54ba0b128b616c0bd05b65bf9ad5e66f2e.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
@@ -276,7 +276,7 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
     private boolean areSrcsBlacklisted() {
       return !new ProtoSourceFileBlacklist(
               ruleContext, getProtoToolchainProvider().blacklistedProtos())
-          .checkSrcs(protoInfo.getOriginalDirectProtoSources(), "cc_proto_library");
+          .checkSrcs(protoInfo.getOriginalTransitiveProtoSources(), "cc_proto_library");
     }
 
     private FeatureConfiguration getFeatureConfiguration() {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
@@ -276,7 +276,7 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
     private boolean areSrcsBlacklisted() {
       return !new ProtoSourceFileBlacklist(
               ruleContext, getProtoToolchainProvider().blacklistedProtos())
-          .checkSrcs(protoInfo.getOriginalTransitiveProtoSources(), "cc_proto_library");
+          .checkSrcs(protoInfo.getOriginalDirectProtoSources(), "cc_proto_library");
     }
 
     private FeatureConfiguration getFeatureConfiguration() {

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCommon.java
@@ -127,6 +127,19 @@ public class ProtoCommon {
     return result.build();
   }
 
+  private static NestedSet<Artifact> computeTransitiveOriginalProtoSources(
+      RuleContext ruleContext, ImmutableList<Artifact> originalProtoSources) {
+    NestedSetBuilder<Artifact> result = NestedSetBuilder.naiveLinkOrder();
+
+    result.addAll(originalProtoSources);
+
+    for (ProtoInfo dep : ruleContext.getPrerequisites("deps", Mode.TARGET, ProtoInfo.PROVIDER)) {
+      result.addTransitive(dep.getOriginalTransitiveProtoSources());
+    }
+
+    return result.build();
+  }
+
   static NestedSet<Artifact> computeDependenciesDescriptorSets(RuleContext ruleContext) {
     NestedSetBuilder<Artifact> result = NestedSetBuilder.stableOrder();
 
@@ -462,6 +475,8 @@ public class ProtoCommon {
 
     NestedSet<Artifact> transitiveProtoSources =
         computeTransitiveProtoSources(ruleContext, library.getSources());
+    NestedSet<Artifact> transitiveOriginalProtoSources =
+        computeTransitiveOriginalProtoSources(ruleContext, directProtoSources);
     NestedSet<String> transitiveProtoSourceRoots =
         computeTransitiveProtoSourceRoots(ruleContext, library.getSourceRoot());
 
@@ -491,8 +506,8 @@ public class ProtoCommon {
     ProtoInfo protoInfo =
         new ProtoInfo(
             library.getSources(),
-            directProtoSources,
             library.getSourceRoot(),
+            transitiveOriginalProtoSources,
             transitiveProtoSources,
             transitiveProtoSourceRoots,
             strictImportableProtosForDependents,

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCommon.java
@@ -506,9 +506,10 @@ public class ProtoCommon {
     ProtoInfo protoInfo =
         new ProtoInfo(
             library.getSources(),
+            directProtoSources,
             library.getSourceRoot(),
-            transitiveOriginalProtoSources,
             transitiveProtoSources,
+            transitiveOriginalProtoSources,
             transitiveProtoSourceRoots,
             strictImportableProtosForDependents,
             strictImportableProtos,

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoInfo.java
@@ -54,7 +54,7 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
   public static final String LEGACY_SKYLARK_NAME = "proto";
 
   private final ImmutableList<Artifact> directProtoSources;
-  private final ImmutableList<Artifact> originalDirectProtoSources;
+  private final NestedSet<Artifact> originalTransitiveProtoSources;
   private final String directProtoSourceRoot;
   private final NestedSet<Artifact> transitiveProtoSources;
   private final NestedSet<String> transitiveProtoSourceRoots;
@@ -71,8 +71,8 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
   @AutoCodec.Instantiator
   public ProtoInfo(
       ImmutableList<Artifact> directProtoSources,
-      ImmutableList<Artifact> originalDirectProtoSources,
       String directProtoSourceRoot,
+      NestedSet<Artifact> originalTransitiveProtoSources,
       NestedSet<Artifact> transitiveProtoSources,
       NestedSet<String> transitiveProtoSourceRoots,
       NestedSet<Artifact> strictImportableProtoSourcesForDependents,
@@ -86,7 +86,7 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
       Location location) {
     super(PROVIDER, location);
     this.directProtoSources = directProtoSources;
-    this.originalDirectProtoSources = originalDirectProtoSources;
+    this.originalTransitiveProtoSources = originalTransitiveProtoSources;
     this.directProtoSourceRoot = directProtoSourceRoot;
     this.transitiveProtoSources = transitiveProtoSources;
     this.transitiveProtoSourceRoots = transitiveProtoSourceRoots;
@@ -103,17 +103,18 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
 
   /**
    * The proto source files that are used in compiling this {@code proto_library}.
-   *
-   * <p>Different from {@link #getOriginalDirectProtoSources()} when a virtual import root is used.
    */
   @Override
   public ImmutableList<Artifact> getDirectProtoSources() {
     return directProtoSources;
   }
 
-  /** The proto sources of the {@code proto_library} declaring this provider. */
-  public ImmutableList<Artifact> getOriginalDirectProtoSources() {
-    return originalDirectProtoSources;
+  /**
+   * The non-virtual transitive proto source files. Different from {@link
+   * #getTransitiveProtoSources()} if a transitive dependency has {@code import_prefix} or the like.
+   */
+  public NestedSet<Artifact> getOriginalTransitiveProtoSources() {
+    return originalTransitiveProtoSources;
   }
 
   /** The source root of the current library. */

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoInfo.java
@@ -54,9 +54,10 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
   public static final String LEGACY_SKYLARK_NAME = "proto";
 
   private final ImmutableList<Artifact> directProtoSources;
-  private final NestedSet<Artifact> originalTransitiveProtoSources;
+  private final ImmutableList<Artifact> originalDirectProtoSources;
   private final String directProtoSourceRoot;
   private final NestedSet<Artifact> transitiveProtoSources;
+  private final NestedSet<Artifact> originalTransitiveProtoSources;
   private final NestedSet<String> transitiveProtoSourceRoots;
   private final NestedSet<Artifact> strictImportableProtoSourcesForDependents;
   private final NestedSet<Pair<Artifact, String>> strictImportableProtoSourcesImportPaths;
@@ -71,9 +72,10 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
   @AutoCodec.Instantiator
   public ProtoInfo(
       ImmutableList<Artifact> directProtoSources,
+      ImmutableList<Artifact> originalDirectProtoSources,
       String directProtoSourceRoot,
-      NestedSet<Artifact> originalTransitiveProtoSources,
       NestedSet<Artifact> transitiveProtoSources,
+      NestedSet<Artifact> originalTransitiveProtoSources,
       NestedSet<String> transitiveProtoSourceRoots,
       NestedSet<Artifact> strictImportableProtoSourcesForDependents,
       NestedSet<Pair<Artifact, String>> strictImportableProtoSourcesImportPaths,
@@ -86,9 +88,10 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
       Location location) {
     super(PROVIDER, location);
     this.directProtoSources = directProtoSources;
-    this.originalTransitiveProtoSources = originalTransitiveProtoSources;
+    this.originalDirectProtoSources = originalDirectProtoSources;
     this.directProtoSourceRoot = directProtoSourceRoot;
     this.transitiveProtoSources = transitiveProtoSources;
+    this.originalTransitiveProtoSources = originalTransitiveProtoSources;
     this.transitiveProtoSourceRoots = transitiveProtoSourceRoots;
     this.strictImportableProtoSourcesForDependents = strictImportableProtoSourcesForDependents;
     this.strictImportableProtoSourcesImportPaths = strictImportableProtoSourcesImportPaths;
@@ -110,11 +113,13 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
   }
 
   /**
-   * The non-virtual transitive proto source files. Different from {@link
-   * #getTransitiveProtoSources()} if a transitive dependency has {@code import_prefix} or the like.
+   * The non-virtual proto sources of the {@code proto_library} declaring this provider.
+   *
+   * <p> Different from {@link #getDirectProtoSources()} if a transitive dependency has
+   * {@code import_prefix} or the like.
    */
-  public NestedSet<Artifact> getOriginalTransitiveProtoSources() {
-    return originalTransitiveProtoSources;
+  public ImmutableList<Artifact> getOriginalDirectProtoSources() {
+    return originalDirectProtoSources;
   }
 
   /** The source root of the current library. */
@@ -132,6 +137,17 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
   public NestedSet<Artifact> getTransitiveProtoSources() {
     return transitiveProtoSources;
   }
+
+  /**
+   * The non-virtual transitive proto source files.
+   *
+   * <p> Different from {@link #getTransitiveProtoSources()} if a transitive dependency has
+   * {@code import_prefix} or the like.
+   */
+  public NestedSet<Artifact> getOriginalTransitiveProtoSources() {
+    return originalTransitiveProtoSources;
+  }
+
 
   /**
    * The proto source roots of the transitive closure of this rule. These flags will be passed to

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchain.java
@@ -44,8 +44,10 @@ public class ProtoLangToolchain implements RuleConfiguredTargetFactory {
       ProtoInfo protoInfo = protos.get(ProtoInfo.PROVIDER);
       // TODO(cushon): it would be nice to make this mandatory and stop adding files to build too
       if (protoInfo != null) {
-        blacklistedProtos.addTransitive(protoInfo.getTransitiveProtoSources());
+        blacklistedProtos.addTransitive(protoInfo.getOriginalTransitiveProtoSources());
       } else {
+        // Only add files from FileProvider if |protos| is not a proto_library to avoid adding
+        // the descriptor_set of proto_library to the list of blacklisted files.
         blacklistedProtos.addTransitive(protos.getProvider(FileProvider.class).getFilesToBuild());
       }
     }

--- a/src/test/java/com/google/devtools/build/lib/rules/proto/ProtoCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/proto/ProtoCompileActionBuilderTest.java
@@ -65,8 +65,8 @@ public class ProtoCompileActionBuilderTest {
       NestedSet<Pair<Artifact, String>> exportedProtos) {
     return new ProtoInfo(
         directProtos,
-        directProtos,
-        "",
+        /* directProtoSourceRoot= */ "",
+        transitiveProtos,
         transitiveProtos,
         transitiveProtoSourceRoots,
         /* strictImportableProtosForDependents */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),

--- a/src/test/java/com/google/devtools/build/lib/rules/proto/ProtoCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/proto/ProtoCompileActionBuilderTest.java
@@ -65,6 +65,7 @@ public class ProtoCompileActionBuilderTest {
       NestedSet<Pair<Artifact, String>> exportedProtos) {
     return new ProtoInfo(
         directProtos,
+        directProtos,
         /* directProtoSourceRoot= */ "",
         transitiveProtos,
         transitiveProtos,

--- a/src/test/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchainTest.java
@@ -39,10 +39,27 @@ public class ProtoLangToolchainTest extends BuildViewTestCase {
     invalidatePackages();
   }
 
+  private void validateProtoLangToolchain(ProtoLangToolchainProvider toolchain) throws Exception {
+    assertThat(toolchain.commandLine()).isEqualTo("cmd-line");
+    assertThat(toolchain.pluginExecutable().getExecutable().getRootRelativePathString())
+        .isEqualTo("third_party/x/plugin");
+
+    TransitiveInfoCollection runtimes = toolchain.runtime();
+    assertThat(runtimes.getLabel())
+        .isEqualTo(Label.parseAbsolute("//third_party/x:runtime", ImmutableMap.of()));
+
+    assertThat(prettyArtifactNames(toolchain.blacklistedProtos()))
+        .containsExactly(
+            "third_party/x/metadata.proto",
+            "third_party/x/descriptor.proto",
+            "third_party/x/any.proto");
+  }
+
   @Test
   public void protoToolchain() throws Exception {
     scratch.file(
-        "x/BUILD",
+        "third_party/x/BUILD",
+        "licenses(['unencumbered'])",
         "cc_binary(name = 'plugin', srcs = ['plugin.cc'])",
         "cc_library(name = 'runtime', srcs = ['runtime.cc'])",
         "filegroup(name = 'descriptors', srcs = ['metadata.proto', 'descriptor.proto'])",
@@ -52,29 +69,82 @@ public class ProtoLangToolchainTest extends BuildViewTestCase {
     scratch.file(
         "foo/BUILD",
         TestConstants.LOAD_PROTO_LANG_TOOLCHAIN,
+        "licenses(['unencumbered'])",
         "proto_lang_toolchain(",
         "    name = 'toolchain',",
         "    command_line = 'cmd-line',",
-        "    plugin = '//x:plugin',",
-        "    runtime = '//x:runtime',",
-        "    blacklisted_protos = ['//x:blacklist']",
+        "    plugin = '//third_party/x:plugin',",
+        "    runtime = '//third_party/x:runtime',",
+        "    blacklisted_protos = ['//third_party/x:blacklist']",
         ")");
 
     update(ImmutableList.of("//foo:toolchain"), false, 1, true, new EventBus());
 
-    ProtoLangToolchainProvider toolchain =
-        getConfiguredTarget("//foo:toolchain").getProvider(ProtoLangToolchainProvider.class);
+    validateProtoLangToolchain(
+        getConfiguredTarget("//foo:toolchain").getProvider(ProtoLangToolchainProvider.class));
+  }
 
-    assertThat(toolchain.commandLine()).isEqualTo("cmd-line");
-    assertThat(toolchain.pluginExecutable().getExecutable().getRootRelativePathString())
-        .isEqualTo("x/plugin");
+  @Test
+  public void protoToolchainBlacklistProtoLibraries() throws Exception {
+    scratch.file(
+        "third_party/x/BUILD",
+        TestConstants.LOAD_PROTO_LIBRARY,
+        "licenses(['unencumbered'])",
+        "cc_binary(name = 'plugin', srcs = ['plugin.cc'])",
+        "cc_library(name = 'runtime', srcs = ['runtime.cc'])",
+        "proto_library(name = 'descriptors', srcs = ['metadata.proto', 'descriptor.proto'])",
+        "proto_library(name = 'any', srcs = ['any.proto'], strip_import_prefix = '/third_party')");
 
-    TransitiveInfoCollection runtimes = toolchain.runtime();
-    assertThat(runtimes.getLabel())
-        .isEqualTo(Label.parseAbsolute("//x:runtime", ImmutableMap.of()));
+    scratch.file(
+        "foo/BUILD",
+        TestConstants.LOAD_PROTO_LANG_TOOLCHAIN,
+        "proto_lang_toolchain(",
+        "    name = 'toolchain',",
+        "    command_line = 'cmd-line',",
+        "    plugin = '//third_party/x:plugin',",
+        "    runtime = '//third_party/x:runtime',",
+        "    blacklisted_protos = ['//third_party/x:descriptors', '//third_party/x:any']",
+        ")");
 
-    assertThat(prettyArtifactNames(toolchain.blacklistedProtos()))
-        .containsExactly("x/metadata.proto", "x/descriptor.proto", "x/any.proto");
+    update(ImmutableList.of("//foo:toolchain"), false, 1, true, new EventBus());
+
+    validateProtoLangToolchain(
+        getConfiguredTarget("//foo:toolchain").getProvider(ProtoLangToolchainProvider.class));
+  }
+
+  @Test
+  public void protoToolchainMixedBlacklist() throws Exception {
+    scratch.file(
+        "third_party/x/BUILD",
+        TestConstants.LOAD_PROTO_LIBRARY,
+        "licenses(['unencumbered'])",
+        "cc_binary(name = 'plugin', srcs = ['plugin.cc'])",
+        "cc_library(name = 'runtime', srcs = ['runtime.cc'])",
+        "proto_library(name = 'metadata', srcs = ['metadata.proto'])",
+        "proto_library(",
+        "    name = 'descriptor',",
+        "    srcs = ['descriptor.proto'],",
+        "    strip_import_prefix = '/third_party')",
+        "filegroup(name = 'any', srcs = ['any.proto'])");
+
+    scratch.file(
+        "foo/BUILD",
+        TestConstants.LOAD_PROTO_LANG_TOOLCHAIN,
+        "proto_lang_toolchain(",
+        "    name = 'toolchain',",
+        "    command_line = 'cmd-line',",
+        "    plugin = '//third_party/x:plugin',",
+        "    runtime = '//third_party/x:runtime',",
+        "    blacklisted_protos = [",
+        "        '//third_party/x:metadata',",
+        "        '//third_party/x:descriptor',",
+        "        '//third_party/x:any']",
+        ")");
+
+    update(ImmutableList.of("//foo:toolchain"), false, 1, true, new EventBus());
+
+    validateProtoLangToolchain(
+        getConfiguredTarget("//foo:toolchain").getProvider(ProtoLangToolchainProvider.class));
   }
 
   @Test


### PR DESCRIPTION
proto_lang_toolchain: Add original sources of ProtoInfo to blacklistedProtos

This fixes the problem reported in #10588

Fixes #10484
