### PR TITLE
Prevent downloading of repositories inside integration tests.

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -5,11 +5,16 @@ tasks:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
       - rm -f WORKSPACE.bak
+      - mkdir $HOME/bazeltest
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
     test_flags:
-      - "--test_timeout=1200"
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
@@ -36,11 +41,16 @@ tasks:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
       - rm -f WORKSPACE.bak
+      - mkdir $HOME/bazeltest
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
     test_flags:
-      - "--test_timeout=1200"
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
@@ -63,11 +73,16 @@ tasks:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
       - rm -f WORKSPACE.bak
+      - mkdir $HOME/bazeltest
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
     test_flags:
-      - "--test_timeout=1200"
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
       # Configure and enable tests that require access to the network.
       - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
     test_targets:
@@ -96,11 +111,16 @@ tasks:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
       - rm -f WORKSPACE.bak
+      - mkdir $HOME/bazeltest
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
     test_flags:
-      - "--test_timeout=1200"
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
     test_targets:
       - "//src/test/shell/bazel:cc_integration_test"
     include_json_profile:
@@ -111,13 +131,18 @@ tasks:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
       - rm -f WORKSPACE.bak
+      - mkdir $HOME/bazeltest
     build_flags:
       - "--apple_platform_type=macos"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
     test_flags:
-      - "--test_timeout=1200"
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
       # Configure and enable tests that require access to the network.
       - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
     test_targets:
@@ -141,17 +166,20 @@ tasks:
   windows:
     batch_commands:
       - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
+      - mkdir D:\\bazeltest
     build_flags:
       - "--copt=-w"
       - "--host_copt=-w"
     build_targets:
       - "//src:bazel.exe"
       - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
     test_flags:
       - "--copt=-w"
       - "--host_copt=-w"
       - "--test_env=JAVA_HOME"
-      - "--test_timeout=1200"
+      - "--test_env=TEST_INSTALL_BASE=D:/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
     test_targets:
       - "//src:all_windows_tests"
     include_json_profile:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,11 +6,16 @@ tasks:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
       - rm -f WORKSPACE.bak
+      - mkdir $HOME/bazeltest
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
     test_flags:
-      - "--test_timeout=1200"
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
@@ -35,11 +40,16 @@ tasks:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
       - rm -f WORKSPACE.bak
+      - mkdir $HOME/bazeltest
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
     test_flags:
-      - "--test_timeout=1200"
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
     test_targets:
       - "//scripts/..."
       - "//src/java_tools/..."
@@ -60,11 +70,16 @@ tasks:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
       - rm -f WORKSPACE.bak
+      - mkdir $HOME/bazeltest
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
     test_flags:
-      - "--test_timeout=1200"
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
       # Configure and enable tests that require access to the network.
       - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
     test_targets:
@@ -90,11 +105,16 @@ tasks:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
       - rm -f WORKSPACE.bak
+      - mkdir $HOME/bazeltest
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
     test_flags:
-      - "--test_timeout=1200"
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
     test_targets:
       - "//src/test/shell/bazel:cc_integration_test"
   macos:
@@ -103,13 +123,18 @@ tasks:
       - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/' -e 's/^#
         android_ndk_repository/android_ndk_repository/' WORKSPACE
       - rm -f WORKSPACE.bak
+      - mkdir $HOME/bazeltest
     build_flags:
       - "--apple_platform_type=macos"
     build_targets:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
     test_flags:
-      - "--test_timeout=1200"
+      - "--sandbox_default_allow_network=false"
+      - "--sandbox_writable_path=$HOME/bazeltest"
+      - "--test_env=TEST_INSTALL_BASE=$HOME/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
       # Configure and enable tests that require access to the network.
       - "--test_env=REMOTE_NETWORK_ADDRESS=bazel.build:80"
     test_targets:
@@ -134,17 +159,20 @@ tasks:
     shards: 4
     batch_commands:
       - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
+      - mkdir D:\\bazeltest
     build_flags:
       - "--copt=-w"
       - "--host_copt=-w"
     build_targets:
       - "//src:bazel.exe"
       - "//src:bazel_jdk_minimal"
+      - "//src:test_repos"
     test_flags:
       - "--copt=-w"
       - "--host_copt=-w"
       - "--test_env=JAVA_HOME"
-      - "--test_timeout=1200"
+      - "--test_env=TEST_INSTALL_BASE=D:/bazeltest/install_base"
+      - "--test_env=TEST_REPOSITORY_HOME=$OUTPUT_BASE/external"
     test_targets:
       - "//src:all_windows_tests"
   rbe_ubuntu1604:


### PR DESCRIPTION
Downloading and extracting external repositories over and over again is the biggest performance and SSD killer in our integration tests.

This PR introduces a mechanism where the integration tests can reuse the repositories downloaded by the "outer" Bazel. It also means we can disable network access for most tests, increasing hermeticity.