### PR TITLE
Use minutes instead of seconds

### DIFF
--- a/site/docs/test-encyclopedia.html
+++ b/site/docs/test-encyclopedia.html
@@ -102,13 +102,13 @@ on its timeout attribute according to the following table:</p>
 
 <table class="table table-bordered table-striped table-condensed">
   <thead>
-    <tr><th>timeout</th><th>Time Limit (sec.)</th></tr>
+    <tr><th>timeout</th><th>Time Limit (minutes)</th></tr>
   </thead>
   <tbody>
-    <tr><td><code>short</code></td><td>60</td></tr>
-    <tr><td><code>moderate</code></td><td>300</td></tr>
-    <tr><td><code>long</code></td><td>900</td></tr>
-    <tr><td><code>eternal</code></td><td>3600</td></tr>
+    <tr><td><code>short</code></td><td>1</td></tr>
+    <tr><td><code>moderate</code></td><td>5</td></tr>
+    <tr><td><code>long</code></td><td>15</td></tr>
+    <tr><td><code>eternal</code></td><td>60</td></tr>
   </tbody>
 </table>
 
@@ -142,13 +142,13 @@ flakiness.</p>
 
 <table class="table table-bordered table-striped table-condensed">
   <thead>
-    <tr><th>timeout</th><th>Time minimum (sec.)</th></tr>
+    <tr><th>timeout</th><th>Time minimum (minutes)</th></tr>
   </thead>
   <tbody>
     <tr><td><code>short</code></td><td>0</td></tr>
-    <tr><td><code>moderate</code></td><td>30</td></tr>
-    <tr><td><code>long</code></td><td>300</td></tr>
-    <tr><td><code>eternal</code></td><td>900</td></tr>
+    <tr><td><code>moderate</code></td><td>0.5</td></tr>
+    <tr><td><code>long</code></td><td>5</td></tr>
+    <tr><td><code>eternal</code></td><td>15</td></tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
to be more human-friendly