### PR TITLE
Fix a memory leak in linux sandbox

### DIFF
--- a/src/main/tools/linux-sandbox-options.cc
+++ b/src/main/tools/linux-sandbox-options.cc
@@ -263,6 +263,9 @@ void ParseOptions(int argc, char *argv[]) {
 
   if (opt.working_dir.empty()) {
     char *working_dir = getcwd(nullptr, 0);
+    if(!working_dir) {
+      DIE("getcwd");
+    }
     opt.working_dir = working_dir;
     free(working_dir);
   }

--- a/src/main/tools/linux-sandbox-options.cc
+++ b/src/main/tools/linux-sandbox-options.cc
@@ -262,6 +262,8 @@ void ParseOptions(int argc, char *argv[]) {
   }
 
   if (opt.working_dir.empty()) {
-    opt.working_dir = getcwd(nullptr, 0);
+    char *working_dir = getcwd(nullptr, 0);
+    opt.working_dir = working_dir;
+    free(working_dir);
   }
 }


### PR DESCRIPTION
`getcwd` result is allocated using `malloc` and should be deallocated with
`free`.

However `opt.working_dir` won't own it because that's an `std::string` and
the current `operator=` call will allocate a new buffer and copy the
content of `getcwd` result.

Hence, in the previous solution, the result of `getcwd` was just leaked at
the end of the function.

This commit adds the necessary `free`.

*edit*: I found that when running a C++ ASAN sanitizer during my build. I have a rule which setups the environment with `LD_PRELOAD and apparently bazel is calling the sandbox inside the build environment, hence it inherit the `LD_PRELOAD` setting.