### PR TITLE
Windows environment variable name can contain brackets

### DIFF
--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -563,7 +563,7 @@ static bool IsValidEnvName(const char* p) {
 #if defined(_WIN32) || defined(__CYGWIN__)
   for (; *p && *p != '='; ++p) {
     if (!((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
-          (*p >= '0' && *p <= '9') || *p == '_')) {
+          (*p >= '0' && *p <= '9') || *p == '_' || *p == '(' || *p == ')' )) {
       return false;
     }
   }


### PR DESCRIPTION
Bazel cuts off environment variables with brackets in name.
It leads to a problem for me.

I have Visual Studio 2017 with workloads "Desktop C++ development", "TypeScript 3.1 SDK", "Python Web Support" installed.
I use Visual Studio toolchain configuration script similar to `tools/cpp/windows_cc_configure.bzl`.
My script in contrast to original finds more tools and checks a result of `VCVARSALL.BAT` also.
I noticed that `VCVARSALL.BAT` fails with error:
```
[ERROR:typescript.bat] TypeScript was not added to PATH since a valid installation was not found
[ERROR:VsDevCmd.bat] *** VsDevCmd.bat encountered errors. Environment may be incomplete and/or incorrect. ***
[ERROR:VsDevCmd.bat] In an uninitialized command prompt, please 'set VSCMD_DEBUG=[value]' and then re-run
[ERROR:VsDevCmd.bat] vsdevcmd.bat [args] for additional details.
[ERROR:VsDevCmd.bat] Where [value] is:
[ERROR:VsDevCmd.bat]    1 : basic debug logging
[ERROR:VsDevCmd.bat]    2 : detailed debug logging
[ERROR:VsDevCmd.bat]    3 : trace level logging. Redirection of output to a file when using this level is recommended.
[ERROR:VsDevCmd.bat] Example: set VSCMD_DEBUG=3
[ERROR:VsDevCmd.bat]          vsdevcmd.bat > vsdevcmd.trace.txt 2>&1
```
It happens because `typescript.bat` can't access `ProgramFiles(x86)` environment variable:
**typescript.bat**:
```
...
if exist "%ProgramFiles(x86)%\Microsoft SDKs\TypeScript\3.1" (
    set "PATH=%ProgramFiles(x86)%\Microsoft SDKs\TypeScript\3.1;%PATH%"
    set _TypeScript_Found=1
)
...
```

Exit code of `VCVARSALL.BAT` is ignored in original `tools/cpp/windows_cc_configure.bzl` so it is not critical bug but it can lead to unobvious errors for users who find external tools (TypeScript compiler, for example) with own scripts.