### PR TITLE
Do glob result sorting and @-escaping at the last moment.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/GlobCache.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/GlobCache.java
@@ -180,10 +180,6 @@ public class GlobCache {
       // invalid as a label, plus users should say explicitly if they
       // really want to name the package directory.
       if (!relative.isEmpty()) {
-        if (relative.charAt(0) == '@') {
-          // Add explicit colon to disambiguate from external repository.
-          relative = ":" + relative;
-        }
         result.add(relative);
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/packages/Globber.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Globber.java
@@ -39,11 +39,11 @@ public interface Globber {
       throws BadGlobException, InterruptedException;
 
   /**
-   * Fetches the result of a previously started glob computation. The returned list must be ordered
-   * deterministically. For more obvious correctness, implementations should generally sort the list
-   * they return.
+   * Fetches the result of a previously started glob computation. The returned list has an arbitrary
+   * order.
    */
-  List<String> fetch(Token token) throws BadGlobException, IOException, InterruptedException;
+  List<String> fetchUnsorted(Token token)
+      throws BadGlobException, IOException, InterruptedException;
 
   /** Should be called when the globber is about to be discarded due to an interrupt. */
   void onInterrupt();

--- a/src/main/java/com/google/devtools/build/lib/packages/PackageFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/PackageFactory.java
@@ -73,7 +73,6 @@ import com.google.devtools.build.lib.vfs.RootedPath;
 import com.google.devtools.build.lib.vfs.UnixGlob;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -265,11 +264,9 @@ public final class PackageFactory {
   /** {@link Globber} that uses the legacy GlobCache. */
   public static class LegacyGlobber implements Globber {
     private final GlobCache globCache;
-    private final boolean sort;
 
-    private LegacyGlobber(GlobCache globCache, boolean sort) {
+    private LegacyGlobber(GlobCache globCache) {
       this.globCache = globCache;
-      this.sort = sort;
     }
 
     private static class Token extends Globber.Token {
@@ -299,7 +296,7 @@ public final class PackageFactory {
     }
 
     @Override
-    public List<String> fetch(Globber.Token token)
+    public List<String> fetchUnsorted(Globber.Token token)
         throws BadGlobException, IOException, InterruptedException {
       List<String> result;
       Token legacyToken = (Token) token;
@@ -309,9 +306,6 @@ public final class PackageFactory {
               legacyToken.excludes,
               legacyToken.excludeDirs,
               legacyToken.allowEmpty);
-      if (sort) {
-        Collections.sort(result);
-      }
       return result;
     }
 
@@ -792,7 +786,7 @@ public final class PackageFactory {
 
   /** Returns a new {@link LegacyGlobber}. */
   public static LegacyGlobber createLegacyGlobber(GlobCache globCache) {
-    return new LegacyGlobber(globCache, /*sort=*/ true);
+    return new LegacyGlobber(globCache);
   }
 
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageFunction.java
@@ -76,7 +76,6 @@ import com.google.devtools.build.skyframe.ValueOrException2;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -891,9 +890,9 @@ public class PackageFunction implements SkyFunction {
     }
 
     @Override
-    public List<String> fetch(Token token)
+    public List<String> fetchUnsorted(Token token)
         throws BadGlobException, IOException, InterruptedException {
-      return delegate.fetch(token);
+      return delegate.fetchUnsorted(token);
     }
 
     @Override
@@ -1016,7 +1015,7 @@ public class PackageFunction implements SkyFunction {
     }
 
     @Override
-    public List<String> fetch(Token token)
+    public List<String> fetchUnsorted(Token token)
         throws BadGlobException, IOException, InterruptedException {
       HybridToken hybridToken = (HybridToken) token;
       return hybridToken.resolve(legacyGlobber);
@@ -1083,13 +1082,10 @@ public class PackageFunction implements SkyFunction {
           }
         }
         if (legacyIncludesToken != null) {
-          matches.addAll(delegate.fetch(legacyIncludesToken));
+          matches.addAll(delegate.fetchUnsorted(legacyIncludesToken));
         }
         UnixGlob.removeExcludes(matches, excludes);
         List<String> result = new ArrayList<>(matches);
-        // Skyframe glob results are unsorted. And we used a LegacyGlobber that doesn't sort.
-        // Therefore, we want to unconditionally sort here.
-        Collections.sort(result);
 
         if (!allowEmpty && result.isEmpty()) {
           throw new BadGlobException(


### PR DESCRIPTION
c4f2d80270f1ce947fcf7fb0a4e5f0afb3a7062d changed legacy globbing (without a test) to prepend ':' to any targets starting with '@'. It did not change the skyframe globbing logic, which means incrementality bugs. Fix this issue by doing the escaping just before glob() returns its result, which is a common path for both glob implementations.

Fixes https://github.com/bazelbuild/bazel/issues/10606.