### PR TITLE
Always add '-fmodules' flag when objc_library's enable_modules is set to True

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
@@ -1229,7 +1229,7 @@ public class CompilationSupport {
       }
     }
 
-    if (attributes.enableModules() && !getCustomModuleMap(ruleContext).isPresent()) {
+    if (attributes.enableModules()) {
       copts.add("-fmodules");
     }
     if (copts.contains("-fmodules")) {


### PR DESCRIPTION
I wasn't able to find any documentation on why modules was not enabled even though users explicitly specify it.