### PR TITLE
Check included and subninja Ninja files against passed Artifacts paths

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParser.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParser.java
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package com.google.devtools.build.lib.bazel.rules.ninja.parser;
 
@@ -35,10 +34,14 @@ import java.io.IOException;
 public class NinjaParser implements DeclarationConsumer {
   private final NinjaPipeline pipeline;
   private final NinjaFileParseResult parseResult;
+  private final String ninjaFileName;
 
-  public NinjaParser(NinjaPipeline pipeline, NinjaFileParseResult parseResult) {
+  public NinjaParser(NinjaPipeline pipeline,
+      NinjaFileParseResult parseResult,
+      String ninjaFileName) {
     this.pipeline = pipeline;
     this.parseResult = parseResult;
+    this.ninjaFileName = ninjaFileName;
   }
 
   @Override
@@ -82,13 +85,15 @@ public class NinjaParser implements DeclarationConsumer {
       case INCLUDE:
         NinjaVariableValue includeStatement = parser.parseIncludeStatement();
         NinjaPromise<NinjaFileParseResult> includeFuture =
-            pipeline.createChildFileParsingPromise(includeStatement, declarationStart);
+            pipeline.createChildFileParsingPromise(includeStatement, declarationStart,
+                ninjaFileName);
         parseResult.addIncludeScope(declarationStart, includeFuture);
         break;
       case SUBNINJA:
         NinjaVariableValue subNinjaStatement = parser.parseSubNinjaStatement();
         NinjaPromise<NinjaFileParseResult> subNinjaFuture =
-            pipeline.createChildFileParsingPromise(subNinjaStatement, declarationStart);
+            pipeline.createChildFileParsingPromise(subNinjaStatement, declarationStart,
+                ninjaFileName);
         parseResult.addSubNinjaScope(declarationStart, subNinjaFuture);
         break;
       case BUILD:

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/pipeline/NinjaPipeline.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/pipeline/NinjaPipeline.java
@@ -17,7 +17,6 @@ package com.google.devtools.build.lib.bazel.rules.ninja.pipeline;
 import static com.google.devtools.build.lib.concurrent.MoreFutures.waitForFutureAndGetWithCheckedException;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -38,7 +37,6 @@ import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaTarget;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaVariableValue;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.Path;
-import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
@@ -56,22 +54,22 @@ import java.util.Map;
 public class NinjaPipeline {
   private final Path basePath;
   private final ListeningExecutorService service;
-  private final Collection<Path> childNinjaFiles;
+  private final Collection<Path> includedOrSubninjaFiles;
   private final String ownerTargetName;
 
   /**
    * @param basePath base path for resolving include and subninja paths.
    * @param service service to use for scheduling tasks in parallel.
-   * @param childNinjaFiles Ninja files expected in include/subninja statements
+   * @param includedOrSubninjaFiles Ninja files expected in include/subninja statements
    * @param ownerTargetName name of the owner ninja_graph target
    */
   public NinjaPipeline(Path basePath,
       ListeningExecutorService service,
-      Collection<Path> childNinjaFiles,
+      Collection<Path> includedOrSubninjaFiles,
       String ownerTargetName) {
     this.basePath = basePath;
     this.service = service;
-    this.childNinjaFiles = childNinjaFiles;
+    this.includedOrSubninjaFiles = includedOrSubninjaFiles;
     this.ownerTargetName = ownerTargetName;
   }
 
@@ -81,7 +79,7 @@ public class NinjaPipeline {
    * @return {@link Pair} of {@link NinjaScope} with rules and expanded variables (and child
    *     scopes), and list of {@link NinjaTarget}.
    */
-  public Pair<NinjaScope, ImmutableSortedMap<PathFragment, NinjaTarget>> pipeline(Path mainFile)
+  public Pair<NinjaScope, List<NinjaTarget>> pipeline(Path mainFile)
       throws GenericParsingException, InterruptedException, IOException {
     NinjaFileParseResult result =
         waitForFutureAndGetWithCheckedException(
@@ -99,7 +97,7 @@ public class NinjaPipeline {
    * variables in targets are immediately expanded.) We are iterating main and all transitively
    * included scopes, and parsing corresponding targets.
    */
-  private ImmutableSortedMap<PathFragment, NinjaTarget> iterateScopesScheduleTargetsParsing(
+  private List<NinjaTarget> iterateScopesScheduleTargetsParsing(
       NinjaScope scope, Map<NinjaScope, List<ByteFragmentAtOffset>> rawTargets)
       throws GenericParsingException, InterruptedException {
     ArrayDeque<NinjaScope> queue = new ArrayDeque<>();
@@ -120,11 +118,7 @@ public class NinjaPipeline {
       queue.addAll(currentScope.getIncludedScopes());
       queue.addAll(currentScope.getSubNinjaScopes());
     }
-    ImmutableSortedMap.Builder<PathFragment, NinjaTarget> builder =
-        ImmutableSortedMap.naturalOrder();
-    List<NinjaTarget> result = future.getResult();
-    result.forEach(t -> t.getAllOutputs().forEach(pf -> builder.put(pf, t)));
-    return builder.build();
+    return future.getResult();
   }
 
   /**
@@ -141,11 +135,11 @@ public class NinjaPipeline {
    * parsing result in the parent file {@link NinjaFileParseResult} structure.
    */
   public NinjaPromise<NinjaFileParseResult> createChildFileParsingPromise(
-      NinjaVariableValue value, Integer offset) throws IOException {
+      NinjaVariableValue value, Integer offset, String parentNinjaFileName) throws IOException {
     if (value.isPlainText()) {
       // If the value of the path is already known, we can immediately schedule parsing
       // of the child Ninja file.
-      Path path = getChildNinjaPath(value.getRawText());
+      Path path = getChildNinjaPath(value.getRawText(), parentNinjaFileName);
       ListenableFuture<NinjaFileParseResult> parsingFuture = scheduleParsing(path);
       return (scope) ->
           waitForFutureAndGetWithCheckedException(
@@ -158,18 +152,19 @@ public class NinjaPipeline {
         if (expandedValue.isEmpty()) {
           throw new GenericParsingException("Expected non-empty path.");
         }
-        Path path = getChildNinjaPath(expandedValue);
+        Path path = getChildNinjaPath(expandedValue, parentNinjaFileName);
         return waitForFutureAndGetWithCheckedException(
             scheduleParsing(path), GenericParsingException.class, IOException.class);
       };
     }
   }
 
-  private Path getChildNinjaPath(String rawText) throws FileNotFoundException {
+  private Path getChildNinjaPath(String rawText, String parentNinjaFileName) throws FileNotFoundException {
     Path childPath = basePath.getRelative(rawText);
-    if (!this.childNinjaFiles.contains(childPath)) {
-      throw new FileNotFoundException(String.format("Child Ninja file requested from '%s' "
-          + "not declared in 'srcs' attribute of '%s'.", this.basePath.asFragment().getPathString(),
+    if (!this.includedOrSubninjaFiles.contains(childPath)) {
+      throw new FileNotFoundException(String.format("Ninja file requested from '%s' "
+          + "not declared in 'srcs' attribute of '%s'.",
+          parentNinjaFileName,
           this.ownerTargetName));
     }
     return childPath;
@@ -191,7 +186,7 @@ public class NinjaPipeline {
                 () -> {
                   NinjaFileParseResult parseResult = new NinjaFileParseResult();
                   pieces.add(parseResult);
-                  return new NinjaParser(NinjaPipeline.this, parseResult);
+                  return new NinjaParser(NinjaPipeline.this, parseResult, path.getBaseName());
                 },
                 service,
                 NinjaSeparatorFinder.INSTANCE);


### PR DESCRIPTION
In the future ninja_graph rule, paths to all the included and subninja files should be passed in the srcs attribute.