### PR TITLE
Tweak third_party/BUILD for OpenBSD.

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -469,6 +469,7 @@ UNNECESSARY_DYNAMIC_LIBRARIES = select({
     "//src/conditions:arm": "*.so *.jnilib *.dll",
     "//src/conditions:linux_aarch64": "*.so *.jnilib *.dll",
     "//src/conditions:linux_ppc": "*.so *.jnilib *.dll",
+    "//src/conditions:openbsd": "*.so *.jnilib *.dll",
     # Play it safe -- better have a big binary than a slow binary
     # zip -d does require an argument. Supply something bogus.
     "//conditions:default": "*.bogusextension",
@@ -625,6 +626,11 @@ config_setting(
 config_setting(
     name = "freebsd",
     values = {"host_cpu": "freebsd"},
+)
+
+config_setting(
+    name = "openbsd",
+    values = {"host_cpu": "openbsd"},
 )
 
 config_setting(


### PR DESCRIPTION
This change was part of https://github.com/bazelbuild/bazel/pull/10567, which was merged as commit https://github.com/bazelbuild/bazel/commit/d6145a0836e5856e5b6183bd484c4a6a3f6927a0, but somehow that commit contains all of the changes in the PR *except* the changes to `third_party/BUILD`. Apparently the changes to that file were lost when the PR was imported into Google's internal code repository. Here is another PR for those changes that disappeared.

@aehlig FYI.

This change is part of the OpenBSD port in https://github.com/bazelbuild/bazel/issues/10250.