### PR TITLE
Correct failure of netty build component on s390x (due to zip -qd needing something to delete)

### DIFF
--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -17,6 +17,12 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_s390x",
+    values = {"cpu": "s390x"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "linux_x86_64",
     values = {"cpu": "k8"},
     visibility = ["//visibility:public"],

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -469,9 +469,9 @@ UNNECESSARY_DYNAMIC_LIBRARIES = select({
     "//src/conditions:arm": "*.so *.jnilib *.dll",
     "//src/conditions:linux_aarch64": "*.so *.jnilib *.dll",
     "//src/conditions:linux_ppc": "*.so *.jnilib *.dll",
+    "//src/conditions:linux_s390x": "*.so *.jnilib *.dll",
     # Play it safe -- better have a big binary than a slow binary
-    # zip -d does require an argument. Supply something bogus.
-    "//conditions:default": "*.bogusextension",
+    "//conditions:default": "",
 })
 
 # Remove native libraries that are for a platform different from the one we are
@@ -480,7 +480,10 @@ genrule(
     name = "filter_netty_dynamic_libs",
     srcs = ["netty_tcnative/netty-tcnative-boringssl-static-2.0.24.Final.jar"],
     outs = ["netty_tcnative/netty-tcnative-filtered.jar"],
-    cmd = "cp $< $@ && zip -qd $@ " + UNNECESSARY_DYNAMIC_LIBRARIES,
+    cmd = "cp $< $@ && " +
+      # End successfully if there is nothing to be deleted from the archive
+      "if [ -n '" + UNNECESSARY_DYNAMIC_LIBRARIES + "' ]; then " +
+      "zip -qd $@ " + UNNECESSARY_DYNAMIC_LIBRARIES + "; fi",
 )
 
 java_import(


### PR DESCRIPTION
Build on s390x fails because the process to remove unnecessary libraries from netty was not configured for x86.  As a result, zip -d failed because it had nothing to remove.  This PR does two things:

1.  Adds conditions for s390x to the src and third_party BUILD files, and
2.  Adds a condition to the genrule so that 'zip -d' does not execute if there's nothing to do.

See also Issue #9263; Pull Requests #9346 and #9945