### PR TITLE
Enable "bazel run" tests on Windows

### DIFF
--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -191,7 +191,7 @@ sh_test(
     srcs = ["run_test.sh"],
     data = [":test-deps"],
     shard_count = 3,
-    tags = ["no_windows"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(


### PR DESCRIPTION
Also, disable the failing test cases on Windows.
Enabling the test suite though allows adding an
integration test for the upcoming fix of
https://github.com/bazelbuild/bazel/issues/10621