### PR TITLE
Export the WORKSPACE files of third_party/{protobuf,rules_python}.

### DIFF
--- a/third_party/protobuf/3.6.1/BUILD
+++ b/third_party/protobuf/3.6.1/BUILD
@@ -934,3 +934,8 @@ objc_library(
     non_arc_srcs = OBJC_SRCS,
     visibility = ["//visibility:public"],
 )
+
+exports_files(
+    ["WORKSPACE"],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/rules_python/BUILD
+++ b/third_party/rules_python/BUILD
@@ -3,3 +3,10 @@ filegroup(
     srcs = glob(["**"]) + ["//third_party/rules_python/python:srcs"],
     visibility = ["//third_party:__pkg__"],
 )
+
+# The file is called rules_python.WORKSPACE, but renamed to WORKSPACE
+# via new_local_repository, so this works out fine.
+exports_files(
+    ["WORKSPACE"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This is required for the upcoming "override all the repositories" change that reduces I/O and network traffic of our CI test jobs.