### PR TITLE
Wrap FindMissingBlobs exceptions in IOException

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -203,7 +203,7 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
             MoreExecutors.directExecutor());
     return Futures.catchingAsync(
         success,
-        Exception.class,
+        RuntimeException.class,
         (e) -> Futures.immediateFailedFuture(
             new IOException(
                 String.format(


### PR DESCRIPTION
Consistent with #7860, present an IOException with context to ensure
fallback if configured, rather than an unhandled RuntimeException and
bazel crash, when issuing FindMissingBlobs requests.