### PR TITLE
Ensure correct environment variables in test environment

### DIFF
--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -104,6 +104,14 @@ cc_test(
     }),
 )
 
+cc_test(
+    name = "testsetup_test",
+    srcs = ["testsetup_test.cc"],
+    deps = [
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),

--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -63,13 +63,19 @@ is_absolute "$TEST_UNDECLARED_OUTPUTS_ANNOTATIONS_DIR" ||
 
 is_absolute "$TEST_SRCDIR" || TEST_SRCDIR="$PWD/$TEST_SRCDIR"
 is_absolute "$TEST_TMPDIR" || TEST_TMPDIR="$PWD/$TEST_TMPDIR"
-is_absolute "$HOME" || HOME="$TEST_TMPDIR"
+is_absolute "$HOME" || export HOME="$TEST_TMPDIR"
 is_absolute "$XML_OUTPUT_FILE" || XML_OUTPUT_FILE="$PWD/$XML_OUTPUT_FILE"
 
 # Set USER to the current user, unless passed by Bazel via --test_env.
 if [[ -z "$USER" ]]; then
   export USER=$(whoami)
 fi
+# Set LOGNAME to USER, unless passed by Bazel via --test_env.
+if [[ -z "$LOGNAME" ]]; then
+  export LOGNAME=$USER
+fi
+# SHLVL should always be set to 2
+export SHLVL=2
 
 # The test shard status file is only set for sharded tests.
 if [[ -n "$TEST_SHARD_STATUS_FILE" ]]; then

--- a/tools/test/testsetup_test.cc
+++ b/tools/test/testsetup_test.cc
@@ -20,7 +20,7 @@ static bool IsDirectory(const char *path, bool optional) {
     return optional;
   }
   return (st.st_mode & S_IFDIR) == S_IFDIR;
-} 
+}
 
 
 // Return true if the path is a regular file; if optional,
@@ -41,6 +41,8 @@ static bool IsFile(const char *path, bool optional) {
 // <https://docs.bazel.build/versions/master/test-encyclopedia.html>
 TEST(TestSetup, Env) {
   // Test values in same order as in the Test Encyclopedia.
+  // Only test optional values that are files or directories to
+  // verify that they are indeed files or directories.
 
   // TEST_SRCDIR and TEST_TMPDIR are tested out-of-order as several
   // other values are based on their values.
@@ -70,7 +72,6 @@ TEST(TestSetup, Env) {
   // JAVA_RUNFILES is marked as deprecated
   EXPECT_NE(getenv("JAVA_RUNFILES"), nullptr);
   EXPECT_TRUE(IsDirectory(getenv("JAVA_RUNFILES"), MUST_EXIST));
-  EXPECT_STREQ(getenv("JAVA_RUNFILES"), testSrcDir);
 
   // LOGNAME should be set to USER
   EXPECT_NE(getenv("USER"), nullptr);
@@ -79,12 +80,10 @@ TEST(TestSetup, Env) {
 
   EXPECT_NE(getenv("PATH"), nullptr);
 
-  // PWD is recommended, but is only set on *nix systems, and should
-  // be $TEST_SRCDIR/workspace-name
-  char *pwd = getenv("PWD");
-  EXPECT_TRUE(IsDirectory(pwd, OPTIONAL));
+  // PWD is recommended, but is only set on *nix systems
+  EXPECT_TRUE(IsDirectory(getenv("PWD"), OPTIONAL));
 
-  EXPECT_STREQ(getenv("SHLVL"), "2");
+  // SHLVL is recommended as 2 but is unset on Windows
   EXPECT_TRUE(IsFile(getenv("TEST_PREMATURE_EXIT_FILE"), OPTIONAL));
   // TEST_RANDOM_SEED is optional
   // TEST_TARGET is optional
@@ -96,7 +95,7 @@ TEST(TestSetup, Env) {
   // TEST_TOTAL_SHARDS is optional
   // TEST_TMPDIR already tested
   EXPECT_TRUE(IsFile(getenv("TEST_WARNINGS_OUTPUT_FILE"), OPTIONAL));
-  // TESTBRIDGE_TEST_ONLY: is optional
+  // TESTBRIDGE_TEST_ONLY is optional
   EXPECT_STREQ(getenv("TZ"), "UTC");
   // USER already tested
   EXPECT_TRUE(IsFile(getenv("XML_OUTPUT_FILE"), OPTIONAL));

--- a/tools/test/testsetup_test.cc
+++ b/tools/test/testsetup_test.cc
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <strings.h>
+#include <string.h>
 #include <sys/stat.h>
 #include "googletest/include/gtest/gtest.h"
 

--- a/tools/test/testsetup_test.cc
+++ b/tools/test/testsetup_test.cc
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include <string.h>
 #include <sys/stat.h>
 #include "googletest/include/gtest/gtest.h"
 
@@ -80,11 +79,10 @@ TEST(TestSetup, Env) {
 
   EXPECT_NE(getenv("PATH"), nullptr);
 
-  // PWD is recommended, and should be $TEST_SRCDIR/workspace-name
+  // PWD is recommended, but is only set on *nix systems, and should
+  // be $TEST_SRCDIR/workspace-name
   char *pwd = getenv("PWD");
-  EXPECT_NE(pwd, nullptr);
-  EXPECT_TRUE(IsDirectory(pwd, MUST_EXIST));
-  EXPECT_EQ(strstr(pwd, testSrcDir), pwd); // should be prefix
+  EXPECT_TRUE(IsDirectory(pwd, OPTIONAL));
 
   EXPECT_STREQ(getenv("SHLVL"), "2");
   EXPECT_TRUE(IsFile(getenv("TEST_PREMATURE_EXIT_FILE"), OPTIONAL));

--- a/tools/test/testsetup_test.cc
+++ b/tools/test/testsetup_test.cc
@@ -1,0 +1,106 @@
+#include <stdio.h>
+#include <strings.h>
+#include <sys/stat.h>
+#include "googletest/include/gtest/gtest.h"
+
+// Test helper functions
+
+// Two constants used for path-type checks
+#define OPTIONAL (true)
+#define MUST_EXIST (false)
+
+// Return true if the path is a directory; if optional,
+// then returns true if the path is NULL or doesn't exist
+static bool IsDirectory(const char *path, bool optional) {
+  if(path == NULL) {
+    return optional;
+  }
+
+  struct stat st;
+  if (stat(path, &st) < 0) {
+    return optional;
+  }
+  return (st.st_mode & S_IFDIR) == S_IFDIR;
+} 
+
+
+// Return true if the path is a regular file; if optional,
+// then returns true if the path is NULL or doesn't exist
+static bool IsFile(const char *path, bool optional) {
+  if(path == NULL) {
+    return optional;
+  }
+
+  struct stat st;
+  if (stat(path, &st) < 0) {
+    return optional;
+  }
+  return (st.st_mode & S_IFREG) == S_IFREG;
+}
+
+// Verify the test environment as described by the Test Encyclopedia
+// <https://docs.bazel.build/versions/master/test-encyclopedia.html>
+TEST(TestSetup, Env) {
+  // Test values in same order as in the Test Encyclopedia.
+
+  // TEST_SRCDIR and TEST_TMPDIR are tested out-of-order as several
+  // other values are based on their values.
+  char *testSrcDir = getenv("TEST_SRCDIR");
+  EXPECT_NE(testSrcDir, nullptr);
+  EXPECT_TRUE(IsDirectory(testSrcDir, MUST_EXIST));
+  char *testTmpDir = getenv("TEST_TMPDIR");
+  EXPECT_NE(testTmpDir, nullptr);
+  EXPECT_TRUE(IsDirectory(testTmpDir, MUST_EXIST));
+
+  // HOME is recommended, and should be TEST_TMPDIR
+  EXPECT_NE(getenv("HOME"), nullptr);
+  EXPECT_STREQ(getenv("HOME"), testTmpDir);
+
+  EXPECT_EQ(getenv("LANG"), nullptr);
+  EXPECT_EQ(getenv("LANGUAGE"), nullptr);
+  EXPECT_EQ(getenv("LC_ALL"), nullptr);
+  EXPECT_EQ(getenv("LC_COLLATE"), nullptr);
+  EXPECT_EQ(getenv("LC_CTYPE"), nullptr);
+  EXPECT_EQ(getenv("LC_MESSAGES"), nullptr);
+  EXPECT_EQ(getenv("LC_MONETARY"), nullptr);
+  EXPECT_EQ(getenv("LC_NUMERIC"), nullptr);
+  EXPECT_EQ(getenv("LC_TIME"), nullptr);
+
+  // LD_LIBRARY_PATH is optional
+
+  // JAVA_RUNFILES is marked as deprecated
+  EXPECT_NE(getenv("JAVA_RUNFILES"), nullptr);
+  EXPECT_TRUE(IsDirectory(getenv("JAVA_RUNFILES"), MUST_EXIST));
+  EXPECT_STREQ(getenv("JAVA_RUNFILES"), testSrcDir);
+
+  // LOGNAME should be set to USER
+  EXPECT_NE(getenv("USER"), nullptr);
+  EXPECT_NE(getenv("LOGNAME"), nullptr);
+  EXPECT_STREQ(getenv("LOGNAME"), getenv("USER"));
+
+  EXPECT_NE(getenv("PATH"), nullptr);
+
+  // PWD is recommended, and should be $TEST_SRCDIR/workspace-name
+  char *pwd = getenv("PWD");
+  EXPECT_NE(pwd, nullptr);
+  EXPECT_TRUE(IsDirectory(pwd, MUST_EXIST));
+  EXPECT_EQ(strstr(pwd, testSrcDir), pwd); // should be prefix
+
+  EXPECT_STREQ(getenv("SHLVL"), "2");
+  EXPECT_TRUE(IsFile(getenv("TEST_PREMATURE_EXIT_FILE"), OPTIONAL));
+  // TEST_RANDOM_SEED is optional
+  // TEST_TARGET is optional
+  // TEST_SIZE is optional
+  // TEST_TIMEOUT is optional
+  // TEST_SHARD_INDEX is optional
+  EXPECT_TRUE(IsFile(getenv("TEST_SHARD_STATUS_FILE"), OPTIONAL));
+  // TEST_SRCDIR already tested
+  // TEST_TOTAL_SHARDS is optional
+  // TEST_TMPDIR already tested
+  EXPECT_TRUE(IsFile(getenv("TEST_WARNINGS_OUTPUT_FILE"), OPTIONAL));
+  // TESTBRIDGE_TEST_ONLY: is optional
+  EXPECT_STREQ(getenv("TZ"), "UTC");
+  // USER already tested
+  EXPECT_TRUE(IsFile(getenv("XML_OUTPUT_FILE"), OPTIONAL));
+  EXPECT_NE(getenv("TEST_WORKSPACE"), nullptr);
+}

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -486,6 +486,23 @@ bool ExportUserName() {
   return SetEnv(L"USER", buffer);
 }
 
+// Set LOGNAME as required by the Bazel Test Encyclopedia.
+// Assumes that ExportUserName() has already been called successfully.
+bool ExportLogName() {
+  std::wstring value;
+  if (!GetEnv(L"LOGNAME", &value)) {
+    return false;
+  }
+  if (!value.empty()) {
+    // Respect the value passed by Bazel via --test_env.
+    return true;
+  }
+  if (!GetEnv(L"USER", &value)) {
+    return false;
+  }
+  return SetEnv(L"LOGNAME", value);
+}
+
 // Gets a path envvar, and re-exports it as an absolute path.
 // Returns:
 // - true, if the envvar was defined, and was already absolute or was

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -487,7 +487,7 @@ bool ExportUserName() {
   if (userValue.empty() && !SetEnv(L"USER", buffer)) {
     return false;
   }
-  if (!lognameValue.empty() && !SetEnv(L"LOGNAME", buffer)) {
+  if (lognameValue.empty() && !SetEnv(L"LOGNAME", buffer)) {
     return false;
   }
   return true;

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -1882,7 +1882,8 @@ int TestWrapperMain(int argc, wchar_t** argv) {
   if (!ParseArgs(argc, argv, &argv0, &test_path_arg, &args) ||
       !PrintTestLogStartMarker() || !GetCwd(&exec_root) ||
       !FindTestBinary(argv0, exec_root, test_path_arg, &test_path) ||
-      !ExportUserName() || !ExportSrcPath(exec_root, &srcdir) ||
+      !ExportUserName() || !ExportLogName() ||
+      !ExportSrcPath(exec_root, &srcdir) ||
       !ChdirToRunfiles(exec_root, srcdir) ||
       !ExportTmpPath(exec_root, &tmpdir) || !ExportHome(tmpdir) ||
       !ExportRunfiles(exec_root, srcdir) || !ExportShardStatusFile(exec_root) ||


### PR DESCRIPTION
This PR adds a simple C++ test (`tools/test/testsetup_test`) to verify test environment matches as defined in the [Test Encyclopedia](https://docs.bazel.build/versions/master/test-encyclopedia.html#initial-conditions).  This test identified 3 problems:
  - `HOME` is unset (#10652)
  - `LOGNAME` is unset
  - `SHLVL` is not `2`

The PR fixes `tools/test/test-setup.sh` such that:
  - explicitly export `HOME` when changed (reported in #10652)
  - update `LOGNAME` to `USER` when unset
  - `SHLVL` is always set to `2`

Fixes #10652 
