### PR TITLE
Re-enable //src/test/res:res_test on Windows.

### DIFF
--- a/src/test/res/BUILD
+++ b/src/test/res/BUILD
@@ -43,9 +43,6 @@ file_test(
         "//conditions:default": "not supported",
     }),
     file = ":run_app",
-    # TODO(pcloudy): Re-enable this test after Bazel 0.29.0 is released.
-    # https://github.com/bazelbuild/bazel/issues/9104#issuecomment-521231693
-    tags = ["no_windows"],
 )
 
 test_suite(name = "all_tests")


### PR DESCRIPTION
We are far past Bazel release 0.29.0.

Fixes #9148.

Change-Id: I6cbd907f9a3e63c2337b367626441d8698f56d60