### PR TITLE
Update gtest.BUILD prior to strip_prefix

### DIFF
--- a/site/docs/cpp-use-cases.md
+++ b/site/docs/cpp-use-cases.md
@@ -155,7 +155,8 @@ cc_library(
         "googletest-release-1.7.0/src/*.h"
     ]),
     copts = [
-        "-Iexternal/gtest/googletest-release-1.7.0/include"
+        "-Iexternal/gtest/googletest-release-1.7.0/include",
+        "-Iexternal/gtest/googletest-release-1.7.0"
     ],
     linkopts = ["-pthread"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Before when `strip_prefix` is introduced, the snippet of gtest.BUILD has a glitch.
`bazel build @gtest//:main` has error with below message
```
external/gtest/googletest-release-1.7.0/src/gtest-test-part.cc:42:10: fatal error: 'src/gtest-internal-inl.h' file not found
#include "src/gtest-internal-inl.h"
```

The 1-liner PR enables `bazel build @gtest//:main`. Verified on bazel 2.0.0