### PR TITLE
On OpenBSD, search the PATH to find the Bazel executable.

### DIFF
--- a/src/main/cpp/blaze_util_bsd.cc
+++ b/src/main/cpp/blaze_util_bsd.cc
@@ -131,13 +131,15 @@ string GetSelfPath(const char* argv0) {
     return blaze_util::GetCwd() + "/" + argv0str;
   }
 
-  // TODO(aldersondrive): Try to find the executable by inspecting the PATH.
+  // Otherwise, try to find the executable by searching the PATH.
+  std::string from_search_path = Which(argv0);
+  if (!from_search_path.empty()) {
+    return from_search_path;
+  }
 
   // None of the above worked. Give up.
   BAZEL_DIE(blaze_exit_code::BAD_ARGV)
-      << "Unable to determine the location of this Bazel executable. "
-         "Currently, argv[0] must be an absolute or relative path to the "
-         "executable.";
+      << "Unable to determine the location of this Bazel executable.";
   return "";  // Never executed. Needed so compiler does not complain.
 #else
 # error This BSD is not supported

--- a/src/main/cpp/blaze_util_bsd.cc
+++ b/src/main/cpp/blaze_util_bsd.cc
@@ -132,7 +132,7 @@ string GetSelfPath(const char* argv0) {
   }
 
   // Otherwise, try to find the executable by searching the PATH.
-  std::string from_search_path = Which(argv0);
+  const std::string from_search_path = Which(argv0);
   if (!from_search_path.empty()) {
     return from_search_path;
   }

--- a/src/main/cpp/blaze_util_linux.cc
+++ b/src/main/cpp/blaze_util_linux.cc
@@ -132,29 +132,6 @@ bool IsSharedLibrary(const string &filename) {
   return blaze_util::ends_with(filename, ".so");
 }
 
-static string Which(const string &executable) {
-  string path(GetPathEnv("PATH"));
-  if (path.empty()) {
-    return "";
-  }
-
-  vector<string> pieces = blaze_util::Split(path, ':');
-  for (auto piece : pieces) {
-    if (piece.empty()) {
-      piece = ".";
-    }
-
-    struct stat file_stat;
-    string candidate = blaze_util::JoinPath(piece, executable);
-    if (access(candidate.c_str(), X_OK) == 0 &&
-        stat(candidate.c_str(), &file_stat) == 0 &&
-        S_ISREG(file_stat.st_mode)) {
-      return candidate;
-    }
-  }
-  return "";
-}
-
 string GetSystemJavabase() {
   // if JAVA_HOME is defined, then use it as default.
   string javahome = GetPathEnv("JAVA_HOME");

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -107,6 +107,10 @@ void SigPrintf(const char *format, ...);
 
 std::string GetProcessIdAsString();
 
+// Locates a file named `executable` in the PATH. Returns a path to the first
+// matching file, or an empty string if `executable` is not found on the PATH.
+std::string Which(const std::string& executable);
+
 // Gets an absolute path to the binary being executed that is guaranteed to be
 // readable.
 std::string GetSelfPath(const char* argv0);

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -54,6 +54,7 @@
 #include "src/main/cpp/util/numbers.h"
 #include "src/main/cpp/util/path.h"
 #include "src/main/cpp/util/path_platform.h"
+#include "src/main/cpp/util/strings.h"
 
 namespace blaze {
 
@@ -216,6 +217,29 @@ string GetProcessIdAsString() {
 string GetHomeDir() { return GetPathEnv("HOME"); }
 
 string GetJavaBinaryUnderJavabase() { return "bin/java"; }
+
+string Which(const string& executable) {
+  string path = GetPathEnv("PATH");
+  if (path.empty()) {
+    return "";
+  }
+
+  vector<string> pieces = blaze_util::Split(path, ':');
+  for (string piece : pieces) {
+    if (piece.empty()) {
+      piece = ".";
+    }
+
+    struct stat file_stat;
+    string candidate = blaze_util::JoinPath(piece, executable);
+    if (access(candidate.c_str(), X_OK) == 0 &&
+        stat(candidate.c_str(), &file_stat) == 0 &&
+        (S_ISREG(file_stat.st_mode) || S_ISLNK(file_stat.st_mode))) {
+      return candidate;
+    }
+  }
+  return "";
+}
 
 // Converter of C++ data structures to a C-style array of strings.
 //

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -219,22 +219,22 @@ string GetHomeDir() { return GetPathEnv("HOME"); }
 string GetJavaBinaryUnderJavabase() { return "bin/java"; }
 
 string Which(const string& executable) {
-  string path = GetPathEnv("PATH");
+  const string path = GetPathEnv("PATH");
   if (path.empty()) {
     return "";
   }
 
-  vector<string> pieces = blaze_util::Split(path, ':');
+  const vector<string> pieces = blaze_util::Split(path, ':');
   for (string piece : pieces) {
     if (piece.empty()) {
       piece = ".";
     }
 
     struct stat file_stat;
-    string candidate = blaze_util::JoinPath(piece, executable);
+    const string candidate = blaze_util::JoinPath(piece, executable);
     if (access(candidate.c_str(), X_OK) == 0 &&
         stat(candidate.c_str(), &file_stat) == 0 &&
-        (S_ISREG(file_stat.st_mode) || S_ISLNK(file_stat.st_mode))) {
+        S_ISREG(file_stat.st_mode)) {
       return candidate;
     }
   }


### PR DESCRIPTION
Searching the `PATH` is the only feasible way to find the executable on OpenBSD when `argv[0]` is not an absolute path or a relative path. This change resolves a TODO.

This change moves a preexisting `Which` function for searching the `PATH` out of `blaze_util_linux.cc` and into `blaze_util_posix.cc`, so that the Linux code and the BSD code can share this function.

In my testing on OpenBSD 6.6-current, a bootstrap build of Bazel succeeds and the resulting `bazel` binary can find itself on the `PATH`. (One caveat: For the bootstrap build to succeed, I had to manually apply the unrelated change in https://github.com/bazelbuild/bazel/pull/10639, since it's not merged yet.)

This change is part of the OpenBSD port in https://github.com/bazelbuild/bazel/issues/10250.

@jmmv FYI.