### PR TITLE
Use target config for toolchain

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/DependencyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/DependencyResolver.java
@@ -332,8 +332,9 @@ public abstract class DependencyResolver {
             TOOLCHAIN_DEPENDENCY,
             PartiallyResolvedDependency.of(
                 toLabel,
-                // TODO(jcater): Replace this with a proper transition for the execution platform.
-                HostTransition.INSTANCE,
+                // Use target configuration. The toolchain is expected to use HOST transition for
+                // compiler files.
+                NoTransition.INSTANCE,
                 ImmutableList.of()));
         continue;
       }


### PR DESCRIPTION
Toolchain typically contains two parts: Compiler and runtime.
Runtime should be using target config.
For compilers that needs host/exec config, the toolchain should do own
transition.

Currently the toolchain is using host config if enabled new toolchain
resolution, which caused the runtime not able to be linked as expected.