### PR TITLE
Make Java code coverage output compatible with genhtml

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoCoverageRunner.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoCoverageRunner.java
@@ -123,16 +123,15 @@ public class JacocoCoverageRunner {
     // report. The lcov formatter doesn't seem to care, and we're only using one bundle anyway.
     final IBundleCoverage bundleCoverage = analyzeStructure();
 
-    final Map<String, BranchCoverageDetail> branchDetails = analyzeBranch();
-    createReport(bundleCoverage, branchDetails);
+    createReport(bundleCoverage);
   }
 
   @VisibleForTesting
   void createReport(
-      final IBundleCoverage bundleCoverage, final Map<String, BranchCoverageDetail> branchDetails)
+      final IBundleCoverage bundleCoverage)
       throws IOException {
     JacocoLCOVFormatter formatter = new JacocoLCOVFormatter(createPathsSet());
-    final IReportVisitor visitor = formatter.createVisitor(reportFile, branchDetails);
+    final IReportVisitor visitor = formatter.createVisitor(reportFile);
 
     // Initialize the report with all of the execution and session information. At this point the
     // report doesn't know about the structure of the report being created.
@@ -182,27 +181,6 @@ public class JacocoCoverageRunner {
 
     // TODO(bazel-team): Find out where the name of the bundle can pop out in the report.
     return coverageBuilder.getBundle("isthisevenused");
-  }
-
-  // Additional pass to process the branch details of the classes
-  private Map<String, BranchCoverageDetail> analyzeBranch() throws IOException {
-    final BranchDetailAnalyzer analyzer =
-        new BranchDetailAnalyzer(execFileLoader.getExecutionDataStore());
-
-    Map<String, BranchCoverageDetail> result = new TreeMap<>();
-    Set<String> alreadyInstrumentedClasses = new HashSet<>();
-    if (uninstrumentedClasses == null) {
-      for (File classesJar : classesJars) {
-        analyzeUninstrumentedClassesFromJar(analyzer, classesJar, alreadyInstrumentedClasses);
-        result.putAll(analyzer.getBranchDetails());
-      }
-    } else {
-      for (Map.Entry<String, byte[]> entry : uninstrumentedClasses.entrySet()) {
-        analyzer.analyzeClass(entry.getValue(), entry.getKey());
-      }
-      result.putAll(analyzer.getBranchDetails());
-    }
-    return result;
   }
 
   /**

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BranchCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BranchCoverage.java
@@ -45,7 +45,9 @@ abstract class BranchCoverage {
         first.lineNumber(),
         first.blockNumber(),
         first.branchNumber(),
-        first.nrOfExecutions() + second.nrOfExecutions());
+        first.nrOfExecutions() > -1 && second.nrOfExecutions() > -1
+            ? first.nrOfExecutions() + second.nrOfExecutions()
+            : Math.max(first.nrOfExecutions(), second.nrOfExecutions()));
   }
 
   abstract int lineNumber();

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovParser.java
@@ -278,11 +278,9 @@ class LcovParser {
       String branchNumber = lineData[2];
       String taken = lineData[3];
 
-      boolean wasExecuted = false;
-      int executionCount = 0;
-      if (taken.equals(TAKEN)) {
+      int executionCount = -1; // not executed
+      if (!taken.equals(TAKEN)) {
         executionCount = Integer.parseInt(taken);
-        wasExecuted = true;
       }
       BranchCoverage branchCoverage =
           BranchCoverage.createWithBlockAndBranch(

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -131,42 +132,46 @@ class LcovPrinter {
 
   // BRDA:<line number>,<block number>,<branch number>,<taken>
   private void printBRDALines(SourceFileCoverage sourceFile) throws IOException {
-    for (BranchCoverage branch : sourceFile.getAllBranches()) {
-      if (branch.blockNumber().isEmpty() || branch.branchNumber().isEmpty()) {
-        // We skip printing this as a BRDA line and print it later as a BA line.
-        continue;
+    for (List<BranchCoverage> branches : sourceFile.getAllBranches()) {
+      for (BranchCoverage branch : branches) {
+        if (branch.blockNumber().isEmpty() || branch.branchNumber().isEmpty()) {
+          // We skip printing this as a BRDA line and print it later as a BA line.
+          continue;
+        }
+        bufferedWriter.write(Constants.BRDA_MARKER);
+        bufferedWriter.write(Integer.toString(branch.lineNumber()));
+        bufferedWriter.write(Constants.DELIMITER);
+        bufferedWriter.write(branch.blockNumber());
+        bufferedWriter.write(Constants.DELIMITER);
+        bufferedWriter.write(branch.branchNumber());
+        bufferedWriter.write(Constants.DELIMITER);
+        if (branch.nrOfExecutions() > -1) {
+          bufferedWriter.write(Integer.toString(branch.nrOfExecutions()));
+        } else {
+          bufferedWriter.write(Constants.TAKEN);
+        }
+        bufferedWriter.newLine();
       }
-      bufferedWriter.write(Constants.BRDA_MARKER);
-      bufferedWriter.write(Integer.toString(branch.lineNumber()));
-      bufferedWriter.write(Constants.DELIMITER);
-      bufferedWriter.write(branch.blockNumber());
-      bufferedWriter.write(Constants.DELIMITER);
-      bufferedWriter.write(branch.branchNumber());
-      bufferedWriter.write(Constants.DELIMITER);
-      if (branch.wasExecuted()) {
-        bufferedWriter.write(Integer.toString(branch.nrOfExecutions()));
-      } else {
-        bufferedWriter.write(Constants.TAKEN);
-      }
-      bufferedWriter.newLine();
     }
   }
 
   // BA:<line number>,<taken>
   private void printBALines(SourceFileCoverage sourceFile) throws IOException {
-    for (BranchCoverage branch : sourceFile.getAllBranches()) {
-      if (!branch.blockNumber().isEmpty() && !branch.branchNumber().isEmpty()) {
-        // This branch was already printed with more information as a BRDA line.
-        continue;
+    for (List<BranchCoverage> branches : sourceFile.getAllBranches()) {
+      for (BranchCoverage branch : branches) {
+        if (!branch.blockNumber().isEmpty() && !branch.branchNumber().isEmpty()) {
+          // This branch was already printed with more information as a BRDA line.
+          continue;
+        }
+        bufferedWriter.write(Constants.BA_MARKER);
+        bufferedWriter.write(Integer.toString(branch.lineNumber()));
+        bufferedWriter.write(Constants.DELIMITER);
+        // 0 = branch was not executed
+        // 1 = branch was executed but not taken
+        // 2 = branch was executed and taken
+        bufferedWriter.write(branch.wasExecuted() ? "2" : "0");
+        bufferedWriter.newLine();
       }
-      bufferedWriter.write(Constants.BA_MARKER);
-      bufferedWriter.write(Integer.toString(branch.lineNumber()));
-      bufferedWriter.write(Constants.DELIMITER);
-      // 0 = branch was not executed
-      // 1 = branch was executed but not taken
-      // 2 = branch was executed and taken
-      bufferedWriter.write(branch.wasExecuted() ? "2" : "0");
-      bufferedWriter.newLine();
     }
   }
 

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/SourceFileCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/SourceFileCoverage.java
@@ -15,9 +15,14 @@
 package com.google.devtools.coverageoutputgenerator;
 
 import com.google.common.annotations.VisibleForTesting;
+import static com.google.common.collect.MoreCollectors.toOptional;
+
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -31,7 +36,7 @@ class SourceFileCoverage {
   private String sourceFileName;
   private final TreeMap<String, Integer> lineNumbers; // function name to line numbers
   private final TreeMap<String, Integer> functionsExecution; // function name to execution count
-  private final TreeMap<Integer, BranchCoverage> branches; // line number to branch
+  private final TreeMap<Integer, List<BranchCoverage>> branches; // line number to branches
   private final TreeMap<Integer, LineCoverage> lines; // line number to line execution
 
   SourceFileCoverage(String sourcefile) {
@@ -90,21 +95,22 @@ class SourceFileCoverage {
    * Returns the merged branches found in the two given {@code SourceFileCoverage}s.
    */
   @VisibleForTesting
-  static TreeMap<Integer, BranchCoverage> mergeBranches(
+  static TreeMap<Integer, List<BranchCoverage>> mergeBranches(
       SourceFileCoverage s1, SourceFileCoverage s2) {
-    return Stream.of(s1.branches, s2.branches)
-        .map(Map::entrySet)
-        .flatMap(Collection::stream)
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey, Map.Entry::getValue, BranchCoverage::merge, TreeMap::new));
+    TreeMap<Integer, List<BranchCoverage>> merged = new TreeMap<>();
+    merged.putAll(s1.branches);
+    s2.branches
+        .entrySet()
+        .stream()
+        .forEach(e -> e.getValue().forEach(b -> addBranch(e.getKey(), b, merged)));
+    return merged;
   }
 
   static int getNumberOfBranchesHit(SourceFileCoverage sourceFileCoverage) {
-    return (int)
-        sourceFileCoverage.branches.entrySet().stream()
-            .filter(branch -> branch.getValue().wasExecuted())
-            .count();
+    return (int)sourceFileCoverage.branches.entrySet().stream()
+        .map(e -> e.getValue().stream().filter(b -> b.wasExecuted()))
+        .mapToLong(Stream::count)
+        .sum();
   }
 
   /*
@@ -198,7 +204,7 @@ class SourceFileCoverage {
     return functionsExecution.entrySet();
   }
 
-  Collection<BranchCoverage> getAllBranches() {
+  Collection<List<BranchCoverage>> getAllBranches() {
     return branches.values();
   }
 
@@ -224,14 +230,10 @@ class SourceFileCoverage {
   }
 
   void addBranch(Integer lineNumber, BranchCoverage branch) {
-    if (this.branches.get(lineNumber) != null) {
-      this.branches.put(lineNumber, BranchCoverage.merge(this.branches.get(lineNumber), branch));
-      return;
-    }
-    this.branches.put(lineNumber, branch);
+    addBranch(lineNumber, branch, branches);
   }
 
-  void addAllBranches(TreeMap<Integer, BranchCoverage> branches) {
+  void addAllBranches(TreeMap<Integer, List<BranchCoverage>> branches) {
     this.branches.putAll(branches);
   }
 
@@ -245,5 +247,17 @@ class SourceFileCoverage {
 
   void addAllLines(TreeMap<Integer, LineCoverage> lines) {
     this.lines.putAll(lines);
+  }
+
+  private static void addBranch(int lineNumber, BranchCoverage branch, TreeMap<Integer, List<BranchCoverage>> target) {
+    List<BranchCoverage> branches = target.computeIfAbsent(lineNumber, b -> new ArrayList<>());
+    Optional<BranchCoverage> match = branches.stream()
+        .filter(b -> b.blockNumber().equals(branch.blockNumber()) && b.branchNumber().equals(branch.branchNumber()))
+        .collect(toOptional());
+    match.ifPresentOrElse(b -> {
+            branches.remove(b);
+            branches.add(BranchCoverage.merge(b, branch));
+        },
+        () -> branches.add(branch));
   }
 }

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BUILD
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BUILD
@@ -35,6 +35,7 @@ java_test(
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:truth",
+        "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:BranchCoverage",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:LineCoverage",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:SourceFileCoverage",
     ],

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BranchCoverageTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BranchCoverageTest.java
@@ -91,6 +91,24 @@ public class BranchCoverageTest {
   }
 
   @Test
+  public void testExecuted() {
+    BranchCoverage b1 = BranchCoverage.createWithBlockAndBranch(1, "1", "1", -1);
+    BranchCoverage b2 = BranchCoverage.createWithBlockAndBranch(1, "1", "1", -1);
+    BranchCoverage b3 = BranchCoverage.createWithBlockAndBranch(1, "1", "1", 0);
+    BranchCoverage b4 = BranchCoverage.createWithBlockAndBranch(1, "1", "1", 1);
+
+    assertThat(b1.wasExecuted()).isFalse();
+    assertThat(b2.wasExecuted()).isFalse();
+    assertThat(b3.wasExecuted()).isFalse();
+    assertThat(b4.wasExecuted()).isTrue();
+
+    assertThat(BranchCoverage.merge(b1, b2).wasExecuted()).isFalse();
+    assertThat(BranchCoverage.merge(b1, b3).wasExecuted()).isFalse();
+    assertThat(BranchCoverage.merge(b1, b4).wasExecuted()).isTrue();
+    assertThat(BranchCoverage.merge(b3, b4).wasExecuted()).isTrue();
+  }
+
+  @Test
   public void testMergeBranch1Branch2AssertationError() {
     BranchCoverage branch1 = getBranch1CoverageData();
     BranchCoverage branch2 = getBranch2CoverageData();

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/GcovParserTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/GcovParserTest.java
@@ -168,13 +168,13 @@ public class GcovParserTest {
 
     assertThat(sourceFileCoverage.getAllBranches())
         .containsExactly(
-            BranchCoverage.create(21, 2),
-            BranchCoverage.create(23, 2),
-            BranchCoverage.create(24, 2),
-            BranchCoverage.create(27, 2),
-            BranchCoverage.create(30, 2),
-            BranchCoverage.create(32, 2),
-            BranchCoverage.create(33, 0),
-            BranchCoverage.create(35, 2));
+            List.of(BranchCoverage.create(21, 2)),
+            List.of(BranchCoverage.create(23, 2)),
+            List.of(BranchCoverage.create(24, 2)),
+            List.of(BranchCoverage.create(27, 2)),
+            List.of(BranchCoverage.create(30, 2)),
+            List.of(BranchCoverage.create(32, 2)),
+            List.of(BranchCoverage.create(33, 0)),
+            List.of(BranchCoverage.create(35, 2)));
   }
 }

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/SourceFileCoverageTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/SourceFileCoverageTest.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.coverageoutputgenerator;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.assertMergedFunctionsExecution;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.assertMergedLineNumbers;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.assertMergedLines;
@@ -23,6 +24,9 @@ import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.cr
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createLinesExecution2;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createSourceFile1;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createSourceFile2;
+
+import java.util.List;
+import java.util.TreeMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -73,5 +77,61 @@ public class SourceFileCoverageTest {
   public void testMerge() {
     assertMergedSourceFile(
         SourceFileCoverage.merge(sourceFile1, sourceFile2), linesExecution1, linesExecution2);
+
+    SourceFileCoverage c4 = new SourceFileCoverage("");
+    c4.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "1", -1));
+    SourceFileCoverage c5 = new SourceFileCoverage("");
+    c5.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "1", -1));
+    SourceFileCoverage c6 = new SourceFileCoverage("");
+    c6.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "1", 0));
+    SourceFileCoverage c7 = new SourceFileCoverage("");
+    c7.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "1", 1));
+    SourceFileCoverage c8 = new SourceFileCoverage("");
+    c8.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "1", 4));
+
+    assertThat(SourceFileCoverage.merge(c4, c5).nrBranchesHit()).isEqualTo(0);
+    assertThat(SourceFileCoverage.merge(c4, c6).nrBranchesHit()).isEqualTo(0);
+    assertThat(SourceFileCoverage.merge(c4, c7).nrBranchesHit()).isEqualTo(1);
+    assertThat(SourceFileCoverage.merge(c7, c8).nrBranchesHit()).isEqualTo(1);
+  }
+
+  @Test
+  public void testMergeBranches() {
+    SourceFileCoverage c1 = new SourceFileCoverage("");
+    c1.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "1", 0));
+
+    SourceFileCoverage c2 = new SourceFileCoverage("");
+    c2.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "2", 1));
+    c2.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "2", 2));
+
+    SourceFileCoverage c3 = new SourceFileCoverage("");
+    c3.addBranch(2, BranchCoverage.createWithBlockAndBranch(2, "2", "1", 2));
+
+    assertThat(SourceFileCoverage.mergeBranches(c1, c2).size()).isEqualTo(1);
+    assertThat(SourceFileCoverage.mergeBranches(c1, c3).size()).isEqualTo(2);
+  }
+
+  @Test
+  public void testNrBranchesHit() {
+    SourceFileCoverage c1 = new SourceFileCoverage("");
+    c1.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "1", 0));
+    assertThat(c1.nrBranchesHit()).isEqualTo(0);
+    c1.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "2", 0));
+    assertThat(c1.nrBranchesHit()).isEqualTo(0);
+    c1.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "3", 1));
+    assertThat(c1.nrBranchesHit()).isEqualTo(1);
+
+    SourceFileCoverage c2 = new SourceFileCoverage("");
+    c2.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "2", 1));
+    c2.addBranch(1, BranchCoverage.createWithBlockAndBranch(1, "1", "2", 2));
+    assertThat(c2.nrBranchesHit()).isEqualTo(1);
+
+    SourceFileCoverage c3 = new SourceFileCoverage("");
+    c3.addBranch(2, BranchCoverage.createWithBlockAndBranch(2, "2", "1", 2));
+    c3.addBranch(2, BranchCoverage.createWithBlockAndBranch(2, "2", "2", 0));
+    assertThat(c3.nrBranchesHit()).isEqualTo(1);
+
+    c3.addBranch(2, BranchCoverage.createWithBlockAndBranch(2, "2", "2", 1));
+    assertThat(c3.nrBranchesHit()).isEqualTo(2);
   }
 }


### PR DESCRIPTION
- Switch output from BA to BRDA that is understood by genhtml
- Ditch the custom branch detail gathering and use the Jacoco data which includes filtering
- Differentiate between branch not executed and not taken
- Display all branches per line, not just a single one

Fixes #10676