### PR TITLE
Add test for null build with Ninja execution.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/SymlinkForest.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/SymlinkForest.java
@@ -102,14 +102,17 @@ public class SymlinkForest {
   }
 
   /**
-   * Delete all dir trees under a given 'dir' that don't start with a given 'prefix'. Does not
-   * follow any symbolic links.
+   * Delete all dir trees under a given 'dir' that don't start with a given 'prefix',
+   * and is not special case of not symlinked to exec root directories (those directories are
+   * special case of output roots, so they must be kept before commands).
+   * Does not follow any symbolic links.
    */
   @VisibleForTesting
   @ThreadSafety.ThreadSafe
-  static void deleteTreesBelowNotPrefixed(Path dir, String prefix) throws IOException {
+  void deleteTreesBelowNotPrefixed(Path dir, String prefix) throws IOException {
     for (Path p : dir.getDirectoryEntries()) {
-      if (!p.getBaseName().startsWith(prefix)) {
+      if (!p.getBaseName().startsWith(prefix)
+          && !notSymlinkedInExecrootDirectories.contains(p.getBaseName())) {
         p.deleteTree();
       }
     }

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/BUILD
@@ -53,7 +53,7 @@ java_test(
 
 java_test(
     name = "NinjaBlackBoxTest",
-    size = "small",
+    timeout = "moderate",
     srcs = ["NinjaBlackBoxTest.java"],
     tags = ["black_box_test"],
     deps = [


### PR DESCRIPTION
Also, fix symlink forest creation to not delete special not-symlinked
directories under the exec root, since they should be treated as special
output directories.