### PR TITLE
Fix parsing the fragments with Ninja declarations to start from offset

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParser.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParser.java
@@ -49,7 +49,11 @@ public class NinjaParser implements DeclarationConsumer {
     ByteBufferFragment fragment = byteFragmentAtOffset.getFragment();
     int offset = byteFragmentAtOffset.getRealStartOffset();
 
-    NinjaLexer lexer = new NinjaLexer(fragment);
+    // Lexer should start at the beginning of byteFragmentAtOffset -> apply offset.
+    ByteBufferFragment subFragment = fragment.subFragment(
+        byteFragmentAtOffset.getOffset(),
+        fragment.length());
+    NinjaLexer lexer = new NinjaLexer(subFragment);
 
     if (!lexer.hasNextToken()) {
       throw new IllegalStateException("Empty fragment passed as declaration.");
@@ -99,7 +103,8 @@ public class NinjaParser implements DeclarationConsumer {
         ByteFragmentAtOffset targetFragment =
             declarationStart == offset
                 ? byteFragmentAtOffset
-                : new ByteFragmentAtOffset(declarationStart, fragment);
+                // We pass an offset *inside the fragment* into ByteFragmentAtOffset constructor
+                : new ByteFragmentAtOffset(declarationStart - fragment.getStartIncl(), fragment);
         parseResult.addTarget(targetFragment);
         break;
       case DEFAULT:

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaPipelineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaPipelineTest.java
@@ -117,6 +117,33 @@ public class NinjaPipelineTest {
   }
 
   @Test
+  public void testOneFilePipelineWithNewlines() throws Exception {
+    Path vfsPath =
+        tester.writeTmpFile(
+            "test.ninja",
+            "",
+            "",
+            "",
+            "",
+            "rule r1",
+            "  command = c $in $out",
+            "",
+            "",
+            "",
+            "build t1: r1 in1 in2",
+            "",
+            "",
+            "",
+            "build t2: r1 in3",
+            "");
+    NinjaPipeline pipeline =
+        new NinjaPipeline(
+            vfsPath.getParentDirectory(), tester.getService(), ImmutableList.of(), "ninja_target");
+    List<NinjaTarget> targets = pipeline.pipeline(vfsPath);
+    checkTargets(targets);
+  }
+
+  @Test
   public void testWithIncluded() throws Exception {
     Path vfsPath =
         tester.writeTmpFile(


### PR DESCRIPTION
The was a problem that we created NinjaLexer without paying attention to the inner offset in ByteFragmentAtOffset.
There was additionally a problem that we recorded build statement to start at the wrong offset.
Add test for the Ninja file with newlines.