### PR TITLE
Do not kill Android persistent workers if the response has warnings

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -153,7 +153,7 @@ distdir_tar(
         "c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz",
         "1.25.0.zip",
         "rules_nodejs-1.3.0.tar.gz",
-        "android_tools_pkg-0.15.tar.gz",
+        "android_tools_pkg-0.15.1.tar.gz",
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
         # bazelbuild/platforms
@@ -183,7 +183,7 @@ distdir_tar(
         "1.25.0.zip": "c78be58f5e0a29a04686b628cf54faaee0094322ae0ac99da5a8a8afca59a647",
         # rules_nodejs
         "rules_nodejs-1.3.0.tar.gz": "b6670f9f43faa66e3009488bbd909bc7bc46a5a9661a33f6bc578068d1837f37",
-        "android_tools_pkg-0.15.tar.gz": "6b9b9a88a700ae0cdeb75d787f55cab2e939e19af81345e68c9be34f733a2abb",
+        "android_tools_pkg-0.15.1.tar.gz": "6b9b9a88a700ae0cdeb75d787f55cab2e939e19af81345e68c9be34f733a2abb",
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": "c00ceec469dbcf7929972e3c79f20c14033824538038a554952f5c31d8832f96",
         # bazelbuild/platforms
@@ -230,8 +230,8 @@ distdir_tar(
             "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/archive/rules_nodejs-1.3.0.tar.gz",
             "https://github.com/bazelbuild/rules_nodejs/archive/rules_nodejs-1.3.0.tar.gz",
         ],
-        "android_tools_pkg-0.15.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.tar.gz",
+        "android_tools_pkg-0.15.1.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.1.tar.gz",
         ],
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": [
@@ -482,7 +482,7 @@ distdir_tar(
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz",
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz",
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip",
-        "android_tools_pkg-0.15.tar.gz",
+        "android_tools_pkg-0.15.1.tar.gz",
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
         # bazelbuild/platforms
@@ -506,7 +506,7 @@ distdir_tar(
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz": "a452f1b9682d9f83c1c14e54d1446e1c51b5173a3a05dcb013d380f9508562e4",
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz": "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip": "a9695617b8374bfa171f166951214965b1d1d08f43218db9a2a780b71c665c18",
-        "android_tools_pkg-0.15.tar.gz": "6b9b9a88a700ae0cdeb75d787f55cab2e939e19af81345e68c9be34f733a2abb",
+        "android_tools_pkg-0.15.1.tar.gz": "6b9b9a88a700ae0cdeb75d787f55cab2e939e19af81345e68c9be34f733a2abb",
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": "c00ceec469dbcf7929972e3c79f20c14033824538038a554952f5c31d8832f96",
         # bazelbuild/platforms
@@ -529,8 +529,8 @@ distdir_tar(
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.48-ca-jdk11.0.6/zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz"],
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz"],
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64.zip"],
-        "android_tools_pkg-0.15.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.tar.gz",
+        "android_tools_pkg-0.15.1.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.1.tar.gz",
         ],
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": [
@@ -629,7 +629,7 @@ http_archive(
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
     sha256 = "6b9b9a88a700ae0cdeb75d787f55cab2e939e19af81345e68c9be34f733a2abb", # ANDROID_TOOLS_UPDATE_MARKER_DO_NOT_REMOVE
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.tar.gz",
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.1.tar.gz",
 )
 
 # This must be kept in sync with src/main/java/com/google/devtools/build/lib/bazel/rules/coverage.WORKSPACE.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -153,7 +153,7 @@ distdir_tar(
         "c7bbde2950769aac9a99364b0926230060a3ce04.tar.gz",
         "1.25.0.zip",
         "rules_nodejs-1.3.0.tar.gz",
-        "android_tools_pkg-0.14.tar.gz",
+        "android_tools_pkg-0.15.tar.gz",
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
         # bazelbuild/platforms
@@ -183,7 +183,7 @@ distdir_tar(
         "1.25.0.zip": "c78be58f5e0a29a04686b628cf54faaee0094322ae0ac99da5a8a8afca59a647",
         # rules_nodejs
         "rules_nodejs-1.3.0.tar.gz": "b6670f9f43faa66e3009488bbd909bc7bc46a5a9661a33f6bc578068d1837f37",
-        "android_tools_pkg-0.14.tar.gz": "a3a951838448483e7af25afd10671b266cc6283104b4a2a427d31cac12cf0912",  # built at 6c63d70ef9c11a662b8323c0ae4f6d3ac53b1a60
+        "android_tools_pkg-0.15.tar.gz": "6b9b9a88a700ae0cdeb75d787f55cab2e939e19af81345e68c9be34f733a2abb",
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": "c00ceec469dbcf7929972e3c79f20c14033824538038a554952f5c31d8832f96",
         # bazelbuild/platforms
@@ -482,7 +482,7 @@ distdir_tar(
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz",
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz",
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip",
-        "android_tools_pkg-0.14.tar.gz",
+        "android_tools_pkg-0.15.tar.gz",
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
         # bazelbuild/platforms
@@ -506,7 +506,7 @@ distdir_tar(
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz": "a452f1b9682d9f83c1c14e54d1446e1c51b5173a3a05dcb013d380f9508562e4",
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz": "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip": "a9695617b8374bfa171f166951214965b1d1d08f43218db9a2a780b71c665c18",
-        "android_tools_pkg-0.14.tar.gz": "a3a951838448483e7af25afd10671b266cc6283104b4a2a427d31cac12cf0912",  # built at 6c63d70ef9c11a662b8323c0ae4f6d3ac53b1a60
+        "android_tools_pkg-0.15.tar.gz": "6b9b9a88a700ae0cdeb75d787f55cab2e939e19af81345e68c9be34f733a2abb",
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": "c00ceec469dbcf7929972e3c79f20c14033824538038a554952f5c31d8832f96",
         # bazelbuild/platforms
@@ -529,8 +529,8 @@ distdir_tar(
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.48-ca-jdk11.0.6/zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz"],
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz"],
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64.zip"],
-        "android_tools_pkg-0.14.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.14.tar.gz",
+        "android_tools_pkg-0.15.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.tar.gz",
         ],
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": [
@@ -628,7 +628,7 @@ http_archive(
     name = "android_tools_for_testing",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "bfe86223e08e457c3dd50fe3eb381e9643d236d04e353b8e8e5018085e68722f", # ANDROID_TOOLS_UPDATE_MARKER_DO_NOT_REMOVE
+    sha256 = "6b9b9a88a700ae0cdeb75d787f55cab2e939e19af81345e68c9be34f733a2abb", # ANDROID_TOOLS_UPDATE_MARKER_DO_NOT_REMOVE
     url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.tar.gz",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -230,8 +230,8 @@ distdir_tar(
             "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/archive/rules_nodejs-1.3.0.tar.gz",
             "https://github.com/bazelbuild/rules_nodejs/archive/rules_nodejs-1.3.0.tar.gz",
         ],
-        "android_tools_pkg-0.14.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.14.tar.gz",
+        "android_tools_pkg-0.15.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.tar.gz",
         ],
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": [
@@ -628,8 +628,8 @@ http_archive(
     name = "android_tools_for_testing",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "a3a951838448483e7af25afd10671b266cc6283104b4a2a427d31cac12cf0912",  # built at 6c63d70ef9c11a662b8323c0ae4f6d3ac53b1a60
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.14.tar.gz",
+    sha256 = "bfe86223e08e457c3dd50fe3eb381e9643d236d04e353b8e8e5018085e68722f", # ANDROID_TOOLS_UPDATE_MARKER_DO_NOT_REMOVE
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.tar.gz",
 )
 
 # This must be kept in sync with src/main/java/com/google/devtools/build/lib/bazel/rules/coverage.WORKSPACE.

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -4,5 +4,5 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "android_tools",
     sha256 = "6b9b9a88a700ae0cdeb75d787f55cab2e939e19af81345e68c9be34f733a2abb",
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.tar.gz",
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.1.tar.gz",
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -3,6 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "android_tools",
-    sha256 = "bfe86223e08e457c3dd50fe3eb381e9643d236d04e353b8e8e5018085e68722f",
+    sha256 = "6b9b9a88a700ae0cdeb75d787f55cab2e939e19af81345e68c9be34f733a2abb",
     url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.tar.gz",
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -3,6 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "android_tools",
-    sha256 = "a3a951838448483e7af25afd10671b266cc6283104b4a2a427d31cac12cf0912",  # built at 6c63d70ef9c11a662b8323c0ae4f6d3ac53b1a60
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.14.tar.gz",
+    sha256 = "bfe86223e08e457c3dd50fe3eb381e9643d236d04e353b8e8e5018085e68722f",
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.15.tar.gz",
 )

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -799,11 +799,10 @@ public class AndroidConfiguration extends BuildConfiguration.Fragment
           "--strategy=AndroidAssetMerger=worker",
           "--strategy=AndroidResourceMerger=worker",
           "--strategy=AndroidCompiledResourceMerger=worker",
-          // TODO(jingwen): ManifestMerger prints to stdout when there's a manifest merge
-          // conflict. The worker protocol does not like this because it uses std i/o to
-          // for communication. To get around this, re-configure manifest merger to *not*
-          // use stdout for merge conflict warnings.
-          // "--strategy=ManifestMerger=worker",
+          "--strategy=ManifestMerger=worker",
+          "--strategy=AndroidManifestMerger=worker",
+          "--strategy=Aapt2Optimize=worker",
+          "--strategy=AARGenerator=worker",
         })
     public Void persistentResourceProcessor;
 

--- a/src/main/java/com/google/devtools/build/lib/rules/android/BusyBoxActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/BusyBoxActionBuilder.java
@@ -339,6 +339,7 @@ public final class BusyBoxActionBuilder {
         .setMnemonic(mnemonic);
 
     if (dataContext.isPersistentBusyboxToolsEnabled()) {
+      commandLine.add("--logWarnings=false");
       spawnActionBuilder
           .setExecutionInfo(ExecutionRequirements.WORKER_MODE_ENABLED)
           .addCommandLine(commandLine.build(), WORKERS_FORCED_PARAM_FILE_INFO);

--- a/src/test/shell/bazel/android/resource_processing_integration_test.sh
+++ b/src/test/shell/bazel/android/resource_processing_integration_test.sh
@@ -77,7 +77,12 @@ EOF
   cat > java/bazel/AndroidManifest.xml <<EOF
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="bazel.android">
+
+    <!-- tools:replace is a deprecated attribute, and will cause the manifest merger action to log a warning -->
+    <uses-feature android:name="android.hardware.location" android:required="false" tools:replace="android:required" />
+
     <application
         android:label="Bazel App"
         android:theme="@style/AppTheme" >

--- a/src/tools/android/java/com/google/devtools/build/android/Aapt2OptimizeAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/Aapt2OptimizeAction.java
@@ -36,7 +36,7 @@ class Aapt2OptimizeAction {
   private static List<String> buildCommand(String... args) {
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(Aapt2ConfigOptions.class)
+            .optionsClasses(Aapt2ConfigOptions.class, ResourceProcessorCommonOptions.class)
             .argsPreProcessor(new ShellQuotedParamsFilePreProcessor(FileSystems.getDefault()))
             .allowResidue(true)
             .build();

--- a/src/tools/android/java/com/google/devtools/build/android/Aapt2ResourcePackagingAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/Aapt2ResourcePackagingAction.java
@@ -316,13 +316,14 @@ public class Aapt2ResourcePackagingAction {
         effectTags = {OptionEffectTag.NO_OP},
         help = "Unused/deprecated option.")
     public boolean isTestWithResources;
+
   }
 
   public static void main(String[] args) throws Exception {
     Profiler profiler = InMemoryProfiler.createAndStart("setup");
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(Options.class, Aapt2ConfigOptions.class)
+            .optionsClasses(Options.class, Aapt2ConfigOptions.class, ResourceProcessorCommonOptions.class)
             .argsPreProcessor(new ShellQuotedParamsFilePreProcessor(FileSystems.getDefault()))
             .build();
     optionsParser.parseAndExitUponError(args);
@@ -365,7 +366,8 @@ public class Aapt2ResourcePackagingAction {
                               options.versionCode,
                               options.versionName,
                               manifest,
-                              processedManifest))
+                              processedManifest,
+                              optionsParser.getOptions(ResourceProcessorCommonOptions.class).logWarnings))
               .processManifest(
                   manifest ->
                       new DensitySpecificManifestProcessor(options.densities, densityManifest)

--- a/src/tools/android/java/com/google/devtools/build/android/Aapt2ResourceShrinkingAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/Aapt2ResourceShrinkingAction.java
@@ -48,7 +48,7 @@ public class Aapt2ResourceShrinkingAction {
     // Parse arguments.
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(Options.class, Aapt2ConfigOptions.class)
+            .optionsClasses(Options.class, Aapt2ConfigOptions.class, ResourceProcessorCommonOptions.class)
             .argsPreProcessor(new ShellQuotedParamsFilePreProcessor(FileSystems.getDefault()))
             .build();
     optionsParser.parseAndExitUponError(args);

--- a/src/tools/android/java/com/google/devtools/build/android/AarGeneratorAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/AarGeneratorAction.java
@@ -164,7 +164,7 @@ public class AarGeneratorAction {
     Stopwatch timer = Stopwatch.createStarted();
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(AarGeneratorOptions.class)
+            .optionsClasses(AarGeneratorOptions.class, ResourceProcessorCommonOptions.class)
             .argsPreProcessor(new ShellQuotedParamsFilePreProcessor(FileSystems.getDefault()))
             .build();
     optionsParser.parseAndExitUponError(args);

--- a/src/tools/android/java/com/google/devtools/build/android/AndroidAssetMergingAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/AndroidAssetMergingAction.java
@@ -47,7 +47,7 @@ public class AndroidAssetMergingAction extends AbstractBusyBoxAction {
   private static AndroidAssetMergingAction create() {
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(Options.class)
+            .optionsClasses(Options.class, ResourceProcessorCommonOptions.class)
             .argsPreProcessor(new ShellQuotedParamsFilePreProcessor(FileSystems.getDefault()))
             .build();
     return new AndroidAssetMergingAction(optionsParser);

--- a/src/tools/android/java/com/google/devtools/build/android/AndroidCompiledResourceMergingAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/AndroidCompiledResourceMergingAction.java
@@ -183,13 +183,14 @@ public class AndroidCompiledResourceMergingAction {
         help =
             "Path to where an R.txt file declaring potentially-used resources should be written.")
     public Path rTxtOut;
+
   }
 
   public static void main(String[] args) throws Exception {
     final Stopwatch timer = Stopwatch.createStarted();
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(Options.class, AaptConfigOptions.class)
+            .optionsClasses(Options.class, AaptConfigOptions.class, ResourceProcessorCommonOptions.class)
             .argsPreProcessor(new ShellQuotedParamsFilePreProcessor(FileSystems.getDefault()))
             .build();
     optionsParser.parseAndExitUponError(args);
@@ -248,7 +249,7 @@ public class AndroidCompiledResourceMergingAction {
       processedManifest =
           AndroidManifestProcessor.with(stdLogger)
               .processLibraryManifest(
-                  options.packageForR, options.primaryManifest, processedManifest);
+                  options.packageForR, options.primaryManifest, processedManifest, optionsParser.getOptions(ResourceProcessorCommonOptions.class).logWarnings);
 
       Files.createDirectories(options.manifestOutput.getParent());
       Files.copy(processedManifest, options.manifestOutput);

--- a/src/tools/android/java/com/google/devtools/build/android/AndroidDataBindingProcessingAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/AndroidDataBindingProcessingAction.java
@@ -101,7 +101,8 @@ public class AndroidDataBindingProcessingAction {
 
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(Options.class, AaptConfigOptions.class)
+            .allowResidue(true)
+            .optionsClasses(Options.class, AaptConfigOptions.class, ResourceProcessorCommonOptions.class)
             .argsPreProcessor(new ShellQuotedParamsFilePreProcessor(FileSystems.getDefault()))
             .build();
     optionsParser.parseAndExitUponError(args);

--- a/src/tools/android/java/com/google/devtools/build/android/AndroidManifestProcessor.java
+++ b/src/tools/android/java/com/google/devtools/build/android/AndroidManifestProcessor.java
@@ -112,7 +112,8 @@ public class AndroidManifestProcessor {
       Map<String, String> values,
       String customPackage,
       Path output,
-      Path logFile)
+      Path logFile,
+      boolean logWarnings)
       throws ManifestProcessingException {
     if (mergeeManifests.isEmpty() && values.isEmpty() && Strings.isNullOrEmpty(customPackage)) {
       return manifest;
@@ -170,7 +171,9 @@ public class AndroidManifestProcessor {
       }
       switch (mergingReport.getResult()) {
         case WARNING:
-          mergingReport.log(stdLogger);
+          if (logWarnings) {
+            mergingReport.log(stdLogger);
+          }
           Files.createDirectories(output.getParent());
           writeMergedManifest(mergedManifestKind, mergingReport, output);
           break;
@@ -200,7 +203,8 @@ public class AndroidManifestProcessor {
       int versionCode,
       String versionName,
       MergedAndroidData primaryData,
-      Path processedManifest) {
+      Path processedManifest,
+      boolean logWarnings) {
 
     ManifestMerger2.MergeType mergeType =
         variantType == VariantType.DEFAULT
@@ -217,7 +221,8 @@ public class AndroidManifestProcessor {
           primaryData.getManifest(),
           processedManifest,
           mergeType,
-          newManifestPackage);
+          newManifestPackage,
+          logWarnings);
       return new MergedAndroidData(
           primaryData.getResourceDir(), primaryData.getAssetDir(), processedManifest);
     }
@@ -230,7 +235,8 @@ public class AndroidManifestProcessor {
       int versionCode,
       String versionName,
       Path manifest,
-      Path processedManifest) {
+      Path processedManifest,
+      boolean logWarnings) {
 
     if (versionCode != -1 || versionName != null || applicationId != null) {
       processManifest(
@@ -239,7 +245,8 @@ public class AndroidManifestProcessor {
           manifest,
           processedManifest,
           MergeType.APPLICATION,
-          applicationId);
+          applicationId,
+          logWarnings);
       return processedManifest;
     }
     return manifest;
@@ -247,7 +254,7 @@ public class AndroidManifestProcessor {
 
   /** Processes the manifest for a library and return the manifest Path. */
   public Path processLibraryManifest(
-      String newManifestPackage, Path manifest, Path processedManifest) {
+      String newManifestPackage, Path manifest, Path processedManifest, boolean logWarnings) {
 
     if (newManifestPackage != null) {
       processManifest(
@@ -256,7 +263,8 @@ public class AndroidManifestProcessor {
           manifest,
           processedManifest,
           MergeType.LIBRARY,
-          newManifestPackage);
+          newManifestPackage,
+          logWarnings);
       return processedManifest;
     }
     return manifest;
@@ -268,7 +276,8 @@ public class AndroidManifestProcessor {
       Path primaryManifest,
       Path processedManifest,
       MergeType mergeType,
-      String newManifestPackage) {
+      String newManifestPackage,
+      boolean logWarnings) {
     try {
       Files.createDirectories(processedManifest.getParent());
 
@@ -296,7 +305,9 @@ public class AndroidManifestProcessor {
       MergingReport mergingReport = manifestMergerInvoker.merge();
       switch (mergingReport.getResult()) {
         case WARNING:
-          mergingReport.log(stdLogger);
+          if (logWarnings) {
+            mergingReport.log(stdLogger);
+          }
           writeMergedManifest(mergedManifestKind, mergingReport, processedManifest);
           break;
         case SUCCESS:

--- a/src/tools/android/java/com/google/devtools/build/android/AndroidResourceParsingAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/AndroidResourceParsingAction.java
@@ -66,12 +66,13 @@ public class AndroidResourceParsingAction {
       help = "Path to write the output protobuf."
     )
     public Path output;
+
   }
 
   public static void main(String[] args) throws Exception {
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(Options.class)
+            .optionsClasses(Options.class, ResourceProcessorCommonOptions.class)
             .argsPreProcessor(new ShellQuotedParamsFilePreProcessor(FileSystems.getDefault()))
             .build();
     optionsParser.parseAndExitUponError(args);

--- a/src/tools/android/java/com/google/devtools/build/android/CompileLibraryResourcesAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/CompileLibraryResourcesAction.java
@@ -105,7 +105,7 @@ public class CompileLibraryResourcesAction {
   public static void main(String[] args) throws Exception {
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(Options.class, Aapt2ConfigOptions.class)
+            .optionsClasses(Options.class, Aapt2ConfigOptions.class, ResourceProcessorCommonOptions.class)
             .argsPreProcessor(new ShellQuotedParamsFilePreProcessor(FileSystems.getDefault()))
             .build();
     optionsParser.parseAndExitUponError(args);

--- a/src/tools/android/java/com/google/devtools/build/android/ManifestMergerAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/ManifestMergerAction.java
@@ -187,7 +187,7 @@ public class ManifestMergerAction {
   public static void main(String[] args) throws Exception {
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(Options.class)
+            .optionsClasses(Options.class, ResourceProcessorCommonOptions.class)
             .argsPreProcessor(new ShellQuotedParamsFilePreProcessor(FileSystems.getDefault()))
             .build();
     optionsParser.parseAndExitUponError(args);
@@ -221,7 +221,8 @@ public class ManifestMergerAction {
               options.manifestValues,
               options.customPackage,
               options.manifestOutput,
-              options.log);
+              options.log,
+              optionsParser.getOptions(ResourceProcessorCommonOptions.class).logWarnings);
 
       if (!mergedManifest.equals(options.manifestOutput)) {
         // manifestProcess.mergeManifest returns the merged manifest, or, if merging was a no-op,

--- a/src/tools/android/java/com/google/devtools/build/android/RClassGeneratorAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/RClassGeneratorAction.java
@@ -150,7 +150,7 @@ public class RClassGeneratorAction {
     final Stopwatch timer = Stopwatch.createStarted();
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(Options.class)
+            .optionsClasses(Options.class, ResourceProcessorCommonOptions.class)
             .argsPreProcessor(new ShellQuotedParamsFilePreProcessor(FileSystems.getDefault()))
             .build();
     optionsParser.parseAndExitUponError(args);

--- a/src/tools/android/java/com/google/devtools/build/android/ResourceProcessorBusyBox.java
+++ b/src/tools/android/java/com/google/devtools/build/android/ResourceProcessorBusyBox.java
@@ -170,13 +170,13 @@ public class ResourceProcessorBusyBox {
     // initialize Options/OptionsParser here. This keeps the processRequest interface minimal and
     // minimizes moving option state between these methods.
     if (args.length == 1 && args[0].equals("--persistent_worker")) {
-      System.exit(runPersistentWorker());
+      runPersistentWorker();
     } else {
-      System.exit(processRequest(Arrays.asList(args)));
+      processRequest(Arrays.asList(args));
     }
   }
 
-  private static int runPersistentWorker() throws Exception {
+  private static void runPersistentWorker() throws Exception {
     while (true) {
       try {
         WorkRequest request = WorkRequest.parseDelimitedFrom(System.in);
@@ -194,10 +194,8 @@ public class ResourceProcessorBusyBox {
       } catch (IOException e) {
         logger.severe(e.getMessage());
         e.printStackTrace();
-        return 1;
       }
     }
-    return 0;
   }
 
   private static int processRequest(List<String> args) throws Exception {

--- a/src/tools/android/java/com/google/devtools/build/android/ResourceProcessorCommonOptions.java
+++ b/src/tools/android/java/com/google/devtools/build/android/ResourceProcessorCommonOptions.java
@@ -1,0 +1,37 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.android;
+
+import com.google.devtools.common.options.Option;
+import com.google.devtools.common.options.OptionDocumentationCategory;
+import com.google.devtools.common.options.OptionEffectTag;
+import com.google.devtools.common.options.OptionsBase;
+
+
+/**
+ * Common options shared between tools of ResourceProcessorBusyBox
+ */
+public class ResourceProcessorCommonOptions extends OptionsBase {
+
+  @Option(
+     name = "logWarnings",
+     defaultValue = "true",
+     documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+     effectTags = {OptionEffectTag.UNKNOWN},
+     converter = com.google.devtools.common.options.Converters.BooleanConverter.class,
+     help = ""
+  )
+  public boolean logWarnings;
+
+}

--- a/src/tools/android/java/com/google/devtools/build/android/ValidateAndLinkResourcesAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/ValidateAndLinkResourcesAction.java
@@ -154,7 +154,7 @@ public class ValidateAndLinkResourcesAction {
   public static void main(String[] args) throws Exception {
     OptionsParser optionsParser =
         OptionsParser.builder()
-            .optionsClasses(Options.class, Aapt2ConfigOptions.class)
+            .optionsClasses(Options.class, Aapt2ConfigOptions.class, ResourceProcessorCommonOptions.class)
             .argsPreProcessor(new ShellQuotedParamsFilePreProcessor(FileSystems.getDefault()))
             .build();
     optionsParser.parse(args);

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -48,7 +48,7 @@ cp $android_tools_archive $versioned_android_tools_archive
 
 # Upload the tarball to GCS.
 # -n for no-clobber, so we don't overwrite existing files
-gsutil cp -n $versioned_android_tools_archive \
+gsutil cp $versioned_android_tools_archive \
   gs://bazel-mirror/bazel_android_tools/$VERSIONED_FILENAME
 
 checksum=$(sha256sum $versioned_android_tools_archive | cut -f 1 -d ' ')

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -31,7 +31,7 @@
 set -euo pipefail
 
 # The version of android_tools.tar.gz
-VERSION="0.15"
+VERSION="0.15.1"
 VERSIONED_FILENAME="android_tools_pkg-$VERSION.tar.gz"
 
 # Create a temp directory to hold the versioned tarball, and clean it up when the script exits.

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -31,7 +31,7 @@
 set -euo pipefail
 
 # The version of android_tools.tar.gz
-VERSION="0.14"
+VERSION="0.15"
 VERSIONED_FILENAME="android_tools_pkg-$VERSION.tar.gz"
 
 # Create a temp directory to hold the versioned tarball, and clean it up when the script exits.
@@ -52,7 +52,6 @@ gsutil cp -n $versioned_android_tools_archive \
   gs://bazel-mirror/bazel_android_tools/$VERSIONED_FILENAME
 
 checksum=$(sha256sum $versioned_android_tools_archive | cut -f 1 -d ' ')
-commit=$(cd $BUILD_WORKSPACE_DIRECTORY && git rev-parse HEAD)
 
 echo
 echo "Run this command to update Bazel to use the new version:"
@@ -60,9 +59,10 @@ echo
 
 cat <<EOF
 sed -i 's/android_tools_pkg.*\.tar\.gz/$VERSIONED_FILENAME/g' WORKSPACE  && \\
-  sed -i 's/"android_tools_pkg.*[0-9a-FA-F]\{64\}",.*/"$VERSIONED_FILENAME": "$checksum", # built at $commit/g' WORKSPACE && \\
+  sed -i 's/"[0-9a-fA-F]\{64\}", # ANDROID_TOOLS_UPDATE_MARKER_DO_NOT_REMOVE/"$checksum", # ANDROID_TOOLS_UPDATE_MARKER_DO_NOT_REMOVE/g' WORKSPACE && \\
+  sed -i 's/"android_tools_pkg.*[0-9a-FA-F]\{64\}",.*/"$VERSIONED_FILENAME": "$checksum",/g' WORKSPACE && \\
   sed -i 's/android_tools_pkg.*\.tar\.gz/$VERSIONED_FILENAME/g' src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE && \\
-  sed -i 's/"[0-9a-fA-F]\{64\}",.*/"$checksum", # built at $commit/g' src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+  sed -i 's/"[0-9a-fA-F]\{64\}",.*/"$checksum",/g' src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
 EOF
 
 echo


### PR DESCRIPTION
The Android manifest merging action will log warnings to standard out. This is bad for the persistent worker protocol, since it uses stdout for communication. The manifest merging action is also called by other busybox tools, so omitting ManifestMerger and AndroidManifestMerger mnemonics from --persistent_android_resource_processor doesn't work.

Add a --logWarning boolean flag to the busybox tools. If --persistent_android_resource_processor or --internal_persistent_busybox_tools is enabled, stop logging warnings in manifest merging actions. 

Also re-enable manifest merging actions in --persistent_android_resource_processor.

Fixes https://github.com/bazelbuild/bazel/issues/8505