### PR TITLE
Tweak third_party/BUILD for FreeBSD.

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -469,6 +469,7 @@ UNNECESSARY_DYNAMIC_LIBRARIES = select({
     "//src/conditions:arm": "*.so *.jnilib *.dll",
     "//src/conditions:linux_aarch64": "*.so *.jnilib *.dll",
     "//src/conditions:linux_ppc": "*.so *.jnilib *.dll",
+    "//src/conditions:freebsd": "*.so *.jnilib *.dll",
     "//src/conditions:openbsd": "*.so *.jnilib *.dll",
     # Play it safe -- better have a big binary than a slow binary
     # zip -d does require an argument. Supply something bogus.


### PR DESCRIPTION
This way there's no need for FreeBSD's `bazel` port to [patch `third_party/BUILD`](https://github.com/freebsd/freebsd-ports/blob/f5c3ba467a9cc5e834c157b0364d327425981c24/devel/bazel/files/patch-third_party__BUILD) anymore. Also, this change moves one step closer to a bootstrap build on FreeBSD succeeding using unmodified sources.

https://github.com/bazelbuild/bazel/pull/10639 made the equivalent change for OpenBSD. AFAICS the same kind of change would be helpful for FreeBSD also.