### PR TITLE
Use a capital B to represent bytes in download progress

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadProgressEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadProgressEvent.java
@@ -75,7 +75,7 @@ public class DownloadProgressEvent implements ExtendedEventHandler.FetchProgress
     if (bytesRead > 0) {
       NumberFormat formatter = NumberFormat.getIntegerInstance(Locale.ENGLISH);
       formatter.setGroupingUsed(true);
-      return formatter.format(bytesRead) + "b";
+      return formatter.format(bytesRead) + "B";
     } else {
       return "";
     }


### PR DESCRIPTION
Change the download progress to use a capital B to represent bytes instead of a lowercase b (which normally represents bits).

Old behavior:
```
    Fetching @go_sdk; fetching 69s
    Fetching https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz; 19,298,881b 69s
```

New behavior:
```
    Fetching @go_sdk; fetching 69s
    Fetching https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz; 19,298,881B 69s
```