### PR TITLE
Add aarch64 configuration condition for jni gcc includes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BUILD
@@ -164,6 +164,7 @@ cc_library(
     name = "jni",
     hdrs = ["@bazel_tools//tools/jdk:jni_header"] + select({
         "//src/conditions:linux_x86_64": ["@bazel_tools//tools/jdk:jni_md_header-linux"],
+        "//src/conditions:linux_aarch64": ["@bazel_tools//tools/jdk:jni_md_header-linux"],
         "//src/conditions:darwin": ["@bazel_tools//tools/jdk:jni_md_header-darwin"],
         "//src/conditions:windows": ["@bazel_tools//tools/jdk:jni_md_header-windows"],
         "//conditions:default": [],
@@ -171,6 +172,7 @@ cc_library(
     includes = ["../../../../../../../../../external/bazel_tools/tools/jdk/include"] + select({
         # Remove these crazy prefixes when we move this rule.
         "//src/conditions:linux_x86_64": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/linux"],
+        "//src/conditions:linux_aarch64": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/linux"],
         "//src/conditions:darwin": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/darwin"],
         "//src/conditions:windows": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/win32"],
         "//conditions:default": [],


### PR DESCRIPTION
Very light PR which adds arm64 platform rule for building bazel.

When building bazel from sources on linux_aarch64, the build would fail during c++ compilation, complaining about a missing jni platform include:

```
INFO: Analyzed target //src:bazel (1 packages loaded, 194 targets configured).
INFO: Found 1 target...
ERROR: /home/ubuntu/dev/bazel/src/main/java/com/google/devtools/build/lib/syntax/BUILD:150:1: C++ compilation of rule '//src/main/java/com/google/devtools/build/lib/syntax:libcpu_profiler.so' failed (Exit 1) gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 24 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
In file included from src/main/java/com/google/devtools/build/lib/syntax/cpu_profiler_unimpl.cc:17:0:
bazel-out/aarch64-fastbuild/bin/external/bazel_tools/tools/jdk/include/jni.h:45:10: fatal error: jni_md.h: No such file or directory
 #include "jni_md.h"
          ^~~~~~~~~~
compilation terminated.
Target //src:bazel failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 2.737s, Critical Path: 0.73s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
```

After adding aarch64 select, the build is successful.