### PR TITLE
fix cpu profiler compile on ppc64le

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BUILD
@@ -165,6 +165,7 @@ cc_library(
     hdrs = ["@bazel_tools//tools/jdk:jni_header"] + select({
         "//src/conditions:linux_x86_64": ["@bazel_tools//tools/jdk:jni_md_header-linux"],
         "//src/conditions:linux_aarch64": ["@bazel_tools//tools/jdk:jni_md_header-linux"],
+        "//src/conditions:linux_ppc": ["@bazel_tools//tools/jdk:jni_md_header-linux"],
         "//src/conditions:darwin": ["@bazel_tools//tools/jdk:jni_md_header-darwin"],
         "//src/conditions:freebsd": ["@bazel_tools//tools/jdk:jni_md_header-freebsd"],
         "//src/conditions:openbsd": ["@bazel_tools//tools/jdk:jni_md_header-openbsd"],
@@ -175,6 +176,7 @@ cc_library(
         # Remove these crazy prefixes when we move this rule.
         "//src/conditions:linux_x86_64": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/linux"],
         "//src/conditions:linux_aarch64": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/linux"],
+        "//src/conditions:linux_ppc": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/linux"],
         "//src/conditions:darwin": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/darwin"],
         "//src/conditions:freebsd": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/freebsd"],
         "//src/conditions:openbsd": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/openbsd"],


### PR DESCRIPTION
Add conditions for linux/ppc instead of just linux/x86_64.

Other headers might be in the same place (for s390x, arm*, etc.), but
would need to be tested first. This fix is only tested on ppc64le.

Fixes https://github.com/bazelbuild/bazel/issues/10746

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>