### PR TITLE
Add READ access of mmap() in docker env

### DIFF
--- a/third_party/ijar/mapped_file_unix.cc
+++ b/third_party/ijar/mapped_file_unix.cc
@@ -113,7 +113,8 @@ MappedOutputFile::MappedOutputFile(const char* name, size_t estimated_size)
   size_t mmap_length =
       std::min(static_cast<size_t>(estimated_size + sysconf(_SC_PAGESIZE)),
                std::numeric_limits<size_t>::max());
-  void* mapped = mmap(NULL, mmap_length, PROT_WRITE, MAP_SHARED, fd, 0);
+  void* mapped = mmap(NULL, mmap_length, PROT_READ|PROT_WRITE,
+                      MAP_SHARED, fd, 0);
   if (mapped == MAP_FAILED) {
     snprintf(errmsg, MAX_ERROR, "mmap(): %s", strerror(errno));
     errmsg_ = errmsg;


### PR DESCRIPTION
In docker multi-architecture environment, calling the
mmap() with only PROT_WRITE would fail the following
write(). Adding PROT_READ access would solve the issue.
The logic there only needs WRITE access, however, it
should be fine to assign READ access too. Actually,
PROT_WRITE is offen implementated as PROT_READ|PROT_WRITE.

fix: #7135.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>