### PR TITLE
Support always-dirty Ninja actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaAction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaAction.java
@@ -44,7 +44,8 @@ public class NinjaAction extends SpawnAction {
       CommandLines commandLines,
       ActionEnvironment env,
       ImmutableMap<String, String> executionInfo,
-      RunfilesSupplier runfilesSupplier) {
+      RunfilesSupplier runfilesSupplier,
+      boolean executeUnconditionally) {
     super(
         /* owner= */ owner,
         /* tools= */ tools,
@@ -60,7 +61,7 @@ public class NinjaAction extends SpawnAction {
         /* progressMessage= */ createProgressMessage(outputs),
         /* runfilesSupplier= */ runfilesSupplier,
         /* mnemonic= */ MNEMONIC,
-        /* executeUnconditionally= */ false,
+        /* executeUnconditionally= */ executeUnconditionally,
         /* extraActionInfoSupplier= */ null,
         /* resultConsumer= */ null);
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaActionsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaActionsHelper.java
@@ -31,7 +31,6 @@ import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaRuleVariable;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaScope;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaTarget;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaVariableValue;
-import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.packages.TargetUtils;
@@ -49,7 +48,7 @@ public class NinjaActionsHelper {
   private final RuleContext ruleContext;
   private final List<String> outputRootInputs;
   private final ImmutableSortedMap<PathFragment, NinjaTarget> allUsualTargets;
-  private final ImmutableSortedMap<PathFragment, NestedSet<Artifact>> phonyTargets;
+  private final ImmutableSortedMap<PathFragment, PhonyTarget<Artifact>> phonyTargets;
 
   private final NinjaGraphArtifactsHelper artifactsHelper;
 
@@ -58,11 +57,10 @@ public class NinjaActionsHelper {
 
   /**
    * Constructor
-   *
-   * @param ruleContext parent NinjaGraphRule rule context
+   *  @param ruleContext parent NinjaGraphRule rule context
    * @param artifactsHelper helper object to create artifacts
    * @param outputRootInputs inputs under output_root directory. Should be symlinked by absolute
-   *     paths under execroot/output_root.
+ *     paths under execroot/output_root.
    * @param allUsualTargets mapping of outputs to all non-phony Ninja targets from Ninja file
    * @param phonyTargets mapping of names to all phony Ninja actions from Ninja file
    */
@@ -71,7 +69,7 @@ public class NinjaActionsHelper {
       NinjaGraphArtifactsHelper artifactsHelper,
       List<String> outputRootInputs,
       ImmutableSortedMap<PathFragment, NinjaTarget> allUsualTargets,
-      ImmutableSortedMap<PathFragment, NestedSet<Artifact>> phonyTargets) {
+      ImmutableSortedMap<PathFragment, PhonyTarget<Artifact>> phonyTargets) {
     this.ruleContext = ruleContext;
     this.artifactsHelper = artifactsHelper;
     this.outputRootInputs = outputRootInputs;
@@ -117,7 +115,7 @@ public class NinjaActionsHelper {
 
     NestedSetBuilder<Artifact> inputsBuilder = NestedSetBuilder.stableOrder();
     ImmutableList.Builder<Artifact> outputsBuilder = ImmutableList.builder();
-    fillArtifacts(target, inputsBuilder, outputsBuilder);
+    boolean isAlwaysDirty = fillArtifacts(target, inputsBuilder, outputsBuilder);
 
     NinjaScope targetScope = createTargetScope(target);
     int targetOffset = target.getOffset();
@@ -140,18 +138,24 @@ public class NinjaActionsHelper {
             commandLines,
             Preconditions.checkNotNull(ruleContext.getConfiguration()).getActionEnvironment(),
             executionInfo,
-            EmptyRunfilesSupplier.INSTANCE));
+            EmptyRunfilesSupplier.INSTANCE,
+            isAlwaysDirty));
   }
 
-  private void fillArtifacts(
+  /**
+   * Returns true is the action shpould be marked as always dirty.
+   */
+  private boolean fillArtifacts(
       NinjaTarget target,
       NestedSetBuilder<Artifact> inputsBuilder,
       ImmutableList.Builder<Artifact> outputsBuilder)
       throws GenericParsingException {
+    boolean isAlwaysDirty = false;
     for (PathFragment input : target.getAllInputs()) {
-      NestedSet<Artifact> nestedSet = this.phonyTargets.get(input);
-      if (nestedSet != null) {
-        inputsBuilder.addTransitive(nestedSet);
+      PhonyTarget<Artifact> phonyTarget = this.phonyTargets.get(input);
+      if (phonyTarget != null) {
+        inputsBuilder.addTransitive(phonyTarget.getInputs());
+        isAlwaysDirty |= phonyTarget.isAlwaysDirty();
       } else {
         inputsBuilder.add(artifactsHelper.getInputArtifact(input));
       }
@@ -160,6 +164,7 @@ public class NinjaActionsHelper {
     for (PathFragment output : target.getAllOutputs()) {
       outputsBuilder.add(artifactsHelper.createOutputArtifact(output));
     }
+    return isAlwaysDirty;
   }
 
   private void maybeCreateRspFile(

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraph.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraph.java
@@ -189,13 +189,13 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
 
   private static class TargetsPreparer {
     private ImmutableSortedMap<PathFragment, NinjaTarget> usualTargets;
-    private ImmutableSortedMap<PathFragment, NestedSet<Artifact>> phonyTargetsMap;
+    private ImmutableSortedMap<PathFragment, PhonyTarget<Artifact>> phonyTargetsMap;
 
     public ImmutableSortedMap<PathFragment, NinjaTarget> getUsualTargets() {
       return usualTargets;
     }
 
-    public ImmutableSortedMap<PathFragment, NestedSet<Artifact>> getPhonyTargetsMap() {
+    public ImmutableSortedMap<PathFragment, PhonyTarget<Artifact>> getPhonyTargetsMap() {
       return phonyTargetsMap;
     }
 
@@ -268,14 +268,14 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
   private static NestedSet<Artifact> getGroupArtifacts(
       RuleContext ruleContext,
       List<String> targets,
-      ImmutableSortedMap<PathFragment, NestedSet<Artifact>> phonyTargetsMap,
+      ImmutableSortedMap<PathFragment, PhonyTarget<Artifact>> phonyTargetsMap,
       ImmutableSortedMap<PathFragment, Artifact> outputsMap) {
     NestedSetBuilder<Artifact> nestedSetBuilder = NestedSetBuilder.stableOrder();
     for (String target : targets) {
       PathFragment path = PathFragment.create(target);
-      NestedSet<Artifact> artifacts = phonyTargetsMap.get(path);
-      if (artifacts != null) {
-        nestedSetBuilder.addTransitive(artifacts);
+      PhonyTarget<Artifact> phonyTarget = phonyTargetsMap.get(path);
+      if (phonyTarget != null) {
+        nestedSetBuilder.addTransitive(phonyTarget.getInputs());
       } else {
         Artifact usualArtifact = outputsMap.get(path);
         if (usualArtifact == null) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTarget.java
@@ -1,0 +1,52 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.rules.ninja.actions;
+
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+
+/**
+ * Helper class to represent "evaluated" phony target: it contains the NestedSet with all
+ * non-phony inputs to the phony target (with Artifacts for the real computation,
+ * and PathFragments for the tests);
+ * and it contains the flag whether this phony target is always dirty, i.e. must be rebuild
+ * each time.
+ *
+ * Always-dirty phony targets are those which do not have any inputs: "build alias: phony".
+ * All usual direct dependants of those actions automatically also always-dirty (but not
+ * the transitive dependants: they should check whether their computed inputs have changed).
+ * As phony targets are not performing any actions,
+ * <b>all phony transitive dependants of always-dirty phony targets
+ * are themselves always-dirty.</b>
+ * That is why we can compute the always-dirty flag for the phony targets, and use it for marking
+ * their direct non-phony dependants as actions to be executed unconditionally.
+ * @param <T>
+ */
+public class PhonyTarget<T> {
+  private final NestedSet<T> inputs;
+  private final boolean isAlwaysDirty;
+
+  public PhonyTarget(NestedSet<T> inputs, boolean isAlwaysDirty) {
+    this.inputs = inputs;
+    this.isAlwaysDirty = isAlwaysDirty;
+  }
+
+  public NestedSet<T> getInputs() {
+    return inputs;
+  }
+
+  public boolean isAlwaysDirty() {
+    return isAlwaysDirty;
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaPhonyTargetsUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaPhonyTargetsUtilTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.bazel.rules.ninja.actions.NinjaPhonyTargetsUtil;
+import com.google.devtools.build.lib.bazel.rules.ninja.actions.PhonyTarget;
 import com.google.devtools.build.lib.bazel.rules.ninja.file.ByteBufferFragment;
 import com.google.devtools.build.lib.bazel.rules.ninja.file.GenericParsingException;
 import com.google.devtools.build.lib.bazel.rules.ninja.lexer.NinjaLexer;
@@ -52,7 +53,7 @@ public class NinjaPhonyTargetsUtilTest {
             "build alias3: phony alias4 direct4 direct5",
             "build alias4: phony alias2");
 
-    ImmutableSortedMap<PathFragment, NestedSet<PathFragment>> pathsMap =
+    ImmutableSortedMap<PathFragment, PhonyTarget<PathFragment>> pathsMap =
         NinjaPhonyTargetsUtil.getPhonyPathsMap(buildPhonyTargets(targetTexts), pf -> pf);
 
     assertThat(pathsMap).hasSize(4);
@@ -72,7 +73,7 @@ public class NinjaPhonyTargetsUtilTest {
             "build deep1: phony leaf1",
             "build deep2: phony leaf2 alias1");
 
-    ImmutableSortedMap<PathFragment, NestedSet<PathFragment>> pathsMap =
+    ImmutableSortedMap<PathFragment, PhonyTarget<PathFragment>> pathsMap =
         NinjaPhonyTargetsUtil.getPhonyPathsMap(buildPhonyTargets(targetTexts), pf -> pf);
 
     assertThat(pathsMap).hasSize(5);
@@ -83,14 +84,45 @@ public class NinjaPhonyTargetsUtilTest {
     checkMapping(pathsMap, "deep2", "leaf1", "leaf2");
   }
 
+  @Test
+  public void testAlwaysDirty() throws Exception {
+    ImmutableList<String> targetTexts =
+        ImmutableList.of(
+            "build alias9: phony alias2 alias3 direct1 direct2",
+            "build alias2: phony direct3 direct4",
+            "build alias3: phony alias4 direct4 direct5",
+            // alias4 is always-dirty
+            "build alias4: phony");
+
+    ImmutableSortedMap<PathFragment, PhonyTarget<PathFragment>> pathsMap =
+        NinjaPhonyTargetsUtil.getPhonyPathsMap(buildPhonyTargets(targetTexts), pf -> pf);
+
+    assertThat(pathsMap).hasSize(4);
+    // alias4 and its transitive closure is always-dirty
+    checkMapping(pathsMap, "alias9", true, "direct1", "direct2", "direct3", "direct4", "direct5");
+    checkMapping(pathsMap, "alias2", false, "direct3", "direct4");
+    checkMapping(pathsMap, "alias3", true, "direct4", "direct5");
+    checkMapping(pathsMap, "alias4", true);
+  }
+
   private static void checkMapping(
-      ImmutableSortedMap<PathFragment, NestedSet<PathFragment>> pathsMap,
+      ImmutableSortedMap<PathFragment, PhonyTarget<PathFragment>> pathsMap,
       String key,
+      String... values) {
+    checkMapping(pathsMap, key, false, values);
+  }
+
+  private static void checkMapping(
+      ImmutableSortedMap<PathFragment, PhonyTarget<PathFragment>> pathsMap,
+      String key,
+      boolean isAlwaysDirty,
       String... values) {
     Set<PathFragment> expectedPaths =
         Arrays.stream(values).map(PathFragment::create).collect(Collectors.toSet());
-    assertThat(pathsMap.get(PathFragment.create(key)).toSet())
-        .containsExactlyElementsIn(expectedPaths);
+    PhonyTarget<PathFragment> phonyTarget = pathsMap.get(PathFragment.create(key));
+    assertThat(phonyTarget).isNotNull();
+    assertThat(phonyTarget.isAlwaysDirty()).isEqualTo(isAlwaysDirty);
+    assertThat(phonyTarget.getInputs().toSet()).containsExactlyElementsIn(expectedPaths);
   }
 
   private static ImmutableSortedMap<PathFragment, NinjaTarget> buildPhonyTargets(


### PR DESCRIPTION
Always-dirty phony targets are those which do not have any inputs: "build alias: phony".
Ninja specification says:
"phony can also be used to create dummy targets for files which may not exist at build time. If a phony build statement is written without any dependencies, the target will be considered out of date if it does not exist. Without a phony build statement, Ninja will report an error if the file does not exist and is required by the build."
So actually Ninja leaves the possibility that the phony target file *may* exist, and then it is not always dirty.
However in our case, we in general do not allow explicit expression of the circular dependency on self-outputs (instead, action cache should determine whether the outputs already exist and do not have to be rebuilt), so we will interpret phony actions without inputs as always dirty.

All usual direct dependants of those actions automatically also always-dirty (but not
the transitive dependants: they should check whether their computed inputs have changed).
As phony targets are not performing any actions,

*all phony transitive dependants of always-dirty phony targets are themselves always-dirty.*

That is why we can compute the always-dirty flag for the phony targets, and use it for marking their direct non-phony dependants as actions to be executed unconditionally.