### PR TITLE
Execute only the subgraph of Ninja targets, needed to produce require…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphArtifactsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphArtifactsHelper.java
@@ -17,7 +17,6 @@ package com.google.devtools.build.lib.bazel.rules.ninja.actions;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
@@ -26,8 +25,6 @@ import com.google.devtools.build.lib.bazel.rules.ninja.file.GenericParsingExcept
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
-import java.util.List;
-import java.util.SortedMap;
 
 /**
  * Helper class to create artifacts for {@link NinjaAction} to be used from {@link NinjaGraphRule}.
@@ -40,7 +37,6 @@ import java.util.SortedMap;
  */
 class NinjaGraphArtifactsHelper {
   private final RuleContext ruleContext;
-  private final List<PathFragment> pathsToBuild;
   private final Path outputRootInSources;
   private final PathFragment outputRootPath;
   private final PathFragment workingDirectory;
@@ -48,7 +44,6 @@ class NinjaGraphArtifactsHelper {
 
   private final ImmutableSortedMap<PathFragment, Artifact> depsNameToArtifact;
   private final ImmutableSortedMap<PathFragment, Artifact> srcsMap;
-  private final SortedMap<PathFragment, Artifact> outputsMap;
 
   /**
    * Constructor
@@ -61,7 +56,6 @@ class NinjaGraphArtifactsHelper {
    * @param srcsMap mapping between the path fragment and artifact for the files passed in 'srcs'
    *     attribute
    * @param depsNameToArtifact mapping between the path fragment in the Ninja file and prebuilt
-   * @param pathsToBuild list of paths to files required in output groups
    */
   NinjaGraphArtifactsHelper(
       RuleContext ruleContext,
@@ -69,15 +63,12 @@ class NinjaGraphArtifactsHelper {
       PathFragment outputRootPath,
       PathFragment workingDirectory,
       ImmutableSortedMap<PathFragment, Artifact> srcsMap,
-      ImmutableSortedMap<PathFragment, Artifact> depsNameToArtifact,
-      List<PathFragment> pathsToBuild) {
+      ImmutableSortedMap<PathFragment, Artifact> depsNameToArtifact) {
     this.ruleContext = ruleContext;
-    this.pathsToBuild = pathsToBuild;
     this.outputRootInSources =
         Preconditions.checkNotNull(sourceRoot.asPath()).getRelative(outputRootPath);
     this.outputRootPath = outputRootPath;
     this.workingDirectory = workingDirectory;
-    this.outputsMap = Maps.newTreeMap();
     this.srcsMap = srcsMap;
     this.depsNameToArtifact = depsNameToArtifact;
     Path execRoot =
@@ -105,9 +96,6 @@ class NinjaGraphArtifactsHelper {
     DerivedArtifact derivedArtifact =
         ruleContext.getDerivedArtifact(
             pathRelativeToWorkspaceRoot.relativeTo(outputRootPath), derivedOutputRoot);
-    if (pathsToBuild.contains(pathRelativeToWorkingDirectory)) {
-      outputsMap.put(pathRelativeToWorkingDirectory, derivedArtifact);
-    }
     return derivedArtifact;
   }
 
@@ -139,9 +127,5 @@ class NinjaGraphArtifactsHelper {
 
   public PathFragment getWorkingDirectory() {
     return workingDirectory;
-  }
-
-  public ImmutableSortedMap<PathFragment, Artifact> getOutputsMap() {
-    return ImmutableSortedMap.copyOf(outputsMap);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTarget.java
@@ -1,0 +1,54 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.rules.ninja.actions;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.util.function.Consumer;
+
+/**
+ * Helper class to represent "evaluated" phony target.
+ */
+public class PhonyTarget {
+  private final ImmutableList<PathFragment> phonyClosureNames;
+  private final ImmutableList<PathFragment> directUsualInputs;
+
+  public PhonyTarget(
+      ImmutableList<PathFragment> phonyClosureNames,
+      ImmutableList<PathFragment> directUsualInputs) {
+    this.phonyClosureNames = phonyClosureNames;
+    this.directUsualInputs = directUsualInputs;
+  }
+
+  public ImmutableList<PathFragment> getPhonyClosureNames() {
+    return phonyClosureNames;
+  }
+
+  public ImmutableList<PathFragment> getDirectUsualInputs() {
+    return directUsualInputs;
+  }
+
+  public void visitUsualInputs(ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap,
+      Consumer<ImmutableList<PathFragment>> consumer) {
+    consumer.accept(directUsualInputs);
+    // phonyTarget.getPhonyClosureNames() is flattened transitive closure,
+    // only visit first layer.
+    phonyClosureNames.forEach(name ->
+        consumer.accept(
+            Preconditions.checkNotNull(phonyTargetsMap.get(name)).getDirectUsualInputs()));
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTargetArtifacts.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTargetArtifacts.java
@@ -1,0 +1,73 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.rules.ninja.actions;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.bazel.rules.ninja.file.GenericParsingException;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Helper class for caching computation of transitive inclusion of usual targets into phony.
+ * (We can not compute all artifacts for all phony targets because some of them may not be created
+ * by a subgraph of required actions.)
+ */
+public class PhonyTargetArtifacts {
+  private final LoadingCache<PathFragment, NestedSet<Artifact>> cache;
+
+  public PhonyTargetArtifacts(
+      ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap,
+      NinjaGraphArtifactsHelper artifactsHelper) {
+    // phonyClosureNames are flattened list of the phony target names in the transitive closure.
+    CacheLoader<PathFragment, NestedSet<Artifact>> loader = new CacheLoader<PathFragment, NestedSet<Artifact>>() {
+      @Override
+      public NestedSet<Artifact> load(PathFragment phonyName) throws Exception {
+        PhonyTarget phonyTarget = phonyTargetsMap.get(phonyName);
+        Preconditions.checkNotNull(phonyTarget);
+        NestedSetBuilder<Artifact> builder = NestedSetBuilder.stableOrder();
+        for (PathFragment input : phonyTarget.getDirectUsualInputs()) {
+          builder.add(artifactsHelper.getInputArtifact(input));
+        }
+        // phonyClosureNames are flattened list of the phony target names in the transitive closure.
+        for (PathFragment phonyClosureName : phonyTarget.getPhonyClosureNames()) {
+          NestedSet<Artifact> nestedSet = cache.get(phonyClosureName);
+          Preconditions.checkNotNull(nestedSet);
+          builder.addTransitive(nestedSet);
+        }
+        return builder.build();
+      }
+    };
+    cache = CacheBuilder.newBuilder().build(loader);
+  }
+
+  public NestedSet<Artifact> getPhonyTargetArtifacts(PathFragment phonyName)
+      throws GenericParsingException {
+    try {
+      return cache.get(phonyName);
+    } catch (ExecutionException e) {
+      Throwables.throwIfInstanceOf(e, GenericParsingException.class);
+      Throwables.throwIfInstanceOf(e, Error.class);
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaTarget.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.Immutable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /** Ninja target (build statement) representation. */
@@ -180,6 +181,26 @@ public final class NinjaTarget {
         + prettyPrintPaths("\n", getUsualInputs())
         + prettyPrintPaths("\n| ", getImplicitInputs())
         + prettyPrintPaths("\n|| ", getOrderOnlyInputs());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NinjaTarget that = (NinjaTarget) o;
+    // Note: NinjaScope is compared with default Object#equals; it is enough
+    // because we do not do any copies of NinjaScope.
+    return offset == that.offset &&
+        scope.equals(that.scope);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(scope, offset);
   }
 
   private static String prettyPrintPaths(String startDelimiter, Collection<PathFragment> paths) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaGraphTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaGraphTest.java
@@ -75,7 +75,7 @@ public class NinjaGraphTest extends BuildViewTestCase {
             "ninja_graph(name = 'graph', output_root = 'build_config',",
             " working_directory = 'build_config',",
             " main = 'build_config/build.ninja',",
-            " output_root_inputs = ['input.txt'])");
+            " output_root_inputs = ['input.txt'], output_groups= {'main': ['hello.txt']})");
     assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
     RuleConfiguredTarget ninjaConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
     ImmutableList<ActionAnalysisMetadata> actions = ninjaConfiguredTarget.getActions();
@@ -128,7 +128,7 @@ public class NinjaGraphTest extends BuildViewTestCase {
             "ninja_graph(name = 'graph', output_root = 'build_config',",
             " working_directory = 'build_config',",
             " main = 'build_config/build.ninja',",
-            " output_root_inputs = ['input.txt'])");
+            " output_root_inputs = ['input.txt'], output_groups= {'main': ['alias']})");
     assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
     RuleConfiguredTarget ninjaConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
     ImmutableList<ActionAnalysisMetadata> actions = ninjaConfiguredTarget.getActions();
@@ -196,7 +196,8 @@ public class NinjaGraphTest extends BuildViewTestCase {
             "ninja_graph(name = 'graph', output_root = 'build_config',",
             " working_directory = 'build_config',",
             " main = 'build_config/build.ninja',",
-            " output_root_inputs = ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt'])");
+            " output_root_inputs = ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt'],",
+            " output_groups= {'main': ['alias']})");
     assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
     RuleConfiguredTarget ninjaConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
     ImmutableList<ActionAnalysisMetadata> actions = ninjaConfiguredTarget.getActions();
@@ -279,7 +280,8 @@ public class NinjaGraphTest extends BuildViewTestCase {
             "ninja_graph(name = 'graph', output_root = 'build_config',",
             " working_directory = 'build_config',",
             " main = 'build_config/build.ninja',",
-            " deps_mapping = {'placeholder': ':input.txt'})");
+            " deps_mapping = {'placeholder': ':input.txt'},",
+            " output_groups= {'main': ['hello.txt']})");
     assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
     RuleConfiguredTarget ninjaConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
     ImmutableList<ActionAnalysisMetadata> actions = ninjaConfiguredTarget.getActions();
@@ -296,5 +298,63 @@ public class NinjaGraphTest extends BuildViewTestCase {
     assertThat(ninjaAction.getPrimaryInput().getExecPathString()).isEqualTo("input.txt");
     assertThat(ninjaAction.getPrimaryOutput().getExecPathString())
         .isEqualTo("build_config/hello.txt");
+  }
+
+  @Test
+  public void testOnlySubGraphIsCreated() throws Exception {
+    rewriteWorkspace(
+        "workspace(name = 'test')",
+        "dont_symlink_directories_in_execroot(paths = ['build_config'])");
+
+    scratch.file("build_config/a.txt", "A");
+    scratch.file("build_config/b.txt", "B");
+    scratch.file("build_config/c.txt", "C");
+    scratch.file("build_config/d.txt", "D");
+    scratch.file("build_config/e.txt", "E");
+
+    scratch.file(
+        "build_config/build.ninja",
+        "rule cat",
+        "  command = cat ${in} > ${out}",
+        "rule echo",
+        "  command = echo \"Hello $$(cat ${in} | tr '\\r\\n' ' ')!\" > ${out}",
+        "build a: cat a.txt",
+        "build b: cat b.txt",
+        "build c: cat c.txt",
+        "build d: cat d.txt",
+        "build e: cat e.txt",
+        "build group1: phony a b c",
+        "build group2: phony d e",
+        "build inputs_alias: phony group1 group2",
+        "build hello.txt: echo inputs_alias",
+        "build alias: phony hello.txt");
+
+    ConfiguredTarget configuredTarget =
+        scratchConfiguredTarget(
+            "",
+            "graph",
+            "ninja_graph(name = 'graph', output_root = 'build_config',",
+            " working_directory = 'build_config',",
+            " main = 'build_config/build.ninja',",
+            " output_root_inputs = ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt'],",
+            " output_groups= {'main': ['group1']})");
+    assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
+    RuleConfiguredTarget ninjaConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
+    ImmutableList<ActionAnalysisMetadata> actions = ninjaConfiguredTarget.getActions();
+    assertThat(actions).hasSize(8);
+    List<String> outputs = Lists.newArrayList();
+    actions.forEach(a -> outputs.add(Iterables.getOnlyElement(a.getOutputs()).getExecPathString()));
+    assertThat(outputs)
+        .containsExactlyElementsIn(
+            new String[]{
+                "build_config/a.txt",
+                "build_config/b.txt",
+                "build_config/c.txt",
+                "build_config/d.txt",
+                "build_config/e.txt",
+                "build_config/a",
+                "build_config/b",
+                "build_config/c",
+            });
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaPhonyTargetsUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaPhonyTargetsUtilTest.java
@@ -18,9 +18,12 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.testutil.MoreAsserts.assertThrows;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.bazel.rules.ninja.actions.NinjaPhonyTargetsUtil;
+import com.google.devtools.build.lib.bazel.rules.ninja.actions.PhonyTarget;
 import com.google.devtools.build.lib.bazel.rules.ninja.file.ByteBufferFragment;
 import com.google.devtools.build.lib.bazel.rules.ninja.file.GenericParsingException;
 import com.google.devtools.build.lib.bazel.rules.ninja.lexer.NinjaLexer;
@@ -52,8 +55,8 @@ public class NinjaPhonyTargetsUtilTest {
             "build alias3: phony alias4 direct4 direct5",
             "build alias4: phony alias2");
 
-    ImmutableSortedMap<PathFragment, NestedSet<PathFragment>> pathsMap =
-        NinjaPhonyTargetsUtil.getPhonyPathsMap(buildPhonyTargets(targetTexts), pf -> pf);
+    ImmutableSortedMap<PathFragment, PhonyTarget> pathsMap =
+        NinjaPhonyTargetsUtil.getPhonyPathsMap(buildPhonyTargets(targetTexts));
 
     assertThat(pathsMap).hasSize(4);
     checkMapping(pathsMap, "alias9", "direct1", "direct2", "direct3", "direct4", "direct5");
@@ -72,8 +75,8 @@ public class NinjaPhonyTargetsUtilTest {
             "build deep1: phony leaf1",
             "build deep2: phony leaf2 alias1");
 
-    ImmutableSortedMap<PathFragment, NestedSet<PathFragment>> pathsMap =
-        NinjaPhonyTargetsUtil.getPhonyPathsMap(buildPhonyTargets(targetTexts), pf -> pf);
+    ImmutableSortedMap<PathFragment, PhonyTarget> pathsMap =
+        NinjaPhonyTargetsUtil.getPhonyPathsMap(buildPhonyTargets(targetTexts));
 
     assertThat(pathsMap).hasSize(5);
     checkMapping(pathsMap, "_alias9", "leaf1", "leaf2");
@@ -84,13 +87,14 @@ public class NinjaPhonyTargetsUtilTest {
   }
 
   private static void checkMapping(
-      ImmutableSortedMap<PathFragment, NestedSet<PathFragment>> pathsMap,
+      ImmutableSortedMap<PathFragment, PhonyTarget> pathsMap,
       String key,
       String... values) {
     Set<PathFragment> expectedPaths =
         Arrays.stream(values).map(PathFragment::create).collect(Collectors.toSet());
-    assertThat(pathsMap.get(PathFragment.create(key)).toSet())
-        .containsExactlyElementsIn(expectedPaths);
+    ImmutableSortedSet.Builder<PathFragment> paths = ImmutableSortedSet.naturalOrder();
+    pathsMap.get(PathFragment.create(key)).visitUsualInputs(pathsMap, paths::addAll);
+    assertThat(paths.build()).containsExactlyElementsIn(expectedPaths);
   }
 
   private static ImmutableSortedMap<PathFragment, NinjaTarget> buildPhonyTargets(
@@ -106,7 +110,7 @@ public class NinjaPhonyTargetsUtilTest {
 
   @Test
   public void testEmptyMap() throws Exception {
-    assertThat(NinjaPhonyTargetsUtil.getPhonyPathsMap(ImmutableSortedMap.of(), pf -> pf)).isEmpty();
+    assertThat(NinjaPhonyTargetsUtil.getPhonyPathsMap(ImmutableSortedMap.of())).isEmpty();
   }
 
   @Test
@@ -118,7 +122,7 @@ public class NinjaPhonyTargetsUtilTest {
     GenericParsingException exception =
         assertThrows(
             GenericParsingException.class,
-            () -> NinjaPhonyTargetsUtil.getPhonyPathsMap(buildPhonyTargets(targetTexts), pf -> pf));
+            () -> NinjaPhonyTargetsUtil.getPhonyPathsMap(buildPhonyTargets(targetTexts)));
     assertThat(exception)
         .hasMessageThat()
         .isEqualTo("Detected a dependency cycle involving the phony target 'alias1'");


### PR DESCRIPTION
…d outputs

Additionally, we have to modify how we work with phony targets transitive closure of artifacts: we can not compute artifacts for phony targets right away, because artifacts are registered by RuleContext and later appear to be obsolete if we do not create the actions for those artifacts (and since we now executing only a subgraph, we do not create actions for everything).
So we introduce a cache for reusing already computed transitive closures, and we keep information for phony targets which other phony targets they include.
The same cache can be reused for creating the output groups provider.