### PR TITLE
Add support for invoking bazel with args from file

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -715,6 +715,20 @@ static void RunBatchMode(
 
   jvm_args_vector.insert(jvm_args_vector.end(), command_arguments.begin(),
                          command_arguments.end());
+  if (option_processor.UsingParamFile()) {
+    blaze_util::Path param_file =
+      blaze_util::Path(startup_options.output_base).GetRelative("params");
+    string jvm_execve_exe = jvm_args_vector[0];
+
+    string content;
+    for(auto i = jvm_args_vector.begin()+1; i != jvm_args_vector.end(); ++i) {
+      content.length() == 0 ?
+        content = blaze_util::Quoted(*i) :
+        content += '\n' + blaze_util::Quoted(*i);
+    }
+    blaze_util::WriteFile(content, param_file);
+    jvm_args_vector = {jvm_execve_exe, "@" + param_file.AsCommandLineArgument()};
+  }
 
   GoToWorkspace(workspace_layout, workspace);
 

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -727,6 +727,11 @@ std::string OptionProcessor::GetCommand() const {
   return cmd_line_->command;
 }
 
+bool OptionProcessor::UsingParamFile() const {
+  assert(cmd_line_ != nullptr);
+  return cmd_line_->using_param_file;
+}
+
 StartupOptions* OptionProcessor::GetParsedStartupOptions() const {
   assert(parse_options_called_);
   return startup_options_.get();

--- a/src/main/cpp/option_processor.h
+++ b/src/main/cpp/option_processor.h
@@ -108,6 +108,9 @@ class OptionProcessor {
   // executed in.
   std::vector<std::string> GetCommandArguments() const;
 
+  // TODO
+  bool UsingParamFile() const;
+
   // Gets the arguments explicitly provided by the user's command line.
   std::vector<std::string> GetExplicitCommandArguments() const;
 

--- a/src/main/cpp/option_processor.h
+++ b/src/main/cpp/option_processor.h
@@ -38,15 +38,18 @@ struct CommandLine {
   std::vector<std::string> startup_args;
   std::string command;
   std::vector<std::string> command_args;
+  bool using_param_file;
 
   CommandLine(std::string path_to_binary_arg,
               std::vector<std::string> startup_args_arg,
               std::string command_arg,
-              std::vector<std::string> command_args_arg)
+              std::vector<std::string> command_args_arg,
+              bool using_param_file)
       : path_to_binary(std::move(path_to_binary_arg)),
         startup_args(std::move(startup_args_arg)),
         command(std::move(command_arg)),
-        command_args(std::move(command_args_arg)) {}
+        command_args(std::move(command_args_arg)),
+        using_param_file(using_param_file) {}
 };
 
 // This class is responsible for parsing the command line of the Blaze binary,

--- a/src/main/cpp/util/strings.cc
+++ b/src/main/cpp/util/strings.cc
@@ -30,6 +30,8 @@
 
 #include <cassert>
 #include <memory>  // unique_ptr
+#include <sstream>
+#include <iomanip>
 
 #include "src/main/cpp/util/exit_code.h"
 
@@ -269,6 +271,13 @@ void StringPrintf(string *str, const char *format, ...) {
 
   *str = buf;
   delete[] buf;
+}
+
+std::string Quoted(const std::string s)
+{
+  std::ostringstream ss;
+  ss << std::quoted( s.c_str() );
+  return ss.str();
 }
 
 void ToLower(string *str) {

--- a/src/main/cpp/util/strings.h
+++ b/src/main/cpp/util/strings.h
@@ -102,6 +102,9 @@ void Tokenize(const std::string &str, const char &comment,
 // Evaluate a format string and store the result in 'str'.
 void StringPrintf(std::string *str, const char *format, ...);
 
+// TODO
+std::string Quoted(const std::string s);
+
 // Convert str to lower case. No locale handling, this is just for ASCII.
 void ToLower(std::string *str);
 

--- a/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
@@ -50,6 +50,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
@@ -60,6 +61,7 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Scanner;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -594,6 +596,20 @@ public class GrpcServerImpl extends CommandServerGrpc.CommandServerImplBase impl
         ImmutableList<String> args = request.getArgList().stream()
             .map(arg -> arg.toString(StandardCharsets.ISO_8859_1))
             .collect(ImmutableList.toImmutableList());
+
+        if (args.isEmpty() && !request.getParameterFile().isEmpty()) {
+          ImmutableList.Builder<String> builder = ImmutableList.builder();
+          File file = new File(request.getParameterFile());
+          try {
+            Scanner sc = new Scanner(file);
+            sc.useDelimiter("\u0000");
+            while (sc.hasNext()) {
+              builder.add(sc.next());
+            }
+            args = builder.build();
+          } catch (IOException e) {
+          }
+        }
 
         InvocationPolicy policy = InvocationPolicyParser.parsePolicy(request.getInvocationPolicy());
         logger.info(BlazeRuntime.getRequestLogString(args));

--- a/src/main/protobuf/command_server.proto
+++ b/src/main/protobuf/command_server.proto
@@ -58,6 +58,8 @@ message RunRequest {
   // came from. These options have already been parsed and already have had
   // their effect. This information should only be used for logging.
   repeated StartupOption startup_options = 6;
+
+  string parameter_file = 7;
 }
 
 // Contains the a startup option with its source file. Uses bytes to preserve


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/8609. Also see https://groups.google.com/d/msg/bazel-discuss/895-OjU2Z2A/mYlw05rpDgAJ. Allows Bazel to be invoked with all arguments coming from a file rather than using commandline arguments. For example:

```
$ cat args.txt
build
//...
$ bazel-bin/src/bazel @args.txt
INFO: Invocation ID: 5a582c6a-4a3c-4c16-bff1-619aba804783
...
```

With the current implementation: only one argfile is allowed, it should be prefixed with an `@` and the first argument (argv[1]). Argfiles should be newline separated (`\n`), one argument per line.

TODO:
- [ ] Decide param file location (tempfile? somewhere in output_base?).
- [ ] Decide `command_server.proto` changes/semantics when using argfile.
- [ ] Investigate special quoting needs of param file for JVM on Windows.
- [ ] Tests
- [ ] Documentation