### PR TITLE
Add s390x and make zip -d step more resilient

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -469,11 +469,12 @@ UNNECESSARY_DYNAMIC_LIBRARIES = select({
     "//src/conditions:arm": "*.so *.jnilib *.dll",
     "//src/conditions:linux_aarch64": "*.so *.jnilib *.dll",
     "//src/conditions:linux_ppc": "*.so *.jnilib *.dll",
-    "//src/conditions:freebsd": "*.so *.jnilib *.dll",
-    "//src/conditions:openbsd": "*.so *.jnilib *.dll",
-    # Play it safe -- better have a big binary than a slow binary
-    # zip -d does require an argument. Supply something bogus.
-    "//conditions:default": "*.bogusextension",
+    "//src/conditions:linux_s390x": "*.so *.jnilib *.dll",
+    # Default is to play it safe -- better have a big binary than a slow binary
+    #   The empty string means nothing is to be removed from the library;
+    #   the rule command tests for the empty string explictly to avoid
+    #   zip erroring when it finds nothing to remove.
+    "//conditions:default": "",
 })
 
 # Remove native libraries that are for a platform different from the one we are
@@ -482,7 +483,10 @@ genrule(
     name = "filter_netty_dynamic_libs",
     srcs = ["netty_tcnative/netty-tcnative-boringssl-static-2.0.24.Final.jar"],
     outs = ["netty_tcnative/netty-tcnative-filtered.jar"],
-    cmd = "cp $< $@ && zip -qd $@ " + UNNECESSARY_DYNAMIC_LIBRARIES,
+    cmd = "cp $< $@ && " +
+      # End successfully if there is nothing to be deleted from the archive
+      "if [ -n '" + UNNECESSARY_DYNAMIC_LIBRARIES + "' ]; then " +
+      "zip -qd $@ " + UNNECESSARY_DYNAMIC_LIBRARIES + "; fi",
 )
 
 java_import(

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -470,6 +470,8 @@ UNNECESSARY_DYNAMIC_LIBRARIES = select({
     "//src/conditions:linux_aarch64": "*.so *.jnilib *.dll",
     "//src/conditions:linux_ppc": "*.so *.jnilib *.dll",
     "//src/conditions:linux_s390x": "*.so *.jnilib *.dll",
+    "//src/conditions:freebsd": "*.so *.jnilib *.dll",
+    "//src/conditions:openbsd": "*.so *.jnilib *.dll",
     # Default is to play it safe -- better have a big binary than a slow binary
     #   The empty string means nothing is to be removed from the library;
     #   the rule command tests for the empty string explictly to avoid


### PR DESCRIPTION
Continuation of PR #10643 for application to third_party directory

Build on s390x fails because the process to remove unnecessary libraries from netty was not configured for x86. As a result, zip -d failed because it had nothing to remove. This PR does two things:

    Adds conditions for s390x to the src and third_party BUILD files, and
    Adds a condition to the genrule so that 'zip -d' does not execute if there's nothing to do.

See also Issue #9263; Pull Requests #9346 and #9945

