### PR TITLE
Introduce ninja_build for the correct composition of targets.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaActionsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaActionsHelper.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.bazel.rules.ninja.actions;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
@@ -25,7 +26,6 @@ import com.google.devtools.build.lib.actions.EmptyRunfilesSupplier;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.ShToolchain;
 import com.google.devtools.build.lib.analysis.actions.FileWriteAction;
-import com.google.devtools.build.lib.analysis.actions.SymlinkAction;
 import com.google.devtools.build.lib.bazel.rules.ninja.file.GenericParsingException;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaRule;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaRuleVariable;
@@ -41,6 +41,8 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -51,7 +53,6 @@ import java.util.stream.Collectors;
  */
 public class NinjaActionsHelper {
   private final RuleContext ruleContext;
-  private final List<String> outputRootInputs;
   private final ImmutableSortedMap<PathFragment, NinjaTarget> allUsualTargets;
   private final ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargets;
 
@@ -67,8 +68,6 @@ public class NinjaActionsHelper {
    *
    * @param ruleContext parent NinjaGraphRule rule context
    * @param artifactsHelper helper object to create artifacts
-   * @param outputRootInputs inputs under output_root directory. Should be symlinked by absolute
-   *     paths under execroot/output_root.
    * @param allUsualTargets mapping of outputs to all non-phony Ninja targets from Ninja file
    * @param phonyTargets mapping of names to all phony Ninja actions from Ninja file
    * @param phonyTargetArtifacts helper class for computing transitively included artifacts of phony
@@ -78,14 +77,12 @@ public class NinjaActionsHelper {
   NinjaActionsHelper(
       RuleContext ruleContext,
       NinjaGraphArtifactsHelper artifactsHelper,
-      List<String> outputRootInputs,
       ImmutableSortedMap<PathFragment, NinjaTarget> allUsualTargets,
       ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargets,
       PhonyTargetArtifacts phonyTargetArtifacts,
       List<PathFragment> pathsToBuild) {
     this.ruleContext = ruleContext;
     this.artifactsHelper = artifactsHelper;
-    this.outputRootInputs = outputRootInputs;
     this.allUsualTargets = allUsualTargets;
     this.phonyTargets = phonyTargets;
     this.shellExecutable = ShToolchain.getPathOrError(ruleContext);
@@ -94,39 +91,7 @@ public class NinjaActionsHelper {
     this.pathsToBuild = pathsToBuild;
   }
 
-  void process() throws GenericParsingException {
-    createSymlinkActions();
-    createNinjaActions();
-  }
-
-  private void createSymlinkActions() throws GenericParsingException {
-    if (this.outputRootInputs.isEmpty()) {
-      return;
-    }
-    for (String input : this.outputRootInputs) {
-      // output_root_inputs are relative to the output_root directory, and we should
-      // pass inside createOutputArtifact() paths, relative to working directory.
-      DerivedArtifact derivedArtifact =
-          artifactsHelper.createOutputArtifact(
-              artifactsHelper
-                  .getOutputRootPath()
-                  .getRelative(input)
-                  .relativeTo(artifactsHelper.getWorkingDirectory()));
-      // This method already expects the path relative to output_root.
-      PathFragment absolutePath =
-          artifactsHelper.createAbsolutePathUnderOutputRoot(PathFragment.create(input));
-      SymlinkAction symlinkAction =
-          SymlinkAction.toAbsolutePath(
-              ruleContext.getActionOwner(),
-              absolutePath,
-              derivedArtifact,
-              String.format(
-                  "Symlinking %s under <execroot>/%s", input, artifactsHelper.getOutputRootPath()));
-      ruleContext.registerAction(symlinkAction);
-    }
-  }
-
-  private void createNinjaActions() throws GenericParsingException {
+  void createNinjaActions() throws GenericParsingException {
     // Traverse the action graph starting from the targets, specified by the user.
     // Only create the required actions.
     Set<PathFragment> visitedPaths = Sets.newHashSet();
@@ -165,9 +130,10 @@ public class NinjaActionsHelper {
 
     NestedSetBuilder<Artifact> inputsBuilder = NestedSetBuilder.stableOrder();
     ImmutableList.Builder<Artifact> outputsBuilder = ImmutableList.builder();
-    boolean isAlwaysDirty = fillArtifacts(target, inputsBuilder, outputsBuilder);
+    TreeMap<PathFragment, Artifact> depsReplacements = Maps.newTreeMap();
+    boolean isAlwaysDirty = fillArtifacts(target, inputsBuilder, outputsBuilder, depsReplacements);
 
-    NinjaScope targetScope = createTargetScope(target);
+    NinjaScope targetScope = createTargetScope(target, depsReplacements);
     int targetOffset = target.getOffset();
     maybeCreateRspFile(rule, targetScope, targetOffset, inputsBuilder);
 
@@ -196,16 +162,23 @@ public class NinjaActionsHelper {
   private boolean fillArtifacts(
       NinjaTarget target,
       NestedSetBuilder<Artifact> inputsBuilder,
-      ImmutableList.Builder<Artifact> outputsBuilder)
+      ImmutableList.Builder<Artifact> outputsBuilder,
+      SortedMap<PathFragment, Artifact> depsReplacements)
       throws GenericParsingException {
     boolean isAlwaysDirty = false;
+    Set<PathFragment> usualInputs = Sets.newHashSet(target.getUsualInputs());
     for (PathFragment input : target.getAllInputs()) {
       PhonyTarget phonyTarget = this.phonyTargets.get(input);
       if (phonyTarget != null) {
         inputsBuilder.addTransitive(phonyTargetArtifacts.getPhonyTargetArtifacts(input));
         isAlwaysDirty |= phonyTarget.isAlwaysDirty();
       } else {
-        inputsBuilder.add(artifactsHelper.getInputArtifact(input));
+        Pair<Artifact, Boolean> pair = artifactsHelper.getInputArtifact(input);
+        Artifact artifact = pair.getFirst();
+        inputsBuilder.add(artifact);
+        if (pair.getSecond() && usualInputs.contains(input)) {
+          depsReplacements.put(input, artifact);
+        }
       }
     }
 
@@ -244,7 +217,8 @@ public class NinjaActionsHelper {
     }
   }
 
-  private static NinjaScope createTargetScope(NinjaTarget target) {
+  private static NinjaScope createTargetScope(NinjaTarget target,
+      TreeMap<PathFragment, Artifact> depsReplacements) {
     ImmutableSortedMap.Builder<String, List<Pair<Integer, String>>> builder =
         ImmutableSortedMap.naturalOrder();
     target
@@ -252,7 +226,13 @@ public class NinjaActionsHelper {
         .forEach((key, value) -> builder.put(key, ImmutableList.of(Pair.of(0, value))));
     String inNewline =
         target.getUsualInputs().stream()
-            .map(PathFragment::getPathString)
+            .map(fragment -> {
+              Artifact bazelArtifact = depsReplacements.get(fragment);
+              if (bazelArtifact != null) {
+                return bazelArtifact.getPath().getPathString();
+              }
+              return fragment.getPathString();
+            })
             .collect(Collectors.joining("\n"));
     String out =
         target.getOutputs().stream()

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaBuild.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaBuild.java
@@ -1,0 +1,190 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.rules.ninja.actions;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.MutableActionGraph.ActionConflictException;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.FileProvider;
+import com.google.devtools.build.lib.analysis.RuleConfiguredTargetBuilder;
+import com.google.devtools.build.lib.analysis.RuleConfiguredTargetFactory;
+import com.google.devtools.build.lib.analysis.RuleContext;
+import com.google.devtools.build.lib.analysis.RunfilesProvider;
+import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
+import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget.Mode;
+import com.google.devtools.build.lib.bazel.rules.ninja.file.GenericParsingException;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetVisitor;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetVisitor.VisitedState;
+import com.google.devtools.build.lib.collect.nestedset.Order;
+import com.google.devtools.build.lib.packages.Type;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/** Configured target factory for {@link NinjaBuildRule}. */
+public class NinjaBuild implements RuleConfiguredTargetFactory {
+
+  @Override
+  public ConfiguredTarget create(RuleContext ruleContext)
+      throws InterruptedException, RuleErrorException, ActionConflictException {
+    Map<String, List<String>> outputGroupsMap =
+        ruleContext.attributes().get("output_groups", Type.STRING_LIST_DICT);
+    NinjaGraphProvider graphProvider =
+        ruleContext.getPrerequisite("ninja_graph", Mode.TARGET, NinjaGraphProvider.class);
+    Preconditions.checkNotNull(graphProvider);
+    List<PathFragment> pathsToBuild =
+        outputGroupsMap.values().stream()
+            .flatMap(List::stream)
+            .map(PathFragment::create)
+            .collect(Collectors.toList());
+    NinjaGraphArtifactsHelper artifactsHelper =
+        new NinjaGraphArtifactsHelper(
+            ruleContext,
+            graphProvider.getOutputRoot(),
+            graphProvider.getWorkingDirectory(),
+            createSrcsMap(ruleContext),
+            createDepsMap(ruleContext, graphProvider.getWorkingDirectory()));
+    if (ruleContext.hasErrors()) {
+      return null;
+    }
+
+    try {
+      PhonyTargetArtifacts phonyTargetArtifacts = new PhonyTargetArtifacts(
+          graphProvider.getPhonyTargetsMap(), artifactsHelper);
+      new NinjaActionsHelper(
+          ruleContext,
+          artifactsHelper,
+          graphProvider.getUsualTargets(),
+          graphProvider.getPhonyTargetsMap(),
+          phonyTargetArtifacts, pathsToBuild).createNinjaActions();
+
+      if (!checkOrphanArtifacts(ruleContext)) {
+        return null;
+      }
+
+      NestedSetBuilder<Artifact> filesToBuild = NestedSetBuilder.stableOrder();
+      TreeMap<String, NestedSet<Artifact>> groups = Maps.newTreeMap();
+      for (Map.Entry<String, List<String>> entry : outputGroupsMap.entrySet()) {
+        NestedSet<Artifact> artifacts =
+            getGroupArtifacts(
+                ruleContext,
+                entry.getValue(),
+                graphProvider.getPhonyTargetsMap(),
+                phonyTargetArtifacts, artifactsHelper);
+        groups.put(entry.getKey(), artifacts);
+        filesToBuild.addTransitive(artifacts);
+      }
+
+      if (ruleContext.hasErrors()) {
+        return null;
+      }
+
+      return new RuleConfiguredTargetBuilder(ruleContext)
+          .addProvider(RunfilesProvider.class, RunfilesProvider.EMPTY)
+          .setFilesToBuild(filesToBuild.build())
+          .addOutputGroups(groups)
+          .build();
+    } catch (GenericParsingException e) {
+      ruleContext.ruleError(e.getMessage());
+      return null;
+    }
+  }
+
+  private static boolean checkOrphanArtifacts(RuleContext ruleContext) {
+    ImmutableSet<Artifact> orphanArtifacts =
+        ruleContext.getAnalysisEnvironment().getOrphanArtifacts();
+    if (!orphanArtifacts.isEmpty()) {
+      List<String> paths =
+          orphanArtifacts.stream().map(Artifact::getExecPathString).collect(Collectors.toList());
+      ruleContext.ruleError(
+          "The following artifacts do not have a generating action in Ninja file: "
+              + String.join(", ", paths));
+      return false;
+    }
+    return true;
+  }
+
+  private static NestedSet<Artifact> getGroupArtifacts(
+      RuleContext ruleContext,
+      List<String> targets,
+      ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap,
+      PhonyTargetArtifacts phonyTargetsArtifacts,
+      NinjaGraphArtifactsHelper artifactsHelper) throws GenericParsingException {
+    NestedSetBuilder<Artifact> nestedSetBuilder = NestedSetBuilder.stableOrder();
+    for (String target : targets) {
+      PathFragment path = PathFragment.create(target);
+      if (phonyTargetsMap.containsKey(path)) {
+        NestedSet<Artifact> artifacts = phonyTargetsArtifacts.getPhonyTargetArtifacts(path);
+        nestedSetBuilder.addTransitive(artifacts);
+      } else {
+        Artifact usualArtifact = artifactsHelper.createOutputArtifact(path);
+        if (usualArtifact == null) {
+          ruleContext.ruleError(
+              String.format("Required target '%s' is not created in ninja_graph.", path));
+          return NestedSetBuilder.emptySet(Order.STABLE_ORDER);
+        }
+        nestedSetBuilder.add(usualArtifact);
+      }
+    }
+    return nestedSetBuilder.build();
+  }
+
+  private static ImmutableSortedMap<PathFragment, Artifact> createSrcsMap(RuleContext ruleContext) {
+    ImmutableList<Artifact> srcs = ruleContext.getPrerequisiteArtifacts("srcs", Mode.TARGET).list();
+    ImmutableSortedMap.Builder<PathFragment, Artifact> inputsMapBuilder =
+        ImmutableSortedMap.naturalOrder();
+    srcs.forEach(a -> inputsMapBuilder.put(a.getRootRelativePath(), a));
+    return inputsMapBuilder.build();
+  }
+
+  private static ImmutableSortedMap<PathFragment, Artifact> createDepsMap(
+      RuleContext ruleContext,
+      PathFragment workingDirectory)
+      throws InterruptedException {
+    FileProvider fileProvider = ruleContext
+        .getPrerequisite("ninja_graph", Mode.TARGET, FileProvider.class);
+    Preconditions.checkNotNull(fileProvider);
+    Map<String, TransitiveInfoCollection> mapping = ruleContext.getPrerequisiteMap("deps_mapping");
+    ImmutableSortedMap.Builder<PathFragment, Artifact> builder = ImmutableSortedMap.naturalOrder();
+    new NestedSetVisitor<Artifact>(a -> {
+      builder.put(a.getExecPath().relativeTo(workingDirectory), a);
+    },
+        new VisitedState<>()).visit(fileProvider.getFilesToBuild());
+    for (Map.Entry<String, TransitiveInfoCollection> entry : mapping.entrySet()) {
+      NestedSet<Artifact> filesToBuild =
+          entry.getValue().getProvider(FileProvider.class).getFilesToBuild();
+      if (!filesToBuild.isSingleton()) {
+        ruleContext.attributeError(
+            "deps_mapping",
+            String.format(
+                "'%s' contains more than one output. "
+                    + "deps_mapping should only contain targets, producing a single output file.",
+                entry.getValue().getLabel().getCanonicalForm()));
+        return ImmutableSortedMap.of();
+      }
+      builder.put(PathFragment.create(entry.getKey()), filesToBuild.getSingleton());
+    }
+    return builder.build();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaBuildRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaBuildRule.java
@@ -1,0 +1,80 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.rules.ninja.actions;
+
+import static com.google.devtools.build.lib.packages.Attribute.attr;
+import static com.google.devtools.build.lib.packages.BuildType.LABEL;
+import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.analysis.BaseRuleClasses;
+import com.google.devtools.build.lib.analysis.RuleDefinition;
+import com.google.devtools.build.lib.analysis.RuleDefinitionEnvironment;
+import com.google.devtools.build.lib.packages.BuildType;
+import com.google.devtools.build.lib.packages.RuleClass;
+import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
+import com.google.devtools.build.lib.packages.Type;
+import com.google.devtools.build.lib.util.FileType;
+import com.google.devtools.build.lib.util.FileTypeSet;
+
+/**
+ * The rule creates the action subgraph from graph of
+ * {@link com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaTarget},
+ * parsed by {@link NinjaGraphRule} and passed in the form of {@link NinjaGraphProvider}.
+ *
+ * The subgraph is computed as all actions needed to build targets from 'output_groups'
+ * (phony targets can also be passed there).
+ * Bazel-built inputs should be passed with 'deps_mapping' attribute.
+ */
+public class NinjaBuildRule implements RuleDefinition {
+  @Override
+  public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment environment) {
+    return builder
+        .add(
+            attr("ninja_graph", LABEL)
+                .allowedFileTypes(FileTypeSet.ANY_FILE)
+                .allowedRuleClasses("ninja_graph")
+                .setDoc("ninja_graph that parses all Ninja files that compose a graph of actions."))
+        .add(
+            attr("srcs", LABEL_LIST)
+                .allowedFileTypes(FileTypeSet.ANY_FILE)
+                .setDoc("Source files requested by Ninja graph actions."))
+        .add(
+            attr("deps_mapping", BuildType.LABEL_DICT_UNARY)
+                .allowedFileTypes(FileTypeSet.ANY_FILE)
+                .setDoc(
+                    "Mapping of paths in the Ninja file to the Bazel-built dependencies. Main"
+                        + " output of each dependency will be used as an input to the Ninja"
+                        + " action,which refers to the corresponding path.")
+                .value(ImmutableMap.of()))
+        .add(
+            attr("output_groups", Type.STRING_LIST_DICT)
+                .setDoc(
+                    "Mapping of output groups to the list of output paths in the Ninja file. "
+                        + "Only the output paths mentioned in this attribute will be built."
+                        + " Phony target names may be specified as the output paths."))
+        .build();
+  }
+
+  @Override
+  public Metadata getMetadata() {
+    return RuleDefinition.Metadata.builder()
+        .name("ninja_build")
+        .type(RuleClassType.NORMAL)
+        .ancestors(BaseRuleClasses.BaseRule.class)
+        .factoryClass(NinjaBuild.class)
+        .build();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraph.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraph.java
@@ -17,24 +17,20 @@ package com.google.devtools.build.lib.bazel.rules.ninja.actions;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.actions.MutableActionGraph.ActionConflictException;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
-import com.google.devtools.build.lib.analysis.FileProvider;
 import com.google.devtools.build.lib.analysis.RuleConfiguredTargetBuilder;
 import com.google.devtools.build.lib.analysis.RuleConfiguredTargetFactory;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.RunfilesProvider;
-import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.actions.SymlinkAction;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget.Mode;
 import com.google.devtools.build.lib.bazel.rules.ninja.file.GenericParsingException;
@@ -55,8 +51,6 @@ import com.google.devtools.build.skyframe.SkyKey;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 
@@ -102,6 +96,7 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
             ruleContext,
             outputRoot,
             workingDirectory,
+            ImmutableSortedMap.of(),
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of());
     if (ruleContext.hasErrors()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphProvider.java
@@ -1,0 +1,58 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.rules.ninja.actions;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.devtools.build.lib.analysis.TransitiveInfoProvider;
+import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaTarget;
+import com.google.devtools.build.lib.vfs.PathFragment;
+
+/**
+ * Provider for passing information between {@link NinjaGraphRule} and {@link NinjaBuildRule}.
+ * Represents all usual and phony {@link NinjaTarget}s from the Ninja graph.
+ */
+public class NinjaGraphProvider implements TransitiveInfoProvider {
+  private final PathFragment outputRoot;
+  private final PathFragment workingDirectory;
+  private final ImmutableSortedMap<PathFragment, NinjaTarget> usualTargets;
+  private final ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap;
+
+  public NinjaGraphProvider(
+      PathFragment outputRoot,
+      PathFragment workingDirectory,
+      ImmutableSortedMap<PathFragment, NinjaTarget> usualTargets,
+      ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap) {
+    this.outputRoot = outputRoot;
+    this.workingDirectory = workingDirectory;
+    this.usualTargets = usualTargets;
+    this.phonyTargetsMap = phonyTargetsMap;
+  }
+
+  public PathFragment getOutputRoot() {
+    return outputRoot;
+  }
+
+  public PathFragment getWorkingDirectory() {
+    return workingDirectory;
+  }
+
+  public ImmutableSortedMap<PathFragment, NinjaTarget> getUsualTargets() {
+    return usualTargets;
+  }
+
+  public ImmutableSortedMap<PathFragment, PhonyTarget> getPhonyTargetsMap() {
+    return phonyTargetsMap;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaRulesModule.java
@@ -22,5 +22,6 @@ public class NinjaRulesModule extends BlazeModule {
   @Override
   public void initializeRuleClasses(ConfiguredRuleClassProvider.Builder builder) {
     builder.addRuleDefinition(new NinjaGraphRule());
+    builder.addRuleDefinition(new NinjaBuildRule());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTargetArtifacts.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTargetArtifacts.java
@@ -53,7 +53,7 @@ public class PhonyTargetArtifacts {
     Preconditions.checkNotNull(phonyTarget);
     NestedSetBuilder<Artifact> builder = NestedSetBuilder.stableOrder();
     for (PathFragment input : phonyTarget.getDirectUsualInputs()) {
-      builder.add(artifactsHelper.getInputArtifact(input).getFirst());
+      builder.add(artifactsHelper.getInputArtifact(input));
     }
     for (PathFragment phonyName : phonyTarget.getPhonyNames()) {
       // We already checked for cycles during loading.

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTargetArtifacts.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTargetArtifacts.java
@@ -53,7 +53,7 @@ public class PhonyTargetArtifacts {
     Preconditions.checkNotNull(phonyTarget);
     NestedSetBuilder<Artifact> builder = NestedSetBuilder.stableOrder();
     for (PathFragment input : phonyTarget.getDirectUsualInputs()) {
-      builder.add(artifactsHelper.getInputArtifact(input));
+      builder.add(artifactsHelper.getInputArtifact(input).getFirst());
     }
     for (PathFragment phonyName : phonyTarget.getPhonyNames()) {
       // We already checked for cycles during loading.

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaBuildTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaBuildTest.java
@@ -1,0 +1,334 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.bazel.rules.ninja;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.devtools.build.lib.actions.ActionAnalysisMetadata;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.CommandLines.CommandLineAndParamFileInfo;
+import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.actions.SymlinkAction;
+import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
+import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.bazel.rules.ninja.actions.NinjaAction;
+import com.google.devtools.build.lib.bazel.rules.ninja.actions.NinjaBuildRule;
+import com.google.devtools.build.lib.bazel.rules.ninja.actions.NinjaGraphRule;
+import com.google.devtools.build.lib.testutil.TestRuleClassProvider;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class NinjaBuildTest extends BuildViewTestCase {
+
+  @Override
+  protected ConfiguredRuleClassProvider getRuleClassProvider() {
+    ConfiguredRuleClassProvider.Builder builder = new ConfiguredRuleClassProvider.Builder();
+    TestRuleClassProvider.addStandardRules(builder);
+    builder.addRuleDefinition(new NinjaGraphRule());
+    builder.addRuleDefinition(new NinjaBuildRule());
+    return builder.build();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    setSkylarkSemanticsOptions("--experimental_ninja_actions");
+  }
+
+  @Test
+  public void testNinjaBuildRule() throws Exception {
+    rewriteWorkspace(
+        "workspace(name = 'test')",
+        "dont_symlink_directories_in_execroot(paths = ['build_config'])");
+
+    scratch.file("build_config/input.txt", "World");
+    scratch.file(
+        "build_config/build.ninja",
+        "rule echo",
+        "  command = echo \"Hello $$(cat ${in})!\" > ${out}",
+        "build build_config/hello.txt: echo build_config/input.txt");
+
+    // Working directory is workspace root.
+    ConfiguredTarget configuredTarget =
+        scratchConfiguredTarget(
+            "",
+            "ninja_target",
+            "ninja_graph(name = 'graph', output_root = 'build_config',",
+            " main = 'build_config/build.ninja',",
+            " output_root_inputs = ['input.txt'])",
+            "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
+            " output_groups= {'main': ['build_config/hello.txt']})");
+    assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
+    RuleConfiguredTarget ninjaConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
+    ImmutableList<ActionAnalysisMetadata> actions = ninjaConfiguredTarget.getActions();
+    assertThat(actions).hasSize(1);
+    ActionAnalysisMetadata action = Iterables.getOnlyElement(actions);
+    assertThat(action).isInstanceOf(NinjaAction.class);
+    NinjaAction ninjaAction = (NinjaAction) action;
+    List<CommandLineAndParamFileInfo> commandLines =
+        ninjaAction.getCommandLines().getCommandLines();
+    assertThat(commandLines).hasSize(1);
+    assertThat(commandLines.get(0).commandLine.toString())
+        .endsWith("echo \"Hello $(cat build_config/input.txt)!\" > build_config/hello.txt");
+    assertThat(ninjaAction.getPrimaryInput().getExecPathString())
+        .isEqualTo("build_config/input.txt");
+    assertThat(ninjaAction.getPrimaryOutput().getExecPathString())
+        .isEqualTo("build_config/hello.txt");
+  }
+
+  @Test
+  public void testNinjaGraphRuleWithPhonyTarget() throws Exception {
+    rewriteWorkspace(
+        "workspace(name = 'test')",
+        "dont_symlink_directories_in_execroot(paths = ['build_config'])");
+
+    scratch.file("build_config/input.txt", "World");
+    scratch.file(
+        "build_config/build.ninja",
+        "rule echo",
+        "  command = echo \"Hello $$(cat ${in})!\" > ${out}",
+        "build hello.txt: echo input.txt",
+        "build alias: phony hello.txt");
+
+    ConfiguredTarget configuredTarget =
+        scratchConfiguredTarget(
+            "",
+            "ninja_target",
+            "ninja_graph(name = 'graph', output_root = 'build_config',",
+            " working_directory = 'build_config',",
+            " main = 'build_config/build.ninja',",
+            " output_root_inputs = ['input.txt'])",
+            "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
+            " output_groups= {'main': ['alias']})");
+    assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
+    RuleConfiguredTarget ninjaConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
+    ImmutableList<ActionAnalysisMetadata> actions = ninjaConfiguredTarget.getActions();
+    ActionAnalysisMetadata action = Iterables.getOnlyElement(actions);
+
+    assertThat(actions).hasSize(1);
+    assertThat(action).isInstanceOf(NinjaAction.class);
+    NinjaAction ninjaAction = (NinjaAction) action;
+    List<CommandLineAndParamFileInfo> commandLines =
+        ninjaAction.getCommandLines().getCommandLines();
+    assertThat(commandLines).hasSize(1);
+    assertThat(commandLines.get(0).commandLine.toString())
+        .endsWith("cd build_config && echo \"Hello $(cat input.txt)!\" > hello.txt");
+    assertThat(ninjaAction.getPrimaryInput().getExecPathString())
+        .isEqualTo("build_config/input.txt");
+    assertThat(ninjaAction.getPrimaryOutput().getExecPathString())
+        .isEqualTo("build_config/hello.txt");
+  }
+
+  @Test
+  public void testNinjaGraphRuleWithPhonyTree() throws Exception {
+    rewriteWorkspace(
+        "workspace(name = 'test')",
+        "dont_symlink_directories_in_execroot(paths = ['build_config'])");
+
+    scratch.file("build_config/a.txt", "A");
+    scratch.file("build_config/b.txt", "B");
+    scratch.file("build_config/c.txt", "C");
+    scratch.file("build_config/d.txt", "D");
+    scratch.file("build_config/e.txt", "E");
+
+    scratch.file(
+        "build_config/build.ninja",
+        "rule cat",
+        "  command = cat ${in} > ${out}",
+        "rule echo",
+        "  command = echo \"Hello $$(cat ${in} | tr '\\r\\n' ' ')!\" > ${out}",
+        "build a: cat a.txt",
+        "build b: cat b.txt",
+        "build c: cat c.txt",
+        "build d: cat d.txt",
+        // e should be executed unconditionally as it depends on always-dirty phony action
+        "build e: cat e.txt always_dirty",
+        "build always_dirty: phony",
+        "build group1: phony a b c",
+        "build group2: phony d e",
+        "build inputs_alias: phony group1 group2",
+        "build hello.txt: echo inputs_alias",
+        "build alias: phony hello.txt");
+
+    ConfiguredTarget configuredTarget =
+        scratchConfiguredTarget(
+            "",
+            "ninja_target",
+            "ninja_graph(name = 'graph', output_root = 'build_config',",
+            " working_directory = 'build_config',",
+            " main = 'build_config/build.ninja',",
+            " output_root_inputs = ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt'])",
+            "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
+            " output_groups= {'main': ['alias']})");
+    assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
+    RuleConfiguredTarget ninjaConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
+    ImmutableList<ActionAnalysisMetadata> actions = ninjaConfiguredTarget.getActions();
+    assertThat(actions).hasSize(6);
+    List<String> outputs = Lists.newArrayList();
+    actions.forEach(a -> outputs.add(Iterables.getOnlyElement(a.getOutputs()).getExecPathString()));
+    assertThat(outputs)
+        .containsExactlyElementsIn(
+            new String[] {
+                "build_config/hello.txt",
+                "build_config/a",
+                "build_config/b",
+                "build_config/c",
+                "build_config/d",
+                "build_config/e"
+            });
+
+    for (ActionAnalysisMetadata action : actions) {
+      Artifact artifact = action.getPrimaryOutput();
+      if ("hello.txt".equals(artifact.getFilename())) {
+        assertThat(action).isInstanceOf(NinjaAction.class);
+        NinjaAction ninjaAction = (NinjaAction) action;
+        List<CommandLineAndParamFileInfo> commandLines =
+            ninjaAction.getCommandLines().getCommandLines();
+        assertThat(commandLines).hasSize(1);
+        assertThat(commandLines.get(0).commandLine.toString())
+            .contains(
+                "cd build_config && echo \"Hello $(cat inputs_alias | tr '\\r\\n' ' ')!\""
+                    + " > hello.txt");
+        List<String> inputPaths =
+            ninjaAction.getInputs().toList().stream()
+                .map(Artifact::getExecPathString)
+                .collect(Collectors.toList());
+        assertThat(inputPaths)
+            .containsExactly(
+                "build_config/a",
+                "build_config/b",
+                "build_config/c",
+                "build_config/d",
+                "build_config/e");
+        assertThat(ninjaAction.getPrimaryOutput().getExecPathString())
+            .isEqualTo("build_config/hello.txt");
+      } else if ("e".equals(artifact.getFilename())) {
+        assertThat(action).isInstanceOf(NinjaAction.class);
+        NinjaAction ninjaAction = (NinjaAction) action;
+        List<CommandLineAndParamFileInfo> commandLines =
+            ninjaAction.getCommandLines().getCommandLines();
+        assertThat(commandLines).hasSize(1);
+        assertThat(commandLines.get(0).commandLine.toString())
+            .endsWith("cd build_config && cat e.txt always_dirty > e");
+        assertThat(ninjaAction.executeUnconditionally()).isTrue();
+      }
+    }
+  }
+
+  @Test
+  public void testDepsMapping() throws Exception {
+    rewriteWorkspace(
+        "workspace(name = 'test')",
+        "dont_symlink_directories_in_execroot(paths = ['build_config'])");
+
+    scratch.file("input.txt", "World");
+    scratch.file(
+        "build_config/build.ninja",
+        "rule echo",
+        "  command = echo \"Hello $$(cat ${in})!\" > ${out}",
+        "build hello.txt: echo placeholder");
+
+    ConfiguredTarget configuredTarget =
+        scratchConfiguredTarget(
+            "",
+            "ninja_target",
+            "ninja_graph(name = 'graph', output_root = 'build_config',",
+            " working_directory = 'build_config',",
+            " main = 'build_config/build.ninja')",
+            "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
+            " output_groups= {'main': ['hello.txt']},",
+            " deps_mapping = {'placeholder': ':input.txt'})");
+    assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
+    RuleConfiguredTarget ninjaConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
+    ImmutableList<ActionAnalysisMetadata> actions = ninjaConfiguredTarget.getActions();
+    assertThat(actions).hasSize(1);
+
+    ActionAnalysisMetadata action = Iterables.getOnlyElement(actions);
+    assertThat(action).isInstanceOf(NinjaAction.class);
+    NinjaAction ninjaAction = (NinjaAction) action;
+    List<CommandLineAndParamFileInfo> commandLines =
+        ninjaAction.getCommandLines().getCommandLines();
+    assertThat(commandLines).hasSize(1);
+    assertThat(commandLines.get(0).commandLine.toString())
+        .endsWith("cd build_config && echo \"Hello $(cat placeholder)!\" > hello.txt");
+    assertThat(ninjaAction.getPrimaryInput().getExecPathString()).isEqualTo("input.txt");
+    assertThat(ninjaAction.getPrimaryOutput().getExecPathString())
+        .isEqualTo("build_config/hello.txt");
+  }
+
+  @Test
+  public void testOnlySubGraphIsCreated() throws Exception {
+    rewriteWorkspace(
+        "workspace(name = 'test')",
+        "dont_symlink_directories_in_execroot(paths = ['build_config'])");
+
+    scratch.file("build_config/a.txt", "A");
+    scratch.file("build_config/b.txt", "B");
+    scratch.file("build_config/c.txt", "C");
+    scratch.file("build_config/d.txt", "D");
+    scratch.file("build_config/e.txt", "E");
+
+    scratch.file(
+        "build_config/build.ninja",
+        "rule cat",
+        "  command = cat ${in} > ${out}",
+        "rule echo",
+        "  command = echo \"Hello $$(cat ${in} | tr '\\r\\n' ' ')!\" > ${out}",
+        "build a: cat a.txt",
+        "build b: cat b.txt",
+        "build c: cat c.txt",
+        "build d: cat d.txt",
+        "build e: cat e.txt",
+        "build group1: phony a b c",
+        "build group2: phony d e",
+        "build inputs_alias: phony group1 group2",
+        "build hello.txt: echo inputs_alias",
+        "build alias: phony hello.txt");
+
+    ConfiguredTarget configuredTarget =
+        scratchConfiguredTarget(
+            "",
+            "ninja_target",
+            "ninja_graph(name = 'graph', output_root = 'build_config',",
+            " working_directory = 'build_config',",
+            " main = 'build_config/build.ninja',",
+            " output_root_inputs = ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt'])",
+            "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
+            " output_groups= {'main': ['group1']})");
+    assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
+    RuleConfiguredTarget ninjaConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
+    ImmutableList<ActionAnalysisMetadata> actions = ninjaConfiguredTarget.getActions();
+    assertThat(actions).hasSize(3);
+    List<String> outputs = Lists.newArrayList();
+    actions.forEach(a -> outputs.add(Iterables.getOnlyElement(a.getOutputs()).getExecPathString()));
+    assertThat(outputs)
+        .containsExactlyElementsIn(
+            new String[]{
+                "build_config/a",
+                "build_config/b",
+                "build_config/c",
+            });
+  }
+
+}

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaBuildTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaBuildTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+/** Test for {@link NinjaBuild} configured target factory. */
 @RunWith(JUnit4.class)
 public class NinjaBuildTest extends BuildViewTestCase {
 
@@ -271,7 +272,7 @@ public class NinjaBuildTest extends BuildViewTestCase {
         ninjaAction.getCommandLines().getCommandLines();
     assertThat(commandLines).hasSize(1);
     assertThat(commandLines.get(0).commandLine.toString())
-        .endsWith("cd build_config && echo \"Hello $(cat placeholder)!\" > hello.txt");
+        .endsWith("cd build_config && echo \"Hello $(cat /workspace/input.txt)!\" > hello.txt");
     assertThat(ninjaAction.getPrimaryInput().getExecPathString()).isEqualTo("input.txt");
     assertThat(ninjaAction.getPrimaryOutput().getExecPathString())
         .isEqualTo("build_config/hello.txt");

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/NinjaBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/NinjaBlackBoxTest.java
@@ -46,18 +46,19 @@ public class NinjaBlackBoxTest extends AbstractBlackBoxTest {
             "ninja_graph(name = 'graph', output_root = 'build_dir',",
             " working_directory = 'build_dir',",
             " main = 'build_dir/build.ninja',",
-            " output_root_inputs = ['input.txt'],",
+            " output_root_inputs = ['input.txt'])",
+            "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
             " output_groups = {'group': ['hello.txt']})");
 
     BuilderRunner bazel = context().bazel().withFlags("--experimental_ninja_actions");
-    assertConfigured(bazel.build("//:graph"));
+    assertConfigured(bazel.build("//:ninja_target"));
     Path path = context().resolveExecRootPath(bazel, "build_dir/hello.txt");
     assertThat(path.toFile().exists()).isTrue();
     assertThat(Files.readAllLines(path)).containsExactly("Hello World!");
 
     // React to input change.
     context().write("build_dir/input.txt", "Sun");
-    assertNothingConfigured(bazel.build("//:graph"));
+    assertNothingConfigured(bazel.build("//:ninja_target"));
     assertThat(Files.readAllLines(path)).containsExactly("Hello Sun!");
 
     // React to Ninja file change.
@@ -67,7 +68,7 @@ public class NinjaBlackBoxTest extends AbstractBlackBoxTest {
             "rule echo",
             "  command = echo \"Hello $$(cat ${in}):)\" > ${out}",
             "build hello.txt: echo input.txt");
-    assertConfigured(bazel.build("//:graph"));
+    assertConfigured(bazel.build("//:ninja_target"));
     assertThat(Files.readAllLines(path)).containsExactly("Hello Sun:)");
   }
 
@@ -91,11 +92,12 @@ public class NinjaBlackBoxTest extends AbstractBlackBoxTest {
             "ninja_graph(name = 'graph', output_root = 'build_dir',",
             " working_directory = 'build_dir',",
             " main = 'build_dir/build.ninja',",
-            " output_root_inputs = ['input.txt'],",
+            " output_root_inputs = ['input.txt'])",
+            "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
             " output_groups = {'group': ['hello.txt']})");
 
     BuilderRunner bazel = context().bazel();
-    ProcessResult result = bazel.shouldFail().build("//:graph");
+    ProcessResult result = bazel.shouldFail().build("//:ninja_target");
     assertThat(result.errString())
         .contains("name 'dont_symlink_directories_in_execroot' is not defined");
     assertThat(result.errString()).contains("FAILED: Build did NOT complete successfully");
@@ -120,11 +122,12 @@ public class NinjaBlackBoxTest extends AbstractBlackBoxTest {
             "BUILD",
             "ninja_graph(name = 'graph', output_root = 'build_dir',",
             " working_directory = 'build_dir',",
-            " output_root_inputs = ['input.txt'],",
+            " output_root_inputs = ['input.txt'])",
+            "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
             " output_groups = {'group': ['hello.txt']})");
 
     BuilderRunner bazel = context().bazel().withFlags("--experimental_ninja_actions");
-    ProcessResult result = bazel.shouldFail().build("//:graph");
+    ProcessResult result = bazel.shouldFail().build("//:ninja_target");
     assertThat(result.errString())
         .contains("//:graph: missing value for mandatory attribute 'main' in 'ninja_graph' rule");
     assertThat(result.errString()).contains("FAILED: Build did NOT complete successfully");
@@ -149,14 +152,15 @@ public class NinjaBlackBoxTest extends AbstractBlackBoxTest {
             "BUILD",
             "ninja_graph(name = 'graph', output_root = 'build_dir',",
             " working_directory = 'build_dir',",
-            " main = 'build_dir/build.ninja',",
+            " main = 'build_dir/build.ninja')",
+            "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
             " output_groups = {'group': ['hello.txt']})");
 
     BuilderRunner bazel = context().bazel().withFlags("--experimental_ninja_actions");
-    ProcessResult result = bazel.shouldFail().build("//:graph");
+    ProcessResult result = bazel.shouldFail().build("//:ninja_target");
     assertThat(result.errString())
         .contains(
-            "in ninja_graph rule //:graph: Ninja actions are allowed to create outputs only "
+            "in ninja_build rule //:ninja_target: Ninja actions are allowed to create outputs only "
                 + "under output_root, path '../input.txt' is not allowed.");
     assertThat(result.errString()).contains("FAILED: Build did NOT complete successfully");
   }
@@ -180,27 +184,28 @@ public class NinjaBlackBoxTest extends AbstractBlackBoxTest {
             "BUILD",
             "ninja_graph(name = 'graph', output_root = 'build_dir',",
             " working_directory = 'build_dir',",
-            " main = 'build_dir/build.ninja',",
+            " main = 'build_dir/build.ninja')",
+            "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
             " output_groups = {'group': ['hello.txt']})");
 
     BuilderRunner bazel = context().bazel().withFlags("--experimental_ninja_actions");
-    ProcessResult result = bazel.shouldFail().build("//:graph");
+    ProcessResult result = bazel.shouldFail().build("//:ninja_target");
     assertThat(result.errString())
         .contains(
-            "in ninja_graph rule //:graph: The following artifacts do not have a generating "
+            "in ninja_build rule //:ninja_target: The following artifacts do not have a generating "
                 + "action in Ninja file: build_dir/build_dir/input.txt");
     assertThat(result.errString()).contains("FAILED: Build did NOT complete successfully");
   }
 
   private static void assertNothingConfigured(ProcessResult result) {
     assertThat(result.errString())
-        .contains("INFO: Analyzed target //:graph (0 packages loaded, 0 targets configured).");
+        .contains("INFO: Analyzed target //:ninja_target (0 packages loaded, 0 targets configured).");
   }
 
   private static void assertConfigured(ProcessResult result) {
     assertThat(result.errString())
         .doesNotContain(
-            "INFO: Analyzed target //:graph (0 packages loaded, 0 targets configured).");
+            "INFO: Analyzed target //:ninja_target (0 packages loaded, 0 targets configured).");
   }
 
   @Test
@@ -224,11 +229,12 @@ public class NinjaBlackBoxTest extends AbstractBlackBoxTest {
             "ninja_graph(name = 'graph', ",
             "output_root = 'build_config',",
             " working_directory = 'build_config',",
-            " main = 'build_config/build.ninja',",
-            " output_groups = {'main': ['nano.txt']})");
+            " main = 'build_config/build.ninja')",
+            "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
+            " output_groups = {'group': ['nano.txt']})");
 
     BuilderRunner bazel = context().bazel().withFlags("--experimental_ninja_actions");
-    assertConfigured(bazel.build("//:graph"));
+    assertConfigured(bazel.build("//:ninja_target"));
     Path path = context().resolveExecRootPath(bazel, "build_config/nano.txt");
     assertThat(path.toFile().exists()).isTrue();
     List<String> text = Files.readAllLines(path);
@@ -236,8 +242,51 @@ public class NinjaBlackBoxTest extends AbstractBlackBoxTest {
     long lastModified = path.toFile().lastModified();
 
     // Should be null build, as nothing changed.
-    assertNothingConfigured(bazel.build("//:graph"));
+    assertNothingConfigured(bazel.build("//:ninja_target"));
     assertThat(Files.readAllLines(path)).containsExactly(text.get(0));
     assertThat(path.toFile().lastModified()).isEqualTo(lastModified);
+  }
+
+  @Test
+  public void testInteroperabilityWithBazel() throws Exception {
+    context()
+        .write(
+            WORKSPACE,
+            "workspace(name = 'test')",
+            "dont_symlink_directories_in_execroot(paths = ['build_dir'])");
+    context().write("bazel_input.txt", "World");
+    context()
+        .write(
+            "build_dir/build.ninja",
+            "rule echo",
+            "  command = echo \"Hello $$(cat ${in})!\" > ${out}",
+            "build hello.txt: echo placeholder",
+            "build hello2.txt: echo placeholder2");
+    context()
+        .write(
+            "BUILD",
+            "ninja_graph(name = 'graph', output_root = 'build_dir',",
+            " working_directory = 'build_dir',",
+            " main = 'build_dir/build.ninja')",
+
+            "filegroup(name = 'bazel_built_input', srcs = [':bazel_input.txt'])",
+
+            "ninja_build(name = 'ninja_target1', ninja_graph = 'graph',",
+            " deps_mapping = {'placeholder': ':bazel_built_input'},",
+            " output_groups = {'group': ['hello.txt']})",
+
+            "filegroup(name = 'bazel_middle', srcs = [':ninja_target1'])",
+
+            "ninja_build(name = 'ninja_target2', ninja_graph = 'graph',",
+            " deps_mapping = {'placeholder2': ':bazel_middle'},",
+            " output_groups = {'group': ['hello2.txt']})");
+
+    BuilderRunner bazel = context().bazel().withFlags("--experimental_ninja_actions");
+    assertConfigured(bazel.build("//..."));
+    Path path1 = context().resolveExecRootPath(bazel, "build_dir/hello.txt");
+    Path path2 = context().resolveExecRootPath(bazel, "build_dir/hello2.txt");
+
+    assertThat(Files.readAllLines(path1)).containsExactly("Hello World!");
+    assertThat(Files.readAllLines(path2)).containsExactly("Hello Hello World!!");
   }
 }


### PR DESCRIPTION
ninja_graph is responsible now only for parsing the graph and symlinking inputs under output_root. This way it will always be a leaf in the build graph, and all combinations of non-cyclic dependencies between Bazel-built and Ninja-built targets are possible.
ninja_build absorbs parsed NinjaTarget objects through NinjaGraphProvider.
ninja_build creates actions for the subgraph for the targets from output_groups.
Bazel-built dependencies are passed to ninja_build with deps_mapping attribute.
There is an interoperability with Bazel test.

! this CL additionally contains a fix for deps_mapping to also replace the path to bazel-built file in the constructed command line.