### PR TITLE
Fix builds with indirect dependency on //external with --experimental_sibling_repository_layout

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/SymlinkForest.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/SymlinkForest.java
@@ -332,8 +332,10 @@ public class SymlinkForest {
 
     for (Map.Entry<PackageIdentifier, Root> entry : packageRoots.entrySet()) {
       PackageIdentifier pkgId = entry.getKey();
-      if (!siblingRepositoryLayout && pkgId.equals(LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER)) {
-        // This isn't a "real" package, don't add it to the symlink tree.
+      if (pkgId.equals(LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER)) {
+        // //external is a virtual package, don't add it to the symlink tree. Subpackages of
+        // external, like //external/foo, are fine though.
+        // If we're using --experimental_sibling_repository_layout, we'll let the l
         continue;
       }
       RepositoryName repository = pkgId.getRepository();


### PR DESCRIPTION
Added regression tests as well. 