### PR TITLE
Fix computation of Ninja rule command line with respect to variables

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParserStep.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParserStep.java
@@ -317,7 +317,7 @@ public class NinjaParserStep {
         parseExpected(NinjaToken.NEWLINE);
       }
     }
-    return fileScope.createTargetsScope(ImmutableSortedMap.copyOf(expandedVariables));
+    return fileScope.createScopeFromExpandedValues(ImmutableSortedMap.copyOf(expandedVariables));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaScope.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaScope.java
@@ -210,7 +210,7 @@ public class NinjaScope {
     return Pair.of(pair.getFirst(), pair.getSecond());
   }
 
-  public NinjaScope createTargetsScope(
+  public NinjaScope createScopeFromExpandedValues(
       ImmutableSortedMap<String, List<Pair<Integer, String>>> expandedVariables) {
     NinjaScope scope = new NinjaScope(this, Integer.MAX_VALUE);
     scope.expandedVariables.putAll(expandedVariables);

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaBuildTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaBuildTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.actions.ActionAnalysisMetadata;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.CommandLines;
 import com.google.devtools.build.lib.actions.CommandLines.CommandLineAndParamFileInfo;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
@@ -326,5 +327,44 @@ public class NinjaBuildTest extends BuildViewTestCase {
             new String[] {
               "build_config/a", "build_config/b", "build_config/c",
             });
+  }
+
+  @Test
+  public void testRuleWithDepfileVariable() throws Exception {
+    rewriteWorkspace(
+        "workspace(name = 'test')",
+        "dont_symlink_directories_in_execroot(paths = ['build_config'])");
+
+    scratch.file("input");
+    scratch.file(
+        "build_config/build.ninja",
+        "rule rule123",
+        "  command = executable -d ${depfile} ${in} > ${out}",
+        "  depfile = ${out}.d",
+        "  deps = gcc",
+        "build out_file: rule123 ../input");
+
+    ConfiguredTarget configuredTarget =
+        scratchConfiguredTarget(
+            "",
+            "ninja_target",
+            "ninja_graph(name = 'graph', output_root = 'build_config',",
+            " working_directory = 'build_config',",
+            " main = 'build_config/build.ninja')",
+            "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
+            " srcs = ['input'],",
+            " output_groups= {'main': ['out_file']})");
+    assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
+    RuleConfiguredTarget ninjaConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
+    ImmutableList<ActionAnalysisMetadata> actions = ninjaConfiguredTarget.getActions();
+    assertThat(actions).hasSize(1);
+
+    ActionAnalysisMetadata action = Iterables.getOnlyElement(actions);
+    assertThat(action).isInstanceOf(NinjaAction.class);
+    List<CommandLineAndParamFileInfo> commandLines =
+        ((NinjaAction) action).getCommandLines().getCommandLines();
+    assertThat(commandLines).hasSize(1);
+    assertThat(commandLines.get(0).commandLine.toString())
+        .endsWith("cd build_config && executable -d out_file.d ../input > out_file");
   }
 }


### PR DESCRIPTION
Rule's command can refer to depfile variable (and maybe rspfile),
defined in the rule itself:

rule abcde
  command = gcc -d ${depfile} ${flags} -o ${out} ${in}
  depfile = {out}.d

However, rule variables expansion should be done with the use of build statement's scope and offset (https://ninja-build.org/manual.html#_variable_expansion).