### PR TITLE
Fix rspfile value to be computed with target variables

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaRuleVariable.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaRuleVariable.java
@@ -31,6 +31,10 @@ public enum NinjaRuleVariable {
   RSPFILE_CONTENT,
   POOL;
 
+  public String getText() {
+    return Ascii.toLowerCase(name());
+  }
+
   public static NinjaRuleVariable nullOrValue(String name) {
     try {
       return valueOf(Ascii.toUpperCase(name));


### PR DESCRIPTION
Support the case when rspfile = ${out}.rsp, and
rspfile_content = ${in}