### PR TITLE
Add box-shadow and border-radius to `<pre>` code blocks

### DIFF
--- a/site/_sass/style.scss
+++ b/site/_sass/style.scss
@@ -145,6 +145,8 @@ pre {
   font-size: 100%;
   line-height: 20px;
   color: $code-color;
+  border-radius: 6px;
+  box-shadow: 1px 1px 5px #aaa;
 }
 
 code {


### PR DESCRIPTION
![ss](https://user-images.githubusercontent.com/347918/75177689-ac465e80-5704-11ea-92eb-e8b5e50a1feb.png)
![ss](https://user-images.githubusercontent.com/347918/75177772-caac5a00-5704-11ea-84b1-3d57587fd672.png)
![ss](https://user-images.githubusercontent.com/347918/75177894-07785100-5705-11ea-8ad2-37e38b9e1f4f.png)

Before this change:

![ss](https://user-images.githubusercontent.com/347918/75177939-1c54e480-5705-11ea-910d-97d1304445ed.png)
