### PR TITLE
Coverage: Do not prepend a second forward slash in LCOVFormatter

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoLCOVFormatter.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoLCOVFormatter.java
@@ -70,8 +70,10 @@ public class JacocoLCOVFormatter {
         if (execPathsOfUninstrumentedFiles.isEmpty()) {
           return fileName;
         }
+
+        String matchingFileName = fileName.startsWith("/") ? fileName : "/" + fileName;
         for (String execPath : execPathsOfUninstrumentedFiles) {
-          if (execPath.endsWith("/" + fileName)) {
+          if (execPath.endsWith(matchingFileName)) {
             return execPath;
           }
         }


### PR DESCRIPTION
This fixes: https://github.com/bazelbuild/bazel/issues/10863