### PR TITLE
test_exec_properties to control test action

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -230,6 +230,8 @@ public class BaseRuleClasses {
                           env.getToolsLabel(DEFAULT_COVERAGE_REPORT_GENERATOR_VALUE))))
           // The target itself and run_under both run on the same machine.
           .add(attr(":run_under", LABEL).value(RUN_UNDER).skipPrereqValidatorCheck())
+          // Exec properties used only for the test execution
+          .add(attr(RuleClass.TEST_EXEC_PROPERTIES, Type.STRING_DICT).value(ImmutableMap.of()))
           .build();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -1249,6 +1249,14 @@ public final class RuleContext extends TargetContext
     }
   }
 
+  public Map<String, String> getTestExecProperties() {
+    if (isTestTarget() && isAttrDefined(RuleClass.TEST_EXEC_PROPERTIES, Type.STRING_DICT)) {
+      return attributes.get(RuleClass.TEST_EXEC_PROPERTIES, Type.STRING_DICT);
+    } else {
+      return ImmutableMap.of();
+    }
+  }
+
   @Override
   @Nullable
   public PlatformInfo getExecutionPlatform() {

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
@@ -137,6 +137,7 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
                   .mandatoryProviders(ImmutableList.of(TemplateVariableInfo.PROVIDER.id()))
                   .dontCheckConstraints())
           .add(attr(RuleClass.EXEC_PROPERTIES, Type.STRING_DICT).value(ImmutableMap.of()))
+          .add(attr(RuleClass.TEST_EXEC_PROPERTIES, Type.STRING_DICT).value(ImmutableMap.of()))
           .add(
               attr(RuleClass.EXEC_COMPATIBLE_WITH_ATTR, BuildType.LABEL_LIST)
                   .allowedFileTypes()

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -440,7 +440,8 @@ public final class TestActionBuilder {
                     ? ShToolchain.getPathOrError(ruleContext)
                     : null,
                 cancelConcurrentTests,
-                tools.build());
+                tools.build(),
+                ruleContext.getTestExecProperties());
 
         testOutputs.addAll(testRunnerAction.getSpawnOutputs());
         testOutputs.addAll(testRunnerAction.getOutputs());

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -135,6 +135,7 @@ public class RuleClass {
   public static final PathFragment EXPERIMENTAL_PREFIX = PathFragment.create("experimental");
   public static final String EXEC_COMPATIBLE_WITH_ATTR = "exec_compatible_with";
   public static final String EXEC_PROPERTIES = "exec_properties";
+  public static final String TEST_EXEC_PROPERTIES = "test_exec_properties";
   /*
    * The attribute that declares the set of license labels which apply to this target.
    */


### PR DESCRIPTION
If specified for a test action, these properties will be added to the
effective exec_properties for a target, overriding any keys which match
by name, and only being effective for the test's execution, not any
other actions from the rule's context.

Closes #10799 