### PR TITLE
Allow "pool" as an expected NinjaToken after rule name in a declaration

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParser.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParser.java
@@ -114,7 +114,8 @@ public class NinjaParser implements DeclarationConsumer {
         break;
       case DEFAULT:
       case POOL:
-        // Do nothing.
+        NinjaPool pool = parser.parseNinjaPool();
+        parseResult.addPool(declarationStart, pool);
         break;
       default:
         throw new UnsupportedOperationException("Unknown type of Ninja token.");

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaPool.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaPool.java
@@ -1,0 +1,48 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.google.devtools.build.lib.bazel.rules.ninja.parser;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSortedMap;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Ninja rule representation.
+ *
+ * <p>{@link NinjaVariableValue} to be replaced for each target according to the scope rules.
+ */
+@Immutable
+public final class NinjaPool {
+  private final ImmutableSortedMap<NinjaPoolVariable, NinjaVariableValue> variables;
+
+  public NinjaPool(ImmutableSortedMap<NinjaPoolVariable, NinjaVariableValue> variables) {
+    this.variables = variables;
+  }
+
+  public ImmutableSortedMap<NinjaPoolVariable, NinjaVariableValue> getVariables() {
+    return variables;
+  }
+
+  public String getName() {
+    NinjaVariableValue value = Preconditions.checkNotNull(variables.get(NinjaPoolVariable.NAME));
+    return value.getRawText();
+  }
+
+  public Integer getDepth() {
+    NinjaVariableValue value = Preconditions.checkNotNull(variables.get(NinjaPoolVariable.DEPTH));
+    return Integer.parseInt(value.getRawText());
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaPoolVariable.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaPoolVariable.java
@@ -1,4 +1,4 @@
-// Copyright 2019 The Bazel Authors. All rights reserved.
+// Copyright 2020 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,26 +17,16 @@ package com.google.devtools.build.lib.bazel.rules.ninja.parser;
 
 import com.google.common.base.Ascii;
 
-/** Enum to represent {@link NinjaRule} variables with the special value, like name or command. */
-public enum NinjaRuleVariable {
+/** Enum to represent {@link NinjaPool} variables with the special value, like name or depth. */
+public enum NinjaPoolVariable {
   NAME,
-  COMMAND,
-  DEPFILE,
-  DEPS,
-  DEPTH,
-  MSVC_DEPS_PREFIX,
-  DESCRIPTION,
-  GENERATOR,
-  RESTAT,
-  RSPFILE,
-  RSPFILE_CONTENT,
-  POOL;
+  DEPTH;
 
   public String lowerCaseName() {
     return Ascii.toLowerCase(name());
   }
 
-  public static NinjaRuleVariable nullOrValue(String name) {
+  public static NinjaPoolVariable nullOrValue(String name) {
     try {
       return valueOf(Ascii.toUpperCase(name));
     } catch (IllegalArgumentException e) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaScope.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaScope.java
@@ -48,6 +48,7 @@ public class NinjaScope {
   private final NavigableMap<Integer, NinjaScope> subNinjaScopes;
   private Map<String, List<Pair<Integer, String>>> expandedVariables;
   private final Map<String, List<Pair<Integer, NinjaRule>>> rules;
+  private final Map<String, List<Pair<Integer, NinjaPool>>> pools;
 
   public NinjaScope() {
     this(null, null);
@@ -57,6 +58,7 @@ public class NinjaScope {
     this.parentScope = parentScope;
     this.includePoint = includePoint;
     this.rules = Maps.newTreeMap();
+    this.pools = Maps.newTreeMap();
     this.includedScopes = Maps.newTreeMap();
     this.subNinjaScopes = Maps.newTreeMap();
     this.expandedVariables = Maps.newHashMap();
@@ -66,9 +68,18 @@ public class NinjaScope {
     this.rules.putAll(rules);
   }
 
+  public void setPools(Map<String, List<Pair<Integer, NinjaPool>>> pools) {
+    this.pools.putAll(pools);
+  }
+
   @VisibleForTesting
   public Map<String, List<Pair<Integer, NinjaRule>>> getRules() {
     return rules;
+  }
+
+  @VisibleForTesting
+  public Map<String, List<Pair<Integer, NinjaPool>>> getPools() {
+    return pools;
   }
 
   public Collection<NinjaScope> getIncludedScopes() {

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaParserStepTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaParserStepTest.java
@@ -26,6 +26,8 @@ import com.google.devtools.build.lib.bazel.rules.ninja.file.GenericParsingExcept
 import com.google.devtools.build.lib.bazel.rules.ninja.lexer.NinjaLexer;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaFileParseResult;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaParserStep;
+import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaPool;
+import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaPoolVariable;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaRule;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaRuleVariable;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaScope;
@@ -191,6 +193,38 @@ public class NinjaParserStepTest {
     assertThat(variables.get(NinjaRuleVariable.NAME).getRawText()).isEqualTo("testRule");
     assertThat(variables.get(NinjaRuleVariable.DESCRIPTION).getRawText()).isEmpty();
   }
+
+  @Test
+  public void testParsePoolInRule() throws Exception {
+    NinjaParserStep parser =
+        createParser(
+            "rule testRule  \n"
+                + " pool = some_pool\n");
+    NinjaRule ninjaRule = parser.parseNinjaRule();
+    ImmutableSortedMap<NinjaRuleVariable, NinjaVariableValue> variables = ninjaRule.getVariables();
+    assertThat(variables.keySet())
+        .containsExactly(
+            NinjaRuleVariable.NAME, NinjaRuleVariable.POOL);
+    assertThat(variables.get(NinjaRuleVariable.NAME).getRawText()).isEqualTo("testRule");
+    assertThat(variables.get(NinjaRuleVariable.POOL).getRawText()).isEqualTo("some_pool");
+  }
+
+  @Test
+  public void testParsePoolDeclaration() throws Exception {
+    NinjaParserStep parser =
+        createParser(
+            "pool link_pool\n"
+            + "  depth = 4\n");
+    NinjaPool ninjaPool = parser.parseNinjaPool();
+    ImmutableSortedMap<NinjaPoolVariable, NinjaVariableValue> variables = ninjaPool.getVariables();
+    assertThat(variables.keySet())
+        .containsExactly(
+            NinjaPoolVariable.NAME, NinjaPoolVariable.DEPTH);
+    assertThat(variables.get(NinjaPoolVariable.NAME).getRawText()).isEqualTo("link_pool");
+    assertThat(variables.get(NinjaPoolVariable.DEPTH).getRawText()).isEqualTo("4");
+  }
+
+
 
   @Test
   public void testNinjaRuleParsingException() {


### PR DESCRIPTION
Repro:

```ninja
rule some_name
    pool = some_pool
    command = echo hello
```

```starlark
ninja_graph(
   name = "simple",
   main = "simple.ninja",
   ninja_srcs = [
       "simple.ninja",
   ],
   output_root = "out",
   output_root_inputs = [
   ],
)
```


```
ERROR: in ninja_graph rule //:simple: Expected [IDENTIFIER], but got pool in fragment:
rule some_name
    pool = some_pool
    command = echo hello

ERROR: Analysis of target '//:simple' failed; build aborted: Analysis of target '//:simple' failed; build aborted
FAILED: Build did NOT complete successfully (6 packages loaded, 11 targets configured)
```