### PR TITLE
C++: Allow any type of file in cc_import hdrs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcImportRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcImportRule.java
@@ -74,7 +74,7 @@ public final class CcImportRule implements RuleDefinition {
             attr("hdrs", LABEL_LIST)
                 .orderIndependent()
                 .direct_compile_time_input()
-                .allowedFileTypes(CppFileTypes.CPP_HEADER))
+                .allowedFileTypes(FileTypeSet.ANY_FILE))
         /*<!-- #BLAZE_RULE(cc_import).ATTRIBUTE(system_provided) -->
         If 1, it indicates the shared library required at runtime is provided by the system. In
         this case, <code>interface_library</code> should be specified and


### PR DESCRIPTION
cc_library allows any type of file in the headers but cc_import only allows 
cpp header files.
This commit makes it consistent to allow cc_import to have any type of file
in the header files.