### PR TITLE
Add missing load statements for proto_library

### DIFF
--- a/src/main/java/com/google/devtools/build/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/skyframe/BUILD
@@ -1,4 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//tools/build_rules:utilities.bzl", "java_library_srcs")
 
 # Description:


### PR DESCRIPTION
This makes Bazel compatible with
`--incompatible_load_proto_rules_from_bzl`, which was presumably broken by
https://github.com/bazelbuild/bazel/commit/65970e5e19d0e30a03fa0cb3dcf660a4a141ab25.

This change was generated by `buildifier --lint=fix
--warnings=native-proto -r src/main src/test/java`.