### PR TITLE
Add output_root_symlinks attribute to ninja_build rule

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaBuild.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaBuild.java
@@ -71,7 +71,8 @@ public class NinjaBuild implements RuleConfiguredTargetFactory {
             graphProvider.getWorkingDirectory(),
             createSrcsMap(ruleContext),
             depsMapBuilder.build(),
-            symlinksMapBuilder.build());
+            symlinksMapBuilder.build(),
+            graphProvider.getOutputRootSymlinks());
     if (ruleContext.hasErrors()) {
       return null;
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraph.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraph.java
@@ -81,6 +81,8 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
         PathFragment.create(ruleContext.attributes().get("working_directory", Type.STRING));
     List<String> outputRootInputs =
         ruleContext.attributes().get("output_root_inputs", Type.STRING_LIST);
+    List<String> outputRootSymlinks =
+        ruleContext.attributes().get("output_root_symlinks", Type.STRING_LIST);
 
     Environment env = ruleContext.getAnalysisEnvironment().getSkyframeEnv();
     establishDependencyOnNinjaFiles(env, mainArtifact, ninjaSrcs);
@@ -98,7 +100,8 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
             workingDirectory,
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of(),
-            ImmutableSortedMap.of());
+            ImmutableSortedMap.of(),
+            ImmutableList.of());
     if (ruleContext.hasErrors()) {
       return null;
     }
@@ -126,7 +129,10 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
               outputRoot,
               workingDirectory,
               targetsPreparer.getUsualTargets(),
-              targetsPreparer.getPhonyTargetsMap());
+              targetsPreparer.getPhonyTargetsMap(),
+              ImmutableList.copyOf(outputRootSymlinks.stream()
+                  .map(PathFragment::create).collect(
+                  Collectors.toList())));
 
       NestedSet<Artifact> filesToBuild =
           createSymlinkActions(

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphProvider.java
@@ -14,11 +14,13 @@
 
 package com.google.devtools.build.lib.bazel.rules.ninja.actions;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.lib.analysis.TransitiveInfoProvider;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaTarget;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import java.util.List;
 
 /**
  * Provider for passing information between {@link NinjaGraphRule} and {@link NinjaBuildRule}.
@@ -30,16 +32,19 @@ public final class NinjaGraphProvider implements TransitiveInfoProvider {
   private final PathFragment workingDirectory;
   private final ImmutableSortedMap<PathFragment, NinjaTarget> usualTargets;
   private final ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap;
+  private final ImmutableList<PathFragment> outputRootSymlinks;
 
   public NinjaGraphProvider(
       PathFragment outputRoot,
       PathFragment workingDirectory,
       ImmutableSortedMap<PathFragment, NinjaTarget> usualTargets,
-      ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap) {
+      ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap,
+      ImmutableList<PathFragment> outputRootSymlinks) {
     this.outputRoot = outputRoot;
     this.workingDirectory = workingDirectory;
     this.usualTargets = usualTargets;
     this.phonyTargetsMap = phonyTargetsMap;
+    this.outputRootSymlinks = outputRootSymlinks;
   }
 
   public PathFragment getOutputRoot() {
@@ -56,5 +61,12 @@ public final class NinjaGraphProvider implements TransitiveInfoProvider {
 
   public ImmutableSortedMap<PathFragment, PhonyTarget> getPhonyTargetsMap() {
     return phonyTargetsMap;
+  }
+
+  /**
+   * Output paths under output_root, that should be treated as symlink artifacts.
+   */
+  public ImmutableList<PathFragment> getOutputRootSymlinks() {
+    return outputRootSymlinks;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphRule.java
@@ -78,6 +78,12 @@ public class NinjaGraphRule implements RuleDefinition {
                         + " <execroot>/<output_root> will be a separate directory, not a"
                         + " symlink.</p>"))
         .add(
+            attr("output_root_symlinks", STRING_LIST)
+                .value(ImmutableList.of())
+                .setDoc(
+                    "<p>Output paths under output_root, that should be treated as symlink"
+                        + " artifacts.</p><p>In combination with --experimental_allow_unresolved_symlinks flag, this allows Ninja actions to create symlinks, not pointing to the existing file.</p>"))
+        .add(
             attr("working_directory", STRING)
                 .value("")
                 .setDoc(


### PR DESCRIPTION
output_root_symlinks allow to list utput paths under output_root, that should be treated as symlink artifacts.
In combination with --experimental_allow_unresolved_symlinks flag, this allows Ninja actions to create symlinks, not pointing to the existing file.