### PR TITLE
Improve reaction to not allowed symbols in repository name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
+++ b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java
@@ -114,7 +114,7 @@ public final class RepositoryName implements Serializable {
     try {
       return repositoryNameCache.get(name);
     } catch (ExecutionException e) {
-      Throwables.propagateIfInstanceOf(e.getCause(), LabelSyntaxException.class);
+      Throwables.propagateIfPossible(e.getCause(), LabelSyntaxException.class);
       throw new IllegalStateException("Failed to create RepositoryName from " + name, e);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/packages/WorkspaceFactoryHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/WorkspaceFactoryHelper.java
@@ -109,11 +109,14 @@ public class WorkspaceFactoryHelper {
    * should also evaluate to the same thing.
    */
   public static void addMainRepoEntry(
-      Package.Builder builder, String externalRepoName, StarlarkSemantics semantics) {
+      Package.Builder builder, String externalRepoName, StarlarkSemantics semantics)
+      throws LabelSyntaxException {
     if (!Strings.isNullOrEmpty(builder.getPackageWorkspaceName())) {
+      // Create repository names with validation, LabelSyntaxException is thrown is the name
+      // is not valid.
       builder.addRepositoryMappingEntry(
-          RepositoryName.createFromValidStrippedName(externalRepoName),
-          RepositoryName.createFromValidStrippedName(builder.getPackageWorkspaceName()),
+          RepositoryName.create("@" + externalRepoName),
+          RepositoryName.create("@" + builder.getPackageWorkspaceName()),
           RepositoryName.MAIN);
     }
   }
@@ -141,8 +144,10 @@ public class WorkspaceFactoryHelper {
       @SuppressWarnings("unchecked")
       Map<String, String> map = (Map<String, String>) kwargs.get("repo_mapping");
       for (Map.Entry<String, String> e : map.entrySet()) {
+        // Create repository names with validation, LabelSyntaxException is thrown is the name
+        // is not valid.
         builder.addRepositoryMappingEntry(
-            RepositoryName.createFromValidStrippedName(externalRepoName),
+            RepositoryName.create("@" + externalRepoName),
             RepositoryName.create(e.getKey()),
             RepositoryName.create(e.getValue()));
       }

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/WorkspaceBlackBoxTest.java
@@ -254,4 +254,13 @@ public class WorkspaceBlackBoxTest extends AbstractBlackBoxTest {
   }
   // TODO(ichern) move other tests from workspace_test.sh here.
 
+  @Test
+  public void testBadRepoName() throws Exception {
+    context().write(WORKSPACE, "local_repository(name = '@a', path = 'abc')");
+    context().write("BUILD");
+    ProcessResult result = context().bazel().shouldFail().build("//...");
+    assertThat(result.errString())
+        .contains("invalid repository name '@@a': workspace names may contain only "
+            + "A-Z, a-z, 0-9, '-', '_' and '.'");
+  }
 }


### PR DESCRIPTION
- when using user-defined repository name, do not call "createFromValidStrippedName" method, because the name have not been validated yet. Use "create" method that does validation.
- add a test
- fixes #10876