### PR TITLE
remote: fail if repository_ctx.execute() has a non-zero exit status

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.bazel.repository.downloader.Checksum;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpUtils;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler.FetchProgress;
 import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.Rule;
@@ -444,6 +445,14 @@ public class SkylarkRepositoryContext
         OutErr outErr = OutErr.SYSTEM_OUT_ERR;
         outErr.printOut(stdout);
         outErr.printErr(stderr);
+      }
+
+      if (result.exitCode() != 0) {
+        String warningMsg = String.format("@%s: '%s' exited with status %d. A remote execution"
+                + " system only caches commands with a zero exit status."
+            + " A non-zero exit status increases the runtime of the repository rule.",
+            rule.getName(), String.join(" ", arguments), result.exitCode());
+        env.getListener().handle(Event.warn(warningMsg));
       }
 
       return new SkylarkExecutionResult(result.exitCode(), stdout, stderr);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContext.java
@@ -448,11 +448,10 @@ public class SkylarkRepositoryContext
       }
 
       if (result.exitCode() != 0) {
-        String warningMsg = String.format("@%s: '%s' exited with status %d. A remote execution"
-                + " system only caches commands with a zero exit status."
-            + " A non-zero exit status increases the runtime of the repository rule.",
-            rule.getName(), String.join(" ", arguments), result.exitCode());
-        env.getListener().handle(Event.warn(warningMsg));
+        String errorTemplate = "Command '%s' exited with status %d. Commands with non-zero exit status are not"
+                + " support with remote execution as they cannot be cached. Update the command to always exit"
+                + " with status 0.";
+        throw Starlark.errorf(errorTemplate, String.join(" ", arguments), result.exitCode());
       }
 
       return new SkylarkExecutionResult(result.exitCode(), stdout, stderr);


### PR DESCRIPTION
Remote execution systems generally don't cache actions with a non-zero
exit status. A uncachable command significantly increases the runtime
of a repository_rule with remote execution enabled. This change makes
it an error if repository_ctx.execute() returns a non-zero exit status.