### PR TITLE
Add missing NS_BLOCK_ASSERTIONS for more architectures

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5324,6 +5324,7 @@ def _impl(ctx):
                                 "-O2",
                                 "-D_FORTIFY_SOURCE=1",
                                 "-DNDEBUG",
+                                "-DNS_BLOCK_ASSERTIONS=1",
                             ],
                         ),
                     ],


### PR DESCRIPTION
This flag was passed for some architectures in the conditional above
this one, but not for all

RELNOTES: NS_BLOCK_ASSERTIONS is now passed for all Apple architectures