### PR TITLE
Make FilterTestHeaderOutputStream respect line separator on Windows

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/TestLogHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/TestLogHelper.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.exec;
 
 import com.google.common.io.ByteStreams;
 import com.google.devtools.build.lib.exec.TestStrategy.TestOutputFormat;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.BufferedOutputStream;
 import java.io.FilterOutputStream;
@@ -105,7 +106,9 @@ public class TestLogHelper {
       } else if (b == NEWLINE) {
         String line = lineBuilder.toString();
         lineBuilder = new StringBuilder();
-        if (line.equals(TestLogHelper.HEADER_DELIMITER)) {
+        if (line.equals(TestLogHelper.HEADER_DELIMITER) ||
+            // On Windows, the line break could be \r\n, we want this case to work as well.
+            (OS.getCurrent() == OS.WINDOWS && line.equals(TestLogHelper.HEADER_DELIMITER + "\r"))) {
           seenDelimiter = true;
         }
       } else if (lineBuilder.length() <= TestLogHelper.HEADER_DELIMITER.length()) {

--- a/src/test/java/com/google/devtools/build/lib/exec/StreamedTestOutputTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/StreamedTestOutputTest.java
@@ -66,11 +66,6 @@ public class StreamedTestOutputTest {
 
   @Test
   public void testOnlyOutputsContentsAfterHeaderWhenPresent() throws IOException {
-    if (OS.getCurrent() == OS.WINDOWS) {
-      // TODO(b/151095783): Disabled because underlying code doesn't respect system line separator.
-      return;
-    }
-
     Path watchedPath = fileSystem.getPath("/myfile");
     FileSystemUtils.writeLinesAs(
         watchedPath,
@@ -86,7 +81,8 @@ public class StreamedTestOutputTest {
     try (StreamedTestOutput underTest =
         new StreamedTestOutput(OutErr.create(out, err), fileSystem.getPath("/myfile"))) {}
 
-    assertThat(out.toString(StandardCharsets.UTF_8.name())).isEqualTo("included\nlines\n");
+    assertThat(out.toString(StandardCharsets.UTF_8.name()))
+        .isEqualTo(String.format("included%nlines%n"));
     assertThat(err.toString(StandardCharsets.UTF_8.name())).isEmpty();
   }
 


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/10931