### PR TITLE
Add option to filter events from UI

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
@@ -114,6 +114,7 @@ public class UiEventHandler implements EventHandler {
   private final boolean showTimestamp;
   private final boolean deduplicate;
   private final OutErr outErr;
+  private final ImmutableSet<EventKind> allowedEvents;
   private long minimalDelayMillis;
   private long minimalUpdateInterval;
   private long lastRefreshMillis;
@@ -291,6 +292,8 @@ public class UiEventHandler implements EventHandler {
     this.dateShown = false;
     this.updateThread = new AtomicReference<>();
     this.updateLock = new ReentrantLock();
+    this.allowedEvents = ImmutableSet
+        .copyOf(options.eventFilters != null ? options.eventFilters : EventKind.ALL_EVENTS);
     // The progress bar has not been updated yet.
     ignoreRefreshLimitOnce();
   }
@@ -367,6 +370,9 @@ public class UiEventHandler implements EventHandler {
   }
 
   private synchronized void handleLocked(Event event, boolean isFollowUp) {
+    if (!this.allowedEvents.contains(event.getKind())) {
+      return;
+    }
     try {
       if (debugAllEvents) {
         // Debugging only: show all events visible to the new UI.

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
@@ -114,7 +114,7 @@ public class UiEventHandler implements EventHandler {
   private final boolean showTimestamp;
   private final boolean deduplicate;
   private final OutErr outErr;
-  private final ImmutableSet<EventKind> allowedEvents;
+  private final ImmutableSet<EventKind> filteredEvents;
   private long minimalDelayMillis;
   private long minimalUpdateInterval;
   private long lastRefreshMillis;
@@ -292,8 +292,7 @@ public class UiEventHandler implements EventHandler {
     this.dateShown = false;
     this.updateThread = new AtomicReference<>();
     this.updateLock = new ReentrantLock();
-    this.allowedEvents = ImmutableSet
-        .copyOf(options.eventFilters != null ? options.eventFilters : EventKind.ALL_EVENTS);
+    this.filteredEvents = ImmutableSet.copyOf(options.eventFilters);
     // The progress bar has not been updated yet.
     ignoreRefreshLimitOnce();
   }
@@ -370,7 +369,7 @@ public class UiEventHandler implements EventHandler {
   }
 
   private synchronized void handleLocked(Event event, boolean isFollowUp) {
-    if (!this.allowedEvents.contains(event.getKind())) {
+    if (this.filteredEvents.contains(event.getKind())) {
       return;
     }
     try {

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiOptions.java
@@ -238,10 +238,13 @@ public class UiOptions extends OptionsBase {
       name = "ui_event_filters",
       converter = EventFiltersConverter.class,
       defaultValue = "null",
-      metadataTags = {OptionMetadataTag.HIDDEN},
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      help = "Specifies which events to show in the UI.",
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
+      help =
+          "Specifies which events to show in the UI. It is possible to add or remove events "
+              + "to the default ones using leading +/-, or override the default "
+              + "set completely with direct assignment. The set of supported event kinds "
+              + "include INFO, DEBUG, ERROR and more.",
       allowMultiple = true)
   public List<EventKind> eventFilters;
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiOptions.java
@@ -63,29 +63,31 @@ public class UiOptions extends OptionsBase {
 
     public List<EventKind> convert(String input) throws OptionsParsingException {
       if (input.isEmpty()) {
-       return new ArrayList<>();
+        // This method is not called to convert the default value
+        // Empty list means that the user wants to filter all events
+       return new ArrayList<>(EventKind.ALL_EVENTS);
       }
       List<String> filters = this.delegate.convert(input);
       EnumConverter<EventKind> eventKindConverter = new EventKindConverter(input);
 
-      HashSet<EventKind> allowedEvents = new HashSet<>(EventKind.ALL_EVENTS);
+      HashSet<EventKind> filteredEvents = new HashSet<>();
       for (String filter: filters) {
         if (!filter.startsWith("+") && !filter.startsWith("-")) {
-          allowedEvents.clear();
+          filteredEvents.addAll(EventKind.ALL_EVENTS);
           break;
         }
       }
 
       for (String filter : filters) {
         if (filter.startsWith("+")) {
-          allowedEvents.add(eventKindConverter.convert(filter.substring(1)));
+          filteredEvents.remove(eventKindConverter.convert(filter.substring(1)));
         } else if (filter.startsWith("-")) {
-          allowedEvents.remove(eventKindConverter.convert(filter.substring(1)));
+          filteredEvents.add(eventKindConverter.convert(filter.substring(1)));
         } else {
-          allowedEvents.add(eventKindConverter.convert(filter));
+          filteredEvents.remove(eventKindConverter.convert(filter));
         }
       }
-      return new ArrayList<>(allowedEvents);
+      return new ArrayList<>(filteredEvents);
     }
 
     @Override

--- a/src/test/shell/integration/ui_test.sh
+++ b/src/test/shell/integration/ui_test.sh
@@ -580,22 +580,22 @@ function test_ui_events_filters() {
   bazel clean || fail "${PRODUCT_NAME} clean failed"
 
   bazel build pkgloadingerror:all > "${TEST_log}" 2>&1 && fail "expected failure"
-  expect_log "^ERROR: $(pwd)/bzl/bzl.bzl:1:5: name 'invalidsyntax' is not defined"
+  expect_log "^ERROR: .*/bzl/bzl.bzl:1:5: name 'invalidsyntax' is not defined"
   expect_log "^WARNING: Target pattern parsing failed."
   expect_log "^INFO: 0 processes."
 
   bazel build --ui_event_filters=-error pkgloadingerror:all > "${TEST_log}" 2>&1 && fail "expected failure"
-  expect_not_log "^ERROR: $(pwd)/bzl/bzl.bzl:1:5: name 'invalidsyntax' is not defined"
+  expect_not_log "^ERROR: .*bzl/bzl.bzl:1:5: name 'invalidsyntax' is not defined"
   expect_log "^WARNING: Target pattern parsing failed."
   expect_log "^INFO: 0 processes."
 
   bazel build --ui_event_filters=info pkgloadingerror:all > "${TEST_log}" 2>&1 && fail "expected failure"
-  expect_not_log "^ERROR: $(pwd)/bzl/bzl.bzl:1:5: name 'invalidsyntax' is not defined"
+  expect_not_log "^ERROR: .*/bzl/bzl.bzl:1:5: name 'invalidsyntax' is not defined"
   expect_not_log "^WARNING: Target pattern parsing failed."
   expect_log "^INFO: 0 processes."
 
   bazel build  --ui_event_filters= pkgloadingerror:all > "${TEST_log}" 2>&1 && fail "expected failure"
-  expect_not_log "^ERROR: $(pwd)/bzl/bzl.bzl:1:5: name 'invalidsyntax' is not defined"
+  expect_not_log "^ERROR: .*/bzl/bzl.bzl:1:5: name 'invalidsyntax' is not defined"
   expect_not_log "^WARNING: Target pattern parsing failed."
   expect_not_log "^INFO: 0 processes."
 }

--- a/src/test/shell/integration/ui_test.sh
+++ b/src/test/shell/integration/ui_test.sh
@@ -576,4 +576,28 @@ function test_fancy_symbol_encoding() {
     expect_log $'\xF0\x9F\x8D\x83'
 }
 
+function test_ui_events_filters() {
+  bazel clean || fail "${PRODUCT_NAME} clean failed"
+
+  bazel build pkgloadingerror:all > "${TEST_log}" 2>&1 && fail "expected failure"
+  expect_log "^ERROR: $(pwd)/bzl/bzl.bzl:1:5: name 'invalidsyntax' is not defined"
+  expect_log "^WARNING: Target pattern parsing failed."
+  expect_log "^INFO: 0 processes."
+
+  bazel build --ui_event_filters=-error pkgloadingerror:all > "${TEST_log}" 2>&1 && fail "expected failure"
+  expect_not_log "^ERROR: $(pwd)/bzl/bzl.bzl:1:5: name 'invalidsyntax' is not defined"
+  expect_log "^WARNING: Target pattern parsing failed."
+  expect_log "^INFO: 0 processes."
+
+  bazel build --ui_event_filters=info pkgloadingerror:all > "${TEST_log}" 2>&1 && fail "expected failure"
+  expect_not_log "^ERROR: $(pwd)/bzl/bzl.bzl:1:5: name 'invalidsyntax' is not defined"
+  expect_not_log "^WARNING: Target pattern parsing failed."
+  expect_log "^INFO: 0 processes."
+
+  bazel build  --ui_event_filters= pkgloadingerror:all > "${TEST_log}" 2>&1 && fail "expected failure"
+  expect_not_log "^ERROR: $(pwd)/bzl/bzl.bzl:1:5: name 'invalidsyntax' is not defined"
+  expect_not_log "^WARNING: Target pattern parsing failed."
+  expect_not_log "^INFO: 0 processes."
+}
+
 run_suite "Integration tests for ${PRODUCT_NAME}'s UI"


### PR DESCRIPTION
At the moment there is not an option to easily control the verbosity of Bazel UI. The `ui_event_filters` option allows to arbitrarily filter events from the UI. The syntax is the same as `build_tag_filters` or `output_group`, so it is possible to add or remove events, using leading `+/-`, or override the default set completely with direct assignment.

Related: #4867