### PR TITLE
Don't consider a workspace directory a marker of being in a workspace

### DIFF
--- a/src/main/cpp/workspace_layout.cc
+++ b/src/main/cpp/workspace_layout.cc
@@ -35,10 +35,10 @@ string WorkspaceLayout::GetOutputRoot() const {
 }
 
 bool WorkspaceLayout::InWorkspace(const string &workspace) const {
-  return blaze_util::PathExists(
-             blaze_util::JoinPath(workspace, kWorkspaceDotBazelMarker)) ||
-         blaze_util::PathExists(
-             blaze_util::JoinPath(workspace, kWorkspaceMarker));
+  auto workspaceDotBazelPath = blaze_util::JoinPath(workspace, kWorkspaceDotBazelMarker);
+  auto workspacePath = blaze_util::JoinPath(workspace, kWorkspaceMarker);
+  return (blaze_util::PathExists(workspaceDotBazelPath) && !blaze_util::IsDirectory(workspaceDotBazelPath)) ||
+         (blaze_util::PathExists(workspacePath) && !blaze_util::IsDirectory(workspacePath));
 }
 
 string WorkspaceLayout::GetWorkspace(const string &cwd) const {


### PR DESCRIPTION
Jenkins workers tend to place all of their Jenkins workspaces in a
directory named `workspace`. On a case-insensitive filesystem,
Bazel would consider anything run by Jenkins as being in a Bazel
workspace, because of that `workspace` directory being in the
filesystem hierarchy of the cwd.

Avoid this by only looking for _files_ named `workspace` when
determining if a directory is potentially a Bazel workspace.