### PR TITLE
Fix calls to Truth's isStrictlyOrdered and containsAllIn methods.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/android/SdkMavenRepositoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/android/SdkMavenRepositoryTest.java
@@ -95,7 +95,7 @@ public class SdkMavenRepositoryTest extends BuildViewTestCase {
     sdkMavenRepository.writeBuildFiles(workspaceDir);
 
     Path groupIdPath = scratch.resolve("com.google.android");
-    assertThat(workspaceDir.getDirectoryEntries()).containsAllOf(repoPath, groupIdPath);
+    assertThat(workspaceDir.getDirectoryEntries()).containsAtLeast(repoPath, groupIdPath);
 
     Path buildFilePath = groupIdPath.getRelative("BUILD");
     assertThat(groupIdPath.getDirectoryEntries()).containsExactly(buildFilePath);

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
@@ -235,8 +235,8 @@ public class DirectoryTreeTest {
     // Assert the lexicographical order as defined by the remote execution protocol
     tree.visit(
         (PathFragment dirname, List<FileNode> files, List<DirectoryNode> dirs) -> {
-          assertThat(files).isStrictlyOrdered();
-          assertThat(dirs).isStrictlyOrdered();
+          assertThat(files).isInStrictOrder();
+          assertThat(dirs).isInStrictOrder();
         });
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/MerkleTreeTest.java
@@ -133,8 +133,8 @@ public class MerkleTreeTest {
 
     Digest[] allDigests = Iterables.toArray(tree.getAllDigests(), Digest.class);
     assertThat(allDigests.length).isEqualTo(dirDigests.length + inputDigests.length);
-    assertThat(allDigests).asList().containsAllIn(dirDigests);
-    assertThat(allDigests).asList().containsAllIn(inputDigests);
+    assertThat(allDigests).asList().containsAtLeastElementsIn(dirDigests);
+    assertThat(allDigests).asList().containsAtLeastElementsIn(inputDigests);
   }
 
   private Artifact addFile(


### PR DESCRIPTION
These were removed between Truth 0.45 and Truth 1.0.1

RELNOTES: None.