### PR TITLE
Fix no-remote-exec caching functionality

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -114,6 +114,10 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
     if (cache == null) {
       cache = SpawnCache.NO_CACHE;
     }
+    // If we are using the RemoteSpawnRunner, it handles caching internally so avoid caching logic here.
+    if (spawnRunner.getName().equals("remote")) {
+      cache = SpawnCache.NO_CACHE;
+    }
     SpawnResult spawnResult;
     ExecException ex = null;
     try (CacheHandle cacheHandle = cache.lookup(spawn, context)) {

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -107,9 +107,7 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
     final Duration timeout = Spawns.getTimeout(spawn);
     SpawnExecutionContext context =
         new SpawnExecutionContextImpl(spawn, actionExecutionContext, stopConcurrentSpawns, timeout);
-    // TODO(ulfjack): Provide a way to disable the cache. We don't want the RemoteSpawnStrategy to
-    // check the cache twice. Right now that can't happen because this is hidden behind an
-    // experimental flag.
+
     SpawnCache cache = actionExecutionContext.getContext(SpawnCache.class);
     // In production, the getContext method guarantees that we never get null back. However, our
     // integration tests don't set it up correctly, so cache may be null in testing.

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -114,8 +114,8 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
     if (cache == null) {
       cache = SpawnCache.NO_CACHE;
     }
-    // If we are using the RemoteSpawnRunner, it handles caching internally so avoid caching logic here.
-    if (spawnRunner.getName().equals("remote")) {
+    // Avoid caching for runners which handle caching internally e.g. RemoteSpawnRunner
+    if (spawnRunner.handlesCaching()) {
       cache = SpawnCache.NO_CACHE;
     }
     SpawnResult spawnResult;

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnRunner.java
@@ -258,6 +258,9 @@ public interface SpawnRunner {
   /** Returns whether this SpawnRunner supports executing the given Spawn. */
   boolean canExec(Spawn spawn);
 
+  /** Returns whether this SpawnRunner handles caching of actions internally. */
+  boolean handlesCaching();
+
   /** Returns the name of the SpawnRunner. */
   String getName();
 

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -181,6 +181,11 @@ public class LocalSpawnRunner implements SpawnRunner {
     return true;
   }
 
+  @Override
+  public boolean handlesCaching() {
+    return false;
+  }
+
   protected Path createActionTemp(Path execRoot) throws IOException {
     return execRoot.getRelative(
         java.nio.file.Files.createTempDirectory(

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -112,16 +112,11 @@ final class RemoteActionContextProvider implements ExecutorLifecycleListener {
   }
 
   /**
-   * Registers a spawn cache action context if this instance was created without an executor,
-   * otherwise does nothing.
+   * Registers a spawn cache action context
    *
    * @param registryBuilder builder with which to register the cache
    */
-  public void registerSpawnCacheIfApplicable(ModuleActionContextRegistry.Builder registryBuilder) {
-    if (executor != null) {
-      return; // No need to register cache if we're using a remote executor.
-    }
-
+  public void registerSpawnCache(ModuleActionContextRegistry.Builder registryBuilder) {
     RemoteSpawnCache spawnCache =
         new RemoteSpawnCache(
             env.getExecRoot(),

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -645,7 +645,7 @@ public final class RemoteModule extends BlazeModule {
     if (actionContextProvider == null) {
       return;
     }
-    actionContextProvider.registerSpawnCacheIfApplicable(registryBuilder);
+    actionContextProvider.registerSpawnCache(registryBuilder);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -314,7 +314,7 @@ final class RemoteSpawnCache implements SpawnCache {
   }
 
   private static boolean useRemoteCache(RemoteOptions options) {
-    return !isNullOrEmpty(options.remoteCache);
+    return !isNullOrEmpty(options.remoteCache) || !isNullOrEmpty(options.remoteExecutor);
   }
 
   private static boolean useDiskCache(RemoteOptions options) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -472,6 +472,11 @@ public class RemoteSpawnRunner implements SpawnRunner {
     return Spawns.mayBeExecutedRemotely(spawn);
   }
 
+  @Override
+  public boolean handlesCaching() {
+    return true;
+  }
+
   private void maybeWriteParamFilesLocally(Spawn spawn) throws IOException {
     if (!executionOptions.shouldMaterializeParamFiles()) {
       return;

--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -92,6 +92,11 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
     return Spawns.mayBeSandboxed(spawn);
   }
 
+  @Override
+  public boolean handlesCaching() {
+    return false;
+  }
+
   protected abstract SandboxedSpawn prepareSpawn(Spawn spawn, SpawnExecutionContext context)
       throws IOException, ExecException;
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -467,6 +467,11 @@ public final class SandboxModule extends BlazeModule {
     }
 
     @Override
+    public boolean handlesCaching() {
+      return false;
+    }
+
+    @Override
     public void cleanupSandboxBase(Path sandboxBase, TreeDeleter treeDeleter) throws IOException {
       sandboxSpawnRunner.cleanupSandboxBase(sandboxBase, treeDeleter);
       fallbackSpawnRunner.cleanupSandboxBase(sandboxBase, treeDeleter);

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -140,6 +140,11 @@ final class WorkerSpawnRunner implements SpawnRunner {
     return Spawns.supportsWorkers(spawn) || Spawns.supportsMultiplexWorkers(spawn);
   }
 
+  @Override
+  public boolean handlesCaching() {
+    return false;
+  }
+
   private SpawnResult actuallyExec(Spawn spawn, SpawnExecutionContext context)
       throws ExecException, IOException, InterruptedException {
     if (spawn.getToolFiles().isEmpty()) {

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1435,6 +1435,16 @@ EOF
 
   expect_log "1 local"
   expect_not_log "1 remote"
+
+  bazel clean
+
+  bazel build \
+    --spawn_strategy=remote,local \
+    --remote_executor=grpc://localhost:${worker_port} \
+    //a:foo >& $TEST_log || "Failed to build //a:foo"
+
+  expect_log "1 remote cache hit"
+  expect_not_log "1 local"
 }
 
 function test_nobuild_runfile_links() {


### PR DESCRIPTION
This commit addresses issue #9412 and provides all
instances of the RemoteSpawnStrategy with a RemoteSpawnCache
to ensure that the AbstractSpawnStrategy caching logic behaves
as expected for no-remote-exec actions.

This patch was written for 1.2.1 and adapted to latest master.

EDIT: Force pushed different changes 19/03/2020, see below for further discussion
EDIT: Rebased as of 28/04/20, unsure if 08efd761721 should be needed