### PR TITLE
Provide error details if capabilities call fails

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -18,6 +18,7 @@ import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -138,6 +139,7 @@ public final class RemoteModule extends BlazeModule {
     try {
       capabilities = rsc.get(env.getCommandId().toString(), env.getBuildRequestId());
     } catch (IOException e) {
+      env.getReporter().handle(Event.error(Throwables.getStackTraceAsString(e)));
       throw new AbruptExitException(
           "Failed to query remote execution capabilities: " + Utils.grpcAwareErrorMessage(e),
           ExitCode.REMOTE_ERROR,


### PR DESCRIPTION
The exception cause of the AbruptExitException is never printed anywhere,
so by default, when an error happens in this call, it usually looks like this:
```
ERROR: Failed to query remote execution capabilities: UNAVAILABLE: io exception
```

This is independent of whether the failure happened because the connection
failed or the ssl certificate did not validate. Needless to say, this is a
pretty bad user experience.

Change-Id: I846d1f5b6cd73f7663593b1292db3336d998ecfb