### PR TITLE
Reduce exception wrapping for cleaner stack traces

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
@@ -76,6 +76,9 @@ class RemoteServerCapabilities {
               : GetCapabilitiesRequest.newBuilder().setInstanceName(instanceName).build();
       return retrier.execute(() -> capabilitiesBlockingStub().getCapabilities(request));
     } catch (StatusRuntimeException e) {
+      if (e.getCause() instanceof IOException) {
+        throw (IOException) e.getCause();
+      }
       throw new IOException(e);
     } finally {
       withMetadata.detach(previous);


### PR DESCRIPTION
The StatusRuntimeException often already wraps an IOException, and provides no
value on top of that (because it's created internally in gRPC and has no
relationship to Bazel code). If so, just throw the wrapped IOException directly
to reduce the output spam (if the exception is printed).

Change-Id: Ib2bbad230cf632c491aea0fb24a7721e96178499