### PR TITLE
Ninja implementation refactor: remove usage of the word "usual"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaActionsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaActionsHelper.java
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
  */
 public class NinjaActionsHelper {
   private final RuleContext ruleContext;
-  private final ImmutableSortedMap<PathFragment, NinjaTarget> allUsualTargets;
+  private final ImmutableSortedMap<PathFragment, NinjaTarget> targetsMap;
   private final ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargets;
 
   private final NinjaGraphArtifactsHelper artifactsHelper;
@@ -71,7 +71,7 @@ public class NinjaActionsHelper {
    *
    * @param ruleContext parent NinjaGraphRule rule context
    * @param artifactsHelper helper object to create artifacts
-   * @param allUsualTargets mapping of outputs to all non-phony Ninja targets from Ninja file
+   * @param targetsMap mapping of outputs to all non-phony Ninja targets from Ninja file
    * @param phonyTargets mapping of names to all phony Ninja actions from Ninja file
    * @param phonyTargetArtifacts helper class for computing transitively included artifacts of phony
    *     targets
@@ -80,14 +80,14 @@ public class NinjaActionsHelper {
   NinjaActionsHelper(
       RuleContext ruleContext,
       NinjaGraphArtifactsHelper artifactsHelper,
-      ImmutableSortedMap<PathFragment, NinjaTarget> allUsualTargets,
+      ImmutableSortedMap<PathFragment, NinjaTarget> targetsMap,
       ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargets,
       PhonyTargetArtifacts phonyTargetArtifacts,
       List<PathFragment> pathsToBuild,
       ImmutableSet<PathFragment> outputRootInputsSymlinks) {
     this.ruleContext = ruleContext;
     this.artifactsHelper = artifactsHelper;
-    this.allUsualTargets = allUsualTargets;
+    this.targetsMap = targetsMap;
     this.phonyTargets = phonyTargets;
     this.shellExecutable = ShToolchain.getPathOrError(ruleContext);
     this.executionInfo = createExecutionInfo(ruleContext);
@@ -113,7 +113,7 @@ public class NinjaActionsHelper {
         };
     while (!queue.isEmpty()) {
       PathFragment fragment = queue.remove();
-      NinjaTarget target = allUsualTargets.get(fragment);
+      NinjaTarget target = targetsMap.get(fragment);
       if (target != null) {
         // If the output is already created by a symlink action created from specifying that
         // file in output_root_inputs attribute of the ninja_graph rule, do not create other
@@ -150,7 +150,7 @@ public class NinjaActionsHelper {
         }
       } else {
         PhonyTarget phonyTarget = phonyTargets.get(fragment);
-        // Phony target can be null, if the path in neither usual or phony target,
+        // Phony target can be null, if the path in neither regular or phony target,
         // but the source file.
         if (phonyTarget != null) {
           phonyTarget.visitUsualInputs(phonyTargets, enqueuer::accept);

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaBuild.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaBuild.java
@@ -92,7 +92,7 @@ public class NinjaBuild implements RuleConfiguredTargetFactory {
       new NinjaActionsHelper(
               ruleContext,
               artifactsHelper,
-              graphProvider.getUsualTargets(),
+              graphProvider.getTargetsMap(),
               graphProvider.getPhonyTargetsMap(),
               phonyTargetArtifacts,
               pathsToBuild,

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraph.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraph.java
@@ -146,7 +146,7 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
           new NinjaGraphProvider(
               outputRoot,
               workingDirectory,
-              targetsPreparer.getUsualTargets(),
+              targetsPreparer.getTargetsMap(),
               targetsPreparer.getPhonyTargetsMap(),
               outputRootSymlinksPathFragments,
               outputRootInputsSymlinksPathFragments);
@@ -205,11 +205,11 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
   }
 
   private static class TargetsPreparer {
-    private ImmutableSortedMap<PathFragment, NinjaTarget> usualTargets;
+    private ImmutableSortedMap<PathFragment, NinjaTarget> targetsMap;
     private ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap;
 
-    public ImmutableSortedMap<PathFragment, NinjaTarget> getUsualTargets() {
-      return usualTargets;
+    public ImmutableSortedMap<PathFragment, NinjaTarget> getTargetsMap() {
+      return targetsMap;
     }
 
     public ImmutableSortedMap<PathFragment, PhonyTarget> getPhonyTargetsMap() {
@@ -217,18 +217,18 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
     }
 
     void process(List<NinjaTarget> ninjaTargets) throws GenericParsingException {
-      ImmutableSortedMap.Builder<PathFragment, NinjaTarget> usualTargetsBuilder =
+      ImmutableSortedMap.Builder<PathFragment, NinjaTarget> targetsMapBuilder =
           ImmutableSortedMap.naturalOrder();
       ImmutableSortedMap.Builder<PathFragment, NinjaTarget> phonyTargetsBuilder =
           ImmutableSortedMap.naturalOrder();
-      separatePhonyTargets(ninjaTargets, usualTargetsBuilder, phonyTargetsBuilder);
-      usualTargets = usualTargetsBuilder.build();
+      separatePhonyTargets(ninjaTargets, targetsMapBuilder, phonyTargetsBuilder);
+      targetsMap = targetsMapBuilder.build();
       phonyTargetsMap = NinjaPhonyTargetsUtil.getPhonyPathsMap(phonyTargetsBuilder.build());
     }
 
     private static void separatePhonyTargets(
         List<NinjaTarget> ninjaTargets,
-        ImmutableSortedMap.Builder<PathFragment, NinjaTarget> usualTargetsBuilder,
+        ImmutableSortedMap.Builder<PathFragment, NinjaTarget> targetsBuilder,
         ImmutableSortedMap.Builder<PathFragment, NinjaTarget> phonyTargetsBuilder)
         throws GenericParsingException {
       for (NinjaTarget target : ninjaTargets) {
@@ -246,7 +246,7 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
           phonyTargetsBuilder.put(Iterables.getOnlyElement(target.getAllOutputs()), target);
         } else {
           for (PathFragment output : target.getAllOutputs()) {
-            usualTargetsBuilder.put(output, target);
+             targetsBuilder.put(output, target);
           }
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphProvider.java
@@ -24,13 +24,13 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 
 /**
  * Provider for passing information between {@link NinjaGraphRule} and {@link NinjaBuildRule}.
- * Represents all usual and phony {@link NinjaTarget}s from the Ninja graph.
+ * Represents all regular and phony {@link NinjaTarget}s from the Ninja graph.
  */
 @Immutable
 public final class NinjaGraphProvider implements TransitiveInfoProvider {
   private final PathFragment outputRoot;
   private final PathFragment workingDirectory;
-  private final ImmutableSortedMap<PathFragment, NinjaTarget> usualTargets;
+  private final ImmutableSortedMap<PathFragment, NinjaTarget> targetsMap;
   private final ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap;
   private final ImmutableSortedSet<PathFragment> outputRootSymlinks;
   private final ImmutableSet<PathFragment> outputRootInputsSymlinks;
@@ -38,14 +38,14 @@ public final class NinjaGraphProvider implements TransitiveInfoProvider {
   public NinjaGraphProvider(
       PathFragment outputRoot,
       PathFragment workingDirectory,
-      ImmutableSortedMap<PathFragment, NinjaTarget> usualTargets,
+      ImmutableSortedMap<PathFragment, NinjaTarget> targetsMap,
       ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap,
       ImmutableSortedSet<PathFragment> outputRootSymlinks,
       ImmutableSet<PathFragment> outputRootInputsSymlinks) {
 
     this.outputRoot = outputRoot;
     this.workingDirectory = workingDirectory;
-    this.usualTargets = usualTargets;
+    this.targetsMap = targetsMap;
     this.phonyTargetsMap = phonyTargetsMap;
     this.outputRootSymlinks = outputRootSymlinks;
     this.outputRootInputsSymlinks = outputRootInputsSymlinks;
@@ -59,8 +59,8 @@ public final class NinjaGraphProvider implements TransitiveInfoProvider {
     return workingDirectory;
   }
 
-  public ImmutableSortedMap<PathFragment, NinjaTarget> getUsualTargets() {
-    return usualTargets;
+  public ImmutableSortedMap<PathFragment, NinjaTarget> getTargetsMap() {
+    return targetsMap;
   }
 
   public ImmutableSortedMap<PathFragment, PhonyTarget> getPhonyTargetsMap() {

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaGraphTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaGraphTest.java
@@ -94,9 +94,9 @@ public class NinjaGraphTest extends BuildViewTestCase {
     assertThat(provider.getOutputRoot()).isEqualTo(PathFragment.create("build_config"));
     assertThat(provider.getWorkingDirectory()).isEqualTo(PathFragment.EMPTY_FRAGMENT);
     assertThat(provider.getPhonyTargetsMap()).isEmpty();
-    assertThat(provider.getUsualTargets()).hasSize(1);
+    assertThat(provider.getTargetsMap()).hasSize(1);
 
-    NinjaTarget target = Iterables.getOnlyElement(provider.getUsualTargets().values());
+    NinjaTarget target = Iterables.getOnlyElement(provider.getTargetsMap().values());
     assertThat(target.getRuleName()).isEqualTo("echo");
     assertThat(target.getAllInputs())
         .containsExactly(PathFragment.create("build_config/input.txt"));
@@ -146,9 +146,9 @@ public class NinjaGraphTest extends BuildViewTestCase {
     assertThat(provider).isNotNull();
     assertThat(provider.getOutputRoot()).isEqualTo(PathFragment.create("build_config"));
     assertThat(provider.getWorkingDirectory()).isEqualTo(PathFragment.create("build_config"));
-    assertThat(provider.getUsualTargets()).hasSize(1);
+    assertThat(provider.getTargetsMap()).hasSize(1);
 
-    NinjaTarget target = Iterables.getOnlyElement(provider.getUsualTargets().values());
+    NinjaTarget target = Iterables.getOnlyElement(provider.getTargetsMap().values());
     assertThat(target.getRuleName()).isEqualTo("echo");
     assertThat(target.getAllInputs()).containsExactly(PathFragment.create("input.txt"));
     assertThat(target.getAllOutputs()).containsExactly(PathFragment.create("hello.txt"));


### PR DESCRIPTION
It's not clear what "usual" targets meant when reading the code. It
turns out that they're just non-phony targets. Simplify by removing the
word.