### PR TITLE
remote: support building merkle trees from Paths

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -118,9 +118,25 @@ public class MerkleTree {
       Path execRoot,
       DigestUtil digestUtil)
       throws IOException {
-    try (SilentCloseable c = Profiler.instance().profile("MerkleTree.build")) {
+    try (SilentCloseable c = Profiler.instance().profile("MerkleTree.build(ActionInput)")) {
       DirectoryTree tree =
           DirectoryTreeBuilder.fromActionInputs(inputs, metadataProvider, execRoot, digestUtil);
+      return build(tree, digestUtil);
+    }
+  }
+
+  /**
+   * Constructs a merkle tree from a lexicographically sorted map of files.
+   *
+   * @param inputFiles a map of path to files. The map is required to be sorted lexicographically by
+   *     paths.
+   * @param digestUtil a hashing utility
+   */
+  public static MerkleTree build(
+      SortedMap<PathFragment, Path> inputFiles,
+      DigestUtil digestUtil) throws IOException {
+    try(SilentCloseable c = Profiler.instance().profile("MerkleTree.build(Path)")) {
+      DirectoryTree tree = DirectoryTreeBuilder.fromPaths(inputFiles, digestUtil);
       return build(tree, digestUtil);
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/ActionInputDirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/ActionInputDirectoryTreeTest.java
@@ -1,0 +1,154 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.merkletree;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.ActionInputHelper;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.FileArtifactValue;
+import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
+import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.FileNode;
+import com.google.devtools.build.lib.remote.util.StaticMetadataProvider;
+import com.google.devtools.build.lib.remote.util.StringActionInput;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.junit.Test;
+
+/** Tests for {@link DirectoryTreeBuilder#buildFromActionInputs}. */
+public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
+
+  @Override
+  protected DirectoryTree build(Path... paths) throws IOException {
+    SortedMap<PathFragment, ActionInput> inputFiles = new TreeMap<>();
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+
+    for (Path path : paths) {
+      PathFragment relPath = path.relativeTo(execRoot);
+      Artifact a = ActionsTestUtil.createArtifact(artifactRoot, path);
+
+      inputFiles.put(relPath, a);
+      metadata.put(a, FileArtifactValue.createForTesting(a));
+    }
+
+    return DirectoryTreeBuilder.fromActionInputs(inputFiles, new StaticMetadataProvider(metadata), execRoot, digestUtil);
+  }
+
+  @Test
+  public void virtualActionInputShouldWork() throws Exception {
+    SortedMap<PathFragment, ActionInput> sortedInputs = new TreeMap<>();
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+
+    Artifact foo = addFile("srcs/foo.cc", "foo", sortedInputs, metadata);
+    VirtualActionInput bar = addVirtualFile("srcs/bar.cc", "bar", sortedInputs);
+
+    DirectoryTree tree =
+        DirectoryTreeBuilder.fromActionInputs(
+            sortedInputs, new StaticMetadataProvider(metadata), execRoot, digestUtil);
+    assertLexicographicalOrder(tree);
+
+    assertThat(directoriesAtDepth(0, tree)).containsExactly("srcs");
+    assertThat(directoriesAtDepth(1, tree)).isEmpty();
+
+    FileNode expectedFooNode =
+        new FileNode("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
+    FileNode expectedBarNode =
+        new FileNode("bar.cc", bar.getBytes(), digestUtil.computeAsUtf8("bar"));
+    assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
+    assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode, expectedBarNode);
+  }
+
+  @Test
+  public void directoryInputShouldBeExpanded() throws Exception {
+    // Test that directory inputs are fully expanded and added to the input tree.
+    // Note that this test is not about tree artifacts, but normal artifacts that point to
+    // a directory on disk.
+
+    SortedMap<PathFragment, ActionInput> sortedInputs = new TreeMap<>();
+    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+
+    Artifact foo = addFile("srcs/foo.cc", "foo", sortedInputs, metadata);
+
+    Path dirPath = execRoot.getRelative("srcs/dir");
+    dirPath.createDirectoryAndParents();
+
+    Path barPath = dirPath.getRelative("bar.cc");
+    FileSystemUtils.writeContentAsLatin1(barPath, "bar");
+    ActionInput bar = ActionInputHelper.fromPath(barPath.relativeTo(execRoot));
+    metadata.put(bar, FileArtifactValue.createForTesting(barPath));
+
+    dirPath.getRelative("fizz").createDirectoryAndParents();
+    Path buzzPath = dirPath.getRelative("fizz/buzz.cc");
+    FileSystemUtils.writeContentAsLatin1(dirPath.getRelative("fizz/buzz.cc"), "buzz");
+    ActionInput buzz = ActionInputHelper.fromPath(buzzPath.relativeTo(execRoot));
+    metadata.put(buzz, FileArtifactValue.createForTesting(buzzPath));
+
+    Artifact dir = ActionsTestUtil.createArtifact(artifactRoot, dirPath);
+    sortedInputs.put(dirPath.relativeTo(execRoot), dir);
+    metadata.put(dir, FileArtifactValue.createForTesting(dirPath));
+
+    DirectoryTree tree =
+        DirectoryTreeBuilder.fromActionInputs(
+            sortedInputs, new StaticMetadataProvider(metadata), execRoot, digestUtil);
+    assertLexicographicalOrder(tree);
+
+    assertThat(directoriesAtDepth(0, tree)).containsExactly("srcs");
+    assertThat(directoriesAtDepth(1, tree)).containsExactly("dir");
+    assertThat(directoriesAtDepth(2, tree)).containsExactly("fizz");
+    assertThat(directoriesAtDepth(3, tree)).isEmpty();
+
+    FileNode expectedFooNode =
+        new FileNode("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
+    FileNode expectedBarNode =
+        new FileNode(
+            "bar.cc", execRoot.getRelative(bar.getExecPath()), digestUtil.computeAsUtf8("bar"));
+    FileNode expectedBuzzNode =
+        new FileNode(
+            "buzz.cc", execRoot.getRelative(buzz.getExecPath()), digestUtil.computeAsUtf8("buzz"));
+    assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
+    assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode);
+    assertThat(fileNodesAtDepth(tree, 2)).containsExactly(expectedBarNode);
+    assertThat(fileNodesAtDepth(tree, 3)).containsExactly(expectedBuzzNode);
+  }
+
+  private VirtualActionInput addVirtualFile(
+      String path, String content, SortedMap<PathFragment, ActionInput> sortedInputs) {
+    VirtualActionInput input = new StringActionInput(content, PathFragment.create(path));
+    sortedInputs.put(PathFragment.create(path), input);
+    return input;
+  }
+
+  private Artifact addFile(
+      String path,
+      String content,
+      SortedMap<PathFragment, ActionInput> sortedInputs,
+      Map<ActionInput, FileArtifactValue> metadata) throws IOException {
+    Path p = execRoot.getRelative(path);
+    p.getParentDirectory().createDirectoryAndParents();
+    FileSystemUtils.writeContentAsLatin1(p, content);
+    Artifact a = ActionsTestUtil.createArtifact(artifactRoot, p);
+
+    sortedInputs.put(PathFragment.create(path), a);
+    metadata.put(a, FileArtifactValue.createForTesting(a));
+    return a;
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
@@ -51,11 +51,11 @@ import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link DirectoryTree}. */
 @RunWith(JUnit4.class)
-public class DirectoryTreeTest {
+public abstract class DirectoryTreeTest {
 
-  private Path execRoot;
-  private ArtifactRoot artifactRoot;
-  private DigestUtil digestUtil;
+  protected Path execRoot;
+  protected ArtifactRoot artifactRoot;
+  protected DigestUtil digestUtil;
 
   @Before
   public void setup() {
@@ -65,30 +65,22 @@ public class DirectoryTreeTest {
     digestUtil = new DigestUtil(fs.getDigestFunction());
   }
 
+  protected abstract DirectoryTree build(Path... paths) throws IOException;
+
   @Test
   public void emptyTreeShouldWork() throws Exception {
-    DirectoryTree tree =
-        DirectoryTreeBuilder.fromActionInputs(
-            new TreeMap<>(),
-            new StaticMetadataProvider(Collections.emptyMap()),
-            execRoot,
-            digestUtil);
+    DirectoryTree tree = build();
     assertThat(directoryNodesAtDepth(tree, 0)).isEmpty();
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
   }
 
   @Test
   public void buildingATreeOfFilesShouldWork() throws Exception {
-    SortedMap<PathFragment, ActionInput> sortedInputs = new TreeMap<>();
-    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Path foo = createFile("srcs/foo.cc", "foo");
+    Path bar = createFile("srcs/bar.cc", "bar");
+    Path buzz = createFile("srcs/fizz/buzz.cc", "buzz");
 
-    Artifact foo = addFile("srcs/foo.cc", "foo", sortedInputs, metadata);
-    Artifact bar = addFile("srcs/bar.cc", "bar", sortedInputs, metadata);
-    Artifact buzz = addFile("srcs/fizz/buzz.cc", "buzz", sortedInputs, metadata);
-
-    DirectoryTree tree =
-        DirectoryTreeBuilder.fromActionInputs(
-            sortedInputs, new StaticMetadataProvider(metadata), execRoot, digestUtil);
+    DirectoryTree tree = build(foo, bar, buzz);
     assertLexicographicalOrder(tree);
 
     assertThat(directoriesAtDepth(0, tree)).containsExactly("srcs");
@@ -96,92 +88,16 @@ public class DirectoryTreeTest {
     assertThat(directoriesAtDepth(2, tree)).isEmpty();
 
     FileNode expectedFooNode =
-        new FileNode("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
+        new FileNode("foo.cc", foo, digestUtil.computeAsUtf8("foo"));
     FileNode expectedBarNode =
-        new FileNode("bar.cc", bar.getPath(), digestUtil.computeAsUtf8("bar"));
+        new FileNode("bar.cc", bar, digestUtil.computeAsUtf8("bar"));
     FileNode expectedBuzzNode =
-        new FileNode("buzz.cc", buzz.getPath(), digestUtil.computeAsUtf8("buzz"));
+        new FileNode("buzz.cc", buzz, digestUtil.computeAsUtf8("buzz"));
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
     assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode, expectedBarNode);
     assertThat(fileNodesAtDepth(tree, 2)).containsExactly(expectedBuzzNode);
   }
 
-  @Test
-  public void virtualActionInputShouldWork() throws Exception {
-    SortedMap<PathFragment, ActionInput> sortedInputs = new TreeMap<>();
-    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
-
-    Artifact foo = addFile("srcs/foo.cc", "foo", sortedInputs, metadata);
-    VirtualActionInput bar = addVirtualFile("srcs/bar.cc", "bar", sortedInputs);
-
-    DirectoryTree tree =
-        DirectoryTreeBuilder.fromActionInputs(
-            sortedInputs, new StaticMetadataProvider(metadata), execRoot, digestUtil);
-    assertLexicographicalOrder(tree);
-
-    assertThat(directoriesAtDepth(0, tree)).containsExactly("srcs");
-    assertThat(directoriesAtDepth(1, tree)).isEmpty();
-
-    FileNode expectedFooNode =
-        new FileNode("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
-    FileNode expectedBarNode =
-        new FileNode("bar.cc", bar.getBytes(), digestUtil.computeAsUtf8("bar"));
-    assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
-    assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode, expectedBarNode);
-  }
-
-  @Test
-  public void directoryInputShouldBeExpanded() throws Exception {
-    // Test that directory inputs are fully expanded and added to the input tree.
-    // Note that this test is not about tree artifacts, but normal artifacts that point to
-    // a directory on disk.
-
-    SortedMap<PathFragment, ActionInput> sortedInputs = new TreeMap<>();
-    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
-
-    Artifact foo = addFile("srcs/foo.cc", "foo", sortedInputs, metadata);
-
-    Path dirPath = execRoot.getRelative("srcs/dir");
-    dirPath.createDirectoryAndParents();
-
-    Path barPath = dirPath.getRelative("bar.cc");
-    FileSystemUtils.writeContentAsLatin1(barPath, "bar");
-    ActionInput bar = ActionInputHelper.fromPath(barPath.relativeTo(execRoot));
-    metadata.put(bar, FileArtifactValue.createForTesting(barPath));
-
-    dirPath.getRelative("fizz").createDirectoryAndParents();
-    Path buzzPath = dirPath.getRelative("fizz/buzz.cc");
-    FileSystemUtils.writeContentAsLatin1(dirPath.getRelative("fizz/buzz.cc"), "buzz");
-    ActionInput buzz = ActionInputHelper.fromPath(buzzPath.relativeTo(execRoot));
-    metadata.put(buzz, FileArtifactValue.createForTesting(buzzPath));
-
-    Artifact dir = ActionsTestUtil.createArtifact(artifactRoot, dirPath);
-    sortedInputs.put(dirPath.relativeTo(execRoot), dir);
-    metadata.put(dir, FileArtifactValue.createForTesting(dirPath));
-
-    DirectoryTree tree =
-        DirectoryTreeBuilder.fromActionInputs(
-            sortedInputs, new StaticMetadataProvider(metadata), execRoot, digestUtil);
-    assertLexicographicalOrder(tree);
-
-    assertThat(directoriesAtDepth(0, tree)).containsExactly("srcs");
-    assertThat(directoriesAtDepth(1, tree)).containsExactly("dir");
-    assertThat(directoriesAtDepth(2, tree)).containsExactly("fizz");
-    assertThat(directoriesAtDepth(3, tree)).isEmpty();
-
-    FileNode expectedFooNode =
-        new FileNode("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
-    FileNode expectedBarNode =
-        new FileNode(
-            "bar.cc", execRoot.getRelative(bar.getExecPath()), digestUtil.computeAsUtf8("bar"));
-    FileNode expectedBuzzNode =
-        new FileNode(
-            "buzz.cc", execRoot.getRelative(buzz.getExecPath()), digestUtil.computeAsUtf8("buzz"));
-    assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
-    assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode);
-    assertThat(fileNodesAtDepth(tree, 2)).containsExactly(expectedBarNode);
-    assertThat(fileNodesAtDepth(tree, 3)).containsExactly(expectedBuzzNode);
-  }
 
   @Test
   public void testLexicographicalOrder() throws Exception {
@@ -196,42 +112,22 @@ public class DirectoryTreeTest {
     //
     // However, the tree node [system-root, system] is not (note the missing / suffix).
 
-    SortedMap<PathFragment, ActionInput> sortedInputs = new TreeMap<>();
-    Map<ActionInput, FileArtifactValue> metadata = new HashMap<>();
+    Path file1 = createFile("srcs/system/foo.txt", "foo");
+    Path file2 = createFile("srcs/system-root/bar.txt", "bar");
 
-    addFile("srcs/system/foo.txt", "foo", sortedInputs, metadata);
-    addFile("srcs/system-root/bar.txt", "bar", sortedInputs, metadata);
+    DirectoryTree tree = build(file1, file2);
 
-    DirectoryTree tree =
-        DirectoryTreeBuilder.fromActionInputs(
-            sortedInputs, new StaticMetadataProvider(metadata), execRoot, digestUtil);
     assertLexicographicalOrder(tree);
   }
 
-  private Artifact addFile(
-      String path,
-      String content,
-      SortedMap<PathFragment, ActionInput> sortedInputs,
-      Map<ActionInput, FileArtifactValue> metadata)
-      throws IOException {
+  protected Path createFile(String path, String content) throws IOException {
     Path p = execRoot.getRelative(path);
     p.getParentDirectory().createDirectoryAndParents();
     FileSystemUtils.writeContentAsLatin1(p, content);
-    Artifact a = ActionsTestUtil.createArtifact(artifactRoot, p);
-
-    sortedInputs.put(PathFragment.create(path), a);
-    metadata.put(a, FileArtifactValue.createForTesting(a));
-    return a;
+    return p;
   }
 
-  private VirtualActionInput addVirtualFile(
-      String path, String content, SortedMap<PathFragment, ActionInput> sortedInputs) {
-    VirtualActionInput input = new StringActionInput(content, PathFragment.create(path));
-    sortedInputs.put(PathFragment.create(path), input);
-    return input;
-  }
-
-  private static void assertLexicographicalOrder(DirectoryTree tree) {
+  static void assertLexicographicalOrder(DirectoryTree tree) {
     // Assert the lexicographical order as defined by the remote execution protocol
     tree.visit(
         (PathFragment dirname, List<FileNode> files, List<DirectoryNode> dirs) -> {
@@ -240,7 +136,7 @@ public class DirectoryTreeTest {
         });
   }
 
-  private static List<String> directoriesAtDepth(int depth, DirectoryTree tree) {
+  static List<String> directoriesAtDepth(int depth, DirectoryTree tree) {
     return asPathSegments(directoryNodesAtDepth(tree, depth));
   }
 
@@ -260,7 +156,7 @@ public class DirectoryTreeTest {
     return directoryNodes;
   }
 
-  private static List<FileNode> fileNodesAtDepth(DirectoryTree tree, int depth) {
+  static List<FileNode> fileNodesAtDepth(DirectoryTree tree, int depth) {
     List<FileNode> fileNodes = new ArrayList<>();
     tree.visit(
         (PathFragment dirname, List<FileNode> files, List<DirectoryNode> dirs) -> {

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/PathDirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/PathDirectoryTreeTest.java
@@ -1,0 +1,33 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.merkletree;
+
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/** Tests for {@link DirectoryTreeBuilder#fromPaths}. */
+public class PathDirectoryTreeTest extends DirectoryTreeTest {
+
+  @Override
+  protected DirectoryTree build(Path... paths) throws IOException {
+    SortedMap<PathFragment, Path> inputFiles = new TreeMap<>();
+    for (Path path : paths) {
+      inputFiles.put(path.relativeTo(execRoot), path);
+    }
+    return DirectoryTreeBuilder.fromPaths(inputFiles, digestUtil);
+  }
+}


### PR DESCRIPTION
The MerkleTree builder is coupled to ActionInput, a type of the
execution phase. This change adds support for building merkle
trees from Path objects. This is needed for supporting file uploads
in repository_ctx.execute which runs before the execution phase.