### PR TITLE
 remote: add file uploads to repository_ctx.execute

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEvent.java
@@ -40,7 +40,7 @@ public final class WorkspaceRuleEvent implements ProgressLike {
 
   /** Creates a new WorkspaceRuleEvent for an execution event. */
   public static WorkspaceRuleEvent newExecuteEvent(
-      Iterable<?> args, // <String> or <SkylarkPath> expected
+      Iterable<String> args,
       Integer timeout,
       Map<String, String> commonEnvironment,
       Map<String, String> customEnvironment,
@@ -61,8 +61,8 @@ public final class WorkspaceRuleEvent implements ProgressLike {
       e = e.putAllEnvironment(customEnvironment);
     }
 
-    for (Object a : args) {
-      e.addArguments(a.toString());
+    for (String a : args) {
+      e.addArguments(a);
     }
 
     WorkspaceLogProtos.WorkspaceEvent.Builder result =

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkExecutionResult.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkExecutionResult.java
@@ -99,20 +99,9 @@ final class SkylarkExecutionResult implements SkylarkExecutionResultApi {
      * Adds arguments to the list of arguments to pass to the command. The first argument is
      * expected to be the binary to execute. The subsequent arguments are the arguments passed to
      * the binary.
-     *
-     * <p>Each argument can be either a string or a {@link SkylarkPath}, passing another argument
-     * will fail when executing the command.
      */
-    Builder addArguments(Iterable<?> args) throws EvalException {
-      for (Object arg : args) {
-        // We might have skylark path, do conversion.
-        if (!(arg instanceof String || arg instanceof SkylarkPath)) {
-          throw new EvalException(
-              Location.BUILTIN,
-              "Argument " + this.args.size() + " of execute is neither a path nor a string.");
-        }
-        this.args.add(arg.toString());
-      }
+    Builder addArguments(List<String> args) {
+      this.args.addAll(args);
       return this;
     }
 
@@ -120,7 +109,7 @@ final class SkylarkExecutionResult implements SkylarkExecutionResultApi {
      * Set the path to the directory to execute the result process. This method must be called
      * before calling {@link #execute()}.
      */
-    Builder setDirectory(File path) throws EvalException {
+    Builder setDirectory(File path) {
       this.directory = path;
       return this;
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
@@ -30,6 +30,8 @@ import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.protobuf.Message;
 import io.grpc.Context;
 import java.io.IOException;
@@ -84,6 +86,7 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
   @Override
   public ExecutionResult execute(
       ImmutableList<String> arguments,
+      ImmutableSortedMap<PathFragment, Path> inputFiles,
       ImmutableMap<String, String> executionProperties,
       ImmutableMap<String, String> environment,
       String workingDirectory,
@@ -100,12 +103,7 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
               platform,
               workingDirectory);
       Digest commandHash = digestUtil.compute(command);
-      MerkleTree merkleTree =
-          MerkleTree.build(
-              ImmutableSortedMap.of(),
-              /* metadataProvider= */ null,
-              /* execRoot= */ null,
-              digestUtil);
+      MerkleTree merkleTree = MerkleTree.build(inputFiles, digestUtil);
       Action action =
           RemoteSpawnRunner.buildAction(
               commandHash, merkleTree.getRootDigest(), timeout, acceptCached);

--- a/src/main/java/com/google/devtools/build/lib/runtime/RepositoryRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/RepositoryRemoteExecutor.java
@@ -15,6 +15,9 @@ package com.google.devtools.build.lib.runtime;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.time.Duration;
 
@@ -51,6 +54,9 @@ public interface RepositoryRemoteExecutor {
    * Execute a command remotely.
    *
    * @param arguments the command arguments.
+   * @param inputFiles the files to upload and stage for the command. The key describes where to
+   *               stage the file on the remote machine. The value is the path of the file on
+   *               the host machine (where Bazel is running).
    * @param executionProperties the remote platform the command should run on.
    * @param environment any environment variables that should be set in the command's environment.
    * @param workingDirectory the working directory to run the command under. {@code ""} means that
@@ -59,6 +65,7 @@ public interface RepositoryRemoteExecutor {
    */
   ExecutionResult execute(
       ImmutableList<String> arguments,
+      ImmutableSortedMap<PathFragment, Path> inputFiles,
       ImmutableMap<String, String> executionProperties,
       ImmutableMap<String, String> environment,
       String workingDirectory,

--- a/src/test/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEventTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleEventTest.java
@@ -31,12 +31,6 @@ import org.junit.runners.JUnit4;
 /** Tests handling of WorkspaceRuleEvent */
 @RunWith(JUnit4.class)
 public final class WorkspaceRuleEventTest {
-  static class DummyString {
-    @Override
-    public String toString() {
-      return "dummy string";
-    }
-  }
 
   @Before
   public void setUp() {}
@@ -44,9 +38,9 @@ public final class WorkspaceRuleEventTest {
   @Test
   public void newExecuteEvent_expectedResult() {
     // Set up arguments, as a combination of String and SkylarkPath
-    ArrayList<Object> arguments = new ArrayList<>();
+    ArrayList<String> arguments = new ArrayList<>();
     arguments.add("argument 1");
-    arguments.add(new DummyString());
+    arguments.add("dummy string");
 
     Map<String, String> commonEnv = ImmutableMap.of("key1", "val1", "key3", "val3");
     Map<String, String> customEnv = ImmutableMap.of("key2", "val2!", "key3", "val3!");

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.io.CharStreams;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
@@ -398,7 +399,7 @@ public final class SkylarkRepositoryContextTest {
             0,
             "test-stdout".getBytes(StandardCharsets.US_ASCII),
             "test-stderr".getBytes(StandardCharsets.US_ASCII));
-    when(repoRemoteExecutor.execute(any(), any(), any(), any(), any())).thenReturn(executionResult);
+    when(repoRemoteExecutor.execute(any(), any(), any(), any(), any(), any())).thenReturn(executionResult);
 
     setUpContextForRule(
         attrValues,
@@ -422,6 +423,7 @@ public final class SkylarkRepositoryContextTest {
     verify(repoRemoteExecutor)
         .execute(
             /* arguments= */ ImmutableList.of("/bin/cmd", "arg1"),
+            /* inputFiles= */ ImmutableSortedMap.of(),
             /* executionProperties= */ ImmutableMap.of("OSFamily", "Linux"),
             /* environment= */ ImmutableMap.of(),
             /* workingDirectory= */ "",

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorTest.java
@@ -25,6 +25,7 @@ import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.ExecuteResponse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor.ExecutionResult;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -78,6 +79,7 @@ public class RemoteRepositoryRemoteExecutorTest {
     ExecutionResult executionResult =
         repoExecutor.execute(
             ImmutableList.of("/bin/bash", "-c", "exit 0"),
+            /* inputFiles= */ ImmutableSortedMap.of(),
             /* executionProperties= */ ImmutableMap.of(),
             /* environment= */ ImmutableMap.of(),
             /* workingDirectory= */ null,
@@ -107,6 +109,7 @@ public class RemoteRepositoryRemoteExecutorTest {
     ExecutionResult executionResult =
         repoExecutor.execute(
             ImmutableList.of("/bin/bash", "-c", "exit 1"),
+            /* inputFiles= */ ImmutableSortedMap.of(),
             /* executionProperties= */ ImmutableMap.of(),
             /* environment= */ ImmutableMap.of(),
             /* workingDirectory= */ null,
@@ -143,6 +146,7 @@ public class RemoteRepositoryRemoteExecutorTest {
     ExecutionResult executionResult =
         repoExecutor.execute(
             ImmutableList.of("/bin/bash", "-c", "echo hello"),
+            /* inputFiles= */ ImmutableSortedMap.of(),
             /* executionProperties= */ ImmutableMap.of(),
             /* environment= */ ImmutableMap.of(),
             /* workingDirectory= */ null,


### PR DESCRIPTION
This change adds file uploads to repository_ctx.execute when used with
--experimental_repo_remote_exec and remote execution. When passing a
Label as an argument the respective file is uploaded and added as an
input to the remote action. The Label argument is converted to the
remote path of the file. Labels in the main workspace are translated
to their workspace relative part. Labels in external repositories are
translated to paths starting with external/<repo_name>/....

Example:

repository_ctx.execute([Label("//config:find_config.py"),
Label("@foo_repo//config:options.json"), "foo"])

This will upload both find_config.py and options.json and stage them on
the remote machine at

./config/find_config.py
./external/foo_repo/config/options.json

and execute the command "./config/find_config.py
./external/foo_repo/config/options.json foo" on the remote machine. For
local execution the paths will refer to machines.

Additional information at https://docs.google.com/document/d/1V0EbErjsg24lmwTn21Z3_0K9tmzg9kk8VOCestNrri4/edit#heading=h.os7cq3rrq6dl