### PR TITLE
make_deb: fix length computation for extrafiles

### DIFF
--- a/tools/build_defs/pkg/make_deb.py
+++ b/tools/build_defs/pkg/make_deb.py
@@ -179,9 +179,10 @@ def CreateDebControl(extrafiles=None, **kwargs):
       if extrafiles:
         for name, (data, mode) in extrafiles.items():
           tarinfo = tarfile.TarInfo(name)
-          tarinfo.size = len(data)
+          data_utf8 = six.ensure_binary(data, 'utf-8')
+          tarinfo.size = len(data_utf8)
           tarinfo.mode = mode
-          f.addfile(tarinfo, fileobj=BytesIO(six.ensure_binary(data, 'utf-8')))
+          f.addfile(tarinfo, fileobj=BytesIO(data_utf8))
   control = tar.getvalue()
   tar.close()
   return control


### PR DESCRIPTION
When adding the `extrafiles` (e.g. `preinst`, `postinst` etc.) with non-ascii characters in the content to the tar, a potentially faulty length was used. This would result in truncated files.
This seems to only occur when using files that are the result of build rules, i.e. the problem does not seem to occur when using a plain file as input for e.g. `postinst`.

This seems to have been be an oversight in 70e3c339bea02f6e9273b13de11d078ca6c2752f, where the same problem was fixed for the main `control` file.
This change makes the handling of the length of the `extrafiles` identical to the main `control` file.