### PR TITLE
refactor: remove misleading RuleClass#addOrOverrideAttribute

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java
@@ -436,8 +436,8 @@ public class SkylarkRuleClassFunctions implements SkylarkRuleFunctionsApi<Artifa
   private static void addAttribute(RuleClass.Builder builder, Attribute attribute)
       throws EvalException {
     try {
-      builder.addOrOverrideAttribute(attribute);
-    } catch (IllegalArgumentException ex) {
+      builder.addAttribute(attribute);
+    } catch (IllegalStateException ex) {
       throw new EvalException(null, ex);
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryModule.java
@@ -76,13 +76,13 @@ public class SkylarkRepositoryModule implements RepositoryModuleApi {
     builder.setCallStack(
         callstack.subList(0, callstack.size() - 1)); // pop 'repository_rule' itself
 
-    builder.addOrOverrideAttribute(attr("$local", BOOLEAN).defaultValue(local).build());
-    builder.addOrOverrideAttribute(attr("$configure", BOOLEAN).defaultValue(configure).build());
+    builder.addAttribute(attr("$local", BOOLEAN).defaultValue(local).build());
+    builder.addAttribute(attr("$configure", BOOLEAN).defaultValue(configure).build());
     if (thread.getSemantics().experimentalRepoRemoteExec()) {
-      builder.addOrOverrideAttribute(attr("$remotable", BOOLEAN).defaultValue(remotable).build());
+      builder.addAttribute(attr("$remotable", BOOLEAN).defaultValue(remotable).build());
       BaseRuleClasses.execPropertiesAttribute(builder);
     }
-    builder.addOrOverrideAttribute(
+    builder.addAttribute(
         attr("$environ", STRING_LIST).defaultValue(environ).build());
     BaseRuleClasses.nameAttribute(builder);
     BaseRuleClasses.commonCoreAndSkylarkAttributes(builder);

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -1129,7 +1129,7 @@ public class RuleClass {
 
     public Builder addAttribute(Attribute attribute) {
       Preconditions.checkState(!attributes.containsKey(attribute.getName()),
-          "An attribute with the name '%s' already exists.", attribute.getName());
+          "There is already a built-in attribute '%s' which cannot be overridden.", attribute.getName());
       attributes.put(attribute.getName(), attribute);
       return this;
     }
@@ -1166,20 +1166,6 @@ public class RuleClass {
     public <TYPE> Builder override(Attribute.Builder<TYPE> attr) {
       overrideAttribute(attr.build());
       return this;
-    }
-
-    /**
-     * Adds or overrides the attribute in the rule class. Meant for Skylark usage.
-     *
-     * @throws IllegalArgumentException if the attribute overrides an existing attribute (will be
-     * legal in the future).
-     */
-    public void addOrOverrideAttribute(Attribute attribute) {
-      String name = attribute.getName();
-      // Attributes may be overridden in the future.
-      Preconditions.checkArgument(!attributes.containsKey(name),
-          "There is already a built-in attribute '%s' which cannot be overridden", name);
-      addAttribute(attribute);
     }
 
     /** True if the rule class contains an attribute named {@code name}. */

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryContextTest.java
@@ -95,7 +95,7 @@ public final class SkylarkRepositoryContextTest {
     RuleClass.Builder ruleClassBuilder =
         new RuleClass.Builder("test", RuleClassType.WORKSPACE, true);
     for (Attribute attr : attributes) {
-      ruleClassBuilder.addOrOverrideAttribute(attr);
+      ruleClassBuilder.addAttribute(attr);
     }
     ruleClassBuilder.setWorkspaceOnly();
     ruleClassBuilder.setConfiguredTargetFunction(


### PR DESCRIPTION
Despite the name RuleClass#addOrOverrideAttribute does not allow overrides of attributes. It's semantically equivalent to RuleClass#addAttribute.

The method is misleading at best. Remove it.