### PR TITLE
Add option to preserve input tar mtimes in TarFileWriter

### DIFF
--- a/tools/build_defs/pkg/archive_test.py
+++ b/tools/build_defs/pkg/archive_test.py
@@ -161,6 +161,34 @@ class TarFileWriterTest(unittest.TestCase):
     } for n in names])
     self.assertTarFileContent(self.tempfile, content)
 
+  def testDefaultMtimeNotProvided(self):
+    with archive.TarFileWriter(self.tempfile) as f:
+      self.assertEqual(f.default_mtime, 0)
+
+  def testDefaultMtimeProvided(self):
+    with archive.TarFileWriter(self.tempfile, default_mtime=1234) as f:
+      self.assertEqual(f.default_mtime, 1234)
+
+  def testPortableMtime(self):
+    with archive.TarFileWriter(self.tempfile, default_mtime="portable") as f:
+      self.assertEqual(f.default_mtime, 946684800)
+
+  def testPreserveTarMtimesTrue(self):
+    with archive.TarFileWriter(self.tempfile, preserve_tar_mtimes=True) as f:
+      input_tar_path = os.path.join(testenv.TESTDATA_PATH, "tar_test.tar")
+      f.add_tar(input_tar_path)
+      input_tar = tarfile.open(input_tar_path, "r")
+      for file_name in f.members:
+        input_file = input_tar.getmember(file_name)
+        output_file = f.tar.getmember(file_name)
+        self.assertEqual(input_file.mtime, output_file.mtime)
+
+  def testPreserveTarMtimesFalse(self):
+    with archive.TarFileWriter(self.tempfile, preserve_tar_mtimes=False) as f:
+      f.add_tar(os.path.join(testenv.TESTDATA_PATH, "tar_test.tar"))
+      for output_file in f.tar:
+        self.assertEqual(output_file.mtime, 0)
+
   def testAddFile(self):
     self.assertSimpleFileContent(["./a"])
     self.assertSimpleFileContent(["./b"])


### PR DESCRIPTION
Also backfill unit tests of default mtime functionality.

This is the first in a short sequence of changes aimed at fixing static file caching issues in applications deployed using the container_image rule in [rules_docker](https://github.com/bazelbuild/rules_docker). That rule relies on TarFileWriter, which currently copies files from one tar to another and overwrites the input files' mtimes, which causes the Last-Modified HTTP header to always return the same value and breaks browser caches.

This PR contains an additive change in the form of an optional parameter to TarFileWriter that copies mtimes from the input tar files to the output tar. It should not affect any existing behavior.