### PR TITLE
make --experimental_repo_remote_exec compatible with rbe_autconfig

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -37,6 +37,7 @@ import com.google.devtools.build.lib.analysis.constraints.EnvironmentRule;
 import com.google.devtools.build.lib.analysis.test.TestConfiguration;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.Attribute;
+import com.google.devtools.build.lib.packages.Attribute.Builder;
 import com.google.devtools.build.lib.packages.Attribute.LabelLateBoundDefault;
 import com.google.devtools.build.lib.packages.Attribute.LabelListLateBoundDefault;
 import com.google.devtools.build.lib.packages.Attribute.LateBoundDefault.Resolver;
@@ -49,6 +50,7 @@ import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.packages.Type.ConversionException;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.util.FileTypeSet;
+import java.util.Map;
 
 /**
  * Rule class definitions used by (almost) every rule.
@@ -345,10 +347,19 @@ public class BaseRuleClasses {
     return builder.add(attr("name", STRING).nonconfigurable("Rule name"));
   }
 
-  public static RuleClass.Builder execPropertiesAttribute(RuleClass.Builder builder)
+  /**
+   * Adds an {@code exec_properties} attribute of type {@code STRING_DICT} if the rule does not
+   * already have one.
+   */
+  public static void addOrOverrideExecPropertiesAttribute(RuleClass.Builder builder)
       throws ConversionException {
-    return builder.add(
-        attr(RuleClass.EXEC_PROPERTIES, STRING_DICT).defaultValue(ImmutableMap.of()));
+    Builder<Map<String, String>> attr =
+        attr(RuleClass.EXEC_PROPERTIES, STRING_DICT).defaultValue(ImmutableMap.of());
+    if (builder.contains(RuleClass.EXEC_PROPERTIES)) {
+      builder.override(attr);
+    } else {
+      builder.add(attr);
+    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/skylark/SkylarkRepositoryModule.java
@@ -80,7 +80,6 @@ public class SkylarkRepositoryModule implements RepositoryModuleApi {
     builder.addOrOverrideAttribute(attr("$configure", BOOLEAN).defaultValue(configure).build());
     if (thread.getSemantics().experimentalRepoRemoteExec()) {
       builder.addOrOverrideAttribute(attr("$remotable", BOOLEAN).defaultValue(remotable).build());
-      BaseRuleClasses.execPropertiesAttribute(builder);
     }
     builder.addOrOverrideAttribute(
         attr("$environ", STRING_LIST).defaultValue(environ).build());
@@ -102,6 +101,13 @@ public class SkylarkRepositoryModule implements RepositoryModuleApi {
         }
         builder.addAttribute(attrDescriptor.build(attrName));
       }
+    }
+    if (thread.getSemantics().experimentalRepoRemoteExec()) {
+      // Add the 'exec_properties' attribute last. That way it's backwards compatible with
+      // repository rules that already declare 'exec_properties'. In particular
+      // https://github.com/bazelbuild/bazel-toolchains
+      // TODO(buchgr): Remove this backwards compatiblity hack once the feature is marked stable.
+      BaseRuleClasses.addOrOverrideExecPropertiesAttribute(builder);
     }
     builder.setConfiguredTargetFunction(implementation);
     builder.setRuleDefinitionEnvironmentLabelAndHashCode(

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1781,6 +1781,47 @@ EOF
   expect_log "exceeded deadline"
 }
 
+function test_repo_remote_exec_override_exec_properties() {
+  # Test that --experimental_repo_remote_exec continues to work if a repository_rule declares an
+  # "exec_properties" attribute. In particular, this is to ensure backwards compatibility with
+  # https://github.com/bazelbuild/bazel-toolchains
+
+  touch BUILD
+
+  cat > test.bzl <<'EOF'
+def _impl(repository_ctx):
+  if repository_ctx.attr.exec_properties["foo"] != "bar":
+    fail("Expected exec_properties attribute to be a dict with key foo and value bar")
+  repository_ctx.file("BUILD")
+
+foo_configure = repository_rule(
+  implementation = _impl,
+  attrs = {
+    "exec_properties" : attr.string_dict(),
+  },
+)
+EOF
+
+cat > WORKSPACE <<'EOF'
+load("//:test.bzl", "foo_configure")
+
+foo_configure(
+  name = "default_foo",
+  exec_properties = {
+    "foo" : "bar",
+  },
+)
+EOF
+
+  bazel fetch @default_foo//:all
+
+  bazel clean --expunge
+
+  bazel fetch \
+    --experimental_repo_remote_exec \
+    @default_foo//:all
+}
+
 # TODO(alpha): Add a test that fails remote execution when remote worker
 # supports sandbox.
 


### PR DESCRIPTION
rbe_autoconfig has an attribute 'exec_properties' of type string_dict [1].
As do all repository rules if --experimental_repo_remote_exec is set.
Bazel reports an error if both are used together. This change fixes this
so if a repository_rule declares an attribute 'exec_properties' of type
string_dict Bazel no longer tries to add its own.

[1] https://github.com/bazelbuild/bazel-toolchains/blob/b5928f980c79cbdbfd0b5c5a924aeb2cd61eb4f9/rules/rbe_repo.bzl#L758