### PR TITLE
Fix horizontal scrollbar on desktop docs

### DIFF
--- a/site/_sass/sidebar.scss
+++ b/site/_sass/sidebar.scss
@@ -8,6 +8,9 @@ $sidebar-hover-border-color: #66bb6a;
   padding-top: 40px;
   padding-left: 1.5rem;
 
+  // override parent row padding-left. bootstrap's default is 15px.
+  margin-left: -15px;
+
   li {
     font-size: $font-size-base * .95;
   }

--- a/site/_sass/style.scss
+++ b/site/_sass/style.scss
@@ -179,11 +179,6 @@ $md-shadow-3: rgba(0, 0, 0, .12);
   .content {
     max-width: 85%;
   }
-
-  body > .container {
-    padding-left: 0;
-    padding-right: 0;
-  }
 }
 
 .content {


### PR DESCRIPTION
docs.bazel.build on desktop now shows a horizontal scrollbar. Let's not change the bootstrap default css for `.container`, but modify our child div's margin to override the parent's instead.