### PR TITLE
always making the directory executable before deleting it

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/unix/UnixFileSystem.java
@@ -430,6 +430,9 @@ public class UnixFileSystem extends AbstractFileSystemWithCustomStat {
       long startTime = Profiler.nanoTimeMaybe();
       try {
         NativePosixFiles.deleteTreesBelow(dir.toString());
+      } catch (IOException e) {
+        // retry with less efficient but more powerful generic implementation
+        super.deleteTreesBelow(dir);
       } finally {
         profiler.logSimpleTask(startTime, ProfilerTask.VFS_DELETE, dir.toString());
       }

--- a/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/FileSystem.java
@@ -229,15 +229,9 @@ public abstract class FileSystem {
   public void deleteTreesBelow(Path dir) throws IOException {
     if (dir.isDirectory(Symlinks.NOFOLLOW)) {
       Collection<Path> entries;
-      try {
-        entries = dir.getDirectoryEntries();
-      } catch (IOException e) {
-        // If we couldn't read the directory, it may be because it's not readable. Try granting this
-        // permission and retry. If the retry fails, give up.
-        dir.setReadable(true);
-        dir.setExecutable(true);
-        entries = dir.getDirectoryEntries();
-      }
+      dir.setReadable(true);
+      dir.setExecutable(true);
+      entries = dir.getDirectoryEntries();
 
       Iterator<Path> iterator = entries.iterator();
       if (iterator.hasNext()) {


### PR DESCRIPTION
When a directory doesn't have the executable bit, `ls` will return an empty list without errors. However, if we won't be able to delete it because it's not empty.

This PR make sure the executable bit is set before listing it. It also make the `UnixFileSystem` to fallback to the generic one if it can't delete the file possibly due to the above mentioned permission issue.

Fixed #11010