### PR TITLE
[Docs] Remove to_list that causes failure in example code

### DIFF
--- a/site/docs/skylark/aspects.md
+++ b/site/docs/skylark/aspects.md
@@ -80,7 +80,7 @@ def _print_aspect_impl(target, ctx):
     if hasattr(ctx.rule.attr, 'srcs'):
         # Iterate through the files that make up the sources and
         # print their paths.
-        for src in ctx.rule.attr.srcs.to_list():
+        for src in ctx.rule.attr.srcs:
             for f in src.files.to_list():
                 print(f.path)
     return []


### PR DESCRIPTION
Running the example (`bazel build //MyExample:example --aspects print.bzl%print_aspect`) in the docs threw the following error for me:

```
Traceback (most recent call last):
	File "/Users/patrickb/.../BUILD", line 3
		//:print.bzl%print_aspect(...)
	File "/Users/patrickb/.../print.bzl", line 6, in _print_aspect_impl
		ctx.rule.attr.srcs.to_list
'list' value has no field or method 'to_list'
```

Removing the `to_list()` fixed it for me since `srcs` seems to be already a `list`.