### PR TITLE
Windows native launcher: support launching with 8dot3 Windows path

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -184,6 +184,8 @@ tasks:
   windows:
     batch_commands:
       - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
+      # TODO(pcloudy): Remove the following after Windows machine already install pywin32
+      - pip install pywin32
     build_flags:
       - "--copt=-w"
       - "--host_copt=-w"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -177,6 +177,8 @@ tasks:
     shards: 4
     batch_commands:
       - powershell -Command "(Get-Content WORKSPACE) -Replace '# android_', 'android_' | Set-Content WORKSPACE"
+      # TODO(pcloudy): Remove the following after Windows machine already install pywin32
+      - pip install pywin32
     build_flags:
       - "--copt=-w"
       - "--host_copt=-w"

--- a/src/test/py/bazel/launcher_test.py
+++ b/src/test/py/bazel/launcher_test.py
@@ -17,6 +17,8 @@ import os
 import stat
 import string
 import unittest
+if os.name == 'nt':
+  import win32api
 from src.test.py.bazel import test_base
 
 
@@ -630,16 +632,31 @@ class LauncherTest(test_base.TestBase):
     exit_code, stdout, stderr = self.RunProgram([long_binary_path], shell=True)
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertEqual('helloworld', ''.join(stdout))
+    # Make sure we can launch the binary with a shortened Windows 8dot3 path
+    short_binary_path = win32api.GetShortPathName(long_binary_path)
+    exit_code, stdout, stderr = self.RunProgram([short_binary_path], shell=True)
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertEqual('helloworld', ''.join(stdout))
 
     long_binary_path = os.path.abspath(long_dir_path + '/bin_sh.exe')
     # subprocess doesn't support long path without shell=True
     exit_code, stdout, stderr = self.RunProgram([long_binary_path], shell=True)
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertEqual('helloworld', ''.join(stdout))
+    # Make sure we can launch the binary with a shortened Windows 8dot3 path
+    short_binary_path = win32api.GetShortPathName(long_binary_path)
+    exit_code, stdout, stderr = self.RunProgram([short_binary_path], shell=True)
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertEqual('helloworld', ''.join(stdout))
 
     long_binary_path = os.path.abspath(long_dir_path + '/bin_py.exe')
     # subprocess doesn't support long path without shell=True
     exit_code, stdout, stderr = self.RunProgram([long_binary_path], shell=True)
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertEqual('helloworld', ''.join(stdout))
+    # Make sure we can launch the binary with a shortened Windows 8dot3 path
+    short_binary_path = win32api.GetShortPathName(long_binary_path)
+    exit_code, stdout, stderr = self.RunProgram([short_binary_path], shell=True)
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertEqual('helloworld', ''.join(stdout))
 

--- a/src/tools/launcher/bash_launcher.cc
+++ b/src/tools/launcher/bash_launcher.cc
@@ -52,7 +52,10 @@ ExitCode BashBinaryLauncher::Launch() {
 
   vector<wstring> origin_args = this->GetCommandlineArguments();
   wostringstream bash_command;
-  wstring bash_main_file = GetBinaryPathWithoutExtension(origin_args[0]);
+  // In case the given binary path is a shortened Windows 8dot3 path, we need to convert it back to
+  // its long path form before using it to find the bash main file.
+  wstring full_binary_path = GetWindowsLongPath(origin_args[0]);
+  wstring bash_main_file = GetBinaryPathWithoutExtension(full_binary_path);
   bash_command << BashEscapeArg(bash_main_file);
   for (int i = 1; i < origin_args.size(); i++) {
     bash_command << L' ';

--- a/src/tools/launcher/python_launcher.cc
+++ b/src/tools/launcher/python_launcher.cc
@@ -56,10 +56,13 @@ ExitCode PythonBinaryLauncher::Launch() {
   vector<wstring> args = this->GetCommandlineArguments();
   wstring use_zip_file = this->GetLaunchInfoByKey(USE_ZIP_FILE);
   wstring python_file;
+  // In case the given binary path is a shortened Windows 8dot3 path, we need to convert it back to
+  // its long path form before using it to find the python file.
+  wstring full_binary_path = GetWindowsLongPath(args[0]);
   if (use_zip_file == L"1") {
-    python_file = GetBinaryPathWithoutExtension(args[0]) + L".zip";
+    python_file = GetBinaryPathWithoutExtension(full_binary_path) + L".zip";
   } else {
-    python_file = GetBinaryPathWithoutExtension(args[0]);
+    python_file = GetBinaryPathWithoutExtension(full_binary_path);
   }
 
   // Replace the first argument with python file path

--- a/src/tools/launcher/util/launcher_util.cc
+++ b/src/tools/launcher/util/launcher_util.cc
@@ -133,7 +133,7 @@ wstring GetWindowsLongPath(const wstring& path) {
   if (!error.empty()) {
     PrintError(L"Failed to get long path for %s: %s", path.c_str(), error.c_str());
   }
-  return wstring(result.get());
+  return wstring(blaze_util::RemoveUncPrefixMaybe(result.get()));
 }
 
 wstring GetBinaryPathWithoutExtension(const wstring& binary) {

--- a/src/tools/launcher/util/launcher_util.cc
+++ b/src/tools/launcher/util/launcher_util.cc
@@ -30,6 +30,7 @@
 #include <string>
 
 #include "src/main/cpp/util/path_platform.h"
+#include "src/main/native/windows/file.h"
 #include "src/tools/launcher/util/launcher_util.h"
 
 namespace bazel {
@@ -123,6 +124,16 @@ bool DeleteDirectoryByPath(const wchar_t* path) {
 
 static bool EndsWithExe(const wstring& s) {
   return s.size() >= 4 && _wcsnicmp(s.c_str() + s.size() - 4, L".exe", 4) == 0;
+}
+
+wstring GetWindowsLongPath(const wstring& path) {
+  std::unique_ptr<WCHAR[]> result;
+  wstring abs_path = AsAbsoluteWindowsPath(path.c_str());
+  wstring error = bazel::windows::GetLongPath(abs_path.c_str(), &result);
+  if (!error.empty()) {
+    PrintError(L"Failed to get long path for %s: %s", path.c_str(), error.c_str());
+  }
+  return wstring(result.get());
 }
 
 wstring GetBinaryPathWithoutExtension(const wstring& binary) {

--- a/src/tools/launcher/util/launcher_util.h
+++ b/src/tools/launcher/util/launcher_util.h
@@ -31,6 +31,12 @@ __declspec(noreturn) void die(const wchar_t* format, ...)
 // Prints the specified error message.
 void PrintError(const wchar_t* format, ...) PRINTF_ATTRIBUTE(1, 2);
 
+// Converts the specified path (Windows 8dot3 style short path) to its long form
+//
+// eg. C:\FO~1\BAR\B~1 -> C:\Foooo\Bar\bin.exe
+// Note that: the given path must be an existing path.
+std::wstring GetWindowsLongPath(const std::wstring& path);
+
 // Strip the .exe extension from binary path.
 //
 // On Windows, if the binary path is foo/bar/bin.exe then return foo/bar/bin


### PR DESCRIPTION
Windows native launcher finds the shell/python script to launch based on the first command line argument (the path name of itself). But it could be a shortened 8dot3 windows path. Eg. when `bazel test` runs a test, if the test binary path is too long (> 260), Bazel will convert it to a short path. The native launcher should convert it back to its full path before using it to find the script to launch.

Fixes https://github.com/bazelbuild/bazel/issues/11023