### PR TITLE
docs: change link target for --define flag in configurable build attributes page

### DIFF
--- a/site/docs/configurable-attributes.md
+++ b/site/docs/configurable-attributes.md
@@ -180,7 +180,7 @@ flag for `IncludeSpecialProjectFeatureX`.
 
 Plans for [truly custom flags](
 https://docs.google.com/document/d/1vc8v-kXjvgZOdQdnxPTaV0rrLxtP2XwnD2tAZlYJOqw/edit?usp=sharing)
-are underway. In the meantime, [`--define`](user-manual.html#flag--define) is
+are underway. In the meantime, [`--define`](command-line-reference.html#flag--define) is
 the best approach for these purposes.
 `--define` is a bit awkward to use and wasn't originally designed for this
 purpose. We recommend using it sparingly until true custom flags are available.


### PR DESCRIPTION
Reference command-line-reference doc page instead of the user-manual for `--define` flag link.

The docs previously were referencing the user-manual for the `--define` flag, however this flag is not covered on this page