### PR TITLE
Use @bazel_tools//tools/jdk:jni.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BUILD
@@ -156,30 +156,5 @@ cc_binary(
         "//conditions:default": ["cpu_profiler_unimpl.cc"],
     }),
     linkshared = 1,
-    deps = [":jni"],  # TODO(adonovan): use @bazel_tools//tools/jdk:jni when released
-)
-
-# This has been copied to @bazel_tools//tools/jdk:jni and will appear in the next release.
-cc_library(
-    name = "jni",
-    hdrs = ["@bazel_tools//tools/jdk:jni_header"] + select({
-        "//src/conditions:linux_x86_64": ["@bazel_tools//tools/jdk:jni_md_header-linux"],
-        "//src/conditions:linux_aarch64": ["@bazel_tools//tools/jdk:jni_md_header-linux"],
-        "//src/conditions:linux_ppc": ["@bazel_tools//tools/jdk:jni_md_header-linux"],
-        "//src/conditions:darwin": ["@bazel_tools//tools/jdk:jni_md_header-darwin"],
-        "//src/conditions:freebsd": ["@bazel_tools//tools/jdk:jni_md_header-freebsd"],
-        "//src/conditions:openbsd": ["@bazel_tools//tools/jdk:jni_md_header-openbsd"],
-        "//src/conditions:windows": ["@bazel_tools//tools/jdk:jni_md_header-windows"],
-        "//conditions:default": [],
-    }),
-    includes = ["../../../../../../../../../external/bazel_tools/tools/jdk/include"] + select({
-        "//src/conditions:linux_x86_64": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/linux"],
-        "//src/conditions:linux_aarch64": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/linux"],
-        "//src/conditions:linux_ppc": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/linux"],
-        "//src/conditions:darwin": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/darwin"],
-        "//src/conditions:freebsd": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/freebsd"],
-        "//src/conditions:openbsd": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/openbsd"],
-        "//src/conditions:windows": ["../../../../../../../../../external/bazel_tools/tools/jdk/include/win32"],
-        "//conditions:default": [],
-    }),
+    deps = ["@bazel_tools//tools/jdk:jni"],
 )


### PR DESCRIPTION
This eliminates annoying analysis warnings from the cc rules.