### PR TITLE
Add rationale for preferring http_archive over git_repository.

### DIFF
--- a/site/docs/external.md
+++ b/site/docs/external.md
@@ -307,7 +307,10 @@ bootstrap test.
 ### Repository rules
 
 Prefer [`http_archive`](repo/http.html#http_archive) to `git_repository` and
-`new_git_repository`.
+`new_git_repository`. Rationale: Git repository rules depend on system `git(1)` whereas
+the HTTP downloader is built into Bazel and has no system dependencies. `http_archive` 
+also supports a list of `urls` as mirrors, and `git_repository` supports only a single
+`remote`.
 
 Do not use `bind()`.  See "[Consider removing
 bind](https://github.com/bazelbuild/bazel/issues/1952)" for a long discussion of its issues and

--- a/site/docs/external.md
+++ b/site/docs/external.md
@@ -307,10 +307,16 @@ bootstrap test.
 ### Repository rules
 
 Prefer [`http_archive`](repo/http.html#http_archive) to `git_repository` and
-`new_git_repository`. Rationale: Git repository rules depend on system `git(1)` whereas
-the HTTP downloader is built into Bazel and has no system dependencies. `http_archive` 
-also supports a list of `urls` as mirrors, and `git_repository` supports only a single
-`remote`.
+`new_git_repository`. The reasons are: 
+
+* Git repository rules depend on system `git(1)` whereas the HTTP downloader is built 
+  into Bazel and has no system dependencies. `
+* http_archive` supports a list of `urls` as mirrors, and `git_repository` supports only 
+  a single `remote`.
+* `http_archive` works with the [repository cache](guide.html#repository-cache), but not
+  `git_repository`. See
+   [#5116](https://github.com/bazelbuild/bazel/issues/5116) for more information.
+
 
 Do not use `bind()`.  See "[Consider removing
 bind](https://github.com/bazelbuild/bazel/issues/1952)" for a long discussion of its issues and

--- a/site/docs/external.md
+++ b/site/docs/external.md
@@ -307,11 +307,11 @@ bootstrap test.
 ### Repository rules
 
 Prefer [`http_archive`](repo/http.html#http_archive) to `git_repository` and
-`new_git_repository`. The reasons are: 
+`new_git_repository`. The reasons are:
 
 * Git repository rules depend on system `git(1)` whereas the HTTP downloader is built 
-  into Bazel and has no system dependencies. `
-* http_archive` supports a list of `urls` as mirrors, and `git_repository` supports only 
+  into Bazel and has no system dependencies.
+* `http_archive` supports a list of `urls` as mirrors, and `git_repository` supports only
   a single `remote`.
 * `http_archive` works with the [repository cache](guide.html#repository-cache), but not
   `git_repository`. See


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/10874