### PR TITLE
allowing versioned dylib

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -176,19 +176,21 @@ public final class CppFileTypes {
 
   // Matches shared libraries with version names in the extension, i.e.
   // libmylib.so.2 or libmylib.so.2.10 or libmylib.so.1a_b35.
-  private static final Pattern VERSIONED_SHARED_LIBRARY_PATTERN =
-      Pattern.compile("^.+\\.so(\\.\\d\\w*)+$");
+  private static final Pattern VERSIONED_SO_PATTERN = Pattern.compile("^.+\\.so(\\.\\d\\w*)+$");
+  private static final Pattern VERSIONED_DYLIB_PATTERN =
+      Pattern.compile("^.+\\.dylib(\\.\\d\\w*)+$");
   public static final FileType VERSIONED_SHARED_LIBRARY =
       new FileType() {
         @Override
         public boolean apply(String path) {
-          // Because regex matching can be slow, we first do a quick check for ".so."
+          // Because regex matching can be slow, we first do a quick check for ".so." and ".dylib."
           // substring before risking the full-on regex match. This should eliminate the performance
           // hit on practically every non-qualifying file type.
-          if (!path.contains(".so.")) {
+          if (!path.contains(".so.") && !path.contains(".dylib.")) {
             return false;
           }
-          return VERSIONED_SHARED_LIBRARY_PATTERN.matcher(path).matches();
+          return VERSIONED_SO_PATTERN.matcher(path).matches()
+              || VERSIONED_DYLIB_PATTERN.matcher(path).matches();
         }
       };
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -176,9 +176,8 @@ public final class CppFileTypes {
 
   // Matches shared libraries with version names in the extension, i.e.
   // libmylib.so.2 or libmylib.so.2.10 or libmylib.so.1a_b35.
-  private static final Pattern VERSIONED_SO_PATTERN = Pattern.compile("^.+\\.so(\\.\\d\\w*)+$");
-  private static final Pattern VERSIONED_DYLIB_PATTERN =
-      Pattern.compile("^.+\\.dylib(\\.\\d\\w*)+$");
+  private static final Pattern VERSIONED_SHARED_LIBRARY_PATTERN =
+      Pattern.compile("^.+\\.((so)|(dylib))(\\.\\d\\w*)+$");
   public static final FileType VERSIONED_SHARED_LIBRARY =
       new FileType() {
         @Override
@@ -189,8 +188,7 @@ public final class CppFileTypes {
           if (!path.contains(".so.") && !path.contains(".dylib.")) {
             return false;
           }
-          return VERSIONED_SO_PATTERN.matcher(path).matches()
-              || VERSIONED_DYLIB_PATTERN.matcher(path).matches();
+          return VERSIONED_SHARED_LIBRARY_PATTERN.matcher(path).matches();
         }
       };
 


### PR DESCRIPTION
Some precompiled dylib files (e.g., [Oracle instant client](https://www.oracle.com/database/technologies/instant-client/macos-intel-x86-downloads.html)) are versioned. Those files also indicate their name to should have versions in it:

```
otool -l $(bazel info output_base)/external/oracle_instantclient_macos_x64/libclntsh.dylib.12.1 | grep LC_ID_DYLIB -A2
INFO: Invocation ID: 6fee0fc5-d1bd-476e-8d20-2b721671a14d
          cmd LC_ID_DYLIB
      cmdsize 56
         name @rpath/libclntsh.dylib.12.1 (offset 24)
```

As a result, renaming thosee dylib files won't work. This PR makes `cc_library` accepts versioned `.dylib` files in the same way it accepts versioned `.so` files