### PR TITLE
Add rel="noopener" to links with target="_blank" attribute

### DIFF
--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -331,7 +331,7 @@ nav: docs
                 <ul class="collapse sidebar-nav sidebar-submenu" id="starlark-practices">
                   <li><a href="/versions/{{ current_version }}/skylark/bzl-style.html">.bzl style guide</a></li>
                   <li><a href="/versions/{{ current_version }}/skylark/testing.html">Testing extensions</a></li>
-                  <li><a href="https://github.com/bazelbuild/stardoc" target="_blank">Documenting rules with Stardoc</a></li>
+                  <li><a href="https://github.com/bazelbuild/stardoc">Documenting rules with Stardoc</a></li>
                   <li><a href="https://github.com/bazelbuild/buildtools/tree/master/buildifier">Linting</a></li>
                   <li><a href="/versions/{{ current_version }}/skylark/performance.html">Optimizing performance</a></li>
                   <li><a href="/versions/{{ current_version }}/skylark/deploying.html">Deploying rules</a></li>

--- a/src/main/java/com/google/devtools/build/docgen/templates/be/be-nav.vm
+++ b/src/main/java/com/google/devtools/build/docgen/templates/be/be-nav.vm
@@ -32,19 +32,19 @@
   #end
 #end
 
-  <li><a href="${bazelbuildGithub}/rules_appengine" target="_blank">AppEngine</a></li>
-  <li><a href="${bazelbuildGithub}/rules_apple" target="_blank">Apple (Swift, iOS, macOS, tvOS, watchOS)</a></li>
-  <li><a href="${bazelbuildGithub}/rules_dotnet" target="_blank">C#</a></li>
-  <li><a href="${bazelbuildGithub}/rules_d" target="_blank">D</a></li>
-  <li><a href="${bazelbuildGithub}/rules_docker" target="_blank">Docker</a></li>
-  <li><a href="${bazelbuildGithub}/rules_groovy" target="_blank">Groovy</a></li>
-  <li><a href="${bazelbuildGithub}/rules_go" target="_blank">Go</a></li>
-  <li><a href="${bazelbuildGithub}/rules_closure" target="_blank">JavaScript (Closure)</a></li>
-  <li><a href="${bazelbuildGithub}/rules_jsonnet" target="_blank">Jsonnet</a></li>
+  <li><a href="${bazelbuildGithub}/rules_appengine" target="_blank" rel="noopener">AppEngine</a></li>
+  <li><a href="${bazelbuildGithub}/rules_apple" target="_blank" rel="noopener">Apple (Swift, iOS, macOS, tvOS, watchOS)</a></li>
+  <li><a href="${bazelbuildGithub}/rules_dotnet" target="_blank" rel="noopener">C#</a></li>
+  <li><a href="${bazelbuildGithub}/rules_d" target="_blank" rel="noopener">D</a></li>
+  <li><a href="${bazelbuildGithub}/rules_docker" target="_blank" rel="noopener">Docker</a></li>
+  <li><a href="${bazelbuildGithub}/rules_groovy" target="_blank" rel="noopener">Groovy</a></li>
+  <li><a href="${bazelbuildGithub}/rules_go" target="_blank" rel="noopener">Go</a></li>
+  <li><a href="${bazelbuildGithub}/rules_closure" target="_blank" rel="noopener">JavaScript (Closure)</a></li>
+  <li><a href="${bazelbuildGithub}/rules_jsonnet" target="_blank" rel="noopener">Jsonnet</a></li>
   <li><a href="${path}/pkg.html">Packaging</a></li>
-  <li><a href="${bazelbuildGithub}/rules_rust" target="_blank">Rust</a></li>
-  <li><a href="${bazelbuildGithub}/rules_sass" target="_blank">Sass</a></li>
-  <li><a href="${bazelbuildGithub}/rules_scala" target="_blank">Scala</a></li>
+  <li><a href="${bazelbuildGithub}/rules_rust" target="_blank" rel="noopener">Rust</a></li>
+  <li><a href="${bazelbuildGithub}/rules_sass" target="_blank" rel="noopener">Sass</a></li>
+  <li><a href="${bazelbuildGithub}/rules_scala" target="_blank" rel="noopener">Scala</a></li>
   </ul>
   </li>
 


### PR DESCRIPTION
See https://web.dev/external-anchors-use-rel-noopener/

Also remove one instance of `target="_blank"` on the link to stardoc, since none of the other links in the page uses `_blank`.