### PR TITLE
Add //site:site_latest to presubmit build

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -53,6 +53,7 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
+      - "//site:site_latest"
     test_flags:
       - "--sandbox_default_allow_network=false"
       - "--sandbox_writable_path=$HOME/bazeltest"
@@ -88,6 +89,7 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
+      - "//site:site_latest"
     test_flags:
       - "--sandbox_default_allow_network=false"
       - "--sandbox_writable_path=$HOME/bazeltest"
@@ -150,6 +152,7 @@ tasks:
       - "//src:bazel"
       - "//src:bazel_jdk_minimal"
       - "//src:test_repos"
+      - "//site:site_latest"
     test_flags:
       - "--sandbox_default_allow_network=false"
       - "--sandbox_writable_path=$HOME/bazeltest"

--- a/site/BUILD
+++ b/site/BUILD
@@ -158,3 +158,13 @@ jekyll_build(
     ] + [":jekyll-tree"],  # jekyll-tree *must* come last to be the default.
     bucket = "docs.bazel.build",
 )
+
+# A smaller site target to build. Includes master and latest release version of docs only.
+# Used for development and CI smoke tests.
+jekyll_build(
+    name = "site_latest",
+    srcs = [
+        "@jekyll_tree_%s//file" % DOC_VERSIONS[0]["version"].replace(".", "_")
+    ] + [":jekyll-tree"],  # jekyll-tree *must* come last to be the default.
+    bucket = "docs.bazel.build",
+)


### PR DESCRIPTION
This adds a smoke test to build the site on presubmits to ensure that the documentation generator works e2e.