### PR TITLE
proto_lang_toolchain: Add test to verify that blacklisted_protos contains transitive (original) source

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchainTest.java
@@ -113,6 +113,34 @@ public class ProtoLangToolchainTest extends BuildViewTestCase {
   }
 
   @Test
+  public void protoToolchainBlacklistTransitiveProtos() throws Exception {
+    scratch.file(
+        "third_party/x/BUILD",
+        TestConstants.LOAD_PROTO_LIBRARY,
+        "licenses(['unencumbered'])",
+        "cc_binary(name = 'plugin', srcs = ['plugin.cc'])",
+        "cc_library(name = 'runtime', srcs = ['runtime.cc'])",
+        "proto_library(name = 'descriptors', srcs = ['metadata.proto', 'descriptor.proto'])",
+        "proto_library(name = 'any', srcs = ['any.proto'], deps = [':descriptors'])");
+
+    scratch.file(
+        "foo/BUILD",
+        TestConstants.LOAD_PROTO_LANG_TOOLCHAIN,
+        "proto_lang_toolchain(",
+        "    name = 'toolchain',",
+        "    command_line = 'cmd-line',",
+        "    plugin = '//third_party/x:plugin',",
+        "    runtime = '//third_party/x:runtime',",
+        "    blacklisted_protos = ['//third_party/x:any']",
+        ")");
+
+    update(ImmutableList.of("//foo:toolchain"), false, 1, true, new EventBus());
+
+    validateProtoLangToolchain(
+        getConfiguredTarget("//foo:toolchain").getProvider(ProtoLangToolchainProvider.class));
+  }
+
+  @Test
   public void protoToolchainMixedBlacklist() throws Exception {
     scratch.file(
         "third_party/x/BUILD",


### PR DESCRIPTION
This adds a test for 01df1e5c3aaf709e9388293514ae978e59ae2cbb, which
didn't come with a (OSS) test.