### PR TITLE
In repo rules, don't warn about generator_* attributes being non-canonical

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryResolvedEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryResolvedEvent.java
@@ -248,8 +248,8 @@ public class RepositoryResolvedEvent implements ResolvedEvent {
    * Attributes that may be defined on a repository rule without affecting its canonical
    * representation. These may be created implicitly by Bazel.
    */
-  private static final ImmutableList<String> IGNORED_ATTRIBUTE_NAMES =
-      ImmutableList.of("generator_name", "generator_function", "generator_location");
+  private static final ImmutableSet<String> IGNORED_ATTRIBUTE_NAMES =
+      ImmutableSet.of("generator_name", "generator_function", "generator_location");
 
   /**
    * Compare two maps from Strings to objects, returning a pair of the map with all entries not in

--- a/src/test/shell/bazel/workspace_resolved_test.sh
+++ b/src/test/shell/bazel/workspace_resolved_test.sh
@@ -1216,6 +1216,8 @@ EOF
   expect_log "  TEST_TMPDIR/.*/external/bazel_tools/tools/build_defs/repo/http.bzl:"
 }
 
+# Regression test for #11040.
+#
 # Test that a canonical repo warning is generated for explicitly specified
 # attributes whose values differ, and that it is never generated for implicitly
 # created attributes (in particular, the generator_* attributes).
@@ -1254,7 +1256,7 @@ EOF
   cd main
   # We should get a warning for "myattr" having a changed value and for "name"
   # being dropped, but not for the generator_* attributes.
-  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir > $TEST_log 2>&1
+  bazel sync --distdir=${EXTREPODIR}/test_WORKSPACE/distdir >/dev/null 2>$TEST_log
   expect_log "Rule 'myrepo' indicated that a canonical reproducible form \
 can be obtained by modifying arguments myattr = \"bar\" and dropping \
 \[.*\"name\".*\]"


### PR DESCRIPTION
Fixes #11040.

Sending to @alandonovan for internal review.