### PR TITLE
Thread maven_coordinates from jvm_maven_import_external into the underlying java_import rule

### DIFF
--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -623,6 +623,10 @@ EOF
   bazel fetch //zoo:ball-pit >& $TEST_log || fail "Fetch failed"
   [[ $(ls $external_dir | grep $needle) ]] || fail "$needle not added to $external_dir"
 
+  bazel query --output=build --nohost_deps --noimplicit_deps 'deps(//zoo:ball-pit)' >& $TEST_log \
+    || fail "bazel query failed"
+  expect_log "maven_coordinates=com.example.carnivore:carnivore:1.23"
+
   # Rerun fetch while nc isn't serving anything to make sure the fetched result
   # is cached.
   bazel fetch //zoo:ball-pit >& $TEST_log || fail "Incremental fetch failed"

--- a/tools/build_defs/repo/jvm.bzl
+++ b/tools/build_defs/repo/jvm.bzl
@@ -268,10 +268,14 @@ def jvm_maven_import_external(
 
         srcjar_urls = _convert_coordinates_to_urls(src_coordinates, server_urls)
 
+    tags = kwargs.pop("tags", [])
+    tags.append("maven_coordinates=" + artifact)
+
     jvm_import_external(
         artifact_urls = jar_urls,
         srcjar_urls = srcjar_urls,
         rule_name = rule_name,
         rule_load = rule_load,
+        tags = tags,
         **kwargs
     )


### PR DESCRIPTION
The `maven_coordinates` tag is also used for rules_jvm_external and bazel-common's `pom_file` aspect.

See https://github.com/bazelbuild/rules_jvm_external/tree/master/examples/pom_file_generation for an example.