### PR TITLE
Add .tcc as accepted cc_library header extension

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -49,7 +49,7 @@ public final class CppFileTypes {
 
   public static final FileType CPP_HEADER =
       FileType.of(
-          ".h", ".hh", ".hpp", ".ipp", ".hxx", ".h++", ".inc", ".inl", ".tlh", ".tli", ".H");
+          ".h", ".hh", ".hpp", ".ipp", ".hxx", ".h++", ".inc", ".inl", ".tlh", ".tli", ".H", ".tcc");
   public static final FileType PCH = FileType.of(".pch");
   public static final FileTypeSet OBJC_HEADER = FileTypeSet.of(CPP_HEADER, PCH);
 


### PR DESCRIPTION
fbthrift produces header file with suffix tcc，but bazel dose not support .tcc header file.