### PR TITLE
Move Ninja's PathFragment interner from NinjaParserStep to NinjaPipeline, and make it non-static.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/lexer/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/lexer/BUILD
@@ -16,6 +16,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/file",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",
         "//third_party:jsr305",
     ],

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/lexer/NinjaLexer.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/lexer/NinjaLexer.java
@@ -17,10 +17,12 @@ package com.google.devtools.build.lib.bazel.rules.ninja.lexer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Interner;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.bazel.rules.ninja.file.FileFragment;
 import com.google.devtools.build.lib.util.Pair;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -47,10 +49,15 @@ public class NinjaLexer {
   private TextKind expectedTextKind = TextKind.IDENTIFIER;
 
   private boolean interpretPoolAsVariable = false;
+  private final Interner<PathFragment> pathFragmentInterner;
 
-  /** @param fragment fragment to do the lexing on */
-  public NinjaLexer(FileFragment fragment) {
+  /**
+   * @param fragment fragment to do the lexing on
+   * @param pathFragmentInterner a thread safe interner for {@link PathFragment}. */
+  public NinjaLexer(FileFragment fragment,
+      Interner<PathFragment> pathFragmentInterner) {
     this.fragment = fragment;
+    this.pathFragmentInterner = pathFragmentInterner;
     step = new NinjaLexerStep(fragment, 0);
     ranges = Lists.newArrayList();
     tokens = Lists.newArrayList();
@@ -225,6 +232,10 @@ public class NinjaLexer {
 
   public FileFragment getFragment() {
     return fragment;
+  }
+
+  public Interner<PathFragment> getPathFragmentInterner() {
+    return pathFragmentInterner;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParser.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParser.java
@@ -46,7 +46,7 @@ public class NinjaParser implements DeclarationConsumer {
   public void declaration(FileFragment fragment) throws GenericParsingException, IOException {
     long offset = fragment.getFragmentOffset();
 
-    NinjaLexer lexer = new NinjaLexer(fragment);
+    NinjaLexer lexer = new NinjaLexer(fragment, pipeline.getPathFragmentInterner());
     if (!lexer.hasNextToken()) {
       throw new IllegalStateException("Empty fragment passed as declaration.");
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParserStep.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParserStep.java
@@ -39,16 +39,6 @@ import javax.annotation.Nullable;
 
 /** Ninja files parser. The types of tokens: {@link NinjaToken}. Ninja lexer: {@link NinjaLexer}. */
 public class NinjaParserStep {
-  /**
-   * An interner for {@link PathFragment} instances for the inputs and outputs of {@link
-   * NinjaTarget}.
-   */
-  // TODO(lberki): Make this non-static.
-  // The reason why this field is static is that I haven't grokked yet what the lifetime of each
-  // object in Ninja parsing is. Once I figure out which object has the lifetime of "exactly as long
-  // as the parsing is running", I can just put this in a field of that object and plumb it here.
-  private static final Interner<PathFragment> PATH_FRAGMENT_INTERNER =
-      BlazeInterners.newWeakInterner();
 
   private final NinjaLexer lexer;
 
@@ -311,7 +301,7 @@ public class NinjaParserStep {
           entry.getValue().stream()
               .map(
                   value ->
-                      PATH_FRAGMENT_INTERNER.intern(
+                      lexer.getPathFragmentInterner().intern(
                           PathFragment.create(targetScope.getExpandedValue(Long.MAX_VALUE, value))))
               .collect(Collectors.toList());
       InputOutputKind inputOutputKind = entry.getKey();

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/pipeline/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/pipeline/BUILD
@@ -16,6 +16,8 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/file",
         "//src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser:parser_impl",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//third_party:guava",
     ],
 )
 
@@ -31,6 +33,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/pipeline/NinjaPipeline.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/pipeline/NinjaPipeline.java
@@ -15,12 +15,14 @@
 package com.google.devtools.build.lib.bazel.rules.ninja.pipeline;
 
 
+import com.google.common.collect.Interner;
 import com.google.devtools.build.lib.bazel.rules.ninja.file.GenericParsingException;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaFileParseResult;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaFileParseResult.NinjaPromise;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaScope;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaTarget;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaVariableValue;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 
 /**
@@ -47,4 +49,11 @@ public interface NinjaPipeline {
   NinjaPromise<NinjaFileParseResult> createChildFileParsingPromise(
       NinjaVariableValue value, long offset, String parentNinjaFileName)
       throws GenericParsingException, IOException;
+
+  /**
+   * An interner for {@link PathFragment} instances for the inputs and outputs of {@link
+   * NinjaTarget}.
+   */
+  Interner<PathFragment> getPathFragmentInterner();
 }
+

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/pipeline/NinjaPipelineImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/pipeline/NinjaPipelineImpl.java
@@ -18,6 +18,7 @@ import static com.google.devtools.build.lib.concurrent.MoreFutures.waitForFuture
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Interner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -36,8 +37,10 @@ import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaParserStep;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaScope;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaTarget;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaVariableValue;
+import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayDeque;
@@ -59,6 +62,8 @@ public class NinjaPipelineImpl implements NinjaPipeline {
   private final String ownerTargetName;
   private final Set<Path> childPaths;
   private Integer readBlockSize;
+
+  private Interner<PathFragment> PATH_FRAGMENT_INTERNER = BlazeInterners.newWeakInterner();
 
   /**
    * @param basePath base path for resolving include and subninja paths.
@@ -117,7 +122,7 @@ public class NinjaPipelineImpl implements NinjaPipeline {
         future.add(
             service.submit(
                 () ->
-                    new NinjaParserStep(new NinjaLexer(fragment))
+                    new NinjaParserStep(new NinjaLexer(fragment, PATH_FRAGMENT_INTERNER))
                         .parseNinjaTarget(currentScope, fragment.getFragmentOffset())));
       }
       queue.addAll(currentScope.getIncludedScopes());
@@ -206,5 +211,9 @@ public class NinjaPipelineImpl implements NinjaPipeline {
             return NinjaFileParseResult.merge(pieces);
           }
         });
+  }
+
+  public Interner<PathFragment> getPathFragmentInterner() {
+    return PATH_FRAGMENT_INTERNER;
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaLexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaLexerTest.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.bazel.rules.ninja.file.FileFragment;
 import com.google.devtools.build.lib.bazel.rules.ninja.lexer.NinjaLexer;
 import com.google.devtools.build.lib.bazel.rules.ninja.lexer.NinjaLexer.TextKind;
 import com.google.devtools.build.lib.bazel.rules.ninja.lexer.NinjaToken;
+import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.Nullable;
@@ -210,7 +211,8 @@ public class NinjaLexerTest {
   @Test
   public void testZeroByte() {
     byte[] bytes = {'a', 0, 'b'};
-    NinjaLexer lexer = new NinjaLexer(new FileFragment(ByteBuffer.wrap(bytes), 0, 0, bytes.length));
+    NinjaLexer lexer = new NinjaLexer(new FileFragment(ByteBuffer.wrap(bytes), 0, 0, bytes.length),
+        BlazeInterners.newWeakInterner());
     assertTokenBytes(lexer, NinjaToken.IDENTIFIER, null);
     assertThat(lexer.hasNextToken()).isFalse();
   }
@@ -233,6 +235,6 @@ public class NinjaLexerTest {
 
   private static NinjaLexer createLexer(String text) {
     ByteBuffer buffer = ByteBuffer.wrap(text.getBytes(StandardCharsets.ISO_8859_1));
-    return new NinjaLexer(new FileFragment(buffer, 0, 0, buffer.limit()));
+    return new NinjaLexer(new FileFragment(buffer, 0, 0, buffer.limit()), BlazeInterners.newWeakInterner());
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaParserStepTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaParserStepTest.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaRuleVariable;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaScope;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaTarget;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaVariableValue;
+import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.nio.ByteBuffer;
@@ -458,7 +459,8 @@ public class NinjaParserStepTest {
 
   private static NinjaParserStep createParser(String text) {
     ByteBuffer buffer = ByteBuffer.wrap(text.getBytes(StandardCharsets.ISO_8859_1));
-    NinjaLexer lexer = new NinjaLexer(new FileFragment(buffer, 0, 0, buffer.limit()));
+    NinjaLexer lexer = new NinjaLexer(new FileFragment(buffer, 0, 0, buffer.limit()),
+        BlazeInterners.newWeakInterner());
     return new NinjaParserStep(lexer);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaPhonyTargetsUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaPhonyTargetsUtilTest.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.bazel.rules.ninja.lexer.NinjaLexer;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaParserStep;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaScope;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaTarget;
+import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -164,7 +165,8 @@ public class NinjaPhonyTargetsUtilTest {
 
   private static NinjaParserStep createParser(String text) {
     ByteBuffer buffer = ByteBuffer.wrap(text.getBytes(StandardCharsets.ISO_8859_1));
-    NinjaLexer lexer = new NinjaLexer(new FileFragment(buffer, 0, 0, buffer.limit()));
+    NinjaLexer lexer = new NinjaLexer(new FileFragment(buffer, 0, 0, buffer.limit()),
+        BlazeInterners.newWeakInterner());
     return new NinjaParserStep(lexer);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaScopeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaScopeTest.java
@@ -29,6 +29,7 @@ import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaRule;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaRuleVariable;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaScope;
 import com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaVariableValue;
+import com.google.devtools.build.lib.concurrent.BlazeInterners;
 import com.google.devtools.build.lib.util.Pair;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -306,7 +307,7 @@ public class NinjaScopeTest {
 
   private static NinjaVariableValue parseValue(String text) throws Exception {
     ByteBuffer bb = ByteBuffer.wrap(text.getBytes(StandardCharsets.ISO_8859_1));
-    NinjaLexer lexer = new NinjaLexer(new FileFragment(bb, 0, 0, bb.limit()));
+    NinjaLexer lexer = new NinjaLexer(new FileFragment(bb, 0, 0, bb.limit()), BlazeInterners.newWeakInterner());
     return new NinjaParserStep(lexer).parseVariableValue();
   }
 }


### PR DESCRIPTION
Make the Ninja PathFragment interner non-static, and share it across lexer/parser execution threads, reducing the number of PathFragment weak references by ~99.8%.

While the lexer/parser is executed across threads, Guava interners are thread-safe, so it's safe to reference it from NinjaPipeline.