### PR TITLE
Use filename length value in host order

### DIFF
--- a/src/tools/singlejar/zip_headers.h
+++ b/src/tools/singlejar/zip_headers.h
@@ -265,7 +265,7 @@ class LH {
   void file_name(const char *filename, uint16_t len) {
     file_name_length_ = htole16(len);
     if (len) {
-      memcpy(file_name_, filename, file_name_length_);
+      memcpy(file_name_, filename, len);
     }
   }
   bool file_name_is(const char *name) const {


### PR DESCRIPTION
singlejar_cc_bin segfaults on a big-endian machine (s390x). This is caused by the incorrect use of a little-endian encoded variable value. Instead the host order value should be used.

fixes #11098
