### PR TITLE
Make it possible to bootstrap Bazel from original source

### DIFF
--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -31,13 +31,19 @@ fi
 
 : ${JAVA_VERSION:="1.8"}
 
-_BAZEL_ARGS="--java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \
+if [ -d derived ] then
+  # Flags we need to bootstrap from the dist archive.
+  DIST_BOOTSTRAP_ARGS="--java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \
       --host_java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \
-      --spawn_strategy=standalone \
+      --distdir=derived/distdir"
+fi
+
+_BAZEL_ARGS="--spawn_strategy=standalone \
       --nojava_header_compilation \
       --strategy=Javac=worker --worker_quit_after_build --ignore_unsupported_sandboxing \
       --compilation_mode=opt \
       --distdir=derived/distdir \
+      ${DIST_BOOTSTRAP_ARGS:-} \
       ${EXTRA_BAZEL_ARGS:-}"
 
 if [ -z "${BAZEL-}" ]; then

--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -31,7 +31,7 @@ fi
 
 : ${JAVA_VERSION:="1.8"}
 
-if [ -d derived ] then
+if [ -d derived ]; then
   # Flags we need to bootstrap from the dist archive.
   DIST_BOOTSTRAP_ARGS="--java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \
       --host_java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \

--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -42,7 +42,6 @@ _BAZEL_ARGS="--spawn_strategy=standalone \
       --nojava_header_compilation \
       --strategy=Javac=worker --worker_quit_after_build --ignore_unsupported_sandboxing \
       --compilation_mode=opt \
-      --distdir=derived/distdir \
       ${DIST_BOOTSTRAP_ARGS:-} \
       ${EXTRA_BAZEL_ARGS:-}"
 

--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -16,8 +16,13 @@
 
 # Script for building bazel from scratch without bazel
 
-PROTO_FILES=$(ls src/main/protobuf/*.proto src/main/java/com/google/devtools/build/lib/buildeventstream/proto/*.proto src/main/java/com/google/devtools/build/skyframe/*.proto src/main/java/com/google/devtools/build/lib/skyframe/proto/*.proto)
-LIBRARY_JARS=$(find derived/jars third_party -name '*.jar' | grep -Fv JavaBuilder | grep -Fv third_party/guava | grep -Fv third_party/guava | grep -ve 'third_party/grpc/grpc.*jar' | tr "\n" " ")
+if [ -d derived/jars ] then
+  PROTOBUF_JARS=derived/jars
+else
+  PROTOBUF_JARS="/usr/share/java/protobuf-3.11.4.jar /usr/share/java/protobuf-java-util-3.11.4.jar"
+fi
+PROTO_FILES=$(find third_party/remoteapis third_party/googleapis third_party/pprof src/main/protobuf src/main/java/com/google/devtools/build/lib/buildeventstream/proto src/main/java/com/google/devtools/build/skyframe src/main/java/com/google/devtools/build/lib/skyframe/proto src/main/java/com/google/devtools/build/lib/bazel/debug src/main/java/com/google/devtools/build/lib/skylarkdebug/proto -name "*.proto")
+LIBRARY_JARS=$(find $PROTOBUF_JARS third_party -name '*.jar' | grep -Fv JavaBuilder | grep -Fv third_party/guava | grep -Fv third_party/guava | grep -ve 'third_party/grpc/grpc.*jar' | tr "\n" " ")
 GRPC_JAVA_VERSION=1.20.0
 GRPC_LIBRARY_JARS=$(find third_party/grpc -name '*.jar' | grep -e ".*${GRPC_JAVA_VERSION}.*jar" | tr "\n" " ")
 GUAVA_VERSION=25.1
@@ -230,6 +235,11 @@ if [ -z "${BAZEL_SKIP_JAVA_COMPILATION}" ]; then
                 -Isrc/main/java/com/google/devtools/build/lib/buildeventstream/proto/ \
                 -Isrc/main/java/com/google/devtools/build/lib/skyframe/proto/ \
                 -Isrc/main/java/com/google/devtools/build/skyframe/ \
+                -Isrc/main/java/com/google/devtools/build/lib/bazel/debug/ \
+                -Isrc/main/java/com/google/devtools/build/lib/skylarkdebug/proto/ \
+                -Ithird_party/remoteapis/ \
+                -Ithird_party/googleapis/ \
+                -Ithird_party/pprof/ \
                 --java_out=${OUTPUT_DIR}/src \
                 --plugin=protoc-gen-grpc="${GRPC_JAVA_PLUGIN-}" \
                 --grpc_out=${OUTPUT_DIR}/src "$f"

--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -16,10 +16,11 @@
 
 # Script for building bazel from scratch without bazel
 
-if [ -d derived/jars ] then
+if [ -d derived/jars ]; then
   PROTOBUF_JARS=derived/jars
 else
-  PROTOBUF_JARS="/usr/share/java/protobuf-3.11.4.jar /usr/share/java/protobuf-java-util-3.11.4.jar"
+  PROTOBUF_JAVA_VERSION=3.11.4
+  PROTOBUF_JARS="/usr/share/java/protobuf-$PROTOBUF_JAVA_VERSION.jar /usr/share/java/protobuf-java-util-$PROTOBUF_JAVA_VERSION.jar"
 fi
 PROTO_FILES=$(find third_party/remoteapis third_party/googleapis third_party/pprof src/main/protobuf src/main/java/com/google/devtools/build/lib/buildeventstream/proto src/main/java/com/google/devtools/build/skyframe src/main/java/com/google/devtools/build/lib/skyframe/proto src/main/java/com/google/devtools/build/lib/bazel/debug src/main/java/com/google/devtools/build/lib/skylarkdebug/proto -name "*.proto")
 LIBRARY_JARS=$(find $PROTOBUF_JARS third_party -name '*.jar' | grep -Fv JavaBuilder | grep -Fv third_party/guava | grep -Fv third_party/guava | grep -ve 'third_party/grpc/grpc.*jar' | tr "\n" " ")


### PR DESCRIPTION
Related https://github.com/bazelbuild/bazel/issues/9408

When providing required `protoc` compiler and relevant tools and libraries, Bazel should be able to bootstrap itself from the original source.

This change fixes the bootstrap scripts by

- Adding missing proto compilation.
- Search for protobuf jars under /usr/share/java if the derived directory doesn't exist. (Should be available by `apt-get install libprotobuf-java`)
- Don't use the bootstrap toolchain if not bootstrapping from the dist archive. Because using that toolchain will make Bazel depend on things under derived directory, which doesn't exist if we bootstrap from Bazel original source and it's not necessary in this case.
