### PR TITLE
Convert to Python 3

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
@@ -208,7 +208,7 @@ public class BazelPythonSemantics implements PythonSemantics {
      * logic will extract the zip's runfiles into a temporary directory.
      *
      * The stub script has a shebang pointing to a first-stage Python interpreter (as of this
-     * writing "#!/usr/bin/env python"). When a zip file is built on unix, this shebang is also
+     * writing "#!/usr/bin/env python3"). When a zip file is built on unix, this shebang is also
      * prepended to the final zip artifact. On Windows shebangs are ignored, and the launcher
      * runs the first stage with an interpreter whose path is passed in as LaunchInfo.
      */
@@ -240,7 +240,7 @@ public class BazelPythonSemantics implements PythonSemantics {
         PathFragment shExecutable = ShToolchain.getPathOrError(ruleContext);
         // TODO(#8685): Remove this special-case handling as part of making the proper shebang a
         // property of the Python toolchain configuration.
-        String pythonExecutableName = OS.getCurrent() == OS.OPENBSD ? "python3" : "python";
+        String pythonExecutableName = "python3";
         // NOTE: keep the following line intact to support nix builds
         String pythonShebang = "#!/usr/bin/env " + pythonExecutableName;
         ruleContext.registerAction(

--- a/src/test/py/bazel/launcher_test.py
+++ b/src/test/py/bazel/launcher_test.py
@@ -355,7 +355,7 @@ class LauncherTest(test_base.TestBase):
         'helloworld(', '  name = "hello",', '  out = "hello.txt",', ')'
     ])
     foo_py = self.ScratchFile('foo/foo.py', [
-        '#!/usr/bin/env python',
+        '#!/usr/bin/env python3',
         'import sys',
         'if len(sys.argv) == 2:',
         '  with open(sys.argv[1], "w") as f:',
@@ -364,7 +364,7 @@ class LauncherTest(test_base.TestBase):
         '  print("Hello World!")',
     ])
     test_py = self.ScratchFile('foo/test.py', [
-        '#!/usr/bin/env python',
+        '#!/usr/bin/env python3',
         'import unittest',
         'class MyTest(unittest.TestCase):',
         '  def test_dummy(self):',

--- a/third_party/py/mock/setup.py
+++ b/third_party/py/mock/setup.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Copyright (C) 2007-2012 Michael Foord & the mock team
 # E-mail: fuzzyman AT voidspace DOT org DOT uk


### PR DESCRIPTION
Python 2 has reached end-of-life.
This change was imported from Debian packaging.