### PR TITLE
Introduce new option experimental_use_starlark_python.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkSemanticsOptions.java
@@ -291,6 +291,19 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
   public boolean experimentalAllowTagsPropagation;
 
   @Option(
+      name = "experimental_use_starlark_python",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
+      effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
+      metadataTags = {
+        OptionMetadataTag.EXPERIMENTAL,
+      },
+      help =
+          "If set to true, Python rule implementations in Starlark will be used."
+              + "Java implementation no longer works then.")
+  public boolean experimentalUseStarlarkPython;
+
+  @Option(
       name = "incompatible_always_check_depset_elements",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
@@ -649,6 +662,7 @@ public class StarlarkSemanticsOptions extends OptionsBase implements Serializabl
             .experimentalDisableExternalPackage(experimentalDisableExternalPackage)
             .experimentalSiblingRepositoryLayout(experimentalSiblingRepositoryLayout)
             .experimentalExecGroups(experimentalExecGroups)
+            .experimentalUseStarlarkPython(experimentalUseStarlarkPython)
             .incompatibleApplicableLicenses(incompatibleApplicableLicenses)
             .incompatibleDisableTargetProviderFields(incompatibleDisableTargetProviderFields)
             .incompatibleDisableThirdPartyLicenseChecking(

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkSemantics.java
@@ -93,6 +93,8 @@ public abstract class StarlarkSemantics {
         "experimental_starlark_unused_inputs_list";
     public static final String EXPERIMENTAL_REPO_REMOTE_EXEC = "experimental_repo_remote_exec";
     public static final String EXPERIMENTAL_EXEC_GROUPS = "experimental_exec_groups";
+    public static final String EXPERIMENTAL_USE_STARLARK_PYTHON =
+        "experimental_use_starlark_python";
     public static final String INCOMPATIBLE_APPLICABLE_LICENSES =
         "incompatible_applicable_licenses";
     public static final String INCOMPATIBLE_DISABLE_DEPSET_INPUTS =
@@ -144,6 +146,8 @@ public abstract class StarlarkSemantics {
         return experimentalRepoRemoteExec();
       case FlagIdentifier.EXPERIMENTAL_EXEC_GROUPS:
         return experimentalExecGroups();
+      case FlagIdentifier.EXPERIMENTAL_USE_STARLARK_PYTHON:
+        return experimentalUseStarlarkPython();
       case FlagIdentifier.INCOMPATIBLE_APPLICABLE_LICENSES:
         return incompatibleApplicableLicenses();
       case FlagIdentifier.INCOMPATIBLE_DISABLE_DEPSET_INPUTS:
@@ -234,6 +238,8 @@ public abstract class StarlarkSemantics {
   public abstract boolean experimentalSiblingRepositoryLayout();
 
   public abstract boolean experimentalExecGroups();
+
+  public abstract boolean experimentalUseStarlarkPython();
 
   public abstract boolean incompatibleAlwaysCheckDepsetElements();
 
@@ -336,6 +342,7 @@ public abstract class StarlarkSemantics {
           .experimentalDisableExternalPackage(false)
           .experimentalSiblingRepositoryLayout(false)
           .experimentalExecGroups(false)
+          .experimentalUseStarlarkPython(false)
           .incompatibleAlwaysCheckDepsetElements(true)
           .incompatibleApplicableLicenses(false)
           .incompatibleDisableTargetProviderFields(false)
@@ -402,6 +409,8 @@ public abstract class StarlarkSemantics {
     public abstract Builder experimentalSiblingRepositoryLayout(boolean value);
 
     public abstract Builder experimentalExecGroups(boolean value);
+
+    public abstract Builder experimentalUseStarlarkPython(boolean value);
 
     public abstract Builder incompatibleAlwaysCheckDepsetElements(boolean value);
 

--- a/src/test/java/com/google/devtools/build/lib/packages/SkylarkSemanticsConsistencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/SkylarkSemanticsConsistencyTest.java
@@ -192,6 +192,7 @@ public class SkylarkSemanticsConsistencyTest {
         .experimentalCcSharedLibrary(rand.nextBoolean())
         .experimentalRepoRemoteExec(rand.nextBoolean())
         .experimentalExecGroups(rand.nextBoolean())
+        .experimentalUseStarlarkPython(rand.nextBoolean())
         .incompatibleAlwaysCheckDepsetElements(rand.nextBoolean())
         .incompatibleApplicableLicenses(rand.nextBoolean())
         .incompatibleDepsetForLibrariesToLinkGetter(rand.nextBoolean())


### PR DESCRIPTION
Can be used to test Starlark implementation of Python rules.
Currently would expect rules_python to disable loading symbols from native.
Also in the future this should lead to a broken Java implementation to
find errors in transition fast.