### PR TITLE
Update python tests to use the remote worker via the deploy jar.

### DIFF
--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -13,7 +13,10 @@ filegroup(
     name = "test-deps",
     testonly = 1,
     srcs = ["//src:bazel"],
-    data = ["//src/tools/remote:worker"],
+    data = [
+        "//src/tools/remote:worker",
+        "//src/tools/remote:worker_deploy.jar",
+    ],
 )
 
 py_library(

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -372,6 +372,7 @@ class TestBase(unittest.TestCase):
     self._worker_proc = subprocess.Popen(
         [
             worker_exe,
+            '--singlejar',
             '--listen_port=' + str(port),
             # This path has to be extremely short to avoid Windows path
             # length restrictions.


### PR DESCRIPTION
This is needed to prevent failures after the change to break up build-base.