### PR TITLE
Remote tests use worker via singlejar

### DIFF
--- a/src/test/shell/bazel/remote/BUILD
+++ b/src/test/shell/bazel/remote/BUILD
@@ -12,6 +12,7 @@ sh_library(
     srcs = ["remote_utils.sh"],
     data = [
         "//src/tools/remote:worker",
+        "//src/tools/remote:worker_deploy.jar",
     ],
 )
 

--- a/src/test/shell/bazel/remote/BUILD
+++ b/src/test/shell/bazel/remote/BUILD
@@ -27,6 +27,7 @@ sh_test(
         "//src/tools/remote:worker",
         "@bazel_tools//tools/bash/runfiles",
     ],
+    shard_count = 5,
 )
 
 sh_test(

--- a/src/test/shell/bazel/remote/BUILD
+++ b/src/test/shell/bazel/remote/BUILD
@@ -6,15 +6,26 @@ filegroup(
     visibility = ["//src/test/shell/bazel:__pkg__"],
 )
 
+sh_library(
+    name = "remote_utils",
+    testonly = True,
+    srcs = ["remote_utils.sh"],
+    data = [
+        "//src/tools/remote:worker",
+    ],
+)
+
 sh_test(
     name = "remote_execution_test",
     size = "large",
     timeout = "eternal",
     srcs = ["remote_execution_test.sh"],
     data = [
+        ":remote_utils",
         ":uds_proxy.py",
         "//src/test/shell/bazel:test-deps",
         "//src/tools/remote:worker",
+        "@bazel_tools//tools/bash/runfiles",
     ],
 )
 
@@ -23,8 +34,10 @@ sh_test(
     size = "large",
     srcs = ["remote_execution_http_test.sh"],
     data = [
+        ":remote_utils",
         "//src/test/shell/bazel:test-deps",
         "//src/tools/remote:worker",
+        "@bazel_tools//tools/bash/runfiles",
     ],
     tags = [
         "requires-network",
@@ -36,9 +49,11 @@ sh_test(
     size = "large",
     srcs = ["remote_execution_sandboxing_test.sh"],
     data = [
+        ":remote_utils",
         "//src/test/shell:sandboxing_test_utils.sh",
         "//src/test/shell/bazel:test-deps",
         "//src/tools/remote:worker",
+        "@bazel_tools//tools/bash/runfiles",
     ],
 )
 
@@ -49,9 +64,11 @@ sh_test(
     srcs = ["remote_execution_tls_test.sh"],
     args = ["--tls"],
     data = [
+        ":remote_utils",
         "//src/test/shell/bazel:test-deps",
         "//src/test/testdata/test_tls_certificate",
         "//src/tools/remote:worker",
+        "@bazel_tools//tools/bash/runfiles",
     ],
 )
 
@@ -62,8 +79,10 @@ sh_test(
     srcs = ["remote_execution_tls_test.sh"],
     args = ["--mtls"],
     data = [
+        ":remote_utils",
         "//src/test/shell/bazel:test-deps",
         "//src/test/testdata/test_tls_certificate",
         "//src/tools/remote:worker",
+        "@bazel_tools//tools/bash/runfiles",
     ],
 )

--- a/src/test/shell/bazel/remote/remote_execution_sandboxing_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_sandboxing_test.sh
@@ -15,37 +15,43 @@
 # limitations under the License.
 #
 # Tests remote execution and caching.
-#
 
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../../integration_test_setup.sh" \
+set -euo pipefail
+
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
-source "${CURRENT_DIR}/../../sandboxing_test_utils.sh" \
+source "$(rlocation "io_bazel/src/test/shell/sandboxing_test_utils.sh")" \
   || { echo "sandboxing_test_utils.sh not found!" >&2; exit 1; }
+source "$(rlocation "io_bazel/src/test/shell/bazel/remote/remote_utils.sh")" \
+  || { echo "remote_utils.sh not found!" >&2; exit 1; }
 
 function set_up() {
-  work_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
-  cas_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
   writable_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
   readonly_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
-  pid_file=$(mktemp -u "${TEST_TMPDIR}/remote.XXXXXXXX")
-  worker_port=$(pick_random_unused_tcp_port) || fail "no port found"
-  "${BAZEL_RUNFILES}/src/tools/remote/worker" \
-      --work_path="${work_path}" \
-      --cas_path="${cas_path}" \
-      --listen_port=${worker_port} \
+  start_worker \
       --sandboxing \
-      --sandboxing_writable_path="${writable_path}" \
-      --pid_file="${pid_file}" >& $TEST_log &
-  local wait_seconds=0
-  until [ -s "${pid_file}" ] || [ "$wait_seconds" -eq 30 ]; do
-    sleep 1
-    ((wait_seconds++)) || true
-  done
-  if [ ! -s "${pid_file}" ]; then
-    fail "Timed out waiting for remote worker to start."
-  fi
+      --sandboxing_writable_path="${writable_path}"
 
   mkdir -p examples/genrule
   cat > examples/genrule/BUILD <<'EOF'
@@ -76,13 +82,14 @@ EOF
 }
 
 function tear_down() {
-  if [ -s "${pid_file}" ]; then
-    local pid=$(cat "${pid_file}")
-    kill "${pid}" || true
+  bazel clean >& $TEST_log
+  stop_worker
+  if [ -d "${readonly_path}" ]; then
+    rm -rf "${readonly_path}"
   fi
-  rm -rf "${pid_file}"
-  rm -rf "${work_path}"
-  rm -rf "${cas_path}"
+  if [ -d "${writable_path}" ]; then
+    rm -rf "${writable_path}"
+  fi
 }
 
 function test_genrule() {

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -15,50 +15,43 @@
 # limitations under the License.
 #
 # Tests remote execution and caching.
-#
 
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../../integration_test_setup.sh" \
+set -euo pipefail
+
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+source "$(rlocation "io_bazel/src/test/shell/bazel/remote/remote_utils.sh")" \
+  || { echo "remote_utils.sh not found!" >&2; exit 1; }
 
 function set_up() {
-  work_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
-  cas_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
-  pid_file=$(mktemp -u "${TEST_TMPDIR}/remote.XXXXXXXX")
-  attempts=1
-  while [ $attempts -le 5 ]; do
-    (( attempts++ ))
-    worker_port=$(pick_random_unused_tcp_port) || fail "no port found"
-    "${BAZEL_RUNFILES}/src/tools/remote/worker" \
-        --work_path="${work_path}" \
-        --listen_port=${worker_port} \
-        --cas_path=${cas_path} \
-        --incompatible_remote_symlinks \
-        --pid_file="${pid_file}" >& $TEST_log &
-    local wait_seconds=0
-    until [ -s "${pid_file}" ] || [ "$wait_seconds" -eq 15 ]; do
-      sleep 1
-      ((wait_seconds++)) || true
-    done
-    if [ -s "${pid_file}" ]; then
-      break
-    fi
-  done
-  if [ ! -s "${pid_file}" ]; then
-    fail "Timed out waiting for remote worker to start."
-  fi
+  start_worker \
+        --incompatible_remote_symlinks
 }
 
 function tear_down() {
   bazel clean >& $TEST_log
-  if [ -s "${pid_file}" ]; then
-    local pid=$(cat "${pid_file}")
-    kill "${pid}" || true
-  fi
-  rm -rf "${pid_file}"
-  rm -rf "${work_path}"
-  rm -rf "${cas_path}"
+  stop_worker
 }
 
 case "$(uname -s | tr [:upper:] [:lower:])" in
@@ -118,7 +111,8 @@ EOF
   # Note: not using $TEST_TMPDIR because many OSes, notably macOS, have
   # small maximum length limits for UNIX domain sockets.
   socket_dir=$(mktemp -d -t "remote_executor.XXXXXXXX")
-  python "${CURRENT_DIR}/uds_proxy.py" "${socket_dir}/executor-socket" "localhost:${worker_port}" &
+  PROXY="$(rlocation io_bazel/src/test/shell/bazel/remote/uds_proxy.py)"
+  python "${PROXY}" "${socket_dir}/executor-socket" "localhost:${worker_port}" &
   proxy_pid=$!
 
   bazel build \

--- a/src/test/shell/bazel/remote/remote_execution_tls_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_tls_test.sh
@@ -15,12 +15,34 @@
 # limitations under the License.
 #
 # Tests remote caching with TLS.
-#
 
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../../integration_test_setup.sh" \
+set -euo pipefail
+
+# --- begin runfiles.bash initialization ---
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+source "$(rlocation "io_bazel/src/test/shell/bazel/remote/remote_utils.sh")" \
+  || { echo "remote_utils.sh not found!" >&2; exit 1; }
 
 cert_path="${BAZEL_RUNFILES}/src/test/testdata/test_tls_certificate"
 client_mtls_flags=
@@ -31,37 +53,14 @@ if [[ $1 == "--mtls" ]]; then
 fi
 
 function set_up() {
-  work_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
-  cas_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
-  pid_file=$(mktemp -u "${TEST_TMPDIR}/remote.XXXXXXXX")
-  attempts=1
   mtls_flag=
   if [[ $enable_mtls == 1 ]]; then
     mtls_flag=--tls_ca_certificate="${cert_path}/ca.crt"
   fi
-  while [ $attempts -le 3 ]; do
-    (( attempts++ ))
-    worker_port=$(pick_random_unused_tcp_port) || fail "no port found"
-    "${BAZEL_RUNFILES}/src/tools/remote/worker" \
-        --work_path="${work_path}" \
-        --listen_port=${worker_port} \
-        --cas_path=${cas_path} \
+  start_worker \
         --tls_certificate="${cert_path}/server.crt" \
         --tls_private_key="${cert_path}/server.pem" \
-        $mtls_flag \
-        --pid_file="${pid_file}" >& $TEST_log &
-    local wait_seconds=0
-    until [ -s "${pid_file}" ] || [ "$wait_seconds" -eq 15 ]; do
-      sleep 1
-      ((wait_seconds++)) || true
-    done
-    if [ -s "${pid_file}" ]; then
-      break
-    fi
-  done
-  if [ ! -s "${pid_file}" ]; then
-    fail "Timed out waiting for remote worker to start."
-  fi
+        $mtls_flag
 }
 
 function _prepareBasicRule(){
@@ -77,13 +76,7 @@ EOF
 }
 function tear_down() {
   bazel clean >& $TEST_log
-  if [ -s "${pid_file}" ]; then
-    local pid=$(cat "${pid_file}")
-    kill "${pid}" || true
-  fi
-  rm -rf "${pid_file}"
-  rm -rf "${work_path}"
-  rm -rf "${cas_path}"
+  stop_worker
 }
 
 function test_remote_grpcs_cache() {

--- a/src/test/shell/bazel/remote/remote_utils.sh
+++ b/src/test/shell/bazel/remote/remote_utils.sh
@@ -28,11 +28,11 @@ function start_worker() {
       --cas_path="${cas_path}" \
       --listen_port=${worker_port} \
       --pid_file="${pid_file}" \
-      $@ >& $TEST_log &
+      "$@" >& $TEST_log &
   local wait_seconds=0
-  until [ -s "${pid_file}" ] || [ "$wait_seconds" -eq 30 ]; do
+  until [[ -s "${pid_file}" || "$wait_seconds" -eq 30 ]]; do
     sleep 1
-    ((wait_seconds++)) || true
+    wait_seconds=$((${wait_seconds} + 1))
   done
   if [ ! -s "${pid_file}" ]; then
     fail "Timed out waiting for remote worker to start."
@@ -42,7 +42,7 @@ function start_worker() {
 function stop_worker() {
   if [ -s "${pid_file}" ]; then
     local pid=$(cat "${pid_file}")
-    kill "${pid}" || true
+    kill -9 "${pid}" || true
   rm -rf "${pid_file}"
   fi
   if [ -d "${work_path}" ]; then

--- a/src/test/shell/bazel/remote/remote_utils.sh
+++ b/src/test/shell/bazel/remote/remote_utils.sh
@@ -42,7 +42,7 @@ function start_worker() {
 function stop_worker() {
   if [ -s "${pid_file}" ]; then
     local pid=$(cat "${pid_file}")
-    kill -9 "${pid}" || true
+    kill -9 "${pid}"
   rm -rf "${pid_file}"
   fi
   if [ -d "${work_path}" ]; then

--- a/src/test/shell/bazel/remote/remote_utils.sh
+++ b/src/test/shell/bazel/remote/remote_utils.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Utilities for remote execution.
+
+REMOTE_WORKER="$(rlocation io_bazel/src/tools/remote/worker)"
+
+function start_worker() {
+  work_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
+  cas_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
+  pid_file=$(mktemp -u "${TEST_TMPDIR}/remote.XXXXXXXX")
+  worker_port=$(pick_random_unused_tcp_port) || fail "no port found"
+  "${REMOTE_WORKER}" \
+      --work_path="${work_path}" \
+      --cas_path="${cas_path}" \
+      --listen_port=${worker_port} \
+      --pid_file="${pid_file}" \
+      $@ >& $TEST_log &
+  local wait_seconds=0
+  until [ -s "${pid_file}" ] || [ "$wait_seconds" -eq 30 ]; do
+    sleep 1
+    ((wait_seconds++)) || true
+  done
+  if [ ! -s "${pid_file}" ]; then
+    fail "Timed out waiting for remote worker to start."
+  fi
+}
+
+function stop_worker() {
+  if [ -s "${pid_file}" ]; then
+    local pid=$(cat "${pid_file}")
+    kill "${pid}" || true
+  rm -rf "${pid_file}"
+  fi
+  if [ -d "${work_path}" ]; then
+    rm -rf "${work_path}"
+  fi
+  if [ -d "${cas_path}" ]; then
+    rm -rf "${cas_path}"
+  fi
+}

--- a/src/test/shell/bazel/remote/remote_utils.sh
+++ b/src/test/shell/bazel/remote/remote_utils.sh
@@ -23,7 +23,10 @@ function start_worker() {
   cas_path=$(mktemp -d "${TEST_TMPDIR}/remote.XXXXXXXX")
   pid_file=$(mktemp -u "${TEST_TMPDIR}/remote.XXXXXXXX")
   worker_port=$(pick_random_unused_tcp_port) || fail "no port found"
+  native_lib="${BAZEL_RUNFILES}/src/main/native/"
   "${REMOTE_WORKER}" \
+      --singlejar \
+      --jvm_flag=-Djava.library.path="${native_lib}" \
       --work_path="${work_path}" \
       --cas_path="${cas_path}" \
       --listen_port=${worker_port} \


### PR DESCRIPTION
This is needed to prevent failures after the change to break up build-base.
This depends on #11198