### PR TITLE
remote: don't fail in the remote package if an in-memory output wasn'…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
@@ -560,7 +560,12 @@ public class RemoteCache implements AutoCloseable {
     for (ActionInput output : outputs) {
       if (inMemoryOutputPath != null && output.getExecPath().equals(inMemoryOutputPath)) {
         Path p = execRoot.getRelative(output.getExecPath());
-        FileMetadata m = Preconditions.checkNotNull(metadata.file(p), "inMemoryOutputMetadata");
+        FileMetadata m = metadata.file(p);
+        if (m == null) {
+          // A declared output wasn't created. Ignore it here. SkyFrame will fail if not all
+          // outputs were created.
+          continue;
+        }
         inMemoryOutputDigest = m.digest();
         inMemoryOutput = output;
       }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTests.java
@@ -1151,6 +1151,40 @@ public class RemoteCacheTests {
   }
 
   @Test
+  public void testDownloadMinimalWithMissingInMemoryOutput() throws Exception {
+    // Test that downloadMinimal returns null if a declared in-memory output is missing.
+
+    // arrange
+    InMemoryRemoteCache remoteCache = newRemoteCache();
+    Digest d1 = remoteCache.addContents("in-memory output");
+    ActionResult r =
+        ActionResult.newBuilder()
+            .setExitCode(0)
+            .build();
+    Artifact a1 = ActionsTestUtil.createArtifact(artifactRoot, "file1");
+    MetadataInjector injector = mock(MetadataInjector.class);
+    // a1 should be provided as an InMemoryOutput
+    PathFragment inMemoryOutputPathFragment = a1.getPath().relativeTo(execRoot);
+
+    // act
+    InMemoryOutput inMemoryOutput =
+        remoteCache.downloadMinimal(
+            r,
+            ImmutableList.of(a1),
+            inMemoryOutputPathFragment,
+            new FileOutErr(),
+            execRoot,
+            injector,
+            outputFilesLocker);
+
+    // assert
+    assertThat(inMemoryOutput).isNull();
+    // The in memory file metadata also should not have been injected.
+    verify(injector, never())
+        .injectRemoteFile(eq(a1), eq(toBinaryDigest(d1)), eq(d1.getSizeBytes()), anyInt());
+  }
+
+  @Test
   public void testDownloadEmptyBlobAndFile() throws Exception {
     // Test that downloading an empty BLOB/file does not try to perform a download.
 


### PR DESCRIPTION
…t created

Instead ignore it. The ActionExecutionFunction will ensure that all
declared outputs have been created and fail with a more detailed
error than is possible in the remote package.

This behaviour already exists for normal outputs. It's been overlooked
for in-memory outputs. In-memory outputs are typically .d files in C++
compilation.