### PR TITLE
Create output child directories before their parents

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerExecRoot.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerExecRoot.java
@@ -63,7 +63,7 @@ final class WorkerExecRoot extends SymlinkedSandboxedSpawn {
     // First compute all the inputs and directories that we need. This is based only on
     // `workerFiles`, `inputs` and `outputs` and won't do any I/O.
     Set<PathFragment> inputsToCreate = new LinkedHashSet<>();
-    Set<PathFragment> dirsToCreate = new LinkedHashSet<>();
+    LinkedHashSet<PathFragment> dirsToCreate = new LinkedHashSet<>();
     populateInputsAndDirsToCreate(inputsToCreate, dirsToCreate);
 
     // Then do a full traversal of the `workDir`. This will use what we computed above, delete
@@ -80,7 +80,7 @@ final class WorkerExecRoot extends SymlinkedSandboxedSpawn {
 
   /** Populates the provided sets with the inputs and directories than need to be created. */
   private void populateInputsAndDirsToCreate(
-      Set<PathFragment> inputsToCreate, Set<PathFragment> dirsToCreate) {
+      Set<PathFragment> inputsToCreate, LinkedHashSet<PathFragment> dirsToCreate) {
     // Add all worker files and the ancestor directories.
     for (PathFragment path : workerFiles) {
       inputsToCreate.add(path);
@@ -107,7 +107,7 @@ final class WorkerExecRoot extends SymlinkedSandboxedSpawn {
       }
     }
 
-    // Add all ouput directories.
+    // Add all ouput directories, must be created after their parents above
     dirsToCreate.addAll(outputs.dirs());
   }
 

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerExecRoot.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerExecRoot.java
@@ -99,9 +99,6 @@ final class WorkerExecRoot extends SymlinkedSandboxedSpawn {
       }
     }
 
-    // Add all ouput directories.
-    dirsToCreate.addAll(outputs.dirs());
-
     // And all ancestor directories of outputs. Note that we don't add the files themselves -- any
     // pre-existing files that have the same path as an output should get deleted.
     for (PathFragment path : Iterables.concat(outputs.files(), outputs.dirs())) {
@@ -109,6 +106,9 @@ final class WorkerExecRoot extends SymlinkedSandboxedSpawn {
         dirsToCreate.add(path.subFragment(0, i));
       }
     }
+
+    // Add all ouput directories.
+    dirsToCreate.addAll(outputs.dirs());
   }
 
   /**

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerExecRootTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerExecRootTest.java
@@ -131,6 +131,7 @@ public class WorkerExecRootTest {
             execRoot,
             new SandboxInputs(
                 ImmutableMap.of(),
+                ImmutableSet.of(),
                 ImmutableMap.of()),
             SandboxOutputs.create(
                 ImmutableSet.of(

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerExecRootTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerExecRootTest.java
@@ -125,6 +125,34 @@ public class WorkerExecRootTest {
   }
 
   @Test
+  public void createsOutputDirs() throws Exception {
+    WorkerExecRoot workerExecRoot =
+        new WorkerExecRoot(
+            execRoot,
+            new SandboxInputs(
+                ImmutableMap.of(),
+                ImmutableMap.of()),
+            SandboxOutputs.create(
+                ImmutableSet.of(
+                    PathFragment.create("dir/foo/bar_kt.jar"),
+                    PathFragment.create("dir/foo/bar_kt.jdeps"),
+                    PathFragment.create("dir/foo/bar_kt-sources.jar")),
+                ImmutableSet.of(
+                    PathFragment.create("dir/foo/_kotlinc/bar_kt_jvm/bar_kt_sourcegenfiles"),
+                    PathFragment.create("dir/foo/_kotlinc/bar_kt_jvm/bar_kt_classes"),
+                    PathFragment.create("dir/foo/_kotlinc/bar_kt_jvm/bar_kt_temp"),
+                    PathFragment.create("dir/foo/_kotlinc/bar_kt_jvm/bar_kt_generated_classes"))),
+            ImmutableSet.of());
+
+    workerExecRoot.createFileSystem();
+
+    assertThat(execRoot.getRelative("dir/foo/_kotlinc/bar_kt_jvm/bar_kt_sourcegenfiles").exists()).isTrue();
+    assertThat(execRoot.getRelative("dir/foo/_kotlinc/bar_kt_jvm/bar_kt_classes").exists()).isTrue();
+    assertThat(execRoot.getRelative("dir/foo/_kotlinc/bar_kt_jvm/bar_kt_temp").exists()).isTrue();
+    assertThat(execRoot.getRelative("dir/foo/_kotlinc/bar_kt_jvm/bar_kt_generated_classes").exists()).isTrue();
+  }
+
+  @Test
   public void workspaceFilesAreNotDeleted() throws Exception {
     // We want to check that `WorkerExecRoot` deletes pre-existing symlinks if they're not in the
     // `SandboxInputs`, but it does not delete the files that the symlinks point to (i.e., the files


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/bazel/issues/11210

Parent directories now created before children.