### PR TITLE
Generate grpc using built-in shell environment

### DIFF
--- a/third_party/grpc/bazel/generate_cc.bzl
+++ b/third_party/grpc/bazel/generate_cc.bzl
@@ -123,6 +123,7 @@ def generate_cc_impl(ctx):
         outputs = out_files,
         executable = ctx.executable.protoc,
         arguments = arguments,
+        use_default_shell_env = True,
     )
 
     return struct(files = depset(out_files))


### PR DESCRIPTION
This commit updates the implementation of `cc_grpc_library` to use the built-in shell environment. It aligns the implementation with the `proto_gen` rule for protocol buffers.