### PR TITLE
Reintroduce support for Python 2.6 to python_stub_template

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
@@ -18,7 +18,6 @@ import shutil
 import subprocess
 import tempfile
 import zipfile
-import collections
 
 # Return True if running on Windows
 def IsWindows():
@@ -264,7 +263,11 @@ https://github.com/bazelbuild/bazel/issues/7899 for more information.
 
 def Deduplicate(items):
   """Efficiently filter out duplicates, keeping the first element only."""
-  return list(collections.OrderedDict((it, None) for it in items).keys())
+  seen = set()
+  for it in items:
+      if it not in seen:
+          seen.add(it)
+          yield it
 
 def Main():
   args = sys.argv[1:]
@@ -281,8 +284,10 @@ def Main():
   python_path_entries += GetRepositoriesImports(module_space, %import_all%)
   # Remove duplicates to avoid overly long PYTHONPATH (#10977). Preserve order,
   # keep first occurrence only.
-  python_path_entries = Deduplicate(python_path_entries)
-  python_path_entries = [GetWindowsPathWithUNCPrefix(d) for d in python_path_entries]
+  python_path_entries = [
+    GetWindowsPathWithUNCPrefix(d)
+    for d in Deduplicate(python_path_entries)
+  ]
 
   old_python_path = os.environ.get('PYTHONPATH')
   python_path = os.pathsep.join(python_path_entries)


### PR DESCRIPTION
Commit d5012a7ed19c1e75e413373fa22c5f1b08a9ee29 introduced a Python
2.7 dependency into python_stub_template.txt.  Unfortunately this stub
is non-hermetic, so even if the user has configured Python 2.7 and 3
`py_runtime`s, their builds may fail if the system-provided Python is ancient
(ex: CentOS 6.6 provides Python 2.6.6).

Accommodate ancient Python by reworking the path deduplication in terms
of a `set` and a generator instead of `collections.OrderedDict`.

Workaround for #11265.

Testing Done:
- `bazelisk test //src/test/shell/integration:python_stub_test`
- In a CentOS 6.6 env:
```console
$ /usr/bin/env python -V
Python 2.6.6
$ cat >test.py <<EOF
import sys
print(sys.executable)
EOF
$ cat >BUILD <<EOF
py_binary(name = "test", srcs = ["test.py"])
EOF
$ bazel run :test
/path/to/my/hermetic/python3
```