### PR TITLE
Add zsh completion to debian package

### DIFF
--- a/scripts/packages/debian/BUILD
+++ b/scripts/packages/debian/BUILD
@@ -26,15 +26,25 @@ pkg_tar(
 )
 
 genrule(
-    name = "rename-bazel-completion",
+    name = "rename-bash-completion",
     srcs = ["//scripts:bash_completion"],
     outs = ["etc/bash_completion.d/bazel"],
     cmd = "cp $< $@",
 )
 
+genrule(
+    name = "rename-zsh-completion",
+    srcs = ["//scripts/zsh_completion:_bazel"],
+    outs = ["usr/share/zsh/vendor-completions/_bazel"],
+    cmd = "cp $< $@",
+)
+
 pkg_tar(
     name = "bazel-completion",
-    srcs = [":etc/bash_completion.d/bazel"],
+    srcs = [
+        ":etc/bash_completion.d/bazel",
+        ":usr/share/zsh/vendor-completions/_bazel",
+    ],
     mode = "0644",
     strip_prefix = ".",
 )
@@ -73,6 +83,7 @@ pkg_deb(
     conffiles = [
         "/etc/bash_completion.d/bazel",
         "/etc/bazel.bazelrc",
+        "/usr/share/zsh/vendor-completions/_bazel",
     ],
     data = ":debian-data",
     depends = [

--- a/site/docs/completion.md
+++ b/site/docs/completion.md
@@ -18,6 +18,9 @@ If you installed Bazel:
 *   From the APT repository, then you're done -- the Bash completion script is
     already installed in `/etc/bash_completion.d`.
 
+*   From Homebrew, then you're done -- the Bash completion script is
+    already installed in `$(brew --prefix)/etc/bash_completion.d`.
+
 *   From the installer downloaded from GitHub, then:
     1.  Locate the absolute path of the completion file. The installer copied it
         to the `bin` directory.
@@ -67,24 +70,40 @@ If you installed Bazel:
 
 <h2 id="zsh">Zsh</h2>
 
-Bazel also comes with a Zsh completion script. To install it:
+Bazel comes with a Zsh completion script.
 
-1.  Add this script to a directory on your `$fpath`:
+If you installed Bazel:
 
-    ```
-    fpath[1,0]=~/.zsh/completion/
-    mkdir -p ~/.zsh/completion/
-    cp scripts/zsh_completion/_bazel ~/.zsh/completion
-    ```
+*   From the APT repository, then you're done -- the Zsh completion script is
+    already installed in `/usr/share/zsh/vendor-completions`.
 
-    You may have to call `rm -f ~/.zcompdump; compinit`
-    the first time to make it work.
+*   From Homebrew, then you're done -- the Zsh completion script is
+    already installed in `$(brew --prefix)/share/zsh/site-functions`.
 
-2.  Optionally, add the following to your .zshrc.
+*   From the installer downloaded from GitHub, then:
+    1.  Locate the absolute path of the completion file. The installer copied it
+        to the `bin` directory.
 
-    ```
-    # This way the completion script does not have to parse Bazel's options
-    # repeatedly.  The directory in cache-path must be created manually.
-    zstyle ':completion:*' use-cache on
-    zstyle ':completion:*' cache-path ~/.zsh/cache
-    ```
+        Example: if you ran the installer with `--user`, this will be
+        `$HOME/.bazel/bin`. If you ran the installer as root, this will be
+        `/usr/local/lib/bazel/bin`.
+
+    2.  Add this script to a directory on your `$fpath`:
+
+        ```
+        fpath[1,0]=~/.zsh/completion/
+        mkdir -p ~/.zsh/completion/
+        cp /path/from/above/step/_bazel ~/.zsh/completion
+        ```
+
+        You may have to call `rm -f ~/.zcompdump; compinit`
+        the first time to make it work.
+
+    3.  Optionally, add the following to your .zshrc.
+
+        ```
+        # This way the completion script does not have to parse Bazel's options
+        # repeatedly.  The directory in cache-path must be created manually.
+        zstyle ':completion:*' use-cache on
+        zstyle ':completion:*' cache-path ~/.zsh/cache
+        ```


### PR DESCRIPTION
The zsh completion script was missing from the debian package. It is already packaged in the installer, and is installed by Homebrew, so might as well do the same thing for the debian package.

Also updated the documentation to be more current.