### PR TITLE
Resource linking for android_library targets is unnecessary.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AarImport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AarImport.java
@@ -113,7 +113,8 @@ public class AarImport implements RuleConfiguredTargetFactory {
                 dataContext,
                 manifest,
                 DataBinding.contextFrom(ruleContext, dataContext.getAndroidConfig()),
-                neverlink);
+                neverlink,
+                dataContext.getAndroidConfig().linkLibraryResources());
 
     MergedAndroidAssets mergedAssets =
         AndroidAssets.forAarImport(assets)

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -882,6 +882,14 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     public boolean useRTxtFromMergedResources;
 
     @Option(
+        name = "link_library_resources",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.CHANGES_INPUTS},
+        help = "If disabled does not run aapt2 link for android_library targets")
+    public boolean linkLibraryResources;
+
+    @Option(
         name = "legacy_main_dex_list_generator",
         // TODO(b/147692286): Update this default value to R8's GenerateMainDexList binary after
         // migrating usage.
@@ -990,6 +998,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   private final boolean alwaysFilterDuplicateClassesFromAndroidTest;
   private final boolean filterLibraryJarWithProgramJar;
   private final boolean useRTxtFromMergedResources;
+  private final boolean linkLibraryResources;
   private final Label legacyMainDexListGenerator;
 
   private AndroidConfiguration(Options options) throws InvalidConfigurationException {
@@ -1044,6 +1053,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
         options.alwaysFilterDuplicateClassesFromAndroidTest;
     this.filterLibraryJarWithProgramJar = options.filterLibraryJarWithProgramJar;
     this.useRTxtFromMergedResources = options.useRTxtFromMergedResources;
+    this.linkLibraryResources = options.linkLibraryResources;
     this.legacyMainDexListGenerator = options.legacyMainDexListGenerator;
 
     if (options.androidAaptVersion != AndroidAaptVersion.AAPT2) {
@@ -1295,6 +1305,10 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
 
   boolean useRTxtFromMergedResources() {
     return useRTxtFromMergedResources;
+  }
+
+  boolean linkLibraryResources() {
+    return linkLibraryResources;
   }
 
   /** Returns the label provided with --legacy_main_dex_list_generator, if any. */

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidLibrary.java
@@ -162,7 +162,8 @@ public abstract class AndroidLibrary implements RuleConfiguredTargetFactory {
                   dataContext,
                   manifest,
                   DataBinding.contextFrom(ruleContext, dataContext.getAndroidConfig()),
-                  isNeverLink);
+                  isNeverLink,
+                  androidConfig.linkLibraryResources());
 
       MergedAndroidAssets assets = AndroidAssets.from(ruleContext).process(dataContext, assetDeps);
 

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidResources.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidResources.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.analysis.TransitionMode;
 import com.google.devtools.build.lib.packages.AttributeMap;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
 import com.google.devtools.build.lib.packages.RuleErrorConsumer;
+import com.google.devtools.build.lib.rules.android.databinding.DataBinding;
 import com.google.devtools.build.lib.rules.android.databinding.DataBindingContext;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.Arrays;
@@ -410,24 +411,27 @@ public class AndroidResources {
       AndroidDataContext dataContext,
       StampedAndroidManifest manifest,
       DataBindingContext dataBindingContext,
-      boolean neverlink)
+      boolean neverlink,
+      boolean linkResources)
       throws RuleErrorException, InterruptedException {
     return process(
         dataContext,
         manifest,
         ResourceDependencies.fromRuleDeps(ruleContext, neverlink),
-        dataBindingContext);
+        dataBindingContext,
+        linkResources);
   }
 
   ValidatedAndroidResources process(
       AndroidDataContext dataContext,
       StampedAndroidManifest manifest,
       ResourceDependencies resourceDeps,
-      DataBindingContext dataBindingContext)
+      DataBindingContext dataBindingContext,
+      boolean linkResources)
       throws InterruptedException {
-    return parse(dataContext, manifest, dataBindingContext)
-        .merge(dataContext, resourceDeps)
-        .validate(dataContext);
+    MergedAndroidResources merge = parse(dataContext, manifest, dataBindingContext)
+        .merge(dataContext, resourceDeps);
+    return linkResources ? merge.validate(dataContext) : merge.validateNoLink(dataContext);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidRuleClasses.java
@@ -374,7 +374,6 @@ public final class AndroidRuleClasses {
 
           if (AndroidResources.definesAndroidResources(attributes)) {
             implicitOutputs.add(
-                AndroidRuleClasses.ANDROID_JAVA_SOURCE_JAR,
                 AndroidRuleClasses.ANDROID_R_TXT,
                 AndroidRuleClasses.ANDROID_RESOURCES_CLASS_JAR);
           }

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidStarlarkData.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidStarlarkData.java
@@ -173,7 +173,8 @@ public abstract class AndroidStarlarkData
               ResourceDependencies.fromProviders(
                   Sequence.cast(deps, AndroidResourcesInfo.class, "deps"), neverlink),
               DataBinding.contextFrom(
-                  enableDataBinding, ctx.getActionConstructionContext(), ctx.getAndroidConfig()));
+                  enableDataBinding, ctx.getActionConstructionContext(), ctx.getAndroidConfig()),
+              ctx.getAndroidConfig().linkLibraryResources());
     } catch (RuleErrorException e) {
       throw handleRuleException(errorReporter, e);
     }
@@ -273,7 +274,8 @@ public abstract class AndroidStarlarkData
                 ResourceDependencies.fromProviders(
                     getProviders(depsTargets, AndroidResourcesInfo.PROVIDER),
                     /* neverlink = */ false),
-                DataBinding.getDisabledDataBindingContext(ctx));
+                DataBinding.getDisabledDataBindingContext(ctx),
+                ctx.getAndroidConfig().linkLibraryResources());
 
     MergedAndroidAssets mergedAssets =
         AndroidAssets.forAarImport(assets)

--- a/src/main/java/com/google/devtools/build/lib/rules/android/MergedAndroidResources.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/MergedAndroidResources.java
@@ -59,8 +59,13 @@ public class MergedAndroidResources extends ParsedAndroidResources {
     parsed.asDataBindingContext().supplyLayoutInfo(builder::setDataBindingInfoZip);
 
     if (dataContext.getAndroidConfig().useRTxtFromMergedResources()) {
-      builder.setAapt2RTxtOut(
-          dataContext.createOutputArtifact(AndroidRuleClasses.ANDROID_RESOURCES_AAPT2_R_TXT));
+      if (dataContext.getAndroidConfig().linkLibraryResources()) {
+        builder.setAapt2RTxtOut(
+            dataContext.createOutputArtifact(AndroidRuleClasses.ANDROID_RESOURCES_AAPT2_R_TXT));
+      } else {
+        builder.setAapt2RTxtOut(
+            dataContext.createOutputArtifact(AndroidRuleClasses.ANDROID_R_TXT));
+      }
     }
 
     return builder
@@ -172,6 +177,10 @@ public class MergedAndroidResources extends ParsedAndroidResources {
   public ValidatedAndroidResources validate(AndroidDataContext dataContext)
       throws InterruptedException {
     return ValidatedAndroidResources.validateFrom(dataContext, this);
+  }
+
+  public ValidatedAndroidResources validateNoLink(AndroidDataContext dataContext) {
+    return ValidatedAndroidResources.of(this, this.getAapt2RTxt(), null, null, null, null, null, dataContext.getAndroidConfig().useRTxtFromMergedResources());
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/android/ValidatedAndroidResources.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/ValidatedAndroidResources.java
@@ -99,7 +99,7 @@ public class ValidatedAndroidResources extends MergedAndroidResources
   static ValidatedAndroidResources of(
       MergedAndroidResources merged,
       Artifact rTxt,
-      Artifact sourceJar,
+      @Nullable Artifact sourceJar,
       Artifact apk,
       @Nullable Artifact aapt2ValidationArtifact,
       @Nullable Artifact aapt2SourceJar,
@@ -119,7 +119,7 @@ public class ValidatedAndroidResources extends MergedAndroidResources
   private ValidatedAndroidResources(
       MergedAndroidResources merged,
       Artifact rTxt,
-      Artifact sourceJar,
+      @Nullable Artifact sourceJar,
       Artifact apk,
       @Nullable Artifact aapt2ValidationArtifact,
       @Nullable Artifact aapt2SourceJar,
@@ -151,6 +151,7 @@ public class ValidatedAndroidResources extends MergedAndroidResources
   }
 
   @Override
+  @Nullable
   public Artifact getJavaSourceJar() {
     return sourceJar;
   }

--- a/src/test/java/com/google/devtools/build/lib/rules/android/AndroidResourcesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/AndroidResourcesTest.java
@@ -160,7 +160,8 @@ public class AndroidResourcesTest extends ResourceTestBase {
                 dataContext,
                 getManifest(),
                 DataBinding.contextFrom(ruleContext, dataContext.getAndroidConfig()),
-                /* neverlink = */ false);
+                /* neverlink = */ false,
+                /* linkResources */ true);
     Optional<? extends AndroidResources> maybeFiltered =
         assertFilter(unfiltered, filteredResources, /* isDependency = */ true);
 


### PR DESCRIPTION
Use R.txt from AndroidCompiledResourceMerger
Don't include R.java in srcjar output
Avoid AndroidResourceLink action
Avoid large library.ap_ + resource.srcjar outputs
Enable with the following flags:-

--nolink_library_resources --experimental_use_rtxt_from_merged_resources