### PR TITLE
Add link to community CentOS 6 builds

### DIFF
--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -15,6 +15,7 @@ See the instructions for installing Bazel on:
 
 *   [Arch Linux](https://www.archlinux.org/packages/community/x86_64/bazel/)
 *   [Fedora 25, 26, 27, 28, and CentOS 7](install-redhat.md)
+*   [CentOS 6](https://github.com/sub-mod/bazel-builds)
 *   [FreeBSD](https://www.freshports.org/devel/bazel)
 *   [Gentoo](https://packages.gentoo.org/packages/dev-util/bazel)
 *   [Linuxbrew](https://github.com/Linuxbrew/homebrew-core/blob/master/Formula/bazel.rb)


### PR DESCRIPTION
@sub-mod from RedHat has prepared Bazel binaries for CentOS 6. I've requested some additions to the repo README just to clarify some things, but could be linked to even now.

The builds are on the releases/ tab.