### PR TITLE
Fix C++ string include

### DIFF
--- a/tools/osx/crosstool/wrapped_clang.cc
+++ b/tools/osx/crosstool/wrapped_clang.cc
@@ -49,7 +49,7 @@
 #include <map>
 #include <memory>
 #include <sstream>
-#include <string>
+#include <string.h>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
This file uses functions like `strrchr` that are provided by string.h,
it seems like somehow this works implicitly on macOS but this seems to
be more correct.