### PR TITLE
Introduce distrib_cc_library

### DIFF
--- a/tools/distributions/debian/deps.bzl
+++ b/tools/distributions/debian/deps.bzl
@@ -16,6 +16,7 @@
 
 def debian_deps():
     debian_java_deps()
+    debian_cc_deps()
 
 def debian_java_deps():
     # An external repository for providing Debian system installed java libraries.
@@ -23,4 +24,12 @@ def debian_java_deps():
         name = "debian_java_deps",
         path = "/usr/share/java",
         build_file = "//tools/distributions/debian:debian_java.BUILD",
+    )
+
+def debian_cc_deps():
+    # An external repository for providing Debian system installed java libraries.
+    native.new_local_repository(
+        name = "debian_cc_deps",
+        path = "/usr/lib",
+        build_file = "//tools/distributions/debian:debian_cc.BUILD",
     )

--- a/tools/distributions/distribution_rules.bzl
+++ b/tools/distributions/distribution_rules.bzl
@@ -28,3 +28,19 @@ def distrib_java_import(name, enable_distributions = [], **kwargs):
         conditions["//src/conditions:debian_build"] = "@debian_java_deps//:" + name
 
     native.alias(name = name, actual = select(conditions))
+
+
+def distrib_cc_library(name, visibility = None, enable_distributions = [], **kwargs):
+    """A macro for cc_library rule to support distributions build (eg. Debian)"""
+    checked_in_name = name + "_checked_in"
+
+    native.cc_library(name = checked_in_name, visibility = visibility, **kwargs)
+
+    conditions = {
+        "//conditions:default": ":" + checked_in_name,
+    }
+
+    if "debian" in enable_distributions:
+        conditions["//src/conditions:debian_build"] = "@debian_cc_deps//:" + name
+
+    native.alias(name = name, actual = select(conditions), visibility = visibility)


### PR DESCRIPTION
Similar to distrib_java_import, this macro rule is for redirecting
Bazel's cc dependencies to Debian's system libraries.

Related https://github.com/bazelbuild/bazel/issues/9408