### PR TITLE
Use a custom LICENSE file for the Debian build

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -450,7 +450,17 @@ merge_licenses(
         "//:LICENSE",
         "//third_party:srcs",
     ],
-    out = "runtime/commands/LICENSE",
+    out = "LICENSE.merged",
+)
+
+genrule(
+    name = "bazel_license",
+    srcs = select({
+        "//src/conditions:debian_build": ["//tools/distributions/debian:bazel_debian_license"],
+        "//conditions:default": [":merge_licenses"],
+    }),
+    outs = ["runtime/commands/LICENSE"],
+    cmd = "cp $< $@",
 )
 
 java_library(

--- a/src/main/java/com/google/devtools/build/lib/bazel/commands/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/commands/BUILD
@@ -16,7 +16,7 @@ java_library(
     resources = [
         "fetch.txt",
         "sync.txt",
-        "//src/main/java/com/google/devtools/build/lib:merge_licenses",  # license
+        "//src/main/java/com/google/devtools/build/lib:bazel_license",  # license
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib:keep-going-option",

--- a/tools/distributions/debian/BUILD
+++ b/tools/distributions/debian/BUILD
@@ -1,3 +1,5 @@
+exports_files(["bazel_debian_license"])
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),

--- a/tools/distributions/debian/bazel_debian_license
+++ b/tools/distributions/debian/bazel_debian_license
@@ -1,0 +1,2 @@
+Please find the license file of Bazel at /usr/share/doc/bazel/copyright
+


### PR DESCRIPTION
The `//src/main/java/com/google/devtools/build/lib:merge_licenses` target causes the Bazel binary to depend on `//third_party:srcs`, which introduced many unnecessary third party dependencies.

This change excluded that target for Debian build and point users to a standard location for license file in Debian.

With this change, we can get rid of all deps in [Bazel dependencies](https://docs.google.com/spreadsheets/d/1yqbzbR0PntWAxt4AxwyuXGn-5CjeKaGEEfCJ91n6VPA/edit#gid=0) marked as "Exclude" for the Debian build.

Related https://github.com/bazelbuild/bazel/issues/9408