### PR TITLE
Reduce AndroidAssetMerger intermediate outputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidAssets.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidAssets.java
@@ -179,7 +179,14 @@ public class AndroidAssets {
   /** Convenience method to do all of asset processing - parsing and merging. */
   public MergedAndroidAssets process(AndroidDataContext dataContext, AssetDependencies assetDeps)
       throws InterruptedException {
-    return parse(dataContext).merge(dataContext, assetDeps);
+    ParsedAndroidAssets parsedAssets = parse(dataContext);
+
+    boolean mergeAssets = dataContext.getAndroidConfig().outputLibraryMergedAssets()
+        || dataContext.throwOnResourceConflict();
+
+    return mergeAssets ?
+        parsedAssets.merge(dataContext, assetDeps) :
+        MergedAndroidAssets.of(parsedAssets, null, assetDeps);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -882,6 +882,14 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     public boolean useRTxtFromMergedResources;
 
     @Option(
+            name = "output_library_merged_assets",
+            defaultValue = "true",
+            documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+            effectTags = {OptionEffectTag.UNKNOWN},
+            help = "If disabled, does not produce merged asset.zip outputs for library targets")
+    public boolean outputLibraryMergedAssets;
+
+    @Option(
         name = "legacy_main_dex_list_generator",
         // TODO(b/147692286): Update this default value to R8's GenerateMainDexList binary after
         // migrating usage.
@@ -990,6 +998,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   private final boolean alwaysFilterDuplicateClassesFromAndroidTest;
   private final boolean filterLibraryJarWithProgramJar;
   private final boolean useRTxtFromMergedResources;
+  private final boolean outputLibraryMergedAssets;
   private final Label legacyMainDexListGenerator;
 
   private AndroidConfiguration(Options options) throws InvalidConfigurationException {
@@ -1044,6 +1053,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
         options.alwaysFilterDuplicateClassesFromAndroidTest;
     this.filterLibraryJarWithProgramJar = options.filterLibraryJarWithProgramJar;
     this.useRTxtFromMergedResources = options.useRTxtFromMergedResources;
+    this.outputLibraryMergedAssets = options.outputLibraryMergedAssets;
     this.legacyMainDexListGenerator = options.legacyMainDexListGenerator;
 
     if (options.androidAaptVersion != AndroidAaptVersion.AAPT2) {
@@ -1295,6 +1305,10 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
 
   boolean useRTxtFromMergedResources() {
     return useRTxtFromMergedResources;
+  }
+
+  boolean outputLibraryMergedAssets() {
+    return outputLibraryMergedAssets;
   }
 
   /** Returns the label provided with --legacy_main_dex_list_generator, if any. */

--- a/src/main/java/com/google/devtools/build/lib/rules/android/MergedAndroidAssets.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/MergedAndroidAssets.java
@@ -27,8 +27,8 @@ public class MergedAndroidAssets extends ParsedAndroidAssets {
       AndroidDataContext dataContext, ParsedAndroidAssets parsed, AssetDependencies deps)
       throws InterruptedException {
 
-    Artifact mergedAssets =
-        dataContext.createOutputArtifact(AndroidRuleClasses.ANDROID_ASSETS_ZIP);
+    Artifact mergedAssets = dataContext.getAndroidConfig().outputLibraryMergedAssets() ?
+        dataContext.createOutputArtifact(AndroidRuleClasses.ANDROID_ASSETS_ZIP) : null;
 
     BusyBoxActionBuilder builder = BusyBoxActionBuilder.create(dataContext, "MERGE_ASSETS");
     if (dataContext.throwOnResourceConflict()) {
@@ -36,7 +36,7 @@ public class MergedAndroidAssets extends ParsedAndroidAssets {
     }
 
     builder
-        .addOutput("--assetsOutput", mergedAssets)
+        .maybeAddOutput("--assetsOutput", mergedAssets)
         .addInput(
             "--primaryData",
             AndroidDataConverter.PARSED_ASSET_CONVERTER.map(parsed),


### PR DESCRIPTION
They are not required in the final build.

For our builds:-

This results in 503MB of outputs (assets.zip files) - each of these includes the transitive closure of all assets. To put in perspective we have only 2.5MB of assets.

This is very costly for remote builds with caches especially on slower connections

If resource conflict checking is not enabled (it is not for our build) this will also avoid running AndroidAssetMerger all together saving 896 actions ~3mins total CPU time.

https://github.com/bazelbuild/rules_android/issues/10