### PR TITLE
Add javax.annotations to Debian distribution build

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -424,11 +424,12 @@ filegroup(
 
 # javax.annotation.Generated is not included in the default root modules in 9,
 # see: http://openjdk.java.net/jeps/320.
-java_import(
+distrib_java_import(
     name = "javax_annotations",
     jars = ["javax_annotations/javax.annotation-api-1.3.2.jar"],
     neverlink = 1,  # @Generated is source-retention
     srcjar = "javax_annotations/javax.annotation-api-1.3.2-sources.jar",
+    enable_distributions = ["debian"],
 )
 
 java_import(

--- a/tools/distributions/debian/debian_java.BUILD
+++ b/tools/distributions/debian/debian_java.BUILD
@@ -63,3 +63,9 @@ java_import(
     name = "allocation_instrumenter",
     jars = ["java-allocation-instrumenter.jar"],
 )
+
+# javax.annotation-api
+java_import(
+    name = "javax_annotations",
+    jars = ["geronimo-annotation-1.3-spec.jar"],
+)


### PR DESCRIPTION
Extending the Debian integration that @meteorcloudy started based on [clarification](https://lists.debian.org/debian-devel/2020/05/msg00055.html) and current [package location](https://packages.debian.org/sid/all/libgeronimo-annotation-1.3-spec-java/filelist).