### PR TITLE
Fix headers checking mode for cc_common.compile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -1743,7 +1743,8 @@ public abstract class CcModule
             .addAdditionalCompilationInputs(
                 Sequence.cast(additionalInputs, Artifact.class, "additional_inputs"))
             .addAditionalIncludeScanningRoots(headersForClifDoNotUseThisParam)
-            .setPurpose(common.getPurpose(getSemantics()));
+            .setPurpose(common.getPurpose(getSemantics()))
+            .setHeadersCheckingMode(getSemantics().determineHeadersCheckingMode(actions.getRuleContext()));
     if (disallowNopicOutputs) {
       helper.setGenerateNoPicAction(false);
     }


### PR DESCRIPTION
Looks like Bazel should always use STRICT headersCheckingMode.

cc_binary & cc_library get this mode from semantic, but for cc_common.compile LOOSE mode used as a default value in CcCompilationHelper.

It leads to extra looseIncludeDirs and some headers checking are missed.