### PR TITLE
Replace the usage of 'usual' with 'explicit' or 'non-phony', depending on context, in Ninja code

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaActionsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaActionsHelper.java
@@ -146,10 +146,10 @@ public class NinjaActionsHelper {
         }
       } else {
         PhonyTarget phonyTarget = phonyTargets.get(fragment);
-        // Phony target can be null, if the path in neither usual or phony target,
+        // Phony target can be null, if the path in neither regular or phony target,
         // but the source file.
         if (phonyTarget != null) {
-          phonyTarget.visitUsualInputs(phonyTargets, enqueuer::accept);
+          phonyTarget.visitExplicitInputs(phonyTargets, enqueuer::accept);
         }
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaBuild.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaBuild.java
@@ -182,13 +182,13 @@ public class NinjaBuild implements RuleConfiguredTargetFactory {
         NestedSet<Artifact> artifacts = phonyTargetsArtifacts.getPhonyTargetArtifacts(path);
         nestedSetBuilder.addTransitive(artifacts);
       } else {
-        Artifact usualArtifact = artifactsHelper.createOutputArtifact(path);
-        if (usualArtifact == null) {
+        Artifact outputArtifact = artifactsHelper.createOutputArtifact(path);
+        if (outputArtifact == null) {
           ruleContext.ruleError(
               String.format("Required target '%s' is not created in ninja_graph.", path));
           return NestedSetBuilder.emptySet(Order.STABLE_ORDER);
         }
-        nestedSetBuilder.add(usualArtifact);
+        nestedSetBuilder.add(outputArtifact);
       }
     }
     return nestedSetBuilder.build();

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphRule.java
@@ -33,7 +33,7 @@ import com.google.devtools.build.lib.util.FileTypeSet;
 /**
  * The rule that parses the Ninja graph and symlinks inputs into output_root.
  *
- * <p>The rule exposes {@link NinjaGraphProvider} with maps of usual and phony {@link
+ * <p>The rule exposes {@link NinjaGraphProvider} with maps of both non-phony and phony {@link
  * com.google.devtools.build.lib.bazel.rules.ninja.parser.NinjaTarget} for {@link NinjaBuildRule} to
  * use for action creation.
  *

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaPhonyTargetsUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaPhonyTargetsUtil.java
@@ -85,7 +85,7 @@ public class NinjaPhonyTargetsUtil {
           isAlwaysDirty |= alreadyComputed.isAlwaysDirty();
           phonyNames.add(Iterables.getOnlyElement(phonyInput.getAllOutputs()));
         } else {
-          // The input is the usual file.
+          // The input is an explicit input file.
           directInputs.add(input);
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTarget.java
@@ -30,25 +30,25 @@ import java.util.function.Consumer;
  * the flag whether this phony target is always dirty, i.e. must be rebuild each time.
  *
  * <p>Always-dirty phony targets are those which do not have any inputs: "build alias: phony". All
- * usual direct dependants of those actions automatically also always-dirty (but not the transitive
- * dependants: they should check whether their computed inputs have changed). As phony targets are
- * not performing any actions, <b>all phony transitive dependants of always-dirty phony targets are
- * themselves always-dirty.</b> That is why we can compute the always-dirty flag for the phony
- * targets, and use it for marking their direct non-phony dependants as actions to be executed
- * unconditionally.
+ * non-phony direct dependants of those actions automatically also always-dirty (but not the
+ * transitive dependants: they should check whether their computed inputs have changed). As phony
+ * targets are not performing any actions, <b>all phony transitive dependants of always-dirty phony
+ * targets are themselves always-dirty.</b> That is why we can compute the always-dirty flag for
+ * the phony targets, and use it for marking their direct non-phony dependants as actions to be
+ * executed unconditionally.
  */
 @Immutable
 public final class PhonyTarget {
   private final ImmutableList<PathFragment> phonyNames;
-  private final ImmutableList<PathFragment> directUsualInputs;
+  private final ImmutableList<PathFragment> directExplicitInputs;
   private final boolean isAlwaysDirty;
 
   public PhonyTarget(
       ImmutableList<PathFragment> phonyNames,
-      ImmutableList<PathFragment> directUsualInputs,
+      ImmutableList<PathFragment> directExplicitInputs,
       boolean isAlwaysDirty) {
     this.phonyNames = phonyNames;
-    this.directUsualInputs = directUsualInputs;
+    this.directExplicitInputs = directExplicitInputs;
     this.isAlwaysDirty = isAlwaysDirty;
   }
 
@@ -56,18 +56,18 @@ public final class PhonyTarget {
     return phonyNames;
   }
 
-  public ImmutableList<PathFragment> getDirectUsualInputs() {
-    return directUsualInputs;
+  public ImmutableList<PathFragment> getDirectExplicitInputs() {
+    return directExplicitInputs;
   }
 
   public boolean isAlwaysDirty() {
     return isAlwaysDirty;
   }
 
-  public void visitUsualInputs(
+  public void visitExplicitInputs(
       ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap,
       Consumer<ImmutableList<PathFragment>> consumer) {
-    consumer.accept(directUsualInputs);
+    consumer.accept(directExplicitInputs);
 
     ArrayDeque<PathFragment> queue = new ArrayDeque<>(phonyNames);
     Set<PathFragment> visited = Sets.newHashSet();
@@ -75,7 +75,7 @@ public final class PhonyTarget {
       PathFragment fragment = queue.remove();
       if (visited.add(fragment)) {
         PhonyTarget phonyTarget = Preconditions.checkNotNull(phonyTargetsMap.get(fragment));
-        consumer.accept(phonyTarget.getDirectUsualInputs());
+        consumer.accept(phonyTarget.getDirectExplicitInputs());
         queue.addAll(phonyTarget.getPhonyNames());
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTargetArtifacts.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/PhonyTargetArtifacts.java
@@ -26,9 +26,9 @@ import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * Helper class for caching computation of transitive inclusion of usual targets into phony. (We can
- * not compute all artifacts for all phony targets because some of them may not be created by a
- * subgraph of required actions.)
+ * Helper class for caching computation of transitive inclusion of non-phony targets into phony
+ * ones. We cannot compute all artifacts for all phony targets because some of them may not be
+ * created by a subgraph of required actions.
  */
 @ThreadSafe
 public class PhonyTargetArtifacts {
@@ -52,7 +52,7 @@ public class PhonyTargetArtifacts {
     PhonyTarget phonyTarget = phonyTargetsMap.get(name);
     Preconditions.checkNotNull(phonyTarget);
     NestedSetBuilder<Artifact> builder = NestedSetBuilder.stableOrder();
-    for (PathFragment input : phonyTarget.getDirectUsualInputs()) {
+    for (PathFragment input : phonyTarget.getDirectExplicitInputs()) {
       builder.add(artifactsHelper.getInputArtifact(input));
     }
     for (PathFragment phonyName : phonyTarget.getPhonyNames()) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParserStep.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaParserStep.java
@@ -233,9 +233,9 @@ public class NinjaParserStep {
   }
 
   private enum NinjaTargetParsingPart {
-    OUTPUTS(OutputKind.USUAL, true),
+    OUTPUTS(OutputKind.EXPLICIT, true),
     IMPLICIT_OUTPUTS(OutputKind.IMPLICIT, true),
-    INPUTS(InputKind.USUAL, false),
+    INPUTS(InputKind.EXPLICIT, false),
     IMPLICIT_INPUTS(InputKind.IMPLICIT, false),
     ORDER_ONLY_INPUTS(InputKind.ORDER_ONLY, false),
     RULE_NAME(null, false),

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaTarget.java
@@ -163,7 +163,7 @@ public final class NinjaTarget {
   /** Enum with possible kinds of inputs. */
   @Immutable
   public enum InputKind implements InputOutputKind {
-    USUAL,
+    EXPLICIT,
     IMPLICIT,
     ORDER_ONLY
   }
@@ -171,7 +171,7 @@ public final class NinjaTarget {
   /** Enum with possible kinds of outputs. */
   @Immutable
   public enum OutputKind implements InputOutputKind {
-    USUAL,
+    EXPLICIT,
     IMPLICIT
   }
 
@@ -211,7 +211,7 @@ public final class NinjaTarget {
   }
 
   public List<PathFragment> getOutputs() {
-    return outputs.get(OutputKind.USUAL);
+    return outputs.get(OutputKind.EXPLICIT);
   }
 
   public List<PathFragment> getImplicitOutputs() {
@@ -226,8 +226,8 @@ public final class NinjaTarget {
     return inputs.values();
   }
 
-  public Collection<PathFragment> getUsualInputs() {
-    return inputs.get(InputKind.USUAL);
+  public Collection<PathFragment> getExplicitInputs() {
+    return inputs.get(InputKind.EXPLICIT);
   }
 
   public Collection<PathFragment> getImplicitInputs() {
@@ -252,7 +252,7 @@ public final class NinjaTarget {
         + prettyPrintPaths("\n| ", getImplicitOutputs())
         + "\n: "
         + this.ruleName
-        + prettyPrintPaths("\n", getUsualInputs())
+        + prettyPrintPaths("\n", getExplicitInputs())
         + prettyPrintPaths("\n| ", getImplicitInputs())
         + prettyPrintPaths("\n|| ", getOrderOnlyInputs());
   }
@@ -298,11 +298,11 @@ public final class NinjaTarget {
   private ImmutableSortedMap<String, String> computeInputOutputVariables() {
     ImmutableSortedMap.Builder<String, String> builder = ImmutableSortedMap.naturalOrder();
     String inNewline =
-        inputs.get(InputKind.USUAL).stream()
+        inputs.get(InputKind.EXPLICIT).stream()
             .map(PathFragment::getPathString)
             .collect(Collectors.joining("\n"));
     String out =
-        outputs.get(OutputKind.USUAL).stream()
+        outputs.get(OutputKind.EXPLICIT).stream()
             .map(PathFragment::getPathString)
             .collect(Collectors.joining(" "));
     builder.put("in", inNewline.replace('\n', ' '));

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaGraphTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaGraphTest.java
@@ -156,7 +156,7 @@ public class NinjaGraphTest extends BuildViewTestCase {
     PhonyTarget phonyTarget = provider.getPhonyTargetsMap().get(alias);
     assertThat(phonyTarget.isAlwaysDirty()).isFalse();
     assertThat(phonyTarget.getPhonyNames()).isEmpty();
-    assertThat(phonyTarget.getDirectUsualInputs())
+    assertThat(phonyTarget.getDirectExplicitInputs())
         .containsExactly(PathFragment.create("hello.txt"));
   }
 

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaParserStepTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaParserStepTest.java
@@ -324,7 +324,7 @@ public class NinjaParserStepTest {
             .parseNinjaTarget(scope, LINE_NUM_AFTER_RULE_DEFS);
     assertThat(target.getRuleName()).isEqualTo("command");
     assertThat(target.getOutputs()).containsExactly(PathFragment.create("output"));
-    assertThat(target.getUsualInputs()).containsExactly(PathFragment.create("input"));
+    assertThat(target.getExplicitInputs()).containsExactly(PathFragment.create("input"));
 
     NinjaTarget target1 =
         createParser("build o1 o2 | io1 io2: command i1 i2 | ii1 ii2 || ooi1 ooi2")
@@ -334,7 +334,7 @@ public class NinjaParserStepTest {
         .containsExactly(PathFragment.create("o1"), PathFragment.create("o2"));
     assertThat(target1.getImplicitOutputs())
         .containsExactly(PathFragment.create("io1"), PathFragment.create("io2"));
-    assertThat(target1.getUsualInputs())
+    assertThat(target1.getExplicitInputs())
         .containsExactly(PathFragment.create("i1"), PathFragment.create("i2"));
     assertThat(target1.getImplicitInputs())
         .containsExactly(PathFragment.create("ii1"), PathFragment.create("ii2"));
@@ -389,7 +389,7 @@ public class NinjaParserStepTest {
             .parseNinjaTarget(scope, LINE_NUM_AFTER_RULE_DEFS);
     assertThat(target.getRuleName()).isEqualTo("testRule");
     assertThat(target.getOutputs()).containsExactly(PathFragment.create("out123"));
-    assertThat(target.getUsualInputs())
+    assertThat(target.getExplicitInputs())
         .containsExactly(PathFragment.create("in123"), PathFragment.create("defin123/abcde"));
     assertThat(target.computeRuleVariables().get(NinjaRuleVariable.COMMAND))
         .isEqualTo("executable dir=defin123 empty='' end");
@@ -418,7 +418,7 @@ public class NinjaParserStepTest {
 
     assertThat(target.getRuleName()).isEqualTo("command");
     assertThat(target.getOutputs()).containsExactly(PathFragment.create("output"));
-    assertThat(target.getUsualInputs())
+    assertThat(target.getExplicitInputs())
         .containsExactly(PathFragment.create("input with space"), PathFragment.create("other"));
   }
 
@@ -432,7 +432,7 @@ public class NinjaParserStepTest {
             .parseNinjaTarget(scope, LINE_NUM_AFTER_RULE_DEFS);
     assertThat(target.getRuleName()).isEqualTo("command");
     assertThat(target.getOutputs()).containsExactly(PathFragment.create("output"));
-    assertThat(target.getUsualInputs())
+    assertThat(target.getExplicitInputs())
         .containsExactly(
             PathFragment.create("input"),
             PathFragment.create("with"),
@@ -449,7 +449,7 @@ public class NinjaParserStepTest {
 
     assertThat(target.getRuleName()).isEqualTo("command");
     assertThat(target.getOutputs()).containsExactly(PathFragment.create("output"));
-    assertThat(target.getUsualInputs()).containsExactly(PathFragment.create("input"));
+    assertThat(target.getExplicitInputs()).containsExactly(PathFragment.create("input"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaPhonyTargetsUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaPhonyTargetsUtilTest.java
@@ -123,7 +123,7 @@ public class NinjaPhonyTargetsUtilTest {
     assertThat(phonyTarget.isAlwaysDirty()).isEqualTo(isAlwaysDirty);
 
     ImmutableSortedSet.Builder<PathFragment> paths = ImmutableSortedSet.naturalOrder();
-    pathsMap.get(PathFragment.create(key)).visitUsualInputs(pathsMap, paths::addAll);
+    pathsMap.get(PathFragment.create(key)).visitExplicitInputs(pathsMap, paths::addAll);
     assertThat(paths.build()).containsExactlyElementsIn(expectedPaths);
   }
 


### PR DESCRIPTION
This makes the code slightly clearer to read.