### PR TITLE
Fix windows --watchfs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/LocalDiffAwareness.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/LocalDiffAwareness.java
@@ -52,8 +52,18 @@ public abstract class LocalDiffAwareness implements DiffAwareness {
         help =
             "On Linux/macOS: If true, %{product} tries to use the operating system's file watch "
                 + "service for local changes instead of scanning every file for a change. On "
-                + "Windows: this flag is a non-op.")
+                + "Windows: this flag currently is a non-op but can be enabled in conjunction "
+                + "with --experimental_windows_watchfs.")
     public boolean watchFS;
+    @Option(
+        name = "experimental_windows_watchfs",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        help =
+            "If true, experimental Windows support for --watchfs is enabled. Otherwise --watchfs"
+                + "is a non-op on Windows. Make sure to also enable --watchfs.")
+    public boolean windowsWatchFS;
   }
 
   /** Factory for creating {@link LocalDiffAwareness} instances. */

--- a/src/main/java/com/google/devtools/build/lib/skyframe/LocalDiffAwareness.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/LocalDiffAwareness.java
@@ -55,6 +55,7 @@ public abstract class LocalDiffAwareness implements DiffAwareness {
                 + "Windows: this flag currently is a non-op but can be enabled in conjunction "
                 + "with --experimental_windows_watchfs.")
     public boolean watchFS;
+    
     @Option(
         name = "experimental_windows_watchfs",
         defaultValue = "false",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/WatchServiceDiffAwareness.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/WatchServiceDiffAwareness.java
@@ -19,6 +19,7 @@ import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.common.options.OptionsProvider;
+import com.sun.nio.file.ExtendedWatchEventModifier;
 import java.io.IOException;
 import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.FileSystems;
@@ -86,8 +87,7 @@ public final class WatchServiceDiffAwareness extends LocalDiffAwareness {
     //      already taken into account for the current build, as we ended up with
     //      ModifiedFileSet.EVERYTHING_MODIFIED in the current build.
     // Disable WatchFs on Windows, because it is not implemented correctly on Windows.
-    // TODO(pcloudy): Enable watchFs on Windows, https://github.com/bazelbuild/bazel/issues/1931
-    boolean watchFs = options.getOptions(Options.class).watchFS && OS.getCurrent() != OS.WINDOWS;
+    boolean watchFs = options.getOptions(Options.class).watchFS;
     if (watchFs && watchService == null) {
       init();
     } else if (!watchFs && (watchService != null)) {
@@ -115,7 +115,23 @@ public final class WatchServiceDiffAwareness extends LocalDiffAwareness {
     Set<Path> modifiedAbsolutePaths;
     if (isFirstCall()) {
       try {
-        registerSubDirectoriesAndReturnContents(watchRootPath);
+        // Due to a known issue nested watches may result in errors on windows: https://bugs.openjdk.java.net/browse/JDK-6972833
+        // Therefore on windows we register using the special ExtendedWatchEventModifier.FILE_TREE
+        // This watches a folder recursively so there is no need to apply this ourselves
+        if(OS.getCurrent() == OS.WINDOWS) {
+            WatchKey key =
+                watchRootPath.register(
+                    watchService,
+                    new WatchEvent.Kind[] { 
+                        StandardWatchEventKinds.ENTRY_CREATE,
+                        StandardWatchEventKinds.ENTRY_MODIFY,
+                        StandardWatchEventKinds.ENTRY_DELETE,
+                    },
+                    ExtendedWatchEventModifier.FILE_TREE);
+            watchKeyToDirBiMap.put(key, watchRootPath);
+        } else {
+            registerSubDirectoriesAndReturnContents(watchRootPath);
+        }
       } catch (IOException e) {
         close();
         throw new BrokenDiffAwarenessException(
@@ -285,15 +301,19 @@ public final class WatchServiceDiffAwareness extends LocalDiffAwareness {
       // are guaranteed to see new files/directories either on this #getDiff or the next one.
       // Otherwise, e.g., an intra-build creation of a child directory will be forever missed if it
       // happens before the directory is listed as part of the visitation.
-      WatchKey key =
-          path.register(
-              watchService,
-              StandardWatchEventKinds.ENTRY_CREATE,
-              StandardWatchEventKinds.ENTRY_MODIFY,
-              StandardWatchEventKinds.ENTRY_DELETE);
       Preconditions.checkState(path.isAbsolute(), path);
+      // On windows we register the root path with ExtendedWatchEventModifier.FILE_TREE
+      // Therefore there is no need to register recursive watchers
+      if(OS.getCurrent() != OS.WINDOWS) {
+          WatchKey key =
+              path.register(
+                  watchService,
+                  StandardWatchEventKinds.ENTRY_CREATE,
+                  StandardWatchEventKinds.ENTRY_MODIFY,
+                  StandardWatchEventKinds.ENTRY_DELETE);
+          watchKeyToDirBiMap.put(key, path);
+      }
       visitedAbsolutePaths.add(path);
-      watchKeyToDirBiMap.put(key, path);
       return FileVisitResult.CONTINUE;
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/WatchServiceDiffAwareness.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/WatchServiceDiffAwareness.java
@@ -86,8 +86,9 @@ public final class WatchServiceDiffAwareness extends LocalDiffAwareness {
     //      contain files that are modified between init() and poll() below, because those are
     //      already taken into account for the current build, as we ended up with
     //      ModifiedFileSet.EVERYTHING_MODIFIED in the current build.
-    // Disable WatchFs on Windows, because it is not implemented correctly on Windows.
-    boolean watchFs = options.getOptions(Options.class).watchFS;
+    boolean watchFs = options.getOptions(Options.class).watchFS &&
+        // Guard WatchFs on Windows behind --experimental_windows_watchfs.
+        (OS.getCurrent() != OS.WINDOWS || options.getOptions(Options.class).windowsWatchFS);
     if (watchFs && watchService == null) {
       init();
     } else if (!watchFs && (watchService != null)) {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/WatchServiceDiffAwareness.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/WatchServiceDiffAwareness.java
@@ -125,7 +125,7 @@ public final class WatchServiceDiffAwareness extends LocalDiffAwareness {
             WatchKey key =
                 watchRootPath.register(
                     watchService,
-                    new WatchEvent.Kind[] { 
+                    new Kind<?>[] { 
                         StandardWatchEventKinds.ENTRY_CREATE,
                         StandardWatchEventKinds.ENTRY_MODIFY,
                         StandardWatchEventKinds.ENTRY_DELETE,


### PR DESCRIPTION
As discussed in #1931 --watchfs was made a no-op on windows in d04d7baa1605c8c3a637255bd61c00dba73ad800. The reason for this is that it will hold locks for the (parent-directories of) directories it is watching. Since we recursively register the watcher this leads to locks on folders we do not want to be locked.

The issue is known and tracked at https://bugs.openjdk.java.net/browse/JDK-6972833 but is marked as a Won't Fix. The suggested fix is to instead use ExtendedWatchEventModifier.FILE_TREE which allows a single WatchKey to recursively watch a folder on windows.

This pull request implements the FILE_TREE flag for the root folder that is being watched, and disables the registration of the recursive folders. I have tried to keep the change as small as possible, but I can imagine that we wish to separate this logic to dedicated windows class similar to the OSX variant.

Fixes #1931