### PR TITLE
Add a new providers output formatter to cquery

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/RuleConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/RuleConfiguredTarget.java
@@ -223,8 +223,7 @@ public final class RuleConfiguredTarget extends AbstractConfiguredTarget {
   @Override
   public void debugPrint(Printer printer) {
     printer.append("<target " + getLabel() + ", keys:[");
-    ImmutableList<String> starlarkProviderKeyStrings = getStarlarkProviderKeyStrings(/*showOutputGroupInfo=*/false);
-    printer.append(Joiner.on(", ").join(starlarkProviderKeyStrings));
+    printer.append(Joiner.on(", ").join(getStarlarkProviderKeyStrings(/*showOutputGroupInfo=*/false)));
     printer.append("]>");
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/RuleConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/RuleConfiguredTarget.java
@@ -49,9 +49,7 @@ import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec.
 import com.google.devtools.build.lib.skylarkbuildapi.ActionApi;
 import com.google.devtools.build.lib.syntax.Printer;
 import com.google.devtools.build.lib.syntax.Starlark;
-import com.google.protobuf.ByteString.Output;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**

--- a/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryBuildTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryBuildTool.java
@@ -128,15 +128,13 @@ public abstract class PostAnalysisQueryBuildTool<T> extends BuildTool {
     NamedThreadSafeOutputFormatterCallback<T> callback =
         NamedThreadSafeOutputFormatterCallback.selectCallback(outputFormat, callbacks);
     if (callback == null) {
-      env.getReporter()
-          .handle(
-              Event.error(
-                  String.format(
-                      "Invalid output format '%s'. Valid values are: %s",
-                      outputFormat,
-                      NamedThreadSafeOutputFormatterCallback.callbackNames(callbacks))));
-      throw new QueryException("Invalid output format.");
-      // return;
+      String errorMessage =
+          String.format(
+              "Invalid output format '%s'. Valid values are: %s",
+              outputFormat,
+              NamedThreadSafeOutputFormatterCallback.callbackNames(callbacks));
+      env.getReporter().handle(Event.error(errorMessage));
+      throw new QueryException(errorMessage);
     }
     QueryEvalResult result =
         postAnalysisQueryEnvironment.evaluateQuery(queryExpression, callback);

--- a/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryBuildTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryBuildTool.java
@@ -135,7 +135,8 @@ public abstract class PostAnalysisQueryBuildTool<T> extends BuildTool {
                       "Invalid output format '%s'. Valid values are: %s",
                       outputFormat,
                       NamedThreadSafeOutputFormatterCallback.callbackNames(callbacks))));
-      return;
+      throw new QueryException("Invalid output format.");
+      // return;
     }
     QueryEvalResult result =
         postAnalysisQueryEnvironment.evaluateQuery(queryExpression, callback);

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
@@ -210,7 +210,10 @@ public class ConfiguredTargetQueryEnvironment
           PackageManager packageManager) {
     AspectResolver aspectResolver =
         cqueryOptions.aspectDeps.createResolver(packageManager, eventHandler);
-    return ImmutableList.of(
+    ImmutableList.Builder<NamedThreadSafeOutputFormatterCallback<ConfiguredTarget>> callbacks =
+        ImmutableList.builder();
+    callbacks.addAll(
+        ImmutableList.of(
         new LabelAndConfigurationOutputFormatterCallback(
             eventHandler, cqueryOptions, out, skyframeExecutor, accessor, true),
         new LabelAndConfigurationOutputFormatterCallback(
@@ -248,7 +251,14 @@ public class ConfiguredTargetQueryEnvironment
             aspectResolver,
             OutputType.JSON),
         new BuildOutputFormatterCallback(
-            eventHandler, cqueryOptions, out, skyframeExecutor, accessor));
+            eventHandler, cqueryOptions, out, skyframeExecutor, accessor)));
+
+    if (cqueryOptions.experimentalProvidersOutput){
+      callbacks.add(
+          new ProvidersOutputFormatterCallback(
+              eventHandler, cqueryOptions, out, skyframeExecutor, accessor));
+    }
+    return callbacks.build();
   }
 
   public String getOutputFormat() {

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryOptions.java
@@ -82,4 +82,15 @@ public class CqueryOptions extends CommonQueryOptions {
           "if enabled, proto output will include information about configurations. When disabled,"
               + "cquery proto output format resembles query output format.")
   public boolean protoIncludeConfigurations;
+
+  @Option(
+      name = "experimental_providers_output",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.QUERY,
+      effectTags = {OptionEffectTag.NO_OP},
+      help =
+          "If enabled, allow the use of --output=providers with cquery. This output format prints "
+              + "the providers and output groups associated with each configured target."
+  )
+  public boolean experimentalProvidersOutput;
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ProvidersOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ProvidersOutputFormatterCallback.java
@@ -20,6 +20,7 @@ import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccess
 import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
 import java.io.OutputStream;
 
+/** Provider name output formatter for cquery results */
 public class ProvidersOutputFormatterCallback extends CqueryThreadsafeCallback {
 
   ProvidersOutputFormatterCallback(
@@ -38,17 +39,16 @@ public class ProvidersOutputFormatterCallback extends CqueryThreadsafeCallback {
   @Override
   public void processOutput(Iterable<ConfiguredTarget> partialResult) {
     for (ConfiguredTarget configuredTarget : partialResult) {
-      if (!(configuredTarget instanceof RuleConfiguredTarget)) {
-        continue;
+      if (configuredTarget instanceof RuleConfiguredTarget) {
+        RuleConfiguredTarget ruleConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
+        StringBuilder output = new StringBuilder();
+        output
+            .append(configuredTarget.getLabel())
+            .append(" ")
+            .append(
+                ruleConfiguredTarget.getStarlarkProviderKeyStrings(/*showOutputGroupInfo=*/true));
+        addResult(output.toString());
       }
-
-      RuleConfiguredTarget ruleConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
-      StringBuilder output = new StringBuilder();
-      output
-          .append(configuredTarget.getLabel())
-          .append(" ")
-          .append(ruleConfiguredTarget.getStarlarkProviderKeyStrings(/*showOutputGroupInfo=*/true));
-      addResult(output.toString());
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ProvidersOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ProvidersOutputFormatterCallback.java
@@ -1,0 +1,52 @@
+package com.google.devtools.build.lib.query2.cquery;
+
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.OutputGroupInfo;
+import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccessor;
+import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class ProvidersOutputFormatterCallback extends CqueryThreadsafeCallback {
+
+  ProvidersOutputFormatterCallback(
+      ExtendedEventHandler eventHandler,
+      CqueryOptions options, OutputStream out,
+      SkyframeExecutor skyframeExecutor,
+      TargetAccessor<ConfiguredTarget> accessor) {
+    super(eventHandler, options, out, skyframeExecutor, accessor);
+  }
+
+  @Override
+  public String getName() {
+    return "providers";
+  }
+
+  @Override
+  public void processOutput(Iterable<ConfiguredTarget> partialResult)
+      throws IOException, InterruptedException {
+    for (ConfiguredTarget configuredTarget : partialResult) {
+      if (!(configuredTarget instanceof RuleConfiguredTarget)) {
+        continue;
+      }
+
+      RuleConfiguredTarget ruleConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
+
+      // BuildConfiguration config =
+      //     skyframeExecutor.getConfiguration(eventHandler, configuredTarget.getConfigurationKey());
+      StringBuilder output = new StringBuilder();
+      // Target actualTarget = accessor.getTargetFromConfiguredTarget(configuredTarget);
+
+      output =
+          output
+              .append(configuredTarget.getLabel())
+              .append(" ")
+              .append(ruleConfiguredTarget.getStarlarkProviderKeyStrings().build());
+
+      addResult(output.toString());
+    }
+
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ProvidersOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ProvidersOutputFormatterCallback.java
@@ -47,7 +47,7 @@ public class ProvidersOutputFormatterCallback extends CqueryThreadsafeCallback {
       output
           .append(configuredTarget.getLabel())
           .append(" ")
-          .append(ruleConfiguredTarget.getStarlarkProviderKeyStrings().build());
+          .append(ruleConfiguredTarget.getStarlarkProviderKeyStrings(/*showOutputGroupInfo=*/true));
       addResult(output.toString());
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ProvidersOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ProvidersOutputFormatterCallback.java
@@ -1,12 +1,23 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
-import com.google.devtools.build.lib.analysis.OutputGroupInfo;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccessor;
 import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
-import java.io.IOException;
 import java.io.OutputStream;
 
 public class ProvidersOutputFormatterCallback extends CqueryThreadsafeCallback {
@@ -25,28 +36,19 @@ public class ProvidersOutputFormatterCallback extends CqueryThreadsafeCallback {
   }
 
   @Override
-  public void processOutput(Iterable<ConfiguredTarget> partialResult)
-      throws IOException, InterruptedException {
+  public void processOutput(Iterable<ConfiguredTarget> partialResult) {
     for (ConfiguredTarget configuredTarget : partialResult) {
       if (!(configuredTarget instanceof RuleConfiguredTarget)) {
         continue;
       }
 
       RuleConfiguredTarget ruleConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
-
-      // BuildConfiguration config =
-      //     skyframeExecutor.getConfiguration(eventHandler, configuredTarget.getConfigurationKey());
       StringBuilder output = new StringBuilder();
-      // Target actualTarget = accessor.getTargetFromConfiguredTarget(configuredTarget);
-
-      output =
-          output
-              .append(configuredTarget.getLabel())
-              .append(" ")
-              .append(ruleConfiguredTarget.getStarlarkProviderKeyStrings().build());
-
+      output
+          .append(configuredTarget.getLabel())
+          .append(" ")
+          .append(ruleConfiguredTarget.getStarlarkProviderKeyStrings().build());
       addResult(output.toString());
     }
-
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
@@ -156,3 +156,19 @@ java_test(
         "//third_party:truth",
     ],
 )
+
+java_test(
+    name = "ProvidersOutputFormatterCallbackTest",
+    srcs = ["ProvidersOutputFormatterCallbackTest.java"],
+    deps = [
+        ":configured_target_query_helper",
+        ":configured_target_query_test",
+        "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
+        "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/query2",
+        "//src/main/java/com/google/devtools/build/lib/query2/engine",
+        "//src/test/java/com/google/devtools/build/lib/analysis/util:util_internal",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ProvidersOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ProvidersOutputFormatterCallbackTest.java
@@ -1,0 +1,92 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.query2.cquery;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.eventbus.EventBus;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.events.Event;
+import com.google.devtools.build.lib.events.Reporter;
+import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment;
+import com.google.devtools.build.lib.query2.engine.QueryExpression;
+import com.google.devtools.build.lib.query2.engine.QueryParser;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ProvidersOutputFormatterCallbackTest extends ConfiguredTargetQueryTest {
+
+  private CqueryOptions options;
+  private Reporter reporter;
+  private final List<Event> events = new ArrayList<>();
+
+  @Before
+  public final void setUpCqueryOptions() {
+    this.options = new CqueryOptions();
+    options.experimentalProvidersOutput = true;
+    this.reporter = new Reporter(new EventBus(), events::add);
+  }
+
+  @Test
+  public void testProvidersOutput() throws Exception {
+    writeFile(
+        "BUILD",
+        "load(':my_rule.bzl', 'my_rule')",
+        "my_rule(name = 'foo')",
+        "my_rule(name = 'bar')");
+
+     writeFile("my_rule.bzl",
+         "MyInfo = provider()",
+         "def _my_rule_impl(ctx):",
+         "  return [",
+         "    DefaultInfo(),",
+         "    MyInfo(),",
+         "    OutputGroupInfo(foo_group = depset(), bar_group = depset()),",
+         "  ]",
+         "my_rule = rule(implementation = _my_rule_impl, attrs = {})");
+
+    List<String> result = getOutput("//:foo");
+    assertThat(result.get(0)).isEqualTo("//:foo [MyInfo, OutputGroupInfo[bar_group, foo_group]]");
+
+    List<String> multipleResults = getOutput("//:all");
+    assertThat(
+        multipleResults.get(0)).isEqualTo(
+            "//:bar [MyInfo, OutputGroupInfo[bar_group, foo_group]]");
+    assertThat(
+        multipleResults.get(1)).isEqualTo(
+            "//:foo [MyInfo, OutputGroupInfo[bar_group, foo_group]]");
+  }
+
+  private List<String> getOutput(String queryExpression)
+      throws Exception {
+    QueryExpression expression = QueryParser.parse(queryExpression, getDefaultFunctions());
+    Set<String> targetPatternSet = new LinkedHashSet<>();
+    expression.collectTargetPatterns(targetPatternSet);
+    PostAnalysisQueryEnvironment<ConfiguredTarget> env =
+        ((ConfiguredTargetQueryHelper) helper).getPostAnalysisQueryEnvironment(targetPatternSet);
+    ProvidersOutputFormatterCallback callback =
+        new ProvidersOutputFormatterCallback(
+            reporter,
+            options,
+            /*out=*/ null,
+            getHelper().getSkyframeExecutor(),
+            env.getAccessor());
+    env.evaluateQuery(env.transformParsedQuery(QueryParser.parse(queryExpression, env)), callback);
+    return callback.getResult();
+  }
+}


### PR DESCRIPTION
Add a new `providers` output formatter to cquery, and hide it behind the `--experimental_providers_output` cquery option.

The use case is for rule configured target introspection during Starlark rule development. Also see https://github.com/bazelbuild/bazel/issues/9422 for the feature request.

When `cquery` is used with `--output=providers` and `--experimental_providers_output`, Bazel will print the names of propagated provider keys for each target, as well as non-internal and non-hidden output group names if OutputGroupInfo exists on the target. 

For example:

```
//third_party/jetifier:jetifier [InstrumentedFilesInfo, JavaInfo, OutputGroupInfo[_source_jars, compilation_outputs]]
//third_party/jetifier:jetifier [InstrumentedFilesInfo, JavaInfo, OutputGroupInfo[_source_jars, compilation_outputs]]
//third_party/jetifier:jetifier_jars [JavaCcLinkParamsInfo, InstrumentedFilesInfo, JavaInfo, ProguardSpecProvider, OutputGroupInfo[_source_jars, compilation_outputs]]
//third_party/jetifier:jetifier_jars [JavaCcLinkParamsInfo, InstrumentedFilesInfo, JavaInfo, ProguardSpecProvider, OutputGroupInfo[_source_jars, compilation_outputs]]
//migration:maven_jar [InstrumentedFilesInfo, JavaInfo, OutputGroupInfo[_source_jars, compilation_outputs]]
//private/tools:hasher [InstrumentedFilesInfo, JavaInfo, OutputGroupInfo[_source_jars, compilation_outputs]]
//private/tools:lib [JavaCcLinkParamsInfo, InstrumentedFilesInfo, ProguardSpecProvider, JavaInfo, OutputGroupInfo[_source_jars, compilation_outputs]]
//private/tools:test [InstrumentedFilesInfo, JavaInfo, OutputGroupInfo[_source_jars, compilation_outputs]]
//settings:stamp_manifest [StampManifestProvider]
//settings:stamp_manifest [StampManifestProvider]
//tests/integration:testonly-deps []
//tests/unit:proxy_tests []
```

Fixes https://github.com/bazelbuild/bazel/issues/9422

RELNOTES: Added a new `cquery` output format for enumerating providers and output groups on targets. Enable it by passing `--experimental_providers_output` and `--output=providers` to a `cquery` command. An example output looks like: `//foo:bar [BazInfo, QuxInfo, OutputGroupInfo[group_foo, group_bar]]`.