### PR TITLE
Add --compilation_mode support in transitions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1551,7 +1551,10 @@ java_library(
 java_library(
     name = "config/compilation_mode",
     srcs = ["config/CompilationMode.java"],
-    deps = ["//src/main/java/com/google/devtools/common/options"],
+    deps = [
+        "//src/main/java/com/google/devtools/common/options",
+        "//src/main/java/net/starlark/java/eval",
+    ],
 )
 
 java_library(

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CompilationMode.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CompilationMode.java
@@ -14,12 +14,17 @@
 package com.google.devtools.build.lib.analysis.config;
 
 import com.google.devtools.common.options.EnumConverter;
+import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.StarlarkValue;
 
 /**
  * This class represents the debug/optimization mode the binaries will be
  * built for.
  */
-public enum CompilationMode {
+// TODO: Implementing StarlarkValue is a workaround until a well-defined Java-Starlark conversion
+// interface has been created. Avoid replicating this workaround.
+// See also https://github.com/bazelbuild/bazel/pull/11347#issuecomment-630260102
+public enum CompilationMode implements StarlarkValue {
 
   // Fast build mode (-g0).
   FASTBUILD("fastbuild"),
@@ -46,5 +51,10 @@ public enum CompilationMode {
     public Converter() {
       super(CompilationMode.class, "compilation mode");
     }
+  }
+
+  @Override
+  public void repr(Printer printer) {
+    printer.append(toString());
   }
 }


### PR DESCRIPTION
Add support for converting //command_line_option:compilation_mode from
Java value to Starlark value so that it can be read in a transition.

Fixes --compilation_mode in #10690, but not the general case.

This patch does not contain any tests. What kind of test is expected and where should it be implemented?