### PR TITLE
Add --output_base_suffix as startup option

### DIFF
--- a/src/main/cpp/bazel_startup_options.cc
+++ b/src/main/cpp/bazel_startup_options.cc
@@ -82,21 +82,36 @@ void BazelStartupOptions::MaybeLogStartupOptionWarnings() const {
   }
   bool output_user_root_has_space =
       output_user_root.find_first_of(' ') != std::string::npos;
+  bool output_base_has_space =
+      output_base_option.find_first_of(' ') != std::string::npos;
+  bool output_base_suffix_has_space =
+      output_base_suffix.find_first_of(' ') != std::string::npos;
   if (output_user_root_has_space) {
     BAZEL_LOG(WARNING)
         << "Output user root \"" << output_user_root
         << "\" contains a space. This will probably break the build. "
            "You should set a different --output_user_root.";
-  } else if (output_base.Contains(' ')) {
+  } else if (output_base_has_space) {
     // output_base is computed from output_user_root by default.
     // If output_user_root was bad, don't check output_base: while output_base
     // may also be bad, we already warned about output_user_root so there's no
     // point in another warning.
     BAZEL_LOG(WARNING)
-        << "Output base \"" << output_base.AsPrintablePath()
+        << "Output base \"" << output_base_option
         << "\" contains a space. This will probably break the build. "
            "You should not set --output_base and let Bazel use the default, or "
            "set --output_base to a path without space.";
+  } else if (output_base_suffix_has_space) {
+    // If output_user_root or output_base was bad, don't check
+    // output_base_suffix: while output_base_suffix may also be bad, we
+    // already warned about output_user_root or output_base so there's no
+    // point in another warning.
+    BAZEL_LOG(WARNING)
+        << "Output base suffix \"" << output_base_suffix
+        << "\" contains a space. This will probably break the build. "
+           "You should not set --output_base_suffix and let Bazel use the "
+           "default empty suffix, or set --output_base_suffix to a string "
+           "without space.";
   }
 }
 

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1315,13 +1315,19 @@ static void UpdateConfiguration(const string &install_md5,
         blaze_util::JoinPath(install_user_root, install_md5);
   }
 
-  if (startup_options->output_base.IsEmpty()) {
+  if (startup_options->output_base_option.empty()) {
     if (server_mode) {
       BAZEL_DIE(blaze_exit_code::BAD_ARGV)
           << "exec-server requires --output_base";
     }
     startup_options->output_base = blaze_util::Path(
-        blaze::GetHashedBaseDir(startup_options->output_user_root, workspace));
+        blaze::GetHashedBaseDir(startup_options->output_user_root, workspace)
+        + startup_options->output_base_suffix);
+  } else {
+    startup_options->output_base = blaze_util::Path(
+        blaze::AbsolutePathFromFlag(
+            startup_options->output_base_option
+            + startup_options->output_base_suffix));
   }
 
   if (!blaze_util::PathExists(startup_options->output_base)) {

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -159,6 +159,7 @@ StartupOptions::StartupOptions(const string &product_name,
   RegisterUnaryStartupFlag("macos_qos_class");
   RegisterUnaryStartupFlag("max_idle_secs");
   RegisterUnaryStartupFlag("output_base");
+  RegisterUnaryStartupFlag("output_base_suffix");
   RegisterUnaryStartupFlag("output_user_root");
   RegisterUnaryStartupFlag("server_jvm_out");
   RegisterUnaryStartupFlag("failure_detail_out");
@@ -262,8 +263,11 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
   }
 
   if ((value = GetUnaryOption(arg, next_arg, "--output_base")) != NULL) {
-    output_base = blaze_util::Path(blaze::AbsolutePathFromFlag(value));
+    output_base_option = blaze::AbsolutePathFromFlag(value);
     option_sources["output_base"] = rcfile;
+  } else if ((value = GetUnaryOption(arg, next_arg, "--output_base_suffix")) != NULL) {
+    output_base_suffix = value;
+    option_sources["output_base_suffix"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg,
                                      "--install_base")) != NULL) {
     install_base = blaze::AbsolutePathFromFlag(value);

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -142,6 +142,11 @@ class StartupOptions {
   // Blaze's output base.  Everything is relative to this.  See
   // the BlazeDirectories Java class for details.
   blaze_util::Path output_base;
+  std::string output_base_option;
+
+  // Suffix to append to Blaze's output base, e.g. `-extra` or `/../no-hash`.
+  // See the BlazeDirectories Java class for details.
+  std::string output_base_suffix;
 
   // Installation base for a specific release installation.
   std::string install_base;


### PR DESCRIPTION
Simplify how to specify an output_base parallel to the default one or the output_base specified in the user .bazelrc file. Use case include using different `--output_base_suffix` depending on configuration to avoid discarding the analysis cache or to avoid interrupting a long running test.

I know this patch does not contain any tests, which of course is needed if this should be merged at all. 

To start with, is this a reasonable feature to add?