### PR TITLE
Enable coverage for generated source files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -566,6 +566,13 @@ public class BuildConfigurationValue implements BuildConfigurationApi, SkyValue 
   }
 
   /**
+   * Returns a boolean of whether to collect code coverage for generated files or not.
+   */
+  public boolean shouldCollectCodeCoverageForGeneratedFiles() {
+    return options.collectCodeCoverageForGeneratedFiles;
+  }
+
+  /**
    * Returns a new, unordered mapping of names to values of "Make" variables defined by this
    * configuration.
    *

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -441,6 +441,14 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   public boolean collectCodeCoverage;
 
   @Option(
+          name = "experimental_collect_code_coverage_for_generated_files",
+          defaultValue = "false",
+          documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+          effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+          help = "If specified, Bazel will also generate collect coverage information for generated files.")
+  public boolean collectCodeCoverageForGeneratedFiles;
+
+  @Option(
       name = "build_runfile_manifests",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesCollector.java
@@ -208,7 +208,8 @@ public final class InstrumentedFilesCollector {
       for (TransitiveInfoCollection dep :
           getPrerequisitesForAttributes(ruleContext, spec.sourceAttributes)) {
         for (Artifact artifact : dep.getProvider(FileProvider.class).getFilesToBuild().toList()) {
-          if (spec.instrumentedFileTypes.matches(artifact.getFilename())) {
+          if (shouldIncludeArtifact(ruleContext.getConfiguration(), artifact) &&
+              spec.instrumentedFileTypes.matches(artifact.getFilename())) {
             localSourcesBuilder.add(artifact);
           }
         }
@@ -254,6 +255,15 @@ public final class InstrumentedFilesCollector {
       BuildConfigurationValue config, Label label, boolean isTest) {
     return ((config.shouldInstrumentTestTargets() || !isTest)
         && config.getInstrumentationFilter().isIncluded(label.toString()));
+  }
+
+  /**
+   * Return whether the artifact should be collected based on the origin of the artifact
+   * and the --experimental_collect_code_coverage_for_generated_files config setting.
+   */
+  public static boolean shouldIncludeArtifact(
+          BuildConfigurationValue config, Artifact artifact) {
+    return artifact.isSourceArtifact() || config.shouldCollectCodeCoverageForGeneratedFiles();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/InstrumentedFilesCollector.java
@@ -208,8 +208,7 @@ public final class InstrumentedFilesCollector {
       for (TransitiveInfoCollection dep :
           getPrerequisitesForAttributes(ruleContext, spec.sourceAttributes)) {
         for (Artifact artifact : dep.getProvider(FileProvider.class).getFilesToBuild().toList()) {
-          if (artifact.isSourceArtifact() &&
-              spec.instrumentedFileTypes.matches(artifact.getFilename())) {
+          if (spec.instrumentedFileTypes.matches(artifact.getFilename())) {
             localSourcesBuilder.add(artifact);
           }
         }


### PR DESCRIPTION
Currently generated source files can't be included in the coverage report. Remove the check to enable coverage for the generated files.