### PR TITLE
Replace protobuf with Debian system libs

### DIFF
--- a/tools/distributions/debian/BUILD
+++ b/tools/distributions/debian/BUILD
@@ -1,5 +1,7 @@
 filegroup(
     name = "srcs",
-    srcs = glob(["**"]),
+    srcs = glob(["**"]) + [
+        "//tools/distributions/debian/protobuf:srcs",
+    ],
     visibility = ["//tools/distributions:__pkg__"],
 )

--- a/tools/distributions/debian/debian_bin.BUILD
+++ b/tools/distributions/debian/debian_bin.BUILD
@@ -14,24 +14,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
-# zlib1g-dev
-cc_library(
-    name = "zlib",
-    linkopts = ["-lz"],
-    visibility = ["//visibility:public"],
-)
-
-# libprotobuf-dev
-cc_library(
-    name = "protobuf",
-    linkopts = ["-lprotobuf"],
-    visibility = ["//visibility:public"],
-)
-
-# libprotoc-dev
-cc_library(
-    name = "protoc_lib",
-    linkopts = ["-lprotoc", "-lpthread", "-lm"],
-    deps = [":protobuf"],
-    visibility = ["//visibility:public"],
+# protobuf-compiler
+filegroup(
+    name = "protobuf-compiler",
+    srcs = ["protoc"],
 )

--- a/tools/distributions/debian/debian_java.BUILD
+++ b/tools/distributions/debian/debian_java.BUILD
@@ -63,3 +63,15 @@ java_import(
     name = "allocation_instrumenter",
     jars = ["java-allocation-instrumenter.jar"],
 )
+
+# libprotobuf-java
+java_import(
+    name = "protobuf_java",
+    jars = ["protobuf.jar"],
+)
+
+# libprotobuf-java
+java_import(
+    name = "protobuf_java_util",
+    jars = ["protobuf-util.jar"],
+)

--- a/tools/distributions/debian/debian_proto.BUILD
+++ b/tools/distributions/debian/debian_proto.BUILD
@@ -14,24 +14,34 @@
 
 package(default_visibility = ["//visibility:public"])
 
-# zlib1g-dev
-cc_library(
-    name = "zlib",
-    linkopts = ["-lz"],
-    visibility = ["//visibility:public"],
+# Begin - libprotobuf-dev
+proto_library(
+    name = "any_proto",
+    srcs = ["google/protobuf/any.proto"],
 )
 
-# libprotobuf-dev
-cc_library(
-    name = "protobuf",
-    linkopts = ["-lprotobuf"],
-    visibility = ["//visibility:public"],
+proto_library(
+    name = "descriptor_proto",
+    srcs = ["google/protobuf/descriptor.proto"],
 )
 
-# libprotoc-dev
-cc_library(
-    name = "protoc_lib",
-    linkopts = ["-lprotoc", "-lpthread", "-lm"],
-    deps = [":protobuf"],
-    visibility = ["//visibility:public"],
+proto_library(
+    name = "duration_proto",
+    srcs = ["google/protobuf/duration.proto"],
 )
+
+proto_library(
+    name = "empty_proto",
+    srcs = ["google/protobuf/empty.proto"],
+)
+
+proto_library(
+    name = "timestamp_proto",
+    srcs = ["google/protobuf/timestamp.proto"],
+)
+
+proto_library(
+    name = "wrappers_proto",
+    srcs = ["google/protobuf/wrappers.proto"],
+)
+# End - libprotobuf-dev

--- a/tools/distributions/debian/deps.bzl
+++ b/tools/distributions/debian/deps.bzl
@@ -17,6 +17,8 @@
 def debian_deps():
     debian_java_deps()
     debian_cc_deps()
+    debian_proto_deps()
+    debian_bin_deps()
 
 def debian_java_deps():
     # An external repository for providing Debian system installed java libraries.
@@ -27,9 +29,25 @@ def debian_java_deps():
     )
 
 def debian_cc_deps():
-    # An external repository for providing Debian system installed java libraries.
+    # An external repository for providing Debian system installed C/C++ libraries.
     native.new_local_repository(
         name = "debian_cc_deps",
         path = "/usr/lib",
         build_file = "//tools/distributions/debian:debian_cc.BUILD",
+    )
+
+def debian_proto_deps():
+    # An external repository for providing Debian system installed proto files.
+    native.new_local_repository(
+        name = "debian_proto_deps",
+        path = "/usr/include",
+        build_file = "//tools/distributions/debian:debian_proto.BUILD",
+    )
+
+def debian_bin_deps():
+    # An external repository for providing Debian system installed binaries.
+    native.new_local_repository(
+        name = "debian_bin_deps",
+        path = "/usr/bin",
+        build_file = "//tools/distributions/debian:debian_bin.BUILD",
     )

--- a/tools/distributions/debian/protobuf/BUILD
+++ b/tools/distributions/debian/protobuf/BUILD
@@ -1,0 +1,87 @@
+
+load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+# Protobuf targets needed for building //src:bazel_nojdk
+# @com_google_protobuf//:protobuf_headers
+# @com_google_protobuf//:protobuf_java
+# @com_google_protobuf//:protobuf_java_util
+# @com_google_protobuf//:protoc
+# @com_google_protobuf//:protoc_lib
+# @com_google_protobuf//:any_proto
+# @com_google_protobuf//:descriptor_proto
+# @com_google_protobuf//:duration_proto
+# @com_google_protobuf//:empty_proto
+# @com_google_protobuf//:timestamp_proto
+# @com_google_protobuf//:wrappers_proto
+# @com_google_protobuf//:cc_toolchain
+# @com_google_protobuf//:java_toolchain
+
+# This could be empty because all headers are installed at /usr/include
+# which is the default search path for gcc on Debian.
+cc_library(
+    name = "protobuf_headers",
+)
+
+alias(
+    name = "protobuf_java",
+    actual = "@debian_java_deps//:protobuf_java",
+)
+
+alias(
+    name = "protobuf_java_util",
+    actual = "@debian_java_deps//:protobuf_java_util",
+)
+
+alias(
+    name = "protoc",
+    actual = "@debian_bin_deps//:protobuf-compiler",
+)
+
+alias(
+    name = "protoc_lib",
+    actual = "@debian_cc_deps//:protoc_lib",
+)
+
+alias(
+    name = "any_proto",
+    actual = "@debian_proto_deps//:any_proto",
+)
+
+alias(
+    name = "descriptor_proto",
+    actual = "@debian_proto_deps//:descriptor_proto",
+)
+
+alias(
+    name = "duration_proto",
+    actual = "@debian_proto_deps//:duration_proto",
+)
+
+alias(
+    name = "empty_proto",
+    actual = "@debian_proto_deps//:empty_proto",
+)
+
+alias(
+    name = "timestamp_proto",
+    actual = "@debian_proto_deps//:timestamp_proto",
+)
+
+alias(
+    name = "wrappers_proto",
+    actual = "@debian_proto_deps//:wrappers_proto",
+)
+
+proto_lang_toolchain(
+    name = "cc_toolchain",
+    command_line = "--cpp_out=$(OUT)",
+    runtime = ":protoc_lib",
+)
+
+proto_lang_toolchain(
+    name = "java_toolchain",
+    command_line = "--java_out=$(OUT)",
+    runtime = ":protobuf_java",
+)

--- a/tools/distributions/debian/protobuf/BUILD
+++ b/tools/distributions/debian/protobuf/BUILD
@@ -3,6 +3,11 @@ load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+)
+
 # Protobuf targets needed for building //src:bazel_nojdk
 # @com_google_protobuf//:protobuf_headers
 # @com_google_protobuf//:protobuf_java

--- a/tools/distributions/debian/protobuf/WORKSPACE
+++ b/tools/distributions/debian/protobuf/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "com_google_protobuf")

--- a/tools/distributions/debian/protobuf/protobuf.bzl
+++ b/tools/distributions/debian/protobuf/protobuf.bzl
@@ -1,0 +1,3 @@
+# Make Bazel happy when parsing src/main/protobuf/BUILD
+def py_proto_library(name, **kargs):
+    pass


### PR DESCRIPTION
The build should pass with --override_repository=com_google_protobuf=$PWD/tools/distributions/debian/protobuf flag,
and the source of com_google_protobuf will not be downloaded.

Required Debian packages are:
protobuf-compiler
libprotobuf-dev
libprotoc-dev
libprotobuf-java

Working towards https://github.com/bazelbuild/bazel/issues/9408