### PR TITLE
Add Debian support for more Java targets

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -102,38 +102,44 @@ java_import(
     ],
 )
 
-java_import(
+distrib_java_import(
     name = "apache_commons_collections",
     jars = ["apache_commons_collections/commons-collections-3.2.2.jar"],
+    enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "apache_commons_lang",
     jars = ["apache_commons_lang/commons-lang-2.6.jar"],
+    enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "apache_commons_compress",
     jars = ["apache_commons_compress/apache-commons-compress-1.9.jar"],
+    enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "apache_commons_logging",
     jars = ["apache_commons_logging/commons-logging-1.1.1.jar"],
+    enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "apache_commons_pool2",
     jars = ["apache_commons_pool2/commons-pool2-2.8.0.jar"],
+    enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "apache_velocity",
     jars = ["apache_velocity/velocity-1.7.jar"],
     deps = [
         ":apache_commons_collections",
         ":apache_commons_lang",
     ],
+    enable_distributions = ["debian"],
 )
 
 java_import(
@@ -149,10 +155,11 @@ java_import(
     ],
 )
 
-java_import(
+distrib_java_import(
     name = "asm",
     jars = ["asm/asm-8.0.jar"],
     srcjar = "asm/asm-8.0-sources.jar",
+    enable_distributions = ["debian"],
 )
 
 java_import(
@@ -347,18 +354,20 @@ java_import(
     ],
 )
 
-java_import(
+distrib_java_import(
     name = "jackson2",
     jars = [
         "jackson2/jackson-core-2.8.6.jar",
     ],
+    enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "jcip_annotations",
     jars = [
         "jcip_annotations/jcip-annotations-1.0-1.jar",
     ],
+    enable_distributions = ["debian"],
 )
 
 java_import(
@@ -423,11 +432,12 @@ filegroup(
 
 # javax.annotation.Generated is not included in the default root modules in 9,
 # see: http://openjdk.java.net/jeps/320.
-java_import(
+distrib_java_import(
     name = "javax_annotations",
     jars = ["javax_annotations/javax.annotation-api-1.3.2.jar"],
     neverlink = 1,  # @Generated is source-retention
     srcjar = "javax_annotations/javax.annotation-api-1.3.2-sources.jar",
+    enable_distributions = ["debian"],
 )
 
 java_import(
@@ -435,9 +445,10 @@ java_import(
     jars = ["jimfs/jimfs-1.1.jar"],
 )
 
-java_import(
+distrib_java_import(
     name = "jsr305",
     jars = ["jsr305/jsr-305.jar"],
+    enable_distributions = ["debian"],
 )
 
 # For bootstrapping JavaBuilder
@@ -485,13 +496,13 @@ genrule(
 distrib_java_import(
     name = "netty",
     jars = ["netty/netty-all-4.1.34.Final.jar"],
-    # TODO: The debian netty-all.jar is empty, fix it then enable the following
-    # enable_distributions = ["debian"],
+    enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "netty_tcnative",
     jars = ["netty_tcnative/netty-tcnative-filtered.jar"],
+    enable_distributions = ["debian"],
 )
 
 distrib_java_import(
@@ -572,9 +583,10 @@ java_import(
     jars = ["truth8/truth-java8-extension-1.0.1.jar"],
 )
 
-java_import(
+distrib_java_import(
     name = "xz",
     jars = ["xz/xz-1.5.jar"],
+    enable_distributions = ["debian"],
 )
 
 # To be used by the skylark example.

--- a/third_party/java/javapoet/BUILD
+++ b/third_party/java/javapoet/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_import")
+load("//tools/distributions:distribution_rules.bzl", "distrib_java_import")
 
 licenses(["notice"])  # Apache License 2.0
 
@@ -13,7 +13,8 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-java_import(
+distrib_java_import(
     name = "javapoet",
     jars = ["javapoet-1.8.0.jar"],
+    enable_distributions = ["debian"],
 )

--- a/third_party/jaxb/BUILD
+++ b/third_party/jaxb/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_import")
+load("//tools/distributions:distribution_rules.bzl", "distrib_java_import")
 
 licenses(["reciprocal"])  #  CDDL License
 
@@ -9,8 +9,9 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-java_import(
+distrib_java_import(
     name = "jaxb",
     jars = ["jaxb-api-2.3.1-patched.jar"],
     srcjar = "jaxb-api-2.3.1-sources.jar",
+    enable_distributions = ["debian"],
 )


### PR DESCRIPTION
Working towards: #9408

This change is tested for Bazel's Debian build with `--define=distribution=debian`, all dependencies replaced work for building Bazel.

Follow up: https://github.com/bazelbuild/bazel/pull/11352