### PR TITLE
Allow reading of MANIFEST file over MAX_PATH

### DIFF
--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -57,11 +57,17 @@ cc_binary(
 cc_library(
     name = "tw_lib",
     srcs = select({
-        "@bazel_tools//src/conditions:windows": ["windows/tw.cc"],
+        "@bazel_tools//src/conditions:windows": [
+            "windows/tw.cc",
+            "windows/wrunfiles_src.cc",
+        ],
         "//conditions:default": ["empty_test_wrapper.cc"],
     }),
     hdrs = select({
-        "@bazel_tools//src/conditions:windows": ["windows/tw.h"],
+        "@bazel_tools//src/conditions:windows": [
+            "windows/tw.h",
+            "windows/wrunfiles_src.h"
+        ],
         "//conditions:default": [],
     }),
     linkopts = select({
@@ -78,7 +84,6 @@ cc_library(
             "//src/main/native/windows:lib-file",
             "//src/main/native/windows:lib-process",
             "//third_party/ijar:zip",
-            "@bazel_tools//tools/cpp/runfiles",
         ],
         "//conditions:default": [],
     }),

--- a/tools/test/windows/wrunfiles_src.cc
+++ b/tools/test/windows/wrunfiles_src.cc
@@ -1,0 +1,323 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The "srcs_for_embedded_tools" rule in the same package sets the line below to
+// include runfiles.h from the correct path. Do not modify the line below.
+#include "wrunfiles_src.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else  // not _WIN32
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif  // _WIN32
+
+#include <fstream>
+#include <functional>
+#include <map>
+#include <sstream>
+#include <vector>
+
+#ifdef _WIN32
+#include <memory>
+#endif  // _WIN32
+
+#include "src/main/cpp/util/path_platform.h"
+
+namespace bazel {
+namespace tools {
+namespace cpp {
+namespace wrunfiles {
+
+using std::function;
+using std::map;
+using std::pair;
+using std::vector;
+
+namespace {
+
+bool starts_with(const std::wstring& s, const wchar_t* prefix) {
+  if (!prefix || !*prefix) {
+    return true;
+  }
+  if (s.empty()) {
+    return false;
+  }
+  return s.find(prefix) == 0;
+}
+
+bool contains(const std::wstring& s, const wchar_t* substr) {
+  if (!substr || !*substr) {
+    return true;
+  }
+  if (s.empty()) {
+    return false;
+  }
+  return s.find(substr) != std::wstring::npos;
+}
+
+bool ends_with(const std::wstring& s, const std::wstring& suffix) {
+  if (suffix.empty()) {
+    return true;
+  }
+  if (s.empty()) {
+    return false;
+  }
+  return s.rfind(suffix) == s.size() - suffix.size();
+}
+
+bool IsReadableFile(const std::wstring& path) {
+  return std::wifstream(path).is_open();
+}
+
+bool IsDirectory(const std::wstring& path) {
+#ifdef _WIN32
+  DWORD attrs = GetFileAttributesW(path.c_str());
+  return (attrs != INVALID_FILE_ATTRIBUTES) &&
+         (attrs & FILE_ATTRIBUTE_DIRECTORY);
+#else
+  struct stat buf;
+  return stat(path.c_str(), &buf) == 0 && S_ISDIR(buf.st_mode);
+#endif
+}
+
+bool PathsFrom(const std::wstring& argv0, std::wstring runfiles_manifest_file,
+               std::wstring runfiles_dir, std::wstring* out_manifest,
+               std::wstring* out_directory);
+
+bool PathsFrom(const std::wstring& argv0, std::wstring runfiles_manifest_file,
+               std::wstring runfiles_dir,
+               std::function<bool(const std::wstring&)> is_runfiles_manifest,
+               std::function<bool(const std::wstring&)> is_runfiles_directory,
+               std::wstring* out_manifest, std::wstring* out_directory);
+
+bool ParseManifest(const std::wstring& path, map<std::wstring, std::wstring>* result,
+                   std::wstring* error);
+
+}  // namespace
+
+Runfiles* Runfiles::Create(const std::wstring& argv0,
+                           const std::wstring& runfiles_manifest_file,
+                           const std::wstring& runfiles_dir, std::wstring* error) {
+  std::wstring manifest, directory;
+  if (!PathsFrom(argv0, runfiles_manifest_file, runfiles_dir, &manifest,
+                 &directory)) {
+    if (error) {
+      std::wostringstream err;
+      err << L"ERROR: " << __FILE__ << L"(" << __LINE__
+          << L"): cannot find runfiles (argv0=\"" << argv0 << L"\")";
+      *error = err.str();
+    }
+    return nullptr;
+  }
+
+  const vector<pair<std::wstring, std::wstring> > envvars = {
+      {L"RUNFILES_MANIFEST_FILE", manifest},
+      {L"RUNFILES_DIR", directory},
+      // TODO(laszlocsomor): remove JAVA_RUNFILES once the Java launcher can
+      // pick up RUNFILES_DIR.
+      {L"JAVA_RUNFILES", directory}};
+
+  map<std::wstring, std::wstring> runfiles;
+  if (!manifest.empty()) {
+    if (!ParseManifest(manifest, &runfiles, error)) {
+      return nullptr;
+    }
+  }
+
+  return new Runfiles(std::move(runfiles), std::move(directory),
+                      std::move(envvars));
+}
+
+bool IsAbsolute(const std::wstring& path) {
+  if (path.empty()) {
+    return false;
+  }
+  wchar_t c = path.front();
+  return (c == '/' && (path.size() < 2 || path[1] != '/')) ||
+         (path.size() >= 3 &&
+          ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) &&
+          path[1] == ':' && (path[2] == '\\' || path[2] == '/'));
+}
+
+std::wstring GetEnv(const std::wstring& key) {
+#ifdef _WIN32
+  DWORD size = ::GetEnvironmentVariableW(key.c_str(), NULL, 0);
+  if (size == 0) {
+    return std::wstring();  // unset or empty envvar
+  }
+  std::unique_ptr<wchar_t[]> value(new wchar_t[size]);
+  ::GetEnvironmentVariableW(key.c_str(), value.get(), size);
+  return value.get();
+#else
+  wchar_t* result = getenv(key.c_str());
+  return (result == NULL) ? std::wstring() : std::wstring(result);
+#endif
+}
+
+std::wstring Runfiles::Rlocation(const std::wstring& path) const {
+  if (path.empty() || starts_with(path, L"../") || contains(path, L"/..") ||
+      starts_with(path, L"./") || contains(path, L"/./") ||
+      ends_with(path, L"/.") || contains(path, L"//")) {
+    return std::wstring();
+  }
+  if (IsAbsolute(path)) {
+    return path;
+  }
+  const auto value = runfiles_map_.find(path);
+  if (value != runfiles_map_.end()) {
+    return value->second;
+  }
+  if (!directory_.empty()) {
+    return directory_ + L"/" + path;
+  }
+  return L"";
+}
+
+namespace {
+
+bool ParseManifest(const std::wstring& path, map<std::wstring, std::wstring>* result,
+                   std::wstring* error) {
+  std::wifstream stm(path);
+  if (!stm.is_open()) {
+    if (error) {
+      std::wostringstream err;
+      err << L"ERROR: " << __FILE__ << L"(" << __LINE__
+          << L"): cannot open runfiles manifest \"" << path << L"\"";
+      *error = err.str();
+    }
+    return false;
+  }
+  std::wstring line;
+  std::getline(stm, line);
+  size_t line_count = 1;
+  while (!line.empty()) {
+    std::wstring::size_type idx = line.find_first_of(' ');
+    if (idx == std::wstring::npos) {
+      if (error) {
+        std::wostringstream err;
+        err << L"ERROR: " << __FILE__ << L"(" << __LINE__
+            << L"): bad runfiles manifest entry in \"" << path << L"\" line #"
+            << line_count << L": \"" << line << L"\"";
+        *error = err.str();
+      }
+      return false;
+    }
+    (*result)[line.substr(0, idx)] = line.substr(idx + 1);
+    std::getline(stm, line);
+    ++line_count;
+  }
+  return true;
+}
+
+}  // namespace
+
+namespace testing {
+
+bool TestOnly_PathsFrom(const std::wstring& argv0, std::wstring mf, std::wstring dir,
+                        function<bool(const std::wstring&)> is_runfiles_manifest,
+                        function<bool(const std::wstring&)> is_runfiles_directory,
+                        std::wstring* out_manifest, std::wstring* out_directory) {
+  return PathsFrom(argv0, mf, dir, is_runfiles_manifest, is_runfiles_directory,
+                   out_manifest, out_directory);
+}
+
+bool TestOnly_IsAbsolute(const std::wstring& path) { return IsAbsolute(path); }
+
+}  // namespace testing
+
+Runfiles* Runfiles::Create(const std::wstring& argv0, std::wstring* error) {
+  return Runfiles::Create(argv0, GetEnv(L"RUNFILES_MANIFEST_FILE"),
+                          GetEnv(L"RUNFILES_DIR"), error);
+}
+
+Runfiles* Runfiles::CreateForTest(std::wstring* error) {
+  return Runfiles::Create(std::wstring(), GetEnv(L"RUNFILES_MANIFEST_FILE"),
+                          GetEnv(L"TEST_SRCDIR"), error);
+}
+
+namespace {
+
+bool PathsFrom(const std::wstring& argv0, std::wstring mf, std::wstring dir, std::wstring* out_manifest,
+               std::wstring* out_directory) {
+  return PathsFrom(argv0, mf, dir,
+                   [](const std::wstring& path) { return IsReadableFile(path); },
+                   [](const std::wstring& path) { return IsDirectory(path); },
+                   out_manifest, out_directory);
+}
+
+bool PathsFrom(const std::wstring& argv0, std::wstring mf, std::wstring dir,
+               function<bool(const std::wstring&)> is_runfiles_manifest,
+               function<bool(const std::wstring&)> is_runfiles_directory,
+               std::wstring* out_manifest, std::wstring* out_directory) {
+  out_manifest->clear();
+  out_directory->clear();
+
+  std::string error;
+  blaze_util::AsAbsoluteWindowsPath(mf, &mf, &error);
+  blaze_util::AsAbsoluteWindowsPath(dir, &dir, &error);
+
+  bool mfValid = is_runfiles_manifest(mf);
+  bool dirValid = is_runfiles_directory(dir);
+
+  if (!argv0.empty() && !mfValid && !dirValid) {
+    mf = argv0 + L".runfiles/MANIFEST";
+    dir = argv0 + L".runfiles";
+    mfValid = is_runfiles_manifest(mf);
+    dirValid = is_runfiles_directory(dir);
+    if (!mfValid) {
+      mf = argv0 + L".runfiles_manifest";
+      mfValid = is_runfiles_manifest(mf);
+    }
+  }
+
+  if (!mfValid && !dirValid) {
+    return false;
+  }
+
+  if (!mfValid) {
+    mf = dir + L"/MANIFEST";
+    mfValid = is_runfiles_manifest(mf);
+    if (!mfValid) {
+      mf = dir + L"_manifest";
+      mfValid = is_runfiles_manifest(mf);
+    }
+  }
+
+  if (!dirValid &&
+      (ends_with(mf, L".runfiles_manifest") || ends_with(mf, L"/MANIFEST"))) {
+    static const size_t kSubstrLen = 9;  // "_manifest" or "/MANIFEST"
+    dir = mf.substr(0, mf.size() - kSubstrLen);
+    dirValid = is_runfiles_directory(dir);
+  }
+
+  if (mfValid) {
+    *out_manifest = mf;
+  }
+
+  if (dirValid) {
+    *out_directory = dir;
+  }
+
+  return true;
+}
+
+}  // namespace
+
+}  // namespace runfiles
+}  // namespace cpp
+}  // namespace tools
+}  // namespace bazel

--- a/tools/test/windows/wrunfiles_src.h
+++ b/tools/test/windows/wrunfiles_src.h
@@ -1,0 +1,222 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Runfiles lookup library for Bazel-built C++ binaries and tests.
+//
+// USAGE:
+// 1.  Depend on this runfiles library from your build rule:
+//
+//       cc_binary(
+//           name = "my_binary",
+//           ...
+//           deps = ["@bazel_tools//tools/cpp/runfiles"],
+//       )
+//
+// 2.  Include the runfiles library.
+//
+//       #include "tools/cpp/runfiles/runfiles.h"
+//
+//       using bazel::tools::cpp::runfiles::Runfiles;
+//
+// 3.  Create a Runfiles object and use rlocation to look up runfile paths:
+//
+//       int main(int argc, char** argv) {
+//         std::string error;
+//         std::unique_ptr<Runfiles> runfiles(
+//             Runfiles::Create(argv[0], &error));
+//
+//         // Important:
+//         //   If this is a test, use Runfiles::CreateForTest(&error).
+//         //   Otherwise, if you don't have the value for argv[0] for whatever
+//         //   reason, then use Runfiles::Create(&error).
+//
+//         if (runfiles == nullptr) {
+//           ...  // error handling
+//         }
+//         std::string path =
+//             runfiles->Rlocation("my_workspace/path/to/my/data.txt");
+//         ...
+//
+//      The code above creates a Runfiles object and retrieves a runfile path.
+//
+//      The Runfiles::Create function uses the runfiles manifest and the
+//      runfiles directory from the RUNFILES_MANIFEST_FILE and RUNFILES_DIR
+//      environment variables. If not present, the function looks for the
+//      manifest and directory near argv[0], the path of the main program.
+//
+// To start child processes that also need runfiles, you need to set the right
+// environment variables for them:
+//
+//   std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0], &error));
+//
+//   std::string path = runfiles->Rlocation("path/to/binary"));
+//   if (!path.empty()) {
+//     ... // create "args" argument vector for execv
+//     const auto envvars = runfiles->EnvVars();
+//     pid_t child = fork();
+//     if (child) {
+//       int status;
+//       waitpid(child, &status, 0);
+//     } else {
+//       for (const auto i : envvars) {
+//         setenv(i.first.c_str(), i.second.c_str(), 1);
+//       }
+//       execv(args[0], args);
+//     }
+
+#ifndef TOOLS_CPP_RUNFILES_RUNFILES_H_
+#define TOOLS_CPP_RUNFILES_RUNFILES_H_ 1
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace bazel {
+namespace tools {
+namespace cpp {
+namespace wrunfiles {
+
+class Runfiles {
+ public:
+  virtual ~Runfiles() {}
+
+  // Returns a new `Runfiles` instance.
+  //
+  // Use this from within `cc_test` rules.
+  //
+  // Returns nullptr on error. If `error` is provided, the method prints an
+  // error message into it.
+  //
+  // This method looks at the RUNFILES_MANIFEST_FILE and TEST_SRCDIR
+  // environment variables.
+  static Runfiles* CreateForTest(std::wstring* error = nullptr);
+
+  // Returns a new `Runfiles` instance.
+  //
+  // Use this from `cc_binary` or `cc_library` rules. You may pass an empty
+  // `argv0` if `argv[0]` from the `main` method is unknown.
+  //
+  // Returns nullptr on error. If `error` is provided, the method prints an
+  // error message into it.
+  //
+  // This method looks at the RUNFILES_MANIFEST_FILE and RUNFILES_DIR
+  // environment variables. If either is empty, the method looks for the
+  // manifest or directory using the other environment variable, or using argv0
+  // (unless it's empty).
+  static Runfiles* Create(const std::wstring& argv0,
+                          std::wstring* error = nullptr);
+
+  // Returns a new `Runfiles` instance.
+  //
+  // Use this from any `cc_*` rule if you want to manually specify the paths to
+  // the runfiles manifest and/or runfiles directory. You may pass an empty
+  // `argv0` if `argv[0]` from the `main` method is unknown.
+  //
+  // This method is the same as `Create(argv0, error)`, except it uses
+  // `runfiles_manifest_file` and `runfiles_dir` as the corresponding
+  // environment variable values, instead of looking up the actual environment
+  // variables.
+  static Runfiles* Create(const std::wstring& argv0,
+                          const std::wstring& runfiles_manifest_file,
+                          const std::wstring& runfiles_dir,
+                          std::wstring* error = nullptr);
+
+  // Returns the runtime path of a runfile.
+  //
+  // Runfiles are data-dependencies of Bazel-built binaries and tests.
+  //
+  // The returned path may not exist. The caller should verify the path's
+  // existence.
+  //
+  // The function may return an empty string if it cannot find a runfile.
+  //
+  // Args:
+  //   path: runfiles-root-relative path of the runfile; must not be empty and
+  //     must not contain uplevel references.
+  // Returns:
+  //   the path to the runfile, which the caller should check for existence, or
+  //   an empty string if the method doesn't know about this runfile
+  std::wstring Rlocation(const std::wstring& path) const;
+
+  // Returns environment variables for subprocesses.
+  //
+  // The caller should set the returned key-value pairs in the environment of
+  // subprocesses, so that those subprocesses can also access runfiles (in case
+  // they are also Bazel-built binaries).
+  const std::vector<std::pair<std::wstring, std::wstring> >& EnvVars() const {
+    return envvars_;
+  }
+
+ private:
+  Runfiles(const std::map<std::wstring, std::wstring>&& runfiles_map,
+           const std::wstring&& directory,
+           const std::vector<std::pair<std::wstring, std::wstring> >&& envvars)
+      : runfiles_map_(std::move(runfiles_map)),
+        directory_(std::move(directory)),
+        envvars_(std::move(envvars)) {}
+  Runfiles(const Runfiles&) = delete;
+  Runfiles(Runfiles&&) = delete;
+  Runfiles& operator=(const Runfiles&) = delete;
+  Runfiles& operator=(Runfiles&&) = delete;
+
+  const std::map<std::wstring, std::wstring> runfiles_map_;
+  const std::wstring directory_;
+  const std::vector<std::pair<std::wstring, std::wstring> > envvars_;
+};
+
+// The "testing" namespace contains functions that allow unit testing the code.
+// Do not use these outside of runfiles_test.cc, they are only part of the
+// public API for the benefit of the tests.
+// These functions and their interface may change without notice.
+namespace testing {
+
+// For testing only.
+//
+// Computes the path of the runfiles manifest and the runfiles directory.
+//
+// If the method finds both a valid manifest and valid directory according to
+// `is_runfiles_manifest` and `is_runfiles_directory`, then the method sets
+// the corresponding values to `out_manifest` and `out_directory` and returns
+// true.
+//
+// If the method only finds a valid manifest or a valid directory, but not
+// both, then it sets the corresponding output variable (`out_manifest` or
+// `out_directory`) to the value while clearing the other output variable. The
+// method still returns true in this case.
+//
+// If the method cannot find either a valid manifest or valid directory, it
+// clears both output variables and returns false.
+bool TestOnly_PathsFrom(
+    const std::wstring& argv0, std::wstring runfiles_manifest_file,
+    std::wstring runfiles_dir,
+    std::function<bool(const std::wstring&)> is_runfiles_manifest,
+    std::function<bool(const std::wstring&)> is_runfiles_directory,
+    std::wstring* out_manifest, std::wstring* out_directory);
+
+// For testing only.
+// Returns true if `path` is an absolute Unix or Windows path.
+// For Windows paths, this function does not regard drive-less absolute paths
+// (i.e. absolute-on-current-drive, e.g. "\foo\bar") as absolute and returns
+// false for these.
+bool TestOnly_IsAbsolute(const std::wstring& path);
+
+}  // namespace testing
+}  // namespace runfiles
+}  // namespace cpp
+}  // namespace tools
+}  // namespace bazel
+
+#endif  // TOOLS_CPP_RUNFILES_RUNFILES_H_


### PR DESCRIPTION
Not using the wide API made it impossible to read the
MANIFEST file on a path longer than 260 chars. This affects
the test wrapper (tw.exe).

Note that this wrunfiles use Bazel internal logic, and therefore
much of the runfiles logic is copied from cpp/runfiles.

Change-Id: I238d644430653aea0b74a892b4441383b95942d1