### PR TITLE
docs: hide 'edit this page' link on command-line-reference docs as the page is generated

### DIFF
--- a/site/_layouts/documentation.html
+++ b/site/_layouts/documentation.html
@@ -378,7 +378,8 @@ nav: docs
                      && window.location.pathname.match(versionDocsURLRegex)
                      && window.location.pathname.lastIndexOf('/be/') == -1
                      && window.location.pathname.lastIndexOf('/repo/') == -1
-                     && window.location.pathname.lastIndexOf('/skylark/lib/') == -1) {
+                     && window.location.pathname.lastIndexOf('/skylark/lib/') == -1
+                     && window.location.pathname.lastIndexOf('/command-line-reference.html') == -1) {
                      var docFile = window.location.pathname.match(versionDocsURLRegex)[1];
                      // some pages are not using markdown :(
                      if (docFile !== 'user-manual.html'


### PR DESCRIPTION
Hides the 'Edit this page' link on the command line reference docs, as this page is generated and not present in markdown.

Noticed as part of SO question:
https://stackoverflow.com/questions/61719794/bazel-help-in-machine-readable-format