### PR TITLE
Catch SocketException instead of BindException to handle disabled IPv6

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/DebugServerTransportTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/DebugServerTransportTest.java
@@ -23,11 +23,11 @@ import com.google.devtools.build.lib.starlarkdebugging.StarlarkDebuggingProtos.D
 import com.google.devtools.build.lib.starlarkdebugging.StarlarkDebuggingProtos.DebugRequest;
 import com.google.devtools.build.lib.starlarkdebugging.StarlarkDebuggingProtos.StartDebuggingRequest;
 import java.io.IOException;
-import java.net.BindException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -90,7 +90,7 @@ public class DebugServerTransportTest {
     // and if that fails, try again with IPv4.
     try {
       return new ServerSocket(0, 1, InetAddress.getByName("[::1]"));
-    } catch (BindException e) {
+    } catch (SocketException e) {
       return new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdebug/server/StarlarkDebugServerTest.java
@@ -49,9 +49,9 @@ import com.google.devtools.build.lib.syntax.StarlarkList;
 import com.google.devtools.build.lib.syntax.StarlarkThread;
 import com.google.devtools.build.lib.syntax.SyntaxError;
 import java.io.IOException;
-import java.net.BindException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.net.SocketException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
@@ -100,7 +100,7 @@ public class StarlarkDebugServerTest {
     // and if that fails, try again with IPv4.
     try {
       return new ServerSocket(0, 1, InetAddress.getByName("[::1]"));
-    } catch (BindException e) {
+    } catch (SocketException e) {
       return new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
     }
   }


### PR DESCRIPTION
**Problem:**
`StarlarkDebugServerTest` and `DebugServerTransportTest` fails with error `java.net.SocketException: Protocol family unavailable` in some enviroments.

**Explanation:**
If IPv6 is disabled in docker container ServerSocket fails to bind to ::1 with `java.net.SocketException`.
But bazel tests falls back to IPv4 only if `java.net.BindException` (subclass of `java.net.SocketException`) occurs.
Let's catch more generic `java.net.SocketException`
