### PR TITLE
[RFC] Fix Java Builder Stub Action always using jdk11

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -228,7 +228,12 @@ else
 fi
 
 # Set JAVABIN to the path to the JVM launcher.
-%javabin%
+JAVABIN=""
+if [[ -z "$JAVA_HOME" ]]; then
+    %javabin%
+else
+    JAVABIN=${JAVA_HOME}/bin/java
+fi
 
 if [[ "$PRINT_JAVABIN" == 1 || "%java_start_class%" == "--print_javabin" ]]; then
   echo -n "$JAVABIN"


### PR DESCRIPTION
### Background
Issue: https://github.com/bazelbuild/bazel/issues/11382

As stated in the issue above, in certain cases we want the stub action to take into account of the current JAVA_HOME. Example: https://github.com/bazelbuild/rules_kotlin/pull/330 

### Change
If JAVA_HOME is set, use it to locate javabin