### PR TITLE
Install the Bazel Homebrew package directly

### DIFF
--- a/site/docs/install-os-x.md
+++ b/site/docs/install-os-x.md
@@ -110,8 +110,7 @@ recommend using the `bazelbuild` tap, which is maintained by the Bazel team._
 Install the Bazel package via Homebrew as follows:
 
 ```bash
-brew tap bazelbuild/tap
-brew install bazelbuild/tap/bazel
+brew install bazel
 ```
 
 All set! You can confirm Bazel is installed successfully by running the following command:
@@ -123,7 +122,7 @@ bazel --version
 Once installed, you can upgrade to a newer version of Bazel using the following command:
 
 ```bash
-brew upgrade bazelbuild/tap/bazel
+brew upgrade bazel
 ```
 
 <h2 id="install-on-mac-os-x-bazelisk">Install using Bazelisk</h2>


### PR DESCRIPTION
I try to install bazel in the way provided by documents over and over again, but it always failed :

```bash
$ brew install bazelbuild/tap/bazel
Updating Homebrew...
==> Installing bazel from bazelbuild/tap
==> Downloading https://releases.bazel.build/3.1.0/release/bazel-3.1.0-installer-darwin-x86_64.sh
-=O=-            #     #     #     #                                          
curl: (7) Failed to connect to releases.bazel.build port 443: Operation timed out
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "bazel"
Download failed: https://releases.bazel.build/3.1.0/release/bazel-3.1.0-installer-darwin-x86_64.sh
```

![image](https://user-images.githubusercontent.com/18191964/82027733-45af5c00-96c7-11ea-922a-eb87c1f2a847.png)

However, I found we can install bazel directly with Homebrew successfully:

```bash
brew install bazel
```

![image](https://user-images.githubusercontent.com/18191964/82028947-d76b9900-96c8-11ea-812c-31eaa4c0715f.png)

Here is the information:

```bash
$ brew info bazel
bazel: stable 3.1.0 (bottled)
Google's own build tool
https://bazel.build/
Not installed
From: https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/homebrew-core.git/Formula/bazel.rb
==> Dependencies
Build: python@3.8 ✔
Required: openjdk@11 ✘
==> Requirements
Required: macOS >= 10.10 ✔
==> Analytics
install: 4,734 (30 days), 17,069 (90 days), 70,323 (365 days)
install-on-request: 4,434 (30 days), 15,988 (90 days), 65,300 (365 days)
build-error: 0 (30 days)
```
![image](https://user-images.githubusercontent.com/18191964/82028641-8196f100-96c8-11ea-856e-44397532435c.png)

![image](https://user-images.githubusercontent.com/18191964/82029009-ee11f000-96c8-11ea-9e1f-ee5dea390a43.png)
