### PR TITLE
Fixing typo from embeded to embedded

### DIFF
--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -43,7 +43,7 @@ title: Concepts and terminology
 <p>The workspace rules bundled with Bazel are documented in the
    <a href="be/workspace.html">Workspace Rules</a> section in the Build
    Encyclopedia and the documentation on
-   <a href="repo/index.html">embeded Starlark repository rules</a>.</p>
+   <a href="repo/index.html">embedded Starlark repository rules</a>.</p>
 
 <p>As external repositories are repositories themselves, they often contain
    a <code>WORKSPACE</code> file as well. However, these additional


### PR DESCRIPTION
The word `embeded` should have been spelled as `embedded`.