### PR TITLE
Don't retry UNAUTHENTICATED gRPC responses

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
@@ -57,7 +57,6 @@ public class RemoteRetrier extends Retrier {
           case ABORTED:
           case INTERNAL:
           case UNAVAILABLE:
-          case UNAUTHENTICATED:
           case RESOURCE_EXHAUSTED:
             return true;
           default:


### PR DESCRIPTION
These failures will not be resolved by simply retrying, they require
performing some kind of authentication (or attaching some form of
authorization), which the RemoteRetrier will not automatically do.