### PR TITLE
Add embedded jdk support for ppc64le

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -320,6 +320,15 @@ http_file(
 )
 
 http_file(
+    name = "openjdk_linux_ppc64le_vanilla",
+    downloaded_file_path="adoptopenjdk-ppc64le-vanilla.tar.gz",
+    urls = [
+        "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+        "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+    ],
+)
+
+http_file(
     name = "openjdk_macos",
     downloaded_file_path = "zulu-macos.tar.gz",
     sha256 = "8e283cfd23c7555be8e17295ed76eb8f00324c88ab904b8de37bbe08f90e569b",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -699,7 +699,10 @@ http_archive(
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_BAZEL_FILE_WIN,
     sha256 = "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
     strip_prefix = "jdk-11.0.7+10",
-    urls = ["https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz"],
+    urls = [
+        "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+        "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+    ],
 )
 
 # This must be kept in sync with src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -322,6 +322,7 @@ http_file(
 http_file(
     name = "openjdk_linux_ppc64le_vanilla",
     downloaded_file_path="adoptopenjdk-ppc64le-vanilla.tar.gz",
+    sha256 = "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a"
     urls = [
         "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
         "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -322,7 +322,7 @@ http_file(
 http_file(
     name = "openjdk_linux_ppc64le_vanilla",
     downloaded_file_path="adoptopenjdk-ppc64le-vanilla.tar.gz",
-    sha256 = "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a"
+    sha256 = "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
     urls = [
         "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
         "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -693,6 +693,17 @@ http_archive(
 
 # This must be kept in sync with src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.
 http_archive(
+    name = "remotejdk11_linux_ppc64le_for_testing",
+    build_file = "@local_jdk//:BUILD.bazel",
+    patch_cmds = EXPORT_WORKSPACE_IN_BUILD_BAZEL_FILE,
+    patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_BAZEL_FILE_WIN,
+    sha256 = "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
+    strip_prefix = "jdk-11.0.7+10",
+    urls = ["https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz"],
+)
+
+# This must be kept in sync with src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.
+http_archive(
     name = "remotejdk11_macos_for_testing",
     build_file = "@local_jdk//:BUILD.bazel",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_BAZEL_FILE,

--- a/src/BUILD
+++ b/src/BUILD
@@ -226,6 +226,9 @@ filegroup(
         "//src/conditions:linux_aarch64": [
             "@openjdk_linux_aarch64_vanilla//file",
         ],
+        "//src/conditions:linux_ppc64le": [
+            "@openjdk_linux_ppc64le_vanilla//file",
+        ],
         "//conditions:default": [
             "@openjdk_linux_vanilla//file",
         ],

--- a/src/BUILD
+++ b/src/BUILD
@@ -760,6 +760,7 @@ filegroup(
         "@remote_java_tools_linux_for_testing//:WORKSPACE",
         "@remote_java_tools_windows_for_testing//:WORKSPACE",
         "@remotejdk11_linux_aarch64_for_testing//:WORKSPACE",
+        "@remotejdk11_linux_ppc64le_for_testing//:WORKSPACE",
         "@remotejdk11_linux_for_testing//:WORKSPACE",
         "@remotejdk11_macos_for_testing//:WORKSPACE",
         "@remotejdk11_win_for_testing//:WORKSPACE",

--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -23,6 +23,12 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_ppc64le",
+    values = {"cpu": "ppc"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "linux_s390x",
     values = {"cpu": "s390x"},
     visibility = ["//visibility:public"],

--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -23,6 +23,12 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_ppc64le",
+    values = {"cpu": "ppc"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "linux_s390x",
     values = {"cpu": "s390x"},
     visibility = ["//visibility:public"],

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -122,7 +122,7 @@ maybe(
     http_archive,
     name = "remotejdk11_linux_ppc64le",
     build_file = "@local_jdk//:BUILD.bazel",
-    sha256 = "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a"
+    sha256 = "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
     strip_prefix = "jdk-11.0.7+10",
     urls = [
         "https://mirror.bazel.com/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -120,6 +120,18 @@ maybe(
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
     http_archive,
+    name = "remotejdk11_linux_ppc64le",
+    build_file = "@local_jdk//:BUILD.bazel",
+    strip_prefix = "jdk-11.0.7+10",
+    urls = [
+        "https://mirror.bazel.com/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+        "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+    ],
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    http_archive,
     name = "remotejdk11_macos",
     build_file = "@local_jdk//:BUILD.bazel",
     sha256 = "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -122,10 +122,11 @@ maybe(
     http_archive,
     name = "remotejdk11_linux_ppc64le",
     build_file = "@local_jdk//:BUILD.bazel",
+    sha256 = "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a"
     strip_prefix = "jdk-11.0.7+10",
     urls = [
-        "https://mirror.bazel.com/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
-        "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+        "https://mirror.bazel.com/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+        "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
     ],
 )
 

--- a/src/minimize_jdk.sh
+++ b/src/minimize_jdk.sh
@@ -30,6 +30,14 @@ else
 fi
 fulljdk=$1
 out=$3
+ARCH=`uname -p`
+if [[ "${ARCH}" == 'ppc64le' ]]; then
+  FULL_JDK_DIR="jdk*"
+  DOCS=""
+else
+  FULL_JDK_DIR="zulu*"
+  DOCS="DISCLAIMER readme.txt"
+fi
 
 UNAME=$(uname -s | tr 'A-Z' 'a-z')
 
@@ -38,11 +46,11 @@ if [[ "$UNAME" =~ msys_nt* ]]; then
   mkdir "tmp.$$"
   cd "tmp.$$"
   unzip "../$fulljdk"
-  cd zulu*
+  cd $FULL_JDK_DIR
   ./bin/jlink --module-path ./jmods/ --add-modules "$modules" \
     --vm=server --strip-debug --no-man-pages \
     --output reduced
-  cp DISCLAIMER readme.txt legal/java.base/ASSEMBLY_EXCEPTION \
+  cp $DOCS legal/java.base/ASSEMBLY_EXCEPTION \
     reduced/
   # These are necessary for --host_jvm_debug to work.
   cp bin/dt_socket.dll bin/jdwp.dll reduced/bin
@@ -55,11 +63,11 @@ else
   # to the owner stored in the archive - it will try to do that when running as
   # root, but fail when running inside Docker, so we explicitly disable it.
   tar xf "$fulljdk" --no-same-owner
-  cd zulu*
+  cd $FULL_JDK_DIR
   ./bin/jlink --module-path ./jmods/ --add-modules "$modules" \
     --vm=server --strip-debug --no-man-pages \
     --output reduced
-  cp DISCLAIMER readme.txt legal/java.base/ASSEMBLY_EXCEPTION \
+  cp $DOCS legal/java.base/ASSEMBLY_EXCEPTION \
     reduced/
   # These are necessary for --host_jvm_debug to work.
   if [[ "$UNAME" =~ darwin ]]; then

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -58,6 +58,7 @@ class TestBase(unittest.TestCase):
       'rules_proto',
       'remotejdk11_linux_for_testing',
       'remotejdk11_linux_aarch64_for_testing',
+      'remotejdk11_linux_ppc64le_for_testing',
       'remotejdk11_macos_for_testing',
       'remotejdk11_win_for_testing',
       'remote_java_tools_darwin_for_testing',

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -309,6 +309,7 @@ EOF
         "remote_java_tools_windows_for_testing"
         "remotejdk11_linux_for_testing"
         "remotejdk11_linux_aarch64_for_testing"
+        "remotejdk11_linux_ppc64le_for_testing"
         "remotejdk11_macos_for_testing"
         "remotejdk11_win_for_testing"
         "rules_cc"

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -498,6 +498,7 @@ alias(
             "//src/conditions:windows": "@remotejdk11_win//:jdk",
             "//src/conditions:linux_aarch64": "@remotejdk11_linux_aarch64//:jdk",
             "//src/conditions:linux_x86_64": "@remotejdk11_linux//:jdk",
+            "//src/conditions:linux_ppc64le": "@remotejdk11_linux_ppc64le//:jdk",
         },
         no_match_error = "Could not find a JDK for host execution environment, please explicitly" +
                          " provide one using `--host_javabase.`",


### PR DESCRIPTION
This adds support for embedding OpenJDK in bazel for ppc64le.
Azul Systems does not create Zulu/OpenJDK builds for ppc64le, but AdoptOpenjdk.net does.

This PR adds the necessary configs and conditionals and http_file configuration URLs for adoptopenjdk downloads.
The minimize_jdk.sh script needed a slight generalization.

I've been using adoptOpenjdk-embedded bazel for quite a while and can vouch for its stability.