### PR TITLE
[Profiler] Add target label of action owner to profiler trace files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -391,7 +391,8 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
             execStartTimeNanos,
             options.enableCpuUsageProfiling,
             options.slimProfile,
-            options.includePrimaryOutput);
+            options.includePrimaryOutput,
+            options.profileIncludeTargetLabel);
         // Instead of logEvent() we're calling the low level function to pass the timings we took in
         // the launcher. We're setting the INIT phase marker so that it follows immediately the
         // LAUNCH phase.

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -289,6 +289,14 @@ public class CommonCommandOptions extends OptionsBase {
   public boolean includePrimaryOutput;
 
   @Option(
+          name = "experimental_profile_include_target_label",
+          defaultValue = "false",
+          documentationCategory = OptionDocumentationCategory.LOGGING,
+          effectTags = {OptionEffectTag.AFFECTS_OUTPUTS, OptionEffectTag.BAZEL_MONITORING},
+          help = "Includes target label in action events' JSON profile data.")
+  public boolean profileIncludeTargetLabel;
+
+  @Option(
       name = "experimental_announce_profile_path",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.LOGGING,

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -44,6 +44,7 @@ import com.google.devtools.build.lib.actions.ActionKeyContext;
 import com.google.devtools.build.lib.actions.ActionLogBufferPathGenerator;
 import com.google.devtools.build.lib.actions.ActionLookupData;
 import com.google.devtools.build.lib.actions.ActionMiddlemanEvent;
+import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.ActionResult;
 import com.google.devtools.build.lib.actions.ActionResultReceivedEvent;
 import com.google.devtools.build.lib.actions.ActionScanningCompletedEvent;
@@ -830,7 +831,8 @@ public final class SkyframeActionExecutor {
           profiler.profileAction(
               ProfilerTask.ACTION,
               action.describe(),
-              action.getPrimaryOutput().getExecPathString())) {
+              action.getPrimaryOutput().getExecPathString(),
+              getOwnerLabelAsString(action))) {
         String message = action.getProgressMessage();
         if (message != null) {
           reporter.startTask(null, prependExecPhaseStats(message));
@@ -897,6 +899,18 @@ public final class SkyframeActionExecutor {
 
         return continueAction(env.getListener(), runFully(action, actionExecutionContext));
       }
+    }
+
+    private String getOwnerLabelAsString(Action action) {
+      ActionOwner owner = action.getOwner();
+      if (owner == null) {
+        return "";
+      }
+      Label ownerLabel = owner.getLabel();
+      if (ownerLabel == null) {
+        return "";
+      }
+      return ownerLabel.getCanonicalForm();
     }
 
     private void notifyActionCompletion(

--- a/src/test/java/com/google/devtools/build/lib/profiler/ProfilerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/profiler/ProfilerTest.java
@@ -94,7 +94,8 @@ public class ProfilerTest {
         BlazeClock.nanoTime(),
         /* enabledCpuUsageProfiling= */ false,
         /* slimProfile= */ false,
-        /* includePrimaryOutput= */ false);
+        /* includePrimaryOutput= */ false,
+        /* includeTargetLabel= */ false);
     return buffer;
   }
 
@@ -110,7 +111,8 @@ public class ProfilerTest {
         BlazeClock.nanoTime(),
         /* enabledCpuUsageProfiling= */ false,
         /* slimProfile= */ false,
-        /* includePrimaryOutput= */ false);
+        /* includePrimaryOutput= */ false,
+        /* includeTargetLabel= */ false);
   }
 
   @Test
@@ -207,7 +209,8 @@ public class ProfilerTest {
         clock.nanoTime(),
         /* enabledCpuUsageProfiling= */ false,
         /* slimProfile= */ false,
-        /* includePrimaryOutput= */ false);
+        /* includePrimaryOutput= */ false,
+        /* includeTargetLabel= */ false);
     try (SilentCloseable c = profiler.profile(ProfilerTask.ACTION, "action task")) {
       // Next task takes less than 10 ms but should be recorded anyway.
       long before = clock.nanoTime();
@@ -252,7 +255,8 @@ public class ProfilerTest {
         BlazeClock.instance().nanoTime(),
         /* enabledCpuUsageProfiling= */ false,
         /* slimProfile= */ false,
-        /* includePrimaryOutput= */ false);
+        /* includePrimaryOutput= */ false,
+        /* includeTargetLabel= */ false);
     profiler.logSimpleTask(10000, 20000, ProfilerTask.VFS_STAT, "stat");
     // Unlike the VFS_STAT event above, the remote execution event will not be recorded since we
     // don't record the slowest remote exec events (see ProfilerTask.java).
@@ -368,7 +372,8 @@ public class ProfilerTest {
         BlazeClock.instance().nanoTime(),
         /* enabledCpuUsageProfiling= */ false,
         /* slimProfile= */ false,
-        /* includePrimaryOutput= */ false);
+        /* includePrimaryOutput= */ false,
+        /* includeTargetLabel= */ false);
     profiler.logSimpleTask(10000, 20000, ProfilerTask.VFS_STAT, "stat");
 
     assertThat(ProfilerTask.VFS_STAT.collectsSlowestInstances()).isTrue();
@@ -549,7 +554,8 @@ public class ProfilerTest {
         initialNanoTime,
         /* enabledCpuUsageProfiling= */ false,
         /* slimProfile= */ false,
-        /* includePrimaryOutput= */ false);
+        /* includePrimaryOutput= */ false,
+        /* includeTargetLabel= */ false);
     profiler.logSimpleTask(badClock.nanoTime(), ProfilerTask.INFO, "some task");
     profiler.stop();
   }
@@ -603,7 +609,8 @@ public class ProfilerTest {
         BlazeClock.instance().nanoTime(),
         /* enabledCpuUsageProfiling= */ false,
         /* slimProfile= */ false,
-        /* includePrimaryOutput= */ false);
+        /* includePrimaryOutput= */ false,
+        /* includeTargetLabel= */ false);
     profiler.logSimpleTaskDuration(
         Profiler.nanoTimeMaybe(), Duration.ofSeconds(10), ProfilerTask.INFO, "foo");
     IOException expected = assertThrows(IOException.class, () -> profiler.stop());
@@ -629,7 +636,8 @@ public class ProfilerTest {
         BlazeClock.instance().nanoTime(),
         /* enabledCpuUsageProfiling= */ false,
         /* slimProfile= */ false,
-        /* includePrimaryOutput= */ false);
+        /* includePrimaryOutput= */ false,
+        /* includeTargetLabel= */ false);
     profiler.logSimpleTaskDuration(
         Profiler.nanoTimeMaybe(), Duration.ofSeconds(10), ProfilerTask.INFO, "foo");
     IOException expected = assertThrows(IOException.class, () -> profiler.stop());
@@ -651,8 +659,9 @@ public class ProfilerTest {
         clock.nanoTime(),
         /* enabledCpuUsageProfiling= */ false,
         /* slimProfile= */ false,
-        /* includePrimaryOutput= */ true);
-    try (SilentCloseable c = profiler.profileAction(ProfilerTask.ACTION, "test", "foo.out")) {
+        /* includePrimaryOutput= */ true,
+        /* includeTargetLabel= */ false);
+    try (SilentCloseable c = profiler.profileAction(ProfilerTask.ACTION, "test", "foo.out", "")) {
       profiler.logEvent(ProfilerTask.PHASE, "event1");
     }
     profiler.stop();
@@ -664,6 +673,37 @@ public class ProfilerTest {
                 .filter(traceEvent -> "foo.out".equals(traceEvent.primaryOutputPath()))
                 .collect(Collectors.toList()))
         .hasSize(1);
+  }
+
+  @Test
+  public void testTargetLabelForAction() throws Exception {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+    profiler.start(
+            getAllProfilerTasks(),
+            buffer,
+            JSON_TRACE_FILE_FORMAT,
+            "dummy_output_base",
+            UUID.randomUUID(),
+            true,
+            clock,
+            clock.nanoTime(),
+            /* enabledCpuUsageProfiling= */ false,
+            /* slimProfile= */ false,
+            /* includePrimaryOutput= */ false,
+            /* includeTargetLabel= */ true);
+    try (SilentCloseable c = profiler.profileAction(ProfilerTask.ACTION, "test", "foo.out", "//foo:bar")) {
+      profiler.logEvent(ProfilerTask.PHASE, "event1");
+    }
+    profiler.stop();
+
+    JsonProfile jsonProfile = new JsonProfile(new ByteArrayInputStream(buffer.toByteArray()));
+
+    assertThat(
+            jsonProfile.getTraceEvents().stream()
+                    .filter(traceEvent -> traceEvent.args() != null && "//foo:bar".equals(traceEvent.args().get("target")))
+                    .collect(Collectors.toList()))
+            .hasSize(1);
   }
 
   private ByteArrayOutputStream getJsonProfileOutputStream(boolean slimProfile) throws IOException {
@@ -679,7 +719,8 @@ public class ProfilerTest {
         BlazeClock.instance().nanoTime(),
         /* enabledCpuUsageProfiling= */ false,
         slimProfile,
-        /* includePrimaryOutput= */ false);
+        /* includePrimaryOutput= */ false,
+        /* includeTargetLabel= */ false);
     long curTime = Profiler.nanoTimeMaybe();
     for (int i = 0; i < 100_000; i++) {
       Duration duration;


### PR DESCRIPTION
While analyzing trace files, it is useful to have target label associated with the action which was created by that target. This change adds target label under trace events which have owner, mostly Action-type event. Target label is saved as a custom entry to "args" map attached to each Action event, as per trace format definition.
The change is guarded by new flag `--experimental_include_target_label`