### PR TITLE
Allow any header extensions in the cc_common.compile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -420,10 +420,8 @@ public final class CcCompilationHelper {
   }
 
   private CcCompilationHelper addPrivateHeader(Artifact privateHeader, Label label) {
-    boolean isHeader = CppFileTypes.CPP_HEADER.matches(privateHeader.getExecPath());
     boolean isTextualInclude =
         CppFileTypes.CPP_TEXTUAL_INCLUDE.matches(privateHeader.getExecPath());
-    Preconditions.checkState(isHeader || isTextualInclude);
 
     if (ccToolchain.shouldProcessHeaders(featureConfiguration, cppConfiguration)
         && !isTextualInclude) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -1695,16 +1695,6 @@ public abstract class CcModule
         sources,
         CppFileTypes.ALL_C_CLASS_SOURCE.including(CppFileTypes.ASSEMBLER),
         FileTypeSet.of(CppFileTypes.CPP_SOURCE, CppFileTypes.C_SOURCE, CppFileTypes.ASSEMBLER));
-    validateExtensions(
-        "public_hdrs",
-        publicHeaders,
-        FileTypeSet.of(CppFileTypes.CPP_HEADER),
-        FileTypeSet.of(CppFileTypes.CPP_HEADER));
-    validateExtensions(
-        "private_hdrs",
-        privateHeaders,
-        FileTypeSet.of(CppFileTypes.CPP_HEADER),
-        FileTypeSet.of(CppFileTypes.CPP_HEADER));
 
     if (disallowNopicOutputs && disallowPicOutputs) {
       throw Starlark.errorf("Either PIC or no PIC actions have to be created.");

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/StarlarkCcCommonTest.java
@@ -70,6 +70,7 @@ import com.google.devtools.build.lib.view.config.crosstool.CrosstoolConfig.MakeV
 import com.google.devtools.build.lib.view.config.crosstool.CrosstoolConfig.ToolPath;
 import com.google.protobuf.TextFormat;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -5594,30 +5595,44 @@ public class StarlarkCcCommonTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testPossiblePrivateHdrExtensions() throws Exception {
+  public void testCustomPrivateHdrsExtensions() throws Exception {
+    ArrayList<String> extensions = new ArrayList<>();
+    extensions.add(".unknown");
+    extensions.add(".foo");
+    doTestPossibleExtensionsOfSrcsAndHdrs("private_hdrs", extensions);
+  }
+
+  @Test
+  public void testPrivateHdrEmptyExtensions() throws Exception {
+    ArrayList<String> extensions = new ArrayList<>();
+    extensions.add("");
+    doTestPossibleExtensionsOfSrcsAndHdrs("private_hdrs", extensions);
+  }
+
+  @Test
+  public void testWellKnownPrivateHdrExtensions() throws Exception {
     doTestPossibleExtensionsOfSrcsAndHdrs("private_hdrs", CppFileTypes.CPP_HEADER.getExtensions());
   }
 
   @Test
-  public void testPossiblePublicHdrExtensions() throws Exception {
+  public void testWellKnownPublicHdrExtensions() throws Exception {
     doTestPossibleExtensionsOfSrcsAndHdrs("public_hdrs", CppFileTypes.CPP_HEADER.getExtensions());
   }
 
   @Test
-  public void testWrongSrcsExtensionGivesError() throws Exception {
-    doTestWrongExtensionOfSrcsAndHdrs("srcs");
+  public void testUnknownPublicHdrExtensions() throws Exception {
+    ArrayList<String> extensions = new ArrayList<>();
+    extensions.add(".unknown");
+    extensions.add(".foo");
+    doTestPossibleExtensionsOfSrcsAndHdrs("public_hdrs", extensions);
   }
 
   @Test
-  public void testWrongPrivateHdrExtensionGivesError() throws Exception {
-    doTestWrongExtensionOfSrcsAndHdrs("private_hdrs");
+  public void testEmptyPublicHdrExtension() throws Exception {
+    ArrayList<String> extensions = new ArrayList<>();
+    extensions.add("");
+    doTestPossibleExtensionsOfSrcsAndHdrs("public_hdrs", extensions);
   }
-
-  @Test
-  public void testWrongPublicHdrExtensionGivesError() throws Exception {
-    doTestWrongExtensionOfSrcsAndHdrs("public_hdrs");
-  }
-
 
   @Test
   public void testWrongSrcExtensionGivesError() throws Exception {


### PR DESCRIPTION
#11356

Allow any extension in the cc_common.compile, but still use a hardcoded list of extensions in CcCommon to separate sources and headers from "srcs" attribute for cc_binary and cc_library.