### PR TITLE
Always use //src/java_tools/buildjar:bootstrap_toolchain

### DIFF
--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -31,17 +31,13 @@ fi
 
 : ${JAVA_VERSION:="1.8"}
 
-if [ -d derived ]; then
-  # Flags we need to bootstrap from the dist archive.
-  DIST_BOOTSTRAP_ARGS="--java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \
-      --host_java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \
-      --distdir=derived/distdir"
-fi
-
 _BAZEL_ARGS="--spawn_strategy=standalone \
       --nojava_header_compilation \
       --strategy=Javac=worker --worker_quit_after_build --ignore_unsupported_sandboxing \
       --compilation_mode=opt \
+      --distdir=derived/distdir \
+      --java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \
+      --host_java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \
       ${DIST_BOOTSTRAP_ARGS:-} \
       ${EXTRA_BAZEL_ARGS:-}"
 


### PR DESCRIPTION
To build Bazel without downloading remote java tools, we'll have to use the bootstrap toolchain.

This is basically a part of rollback of https://github.com/bazelbuild/bazel/pull/11192

Working towards: #9408