### PR TITLE
Use system_repo rule in Debian build

### DIFF
--- a/tools/distributions/debian/deps.bzl
+++ b/tools/distributions/debian/deps.bzl
@@ -14,6 +14,8 @@
 
 """Macros for defining external repositories for Debian system installed libraries."""
 
+load("//tools/distributions:system_repo.bzl", "system_repo")
+
 def debian_deps():
     debian_java_deps()
     debian_cc_deps()
@@ -30,24 +32,31 @@ def debian_java_deps():
 
 def debian_cc_deps():
     # An external repository for providing Debian system installed C/C++ libraries.
-    native.new_local_repository(
+    system_repo(
         name = "debian_cc_deps",
-        path = "/usr/lib",
+        # /usr/lib is the default library search path for every cc compile in Debian,
+        # we use -l as linkopts in debian_cc.BUILD so we actually don't have to link
+        # any system paths for this repo.
+        symlinks = {},
         build_file = "//tools/distributions/debian:debian_cc.BUILD",
     )
 
 def debian_proto_deps():
     # An external repository for providing Debian system installed proto files.
-    native.new_local_repository(
+    system_repo(
         name = "debian_proto_deps",
-        path = "/usr/include",
+        symlinks = {
+            "google/protobuf": "/usr/include/google/protobuf",
+        },
         build_file = "//tools/distributions/debian:debian_proto.BUILD",
     )
 
 def debian_bin_deps():
     # An external repository for providing Debian system installed binaries.
-    native.new_local_repository(
+    system_repo(
         name = "debian_bin_deps",
-        path = "/usr/bin",
+        symlinks = {
+            "protoc": "/usr/bin/protoc",
+        },
         build_file = "//tools/distributions/debian:debian_bin.BUILD",
     )

--- a/tools/distributions/system_repo.bzl
+++ b/tools/distributions/system_repo.bzl
@@ -1,0 +1,41 @@
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repository rule for providing system libraries for Bazel build."""
+
+def _system_repo_impl(ctx):
+    symlinks = ctx.attr.symlinks
+    for link in symlinks:
+        target = symlinks[link]
+        ctx.symlink(target, link)
+
+    ctx.file("WORKSPACE", "workspace(name = \"{name}\")\n".format(name = ctx.name))
+    ctx.file("BUILD.bazel", ctx.read(ctx.attr.build_file))
+
+system_repo = repository_rule(
+    implementation = _system_repo_impl,
+    attrs = {
+        "symlinks": attr.string_dict(
+            doc = """
+                Symlinks to create for this system repo. The key is the link path under this repo,
+                the value should be an absolute target path on the system that we want to link.
+            """,
+        ),
+        "build_file": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "The file to use as the BUILD file for this repository."
+        ),
+    },
+    doc = "A repository rule for providing system libraries for Bazel build",
+)


### PR DESCRIPTION
Previously, we use `new_local_repository` to make binaries and headers under `/usr/bin`, `/usr/include` available to the Debian build. Because `new_local_repository` symlinks everything under the directory, it has the following problems:

- headers under `/usr/include` will get leaked from the external repo. Eg, `limits.h` gets found via `external/debian_proto_deps/limits.h`. Bazel will throw an error for this while doing header checking because it's an undeclared dependency.
- `/usr/bin` may contain infinite symlink loop. Eg. `/usr/bin/X11 -> /usr/bin` ([why](https://askubuntu.com/questions/191654/why-are-there-infinitely-many-x11-subdirectories-in-usr-bin-x11)). Bazel doesn't like this and throws an error when it's detected.

In this PR, we introduce a new repository rule called `system_repo`. Instead of symlinking everything under a directory, it only creates given symlink paths. This will not only avoid the above problems, but also increase the performance by a bit.

Working towards: #9408