### PR TITLE
Bootstrap JavaBuilder with Debain system jars (third_party)

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,5 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_import", "java_library", "java_plugin")
-load("//tools/distributions:distribution_rules.bzl", "distrib_java_import")
+load("//tools/distributions:distribution_rules.bzl", "distrib_java_import", "distrib_jar_filegroup")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -371,6 +371,15 @@ distrib_java_import(
     enable_distributions = ["debian"],
 )
 
+# For bootstrapping JavaBuilder
+distrib_jar_filegroup(
+    name = "jcip_annotations-jars",
+    srcs = [
+        "jcip_annotations/jcip-annotations-1.0-1.jar",
+    ],
+    enable_distributions = ["debian"],
+)
+
 java_import(
     name = "pcollections",
     jars = [
@@ -383,9 +392,9 @@ filegroup(
     name = "bootstrap_guava_and_error_prone-jars",
     srcs = [
         "error_prone/error_prone_annotations-2.2.0.jar",
-        "guava/guava-25.1-jre.jar",
-        "jcip_annotations/jcip-annotations-1.0-1.jar",
-        "jsr305/jsr-305.jar",
+        ":guava-jars",
+        ":jcip_annotations-jars",
+        ":jsr305-jars",
     ],
 )
 
@@ -453,9 +462,10 @@ distrib_java_import(
 )
 
 # For bootstrapping JavaBuilder
-filegroup(
+distrib_jar_filegroup(
     name = "jsr305-jars",
     srcs = ["jsr305/jsr-305.jar"],
+    enable_distributions = ["debian"],
 )
 
 java_import(
@@ -513,9 +523,10 @@ distrib_java_import(
 )
 
 # For bootstrapping JavaBuilder
-filegroup(
+distrib_jar_filegroup(
     name = "tomcat_annotations_api-jars",
     srcs = ["tomcat_annotations_api/tomcat-annotations-api-8.0.5.jar"],
+    enable_distributions = ["debian"],
 )
 
 java_import(


### PR DESCRIPTION
The bootstrap_toolchain depends on jar files directly. We also need to replace them with system libraries for the Debian build.

Working towards: #9408