### PR TITLE
Bootstrap JavaBuilder with Debian system jars (main)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,6 @@
 # Bazel - Google's Build System
 
+load("//tools/distributions:distribution_rules.bzl", "distrib_jar_filegroup")
 load("//tools/python:private/defs.bzl", "py_binary")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
@@ -74,13 +75,14 @@ pkg_tar(
     visibility = ["//:__subpackages__"],
 )
 
-filegroup(
+distrib_jar_filegroup(
     name = "bootstrap-derived-java-jars",
     srcs = glob(
         ["derived/jars/**/*.jar"],
         allow_empty = True,
     ),
     visibility = ["//:__subpackages__"],
+    enable_distributions = ["debian"],
 )
 
 filegroup(

--- a/tools/distributions/debian/debian_java.BUILD
+++ b/tools/distributions/debian/debian_java.BUILD
@@ -58,6 +58,12 @@ java_import(
     jars = ["tomcat9-annotations-api.jar"],
 )
 
+# For bootstrapping java toolcahin
+filegroup(
+    name = "tomcat_annotations_api-jars",
+    srcs = ["tomcat9-annotations-api.jar"],
+)
+
 # libjava-allocation-instrumenter-java
 java_import(
     name = "allocation_instrumenter",
@@ -74,6 +80,15 @@ java_import(
 java_import(
     name = "protobuf_java_util",
     jars = ["protobuf-util.jar"],
+)
+
+# For bootstrapping java toolcahin
+filegroup(
+    name = "bootstrap-derived-java-jars",
+    srcs = [
+        "protobuf.jar",
+        "protobuf-util.jar",
+    ],
 )
 
 # libcommons-collections3-java
@@ -134,10 +149,24 @@ java_import(
     ],
 )
 
+# For bootstrapping java toolcahin
+filegroup(
+    name = "jcip_annotations-jars",
+    srcs = [
+        "jcip-annotations.jar",
+    ],
+)
+
 # libjsr305-java
 java_import(
     name = "jsr305",
     jars = ["jsr305.jar"],
+)
+
+# For bootstrapping java toolcahin
+filegroup(
+    name = "jsr305-jars",
+    srcs = ["jsr305.jar"],
 )
 
 # libnetty-tcnative-java

--- a/tools/distributions/distribution_rules.bzl
+++ b/tools/distributions/distribution_rules.bzl
@@ -43,3 +43,18 @@ def distrib_cc_library(name, visibility = None, enable_distributions = [], **kwa
         conditions["//src/conditions:debian_build"] = "@debian_cc_deps//:" + name
 
     native.alias(name = name, actual = select(conditions), visibility = visibility)
+
+def distrib_jar_filegroup(name, visibility = None, enable_distributions = [], **kwargs):
+    """A macro for filegroup rule to support distributions build (eg. Debian)"""
+    checked_in_name = name + "_checked_in"
+
+    native.filegroup(name = checked_in_name, visibility = visibility, **kwargs)
+
+    conditions = {
+        "//conditions:default": ":" + checked_in_name,
+    }
+
+    if "debian" in enable_distributions:
+        conditions["//src/conditions:debian_build"] = "@debian_java_deps//:" + name
+
+    native.alias(name = name, actual = select(conditions), visibility = visibility)


### PR DESCRIPTION
The bootstrap_toolchain depends on jar files directly. We also need to replace them with system libraries for the Debian build.

Working towards: #9408