### PR TITLE
Pass missing target flag for watchos_arm64_32 and watchos_x86_64

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -4915,9 +4915,39 @@ def _impl(ctx):
                 ),
             ],
         )
+    elif (ctx.attr.cpu == "watchos_x86_64"):
+        unfiltered_compile_flags_feature = feature(
+            name = "unfiltered_compile_flags",
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.linkstamp_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-no-canonical-prefixes",
+                                "-Wno-builtin-macro-redefined",
+                                "-D__DATE__=\"redacted\"",
+                                "-D__TIMESTAMP__=\"redacted\"",
+                                "-D__TIME__=\"redacted\"",
+                                "-target",
+                                "x86_64-apple-watchos",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
     elif (ctx.attr.cpu == "armeabi-v7a" or
-          ctx.attr.cpu == "darwin_x86_64" or
-          ctx.attr.cpu == "watchos_x86_64"):
+          ctx.attr.cpu == "darwin_x86_64"):
         unfiltered_compile_flags_feature = feature(
             name = "unfiltered_compile_flags",
             flag_sets = [

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -4698,6 +4698,37 @@ def _impl(ctx):
                 ),
             ],
         )
+    elif (ctx.attr.cpu == "watchos_arm64_32"):
+        unfiltered_compile_flags_feature = feature(
+            name = "unfiltered_compile_flags",
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.linkstamp_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-no-canonical-prefixes",
+                                "-Wno-builtin-macro-redefined",
+                                "-D__DATE__=\"redacted\"",
+                                "-D__TIMESTAMP__=\"redacted\"",
+                                "-D__TIME__=\"redacted\"",
+                                "-target",
+                                "arm64_32-apple-watchos",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
     elif (ctx.attr.cpu == "ios_armv7"):
         unfiltered_compile_flags_feature = feature(
             name = "unfiltered_compile_flags",
@@ -4886,7 +4917,6 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
-          ctx.attr.cpu == "watchos_arm64_32" or
           ctx.attr.cpu == "watchos_x86_64"):
         unfiltered_compile_flags_feature = feature(
             name = "unfiltered_compile_flags",


### PR DESCRIPTION
Fixes #11484 

Passing this flag for `watchos_x86_64` is not strictly necessary to fix the linked issue, but since we're doing it for all other architectures, I think we should it as well for the missing architectures since that's what Xcode does.