### PR TITLE
Minor bugfixes to generate Gcov/Lcov branch coverage

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BranchCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BranchCoverage.java
@@ -22,7 +22,7 @@ abstract class BranchCoverage {
 
   static BranchCoverage create(int lineNumber, int nrOfExecutions) {
     return new AutoValue_BranchCoverage(
-        lineNumber, /*blockNumber=*/ "", /*branchNumber=*/ "", nrOfExecutions);
+        lineNumber, /*blockNumber=*/ "0", /*branchNumber=*/ "0", nrOfExecutions);
   }
 
   static BranchCoverage createWithBlockAndBranch(

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Constants.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Constants.java
@@ -29,7 +29,6 @@ class Constants {
   static final String FNF_MARKER = "FNF:";
   static final String FNH_MARKER = "FNH:";
   static final String BRDA_MARKER = "BRDA:";
-  static final String BA_MARKER = "BA:";
   static final String BRF_MARKER = "BRF:";
   static final String BRH_MARKER = "BRH:";
   static final String DA_MARKER = "DA:";

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovParser.java
@@ -280,7 +280,7 @@ class LcovParser {
 
       boolean wasExecuted = false;
       int executionCount = 0;
-      if (taken.equals(TAKEN)) {
+      if (!taken.equals(TAKEN)) {
         executionCount = Integer.parseInt(taken);
         wasExecuted = true;
       }

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovParser.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.coverageoutputgenerator;
 
-import static com.google.devtools.coverageoutputgenerator.Constants.BA_MARKER;
 import static com.google.devtools.coverageoutputgenerator.Constants.BRDA_MARKER;
 import static com.google.devtools.coverageoutputgenerator.Constants.BRF_MARKER;
 import static com.google.devtools.coverageoutputgenerator.Constants.BRH_MARKER;
@@ -114,9 +113,6 @@ class LcovParser {
     }
     if (line.startsWith(BRDA_MARKER)) {
       return parseBRDALine(line);
-    }
-    if (line.startsWith(BA_MARKER)) {
-      return parseBALine(line);
     }
     if (line.startsWith(BRF_MARKER)) {
       return parseBRFLine(line);
@@ -225,34 +221,6 @@ class LcovParser {
     } catch (NumberFormatException e) {
       logger.log(
           Level.WARNING, "Tracefile contains invalid number of functions hit on FNH line " + line);
-      return false;
-    }
-    return true;
-  }
-
-  // BA:<line number>,<taken>
-  private boolean parseBALine(String line) {
-    String lineContent = line.substring(BA_MARKER.length());
-    String[] lineData = lineContent.split(DELIMITER, -1);
-    if (lineData.length != 2) {
-      logger.log(Level.WARNING, "Tracefile contains invalid BRDA line " + line);
-      return false;
-    }
-    for (String data : lineData) {
-      if (data.isEmpty()) {
-        logger.log(Level.WARNING, "Tracefile contains invalid BRDA line " + line);
-        return false;
-      }
-    }
-    try {
-      int lineNumber = Integer.parseInt(lineData[0]);
-      int taken = Integer.parseInt(lineData[1]);
-
-      BranchCoverage branchCoverage = BranchCoverage.create(lineNumber, taken);
-
-      currentSourceFileCoverage.addBranch(lineNumber, branchCoverage);
-    } catch (NumberFormatException e) {
-      logger.log(Level.WARNING, "Tracefile contains an invalid number BA line " + line);
       return false;
     }
     return true;

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
@@ -77,7 +77,6 @@ class LcovPrinter {
     printFNFLine(sourceFile);
     printFNHLine(sourceFile);
     printBRDALines(sourceFile);
-    printBALines(sourceFile);
     printBRFLine(sourceFile);
     printBRHLine(sourceFile);
     printDALines(sourceFile);
@@ -132,16 +131,12 @@ class LcovPrinter {
   // BRDA:<line number>,<block number>,<branch number>,<taken>
   private void printBRDALines(SourceFileCoverage sourceFile) throws IOException {
     for (BranchCoverage branch : sourceFile.getAllBranches()) {
-      if (branch.blockNumber().isEmpty() || branch.branchNumber().isEmpty()) {
-        // We skip printing this as a BRDA line and print it later as a BA line.
-        continue;
-      }
       bufferedWriter.write(Constants.BRDA_MARKER);
       bufferedWriter.write(Integer.toString(branch.lineNumber()));
       bufferedWriter.write(Constants.DELIMITER);
-      bufferedWriter.write(branch.blockNumber());
+      bufferedWriter.write(branch.blockNumber().isEmpty() ? "0" : branch.blockNumber());
       bufferedWriter.write(Constants.DELIMITER);
-      bufferedWriter.write(branch.branchNumber());
+      bufferedWriter.write(branch.branchNumber().isEmpty() ? "0" : branch.branchNumber());
       bufferedWriter.write(Constants.DELIMITER);
       if (branch.wasExecuted()) {
         bufferedWriter.write(Integer.toString(branch.nrOfExecutions()));

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
@@ -134,9 +134,9 @@ class LcovPrinter {
       bufferedWriter.write(Constants.BRDA_MARKER);
       bufferedWriter.write(Integer.toString(branch.lineNumber()));
       bufferedWriter.write(Constants.DELIMITER);
-      bufferedWriter.write(branch.blockNumber().isEmpty() ? "0" : branch.blockNumber());
+      bufferedWriter.write(branch.blockNumber());
       bufferedWriter.write(Constants.DELIMITER);
-      bufferedWriter.write(branch.branchNumber().isEmpty() ? "0" : branch.branchNumber());
+      bufferedWriter.write(branch.branchNumber());
       bufferedWriter.write(Constants.DELIMITER);
       if (branch.wasExecuted()) {
         bufferedWriter.write(Integer.toString(branch.nrOfExecutions()));

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
@@ -147,24 +147,6 @@ class LcovPrinter {
     }
   }
 
-  // BA:<line number>,<taken>
-  private void printBALines(SourceFileCoverage sourceFile) throws IOException {
-    for (BranchCoverage branch : sourceFile.getAllBranches()) {
-      if (!branch.blockNumber().isEmpty() && !branch.branchNumber().isEmpty()) {
-        // This branch was already printed with more information as a BRDA line.
-        continue;
-      }
-      bufferedWriter.write(Constants.BA_MARKER);
-      bufferedWriter.write(Integer.toString(branch.lineNumber()));
-      bufferedWriter.write(Constants.DELIMITER);
-      // 0 = branch was not executed
-      // 1 = branch was executed but not taken
-      // 2 = branch was executed and taken
-      bufferedWriter.write(branch.wasExecuted() ? "2" : "0");
-      bufferedWriter.newLine();
-    }
-  }
-
   // BRF:<number of branches found>
   private void printBRFLine(SourceFileCoverage sourceFile) throws IOException {
     if (sourceFile.nrBranchesFound() > 0) {

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/SourceFileCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/SourceFileCoverage.java
@@ -203,6 +203,11 @@ class SourceFileCoverage {
   }
 
   @VisibleForTesting
+  Map<Integer, BranchCoverage> getBranches() {
+    return branches;
+  }
+
+  @VisibleForTesting
   Map<Integer, LineCoverage> getLines() {
     return lines;
   }

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BUILD
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BUILD
@@ -136,6 +136,7 @@ java_library(
     deps = [
         "//third_party:guava",
         "//third_party:truth",
+        "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:BranchCoverage",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:LineCoverage",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:SourceFileCoverage",
     ],

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/CoverageTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/CoverageTest.java
@@ -19,6 +19,7 @@ import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.as
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.assertTracefile1;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createLinesExecution1;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createLinesExecution2;
+import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createBranchExecution1;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createSourceFile1;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createSourceFile2;
 
@@ -46,7 +47,7 @@ public class CoverageTest {
 
   @Test
   public void testOneTracefile() {
-    SourceFileCoverage sourceFileCoverage = createSourceFile1(createLinesExecution1());
+    SourceFileCoverage sourceFileCoverage = createSourceFile1(createLinesExecution1(), createBranchExecution1());
     coverage.add(sourceFileCoverage);
     assertThat(coverage.getAllSourceFiles()).hasSize(1);
     assertTracefile1(Iterables.get(coverage.getAllSourceFiles(), 0));
@@ -56,7 +57,7 @@ public class CoverageTest {
   public void testTwoOverlappingTracefiles() {
     int[] linesExecution1 = createLinesExecution1();
     int[] linesExecution2 = createLinesExecution2();
-    SourceFileCoverage sourceFileCoverage1 = createSourceFile1(linesExecution1);
+    SourceFileCoverage sourceFileCoverage1 = createSourceFile1(linesExecution1, createBranchExecution1());
     SourceFileCoverage sourceFileCoverage2 = createSourceFile2(linesExecution2);
 
     coverage.add(sourceFileCoverage1);
@@ -69,9 +70,9 @@ public class CoverageTest {
 
   @Test
   public void testTwoTracefiles() {
-    SourceFileCoverage sourceFileCoverage1 = createSourceFile1(createLinesExecution1());
+    SourceFileCoverage sourceFileCoverage1 = createSourceFile1(createLinesExecution1(), createBranchExecution1());
     SourceFileCoverage sourceFileCoverage2 =
-        createSourceFile1("SOME_OTHER_FILENAME", createLinesExecution1());
+        createSourceFile1("SOME_OTHER_FILENAME", createLinesExecution1(), createBranchExecution1());
 
     coverage.add(sourceFileCoverage1);
     coverage.add(sourceFileCoverage2);

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovMergerTestUtils.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovMergerTestUtils.java
@@ -415,7 +415,7 @@ public class LcovMergerTestUtils {
       lines.add("FNF:0");
       lines.add("FNH:0");
       for (int srcLineNum = 1; srcLineNum <= numLinesPerSourceFile; srcLineNum += 4) {
-        lines.add(String.format("BA:%s,2", srcLineNum));
+        lines.add(String.format("BRDA:%s,0,0,2", srcLineNum));
       }
       lines.add("BRF:" + numLinesPerSourceFile / 4);
       lines.add("BRH:" + numLinesPerSourceFile / 4);

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovPrinterTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovPrinterTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.TRACEFILE1;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.TRACEFILE1_DIFFERENT_NAME;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createLinesExecution1;
+import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createBranchExecution1;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createSourceFile1;
 
 import com.google.common.base.Splitter;
@@ -41,10 +42,10 @@ public class LcovPrinterTest {
 
   @Before
   public void init() {
-    sourceFileCoverage1 = createSourceFile1(createLinesExecution1());
+    sourceFileCoverage1 = createSourceFile1(createLinesExecution1(), createBranchExecution1());
     sourceFileCoverage2 =
         LcovMergerTestUtils.createSourceFile1(
-            TRACEFILE1_DIFFERENT_NAME.get(0).substring(3), createLinesExecution1());
+            TRACEFILE1_DIFFERENT_NAME.get(0).substring(3), createLinesExecution1(), createBranchExecution1());
     byteOutputStream = new ByteArrayOutputStream();
     coverage = new Coverage();
   }

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/SourceFileCoverageTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/SourceFileCoverageTest.java
@@ -21,6 +21,7 @@ import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.as
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.assertTracefile1;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createLinesExecution1;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createLinesExecution2;
+import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createBranchExecution1;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createSourceFile1;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createSourceFile2;
 
@@ -35,6 +36,7 @@ public class SourceFileCoverageTest {
 
   private int[] linesExecution1;
   private int[] linesExecution2;
+  private int[] branchExecution1;
   private SourceFileCoverage sourceFile1;
   private SourceFileCoverage sourceFile2;
 
@@ -42,8 +44,9 @@ public class SourceFileCoverageTest {
   public void initializeExecutionCountTracefiles() {
     linesExecution1 = createLinesExecution1();
     linesExecution2 = createLinesExecution2();
+    branchExecution1 = createBranchExecution1();
 
-    sourceFile1 = createSourceFile1(linesExecution1);
+    sourceFile1 = createSourceFile1(linesExecution1, branchExecution1);
     sourceFile2 = createSourceFile2(linesExecution2);
   }
 


### PR DESCRIPTION
When using bazel to generate C++ branch coverage `BA` entries are created instead of `BRDA` lines. As far as these `BA` lines could not be used by `genhtml`, I changed it be processed as `BRDA`. Doing so the program throws an exception because of the wrong condition, trying to convert a '-' to a number. Inverted this condition to have the correct behavior of '-' which means `wasExecuted = false` and `executionCount = 0`.