### PR TITLE
remove `--nobuild` from build performance example

### DIFF
--- a/site/docs/skylark/performance.md
+++ b/site/docs/skylark/performance.md
@@ -206,7 +206,7 @@ This profiling method consists of two steps, first you have to execute your
 build/test with the `--profile` flag, for example
 
 ```
-$ bazel build --nobuild --profile=/tmp/prof //path/to:target
+$ bazel build --profile=/tmp/prof //path/to:target
 ```
 
 The file generated (in this case `/tmp/prof`) is a binary file, which can be


### PR DESCRIPTION
It's a bit contradictory to not run the build when analyzing the performance of the build, and I found it a bit confusing at first because running
```
$ bazel build --nobuild --profile=/tmp/prof //source/exe:envoy-static`
```
basically just starts Bazel, resolves the target, and exits Bazel, as reflected in the performance analysis:
```
=== PHASE SUMMARY INFORMATION ===

Total launch phase time         0.057 s    0.55%
Total init phase time           0.060 s    0.58%
Total loading phase time        0.131 s    1.26%
Total analysis phase time      10.183 s   97.61%
Total finish phase time         0.000 s    0.01%
------------------------------------------------
Total run time                 10.433 s  100.00%

Critical path (0.00 ms):
```

There isn't even an execution phase like the example has