### PR TITLE
Fix example for label-typed build settings.

### DIFF
--- a/site/docs/skylark/config.md
+++ b/site/docs/skylark/config.md
@@ -273,7 +273,7 @@ the [`configuration_field`](lib/globals.html#configuration_field)
 
 ```python
 # example/rules.bzl
-MyProvider = provider(field = ["my_field"])
+MyProvider = provider(fields = ["my_field"])
 
 def _dep_impl(ctx):
     return MyProvider(my_field = "yeehaw")
@@ -283,7 +283,7 @@ dep_rule = rule(
 )
 
 def _parent_impl(ctx):
-    if ctx.attr.my_field_provider[MyProvider] == "cowabunga":
+    if ctx.attr.my_field_provider[MyProvider].my_field == "cowabunga":
         ...
 
 parent_rule = rule(


### PR DESCRIPTION
- provider function has plural field**s** param, not singular `field`: https://docs.bazel.build/versions/master/skylark/lib/globals.html#provider
- comparison in example should use actual field within provider, instead of comparing struct (which `[MyProvider]` returns) with a string