### PR TITLE
First check-in of configuration overhead measurement tool

### DIFF
--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -29,6 +29,7 @@ py_library(
         "//third_party/def_parser:__pkg__",
         "//tools/android:__pkg__",
         "//tools/build_rules:__pkg__",
+        "//tools/ctexplain:__pkg__",
         "//tools/python:__pkg__",
     ],
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -15,6 +15,7 @@ filegroup(
         "//tools/build_rules:srcs",
         "//tools/config:srcs",
         "//tools/coverage:srcs",
+        "//tools/ctexplain:srcs",
         "//tools/distributions:srcs",
         "//tools/java:srcs",
         "//tools/jdk:srcs",

--- a/tools/ctexplain/BUILD
+++ b/tools/ctexplain/BUILD
@@ -29,3 +29,10 @@ py_library(
     ],
     srcs_version = "PY3ONLY",
 )
+
+py_test(
+    name = "types_test",
+    size = "small",
+    srcs = ["types_test.py"],
+    deps = [":base"]
+)

--- a/tools/ctexplain/BUILD
+++ b/tools/ctexplain/BUILD
@@ -1,8 +1,8 @@
 py_binary(
     name = "ctexplain",
     srcs = ["ctexplain.py"],
-    deps = [":bazel_api"],
     python_version = "PY3",
+    deps = [":bazel_api"],
 )
 
 py_library(
@@ -17,8 +17,8 @@ py_test(
     size = "small",
     srcs = ["bazel_api_test.py"],
     deps = [
-        "//src/test/py/bazel:test_base",
         ":bazel_api",
+        "//src/test/py/bazel:test_base",
     ],
 )
 

--- a/tools/ctexplain/BUILD
+++ b/tools/ctexplain/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//visibility:public"])
+
 py_binary(
     name = "ctexplain",
     srcs = ["ctexplain.py"],
@@ -35,4 +37,9 @@ py_test(
     size = "small",
     srcs = ["types_test.py"],
     deps = [":base"]
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["*"]),
 )

--- a/tools/ctexplain/BUILD
+++ b/tools/ctexplain/BUILD
@@ -1,0 +1,31 @@
+py_binary(
+    name = "ctexplain",
+    srcs = ["ctexplain.py"],
+    deps = [":bazel_api"],
+    python_version = "PY3",
+)
+
+py_library(
+    name = "bazel_api",
+    srcs = ["bazel_api.py"],
+    srcs_version = "PY3ONLY",
+    deps = [":base"],
+)
+
+py_test(
+    name = "bazel_api_test",
+    size = "small",
+    srcs = ["bazel_api_test.py"],
+    deps = [
+        "//src/test/py/bazel:test_base",
+        ":bazel_api",
+    ],
+)
+
+py_library(
+    name = "base",
+    srcs = [
+        "types.py",
+    ],
+    srcs_version = "PY3ONLY",
+)

--- a/tools/ctexplain/BUILD
+++ b/tools/ctexplain/BUILD
@@ -1,4 +1,10 @@
+# Description:
+#   Tool for measuring how configuration transitions affect build graph size.
+load("//tools/python:private/defs.bzl", "py_binary", "py_library")
+
 package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
 
 py_binary(
     name = "ctexplain",
@@ -18,6 +24,7 @@ py_test(
     name = "bazel_api_test",
     size = "small",
     srcs = ["bazel_api_test.py"],
+    python_version = "PY3",
     deps = [
         ":bazel_api",
         "//src/test/py/bazel:test_base",
@@ -30,13 +37,21 @@ py_library(
         "types.py",
     ],
     srcs_version = "PY3ONLY",
+    deps = [
+        "//third_party/py/dataclasses",  # Backport for Python < 3.7.
+        "//third_party/py/frozendict",
+    ],
 )
 
 py_test(
     name = "types_test",
     size = "small",
     srcs = ["types_test.py"],
-    deps = [":base"]
+    python_version = "PY3",
+    deps = [
+        ":base",
+        "//third_party/py/frozendict",
+    ],
 )
 
 filegroup(

--- a/tools/ctexplain/bazel_api.py
+++ b/tools/ctexplain/bazel_api.py
@@ -22,13 +22,15 @@ import subprocess
 from typing import Callable
 from typing import List
 from typing import Tuple
+# Do not edit this line. Copybara replaces it with PY2 migration helper.
+from frozendict import frozendict
 from tools.ctexplain.types import Configuration
 from tools.ctexplain.types import ConfiguredTarget
 from tools.ctexplain.types import HostConfiguration
 from tools.ctexplain.types import NullConfiguration
 
 
-def run_bazel_in_client(args: List[str]) -> Tuple[int, str, str]:
+def run_bazel_in_client(args: List[str]) -> Tuple[int, List[str], List[str]]:
   """Calls bazel within the current workspace.
 
   For production use. Tests use an alternative invoker that goes through test
@@ -46,22 +48,21 @@ def run_bazel_in_client(args: List[str]) -> Tuple[int, str, str]:
       stdout=subprocess.PIPE,
       stderr=subprocess.PIPE,
       check=True)
-  return (
-      result.returncode,
-      result.stdout.decode("utf-8").split(os.linesep),
-      result.stderr
-  )
+  return (result.returncode, result.stdout.decode("utf-8").split(os.linesep),
+          result.stderr)
 
 
 class BazelApi():
   """API that accepts injectable Bazel invocation logic."""
 
-  def __init__(self, run_bazel: Callable[
-      List[str], Tuple[int, str, str]] = run_bazel_in_client):
+  def __init__(self,
+               run_bazel: Callable[[List[str]],
+                                   Tuple[int, List[str],
+                                         List[str]]] = run_bazel_in_client):
     self.run_bazel = run_bazel
 
-  def cquery(self, args: List[str]) -> Tuple[
-      bool, str, Tuple[ConfiguredTarget, ...]]:
+  def cquery(self,
+             args: List[str]) -> Tuple[bool, str, Tuple[ConfiguredTarget, ...]]:
     """Calls cquery with the given arguments.
 
     Args:
@@ -111,10 +112,10 @@ class BazelApi():
     fragments = [
         fragment["name"].split(".")[-1] for fragment in config_json["fragments"]
     ]
-    options = {
-        entry["name"].split(".")[-1]: entry["options"]
+    options = frozendict({
+        entry["name"].split(".")[-1]: frozendict(entry["options"])
         for entry in config_json["fragmentOptions"]
-    }
+    })
     return Configuration(fragments, options)
 
 

--- a/tools/ctexplain/bazel_api.py
+++ b/tools/ctexplain/bazel_api.py
@@ -1,0 +1,137 @@
+# Lint as: python3
+"""API for Bazel calls for config, cquery, and required fragment info.
+
+There's no Python Bazel API so we invoke Bazel as a subprocess.
+"""
+import json
+import os
+import re
+import subprocess
+from tools.ctexplain.types import Configuration
+from tools.ctexplain.types import ConfiguredTarget
+from tools.ctexplain.types import HostConfiguration
+from tools.ctexplain.types import NullConfiguration
+from typing import Tuple
+
+def run_bazel_in_client(args):
+    """Calls bazel within the current workspace. For production use.
+
+    Tests use an alternative invoker that goes through test infrastructure.
+    """
+    result = subprocess.run(
+        ["bazel"] + args,
+        cwd=os.getcwd(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+    return [
+        result.returncode,
+        result.stdout.decode("utf-8").split(os.linesep),
+        result.stderr]
+      
+class BazelApi():
+  def __init__(self, run_bazel = run_bazel_in_client):
+    self.run_bazel = run_bazel
+
+  def cquery(self, args):
+      """Calls cquery with the given arguments.
+
+      Args:
+        args: A list of cquery command-line arguments, one argument per entry.
+
+      Returns:
+        (success: bool, stderr: str, cts: Tuple[ConfiguredTarget]), where
+        success is True iff the query succeeded, stderr contains the query's
+        stderr (regardless of success value), and cts is the configured targets
+        found by the query if successful, empty otherwise.
+      """
+      base_args = ["cquery", "--show_config_fragments=transitive"]
+      (returncode, stdout, stderr) = self.run_bazel(base_args + args)
+      if returncode is not 0:
+          return (False, stderr, ())
+      
+      cts = set()
+      for line in stdout:
+        ctinfo = _parse_cquery_result_line(line)
+        if ctinfo is not None:
+            cts.add(ctinfo)
+             
+      return (True, stderr, tuple(cts))
+
+  def get_config(self, config_hash):
+    """Calls "bazel config" with the given config hash.
+
+    Args:
+      config_hash: A config hash as reported by "bazel cquery".
+
+    Returns:
+      A types.Configuration with the matching configuration or None if no match
+      is found.
+
+    Raises:
+      ValueError on any parsing problems.
+    """
+    if config_hash == "HOST":
+      return HostConfiguration()
+    elif config_hash == "null":
+      return NullConfiguration()
+
+    base_args = ["config", "--output=json"]
+    (returncode, stdout, stderr) = self.run_bazel(base_args + [config_hash])
+    if returncode != 0:
+        raise ValueError("Could not get config: " + stderr)
+    config_json = json.loads(os.linesep.join(stdout))
+    fragments = [
+        fragment["name"].split(".")[-1]
+        for fragment in config_json["fragments"]
+    ]
+    options = {
+        entry["name"].split(".")[-1]: entry["options"]
+        for entry in config_json["fragmentOptions"]
+    }
+    return Configuration(fragments, options)
+  
+
+##############################################
+# Regex patterns for matching cquery results:
+
+# Label: "//" followed by one or more non-space characters.
+_label_pattern = "(\/\/[\S]+)"  # pylint: disable=anomalous-backslash-in-string
+# Config hash: one or more non-")" characters surrounded by "()".
+_config_pattern = "\(([^\)]+)\)"  # pylint: disable=anomalous-backslash-in-string
+# Required fragments: zero or more non-"]" characters surrounded by "[]".
+_fragments_pattern = "\[([^\]]*)\]"  # pylint: disable=anomalous-backslash-in-string
+
+# The required fragments pattern is optional. Null-configured targets don't list
+# required fragments.
+_cquery_line_matcher = re.compile(
+    f"{_label_pattern} {_config_pattern}( {_fragments_pattern})?")
+
+##############################################
+
+# TODO(gregce): have cquery --output=jsonproto support --show_config_fragments
+# so we can replace all this regex parsing with JSON reads.
+def _parse_cquery_result_line(line):
+  """Converts a cquery output line to a ConfiguredTargetInfo.
+
+  Expected input is:
+
+      "<label> (<config hash>) [configFragment1, configFragment2, ...]"
+
+  or:
+      "<label> (null)"
+
+  Args:
+    line: The expected input.
+
+  Returns:
+    Corresponding ConfiguredTarget if the line matches else None.
+  """
+  match = _cquery_line_matcher.match(line)
+  if not match:
+    return None
+  transitive_fragments = match.group(4).split(", ") if match.group(4) else []
+  return ConfiguredTarget(
+      label=match.group(1),
+      config=None, # Not yet available: we'll need `bazel config` to get this.
+      config_hash=match.group(2),
+      transitive_fragments=tuple(transitive_fragments))

--- a/tools/ctexplain/bazel_api.py
+++ b/tools/ctexplain/bazel_api.py
@@ -1,4 +1,18 @@
 # Lint as: python3
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """API for Bazel calls for config, cquery, and required fragment info.
 
 There's no Python Bazel API so we invoke Bazel as a subprocess.

--- a/tools/ctexplain/bazel_api.py
+++ b/tools/ctexplain/bazel_api.py
@@ -44,10 +44,11 @@ def run_bazel_in_client(args):
       stdout=subprocess.PIPE,
       stderr=subprocess.PIPE,
       check=True)
-  return [
+  return (
       result.returncode,
-      result.stdout.decode("utf-8").split(os.linesep), result.stderr
-  ]
+      result.stdout.decode("utf-8").split(os.linesep),
+      result.stderr
+  )
 
 
 class BazelApi():

--- a/tools/ctexplain/bazel_api.py
+++ b/tools/ctexplain/bazel_api.py
@@ -56,10 +56,11 @@ def run_bazel_in_client(args: List[str]) -> Tuple[int, str, str]:
 class BazelApi():
   """API that accepts injectable Bazel invocation logic."""
 
-  def __init__(self, run_bazel: Callable[List[str]]=run_bazel_in_client):
+  def __init__(self, run_bazel: Callable[List[str]] = run_bazel_in_client):
     self.run_bazel = run_bazel
 
-  def cquery(self, args: List[str]) -> Tuple[bool, str, Tuple[ConfiguredTarget]]:
+  def cquery(self, args: List[str]) -> Tuple[
+      bool, str, Tuple[ConfiguredTarget]]:
     """Calls cquery with the given arguments.
 
     Args:
@@ -115,6 +116,7 @@ class BazelApi():
     }
     return Configuration(fragments, options)
 
+
 # TODO(gregce): have cquery --output=jsonproto support --show_config_fragments
 # so we can replace all this regex parsing with JSON reads.
 def _parse_cquery_result_line(line: str) -> ConfiguredTarget:
@@ -135,18 +137,18 @@ def _parse_cquery_result_line(line: str) -> ConfiguredTarget:
   """
   tokens = line.split()
   label = tokens[0]
-  if tokens[1][0] != '(' or tokens[1][-1] != ')':
+  if tokens[1][0] != "(" or tokens[1][-1] != ")":
     raise ValueError(f"{tokens[1]} in {line} not surrounded by parentheses")
   config_hash = tokens[1][1:-1]
-  if config_hash == 'null':
+  if config_hash == "null":
     fragments = ()
   else:
-    if tokens[2][0] != '[' or tokens[-1][-1] != ']':
+    if tokens[2][0] != "[" or tokens[-1][-1] != "]":
       raise ValueError(f"{tokens[2:]} in {line} not surrounded by [] brackets")
     # The fragments list looks like '[Fragment1, Fragment2, ...]'. Split the
     # whole line on ' [' to get just this list, then remove the final ']', then
     # split again on ', ' to convert it to a structured tuple.
-    fragments = tuple(line.split(' [')[1][0:-1].split(', '))
+    fragments = tuple(line.split(" [")[1][0:-1].split(", "))
   return ConfiguredTarget(
       label=label,
       config=None,  # Not yet available: we'll need `bazel config` to get this.

--- a/tools/ctexplain/bazel_api.py
+++ b/tools/ctexplain/bazel_api.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """API for Bazel calls for config, cquery, and required fragment info.
 
 There's no Python Bazel API so we invoke Bazel as a subprocess.
@@ -25,51 +24,62 @@ from tools.ctexplain.types import Configuration
 from tools.ctexplain.types import ConfiguredTarget
 from tools.ctexplain.types import HostConfiguration
 from tools.ctexplain.types import NullConfiguration
-from typing import Tuple
+
 
 def run_bazel_in_client(args):
-    """Calls bazel within the current workspace. For production use.
+  """Calls bazel within the current workspace.
 
-    Tests use an alternative invoker that goes through test infrastructure.
-    """
-    result = subprocess.run(
-        ["bazel"] + args,
-        cwd=os.getcwd(),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE)
-    return [
-        result.returncode,
-        result.stdout.decode("utf-8").split(os.linesep),
-        result.stderr]
-      
+  For production use. Tests use an alternative invoker that goes through test
+  infrastructure.
+
+  Args:
+    args: the arguments to call Bazel with
+
+  Returns:
+    Tuple of (return code, stdout, stderr)
+  """
+  result = subprocess.run(
+      ["bazel"] + args,
+      cwd=os.getcwd(),
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE,
+      check=True)
+  return [
+      result.returncode,
+      result.stdout.decode("utf-8").split(os.linesep), result.stderr
+  ]
+
+
 class BazelApi():
-  def __init__(self, run_bazel = run_bazel_in_client):
+  """API that accepts injectable Bazel invocation logic."""
+
+  def __init__(self, run_bazel=run_bazel_in_client):
     self.run_bazel = run_bazel
 
   def cquery(self, args):
-      """Calls cquery with the given arguments.
+    """Calls cquery with the given arguments.
 
-      Args:
-        args: A list of cquery command-line arguments, one argument per entry.
+    Args:
+      args: A list of cquery command-line arguments, one argument per entry.
 
-      Returns:
-        (success: bool, stderr: str, cts: Tuple[ConfiguredTarget]), where
-        success is True iff the query succeeded, stderr contains the query's
-        stderr (regardless of success value), and cts is the configured targets
-        found by the query if successful, empty otherwise.
-      """
-      base_args = ["cquery", "--show_config_fragments=transitive"]
-      (returncode, stdout, stderr) = self.run_bazel(base_args + args)
-      if returncode is not 0:
-          return (False, stderr, ())
-      
-      cts = set()
-      for line in stdout:
-        ctinfo = _parse_cquery_result_line(line)
-        if ctinfo is not None:
-            cts.add(ctinfo)
-             
-      return (True, stderr, tuple(cts))
+    Returns:
+      (success: bool, stderr: str, cts: Tuple[ConfiguredTarget]), where
+      success is True iff the query succeeded, stderr contains the query's
+      stderr (regardless of success value), and cts is the configured targets
+      found by the query if successful, empty otherwise.
+    """
+    base_args = ["cquery", "--show_config_fragments=transitive"]
+    (returncode, stdout, stderr) = self.run_bazel(base_args + args)
+    if returncode != 0:
+      return (False, stderr, ())
+
+    cts = set()
+    for line in stdout:
+      ctinfo = _parse_cquery_result_line(line)
+      if ctinfo is not None:
+        cts.add(ctinfo)
+
+    return (True, stderr, tuple(cts))
 
   def get_config(self, config_hash):
     """Calls "bazel config" with the given config hash.
@@ -92,18 +102,17 @@ class BazelApi():
     base_args = ["config", "--output=json"]
     (returncode, stdout, stderr) = self.run_bazel(base_args + [config_hash])
     if returncode != 0:
-        raise ValueError("Could not get config: " + stderr)
+      raise ValueError("Could not get config: " + stderr)
     config_json = json.loads(os.linesep.join(stdout))
     fragments = [
-        fragment["name"].split(".")[-1]
-        for fragment in config_json["fragments"]
+        fragment["name"].split(".")[-1] for fragment in config_json["fragments"]
     ]
     options = {
         entry["name"].split(".")[-1]: entry["options"]
         for entry in config_json["fragmentOptions"]
     }
     return Configuration(fragments, options)
-  
+
 
 ##############################################
 # Regex patterns for matching cquery results:
@@ -121,6 +130,7 @@ _cquery_line_matcher = re.compile(
     f"{_label_pattern} {_config_pattern}( {_fragments_pattern})?")
 
 ##############################################
+
 
 # TODO(gregce): have cquery --output=jsonproto support --show_config_fragments
 # so we can replace all this regex parsing with JSON reads.
@@ -146,6 +156,6 @@ def _parse_cquery_result_line(line):
   transitive_fragments = match.group(4).split(", ") if match.group(4) else []
   return ConfiguredTarget(
       label=match.group(1),
-      config=None, # Not yet available: we'll need `bazel config` to get this.
+      config=None,  # Not yet available: we'll need `bazel config` to get this.
       config_hash=match.group(2),
       transitive_fragments=tuple(transitive_fragments))

--- a/tools/ctexplain/bazel_api_test.py
+++ b/tools/ctexplain/bazel_api_test.py
@@ -1,3 +1,19 @@
+# Lint as: python3
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for bazel_api.py."""
 import os
 import unittest
 from src.test.py.bazel import test_base
@@ -5,7 +21,6 @@ from tools.ctexplain.bazel_api import BazelApi
 from tools.ctexplain.types import HostConfiguration
 from tools.ctexplain.types import NullConfiguration
 
-# Tests for bazel_api.py.
 class BazelApiTest(test_base.TestBase):
 
     _bazel_api: BazelApi = None

--- a/tools/ctexplain/bazel_api_test.py
+++ b/tools/ctexplain/bazel_api_test.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+from src.test.py.bazel import test_base
+from tools.ctexplain.bazel_api import BazelApi
+
+# Tests for bazel_api.py.
+class BazelApiTest(test_base.TestBase):
+
+    _bazel_api: BazelApi = None
+    
+    def setUp(self):
+        test_base.TestBase.setUp(self)
+        self._bazel_api = BazelApi(lambda args: self.RunBazel(args))
+        self.ScratchFile('WORKSPACE')
+        self.CreateWorkspaceWithDefaultRepos('repo/WORKSPACE')
+
+    def tearDown(self):
+        test_base.TestBase.tearDown(self)
+
+    def testBasicCquery(self):
+        self.ScratchFile('testapp/BUILD', [
+            'filegroup(name = "fg", srcs = ["a.file"])',
+        ])
+        (success, stderr, cts)  = self._bazel_api.cquery(["//testapp:all"])
+        self.assertTrue(success)
+        self.assertEqual(len(cts), 1)
+        self.assertEqual(cts[0].label, "//testapp:fg")
+        self.assertIsNone(cts[0].config)
+        self.assertTrue(len(cts[0].config_hash) > 10)
+        self.assertIn("PlatformConfiguration", cts[0].transitive_fragments)
+
+    def testFailedCquery(self):
+        self.ScratchFile('testapp/BUILD', [
+            'filegroup(name = "fg", srcs = ["a.file"])',
+        ])
+        (success, stderr, cts)  = self._bazel_api.cquery(["//testapp:typo"])
+        self.assertFalse(success)
+        self.assertEqual(len(cts), 0)
+        self.assertIn(
+            "target 'typo' not declared in package 'testapp'",
+            os.linesep.join(stderr))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ctexplain/bazel_api_test.py
+++ b/tools/ctexplain/bazel_api_test.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for bazel_api.py."""
 import os
 import unittest
@@ -21,125 +20,127 @@ from tools.ctexplain.bazel_api import BazelApi
 from tools.ctexplain.types import HostConfiguration
 from tools.ctexplain.types import NullConfiguration
 
+
 class BazelApiTest(test_base.TestBase):
 
-    _bazel_api: BazelApi = None
-    
-    def setUp(self):
-        test_base.TestBase.setUp(self)
-        self._bazel_api = BazelApi(lambda args: self.RunBazel(args))
-        self.ScratchFile('WORKSPACE')
-        self.CreateWorkspaceWithDefaultRepos('repo/WORKSPACE')
+  _bazel_api: BazelApi = None
 
-    def tearDown(self):
-        test_base.TestBase.tearDown(self)
+  def setUp(self):
+    test_base.TestBase.setUp(self)
+    self._bazel_api = BazelApi(self.RunBazel)
+    self.ScratchFile('WORKSPACE')
+    self.CreateWorkspaceWithDefaultRepos('repo/WORKSPACE')
 
-    def testBasicCquery(self):
-        self.ScratchFile('testapp/BUILD', [
-            'filegroup(name = "fg", srcs = ["a.file"])',
-        ])
-        (success, stderr, cts)  = self._bazel_api.cquery(["//testapp:all"])
-        self.assertTrue(success)
-        self.assertEqual(len(cts), 1)
-        self.assertEqual(cts[0].label, "//testapp:fg")
-        self.assertIsNone(cts[0].config)
-        self.assertTrue(len(cts[0].config_hash) > 10)
-        self.assertIn("PlatformConfiguration", cts[0].transitive_fragments)
+  def tearDown(self):
+    test_base.TestBase.tearDown(self)
 
-    def testFailedCquery(self):
-        self.ScratchFile('testapp/BUILD', [
-            'filegroup(name = "fg", srcs = ["a.file"])',
-        ])
-        (success, stderr, cts)  = self._bazel_api.cquery(["//testapp:typo"])
-        self.assertFalse(success)
-        self.assertEqual(len(cts), 0)
-        self.assertIn(
-            "target 'typo' not declared in package 'testapp'",
-            os.linesep.join(stderr))
+  def testBasicCquery(self):
+    self.ScratchFile('testapp/BUILD', [
+        'filegroup(name = "fg", srcs = ["a.file"])',
+    ])
+    res = self._bazel_api.cquery(['//testapp:all'])
+    success = res[0]
+    cts = res[2]
+    self.assertTrue(success)
+    self.assertEqual(len(cts), 1)
+    self.assertEqual(cts[0].label, '//testapp:fg')
+    self.assertIsNone(cts[0].config)
+    self.assertGreater(len(cts[0].config_hash), 10)
+    self.assertIn('PlatformConfiguration', cts[0].transitive_fragments)
 
-    def testTransitiveFragmentsAccuracy(self):
-        self.ScratchFile('testapp/BUILD', [
-            'filegroup(name = "fg", srcs = ["a.file"])',
-            'filegroup(name = "ccfg", srcs = [":ccbin"])',
-            'cc_binary(name = "ccbin", srcs = ["ccbin.cc"])'
-        ])
-        (success1, stderr1, cts1)  = self._bazel_api.cquery(["//testapp:fg"])
-        self.assertNotIn("CppConfiguration", cts1[0].transitive_fragments)
-        (success2, stderr2, cts2)  = self._bazel_api.cquery(["//testapp:ccfg"])
-        self.assertIn("CppConfiguration", cts2[0].transitive_fragments)
-        
-    def testGetTargetConfig(self):
-        self.ScratchFile('testapp/BUILD', [
-            'filegroup(name = "fg", srcs = ["a.file"])',
-        ])
-        (success, stderr, cts)  = self._bazel_api.cquery(["//testapp:fg"])
-        config = self._bazel_api.get_config(cts[0].config_hash)
-        expected_fragments = ["PlatformConfiguration", "JavaConfiguration"]
-        [self.assertIn(exp, config.fragments) for exp in expected_fragments]
-        core_options = config.options["CoreOptions"]
-        self.assertIsNotNone(core_options)
-        self.assertIn(("stamp", "false"), core_options.items())
-        
-    def testGetHostConfig(self):
-        self.ScratchFile('testapp/BUILD', [
-            'genrule(',
-            '    name = "g",',
-            '    srcs = [],',
-            '    cmd = "",',
-            '    outs = ["g.out"],',
-            '    tools = [":fg"])',
-            'filegroup(name = "fg", srcs = ["a.file"])',
-        ])
-        query = ["//testapp:fg", "--universe_scope=//testapp:g"]
-        (success, stderr, cts)  = self._bazel_api.cquery(query)
-        config = self._bazel_api.get_config(cts[0].config_hash)
-        self.assertTrue(isinstance(config, HostConfiguration))
-        # We don't currently populate or read a host configuration's details.
-        self.assertEqual(len(config.fragments), 0)
-        self.assertEqual(len(config.options), 0)
+  def testFailedCquery(self):
+    self.ScratchFile('testapp/BUILD', [
+        'filegroup(name = "fg", srcs = ["a.file"])',
+    ])
+    (success, stderr, cts) = self._bazel_api.cquery(['//testapp:typo'])
+    self.assertFalse(success)
+    self.assertEqual(len(cts), 0)
+    self.assertIn("target 'typo' not declared in package 'testapp'",
+                  os.linesep.join(stderr))
 
-    def testGetNullConfig(self):
-        self.ScratchFile('testapp/BUILD', [
-            'filegroup(name = "fg", srcs = ["a.file"])',
-        ])
-        (success, stderr, cts)  = self._bazel_api.cquery(["//testapp:a.file"])
-        config = self._bazel_api.get_config(cts[0].config_hash)
-        self.assertTrue(isinstance(config, NullConfiguration))
-        # Null configurations have no information by definition.
-        self.assertEqual(len(config.fragments), 0)
-        self.assertEqual(len(config.options), 0)
+  def testTransitiveFragmentsAccuracy(self):
+    self.ScratchFile('testapp/BUILD', [
+        'filegroup(name = "fg", srcs = ["a.file"])',
+        'filegroup(name = "ccfg", srcs = [":ccbin"])',
+        'cc_binary(name = "ccbin", srcs = ["ccbin.cc"])'
+    ])
+    cts1 = self._bazel_api.cquery(['//testapp:fg'])[2]
+    self.assertNotIn('CppConfiguration', cts1[0].transitive_fragments)
+    cts2 = self._bazel_api.cquery(['//testapp:ccfg'])[2]
+    self.assertIn('CppConfiguration', cts2[0].transitive_fragments)
 
-    def testConfigWithDefines(self):
-        self.ScratchFile('testapp/BUILD', [
-            'filegroup(name = "fg", srcs = ["a.file"])',
-        ])
-        cquery_args = ["//testapp:fg", "--define", "a=b"]
-        (success, stderr, cts)  = self._bazel_api.cquery(cquery_args)
-        config = self._bazel_api.get_config(cts[0].config_hash)
-        user_defined_options = config.options["user-defined"]
-        self.assertIsNotNone(user_defined_options)
-        self.assertDictEqual(user_defined_options, {'--define:a': 'b'})
+  def testGetTargetConfig(self):
+    self.ScratchFile('testapp/BUILD', [
+        'filegroup(name = "fg", srcs = ["a.file"])',
+    ])
+    cts = self._bazel_api.cquery(['//testapp:fg'])[2]
+    config = self._bazel_api.get_config(cts[0].config_hash)
+    expected_fragments = ['PlatformConfiguration', 'JavaConfiguration']
+    for exp in expected_fragments:
+      self.assertIn(exp, config.fragments)
+    core_options = config.options['CoreOptions']
+    self.assertIsNotNone(core_options)
+    self.assertIn(('stamp', 'false'), core_options.items())
 
-    def testConfigWithStarlarkFlags(self):
-        self.ScratchFile('testapp/defs.bzl', [
-            'def _flag_impl(settings, attr):',
-            '  pass',
-            'string_flag = rule(',
-            '  implementation = _flag_impl,',
-            '  build_setting = config.string(flag = True)'
-            ')'
-        ])
-        self.ScratchFile('testapp/BUILD', [
-            'load(":defs.bzl", "string_flag")',
-            'string_flag(name = "my_flag", build_setting_default = "nada")',
-            'filegroup(name = "fg", srcs = ["a.file"])',
-        ])
-        cquery_args = ["//testapp:fg", "--//testapp:my_flag", "algo"]
-        (success, stderr, cts)  = self._bazel_api.cquery(cquery_args)
-        config = self._bazel_api.get_config(cts[0].config_hash)
-        user_defined_options = config.options["user-defined"]
-        self.assertIsNotNone(user_defined_options)
-        self.assertDictEqual(user_defined_options, {'//testapp:my_flag': 'algo'})
+  def testGetHostConfig(self):
+    self.ScratchFile('testapp/BUILD', [
+        'genrule(',
+        '    name = "g",',
+        '    srcs = [],',
+        '    cmd = "",',
+        '    outs = ["g.out"],',
+        '    tools = [":fg"])',
+        'filegroup(name = "fg", srcs = ["a.file"])',
+    ])
+    query = ['//testapp:fg', '--universe_scope=//testapp:g']
+    cts = self._bazel_api.cquery(query)[2]
+    config = self._bazel_api.get_config(cts[0].config_hash)
+    self.assertIsInstance(config, HostConfiguration)
+    # We don't currently populate or read a host configuration's details.
+    self.assertEqual(len(config.fragments), 0)
+    self.assertEqual(len(config.options), 0)
 
-if __name__ == "__main__":
-    unittest.main()
+  def testGetNullConfig(self):
+    self.ScratchFile('testapp/BUILD', [
+        'filegroup(name = "fg", srcs = ["a.file"])',
+    ])
+    cts = self._bazel_api.cquery(['//testapp:a.file'])[2]
+    config = self._bazel_api.get_config(cts[0].config_hash)
+    self.assertIsInstance(config, NullConfiguration)
+    # Null configurations have no information by definition.
+    self.assertEqual(len(config.fragments), 0)
+    self.assertEqual(len(config.options), 0)
+
+  def testConfigWithDefines(self):
+    self.ScratchFile('testapp/BUILD', [
+        'filegroup(name = "fg", srcs = ["a.file"])',
+    ])
+    cquery_args = ['//testapp:fg', '--define', 'a=b']
+    cts = self._bazel_api.cquery(cquery_args)[2]
+    config = self._bazel_api.get_config(cts[0].config_hash)
+    user_defined_options = config.options['user-defined']
+    self.assertIsNotNone(user_defined_options)
+    self.assertDictEqual(user_defined_options, {'--define:a': 'b'})
+
+  def testConfigWithStarlarkFlags(self):
+    self.ScratchFile('testapp/defs.bzl', [
+        'def _flag_impl(settings, attr):', '  pass', 'string_flag = rule(',
+        '  implementation = _flag_impl,',
+        '  build_setting = config.string(flag = True)'
+        ')'
+    ])
+    self.ScratchFile('testapp/BUILD', [
+        'load(":defs.bzl", "string_flag")',
+        'string_flag(name = "my_flag", build_setting_default = "nada")',
+        'filegroup(name = "fg", srcs = ["a.file"])',
+    ])
+    cquery_args = ['//testapp:fg', '--//testapp:my_flag', 'algo']
+    cts = self._bazel_api.cquery(cquery_args)[2]
+    config = self._bazel_api.get_config(cts[0].config_hash)
+    user_defined_options = config.options['user-defined']
+    self.assertIsNotNone(user_defined_options)
+    self.assertDictEqual(user_defined_options, {'//testapp:my_flag': 'algo'})
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tools/ctexplain/bazel_api_test.py
+++ b/tools/ctexplain/bazel_api_test.py
@@ -43,7 +43,15 @@ class BazelApiTest(test_base.TestBase):
             os.linesep.join(stderr))
 
     def testTransitiveFragmentsAccuracy(self):
-        pass
+        self.ScratchFile('testapp/BUILD', [
+            'filegroup(name = "fg", srcs = ["a.file"])',
+            'filegroup(name = "ccfg", srcs = [":ccbin"])',
+            'cc_binary(name = "ccbin", srcs = ["ccbin.cc"])'
+        ])
+        (success1, stderr1, cts1)  = self._bazel_api.cquery(["//testapp:fg"])
+        self.assertNotIn("CppConfiguration", cts1[0].transitive_fragments)
+        (success2, stderr2, cts2)  = self._bazel_api.cquery(["//testapp:ccfg"])
+        self.assertIn("CppConfiguration", cts2[0].transitive_fragments)
         
     def testGetTargetConfig(self):
         self.ScratchFile('testapp/BUILD', [
@@ -69,7 +77,6 @@ class BazelApiTest(test_base.TestBase):
         ])
         query = ["//testapp:fg", "--universe_scope=//testapp:g"]
         (success, stderr, cts)  = self._bazel_api.cquery(query)
-        print(stderr)
         config = self._bazel_api.get_config(cts[0].config_hash)
         self.assertTrue(isinstance(config, HostConfiguration))
         # We don't currently populate or read a host configuration's details.
@@ -88,10 +95,36 @@ class BazelApiTest(test_base.TestBase):
         self.assertEqual(len(config.options), 0)
 
     def testConfigWithDefines(self):
-        pass
+        self.ScratchFile('testapp/BUILD', [
+            'filegroup(name = "fg", srcs = ["a.file"])',
+        ])
+        cquery_args = ["//testapp:fg", "--define", "a=b"]
+        (success, stderr, cts)  = self._bazel_api.cquery(cquery_args)
+        config = self._bazel_api.get_config(cts[0].config_hash)
+        user_defined_options = config.options["user-defined"]
+        self.assertIsNotNone(user_defined_options)
+        self.assertDictEqual(user_defined_options, {'--define:a': 'b'})
 
     def testConfigWithStarlarkFlags(self):
-        pass
-    
+        self.ScratchFile('testapp/defs.bzl', [
+            'def _flag_impl(settings, attr):',
+            '  pass',
+            'string_flag = rule(',
+            '  implementation = _flag_impl,',
+            '  build_setting = config.string(flag = True)'
+            ')'
+        ])
+        self.ScratchFile('testapp/BUILD', [
+            'load(":defs.bzl", "string_flag")',
+            'string_flag(name = "my_flag", build_setting_default = "nada")',
+            'filegroup(name = "fg", srcs = ["a.file"])',
+        ])
+        cquery_args = ["//testapp:fg", "--//testapp:my_flag", "algo"]
+        (success, stderr, cts)  = self._bazel_api.cquery(cquery_args)
+        config = self._bazel_api.get_config(cts[0].config_hash)
+        user_defined_options = config.options["user-defined"]
+        self.assertIsNotNone(user_defined_options)
+        self.assertDictEqual(user_defined_options, {'//testapp:my_flag': 'algo'})
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/ctexplain/bazel_api_test.py
+++ b/tools/ctexplain/bazel_api_test.py
@@ -2,6 +2,8 @@ import os
 import unittest
 from src.test.py.bazel import test_base
 from tools.ctexplain.bazel_api import BazelApi
+from tools.ctexplain.types import HostConfiguration
+from tools.ctexplain.types import NullConfiguration
 
 # Tests for bazel_api.py.
 class BazelApiTest(test_base.TestBase):
@@ -40,5 +42,56 @@ class BazelApiTest(test_base.TestBase):
             "target 'typo' not declared in package 'testapp'",
             os.linesep.join(stderr))
 
+    def testTransitiveFragmentsAccuracy(self):
+        pass
+        
+    def testGetTargetConfig(self):
+        self.ScratchFile('testapp/BUILD', [
+            'filegroup(name = "fg", srcs = ["a.file"])',
+        ])
+        (success, stderr, cts)  = self._bazel_api.cquery(["//testapp:fg"])
+        config = self._bazel_api.get_config(cts[0].config_hash)
+        expected_fragments = ["PlatformConfiguration", "JavaConfiguration"]
+        [self.assertIn(exp, config.fragments) for exp in expected_fragments]
+        core_options = config.options["CoreOptions"]
+        self.assertIsNotNone(core_options)
+        self.assertIn(("stamp", "false"), core_options.items())
+        
+    def testGetHostConfig(self):
+        self.ScratchFile('testapp/BUILD', [
+            'genrule(',
+            '    name = "g",',
+            '    srcs = [],',
+            '    cmd = "",',
+            '    outs = ["g.out"],',
+            '    tools = [":fg"])',
+            'filegroup(name = "fg", srcs = ["a.file"])',
+        ])
+        query = ["//testapp:fg", "--universe_scope=//testapp:g"]
+        (success, stderr, cts)  = self._bazel_api.cquery(query)
+        print(stderr)
+        config = self._bazel_api.get_config(cts[0].config_hash)
+        self.assertTrue(isinstance(config, HostConfiguration))
+        # We don't currently populate or read a host configuration's details.
+        self.assertEqual(len(config.fragments), 0)
+        self.assertEqual(len(config.options), 0)
+
+    def testGetNullConfig(self):
+        self.ScratchFile('testapp/BUILD', [
+            'filegroup(name = "fg", srcs = ["a.file"])',
+        ])
+        (success, stderr, cts)  = self._bazel_api.cquery(["//testapp:a.file"])
+        config = self._bazel_api.get_config(cts[0].config_hash)
+        self.assertTrue(isinstance(config, NullConfiguration))
+        # Null configurations have no information by definition.
+        self.assertEqual(len(config.fragments), 0)
+        self.assertEqual(len(config.options), 0)
+
+    def testConfigWithDefines(self):
+        pass
+
+    def testConfigWithStarlarkFlags(self):
+        pass
+    
 if __name__ == "__main__":
     unittest.main()

--- a/tools/ctexplain/bazel_api_test.py
+++ b/tools/ctexplain/bazel_api_test.py
@@ -120,7 +120,7 @@ class BazelApiTest(test_base.TestBase):
     config = self._bazel_api.get_config(cts[0].config_hash)
     user_defined_options = config.options['user-defined']
     self.assertIsNotNone(user_defined_options)
-    self.assertDictEqual(user_defined_options, {'--define:a': 'b'})
+    self.assertDictEqual(user_defined_options._dict, {'--define:a': 'b'})
 
   def testConfigWithStarlarkFlags(self):
     self.ScratchFile('testapp/defs.bzl', [
@@ -139,7 +139,8 @@ class BazelApiTest(test_base.TestBase):
     config = self._bazel_api.get_config(cts[0].config_hash)
     user_defined_options = config.options['user-defined']
     self.assertIsNotNone(user_defined_options)
-    self.assertDictEqual(user_defined_options, {'//testapp:my_flag': 'algo'})
+    self.assertDictEqual(user_defined_options._dict,
+                         {'//testapp:my_flag': 'algo'})
 
 
 if __name__ == '__main__':

--- a/tools/ctexplain/ctexplain.py
+++ b/tools/ctexplain/ctexplain.py
@@ -12,7 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""ctexplain main entry point.
 
+Currently a stump.
+"""
 from tools.ctexplain.bazel_api import BazelApi
 
 bazel_api = BazelApi()

--- a/tools/ctexplain/ctexplain.py
+++ b/tools/ctexplain/ctexplain.py
@@ -1,16 +1,22 @@
 # Lint as: python3
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from tools.ctexplain.bazel_api import BazelApi
 
 bazel_api = BazelApi()
-print("Ready to go.")
-k = bazel_api.cquery(["//tools/ctexplain/examples/simple:split"])
-print("status code: " + str(k[0]))
-print("stderr: " + str(k[1], "utf-8"))
-print("=" * 30)
-print("results: " + str(k[2]))
 
-print("==" * 30)
-print(f"Let's get the config for {k[2][0].config_hash}:")
-config = bazel_api.get_config(k[2][0].config_hash)
-print(config)
+# TODO(gregce): move all logic to a _lib library so we can easily include
+# end-to-end testing. We'll only handle flag parsing here, which we pass
+# into the main invoker as standard Python args.

--- a/tools/ctexplain/ctexplain.py
+++ b/tools/ctexplain/ctexplain.py
@@ -1,0 +1,16 @@
+# Lint as: python3
+
+from tools.ctexplain.bazel_api import BazelApi
+
+bazel_api = BazelApi()
+print("Ready to go.")
+k = bazel_api.cquery(["//tools/ctexplain/examples/simple:split"])
+print("status code: " + str(k[0]))
+print("stderr: " + str(k[1], "utf-8"))
+print("=" * 30)
+print("results: " + str(k[2]))
+
+print("==" * 30)
+print(f"Let's get the config for {k[2][0].config_hash}:")
+config = bazel_api.get_config(k[2][0].config_hash)
+print(config)

--- a/tools/ctexplain/types.py
+++ b/tools/ctexplain/types.py
@@ -1,4 +1,18 @@
 # Lint as: python3
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The core data types ctexplain manipulates."""
 
 from dataclasses import dataclass

--- a/tools/ctexplain/types.py
+++ b/tools/ctexplain/types.py
@@ -12,21 +12,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """The core data types ctexplain manipulates."""
 
-from dataclasses import dataclass
-from dataclasses import field
 from typing import Dict
 from typing import Optional
 from typing import Tuple
+from dataclasses import dataclass
+from dataclasses import field
+
 
 @dataclass(frozen=True)
 class Configuration():
   """Stores a build configuration as a collection of fragments and options."""
   # BuildConfiguration.Fragments in this configuration, as base names without
   # packages. For example: ["PlatformConfiguration", ...].
-  fragments: Tuple[str,...]
+  fragments: Tuple[str, ...]
   # Dict of FragmentOptions to option key/value pairs. For example:
   # {"CoreOptions": {"action_env": "[]", "cpu": "x86", ...}, ...}.
   #
@@ -42,6 +42,7 @@ class Configuration():
       items_to_hash.append(tuple(sorted(self.options[fragment_option])))
     return hash(tuple(items_to_hash))
 
+
 @dataclass(frozen=True)
 class ConfiguredTarget():
   """Encapsulates a target + configuration + required fragments."""
@@ -54,7 +55,8 @@ class ConfiguredTarget():
   # Fragments required by this configured target and its transitive
   # dependencies. Stored as base names without packages. For example:
   # "PlatformOptions".
-  transitive_fragments: Tuple[str,...]
+  transitive_fragments: Tuple[str, ...]
+
 
 @dataclass(frozen=True)
 class HostConfiguration(Configuration):
@@ -70,8 +72,9 @@ class HostConfiguration(Configuration):
   aren't "special" compared to normal configurations.
   """
   # We don't currently read the host config's fragments or option values.
-  fragments: Tuple[str,...] = ()
+  fragments: Tuple[str, ...] = ()
   options: Dict[str, Dict[str, str]] = field(default_factory=lambda: {})
+
 
 @dataclass(frozen=True)
 class NullConfiguration(Configuration):
@@ -79,5 +82,5 @@ class NullConfiguration(Configuration):
 
   By definition this has no fragments or options.
   """
-  fragments: Tuple[str,...] = ()
+  fragments: Tuple[str, ...] = ()
   options: Dict[str, Dict[str, str]] = field(default_factory=lambda: {})

--- a/tools/ctexplain/types.py
+++ b/tools/ctexplain/types.py
@@ -17,8 +17,10 @@
 from typing import Mapping
 from typing import Optional
 from typing import Tuple
+# Do not edit this line. Copybara replaces it with PY2 migration helper.
 from dataclasses import dataclass
 from dataclasses import field
+from frozendict import frozendict
 
 
 @dataclass(frozen=True)
@@ -33,21 +35,7 @@ class Configuration():
   # Option values are stored as strings of whatever "bazel config" outputs.
   #
   # Note that Fragment and FragmentOptions aren't the same thing.
-  options: Mapping[str, Mapping[str, str]]
-
-  def __hash__(self):
-    return self._hash_value()
-
-  def __eq__(self, other):
-    return other._hash_value() == self._hash_value()
-
-  def _hash_value(self):
-    """Explicitly specified because dict isn't hashable."""
-    items_to_hash = list(self.fragments)
-    for item in sorted(self.options.items()):
-      items_to_hash.append(item[0])
-      items_to_hash.append(tuple(sorted(item[1].items())))
-    return hash(tuple(items_to_hash))
+  options: [Mapping[str, Mapping[str, str]]]
 
 
 @dataclass(frozen=True)
@@ -80,7 +68,9 @@ class HostConfiguration(Configuration):
   """
   # We don't currently read the host config's fragments or option values.
   fragments: Tuple[str, ...] = ()
-  options: Mapping[str, Mapping[str, str]] = field(default_factory=lambda: {})
+  options: Mapping[str,
+                   Mapping[str,
+                           str]] = field(default_factory=lambda: frozendict({}))
 
 
 @dataclass(frozen=True)
@@ -90,4 +80,6 @@ class NullConfiguration(Configuration):
   By definition this has no fragments or options.
   """
   fragments: Tuple[str, ...] = ()
-  options: Mapping[str, Mapping[str, str]] = field(default_factory=lambda: {})
+  options: Mapping[str,
+                   Mapping[str,
+                           str]] = field(default_factory=lambda: frozendict({}))

--- a/tools/ctexplain/types.py
+++ b/tools/ctexplain/types.py
@@ -36,10 +36,17 @@ class Configuration():
   options: Dict[str, Dict[str, str]]
 
   def __hash__(self):
-    sorted_fragment_options = sorted(self.options.keys())
-    items_to_hash = [self.fragments, (tuple(sorted_fragment_options))]
-    for fragment_option in sorted_fragment_options:
-      items_to_hash.append(tuple(sorted(self.options[fragment_option])))
+    return self._hash_value()
+
+  def __eq__(self, other):
+    return other._hash_value() == self._hash_value()
+
+  def _hash_value(self):
+    """Explicitly specified because dict isn't hashable."""
+    items_to_hash = list(self.fragments)
+    for item in sorted(self.options.items()):
+      items_to_hash.append(item[0])
+      items_to_hash.append(tuple(sorted(item[1].items())))
     return hash(tuple(items_to_hash))
 
 

--- a/tools/ctexplain/types.py
+++ b/tools/ctexplain/types.py
@@ -29,7 +29,7 @@ class Configuration():
     return hash(tuple(items_to_hash))
 
 @dataclass(frozen=True)
-class ConfiguredTarget:
+class ConfiguredTarget():
   """Encapsulates a target + configuration + required fragments."""
   # Label of the target this represents.
   label: str
@@ -57,7 +57,7 @@ class HostConfiguration(Configuration):
   """
   # We don't currently read the host config's fragments or option values.
   fragments: Tuple[str,...] = ()
-  options: Dict[str, Dict[str, str]] = field(default_factory={})
+  options: Dict[str, Dict[str, str]] = field(default_factory=lambda: {})
 
 @dataclass(frozen=True)
 class NullConfiguration(Configuration):
@@ -66,4 +66,4 @@ class NullConfiguration(Configuration):
   By definition this has no fragments or options.
   """
   fragments: Tuple[str,...] = ()
-  options: Dict[str, Dict[str, str]] = field(default_factory={})
+  options: Dict[str, Dict[str, str]] = field(default_factory=lambda: {})

--- a/tools/ctexplain/types.py
+++ b/tools/ctexplain/types.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """The core data types ctexplain manipulates."""
 
-from typing import Dict
+from typing import Mapping
 from typing import Optional
 from typing import Tuple
 from dataclasses import dataclass
@@ -27,13 +27,13 @@ class Configuration():
   # BuildConfiguration.Fragments in this configuration, as base names without
   # packages. For example: ["PlatformConfiguration", ...].
   fragments: Tuple[str, ...]
-  # Dict of FragmentOptions to option key/value pairs. For example:
+  # Mapping of FragmentOptions to option key/value pairs. For example:
   # {"CoreOptions": {"action_env": "[]", "cpu": "x86", ...}, ...}.
   #
   # Option values are stored as strings of whatever "bazel config" outputs.
   #
   # Note that Fragment and FragmentOptions aren't the same thing.
-  options: Dict[str, Dict[str, str]]
+  options: Mapping[str, Mapping[str, str]]
 
   def __hash__(self):
     return self._hash_value()
@@ -80,7 +80,7 @@ class HostConfiguration(Configuration):
   """
   # We don't currently read the host config's fragments or option values.
   fragments: Tuple[str, ...] = ()
-  options: Dict[str, Dict[str, str]] = field(default_factory=lambda: {})
+  options: Mapping[str, Mapping[str, str]] = field(default_factory=lambda: {})
 
 
 @dataclass(frozen=True)
@@ -90,4 +90,4 @@ class NullConfiguration(Configuration):
   By definition this has no fragments or options.
   """
   fragments: Tuple[str, ...] = ()
-  options: Dict[str, Dict[str, str]] = field(default_factory=lambda: {})
+  options: Mapping[str, Mapping[str, str]] = field(default_factory=lambda: {})

--- a/tools/ctexplain/types_test.py
+++ b/tools/ctexplain/types_test.py
@@ -1,0 +1,54 @@
+# Lint as: python3
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for types.py."""
+import unittest
+from tools.ctexplain.types import Configuration
+
+
+class TypesTest(unittest.TestCase):
+
+  def testConfigurationIsHashable(self):
+    c = Configuration(fragments=('F1'), options={'o1': {'k1': 'v1'}})
+    some_dict = {}
+    some_dict[c] = 4
+
+  def testConfigurationHashAccuracy(self):
+    dict = {}
+    dict[Configuration(fragments=('F1'), options={'o1': {'k1': 'v1'}})] = 4
+    self.assertEqual(len(dict), 1)
+    dict[Configuration(fragments=('F1'), options={'o1': {'k1': 'v1'}})] = 4
+    self.assertEqual(len(dict), 1)
+    dict[Configuration(fragments=('F2'), options={'o1': {'k1': 'v1'}})] = 4
+    self.assertEqual(len(dict), 2)
+    dict[Configuration(fragments=('F2'), options={'o2': {'k1': 'v1'}})] = 4
+    self.assertEqual(len(dict), 3)
+    dict[Configuration(fragments=('F2'), options={'o2': {'k2': 'v1'}})] = 4
+    self.assertEqual(len(dict), 4)
+    dict[Configuration(fragments=('F2'), options={'o2': {'k2': 'v2'}})] = 4
+    self.assertEqual(len(dict), 5)
+
+  def testConfigurationEquality(self):
+    c1 = Configuration(fragments=('F1'), options={'o1': {'k1': 'v1'}})
+    c2 = Configuration(fragments=('F1'), options={'o1': {'k1': 'v1'}})
+    c3 = Configuration(fragments=('F2'), options={'o1': {'k1': 'v1'}})
+    c4 = Configuration(fragments=('F1'), options={'o2': {'k2': 'v2'}})
+
+    self.assertEqual(c1, c2)
+    self.assertNotEqual(c1, c3)
+    self.assertNotEqual(c1, c4)
+    self.assertNotEqual(c3, c4)
+ 
+if __name__ == '__main__':
+  unittest.main()

--- a/tools/ctexplain/types_test.py
+++ b/tools/ctexplain/types_test.py
@@ -14,30 +14,45 @@
 # limitations under the License.
 """Tests for types.py."""
 import unittest
+# Do not edit this line. Copybara replaces it with PY2 migration helper.
+from frozendict import frozendict
 from tools.ctexplain.types import Configuration
 
 
 class TypesTest(unittest.TestCase):
 
   def testConfigurationIsHashable(self):
-    c = Configuration(fragments=('F1'), options={'o1': {'k1': 'v1'}})
+    options = frozendict({'o1': frozendict({'k1': 'v1'})})
+    c = Configuration(fragments=('F1'), options=options)
     some_dict = {}
     some_dict[c] = 4
 
   def testConfigurationHashAccuracy(self):
-    dict = {}
-    dict[Configuration(fragments=('F1'), options={'o1': {'k1': 'v1'}})] = 4
-    self.assertEqual(len(dict), 1)
-    dict[Configuration(fragments=('F1'), options={'o1': {'k1': 'v1'}})] = 4
-    self.assertEqual(len(dict), 1)
-    dict[Configuration(fragments=('F2'), options={'o1': {'k1': 'v1'}})] = 4
-    self.assertEqual(len(dict), 2)
-    dict[Configuration(fragments=('F2'), options={'o2': {'k1': 'v1'}})] = 4
-    self.assertEqual(len(dict), 3)
-    dict[Configuration(fragments=('F2'), options={'o2': {'k2': 'v1'}})] = 4
-    self.assertEqual(len(dict), 4)
-    dict[Configuration(fragments=('F2'), options={'o2': {'k2': 'v2'}})] = 4
-    self.assertEqual(len(dict), 5)
+    d = {}
+
+    options1 = frozendict({'o1': frozendict({'k1': 'v1'})})
+    d[Configuration(fragments=('F1'), options=options1)] = 4
+    self.assertEqual(len(d), 1)
+
+    options2 = frozendict({'o1': frozendict({'k1': 'v1'})})
+    d[Configuration(fragments=('F1'), options=options2)] = 4
+    self.assertEqual(len(d), 1)
+
+    options3 = frozendict({'o1': frozendict({'k1': 'v1'})})
+    d[Configuration(fragments=('F2'), options=options3)] = 4
+    self.assertEqual(len(d), 2)
+
+    options4 = frozendict({'o2': frozendict({'k1': 'v1'})})
+    d[Configuration(fragments=('F2'), options=options4)] = 4
+    self.assertEqual(len(d), 3)
+
+    options5 = frozendict({'o2': frozendict({'k2': 'v1'})})
+    d[Configuration(fragments=('F2'), options=options5)] = 4
+    self.assertEqual(len(d), 4)
+
+    options6 = frozendict({'o2': frozendict({'k2': 'v2'})})
+    d[Configuration(fragments=('F2'), options=options6)] = 4
+    self.assertEqual(len(d), 5)
 
   def testConfigurationEquality(self):
     c1 = Configuration(fragments=('F1'), options={'o1': {'k1': 'v1'}})
@@ -49,6 +64,7 @@ class TypesTest(unittest.TestCase):
     self.assertNotEqual(c1, c3)
     self.assertNotEqual(c1, c4)
     self.assertNotEqual(c3, c4)
- 
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
i.e. first check-in of [Measuring Configuration Overhead](https://docs.google.com/document/d/10ZxO2wZdKJATnYBqAm22xT1k5r4Vp6QX96TkqSUIhs0/edit).

This just establishes supporting structure. The tool is not yet functional.

Specifically:
- `types.py`: defines data structures for "configuration" and "configured target" 
- `bazel_api.py`: API to translate `bazel cquery` and `bazel config` calls into the above data structures
- `bazel_api_test.py`: tests
- `ctexplain.py`: stump of an entry point

The tests utilize an existing Python test framework for invoking Bazel (`//src/test/py/bazel:test_base`).

Work towards https://github.com/bazelbuild/bazel/issues/10613



