### PR TITLE
Remove javac.jar as a dependency of java tools

### DIFF
--- a/src/java_tools/buildjar/BUILD
+++ b/src/java_tools/buildjar/BUILD
@@ -61,7 +61,6 @@ java_toolchain(
     genclass = ["bootstrap_genclass_deploy.jar"],
     ijar = ["//third_party/ijar"],
     javabuilder = ["bootstrap_VanillaJavaBuilder_deploy.jar"],
-    javac = ["//third_party/java/jdk/langtools:javac_jar"],
     jvm_opts = [
         # Prevent "Could not reserve enough space for object heap" errors on Windows.
         "-Xmx512m",

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD
@@ -55,7 +55,6 @@ java_library(
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:jsr305",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -96,7 +95,6 @@ java_library(
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party/java/jacoco:core",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -167,7 +165,6 @@ bootstrap_java_library(
         "//third_party/grpc:bootstrap-grpc-jars",
         "//third_party:tomcat_annotations_api-jars",
     ],
-    neverlink_jars = ["//third_party/java/jdk/langtools:javac_jar"],
     tags = ["manual"],
 )
 

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins/BUILD
@@ -13,7 +13,6 @@ java_library(
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar:invalid_command_line_exception",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/statistics",
         "//third_party:guava",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -28,7 +27,6 @@ java_library(
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:tomcat_annotations_api",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -41,7 +39,6 @@ java_library(
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/statistics",
         "//third_party:error_prone",
         "//third_party:guava",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -52,7 +49,6 @@ java_library(
         ":plugins",
         "//src/main/protobuf:java_compilation_java_proto",
         "//third_party:guava",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 

--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/statistics/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/statistics/BUILD
@@ -8,7 +8,6 @@ java_library(
     deps = [
         "//third_party:auto_value",
         "//third_party:guava",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 

--- a/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/javac/BUILD
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/java/turbine/javac/BUILD
@@ -25,7 +25,6 @@ java_library(
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party:turbine",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -37,7 +36,6 @@ java_library(
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:dependency",
         "//third_party:guava",
         "//third_party:jsr305",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -48,7 +46,6 @@ java_library(
         ":formatted_diagnostic",
         "//third_party:guava",
         "//third_party:jsr305",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -66,7 +63,6 @@ java_library(
         "//third_party:guava",
         "//third_party:jimfs",
         "//third_party:jsr305",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -79,7 +75,6 @@ java_library(
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/plugins:dependency",
         "//src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/statistics",
         "//third_party:jsr305",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -91,7 +86,6 @@ java_library(
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party:turbine",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -100,7 +94,6 @@ java_library(
     srcs = ["ZipUtil.java"],
     deps = [
         "//third_party:jsr305",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
@@ -110,16 +103,12 @@ java_library(
     deps = [
         "//third_party:guava",
         "//third_party:jsr305",
-        "//third_party/java/jdk/langtools:javac",
     ],
 )
 
 java_library(
     name = "formatted_diagnostic",
     srcs = ["FormattedDiagnostic.java"],
-    deps = [
-        "//third_party/java/jdk/langtools:javac",
-    ],
 )
 
 filegroup(

--- a/src/upload_all_java_tools.sh
+++ b/src/upload_all_java_tools.sh
@@ -50,7 +50,7 @@ bazel_version=$(bazel info release | cut -d' ' -f2)
 # uploaded on GCS with the same identifier.
 for java_version in 11 12; do
 
-    bazel build //src:java_tools_java${java_version}_zip
+    bazel build --javabase=@bazel_tools//tools/jdk:remote_jdk11 //src:java_tools_java${java_version}_zip
     zip_path=${PWD}/bazel-bin/src/java_tools_java${java_version}.zip
 
     if "$is_windows"; then
@@ -65,12 +65,14 @@ for java_version in 11 12; do
       --define=LOCAL_JAVA_TOOLS_ZIP_URL="${file_url}"
 
     bazel run //src:upload_java_tools_java${java_version} -- \
+        --javabase=@bazel_tools//tools/jdk:remote_jdk11 \
         --java_tools_zip src/java_tools_java${java_version}.zip \
         --commit_hash ${commit_hash} \
         --timestamp ${timestamp} \
         --bazel_version ${bazel_version}
 
     bazel run //src:upload_java_tools_dist_java${java_version} -- \
+        --javabase=@bazel_tools//tools/jdk:remote_jdk11 \
         --commit_hash ${commit_hash} \
         --timestamp ${timestamp} \
         --bazel_version ${bazel_version}


### PR DESCRIPTION
We no longer need the javac.jar for building java tools if we're building with JDK11.

This helps remove javac.jar as a dependency of the Debian build, which
is a part of OpenJDK and won't be able to be packaged in Debian.

However, the javac jar will still exist in third_party because some tests depend on it.

Working towards: #9408