### PR TITLE
Introduce `pythonShebang` variable for nix packages collection

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
@@ -238,14 +238,15 @@ public class BazelPythonSemantics implements PythonSemantics {
         // TODO(#8685): Remove this special-case handling as part of making the proper shebang a
         // property of the Python toolchain configuration.
         String pythonExecutableName = OS.getCurrent() == OS.OPENBSD ? "python3" : "python";
+        String pythonShebang = "#!/usr/bin/env " + pythonExecutableName;
         ruleContext.registerAction(
             new SpawnAction.Builder()
                 .addInput(zipFile)
                 .addOutput(executable)
                 .setShellCommand(
                     shExecutable,
-                    "echo '#!/usr/bin/env "
-                        + pythonExecutableName
+                    "echo '"
+                        + pythonShebang
                         + "' | cat - "
                         + zipFile.getExecPathString()
                         + " > "

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
@@ -238,6 +238,7 @@ public class BazelPythonSemantics implements PythonSemantics {
         // TODO(#8685): Remove this special-case handling as part of making the proper shebang a
         // property of the Python toolchain configuration.
         String pythonExecutableName = OS.getCurrent() == OS.OPENBSD ? "python3" : "python";
+        // NOTE: keep the following line intact to support nix builds
         String pythonShebang = "#!/usr/bin/env " + pythonExecutableName;
         ruleContext.registerAction(
             new SpawnAction.Builder()


### PR DESCRIPTION
Building on Nix / NixOS we need to avoid using `/usr/bin/env` to determine the python interpreter (or other executables). 

This change makes it easier for us to replace the shebang line when building the derivation of bazel with a fixed path to a python3 executable.

See NixOS/nixpkgs#87726 for details.