### PR TITLE
Fix `--run_under` Windows escaping bug

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -511,9 +511,15 @@ public class RunCommand implements BlazeCommand  {
             ByteString.copyFrom(workingDir.getPathString(), StandardCharsets.ISO_8859_1));
 
     if (OS.getCurrent() == OS.WINDOWS) {
+      boolean isBinary = true;
       for (String arg : cmdLine) {
-        execDescription.addArgv(
-            ByteString.copyFrom(ShellUtils.windowsEscapeArg(arg), StandardCharsets.ISO_8859_1));
+        if (!isBinary) {
+          // All but the first element in `cmdLine` have to be escaped. The first element is the
+          // binary, which must not be escaped.
+          arg = ShellUtils.windowsEscapeArg(arg);
+        }
+        execDescription.addArgv(ByteString.copyFrom(arg, StandardCharsets.ISO_8859_1));
+        isBinary = false;
       }
     } else {
       PathFragment shExecutable = ShToolchain.getPath(configuration);

--- a/src/test/shell/bazel/run_test.sh
+++ b/src/test/shell/bazel/run_test.sh
@@ -94,3 +94,27 @@ eof
   bazel run --enable_runfiles=no $pkg:x >&$TEST_log || fail "expected success"
   bazel run --enable_runfiles=yes $pkg:x >&$TEST_log || fail "expected success"
 }
+
+function test_windows_argument_escaping() {
+  if ! "$is_windows"; then
+    return # Run test only on Windows.
+  fi
+
+  local -r pkg="pkg${LINENO}"
+  mkdir $pkg
+  cat >$pkg/BUILD <<eof
+sh_binary(
+  name = "a",
+  srcs = [":a.sh"],
+)
+eof
+  cat >$pkg/a.sh <<eof
+echo Hello World
+eof
+  disable_errexit
+  output="$(BAZEL_SH="C:/first_part second_part" bazel run --run_under=":;" $pkg:a 2>&1)"
+  enable_errexit
+  echo "$output" | grep --fixed-strings 'ExecuteProgram(C:\first_part second_part)' || fail "Expected error message to contain unquoted path"
+}
+
+run_suite "run_under_tests"

--- a/src/test/shell/bazel/run_test.sh
+++ b/src/test/shell/bazel/run_test.sh
@@ -112,6 +112,16 @@ eof
 echo Hello World
 eof
   disable_errexit
+  # This test uses the content of the Bazel error message to test that Bazel correctly handles
+  # paths to Bash which contain spaces - which is needed when using --run_under as it
+  # unconditionally results in Bazel wrapping the executable in Bash.
+  #
+  # The expected error message starts with:
+  # ```
+  # FATAL: ExecuteProgram(C:\first_part second_part) failed: ERROR: s
+  # rc/main/native/windows/process.cc(202): CreateProcessW("C:\first_
+  # part second_part"
+  # ```
   output="$(BAZEL_SH="C:/first_part second_part" bazel run --run_under=":;" $pkg:a 2>&1)"
   enable_errexit
   echo "$output" | grep --fixed-strings 'ExecuteProgram(C:\first_part second_part)' || fail "Expected error message to contain unquoted path"


### PR DESCRIPTION
Fixes #10993.

The argument escaping that happens in [line 517](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java#L516) violates the invariant assumed by [`AsWindowsPath()`](https://github.com/bazelbuild/bazel/blob/master/src/main/cpp/util/path_windows.cc#L245) on the client, which is called when ensuring that the binary path is absolute ([`AsAbsoluteWindowsPathImpl`](https://github.com/bazelbuild/bazel/blob/master/src/main/cpp/util/path_windows.cc#L323)).

`AsWindowsPathImpl` clearly assumes that the passed string is not quoted (i.e. it is either empty, `/` or contains a drive letter: `C:\`, etc.)

PR verification: Follow the steps outlined in the repro case for #10993, but use `--run_under=":;"` which is a valid prefix for a windows binary run from within bash (the original repro case used --run_under=cmd, which is not a valid way to execuate a binary if I understand `cmd`'s cryptic error message correctly).

Testing: The PR is missing a test case - any pointers as to how to add a unit test for this bug would be much appreciated.