### PR TITLE
URL encode "%" due to rules_jvm_external paths

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -312,8 +312,7 @@ function create_and_run_classpath_jar() {
       path="file:${path}" # e.g. "file:/usr/local/foo.jar"
     fi
 
-    path=$(sed "s/%/%25/g" <<< "${path}")
-    path=$(sed "s/ /%20/g" <<< "${path}")
+    path=$(sed "s/ /%20/g; s/%/%25/g" <<< "${path}")
     MANIFEST_CLASSPATH+=("${path}")
   done
   IFS="$OLDIFS"

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -312,6 +312,7 @@ function create_and_run_classpath_jar() {
       path="file:${path}" # e.g. "file:/usr/local/foo.jar"
     fi
 
+    path=$(sed "s/%/%25/g" <<< "${path}")
     path=$(sed "s/ /%20/g" <<< "${path}")
     MANIFEST_CLASSPATH+=("${path}")
   done

--- a/src/tools/launcher/java_launcher.cc
+++ b/src/tools/launcher/java_launcher.cc
@@ -152,6 +152,9 @@ static void WriteJarClasspath(const wstring& jar_path,
       if (x == L' ') {
         *manifest_classpath << L"%20";
       }
+      if (x == L'%') {
+        *manifest_classpath << L"%25";
+      }
       if (x == L'\\') {
         *manifest_classpath << L"/";
       } else {


### PR DESCRIPTION
Fixes a problem where the manifest classpath is incorrectly written due to not URL-encoding symbols.

The paths provided in the manifest when the command line is too long is supposed to be a URL, which means we have to URL-encode special characters. `rules_jvm_external` generates a bunch of artifacts with paths that are themselves a URL-encoded version of their maven server host so we have a bunch of "%40" strings in the path due to usage of "@" for user@host http auth.