### PR TITLE
Ensure that AspectResolver uses the same ConfiguredTargetKey as

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/AspectResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AspectResolver.java
@@ -124,11 +124,7 @@ public final class AspectResolver {
 
     for (Map.Entry<DependencyKind, Dependency> entry : depValueNames.entries()) {
       Dependency dep = entry.getValue();
-      SkyKey depKey =
-          ConfiguredTargetKey.builder()
-              .setLabel(dep.getLabel())
-              .setConfiguration(dep.getConfiguration())
-              .build();
+      SkyKey depKey = dep.getConfiguredTargetKey();
       ConfiguredTargetAndData depConfiguredTarget = depConfiguredTargetMap.get(depKey);
 
       result.put(


### PR DESCRIPTION
everything else.

Part of work on toolchain transitions, #10523.