### PR TITLE
Check the toolchain transition migration status and use the new transition

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/DependencyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/DependencyResolver.java
@@ -239,15 +239,46 @@ public abstract class DependencyResolver {
       return OrderedSetMultimap.create();
     }
 
+    // TODO(#10523): Remove this when the migration period for toolchain transitions has ended.
+    boolean useToolchainTransition =
+        shouldUseToolchainTransition(node.getConfiguration(), fromRule);
     OrderedSetMultimap<DependencyKind, PartiallyResolvedDependency> partiallyResolvedDeps =
         partiallyResolveDependencies(
-            outgoingLabels, fromRule, attributeMap, toolchainContexts, aspects);
+            outgoingLabels,
+            fromRule,
+            attributeMap,
+            toolchainContexts,
+            useToolchainTransition,
+            aspects);
 
     OrderedSetMultimap<DependencyKind, DependencyKey> outgoingEdges =
         fullyResolveDependencies(
             partiallyResolvedDeps, targetMap, node.getConfiguration(), trimmingTransitionFactory);
 
     return outgoingEdges;
+  }
+
+  /**
+   * Returns whether or not to use the new toolchain transition. Checks the global incompatible
+   * change flag and the rule's toolchain transition readiness attribute.
+   */
+  private boolean shouldUseToolchainTransition(
+      @Nullable BuildConfiguration configuration, @Nullable Rule fromRule) {
+    // Check whether the global incompatible change flag is set.
+    if (configuration != null) {
+      PlatformOptions platformOptions = configuration.getOptions().get(PlatformOptions.class);
+      if (platformOptions != null && platformOptions.overrideToolchainTransition) {
+        return true;
+      }
+    }
+
+    // Check the rule definition to see if it is ready.
+    if (fromRule != null && fromRule.getRuleClassObject().useToolchainTransition()) {
+      return true;
+    }
+
+    // Default to false.
+    return false;
   }
 
   /**
@@ -264,6 +295,7 @@ public abstract class DependencyResolver {
           @Nullable Rule fromRule,
           ConfiguredAttributeMapper attributeMap,
           @Nullable ToolchainCollection<ToolchainContext> toolchainContexts,
+          boolean useToolchainTransition,
           Iterable<Aspect> aspects)
           throws EvalException {
     OrderedSetMultimap<DependencyKind, PartiallyResolvedDependency> partiallyResolvedDeps =
@@ -278,15 +310,29 @@ public abstract class DependencyResolver {
         // use sensible defaults. Not depending on their package makes the error message reporting
         // a missing toolchain a bit better.
         // TODO(lberki): This special-casing is weird. Find a better way to depend on toolchains.
-        partiallyResolvedDeps.put(
-            TOOLCHAIN_DEPENDENCY,
-            PartiallyResolvedDependency.builder()
-                .setLabel(toLabel)
-                // TODO(#10523): Replace this with a proper transition for the execution platform.
-                .setTransition(HostTransition.INSTANCE)
-                // TODO(#10523): Set the toolchainContextKey from ToolchainCollection.
-                .setPropagatingAspects(ImmutableList.of())
-                .build());
+        // TODO(#10523): Remove check when this is fully released.
+        if (useToolchainTransition) {
+          // We need to create an individual PRD for each distinct toolchain context that contains
+          // this toolchain, because each has a different ToolchainContextKey.
+          for (ToolchainContext toolchainContext :
+              toolchainContexts.getContextsForResolvedToolchain(toLabel)) {
+            partiallyResolvedDeps.put(
+                TOOLCHAIN_DEPENDENCY,
+                PartiallyResolvedDependency.builder()
+                    .setLabel(toLabel)
+                    .setTransition(NoTransition.INSTANCE)
+                    .setToolchainContextKey(toolchainContext.key())
+                    .build());
+          }
+        } else {
+          // Legacy approach: use a HostTransition.
+          partiallyResolvedDeps.put(
+              TOOLCHAIN_DEPENDENCY,
+              PartiallyResolvedDependency.builder()
+                  .setLabel(toLabel)
+                  .setTransition(HostTransition.INSTANCE)
+                  .build());
+        }
         continue;
       }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
@@ -218,6 +218,19 @@ public class PlatformOptions extends FragmentOptions {
               + " 'test'.")
   public List<Map.Entry<RegexFilter, List<Label>>> targetFilterToAdditionalExecConstraints;
 
+  @Option(
+      name = "incompatible_override_toolchain_transition",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      effectTags = OptionEffectTag.LOADING_AND_ANALYSIS,
+      metadataTags = {
+        OptionMetadataTag.INCOMPATIBLE_CHANGE,
+        OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+      },
+      help =
+          "If set to true, all rules will use the toolchain transition for toolchain dependencies.")
+  public boolean overrideToolchainTransition;
+
   @Override
   public PlatformOptions getHost() {
     PlatformOptions host = (PlatformOptions) getDefault();
@@ -232,6 +245,7 @@ public class PlatformOptions extends FragmentOptions {
     host.autoConfigureHostPlatform = this.autoConfigureHostPlatform;
     host.useToolchainResolutionForJavaRules = this.useToolchainResolutionForJavaRules;
     host.targetPlatformFallback = this.targetPlatformFallback;
+    host.overrideToolchainTransition = this.overrideToolchainTransition;
     return host;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/ToolchainCollection.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ToolchainCollection.java
@@ -18,6 +18,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -70,6 +71,16 @@ public abstract class ToolchainCollection<T extends ToolchainContext> {
   /** Returns a new builder for {@link ToolchainCollection} instances. */
   public static <T extends ToolchainContext> Builder<T> builder() {
     return new Builder<T>();
+  }
+
+  /**
+   * Returns every instance of {@link ToolchainContext} that uses {@code resolvedToolchainLabel} as
+   * a resolved toolchain.
+   */
+  public ImmutableList<T> getContextsForResolvedToolchain(Label resolvedToolchainLabel) {
+    return getContextMap().values().stream()
+        .filter(tc -> tc.resolvedToolchainLabels().contains(resolvedToolchainLabel))
+        .collect(ImmutableList.toImmutableList());
   }
 
   /** Builder for ToolchainCollection. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/skylark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/skylark/StarlarkRuleClassFunctions.java
@@ -273,6 +273,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi<Arti
       Sequence<?> hostFragments,
       Boolean starlarkTestable,
       Sequence<?> toolchains,
+      boolean useToolchainTransition,
       String doc,
       Sequence<?> providesArg,
       Sequence<?> execCompatibleWith,
@@ -353,6 +354,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi<Arti
         bzlModule.label(), bzlModule.bzlTransitiveDigest());
 
     builder.addRequiredToolchains(parseToolchains(toolchains, thread));
+    builder.useToolchainTransition(useToolchainTransition);
 
     if (execGroups != Starlark.NONE) {
       Map<String, ExecGroup> execGroupDict =

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -715,6 +715,7 @@ public class RuleClass {
     private final Map<String, Attribute> attributes = new LinkedHashMap<>();
     private final Set<Label> requiredToolchains = new HashSet<>();
     private boolean useToolchainResolution = true;
+    private boolean useToolchainTransition = false;
     private Set<Label> executionPlatformConstraints = new HashSet<>();
     private OutputFile.Kind outputFileKind = OutputFile.Kind.FILE;
     private final Map<String, ExecGroup> execGroups = new HashMap<>();
@@ -750,6 +751,7 @@ public class RuleClass {
 
         addRequiredToolchains(parent.getRequiredToolchains());
         useToolchainResolution = parent.useToolchainResolution;
+        useToolchainTransition = parent.useToolchainTransition;
         addExecutionPlatformConstraints(parent.getExecutionPlatformConstraints());
         try {
           addExecGroups(parent.getExecGroups());
@@ -837,6 +839,7 @@ public class RuleClass {
         // Build setting rules should opt out of toolchain resolution, since they form part of the
         // configuration.
         this.useToolchainResolution(false);
+        this.useToolchainTransition(false);
       }
 
       return new RuleClass(
@@ -871,6 +874,7 @@ public class RuleClass {
           thirdPartyLicenseExistencePolicy,
           requiredToolchains,
           useToolchainResolution,
+          useToolchainTransition,
           executionPlatformConstraints,
           execGroups,
           outputFileKind,
@@ -1453,6 +1457,11 @@ public class RuleClass {
       return this;
     }
 
+    public Builder useToolchainTransition(boolean flag) {
+      this.useToolchainTransition = flag;
+      return this;
+    }
+
     /**
      * Adds additional execution platform constraints that apply for all targets from this rule.
      *
@@ -1604,6 +1613,7 @@ public class RuleClass {
 
   private final ImmutableSet<Label> requiredToolchains;
   private final boolean useToolchainResolution;
+  private final boolean useToolchainTransition;
   private final ImmutableSet<Label> executionPlatformConstraints;
   private final ImmutableMap<String, ExecGroup> execGroups;
 
@@ -1660,6 +1670,7 @@ public class RuleClass {
       ThirdPartyLicenseExistencePolicy thirdPartyLicenseExistencePolicy,
       Set<Label> requiredToolchains,
       boolean useToolchainResolution,
+      boolean useToolchainTransition,
       Set<Label> executionPlatformConstraints,
       Map<String, ExecGroup> execGroups,
       OutputFile.Kind outputFileKind,
@@ -1700,6 +1711,7 @@ public class RuleClass {
     this.thirdPartyLicenseExistencePolicy = thirdPartyLicenseExistencePolicy;
     this.requiredToolchains = ImmutableSet.copyOf(requiredToolchains);
     this.useToolchainResolution = useToolchainResolution;
+    this.useToolchainTransition = useToolchainTransition;
     this.executionPlatformConstraints = ImmutableSet.copyOf(executionPlatformConstraints);
     this.execGroups = ImmutableMap.copyOf(execGroups);
     this.buildSetting = buildSetting;
@@ -2610,6 +2622,10 @@ public class RuleClass {
 
   public boolean useToolchainResolution() {
     return useToolchainResolution;
+  }
+
+  public boolean useToolchainTransition() {
+    return useToolchainTransition;
   }
 
   public ImmutableSet<Label> getExecutionPlatformConstraints() {

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/StarlarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/StarlarkRuleFunctionsApi.java
@@ -262,6 +262,15 @@ public interface StarlarkRuleFunctionsApi<FileApiT extends FileApi> {
                     + "found by checking the current platform, and provided to the rule "
                     + "implementation via <code>ctx.toolchain</code>."),
         @Param(
+            name = "incompatible_use_toolchain_transition",
+            type = Boolean.class,
+            defaultValue = "False",
+            named = true,
+            doc =
+                "If set, this rule will use the toolchain transition for toolchain dependencies."
+                    + " This is ignored if the --incompatible_use_toolchain_transition flag is"
+                    + " set."),
+        @Param(
             name = "doc",
             type = String.class,
             named = true,
@@ -356,6 +365,7 @@ public interface StarlarkRuleFunctionsApi<FileApiT extends FileApi> {
       Sequence<?> hostFragments,
       Boolean starlarkTestable,
       Sequence<?> toolchains,
+      boolean useToolchainTransition,
       String doc,
       Sequence<?> providesArg,
       Sequence<?> execCompatibleWith,

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/FakeStarlarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/FakeStarlarkRuleFunctionsApi.java
@@ -128,6 +128,7 @@ public class FakeStarlarkRuleFunctionsApi implements StarlarkRuleFunctionsApi<Fi
       Sequence<?> hostFragments,
       Boolean starlarkTestable,
       Sequence<?> toolchains,
+      boolean useToolchainTransition,
       String doc,
       Sequence<?> providesArg,
       Sequence<?> execCompatibleWith,

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -922,6 +922,7 @@ public class RuleClassTest extends PackageLoadingTestCase {
         ThirdPartyLicenseExistencePolicy.USER_CONTROLLABLE,
         /*requiredToolchains=*/ ImmutableSet.of(),
         /*useToolchainResolution=*/ true,
+        /*useToolchainTransition=*/ true,
         /* executionPlatformConstraints= */ ImmutableSet.of(),
         /* execGroups= */ ImmutableMap.of(),
         OutputFile.Kind.FILE,

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1052,6 +1052,13 @@ sh_test(
 )
 
 sh_test(
+    name = "toolchain_transition_test",
+    srcs = ["toolchain_transition_test.sh"],
+    data = [":test-deps"],
+    tags = ["no_windows"],
+)
+
+sh_test(
     name = "java_launcher_test",
     size = "medium",
     srcs = ["java_launcher_test.sh"],

--- a/src/test/shell/bazel/toolchain_transition_test.sh
+++ b/src/test/shell/bazel/toolchain_transition_test.sh
@@ -1,0 +1,358 @@
+#!/bin/bash
+#
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Test the toolchain transition.
+#
+
+# Load the test setup defined in the parent directory
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CURRENT_DIR}/../integration_test_setup.sh" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+function set_up() {
+  create_new_workspace
+}
+
+function write_constraints() {
+  mkdir constraint
+  cat >constraint/BUILD.bazel <<EOF
+package(default_visibility = ["//visibility:public"])
+
+# Common constraints for testing.
+
+constraint_setting(name = "type")
+
+constraint_value(
+    name = "target",
+    constraint_setting = ":type",
+)
+
+constraint_value(
+    name = "exec",
+    constraint_setting = ":type",
+)
+
+constraint_value(
+    name = "host",
+    constraint_setting = ":type",
+)
+
+constraint_setting(name = "level")
+
+constraint_value(
+    name = "alpha",
+    constraint_setting = ":level",
+)
+
+constraint_value(
+    name = "beta",
+    constraint_setting = ":level",
+)
+EOF
+}
+
+function write_platforms() {
+  mkdir platform
+  cat >platform/platform.bzl <<EOF
+ShowPlatformInfo = provider(fields = ["platform_type", "level"])
+
+def describe_platform_info(platform_info):
+    if platform_info.level:
+        return "%s-%s" % (platform_info.platform_type, platform_info.level)
+    else:
+        return platform_info.platform_type
+
+def _show_platform_impl(ctx):
+    target_constraint = ctx.attr._target_constraint[platform_common.ConstraintValueInfo]
+    exec_constraint = ctx.attr._exec_constraint[platform_common.ConstraintValueInfo]
+    host_constraint = ctx.attr._host_constraint[platform_common.ConstraintValueInfo]
+    alpha_constraint = ctx.attr._alpha_constraint[platform_common.ConstraintValueInfo]
+    beta_constraint = ctx.attr._beta_constraint[platform_common.ConstraintValueInfo]
+    type = "unknown"
+    if ctx.target_platform_has_constraint(target_constraint):
+        type = "target"
+    elif ctx.target_platform_has_constraint(exec_constraint):
+        type = "exec"
+    elif ctx.target_platform_has_constraint(host_constraint):
+        type = "host"
+    level = None
+    if ctx.target_platform_has_constraint(alpha_constraint):
+        level = "alpha"
+    elif ctx.target_platform_has_constraint(beta_constraint):
+        level = "beta"
+
+    return [ShowPlatformInfo(
+        platform_type = type,
+        level = level,
+    )]
+
+show_platform = rule(
+    implementation = _show_platform_impl,
+    attrs = {
+        "_target_constraint": attr.label(default = Label("//constraint:target")),
+        "_exec_constraint": attr.label(default = Label("//constraint:exec")),
+        "_host_constraint": attr.label(default = Label("//constraint:host")),
+        "_alpha_constraint": attr.label(default = Label("//constraint:alpha")),
+        "_beta_constraint": attr.label(default = Label("//constraint:beta")),
+    },
+    provides = [ShowPlatformInfo],
+)
+EOF
+  cat >platform/BUILD.bazel <<EOF
+load(":platform.bzl", "show_platform")
+
+package(default_visibility = ["//visibility:public"])
+
+show_platform(name = "platform")
+
+# Common platforms.
+
+# Execution platforms.
+platform(
+    name = "exec_alpha",
+    constraint_values = [
+        "//constraint:alpha",
+        "//constraint:exec",
+    ],
+)
+
+platform(
+    name = "exec_beta",
+    constraint_values = [
+        "//constraint:beta",
+        "//constraint:exec",
+    ],
+)
+
+# Host platform.
+platform(
+    name = "host",
+    constraint_values = [
+        "//constraint:host",
+    ],
+)
+
+# Target platform.
+platform(
+    name = "target",
+    constraint_values = [
+        "//constraint:target",
+    ],
+)
+EOF
+  # Append to WORKSPACE
+  cat >>WORKSPACE <<EOF
+register_execution_platforms(
+    "//platform:exec_alpha",
+    "//platform:exec_beta",
+)
+EOF
+}
+
+function write_toolchains() {
+  mkdir toolchain
+  cat >toolchain/toolchain.bzl <<EOF
+load("//platform:platform.bzl", "ShowPlatformInfo", "describe_platform_info")
+load(":extra_lib.bzl", "ExtraMessageProvider")
+
+def _sample_toolchain_impl(ctx):
+    target_dep = describe_platform_info(ctx.attr._target_dep[ShowPlatformInfo])
+    tool_dep = describe_platform_info(ctx.attr._tool_dep[ShowPlatformInfo])
+    dep_messages = []
+    for dep in ctx.attr.deps:
+        message = dep[ExtraMessageProvider].message
+        dep_messages.append(message)
+    message = "sample_toolchain: message: %s, target_dep: %s, tool_dep: %s, extra_deps: [%s]" % (
+        ctx.attr.message,
+        target_dep,
+        tool_dep,
+        ", ".join(dep_messages),
+    )
+
+    toolchain = platform_common.ToolchainInfo(
+        message = message,
+    )
+    return [toolchain]
+
+sample_toolchain = rule(
+    implementation = _sample_toolchain_impl,
+    attrs = {
+        "message": attr.string(),
+        "deps": attr.label_list(),
+        "_target_dep": attr.label(cfg = "target", providers = [ShowPlatformInfo], default = Label("//platform")),
+        "_tool_dep": attr.label(cfg = "exec", providers = [ShowPlatformInfo], default = Label("//platform")),
+    },
+)
+EOF
+  cat >toolchain/extra_lib.bzl <<EOF
+load("//platform:platform.bzl", "ShowPlatformInfo", "describe_platform_info")
+
+ExtraMessageProvider = provider(fields = ["message"])
+
+def _extra_lib_impl(ctx):
+    target_dep = describe_platform_info(ctx.attr._target_dep[ShowPlatformInfo])
+    tool_dep = describe_platform_info(ctx.attr._tool_dep[ShowPlatformInfo])
+    message = "extra_lib: message: %s, target_dep: %s, tool_dep: %s" % (
+        ctx.attr.message,
+        target_dep,
+        tool_dep,
+    )
+    provider = ExtraMessageProvider(message = message)
+
+    return [provider]
+
+extra_lib = rule(
+    implementation = _extra_lib_impl,
+    attrs = {
+        "message": attr.string(),
+        "_target_dep": attr.label(cfg = "target", providers = [ShowPlatformInfo], default = Label("//platform")),
+        "_tool_dep": attr.label(cfg = "exec", providers = [ShowPlatformInfo], default = Label("//platform")),
+    },
+    provides = [ExtraMessageProvider],
+)
+EOF
+  cat >toolchain/BUILD.bazel <<EOF
+package(default_visibility = ["//visibility:public"])
+
+load(":toolchain.bzl", "sample_toolchain")
+
+toolchain_type(name = "toolchain_type")
+
+sample_toolchain(
+    name = "sample_toolchain_alpha_impl",
+    message = "alpha toolchain",
+    deps = [
+        ":extra",
+    ],
+)
+
+toolchain(
+    name = "sample_toolchain_alpha",
+    exec_compatible_with = [
+        "//constraint:alpha",
+    ],
+    toolchain = "sample_toolchain_alpha_impl",
+    toolchain_type = ":toolchain_type",
+)
+
+sample_toolchain(
+    name = "sample_toolchain_beta_impl",
+    message = "beta toolchain",
+    deps = [
+        ":extra",
+    ],
+)
+
+load(":extra_lib.bzl", "extra_lib")
+
+extra_lib(
+    name = "extra",
+    message = "extra_lib foo",
+)
+
+toolchain(
+    name = "sample_toolchain_beta",
+    exec_compatible_with = [
+        "//constraint:beta",
+    ],
+    toolchain = "sample_toolchain_beta_impl",
+    toolchain_type = ":toolchain_type",
+)
+EOF
+  # Append to WORKSPACE
+  cat >>WORKSPACE <<EOF
+register_toolchains(
+    "//toolchain:sample_toolchain_alpha",
+    "//toolchain:sample_toolchain_beta",
+)
+EOF
+}
+
+function write_rule() {
+  mkdir rule
+  cat >rule/rule.bzl <<EOF
+load("//platform:platform.bzl", "ShowPlatformInfo", "describe_platform_info")
+
+def _sample_impl(ctx):
+    toolchain = ctx.toolchains["//toolchain:toolchain_type"]
+    message = ctx.attr.message
+    exec_platform = describe_platform_info(ctx.attr._exec[ShowPlatformInfo])
+
+    str = 'Using toolchain: rule message: "%s", exec platform: "%s", toolchain message: "%s"\n' % (message, exec_platform, toolchain.message)
+
+    log = ctx.outputs.log
+    ctx.actions.write(
+        output = log,
+        content = str,
+    )
+    return [DefaultInfo(files = depset([log]))]
+
+sample = rule(
+    implementation = _sample_impl,
+    attrs = {
+        "message": attr.string(),
+        "_exec": attr.label(cfg = "exec", providers = [ShowPlatformInfo], default = Label("//platform")),
+    },
+    outputs = {
+        "log": "%{name}.log",
+    },
+    toolchains = ["//toolchain:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
+)
+EOF
+  cat >rule/BUILD.bazel <<EOF
+package(default_visibility = ["//visibility:public"])
+
+EOF
+}
+
+function test_toolchain_transition() {
+  write_constraints
+  write_platforms
+  write_toolchains
+  write_rule
+
+  cat >BUILD.bazel <<EOF
+package(default_visibility = ["//visibility:public"])
+
+load("//rule:rule.bzl", "sample")
+
+sample(
+    name = "sample",
+    exec_compatible_with = [
+        "//constraint:beta",
+    ],
+    message = "Hello",
+)
+EOF
+
+  bazel build \
+    --platforms=//platform:target \
+    --host_platform=//platform:host \
+     //:sample &> $TEST_log || fail "Build failed"
+
+  # TODO: verify contents of bazel-bin/sample.log.
+  cat bazel-bin/sample.log >> $TEST_log
+  # The execution platform should be beta.
+  expect_log 'rule message: "Hello", exec platform: "exec-beta"'
+  # The toolchain should have proper target and exec matching the top target.
+  expect_log 'sample_toolchain: message: beta toolchain, target_dep: target, tool_dep: exec-beta'
+  # The toolchain's dependencies should use alpha for exec.
+  # Make sure the exec platform does not propagate to further dependencies.
+  expect_log 'extra_lib: message: extra_lib foo, target_dep: target, tool_dep: exec-alpha'
+}
+
+run_suite "toolchain transition tests"


### PR DESCRIPTION
Adds a test for the new toolchain transition functionality.

Adds the --incompatible_use_toolchain_transition flag to force all rules to depend on toolchains via the toolchain transition.
Adds the incompatible_use_toolchain_transition rule attribute to force a
specific rule to depend on toolchains via the toolchain transition.

RELNOTES: Rule authors should use the
incompatible_use_toolchain_transition rule attribute to migrate to using
the toolchain transition. jcater to udpate notes further.

Closes #10523.

Incompatible flag issue is #11584.