### PR TITLE
Check if file already exists before creating it.

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
@@ -96,7 +96,9 @@ public class Main {
       if (profdataFile == null) {
         try {
           logger.log(Level.WARNING, "There was no coverage found.");
-          Files.createFile(outputFile.toPath()); // Generate empty declared output
+          if (!Files.exists(outputFile.toPath())) {
+            Files.createFile(outputFile.toPath()); // Generate empty declared output
+          }
           exitStatus = 0;
         } catch (IOException e) {
           logger.log(
@@ -156,7 +158,9 @@ public class Main {
     if (coverage.isEmpty()) {
       try {
         logger.log(Level.WARNING, "There was no coverage found.");
-        Files.createFile(outputFile.toPath()); // Generate empty declared output
+        if (!Files.exists(outputFile.toPath())) {
+          Files.createFile(outputFile.toPath()); // Generate empty declared output
+        }
         return 0;
       } catch (IOException e) {
         logger.log(


### PR DESCRIPTION
This is a fix of 9964418. In some cases, we already created/touched that
file before calling the coverage output generator, so we don't have to
do that here.

RELNOTES: None