### PR TITLE
Fix export of @bazel_tools//src/main/protobuf

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -126,7 +126,7 @@ JAVA_TOOLS = [
                "//src/tools/launcher:srcs",
                "//src/main/cpp/util:embedded_tools",
                "//src/main/native:embedded_tools",
-               "//src/main/protobuf:srcs",
+               "//src/main/protobuf:embedded_tools",
                "//third_party/def_parser:srcs",
                "//third_party/zlib:embedded_tools",
            ] + select({

--- a/src/main/protobuf/BUILD
+++ b/src/main/protobuf/BUILD
@@ -276,6 +276,15 @@ filegroup(
 )
 
 filegroup(
+    name = "embedded_tools",
+    srcs = glob([
+        "BUILD.tools",
+        "*.proto",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "dist_jars",
     srcs = [s + "_java_proto_srcs" for s in FILES] + [
         ":analysis_java_proto_srcs",

--- a/src/main/protobuf/BUILD.tools
+++ b/src/main/protobuf/BUILD.tools
@@ -1,0 +1,140 @@
+load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(
+    ["execution_statitics.proto"],
+    visibility = [
+        "//src/test/shell/integration:process_wrapper_test",
+    ],
+)
+
+FILES = [
+    "action_cache",
+    "android_deploy_info",
+    "bazel_flags",
+    "build",
+    "builtin",
+    "command_server",
+    "crosstool_config",
+    "deps",
+    "desugar_deps",
+    "execution_statistics",
+    "extra_actions_base",
+    "invocation_policy",
+    "java_compilation",
+    "spawn",
+    "test_status",
+    "worker_protocol",
+]
+
+[proto_library(
+    name = s + "_proto",
+    srcs = [s + ".proto"],
+) for s in FILES]
+
+[java_proto_library(
+    name = s + "_java_proto",
+    deps = [":" + s + "_proto"],
+) for s in FILES]
+
+proto_library(
+    name = "analysis_proto",
+    srcs = ["analysis.proto"],
+    deps = [":build_proto"],
+)
+
+java_proto_library(
+    name = "analysis_java_proto",
+    deps = [":analysis_proto"],
+)
+
+proto_library(
+    name = "analysis_v2_proto",
+    srcs = ["analysis_v2.proto"],
+    deps = [":build_proto"],
+)
+
+java_proto_library(
+    name = "analysis_v2_java_proto",
+    deps = [":analysis_v2_proto"],
+)
+
+# This new option tagging method is in flux while being applied to the options
+# in the Bazel code base. The visibility should not be changed to allow external
+# dependencies until the interface has stabilized and can commit to maintaining
+# backwards compatibility for 6 months' time.
+# TODO(bazel-team) Make these visibility:public when the interface is stable.
+proto_library(
+    name = "option_filters_proto",
+    srcs = ["option_filters.proto"],
+    visibility = ["//visibility:private"],
+)
+
+java_proto_library(
+    name = "option_filters_java_proto",
+    visibility = ["//src:__subpackages__"],
+    deps = [":option_filters_proto"],
+)
+
+proto_library(
+    name = "command_line_proto",
+    srcs = ["command_line.proto"],
+    visibility = ["//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:__pkg__"],
+    deps = [":option_filters_proto"],
+)
+
+java_proto_library(
+    name = "command_line_java_proto",
+    visibility = ["//src:__subpackages__"],
+    deps = [":command_line_proto"],
+)
+
+# Proto needed by singlejar and embedded into the java tools archive.
+genrule(
+    name = "desugar_deps_zip",
+    srcs = ["desugar_deps.proto"],
+    outs = ["desugar_deps.zip"],
+    cmd = "zip -q $@ $<",
+    visibility = ["//src/tools/singlejar:__pkg__"],
+)
+
+filegroup(
+    name = "desugar_deps_filegroup",
+    srcs = ["desugar_deps.proto"],
+    visibility = ["//src/tools/singlejar:__pkg__"],
+)
+
+cc_proto_library(
+    name = "desugar_deps_cc_proto",
+    deps = [":desugar_deps_proto"],
+)
+
+cc_proto_library(
+    name = "worker_protocol_cc_proto",
+    deps = [":worker_protocol_proto"],
+)
+
+cc_proto_library(
+    name = "execution_statistics_cc_proto",
+    deps = [":execution_statistics_proto"],
+)
+
+proto_library(
+    name = "remote_execution_log_proto",
+    srcs = ["remote_execution_log.proto"],
+    deps = [
+        "@com_google_protobuf//:timestamp_proto",
+        "@googleapis//:google_bytestream_bytestream_proto",
+        "@googleapis//:google_longrunning_operations_proto",
+        "@googleapis//:google_rpc_status_proto",
+        "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_proto",
+    ],
+)
+
+java_proto_library(
+    name = "remote_execution_log_java_proto",
+    deps = [":remote_execution_log_proto"],
+)


### PR DESCRIPTION
`src/main/protobuf/BUILD` referenced other parts of the Bazel source tree
which aren't available when repackaged into the embedded tools distribution.
This commit adds a parallel `BUILD.tools` which is stripped of any such
references.

Resolves #8738.

Testing Done:
- Referred to `@bazel_tools//src/main/protobuf:worker_protocol.proto` in
  an internal rule w/o encountering #8738.