### PR TITLE
Fix documentation for createLinkerInput owner

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/CcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/CcModuleApi.java
@@ -633,7 +633,7 @@ public interface CcModuleApi<
       parameters = {
         @Param(
             name = "owner",
-            doc = "List of <code>LibraryToLink</code>.",
+            doc = "The label of the target that produced all files used in this input.",
             positional = false,
             named = true,
             type = Label.class),


### PR DESCRIPTION
The existing text is a clear copy/paste error. My proposed replacement is the most sensible explanation I can give for this field, given my lack of context for this component.

Suggested reviewer: plf@