### PR TITLE
[Fix] Bazel zsh autocompletion on `run`

### DIFF
--- a/scripts/zsh_completion/_bazel
+++ b/scripts/zsh_completion/_bazel
@@ -164,7 +164,7 @@ _get_build_targets() {
       ;;
   esac
   completions=(${$(_bazel_b query "kind(\"${rule_re}\", ${pkg}:all)" 2>/dev/null)##*:})
-  if ( (( ${#completions} > 0 )) && [[ $target_type != run ]] ); then
+  if ( (( ${#completions} > 0 )) && [[ $target_type != bin ]] ); then
     completions+=(all)
   fi
   echo ${completions[*]}


### PR DESCRIPTION
This fix stops `:all` being added to autocomplete with `run`. This issue is that `target_type` can be `bin` `test` or `build` and is mistakenly gated on `run`.