### PR TITLE
Add builtin_sysroot argument to unix_cc_toolchain_config

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -1226,6 +1226,7 @@ def _impl(ctx):
         abi_version = ctx.attr.abi_version,
         abi_libc_version = ctx.attr.abi_libc_version,
         tool_paths = tool_paths,
+        builtin_sysroot = ctx.attr.builtin_sysroot,
     )
 
 cc_toolchain_config = rule(
@@ -1252,6 +1253,7 @@ cc_toolchain_config = rule(
         "coverage_compile_flags": attr.string_list(),
         "coverage_link_flags": attr.string_list(),
         "supports_start_end_lib": attr.bool(),
+        "builtin_sysroot": attr.string(),
     },
     provides = [CcToolchainConfigInfo],
 )


### PR DESCRIPTION
The specified sysroot is forwarded verbatim to cc_common.create_cc_toolchain_config_info.

This allows users to use the %sysroot% placeholder in cxx_builtin_include_directories, that wasn't possible before. See: https://stackoverflow.com/questions/62451307/specify-sysroot-for-bazel-toolchain

I did not find any tests or documentation on unix_cc_toolchain_config in the repository.