### PR TITLE
Add flag --incompatible_blacklisted_protos_requires_proto_info

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoConfiguration.java
@@ -183,6 +183,19 @@ public class ProtoConfiguration extends Fragment implements ProtoConfigurationAp
                 + "the Starlark rules instead at https://github.com/bazelbuild/rules_proto")
     public boolean loadProtoRulesFromBzl;
 
+    @Option(
+        name = "incompatible_blacklisted_protos_requires_proto_info",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+        metadataTags = {
+          OptionMetadataTag.INCOMPATIBLE_CHANGE,
+          OptionMetadataTag.TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES
+        },
+        help =
+            "If enabled, 'proto_lang_toolchain.blacklisted_protos' requires provider 'ProtoInfo'")
+    public boolean blacklistedProtosRequiresProtoInfo;
+
     @Override
     public FragmentOptions getHost() {
       Options host = (Options) super.getHost();
@@ -203,6 +216,7 @@ public class ProtoConfiguration extends Fragment implements ProtoConfigurationAp
       host.experimentalJavaProtoAddAllowedPublicImports =
           experimentalJavaProtoAddAllowedPublicImports;
       host.generatedProtosInVirtualImports = generatedProtosInVirtualImports;
+      host.blacklistedProtosRequiresProtoInfo = blacklistedProtosRequiresProtoInfo;
       return host;
     }
   }
@@ -299,5 +313,9 @@ public class ProtoConfiguration extends Fragment implements ProtoConfigurationAp
 
   public boolean loadProtoRulesFromBzl() {
     return options.loadProtoRulesFromBzl;
+  }
+
+  public boolean blacklistedProtosRequiresProtoInfo() {
+    return options.blacklistedProtosRequiresProtoInfo;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchain.java
@@ -42,8 +42,10 @@ public class ProtoLangToolchain implements RuleConfiguredTargetFactory {
     for (TransitiveInfoCollection protos :
         ruleContext.getPrerequisites("blacklisted_protos", TARGET)) {
       ProtoInfo protoInfo = protos.get(ProtoInfo.PROVIDER);
-      if (ruleContext.getFragment(ProtoConfiguration.class).blacklistedProtosRequiresProtoInfo()
-          && protoInfo == null) {
+      if (protoInfo == null
+          && ruleContext
+              .getFragment(ProtoConfiguration.class)
+              .blacklistedProtosRequiresProtoInfo()) {
         ruleContext.ruleError(
             "'"
                 + ruleContext.getLabel().toString()

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchain.java
@@ -42,7 +42,13 @@ public class ProtoLangToolchain implements RuleConfiguredTargetFactory {
     for (TransitiveInfoCollection protos :
         ruleContext.getPrerequisites("blacklisted_protos", TARGET)) {
       ProtoInfo protoInfo = protos.get(ProtoInfo.PROVIDER);
-      // TODO(cushon): it would be nice to make this mandatory and stop adding files to build too
+      if (ruleContext.getFragment(ProtoConfiguration.class).blacklistedProtosRequiresProtoInfo()
+          && protoInfo == null) {
+        ruleContext.ruleError(
+            "'"
+                + ruleContext.getLabel().toString()
+                + "' does not have mandatory provider 'ProtoInfo'.");
+      }
       if (protoInfo != null) {
         blacklistedProtos.addTransitive(protoInfo.getOriginalTransitiveProtoSources());
       } else {


### PR DESCRIPTION
This change adds a new incompatible flag that makes ProtoInfo mandatory
for skipping code-gen for some proto sources (e.g. WKPs that are already
provided by the proto runtime). Flipping this flag will allow us to get rid of
ProtoInfo#getOriginal{Direct,Transitive}ProtoSources().

https://docs.google.com/document/d/1UmF_P4NDVl6Nw4JsHoHYp74iCdEQNh1O3-SVAX1CdjU/edit#

RELNOTES: Adds --incompatible_blacklisted_protos_requires_proto_info to indicate whether proto_lang_toolchain.blacklisted_protos requires ProtoInfo.
