### PR TITLE
Fix Desugar: incorrect assumption of persistent worker conditional and  missing runtime desugar lib resource for primitive desugaring

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -156,7 +156,7 @@ distdir_tar(
         "1.25.0.zip",
         # rules_nodejs
         "rules_nodejs-1.3.0.tar.gz",
-        "android_tools_pkg-0.17.0.tar.gz",
+        "android_tools_pkg-0.19.0rc1.tar.gz",
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
         # bazelbuild/platforms
@@ -193,7 +193,7 @@ distdir_tar(
         "1.25.0.zip": "c78be58f5e0a29a04686b628cf54faaee0094322ae0ac99da5a8a8afca59a647",
         # rules_nodejs
         "rules_nodejs-1.3.0.tar.gz": "b6670f9f43faa66e3009488bbd909bc7bc46a5a9661a33f6bc578068d1837f37",
-        "android_tools_pkg-0.17.0.tar.gz": "8d0bf8ab83c9e38ec6ed5ce7bf425dbdc6469cec9e078559d4e8da42b705410f",
+        "android_tools_pkg-0.19.0rc1.tar.gz": "761e997a9055fe5e2b70aba8d64e78d4c2113feafaa8ac81909cb63e403f3087",
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": "c00ceec469dbcf7929972e3c79f20c14033824538038a554952f5c31d8832f96",
         # bazelbuild/platforms
@@ -246,8 +246,8 @@ distdir_tar(
             "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz",
             "https://github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz",
         ],
-        "android_tools_pkg-0.17.0.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.17.0.tar.gz",
+        "android_tools_pkg-0.19.0rc1.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc1.tar.gz",
         ],
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": [
@@ -525,7 +525,7 @@ distdir_tar(
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz",
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz",
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip",
-        "android_tools_pkg-0.17.0.tar.gz",
+        "android_tools_pkg-0.19.0rc1.tar.gz",
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz",
         # bazelbuild/platforms
@@ -555,7 +555,7 @@ distdir_tar(
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz": "a452f1b9682d9f83c1c14e54d1446e1c51b5173a3a05dcb013d380f9508562e4",
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz": "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip": "a9695617b8374bfa171f166951214965b1d1d08f43218db9a2a780b71c665c18",
-        "android_tools_pkg-0.17.0.tar.gz": "8d0bf8ab83c9e38ec6ed5ce7bf425dbdc6469cec9e078559d4e8da42b705410f",
+        "android_tools_pkg-0.19.0rc1.tar.gz": "761e997a9055fe5e2b70aba8d64e78d4c2113feafaa8ac81909cb63e403f3087",
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": "c00ceec469dbcf7929972e3c79f20c14033824538038a554952f5c31d8832f96",
         # bazelbuild/platforms
@@ -584,8 +584,8 @@ distdir_tar(
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.48-ca-jdk11.0.6/zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz"],
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz"],
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64.zip"],
-        "android_tools_pkg-0.17.0.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.17.0.tar.gz",
+        "android_tools_pkg-0.19.0rc1.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc1.tar.gz",
         ],
         # bazelbuild/bazel-skylib
         "2d4c9528e0f453b5950eeaeac11d8d09f5a504d4.tar.gz": [
@@ -714,8 +714,8 @@ http_archive(
     name = "android_tools_for_testing",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "8d0bf8ab83c9e38ec6ed5ce7bf425dbdc6469cec9e078559d4e8da42b705410f", # DO_NOT_REMOVE_THIS_ANDROID_TOOLS_UPDATE_MARKER
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.17.0.tar.gz",
+    sha256 = "761e997a9055fe5e2b70aba8d64e78d4c2113feafaa8ac81909cb63e403f3087", # DO_NOT_REMOVE_THIS_ANDROID_TOOLS_UPDATE_MARKER
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc1.tar.gz",
 )
 
 # This must be kept in sync with src/main/java/com/google/devtools/build/lib/bazel/rules/coverage.WORKSPACE.

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -3,6 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "android_tools",
-    sha256 = "8d0bf8ab83c9e38ec6ed5ce7bf425dbdc6469cec9e078559d4e8da42b705410f",
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.17.0.tar.gz",
+    sha256 = "761e997a9055fe5e2b70aba8d64e78d4c2113feafaa8ac81909cb63e403f3087",
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc1.tar.gz",
 )

--- a/src/test/shell/bazel/android/desugarer_integration_test.sh
+++ b/src/test/shell/bazel/android/desugarer_integration_test.sh
@@ -75,6 +75,9 @@ EOF
   cat > java/bazel/MainActivity.java <<EOF
 package bazel;
 import android.app.Activity;
+import java.util.stream.Stream;
+import java.util.Arrays;
+
 public class MainActivity extends Activity {
   interface A {
     int foo(int x, int y);
@@ -82,6 +85,21 @@ public class MainActivity extends Activity {
 
   A bar() {
     return (a, b) -> a * b;
+  }
+
+  int someHashcode() {
+    // JDK 8 language feature depending on primitives desugar
+    return java.lang.Long.hashCode(42L); 
+  }
+
+  int getSumOfInts() {
+    // JDK 8 language feature depending on streams desugar
+    return Arrays
+      .asList("x1", "x2", "x3")
+      .stream()
+      .map(s -> s.substring(1))
+      .mapToInt(Integer::parseInt)
+      .sum();
   }
 }
 EOF

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/BUILD
@@ -35,6 +35,7 @@ java_library(
     ],
     runtime_deps = [
         "//src/tools/android/java/com/google/devtools/build/android/desugar/dependencies",
+        "//src/tools/android/java/com/google/devtools/build/android/desugar/runtime:primitives",
         "//src/tools/android/java/com/google/devtools/build/android/desugar/runtime:string_concats",
         "//src/tools/android/java/com/google/devtools/build/android/desugar/runtime:throwable_extension",
     ],

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/Desugar.java
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/Desugar.java
@@ -943,7 +943,7 @@ public class Desugar {
   public static void main(String[] args) throws Exception {
     verifyLambdaDumpDirectoryRegistered(DUMP_DIRECTORY);
 
-    if (args.length == 1 && "--persistent_worker".equals(args[0])) {
+    if (args.length > 0 && "--persistent_worker".equals(args[0])) {
       runPersistentWorker(DUMP_DIRECTORY);
     } else {
       DesugarOptions options = DesugarOptions.parseCommandLineOptions(args);

--- a/src/tools/android/java/com/google/devtools/build/android/desugar/runtime/BUILD
+++ b/src/tools/android/java/com/google/devtools/build/android/desugar/runtime/BUILD
@@ -20,6 +20,19 @@ java_library(
 )
 
 java_library(
+    name = "primitives",
+    srcs = [
+        "PrimitiveHashcode.java",
+        "UnsignedLongs.java",
+    ],
+    # This library must be compiled with java7, as we directly copy it to the desugared jar.
+    javacopts = [
+        "-source 7",
+        "-target 7",
+    ],
+)
+
+java_library(
     name = "string_concats",
     srcs = ["StringConcats.java"],
     # This library must be compiled with java7, as we directly copy it to the desugared jar.

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -31,7 +31,7 @@
 set -euo pipefail
 
 # The version of android_tools.tar.gz
-VERSION="0.17.0"
+VERSION="0.19.0rc1"
 VERSIONED_FILENAME="android_tools_pkg-$VERSION.tar.gz"
 
 # Create a temp directory to hold the versioned tarball, and clean it up when the script exits.
@@ -48,7 +48,7 @@ cp $android_tools_archive $versioned_android_tools_archive
 
 # Upload the tarball to GCS.
 # -n for no-clobber, so we don't overwrite existing files
-gsutil cp $versioned_android_tools_archive \
+gsutil cp -n $versioned_android_tools_archive \
   gs://bazel-mirror/bazel_android_tools/$VERSIONED_FILENAME
 
 checksum=$(sha256sum $versioned_android_tools_archive | cut -f 1 -d ' ')


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/11618

Needs to be cherry-picked into 3.3.0. 