### PR TITLE
Windows: Always copy DLLs to the binary's directory when it's a source file

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
@@ -1048,10 +1048,12 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
       RuleContext ruleContext, Iterable<Artifact> dynamicLibrariesForRuntime) {
     NestedSetBuilder<Artifact> result = NestedSetBuilder.stableOrder();
     for (Artifact target : dynamicLibrariesForRuntime) {
+      // If the binary and the DLL doesn't belong to the same package or the DLL is a source file,
+      // we should copy the DLL to the binary's directory.
       if (!ruleContext
           .getLabel()
           .getPackageIdentifier()
-          .equals(target.getOwner().getPackageIdentifier())) {
+          .equals(target.getOwner().getPackageIdentifier()) || target.isSourceArtifact()) {
         // SymlinkAction on file is actually copy on Windows.
         Artifact copy = ruleContext.getBinArtifact(target.getFilename());
         ruleContext.registerAction(SymlinkAction.toArtifact(

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -666,6 +666,37 @@ class BazelWindowsCppTest(test_base.TestBase):
     ])
     self.AssertExitCode(exit_code, 0, stderr)
 
+  def testCopyDLLAsSource(self):
+    self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
+    self.ScratchFile('BUILD', [
+        'cc_import(',
+        '  name = "a_import",',
+        '  shared_library = "A.dll",',
+        ')',
+        '',
+        'cc_binary(',
+        '  name = "bin",',
+        '  srcs = ["bin.cc"],',
+        '  deps = ["//:a_import"],',
+        ')',
+    ])
+    self.ScratchFile('A.dll')
+    self.ScratchFile('bin.cc', [
+        'int main() {',
+        '  return 0;',
+        '}',
+    ])
+    exit_code, _, stderr = self.RunBazel([
+        'build', '//:bin',
+    ])
+    self.AssertExitCode(exit_code, 0, stderr)
+
+    bazel_bin = self.getBazelInfo('bazel-bin')
+    a_dll = os.path.join(bazel_bin, 'A.dll')
+    # Even though A.dll is in the same package as bin.exe, but it still should
+    # be copied to the output directory of bin.exe.
+    self.assertTrue(os.path.exists(a_dll))
+
   def testCppErrorShouldBeVisible(self):
     self.CreateWorkspaceWithDefaultRepos('WORKSPACE')
     self.ScratchFile('BUILD', [


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/11150