### PR TITLE
Added Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,77 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This script bootstraps building a Bazel binary without Bazel then
-# use this compiled Bazel to bootstrap Bazel itself. It can also
-# be provided with a previous version of Bazel to bootstrap Bazel itself.
-#
+# This script aids the bootstrapping of building a Bazel binary without Bazel
+# using GNU Makefile. Simply use "make" in the current directory to start.
 # The resulting binary can be found at output/bazel.
 
 all:
-	# Make sure dependencies for bootstrapping bazel are installed
 	sudo apt-get install build-essential openjdk-11-jdk python zip unzip
-	env EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk"
-	
-	# Set the default verbose mode in buildenv.sh so that we do not display command
-	# output unless there is a failure.  We do this conditionally to offer the user
-	# a chance of overriding this in case they want to do so.
-	env VERBOSE=no
-	
-	# Set up the environment for building and output
-	set -o errexit
-	cd "$(dirname "$0")"
-	source scripts/bootstrap/buildenv.sh
-	source scripts/bootstrap/bootstrap.sh
-	mkdir -p output
-	env BAZEL=
-	
-	# Create an initial binary so we can host ourself
-	if [ ! -x "${BAZEL}" ]; then
-  		new_step 'Building Bazel from scratch'
-  		source scripts/bootstrap/compile.sh
-	fi
-	
-	# Bootstrap bazel using the previous bazel binary = release binary
-	if [ "${EMBED_LABEL-x}" = "x" ]; then
-  		# Add a default label when unspecified
-  		git_sha1=$(git_sha1)
-  		EMBED_LABEL="$(get_last_version) (@${git_sha1:-non-git})"
-	fi
-
-	# Set host and target platform directly because we are building for the local host
-	if [[ $PLATFORM == "darwin" ]] && \
-    		xcodebuild -showsdks 2> /dev/null | grep -q '\-sdk iphonesimulator'; then
-  		EXTRA_BAZEL_ARGS="${EXTRA_BAZEL_ARGS-} --define IPHONE_SDK=1"
-	fi
-
-	# Commence Bootstrapping Bazel
-	new_step 'Building Bazel with Bazel'
-	display "."
-	log "Building output/bazel"
-	bazel_build "src:bazel_nojdk${EXE_EXT}" \
-  		--action_env=PATH \
-  		--host_platform=@local_config_platform//:host \
-  		--platforms=@local_config_platform//:host \
-  		|| fail "Could not build Bazel"
-		bazel_bin_path="$(get_bazel_bin_path)/src/bazel_nojdk${EXE_EXT}"
-		[ -e "$bazel_bin_path" ] \
-  		|| fail "Could not find freshly built Bazel binary at '$bazel_bin_path'"
-		cp -f "$bazel_bin_path" "output/bazel${EXE_EXT}" \
-  		|| fail "Could not copy '$bazel_bin_path' to 'output/bazel${EXE_EXT}'"
-	
-	# Set Permissions for the new binary in the output directory
-	chmod 0755 "output/bazel${EXE_EXT}"
-	BAZEL="$(pwd)/output/bazel${EXE_EXT}"
-	clear_log
-	display "Build successful! Binary is here: ${BAZEL}"
-	
+	env EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" bash ./compile.sh
 clean:
-	# Prompt the user to make sure they want to remove the output directory
-	read -p "Are you sure you want to remove the Bazel Bootstrap output? [Y/n]: " answer
-	if [[ $answer == "Y" ]] || [[ $answer == "y" ]]; then
-		display "Removing Bazel Bootstrap output..."
-		rm -rf output/bazel
-		display "Done!"
-	else
-		display "Nothing to do."
-	fi
+	rm -rf output/bazel

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+all:
+	sudo apt-get install build-essential openjdk-11-jdk python zip unzip
+	env EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" bash ./compile.sh
+clean:
+	rm -rf output/bazel


### PR DESCRIPTION
This Makefile makes it simpler to bootstrap Bazel from ARM Linux.
It follows the instructions already available from the building from source page of your website.
Users will download the distribution zip, unzip it inside a directory called "bazel" and enter "make" in the terminal from inside the "bazel" folder.
Users may also enter "make clean" to remove the generated output directory to start the build again from scratch.