### PR TITLE
Add Ubuntu 20.04 platform, but do not test it in CI yet

### DIFF
--- a/.bazelci/build_bazel_binaries.yml
+++ b/.bazelci/build_bazel_binaries.yml
@@ -18,6 +18,12 @@ platforms:
     build_flags:
       - "-c"
       - "opt"
+  ubuntu2004:
+    build_targets:
+      - "//src:bazel"
+    build_flags:
+      - "-c"
+      - "opt"
   macos:
     build_targets:
       - "//src:bazel"


### PR DESCRIPTION
This seems like it might be a prerequisite for adding a ubuntu 20.04 platform to bazelci, based on this CI failure:
https://github.com/bazelbuild/continuous-integration/pull/988