### PR TITLE
Condition out `PR_SET_CHILD_SUBREAPER` on older Linuxes

### DIFF
--- a/src/main/tools/process-wrapper-legacy.cc
+++ b/src/main/tools/process-wrapper-legacy.cc
@@ -44,7 +44,11 @@ void LegacyProcessWrapper::RunCommand() {
 
 void LegacyProcessWrapper::SpawnChild() {
   if (opt.wait_fix) {
-#if defined(__linux__)
+#if defined(__linux__) && HAVE_PR_SET_CHILD_SUBREAPER
+    // PR_SET_CHILD_SUBREAPER appeared in kernel version 3.4.
+    //
+    // wait_fix is implicitly false when Bazel is compiled for older
+    // kernels.  See process-wrapper-options.cc.
     if (prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) == -1) {
       DIE("prctl");
     }

--- a/src/main/tools/process-wrapper-options.cc
+++ b/src/main/tools/process-wrapper-options.cc
@@ -117,7 +117,13 @@ static void ParseCommandLine(const std::vector<char *> &args) {
         opt.debug = true;
         break;
       case 'W':
+#if defined(__linux__) && !HAVE_PR_SET_CHILD_SUBREAPER
+        fprintf(stderr,
+                "warning: The \"wait for subprocesses\" feature requires "
+                "Linux kernel version 3.4 or later.\n");
+#else
         opt.wait_fix = true;
+#endif
         break;
       case '?':
         Usage(args.front(), "Unrecognized argument: -%c (%d)", optopt, optind);

--- a/src/main/tools/process-wrapper-options.h
+++ b/src/main/tools/process-wrapper-options.h
@@ -18,6 +18,15 @@
 #include <string>
 #include <vector>
 
+#if defined(__linux__)
+#  include <linux/version.h>
+#  if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0)
+#    define HAVE_PR_SET_CHILD_SUBREAPER 1
+#  else
+#    define HAVE_PR_SET_CHILD_SUBREAPER 0
+#  endif
+#endif
+
 // Options parsing result.
 struct Options {
   // Whether to gracefully terminate subprocesses on SIGTERM (-g)


### PR DESCRIPTION
Commit c6f0f41c8ee8f40b97b1c1c94ca9b75afb02d961 introduced a compile-time
dependency on Linux kernel 3.4 or later via the `PR_SET_CHILD_SUBREAPER`
macro.  Work our way around this by guarding the `wait_fix` option inside
a `LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,0)` check.

Not sure if this will be accepted upstream, but figured it wouldn't hurt to
put it out there.

Resolves #11637.

Testing Done:
- Built Bazel 3.3.0 w/ a modified version of this patch w/ Linux kernel
  headers for 3.0.27.
- `bazelisk test src/test/shell/integration:process_wrapper_test`