### PR TITLE
process-tools-darwin: EXIT_FAILURE comes from stdlib.h

### DIFF
--- a/src/main/tools/process-tools-darwin.cc
+++ b/src/main/tools/process-tools-darwin.cc
@@ -16,6 +16,7 @@
 #include <inttypes.h>
 #include <signal.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <sys/event.h>
 #include <sys/sysctl.h>
 #include <unistd.h>


### PR DESCRIPTION
No idea why this is failing only in our builds (and not, say, Bazel CI), but I
ran into the following when bootstrapping Bazel 3.3.0 on macOS:

```
src/main/tools/process-tools-darwin.cc:48:5: error: use of undeclared identifier 'EXIT_FAILURE'
    DIE("Expected only one event from the kevent call; got %d", nev);
```

In response, let's pull in stdlib.h.

Resolves #11640.

Testing Done:
- bootstrapped Bazel 3.3.0 on macOS 10.15 (Catalina) w/ Xcode 10.