### PR TITLE
Stop `--apple_generate_dsym` from applying to host targets

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -1060,8 +1060,6 @@ public class CppOptions extends FragmentOptions {
     host.disableNoCopts = disableNoCopts;
     host.loadCcRulesFromBzl = loadCcRulesFromBzl;
     host.validateTopLevelHeaderInclusions = validateTopLevelHeaderInclusions;
-    host.appleGenerateDsym = appleGenerateDsym;
-    host.appleEnableAutoDsymDbg = appleEnableAutoDsymDbg;
 
     // Save host options for further use.
     host.hostCoptList = hostCoptList;


### PR DESCRIPTION
As part of d7d0e972c75a2e83fc5ae19927be38feda006ac9 these flags started
started applying to host targets. This causes unexpected rebuilds of
host tools that you will likely never consume the dSYM from.