### PR TITLE
Add the 'includes' param for the Starlark version of cc_import

### DIFF
--- a/tools/build_defs/cc/cc_import.bzl
+++ b/tools/build_defs/cc/cc_import.bzl
@@ -124,6 +124,7 @@ def _cc_import_impl(ctx):
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
         public_hdrs = ctx.files.hdrs,
+        includes = ctx.attr.includes,
         name = ctx.label.name,
     )
 
@@ -144,6 +145,7 @@ cc_import = rule(
         "system_provided": attr.bool(default = False),
         "alwayslink": attr.bool(default = False),
         "linkopts": attr.string_list(),
+        "includes": attr.string_list(),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
     },
     toolchains = ["@rules_cc//cc:toolchain_type"],  # copybara-use-repo-external-label

--- a/tools/build_defs/cc/tests/cc_import_test.bzl
+++ b/tools/build_defs/cc/tests/cc_import_test.bzl
@@ -55,10 +55,7 @@ def _cc_import_linkopts_test_impl(ctx):
     found = False
     for action in actions:
         if action.mnemonic == "CppLink":
-            for arg in action.argv:
-                if arg.find("-testlinkopt") != -1:
-                    found = True
-                    break
+            found = "-testlinkopt" in action.argv
     asserts.true(env, found, "'-testlinkopt' should be included in arguments passed to the linker")
 
     return analysistest.end(env)
@@ -71,11 +68,7 @@ def _cc_import_includes_test_impl(ctx):
     target_under_test = analysistest.target_under_test(env)
     includes = target_under_test[CcInfo].compilation_context.includes.to_list()
 
-    found = False
-    for include in includes:
-        if include == "testinclude":
-            found = True
-            break
+    found = "testinclude" in includes
 
     asserts.true(env, found, "'testinclude' should be present in the includes of the compilation context")
 


### PR DESCRIPTION
This change allows users to add a list of include dirs when using Starlark version of cc_import rule (currently hidden behind '--experimental_starlark_cc_import' flag).