### PR TITLE
If there's no system JDK, point @local_jdk safely to an empty directory.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/WorkspaceFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/WorkspaceFactory.java
@@ -373,7 +373,9 @@ public class WorkspaceFactory {
 
   private String getDefaultSystemJavabase() {
     // --javabase is empty if there's no locally installed JDK
-    return defaultSystemJavabaseDir != null ? defaultSystemJavabaseDir.toString() : "";
+    return defaultSystemJavabaseDir != null
+        ? defaultSystemJavabaseDir.toString()
+        : installDir.getRelative("embedded_tools/tools/jdk/nosystemjdk").getPathString();
   }
 
   /** Returns the entries to populate the "native" module with, for WORKSPACE-loaded .bzl files. */

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -434,6 +434,7 @@ filegroup(
         "DumpPlatformClassPath.java",
         "default_java_toolchain.bzl",
         "java_toolchain_alias.bzl",
+        "nosystemjdk/README",
         "proguard_whitelister.py",
         "proguard_whitelister_test.py",
         "proguard_whitelister_test_input.pgcfg",

--- a/tools/jdk/nosystemjdk/README
+++ b/tools/jdk/nosystemjdk/README
@@ -1,0 +1,2 @@
+This directory is used as the target of @local_jdk workspace if no system JDK is
+detected.


### PR DESCRIPTION
Previously, if there was no system JDK, `@local_jdk` would point to the main workspace. This could lead to the globs in the local JDK BUILD file picking up unexpected files from the main workspace, including the Bazel output tree. Instead, point `@local_jdk` to an empty directory in the embedded tools reserved for this purpose.

Fixes https://github.com/bazelbuild/bazel/issues/7342.