### PR TITLE
Enable remote options for more commands (any that need to download).

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -683,7 +683,7 @@ public final class RemoteModule extends BlazeModule {
 
   @Override
   public Iterable<Class<? extends OptionsBase>> getCommandOptions(Command command) {
-    return ImmutableList.of("build", "test", "fetch").contains(command.name())
+    return ImmutableList.of("build", "fetch", "query", "sync", "test").contains(command.name())
         ? ImmutableList.of(RemoteOptions.class, AuthAndTLSOptions.class)
         : ImmutableList.of();
   }


### PR DESCRIPTION
During a migration of an internal project to use the remote downloader, I discovered that `bazel query` doesn't have the remote options registered. This prevents it from being able to download dependencies via the remote downloader.

It seems that the set of commands that can have remote options is a hardcoded list; this PR expands that list to include `sync` and `query`.