### PR TITLE
Add python module six as dependency to bazel_external_repository_test

### DIFF
--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -76,7 +76,10 @@ py_test(
     tags = [
         "requires-network",
     ],
-    deps = [":test_base"],
+    deps = [
+        ":test_base",
+        "//third_party/py/six",
+    ],
 )
 
 py_test(


### PR DESCRIPTION
In the test bazel_external_repository_test the python module six was not added as a dependency which caused the test to fail in some envoirnments.

This closes #11663 