### PR TITLE
Add oso_prefix_is_pwd macOS feature

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5451,6 +5451,17 @@ def _impl(ctx):
         requires = [feature_set(features = ["opt"])],
     )
 
+    oso_prefix_feature = feature(
+        name = "oso_prefix_is_pwd",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions +
+                          ["objc-executable", "objc++-executable"],
+                flag_groups = [flag_group(flags = ["OSO_PREFIX_MAP_PWD"])],
+            ),
+        ],
+    )
+
     generate_dsym_file_feature = feature(
         name = "generate_dsym_file",
         flag_sets = [
@@ -5782,6 +5793,7 @@ def _impl(ctx):
             default_compile_flags_feature,
             debug_prefix_map_pwd_is_dot_feature,
             generate_dsym_file_feature,
+            oso_prefix_feature,
             contains_objc_source_feature,
             objc_actions_feature,
             strip_debug_symbols_feature,
@@ -5853,6 +5865,7 @@ def _impl(ctx):
             default_compile_flags_feature,
             debug_prefix_map_pwd_is_dot_feature,
             generate_dsym_file_feature,
+            oso_prefix_feature,
             contains_objc_source_feature,
             objc_actions_feature,
             strip_debug_symbols_feature,
@@ -5926,6 +5939,7 @@ def _impl(ctx):
             default_compile_flags_feature,
             debug_prefix_map_pwd_is_dot_feature,
             generate_dsym_file_feature,
+            oso_prefix_feature,
             contains_objc_source_feature,
             objc_actions_feature,
             strip_debug_symbols_feature,

--- a/tools/osx/crosstool/wrapped_clang.cc
+++ b/tools/osx/crosstool/wrapped_clang.cc
@@ -219,6 +219,9 @@ int main(int argc, char *argv[]) {
     if (SetArgIfFlagPresent(arg, "DEBUG_PREFIX_MAP_PWD", &dest_dir)) {
       arg = "-fdebug-prefix-map=" + std::string(cwd.get()) + "=" + dest_dir;
     }
+    if (arg.compare("OSO_PREFIX_MAP_PWD") == 0) {
+      arg = "-Wl,-oso_prefix," + std::string(cwd.get()) + "/";
+    }
     FindAndReplace("__BAZEL_XCODE_DEVELOPER_DIR__", developer_dir, &arg);
     FindAndReplace("__BAZEL_XCODE_SDKROOT__", sdk_root, &arg);
 


### PR DESCRIPTION
With Xcode 11 Apple's linker introduced a new oso_prefix option which
removes the given prefix from the path in debug info. This improves the
goal of producing reproducible builds.

More info: https://milen.me/writings/apple-linker-ld64-deterministic-builds-oso-prefix

RELNOTES: Add opt in 'oso_prefix_is_pwd' feature for Apple builds