### PR TITLE
Fix xcode-locator preferring some Xcode versions outside of /Applications

### DIFF
--- a/tools/osx/xcode_locator.m
+++ b/tools/osx/xcode_locator.m
@@ -65,8 +65,7 @@
 static void AddEntryToDictionary(
   XcodeVersionEntry *entry,
   NSMutableDictionary<NSString *, XcodeVersionEntry *> *dict) {
-  BOOL inApplications =
-      [entry.url.path rangeOfString:@"/Applications/"].location != NSNotFound;
+  BOOL inApplications = [entry.url.path hasPrefix:@"/Applications/"];
   NSString *entryVersion = entry.version;
   NSString *subversion = entryVersion;
   if (dict[entryVersion] && !inApplications) {


### PR DESCRIPTION
The current xcode-locator prefers Xcode versions in /Applications
over other versions, comments indicate this is to prefer
local versions over mounted versions. The check for for whether Xcode
is in /Applications is only checking if the file path contains
"/Applications/".

This causes issues if Xcode installations can be found on disk that
contains "/Applications/" but are not rooted at /Applications,
e.g. when using TimeMachine these can be found at
/Volumes/MyPassportForMac/Backups.backupdb/.../Macintosh HD/Applications/Xcode.app
The Xcode from the backup can replace the Xcode actually at
/Applications/Xcode.app. This leads to compile errors later when using
that version of Xcode, e.g. "the rule is missing dependency
declarations" for files in the wrong Xcode path.

Fix by checking if the path starts with "/Applications/" instead of
just contains "/Applications/".

This will change behavior and potentially break users if the
"contains" check was relied on, e.g. if anybody expects
"/Users/me/Applications/Xcode.app" to be preferred over
"<network mount>/somewhere/Xcode.app". It's not clear that this was ever
intended to work like this and need to preserve this behavior.
If we wanted to be extra cautious, we could change this to 3 preference
tiers: first choose version in /Applications, then choose versions
containing "/Applications/" anywhere in the path, and finally choose
any other path to Xcode.