### PR TITLE
Replace the remaining dependencies for Bazel Debian build (third_party)

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -164,7 +164,7 @@ distrib_java_import(
     enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "api_client",
     jars = [
         "api_client/google-api-client-1.22.0.jar",
@@ -175,6 +175,7 @@ java_import(
     runtime_deps = [
         ":jackson2",
     ],
+    enable_distributions = ["debian"],
 )
 
 distrib_java_import(
@@ -212,7 +213,7 @@ java_import(
     runtime_deps = [":asm-tree"],
 )
 
-java_import(
+distrib_java_import(
     name = "auth",
     jars = [
         "auth/google-auth-library-oauth2-http-0.17.1.jar",
@@ -223,6 +224,7 @@ java_import(
         ":guava",
         "//third_party/aws-sdk-auth-lite",
     ],
+    enable_distributions = ["debian"],
 )
 
 java_plugin(
@@ -241,9 +243,10 @@ java_plugin(
     ],
 )
 
-java_import(
+distrib_java_import(
     name = "auto_common",
     jars = ["auto/auto-common-0.10.jar"],
+    enable_distributions = ["debian"],
 )
 
 java_library(
@@ -266,9 +269,10 @@ java_plugin(
     ],
 )
 
-java_import(
+distrib_java_import(
     name = "auto_service_lib",
     jars = ["auto/auto-service-1.0-rc4.jar"],
+    enable_distributions = ["debian"],
 )
 
 java_plugin(
@@ -298,21 +302,23 @@ java_library(
     ],
 )
 
-java_import(
+distrib_java_import(
     name = "auto_value_value",
     jars = [
         "auto/auto-value-1.6.3rc1.jar",
         "auto/auto-value-annotations-1.6.3rc1.jar",
     ],
+    enable_distributions = ["debian"],
 )
 
 # For bootstrapping JavaBuilder
-filegroup(
+distrib_jar_filegroup(
     name = "auto_value-jars",
     srcs = [
         "auto/auto-value-1.6.3rc1.jar",
         "auto/auto-value-annotations-1.6.3rc1.jar",
     ],
+    enable_distributions = ["debian"],
 )
 
 java_import(
@@ -323,10 +329,11 @@ java_import(
     ],
 )
 
-java_import(
+distrib_java_import(
     name = "checker_framework_annotations",
     jars = ["checker_framework_annotations/checker-qual-3.2.0.jar"],
     srcjar = "checker_framework_annotations/checker-qual-3.2.0-sources.jar",
+    enable_distributions = ["debian"],
 )
 
 java_import(
@@ -358,12 +365,22 @@ java_import(
     ],
 )
 
-java_import(
+distrib_java_import(
     name = "error_prone_annotations",
     jars = [
         "error_prone/error_prone_annotations-2.4.0.jar",
         "error_prone/error_prone_type_annotations-2.4.0.jar",
     ],
+    enable_distributions = ["debian"],
+)
+
+distrib_jar_filegroup(
+    name = "error_prone_annotations-jar",
+    srcs = [
+        "error_prone/error_prone_annotations-2.4.0.jar",
+        "error_prone/threeten-extra-1.5.0.jar",
+    ],
+    enable_distributions = ["debian"],
 )
 
 java_import(
@@ -426,8 +443,7 @@ java_import(
 filegroup(
     name = "bootstrap_guava_and_error_prone-jars",
     srcs = [
-        "error_prone/error_prone_annotations-2.4.0.jar",
-        "error_prone/threeten-extra-1.5.0.jar",
+        ":error_prone_annotations-jar",
         ":guava-jars",
         ":jcip_annotations-jars",
         ":jsr305-jars",
@@ -445,37 +461,41 @@ distrib_java_import(
     enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "flogger",
     jars = [
         "flogger/flogger-0.5.1.jar",
         "flogger/flogger-system-backend-0.5.1.jar",
         "flogger/google-extensions-0.5.1.jar",
     ],
+    enable_distributions = ["debian"],
 )
 
-filegroup(
+distrib_jar_filegroup(
     name = "flogger-jars",
     srcs = [
         "flogger/flogger-0.5.1.jar",
         "flogger/flogger-system-backend-0.5.1.jar",
         "flogger/google-extensions-0.5.1.jar",
     ],
+    enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "opencensus-api",
     jars = [
         "opencensus/opencensus-api-0.24.0.jar",
         "opencensus/opencensus-contrib-grpc-metrics-0.24.0.jar",
     ],
+    enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "perfmark-api",
     jars = [
         "perfmark/perfmark-api-0.19.0.jar",
     ],
+    enable_distributions = ["debian"],
 )
 
 # For bootstrapping JavaBuilder
@@ -580,9 +600,10 @@ distrib_jar_filegroup(
     enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "java-diff-utils",
     jars = ["java-diff-utils/java-diff-utils-4.0.jar"],
+    enable_distributions = ["debian"],
 )
 
 # Testing

--- a/third_party/grpc/BUILD
+++ b/third_party/grpc/BUILD
@@ -14,24 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_java//java:defs.bzl", "java_import")
+load("//tools/distributions:distribution_rules.bzl", "distrib_java_import", "distrib_jar_filegroup")
 
 licenses(["notice"])  # Apache v2
 
 exports_files(["grpc_1.26.0.patch"])
 
-package(
-    default_visibility = ["//visibility:public"],
-    features = [
-        "-layering_check",
-        "-parse_headers",
-    ],
-)
-
-load(
-    ":build_defs.bzl",
-    "grpc_cc_library",
-)
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "srcs",
@@ -40,12 +29,7 @@ filegroup(
     ],
 )
 
-config_setting(
-    name = "windows",
-    values = {"cpu": "x64_windows"},
-)
-
-filegroup(
+distrib_jar_filegroup(
     name = "bootstrap-grpc-jars",
     srcs = [
         "grpc-api-1.26.0.jar",
@@ -57,9 +41,10 @@ filegroup(
         "grpc-protobuf-lite-1.26.0.jar",
         "grpc-stub-1.26.0.jar",
     ],
+    enable_distributions = ["debian"],
 )
 
-java_import(
+distrib_java_import(
     name = "grpc-jar",
     jars = [":bootstrap-grpc-jars"],
     runtime_deps = [
@@ -70,6 +55,7 @@ java_import(
     deps = [
         "//third_party:guava",
     ],
+    enable_distributions = ["debian"],
 )
 
 cc_binary(
@@ -85,17 +71,26 @@ cc_binary(
 
 alias(
     name = "cpp_plugin",
-    actual = "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
+    actual = select({
+        "//src/conditions:debian_build": "@debian_bin_deps//:grpc-cpp-plugin",
+        "//conditions:default": "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
+    }),
 )
 
 alias(
     name = "grpc++_codegen_proto",
-    actual = "@com_github_grpc_grpc//:grpc++_codegen_proto",
+    actual = select({
+        "//src/conditions:debian_build": "@debian_cc_deps//:grpc++_unsecure",
+        "//conditions:default": "@com_github_grpc_grpc//:grpc++_codegen_proto",
+    }),
 )
 
 alias(
     name = "grpc++_unsecure",
-    actual = "@com_github_grpc_grpc//:grpc++_unsecure",
+    actual = select({
+        "//src/conditions:debian_build": "@debian_cc_deps//:grpc++_unsecure",
+        "//conditions:default": "@com_github_grpc_grpc//:grpc++_unsecure",
+    }),
 )
 
 filegroup(


### PR DESCRIPTION
Working towards https://github.com/bazelbuild/bazel/issues/9408

Thanks to @olekw, the remaining jar dependencies are all packaged for Debian. We'll verify if they work as soon as they are available in unstable distribution.