### PR TITLE
Sketch: function calls faster than fastcall

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkProvider.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.syntax.Printer;
 import com.google.devtools.build.lib.syntax.Starlark;
 import com.google.devtools.build.lib.syntax.StarlarkCallable;
 import com.google.devtools.build.lib.syntax.StarlarkThread;
+import com.google.devtools.build.lib.syntax.UltraFastCallSig;
 import java.util.Collection;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -132,7 +133,7 @@ public final class StarlarkProvider implements StarlarkCallable, StarlarkExporta
   }
 
   @Override
-  public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named)
+  public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named, @Nullable UltraFastCallSig ultraFastCallSig)
       throws EvalException, InterruptedException {
     if (positional.length > 0) {
       throw Starlark.errorf("%s: unexpected positional arguments", getName());

--- a/src/main/java/com/google/devtools/build/lib/syntax/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BUILD
@@ -67,9 +67,11 @@ java_library(
         "StringLiteral.java",
         "SyntaxError.java",
         "TokenKind.java",
+        "UltraFastCallSig.java",
         "UnaryOperatorExpression.java",
     ],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec:serialization-constant",

--- a/src/main/java/com/google/devtools/build/lib/syntax/BuiltinCallable.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BuiltinCallable.java
@@ -62,7 +62,7 @@ public final class BuiltinCallable implements StarlarkCallable {
   }
 
   @Override
-  public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named)
+  public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named, UltraFastCallSig ultraFastCallSig)
       throws EvalException, InterruptedException {
     MethodDescriptor desc =
         this.desc != null ? this.desc : getMethodDescriptor(thread.getSemantics());

--- a/src/main/java/com/google/devtools/build/lib/syntax/Eval.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Eval.java
@@ -612,7 +612,7 @@ final class Eval {
     Location loc = call.getLparenLocation(); // (Location is prematerialized)
     fr.setLocation(loc);
     try {
-      return Starlark.fastcall(fr.thread, fn, positional, named);
+      return Starlark.fastcall(fr.thread, fn, positional, named, call.getUltraFastCallSig());
     } catch (EvalException ex) {
       throw ex.ensureLocation(loc);
     }

--- a/src/main/java/com/google/devtools/build/lib/syntax/EvalUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/EvalUtils.java
@@ -650,7 +650,7 @@ public final class EvalUtils {
     Tuple<Object> defaultValues = Tuple.empty();
     StarlarkFunction toplevel = new StarlarkFunction(file.resolved, defaultValues, module);
 
-    return Starlark.fastcall(thread, toplevel, NOARGS, NOARGS);
+    return Starlark.fastcall(thread, toplevel, NOARGS, NOARGS, null);
   }
 
   /**
@@ -668,7 +668,7 @@ public final class EvalUtils {
     Tuple<Object> defaultValues = Tuple.empty();
     StarlarkFunction exprFunc = new StarlarkFunction(rfn, defaultValues, module);
 
-    return Starlark.fastcall(thread, exprFunc, NOARGS, NOARGS);
+    return Starlark.fastcall(thread, exprFunc, NOARGS, NOARGS, null);
   }
 
   private static final Object[] NOARGS = {};

--- a/src/main/java/com/google/devtools/build/lib/syntax/Starlark.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Starlark.java
@@ -398,7 +398,7 @@ public final class Starlark {
       named[i++] = e.getKey();
       named[i++] = e.getValue();
     }
-    return fastcall(thread, fn, args.toArray(), named);
+    return fastcall(thread, fn, args.toArray(), named, null);
   }
 
   /**
@@ -408,7 +408,7 @@ public final class Starlark {
    * <p>The caller must not subsequently modify or even inspect the two arrays.
    */
   public static Object fastcall(
-      StarlarkThread thread, Object fn, Object[] positional, Object[] named)
+      StarlarkThread thread, Object fn, Object[] positional, Object[] named, @Nullable UltraFastCallSig ultraFastCallSig)
       throws EvalException, InterruptedException {
     StarlarkCallable callable;
     if (fn instanceof StarlarkCallable) {
@@ -425,7 +425,7 @@ public final class Starlark {
 
     thread.push(callable);
     try {
-      return callable.fastcall(thread, positional, named);
+      return callable.fastcall(thread, positional, named, ultraFastCallSig);
     } finally {
       thread.pop();
     }

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkCallable.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkCallable.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.syntax;
 
+import javax.annotation.Nullable;
 import com.google.common.collect.Maps;
 import java.util.LinkedHashMap;
 
@@ -65,12 +66,12 @@ public interface StarlarkCallable extends StarlarkValue {
    *
    * <p>The default implementation forwards the call to {@code call}, after rejecting any duplicate
    * named arguments. Other implementations of this method should similarly reject duplicates.
-   *
    * @param thread the StarlarkThread in which the function is called
    * @param positional a list of positional arguments
    * @param named a list of named arguments, as alternating Strings/Objects. May contain dups.
+   * @param ultraFastCallSig
    */
-  default Object fastcall(StarlarkThread thread, Object[] positional, Object[] named)
+  default Object fastcall(StarlarkThread thread, Object[] positional, Object[] named, @Nullable UltraFastCallSig ultraFastCallSig)
       throws EvalException, InterruptedException {
     LinkedHashMap<String, Object> kwargs = Maps.newLinkedHashMapWithExpectedSize(named.length >> 1);
     for (int i = 0; i < named.length; i += 2) {

--- a/src/main/java/com/google/devtools/build/lib/syntax/UltraFastCallSig.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/UltraFastCallSig.java
@@ -1,0 +1,48 @@
+package com.google.devtools.build.lib.syntax;
+
+import java.util.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.concurrent.BlazeInterners;
+import com.google.common.collect.Interner;
+
+/** Ultra-fast call signature (which is a call without star or star-star args.
+ * Starlark can optimize these calls. */
+public class UltraFastCallSig {
+    /** Number of positional arguments. */
+    public final int numPositional;
+    /** Named arguments. */
+    public final ImmutableList<String> named;
+    public final boolean hasNamed;
+
+    private final int hashCode;
+
+    private UltraFastCallSig(int numPositional, ImmutableList<String> named) {
+        this.numPositional = numPositional;
+        this.named = named;
+        this.hasNamed = !named.isEmpty();
+        this.hashCode = Objects.hash(numPositional, named);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UltraFastCallSig that = (UltraFastCallSig) o;
+        return numPositional == that.numPositional
+                && named.equals(that.named);
+    }
+
+    @Override
+    public int hashCode() {
+        // Cache hash-code, because map lookup by signature must be lightning fast
+        return hashCode;
+    }
+
+    private static final Interner<UltraFastCallSig> interner = BlazeInterners.newWeakInterner();
+
+    public static UltraFastCallSig create(int numPositional, ImmutableList<String> named) {
+        // We need to intern call signatures because cache lookup should be very fast,
+        // and deep `UltraFastCallSig` comparison is not.
+        return interner.intern(new UltraFastCallSig(numPositional, named));
+    }
+}

--- a/src/main/java/com/google/devtools/build/skydoc/SkydocMain.java
+++ b/src/main/java/com/google/devtools/build/skydoc/SkydocMain.java
@@ -77,6 +77,7 @@ import com.google.devtools.build.lib.syntax.StarlarkSemantics;
 import com.google.devtools.build.lib.syntax.StarlarkThread;
 import com.google.devtools.build.lib.syntax.Statement;
 import com.google.devtools.build.lib.syntax.StringLiteral;
+import com.google.devtools.build.lib.syntax.UltraFastCallSig;
 import com.google.devtools.build.skydoc.fakebuildapi.FakeActionsInfoProvider;
 import com.google.devtools.build.skydoc.fakebuildapi.FakeBuildApiGlobals;
 import com.google.devtools.build.skydoc.fakebuildapi.FakeConfigApi;
@@ -625,7 +626,7 @@ public class SkydocMain {
         "depset",
         new StarlarkCallable() {
           @Override
-          public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named) {
+          public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named, UltraFastCallSig sig) {
             // Accept any arguments, return empty Depset.
             return Depset.of(
                 Depset.ElementType.EMPTY, NestedSetBuilder.emptySet(Order.STABLE_ORDER));
@@ -644,7 +645,7 @@ public class SkydocMain {
         "select",
         new StarlarkCallable() {
           @Override
-          public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named)
+          public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named, UltraFastCallSig sig)
               throws EvalException {
             for (Map.Entry<?, ?> e : ((Dict<?, ?>) positional[0]).entrySet()) {
               return e.getValue();

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/FakeStarlarkNativeModuleApi.java
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/FakeStarlarkNativeModuleApi.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.syntax.Starlark;
 import com.google.devtools.build.lib.syntax.StarlarkCallable;
 import com.google.devtools.build.lib.syntax.StarlarkList;
 import com.google.devtools.build.lib.syntax.StarlarkThread;
+import com.google.devtools.build.lib.syntax.UltraFastCallSig;
 import javax.annotation.Nullable;
 
 /** Fake implementation of {@link StarlarkNativeModuleApi}. */
@@ -85,7 +86,7 @@ public class FakeStarlarkNativeModuleApi implements StarlarkNativeModuleApi, Cla
     // "native".
     return new StarlarkCallable() {
       @Override
-      public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named) {
+      public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named, @Nullable UltraFastCallSig sig) {
         return Starlark.NONE;
       }
 

--- a/src/test/java/com/google/devtools/build/lib/profiler/memory/AllocationTrackerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/profiler/memory/AllocationTrackerTest.java
@@ -36,6 +36,7 @@ import com.google.devtools.build.lib.syntax.StarlarkSemantics;
 import com.google.devtools.build.lib.syntax.StarlarkThread;
 import com.google.devtools.build.lib.syntax.SyntaxError;
 import com.google.devtools.build.lib.syntax.TokenKind;
+import com.google.devtools.build.lib.syntax.UltraFastCallSig;
 import com.google.perftools.profiles.ProfileProto.Function;
 import com.google.perftools.profiles.ProfileProto.Profile;
 import com.google.perftools.profiles.ProfileProto.Sample;
@@ -207,7 +208,7 @@ public final class AllocationTrackerTest {
   // A fake Bazel rule. The allocation tracker reports retained memory broken down by rule class.
   private class MyRuleFunction implements RuleFunction, StarlarkCallable {
     @Override
-    public Object fastcall(StarlarkThread thread, Object[] parameters, Object[] named) {
+    public Object fastcall(StarlarkThread thread, Object[] parameters, Object[] named, UltraFastCallSig sig) {
       Object obj = new Object();
       live.add(obj); // ensure that obj outlives the test assertions
       tracker.sampleAllocation(1, "", obj, 128);

--- a/src/test/java/com/google/devtools/build/lib/syntax/EvaluationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/EvaluationTest.java
@@ -104,7 +104,7 @@ public final class EvaluationTest {
     }
 
     @Override
-    public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named) {
+    public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named, UltraFastCallSig sig) {
       callCount++;
       if (positional.length > 0 && Starlark.truth(positional[0])) {
         Thread.currentThread().interrupt();
@@ -191,7 +191,7 @@ public final class EvaluationTest {
           }
 
           @Override
-          public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named) {
+          public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named, UltraFastCallSig sig) {
             int sum = 0;
             for (Object arg : positional) {
               sum += (Integer) arg;

--- a/src/test/java/com/google/devtools/build/lib/syntax/StarlarkEvaluationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/StarlarkEvaluationTest.java
@@ -1951,7 +1951,7 @@ public final class StarlarkEvaluationTest extends EvaluationTestCase {
           }
 
           @Override
-          public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named) {
+          public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named, UltraFastCallSig sig) {
             return "fromValues";
           }
         };

--- a/src/test/java/com/google/devtools/build/lib/syntax/StarlarkThreadDebuggingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/StarlarkThreadDebuggingTest.java
@@ -62,7 +62,7 @@ public class StarlarkThreadDebuggingTest {
           }
 
           @Override
-          public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named) {
+          public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named, UltraFastCallSig ultraFastCallSig) {
             result[0] = Debug.getCallStack(thread);
             result[1] = thread.getCallStack();
             return Starlark.NONE;


### PR DESCRIPTION
TL;DR: instead of look parameter by name during each function call,
cache argument to parameter mapping by call signature.

`class UltraFastCallSig` is a pair of (`numPositional`, `named`)
argument which can be used in callable implementation to cache
parameter resolving.

For invocation:

```
foo(1, 2, 4, c=3, d=4)
```

`UltraFastCallSig` is `(4, ["c", "d"])` regardless of what `foo` is.

`UltraFastCallSig` is only used in calls without varargs. In could
be extended to calls with varargs, but it would be larger change
than this PR.

`StarlarkFunction` implementation now contains a `ConcurrentHashMap`
from `UltraFastCallSig` to a mapping.

The mapping is an integer array, describing, how to populate arguments
after positional arguments (from given indexed named argument, or
from default value).

When mapping exists, it means that this particular call signature
is compatible with this function signature, and parameter population
no longer performs map lookups.

`UltraFastCallSig` can be also used to efficiently generate
`BuiltinFunction` invocations, but that's a story for another PR.

**This PR is a sketch**. I'd like to get some feedback out it before
spending more time on it.

Results for this silly test case:

```
def bar(x, y, z, w, a, b, c):
    pass

def test():
    for i in range(10):
        print(i)
        for j in range(1000):
            for j in range(100):
                bar(x=1, y="a", z=1, w=2, a="x", b="y", c="c")
                bar(x=1, y="a", z=1, w=2, a="x", b="y", c="c")
                bar(x=1, y="a", z=1, w=2, a="x", b="y", c="c")
                bar(x=1, y="a", z=1, w=2, a="x", b="y", c="c")
                bar(x=1, y="a", z=1, w=2, a="x", b="y", c="c")
                bar(x=1, y="a", z=1, w=2, a="x", b="y", c="c")
                bar(x=1, y="a", z=1, w=2, a="x", b="y", c="c")
                bar(x=1, y="a", z=1, w=2, a="x", b="y", c="c")
                bar(x=1, y="a", z=1, w=2, a="x", b="y", c="c")
                bar(x=1, y="a", z=1, w=2, a="x", b="y", c="c")
test()
```

```
Before: 5.6s
After:  4.7s
```

The optimization is not applied for positional-only calls. For this benchmark:

```
def foo():
    pass

def test():
    for i in range(10):
        print(i)
        for j in range(1000):
            for k in range(200):
                foo()
                foo()
                foo()
                foo()
                foo()
                foo()
                foo()
                foo()
                foo()
                foo()

test()
```

The slowdown is within 1%.

Finally, this optimization has a benefit even single-name arg calls:

```
def foo(a):
    pass

def test():
    for i in range(10):
        print(i)
        for j in range(1000):
            for k in range(200):
                foo(a=1)
                foo(a=1)
                foo(a=1)
                foo(a=1)
                foo(a=1)
                foo(a=1)
                foo(a=1)
                foo(a=1)
                foo(a=1)
                foo(a=1)
                foo(a=1)

test()
```

```
A: N=34, r=3.280+-0.077
B: N=34, r=3.222+-0.104
B/A: 0.982
```