### PR TITLE
Tool paths are relative to cc_toolchain not suite

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderHelper.java
@@ -75,7 +75,7 @@ public class CcToolchainProviderHelper {
     CcToolchainFeatures toolchainFeatures;
     PathFragment toolsDirectory =
         getToolsDirectory(
-            ruleContext.getLabel(),
+            attributes.getCcToolchainLabel(),
             ruleContext
                 .getAnalysisEnvironment()
                 .getStarlarkSemantics()

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.platform.ToolchainInfo;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
@@ -183,6 +184,84 @@ public class CcToolchainProviderTest extends BuildViewTestCase {
         "--incompatible_remove_cpu_and_compiler_attributes_from_cc_toolchain");
     getConfiguredTarget("//a:c_suite");
     assertNoEvents();
+  }
+
+  @Test
+  public void testToolchainAndSuiteDifferentPackages() throws Exception {
+      scratch.file(
+          "suite/BUILD",
+          "filegroup(name = 'empty')",
+          "cc_toolchain_suite(",
+          "    name = 'suite',",
+          "    toolchains = { 'banana': '//toolchain' },",
+          ")"
+      );
+      scratch.file(
+          "toolchain/BUILD",
+          "load(':cc_toolchain_config.bzl', 'cc_toolchain_config')",
+          "cc_toolchain(",
+          "    name = 'toolchain',",
+          "    all_files = ':empty',",
+          "    ar_files = ':empty',",
+          "    as_files = ':empty',",
+          "    compiler_files = ':empty',",
+          "    dwp_files = ':empty',",
+          "    linker_files = ':empty',",
+          "    strip_files = ':empty',",
+          "    objcopy_files = ':empty',",
+          "    toolchain_identifier = 'banana',",
+          "    toolchain_config = ':banana_config',",
+          ")",
+          "cc_toolchain_config(name = 'banana_config')");
+
+    scratch.file(
+        "toolchain/cc_toolchain_config.bzl",
+        "load('@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl', 'tool_path')",
+        "def _impl(ctx):",
+        "    return cc_common.create_cc_toolchain_config_info(",
+        "        ctx = ctx,",
+        "        features = [],",
+        "        action_configs = [],",
+        "        artifact_name_patterns = [],",
+        "        cxx_builtin_include_directories = [],",
+        "        toolchain_identifier = 'toolchain',",
+        "        host_system_name = 'host',",
+        "        target_system_name = 'target',",
+        "        target_cpu = 'cpu',",
+        "        target_libc = 'libc',",
+        "        compiler = 'compiler',",
+        "        abi_libc_version = 'abi_libc',",
+        "        abi_version = 'banana',",
+        "        tool_paths = [",
+        "             tool_path(name = 'ar', path = 'some/ar'),",
+        "             tool_path(name = 'cpp', path = 'some/cpp'),",
+        "             tool_path(name = 'gcc', path = 'some/gcc'),",
+        "             tool_path(name = 'gcov', path = 'some/gcov'),",
+        "             tool_path(name = 'gcovtool', path = 'some/gcovtool'),",
+        "             tool_path(name = 'ld', path = 'some/ld'),",
+        "             tool_path(name = 'nm', path = 'some/nm'),",
+        "             tool_path(name = 'objcopy', path = 'some/objcopy'),",
+        "             tool_path(name = 'objdump', path = 'some/objdump'),",
+        "             tool_path(name = 'strip', path = 'some/strip'),",
+        "             tool_path(name = 'dwp', path = 'some/dwp'),",
+        "        ],",
+        "        cc_target_os = 'os',",
+        "        builtin_sysroot = 'sysroot'",
+        "    )",
+        "cc_toolchain_config = rule(",
+        "    implementation = _impl,",
+        "    attrs = {},",
+        "    provides = [CcToolchainConfigInfo],",
+        "    fragments = ['cpp']",
+        ")");
+
+    useConfiguration("--cpu=banana");
+    ConfiguredTarget target = getConfiguredTarget("//suite");
+    RuleContext ruleContext = getRuleContext(target);
+    CcToolchainProvider toolchainProvider =
+            (CcToolchainProvider) target.get(ToolchainInfo.PROVIDER);
+    assertThat(toolchainProvider.getToolPathFragment(CppConfiguration.Tool.CPP, ruleContext).toString())
+            .isEqualTo("toolchain/some/cpp");
   }
 
   /*


### PR DESCRIPTION
If your cc_toolchain_suite references cc_toolchains in different
packages, currently path computation is incorrect because it attempts to
append relative paths to the package containing the cc_toolchain_suite
not the cc_toolchain.

This commit makes the paths be looked up relative to the cc_toolchain.

Where these happen to be the same package (which must always have been
the case before, beacuse this code requires it), the behaviour will be
identical. But if separate packages are used, that will not work too.