### PR TITLE
[Log] Surface error log file for manifest merging issue

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -399,17 +399,21 @@ final class WorkerSpawnRunner implements SpawnRunner {
           // to stdout - it's probably a stack trace or some kind of error message that will help
           // the user figure out why the compiler is failing.
           String recordingStreamMessage = worker.getRecordingStreamMessage();
-          throw new UserExecException(
-              ErrorMessage.builder()
+          ErrorMessage.Builder builder = ErrorMessage.builder()
                   .message(
-                      "Worker process returned an unparseable WorkResponse!\n\n"
-                          + "Did you try to print something to stdout? Workers aren't allowed to "
-                          + "do this, as it breaks the protocol between Bazel and the worker "
-                          + "process.")
-                  .logText(recordingStreamMessage)
-                  .exception(e)
-                  .build()
-                  .toString());
+                          "Worker process returned an unparseable WorkResponse!\n\n"
+                                  + "Did you try to print something to stdout? Workers aren't allowed to "
+                                  + "do this, as it breaks the protocol between Bazel and the worker "
+                                  + "process.")
+                  .exception(e);
+          if (worker.logFile != null) {
+            builder.logFile(worker.logFile);
+          } else {
+            builder.logText(recordingStreamMessage);
+          }
+          throw new UserExecException(
+              builder.build().toString()
+          );
         }
       }
 


### PR DESCRIPTION
### Background
We noticed that some error messages during manifest merging stage will not be surfaced under the current error message reporting mechanism. The reason is that by default, we are fetching the error message from stdout stream while the real error message is stored inside a log file created by worker thread.

For example, the following error message will be logged inside `/private/var/tmp/.../bazel-workers/worker-10-ManifestMerger.log` when we the `minSdkVersion`  defined in third party library is larger than app's minSdkVersion definition. 
```
/private/var/tmp/..../AndroidManifest.xml Error:
	uses-sdk:minSdkVersion 19 cannot be smaller than version 21 declared in library xxx /var/folders/89/gngzz1cn74n0yt9fxth8czhw0000gp/T/manifest_merge_tmp16810264379575934749/bazel-out/darwin-fastbuild/bin/external/android_mvn/_aar/xxx/AndroidManifest.xml
	Suggestion: use tools:overrideLibrary="app.aifactory.analytics" to force usage
```

Without this change, this error message will not be surfaced and what we got is 
```
18:20:01 androidBazel:65  |I| ---8<---8<--- Start of log ---8<---8<---
18:20:01 androidBazel:65  |I| Warning: 
18:20:01 androidBazel:65  |I| See http://g.co/androidstudio/manifest-merger for more information about the manifest merger.
18:20:01 androidBazel:65  |I| anifest merger.
18:20:01 androidBazel:65  |I| ---8<---8<--- End of log ---8<---8<---
```

### Change
Use log file as the first choice while outputting the error message. 
Q: Is it possible that logFile will be empty (but not null) and the real error is in recordingStreamMessage? I can't find a case like that but want to double check 