### PR TITLE
Add support for object files in the Starlark implementation of cc_import

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -394,6 +394,8 @@ public abstract class CcModule
    * @param alwayslink boolean
    * @param dynamicLibraryPath String
    * @param interfaceLibraryPath String
+   * @param picObjectFiles Sequence<Artifact>
+   * @param nopicObjectFiles Sequence<Artifact>
    * @return
    * @throws EvalException
    * @throws InterruptedException
@@ -407,6 +409,8 @@ public abstract class CcModule
       Object picStaticLibraryObject,
       Object dynamicLibraryObject,
       Object interfaceLibraryObject,
+      Object picObjectFiles, // Sequence<Artifact> expected
+      Object nopicObjectFiles, // Sequence<Artifact> expected
       boolean alwayslink,
       String dynamicLibraryPath,
       String interfaceLibraryPath,
@@ -422,6 +426,10 @@ public abstract class CcModule
     Artifact picStaticLibrary = nullIfNone(picStaticLibraryObject, Artifact.class);
     Artifact dynamicLibrary = nullIfNone(dynamicLibraryObject, Artifact.class);
     Artifact interfaceLibrary = nullIfNone(interfaceLibraryObject, Artifact.class);
+    ImmutableList<Artifact> picObjects =
+        nullIfNoneOrEmptySequence(picObjectFiles, Artifact.class, "PIC object files");
+    ImmutableList<Artifact> nopicObjects =
+        nullIfNoneOrEmptySequence(nopicObjectFiles, Artifact.class, "No-PIC object files");
 
     StringBuilder extensionErrorsBuilder = new StringBuilder();
     String extensionErrorMessage = "does not have any of the allowed extensions";
@@ -580,6 +588,8 @@ public abstract class CcModule
         .setResolvedSymlinkDynamicLibrary(resolvedSymlinkDynamicLibrary)
         .setInterfaceLibrary(interfaceLibrary)
         .setResolvedSymlinkInterfaceLibrary(resolvedSymlinkInterfaceLibrary)
+        .setObjectFiles(nopicObjects)
+        .setPicObjectFiles(picObjects)
         .setAlwayslink(alwayslink)
         .build();
   }
@@ -1536,6 +1546,13 @@ public abstract class CcModule
   @Nullable
   private static <T> T nullIfNone(Object object, Class<T> type) {
     return object != Starlark.NONE ? type.cast(object) : null;
+  }
+
+  @Nullable
+  private static <T> ImmutableList<T> nullIfNoneOrEmptySequence(
+      Object object, Class<T> type, String what) throws EvalException {
+    Sequence<T> seq = Sequence.noneableCast(object, type, what);
+    return seq.isEmpty() ? null : seq.getImmutableList();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -395,7 +395,7 @@ public abstract class CcModule
    * @param dynamicLibraryPath String
    * @param interfaceLibraryPath String
    * @param picObjectFiles Sequence<Artifact>
-   * @param nopicObjectFiles Sequence<Artifact>
+   * @param objectFiles Sequence<Artifact>
    * @return
    * @throws EvalException
    * @throws InterruptedException
@@ -410,7 +410,7 @@ public abstract class CcModule
       Object dynamicLibraryObject,
       Object interfaceLibraryObject,
       Object picObjectFiles, // Sequence<Artifact> expected
-      Object nopicObjectFiles, // Sequence<Artifact> expected
+      Object objectFiles, // Sequence<Artifact> expected
       boolean alwayslink,
       String dynamicLibraryPath,
       String interfaceLibraryPath,
@@ -429,7 +429,7 @@ public abstract class CcModule
     ImmutableList<Artifact> picObjects =
         nullIfNoneOrEmptySequence(picObjectFiles, Artifact.class, "PIC object files");
     ImmutableList<Artifact> nopicObjects =
-        nullIfNoneOrEmptySequence(nopicObjectFiles, Artifact.class, "No-PIC object files");
+        nullIfNoneOrEmptySequence(objectFiles, Artifact.class, "No-PIC object files");
 
     StringBuilder extensionErrorsBuilder = new StringBuilder();
     String extensionErrorMessage = "does not have any of the allowed extensions";

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/CcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/CcModuleApi.java
@@ -588,6 +588,24 @@ public interface CcModuleApi<
             defaultValue = "None",
             type = FileApi.class),
         @Param(
+            name = "pic_object_files",
+            doc = "PIC object <code>files</code> to be linked.",
+            positional = false,
+            named = true,
+            noneable = true,
+            defaultValue = "None",
+            type = Sequence.class,
+            generic1 = FileApi.class),
+        @Param(
+            name = "nopic_object_files",
+            doc = "No-PIC object <code>file</code> to be linked.",
+            positional = false,
+            named = true,
+            noneable = true,
+            defaultValue = "None",
+            type = Sequence.class,
+            generic1 = FileApi.class),
+        @Param(
             name = "alwayslink",
             doc = "Whether to link the static library/objects in the --whole_archive block.",
             positional = false,
@@ -620,6 +638,8 @@ public interface CcModuleApi<
       Object picStaticLibrary,
       Object dynamicLibrary,
       Object interfaceLibrary,
+      Object picObjectFiles, // Sequence<Artifact> expected
+      Object nopicObjectFiles, // Sequence<Artifact> expected
       boolean alwayslink,
       String dynamicLibraryPath,
       String interfaceLibraryPath,

--- a/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/CcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/skylarkbuildapi/cpp/CcModuleApi.java
@@ -588,7 +588,7 @@ public interface CcModuleApi<
             defaultValue = "None",
             type = FileApi.class),
         @Param(
-            name = "pic_object_files",
+            name = "pic_objects",
             doc = "PIC object <code>files</code> to be linked.",
             positional = false,
             named = true,
@@ -597,8 +597,8 @@ public interface CcModuleApi<
             type = Sequence.class,
             generic1 = FileApi.class),
         @Param(
-            name = "nopic_object_files",
-            doc = "No-PIC object <code>file</code> to be linked.",
+            name = "objects",
+            doc = "No-PIC object <code>files</code> to be linked.",
             positional = false,
             named = true,
             noneable = true,

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/cpp/FakeCcModule.java
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/cpp/FakeCcModule.java
@@ -165,6 +165,8 @@ public class FakeCcModule
       Object picStaticLibrary,
       Object dynamicLibrary,
       Object interfaceLibrary,
+      Object picObjectFiles,
+      Object nopicObjectFiles,
       boolean alwayslink,
       String dynamicLibraryPath,
       String interfaceLibraryPath,

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/cpp/FakeCcModule.java
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/cpp/FakeCcModule.java
@@ -166,7 +166,7 @@ public class FakeCcModule
       Object dynamicLibrary,
       Object interfaceLibrary,
       Object picObjectFiles,
-      Object nopicObjectFiles,
+      Object objectFiles,
       boolean alwayslink,
       String dynamicLibraryPath,
       String interfaceLibraryPath,

--- a/tools/build_defs/cc/cc_import.bzl
+++ b/tools/build_defs/cc/cc_import.bzl
@@ -155,13 +155,13 @@ def _cc_import_impl(ctx):
 
     output_file = None
 
-    if bool(ctx.files.pic_objects) and not pic_static_library:
+    if ctx.files.pic_objects and not pic_static_library:
         lib_name = "lib" + ctx.label.name + ".pic.a"
         pic_static_library = ctx.actions.declare_file(lib_name)
         output_file = pic_static_library
         object_files = ctx.files.pic_objects
 
-    if bool(ctx.files.objects) and not no_pic_static_library:
+    if ctx.files.objects and not no_pic_static_library:
         lib_name = "lib" + ctx.label.name + ".a"
         no_pic_static_library = ctx.actions.declare_file(lib_name)
         output_file = no_pic_static_library

--- a/tools/build_defs/cc/cc_import.bzl
+++ b/tools/build_defs/cc/cc_import.bzl
@@ -180,9 +180,14 @@ def _cc_import_impl(ctx):
         alwayslink = ctx.attr.alwayslink,
     )
 
+    linker_input = cc_common.create_linker_input(
+        libraries = depset([library_to_link]),
+        user_link_flags = depset(ctx.attr.linkopts),
+        owner = ctx.label,
+    )
+
     linking_context = cc_common.create_linking_context(
-        libraries_to_link = [library_to_link],
-        user_link_flags = ctx.attr.linkopts,
+        linker_inputs = depset([linker_input]),
     )
 
     (compilation_context, compilation_outputs) = cc_common.compile(

--- a/tools/build_defs/cc/tests/cc_import_test.bzl
+++ b/tools/build_defs/cc/tests/cc_import_test.bzl
@@ -125,6 +125,22 @@ def _cc_import_no_objects_no_archive_action_test_impl(ctx):
 
 cc_import_no_objects_no_archive_action_test = analysistest.make(_cc_import_no_objects_no_archive_action_test_impl)
 
+def _cc_import_objects_present_in_linking_context_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target_under_test = analysistest.target_under_test(env)
+    linker_inputs = target_under_test[CcInfo].linking_context.linker_inputs.to_list()
+    asserts.true(env, len(linker_inputs) == 1, "There should be 1 linker input")
+    libraries = linker_inputs[0].libraries
+    asserts.true(env, len(libraries) == 1, "There should be 1 library to link")
+    objects = libraries[0].objects
+    asserts.true(env, len(objects) == 1, "There should be 1 object file")
+    asserts.true(env, objects[0].basename == "object.o", "Object's name should be 'object.o'")
+
+    return analysistest.end(env)
+
+cc_import_objects_present_in_linking_context_test = analysistest.make(_cc_import_objects_present_in_linking_context_test_impl)
+
 def cc_import_test_suite(name):
     _tests = []
 
@@ -154,6 +170,13 @@ def cc_import_test_suite(name):
         test = cc_import_no_objects_no_archive_action_test,
         tests_list = _tests,
         static_library = "libmylib.a",
+        objects = ["object.o"],
+        target_is_binary = False,
+    )
+    _generic_cc_import_test_setup(
+        name = "objects_present_in_linking_context",
+        test = cc_import_objects_present_in_linking_context_test,
+        tests_list = _tests,
         objects = ["object.o"],
         target_is_binary = False,
     )

--- a/tools/build_defs/cc/tests/cc_import_test.bzl
+++ b/tools/build_defs/cc/tests/cc_import_test.bzl
@@ -18,8 +18,9 @@ load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("//tools/build_defs/cc:cc_import.bzl", "cc_import")
 
 TAGS = ["manual", "nobuilder"]
+TESTS_PATH = "tools/build_defs/cc/tests/"
 
-def _generic_cc_import_test_setup(name, test, **kwargs):
+def _generic_cc_import_test_setup(name, test, tests_list, binary_kwargs = dict(), **kwargs):
     test_target_name = "cc_import_" + name + "_test"
     cc_import_target_name = test_target_name + "_import"
     cc_binary_target_name = test_target_name + "_binary"
@@ -27,7 +28,6 @@ def _generic_cc_import_test_setup(name, test, **kwargs):
     cc_import(
         name = cc_import_target_name,
         hdrs = ["mylib.h"],
-        static_library = "libmylib.a",
         tags = TAGS,
         **kwargs
     )
@@ -37,6 +37,7 @@ def _generic_cc_import_test_setup(name, test, **kwargs):
         deps = [":" + cc_import_target_name],
         srcs = ["source.cc"],
         tags = TAGS,
+        **binary_kwargs
     )
 
     test(
@@ -46,18 +47,20 @@ def _generic_cc_import_test_setup(name, test, **kwargs):
         size = "small",
     )
 
-def _cc_import_linkopts_test_impl(ctx):
-    env = analysistest.begin(ctx)
+    tests_list.append(":" + test_target_name)
 
+def _assert_linkopts_present(env, *args):
     target_under_test = analysistest.target_under_test(env)
     actions = analysistest.target_actions(env)
 
-    found = False
     for action in actions:
         if action.mnemonic == "CppLink":
-            found = "-testlinkopt" in action.argv
-    asserts.true(env, found, "'-testlinkopt' should be included in arguments passed to the linker")
+            for linkopt in args:
+                asserts.true(env, linkopt in action.argv, "'" + linkopt + "' should be included in arguments passed to the linker")
 
+def _cc_import_linkopts_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    _assert_linkopts_present(env, "-testlinkopt")
     return analysistest.end(env)
 
 cc_import_linkopts_test = analysistest.make(_cc_import_linkopts_test_impl)
@@ -76,15 +79,84 @@ def _cc_import_includes_test_impl(ctx):
 
 cc_import_includes_test = analysistest.make(_cc_import_includes_test_impl)
 
+def _cc_import_pic_object_files_start_end_lib_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    _assert_linkopts_present(env, "-Wl,--start-lib", TESTS_PATH + "mylib.pic.o", "-Wl,--end-lib")
+    return analysistest.end(env)
+
+cc_import_pic_object_files_start_end_lib_test = analysistest.make(_cc_import_pic_object_files_start_end_lib_test_impl)
+
+def _cc_import_nopic_object_files_start_end_lib_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    _assert_linkopts_present(env, "-Wl,--start-lib", TESTS_PATH + "mylib.o", "-Wl,--end-lib")
+    return analysistest.end(env)
+
+cc_import_nopic_object_files_start_end_lib_test = analysistest.make(_cc_import_nopic_object_files_start_end_lib_test_impl)
+
+def _cc_import_pic_object_files_no_start_end_lib_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    _assert_linkopts_present(env, "bazel-out/k8-fastbuild/bin/" + TESTS_PATH + "libcc_import_pic_object_files_no_start_end_lib_test_import.pic.a")
+    return analysistest.end(env)
+
+cc_import_pic_object_files_no_start_end_lib_test = analysistest.make(_cc_import_pic_object_files_no_start_end_lib_test_impl)
+
+def _cc_import_nopic_object_files_no_start_end_lib_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    for a in analysistest.target_actions(env):
+        print(a.argv)
+    _assert_linkopts_present(env, "bazel-out/k8-fastbuild/bin/" + TESTS_PATH + "libcc_import_nopic_object_files_no_start_end_lib_test_import.a")
+    return analysistest.end(env)
+
+cc_import_nopic_object_files_no_start_end_lib_test = analysistest.make(_cc_import_nopic_object_files_no_start_end_lib_test_impl)
+
 def cc_import_test_suite(name):
-    _generic_cc_import_test_setup(name = "linkopts", test = cc_import_linkopts_test, linkopts = ["-testlinkopt"])
-    _generic_cc_import_test_setup(name = "includes", test = cc_import_includes_test, includes = ["testinclude"])
+    _tests = []
+
+    _generic_cc_import_test_setup(
+        name = "linkopts",
+        test = cc_import_linkopts_test,
+        tests_list = _tests,
+        static_library = "libmylib.a",
+        linkopts = ["-testlinkopt"],
+    )
+    _generic_cc_import_test_setup(
+        name = "includes",
+        test = cc_import_includes_test,
+        tests_list = _tests,
+        static_library = "libmylib.a",
+        includes = ["testinclude"],
+    )
+    _generic_cc_import_test_setup(
+        name = "pic_object_files_start_end_lib",
+        test = cc_import_pic_object_files_start_end_lib_test,
+        tests_list = _tests,
+        pic_object_files = ["mylib.pic.o"],
+        binary_kwargs = {"features": ["supports_start_end_lib"]},
+    )
+    _generic_cc_import_test_setup(
+        name = "nopic_object_files_start_end_lib",
+        test = cc_import_nopic_object_files_start_end_lib_test,
+        tests_list = _tests,
+        nopic_object_files = ["mylib.o"],
+        binary_kwargs = {"features": ["supports_start_end_lib"]},
+    )
+    _generic_cc_import_test_setup(
+        name = "pic_object_files_no_start_end_lib",
+        test = cc_import_pic_object_files_no_start_end_lib_test,
+        tests_list = _tests,
+        pic_object_files = ["mylib.pic.o"],
+        binary_kwargs = {"features": ["-supports_start_end_lib"]},
+    )
+    _generic_cc_import_test_setup(
+        name = "nopic_object_files_no_start_end_lib",
+        test = cc_import_nopic_object_files_no_start_end_lib_test,
+        tests_list = _tests,
+        nopic_object_files = ["mylib.o"],
+        binary_kwargs = {"features": ["-supports_start_end_lib"]},
+    )
 
     native.test_suite(
         name = name,
-        tests = [
-            ":cc_import_linkopts_test",
-            ":cc_import_includes_test",
-        ],
+        tests = _tests,
         tags = TAGS,
     )


### PR DESCRIPTION
This change allows users to import object files when using Starlark version of cc_import rule (currently hidden behind '--experimental_starlark_cc_import' flag). Previously in order to import object files users were required to put them in the srcs field of cc_library.