### PR TITLE
fixup! Gracefully handle the lack of subreaper support in Linux.

### DIFF
--- a/src/main/tools/process-wrapper-options.cc
+++ b/src/main/tools/process-wrapper-options.cc
@@ -127,7 +127,7 @@ static void ParseCommandLine(const std::vector<char *> &args) {
       case 'W':
 #if defined(__linux__)
         unsigned long result;  // NOLINT(runtime/int) - interface requires long
-        if (prctl(PR_GET_CHILD_SUBREAPER, &result, 0, 0, 0) == EINVAL) {
+        if (prctl(PR_GET_CHILD_SUBREAPER, &result, 0, 0, 0) == -1 && errno == EINVAL) {
           fprintf(stderr,
                   "warning: The \"wait for subprocesses\" feature requires "
                   "Linux kernel version 3.4 or later.\n");


### PR DESCRIPTION
This is a tiny amendment to @philwo's patch for #11637 which fixes up `prctl` error handling.

Resolves #11637 