### PR TITLE
Sort repo directories in python_stub_template

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
@@ -153,6 +153,7 @@ def CreateModuleSpace():
 def GetRepositoriesImports(module_space, import_all):
   if import_all:
     repo_dirs = [os.path.join(module_space, d) for d in os.listdir(module_space)]
+    repo_dirs.sort()
     return [d for d in repo_dirs if os.path.isdir(d)]
   return [os.path.join(module_space, '%workspace_name%')]
 


### PR DESCRIPTION
The listdir does not guarantee any order, and lack of the ordering looks like potential issue of non-reproducible runs.