### PR TITLE
Allow keepalives to be enabled for REv2 gRPC channels

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -40,6 +40,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -55,7 +57,9 @@ public final class GoogleAuthUtils {
       String target,
       String proxy,
       AuthAndTLSOptions options,
-      @Nullable List<ClientInterceptor> interceptors)
+      @Nullable List<ClientInterceptor> interceptors,
+      @Nullable Duration keepaliveTime,
+      @Nullable Duration keepaliveTimeout)
       throws IOException {
     Preconditions.checkNotNull(target);
     Preconditions.checkNotNull(options);
@@ -80,6 +84,12 @@ public final class GoogleAuthUtils {
         if (options.tlsAuthorityOverride != null) {
           builder.overrideAuthority(options.tlsAuthorityOverride);
         }
+      }
+      if (keepaliveTime != null) {
+        builder.keepAliveTime(keepaliveTime.toMillis(), TimeUnit.MILLISECONDS);
+      }
+      if (keepaliveTimeout != null) {
+        builder.keepAliveTimeout(keepaliveTimeout.toMillis(), TimeUnit.MILLISECONDS);
       }
       return builder.build();
     } catch (RuntimeException e) {

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BazelBuildEventServiceModule.java
@@ -70,7 +70,7 @@ public class BazelBuildEventServiceModule
   protected ManagedChannel newGrpcChannel(
       BuildEventServiceOptions besOptions, AuthAndTLSOptions authAndTLSOptions) throws IOException {
     return GoogleAuthUtils.newChannel(
-        besOptions.besBackend, besOptions.besProxy, authAndTLSOptions, /* interceptor= */ null);
+        besOptions.besBackend, besOptions.besProxy, authAndTLSOptions, /* interceptor= */ null, null, null);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
@@ -32,6 +32,7 @@ import io.grpc.ClientInterceptor;
 import io.netty.channel.unix.DomainSocketAddress;
 import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -60,10 +61,12 @@ public final class RemoteCacheClientFactory {
       String target,
       String proxyUri,
       AuthAndTLSOptions authOptions,
-      @Nullable List<ClientInterceptor> interceptors)
+      @Nullable List<ClientInterceptor> interceptors,
+      @Nullable Duration keepaliveTime,
+      @Nullable Duration keepaliveTimeout)
       throws IOException {
     return new ReferenceCountedChannel(
-        GoogleAuthUtils.newChannel(target, proxyUri, authOptions, interceptors));
+        GoogleAuthUtils.newChannel(target, proxyUri, authOptions, interceptors, keepaliveTime, keepaliveTimeout));
   }
 
   public static RemoteCacheClient create(

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -268,7 +268,9 @@ public final class RemoteModule extends BlazeModule {
                 remoteOptions.remoteExecutor,
                 remoteOptions.remoteProxy,
                 authAndTlsOptions,
-                interceptors.build());
+                interceptors.build(),
+                remoteOptions.remoteKeepaliveTime,
+                remoteOptions.remoteKeepaliveTimeout);
       } catch (IOException e) {
         handleInitFailure(env, e, Code.EXEC_CHANNEL_INIT_FAILURE);
         return;
@@ -294,7 +296,9 @@ public final class RemoteModule extends BlazeModule {
                 remoteOptions.remoteCache,
                 remoteOptions.remoteProxy,
                 authAndTlsOptions,
-                interceptors.build());
+                interceptors.build(),
+                remoteOptions.remoteKeepaliveTime,
+                remoteOptions.remoteKeepaliveTimeout);
       } catch (IOException e) {
         handleInitFailure(env, e, Code.CACHE_CHANNEL_INIT_FAILURE);
         return;
@@ -317,7 +321,9 @@ public final class RemoteModule extends BlazeModule {
                   remoteOptions.remoteDownloader,
                   remoteOptions.remoteProxy,
                   authAndTlsOptions,
-                  interceptors.build());
+                  interceptors.build(),
+                  remoteOptions.remoteKeepaliveTime,
+                  remoteOptions.remoteKeepaliveTimeout);
         } catch (IOException e) {
           handleInitFailure(env, e, Code.DOWNLOADER_CHANNEL_INIT_FAILURE);
           return;

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -34,10 +34,12 @@ import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.protobuf.TextFormat;
 import com.google.protobuf.TextFormat.ParseException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
+import javax.annotation.Nullable;
 
 /** Options for remote execution and distributed caching. */
 public final class RemoteOptions extends OptionsBase {
@@ -432,6 +434,33 @@ public final class RemoteOptions extends OptionsBase {
           "If set to true, Bazel will compute the hash sum of all remote downloads and "
               + " discard the remotely cached values if they don't match the expected value.")
   public boolean remoteVerifyDownloads;
+
+  @Option(
+      name = "remote_keepalive_time",
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "Sets the time without read activity before sending a keepalive ping. Clients must "
+              + "receive permission from the service owner before enabling this option. Keepalives "
+              + "can increase the load on services and are commonly \"invisible\" making it hard "
+              + "to notice when they are causing excessive load. It is therefore suggested that "
+              + "this option is set to at least one minute.")
+  @Nullable
+  public Duration remoteKeepaliveTime;
+
+  @Option(
+      name = "remote_keepalive_timeout",
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help =
+          "Sets the time waiting for read activity after sending a keepalive ping. If the time "
+              + "expires without any read activity on the connection, the connection is considered "
+              + "dead. This value should be at least multiple times the round-trip time to allow "
+              + "for lost packets.")
+  @Nullable
+  public Duration remoteKeepaliveTimeout;
 
   // The below options are not configurable by users, only tests.
   // This is part of the effort to reduce the overall number of flags.

--- a/src/main/java/com/google/devtools/common/options/Converters.java
+++ b/src/main/java/com/google/devtools/common/options/Converters.java
@@ -176,6 +176,9 @@ public final class Converters {
 
     @Override
     public Duration convert(String input) throws OptionsParsingException {
+      if (input == null || input.equals("null")) {
+        return null;
+      }
       // To be compatible with the previous parser, '0' doesn't need a unit.
       if ("0".equals(input)) {
         return Duration.ZERO;


### PR DESCRIPTION
Bazel currently doesn't make use of gRPC's keepalive options, meaning
that builds may get stuck unnecessarily when connected to a server that
disappears off the network. It may well be the case that reconnecting to
an alternative server allows the build to proceed.

Considering that Bazel's RPC rate is already relatively high, there is
generally little harm in enabling keepalives from a performance point of
view, especially if we don't send them when idle (i.e., the default).

This change introduces two new configuration options,
--remote_keepalive_time (the interval) and --remote_keepalive_timeout.

Fixes: https://github.com/bazelbuild/bazel/issues/7085