### PR TITLE
Add transition support for Apple bitcode

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
@@ -366,7 +366,18 @@ public class AppleCommandLineOptions extends FragmentOptions {
             + "Values: 'none', 'embedded_markers', 'embedded'."
   )
   public AppleBitcodeMode appleBitcodeMode;
-  
+
+  @Option(
+    name = "watchos_force_bitcode",
+    defaultValue = "false",
+    documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+    effectTags = {OptionEffectTag.LOSES_INCREMENTAL_STATE},
+    help =
+        "If true, use 'embedded' bitcode mode for watchOS binaries' compilation steps."
+            + "Enable this option if you only need bitcode for watchOS binaries but not "
+            + "for the iOS companion app, e.g. for App Store submission.")
+  public boolean watchosForceBitcode;
+
   /** Returns whether the minimum OS version is explicitly set for the current platform. */
   public DottedVersion getMinimumOsVersion() {
     DottedVersion.Option option;

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/MultiArchSplitTransitionProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/MultiArchSplitTransitionProvider.java
@@ -36,6 +36,7 @@ import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.packages.AttributeTransitionData;
 import com.google.devtools.build.lib.packages.RuleClass.ConfiguredTargetFactory.RuleErrorException;
 import com.google.devtools.build.lib.rules.apple.AppleCommandLineOptions;
+import com.google.devtools.build.lib.rules.apple.AppleCommandLineOptions.AppleBitcodeMode;
 import com.google.devtools.build.lib.rules.apple.AppleConfiguration;
 import com.google.devtools.build.lib.rules.apple.AppleConfiguration.ConfigurationDistinguisher;
 import com.google.devtools.build.lib.rules.apple.ApplePlatform;
@@ -217,6 +218,10 @@ public class MultiArchSplitTransitionProvider
       List<String> cpus;
       DottedVersion actualMinimumOsVersion;
       ConfigurationDistinguisher configurationDistinguisher;
+      boolean watchosForceBitcode =
+          buildOptions.get(AppleCommandLineOptions.class).watchosForceBitcode;
+      AppleBitcodeMode appleBitcodeMode =
+          buildOptions.get(AppleCommandLineOptions.class).appleBitcodeMode;
       switch (platformType) {
         case IOS:
           configurationDistinguisher = ConfigurationDistinguisher.APPLEBIN_IOS;
@@ -310,6 +315,9 @@ public class MultiArchSplitTransitionProvider
             break;
           case WATCHOS:
             appleCommandLineOptions.watchosMinimumOs = DottedVersion.option(actualMinimumOsVersion);
+            if (watchosForceBitcode) {
+              appleCommandLineOptions.appleBitcodeMode = AppleBitcodeMode.EMBEDDED;
+            }
             break;
           case TVOS:
             appleCommandLineOptions.tvosMinimumOs = DottedVersion.option(actualMinimumOsVersion);


### PR DESCRIPTION
Embedding bitcode to the watchOS app binary is mandatory if you want to
submit the app to the App Store. Previously it wasn't possible to enable
bitcode just for the watchOS app but not for the iOS app that bundles
it.

This patch adds a new `--watchos_force_bitcode` build option --- when
enabled, it will set the bitcode mode to "embedded" for the produced
watchOS binaries, regardless of the value of the global
`--apple_bitcode` option.

Closes https://github.com/bazelbuild/bazel/issues/11278.

RELNOTES: Apple bitcode for watchOS binaries can now be forced embedded
with the new flag `--watchos_force_bitcode`.
