### PR TITLE
Remove always failing include path searching

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -25,7 +25,6 @@ load(
     "@bazel_tools//tools/cpp:unix_cc_configure.bzl",
     "configure_unix_toolchain",
     "get_env",
-    "get_escaped_cxx_inc_directories",
 )
 
 def _get_escaped_xcode_cxx_inc_directories(repository_ctx, cc, xcode_toolchains):
@@ -39,9 +38,7 @@ def _get_escaped_xcode_cxx_inc_directories(repository_ctx, cc, xcode_toolchains)
       include_paths: A list of builtin include paths.
     """
 
-    # TODO(cparsons): Falling back to the default C++ compiler builtin include
-    # paths shouldn't be unnecessary once all actions are using xcrun.
-    include_dirs = get_escaped_cxx_inc_directories(repository_ctx, cc, "-xc++")
+    include_dirs = []
     for toolchain in xcode_toolchains:
         include_dirs.append(escape_string(toolchain.developer_dir))
 

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -116,19 +116,6 @@ def _cxx_inc_convert(path):
         path = path[:-_OSX_FRAMEWORK_SUFFIX_LEN].strip()
     return path
 
-def get_escaped_cxx_inc_directories(repository_ctx, cc, lang_flag, additional_flags = []):
-    """Deprecated. Compute the list of %-escaped C++ include directories.
-
-    This function is no longer needed by cc_configure and is left there only for backwards
-    compatibility reasons.
-    """
-    return [escape_string(s) for s in _get_cxx_include_directories(
-        repository_ctx,
-        cc,
-        lang_flag,
-        additional_flags,
-    )]
-
 def _get_cxx_include_directories(repository_ctx, cc, lang_flag, additional_flags = []):
     """Compute the list of C++ include directories."""
     result = repository_ctx.execute([cc, "-E", lang_flag, "-", "-v"] + additional_flags)


### PR DESCRIPTION
Since this was run as part of the workspace setup, DEVELOPER_DIR and
SDKROOT are not set, which means wrapped_clang, which was being used as
the cc for this, will always fail. Whether or not the invocation fails
isn't taken into account for the result, and the expected output was
never produced, so this always returned nothing.