### PR TITLE
Consider DEVELOPER_DIR when building wrapped_clang

### DIFF
--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -165,6 +165,7 @@ cc_autoconf = repository_rule(
         "CC_CONFIGURE_DEBUG",
         "CC_TOOLCHAIN_NAME",
         "CPLUS_INCLUDE_PATH",
+        "DEVELOPER_DIR",
         "GCOV",
         "HOMEBREW_RUBY_PATH",
         "SYSTEMROOT",

--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -50,9 +50,11 @@ def _get_escaped_xcode_cxx_inc_directories(repository_ctx, cc, xcode_toolchains)
     return include_dirs
 
 def compile_cc_file(repository_ctx, src_name, out_name):
+    env = repository_ctx.os.environ
     xcrun_result = repository_ctx.execute([
         "env",
         "-i",
+        "DEVELOPER_DIR={}".format(env.get("DEVELOPER_DIR", default = "")),
         "xcrun",
         "--sdk",
         "macosx",

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -115,9 +115,11 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
           to build and run xcode-locator, or None if the run was successful.
     """
     xcodeloc_src_path = str(repository_ctx.path(xcode_locator_src_label))
+    env = repository_ctx.os.environ
     xcrun_result = repository_ctx.execute([
         "env",
         "-i",
+        "DEVELOPER_DIR={}".format(env.get("DEVELOPER_DIR", default = "")),
         "xcrun",
         "--sdk",
         "macosx",
@@ -181,10 +183,15 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
 
 def _darwin_build_file(repository_ctx):
     """Evaluates local system state to create xcode_config and xcode_version targets."""
-    xcodebuild_result = repository_ctx.execute(
-        ["env", "-i", "xcrun", "xcodebuild", "-version"],
-        _EXECUTE_TIMEOUT,
-    )
+    env = repository_ctx.os.environ
+    xcodebuild_result = repository_ctx.execute([
+        "env",
+        "-i",
+        "DEVELOPER_DIR={}".format(env.get("DEVELOPER_DIR", default = "")),
+        "xcrun",
+        "xcodebuild",
+        "-version",
+    ], _EXECUTE_TIMEOUT)
 
     (toolchains, xcodeloc_err) = run_xcode_locator(
         repository_ctx,


### PR DESCRIPTION
Resolves #11716, which partially addresses #8902. With this change, and some careful environment manipulation (probably in a wrapper script) you can ensure that `wrapped_clang` is built with the correct version of Xcode.