### PR TITLE
Let --remote_{cache,executor} support gRPC over UNIX sockets

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -104,7 +104,7 @@ public final class GoogleAuthUtils {
     // 'grpcs://' or empty prefix => TLS-enabled
     // when no schema prefix is provided in URL, bazel will treat it as a gRPC request with TLS
     // enabled
-    return !target.startsWith("grpc://");
+    return !target.startsWith("grpc://") && !target.startsWith("unix:");
   }
 
   private static SslContext createSSlContext(
@@ -143,19 +143,10 @@ public final class GoogleAuthUtils {
     }
   }
 
-  private static NettyChannelBuilder newNettyChannelBuilder(String targetUrl, String proxy)
+  private static NettyChannelBuilder newUnixNettyChannelBuilder(String target)
       throws IOException {
-    if (Strings.isNullOrEmpty(proxy)) {
-      return NettyChannelBuilder.forTarget(targetUrl).defaultLoadBalancingPolicy("round_robin");
-    }
-
-    if (!proxy.startsWith("unix:")) {
-      throw new IOException("Remote proxy unsupported: " + proxy);
-    }
-
-    DomainSocketAddress address = new DomainSocketAddress(proxy.replaceFirst("^unix:", ""));
-    NettyChannelBuilder builder =
-        NettyChannelBuilder.forAddress(address).overrideAuthority(targetUrl);
+    DomainSocketAddress address = new DomainSocketAddress(target.replaceFirst("^unix:", ""));
+    NettyChannelBuilder builder = NettyChannelBuilder.forAddress(address);
     if (KQueue.isAvailable()) {
       return builder
           .channelType(KQueueDomainSocketChannel.class)
@@ -168,6 +159,23 @@ public final class GoogleAuthUtils {
     }
 
     throw new IOException("Unix domain sockets are unsupported on this platform");
+  }
+
+  private static NettyChannelBuilder newNettyChannelBuilder(String targetUrl, String proxy)
+      throws IOException {
+    if (targetUrl.startsWith("unix:")) {
+      return newUnixNettyChannelBuilder(targetUrl);
+    }
+
+    if (Strings.isNullOrEmpty(proxy)) {
+      return NettyChannelBuilder.forTarget(targetUrl).defaultLoadBalancingPolicy("round_robin");
+    }
+
+    if (!proxy.startsWith("unix:")) {
+      throw new IOException("Remote proxy unsupported: " + proxy);
+    }
+
+    return newUnixNettyChannelBuilder(proxy).overrideAuthority(targetUrl);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -70,9 +70,10 @@ public final class RemoteOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
-          "HOST or HOST:PORT of a remote execution endpoint.The supported schemas are grpc and"
-              + " grpcs (grpc with TLS enabled). If no schema is provided bazel'll default to"
-              + " grpcs. Specify grpc:// schema to disable TLS.")
+          "HOST or HOST:PORT of a remote execution endpoint. The supported schemas are grpc, "
+              + "grpcs (grpc with TLS enabled) and unix (local UNIX sockets). If no schema is "
+              + "provided Bazel will default to grpcs. Specify grpc:// or unix: schema to "
+              + "disable TLS.")
   public String remoteExecutor;
 
   @Option(
@@ -82,10 +83,10 @@ public final class RemoteOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
-          "A URI of a caching endpoint. The supported schemas are http, https, grpc and grpcs"
-              + " (grpc with TLS enabled). If no schema is provided bazel will default to grpcs."
-              + " Specify grpc:// or http:// schema to disable TLS. See"
-              + " https://docs.bazel.build/versions/master/remote-caching.html")
+          "A URI of a caching endpoint. The supported schemas are http, https, grpc, grpcs "
+              + "(grpc with TLS enabled) and unix (local UNIX sockets). If no schema is provided "
+              + "Bazel will default to grpcs. Specify grpc://, http:// or unix: schema to disable "
+              + "TLS. See https://docs.bazel.build/versions/master/remote-caching.html")
   public String remoteCache;
 
   @Option(
@@ -94,10 +95,10 @@ public final class RemoteOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
-          "A Remote Asset API endpoint URI, to be used as a remote download proxy. The supported"
-              + " schemas are grpc and grpcs (grpc with TLS enabled). If no schema is provided"
-              + " bazel will default to grpcs. See:"
-              + " https://github.com/bazelbuild/remote-apis/blob/master/build/bazel/remote/asset/v1/remote_asset.proto")
+          "A Remote Asset API endpoint URI, to be used as a remote download proxy. The supported "
+              + "schemas are grpc, grpcs (grpc with TLS enabled) and unix (local UNIX sockets). "
+              + "If no schema is provided Bazel will default to grpcs. See: "
+              + "https://github.com/bazelbuild/remote-apis/blob/master/build/bazel/remote/asset/v1/remote_asset.proto")
   public String remoteDownloader;
 
   @Option(


### PR DESCRIPTION
All of the necessary code to construct gRPC clients that communicate
over UNIX sockets is there. It's just that we currently restrict its use
to the creation of proxies using --remote_proxy.

Let's shuffle some code around in GoogleAuthUtils to support the unix:
URL scheme directly. Move all of that code out of
newNettyChannelBuilder() into newUnixNettyChannelBuilder(), so that the
former can use it for both target and proxy channel creation.

UNIX sockets are useful, as they allow peers to authenticate using
light-weight features such as getsockopt(SO_PEERCRED).