### PR TITLE
Fix filter_netty_dynamic_libs to handle the case when the original

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,5 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_import", "java_library", "java_plugin")
-load("//tools/distributions:distribution_rules.bzl", "distrib_java_import", "distrib_jar_filegroup")
+load("//tools/distributions:distribution_rules.bzl", "distrib_jar_filegroup", "distrib_java_import")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -64,6 +64,7 @@ filegroup(
 # The target below is for the Android tools that are not shipped with Bazel.
 distrib_java_import(
     name = "android_common_25_0_0_lite",
+    enable_distributions = ["debian"],
     jars = [
         "android_common/com.android.tools.layoutlib_layoutlib_26.1.2-stripped.jar",
         "android_common/com.android.tools_sdk-common_25.0.0-stripped.jar",
@@ -72,7 +73,6 @@ distrib_java_import(
     deps = [
         "//third_party/jaxb",
     ],
-    enable_distributions = ["debian"],
 )
 
 java_import(
@@ -121,8 +121,8 @@ java_import(
 
 distrib_java_import(
     name = "apache_commons_collections",
-    jars = ["apache_commons_collections/commons-collections-3.2.2.jar"],
     enable_distributions = ["debian"],
+    jars = ["apache_commons_collections/commons-collections-3.2.2.jar"],
 )
 
 java_import(
@@ -132,40 +132,41 @@ java_import(
 
 distrib_java_import(
     name = "apache_commons_lang",
-    jars = ["apache_commons_lang/commons-lang-2.6.jar"],
     enable_distributions = ["debian"],
+    jars = ["apache_commons_lang/commons-lang-2.6.jar"],
 )
 
 distrib_java_import(
     name = "apache_commons_compress",
-    jars = ["apache_commons_compress/apache-commons-compress-1.9.jar"],
     enable_distributions = ["debian"],
+    jars = ["apache_commons_compress/apache-commons-compress-1.9.jar"],
 )
 
 distrib_java_import(
     name = "apache_commons_logging",
-    jars = ["apache_commons_logging/commons-logging-1.1.1.jar"],
     enable_distributions = ["debian"],
+    jars = ["apache_commons_logging/commons-logging-1.1.1.jar"],
 )
 
 distrib_java_import(
     name = "apache_commons_pool2",
-    jars = ["apache_commons_pool2/commons-pool2-2.8.0.jar"],
     enable_distributions = ["debian"],
+    jars = ["apache_commons_pool2/commons-pool2-2.8.0.jar"],
 )
 
 distrib_java_import(
     name = "apache_velocity",
+    enable_distributions = ["debian"],
     jars = ["apache_velocity/velocity-1.7.jar"],
     deps = [
         ":apache_commons_collections",
         ":apache_commons_lang",
     ],
-    enable_distributions = ["debian"],
 )
 
 distrib_java_import(
     name = "api_client",
+    enable_distributions = ["debian"],
     jars = [
         "api_client/google-api-client-1.22.0.jar",
         "api_client/google-api-client-jackson2-1.22.0.jar",
@@ -175,14 +176,13 @@ distrib_java_import(
     runtime_deps = [
         ":jackson2",
     ],
-    enable_distributions = ["debian"],
 )
 
 distrib_java_import(
     name = "asm",
+    enable_distributions = ["debian"],
     jars = ["asm/asm-8.0.jar"],
     srcjar = "asm/asm-8.0-sources.jar",
-    enable_distributions = ["debian"],
 )
 
 java_import(
@@ -215,6 +215,7 @@ java_import(
 
 distrib_java_import(
     name = "auth",
+    enable_distributions = ["debian"],
     jars = [
         "auth/google-auth-library-oauth2-http-0.17.1.jar",
         "auth/google-auth-library-credentials-0.17.1.jar",
@@ -224,7 +225,6 @@ distrib_java_import(
         ":guava",
         "//third_party/aws-sdk-auth-lite",
     ],
-    enable_distributions = ["debian"],
 )
 
 java_plugin(
@@ -245,8 +245,8 @@ java_plugin(
 
 distrib_java_import(
     name = "auto_common",
-    jars = ["auto/auto-common-0.10.jar"],
     enable_distributions = ["debian"],
+    jars = ["auto/auto-common-0.10.jar"],
 )
 
 java_library(
@@ -271,8 +271,8 @@ java_plugin(
 
 distrib_java_import(
     name = "auto_service_lib",
-    jars = ["auto/auto-service-1.0-rc4.jar"],
     enable_distributions = ["debian"],
+    jars = ["auto/auto-service-1.0-rc4.jar"],
 )
 
 java_plugin(
@@ -304,11 +304,11 @@ java_library(
 
 distrib_java_import(
     name = "auto_value_value",
+    enable_distributions = ["debian"],
     jars = [
         "auto/auto-value-1.6.3rc1.jar",
         "auto/auto-value-annotations-1.6.3rc1.jar",
     ],
-    enable_distributions = ["debian"],
 )
 
 # For bootstrapping JavaBuilder
@@ -331,9 +331,9 @@ java_import(
 
 distrib_java_import(
     name = "checker_framework_annotations",
+    enable_distributions = ["debian"],
     jars = ["checker_framework_annotations/checker-qual-3.2.0.jar"],
     srcjar = "checker_framework_annotations/checker-qual-3.2.0-sources.jar",
-    enable_distributions = ["debian"],
 )
 
 java_import(
@@ -343,8 +343,8 @@ java_import(
 
 distrib_java_import(
     name = "gson",
-    jars = ["gson/gson-2.8.0.jar"],
     enable_distributions = ["debian"],
+    jars = ["gson/gson-2.8.0.jar"],
 )
 
 java_import(
@@ -367,11 +367,11 @@ java_import(
 
 distrib_java_import(
     name = "error_prone_annotations",
+    enable_distributions = ["debian"],
     jars = [
         "error_prone/error_prone_annotations-2.4.0.jar",
         "error_prone/error_prone_type_annotations-2.4.0.jar",
     ],
-    enable_distributions = ["debian"],
 )
 
 distrib_jar_filegroup(
@@ -409,18 +409,18 @@ java_import(
 
 distrib_java_import(
     name = "jackson2",
+    enable_distributions = ["debian"],
     jars = [
         "jackson2/jackson-core-2.8.6.jar",
     ],
-    enable_distributions = ["debian"],
 )
 
 distrib_java_import(
     name = "jcip_annotations",
+    enable_distributions = ["debian"],
     jars = [
         "jcip_annotations/jcip-annotations-1.0-1.jar",
     ],
-    enable_distributions = ["debian"],
 )
 
 # For bootstrapping JavaBuilder
@@ -452,23 +452,23 @@ filegroup(
 
 distrib_java_import(
     name = "guava",
+    enable_distributions = ["debian"],
     jars = ["guava/guava-25.1-jre.jar"],
     exports = [
         ":error_prone_annotations",
         ":jcip_annotations",
         ":jsr305",
     ],
-    enable_distributions = ["debian"],
 )
 
 distrib_java_import(
     name = "flogger",
+    enable_distributions = ["debian"],
     jars = [
         "flogger/flogger-0.5.1.jar",
         "flogger/flogger-system-backend-0.5.1.jar",
         "flogger/google-extensions-0.5.1.jar",
     ],
-    enable_distributions = ["debian"],
 )
 
 distrib_jar_filegroup(
@@ -483,19 +483,19 @@ distrib_jar_filegroup(
 
 distrib_java_import(
     name = "opencensus-api",
+    enable_distributions = ["debian"],
     jars = [
         "opencensus/opencensus-api-0.24.0.jar",
         "opencensus/opencensus-contrib-grpc-metrics-0.24.0.jar",
     ],
-    enable_distributions = ["debian"],
 )
 
 distrib_java_import(
     name = "perfmark-api",
+    enable_distributions = ["debian"],
     jars = [
         "perfmark/perfmark-api-0.19.0.jar",
     ],
-    enable_distributions = ["debian"],
 )
 
 # For bootstrapping JavaBuilder
@@ -515,10 +515,10 @@ java_import(
 # see: http://openjdk.java.net/jeps/320.
 distrib_java_import(
     name = "javax_annotations",
+    enable_distributions = ["debian"],
     jars = ["javax_annotations/javax.annotation-api-1.3.2.jar"],
     neverlink = 1,  # @Generated is source-retention
     srcjar = "javax_annotations/javax.annotation-api-1.3.2-sources.jar",
-    enable_distributions = ["debian"],
 )
 
 java_import(
@@ -528,8 +528,8 @@ java_import(
 
 distrib_java_import(
     name = "jsr305",
-    jars = ["jsr305/jsr-305.jar"],
     enable_distributions = ["debian"],
+    jars = ["jsr305/jsr-305.jar"],
 )
 
 # For bootstrapping JavaBuilder
@@ -570,6 +570,8 @@ genrule(
     srcs = ["netty_tcnative/netty-tcnative-boringssl-static-2.0.24.Final.jar"],
     outs = ["netty_tcnative/netty-tcnative-filtered.jar"],
     cmd = "cp $< $@ && " +
+          # Make sure we can write the output file, even if the input isn't writable.
+          "chmod +w $@ && " +
           # End successfully if there is nothing to be deleted from the archive
           "if [ -n '" + UNNECESSARY_DYNAMIC_LIBRARIES + "' ]; then " +
           "zip -qd $@ " + UNNECESSARY_DYNAMIC_LIBRARIES + "; fi",
@@ -577,20 +579,20 @@ genrule(
 
 distrib_java_import(
     name = "netty",
-    jars = ["netty/netty-all-4.1.34.Final.jar"],
     enable_distributions = ["debian"],
+    jars = ["netty/netty-all-4.1.34.Final.jar"],
 )
 
 distrib_java_import(
     name = "netty_tcnative",
-    jars = ["netty_tcnative/netty-tcnative-filtered.jar"],
     enable_distributions = ["debian"],
+    jars = ["netty_tcnative/netty-tcnative-filtered.jar"],
 )
 
 distrib_java_import(
     name = "tomcat_annotations_api",
-    jars = ["tomcat_annotations_api/tomcat-annotations-api-8.0.5.jar"],
     enable_distributions = ["debian"],
+    jars = ["tomcat_annotations_api/tomcat-annotations-api-8.0.5.jar"],
 )
 
 # For bootstrapping JavaBuilder
@@ -602,8 +604,8 @@ distrib_jar_filegroup(
 
 distrib_java_import(
     name = "java-diff-utils",
-    jars = ["java-diff-utils/java-diff-utils-4.0.jar"],
     enable_distributions = ["debian"],
+    jars = ["java-diff-utils/java-diff-utils-4.0.jar"],
 )
 
 # Testing
@@ -669,8 +671,8 @@ java_import(
 
 distrib_java_import(
     name = "xz",
-    jars = ["xz/xz-1.5.jar"],
     enable_distributions = ["debian"],
+    jars = ["xz/xz-1.5.jar"],
 )
 
 # To be used by the skylark example.


### PR DESCRIPTION
source isn't writable.

This happens, for example, with the output from bazel-distfile.tar.

Part of #11741.