### PR TITLE
Starlark: optimize BuiltinCallable by gluing MethodHandle objects

### DIFF
--- a/src/main/java/net/starlark/java/eval/MethodDescriptor.java
+++ b/src/main/java/net/starlark/java/eval/MethodDescriptor.java
@@ -15,8 +15,10 @@
 package net.starlark.java.eval;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.WrongMethodTypeException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import javax.annotation.Nullable;
@@ -32,6 +34,7 @@ import net.starlark.java.annot.StarlarkMethod;
  */
 final class MethodDescriptor {
   private final Method method;
+  private final MethodHandle methodHandle;
   private final StarlarkMethod annotation;
 
   private final String name;
@@ -60,19 +63,281 @@ final class MethodDescriptor {
       boolean allowReturnNones,
       boolean useStarlarkThread,
       boolean useStarlarkSemantics) {
+    boolean isStringModule = method.getDeclaringClass() == StringModule.class;
+
     this.method = method;
     this.annotation = annotation;
     this.name = name;
     this.doc = doc;
     this.documented = documented;
     this.structField = structField;
-    this.parameters = parameters;
+    this.parameters =
+        !isStringModule ? parameters : Arrays.copyOfRange(parameters, 1, parameters.length);
     this.extraPositionals = extraPositionals;
     this.extraKeywords = extraKeywords;
     this.selfCall = selfCall;
     this.allowReturnNones = allowReturnNones;
     this.useStarlarkThread = useStarlarkThread;
     this.useStarlarkSemantics = useStarlarkSemantics;
+
+    MethodHandle mh;
+    try {
+      mh = LOOKUP.unreflect(method);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(e);
+    }
+
+    if (isStringModule) {
+      // String methods get the string as an extra argument
+      // because their true receiver is StringModule.INSTANCE.
+      mh = MethodHandles.insertArguments(mh, 0, StringModule.INSTANCE);
+    }
+
+    // We generate different method handles for field calls and for method calls for performance and
+    // simplicity
+
+    if (!structField) {
+      // Resulting method handle accepts StarlarkThread argument
+      // (to avoid conditional inclusion of StarlarkThread argument at call time)
+      // so we need to drop the StarlarkThread argument if underlying method does not accept
+      // StarlarkThread.
+      if (!useStarlarkThread) {
+        mh = MethodHandles.dropArguments(mh, mh.type().parameterCount(), StarlarkThread.class);
+      }
+
+      // mh: (self, args..., StarlarkThread) -> ?
+
+      // Move non-special arguments to the end of parameter list so we could fold them into a
+      // single array parameter.
+      mh = moveArgument(mh, mh.type().parameterCount() - 1, 1);
+
+      // mh: (self, StarlarkThread, args...) -> ?
+
+      // Convert non-special arguments into single Object[] argument
+      mh = mh.asSpreader(Object[].class, mh.type().parameterCount() - 2);
+
+      // mh: (self, StarlarkThread, args) -> ?
+
+      // This operation "filters" return value of the underlying method.
+      // The resuling operation has extra Mutability argument,
+      // because fromJava functions requires it.
+      mh = filterReturnTypeToCompatibleWithStarlark(mh, allowReturnNones, name);
+
+      // mh: (self, StarlarkThread, args, Mutability) -> ?
+
+      // Now we convert Mutability argument to StarlarkThread argument.
+      // We do that to reduce the number of call arguments by one to make reflective invocation a
+      // little cheaper
+      mh = MethodHandles.filterArguments(mh, 3, THREAD_GET_MUTABILITY);
+
+      // mh: (self, StarlarkThread, args, StarlarkThread) -> ?
+
+      // Fold two StarlarkArguments into single StarlarkThread argument
+      mh = MethodHandles.permuteArguments(mh, mh.type().dropParameterTypes(3, 4), 0, 1, 2, 1);
+
+      // mh: (self, StarlarkThread, args) -> ?
+
+      // The final step converts return type to Object (to be able to use invokeExact)
+      // but also validates that the method handle we have created has a correct type.
+      mh = MethodHandles.explicitCastArguments(mh, CALL_NON_STRUCT_FIELD_METHOD_TYPE);
+
+      // mh: (self, StarlarkThread, args) -> Object
+    } else {
+      // Similarly to above, if underlying method does not accept StarlarkSemantics,
+      // we add ignored StarlarkSemantics argument to make resulting method type the same
+      // regardles of underlying method signature.
+      if (!useStarlarkSemantics) {
+        mh = MethodHandles.dropArguments(mh, mh.type().parameterCount(), StarlarkSemantics.class);
+      }
+
+      // mh: (self, StarlarkSemantics) -> ?
+
+      // Convert return type, same as above
+      mh = filterReturnTypeToCompatibleWithStarlark(mh, allowReturnNones, name);
+
+      // mh: (self, StarlarkSemantics, Mutability) -> ?
+
+      // Convert return to Object and assert type correct
+      mh = MethodHandles.explicitCastArguments(mh, CALL_STRUCT_FIELD_METHOD_TYPE);
+
+      // mh: (self, StarlarkSemantics, Mutability) -> Object
+    }
+
+    this.methodHandle = mh;
+  }
+
+  /**
+   * Take a method handle and return a method handle with additional {@link Mutability} argument.
+   * Resulting method handle ensures that method returns a valid starlark object.
+   */
+  private static MethodHandle filterReturnTypeToCompatibleWithStarlark(
+      MethodHandle mh, boolean allowReturnNones, String name) {
+    if (mh.type().returnType() == void.class) {
+      // The easiest case: if underlying method returns void,
+      // we convert MethodHandle to return None object.
+      mh =
+          MethodHandles.filterReturnValue(
+              mh, MethodHandles.constant(NoneType.class, Starlark.NONE));
+      mh = MethodHandles.dropArguments(mh, mh.type().parameterCount(), Mutability.class);
+    } else if (methodReturnTypeIsGoodAsIsForStarlark(mh.type().returnType())) {
+      // If the underlying method return type is a value compatible with Starlark runtime,
+      // we only perform null-handling.
+      mh = handleNullReturn(mh, allowReturnNones, name);
+      mh = MethodHandles.dropArguments(mh, mh.type().parameterCount(), Mutability.class);
+    } else if (mh.type().returnType() == int.class) {
+      mh = MethodHandles.filterReturnValue(mh, STARLARK_INT_OF_INT);
+      mh = MethodHandles.dropArguments(mh, mh.type().parameterCount(), Mutability.class);
+    } else if (mh.type().returnType() == long.class) {
+      mh = MethodHandles.filterReturnValue(mh, STARLARK_INT_OF_LONG);
+      mh = MethodHandles.dropArguments(mh, mh.type().parameterCount(), Mutability.class);
+    } else {
+      // Otherwise we invoke fromJava function to convert method return type
+      // a value compatible with Starlark runtime.
+      // Note if an underlying method returns a concrete type,
+      // then fromJava invocation is efficiently inlined in MethodHandle object.
+      mh = handleNullReturn(mh, allowReturnNones, name);
+
+      MethodHandle fromJava =
+          MethodHandles.explicitCastArguments(
+              FROM_JAVA,
+              MethodType.methodType(Object.class, mh.type().returnType(), Mutability.class));
+      mh = MethodHandles.collectArguments(fromJava, 0, mh);
+    }
+    return mh;
+  }
+
+  /** @see Starlark#valid(Object) */
+  private static boolean methodReturnTypeIsGoodAsIsForStarlark(Class<?> x) {
+    return x == String.class
+        || x == Boolean.class
+        || x == boolean.class
+        || StarlarkValue.class.isAssignableFrom(x);
+  }
+
+  private static MethodHandle handleNullReturn(
+      MethodHandle mh, boolean allowReturnNones, String name) {
+    // Primitive types are never null
+    if (mh.type().returnType().isPrimitive()) {
+      return mh;
+    }
+
+    if (allowReturnNones) {
+      return nullToNone(mh);
+    } else {
+      return nullToException(mh, name);
+    }
+  }
+
+  private static Object nullToNone(Object object) {
+    return object != null ? object : Starlark.NONE;
+  }
+
+  private static Object nullToException(Object object, String methodName) {
+    if (object == null) {
+      throw new IllegalStateException("method invocation returned null: " + methodName);
+    }
+    return object;
+  }
+
+  private static MethodHandle nullToNone(MethodHandle mh) {
+    MethodHandle filter =
+        MethodHandles.explicitCastArguments(
+            NULL_TO_NONE, MethodType.methodType(Object.class, mh.type().returnType()));
+    return MethodHandles.filterReturnValue(mh, filter);
+  }
+
+  private static MethodHandle nullToException(MethodHandle mh, String name) {
+    MethodHandle filter = MethodHandles.insertArguments(NULL_TO_EXCEPTION, 1, name);
+    filter =
+        MethodHandles.explicitCastArguments(
+            filter, MethodType.methodType(mh.type().returnType(), mh.type().returnType()));
+    return MethodHandles.filterReturnValue(mh, filter);
+  }
+
+  private static final MethodType CALL_NON_STRUCT_FIELD_METHOD_TYPE =
+      MethodType.methodType(
+          // return type
+          Object.class,
+          // self
+          Object.class,
+          StarlarkThread.class,
+          // arguments
+          Object[].class);
+
+  private static final MethodType CALL_STRUCT_FIELD_METHOD_TYPE =
+      MethodType.methodType(
+          // return type
+          Object.class,
+          // self
+          Object.class,
+          StarlarkSemantics.class,
+          Mutability.class);
+
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+  // Cache method handles to avoid looking them up again and again
+  private static final MethodHandle NULL_TO_NONE;
+  private static final MethodHandle NULL_TO_EXCEPTION;
+  private static final MethodHandle FROM_JAVA;
+  private static final MethodHandle THREAD_GET_MUTABILITY;
+  private static final MethodHandle STARLARK_INT_OF_INT;
+  private static final MethodHandle STARLARK_INT_OF_LONG;
+
+  static {
+    try {
+      NULL_TO_NONE =
+          LOOKUP.findStatic(
+              MethodDescriptor.class,
+              "nullToNone",
+              MethodType.methodType(Object.class, Object.class));
+      NULL_TO_EXCEPTION =
+          LOOKUP.findStatic(
+              MethodDescriptor.class,
+              "nullToException",
+              MethodType.methodType(Object.class, Object.class, String.class));
+      FROM_JAVA =
+          LOOKUP.findStatic(
+              Starlark.class,
+              "fromJava",
+              MethodType.methodType(Object.class, Object.class, Mutability.class));
+      STARLARK_INT_OF_INT =
+        LOOKUP.findStatic(StarlarkInt.class, "of", MethodType.methodType(StarlarkInt.class, int.class));
+      STARLARK_INT_OF_LONG =
+        LOOKUP.findStatic(StarlarkInt.class, "of", MethodType.methodType(StarlarkInt.class, long.class));
+      THREAD_GET_MUTABILITY =
+          LOOKUP.findVirtual(
+              StarlarkThread.class, "mutability", MethodType.methodType(Mutability.class));
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Permutate method parameters, by moving {@code oldPos} parameter to {@code newPos}. */
+  private static MethodHandle moveArgument(MethodHandle mh, int oldPos, int newPos) {
+    if (oldPos == newPos) {
+      return mh;
+    } else if (newPos > oldPos) {
+      throw new IllegalArgumentException("newPost must be <= oldPos");
+    }
+
+    int[] reorder = new int[mh.type().parameterCount()];
+    for (int i = 0; i != reorder.length; ++i) {
+      if (i < newPos) {
+        reorder[i] = i;
+      } else if (i < oldPos) {
+        reorder[i] = i + 1;
+      } else if (i == oldPos) {
+        reorder[i] = newPos;
+      } else {
+        reorder[i] = i;
+      }
+    }
+    return MethodHandles.permuteArguments(
+        mh,
+        mh.type()
+            .dropParameterTypes(oldPos, oldPos + 1)
+            .insertParameterTypes(newPos, mh.type().parameterType(oldPos)),
+        reorder);
   }
 
   /** Returns the StarlarkMethod annotation corresponding to this method. */
@@ -108,36 +373,40 @@ final class MethodDescriptor {
         annotation.useStarlarkSemantics());
   }
 
-  private static final Object[] EMPTY = {};
-
-  /** Calls this method, which must have {@code structField=true}. */
+  /**
+   * Calls this method, which must have {@code structField=true}.
+   *
+   * <p>The Mutability is used if it is necessary to allocate a Starlark copy of a Java result.
+   */
   Object callField(Object obj, StarlarkSemantics semantics, @Nullable Mutability mu)
       throws EvalException, InterruptedException {
     if (!structField) {
       throw new IllegalStateException("not a struct field: " + name);
     }
-    Object[] args = useStarlarkSemantics ? new Object[] {semantics} : EMPTY;
-    return call(obj, args, mu);
+    Preconditions.checkNotNull(obj);
+    try {
+      return methodHandle.invokeExact(obj, semantics, mu);
+    } catch (RuntimeException | Error | EvalException | InterruptedException e) {
+      throw e;
+    } catch (Throwable e) {
+      throw wrapOtherException(e);
+    }
   }
 
   /**
    * Invokes this method using {@code obj} as a target and {@code args} as Java arguments.
    *
    * <p>Methods with {@code void} return type return {@code None} following Python convention.
-   *
-   * <p>The Mutability is used if it is necessary to allocate a Starlark copy of a Java result.
    */
-  Object call(Object obj, Object[] args, @Nullable Mutability mu)
+  Object call(Object obj, StarlarkThread starlarkThread, Object[] args)
       throws EvalException, InterruptedException {
+    if (structField) {
+      throw new IllegalStateException("a struct field: " + name);
+    }
     Preconditions.checkNotNull(obj);
-    Object result;
     try {
-      result = method.invoke(obj, args);
-    } catch (IllegalAccessException ex) {
-      // "Can't happen": the annotated processor ensures that annotated methods are accessible.
-      throw new IllegalStateException(ex);
-
-    } catch (IllegalArgumentException ex) {
+      return methodHandle.invokeExact(obj, starlarkThread, args);
+    } catch (WrongMethodTypeException ex) {
       // "Can't happen": unexpected type mismatch.
       // Show details to aid debugging (see e.g. b/162444744).
       StringBuilder buf = new StringBuilder();
@@ -152,31 +421,17 @@ final class MethodDescriptor {
       }
       buf.append(']');
       throw new IllegalArgumentException(buf.toString());
+    } catch (RuntimeException | Error | EvalException | InterruptedException e) {
+      throw e;
+    } catch (Throwable e) {
+      // All other checked exceptions (e.g. LabelSyntaxException) are reported to Starlark.
+      throw wrapOtherException(e);
+    }
+  }
 
-    } catch (InvocationTargetException ex) {
-      Throwable e = ex.getCause();
-      if (e == null) {
-        throw new IllegalStateException(e);
-      }
-      // Don't intercept unchecked exceptions.
-      Throwables.throwIfUnchecked(e);
-      if (e instanceof EvalException) {
-        throw (EvalException) e;
-      } else if (e instanceof InterruptedException) {
-        throw (InterruptedException) e;
-      } else {
-        // All other checked exceptions (e.g. LabelSyntaxException) are reported to Starlark.
-        throw new EvalException(e);
-      }
-    }
-    if (method.getReturnType().equals(Void.TYPE)) {
-      return Starlark.NONE;
-    }
-    if (result == null && !isAllowReturnNones()) {
-      throw new IllegalStateException(
-          "method invocation returned null: " + getName() + Tuple.copyOf(Arrays.asList(args)));
-    }
-    return Starlark.fromJava(result, mu);
+  private EvalException wrapOtherException(Throwable e) throws EvalException {
+    // All other checked exceptions (e.g. LabelSyntaxException) are reported to Starlark.
+    return new EvalException(e);
   }
 
   /** @see StarlarkMethod#name() */


### PR DESCRIPTION
Make it about 10% faster.

Benchmark:

```
def foo():
    for i in range(1000):
        for j in range(1000):
            for k in range(100):
                type(1)
foo()
```

Results:

```
A: N=20, r=15.299+-0.351
B: N=20, r=13.819+-0.197
B/A: 0.903
```

This diff basically replaces runtime checks like `Starlark.isValid`
or `obj instanceof String` with JIT-compile-time checks when possbile.