### PR TITLE
Handle transition exceptions inside AspectFunction

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
 import com.google.devtools.build.lib.analysis.config.DependencyEvaluationException;
 import com.google.devtools.build.lib.analysis.config.InvalidConfigurationException;
 import com.google.devtools.build.lib.analysis.configuredtargets.MergedConfiguredTarget;
+import com.google.devtools.build.lib.analysis.starlark.StarlarkTransition.TransitionException;
 import com.google.devtools.build.lib.causes.Cause;
 import com.google.devtools.build.lib.causes.LabelCause;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -478,6 +479,10 @@ public final class AspectFunction implements SkyFunction {
             new AspectCreationException(cause.getMessage(), cause.getRootCauses()));
       } else if (e.getCause() instanceof InconsistentAspectOrderException) {
         InconsistentAspectOrderException cause = (InconsistentAspectOrderException) e.getCause();
+        throw new AspectFunctionException(
+            new AspectCreationException(cause.getMessage(), key.getLabel(), aspectConfiguration));
+      } else if (e.getCause() instanceof TransitionException) {
+        TransitionException cause = (TransitionException) e.getCause();
         throw new AspectFunctionException(
             new AspectCreationException(cause.getMessage(), key.getLabel(), aspectConfiguration));
       } else {


### PR DESCRIPTION
Otherwise, if there are errors over a starlark transitition’d dependency, an illegal cast exception would be raised when attempting to cast to an InvalidConfigurationException