### PR TITLE
Starlark: Cache descriptor resolution in getattr

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/DotExpression.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/DotExpression.java
@@ -14,6 +14,8 @@
 package com.google.devtools.build.lib.syntax;
 
 
+import javax.annotation.Nullable;
+
 /** Syntax node for a dot expression. e.g. obj.field, but not obj.method() */
 public final class DotExpression extends Expression {
 
@@ -59,4 +61,8 @@ public final class DotExpression extends Expression {
   public Kind kind() {
     return Kind.DOT;
   }
+
+  /** Descriptor resolution cache; used by the interpreter. */
+  @Nullable
+  volatile Object descriptorCache;
 }

--- a/src/main/java/com/google/devtools/build/lib/syntax/Eval.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Eval.java
@@ -509,7 +509,7 @@ final class Eval {
     Object object = eval(fr, dot.getObject());
     String name = dot.getField().getName();
     try {
-      Object result = EvalUtils.getAttr(fr.thread, object, name);
+      Object result = EvalUtils.getAttr(fr.thread, object, name, dot);
       if (result == null) {
         throw EvalUtils.getMissingAttrException(object, name, fr.thread.getSemantics());
       }

--- a/src/main/java/com/google/devtools/build/lib/syntax/MethodLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/MethodLibrary.java
@@ -634,7 +634,7 @@ class MethodLibrary {
       useStarlarkThread = true)
   public Object getattr(Object obj, String name, Object defaultValue, StarlarkThread thread)
       throws EvalException, InterruptedException {
-    Object result = EvalUtils.getAttr(thread, obj, name);
+    Object result = EvalUtils.getAttr(thread, obj, name, null);
     if (result == null) {
       if (defaultValue != Starlark.UNBOUND) {
         return defaultValue;


### PR DESCRIPTION
Even with descriptor cache, hash map lookup is quite expensive.

This is especially hurtful when getattr is invoked for structs:
* we lookup for descriptor before checking if class implements `ClassObject`
* we don't cache negative lookups (and we probably shouldn't because
  structs can have bazillion distinct fields)

Benchmark:

```
def test():
    l = []
    for i in range(10):
        print(i)
        for j in range(1000):
            for k in range(2000):
                a = l.append
                a = l.append
                a = l.append
                a = l.append
                a = l.append
                a = l.append
                a = l.append
                a = l.append

test()
```

Results are:

```
A: N=18, r=10.716+-0.358
B: N=18, r=8.063+-0.386
B/A: 0.752
```

This implementation caches the resolution inside the AST.  With
bytecode interpreter the same caching can be done in the bytecode
object.

The similar optimization can be applied to `Starlark.fastcall`, but
before doing that I'd like to get feedback on this.