### PR TITLE
Fix a bug that `--remote_download_toplevel` doesn't download unused_inputs_list

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -50,7 +50,6 @@ import com.google.devtools.build.lib.actions.CommandLines.ExpandedCommandLines;
 import com.google.devtools.build.lib.actions.CompositeRunfilesSupplier;
 import com.google.devtools.build.lib.actions.EmptyRunfilesSupplier;
 import com.google.devtools.build.lib.actions.ExecException;
-import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.FilesetOutputSymlink;
 import com.google.devtools.build.lib.actions.ParamFileInfo;
 import com.google.devtools.build.lib.actions.ResourceSet;
@@ -89,7 +88,6 @@ import com.google.errorprone.annotations.DoNotCall;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -402,7 +400,6 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     return new ActionSpawn(
         commandLines.allArguments(),
         ImmutableMap.of(),
-        ImmutableMap.of(),
         inputs,
         ImmutableList.of(),
         ImmutableMap.of());
@@ -427,20 +424,8 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       throws CommandLineExpansionException {
     ExpandedCommandLines expandedCommandLines =
         commandLines.expand(artifactExpander, getPrimaryOutput().getExecPath(), commandLineLimits);
-
-    Map<String, String> executionInfo = new HashMap<>();
-    if (this instanceof StarlarkAction) {
-      StarlarkAction starlarkAction = (StarlarkAction) this;
-      if (starlarkAction.getUnusedInputsList().isPresent()) {
-        executionInfo.put(
-            ExecutionRequirements.REMOTE_EXECUTION_INLINE_OUTPUTS,
-            starlarkAction.getUnusedInputsList().get().getExecPathString());
-      }
-    }
-
     return new ActionSpawn(
         ImmutableList.copyOf(expandedCommandLines.arguments()),
-        ImmutableMap.copyOf(executionInfo),
         clientEnv,
         getInputs(),
         expandedCommandLines.getParamFiles(),
@@ -587,7 +572,6 @@ public class SpawnAction extends AbstractAction implements CommandAction {
      */
     private ActionSpawn(
         ImmutableList<String> arguments,
-        Map<String, String> executionInfo,
         Map<String, String> clientEnv,
         NestedSet<Artifact> inputs,
         Iterable<? extends ActionInput> additionalInputs,

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -50,6 +50,7 @@ import com.google.devtools.build.lib.actions.CommandLines.ExpandedCommandLines;
 import com.google.devtools.build.lib.actions.CompositeRunfilesSupplier;
 import com.google.devtools.build.lib.actions.EmptyRunfilesSupplier;
 import com.google.devtools.build.lib.actions.ExecException;
+import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.FilesetOutputSymlink;
 import com.google.devtools.build.lib.actions.ParamFileInfo;
 import com.google.devtools.build.lib.actions.ResourceSet;
@@ -88,6 +89,7 @@ import com.google.errorprone.annotations.DoNotCall;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -400,6 +402,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     return new ActionSpawn(
         commandLines.allArguments(),
         ImmutableMap.of(),
+        ImmutableMap.of(),
         inputs,
         ImmutableList.of(),
         ImmutableMap.of());
@@ -424,8 +427,20 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       throws CommandLineExpansionException {
     ExpandedCommandLines expandedCommandLines =
         commandLines.expand(artifactExpander, getPrimaryOutput().getExecPath(), commandLineLimits);
+
+    Map<String, String> executionInfo = new HashMap<>();
+    if (this instanceof StarlarkAction) {
+      StarlarkAction starlarkAction = (StarlarkAction) this;
+      if (starlarkAction.getUnusedInputsList().isPresent()) {
+        executionInfo.put(
+            ExecutionRequirements.REMOTE_EXECUTION_INLINE_OUTPUTS,
+            starlarkAction.getUnusedInputsList().get().getExecPathString());
+      }
+    }
+
     return new ActionSpawn(
         ImmutableList.copyOf(expandedCommandLines.arguments()),
+        ImmutableMap.copyOf(executionInfo),
         clientEnv,
         getInputs(),
         expandedCommandLines.getParamFiles(),
@@ -572,6 +587,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
      */
     private ActionSpawn(
         ImmutableList<String> arguments,
+        Map<String, String> executionInfo,
         Map<String, String> clientEnv,
         NestedSet<Artifact> inputs,
         Iterable<? extends ActionInput> additionalInputs,

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -247,11 +247,6 @@ public final class StarlarkAction extends SpawnAction implements ActionCacheAwar
       return this;
     }
 
-    private static boolean getInMemoryUnusedInputsListFileFlag(
-        @Nullable BuildConfiguration configuration) {
-      return configuration == null ? false : configuration.inmemoryUnusedInputsList();
-    }
-
     /** Creates a SpawnAction. */
     @Override
     protected SpawnAction createSpawnAction(
@@ -270,7 +265,8 @@ public final class StarlarkAction extends SpawnAction implements ActionCacheAwar
         CharSequence progressMessage,
         RunfilesSupplier runfilesSupplier,
         String mnemonic) {
-      if (unusedInputsList.isPresent() && getInMemoryUnusedInputsListFileFlag(configuration)) {
+      if (unusedInputsList.isPresent()) {
+        // Always download unused_inputs_list file from remote cache.
         executionInfo =
             ImmutableMap.<String, String>builderWithExpectedSize(executionInfo.size() + 1)
                 .putAll(executionInfo)

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfiguration.java
@@ -708,10 +708,6 @@ public class BuildConfiguration implements BuildConfigurationApi {
     return options.actionListeners;
   }
 
-  public boolean inmemoryUnusedInputsList() {
-    return options.inmemoryUnusedInputsList;
-  }
-
   /**
    * Returns whether FileWriteAction may transparently compress its contents in the analysis phase
    * to save memory. Semantics are not affected.

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -764,21 +764,6 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   public TriState useGraphlessQuery;
 
   @Option(
-      name = "experimental_inmemory_unused_inputs_list",
-      defaultValue = "false",
-      documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
-      effectTags = {
-        OptionEffectTag.LOADING_AND_ANALYSIS,
-        OptionEffectTag.EXECUTION,
-        OptionEffectTag.AFFECTS_OUTPUTS
-      },
-      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
-      help =
-          "If enabled, the optional 'unused_inputs_list' file will be passed through in memory "
-              + "directly from the remote build nodes instead of being written to disk.")
-  public boolean inmemoryUnusedInputsList;
-
-  @Option(
       name = "include_config_fragments_provider",
       defaultValue = "off",
       converter = IncludeConfigFragmentsEnumConverter.class,
@@ -881,7 +866,6 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
     host.enforceConstraints = enforceConstraints;
     host.mergeGenfilesDirectory = mergeGenfilesDirectory;
     host.cpu = hostCpu;
-    host.inmemoryUnusedInputsList = inmemoryUnusedInputsList;
     host.includeRequiredConfigFragmentsProvider = includeRequiredConfigFragmentsProvider;
     host.enableAggregatingMiddleman = enableAggregatingMiddleman;
 

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1924,11 +1924,11 @@ EOF
 
   CACHEDIR=$(mktemp -d)
 
-  bazel build --disk_cache="$CACHEDIR" --remote_download_toplevel :test
+  bazel build --disk_cache="$CACHEDIR" --remote_download_toplevel :test || fail "Failed to build :test"
 
-  bazel clean
+  bazel clean || fail "Failed to clean"
 
-  bazel build --disk_cache="$CACHEDIR" --remote_download_toplevel :test
+  bazel build --disk_cache="$CACHEDIR" --remote_download_toplevel :test >& $TEST_log
 
   expect_log "INFO: Build completed successfully"
 }

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -677,6 +677,15 @@ sh_test(
 )
 
 sh_test(
+    name = "starlark_dependency_pruning_test",
+    timeout = "long",
+    srcs = ["starlark_dependency_pruning_test.sh"],
+    data = [":test-deps"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+    shard_count = 2,
+)
+
+sh_test(
     name = "validation_actions_test",
     srcs = ["validation_actions_test.sh"],
     data = [":test-deps"],

--- a/src/test/shell/integration/starlark_dependency_pruning_test.sh
+++ b/src/test/shell/integration/starlark_dependency_pruning_test.sh
@@ -14,12 +14,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# --- begin runfiles.bash initialization ---
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
 set -euo pipefail
-# Load the test setup defined in the parent directory
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${CURRENT_DIR}/../integration_test_setup.sh" \
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*|mingw*|cygwin*)
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+fi
+
+add_to_bazelrc "build --package_path=%workspace%"
 
 #### HELPER FUNCTIONS ##################################################
 
@@ -109,16 +144,22 @@ output=""
 unused=""
 for input in "$@"; do
   if grep -q "invalidUnused" "${input}"; then
-    unused+="${input}_invalid\n"
+    if [[ ! -z "${unused}" ]]; then
+      unused="${unused}\n"
+    fi
+    unused="${unused}${input}_invalid"
   elif grep -q "unused" "${input}"; then
-    unused+="${input}\n"
+    if [[ ! -z "${unused}" ]]; then
+      unused="${unused}\n"
+    fi
+    unused="${unused}${input}"
   else
-    output+="$(cat "${input}") "
+    output="${output}$(cat "${input}") "
   fi
 done
 
-echo -n -e "${output}" > "${output_file}"
-echo -n -e "${unused}" > "${unused_file}"
+echo "${output}" > "${output_file}"
+echo "${unused}" > "${unused_file}"
 EOF
 
   chmod +x pkg/cat_unused.sh

--- a/src/test/shell/integration/starlark_dependency_pruning_test.sh
+++ b/src/test/shell/integration/starlark_dependency_pruning_test.sh
@@ -293,39 +293,4 @@ EOF
   expect_log "Action did not create expected output file listing unused inputs"
 }
 
-# Test with orphaned artifacts features.
-# This requires --experimental_inmemory_unused_inputs_list flag.
-function test_orphaned_artifacts() {
-  options="--discard_orphaned_artifacts --nokeep_state_after_build"
-
-  # Use in-memory files.
-  bazel build ${options} --experimental_inmemory_unused_inputs_list \
-      //pkg:output || fail "build failed"
-
-  # This should fail.
-  bazel build ${options} --noexperimental_inmemory_unused_inputs_list \
-      //pkg:output >& $TEST_log && fail "Expected failure"
-  exitcode=$?
-  assert_equals 1 "$exitcode"
-  expect_log "Action did not create expected output file listing unused inputs"
-}
-
-# Test with orphaned artifacts features with host config.
-# output2 requires a tool (cat_unused2) that uses unused_inputs_list.
-# This requires --experimental_inmemory_unused_inputs_list flag.
-function test_orphaned_artifacts_host_config() {
-  options="--discard_orphaned_artifacts --nokeep_state_after_build"
-
-  # Use in-memory files.
-  bazel build ${options} --experimental_inmemory_unused_inputs_list \
-      //pkg:output2 || fail "build failed"
-
-  # This should fail while building "output", needed by the tool.
-  bazel build ${options} --noexperimental_inmemory_unused_inputs_list \
-      //pkg:output2 >& $TEST_log && fail "Expected failure"
-  exitcode=$?
-  assert_equals 1 "$exitcode"
-  expect_log "Action did not create expected output file listing unused inputs"
-}
-
 run_suite "Tests Starlark dependency pruning"


### PR DESCRIPTION
When enabling remote caching with flag `--remote_download_toplevel`, Bazel only [downloads output directory metadata, stdout and stderr as well as the contents of `inMemoryOutputPath` if specified](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java#L522). However, file specified by`unused_inputs_list` of [`ctx.actions.run`](https://docs.bazel.build/versions/master/skylark/lib/actions.html#run) isn't downloaded in this case but is [required](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java#L195) after starlark action execution.

This PR specify `inMemoryOutputPath` to the `unused_inputs_list` file by inserting `ExecutionRequirements.REMOTE_EXECUTION_INLINE_OUTPUTS` to `SpawnAction`'s `executionInfo`.

Fixes #11732.