### PR TITLE
Check isIpV4StackPreferred before binding with ipv6 address

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/server/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/server/BUILD
@@ -47,6 +47,7 @@ java_library(
         "//third_party:flogger",
         "//third_party:guava",
         "//third_party:jsr305",
+        "//third_party:netty",
         "//third_party/grpc:grpc-jar",
         "//third_party/protobuf:protobuf_java",
     ],

--- a/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
@@ -453,7 +453,7 @@ public class GrpcServerImpl extends CommandServerGrpc.CommandServerImplBase impl
     InetSocketAddress address = new InetSocketAddress("[::1]", port);
     try {
       // TODO(bazel-team): Remove the following check after upgrading netty to a version with a fix
-      //  for https://github.com/netty/netty/issues/10402
+      //   for https://github.com/netty/netty/issues/10402
       if (NetUtil.isIpV4StackPreferred()) {
         throw new IOException("ipv4 is preferred on the system.");
       }

--- a/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
@@ -60,6 +60,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import io.netty.util.NetUtil;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
@@ -451,6 +452,11 @@ public class GrpcServerImpl extends CommandServerGrpc.CommandServerImplBase impl
     // and if that fails, try again with IPv4.
     InetSocketAddress address = new InetSocketAddress("[::1]", port);
     try {
+      // TODO(bazel-team): Remove the following check after upgrading netty to a version with a fix
+      //  for https://github.com/netty/netty/issues/10402
+      if (NetUtil.isIpV4StackPreferred()) {
+        throw new IOException("ipv4 is preferred on the system.");
+      }
       server =
           NettyServerBuilder.forAddress(address).addService(this).directExecutor().build().start();
     } catch (IOException ipv6Exception) {


### PR DESCRIPTION
This is a workaround for a netty bug https://github.com/netty/netty/issues/10402 that caused the rollback of upgrading grpc-java to 1.26.0 (https://github.com/bazelbuild/bazel/issues/11756)