### PR TITLE
Close VanillaJavaBuilder before writing output, in persistent worker mode

### DIFF
--- a/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/VanillaJavaBuilder.java
+++ b/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/VanillaJavaBuilder.java
@@ -103,15 +103,20 @@ public class VanillaJavaBuilder implements Closeable {
         if (request == null) {
           break;
         }
+        WorkResponse response;
         try (VanillaJavaBuilder builder = new VanillaJavaBuilder()) {
           VanillaJavaBuilderResult result = builder.run(request.getArgumentsList());
-          WorkResponse response =
+          response =
               WorkResponse.newBuilder()
                   .setOutput(result.output())
                   .setExitCode(result.ok() ? 0 : 1)
                   .build();
-          response.writeDelimitedTo(System.out);
         }
+        /* As soon as we write the response, bazel will start cleaning
+         * up the working tree. The VanillaJavaBuilder must be fully
+         * closed at this point.
+         */
+        response.writeDelimitedTo(System.out);
         System.out.flush();
       } catch (IOException e) {
         e.printStackTrace();


### PR DESCRIPTION
The VanillaJavaBuilder.close() function turns out to depend on the
input files still existing. In persistent worker mode, as soon as we
write the output, bazel will begin cleaning up the working
directory. We must therefore wait to write the output until after
calling .close()

Fixes #11796