### PR TITLE
Starlark: special case in `type` for list, tuple, dict, ...

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/Starlark.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Starlark.java
@@ -236,6 +236,23 @@ public final class Starlark {
       return "bool";
     }
 
+    // Shortcut for the most common types.
+    // These cases can be handled by `getStarlarkBuiltin`
+    // but `getStarlarkBuiltin` is quite expensive.
+    if (c.equals(StarlarkList.class)) {
+      return "list";
+    } else if (c.equals(Tuple.class)) {
+      return "tuple";
+    } else if (c.equals(Dict.class)) {
+      return "dict";
+    } else if (c.equals(NoneType.class)) {
+      return "NoneType";
+    } else if (c.equals(StarlarkFunction.class)) {
+      return "function";
+    } else if (c.equals(RangeList.class)) {
+      return "range";
+    }
+
     StarlarkBuiltin module = StarlarkInterfaceUtils.getStarlarkBuiltin(c);
     if (module != null) {
       return module.name();


### PR DESCRIPTION
`StarlarkInterfaceUtils.getStarlarkBuiltin` is quite expensive, and
at the same type `type` is usually invoked with simple types like
`list` or `dict`.

Results are:

```
A: N=7, r=5.492+-0.198
B: N=7, r=4.846+-0.354
B/A: 0.882
```

for for test:

```
def test():
    for i in range(10):
        print(i)
        for j in range(200):
            for k in range(1000):
                type([])
                type(())
                type({})
                type([])
                type(())
                type({})
                type([])
                type(())
                type({})
                type([])
                type(())
                type({})
                type([])
                type(())
                type({})

test()
```

For the invocations like `type(int)` the slowdown is about 1% but
less than the measurement noise.