### PR TITLE
Starlark: optimize Dict.plus

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/Dict.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Dict.java
@@ -104,6 +104,10 @@ public final class Dict<K, V>
     this(mutability, new LinkedHashMap<>());
   }
 
+  private Dict(@Nullable Mutability mutability, int initialCapacity) {
+    this(mutability, new LinkedHashMap<>(initialCapacity));
+  }
+
   /**
    * Takes ownership of the supplied LinkedHashMap and returns a new Dict that wraps it. The caller
    * must not subsequently modify the map, but the Dict may do so.
@@ -535,9 +539,10 @@ public final class Dict<K, V>
       Dict<? extends K, ? extends V> left,
       Dict<? extends K, ? extends V> right,
       @Nullable Mutability mu) {
-    Dict<K, V> result = Dict.of(mu);
-    result.putAllUnsafe(left);
-    result.putAllUnsafe(right);
+    Dict<K, V> result = new Dict<>(mu, Math.max(left.size(), right.size()));
+    // Update underlying map contents directly, input dicts already contain valid objects
+    result.contents.putAll(left.contents);
+    result.contents.putAll(right.contents);
     return result;
   }
 


### PR DESCRIPTION
`Dict.plus` is used in implementations of `dict` and `dict.update`.

Optimize:
* allocate capacity at construction
* update resulting dict without validation of input dict maps
* iterate underlying maps of input dicts

This test becomes almost two times faster:

```
def test():
    d = {x: x for x in range(100)}
    for i in range(10):
        print(i)
        for j in range(100000):
            dict(d)

test()
```

```
A: N=9, r=5.129+-0.183
B: N=9, r=3.176+-0.155
B/A: 0.619
```