### PR TITLE
Starlark: specialize toArray in StarlarkList

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkList.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkList.java
@@ -468,4 +468,9 @@ public final class StarlarkList<E> extends AbstractList<E>
     remove(index, (Location) null);
     return result;
   }
+
+  @Override
+  public Object[] toArray() {
+    return size != 0 ? Arrays.copyOf(elems, size) : EMPTY_ARRAY;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/syntax/Tuple.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Tuple.java
@@ -156,7 +156,7 @@ public final class Tuple<E> extends AbstractList<E> implements Sequence<E> {
 
   @Override
   public Object[] toArray() {
-    return Arrays.copyOf(elems, elems.length);
+    return elems.length != 0 ? elems.clone() : elems;
   }
 
   @Override


### PR DESCRIPTION
It is already specialized in `Tuple`.

Also, not not allocate empty arrays in `toArray` of `Tuple` and
`StarlarkList` to save a little memory.

The results are:

```
A: N=29, r=5.262+-0.395
B: N=29, r=4.009+-0.248
B/A: 0.762
```

for benchmark:

```
def test():
    l = list(range(10))
    for i in range(10):
        print(i)
        for j in range(500000):
            list(l)
            list(l)
            list(l)
            list(l)
            list(l)

test()
```