### PR TITLE
Generate a valid Accept header in the request

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpConnector.java
@@ -107,6 +107,8 @@ class HttpConnector {
       try {
         connection = (HttpURLConnection)
             url.openConnection(proxyHelper.createProxyIfNeeded(url));
+        // TODO(zecke): Revise once https://bugs.openjdk.java.net/browse/JDK-8163921 is fixed.
+        connection.addRequestProperty("Accept", "text/html, image/gif, image/jpeg, */*");
         boolean isAlreadyCompressed =
             COMPRESSED_EXTENSIONS.contains(HttpUtils.getExtension(url.getPath()))
                 || COMPRESSED_EXTENSIONS.contains(HttpUtils.getExtension(originalUrl.getPath()));


### PR DESCRIPTION
The OpenJDK generates an accept header that does not follow the BNF of the HTTP
RFC. Generate a conforming default header that can be overridden by the usual request
headers.

Fixes #11788.