### PR TITLE
Add distrib_cc_binary rule

### DIFF
--- a/tools/distributions/debian/debian_bin.BUILD
+++ b/tools/distributions/debian/debian_bin.BUILD
@@ -25,3 +25,9 @@ filegroup(
     name = "grpc-cpp-plugin",
     srcs = ["grpc_cpp_plugin"],
 )
+
+# protobuf-compiler-grpc-java-plugin
+filegroup(
+    name = "grpc-java-plugin",
+    srcs = ["grpc_java_plugin"],
+)

--- a/tools/distributions/debian/deps.bzl
+++ b/tools/distributions/debian/deps.bzl
@@ -58,6 +58,7 @@ def debian_bin_deps():
         symlinks = {
             "protoc": "/usr/bin/protoc",
             "grpc_cpp_plugin": "/usr/bin/grpc_cpp_plugin",
+            "grpc_java_plugin": "/usr/bin/grpc_java_plugin",
         },
         build_file = "//tools/distributions/debian:debian_bin.BUILD",
     )

--- a/tools/distributions/distribution_rules.bzl
+++ b/tools/distributions/distribution_rules.bzl
@@ -44,6 +44,21 @@ def distrib_cc_library(name, visibility = None, enable_distributions = [], **kwa
 
     native.alias(name = name, actual = select(conditions), visibility = visibility)
 
+def distrib_cc_binary(name, visibility = None, enable_distributions = [], **kwargs):
+    """A macro for cc_binary rule to support distributions build (eg. Debian)"""
+    checked_in_name = name + "_checked_in"
+
+    native.cc_binary(name = checked_in_name, visibility = visibility, **kwargs)
+
+    conditions = {
+        "//conditions:default": ":" + checked_in_name,
+    }
+
+    if "debian" in enable_distributions:
+        conditions["//src/conditions:debian_build"] = "@debian_bin_deps//:" + name
+
+    native.alias(name = name, actual = select(conditions), visibility = visibility)
+
 def distrib_jar_filegroup(name, visibility = None, enable_distributions = [], **kwargs):
     """A macro for filegroup rule to support distributions build (eg. Debian)"""
     checked_in_name = name + "_checked_in"


### PR DESCRIPTION
This is for using Debian's `/usr/bin/grpc_java_plugin` in Bazel Debian build.

Working towards https://github.com/bazelbuild/bazel/issues/9408