### PR TITLE
Support Label type as a parameter in repository_ctx.execute()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -484,9 +484,9 @@ public class StarlarkRepositoryContext
               Location.BUILTIN, "Argument " + i + " of execute is neither a label nor a string.");
         }
       } else {
-        if (!(arg instanceof String || arg instanceof StarlarkPath)) {
+        if (!(arg instanceof String || arg instanceof Label || arg instanceof StarlarkPath)) {
           throw new EvalException(
-              Location.BUILTIN, "Argument " + i + " of execute is neither a path nor a string.");
+              Location.BUILTIN, "Argument " + i + " of execute is neither a path, label, nor string.");
         }
       }
     }


### PR DESCRIPTION
This change fixes an inconsistency between remotable and non-remotable
repository rules. If remotable, then repository_ctx.execute() accepts
label and string types as parameters. If non-remotable,
repository_ctx.execute() accepts string and path types as parameters.

An implementation written for a remotable rule should also work for
non-remotable rule. This change makes it so that a non-remotable
repository_rule also accepts a Label type as a parameter.

For context on remotable repository rules see
https://github.com/bazelbuild/bazel/commit/06a26c37126e3eefabd28c24a4e35059b5b136bc