### PR TITLE
make curl fail loudly for non-2xx downloads

### DIFF
--- a/scripts/docs/Dockerfile
+++ b/scripts/docs/Dockerfile
@@ -7,7 +7,7 @@
 # $ docker run -it --rm -p 8000:8000 --entrypoint /bin/bash bazel-jekyll
 # $ git clone https://bazel.googlesource.com/bazel
 # $ cd bazel
-# $ curl -o bazel https://releases.bazel.build/0.19.0/release/bazel-0.19.0-linux-x86_64
+# $ curl -f -o bazel https://releases.bazel.build/0.19.0/release/bazel-0.19.0-linux-x86_64
 # $ chmod +x bazel
 # $ ./bazel build //site
 # $ cd bazel-bin/site/site-build
@@ -25,7 +25,7 @@ RUN apt-get -qqy update && \
 
 RUN ln -fs /usr/bin/python3.7 /usr/bin/python
 
-RUN curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64 && \
+RUN curl -f -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64 && \
     chown root:root /usr/local/bin/bazel && \
     chmod 0755 /usr/local/bin/bazel
 RUN bazel version

--- a/scripts/docs/Dockerfile
+++ b/scripts/docs/Dockerfile
@@ -7,7 +7,7 @@
 # $ docker run -it --rm -p 8000:8000 --entrypoint /bin/bash bazel-jekyll
 # $ git clone https://bazel.googlesource.com/bazel
 # $ cd bazel
-# $ curl -f -o bazel https://releases.bazel.build/0.19.0/release/bazel-0.19.0-linux-x86_64
+# $ curl -fo bazel https://releases.bazel.build/0.19.0/release/bazel-0.19.0-linux-x86_64
 # $ chmod +x bazel
 # $ ./bazel build //site
 # $ cd bazel-bin/site/site-build
@@ -25,7 +25,7 @@ RUN apt-get -qqy update && \
 
 RUN ln -fs /usr/bin/python3.7 /usr/bin/python
 
-RUN curl -f -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64 && \
+RUN curl -fLo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.3.0/bazelisk-linux-amd64 && \
     chown root:root /usr/local/bin/bazel && \
     chmod 0755 /usr/local/bin/bazel
 RUN bazel version

--- a/scripts/docs/doc_versions.bzl
+++ b/scripts/docs/doc_versions.bzl
@@ -15,7 +15,7 @@
 # To get the checksum of the versioned documentation tree tarball, run the
 # following command with the selected Bazel version:
 #
-# $ curl -s https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.20.0.tar | sha256sum | cut -d" " -f1
+# $ curl -f -s https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.20.0.tar | sha256sum | cut -d" " -f1
 # bb79a63810bf1b0aa1f89bd3bbbeb4a547a30ab9af70c9be656cc6866f4b015b
 #
 # This list must be kept in sync with `doc_versions` variable in //site:_config.yml

--- a/scripts/docs/doc_versions.bzl
+++ b/scripts/docs/doc_versions.bzl
@@ -15,7 +15,7 @@
 # To get the checksum of the versioned documentation tree tarball, run the
 # following command with the selected Bazel version:
 #
-# $ curl -f -s https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.20.0.tar | sha256sum | cut -d" " -f1
+# $ curl -fs https://mirror.bazel.build/bazel_versioned_docs/jekyll-tree-0.20.0.tar | sha256sum | cut -d" " -f1
 # bb79a63810bf1b0aa1f89bd3bbbeb4a547a30ab9af70c9be656cc6866f4b015b
 #
 # This list must be kept in sync with `doc_versions` variable in //site:_config.yml

--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -203,7 +203,7 @@ if [[ ! -x $BAZEL_REAL ]]; then
     if [[ -x $(command -v curl) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"
-      echo "  (cd \"${wrapper_dir}\" && curl -LO --fail https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
+      echo "  (cd \"${wrapper_dir}\" && curl -LO -f https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
     elif [[ -x $(command -v wget) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"

--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -203,7 +203,7 @@ if [[ ! -x $BAZEL_REAL ]]; then
     if [[ -x $(command -v curl) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"
-      echo "  (cd \"${wrapper_dir}\" && curl -f -LO https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
+      echo "  (cd \"${wrapper_dir}\" && curl -fLO https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
     elif [[ -x $(command -v wget) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"

--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -203,7 +203,7 @@ if [[ ! -x $BAZEL_REAL ]]; then
     if [[ -x $(command -v curl) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"
-      echo "  (cd \"${wrapper_dir}\" && curl -LO -f https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
+      echo "  (cd \"${wrapper_dir}\" && curl -f -LO -f https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
     elif [[ -x $(command -v wget) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"

--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -203,7 +203,7 @@ if [[ ! -x $BAZEL_REAL ]]; then
     if [[ -x $(command -v curl) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"
-      echo "  (cd \"${wrapper_dir}\" && curl -f -LO -f https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
+      echo "  (cd \"${wrapper_dir}\" && curl -f -LO https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
     elif [[ -x $(command -v wget) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"

--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -203,7 +203,7 @@ if [[ ! -x $BAZEL_REAL ]]; then
     if [[ -x $(command -v curl) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"
-      echo "  (cd \"${wrapper_dir}\" && curl -LO https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
+      echo "  (cd \"${wrapper_dir}\" && curl -LO --fail https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
     elif [[ -x $(command -v wget) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"

--- a/scripts/url-for-sheriff.sh
+++ b/scripts/url-for-sheriff.sh
@@ -17,7 +17,7 @@
 # Prints a github URL for all bugs sheriff needs to look at
 # (open, no category assigned)
 
-NO_LABELS=$(curl https://api.github.com/repos/bazelbuild/bazel/labels 2>/dev/null | grep "url" | awk -f <(cat - <<-'EOD'
+NO_LABELS=$(curl -f https://api.github.com/repos/bazelbuild/bazel/labels 2>/dev/null | grep "url" | awk -f <(cat - <<-'EOD'
   BEGIN {
     ORS = ""
   }

--- a/site/docs/install-os-x.md
+++ b/site/docs/install-os-x.md
@@ -60,7 +60,7 @@ you will need to download the installer from the terminal using `curl`:
 ```shell
 # Example installing version `3.2.0`. Replace the version below as appropriate.
 export BAZEL_VERSION=3.2.0
-curl -f -LO "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
+curl -fLO "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 ```
 
 This is a temporary workaround until we fix notarization in our macOS release

--- a/site/docs/install-os-x.md
+++ b/site/docs/install-os-x.md
@@ -60,7 +60,7 @@ you will need to download the installer from the terminal using `curl`:
 ```shell
 # Example installing version `3.2.0`. Replace the version below as appropriate.
 export BAZEL_VERSION=3.2.0
-curl -LO "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
+curl -f -LO "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 ```
 
 This is a temporary workaround until we fix notarization in our macOS release

--- a/site/docs/install-ubuntu.md
+++ b/site/docs/install-ubuntu.md
@@ -33,7 +33,7 @@ Bazel comes with two completion scripts. After installing Bazel, you can:
 
 ```bash
 sudo apt install curl gnupg
-curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+curl -f https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
 echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 ```
 

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -369,14 +369,14 @@ function setup_network_tests() {
 genrule(
   name = "localhost",
   outs = [ "localhost.txt" ],
-  cmd = "curl -f -o \$@ localhost:${nc_port}",
+  cmd = "curl -fo \$@ localhost:${nc_port}",
   tags = [ ${tags} ],
 )
 
 genrule(
   name = "unix-socket",
   outs = [ "unix-socket.txt" ],
-  cmd = "curl -f --unix-socket ${socket} -o \$@ irrelevant-url",
+  cmd = "curl --unix-socket ${socket} -fo \$@ irrelevant-url",
   tags = [ ${tags} ],
 )
 
@@ -387,7 +387,7 @@ genrule(
       + "pid=\$\$!; "
       + "while ! grep started port.txt; do sleep 1; done; "
       + "port=\$\$(head -n 1 port.txt); "
-      + "curl -f -o \$@ localhost:\$\$port; "
+      + "curl -fo \$@ localhost:\$\$port; "
       + "kill \$\$pid",
 )
 EOF
@@ -410,14 +410,14 @@ EOF
 genrule(
   name = "remote-ip",
   outs = [ "remote-ip.txt" ],
-  cmd = "curl -f -o \$@ ${remote_ip}:80",
+  cmd = "curl -fo \$@ ${remote_ip}:80",
   tags = [ ${tags} ],
 )
 
 genrule(
   name = "remote-name",
   outs = [ "remote-name.txt" ],
-  cmd = "curl -f -o \$@ '${REMOTE_NETWORK_ADDRESS}'",
+  cmd = "curl -fo \$@ '${REMOTE_NETWORK_ADDRESS}'",
   tags = [ ${tags} ],
 )
 EOF

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -369,14 +369,14 @@ function setup_network_tests() {
 genrule(
   name = "localhost",
   outs = [ "localhost.txt" ],
-  cmd = "curl -o \$@ localhost:${nc_port}",
+  cmd = "curl -f -o \$@ localhost:${nc_port}",
   tags = [ ${tags} ],
 )
 
 genrule(
   name = "unix-socket",
   outs = [ "unix-socket.txt" ],
-  cmd = "curl --unix-socket ${socket} -o \$@ irrelevant-url",
+  cmd = "curl -f --unix-socket ${socket} -o \$@ irrelevant-url",
   tags = [ ${tags} ],
 )
 
@@ -387,7 +387,7 @@ genrule(
       + "pid=\$\$!; "
       + "while ! grep started port.txt; do sleep 1; done; "
       + "port=\$\$(head -n 1 port.txt); "
-      + "curl -o \$@ localhost:\$\$port; "
+      + "curl -f -o \$@ localhost:\$\$port; "
       + "kill \$\$pid",
 )
 EOF
@@ -410,14 +410,14 @@ EOF
 genrule(
   name = "remote-ip",
   outs = [ "remote-ip.txt" ],
-  cmd = "curl -o \$@ ${remote_ip}:80",
+  cmd = "curl -f -o \$@ ${remote_ip}:80",
   tags = [ ${tags} ],
 )
 
 genrule(
   name = "remote-name",
   outs = [ "remote-name.txt" ],
-  cmd = "curl -o \$@ '${REMOTE_NETWORK_ADDRESS}'",
+  cmd = "curl -f -o \$@ '${REMOTE_NETWORK_ADDRESS}'",
   tags = [ ${tags} ],
 )
 EOF

--- a/src/test/shell/bazel/bazel_wrapper_test.sh
+++ b/src/test/shell/bazel/bazel_wrapper_test.sh
@@ -175,7 +175,7 @@ test_recommends_curl() {
   if PATH="$(pwd)/mockpath" USE_BAZEL_VERSION="foobar" ../bin/bazel &> "$TEST_log"; then
     fail "Bazel wrapper should have failed"
   fi
-  expect_log "curl -f -LO"
+  expect_log "curl -fLO"
   expect_not_log "wget"
 }
 

--- a/src/test/shell/bazel/bazel_wrapper_test.sh
+++ b/src/test/shell/bazel/bazel_wrapper_test.sh
@@ -175,7 +175,7 @@ test_recommends_curl() {
   if PATH="$(pwd)/mockpath" USE_BAZEL_VERSION="foobar" ../bin/bazel &> "$TEST_log"; then
     fail "Bazel wrapper should have failed"
   fi
-  expect_log "curl -LO"
+  expect_log "curl -f -LO"
   expect_not_log "wget"
 }
 

--- a/src/test/shell/bazel/remote_helpers.sh
+++ b/src/test/shell/bazel/remote_helpers.sh
@@ -185,7 +185,7 @@ function serve_timeout() {
 # connections, which causes flakes.
 function wait_for_server_startup() {
   touch some-file
-  while ! curl http://localhost:$fileserver_port/some-file > /dev/null; do
+  while ! curl -f http://localhost:$fileserver_port/some-file > /dev/null; do
     echo "waiting for server, exit code: $?"
     sleep 1
   done

--- a/src/test/shell/bazel/remote_helpers.sh
+++ b/src/test/shell/bazel/remote_helpers.sh
@@ -185,7 +185,7 @@ function serve_timeout() {
 # connections, which causes flakes.
 function wait_for_server_startup() {
   touch some-file
-  while ! curl -f http://localhost:$fileserver_port/some-file > /dev/null; do
+  while ! curl http://localhost:$fileserver_port/some-file > /dev/null; do
     echo "waiting for server, exit code: $?"
     sleep 1
   done


### PR DESCRIPTION
`curl` fails silently if the status code of the response is not 2xx. This CL makes it fail loudly, and break the pipe.