### PR TITLE
try-import user.bazelrc from the root of the repo

### DIFF
--- a/site/docs/best-practices.md
+++ b/site/docs/best-practices.md
@@ -66,7 +66,7 @@ For project-specific options, use the configuration file your
 If you want to support per-user options for your project that you **do not** want to check
 into source control, include the line
 ```
-try-import user.bazelrc
+try-import %workspace%/user.bazelrc
 ```
 (or any other file name) in your `<workspace>/.bazelrc` and
 add `user.bazelrc` to your `.gitignore`.


### PR DESCRIPTION
Using the syntax `try-import user.bazelrc` will try to import the file from the CWD, so as you move around in your repo your Bazel settings will change.

Using the syntax `try-import %workspace%/user.bazelrc` will always import the file `user.bazelrc` from the root of the repo, which fixes this problem.

Related to https://github.com/bazelbuild/bazel/issues/11803