### PR TITLE
RFC: Starlark: Bytecode interpreter

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BUILD
@@ -31,6 +31,9 @@ java_library(
     srcs = [
         "Argument.java",
         "AssignmentStatement.java",
+        "Bc.java",
+        "BcInstr.java",
+        "BcInstrOperand.java",
         "BinaryOperatorExpression.java",
         "CallExpression.java",
         "Comment.java",
@@ -86,6 +89,7 @@ java_library(
     name = "evaluator",
     srcs = [
         "BuiltinCallable.java",
+        "BcEval.java",
         "CallUtils.java",
         "ClassObject.java",
         "CpuProfiler.java",

--- a/src/main/java/com/google/devtools/build/lib/syntax/Bc.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Bc.java
@@ -1,0 +1,945 @@
+package com.google.devtools.build.lib.syntax;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.*;
+import java.util.stream.IntStream;
+
+/** Starlark bytecode compiler. */
+class Bc {
+
+  /**
+   * This constant enables/disables assertions in Starlark interpreter: when turned on, it checks
+   * that:
+   *
+   * <ul>
+   *   <li>Compiler generates valid opcode arguments, according to opcode spec
+   *   <li>Interpreter decodes opcode arguments correctly (e. g. does not consume extra undeclared
+   *       argument)
+   * </ul>
+   *
+   * Turn assertions on when debugging the compiler or interpreter.
+   *
+   * <p>Note the assertions are turned on when tests are launched from Bazel.
+   */
+  static final boolean ASSERTIONS = Boolean.getBoolean("starlark.bc.assertions");
+
+  static {
+    if (ASSERTIONS) {
+      System.err.println();
+      System.err.println();
+      System.err.println("Bc.ASSERTIONS = true");
+      System.err.println();
+      System.err.println();
+    }
+  }
+
+  /** Function body as a bytecode block. */
+  static class Compiled {
+    /** Assuming all statements belong to the same {@link FileLocations} object. */
+    final FileLocations locs;
+    /** Strings references by the bytecode. */
+    final String[] strings;
+    /** Other objects references by the bytecode. */
+    final Object[] objects;
+    /** The bytecode. */
+    final int[] text;
+    /** Number of registers. */
+    final int slotCount;
+    /** Registers holding constants. */
+    final Object[] constSlots;
+    /** Max depths of for loops. */
+    final int loopDepth;
+    /**
+     * Instruction pointer to a node.
+     *
+     * <p>Key is a beginning of an instruction.
+     */
+    final ImmutableMap<Integer, Node> instrToNode;
+
+    private Compiled(
+        FileLocations locs,
+        String[] strings,
+        Object[] objects,
+        int[] text,
+        int slotCount,
+        Object[] constSlots,
+        int loopDepth,
+        ImmutableMap<Integer, Node> instrToNode) {
+      this.locs = locs;
+      this.strings = strings;
+      this.objects = objects;
+      this.text = text;
+      this.slotCount = slotCount;
+      this.constSlots = constSlots;
+      this.loopDepth = loopDepth;
+      this.instrToNode = instrToNode;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder();
+      int ip = 0;
+      while (ip != text.length) {
+        if (sb.length() != 0) {
+          sb.append("; ");
+        }
+        sb.append(ip).append(": ");
+        int opcode1 = text[ip++];
+        BcInstr.Opcode opcode = BcInstr.Opcode.values()[opcode1];
+        sb.append(opcode);
+        int[] updateIp = new int[] {ip};
+        String argsString =
+            opcode.operands.toStringAndCount(
+                updateIp, text, Arrays.asList(strings), Arrays.asList(constSlots));
+        ip = updateIp[0];
+        sb.append(" ").append(argsString);
+      }
+      if (sb.length() != 0) {
+        sb.append("; ");
+      }
+      // It's useful to know the final address in case someone wants to jump to that address
+      sb.append(ip).append(": EOF");
+      return sb.toString();
+    }
+
+    /** Instruction opcode at IP. */
+    BcInstr.Opcode instrOpcodeAt(int ip) {
+      return BcInstr.Opcode.values()[text[ip]];
+    }
+
+    /** Print instruction at the given pointer. */
+    String instrStringAt(int ip) {
+      if (ip == text.length) {
+        return "EOF";
+      }
+
+      BcInstr.Opcode opcode = instrOpcodeAt(ip++);
+      return opcode + " " + opcode.operands.argToString(ip, this);
+    }
+
+    /** Instruction length at IP. */
+    int instrLenAt(int ip) {
+      return BcInstr.INSTR_HEADER_LEN
+          + instrOpcodeAt(ip)
+              .operands
+              .codeSize(
+                  text,
+                  Arrays.asList(strings),
+                  Arrays.asList(constSlots),
+                  ip + BcInstr.INSTR_HEADER_LEN);
+    }
+  }
+
+  /** Current for block in the compiler; used to compile break and continue statements. */
+  private static class CurrentFor {
+    /** Instruction pointer of the for statement body. */
+    private final int bodyIp;
+
+    /**
+     * Register which stores next iterator value. This register is updated by {@code FOR_INIT} and
+     * {@code CONTINUE} instructions.
+     */
+    private final int nextValueSlot;
+
+    /**
+     * Pointers to the pointers to the end of the for statement body; patched in the end of the for
+     * compilation.
+     */
+    private ArrayList<Integer> endsToPatch = new ArrayList<>();
+
+    private CurrentFor(int bodyIp, int nextValueSlot) {
+      this.bodyIp = bodyIp;
+      this.nextValueSlot = nextValueSlot;
+    }
+  }
+
+  /** Store values indexed by an integer. */
+  private static class IndexedList<T> {
+    private ArrayList<T> values = new ArrayList<>();
+    private HashMap<T, Integer> index = new HashMap<>();
+
+    int index(T s) {
+      return index.computeIfAbsent(
+          s,
+          k -> {
+            int r = values.size();
+            values.add(s);
+            return r;
+          });
+    }
+  }
+
+  /**
+   * The compiler implementation. The entry point to the compiler is static {@link
+   * #compileFunction(FileLocations, List)} function.
+   */
+  private static class Compiler {
+    private static final int[] EMPTY_INTS = {};
+
+    /** Assuming all nodes in the function belong to the same locations object. */
+    private final FileLocations locs;
+    /** {@code 0..ip} of the array is bytecode. */
+    private int[] text = EMPTY_INTS;
+    /** Current instruction pointer. */
+    private int ip = 0;
+    /** Number of currently allocated registers. */
+    private int slots = 0;
+    /** Total number of registers needed to execute this function. */
+    private int maxSlots = 0;
+
+    /** Starlark values as constant registers. */
+    private IndexedList<Object> constSlots = new IndexedList<>();
+
+    /** Strings referenced in currently built bytecode. */
+    private IndexedList<String> strings = new IndexedList<>();
+
+    /** Other untyped objects referenced in currently built bytecode. */
+    private ArrayList<Object> objects = new ArrayList<>();
+
+    /** The stack of for statements. */
+    private ArrayList<CurrentFor> fors = new ArrayList<>();
+    /** Max depth of for loops. */
+    private int maxLoopDepth = 0;
+
+    private ImmutableMap.Builder<Integer, Node> instrToNode = ImmutableMap.builder();
+
+    private Compiler(FileLocations locs) {
+      this.locs = locs;
+    }
+
+    /** Closest containing for statement. */
+    private CurrentFor currentFor() {
+      return fors.get(fors.size() - 1);
+    }
+
+    /** Allocate a register. */
+    private int allocSlot() {
+      int r = slots++;
+      maxSlots = Math.max(slots, maxSlots);
+      return r;
+    }
+
+    /**
+     * Deallocate all registers (except constant registers); done after each statement; since
+     * registered are not shared between statements, only local variables are.
+     */
+    private void decallocateAllSlots() {
+      slots = 0;
+    }
+
+    /**
+     * Store a string in a string pool, return an index of that string. Note these strings are
+     * special strings like variable or field names. These are not constant registers.
+     */
+    private int allocString(String s) {
+      return strings.index(s);
+    }
+
+    /**
+     * Store an arbitrary object in an object storage; the object store is not a const registers.
+     */
+    private int allocObject(Object o) {
+      int r = objects.size();
+      objects.add(o);
+      return r;
+    }
+
+    /** Write complete opcode with validation. */
+    private void write(BcInstr.Opcode opcode, Node node, int... args) {
+      instrToNode.put(ip, node);
+
+      int prevIp = ip;
+
+      int instrLen = BcInstr.INSTR_HEADER_LEN + args.length;
+      if (ip + instrLen > text.length) {
+        text = Arrays.copyOf(text, Math.max(text.length * 2, ip + instrLen));
+      }
+
+      text[ip++] = opcode.ordinal();
+      System.arraycopy(args, 0, text, ip, args.length);
+      ip += args.length;
+
+      if (ASSERTIONS) {
+        int expectedArgCount =
+            opcode.operands.codeSize(
+                text, strings.values, constSlots.values, prevIp + BcInstr.INSTR_HEADER_LEN);
+        Preconditions.checkState(
+            expectedArgCount == args.length,
+            "incorrect signature for %s: expected %s, actual %s",
+            opcode,
+            expectedArgCount,
+            args.length);
+      }
+    }
+
+    /** Marker address for yet unknown forward jump. */
+    private static final int FORWARD_JUMP_ADDR = -17;
+
+    /**
+     * Write forward condition jump instruction. Return an address to be patched when the jump
+     * address is known.
+     */
+    private int writeForwardCondJump(BcInstr.Opcode opcode, Node expression, int cond) {
+      Preconditions.checkState(
+          opcode == BcInstr.Opcode.IF_BR || opcode == BcInstr.Opcode.IF_NOT_BR);
+      write(opcode, expression, cond, FORWARD_JUMP_ADDR);
+      return ip - 1;
+    }
+
+    /**
+     * Write unconditional forward jump. Return an address to be patched when the jump address is
+     * known.
+     */
+    private int writeForwardJump(Node expression) {
+      write(BcInstr.Opcode.BR, expression, FORWARD_JUMP_ADDR);
+      return ip - 1;
+    }
+
+    /** Patch previously registered forward jump address. */
+    private void patchForwardJump(int ip) {
+      Preconditions.checkState(text[ip] == FORWARD_JUMP_ADDR);
+      text[ip] = this.ip;
+    }
+
+    /** Compile. */
+    private void compileStatements(List<Statement> statements, boolean postAssignHook) {
+      for (Statement statement : statements) {
+        compileStatement(statement, postAssignHook);
+      }
+    }
+
+    private void compileStatement(Statement statement, boolean postAssignHook) {
+      // No registers are shared across statements.
+      // We could implement precise register tracking, but there is no need for that at the moment.
+      decallocateAllSlots();
+
+      write(BcInstr.Opcode.DBG, statement);
+
+      if (statement instanceof ExpressionStatement) {
+        // Do not assign it anywhere
+        compileExpression(((ExpressionStatement) statement).getExpression());
+      } else if (statement instanceof AssignmentStatement) {
+        compileAssignment((AssignmentStatement) statement, postAssignHook);
+      } else if (statement instanceof ReturnStatement) {
+        ReturnStatement returnStatement = (ReturnStatement) statement;
+        if (returnStatement.getResult() == null) {
+          write(BcInstr.Opcode.RETURN_NONE, returnStatement);
+        } else {
+          int result = compileExpression(returnStatement.getResult());
+          write(BcInstr.Opcode.RETURN, returnStatement, result);
+        }
+      } else if (statement instanceof IfStatement) {
+        compileIfStatement((IfStatement) statement);
+      } else if (statement instanceof ForStatement) {
+        compileForStatement((ForStatement) statement);
+      } else if (statement instanceof FlowStatement) {
+        compileFlowStatement((FlowStatement) statement);
+      } else if (statement instanceof DefStatement || statement instanceof LoadStatement) {
+        compileGenericStatement(statement);
+      } else {
+        throw new RuntimeException("not impl: " + statement.getClass().getSimpleName());
+      }
+    }
+
+    private void compileGenericStatement(Statement statement) {
+      Preconditions.checkState(
+          statement instanceof DefStatement || statement instanceof LoadStatement);
+      write(BcInstr.Opcode.STMT, statement, allocObject(statement));
+    }
+
+    private void compileIfStatement(IfStatement ifStatement) {
+      Expression condExpr = ifStatement.getCondition();
+
+      int cond;
+      BcInstr.Opcode elseBrOpcode;
+      if (condExpr instanceof UnaryOperatorExpression
+          && ((UnaryOperatorExpression) condExpr).getOperator() == TokenKind.NOT) {
+        // special case `if not cond: ...` micro-optimization
+        cond = compileExpression(((UnaryOperatorExpression) condExpr).getX());
+        elseBrOpcode = BcInstr.Opcode.IF_BR;
+      } else {
+        cond = compileExpression(condExpr);
+        elseBrOpcode = BcInstr.Opcode.IF_NOT_BR;
+      }
+
+      int elseBlock = writeForwardCondJump(elseBrOpcode, ifStatement, cond);
+      compileStatements(ifStatement.getThenBlock(), false);
+      if (ifStatement.getElseBlock() != null) {
+        int end = writeForwardJump(ifStatement);
+        patchForwardJump(elseBlock);
+        compileStatements(ifStatement.getElseBlock(), false);
+        patchForwardJump(end);
+      } else {
+        patchForwardJump(elseBlock);
+      }
+    }
+
+    private void compileFlowStatement(FlowStatement flowStatement) {
+      switch (flowStatement.getKind()) {
+        case BREAK:
+          compileBreak(flowStatement);
+          break;
+        case CONTINUE:
+          compileContinue(flowStatement);
+          break;
+        case PASS:
+          // nop
+          break;
+        default:
+          throw new IllegalStateException("unknown flow statement: " + flowStatement.getKind());
+      }
+    }
+
+    private void compileContinue(Node node) {
+      if (fors.isEmpty()) {
+        compileThrowException(node, "continue statement must be inside a for loop");
+      } else {
+        write(
+            BcInstr.Opcode.CONTINUE,
+            node,
+            currentFor().nextValueSlot,
+            currentFor().bodyIp,
+            FORWARD_JUMP_ADDR);
+        currentFor().endsToPatch.add(ip - 1);
+      }
+    }
+
+    private void compileBreak(Node node) {
+      if (fors.isEmpty()) {
+        compileThrowException(node, "break statement must be inside a for loop");
+      } else {
+        write(BcInstr.Opcode.BREAK, node, FORWARD_JUMP_ADDR);
+        currentFor().endsToPatch.add(ip - 1);
+      }
+    }
+
+    /** Callback invoked to compile the loop body. */
+    private interface ForBody {
+      void compile();
+    }
+
+    /** Generic compile for loop routine, used in for statement and in loop comprehension. */
+    private void compileFor(Expression vars, Expression collection, ForBody body) {
+      int iterable = compileExpression(collection);
+
+      // Register where we are storing the next iterator value.
+      // This register is update by FOR_INIT and CONTINUE instructions.
+      int nextValueSlot = allocSlot();
+
+      write(BcInstr.Opcode.FOR_INIT, collection, iterable, nextValueSlot, FORWARD_JUMP_ADDR);
+      int endToPatch = ip - 1;
+
+      CurrentFor currentFor = new CurrentFor(ip, nextValueSlot);
+      fors.add(currentFor);
+      currentFor.endsToPatch.add(endToPatch);
+
+      compileAssignment(currentFor.nextValueSlot, vars, false);
+
+      maxLoopDepth = Math.max(fors.size(), maxLoopDepth);
+
+      body.compile();
+
+      // We use usual CONTINUE statement in the end of the loop.
+      // Note: CONTINUE does unnecessary goto e in the end of iteration.
+      compileContinue(collection);
+
+      for (int endsToPatch : currentFor.endsToPatch) {
+        patchForwardJump(endsToPatch);
+      }
+      fors.remove(fors.size() - 1);
+    }
+
+    private void compileForStatement(ForStatement forStatement) {
+      compileFor(
+          forStatement.getVars(),
+          forStatement.getCollection(),
+          () -> compileStatements(forStatement.getBody(), false));
+    }
+
+    private void compileAssignment(
+        AssignmentStatement assignmentStatement, boolean postAssignHook) {
+      if (assignmentStatement.isAugmented()) {
+        compileAgumentedAssignment(assignmentStatement);
+      } else {
+        compileAssignmentRegular(assignmentStatement, postAssignHook);
+      }
+    }
+
+    private void compileAssignmentRegular(
+        AssignmentStatement assignmentStatement, boolean postAssignHook) {
+      Preconditions.checkState(!assignmentStatement.isAugmented());
+      int rhs = compileExpression(assignmentStatement.getRHS());
+      compileAssignment(rhs, assignmentStatement.getLHS(), postAssignHook);
+    }
+
+    private void compileAssignment(int rhs, Expression lhs, boolean postAssignHook) {
+      if (lhs instanceof Identifier) {
+        compileSet(rhs, (Identifier) lhs, postAssignHook);
+      } else if (lhs instanceof ListExpression) {
+        compileAssignmentToList(rhs, (ListExpression) lhs, postAssignHook);
+      } else if (lhs instanceof IndexExpression) {
+        IndexExpression indexExpression = (IndexExpression) lhs;
+        int object = compileExpression(indexExpression.getObject());
+        int key = compileExpression(indexExpression.getKey());
+        write(BcInstr.Opcode.SET_INDEX, lhs, object, key, rhs);
+      } else {
+        compileThrowException(lhs, String.format("cannot assign to '%s'", lhs));
+      }
+    }
+
+    private void compileAssignmentToList(int rhs, ListExpression list, boolean postAssignHook) {
+      if (list.getElements().isEmpty()) {
+        // TODO: emit an error in resolver or allow it in the spec:
+        //  https://github.com/bazelbuild/starlark/issues/93
+        compileThrowException(list, String.format("can't assign to %s", list));
+        return;
+      }
+
+      int[] componentRegs =
+          IntStream.range(0, list.getElements().size()).map(i1 -> allocSlot()).toArray();
+
+      int[] args = new int[2 + list.getElements().size()];
+      args[0] = rhs;
+      args[1] = list.getElements().size();
+      System.arraycopy(componentRegs, 0, args, 2, componentRegs.length);
+      write(BcInstr.Opcode.UNPACK, list, args);
+
+      for (int i = 0; i < componentRegs.length; i++) {
+        int componentReg = componentRegs[i];
+        compileAssignment(componentReg, list.getElements().get(i), postAssignHook);
+      }
+    }
+
+    private void compileSet(int rhs, Identifier identifier, boolean postAssignHook) {
+      BcInstr.Opcode opcode;
+      if (identifier.getBinding() != null) {
+        switch (identifier.getBinding().scope) {
+          case LOCAL:
+            opcode = BcInstr.Opcode.SET_LOCAL;
+            break;
+          case GLOBAL:
+            opcode = BcInstr.Opcode.SET_GLOBAL;
+            break;
+          default:
+            throw new IllegalStateException();
+        }
+      } else {
+        // TODO: resolve and remove
+        opcode = BcInstr.Opcode.SET_LEGACY;
+      }
+
+      write(opcode, identifier, rhs, allocString(identifier.getName()), postAssignHook ? 1 : 0);
+    }
+
+    private void compileThrowException(Node node, String message) {
+      // All incorrect AST should be resolved by the resolver,
+      // compile code to throw exception as a stopgap.
+      write(BcInstr.Opcode.EVAL_EXCEPTION, node, allocString(message));
+    }
+
+    private void compileAgumentedAssignment(AssignmentStatement assignmentStatement) {
+      Preconditions.checkState(assignmentStatement.getOperator() != null);
+      if (assignmentStatement.getLHS() instanceof Identifier) {
+        int rhs = compileExpression(assignmentStatement.getRHS());
+        Identifier lhs = (Identifier) assignmentStatement.getLHS();
+        int temp = allocSlot();
+        compileGet(lhs, temp);
+        write(
+            BcInstr.Opcode.BINARY_IN_PLACE,
+            assignmentStatement,
+            temp,
+            rhs,
+            assignmentStatement.getOperator().ordinal(),
+            temp);
+        compileSet(temp, lhs, false);
+      } else if (assignmentStatement.getLHS() instanceof IndexExpression) {
+        IndexExpression indexExpression = (IndexExpression) assignmentStatement.getLHS();
+
+        int object = compileExpression(indexExpression.getObject());
+        int key = compileExpression(indexExpression.getKey());
+        int rhs = compileExpression(assignmentStatement.getRHS());
+        int temp = allocSlot();
+        write(BcInstr.Opcode.INDEX, assignmentStatement, object, key, temp);
+        write(
+            BcInstr.Opcode.BINARY_IN_PLACE,
+            assignmentStatement,
+            temp,
+            rhs,
+            assignmentStatement.getOperator().ordinal(),
+            temp);
+        write(BcInstr.Opcode.SET_INDEX, assignmentStatement, object, key, temp);
+      } else if (assignmentStatement.getLHS() instanceof ListExpression) {
+        compileThrowException(
+            assignmentStatement.getLHS(),
+            "cannot perform augmented assignment on a list or tuple expression");
+      } else {
+        compileThrowException(
+            assignmentStatement.getLHS(),
+            String.format("cannot assign to '%s'", assignmentStatement.getLHS()));
+      }
+    }
+
+    /** Compile a constant, return a register containing the constant. */
+    private int compileConstant(Object constant) {
+      return BcInstr.constSlotFromArrayIndex(constSlots.index(constant));
+    }
+
+    /** Compile a constant, store it in provided register. */
+    private void compileConstantTo(Node expression, Object constant, int result) {
+      Preconditions.checkState(result >= 0);
+      int value = compileConstant(constant);
+      write(BcInstr.Opcode.CP, expression, value, result);
+    }
+
+    /** Compile an expression, store result in provided register. */
+    private void compileExpressionTo(Expression expression, int result) {
+      Preconditions.checkState(result >= 0);
+
+      if (expression instanceof SliceExpression) {
+        compileSliceExpression((SliceExpression) expression, result);
+      } else if (expression instanceof Comprehension) {
+        compileComprehension((Comprehension) expression, result);
+      } else if (expression instanceof ListExpression) {
+        compileList((ListExpression) expression, result);
+      } else if (expression instanceof DictExpression) {
+        compileDict((DictExpression) expression, result);
+      } else if (expression instanceof CallExpression) {
+        compileCall((CallExpression) expression, result);
+      } else if (expression instanceof ConditionalExpression) {
+        compileConditional((ConditionalExpression) expression, result);
+      } else if (expression instanceof DotExpression) {
+        compileDot((DotExpression) expression, result);
+      } else if (expression instanceof IndexExpression) {
+        compileIndex((IndexExpression) expression, result);
+      } else if (expression instanceof UnaryOperatorExpression) {
+        compileUnaryOperator(expression, result);
+      } else if (expression instanceof BinaryOperatorExpression) {
+        compileBinaryOperator(expression, result);
+      } else if (expression instanceof Identifier) {
+        compileGet((Identifier) expression, result);
+      } else if (expression instanceof StringLiteral) {
+        compileConstantTo(expression, ((StringLiteral) expression).getValue(), result);
+      } else if (expression instanceof IntegerLiteral) {
+        compileConstantTo(expression, ((IntegerLiteral) expression).getValue(), result);
+      } else {
+        throw new RuntimeException("not impl: " + expression.getClass().getSimpleName());
+      }
+    }
+
+    /** Compile an expression and return a register containing the result. */
+    private int compileExpression(Expression expression) {
+      if (expression instanceof StringLiteral) {
+        return compileConstant(((StringLiteral) expression).getValue());
+      } else if (expression instanceof IntegerLiteral) {
+        return compileConstant(((IntegerLiteral) expression).getValue());
+      } else {
+        int result = allocSlot();
+        compileExpressionTo(expression, result);
+        return result;
+      }
+    }
+
+    /**
+     * Compile expression, return a register containing result. Given register may or may not be
+     * used to store the result.
+     */
+    private int compileExpressionMaybeReuseSlot(Expression expression, int slot) {
+      if (expression instanceof StringLiteral || expression instanceof IntegerLiteral) {
+        return compileExpression(expression);
+      } else {
+        compileExpressionTo(expression, slot);
+        return slot;
+      }
+    }
+
+    private void compileIndex(IndexExpression expression, int result) {
+      int object = compileExpressionMaybeReuseSlot(expression.getObject(), result);
+      int key = compileExpression(expression.getKey());
+      write(BcInstr.Opcode.INDEX, expression, object, key, result);
+    }
+
+    private void compileDot(DotExpression dotExpression, int result) {
+      int object = compileExpressionMaybeReuseSlot(dotExpression.getObject(), result);
+      write(
+          BcInstr.Opcode.DOT,
+          dotExpression,
+          object,
+          allocString(dotExpression.getField().getName()),
+          result);
+    }
+
+    private void compileSliceExpression(SliceExpression slice, int result) {
+      int object = compileExpressionMaybeReuseSlot(slice.getObject(), result);
+
+      int start = slice.getStart() != null ? compileExpression(slice.getStart()) : BcInstr.NULL_REG;
+      int stop = slice.getStop() != null ? compileExpression(slice.getStop()) : BcInstr.NULL_REG;
+      int step = slice.getStep() != null ? compileExpression(slice.getStep()) : BcInstr.NULL_REG;
+
+      write(BcInstr.Opcode.SLICE, slice, object, start, stop, step, result);
+    }
+
+    private void compileGet(Identifier identifier, int result) {
+      BcInstr.Opcode opcode;
+      if (identifier.getBinding() == null) {
+        opcode = BcInstr.Opcode.GET_LEGACY;
+      } else {
+        switch (identifier.getBinding().scope) {
+          case LOCAL:
+            opcode = BcInstr.Opcode.GET_LOCAL;
+            break;
+          case GLOBAL:
+            opcode = BcInstr.Opcode.GET_GLOBAL;
+            break;
+          case PREDECLARED:
+            opcode = BcInstr.Opcode.GET_PREDECLARED;
+            break;
+          default:
+            throw new IllegalStateException("unknown scope: " + identifier.getBinding().scope);
+        }
+      }
+      write(opcode, identifier, allocString(identifier.getName()), result);
+    }
+
+    private void compileComprehension(Comprehension comprehension, int result) {
+      LinkedHashSet<String> boundIdentifiers = new LinkedHashSet<>();
+      for (Comprehension.Clause clause : comprehension.getClauses()) {
+        if (clause instanceof Comprehension.For) {
+          for (Identifier identifier :
+              Identifier.boundIdentifiers(((Comprehension.For) clause).getVars())) {
+            boundIdentifiers.add(identifier.getName());
+          }
+        }
+      }
+
+      String[] boundIdentifiersArray = boundIdentifiers.toArray(new String[0]);
+      int boundedArrayIndex = allocObject(boundIdentifiersArray);
+
+      write(BcInstr.Opcode.SAVE_LOCALS, comprehension, boundedArrayIndex);
+
+      if (comprehension.isDict()) {
+        write(BcInstr.Opcode.DICT, comprehension.getBody(), 0, result);
+      } else {
+        write(BcInstr.Opcode.LIST, comprehension.getBody(), 0, result);
+      }
+
+      // The Lambda class serves as a recursive lambda closure.
+      class Lambda {
+        // execClauses(index) recursively compiles the clauses starting at index,
+        // and finally compiles the body and adds its value to the result.
+        private void compileClauses(int index) {
+          // recursive case: one or more clauses
+          if (index != comprehension.getClauses().size()) {
+            Comprehension.Clause clause = comprehension.getClauses().get(index);
+            if (clause instanceof Comprehension.For) {
+              compileFor(
+                  ((Comprehension.For) clause).getVars(),
+                  ((Comprehension.For) clause).getIterable(),
+                  () -> compileClauses(index + 1));
+            } else if (clause instanceof Comprehension.If) {
+              int cond = compileExpression(((Comprehension.If) clause).getCondition());
+              int end = writeForwardCondJump(BcInstr.Opcode.IF_NOT_BR, clause, cond);
+              compileClauses(index + 1);
+              patchForwardJump(end);
+            } else {
+              throw new IllegalStateException("unknown compr clause: " + clause);
+            }
+          } else {
+            if (comprehension.isDict()) {
+              DictExpression.Entry entry = (DictExpression.Entry) comprehension.getBody();
+              int key = compileExpression(entry.getKey());
+              int value = compileExpression(entry.getValue());
+              write(BcInstr.Opcode.SET_INDEX, entry, result, key, value);
+            } else {
+              int value = compileExpression((Expression) comprehension.getBody());
+              write(BcInstr.Opcode.LIST_APPEND, comprehension.getBody(), result, value);
+            }
+          }
+        }
+      }
+
+      new Lambda().compileClauses(0);
+
+      write(BcInstr.Opcode.RESTORE_LOCALS, comprehension, boundedArrayIndex);
+    }
+
+    private void compileDict(DictExpression dictExpression, int result) {
+      Preconditions.checkState(result >= 0);
+
+      int[] args = new int[1 + dictExpression.getEntries().size() * 2 + 1];
+      int i = 0;
+      args[i++] = dictExpression.getEntries().size();
+      for (DictExpression.Entry entry : dictExpression.getEntries()) {
+        args[i++] = compileExpression(entry.getKey());
+        args[i++] = compileExpression(entry.getValue());
+      }
+      args[i++] = result;
+      Preconditions.checkState(i == args.length);
+
+      write(BcInstr.Opcode.DICT, dictExpression, args);
+    }
+
+    private void compileList(ListExpression listExpression, int result) {
+      Preconditions.checkState(result >= 0);
+
+      int[] args = new int[1 + listExpression.getElements().size() + 1];
+      int i = 0;
+      args[i++] = listExpression.getElements().size();
+      for (Expression element : listExpression.getElements()) {
+        args[i++] = compileExpression(element);
+      }
+      args[i++] = result;
+      Preconditions.checkState(i == args.length);
+      write(
+          listExpression.isTuple() ? BcInstr.Opcode.TUPLE : BcInstr.Opcode.LIST,
+          listExpression,
+          args);
+    }
+
+    private void compileConditional(ConditionalExpression conditionalExpression, int result) {
+      int cond = compileExpressionMaybeReuseSlot(conditionalExpression.getCondition(), result);
+      int thenAddr = writeForwardCondJump(BcInstr.Opcode.IF_NOT_BR, conditionalExpression, cond);
+      compileExpressionTo(conditionalExpression.getThenCase(), result);
+      int end = writeForwardJump(conditionalExpression);
+      patchForwardJump(thenAddr);
+      compileExpressionTo(conditionalExpression.getElseCase(), result);
+      patchForwardJump(end);
+    }
+
+    private void compileCall(CallExpression callExpression, int result) {
+      ArrayList<Argument.Positional> positionals = new ArrayList<>();
+      ArrayList<Argument.Keyword> nameds = new ArrayList<>();
+      Argument.Star star = null;
+      Argument.StarStar starStar = null;
+      for (Argument argument : callExpression.getArguments()) {
+        if (argument instanceof Argument.Positional) {
+          positionals.add((Argument.Positional) argument);
+        } else if (argument instanceof Argument.Keyword) {
+          nameds.add((Argument.Keyword) argument);
+        } else if (argument instanceof Argument.Star) {
+          star = (Argument.Star) argument;
+        } else if (argument instanceof Argument.StarStar) {
+          starStar = (Argument.StarStar) argument;
+        } else {
+          throw new IllegalStateException();
+        }
+      }
+      int numCallArgs = 2; // lparen + fn
+      numCallArgs += 1 + positionals.size();
+      numCallArgs += 1 + (2 * nameds.size());
+      numCallArgs += 5; // star, star-loc, star-star, star-star-loc, result
+      int[] args = new int[numCallArgs];
+
+      int i = 0;
+      args[i++] = allocObject(callExpression.getLparenLocation());
+      args[i++] = compileExpressionMaybeReuseSlot(callExpression.getFunction(), result);
+
+      args[i++] = positionals.size();
+      for (Argument.Positional positional : positionals) {
+        args[i++] = compileExpression(positional.getValue());
+      }
+      args[i++] = nameds.size();
+      for (Argument.Keyword named : nameds) {
+        args[i++] = allocString(named.getName());
+        args[i++] = compileExpression(named.getValue());
+      }
+      args[i++] = star != null ? compileExpression(star.getValue()) : BcInstr.NULL_REG;
+      args[i++] = star != null ? star.getStartOffset() : BcInstr.UNDEFINED_LOC;
+      args[i++] = starStar != null ? compileExpression(starStar.getValue()) : BcInstr.NULL_REG;
+      args[i++] = starStar != null ? starStar.getStartOffset() : BcInstr.UNDEFINED_LOC;
+
+      args[i++] = result;
+
+      Preconditions.checkState(i == args.length);
+
+      write(BcInstr.Opcode.CALL, callExpression, args);
+    }
+
+    private void compileUnaryOperator(Expression expression, int result) {
+      UnaryOperatorExpression unaryOperatorExpression = (UnaryOperatorExpression) expression;
+      int value = compileExpressionMaybeReuseSlot(unaryOperatorExpression.getX(), result);
+      if (unaryOperatorExpression.getOperator() == TokenKind.NOT) {
+        write(BcInstr.Opcode.NOT, expression, value, result);
+      } else {
+        write(
+            BcInstr.Opcode.UNARY,
+            expression,
+            value,
+            unaryOperatorExpression.getOperator().ordinal(),
+            result);
+      }
+    }
+
+    private void compileBinaryOperator(Expression expression, int result) {
+      Preconditions.checkState(result >= 0);
+
+      BinaryOperatorExpression binaryOperatorExpression = (BinaryOperatorExpression) expression;
+      switch (binaryOperatorExpression.getOperator()) {
+        case AND:
+          {
+            compileExpressionTo(binaryOperatorExpression.getX(), result);
+            int end = writeForwardCondJump(BcInstr.Opcode.IF_NOT_BR, expression, result);
+            compileExpressionTo(binaryOperatorExpression.getY(), result);
+            patchForwardJump(end);
+            break;
+          }
+        case OR:
+          {
+            compileExpressionTo(binaryOperatorExpression.getX(), result);
+            int end = writeForwardCondJump(BcInstr.Opcode.IF_BR, expression, result);
+            compileExpressionTo(binaryOperatorExpression.getY(), result);
+            patchForwardJump(end);
+            break;
+          }
+        case EQUALS_EQUALS:
+          {
+            int x = compileExpression(binaryOperatorExpression.getX());
+            int y = compileExpression(binaryOperatorExpression.getY());
+            write(BcInstr.Opcode.EQ, expression, x, y, result);
+            break;
+          }
+        case NOT_EQUALS:
+          {
+            int x = compileExpression(binaryOperatorExpression.getX());
+            int y = compileExpression(binaryOperatorExpression.getY());
+            write(BcInstr.Opcode.NOT_EQ, expression, x, y, result);
+            break;
+          }
+        default:
+          {
+            int x = compileExpression(binaryOperatorExpression.getX());
+            int y = compileExpression(binaryOperatorExpression.getY());
+            write(
+                BcInstr.Opcode.BINARY,
+                expression,
+                x,
+                y,
+                binaryOperatorExpression.getOperator().ordinal(),
+                result);
+          }
+      }
+    }
+
+    private static final String[] EMPTY_STRINGS = {};
+    private static final Object[] EMPTY = {};
+
+    Compiled finish() {
+      return new Compiled(
+          locs,
+          strings.values.toArray(EMPTY_STRINGS),
+          objects.toArray(EMPTY),
+          Arrays.copyOf(text, ip),
+          maxSlots,
+          constSlots.values.toArray(EMPTY),
+          maxLoopDepth,
+          instrToNode.build());
+    }
+  }
+
+  static Compiled compileFunction(FileLocations locs, List<Statement> statements) {
+    Compiler compiler = new Compiler(locs);
+    compiler.compileStatements(statements, true);
+    return compiler.finish();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/syntax/BcEval.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BcEval.java
@@ -1,0 +1,727 @@
+package com.google.devtools.build.lib.syntax;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+
+import javax.annotation.Nullable;
+import java.util.*;
+
+/** Bytecode interpreter. Takes a compiled function body and returns a result. */
+class BcEval {
+  private static final Object[] EMPTY = {};
+  private static final TokenKind[] TOKENS = TokenKind.values();
+
+  private final StarlarkThread.Frame fr;
+  private final Bc.Compiled compiled;
+
+  /** Registers. */
+  private final Object[] slots;
+
+  /**
+   * Currently executed loops stack: pairs of (iterable, iterator).
+   *
+   * <p>The array is preallocated, {@link #loopDepth} holds the number of currently executed loops.
+   */
+  private final Object[] loops;
+
+  /** Current loop depth. */
+  private int loopDepth = 0;
+
+  /** Stack of save locals in comprehension. */
+  private ArrayList<Object[]> comprSavedLocals = new ArrayList<>();
+
+  /** Program text. */
+  private final int[] text;
+
+  /** Current instruction pointer */
+  private int currentIp;
+
+  /** Instruction pointer while decoding operands */
+  private int ip = 0;
+
+  private BcEval(StarlarkThread.Frame fr, Bc.Compiled compiled) {
+    this.fr = fr;
+
+    this.compiled = compiled;
+    this.slots = new Object[compiled.slotCount];
+    this.loops = new Object[compiled.loopDepth * 2];
+    text = compiled.text;
+  }
+
+  /** Public API. */
+  public static Object eval(StarlarkThread.Frame fr, Bc.Compiled compiled)
+      throws InterruptedException, EvalException {
+    return new BcEval(fr, compiled).eval();
+  }
+
+  private Object eval() throws EvalException, InterruptedException {
+    try {
+      while (ip != text.length) {
+        fr.thread.steps++;
+
+        currentIp = ip;
+
+        // Each instruction is:
+        // * opcode
+        // * operands which depend on opcode
+        int opcode = text[ip++];
+        try {
+          switch (opcode) {
+            case BcInstr.CP:
+              cp();
+              break;
+            case BcInstr.EQ:
+              eq();
+              break;
+            case BcInstr.NOT_EQ:
+              notEq();
+              break;
+            case BcInstr.NOT:
+              not();
+              break;
+            case BcInstr.UNARY:
+              unary();
+              break;
+            case BcInstr.BINARY:
+              binary();
+              break;
+            case BcInstr.BINARY_IN_PLACE:
+              binaryInPlace();
+              break;
+            case BcInstr.BR:
+              br();
+              continue;
+            case BcInstr.IF_BR:
+              ifBr();
+              continue;
+            case BcInstr.IF_NOT_BR:
+              ifNotBr();
+              continue;
+            case BcInstr.DOT:
+              dot();
+              break;
+            case BcInstr.INDEX:
+              index();
+              break;
+            case BcInstr.SLICE:
+              slice();
+              break;
+            case BcInstr.CALL:
+              call();
+              break;
+            case BcInstr.RETURN_NONE:
+              return returnNone();
+            case BcInstr.RETURN:
+              return returnInstr();
+            case BcInstr.TUPLE:
+              tuple();
+              break;
+            case BcInstr.LIST:
+              list();
+              break;
+            case BcInstr.DICT:
+              dict();
+              break;
+            case BcInstr.UNPACK:
+              unpack();
+              break;
+            case BcInstr.GET_LOCAL:
+              getLocal();
+              break;
+            case BcInstr.GET_GLOBAL:
+              getGlobal();
+              break;
+            case BcInstr.GET_PREDECLARED:
+              getPredeclared();
+              break;
+            case BcInstr.GET_LEGACY:
+              getLegacy();
+              break;
+            case BcInstr.SET_GLOBAL:
+              setGlobal();
+              break;
+            case BcInstr.SET_LOCAL:
+              setLocal();
+              break;
+            case BcInstr.SET_LEGACY:
+              setLegacy();
+              break;
+            case BcInstr.STMT:
+              stmt();
+              break;
+            case BcInstr.FOR_INIT:
+              forInit();
+              continue;
+            case BcInstr.BREAK:
+              breakInstr();
+              continue;
+            case BcInstr.CONTINUE:
+              continueInstr();
+              continue;
+            case BcInstr.SAVE_LOCALS:
+              saveLocals();
+              break;
+            case BcInstr.RESTORE_LOCALS:
+              restoreLocals();
+              break;
+            case BcInstr.LIST_APPEND:
+              listAppend();
+              break;
+            case BcInstr.SET_INDEX:
+              setIndex();
+              break;
+            case BcInstr.EVAL_EXCEPTION:
+              evalException();
+              continue;
+            case BcInstr.DBG:
+              dbg();
+              break;
+            default:
+              throw otherOpcode(opcode);
+          }
+
+          validateInstructionDecodedCorrectly();
+
+        } catch (EvalException e) {
+          if (e.canBeAddedToStackTrace()) {
+            throw new EvalExceptionWithStackTrace(e, currentInstrNode());
+          } else {
+            throw e;
+          }
+        }
+      }
+    } finally {
+      while (loopDepth != 0) {
+        popFor();
+      }
+    }
+    return Starlark.NONE;
+  }
+
+  /** Pop one for statement. */
+  private void popFor() {
+    EvalUtils.removeIterator(loops[(loopDepth - 1) * 2]);
+    --loopDepth;
+  }
+
+  /** Next instruction operand. */
+  private int nextOperand() {
+    return text[ip++];
+  }
+
+  /** Get a value from the register slot. */
+  private Object getSlot(int slot) throws EvalException {
+    if (slot >= 0) {
+      Object value = slots[slot];
+      if (value == null) {
+        // Now this is always IllegalStateException,
+        // but it should be also EvalException when we store locals in registers.
+        throw new IllegalStateException("slot value is undefined: " + slot);
+      }
+      return value;
+    } else {
+      return compiled.constSlots[BcInstr.constSlotToArrayIndex(slot)];
+    }
+  }
+
+  /** Get argument with special handling of {@link BcInstr#NULL_REG}. */
+  @Nullable
+  private Object getSlotOrNull(int slot) throws EvalException {
+    return slot != BcInstr.NULL_REG ? getSlot(slot) : null;
+  }
+
+  /** Get argument with special handling of {@link BcInstr#NULL_REG}. */
+  @Nullable
+  private Object getSlotNullAsNone(int slot) throws EvalException {
+    return slot != BcInstr.NULL_REG ? getSlot(slot) : Starlark.NONE;
+  }
+
+  private void setSlot(int slot, Object value) {
+    slots[slot] = value;
+  }
+
+  /** AST node associated with current instruction. */
+  private Node currentInstrNode() {
+    Node node = compiled.instrToNode.get(currentIp);
+    Preconditions.checkState(node != null);
+    return node;
+  }
+
+  private void cp() throws EvalException {
+    Object value = getSlot(nextOperand());
+    setSlot(nextOperand(), value);
+  }
+
+  private void getLocal() throws EvalException {
+    String name = compiled.strings[nextOperand()];
+    Object value = fr.locals.get(name);
+    if (value == null) {
+      throw new EvalException(
+          String.format(
+              "%s variable '%s' is referenced before assignment.", Resolver.Scope.LOCAL, name));
+    }
+    setSlot(nextOperand(), value);
+  }
+
+  private void getGlobal() throws EvalException {
+    String name = compiled.strings[nextOperand()];
+    Object value = Eval.fn(fr).getModule().getGlobal(name);
+    if (value == null) {
+      throw new EvalException(
+          String.format(
+              "%s variable '%s' is referenced before assignment.", Resolver.Scope.GLOBAL, name));
+    }
+    setSlot(nextOperand(), value);
+  }
+
+  private void getPredeclared() throws EvalException {
+    String name = compiled.strings[nextOperand()];
+    Object value = Eval.fn(fr).getModule().get(name);
+    if (value == null) {
+      throw new EvalException(
+          String.format(
+              "%s variable '%s' is referenced before assignment",
+              Resolver.Scope.PREDECLARED, name));
+    }
+    setSlot(nextOperand(), value);
+  }
+
+  private void getLegacy() throws EvalException {
+    String name = compiled.strings[nextOperand()];
+    Object value = fr.getLocals().get(name);
+    if (value == null) {
+      value = Eval.fn(fr).getModule().get(name);
+    }
+    if (value == null) {
+      // Since Scope was set, we know that the local/global variable is defined,
+      // but its assignment was not yet executed.
+      throw new EvalException(String.format("variable '%s' is referenced before assignment", name));
+    }
+    setSlot(nextOperand(), value);
+  }
+
+  private void maybeInvokePostAssignHook(String name, Object value, boolean postAssignHook) {
+    if (postAssignHook && fr.thread.postAssignHook != null) {
+      if (Eval.fn(fr).isToplevel()) {
+        fr.thread.postAssignHook.assign(name, value);
+      }
+    }
+  }
+
+  private void setGlobal() throws EvalException {
+    Object value = getSlot(nextOperand());
+    String name = compiled.strings[nextOperand()];
+    boolean postAssignHook = nextOperand() != 0;
+    Eval.assignGlobal(fr, name, value);
+    maybeInvokePostAssignHook(name, value, postAssignHook);
+  }
+
+  private void setLocal() throws EvalException {
+    Object value = getSlot(nextOperand());
+    String name = compiled.strings[nextOperand()];
+    boolean postAssignHook = nextOperand() != 0;
+    fr.locals.put(name, value);
+    // This is likely not needed, but keeping it because AST interpreter does it
+    maybeInvokePostAssignHook(name, value, postAssignHook);
+  }
+
+  private void setLegacy() throws EvalException {
+    // TODO: scope should be resolved
+    if (Eval.fn(fr).isToplevel() && comprSavedLocals.isEmpty()) {
+      setGlobal();
+    } else {
+      setLocal();
+    }
+  }
+
+  private void stmt() throws EvalException, InterruptedException {
+    Statement statement = (Statement) compiled.objects[nextOperand()];
+    TokenKind token = Eval.exec(fr, statement);
+    Preconditions.checkState(token == TokenKind.PASS);
+  }
+
+  private void setIndex() throws EvalException {
+    Object dict = getSlot(nextOperand());
+    Object key = getSlot(nextOperand());
+    Object value = getSlot(nextOperand());
+    EvalUtils.setIndex(dict, key, value);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void listAppend() throws EvalException {
+    StarlarkList<Object> list = (StarlarkList<Object>) getSlot(nextOperand());
+    Object item = getSlot(nextOperand());
+    list.add(item, null);
+  }
+
+  private void restoreLocals() {
+    String[] localNames = (String[]) compiled.objects[nextOperand()];
+    Object[] toRestore = comprSavedLocals.remove(comprSavedLocals.size() - 1);
+    for (int i1 = 0; i1 < localNames.length; i1++) {
+      String localName = localNames[i1];
+      Object value = toRestore[i1];
+      if (value != null) {
+        fr.locals.put(localName, value);
+      } else {
+        fr.locals.remove(localName);
+      }
+    }
+  }
+
+  private void saveLocals() {
+    String[] localNames = (String[]) compiled.objects[nextOperand()];
+    comprSavedLocals.add(Arrays.stream(localNames).map(n -> fr.locals.get(n)).toArray());
+  }
+
+  private Object returnInstr() throws EvalException {
+    Object result = getSlot(nextOperand());
+    validateInstructionDecodedCorrectly();
+    return result;
+  }
+
+  private Object returnNone() {
+    validateInstructionDecodedCorrectly();
+    return Starlark.NONE;
+  }
+
+  private void br() {
+    int dest = nextOperand();
+    validateInstructionDecodedCorrectly();
+    ip = dest;
+  }
+
+  private void ifBr() throws EvalException {
+    Object cond = getSlot(nextOperand());
+    int dest = nextOperand();
+    if (Starlark.truth(cond)) {
+      validateInstructionDecodedCorrectly();
+      ip = dest;
+    } else {
+      validateInstructionDecodedCorrectly();
+    }
+  }
+
+  private void ifNotBr() throws EvalException {
+    Object cond = getSlot(nextOperand());
+    int dest = nextOperand();
+    if (!Starlark.truth(cond)) {
+      validateInstructionDecodedCorrectly();
+      ip = dest;
+    } else {
+      validateInstructionDecodedCorrectly();
+    }
+  }
+
+  private void forInit() throws EvalException {
+    Object value = getSlot(nextOperand());
+    int nextValueSlot = nextOperand();
+    int end = nextOperand();
+
+    Iterable<?> seq = Starlark.toIterable(value);
+    Iterator<?> iterator = seq.iterator();
+    if (!iterator.hasNext()) {
+      validateInstructionDecodedCorrectly();
+      ip = end;
+      return;
+    }
+
+    EvalUtils.addIterator(seq);
+    loops[loopDepth * 2] = seq;
+    loops[loopDepth * 2 + 1] = iterator;
+    ++loopDepth;
+
+    Object item = iterator.next();
+    setSlot(nextValueSlot, item);
+    validateInstructionDecodedCorrectly();
+  }
+
+  private void continueInstr() throws InterruptedException {
+    int nextValueSlot = nextOperand();
+    int b = nextOperand();
+    int e = nextOperand();
+
+    fr.thread.checkInterrupt();
+
+    Iterator<?> iterator = (Iterator<?>) loops[(loopDepth - 1) * 2 + 1];
+    if (iterator.hasNext()) {
+      setSlot(nextValueSlot, iterator.next());
+      validateInstructionDecodedCorrectly();
+      ip = b;
+    } else {
+      popFor();
+      validateInstructionDecodedCorrectly();
+      ip = e;
+    }
+  }
+
+  private void breakInstr() {
+    int e = nextOperand();
+    popFor();
+    validateInstructionDecodedCorrectly();
+    ip = e;
+  }
+
+  private void unpack() throws EvalException {
+    Object x = getSlot(nextOperand());
+    int nrhs = Starlark.len(x);
+    if (nrhs < 0) {
+      throw Starlark.errorf("got '%s' in sequence assignment", Starlark.type(x));
+    }
+    Iterable<?> rhs = Starlark.toIterable(x); // fails if x is a string
+    int nlhs = nextOperand();
+    if (nrhs != nlhs) {
+      throw Starlark.errorf(
+          "too %s values to unpack (got %d, want %d)", nrhs < nlhs ? "few" : "many", nrhs, nlhs);
+    }
+    for (Object item : rhs) {
+      setSlot(nextOperand(), item);
+    }
+  }
+
+  private void list() throws EvalException {
+    int size = nextOperand();
+    StarlarkList<?> result;
+    if (size == 0) {
+      result = StarlarkList.newList(fr.thread.mutability());
+    } else {
+      Object[] data = new Object[size];
+      for (int j = 0; j != data.length; ++j) {
+        data[j] = getSlot(nextOperand());
+      }
+      result = StarlarkList.wrap(fr.thread.mutability(), data);
+    }
+    setSlot(nextOperand(), result);
+  }
+
+  private void tuple() throws EvalException {
+    int size = nextOperand();
+    Tuple<?> result;
+    if (size == 0) {
+      result = Tuple.empty();
+    } else {
+      Object[] data = new Object[size];
+      for (int j = 0; j != data.length; ++j) {
+        data[j] = getSlot(nextOperand());
+      }
+      result = Tuple.wrap(data);
+    }
+    setSlot(nextOperand(), result);
+  }
+
+  private void dict() throws EvalException {
+    int size = nextOperand();
+    Dict<?, ?> result;
+    if (size == 0) {
+      result = Dict.of(fr.thread.mutability());
+    } else {
+      LinkedHashMap<Object, Object> lhm = new LinkedHashMap<>(size);
+      for (int j = 0; j != size; ++j) {
+        Object key = getSlot(nextOperand());
+        EvalUtils.checkHashable(key);
+        Object value = getSlot(nextOperand());
+        Object prev = lhm.put(key, value);
+        if (prev != null) {
+          throw new EvalException(
+              "Duplicated key " + Starlark.repr(key) + " when creating dictionary");
+        }
+      }
+      result = Dict.wrap(fr.thread.mutability(), lhm);
+    }
+    setSlot(nextOperand(), result);
+  }
+
+  /** Dot operator. */
+  private void dot() throws EvalException, InterruptedException {
+    Object object = getSlot(nextOperand());
+    String name = compiled.strings[nextOperand()];
+    Object result = EvalUtils.getAttr(fr.thread, object, name);
+    if (result == null) {
+      throw EvalUtils.getMissingAttrException(object, name, fr.thread.getSemantics());
+    }
+    setSlot(nextOperand(), result);
+  }
+
+  /** Index operator. */
+  private void index() throws EvalException {
+    Object object = getSlot(nextOperand());
+    Object index = getSlot(nextOperand());
+    setSlot(
+        nextOperand(),
+        EvalUtils.index(fr.thread.mutability(), fr.thread.getSemantics(), object, index));
+  }
+
+  /** Slice operator. */
+  private void slice() throws EvalException {
+    Object object = getSlot(nextOperand());
+    Object start = getSlotNullAsNone(nextOperand());
+    Object stop = getSlotNullAsNone(nextOperand());
+    Object step = getSlotNullAsNone(nextOperand());
+    setSlot(nextOperand(), Starlark.slice(fr.thread.mutability(), object, start, stop, step));
+  }
+
+  /** Call operator. */
+  private void call() throws EvalException, InterruptedException {
+    fr.thread.checkInterrupt();
+
+    Location lparenLocation = (Location) compiled.objects[nextOperand()];
+    fr.setLocation(lparenLocation);
+
+    Object fn = getSlot(nextOperand());
+    int npos = nextOperand();
+    Object[] pos = npos != 0 ? new Object[npos] : EMPTY;
+    for (int i = 0; i < npos; ++i) {
+      pos[i] = getSlot(nextOperand());
+    }
+    int nnamed = nextOperand();
+    Object[] named = nnamed != 0 ? new Object[nnamed * 2] : EMPTY;
+    for (int i = 0; i < nnamed; ++i) {
+      named[i * 2] = compiled.strings[nextOperand()];
+      named[i * 2 + 1] = getSlot(nextOperand());
+    }
+    Object star = getSlotOrNull(nextOperand());
+    int starOffset = nextOperand();
+    Object starStar = getSlotOrNull(nextOperand());
+    int starStarOffset = nextOperand();
+
+    if (star != null) {
+      if (!(star instanceof StarlarkIterable)) {
+        throw new EvalException(
+            compiled.locs.getLocation(starOffset),
+            "argument after * must be an iterable, not " + Starlark.type(star));
+      }
+      Iterable<?> iter = (Iterable<?>) star;
+
+      // TODO(adonovan): opt: if value.size is known, preallocate (and skip if empty).
+      ArrayList<Object> list = new ArrayList<>();
+      Collections.addAll(list, pos);
+      Iterables.addAll(list, iter);
+      pos = list.toArray();
+    }
+
+    if (starStar != null) {
+      if (!(starStar instanceof Dict)) {
+        throw new EvalException(
+            compiled.locs.getLocation(starStarOffset),
+            "argument after ** must be a dict, not " + Starlark.type(starStar));
+      }
+      Dict<?, ?> dict = (Dict<?, ?>) starStar;
+
+      int j = named.length;
+      named = Arrays.copyOf(named, j + 2 * dict.size());
+      for (Map.Entry<?, ?> e : dict.entrySet()) {
+        if (!(e.getKey() instanceof String)) {
+          throw new EvalException(
+              compiled.locs.getLocation(starStarOffset),
+              "keywords must be strings, not " + Starlark.type(e.getKey()));
+        }
+        named[j++] = e.getKey();
+        named[j++] = e.getValue();
+      }
+    }
+
+    try {
+      setSlot(nextOperand(), Starlark.fastcall(fr.thread, fn, pos, named));
+    } catch (EvalExceptionWithStackTrace e) {
+      e.registerNode(currentInstrNode());
+      throw e;
+    } catch (EvalException e) {
+      if (e.canBeAddedToStackTrace()) {
+        throw new EvalExceptionWithStackTrace(e, currentInstrNode());
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /** Not operator. */
+  private void not() throws EvalException {
+    Object value = getSlot(nextOperand());
+    setSlot(nextOperand(), !Starlark.truth(value));
+  }
+
+  /** Generic unary operator. */
+  private void unary() throws EvalException {
+    Object value = getSlot(nextOperand());
+    TokenKind op = TOKENS[nextOperand()];
+    setSlot(nextOperand(), EvalUtils.unaryOp(op, value));
+  }
+
+  /**
+   * Generic binary operator
+   *
+   * <p>Note that {@code and} and {@code or} are not emitted as binary operator instruction. .
+   */
+  private void binary() throws EvalException {
+    Object x = getSlot(nextOperand());
+    Object y = getSlot(nextOperand());
+    TokenKind op = TOKENS[nextOperand()];
+    setSlot(
+        nextOperand(),
+        EvalUtils.binaryOp(op, x, y, fr.thread.getSemantics(), fr.thread.mutability()));
+  }
+
+  /**
+   * Generic binary operator
+   *
+   * <p>Note that {@code and} and {@code or} are not emitted as binary operator instruction. .
+   */
+  private void binaryInPlace() throws EvalException {
+    Object x = getSlot(nextOperand());
+    Object y = getSlot(nextOperand());
+    TokenKind op = TOKENS[nextOperand()];
+    setSlot(nextOperand(), Eval.inplaceBinaryOp(fr, op, x, y));
+  }
+
+  /** Equality. */
+  private void eq() throws EvalException {
+    Object lhs = getSlot(nextOperand());
+    Object rhs = getSlot(nextOperand());
+    setSlot(nextOperand(), lhs.equals(rhs));
+  }
+
+  /** Equality. */
+  private void notEq() throws EvalException {
+    Object lhs = getSlot(nextOperand());
+    Object rhs = getSlot(nextOperand());
+    setSlot(nextOperand(), !lhs.equals(rhs));
+  }
+
+  private void evalException() throws EvalException {
+    String message = compiled.strings[nextOperand()];
+    validateInstructionDecodedCorrectly();
+    throw new EvalException(message);
+  }
+
+  private void dbg() {
+    if (fr.dbg != null) {
+      Location loc = currentInstrNode().getStartLocation(); // not very precise
+      fr.setLocation(loc);
+      fr.dbg.before(fr.thread, loc); // location is now redundant since it's in the thread
+    }
+  }
+
+  private EvalException otherOpcode(int opcode) {
+    if (opcode < BcInstr.Opcode.values().length) {
+      throw new IllegalStateException("not implemented opcode: " + BcInstr.Opcode.values()[opcode]);
+    } else {
+      throw new IllegalStateException("wrong opcode: " + opcode);
+    }
+  }
+
+  private void validateInstructionDecodedCorrectly() {
+    if (Bc.ASSERTIONS) {
+      // Validate the last instruction was decoded correctly
+      // (got all the argument, and no extra arguments).
+      // This is quite helpful, but expensive assertion, only enabled when bytecode assertions
+      // are on.
+      BcInstr.Opcode opcode = BcInstr.Opcode.values()[text[currentIp]];
+      int prevInstrLen = compiled.instrLenAt(currentIp);
+      Preconditions.checkState(
+          ip == currentIp + prevInstrLen,
+          "Instruction %s incorrectly handled len; expected len: %s, actual len: %s",
+          opcode,
+          prevInstrLen,
+          ip - currentIp);
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/syntax/BcInstr.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BcInstr.java
@@ -1,0 +1,295 @@
+package com.google.devtools.build.lib.syntax;
+
+import com.google.common.base.Preconditions;
+
+/** Instructions for the bytecode interpreter. */
+class BcInstr {
+
+  private BcInstr() {}
+
+  /** Undefined file offset. */
+  static final int UNDEFINED_LOC = -19;
+
+  /** Special {@code null} register value, interpretation depends on opcode. */
+  static final int NULL_REG = Integer.MIN_VALUE;
+
+  /** Constants are stored in a separate array. Constant slots are negative integers. */
+  static int constSlotToArrayIndex(int slot) {
+    Preconditions.checkState(slot < 0);
+    return -1 - slot;
+  }
+
+  /** Constants are stored in a separate array. Constant slots are negative integers. */
+  static int constSlotFromArrayIndex(int arrayIndex) {
+    Preconditions.checkState(arrayIndex >= 0);
+    return -1 - arrayIndex;
+  }
+
+  // The instruction header is an opcode.
+  static final int INSTR_HEADER_LEN = 1;
+
+  // We assign integer constants explicitly instead of using enum for performance:
+  // our bytecode stores integers, and converting each opcode to enum might be expensive.
+
+  static final int CP = 0;
+  static final int EQ = 1;
+  static final int NOT_EQ = 2;
+  static final int NOT = 3;
+  static final int UNARY = 4;
+  static final int BR = 5;
+  static final int IF_BR = 6;
+  static final int IF_NOT_BR = 7;
+  static final int BINARY = 8;
+  static final int BINARY_IN_PLACE = 9;
+  static final int GET_LOCAL = 10;
+  static final int GET_GLOBAL = 11;
+  static final int GET_PREDECLARED = 12;
+  static final int GET_LEGACY = 13;
+  static final int SET_LOCAL = 14;
+  static final int SET_GLOBAL = 15;
+  static final int SET_LEGACY = 16;
+  static final int DOT = 17;
+  static final int INDEX = 18;
+  static final int SLICE = 19;
+  static final int CALL = 20;
+  static final int RETURN = 21;
+  static final int RETURN_NONE = 22;
+  static final int FOR_INIT = 23;
+  static final int CONTINUE = 24;
+  static final int BREAK = 25;
+  static final int LIST = 26;
+  static final int TUPLE = 27;
+  static final int DICT = 28;
+  static final int STMT = 29;
+  static final int SAVE_LOCALS = 30;
+  static final int RESTORE_LOCALS = 31;
+  static final int LIST_APPEND = 32;
+  static final int SET_INDEX = 33;
+  static final int EVAL_EXCEPTION = 34;
+  static final int UNPACK = 35;
+  static final int DBG = 36;
+
+  /**
+   * Opcodes as enum. We use enums in the compiler, but we use only raw integers in the interpreter.
+   *
+   * <p>Enums are much nicer to work with, but they are much more expensive. Thus we use enums only
+   * in the compiler, or during debugging.
+   */
+  enum Opcode {
+    /** {@code a1 = a0}. */
+    CP(BcInstr.CP, BcInstrOperand.IN_SLOT, BcInstrOperand.OUT_SLOT),
+    /**
+     * {@code a2 = a0 == a1}. This is quite common operation, which deserves its own opcode to avoid
+     * switching in generic binary operator handling.
+     */
+    EQ(BcInstr.EQ, BcInstrOperand.IN_SLOT, BcInstrOperand.IN_SLOT, BcInstrOperand.OUT_SLOT),
+    /**
+     * {@code a2 = a0 != a1}. This is quite common operation, which deserves its own opcode to avoid
+     * switching in generic binary operator handling.
+     */
+    NOT_EQ(BcInstr.NOT_EQ, BcInstrOperand.IN_SLOT, BcInstrOperand.IN_SLOT, BcInstrOperand.OUT_SLOT),
+    /**
+     * {@code a1 = not a0}.
+     *
+     * <p>This could be handled by generic UNARY opcode, but it is specialized for performance.
+     */
+    NOT(BcInstr.NOT, BcInstrOperand.IN_SLOT, BcInstrOperand.OUT_SLOT),
+    /** {@code a2 = (a1) a0}. */
+    UNARY(
+        BcInstr.UNARY, BcInstrOperand.IN_SLOT, BcInstrOperand.TOKEN_KIND, BcInstrOperand.OUT_SLOT),
+    /** Goto. */
+    BR(BcInstr.BR, BcInstrOperand.addr("j")),
+    /** Goto if. */
+    IF_BR(BcInstr.IF_BR, BcInstrOperand.IN_SLOT, BcInstrOperand.addr("t")),
+    /** Goto if not. */
+    IF_NOT_BR(BcInstr.IF_NOT_BR, BcInstrOperand.IN_SLOT, BcInstrOperand.addr("f")),
+    /** {@code a3 = a0 (a2) a1}. */
+    BINARY(
+        BcInstr.BINARY,
+        BcInstrOperand.IN_SLOT,
+        BcInstrOperand.IN_SLOT,
+        BcInstrOperand.TOKEN_KIND,
+        BcInstrOperand.OUT_SLOT),
+    /** {@code a3 = a0 (a2)= a1}. */
+    BINARY_IN_PLACE(
+        BcInstr.BINARY_IN_PLACE,
+        BcInstrOperand.IN_SLOT,
+        BcInstrOperand.IN_SLOT,
+        BcInstrOperand.TOKEN_KIND,
+        BcInstrOperand.OUT_SLOT),
+    /** Get a local variable and store it in a given register. */
+    GET_LOCAL(BcInstr.GET_LOCAL, BcInstrOperand.STRING, BcInstrOperand.OUT_SLOT),
+    /** Get a global variable and store it in a given register. */
+    GET_GLOBAL(BcInstr.GET_GLOBAL, BcInstrOperand.STRING, BcInstrOperand.OUT_SLOT),
+    /** Get a predeclared variable and store it in a given register. */
+    GET_PREDECLARED(BcInstr.GET_PREDECLARED, BcInstrOperand.STRING, BcInstrOperand.OUT_SLOT),
+    /** Deprecated way to get a variable from any scope. */
+    GET_LEGACY(BcInstr.GET_LEGACY, BcInstrOperand.STRING, BcInstrOperand.OUT_SLOT),
+    /** Assign a value without destructuring to a local variable. */
+    SET_LOCAL(BcInstr.SET_LOCAL,
+      // value
+      BcInstrOperand.IN_SLOT,
+      // name
+      BcInstrOperand.STRING,
+      // 1 if need to invoke post-assign hook, 0 otherwise
+      BcInstrOperand.NUMBER),
+    /** Assign a value without destructuring to a global variable. */
+    SET_GLOBAL(
+        BcInstr.SET_GLOBAL,
+        // value
+        BcInstrOperand.IN_SLOT,
+        // name
+        BcInstrOperand.STRING,
+        // 1 if need to invoke post-assign hook, 0 otherwise
+        BcInstrOperand.NUMBER),
+    SET_LEGACY(
+        BcInstr.SET_LEGACY,
+        // value
+        BcInstrOperand.IN_SLOT,
+        // name
+        BcInstrOperand.STRING,
+        // 1 if need to invoke post-assign hook, 0 otherwise
+        BcInstrOperand.NUMBER),
+    /** {@code a2 = a0.a1} */
+    DOT(BcInstr.DOT, BcInstrOperand.IN_SLOT, BcInstrOperand.STRING, BcInstrOperand.OUT_SLOT),
+    /** {@code a2 = a0[a1]} */
+    INDEX(BcInstr.INDEX, BcInstrOperand.IN_SLOT, BcInstrOperand.IN_SLOT, BcInstrOperand.OUT_SLOT),
+    /** {@code a4 = a0[a1:a2:a3]} */
+    SLICE(
+        BcInstr.SLICE,
+        BcInstrOperand.IN_SLOT,
+        BcInstrOperand.IN_SLOT,
+        BcInstrOperand.IN_SLOT,
+        BcInstrOperand.IN_SLOT,
+        BcInstrOperand.OUT_SLOT),
+    /** Generic call invocation. */
+    CALL(
+        BcInstr.CALL,
+        // prematerialized LParen location
+        BcInstrOperand.OBJECT,
+        // Function
+        BcInstrOperand.IN_SLOT,
+        // Positional arguments
+        BcInstrOperand.lengthDelimited(BcInstrOperand.IN_SLOT),
+        // Named arguments
+        BcInstrOperand.lengthDelimited(
+            BcInstrOperand.fixed(BcInstrOperand.STRING, BcInstrOperand.IN_SLOT)),
+        // *args
+        BcInstrOperand.IN_SLOT,
+        // *args location
+        BcInstrOperand.NUMBER,
+        // **kwargs
+        BcInstrOperand.IN_SLOT,
+        // **kwargs location
+        BcInstrOperand.NUMBER,
+        // Where to store result
+        BcInstrOperand.OUT_SLOT),
+    /** {@code return a0} */
+    RETURN(BcInstr.RETURN, BcInstrOperand.IN_SLOT),
+    /** {@code return None} */
+    RETURN_NONE(BcInstr.RETURN_NONE),
+    /**
+     * For loop init:
+     *
+     * <ul>
+     *   <li>Check if operand is iterable
+     *   <li>Lock the iterable
+     *   <li>Create an iterator
+     *   <li>If iterator has no elements, go to "e".
+     *   <li>Otherwise push iterable and iterator onto the stack
+     *   <li>Fetch the first element of the iterator and store it in the provided register
+     * </ul>
+     */
+    FOR_INIT(
+        BcInstr.FOR_INIT,
+        // Collection parameter
+        BcInstrOperand.IN_SLOT,
+        // Next value register
+        BcInstrOperand.OUT_SLOT,
+        BcInstrOperand.addr("e")),
+    /**
+     * Continue the loop:
+     *
+     * <ul>
+     *   <li>If current iterator (stored on the stack) is empty, unlock the iterable and pop
+     *       iterable and iterable from the stack and go to the label "e" after the end of the loop.
+     *   <li>Otherwise assign the next iterator item to the provided register and go to the label
+     *       "b", loop body.
+     * </ul>
+     */
+    CONTINUE(
+        BcInstr.CONTINUE,
+        // Iterator next value.
+        BcInstrOperand.OUT_SLOT,
+        // Beginning of the loop
+        BcInstrOperand.addr("b"),
+        // End of the loop
+        BcInstrOperand.addr("e")),
+    /**
+     * Exit the loop: unlock the iterable, pop it from the loop stack and goto a label after the
+     * loop.
+     */
+    BREAK(BcInstr.BREAK, BcInstrOperand.addr("e")),
+    /** List constructor. */
+    LIST(
+        BcInstr.LIST,
+        // List size followed by list items.
+        BcInstrOperand.lengthDelimited(BcInstrOperand.IN_SLOT),
+        BcInstrOperand.OUT_SLOT),
+    /** Tuple constructor; similar to the list constructor above. */
+    TUPLE(
+        BcInstr.TUPLE,
+        BcInstrOperand.lengthDelimited(BcInstrOperand.IN_SLOT),
+        BcInstrOperand.OUT_SLOT),
+    /** Dict constructor. */
+    DICT(
+        BcInstr.DICT,
+        BcInstrOperand.lengthDelimited(
+            BcInstrOperand.fixed(BcInstrOperand.IN_SLOT, BcInstrOperand.IN_SLOT)),
+        BcInstrOperand.OUT_SLOT),
+    /**
+     * Invoke a statement using old AST interpreter.
+     *
+     * <p>This is used only to implement def and load statements since they don't interfere with the
+     * rest of the bytecode interpreter. Statements like if or for must not be encoded using this
+     * opcode.
+     */
+    // TODO: implement opcodes for def and load
+    STMT(BcInstr.STMT, BcInstrOperand.OBJECT),
+    /** Save locals before invoking a comprehension. */
+    SAVE_LOCALS(BcInstr.SAVE_LOCALS, BcInstrOperand.OBJECT),
+    /** Restore locals after returning from a comprehension. */
+    RESTORE_LOCALS(BcInstr.RESTORE_LOCALS, BcInstrOperand.OBJECT),
+    /** {@code a0.append(a1)}. */
+    LIST_APPEND(BcInstr.LIST_APPEND, BcInstrOperand.IN_SLOT, BcInstrOperand.IN_SLOT),
+    /** {@code a0[a1] = a2}. */
+    SET_INDEX(
+        BcInstr.SET_INDEX, BcInstrOperand.IN_SLOT, BcInstrOperand.IN_SLOT, BcInstrOperand.IN_SLOT),
+    /** Throw an {@code EvalException} on execution of this instruction. */
+    EVAL_EXCEPTION(BcInstr.EVAL_EXCEPTION, BcInstrOperand.STRING),
+    /** {@code (a1[0], a1[1], a1[2], ...) = a0}. */
+    UNPACK(
+        BcInstr.UNPACK,
+        BcInstrOperand.IN_SLOT,
+        BcInstrOperand.lengthDelimited(BcInstrOperand.OUT_SLOT)),
+    /** Debugger callback. */
+    DBG(BcInstr.DBG);
+    ;
+
+    /** Type of opcode operands. */
+    final BcInstrOperand.Operands operands;
+
+    Opcode(int opcode, BcInstrOperand.Operands... operands) {
+      this(opcode, operands.length != 1 ? BcInstrOperand.fixed(operands) : operands[0]);
+    }
+
+    Opcode(int opcode, BcInstrOperand.Operands operands) {
+      // We maintain the invariant: the opcode is equal to enum variant ordinal.
+      // It is a bit inconvenient to maintain, but make is much easier/safer to work with.
+      Preconditions.checkState(
+          opcode == ordinal(),
+          String.format("wrong index for %s: expected %s, actual %s", name(), ordinal(), opcode));
+      this.operands = operands;
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/syntax/BcInstrOperand.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/BcInstrOperand.java
@@ -1,0 +1,237 @@
+package com.google.devtools.build.lib.syntax;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Describe instruction operands of the Starlark bytecode.
+ *
+ * <p>This code is used only when assertions are enabled, because proper instruction validation
+ * might be expensive.
+ */
+class BcInstrOperand {
+  /** Bytecode operand is an integer, stored in the bytecode. */
+  static final Operands NUMBER = new NumberOperand();
+  /**
+   * Bytecode operand is logically a string, stored in the strings storage; the index is stored in
+   * the bytecode.
+   */
+  static final Operands STRING = new StringOperand();
+  /**
+   * Bytecode operand is logically an object, stored in the strings storage; the index is stored in
+   * the bytecode.
+   */
+  static final Operands OBJECT = new ObjectArg();
+
+  /**
+   * Bytecode operand is an input register. Note current implementation does not validate that it is
+   * actually read, not write register, it is used mostly as a hint when bytecode is printed.
+   *
+   * <p>Operand of this type can be a non-negative integer for regular slot, or negative integer for
+   * constants.
+   */
+  static final Operands IN_SLOT = new Register("r");
+  /**
+   * Bytecode operand is an output register.
+   *
+   * <p>The value of this operand must be a non-negative integer.
+   */
+  static final Operands OUT_SLOT = new Register("w");
+
+  /** Bytecode operand is a fixed integer, storing {@link TokenKind}. */
+  static final Operands TOKEN_KIND = new KindArg();
+
+  private BcInstrOperand() {}
+
+  /** Fixed of operands, e. g. a pair of operands used to describe a dict key and value. */
+  static Operands fixed(Operands... operands) {
+    return new FixedOperandsOpcode(operands);
+  }
+
+  /** Length-delimited operands, e. g. list constructor arguments. */
+  static Operands lengthDelimited(Operands element) {
+    return new LengthDelimited(element);
+  }
+
+  /** Operand is a fixed number storing the instruction pointer. */
+  static Operands addr(String label) {
+    return new AddrArg(label);
+  }
+
+  /**
+   * Sequence of operands.
+   *
+   * <p>Note in Starlark bytecode, the opcode operands are variable length: The number of operands
+   * depend not just on the opcode, but it is encoded in the previous operands. E. g. a list
+   * constructor is encoded as a length delimited sequence of register operands.
+   */
+  abstract static class Operands {
+    private Operands() {}
+
+    /** This is low level operation, do not use directly. */
+    abstract void visit(OpcodeVisitor visitor);
+
+    /**
+     * Get the number of integers occupied by this operands object at the given bytecode offset.
+     *
+     * <p>For example, length-delimited operand may return the different number of ints depending on
+     * the actual bytecode.
+     */
+    int codeSize(int[] text, List<String> strings, List<Object> constantRegs, int offset) {
+      OpcodeVisitor visitor = new OpcodeVisitor(text, strings, constantRegs, offset);
+      visit(visitor);
+      return visitor.ip - offset;
+    }
+
+    /**
+     * Decode this operand to human readable string at a given instruction pointer. This function
+     * may return something unpredictable if the instruction pointer parameter does not point at the
+     * instruction boundary.
+     */
+    String argToString(int ip, Bc.Compiled compiled) {
+      return toStringAndCount(
+          new int[] {ip},
+          compiled.text,
+          Arrays.asList(compiled.strings),
+          Arrays.asList(compiled.constSlots));
+    }
+
+    /** Get both instruction count for this operand and the string representation. */
+    String toStringAndCount(
+        int[] offset, int[] text, List<String> strings, List<Object> constantRegs) {
+      OpcodeVisitor visitor = new OpcodeVisitor(text, strings, constantRegs, offset[0]);
+      visit(visitor);
+      offset[0] = visitor.ip;
+      return visitor.sb.toString();
+    }
+  }
+
+  /** This class is package-private only because it is referenced from {@link Operands}. */
+  private static class OpcodeVisitor {
+    private final int[] text;
+    private final List<String> strings;
+    private final List<Object> constantRegs;
+    private int ip;
+    private StringBuilder sb = new StringBuilder();
+
+    private OpcodeVisitor(int[] text, List<String> strings, List<Object> constantRegs, int ip) {
+      this.text = text;
+      this.strings = strings;
+      this.constantRegs = constantRegs;
+      this.ip = ip;
+    }
+
+    private void append(String s) {
+      sb.append(s);
+    }
+
+    private int nextOperand() {
+      return text[ip++];
+    }
+  }
+
+  private static class NumberOperand extends Operands {
+    @Override
+    public void visit(OpcodeVisitor visitor) {
+      visitor.append(Integer.toString(visitor.nextOperand()));
+    }
+  }
+
+  private static class StringOperand extends Operands {
+    @Override
+    public void visit(OpcodeVisitor visitor) {
+      visitor.append(visitor.strings.get(visitor.nextOperand()));
+    }
+  }
+
+  private static class Register extends Operands {
+    private final String label;
+
+    private Register(String label) {
+      this.label = label;
+    }
+
+    @Override
+    public void visit(OpcodeVisitor visitor) {
+      int reg = visitor.nextOperand();
+      Object valueToPrint;
+      if (reg == BcInstr.NULL_REG) {
+        valueToPrint = "=null";
+      } else if (reg < 0) {
+        valueToPrint = "=" + visitor.constantRegs.get(BcInstr.constSlotToArrayIndex(reg));
+      } else {
+        valueToPrint = "$" + reg;
+      }
+      visitor.sb.append(label).append(valueToPrint);
+    }
+  }
+
+  private static class KindArg extends Operands {
+    @Override
+    public void visit(OpcodeVisitor visitor) {
+      visitor.sb.append(TokenKind.values()[visitor.nextOperand()]);
+    }
+  }
+
+  private static class AddrArg extends Operands {
+    private final String label;
+
+    private AddrArg(String label) {
+      this.label = label;
+    }
+
+    @Override
+    public void visit(OpcodeVisitor visitor) {
+      visitor.append(label + "=&" + visitor.nextOperand());
+    }
+  }
+
+  private static class ObjectArg extends Operands {
+    @Override
+    public void visit(OpcodeVisitor visitor) {
+      visitor.append("o" + visitor.nextOperand());
+    }
+  }
+
+  private static class FixedOperandsOpcode extends Operands {
+    private final Operands[] operands;
+
+    private FixedOperandsOpcode(Operands[] operands) {
+      this.operands = operands;
+    }
+
+    @Override
+    public void visit(OpcodeVisitor visitor) {
+      visitor.append("(");
+      for (int i = 0; i < operands.length; i++) {
+        if (i != 0) {
+          visitor.sb.append(" ");
+        }
+        Operands operand = operands[i];
+        operand.visit(visitor);
+      }
+      visitor.append(")");
+    }
+  }
+
+  private static class LengthDelimited extends Operands {
+    private final Operands element;
+
+    private LengthDelimited(Operands element) {
+      this.element = element;
+    }
+
+    @Override
+    public void visit(OpcodeVisitor visitor) {
+      visitor.append("[");
+      int size = visitor.nextOperand();
+      for (int i = 0; i != size; ++i) {
+        if (i != 0) {
+          visitor.append(" ");
+        }
+        element.visit(visitor);
+      }
+      visitor.append("]");
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/syntax/Eval.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Eval.java
@@ -38,7 +38,7 @@ final class Eval {
     return fr.result;
   }
 
-  private static StarlarkFunction fn(StarlarkThread.Frame fr) {
+  static StarlarkFunction fn(StarlarkThread.Frame fr) {
     return (StarlarkFunction) fr.fn;
   }
 
@@ -217,7 +217,7 @@ final class Eval {
     return TokenKind.RETURN;
   }
 
-  private static TokenKind exec(StarlarkThread.Frame fr, Statement st)
+  static TokenKind exec(StarlarkThread.Frame fr, Statement st)
       throws EvalException, InterruptedException {
     if (fr.dbg != null) {
       Location loc = st.getStartLocation(); // not very precise
@@ -321,16 +321,20 @@ final class Eval {
         fr.locals.put(name, value);
         break;
       case GLOBAL:
-        // Updates a module binding and sets its 'exported' flag.
-        // (Only load bindings are not exported.
-        // But exportedGlobals does at run time what should be done in the resolver.)
-        Module module = fn(fr).getModule();
-        module.setGlobal(name, value);
-        module.exportedGlobals.add(name);
+        assignGlobal(fr, name, value);
         break;
       default:
         throw new IllegalStateException(scope.toString());
     }
+  }
+
+  static void assignGlobal(StarlarkThread.Frame fr, String name, Object value) {
+    // Updates a module binding and sets its 'exported' flag.
+    // (Only load bindings are not exported.
+    // But exportedGlobals does at run time what should be done in the resolver.)
+    Module module = fn(fr).getModule();
+    module.setGlobal(name, value);
+    module.exportedGlobals.add(name);
   }
 
   /**
@@ -399,7 +403,7 @@ final class Eval {
     }
   }
 
-  private static Object inplaceBinaryOp(StarlarkThread.Frame fr, TokenKind op, Object x, Object y)
+  static Object inplaceBinaryOp(StarlarkThread.Frame fr, TokenKind op, Object x, Object y)
       throws EvalException {
     // list += iterable  behaves like  list.extend(iterable)
     // TODO(b/141263526): following Python, allow list+=iterable (but not list+iterable).

--- a/src/main/java/com/google/devtools/build/lib/syntax/StarlarkFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/StarlarkFunction.java
@@ -140,7 +140,8 @@ public final class StarlarkFunction implements StarlarkCallable {
       fr.locals.put(names.get(i), arguments[i]);
     }
 
-    return Eval.execFunctionBody(fr, rfn.body);
+    //return Eval.execFunctionBody(fr, rfn.body);
+    return BcEval.eval(fr, rfn.compiled);
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/syntax/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/syntax/BUILD
@@ -44,6 +44,10 @@ java_test(
         "//third_party:junit4",
         "//third_party:truth",
     ],
+    jvm_flags = [
+        # Run tests with assertions
+        "-Dstarlark.bc.assertions=true",
+    ],
 )
 
 test_suite(


### PR DESCRIPTION
It is faster for about 10-20%, speedup depends on how much named
locals and globals are used (see below).

AST interpreter might be one of the reasons for Starlark Java
performance.

My understanding is: too deep stacks make JVM and CPU unhappy: CPU
mispredict branches and fails to use the CPU cache properly, and
JVM fails to inline things when there are too many branches.

This PR implements a bytecode interpreter in Starlark.

Bytecode is a sequence of instructions.

Each instruction is:
* opcode
* number of operands which depend on the opcode
  (instructions are variable length)

Example instructions:
* `BR`: unconditionally go to to the specified instruction
* `BINARY`: binary operation
* `CALL`: call a function using arguments stored in registers
* `FOR_INIT`: machinery invoked at the beginning of the loop

The VM is a register machine, not a stack machine (each opcode
argument and result are registers; there is no stack except for
`for` loop stack).

The reason for that is that Starlark misses indexed locals
optimization: current implementation can be naturally extended to
storing locals in registers, so there will be no need for special
opcodes to work with locals.

This PR intentionally omits the super important optimizations, such
as:
* globals inlining
* indexed locals
* function re-linking (avoid signature check on each function invocation)

We have implemented these optimizations and some others in our local
branch and combined together they give an additional 20% performance.
Current profiler output: https://i.imgur.com/DKOhELq.png

I omitted these optimizations in this PR:
* to make this PR easier to review
* to prove that speedup is indeed caused by switching to the bytecode
  interpreter

I did not submit these optimizations to the Starlark repository,
because the Bazel team explicitly asked to avoid submitting
optimizations to the interpreter before the interpreter switches
to bytecode interpreter.

Since bytecode interpreter did not happen yet, I do this attempt
to implement it.

However, if you have an almost ready to submit a version of the proper
interpreter, I'd be fine with abandoning this PR.

Implementation notes.

BC interpreter does not properly track location within expressions
(e. g. the position of + operator sign). It is possible to implement
although I have not found how it is used: all interpreter tests pass.

I did not work hard on bytecode interpreter optimization.  For
example, the introduction of specialized instructions or changing
the semantics of existing instructions may give a speedup. For
example, special `FOR_INIT` and `CONTINUE` instructions for
a single-variable loop could help a little.

Certain compile-time incorrect statements (like `a + 1 = b` are
compiled to special `EVAL_EXCEPTION` instruction). This is done for
two reasons. First, these statements should be filtered out by the
resolver. Second, to avoid test modifications: this PR does not
modify any tests.

A lot of existing AST interpreter (`Eval.java` and `Exec.java`) can
be removed (no longer used), but I kept it for a while to avoid
unnecessary noise in this review.

That's it.

The performance of the Starlark interpreter is critical for our
Starlark application, so I would be happy to continue working on
this PR and hope to get feedback and pointers from you folks.