### PR TITLE
Docs: Add BuildBuddy to commercial RBE offerings

### DIFF
--- a/site/docs/remote-execution.md
+++ b/site/docs/remote-execution.md
@@ -36,6 +36,8 @@ To run Bazel with remote execution, you can use one of the following:
 *   Commercial
     *   [EngFlow Remote Execution](https://www.engflow.com) -- Remote execution
         and remote caching service. Can be self-hosted or hosted.
+    *   [BuildBuddy](https://www.buildbuddy.io) -- Remote build 
+    execution, caching, and results UI. Free for individuals and open source projects.
 
 ## Requirements
 


### PR DESCRIPTION
Adding BuildBuddy RBE to the Commercial section of the remote-execution docs.