### PR TITLE
Make dependency files deterministic

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5572,7 +5572,11 @@ def _impl(ctx):
                 ],
                 flag_groups = [
                     flag_group(
-                        flags = ["-MD", "-MF", "%{dependency_file}"],
+                        flags = [
+                            "-MD",
+                            "-MF",
+                            "DEPENDENCY_FILE=%{dependency_file}",
+                        ],
                         expand_if_available = "dependency_file",
                     ),
                 ],


### PR DESCRIPTION
The dependency file generated by Clang can sometimes contain absolute
paths to system headers, system modules and files generated by Bazel
during the build.  These paths can defer between machines and between
Bazel instances, for example:

```
bazel-out/apl-darwin_x86_64-fastbuild/bin/_objs/B/arc/B.o: B.m \
  /private/var/tmp/_bazel_user/b4422045cf7215be2d3fa4e439c7376a/sandbox/darwin-sandbox/214/execroot/__main__/bazel-out/apl-darwin_x86_64-fastbuild/bin/A.modulemap \
  /Applications/Xcode-11.6.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Foundation.framework/Modules/module.modulemap
```

This patch adds a post-process to wrapped_clang to normalize those paths
by:

* converting absolute paths to relative paths for paths to files under
the execution root
* standardizing the paths to system headers, system modules to always
use the standard location of Xcode (`/Applications/Xcode.app`).  The
user doesn't need to have Xcode installed to this location as Bazel are
already mapping them to the correct location locally.

This makes the produced `.d` files deterministic and can reliably be
shared with the remote cache.

Fixes https://github.com/bazelbuild/bazel/issues/11817.