### PR TITLE
Restore shared_library attribute in Starlark's cc_import

### DIFF
--- a/tools/build_defs/cc/cc_import.bzl
+++ b/tools/build_defs/cc/cc_import.bzl
@@ -160,6 +160,7 @@ def _cc_import_impl(ctx):
         static_library = static_library,
         pic_static_library = pic_static_library,
         interface_library = ctx.file.interface_library,
+        dynamic_library = ctx.file.shared_library,
         pic_objects = ctx.files.pic_objects,
         objects = ctx.files.objects,
         alwayslink = ctx.attr.alwayslink,
@@ -192,7 +193,7 @@ cc_import = rule(
         "hdrs": attr.label_list(allow_files = [".h"]),
         "static_library": attr.label(allow_single_file = [".a", ".lib"]),
         "pic_static_library": attr.label(allow_single_file = [".pic.a", ".pic.lib"]),
-        "shared_library": attr.label(allow_single_file = True),
+        "shared_library": attr.label(allow_single_file = [".so", ".dll", ".dylib"]),
         "interface_library": attr.label(
             allow_single_file = [".ifso", ".tbd", ".lib", ".so", ".dylib"],
         ),


### PR DESCRIPTION
Restore shared_library attribute in Starlark's cc_import as it was removed by accident in one of the previous commits