### PR TITLE
Starlark: an option to allow recursion

### DIFF
--- a/src/main/java/net/starlark/java/eval/StarlarkFunction.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkFunction.java
@@ -143,7 +143,7 @@ public final class StarlarkFunction implements StarlarkCallable {
     if (thread.mutability().isFrozen()) {
       throw Starlark.errorf("Trying to call in frozen environment");
     }
-    if (thread.isRecursiveCall(this)) {
+    if (!thread.isAllowRecursion() && thread.isRecursiveCall(this)) {
       throw Starlark.errorf("function '%s' called recursively", getName());
     }
 

--- a/src/main/java/net/starlark/java/eval/StarlarkSemantics.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkSemantics.java
@@ -207,4 +207,9 @@ public final class StarlarkSemantics {
 
   /** Change the behavior of 'print' statements. Used in tests to verify flag propagation. */
   public static final String PRINT_TEST_MARKER = "-print_test_marker";
+  /**
+   * Are recursive function calls allowed. This option is not exposed to Bazel, which
+   * unconditionally prohibits recursion.
+   */
+  public static final String ALLOW_RECURSION = "-allow_recursion";
 }

--- a/src/main/java/net/starlark/java/eval/StarlarkThread.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkThread.java
@@ -191,6 +191,9 @@ public final class StarlarkThread {
   /** The semantics options that affect how Starlark code is evaluated. */
   private final StarlarkSemantics semantics;
 
+  /** Cache from semantics. */
+  private final boolean allowRecursion;
+
   /** PrintHandler for Starlark print statements. */
   private PrintHandler printHandler = StarlarkThread::defaultPrintHandler;
 
@@ -375,6 +378,7 @@ public final class StarlarkThread {
     Preconditions.checkArgument(!mu.isFrozen());
     this.mutability = mu;
     this.semantics = semantics;
+    this.allowRecursion = semantics.getBool(StarlarkSemantics.ALLOW_RECURSION);
   }
 
   /**
@@ -396,6 +400,10 @@ public final class StarlarkThread {
 
   public StarlarkSemantics getSemantics() {
     return semantics;
+  }
+
+  public boolean isAllowRecursion() {
+    return allowRecursion;
   }
 
   // Implementation of Debug.getCallStack.


### PR DESCRIPTION
This option can be set only programmatically and not exposed to
Bazel.  When this option is on, this definitions does not report
recursion error:

```
def sum(l):
    if not l:
        return 0
    else:
        return l[0] + sum(l[1:])
```

Follow-up to this conversation:
https://github.com/bazelbuild/starlark/issues/97