### PR TITLE
ctexplain: first functional check-in

### DIFF
--- a/tools/ctexplain/BUILD
+++ b/tools/ctexplain/BUILD
@@ -10,7 +10,19 @@ py_binary(
     name = "ctexplain",
     srcs = ["ctexplain.py"],
     python_version = "PY3",
-    deps = [":bazel_api"],
+    deps = [
+        ":ctexplain_lib",
+        "//third_party/py/abseil"
+    ],
+)
+
+py_library(
+    name = "ctexplain_lib",
+    srcs = ["ctexplain_lib.py"],
+    srcs_version = "PY3ONLY",
+    deps = [
+        ":base",
+        ":bazel_api"],
 )
 
 py_library(

--- a/tools/ctexplain/BUILD
+++ b/tools/ctexplain/BUILD
@@ -12,6 +12,7 @@ py_binary(
     python_version = "PY3",
     deps = [
         ":ctexplain_lib",
+        ":analyses",
         "//third_party/py/abseil"
     ],
 )
@@ -19,6 +20,15 @@ py_binary(
 py_library(
     name = "ctexplain_lib",
     srcs = ["ctexplain_lib.py"],
+    srcs_version = "PY3ONLY",
+    deps = [
+        ":base",
+        ":bazel_api"],
+)
+
+py_library(
+    name = "analyses",
+    srcs = ["analyses/summary.py"],
     srcs_version = "PY3ONLY",
     deps = [
         ":base",
@@ -47,6 +57,7 @@ py_library(
     name = "base",
     srcs = [
         "types.py",
+        "util.py",
     ],
     srcs_version = "PY3ONLY",
     deps = [

--- a/tools/ctexplain/BUILD
+++ b/tools/ctexplain/BUILD
@@ -6,33 +6,31 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["*"]),
+)
+
 py_binary(
     name = "ctexplain",
     srcs = ["ctexplain.py"],
     python_version = "PY3",
     deps = [
-        ":ctexplain_lib",
         ":analyses",
+        ":base",
+        ":lib",
         "//third_party/py/abseil"
     ],
 )
 
 py_library(
-    name = "ctexplain_lib",
-    srcs = ["ctexplain_lib.py"],
+    name = "lib",
+    srcs = ["lib.py"],
     srcs_version = "PY3ONLY",
     deps = [
         ":base",
-        ":bazel_api"],
-)
-
-py_library(
-    name = "analyses",
-    srcs = ["analyses/summary.py"],
-    srcs_version = "PY3ONLY",
-    deps = [
-        ":base",
-        ":bazel_api"],
+        ":bazel_api",
+    ],
 )
 
 py_library(
@@ -42,15 +40,11 @@ py_library(
     deps = [":base"],
 )
 
-py_test(
-    name = "bazel_api_test",
-    size = "small",
-    srcs = ["bazel_api_test.py"],
-    python_version = "PY3",
-    deps = [
-        ":bazel_api",
-        "//src/test/py/bazel:test_base",
-    ],
+py_library(
+    name = "analyses",
+    srcs = ["analyses/summary.py"],
+    srcs_version = "PY3ONLY",
+    deps = [":base"],
 )
 
 py_library(
@@ -67,6 +61,17 @@ py_library(
 )
 
 py_test(
+    name = "bazel_api_test",
+    size = "small",
+    srcs = ["bazel_api_test.py"],
+    python_version = "PY3",
+    deps = [
+        ":bazel_api",
+        "//src/test/py/bazel:test_base",
+    ],
+)
+
+py_test(
     name = "types_test",
     size = "small",
     srcs = ["types_test.py"],
@@ -75,9 +80,4 @@ py_test(
         ":base",
         "//third_party/py/frozendict",
     ],
-)
-
-filegroup(
-    name = "srcs",
-    srcs = glob(["*"]),
 )

--- a/tools/ctexplain/BUILD
+++ b/tools/ctexplain/BUILD
@@ -18,6 +18,7 @@ py_binary(
     deps = [
         ":analyses",
         ":base",
+        ":bazel_api",
         ":lib",
         "//third_party/py/abseil"
     ],
@@ -61,6 +62,18 @@ py_library(
 )
 
 py_test(
+    name = "lib_test",
+    size = "small",
+    srcs = ["lib_test.py"],
+    python_version = "PY3",
+    deps = [
+        ":bazel_api",
+        ":lib",
+        "//src/test/py/bazel:test_base",
+    ],
+)
+
+py_test(
     name = "bazel_api_test",
     size = "small",
     srcs = ["bazel_api_test.py"],
@@ -68,6 +81,18 @@ py_test(
     deps = [
         ":bazel_api",
         "//src/test/py/bazel:test_base",
+    ],
+)
+
+py_test(
+    name = "analyses_test",
+    size = "small",
+    srcs = ["analyses/summary_test.py"],
+    main = "analyses/summary_test.py", # TODO: generalize this.
+    python_version = "PY3",
+    deps = [
+        ":analyses",
+        ":base",
     ],
 )
 

--- a/tools/ctexplain/analyses/summary.py
+++ b/tools/ctexplain/analyses/summary.py
@@ -20,55 +20,55 @@ from dataclasses import dataclass
 from tools.ctexplain.types import ConfiguredTarget
 from tools.ctexplain.util import percent_diff
 
+
 @dataclass(frozen=True)
 class _Summary():
-    """Analysis result."""
-    # Number of configurations in the build's configured target graph.
-    configurations: int
-    # Number of unique target labels.
-    targets: int
-    # Number of configured targets.
-    configured_targets: int
-    # Number of targets that produce multiple configured targets. This is more
-    # subtle than computing configured_targets - targets. For example, if
-    # targets=2 and configured_targets=4, that could mean both targets are
-    # configured twice. Or it could mean the first target is configured 3 times.
-    repeated_targets: int
+  """Analysis result."""
+  # Number of configurations in the build's configured target graph.
+  configurations: int
+  # Number of unique target labels.
+  targets: int
+  # Number of configured targets.
+  configured_targets: int
+  # Number of targets that produce multiple configured targets. This is more
+  # subtle than computing configured_targets - targets. For example, if
+  # targets=2 and configured_targets=4, that could mean both targets are
+  # configured twice. Or it could mean the first target is configured 3 times.
+  repeated_targets: int
 
 
 def summary_analysis(cts: Tuple[ConfiguredTarget, ...]):
-    """Runs the analysis.
+  """Runs the analysis.
 
-    Args:
-      cts: A build's configured targets
-    """
-    configurations = set()
-    targets = set()
-    label_count = {}
-    for ct in cts:
-        configurations.add(ct.config_hash)
-        targets.add(ct.label)
-        label_count[ct.label] = label_count.setdefault(ct.label, 0) + 1
-    configured_targets = len(cts)
-    repeated_targets = sum([1 for count in label_count.values() if count > 1])
+  Args:
+    cts: A build's configured targets
+  """
+  configurations = set()
+  targets = set()
+  label_count = {}
+  for ct in cts:
+    configurations.add(ct.config_hash)
+    targets.add(ct.label)
+    label_count[ct.label] = label_count.setdefault(ct.label, 0) + 1
+  configured_targets = len(cts)
+  repeated_targets = sum([1 for count in label_count.values() if count > 1])
 
-    result = _Summary(len(configurations), len(targets), configured_targets,
-        repeated_targets)
-    _report_summary(result)
+  result = _Summary(len(configurations), len(targets), configured_targets,
+                    repeated_targets)
+  _report_summary(result)
 
 
 def _report_summary(result: _Summary):
-    """Reports analysis results to the user.
+  """Reports analysis results to the user.
 
-    We intentionally make this its own function to make it easy to support other
-    output formats (like machine-readable) if we ever want to do that.
+  We intentionally make this its own function to make it easy to support other
+  output formats (like machine-readable) if we ever want to do that.
 
-    Args:
-      result: the analysis result
-    """
-    ct_surplus = percent_diff(result.targets, result.configured_targets)
-    print(
-f"""
+  Args:
+    result: the analysis result
+  """
+  ct_surplus = percent_diff(result.targets, result.configured_targets)
+  print(f"""
 Configurations: {result.configurations}
 Targets: {result.targets}
 Configured targets: {result.configured_targets} ({ct_surplus} vs. targets)

--- a/tools/ctexplain/analyses/summary.py
+++ b/tools/ctexplain/analyses/summary.py
@@ -18,7 +18,7 @@ from typing import Tuple
 from dataclasses import dataclass
 
 from tools.ctexplain.types import ConfiguredTarget
-from tools.ctexplain.util import percent_diff
+import tools.ctexplain.util
 
 
 @dataclass(frozen=True)
@@ -37,7 +37,7 @@ class _Summary():
   repeated_targets: int
 
 
-def summary_analysis(cts: Tuple[ConfiguredTarget, ...]):
+def summary_analysis(cts: Tuple[types.ConfiguredTarget, ...]):
   """Runs the analysis.
 
   Args:
@@ -67,7 +67,7 @@ def _report_summary(result: _Summary):
   Args:
     result: the analysis result
   """
-  ct_surplus = percent_diff(result.targets, result.configured_targets)
+  ct_surplus = util.percent_diff(result.targets, result.configured_targets)
   print(f"""
 Configurations: {result.configurations}
 Targets: {result.targets}

--- a/tools/ctexplain/analyses/summary.py
+++ b/tools/ctexplain/analyses/summary.py
@@ -18,7 +18,7 @@ from typing import Tuple
 from dataclasses import dataclass
 
 from tools.ctexplain.types import ConfiguredTarget
-import tools.ctexplain.util
+import tools.ctexplain.util as util
 
 
 @dataclass(frozen=True)
@@ -37,7 +37,7 @@ class _Summary():
   repeated_targets: int
 
 
-def summary_analysis(cts: Tuple[types.ConfiguredTarget, ...]):
+def analyze(cts: Tuple[ConfiguredTarget, ...]):
   """Runs the analysis.
 
   Args:
@@ -53,12 +53,11 @@ def summary_analysis(cts: Tuple[types.ConfiguredTarget, ...]):
   configured_targets = len(cts)
   repeated_targets = sum([1 for count in label_count.values() if count > 1])
 
-  result = _Summary(len(configurations), len(targets), configured_targets,
+  return _Summary(len(configurations), len(targets), configured_targets,
                     repeated_targets)
-  _report_summary(result)
 
 
-def _report_summary(result: _Summary):
+def report(result: _Summary):
   """Reports analysis results to the user.
 
   We intentionally make this its own function to make it easy to support other

--- a/tools/ctexplain/analyses/summary.py
+++ b/tools/ctexplain/analyses/summary.py
@@ -42,6 +42,9 @@ def analyze(cts: Tuple[ConfiguredTarget, ...]):
 
   Args:
     cts: A build's configured targets
+
+  Returns:
+    Analysis result as a _Summary.
   """
   configurations = set()
   targets = set()
@@ -54,7 +57,7 @@ def analyze(cts: Tuple[ConfiguredTarget, ...]):
   repeated_targets = sum([1 for count in label_count.values() if count > 1])
 
   return _Summary(len(configurations), len(targets), configured_targets,
-                    repeated_targets)
+                  repeated_targets)
 
 
 def report(result: _Summary):

--- a/tools/ctexplain/analyses/summary.py
+++ b/tools/ctexplain/analyses/summary.py
@@ -1,0 +1,76 @@
+# Lint as: python3
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Analysis that summarizes basic graph info."""
+from typing import Tuple
+# Do not edit this line. Copybara replaces it with PY2 migration helper.
+from dataclasses import dataclass
+
+from tools.ctexplain.types import ConfiguredTarget
+from tools.ctexplain.util import percent_diff
+
+@dataclass(frozen=True)
+class _Summary():
+    """Analysis result."""
+    # Number of configurations in the build's configured target graph.
+    configurations: int
+    # Number of unique target labels.
+    targets: int
+    # Number of configured targets.
+    configured_targets: int
+    # Number of targets that produce multiple configured targets. This is more
+    # subtle than computing configured_targets - targets. For example, if
+    # targets=2 and configured_targets=4, that could mean both targets are
+    # configured twice. Or it could mean the first target is configured 3 times.
+    repeated_targets: int
+
+
+def summary_analysis(cts: Tuple[ConfiguredTarget, ...]):
+    """Runs the analysis.
+
+    Args:
+      cts: A build's configured targets
+    """
+    configurations = set()
+    targets = set()
+    label_count = {}
+    for ct in cts:
+        configurations.add(ct.config_hash)
+        targets.add(ct.label)
+        label_count[ct.label] = label_count.setdefault(ct.label, 0) + 1
+    configured_targets = len(cts)
+    repeated_targets = sum([1 for count in label_count.values() if count > 1])
+
+    result = _Summary(len(configurations), len(targets), configured_targets,
+        repeated_targets)
+    _report_summary(result)
+
+
+def _report_summary(result: _Summary):
+    """Reports analysis results to the user.
+
+    We intentionally make this its own function to make it easy to support other
+    output formats (like machine-readable) if we ever want to do that.
+
+    Args:
+      result: the analysis result
+    """
+    ct_surplus = percent_diff(result.targets, result.configured_targets)
+    print(
+f"""
+Configurations: {result.configurations}
+Targets: {result.targets}
+Configured targets: {result.configured_targets} ({ct_surplus} vs. targets)
+Targets with multiple configs: {result.repeated_targets}
+""")

--- a/tools/ctexplain/analyses/summary.py
+++ b/tools/ctexplain/analyses/summary.py
@@ -37,15 +37,8 @@ class _Summary():
   repeated_targets: int
 
 
-def analyze(cts: Tuple[ConfiguredTarget, ...]):
-  """Runs the analysis.
-
-  Args:
-    cts: A build's configured targets
-
-  Returns:
-    Analysis result as a _Summary.
-  """
+def analyze(cts: Tuple[ConfiguredTarget, ...]) -> _Summary:
+  """Runs the analysis on a build's configured targets."""
   configurations = set()
   targets = set()
   label_count = {}
@@ -60,7 +53,7 @@ def analyze(cts: Tuple[ConfiguredTarget, ...]):
                   repeated_targets)
 
 
-def report(result: _Summary):
+def report(result: _Summary) -> None:
   """Reports analysis results to the user.
 
   We intentionally make this its own function to make it easy to support other

--- a/tools/ctexplain/analyses/summary_test.py
+++ b/tools/ctexplain/analyses/summary_test.py
@@ -1,0 +1,44 @@
+# Lint as: python3
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for summary.py."""
+import unittest
+# Do not edit this line. Copybara replaces it with PY2 migration helper.
+from frozendict import frozendict
+
+import tools.ctexplain.analyses.summary as summary
+from tools.ctexplain.types import Configuration
+from tools.ctexplain.types import ConfiguredTarget
+from tools.ctexplain.types import NullConfiguration
+
+
+class SummaryTest(unittest.TestCase):
+
+  def testAnalysis(self):
+    config1 = Configuration(None, frozendict({'a': frozendict({'b': 'c'})}))
+    config2 = Configuration(None, frozendict({'d': frozendict({'e': 'f'})}))
+
+    ct1 = ConfiguredTarget('//foo', config1, 'hash1', None)
+    ct2 = ConfiguredTarget('//foo', config2, 'hash2', None)
+    ct3 = ConfiguredTarget('//foo', NullConfiguration(), 'null', None)
+    ct4 = ConfiguredTarget('//bar', config1, 'hash1', None)
+
+    res = summary.analyze((ct1, ct2, ct3, ct4))
+    self.assertEqual(3, res.configurations)
+    self.assertEqual(2, res.targets)
+    self.assertEqual(4, res.configured_targets)
+    self.assertEqual(1, res.repeated_targets)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tools/ctexplain/bazel_api.py
+++ b/tools/ctexplain/bazel_api.py
@@ -81,7 +81,7 @@ class BazelApi():
 
     cts = set()
     for line in stdout:
-      if len(line.strip()) == 0:
+      if not line.strip():
         continue
       ctinfo = _parse_cquery_result_line(line)
       if ctinfo is not None:
@@ -99,7 +99,7 @@ class BazelApi():
       The matching configuration or None if no match is found.
 
     Raises:
-      ValueError on any parsing problems.
+      ValueError: On any parsing problems.
     """
     if config_hash == "HOST":
       return HostConfiguration()
@@ -112,9 +112,9 @@ class BazelApi():
       raise ValueError("Could not get config: " + stderr)
     config_json = json.loads(os.linesep.join(stdout))
     fragments = frozendict({
-      _base_name(entry["name"]): tuple(
-        _base_name(option_class) for option_class in entry["fragmentOptions"])
-      for entry in config_json["fragments"]
+        _base_name(entry["name"]): tuple(
+            _base_name(clazz) for clazz in entry["fragmentOptions"])
+        for entry in config_json["fragments"]
     })
     options = frozendict({
         _base_name(entry["name"]): frozendict(entry["options"])
@@ -160,13 +160,20 @@ def _parse_cquery_result_line(line: str) -> ConfiguredTarget:
       config=None,  # Not yet available: we'll need `bazel config` to get this.
       config_hash=config_hash,
       transitive_fragments=fragments)
-    
+
+
 def _base_name(full_name: str) -> str:
   """Strips a fully qualified Java class name to the file scope.
 
-  Examples: 
+  Examples:
     - "A.B.OuterClass" -> "OuterClass"
     - "A.B.OuterClass$InnerClass" -> "OuterClass$InnerClass"
+
+  Args:
+    full_name: Fully qualified class name.
+
+  Returns:
+    Stripped name.
   """
   return full_name.split(".")[-1]
 

--- a/tools/ctexplain/bazel_api.py
+++ b/tools/ctexplain/bazel_api.py
@@ -73,19 +73,23 @@ class BazelApi():
       stderr contains the query's stderr (regardless of success value), and cts
       is the configured targets found by the query if successful, empty
       otherwise.
+
+      ct order preserves cquery's output order. This is topologically sorted
+      with duplicates removed. So no unique configured target appears twice and
+      if A depends on B, A appears before B.
     """
     base_args = ["cquery", "--show_config_fragments=transitive"]
     (returncode, stdout, stderr) = self.run_bazel(base_args + args)
     if returncode != 0:
       return (False, stderr, ())
 
-    cts = set()
+    cts = []
     for line in stdout:
       if not line.strip():
         continue
       ctinfo = _parse_cquery_result_line(line)
       if ctinfo is not None:
-        cts.add(ctinfo)
+        cts.append(ctinfo)
 
     return (True, stderr, tuple(cts))
 

--- a/tools/ctexplain/bazel_api.py
+++ b/tools/ctexplain/bazel_api.py
@@ -47,7 +47,7 @@ def run_bazel_in_client(args: List[str]) -> Tuple[int, List[str], List[str]]:
       cwd=os.getcwd(),
       stdout=subprocess.PIPE,
       stderr=subprocess.PIPE,
-      check=True)
+      check=False)
   return (result.returncode, result.stdout.decode("utf-8").split(os.linesep),
           result.stderr)
 
@@ -81,6 +81,8 @@ class BazelApi():
 
     cts = set()
     for line in stdout:
+      if len(line.strip()) == 0:
+        continue
       ctinfo = _parse_cquery_result_line(line)
       if ctinfo is not None:
         cts.add(ctinfo)

--- a/tools/ctexplain/bazel_api_test.py
+++ b/tools/ctexplain/bazel_api_test.py
@@ -77,7 +77,7 @@ class BazelApiTest(test_base.TestBase):
     config = self._bazel_api.get_config(cts[0].config_hash)
     expected_fragments = ['PlatformConfiguration', 'JavaConfiguration']
     for exp in expected_fragments:
-      self.assertIn(exp, config.fragments)
+      self.assertIn(exp, config.fragments.keys())
     core_options = config.options['CoreOptions']
     self.assertIsNotNone(core_options)
     self.assertIn(('stamp', 'false'), core_options.items())
@@ -110,6 +110,16 @@ class BazelApiTest(test_base.TestBase):
     # Null configurations have no information by definition.
     self.assertEqual(len(config.fragments), 0)
     self.assertEqual(len(config.options), 0)
+
+  def testConfigFragmentsMap(self):
+    self.ScratchFile('testapp/BUILD', [
+        'filegroup(name = "fg", srcs = ["a.file"])',
+    ])
+    cts = self._bazel_api.cquery(['//testapp:fg'])[2]
+    fragments_map = self._bazel_api.get_config(cts[0].config_hash).fragments
+    self.assertIn("PlatformOptions", fragments_map["PlatformConfiguration"])
+    self.assertIn(
+      "ShellConfiguration$Options", fragments_map["ShellConfiguration"])
 
   def testConfigWithDefines(self):
     self.ScratchFile('testapp/BUILD', [

--- a/tools/ctexplain/bazel_api_test.py
+++ b/tools/ctexplain/bazel_api_test.py
@@ -117,9 +117,9 @@ class BazelApiTest(test_base.TestBase):
     ])
     cts = self._bazel_api.cquery(['//testapp:fg'])[2]
     fragments_map = self._bazel_api.get_config(cts[0].config_hash).fragments
-    self.assertIn("PlatformOptions", fragments_map["PlatformConfiguration"])
+    self.assertIn('PlatformOptions', fragments_map['PlatformConfiguration'])
     self.assertIn(
-      "ShellConfiguration$Options", fragments_map["ShellConfiguration"])
+        'ShellConfiguration$Options', fragments_map['ShellConfiguration'])
 
   def testConfigWithDefines(self):
     self.ScratchFile('testapp/BUILD', [

--- a/tools/ctexplain/ctexplain.py
+++ b/tools/ctexplain/ctexplain.py
@@ -40,10 +40,10 @@ from typing import Tuple
 from absl import app
 from absl import flags
 
-import tools.ctexplain.analyses.summary
-import tools.ctexplain.bazel_api
-import tools.ctexplain.ctexplain_lib
-import tools.ctexplain.util
+import tools.ctexplain.analyses.summary as summary
+import tools.ctexplain.bazel_api as bazel_api
+import tools.ctexplain.lib as lib
+import tools.ctexplain.util as util
 
 FLAGS = flags.FLAGS
 
@@ -51,7 +51,7 @@ FLAGS = flags.FLAGS
 # (implementation(cts: Tuple[ConfiguredTarget, ...]), descriptive help text).
 analyses = {
     "summary": (
-        lambda x: summary.report(summary.analyze(x))
+        lambda x: summary.report(summary.analyze(x)),
         "summarizes build graph size and how trimming could help"
     ),
     "culprits": (
@@ -132,7 +132,7 @@ def main(argv):
   (labels, build_flags) = _get_build_flags(FLAGS.build[0])
   build_desc = ",".join(labels)
   with util.ProgressStep(f'Collecting configured targets for {build_desc}'):
-    cts = lib.analyze_build(BazelApi(), labels, build_flags)
+    cts = lib.analyze_build(bazel_api.BazelApi(), labels, build_flags)
   for analysis in FLAGS.analysis:
     analyses[analysis][0](cts)
 

--- a/tools/ctexplain/ctexplain.py
+++ b/tools/ctexplain/ctexplain.py
@@ -131,7 +131,7 @@ def main(argv):
 
   (labels, build_flags) = _get_build_flags(FLAGS.build[0])
   build_desc = ",".join(labels)
-  with util.ProgressStep(f'Collecting configured targets for {build_desc}'):
+  with util.ProgressStep(f"Collecting configured targets for {build_desc}"):
     cts = lib.analyze_build(bazel_api.BazelApi(), labels, build_flags)
   for analysis in FLAGS.analysis:
     analyses[analysis][0](cts)

--- a/tools/ctexplain/ctexplain_lib.py
+++ b/tools/ctexplain/ctexplain_lib.py
@@ -25,9 +25,6 @@ def analyze_build(bazel_api: BazelApi, labels: Tuple[str, ...],
     cquery_args = [f'deps({",".join(labels)})']
     cquery_args.extend(build_flags)
     (success, stderr, cts) = bazel_api.cquery(cquery_args)
-    print(f"success: {success}")
-    print(f"stderr: {stderr}")
-    print(f"CTs: {len(cts)}")
     return cts
 
 
@@ -35,11 +32,3 @@ def analyze_build(bazel_api: BazelApi, labels: Tuple[str, ...],
 # Report basic statistics
 # Get the trimmed CT graph
 # Report comparative statistics
-
-# Collect results into a machine-readable data structure
-# Pass through user outputters for user-friendly output.
-
-# TODO(gregce): move all logic to a _lib library so we can easily include
-# end-to-end testing. We'll only handle flag parsing here, which we pass
-# into the main invoker as standard Python args.
-

--- a/tools/ctexplain/ctexplain_lib.py
+++ b/tools/ctexplain/ctexplain_lib.py
@@ -21,14 +21,22 @@ from tools.ctexplain.types import ConfiguredTarget
 
 def analyze_build(bazel_api: BazelApi, labels: Tuple[str, ...],
                   build_flags: Tuple[str, ...]) -> Tuple[ConfiguredTarget, ...]:
-    """Documentation here"""
-    cquery_args = [f'deps({",".join(labels)})']
-    cquery_args.extend(build_flags)
-    (success, stderr, cts) = bazel_api.cquery(cquery_args)
-    return cts
+  """Gets a build invocation's configured targets.
 
+  Args:
+    bazel_api: API for invoking Bazel.
+    labels: The targets to build.
+    build_flags: The build flags to use.
 
-# Get a build's CTs
-# Report basic statistics
-# Get the trimmed CT graph
-# Report comparative statistics
+  Returns:
+    Set of configured targets representing the build.
+
+  Raises:
+    RuntimeError: On any invocation errors.
+  """
+  cquery_args = [f'deps({",".join(labels)})']
+  cquery_args.extend(build_flags)
+  (success, stderr, cts) = bazel_api.cquery(cquery_args)
+  if not success:
+    raise RuntimeError("invocation failed: " + stderr)
+  return cts

--- a/tools/ctexplain/ctexplain_lib.py
+++ b/tools/ctexplain/ctexplain_lib.py
@@ -1,0 +1,45 @@
+# Lint as: python3
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ctexplain business logic."""
+from typing import Tuple
+
+from tools.ctexplain.bazel_api import BazelApi
+from tools.ctexplain.types import ConfiguredTarget
+
+
+def analyze_build(bazel_api: BazelApi, labels: Tuple[str, ...],
+                  build_flags: Tuple[str, ...]) -> Tuple[ConfiguredTarget, ...]:
+    """Documentation here"""
+    cquery_args = [f'deps({",".join(labels)})']
+    cquery_args.extend(build_flags)
+    (success, stderr, cts) = bazel_api.cquery(cquery_args)
+    print(f"success: {success}")
+    print(f"stderr: {stderr}")
+    print(f"CTs: {len(cts)}")
+    return cts
+
+
+# Get a build's CTs
+# Report basic statistics
+# Get the trimmed CT graph
+# Report comparative statistics
+
+# Collect results into a machine-readable data structure
+# Pass through user outputters for user-friendly output.
+
+# TODO(gregce): move all logic to a _lib library so we can easily include
+# end-to-end testing. We'll only handle flag parsing here, which we pass
+# into the main invoker as standard Python args.
+

--- a/tools/ctexplain/lib.py
+++ b/tools/ctexplain/lib.py
@@ -45,9 +45,11 @@ def analyze_build(bazel: bazel_api.BazelApi, labels: Tuple[str, ...],
   hashes_to_configs = {}
   cts_with_configs = []
   for ct in cts:
-    config = hashes_to_configs.setdefault(
-        ct.config_hash,
-        lambda: bazel.get_config(ct.config_hash))
+    # Don't use dict.setdefault because that unconditionally calls get_config
+    # as one of its parameters and that's an expensive operation to waste.
+    if ct.config_hash not in hashes_to_configs:
+      hashes_to_configs[ct.config_hash] = bazel.get_config(ct.config_hash)
+    config = hashes_to_configs[ct.config_hash]
     cts_with_configs.append(
         ConfiguredTarget(
             ct.label,

--- a/tools/ctexplain/lib.py
+++ b/tools/ctexplain/lib.py
@@ -47,7 +47,7 @@ def analyze_build(bazel: bazel_api.BazelApi, labels: Tuple[str, ...],
   for ct in cts:
     config = hashes_to_configs.setdefault(
         ct.config_hash,
-        bazel.get_config(ct.config_hash))
+        lambda: bazel.get_config(ct.config_hash))
     cts_with_configs.append(
         ConfiguredTarget(
             ct.label,

--- a/tools/ctexplain/lib.py
+++ b/tools/ctexplain/lib.py
@@ -12,14 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""ctexplain business logic."""
+"""General-purpose business logic."""
 from typing import Tuple
 
-from tools.ctexplain.bazel_api import BazelApi
+import tools.ctexplain.bazel_api
 from tools.ctexplain.types import ConfiguredTarget
 
 
-def analyze_build(bazel_api: BazelApi, labels: Tuple[str, ...],
+def analyze_build(bazel_api: bazel_api.BazelApi, labels: Tuple[str, ...],
                   build_flags: Tuple[str, ...]) -> Tuple[ConfiguredTarget, ...]:
   """Gets a build invocation's configured targets.
 

--- a/tools/ctexplain/lib.py
+++ b/tools/ctexplain/lib.py
@@ -29,7 +29,7 @@ def analyze_build(bazel: bazel_api.BazelApi, labels: Tuple[str, ...],
     build_flags: The build flags to use.
 
   Returns:
-    Set of configured targets representing the build.
+    Configured targets representing the build.
 
   Raises:
     RuntimeError: On any invocation errors.

--- a/tools/ctexplain/lib_test.py
+++ b/tools/ctexplain/lib_test.py
@@ -1,0 +1,91 @@
+# Lint as: python3
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for lib.py."""
+import os
+import unittest
+from src.test.py.bazel import test_base
+import tools.ctexplain.bazel_api as bazel_api
+import tools.ctexplain.lib as lib
+from tools.ctexplain.types import Configuration
+from tools.ctexplain.types import HostConfiguration
+from tools.ctexplain.types import NullConfiguration
+
+
+class LibTest(test_base.TestBase):
+
+  _bazel: bazel_api.BazelApi = None
+
+  def setUp(self):
+    test_base.TestBase.setUp(self)
+    self._bazel = bazel_api.BazelApi(self.RunBazel)
+    self.ScratchFile('WORKSPACE')
+    self.CreateWorkspaceWithDefaultRepos('repo/WORKSPACE')
+
+  def tearDown(self):
+    test_base.TestBase.tearDown(self)
+
+  def testAnalyzeBuild(self):
+    self.ScratchFile('testapp/defs.bzl', [
+        'def _impl(ctx):',
+        '    pass',
+        'rule_with_host_dep = rule(',
+        '    implementation = _impl,',
+        '    attrs = { "host_deps": attr.label_list(cfg = "host") })',
+    ])
+    self.ScratchFile('testapp/BUILD', [
+        'load("//testapp:defs.bzl", "rule_with_host_dep")',
+        'rule_with_host_dep(name = "a", host_deps = [":h"])',
+        'filegroup(name = "h", srcs = ["h.src"])'
+    ])
+    cts = lib.analyze_build(self._bazel, ("//testapp:a",), ())
+    # Remove boilerplate deps to focus on targets declared here.
+    cts = [ct for ct in cts if ct.label.startswith("//testapp")]
+
+    self.assertListEqual(
+        [ct.label for ct in cts],
+        ['//testapp:a', '//testapp:h', '//testapp:h.src'])
+    # Don't use assertIsInstance because we don't want to match subclasses.
+    self.assertEqual(Configuration, type(cts[0].config))
+    self.assertEqual('HOST', cts[1].config_hash)
+    self.assertIsInstance(cts[1].config, HostConfiguration)
+    self.assertEqual('null', cts[2].config_hash)
+    self.assertIsInstance(cts[2].config, NullConfiguration)
+
+  def testAnalyzeBuildNoRepeats(self):
+    self.ScratchFile('testapp/defs.bzl', [
+        'def _impl(ctx):',
+        '    pass',
+        'rule_with_host_dep = rule(',
+        '    implementation = _impl,',
+        '    attrs = { "host_deps": attr.label_list(cfg = "host") })',
+    ])
+    self.ScratchFile('testapp/BUILD', [
+        'load("//testapp:defs.bzl", "rule_with_host_dep")',
+        'rule_with_host_dep(name = "a", host_deps = [":h", ":other"])',
+        'rule_with_host_dep(name = "other")',
+        'filegroup(name = "h", srcs = ["h.src", ":other"])'
+    ])
+    cts = lib.analyze_build(self._bazel, ("//testapp:a",), ())
+    # Remove boilerplate deps to focus on targets declared here.
+    cts = [ct for ct in cts if ct.label.startswith("//testapp")]
+
+    # Even though the build references //testapp:other twice, it only appears
+    # once.
+    self.assertListEqual(
+        [ct.label for ct in cts],
+        ['//testapp:a', '//testapp:h', '//testapp:other', '//testapp:h.src'])
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tools/ctexplain/lib_test.py
+++ b/tools/ctexplain/lib_test.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for lib.py."""
-import os
 import unittest
 from src.test.py.bazel import test_base
 import tools.ctexplain.bazel_api as bazel_api
@@ -49,9 +48,9 @@ class LibTest(test_base.TestBase):
         'rule_with_host_dep(name = "a", host_deps = [":h"])',
         'filegroup(name = "h", srcs = ["h.src"])'
     ])
-    cts = lib.analyze_build(self._bazel, ("//testapp:a",), ())
+    cts = lib.analyze_build(self._bazel, ('//testapp:a',), ())
     # Remove boilerplate deps to focus on targets declared here.
-    cts = [ct for ct in cts if ct.label.startswith("//testapp")]
+    cts = [ct for ct in cts if ct.label.startswith('//testapp')]
 
     self.assertListEqual(
         [ct.label for ct in cts],
@@ -77,9 +76,9 @@ class LibTest(test_base.TestBase):
         'rule_with_host_dep(name = "other")',
         'filegroup(name = "h", srcs = ["h.src", ":other"])'
     ])
-    cts = lib.analyze_build(self._bazel, ("//testapp:a",), ())
+    cts = lib.analyze_build(self._bazel, ('//testapp:a',), ())
     # Remove boilerplate deps to focus on targets declared here.
-    cts = [ct for ct in cts if ct.label.startswith("//testapp")]
+    cts = [ct for ct in cts if ct.label.startswith('//testapp')]
 
     # Even though the build references //testapp:other twice, it only appears
     # once.

--- a/tools/ctexplain/types.py
+++ b/tools/ctexplain/types.py
@@ -26,16 +26,20 @@ from frozendict import frozendict
 @dataclass(frozen=True)
 class Configuration():
   """Stores a build configuration as a collection of fragments and options."""
-  # BuildConfiguration.Fragments in this configuration, as base names without
-  # packages. For example: ["PlatformConfiguration", ...].
-  fragments: Tuple[str, ...]
+  # Mapping of each BuildConfiguration.Fragment in this configuration to the
+  # FragmentOptions it requires.
+  #
+  # All names are qualified up to the base file name, without package prefixes.
+  # For example, foo.bar.BazConfiguration appears as "BazConfiguration".
+  # foo.bar.BazConfiguration$Options appears as "BazeConfiguration$Options".
+  fragments: Mapping[str, Tuple[str, ...]]
   # Mapping of FragmentOptions to option key/value pairs. For example:
   # {"CoreOptions": {"action_env": "[]", "cpu": "x86", ...}, ...}.
   #
   # Option values are stored as strings of whatever "bazel config" outputs.
   #
   # Note that Fragment and FragmentOptions aren't the same thing.
-  options: [Mapping[str, Mapping[str, str]]]
+  options: Mapping[str, Mapping[str, str]]
 
 
 @dataclass(frozen=True)
@@ -49,7 +53,7 @@ class ConfiguredTarget():
   config_hash: str
   # Fragments required by this configured target and its transitive
   # dependencies. Stored as base names without packages. For example:
-  # "PlatformOptions".
+  # "PlatformOptions" or "FooConfiguration$Options".
   transitive_fragments: Tuple[str, ...]
 
 

--- a/tools/ctexplain/util.py
+++ b/tools/ctexplain/util.py
@@ -15,6 +15,7 @@
 """Generic utilities."""
 import time
 
+
 class ProgressStep:
   """A simple context manager that prints a progress message.
 
@@ -50,3 +51,4 @@ def percent_diff(val1, val2):
   """
   diff = (val2 - val1) / val1 * 100
   return f"+{diff:.1f}%" if diff >= 0 else f"{diff:.1f}%"
+  

--- a/tools/ctexplain/util.py
+++ b/tools/ctexplain/util.py
@@ -1,0 +1,52 @@
+# Lint as: python3
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generic utilities."""
+import time
+
+class ProgressStep:
+  """A simple context manager that prints a progress message.
+
+    Forked from a similar project by brandjon@google.com.
+  """
+
+  def __init__(self, msg, show_done=True):
+    self.msg = msg
+    self.show_done = show_done
+
+  def __enter__(self):
+    print(self.msg + "...", flush=True, end="")
+    self.start_time = time.perf_counter()
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    if self.show_done:
+      elapsed_sec = time.perf_counter() - self.start_time
+      if elapsed_sec < 0.1:
+        time_str = f"{elapsed_sec * 1000:.0f} ms"
+      else:
+        time_str = f"{elapsed_sec:.2f} s"
+      print(f" done in {time_str}.", flush=True)
+
+
+def percent_diff(val1, val2):
+  """Returns what percentage a change val2 is from val1.
+
+  For example, if val=10 and val2=15, returns '+50%'.
+
+  Args:
+    val1: Base number.
+    val2: Number to compare against the base number.
+  """
+  diff = (val2 - val1) / val1 * 100
+  return f"+{diff:.1f}%" if diff >= 0 else f"{diff:.1f}%"


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/pull/11511 set up basic project structure.  This PR adds minimum working functionality.

Specifically, you can run it with a build command and it reports basic stats on the build's graph.

Example:

```
$ bazel-bin/tools/ctexplain/ctexplain -b "//testapp:foo"
Collecting configured targets for //testapp:foo... done in 0.62 s.

Configurations: 3
Targets: 79
Configured targets: 92 (+16.5% vs. targets)
Targets with multiple configs: 13
```

Notes:
* Changed import structure to prefer module imports over function, class imports (style guide recommendation)
* Set up structure for injecting arbitrary analyses. Each analysis consumes the build's set of configured targets and can output whatever it wants.
* Implemented one basic analysis
* Structured code to make it easy to fork output formatters (e.g. for machine-readable output). But tried not to add speculative inheritance / boilerplate too soon

Context: [Measuring Configuration Overhead](https://docs.google.com/document/d/10ZxO2wZdKJATnYBqAm22xT1k5r4Vp6QX96TkqSUIhs0/edit).
Work towards #10613