### PR TITLE
Reduce number of digest calculations

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/cache/DigestUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/cache/DigestUtils.java
@@ -244,7 +244,8 @@ public class DigestUtils {
     Cache<CacheKey, byte[]> cache = globalCache;
     CacheKey key = null;
     if (cache != null) {
-      key = new CacheKey(path, path.stat());
+      Path canonicalPath = path.resolveSymbolicLinks();
+      key = new CacheKey(canonicalPath, canonicalPath.stat());
       digest = cache.getIfPresent(key);
       if (digest != null) {
         return digest;


### PR DESCRIPTION
Only calculate digest once per file, even if there are multiple symbolic links pointing to the same file.
This reduce build times when the digests are not already available in memory, e.g. if the bazel server process has been restarted.

Related to #11831