### PR TITLE
Adds a note on symlinking a specific version to `bazel`.

### DIFF
--- a/site/docs/install-ubuntu.md
+++ b/site/docs/install-ubuntu.md
@@ -69,6 +69,13 @@ can be useful if you need a specific version of Bazel to build a project, e.g.
 because it uses a `.bazelversion` file to explicitly state with which Bazel
 version it should be built.
 
+Optionally, this version can be symlinked to `bazel` via the following command:
+
+```shell
+sudo ln -s /usr/bin/bazel-1.0.0 /usr/bin/bazel
+bazel --version  # 1.0.0
+```
+
 ### Step 3: Install a JDK (optional)
 
 Bazel includes a private, bundled JRE as its runtime and doesn't require you to


### PR DESCRIPTION
I use this doc to install specific versions of `bazel` on new machines fairly frequently and would find this helpful.