### PR TITLE
Support deterministic mode when using a version of libtool that supports it.

### DIFF
--- a/tools/objc/libtool.sh
+++ b/tools/objc/libtool.sh
@@ -85,7 +85,7 @@ while [[ $# -gt 0 ]]; do
      OUTPUTFILE="${ARG}"
      ;;
    # Flags with no args
-    -static|-s|-a|-c|-L|-T|-no_warning_for_no_symbols)
+    -static|-s|-a|-c|-L|-T|-D|-no_warning_for_no_symbols)
       ARGS+=("${ARG}")
       ;;
    # Single-arg flags

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -30,6 +30,30 @@ load(
 )
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 
+# The Xcode version from which that has support for deterministic mode
+_SUPPORTS_DETERMINISTIC_MODE = "10.2"
+
+def _compare_versions(dv1, v2):
+    """Return value is <0, 0, >0 depending on DottedVersion dv1 comparison to string v2."""
+    return dv1.compare_to(apple_common.dotted_version(v2))
+
+def _can_use_deterministic_libtool(ctx):
+    """Returns `True` if the current version of `libtool` has support for
+    deterministic mode, and `False` otherwise."""
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    xcode_version = xcode_config.xcode_version()
+    if _compare_versions(xcode_version, _SUPPORTS_DETERMINISTIC_MODE) >= 0:
+        return True
+    else:
+        return False
+
+def _deterministic_libtool_flags(ctx):
+    """Returns additional `libtool` flags to enable deterministic mode, if they
+    are available."""
+    if _can_use_deterministic_libtool(ctx):
+        return ["-D"]
+    return []
+
 def _impl(ctx):
     if (ctx.attr.cpu == "darwin_x86_64"):
         toolchain_identifier = "darwin_x86_64"
@@ -1801,7 +1825,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-filelist",
@@ -1832,7 +1856,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-filelist",
@@ -1864,7 +1888,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-filelist",
@@ -1895,7 +1919,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-filelist",
@@ -1926,7 +1950,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-filelist",
@@ -1957,7 +1981,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-filelist",
@@ -1989,7 +2013,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-filelist",
@@ -2023,7 +2047,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-filelist",
@@ -2805,7 +2829,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-arch_only",
@@ -2846,7 +2870,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-arch_only",
@@ -2888,7 +2912,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-arch_only",
@@ -2929,7 +2953,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-arch_only",
@@ -2970,7 +2994,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-arch_only",
@@ -3011,7 +3035,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-arch_only",
@@ -3053,7 +3077,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-arch_only",
@@ -3097,7 +3121,7 @@ def _impl(ctx):
                 flag_set(
                     flag_groups = [
                         flag_group(
-                            flags = [
+                            flags = _deterministic_libtool_flags(ctx) + [
                                 "-no_warning_for_no_symbols",
                                 "-static",
                                 "-arch_only",
@@ -5010,7 +5034,12 @@ def _impl(ctx):
                 actions = [ACTION_NAMES.cpp_link_static_library],
                 flag_groups = [
                     flag_group(
-                        flags = ["-no_warning_for_no_symbols", "-static", "-o", "%{output_execpath}"],
+                        flags = _deterministic_libtool_flags(ctx) + [
+                            "-no_warning_for_no_symbols",
+                            "-static",
+                            "-o",
+                            "%{output_execpath}",
+                        ],
                         expand_if_available = "output_execpath",
                     ),
                 ],


### PR DESCRIPTION
Xcode 10.2 adds a new flag `-D` to libtool that sets archive contents'
user ids, group ids, dates, and file modes to reasonable defaults.

This patch adds this new flag to all libtool actions to when they're
built with a version of libtool that supports this mode, to ensure
hemertic results for linking actions. Note that this new flag covers the
functionality of the `ZERO_AR_DATE` environment variable, but this
variable is still being left in the libtool wrapper for
backward-compatibility with older versions.

Fixes https://github.com/bazelbuild/bazel/issues/10886.

RENOTES: None.