### PR TITLE
fix int overflow

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovJsonParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovJsonParser.java
@@ -112,7 +112,7 @@ public class GcovJsonParser {
 
   static class GcovJsonLine {
     GcovJsonBranch[] branches;
-    int count;
+    long count;
     int line_number;
     boolean unexecuted_block;
     String function_name;


### PR DESCRIPTION
When a UT test case run very long time. Lines that covered a lot of times. Int 32 could overflow. And in my real project, error occured

Recorded in:
https://github.com/bazelbuild/bazel/issues/9406#issuecomment-664211209