### PR TITLE
Fix environment for protobuf compilation in grpc

### DIFF
--- a/third_party/grpc/bazel/generate_cc.bzl
+++ b/third_party/grpc/bazel/generate_cc.bzl
@@ -124,6 +124,7 @@ def generate_cc_impl(ctx):
         outputs = out_files,
         executable = ctx.executable.protoc,
         arguments = arguments,
+        use_default_shell_env = True,
     )
 
     return struct(files = depset(out_files))

--- a/third_party/grpc/bazel_1.32.0.patch
+++ b/third_party/grpc/bazel_1.32.0.patch
@@ -213,7 +213,7 @@ index 484959ebb7..38a5b460f9 100644
      "get_include_directory",
      "get_plugin_args",
      "get_proto_root",
-@@ -117,34 +117,17 @@ def generate_cc_impl(ctx):
+@@ -118,34 +118,18 @@ def generate_cc_impl(ctx):
      arguments += ["--proto_path={0}{1}".format(dir_out, proto_root)]
      arguments += [_get_srcs_file_path(proto) for proto in protos]
  
@@ -242,6 +242,7 @@ index 484959ebb7..38a5b460f9 100644
 -        executable = ctx.executable._protoc,
 +        executable = ctx.executable.protoc,
          arguments = arguments,
++        use_default_shell_env = True,
      )
  
      return struct(files = depset(out_files))
@@ -251,7 +252,7 @@ index 484959ebb7..38a5b460f9 100644
      attrs = {
          "srcs": attr.label_list(
              mandatory = True,
-@@ -160,13 +143,12 @@ _generate_cc = rule(
+@@ -161,13 +145,12 @@ _generate_cc = rule(
              mandatory = False,
              allow_empty = True,
          ),
@@ -267,7 +268,7 @@ index 484959ebb7..38a5b460f9 100644
              executable = True,
              cfg = "host",
          ),
-@@ -175,12 +157,3 @@ _generate_cc = rule(
+@@ -176,12 +159,3 @@ _generate_cc = rule(
      output_to_genfiles = True,
      implementation = generate_cc_impl,
  )


### PR DESCRIPTION
Add use_default_shell_env = True to protoc invocation for grpc to mirror what the protobuf cc_proto_library & co are doing
Fixes a failure in invocing protoc when it is build in a non-default environment (e.g. with a custom LD_LIBRARY_PATH)

Fixes #11852, fixes #11855

This is a regression from 2.x to 3.0. Not sure what causes these issues but likely the upgrade of the used protobuf from 3.6 to 3.11