### PR TITLE
NDK 21 support

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/ndkcrosstools/AndroidNdkCrosstools.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/ndkcrosstools/AndroidNdkCrosstools.java
@@ -53,6 +53,7 @@ public final class AndroidNdkCrosstools {
           .put(18, new NdkMajorRevisionR18("7.0.2"))
           .put(19, new NdkMajorRevisionR19("8.0.2"))
           .put(20, new NdkMajorRevisionR19("8.0.7")) // no changes relevant to Bazel
+          .put(21, new NdkMajorRevisionR19("9.0.8")) // no changes relevant to Bazel
           .build();
 
   public static final Map.Entry<Integer, NdkMajorRevision> LATEST_KNOWN_REVISION =

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/ndkcrosstools/r19/ApiLevelR19.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/ndkcrosstools/r19/ApiLevelR19.java
@@ -35,6 +35,7 @@ final class ApiLevelR19 extends ApiLevel {
           .putAll("26", "arm", "x86", "arm64", "x86_64")
           .putAll("27", "arm", "x86", "arm64", "x86_64")
           .putAll("28", "arm", "x86", "arm64", "x86_64")
+          .putAll("29", "arm", "x86", "arm64", "x86_64")
           .build();
 
   /** This map fill in the gaps of {@code API_LEVEL_TO_ARCHITECTURES}. */
@@ -53,6 +54,7 @@ final class ApiLevelR19 extends ApiLevel {
           .put("26", "26")
           .put("27", "27")
           .put("28", "28")
+          .put("29", "29")
           .build();
 
   ApiLevelR19(EventHandler eventHandler, String repositoryName, String apiLevel) {

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryTest.java
@@ -117,7 +117,7 @@ public class AndroidNdkRepositoryTest extends BuildViewTestCase {
         eventCollector,
         "The revision of the Android NDK referenced by android_ndk_repository rule 'androidndk' "
             + "could not be determined (the revision string found is 'not a valid release string')."
-            + " Bazel will attempt to treat the NDK as if it was r20.");
+            + " Bazel will attempt to treat the NDK as if it was r21.");
   }
 
   @Test
@@ -145,7 +145,7 @@ public class AndroidNdkRepositoryTest extends BuildViewTestCase {
         eventCollector,
         "The revision of the Android NDK referenced by android_ndk_repository rule 'androidndk' "
             + "could not be determined (the revision string found is 'invalid package revision'). "
-            + "Bazel will attempt to treat the NDK as if it was r20.");
+            + "Bazel will attempt to treat the NDK as if it was r21.");
   }
 
   @Test
@@ -162,16 +162,16 @@ public class AndroidNdkRepositoryTest extends BuildViewTestCase {
         ")");
 
     scratch.overwriteFile(
-        "/ndk/source.properties", "Pkg.Desc = Android NDK", "Pkg.Revision = 21.0.3675639-beta2");
+        "/ndk/source.properties", "Pkg.Desc = Android NDK", "Pkg.Revision = 22.0.3675639-beta2");
     invalidatePackages();
 
     assertThat(getConfiguredTarget("@androidndk//:files")).isNotNull();
     MoreAsserts.assertContainsEvent(
         eventCollector,
         "The major revision of the Android NDK referenced by android_ndk_repository rule "
-            + "'androidndk' is 21. The major revisions supported by Bazel are "
-            + "[10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]. "
-            + "Bazel will attempt to treat the NDK as if it was r20.");
+            + "'androidndk' is 22. The major revisions supported by Bazel are "
+            + "[10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]. "
+            + "Bazel will attempt to treat the NDK as if it was r21.");
   }
 
   @Test


### PR DESCRIPTION
This change includes support for Android NDK r21, largely based on the
support of NDK r19.

Closes #10811
Closes #11084

Signed-off-by: Steeve Morin <steeve@zen.ly>