### PR TITLE
Starlark: do not lose cause in EvalExceptionWithStackTrace

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/EvalExceptionWithStackTrace.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/EvalExceptionWithStackTrace.java
@@ -48,7 +48,7 @@ public class EvalExceptionWithStackTrace extends EvalException {
   EvalExceptionWithStackTrace(EvalException original, Node culprit) {
     // The 'message' here must be non-empty in case getCause() is null,
     // as the super(-fragile) constructor crashes if both are empty.
-    super(nodeLocation(culprit), getNonEmptyMessage(original), original.getCause());
+    super(nodeLocation(culprit), getNonEmptyMessage(original), original);
     registerNode(culprit);
   }
 


### PR DESCRIPTION
Comapare stack traces: exception is thrown from `Eval.evalIdentifier`
but it is not visible before this PR.

Stack trace now:

```
global variable 'func1' is referenced before assignment.
com.google.devtools.build.lib.syntax.EvalExceptionWithStackTrace:
	at com.google.devtools.build.lib.syntax.Eval.maybeTransformException(Eval.java:817)
	at com.google.devtools.build.lib.syntax.Eval.eval(Eval.java:446)
	at com.google.devtools.build.lib.syntax.Eval.evalCall(Eval.java:514)
	at com.google.devtools.build.lib.syntax.Eval.eval(Eval.java:428)
	at com.google.devtools.build.lib.syntax.Eval.execAssignment(Eval.java:80)
	at com.google.devtools.build.lib.syntax.Eval.execDispatch(Eval.java:242)
	at com.google.devtools.build.lib.syntax.Eval.exec(Eval.java:232)
	at com.google.devtools.build.lib.syntax.Eval.execStatements(Eval.java:53)
	at com.google.devtools.build.lib.syntax.Eval.execFunctionBody(Eval.java:37)
	at com.google.devtools.build.lib.syntax.StarlarkFunction.fastcall(StarlarkFunction.java:149)
	at com.google.devtools.build.lib.syntax.Starlark.fastcall(Starlark.java:450)
	at com.google.devtools.build.lib.syntax.EvalUtils.exec(EvalUtils.java:609)
	at com.google.devtools.build.lib.syntax.EvalUtils.exec(EvalUtils.java:595)
	at com.google.devtools.build.lib.syntax.util.EvaluationTestCase.exec(EvaluationTestCase.java:121)
	at com.google.devtools.build.lib.syntax.FunctionTest.testFunctionCallFromFunctionReadGlobalVar(FunctionTest.java:219)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at com.google.testing.junit.runner.internal.junit4.CancellableRequestFactory$CancellableRunner.run(CancellableRequestFactory.java:89)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:112)
	at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:159)
	at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:85)
Caused by: com.google.devtools.build.lib.syntax.EvalException:
	at com.google.devtools.build.lib.syntax.Eval.evalIdentifier(Eval.java:656)
	at com.google.devtools.build.lib.syntax.Eval.eval(Eval.java:430)
	... 48 more
```

before this change:

```
global variable 'func1' is referenced before assignment.
com.google.devtools.build.lib.syntax.EvalExceptionWithStackTrace:
	at com.google.devtools.build.lib.syntax.Eval.maybeTransformException(Eval.java:817)
	at com.google.devtools.build.lib.syntax.Eval.eval(Eval.java:446)
	at com.google.devtools.build.lib.syntax.Eval.evalCall(Eval.java:514)
	at com.google.devtools.build.lib.syntax.Eval.eval(Eval.java:428)
	at com.google.devtools.build.lib.syntax.Eval.execAssignment(Eval.java:80)
	at com.google.devtools.build.lib.syntax.Eval.execDispatch(Eval.java:242)
	at com.google.devtools.build.lib.syntax.Eval.exec(Eval.java:232)
	at com.google.devtools.build.lib.syntax.Eval.execStatements(Eval.java:53)
	at com.google.devtools.build.lib.syntax.Eval.execFunctionBody(Eval.java:37)
	at com.google.devtools.build.lib.syntax.StarlarkFunction.fastcall(StarlarkFunction.java:149)
	at com.google.devtools.build.lib.syntax.Starlark.fastcall(Starlark.java:450)
	at com.google.devtools.build.lib.syntax.EvalUtils.exec(EvalUtils.java:609)
	at com.google.devtools.build.lib.syntax.EvalUtils.exec(EvalUtils.java:595)
	at com.google.devtools.build.lib.syntax.util.EvaluationTestCase.exec(EvaluationTestCase.java:121)
	at com.google.devtools.build.lib.syntax.FunctionTest.testFunctionCallFromFunctionReadGlobalVar(FunctionTest.java:219)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at com.google.testing.junit.runner.internal.junit4.CancellableRequestFactory$CancellableRunner.run(CancellableRequestFactory.java:89)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:112)
	at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:159)
	at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:85)
```