### PR TITLE
Starlark: fix comprehension variable resolution

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/syntax/Resolver.java
+++ b/src/main/java/com/google/devtools/build/lib/syntax/Resolver.java
@@ -496,14 +496,8 @@ public final class Resolver extends NodeVisitor {
     for (Comprehension.Clause clause : node.getClauses()) {
       if (clause instanceof Comprehension.For) {
         Comprehension.For forClause = (Comprehension.For) clause;
-        createBindings(forClause.getVars());
-      }
-    }
-    // TODO(adonovan): opt: combine loops
-    for (Comprehension.Clause clause : node.getClauses()) {
-      if (clause instanceof Comprehension.For) {
-        Comprehension.For forClause = (Comprehension.For) clause;
         visit(forClause.getIterable());
+        createBindings(forClause.getVars());
         assign(forClause.getVars());
       } else {
         Comprehension.If ifClause = (Comprehension.If) clause;

--- a/src/test/java/com/google/devtools/build/lib/syntax/EvaluationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/EvaluationTest.java
@@ -507,14 +507,14 @@ public final class EvaluationTest {
     // because it doesn't record the scope in the syntax tree.)
     ev.new Scenario()
         .testIfErrorContains(
-            "local variable 'y' is referenced before assignment", //
+            "name 'y' is not defined", //
             "[x for x in (1, 2) if y for y in (3, 4)]");
 
     // This is the corresponding test for BUILD files.
-    EvalException ex =
+    SyntaxError.Exception ex =
         assertThrows(
-            EvalException.class, () -> execBUILD("[x for x in (1, 2) if y for y in (3, 4)]"));
-    assertThat(ex).hasMessageThat().isEqualTo("variable 'y' is referenced before assignment");
+            SyntaxError.Exception.class, () -> execBUILD("[x for x in (1, 2) if y for y in (3, 4)]"));
+    assertThat(ex).hasMessageThat().isEqualTo("name 'y' is not defined");
   }
 
   private static void execBUILD(String... lines)
@@ -716,6 +716,16 @@ public final class EvaluationTest {
             // Use short-circuiting to produce valid output in the event
             // the exception is not raised.
             "[y for x in xs for y in (xs.append(4) or xs)]");
+  }
+
+  @Test
+  public void testCompr() throws Exception {
+    ev.new Scenario()
+      .setUp("x = [[1, 2]]")
+      .testExpression(
+        "[x for x in x for y in x]",
+        StarlarkList.of(null, StarlarkList.of(null, 1, 2), StarlarkList.of(null, 1, 2)));
+
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/syntax/ResolverTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/ResolverTest.java
@@ -155,7 +155,6 @@ public class ResolverTest {
     // initialized).
     assertValid("a = a");
     assertValid("a += a");
-    assertValid("[[] for a in a]");
     assertValid("def f():", "  for a in a: pass");
   }
 


### PR DESCRIPTION
Fix this test:

```
x = [[1, 2]]
[x for x in x for y in x]
```

It should perform these steps:
* resolve first `x` in outer scope
* define local `x`
* resolve second `x` in the local scope