### PR TITLE
Remove deprecated usage from ubuntu instructions.

### DIFF
--- a/site/docs/install-ubuntu.md
+++ b/site/docs/install-ubuntu.md
@@ -33,7 +33,8 @@ Bazel comes with two completion scripts. After installing Bazel, you can:
 
 ```bash
 sudo apt install curl gnupg
-curl -f https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
+sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
 echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 ```
 


### PR DESCRIPTION
apt-key add is deprecated, using `/etc/apt/trusted.gpg.d` is the recommended approach now. De-armoring the GPG key before putting it there since some apt versions don't recognize armored keys, see https://github.com/openSUSE/software-o-o/pull/812