### PR TITLE
Add useDefaultShellEnvironment() in two places within the Java rules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/DeployArchiveBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/DeployArchiveBuilder.java
@@ -375,6 +375,7 @@ public class DeployArchiveBuilder {
     if (!usingNativeSinglejar) {
       ruleContext.registerAction(
           new SpawnAction.Builder()
+              .useDefaultShellEnvironment()
               .addTransitiveInputs(inputs.build())
               .addTransitiveInputs(JavaRuntimeInfo.forHost(ruleContext).javaBaseInputsMiddleman())
               .addOutput(outputJar)
@@ -390,6 +391,7 @@ public class DeployArchiveBuilder {
     } else {
       ruleContext.registerAction(
           new SpawnAction.Builder()
+              .useDefaultShellEnvironment()
               .addTransitiveInputs(inputs.build())
               .addOutput(outputJar)
               .setResources(DEPLOY_ACTION_RESOURCE_SET)

--- a/src/main/java/com/google/devtools/build/lib/rules/java/ResourceJarActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/ResourceJarActionBuilder.java
@@ -127,6 +127,7 @@ public class ResourceJarActionBuilder {
     }
     ruleContext.registerAction(
         builder
+            .useDefaultShellEnvironment()
             .addOutput(outputJar)
             .addInputs(messages)
             .addInputs(resources.values())


### PR DESCRIPTION
Two files in the Java tools were not using useDefaultShellEnvironment()
when using the SpawnAction.Builder class. This causes the PATH to be dropped
when using these rules, even if the user passed --action_env=PATH. This is
problematic for me because I depend on the PATH to help Bazel find the MSVCRT
dlls.