### PR TITLE
Use 'long' for execution counts in coverage output

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BranchCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BranchCoverage.java
@@ -20,13 +20,13 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 abstract class BranchCoverage {
 
-  static BranchCoverage create(int lineNumber, int nrOfExecutions) {
+  static BranchCoverage create(int lineNumber, long nrOfExecutions) {
     return new AutoValue_BranchCoverage(
         lineNumber, /*blockNumber=*/ "", /*branchNumber=*/ "", nrOfExecutions);
   }
 
   static BranchCoverage createWithBlockAndBranch(
-      int lineNumber, String blockNumber, String branchNumber, int nrOfExecutions) {
+      int lineNumber, String blockNumber, String branchNumber, long nrOfExecutions) {
     return new AutoValue_BranchCoverage(lineNumber, blockNumber, branchNumber, nrOfExecutions);
   }
 
@@ -54,7 +54,7 @@ abstract class BranchCoverage {
 
   abstract String branchNumber(); // internal gcc internal ID for the branch
 
-  abstract int nrOfExecutions();
+  abstract long nrOfExecutions();
 
   boolean wasExecuted() {
     return nrOfExecutions() > 0;

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovJsonParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovJsonParser.java
@@ -104,7 +104,7 @@ public class GcovJsonParser {
     int start_line;
     String name;
     int blocks_executed;
-    int execution_count;
+    long execution_count;
     String demangled_name;
     int start_column;
     int end_line;
@@ -112,7 +112,7 @@ public class GcovJsonParser {
 
   static class GcovJsonLine {
     GcovJsonBranch[] branches;
-    int count;
+    long count;
     int line_number;
     boolean unexecuted_block;
     String function_name;
@@ -120,7 +120,7 @@ public class GcovJsonParser {
 
   static class GcovJsonBranch {
     boolean fallthrough;
-    int count;
+    long count;
 
     @SerializedName("throw")
     boolean _throw;

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovParser.java
@@ -142,7 +142,7 @@ public class GcovParser {
     try {
       // Ignore end_line_number since it's redundant information.
       int startLine = Integer.parseInt(items[0]);
-      int execCount = items.length == 4 ? Integer.parseInt(items[2]) : Integer.parseInt(items[1]);
+      long execCount = items.length == 4 ? Long.parseLong(items[2]) : Long.parseLong(items[1]);
       String functionName = items.length == 4 ? items[3] : items[2];
       currentSourceFileCoverage.addLineNumber(functionName, startLine);
       currentSourceFileCoverage.addFunctionExecution(functionName, execCount);
@@ -167,7 +167,7 @@ public class GcovParser {
     try {
       // Ignore has_unexecuted_block since it's not used.
       int lineNr = Integer.parseInt(items[0]);
-      int execCount = Integer.parseInt(items[1]);
+      long execCount = Long.parseLong(items[1]);
       currentSourceFileCoverage.addLine(lineNr, LineCoverage.create(lineNr, execCount, null));
     } catch (NumberFormatException e) {
       logger.log(Level.WARNING, "gcov info contains invalid line " + line);

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovParser.java
@@ -184,7 +184,7 @@ class LcovParser {
       return false;
     }
     try {
-      int executionCount = Integer.parseInt(funcData[0]);
+      long executionCount = Long.parseLong(funcData[0]);
       String functionName = funcData[1];
       currentSourceFileCoverage.addFunctionExecution(functionName, executionCount);
     } catch (NumberFormatException e) {
@@ -246,7 +246,7 @@ class LcovParser {
     }
     try {
       int lineNumber = Integer.parseInt(lineData[0]);
-      int taken = Integer.parseInt(lineData[1]);
+      long taken = Long.parseLong(lineData[1]);
 
       BranchCoverage branchCoverage = BranchCoverage.create(lineNumber, taken);
 
@@ -279,9 +279,9 @@ class LcovParser {
       String taken = lineData[3];
 
       boolean wasExecuted = false;
-      int executionCount = 0;
+      long executionCount = 0;
       if (taken.equals(TAKEN)) {
-        executionCount = Integer.parseInt(taken);
+        executionCount = Long.parseLong(taken);
         wasExecuted = true;
       }
       BranchCoverage branchCoverage =
@@ -348,7 +348,7 @@ class LcovParser {
     }
     try {
       int lineNumber = Integer.parseInt(lineData[0]);
-      int executionCount = Integer.parseInt(lineData[1]);
+      long executionCount = Long.parseLong(lineData[1]);
       String checkSum = null;
       if (lineData.length == 3) {
         checkSum = lineData[2];

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
@@ -106,9 +106,9 @@ class LcovPrinter {
 
   // FNDA:<execution count>,<function name>
   private void printFNDALines(SourceFileCoverage sourceFile) throws IOException {
-    for (Entry<String, Integer> entry : sourceFile.getAllExecutionCount()) {
+    for (Entry<String, Long> entry : sourceFile.getAllExecutionCount()) {
       bufferedWriter.write(Constants.FNDA_MARKER);
-      bufferedWriter.write(Integer.toString(entry.getValue())); // execution count
+      bufferedWriter.write(Long.toString(entry.getValue())); // execution count
       bufferedWriter.write(Constants.DELIMITER);
       bufferedWriter.write(entry.getKey()); // function name
       bufferedWriter.newLine();
@@ -144,7 +144,7 @@ class LcovPrinter {
       bufferedWriter.write(branch.branchNumber());
       bufferedWriter.write(Constants.DELIMITER);
       if (branch.wasExecuted()) {
-        bufferedWriter.write(Integer.toString(branch.nrOfExecutions()));
+        bufferedWriter.write(Long.toString(branch.nrOfExecutions()));
       } else {
         bufferedWriter.write(Constants.TAKEN);
       }
@@ -195,7 +195,7 @@ class LcovPrinter {
       bufferedWriter.write(Constants.DA_MARKER);
       bufferedWriter.write(Integer.toString(lineExecution.lineNumber()));
       bufferedWriter.write(Constants.DELIMITER);
-      bufferedWriter.write(Integer.toString(lineExecution.executionCount()));
+      bufferedWriter.write(Long.toString(lineExecution.executionCount()));
       if (lineExecution.checksum() != null) {
         bufferedWriter.write(Constants.DELIMITER);
         bufferedWriter.write(lineExecution.checksum());

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LineCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LineCoverage.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 /** Stores line execution coverage information. */
 @AutoValue
 abstract class LineCoverage {
-  static LineCoverage create(int lineNumber, int executionCount, String checksum) {
+  static LineCoverage create(int lineNumber, long executionCount, String checksum) {
     return new AutoValue_LineCoverage(lineNumber, executionCount, checksum);
   }
 
@@ -34,7 +34,7 @@ abstract class LineCoverage {
 
   abstract int lineNumber();
 
-  abstract int executionCount();
+  abstract long executionCount();
   // The current geninfo implementation uses an MD5 hash as checksumming algorithm.
   @Nullable
   abstract String checksum(); // optional

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/SourceFileCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/SourceFileCoverage.java
@@ -30,7 +30,7 @@ class SourceFileCoverage {
 
   private String sourceFileName;
   private final TreeMap<String, Integer> lineNumbers; // function name to line numbers
-  private final TreeMap<String, Integer> functionsExecution; // function name to execution count
+  private final TreeMap<String, Long> functionsExecution; // function name to execution count
   private final TreeMap<Integer, BranchCoverage> branches; // line number to branch
   private final TreeMap<Integer, LineCoverage> lines; // line number to line execution
 
@@ -76,13 +76,13 @@ class SourceFileCoverage {
    * Returns the merged execution count found in the two given {@code SourceFileCoverage}s.
    */
   @VisibleForTesting
-  static TreeMap<String, Integer> mergeFunctionsExecution(
+  static TreeMap<String, Long> mergeFunctionsExecution(
       SourceFileCoverage s1, SourceFileCoverage s2) {
     return Stream.of(s1.functionsExecution, s2.functionsExecution)
         .map(Map::entrySet)
         .flatMap(Collection::stream)
         .collect(
-            Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Integer::sum, TreeMap::new));
+            Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Long::sum, TreeMap::new));
   }
 
   /*
@@ -190,11 +190,11 @@ class SourceFileCoverage {
   }
 
   @VisibleForTesting
-  TreeMap<String, Integer> getFunctionsExecution() {
+  TreeMap<String, Long> getFunctionsExecution() {
     return functionsExecution;
   }
 
-  Set<Entry<String, Integer>> getAllExecutionCount() {
+  Set<Entry<String, Long>> getAllExecutionCount() {
     return functionsExecution.entrySet();
   }
 
@@ -215,11 +215,11 @@ class SourceFileCoverage {
     this.lineNumbers.putAll(lineNumber);
   }
 
-  void addFunctionExecution(String functionName, Integer executionCount) {
+  void addFunctionExecution(String functionName, Long executionCount) {
     this.functionsExecution.put(functionName, executionCount);
   }
 
-  void addAllFunctionsExecution(TreeMap<String, Integer> functionsExecution) {
+  void addAllFunctionsExecution(TreeMap<String, Long> functionsExecution) {
     this.functionsExecution.putAll(functionsExecution);
   }
 

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BUILD
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BUILD
@@ -71,6 +71,7 @@ java_test(
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Coverage",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:LcovParser",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:SourceFileCoverage",
+        "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:LineCoverage",
     ],
 )
 

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovMergerTestUtils.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovMergerTestUtils.java
@@ -168,18 +168,18 @@ public class LcovMergerTestUtils {
 
   static final String FUNC_1 = "file1-func1";
   static final int FUNC_1_LINE_NR = 10;
-  static final int FUNC_1_NR_EXECUTED_LINES_TRACEFILE1 = 3;
-  static final int FUNC_1_NR_EXECUTED_LINES_TRACEFILE2 = 2;
+  static final long FUNC_1_NR_EXECUTED_LINES_TRACEFILE1 = 3;
+  static final long FUNC_1_NR_EXECUTED_LINES_TRACEFILE2 = 2;
 
   static final String FUNC_2 = "file1-func2";
   static final int FUNC_2_LINE_NR = 20;
-  static final int FUNC_2_NR_EXECUTED_LINES_TRACEFILE1 = 5;
-  static final int FUNC_2_NR_EXECECUTED_LINES_TRACEFILE2 = 3;
+  static final long FUNC_2_NR_EXECUTED_LINES_TRACEFILE1 = 5;
+  static final long FUNC_2_NR_EXECECUTED_LINES_TRACEFILE2 = 3;
 
   static final String FUNC_3 = "file1-func3";
   static final int FUNC_3_LINE_NR = 25;
-  static final int FUNC_3_NR_EXECUTED_LINES_TRACEFILE1 = 0;
-  static final int FUNC_3_NR_EXECUTED_LINES_TRACEFILE2 = 2;
+  static final long FUNC_3_NR_EXECUTED_LINES_TRACEFILE1 = 0;
+  static final long FUNC_3_NR_EXECUTED_LINES_TRACEFILE2 = 2;
 
   static final int NR_LINES_FOUND = 14;
   static final int NR_LINES_HIT_TRACEFILE1 = 10;
@@ -318,7 +318,7 @@ public class LcovMergerTestUtils {
     assertThat(lineNumbers.get(FUNC_2)).isEqualTo(FUNC_2_LINE_NR);
     assertThat(lineNumbers.get(FUNC_3)).isEqualTo(FUNC_3_LINE_NR);
 
-    Map<String, Integer> functionsExecution = sourceFile.getFunctionsExecution();
+    Map<String, Long> functionsExecution = sourceFile.getFunctionsExecution();
     assertThat(functionsExecution.size()).isEqualTo(3);
     assertThat(functionsExecution.keySet()).containsAtLeast(FUNC_1, FUNC_2, FUNC_3);
     assertThat(functionsExecution.get(FUNC_1)).isEqualTo(FUNC_1_NR_EXECUTED_LINES_TRACEFILE1);
@@ -339,7 +339,7 @@ public class LcovMergerTestUtils {
     assertThat(lineNumbers.get(FUNC_2)).isEqualTo(FUNC_2_LINE_NR);
     assertThat(lineNumbers.get(FUNC_3)).isEqualTo(FUNC_3_LINE_NR);
 
-    Map<String, Integer> functionsExecution = sourceFile.getFunctionsExecution();
+    Map<String, Long> functionsExecution = sourceFile.getFunctionsExecution();
     assertThat(functionsExecution.size()).isEqualTo(3);
     assertThat(functionsExecution.keySet()).containsAtLeast(FUNC_1, FUNC_2, FUNC_3);
     assertThat(functionsExecution.get(FUNC_1)).isEqualTo(FUNC_1_NR_EXECUTED_LINES_TRACEFILE2);
@@ -360,7 +360,7 @@ public class LcovMergerTestUtils {
     assertThat(lineNumbers.get(FUNC_3)).isEqualTo(FUNC_3_LINE_NR);
   }
 
-  static void assertMergedFunctionsExecution(TreeMap<String, Integer> functionsExecution) {
+  static void assertMergedFunctionsExecution(TreeMap<String, Long> functionsExecution) {
     assertThat(functionsExecution.size()).isEqualTo(3);
     assertThat(functionsExecution.keySet()).containsAtLeast(FUNC_1, FUNC_2, FUNC_3);
     assertThat(functionsExecution.get(FUNC_1))

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovParserTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovParserTest.java
@@ -22,11 +22,13 @@ import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.as
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -69,4 +71,32 @@ public class LcovParserTest {
     assertTracefile1(sourceFiles.get(0));
     assertTracefile2(sourceFiles.get(1));
   }
+
+  @Test
+  public void testParseTracefileWithLargeCounts() throws IOException {
+      List<String> tracefile = ImmutableList.of(
+          "SF:SOURCE_FILENAME",
+          "FN:4,file1-func1",
+          "FNDA:1000000000000,file1-func1",
+          "FNF:1",
+          "FNH:1",
+          "DA:4,1000000000000",
+          "DA:5,1000000000000",
+          "LH:2",
+          "LF:2",
+          "end_of_record");
+
+      List<SourceFileCoverage> sourceFiles =
+          LcovParser.parse(
+              new ByteArrayInputStream(Joiner.on("\n").join(tracefile).getBytes(UTF_8)));
+      SourceFileCoverage sourceFile = sourceFiles.get(0);
+
+      Map<String, Long> functions = sourceFile.getFunctionsExecution();
+      assertThat(functions.get("file1-func1")).isEqualTo(1000000000000L);
+
+      Map<Integer, LineCoverage> lines = sourceFile.getLines();
+      assertThat(lines.get(4).executionCount()).isEqualTo(1000000000000L);
+      assertThat(lines.get(5).executionCount()).isEqualTo(1000000000000L);
+  }
+
 }


### PR DESCRIPTION
It is possible in large projects for tests to trigger the execution of
some lines or functions more than 2^31-1 times (the signed int limit).
In these cases, combining merging reports will produce nonsense
outputs, perhaps even negative counts, or simply fail to parse the JSON
gcov output if a single test file triggers the problem.

Fixes #11052