### PR TITLE
Remove strange arrow in platforms.md

### DIFF
--- a/site/docs/platforms.md
+++ b/site/docs/platforms.md
@@ -93,7 +93,6 @@ platform(
 Note that it is an error for a platform to specify more than one value of the
 same constraint setting, such as `@platforms//cpu:x86_64` and
 `@platforms//cpu:arm` for `@platforms//cpu:cpu`.
--->
 
 
 ## Generally useful constraints and platforms


### PR DESCRIPTION
Looks like added in https://github.com/bazelbuild/bazel/commit/8ae9f75d6daee8409a11bd50070be42739107db3 , possibly some artifact when cleaning up exported doc from internal google documents?