### PR TITLE
Fix ISE w/--remote_download_toplevel + local exec

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -497,8 +497,9 @@ public final class RemoteModule extends BlazeModule {
       BuildRequest request,
       BuildOptions buildOptions,
       Iterable<ConfiguredTarget> configuredTargets) {
-    if (remoteOutputsMode != null && remoteOutputsMode.downloadToplevelOutputsOnly()) {
-      Preconditions.checkState(actionContextProvider != null, "actionContextProvider was null");
+    // The actionContextProvider may be null if remote execution is disabled or if there was an error during
+    // initialization.
+    if (remoteOutputsMode != null && remoteOutputsMode.downloadToplevelOutputsOnly() && actionContextProvider != null) {
       boolean isTestCommand = env.getCommandName().equals("test");
       TopLevelArtifactContext artifactContext = request.getTopLevelArtifactContext();
       ImmutableSet.Builder<ActionInput> filesToDownload = ImmutableSet.builder();

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1541,6 +1541,12 @@ EOF
   assert_contains "test_case succeeded" "$TESTXML"
 }
 
+# Regression test that Bazel does not crash if remote execution is disabled,
+# but --remote_download_toplevel is enabled.
+function test_download_toplevel_no_remote_execution() {
+  bazel build --remote_download_toplevel \
+      || fail "Failed to run bazel build --remote_download_toplevel"
+}
 
 function test_tag_no_remote_cache() {
   mkdir -p a


### PR DESCRIPTION
This silently ignores --remote_download_toplevel if remote execution is
disabled; some users have the flag enabled by default, but sometimes
run things locally for debugging.

Fixes #11825.

Change-Id: I0419f01ba5a123428e6d2fd0addfc80437da9525