### PR TITLE
Use boolean formulas to express filters in --build_tag_filters and --test_tag_filters

### DIFF
--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -1194,13 +1194,37 @@ memory-saving mode</a>.
   setting is high enough.
 </p>
 
-<h4 id='flag--build_tag_filters'><code class='flag'>--build_tag_filters=<var>tag[,tag]*</var></code></h4>
+<h4 id='flag--build_tag_filters'><code class='flag'>--build_tag_filters <var>tag[,tag]*</var> | <var>boolean expression</var></code></h4>
 <p>
-  If specified, Bazel will build only targets that have at least one required tag
-  (if any of them are specified) and does not have any excluded tags. Build tag
-  filter is specified as comma delimited list of tag keywords, optionally
-  preceded with '-' sign used to denote excluded tags. Required tags may also
-  have a preceding '+' sign.
+  If specified, Bazel will build only targets with matching tags. The
+  value is either a comma-separated list, or a boolean expression.
+</p>
+<p>
+  A comma-separated list matches if the target has any of the tags,
+  and none of the excluded tags. Excluded tags are preceded with '-'
+  signs. Required tags may also have a preceding '+' sign.
+</p>
+<p>
+  For example,
+</p>
+<pre>
+  % bazel build --build_tag_filters=product,stub,-prototype //myproject:all
+</pre>
+  will build targets that are tagged with either <code>product</code> or <code>stub</code> but are
+  <b>not</b> tagged with the <code>prototype</code> tag.
+</p>
+<p>
+  Boolean expressions have the form
+  <code>expr = IDENT | expr 'or' expr | expr 'and' expr | 'not' expr | '(' expr ')'.</code>
+  <code>IDENT</code> is defined as a Starlark identifier, with the same reserved words.
+<p>
+<pre>
+  % bazel build --build_tag_filters='(product or stub) and not prototype' //myproject:all
+</pre>
+  is equivalent to
+<pre>
+  % bazel build --build_tag_filters=product,stub,-prototype //myproject:all
+</pre>
 </p>
 <p>
   When running tests, Bazel ignores <code class='flag'>--build_tag_filters</code> for test targets,
@@ -1244,26 +1268,41 @@ memory-saving mode</a>.
 </p>
 
 
-<h4 id='flag--test_tag_filters'><code class='flag'>--test_tag_filters=<var>tag[,tag]*</var></code></h4>
+<h4 id='flag--test_tag_filters'><code class='flag'>--test_tag_filters <var>tag[,tag]</var> | <var>boolean expression</var></code></h4>
 <p>
   If specified, Bazel will test (or build if <code class='flag'>--build_tests_only</code>
-  is also specified) only test targets that have at least one required tag
-  (if any of them are specified) and does not have any excluded tags. Test tag
-  filter is specified as comma delimited list of tag keywords, optionally
-  preceded with '-' sign used to denote excluded tags. Required tags may also
-  have a preceding '+' sign.
+  is also specified) only targets with matching tags. The value is either a comma-separated
+  list, or a boolean expression.
+</p>
+<p>
+  A comma-separated list matches if the target has any of the tags,
+  and none of the excluded tags. Excluded tags are preceded with '-'
+  signs. Required tags may also have a preceding '+' sign.
 </p>
 <p>
   For example,
+</p>
 <pre>
-  % bazel test --test_tag_filters=performance,stress,-flaky //myproject:all
+  % bazel test --test_tag_filters=release,smoke,-flaky //myproject:all
 </pre>
-<p>
-  will test targets that are tagged with either <code>performance</code> or
-  <code>stress</code> tag but are <b>not</b> tagged with the <code>flaky</code>
-  tag.
+  will test targets that are tagged with either <code>release</code> or <code>smoke</code> but are
+  <b>not</b> tagged with the <code>flaky</code> tag.
 </p>
 <p>
+  Boolean expressions have the form
+  <code>expr = IDENT | expr 'or' expr | expr 'and' expr | 'not' expr | '(' expr ')'.</code>
+  <code>IDENT</code> is defined as a Starlark identifier, with the same reserved words.
+<p>
+<pre>
+  % bazel test --test_tag_filters='(release or smoke) and not flaky' //myproject:all
+</pre>
+  is equivalent to
+<pre>
+  % bazel test --test_tag_filters=release,smoke,-flaky //myproject:all
+</pre>
+</p>
+<p>
+  By default, test tag filtering is not applied.
   By default, test tag filtering is not applied. Note that you can also filter
   on test's <code>size</code> and <code>local</code> tags in
   this manner.

--- a/src/main/java/com/google/devtools/build/lib/pkgcache/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/pkgcache/BUILD
@@ -34,6 +34,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/query2/engine",
         "//src/main/java/com/google/devtools/build/lib/skyframe:detailed_exceptions",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
+        "//src/main/java/net/starlark/java/syntax",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/build/lib/util:resource_converter",
         "//src/main/java/com/google/devtools/build/lib/vfs",

--- a/src/main/java/com/google/devtools/build/lib/pkgcache/TagFilter.java
+++ b/src/main/java/com/google/devtools/build/lib/pkgcache/TagFilter.java
@@ -1,0 +1,108 @@
+package com.google.devtools.build.lib.pkgcache;
+
+import com.google.devtools.common.options.OptionsParsingException;
+import net.starlark.java.syntax.BinaryOperatorExpression;
+import net.starlark.java.syntax.Expression;
+import net.starlark.java.syntax.ParserInput;
+import net.starlark.java.syntax.SyntaxError;
+import net.starlark.java.syntax.TokenKind;
+import net.starlark.java.syntax.UnaryOperatorExpression;
+
+/**
+ * A helper object that converts a tag filter string to an Expression.
+ */
+public class TagFilter {
+
+  private final String originalString;
+  private final Expression expression;
+
+  /**
+   * @param input either a boolean expression (e.g. "tag1 or tag2") or a comma-separated list (e.g. "tag1,-tag2")
+   */
+  public TagFilter(String input) throws OptionsParsingException {
+    originalString = input;
+
+    if (input.isEmpty()) {
+      expression = null;
+    } else {
+      expression = parse(input);
+      validate(expression);
+    }
+  }
+
+  private Expression parse(String input) throws OptionsParsingException {
+    if (isCommaSeparatedListSyntax(input)) {
+      input = convertCommaSeparatedListToBooleanExpression(input);
+    }
+
+    try {
+      return Expression.parse(ParserInput.fromLines(input));
+    } catch (SyntaxError.Exception e) {
+      throw new OptionsParsingException("Failed to parse expression: " + e.getMessage() + " input: " + input, e);
+    }
+  }
+
+  private boolean isCommaSeparatedListSyntax(String input) {
+    return input.contains(",") || input.contains("-");
+  }
+
+  /**
+   * Converts a string containing tags separated by comma to a boolean formula.
+   */
+  private String convertCommaSeparatedListToBooleanExpression(String input) {
+    return input.replaceAll(" *, *-", " and not ")
+            .replaceAll(" *, *", " or ")
+            .replace("-", " not ").trim();
+  }
+
+  /**
+   * Throws an OptionsParsingException if this expression does not follow the grammar:
+   * expr = IDENT | expr 'or' expr | expr 'and' expr | 'not' expr | '(' expr ')'
+   */
+  private void validate(Expression expression) throws OptionsParsingException {
+    switch (expression.kind()) {
+      case IDENTIFIER:
+        break;
+      case BINARY_OPERATOR:
+        BinaryOperatorExpression boe = (BinaryOperatorExpression) expression;
+        if (boe.getOperator() != TokenKind.OR && boe.getOperator() != TokenKind.AND) {
+          throw new OptionsParsingException(String.format("invalid Boolean operator: %s (want 'and' or 'or')",
+                  boe.getOperator()));
+        }
+        validate(boe.getX());
+        validate(boe.getY());
+        break;
+      case UNARY_OPERATOR:
+        UnaryOperatorExpression uoe = (UnaryOperatorExpression) expression;
+        if (uoe.getOperator() != TokenKind.NOT) {
+          throw new OptionsParsingException(String.format("invalid Boolean operator: %s (want 'not')",
+                  uoe.getOperator()));
+        }
+        validate(uoe.getX());
+        break;
+      default:
+        throw new OptionsParsingException("invalid Boolean operator: " + expression.kind());
+    }
+  }
+
+  public Expression getExpression() {
+    return expression;
+  }
+
+  @Override
+  public int hashCode() {
+    return originalString.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof TagFilter)) {
+      return false;
+    }
+    TagFilter other = (TagFilter) o;
+    return this.originalString.equals(other.originalString);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -2409,6 +2409,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/pkgcache",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//src/main/java/net/starlark/java/syntax",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -2960,7 +2960,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory, Configur
             options.compileOneDependency,
             options.buildTestsOnly,
             determineTests,
-            ImmutableList.copyOf(options.buildTagFilterList),
+            options.buildTagFilter.getExpression(),
             options.buildManualTests,
             options.expandTestSuites,
             TestFilter.forOptions(options, eventHandler, pkgFactory.getRuleClassNames()));

--- a/src/main/java/com/google/devtools/build/lib/skyframe/TargetPatternPhaseValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/TargetPatternPhaseValue.java
@@ -33,10 +33,12 @@ import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
+import net.starlark.java.syntax.Expression;
+
+import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 /**
  * A value referring to a computed set of resolved targets. This is used for the results of target
@@ -162,7 +164,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
       boolean compileOneDependency,
       boolean buildTestsOnly,
       boolean determineTests,
-      ImmutableList<String> buildTargetFilter,
+      @Nullable Expression buildTargetFilter,
       boolean buildManualTests,
       boolean expandTestSuites,
       @Nullable TestFilter testFilter) {
@@ -189,7 +191,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
   public static SkyKey keyWithoutFilters(
       ImmutableList<String> targetPatterns, PathFragment offset) {
     return new TargetPatternPhaseKey(
-        targetPatterns, offset, false, false, false, ImmutableList.of(), false, false, null);
+        targetPatterns, offset, false, false, false, null, false, false, null);
   }
 
   /** The configuration needed to run the target pattern evaluation phase. */
@@ -202,7 +204,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
     private final boolean compileOneDependency;
     private final boolean buildTestsOnly;
     private final boolean determineTests;
-    private final ImmutableList<String> buildTargetFilter;
+    @Nullable private final Expression buildTargetFilter;
     private final boolean buildManualTests;
     private final boolean expandTestSuites;
     @Nullable private final TestFilter testFilter;
@@ -213,7 +215,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
         boolean compileOneDependency,
         boolean buildTestsOnly,
         boolean determineTests,
-        ImmutableList<String> buildTargetFilter,
+        @Nullable Expression buildTargetFilter,
         boolean buildManualTests,
         boolean expandTestSuites,
         @Nullable TestFilter testFilter) {
@@ -222,7 +224,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
       this.compileOneDependency = compileOneDependency;
       this.buildTestsOnly = buildTestsOnly;
       this.determineTests = determineTests;
-      this.buildTargetFilter = Preconditions.checkNotNull(buildTargetFilter);
+      this.buildTargetFilter = buildTargetFilter;
       this.buildManualTests = buildManualTests;
       this.expandTestSuites = expandTestSuites;
       this.testFilter = testFilter;
@@ -256,7 +258,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
       return determineTests;
     }
 
-    public ImmutableList<String> getBuildTargetFilter() {
+    @Nullable public Expression getBuildTargetFilter() {
       return buildTargetFilter;
     }
 
@@ -314,7 +316,7 @@ public final class TargetPatternPhaseValue implements SkyValue {
           && other.compileOneDependency == compileOneDependency
           && other.buildTestsOnly == buildTestsOnly
           && other.determineTests == determineTests
-          && other.buildTargetFilter.equals(buildTargetFilter)
+          && Objects.equals(other.buildTargetFilter, buildTargetFilter)
           && other.buildManualTests == buildManualTests
           && other.expandTestSuites == expandTestSuites
           && Objects.equals(other.testFilter, testFilter);

--- a/src/main/java/com/google/devtools/common/options/Converters.java
+++ b/src/main/java/com/google/devtools/common/options/Converters.java
@@ -22,6 +22,7 @@ import com.google.common.cache.CacheBuilderSpec;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
@@ -673,4 +674,5 @@ public final class Converters {
       return "Converts to a CacheBuilderSpec, or null if the input is empty";
     }
   }
+
 }

--- a/src/main/java/net/starlark/java/syntax/Expression.java
+++ b/src/main/java/net/starlark/java/syntax/Expression.java
@@ -66,5 +66,4 @@ public abstract class Expression extends Node {
       throws SyntaxError.Exception {
     return Parser.parseExpression(input, options);
   }
-
 }

--- a/src/test/java/com/google/devtools/build/lib/packages/TestTargetUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/TestTargetUtilsTest.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.packages;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -25,21 +26,25 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.StoredEventHandler;
 import com.google.devtools.build.lib.packages.util.PackageLoadingTestCase;
 import com.google.devtools.build.lib.pkgcache.LoadingOptions;
+import com.google.devtools.build.lib.pkgcache.TagFilter;
 import com.google.devtools.build.lib.pkgcache.TestFilter;
 import com.google.devtools.build.lib.skyframe.TestsForTargetPatternValue;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.skyframe.EvaluationContext;
 import com.google.devtools.build.skyframe.EvaluationResult;
 import com.google.devtools.build.skyframe.SkyKey;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.function.Predicate;
 import net.starlark.java.syntax.Location;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.function.Predicate;
+
+import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(JUnit4.class)
 public class TestTargetUtilsTest extends PackageLoadingTestCase {
@@ -102,7 +107,7 @@ public class TestTargetUtilsTest extends PackageLoadingTestCase {
     options.testLangFilterList = ImmutableList.of("nonexistent", "existent", "-noexist", "-exist");
     options.testSizeFilterSet = ImmutableSet.of();
     options.testTimeoutFilterSet = ImmutableSet.of();
-    options.testTagFilterList = ImmutableList.of();
+    options.testTagFilter = new TagFilter("");
     TestFilter filter =
         TestFilter.forOptions(
             options, eventHandler, ImmutableSet.of("existent_test", "exist_test"));

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TargetPatternPhaseKeyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TargetPatternPhaseKeyTest.java
@@ -27,10 +27,13 @@ import com.google.devtools.build.lib.pkgcache.TestFilter;
 import com.google.devtools.build.lib.skyframe.TargetPatternPhaseValue.TargetPatternPhaseKey;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.Options;
-import javax.annotation.Nullable;
+import net.starlark.java.syntax.Expression;
+import net.starlark.java.syntax.ParserInput;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import javax.annotation.Nullable;
 
 /** Tests for {@link TargetPatternPhaseKey}. */
 @RunWith(JUnit4.class)
@@ -53,7 +56,7 @@ public class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
-                ImmutableList.of(),
+                null,
                 false,
                 true,
                 null,
@@ -62,7 +65,7 @@ public class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
-                ImmutableList.of(),
+                null,
                 false,
                 false,
                 null,
@@ -71,7 +74,7 @@ public class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
-                ImmutableList.of(),
+                null,
                 true,
                 true,
                 null,
@@ -80,7 +83,7 @@ public class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
-                ImmutableList.of(),
+                null,
                 true,
                 false,
                 null,
@@ -89,7 +92,7 @@ public class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
-                ImmutableList.of(),
+                null,
                 false,
                 true,
                 emptyTestFilter(),
@@ -98,7 +101,7 @@ public class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
-                ImmutableList.of(),
+                null,
                 true,
                 true,
                 emptyTestFilter(),
@@ -107,7 +110,7 @@ public class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
-                ImmutableList.of(),
+                null,
                 false,
                 true,
                 emptyTestFilter(),
@@ -116,7 +119,7 @@ public class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
-                ImmutableList.of(),
+                null,
                 true,
                 true,
                 emptyTestFilter(),
@@ -125,7 +128,7 @@ public class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
-                ImmutableList.of("a"),
+                Expression.parse(ParserInput.fromLines("a")),
                 false,
                 true,
                 null))
@@ -133,7 +136,7 @@ public class TargetPatternPhaseKeyTest {
             of(
                 ImmutableList.of(),
                 PathFragment.EMPTY_FRAGMENT,
-                ImmutableList.of("a"),
+                Expression.parse(ParserInput.fromLines("a")),
                 true,
                 true,
                 null))
@@ -143,7 +146,7 @@ public class TargetPatternPhaseKeyTest {
   private static TargetPatternPhaseKey of(
       ImmutableList<String> targetPatterns,
       PathFragment offset,
-      ImmutableList<String> buildTagFilter,
+      Expression buildTagFilter,
       boolean includeManualTests,
       boolean expandTestSuites,
       @Nullable TestFilter testFilter,
@@ -158,7 +161,7 @@ public class TargetPatternPhaseKeyTest {
 
   private static TargetPatternPhaseKey of(
       ImmutableList<String> targetPatterns, PathFragment offset) {
-    return of(targetPatterns, offset, ImmutableList.of(), false, true, null);
+    return of(targetPatterns, offset, null, false, true, null);
   }
 
   private static TestFilter emptyTestFilter() {

--- a/src/test/shell/bazel/bazel_test_test.sh
+++ b/src/test/shell/bazel/bazel_test_test.sh
@@ -870,4 +870,88 @@ EOF
   expect_log "<testcase name=\"x\""
 }
 
+function test_test_tag_filters_with_legacy_syntax() {
+  mkdir -p dir
+
+  touch dir/test.sh
+  chmod u+x dir/test.sh
+  cat <<'EOF' > dir/BUILD
+sh_test(
+    name = 'test1',
+    srcs = ['test.sh'],
+    tags = ['tag1']
+)
+sh_test(
+    name = 'test2',
+    srcs = ['test.sh'],
+    tags = ['tag2']
+)
+sh_test(
+    name = 'test3',
+    srcs = ['test.sh'],
+    tags = ['tag3']
+)
+EOF
+  bazel test //dir/... --test_tag_filters="tag1, tag2" >& $TEST_log
+  expect_log ^//dir:test1
+  expect_log ^//dir:test2
+  expect_not_log ^//dir:test3
+}
+
+function test_test_tag_filters_with_boolean_formula() {
+  mkdir -p dir
+
+  touch dir/test.sh
+  chmod u+x dir/test.sh
+  cat <<'EOF' > dir/BUILD
+sh_test(
+    name = 'test1',
+    srcs = ['test.sh'],
+    tags = ['tag1']
+)
+sh_test(
+    name = 'test2',
+    srcs = ['test.sh'],
+    tags = ['tag2']
+)
+sh_test(
+    name = 'test3',
+    srcs = ['test.sh'],
+    tags = ['tag3']
+)
+EOF
+  bazel test //dir/... --test_tag_filters="tag1 or tag2" >& $TEST_log
+  expect_log ^//dir:test1
+  expect_log ^//dir:test2
+  expect_not_log ^//dir:test3
+}
+
+function test_test_tag_filters_with_legacy_syntax_negative() {
+  mkdir -p dir
+
+  touch dir/test.sh
+  chmod u+x dir/test.sh
+  cat <<'EOF' > dir/BUILD
+sh_test(
+    name = 'test1',
+    srcs = ['test.sh'],
+    tags = ['tag1']
+)
+sh_test(
+    name = 'test2',
+    srcs = ['test.sh'],
+    tags = ['tag1','tag2']
+)
+sh_test(
+    name = 'test3',
+    srcs = ['test.sh'],
+    tags = ['tag3']
+)
+EOF
+  bazel test //dir/... --test_tag_filters="tag1,-tag2" >& $TEST_log
+  expect_log ^//dir:test1
+  expect_not_log ^//dir:test2
+  expect_not_log ^//dir:test3
+}
+
 run_suite "bazel test tests"


### PR DESCRIPTION
Starlark can now be used to express filters instead of a list of tags in --test_tag_filters and --build_tag_filters.

Example of usage:
bazel test ... --test_tag_filters="tag1 and (tag2 or not tag3)"

This is a draft of the functionality requested in #3705. 

### Summary of commit
I modified the method tagFilter which takes a list of tags as input and assumed if this list only contains one required tag and none excluded tag that this is a Starlark expression (there is a problem with this, see Concerns). I implemented the function evalExpression as described by @alandonovan in https://github.com/bazelbuild/bazel/issues/3705#issuecomment-661106688, and it works well. In the case where a user provides an invalid Starlark expression (that fails to parse or uses forbidden operators) a new sub type of RuntimeException is thrown (this is a temporary solution, see Concerns). 

### Concerns
I have a few concerns about the implementation that I need the community's help with.

1. Since tags can be any valid string (meaning it can include spaces) it is possible that we have a situation where we have defined a tag "tag1 and tag2". If we then run --test_tag_filters="tag1 and tag2" there is no way of knowing if this is meant to be a Starlark expression or not.
In my implementation this would also be a problem if we had a tag "tag 1 and 2 " and ran --test_tag_filters="tag 1 and 2" because this would be assumed to be a Starlark expression and then the parsing would fail.

2. It would be better to throw an OptionsParsingException than a sub type of RuntimeException because then this could be caught in an appropriate way and communicated to the user instead of the user getting an internal error. The reason that I did not decide to use OptionsParsingException was that then I would have to add "throws OptionsParsingException" to a lot of methods before finally reaching one where it can be handled appropriately. This was considered unnecessary work at the moment. 

### Proposed solution
I propose that we either add a new flag --build_tag_filter_expression (and same for test) or a flag that specifies if the input given to --build_tag_filters is a Starlark expression or not. 
This way we avoid the problems in Concerns because there is no way that a tag will be misinterpreted as a Starlark expression and we can do the parsing earlier and therefore handle invalid input in a correct manner.
What do you think about this?