### PR TITLE
Fix handling of BA lines in CoverageOutputGenerator

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD
@@ -78,11 +78,17 @@ java_library(
     srcs = ["SourceFileCoverage.java"],
     deps = [
         ":BranchCoverage",
+        ":IncompatibleMergeException",
         ":LineCoverage",
         "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:jsr305",
     ],
+)
+
+java_library(
+    name = "IncompatibleMergeException",
+    srcs = ["IncompatibleMergeException.java"],
 )
 
 java_library(
@@ -152,6 +158,7 @@ java_library(
     srcs = ["Coverage.java"],
     deps = [
         ":Constants",
+        ":IncompatibleMergeException",
         ":SourceFileCoverage",
         "//third_party:guava",
     ],
@@ -176,6 +183,7 @@ java_library(
         ":Coverage",
         ":GcovJsonParser",
         ":GcovParser",
+        ":IncompatibleMergeException",
         ":LcovMergerFlags",
         ":LcovParser",
         ":LcovPrinter",

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BranchCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BranchCoverage.java
@@ -16,7 +16,24 @@ package com.google.devtools.coverageoutputgenerator;
 
 import com.google.auto.value.AutoValue;
 
-/** Stores branch coverage information. */
+/**
+ * Stores branch coverage information.
+ *
+ * Corresponds to either a BRDA or BA (Google only) line in an lcov report.
+ * <p>BA lines correspond to instances where blockNumber and branchNumber are set to empty Strings and have the form:
+ * <pre>BA:[line_number],[taken]</pre>
+ * In this case, nrOfExecutions() actually refers to the "taken" value where:
+ * <ul>
+ * <li>0 = Branch was never evaluated (evaluated() == false)</li>
+ * <li>1 = Branch was evaluated but never taken</li>
+ * <li>2 = Branch was taken</li>
+ * </ul>
+ *
+ * BRDA lines set have the form
+ * <pre>BRDA:[line_number],[block_number],[branch_number],[taken]</pre>
+ * where the block and branch numbers are internal identifiers, and taken is either "-" if the branch was never
+ * executed or a number indicating how often the branch was taken (which may be 0).
+ */
 @AutoValue
 abstract class BranchCoverage {
 

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Constants.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Constants.java
@@ -49,8 +49,8 @@ class Constants {
   static final String GCOV_LINE_MARKER = "lcount:";
   static final String GCOV_BRANCH_MARKER = "branch:";
   static final String GCOV_BRANCH_NOTEXEC = "notexec";
-  static final String GCOV_BRANCH_NOTTAKEN = "taken";
-  static final String GCOV_BRANCH_TAKEN = "nottaken";
+  static final String GCOV_BRANCH_NOTTAKEN = "nottaken";
+  static final String GCOV_BRANCH_TAKEN = "taken";
   // Please keep in sync with the extensions in CppFileTypes.
   static final ImmutableList<String> CC_EXTENSIONS =
       ImmutableList.of(

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovJsonParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovJsonParser.java
@@ -68,8 +68,9 @@ public class GcovJsonParser {
           currentFileCoverage.addLine(
               line.line_number, LineCoverage.create(line.line_number, line.count, null));
           for (GcovJsonBranch branch : line.branches) {
+            int takenValue = line.unexecuted_block ? 0 : branch.count == 0 ? 1 : 2;
             currentFileCoverage.addBranch(
-                line.line_number, BranchCoverage.create(line.line_number, branch.count));
+                line.line_number, BranchCoverage.create(line.line_number, takenValue));
           }
         }
         allSourceFiles.add(currentFileCoverage);

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovParser.java
@@ -188,20 +188,22 @@ public class GcovParser {
       // Ignore has_unexecuted_block since it's not used.
       int lineNr = Integer.parseInt(items[0]);
       String type = items[1];
-      int execCount;
+      int takenValue;
       switch (type) {
         case GCOV_BRANCH_NOTEXEC:
-          execCount = 0;
+          takenValue = 0;
           break;
         case GCOV_BRANCH_NOTTAKEN:
+          takenValue = 1;
+          break;
         case GCOV_BRANCH_TAKEN:
-          execCount = 1;
+          takenValue = 2;
           break;
         default:
           logger.log(Level.WARNING, "gcov info contains invalid line " + line);
           return false;
       }
-      currentSourceFileCoverage.addBranch(lineNr, BranchCoverage.create(lineNr, execCount));
+      currentSourceFileCoverage.addBranch(lineNr, BranchCoverage.create(lineNr, takenValue));
     } catch (NumberFormatException e) {
       logger.log(Level.WARNING, "gcov info contains invalid line " + line);
       return false;

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/IncompatibleMergeException.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/IncompatibleMergeException.java
@@ -1,0 +1,26 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.coverageoutputgenerator;
+
+/**
+ * Exception indicating two source coverage objects cannot be merged together due to irreconcilable differences.
+ */
+public class IncompatibleMergeException extends Exception {
+
+    public IncompatibleMergeException(String message) {
+        super(message);
+    }
+
+}

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovParser.java
@@ -235,18 +235,22 @@ class LcovParser {
     String lineContent = line.substring(BA_MARKER.length());
     String[] lineData = lineContent.split(DELIMITER, -1);
     if (lineData.length != 2) {
-      logger.log(Level.WARNING, "Tracefile contains invalid BRDA line " + line);
+      logger.log(Level.WARNING, "Tracefile contains invalid BA line " + line);
       return false;
     }
     for (String data : lineData) {
       if (data.isEmpty()) {
-        logger.log(Level.WARNING, "Tracefile contains invalid BRDA line " + line);
+        logger.log(Level.WARNING, "Tracefile contains invalid BA line " + line);
         return false;
       }
     }
     try {
       int lineNumber = Integer.parseInt(lineData[0]);
-      long taken = Long.parseLong(lineData[1]);
+      int taken = Integer.parseInt(lineData[1]);
+      if (taken < 0 || taken > 2) {
+        logger.log(Level.WARNING, "Tracefile contains invalid BA " + line + " - value not one of {0, 1, 2}");
+        return false;
+      }
 
       BranchCoverage branchCoverage = BranchCoverage.create(lineNumber, taken);
 

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/LcovPrinter.java
@@ -133,7 +133,7 @@ class LcovPrinter {
   private void printBRDALines(SourceFileCoverage sourceFile) throws IOException {
     for (BranchCoverage branch : sourceFile.getAllBranches()) {
       if (branch.blockNumber().isEmpty() || branch.branchNumber().isEmpty()) {
-        // We skip printing this as a BRDA line and print it later as a BA line.
+        // This branch is a BA line
         continue;
       }
       bufferedWriter.write(Constants.BRDA_MARKER);
@@ -156,16 +156,13 @@ class LcovPrinter {
   private void printBALines(SourceFileCoverage sourceFile) throws IOException {
     for (BranchCoverage branch : sourceFile.getAllBranches()) {
       if (!branch.blockNumber().isEmpty() && !branch.branchNumber().isEmpty()) {
-        // This branch was already printed with more information as a BRDA line.
+        // This branch is a BRDA line
         continue;
       }
       bufferedWriter.write(Constants.BA_MARKER);
       bufferedWriter.write(Integer.toString(branch.lineNumber()));
       bufferedWriter.write(Constants.DELIMITER);
-      // 0 = branch was not executed
-      // 1 = branch was executed but not taken
-      // 2 = branch was executed and taken
-      bufferedWriter.write(branch.wasExecuted() ? "2" : "0");
+      bufferedWriter.write(Long.toString(branch.nrOfExecutions()));
       bufferedWriter.newLine();
     }
   }

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BUILD
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BUILD
@@ -139,6 +139,7 @@ java_library(
     deps = [
         "//third_party:guava",
         "//third_party:truth",
+        "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:BranchCoverage",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:LineCoverage",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:SourceFileCoverage",
     ],

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BUILD
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BUILD
@@ -35,6 +35,8 @@ java_test(
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:truth",
+        "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:BranchCoverage",
+        "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:IncompatibleMergeException",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:LineCoverage",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:SourceFileCoverage",
     ],

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BranchCoverageTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/BranchCoverageTest.java
@@ -26,6 +26,34 @@ import org.junit.runners.JUnit4;
 public class BranchCoverageTest {
 
   @Test
+  public void testNoBlockBranchSemantics() {
+    BranchCoverage b0 = BranchCoverage.create(3, 0);
+    BranchCoverage b1 = BranchCoverage.create(3, 1);
+    BranchCoverage b2 = BranchCoverage.create(3, 2);
+
+    assertThat(b0.lineNumber()).isEqualTo(3);
+    assertThat(b0.evaluated()).isFalse();
+    assertThat(b0.wasExecuted()).isFalse();
+    assertThat(b0.nrOfExecutions()).isEqualTo(0);
+
+    assertThat(b1.lineNumber()).isEqualTo(3);
+    assertThat(b1.evaluated()).isTrue();
+    assertThat(b1.wasExecuted()).isFalse();
+    assertThat(b1.nrOfExecutions()).isEqualTo(1);
+
+    assertThat(b2.lineNumber()).isEqualTo(3);
+    assertThat(b2.evaluated()).isTrue();
+    assertThat(b2.wasExecuted()).isTrue();
+    assertThat(b2.nrOfExecutions()).isEqualTo(2);
+  }
+
+  @Test
+  public void testNoBlockBranchInvalidValuesFail() {
+    assertThrows(AssertionError.class, () -> BranchCoverage.create(3, -1));
+    assertThrows(AssertionError.class, () -> BranchCoverage.create(3, 4));
+  }
+
+  @Test
   public void testMergesBranchesWithBlockBranchEvaluated() {
     BranchCoverage b1 = BranchCoverage.createWithBlockAndBranch(1, "3", "2", true, 3);
     BranchCoverage b2 = BranchCoverage.createWithBlockAndBranch(1, "3", "2", true, 0);
@@ -73,18 +101,22 @@ public class BranchCoverageTest {
 
   @Test
   public void testMergesWithNoBlockBranch() {
-    BranchCoverage b1 = BranchCoverage.create(3, 3);
+    BranchCoverage b1 = BranchCoverage.create(3, 1);
     BranchCoverage b2 = BranchCoverage.create(3, 0);
-    BranchCoverage b3 = BranchCoverage.create(3, 5);
+    BranchCoverage b3 = BranchCoverage.create(3, 2);
 
     BranchCoverage m1 = BranchCoverage.merge(b1, b2);
     BranchCoverage m2 = BranchCoverage.merge(m1, b3);
 
+    assertThat(m1.nrOfExecutions()).isEqualTo(1);
+    assertThat(m1.wasExecuted()).isFalse();
+    assertThat(m1.evaluated()).isTrue();
     assertThat(m2.lineNumber()).isEqualTo(3);
     assertThat(m2.blockNumber()).isEmpty();
     assertThat(m2.branchNumber()).isEmpty();
-    assertThat(m1.nrOfExecutions()).isEqualTo(3);
-    assertThat(m2.nrOfExecutions()).isEqualTo(8);
+    assertThat(m2.nrOfExecutions()).isEqualTo(2);
+    assertThat(m2.wasExecuted()).isTrue();
+    assertThat(m2.evaluated()).isTrue();
   }
 
   @Test

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/CoverageTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/CoverageTest.java
@@ -45,7 +45,7 @@ public class CoverageTest {
   }
 
   @Test
-  public void testOneTracefile() {
+  public void testOneTracefile() throws Exception {
     SourceFileCoverage sourceFileCoverage = createSourceFile1(createLinesExecution1());
     coverage.add(sourceFileCoverage);
     assertThat(coverage.getAllSourceFiles()).hasSize(1);
@@ -53,7 +53,7 @@ public class CoverageTest {
   }
 
   @Test
-  public void testTwoOverlappingTracefiles() {
+  public void testTwoOverlappingTracefiles() throws Exception {
     int[] linesExecution1 = createLinesExecution1();
     int[] linesExecution2 = createLinesExecution2();
     SourceFileCoverage sourceFileCoverage1 = createSourceFile1(linesExecution1);
@@ -68,7 +68,7 @@ public class CoverageTest {
   }
 
   @Test
-  public void testTwoTracefiles() {
+  public void testTwoTracefiles() throws Exception {
     SourceFileCoverage sourceFileCoverage1 = createSourceFile1(createLinesExecution1());
     SourceFileCoverage sourceFileCoverage2 =
         createSourceFile1("SOME_OTHER_FILENAME", createLinesExecution1());
@@ -81,7 +81,7 @@ public class CoverageTest {
   }
 
   @Test
-  public void testFilterSources() {
+  public void testFilterSources() throws Exception {
     Coverage coverage = new Coverage();
 
     coverage.add(new SourceFileCoverage("/filterOut/package/file1.c"));
@@ -98,7 +98,7 @@ public class CoverageTest {
   }
 
   @Test
-  public void testFilterSourcesEmptyResult() {
+  public void testFilterSourcesEmptyResult() throws Exception {
     Coverage coverage = new Coverage();
 
     coverage.add(new SourceFileCoverage("/filterOut/package/file1.c"));
@@ -111,7 +111,7 @@ public class CoverageTest {
   }
 
   @Test
-  public void testFilterSourcesNoMatches() {
+  public void testFilterSourcesNoMatches() throws Exception {
     Coverage coverage = new Coverage();
 
     SourceFileCoverage validSource1 = new SourceFileCoverage("/valid/package/file3.c");
@@ -126,7 +126,7 @@ public class CoverageTest {
   }
 
   @Test
-  public void testFilterSourcesMultipleRegex() {
+  public void testFilterSourcesMultipleRegex() throws Exception {
     Coverage coverage = new Coverage();
 
     coverage.add(new SourceFileCoverage("/filterOut/package/file1.c"));
@@ -145,7 +145,7 @@ public class CoverageTest {
   }
 
   @Test
-  public void testFilterSourcesNoFilter() {
+  public void testFilterSourcesNoFilter() throws Exception {
     Coverage coverage = new Coverage();
 
     SourceFileCoverage validSource1 = new SourceFileCoverage("/valid/package/file3.c");
@@ -178,7 +178,7 @@ public class CoverageTest {
   }
 
   @Test
-  public void testGetOnlyTheseSources() {
+  public void testGetOnlyTheseSources() throws Exception {
     Coverage coverage = new Coverage();
     coverage.add(new SourceFileCoverage("source/common/protobuf/utility.cc"));
     coverage.add(new SourceFileCoverage("source/common/grpc/common.cc"));
@@ -206,7 +206,7 @@ public class CoverageTest {
   }
 
   @Test
-  public void testGetOnlyTheseSourcesEmptySources() {
+  public void testGetOnlyTheseSourcesEmptySources() throws Exception {
     Coverage coverage = new Coverage();
     coverage.add(new SourceFileCoverage("source/common/protobuf/utility.cc"));
     coverage.add(new SourceFileCoverage("source/common/grpc/common.cc"));

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/GcovParserTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/GcovParserTest.java
@@ -122,7 +122,6 @@ public class GcovParserTest {
 
   @Test
   public void testParseTracefileWithOneSourcefile() throws IOException {
-
     List<SourceFileCoverage> sourceFiles =
         GcovParser.parse(
             new ByteArrayInputStream(Joiner.on("\n").join(GCOV_INFO_FILE).getBytes(UTF_8)));
@@ -146,8 +145,8 @@ public class GcovParserTest {
     assertThat(sourceFileCoverage.nrFunctionsHit()).isEqualTo(3);
     assertThat(sourceFileCoverage.nrOfInstrumentedLines()).isEqualTo(14);
     assertThat(sourceFileCoverage.nrOfLinesWithNonZeroExecution()).isEqualTo(13);
-    assertThat(sourceFileCoverage.nrBranchesFound()).isEqualTo(8);
-    assertThat(sourceFileCoverage.nrBranchesHit()).isEqualTo(7);
+    assertThat(sourceFileCoverage.nrBranchesFound()).isEqualTo(16);
+    assertThat(sourceFileCoverage.nrBranchesHit()).isEqualTo(8);
 
     assertThat(sourceFileCoverage.getAllLineExecution())
         .containsExactly(
@@ -169,12 +168,20 @@ public class GcovParserTest {
     assertThat(sourceFileCoverage.getAllBranches())
         .containsExactly(
             BranchCoverage.create(21, 2),
+            BranchCoverage.create(21, 1),
             BranchCoverage.create(23, 2),
+            BranchCoverage.create(23, 1),
             BranchCoverage.create(24, 2),
+            BranchCoverage.create(24, 1),
             BranchCoverage.create(27, 2),
+            BranchCoverage.create(27, 2),
+            BranchCoverage.create(30, 1),
             BranchCoverage.create(30, 2),
+            BranchCoverage.create(32, 1),
             BranchCoverage.create(32, 2),
             BranchCoverage.create(33, 0),
-            BranchCoverage.create(35, 2));
+            BranchCoverage.create(33, 0),
+            BranchCoverage.create(35, 2),
+            BranchCoverage.create(35, 1));
   }
 }

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovMergerTestUtils.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovMergerTestUtils.java
@@ -54,6 +54,14 @@ public class LcovMergerTestUtils {
           "FNDA:0,file1-func3",
           "FNF:3",
           "FNH:2",
+          "BA:15,1",
+          "BA:15,2",
+          "BA:23,2",
+          "BA:23,1",
+          "BA:25,0",
+          "BA:25,0",
+          "BRF:6",
+          "BRH:2",
           "DA:10,3",
           "DA:11,3",
           "DA:12,30",
@@ -83,6 +91,14 @@ public class LcovMergerTestUtils {
           "FNDA:0,file1-func3",
           "FNF:3",
           "FNH:2",
+          "BA:15,1",
+          "BA:15,2",
+          "BA:23,2",
+          "BA:23,1",
+          "BA:25,0",
+          "BA:25,0",
+          "BRF:6",
+          "BRH:2",
           "DA:10,3",
           "DA:11,3",
           "DA:12,30",
@@ -113,6 +129,14 @@ public class LcovMergerTestUtils {
           "FNDA:2,file1-func3",
           "FNF:3",
           "FNH:3",
+          "BA:15,2",
+          "BA:15,1",
+          "BA:23,2",
+          "BA:23,2",
+          "BA:25,1",
+          "BA:25,2",
+          "BRF:6",
+          "BRH:4",
           "DA:10,2",
           "DA:11,2",
           "DA:12,20",
@@ -143,6 +167,14 @@ public class LcovMergerTestUtils {
           "FNDA:2,file1-func3",
           "FNF:3",
           "FNH:3",
+          "BA:15,2",
+          "BA:15,2",
+          "BA:23,2",
+          "BA:23,2",
+          "BA:25,1",
+          "BA:25,2",
+          "BRF:6",
+          "BRH:5",
           "DA:10,5",
           "DA:11,5",
           "DA:12,50",
@@ -184,6 +216,11 @@ public class LcovMergerTestUtils {
   static final int NR_LINES_FOUND = 14;
   static final int NR_LINES_HIT_TRACEFILE1 = 10;
   static final int NR_LINES_HIT_TRACEFILE2 = 13;
+
+  static final int NR_BRANCHES_FOUND = 6;
+  static final int NR_BRANCHES_HIT_TRACEFILE1 = 2;
+  static final int NR_BRANCHES_HIT_TRACEFILE2 = 4;
+  static final int NR_BRANCHES_HIT_MERGED = 5;
 
   static final int MAX_LINES_IN_FILE = 27;
 
@@ -256,28 +293,42 @@ public class LcovMergerTestUtils {
       }
     }
 
+    sourceFile.addBranch(15, BranchCoverage.create(15, 1));
+    sourceFile.addBranch(15, BranchCoverage.create(15, 2));
+    sourceFile.addBranch(23, BranchCoverage.create(23, 2));
+    sourceFile.addBranch(23, BranchCoverage.create(23, 1));
+    sourceFile.addBranch(25, BranchCoverage.create(25, 0));
+    sourceFile.addBranch(25, BranchCoverage.create(25, 0));
+
     return sourceFile;
   }
 
   // Create source file coverage data, excluding branch coverage
   static SourceFileCoverage createSourceFile2(int[] lineExecutionCount) {
-    SourceFileCoverage sourceFileCoverage = new SourceFileCoverage(SOURCE_FILENAME);
+    SourceFileCoverage sourceFile = new SourceFileCoverage(SOURCE_FILENAME);
 
-    sourceFileCoverage.addLineNumber(FUNC_1, FUNC_1_LINE_NR);
-    sourceFileCoverage.addFunctionExecution(FUNC_1, FUNC_1_NR_EXECUTED_LINES_TRACEFILE2);
+    sourceFile.addLineNumber(FUNC_1, FUNC_1_LINE_NR);
+    sourceFile.addFunctionExecution(FUNC_1, FUNC_1_NR_EXECUTED_LINES_TRACEFILE2);
 
-    sourceFileCoverage.addLineNumber(FUNC_2, FUNC_2_LINE_NR);
-    sourceFileCoverage.addFunctionExecution(FUNC_2, FUNC_2_NR_EXECECUTED_LINES_TRACEFILE2);
+    sourceFile.addLineNumber(FUNC_2, FUNC_2_LINE_NR);
+    sourceFile.addFunctionExecution(FUNC_2, FUNC_2_NR_EXECECUTED_LINES_TRACEFILE2);
 
-    sourceFileCoverage.addLineNumber(FUNC_3, FUNC_3_LINE_NR);
-    sourceFileCoverage.addFunctionExecution(FUNC_3, FUNC_3_NR_EXECUTED_LINES_TRACEFILE2);
+    sourceFile.addLineNumber(FUNC_3, FUNC_3_LINE_NR);
+    sourceFile.addFunctionExecution(FUNC_3, FUNC_3_NR_EXECUTED_LINES_TRACEFILE2);
 
     for (int line = FUNC_1_LINE_NR; line < MAX_LINES_IN_FILE; line++) {
       if (lineExecutionCount[line] >= 0) {
-        sourceFileCoverage.addLine(line, LineCoverage.create(line, lineExecutionCount[line], null));
+        sourceFile.addLine(line, LineCoverage.create(line, lineExecutionCount[line], null));
       }
     }
-    return sourceFileCoverage;
+
+    sourceFile.addBranch(15, BranchCoverage.create(15, 2));
+    sourceFile.addBranch(15, BranchCoverage.create(15, 1));
+    sourceFile.addBranch(23, BranchCoverage.create(23, 2));
+    sourceFile.addBranch(23, BranchCoverage.create(23, 2));
+    sourceFile.addBranch(25, BranchCoverage.create(25, 1));
+    sourceFile.addBranch(25, BranchCoverage.create(25, 2));
+    return sourceFile;
   }
 
   private static void assertLinesExecution_tracefile1(Map<Integer, LineCoverage> lines) {
@@ -325,6 +376,9 @@ public class LcovMergerTestUtils {
     assertThat(functionsExecution.get(FUNC_2)).isEqualTo(FUNC_2_NR_EXECUTED_LINES_TRACEFILE1);
     assertThat(functionsExecution.get(FUNC_3)).isEqualTo(FUNC_3_NR_EXECUTED_LINES_TRACEFILE1);
 
+    assertThat(sourceFile.nrBranchesFound()).isEqualTo(NR_BRANCHES_FOUND);
+    assertThat(sourceFile.nrBranchesHit()).isEqualTo(NR_BRANCHES_HIT_TRACEFILE1);
+
     assertLinesExecution_tracefile1(sourceFile.getLines());
 
     assertThat(sourceFile.nrOfInstrumentedLines()).isEqualTo(14);
@@ -345,6 +399,9 @@ public class LcovMergerTestUtils {
     assertThat(functionsExecution.get(FUNC_1)).isEqualTo(FUNC_1_NR_EXECUTED_LINES_TRACEFILE2);
     assertThat(functionsExecution.get(FUNC_2)).isEqualTo(FUNC_2_NR_EXECECUTED_LINES_TRACEFILE2);
     assertThat(functionsExecution.get(FUNC_3)).isEqualTo(FUNC_3_NR_EXECUTED_LINES_TRACEFILE2);
+
+    assertThat(sourceFile.nrBranchesFound()).isEqualTo(NR_BRANCHES_FOUND);
+    assertThat(sourceFile.nrBranchesHit()).isEqualTo(NR_BRANCHES_HIT_TRACEFILE2);
 
     assertLines_tracefile2(sourceFile.getLines());
 
@@ -400,6 +457,9 @@ public class LcovMergerTestUtils {
     assertMergedLineNumbers(merged.getLineNumbers());
     assertMergedFunctionsExecution(merged.getFunctionsExecution());
     assertMergedLines(merged.getLines(), linesExecution1, linesExecution2);
+
+    assertThat(merged.nrBranchesFound()).isEqualTo(NR_BRANCHES_FOUND);
+    assertThat(merged.nrBranchesHit()).isEqualTo(NR_BRANCHES_HIT_MERGED);
 
     assertThat(merged.nrFunctionsFound()).isEqualTo(NR_FUNCTIONS_FOUND);
     assertThat(merged.nrFunctionsHit()).isEqualTo(NR_FUNCTIONS_FOUND);

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovParserTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovParserTest.java
@@ -141,4 +141,42 @@ public class LcovParserTest {
             BranchCoverage.createWithBlockAndBranch(12, "0", "0", false, 0),
             BranchCoverage.createWithBlockAndBranch(12, "0", "1", false, 0));
   }
+
+  @Test
+  public void testParseBaBranches() throws IOException {
+    List<String> traceFile =
+            ImmutableList.of(
+                    "SF:SOURCE_FILE",
+                    "FN:2,func",
+                    "FNDA:1,func",
+                    "DA:1,5",
+                    "BA:2,1",
+                    "BA:2,2",
+                    "DA:3,0",
+                    "BA:4,0",
+                    "BA:4,0",
+                    "DA:5,0",
+                    "DA:6,5",
+                    "BA:7,2",
+                    "BA:7,1",
+                    "BA:7,2",
+                    "DA:8,1",
+                    "DA:9,0",
+                    "DA:10,4",
+                    "end_of_record");
+    List<SourceFileCoverage> sourceFiles =
+            LcovParser.parse(new ByteArrayInputStream(Joiner.on("\n").join(traceFile).getBytes(UTF_8)));
+    SourceFileCoverage sourceFile = sourceFiles.get(0);
+
+    List<BranchCoverage> branches =
+            sourceFile.getAllBranches().stream().collect(Collectors.toList());
+    assertThat(branches).containsExactly(
+            BranchCoverage.create(2, 1),
+            BranchCoverage.create(2, 2),
+            BranchCoverage.create(4, 0),
+            BranchCoverage.create(4, 0),
+            BranchCoverage.create(7, 2),
+            BranchCoverage.create(7, 1),
+            BranchCoverage.create(7, 2));
+  }
 }

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovPrinterTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/LcovPrinterTest.java
@@ -22,7 +22,7 @@ import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.cr
 
 import com.google.common.base.Splitter;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import java.lang.Exception;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
@@ -50,7 +50,7 @@ public class LcovPrinterTest {
   }
 
   @Test
-  public void testPrintTwoFiles() throws IOException {
+  public void testPrintTwoFiles() throws Exception {
     coverage.add(sourceFileCoverage1);
     coverage.add(sourceFileCoverage2);
 
@@ -75,7 +75,7 @@ public class LcovPrinterTest {
   }
 
   @Test
-  public void testPrintOneFile() throws IOException {
+  public void testPrintOneFile() throws Exception {
     coverage.add(sourceFileCoverage1);
     assertThat(LcovPrinter.print(byteOutputStream, coverage)).isTrue();
     byteOutputStream.close();
@@ -92,7 +92,7 @@ public class LcovPrinterTest {
   }
 
   @Test
-  public void testPrintBrdaLines() throws IOException {
+  public void testPrintBrdaLines() throws Exception {
     SourceFileCoverage sourceFile = new SourceFileCoverage("foo");
     sourceFile.addBranch(3, BranchCoverage.createWithBlockAndBranch(3, "0", "0", true, 1));
     sourceFile.addBranch(3, BranchCoverage.createWithBlockAndBranch(3, "0", "1", true, 0));

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/SourceFileCoverageTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/SourceFileCoverageTest.java
@@ -23,6 +23,7 @@ import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.cr
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createLinesExecution2;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createSourceFile1;
 import static com.google.devtools.coverageoutputgenerator.LcovMergerTestUtils.createSourceFile2;
+import static org.junit.Assert.assertThrows;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -70,8 +71,29 @@ public class SourceFileCoverageTest {
   }
 
   @Test
-  public void testMerge() {
+  public void testMerge() throws Exception {
     assertMergedSourceFile(
         SourceFileCoverage.merge(sourceFile1, sourceFile2), linesExecution1, linesExecution2);
+  }
+
+  @Test
+  public void testIncompatibleBaBranchMergeThrows() throws Exception {
+    sourceFile1.addBranch(800, BranchCoverage.create(800, 2));
+    sourceFile1.addBranch(800, BranchCoverage.create(800, 1));
+    sourceFile2.addBranch(800, BranchCoverage.create(800, 2));
+    sourceFile2.addBranch(800, BranchCoverage.create(800, 2));
+    sourceFile2.addBranch(800, BranchCoverage.create(800, 1));
+    assertThrows(
+        IncompatibleMergeException.class, () -> SourceFileCoverage.merge(sourceFile1, sourceFile2));
+  }
+
+  @Test
+  public void testIncompatibleBrdaBranchMergeThrows() throws Exception {
+    sourceFile1.addBranch(800, BranchCoverage.createWithBlockAndBranch(800, "0", "0", true, 1));
+    sourceFile1.addBranch(800, BranchCoverage.createWithBlockAndBranch(800, "0", "1", true, 0));
+    sourceFile2.addBranch(800, BranchCoverage.createWithBlockAndBranch(800, "1", "0", true, 3));
+    sourceFile2.addBranch(800, BranchCoverage.createWithBlockAndBranch(800, "1", "1", true, 4));
+    assertThrows(
+        IncompatibleMergeException.class, () -> SourceFileCoverage.merge(sourceFile1, sourceFile2));
   }
 }


### PR DESCRIPTION
BA lines were not being correctly handled' SourceFileGenerator would
incorrectly merge entries with the same line number and the "taken"
value was frequently being interpreted as an execution count.

This fixes these issues, but merging of branch coverage information is
now more subtle. We have to check for inconsistencies in the input
files where branch data does not match up. There isn't a lot we can do
if this happens, so we just error out quickly.

But "This Should Never Happen (tm)".