### PR TITLE
Add action_names filegroup

### DIFF
--- a/tools/build_defs/cc/BUILD
+++ b/tools/build_defs/cc/BUILD
@@ -16,6 +16,14 @@ filegroup(
 )
 
 filegroup(
+    name = "action_names",
+    srcs = [
+        "action_names.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "action_names_test_files",
     testonly = True,
     srcs = [


### PR DESCRIPTION
This seems to exist internally at google and was imported by rules_swift https://github.com/bazelbuild/rules_swift/pull/461