### PR TITLE
Use definition location for StarlarkRuleFunction.export errors.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -705,7 +705,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi<Arti
         if (attr.hasAnalysisTestTransition()) {
           if (!builder.isAnalysisTest()) {
             throw new EvalException(
-                getLocation(),
+                definitionLocation,
                 "Only rule definitions with analysis_test=True may have attributes with "
                     + "analysis_test_transition transitions");
           }
@@ -717,11 +717,11 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi<Arti
             || name.equals(FunctionSplitTransitionAllowlist.LEGACY_ATTRIBUTE_NAME)) {
           if (!BuildType.isLabelType(attr.getType())) {
             throw new EvalException(
-                getLocation(), "_allowlist_function_transition attribute must be a label type");
+                definitionLocation, "_allowlist_function_transition attribute must be a label type");
           }
           if (attr.getDefaultValueUnchecked() == null) {
             throw new EvalException(
-                getLocation(),
+                definitionLocation,
                 "_allowlist_function_transition attribute must have a default value");
           }
           Label defaultLabel = (Label) attr.getDefaultValueUnchecked();
@@ -740,7 +740,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi<Arti
                       .getName()
                       .equals(FunctionSplitTransitionAllowlist.LEGACY_LABEL.getName()))) {
             throw new EvalException(
-                getLocation(),
+                definitionLocation,
                 "_allowlist_function_transition attribute ("
                     + defaultLabel
                     + ") does not have the expected value "
@@ -755,7 +755,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi<Arti
       if (hasStarlarkDefinedTransition) {
         if (!hasFunctionTransitionAllowlist) {
           throw new EvalException(
-              getLocation(),
+              definitionLocation,
               String.format(
                   "Use of Starlark transition without allowlist attribute"
                       + " '_allowlist_function_transition'. See Starlark transitions documentation"
@@ -765,7 +765,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi<Arti
       } else {
         if (hasFunctionTransitionAllowlist) {
           throw new EvalException(
-              getLocation(),
+              definitionLocation,
               String.format(
                   "Unused function-based split transition allowlist: %s %s",
                   builder.getRuleDefinitionEnvironmentLabel(), builder.getType()));
@@ -775,7 +775,7 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi<Arti
       try {
         this.ruleClass = builder.build(ruleClassName, starlarkLabel + "%" + ruleClassName);
       } catch (IllegalArgumentException | IllegalStateException ex) {
-        throw new EvalException(getLocation(), ex);
+        throw new EvalException(definitionLocation, ex);
       }
 
       this.builder = null;

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -265,7 +265,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
     Event event = ev.getEventCollector().iterator().next();
     assertThat(event.getKind()).isEqualTo(EventKind.ERROR);
     assertThat(event.getMessage())
-        .matches("Attribute r\\.x{150}'s name is too long \\(150 > 128\\)");
+        .matches(":2:9: Attribute r\\.x{150}'s name is too long \\(150 > 128\\)");
   }
 
   @Test


### PR DESCRIPTION
StarlarkRuleFunction.getLocation() always returns BUILTIN.