### PR TITLE
Display remote action as running only if it is actually executing.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
@@ -163,14 +163,16 @@ class GrpcRemoteExecutor {
 
                   // Update execution progress to the caller.
                   //
-                  // After called `execute` above, the action is actually waiting for available
+                  // After called `execute` above, the action is actually waiting for an available
                   // gRPC connection to be sent. Once we get a reply from server, we know the
-                  // connection is up and indicate caller the fact by forwarding the `operation`.
+                  // connection is up and indicate to the caller the fact by forwarding the
+                  // `operation`.
                   //
-                  // The accurate execution status of the action relies on server implementation:
+                  // The accurate execution status of the action relies on the server
+                  // implementation:
                   //   1. Server can reply the accurate status in `operation.metadata.stage`;
                   //   2. Server may send a reply without metadata. In this case, we assume the
-                  //      action is accepted by server and will be executed ASAP;
+                  //      action is accepted by the server and will be executed ASAP;
                   //   3. Server may execute the action silently and send a reply once it is done.
                   if (receiver != null) {
                     receiver.onNextOperation(o);

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
@@ -92,7 +92,7 @@ class GrpcRemoteExecutor {
   }
 
   interface ExecuteOperationUpdateReceiver {
-    void onNextOperation(Operation o);
+    void onNextOperation(Operation o) throws IOException;
   }
 
   /* Execute has two components: the Execute call and (optionally) the WaitExecution call.

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
@@ -158,11 +158,11 @@ class GrpcRemoteExecutor {
               try {
                 while (replies.hasNext()) {
                   Operation o = replies.next();
+                  operation.set(o);
+                  waitExecution.set(!operation.get().getDone());
                   if (receiver != null) {
                     receiver.onNextOperation(o);
                   }
-                  operation.set(o);
-                  waitExecution.set(!operation.get().getDone());
                   ExecuteResponse r = getOperationResponse(o);
                   if (r != null) {
                     return r;

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
@@ -91,7 +91,7 @@ class GrpcRemoteExecutor {
     return executeRemotely(request, null);
   }
 
-  interface ExecuteOperationNotifier {
+  interface ExecuteOperationUpdateReceiver {
     void onNextOperation(Operation o);
   }
 
@@ -113,7 +113,7 @@ class GrpcRemoteExecutor {
    *   are completed and failed; however, some of these errors may be retriable. These errors should
    *   trigger a retry of the Execute call, resulting in a new Operation.
    * */
-  public ExecuteResponse executeRemotely(ExecuteRequest request, ExecuteOperationNotifier notifier)
+  public ExecuteResponse executeRemotely(ExecuteRequest request, ExecuteOperationUpdateReceiver receiver)
       throws IOException, InterruptedException {
     // Execute has two components: the Execute call and (optionally) the WaitExecution call.
     // This is the simple flow without any errors:
@@ -158,8 +158,8 @@ class GrpcRemoteExecutor {
               try {
                 while (replies.hasNext()) {
                   Operation o = replies.next();
-                  if (notifier != null) {
-                    notifier.onNextOperation(o);
+                  if (receiver != null) {
+                    receiver.onNextOperation(o);
                   }
                   operation.set(o);
                   waitExecution.set(!operation.get().getDone());

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -321,13 +321,19 @@ public class RemoteSpawnRunner implements SpawnRunner {
                 spawnMetrics.setUploadTime(
                     uploadTime.elapsed().minus(networkTime.getDuration().minus(networkTimeStart)));
               }
+              final AtomicBoolean reportedExecuting =
+                  new AtomicBoolean(false);
               ExecuteResponse reply;
               try (SilentCloseable c = prof.profile(REMOTE_EXECUTION, "execute remotely")) {
                 reply = remoteExecutor.executeRemotely(request, (operation) -> {
-                  // We should have used operation.metadata to check the execution stage. But some
-                  // server implementations don't return that value. So we assume the action is
-                  // executing if we get any operation from server.
-                  context.report(ProgressStatus.EXECUTING, getName());
+                  if (!reportedExecuting.get()) {
+                    reportedExecuting.set(true);
+
+                    // We should have used operation.metadata to check the execution stage. But some
+                    // server implementations don't return that value. So we assume the action is
+                    // executing if we get any operation from server.
+                    context.report(ProgressStatus.EXECUTING, getName());
+                  }
                 });
               }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -28,9 +28,11 @@ import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.ExecuteOperationMetadata;
 import build.bazel.remote.execution.v2.ExecuteRequest;
 import build.bazel.remote.execution.v2.ExecuteResponse;
 import build.bazel.remote.execution.v2.ExecutedActionMetadata;
+import build.bazel.remote.execution.v2.ExecutionStage.Value;
 import build.bazel.remote.execution.v2.LogFile;
 import build.bazel.remote.execution.v2.Platform;
 import com.google.common.annotations.VisibleForTesting;
@@ -64,6 +66,7 @@ import com.google.devtools.build.lib.exec.SpawnRunner;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
+import com.google.devtools.build.lib.remote.GrpcRemoteExecutor.ExecuteOperationUpdateReceiver;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -79,6 +82,7 @@ import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.util.io.FileOutErr;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
@@ -199,6 +203,42 @@ public class RemoteSpawnRunner implements SpawnRunner {
     return "remote";
   }
 
+  class ExecutingStatusReporter implements ExecuteOperationUpdateReceiver {
+    private boolean reportedExecuting = false;
+    private SpawnExecutionContext context;
+
+    ExecutingStatusReporter(SpawnExecutionContext context) {
+      this.context = context;
+    }
+
+    @Override
+    public void onNextOperation(Operation o) throws IOException {
+      if (!reportedExecuting) {
+        if (o.hasMetadata()) {
+          ExecuteOperationMetadata metadata = o.getMetadata().unpack(ExecuteOperationMetadata.class);
+          if (metadata.getStage() == Value.EXECUTING) {
+            reportExecuting();
+          }
+        } else {
+          // If the server didn't return metadata, we can't know the accurate execution status, so
+          // assuming that the action is accepted by the server and will be executed ASAP.
+          reportExecuting();
+        }
+      }
+    }
+
+    public void reportExecuting() {
+      context.report(ProgressStatus.EXECUTING, getName());
+      reportedExecuting = true;
+    }
+
+    public void reportExecutingIfNot() {
+      if (!reportedExecuting) {
+        reportExecuting();
+      }
+    }
+  }
+
   @Override
   public SpawnResult exec(Spawn spawn, SpawnExecutionContext context)
       throws ExecException, InterruptedException, IOException {
@@ -207,6 +247,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
     boolean uploadLocalResults = remoteOptions.remoteUploadLocalResults && spawnCacheableRemotely;
     boolean acceptCachedResult = remoteOptions.remoteAcceptCached && spawnCacheableRemotely;
 
+    context.report(ProgressStatus.SCHEDULING, getName());
     RemoteOutputsMode remoteOutputsMode = remoteOptions.remoteOutputsMode;
     SortedMap<PathFragment, ActionInput> inputMap = context.getInputMapping();
     final MerkleTree merkleTree =
@@ -321,21 +362,15 @@ public class RemoteSpawnRunner implements SpawnRunner {
                 spawnMetrics.setUploadTime(
                     uploadTime.elapsed().minus(networkTime.getDuration().minus(networkTimeStart)));
               }
-              final AtomicBoolean reportedExecuting =
-                  new AtomicBoolean(false);
+
+              ExecutingStatusReporter reporter = new ExecutingStatusReporter(context);
               ExecuteResponse reply;
               try (SilentCloseable c = prof.profile(REMOTE_EXECUTION, "execute remotely")) {
-                reply = remoteExecutor.executeRemotely(request, (operation) -> {
-                  if (!reportedExecuting.get()) {
-                    reportedExecuting.set(true);
-
-                    // We should have used operation.metadata to check the execution stage. But some
-                    // server implementations don't return that value. So we assume the action is
-                    // executing if we get any operation from server.
-                    context.report(ProgressStatus.EXECUTING, getName());
-                  }
-                });
+                reply = remoteExecutor.executeRemotely(request, reporter);
               }
+              // In case of replies from server contains metadata, but none of them has EXECUTING status.
+              // It's already late at this stage, but we should at least report once.
+              reporter.reportExecutingIfNot();
 
               FileOutErr outErr = context.getFileOutErr();
               String message = reply.getMessage();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -71,6 +71,7 @@ import com.google.devtools.build.lib.exec.RemoteLocalFallbackRegistry;
 import com.google.devtools.build.lib.exec.SpawnRunner;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.exec.util.FakeOwner;
+import com.google.devtools.build.lib.remote.GrpcRemoteExecutor.ExecuteOperationUpdateReceiver;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -180,7 +181,7 @@ public class RemoteSpawnRunnerTest {
         ExecuteResponse.newBuilder()
             .setResult(ActionResult.newBuilder().setExitCode(0).build())
             .build();
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenReturn(succeeded);
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenReturn(succeeded);
 
     Spawn spawn = simpleSpawnWithExecutionInfo(NO_CACHE);
     SpawnExecutionContext policy = getSpawnContext(spawn);
@@ -188,7 +189,7 @@ public class RemoteSpawnRunnerTest {
     runner.exec(spawn, policy);
 
     ArgumentCaptor<ExecuteRequest> requestCaptor = ArgumentCaptor.forClass(ExecuteRequest.class);
-    verify(executor).executeRemotely(requestCaptor.capture());
+    verify(executor).executeRemotely(requestCaptor.capture(), any(ExecuteOperationUpdateReceiver.class));
     assertThat(requestCaptor.getValue().getSkipCacheLookup()).isTrue();
     assertThat(requestCaptor.getValue().getResultsCachePolicy().getPriority()).isEqualTo(1);
     assertThat(requestCaptor.getValue().getExecutionPolicy().getPriority()).isEqualTo(2);
@@ -220,7 +221,7 @@ public class RemoteSpawnRunnerTest {
     RemoteSpawnRunner runner = newSpawnRunner();
 
     // Throw an IOException to trigger the local fallback.
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(IOException.class);
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenThrow(IOException.class);
 
     Spawn spawn = simpleSpawnWithExecutionInfo(NO_CACHE);
     SpawnExecutionContext policy = getSpawnContext(spawn);
@@ -244,7 +245,7 @@ public class RemoteSpawnRunnerTest {
     RemoteSpawnRunner runner = spy(newSpawnRunner());
 
     // Throw an IOException to trigger the local fallback.
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(IOException.class);
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenThrow(IOException.class);
 
     SpawnResult res =
         new SpawnResult.Builder()
@@ -277,7 +278,7 @@ public class RemoteSpawnRunnerTest {
     RemoteSpawnRunner runner = spy(newSpawnRunner());
 
     // Throw an IOException to trigger the local fallback.
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(IOException.class);
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenThrow(IOException.class);
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = getSpawnContext(spawn);
@@ -310,7 +311,7 @@ public class RemoteSpawnRunnerTest {
 
     RemoteSpawnRunner runner = spy(newSpawnRunner());
     // Throw an IOException to trigger the local fallback.
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(IOException.class);
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenThrow(IOException.class);
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = getSpawnContext(spawn);
@@ -348,14 +349,14 @@ public class RemoteSpawnRunnerTest {
         ExecuteResponse.newBuilder()
             .setResult(ActionResult.newBuilder().setExitCode(0).build())
             .build();
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenReturn(succeeded);
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenReturn(succeeded);
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = getSpawnContext(spawn);
 
     runner.exec(spawn, policy);
 
     ArgumentCaptor<ExecuteRequest> requestCaptor = ArgumentCaptor.forClass(ExecuteRequest.class);
-    verify(executor).executeRemotely(requestCaptor.capture());
+    verify(executor).executeRemotely(requestCaptor.capture(), any(ExecuteOperationUpdateReceiver.class));
     assertThat(requestCaptor.getValue().getSkipCacheLookup()).isTrue();
   }
 
@@ -372,7 +373,7 @@ public class RemoteSpawnRunnerTest {
 
     RemoteSpawnRunner runner = newSpawnRunner(reporter);
     // Trigger local fallback
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(new IOException());
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenThrow(new IOException());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = getSpawnContext(spawn);
@@ -413,7 +414,7 @@ public class RemoteSpawnRunnerTest {
 
     RemoteSpawnRunner runner = newSpawnRunner();
     // Trigger local fallback
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(new IOException());
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenThrow(new IOException());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = getSpawnContext(spawn);
@@ -439,7 +440,7 @@ public class RemoteSpawnRunnerTest {
 
     RemoteSpawnRunner runner = newSpawnRunner();
     // Trigger local fallback
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(new IOException());
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenThrow(new IOException());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = getSpawnContext(spawn);
@@ -464,7 +465,7 @@ public class RemoteSpawnRunnerTest {
 
     when(cache.downloadActionResult(any(ActionKey.class), /* inlineOutErr= */ eq(false)))
         .thenReturn(null);
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(new IOException());
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenThrow(new IOException());
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = getSpawnContext(spawn);
@@ -483,7 +484,7 @@ public class RemoteSpawnRunnerTest {
     RemoteSpawnRunner runner = newSpawnRunner();
     Digest logDigest = digestUtil.computeAsUtf8("bla");
     Path logPath = logDir.getRelative(simpleActionId).getRelative("logname");
-    when(executor.executeRemotely(any(ExecuteRequest.class)))
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class)))
         .thenReturn(
             ExecuteResponse.newBuilder()
                 .putServerLogs(
@@ -501,7 +502,7 @@ public class RemoteSpawnRunnerTest {
     SpawnResult res = runner.exec(spawn, policy);
     assertThat(res.status()).isEqualTo(Status.NON_ZERO_EXIT);
 
-    verify(executor).executeRemotely(any(ExecuteRequest.class));
+    verify(executor).executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class));
     verify(cache).downloadFile(eq(logPath), eq(logDigest));
   }
 
@@ -518,7 +519,7 @@ public class RemoteSpawnRunnerTest {
                 "logname", LogFile.newBuilder().setHumanReadable(true).setDigest(logDigest).build())
             .setStatus(timeoutStatus)
             .build();
-    when(executor.executeRemotely(any(ExecuteRequest.class)))
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class)))
         .thenThrow(new IOException(new ExecutionStatusException(resp.getStatus(), resp)));
     SettableFuture<Void> completed = SettableFuture.create();
     completed.set(null);
@@ -530,7 +531,7 @@ public class RemoteSpawnRunnerTest {
     SpawnResult res = runner.exec(spawn, policy);
     assertThat(res.status()).isEqualTo(Status.TIMEOUT);
 
-    verify(executor).executeRemotely(any(ExecuteRequest.class));
+    verify(executor).executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class));
     verify(cache).downloadFile(eq(logPath), eq(logDigest));
   }
 
@@ -540,7 +541,7 @@ public class RemoteSpawnRunnerTest {
 
     Digest logDigest = digestUtil.computeAsUtf8("bla");
     ActionResult result = ActionResult.newBuilder().setExitCode(31).build();
-    when(executor.executeRemotely(any(ExecuteRequest.class)))
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class)))
         .thenReturn(
             ExecuteResponse.newBuilder()
                 .putServerLogs("logname", LogFile.newBuilder().setDigest(logDigest).build())
@@ -552,7 +553,7 @@ public class RemoteSpawnRunnerTest {
     SpawnResult res = runner.exec(spawn, policy);
     assertThat(res.status()).isEqualTo(Status.NON_ZERO_EXIT);
 
-    verify(executor).executeRemotely(any(ExecuteRequest.class));
+    verify(executor).executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class));
     verify(cache).download(eq(result), eq(execRoot), any(FileOutErr.class), any());
     verify(cache, never()).downloadFile(any(Path.class), any(Digest.class));
   }
@@ -563,7 +564,7 @@ public class RemoteSpawnRunnerTest {
 
     Digest logDigest = digestUtil.computeAsUtf8("bla");
     ActionResult result = ActionResult.newBuilder().setExitCode(0).build();
-    when(executor.executeRemotely(any(ExecuteRequest.class)))
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class)))
         .thenReturn(
             ExecuteResponse.newBuilder()
                 .putServerLogs(
@@ -578,7 +579,7 @@ public class RemoteSpawnRunnerTest {
     SpawnResult res = runner.exec(spawn, policy);
     assertThat(res.status()).isEqualTo(Status.SUCCESS);
 
-    verify(executor).executeRemotely(any(ExecuteRequest.class));
+    verify(executor).executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class));
     verify(cache).download(eq(result), eq(execRoot), any(FileOutErr.class), any());
     verify(cache, never()).downloadFile(any(Path.class), any(Digest.class));
   }
@@ -599,7 +600,7 @@ public class RemoteSpawnRunnerTest {
         .download(eq(cachedResult), any(Path.class), any(FileOutErr.class), any());
     ActionResult execResult = ActionResult.newBuilder().setExitCode(31).build();
     ExecuteResponse succeeded = ExecuteResponse.newBuilder().setResult(execResult).build();
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenReturn(succeeded);
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenReturn(succeeded);
     doNothing().when(cache).download(eq(execResult), any(Path.class), any(FileOutErr.class), any());
 
     Spawn spawn = newSimpleSpawn();
@@ -610,7 +611,7 @@ public class RemoteSpawnRunnerTest {
     assertThat(res.status()).isEqualTo(Status.NON_ZERO_EXIT);
     assertThat(res.exitCode()).isEqualTo(31);
 
-    verify(executor).executeRemotely(any(ExecuteRequest.class));
+    verify(executor).executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class));
   }
 
   @Test
@@ -627,7 +628,7 @@ public class RemoteSpawnRunnerTest {
     ExecuteResponse cachedResponse =
         ExecuteResponse.newBuilder().setResult(cachedResult).setCachedResult(true).build();
     ExecuteResponse executedResponse = ExecuteResponse.newBuilder().setResult(execResult).build();
-    when(executor.executeRemotely(any(ExecuteRequest.class)))
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class)))
         .thenReturn(cachedResponse)
         .thenReturn(executedResponse);
     Exception downloadFailure =
@@ -646,7 +647,7 @@ public class RemoteSpawnRunnerTest {
     assertThat(res.exitCode()).isEqualTo(31);
 
     ArgumentCaptor<ExecuteRequest> requestCaptor = ArgumentCaptor.forClass(ExecuteRequest.class);
-    verify(executor, times(2)).executeRemotely(requestCaptor.capture());
+    verify(executor, times(2)).executeRemotely(requestCaptor.capture(), any(ExecuteOperationUpdateReceiver.class));
     List<ExecuteRequest> requests = requestCaptor.getAllValues();
     // first request should have been executed without skip cache lookup
     assertThat(requests.get(0).getSkipCacheLookup()).isFalse();
@@ -673,7 +674,7 @@ public class RemoteSpawnRunnerTest {
                     .setCode(Code.DEADLINE_EXCEEDED.getNumber())
                     .build())
             .build();
-    when(executor.executeRemotely(any(ExecuteRequest.class)))
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class)))
         .thenThrow(new IOException(new ExecutionStatusException(resp.getStatus(), resp)));
 
     Spawn spawn = newSimpleSpawn();
@@ -683,7 +684,7 @@ public class RemoteSpawnRunnerTest {
     SpawnResult res = runner.exec(spawn, policy);
     assertThat(res.status()).isEqualTo(Status.TIMEOUT);
 
-    verify(executor).executeRemotely(any(ExecuteRequest.class));
+    verify(executor).executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class));
     verify(cache).download(eq(cachedResult), eq(execRoot), any(FileOutErr.class), any());
   }
 
@@ -707,7 +708,7 @@ public class RemoteSpawnRunnerTest {
                     .setCode(Code.DEADLINE_EXCEEDED.getNumber())
                     .build())
             .build();
-    when(executor.executeRemotely(any(ExecuteRequest.class)))
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class)))
         .thenThrow(new IOException(new ExecutionStatusException(resp.getStatus(), resp)));
 
     Spawn spawn = newSimpleSpawn();
@@ -717,7 +718,7 @@ public class RemoteSpawnRunnerTest {
     SpawnResult res = runner.exec(spawn, policy);
     assertThat(res.status()).isEqualTo(Status.TIMEOUT);
 
-    verify(executor).executeRemotely(any(ExecuteRequest.class));
+    verify(executor).executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class));
     verify(cache).download(eq(cachedResult), eq(execRoot), any(FileOutErr.class), any());
     verify(localRunner, never()).exec(eq(spawn), eq(policy));
   }
@@ -735,7 +736,7 @@ public class RemoteSpawnRunnerTest {
         ExecuteResponse.newBuilder()
             .setResult(ActionResult.newBuilder().setExitCode(33).build())
             .build();
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenReturn(failed);
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenReturn(failed);
 
     Spawn spawn = newSimpleSpawn();
 
@@ -745,7 +746,7 @@ public class RemoteSpawnRunnerTest {
     assertThat(res.status()).isEqualTo(Status.NON_ZERO_EXIT);
     assertThat(res.exitCode()).isEqualTo(33);
 
-    verify(executor).executeRemotely(any(ExecuteRequest.class));
+    verify(executor).executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class));
     verify(cache, never()).download(eq(cachedResult), eq(execRoot), any(FileOutErr.class), any());
     verify(localRunner, never()).exec(eq(spawn), eq(policy));
   }
@@ -761,7 +762,7 @@ public class RemoteSpawnRunnerTest {
 
     when(cache.downloadActionResult(any(ActionKey.class), /* inlineOutErr= */ eq(false)))
         .thenReturn(null);
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenThrow(new IOException("reasons"));
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenThrow(new IOException("reasons"));
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = getSpawnContext(spawn);
@@ -824,7 +825,7 @@ public class RemoteSpawnRunnerTest {
         ExecuteResponse.newBuilder()
             .setResult(ActionResult.newBuilder().setExitCode(0).build())
             .build();
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenReturn(succeeded);
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenReturn(succeeded);
 
     ImmutableList<String> args = ImmutableList.of("--foo", "--bar");
     ParamFileActionInput input =
@@ -885,7 +886,7 @@ public class RemoteSpawnRunnerTest {
 
     ActionResult succeededAction = ActionResult.newBuilder().setExitCode(0).build();
     ExecuteResponse succeeded = ExecuteResponse.newBuilder().setResult(succeededAction).build();
-    when(executor.executeRemotely(any(ExecuteRequest.class))).thenReturn(succeeded);
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class))).thenReturn(succeeded);
 
     RemoteSpawnRunner runner = newSpawnRunner();
 
@@ -898,7 +899,7 @@ public class RemoteSpawnRunnerTest {
     assertThat(result.status()).isEqualTo(Status.SUCCESS);
 
     // assert
-    verify(executor).executeRemotely(any());
+    verify(executor).executeRemotely(any(), any(ExecuteOperationUpdateReceiver.class));
     verify(cache)
         .downloadMinimal(
             any(), eq(succeededAction), anyCollection(), any(), any(), any(), any(), any());

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -1025,16 +1025,17 @@ public class RemoteSpawnRunnerTest {
         .setResult(ActionResult.newBuilder().setExitCode(0).build())
         .build();
 
-    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class)))
-        .thenAnswer(invocationOnMock -> {
-          ExecuteOperationUpdateReceiver receiver = invocationOnMock.getArgument(1);
-          receiver.onNextOperation(Operation.newBuilder().build());
-          return succeeded;
-        });
-
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = mock(SpawnExecutionContext.class);
     when(policy.getTimeout()).thenReturn(Duration.ZERO);
+
+    when(executor.executeRemotely(any(ExecuteRequest.class), any(ExecuteOperationUpdateReceiver.class)))
+        .thenAnswer(invocationOnMock -> {
+          ExecuteOperationUpdateReceiver receiver = invocationOnMock.getArgument(1);
+          verify(policy, never()).report(eq(ProgressStatus.EXECUTING), any(String.class));
+          receiver.onNextOperation(Operation.newBuilder().build());
+          return succeeded;
+        });
 
     SpawnResult res = runner.exec(spawn, policy);
     assertThat(res.status()).isEqualTo(Status.SUCCESS);


### PR DESCRIPTION
From #11801 

> due to bazel displaying full parallelism even if actions are actually queued waiting for gRPC connections

This PR makes Bazel display running actions only if it is actually executing remotely as a first step to fix parallelism limitation.

With `--jobs=500`, the progress bar is displayed as:
```
[1 / 501] 500 actions running
```

However, the number of actual running actions by remote workers is not 500 since some actions are pending because of the limitation. With this change, the progress bar now become:
```
[1 / 501] 500 actions, 200 running
```