### PR TITLE
Change GcovParser and GcovJsonParser to emit BRDA branch information

### DIFF
--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD
@@ -122,6 +122,7 @@ java_library(
         ":Constants",
         ":LineCoverage",
         ":SourceFileCoverage",
+        "//third_party:guava",
     ],
 )
 

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BranchCoverage.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BranchCoverage.java
@@ -64,6 +64,19 @@ abstract class BranchCoverage {
   }
 
   /**
+   * Create a BranchCoverage object corresponding to a BRDA line with a dummy block number
+   * <pre>BRDA:[line_number],[block_number=0],[branch_number],[taken]</pre>
+   * @param lineNumber
+   * @param branchNumber
+   * @param evaluated if this branch was evaluated (taken != "-")
+   * @param nrOfExecutions how many times the branch was taken (the value of taken if taken != "-")
+   * @return corresponding BranchCoverage
+   */
+  static BranchCoverage createWithBranch(int lineNumber, String branchNumber, boolean evaluated, long nrOfExecutions) {
+    return new AutoValue_BranchCoverage(lineNumber, /*blockNumber=*/ "0", branchNumber, evaluated, nrOfExecutions);
+  }
+
+  /**
    * Create a BranchCoverage object corresponding to a BRDA line
    *
    * <pre>BRDA:[line_number],[block_number],[branch_number],[taken]</pre>
@@ -118,7 +131,7 @@ abstract class BranchCoverage {
   }
 
   abstract int lineNumber();
-  // The two numbers below should be -1 for non-gcc emitted coverage (e.g. Java).
+
   abstract String blockNumber(); // internal gcc ID for the branch
 
   abstract String branchNumber(); // internal gcc ID for the branch

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovJsonParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovJsonParser.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -67,10 +68,14 @@ public class GcovJsonParser {
         for (GcovJsonLine line : file.lines) {
           currentFileCoverage.addLine(
               line.line_number, LineCoverage.create(line.line_number, line.count, null));
+          int branchNumber = 0;
+          boolean taken = Arrays.stream(line.branches).anyMatch(b -> b.count > 0);
           for (GcovJsonBranch branch : line.branches) {
-            int takenValue = line.unexecuted_block ? 0 : branch.count == 0 ? 1 : 2;
             currentFileCoverage.addBranch(
-                line.line_number, BranchCoverage.create(line.line_number, takenValue));
+                line.line_number,
+                BranchCoverage.createWithBranch(
+                    line.line_number, Integer.toString(branchNumber), taken, branch.count));
+            branchNumber += 1;
           }
         }
         allSourceFiles.add(currentFileCoverage);

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovParser.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/GcovParser.java
@@ -14,6 +14,9 @@
 
 package com.google.devtools.coverageoutputgenerator;
 
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.MultimapBuilder;
+
 import static com.google.devtools.coverageoutputgenerator.Constants.DELIMITER;
 import static com.google.devtools.coverageoutputgenerator.Constants.GCOV_BRANCH_MARKER;
 import static com.google.devtools.coverageoutputgenerator.Constants.GCOV_BRANCH_NOTEXEC;
@@ -31,7 +34,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -45,6 +50,7 @@ public class GcovParser {
   private List<SourceFileCoverage> allSourceFiles;
   private final InputStream inputStream;
   private SourceFileCoverage currentSourceFileCoverage;
+  private ListMultimap<Integer, String> branchValues;
 
   private GcovParser(InputStream inputStream) {
     this.inputStream = inputStream;
@@ -87,6 +93,7 @@ public class GcovParser {
     if (currentSourceFileCoverage == null) {
       return;
     }
+    recordBranchInformation(branchValues);
     allSourceFiles.add(currentSourceFileCoverage);
     currentSourceFileCoverage = null;
   }
@@ -125,6 +132,7 @@ public class GcovParser {
       return false;
     }
     currentSourceFileCoverage = new SourceFileCoverage(sourcefile);
+    branchValues = MultimapBuilder.treeKeys().arrayListValues().build();
     return true;
   }
 
@@ -176,38 +184,57 @@ public class GcovParser {
     return true;
   }
 
-  // branch:line_number,branch_coverage_type
+  /**
+   * Valid lines: branch:line number,taken string
+   */
   private boolean parseBranch(String line) {
+    // We can't add this to the source file object because we need to construct "branch numbers", which can only
+    // be done once we have all the branches for a given line number.
     String lineContent = line.substring(GCOV_BRANCH_MARKER.length());
     String[] items = lineContent.split(DELIMITER, -1);
     if (items.length != 2) {
       logger.log(Level.WARNING, "gcov info contains invalid line " + line);
       return false;
     }
+    // Ignore has_unexecuted_block since it's not used.
     try {
-      // Ignore has_unexecuted_block since it's not used.
-      int lineNr = Integer.parseInt(items[0]);
+      int lineNumber = Integer.parseInt(items[0]);
       String type = items[1];
-      int takenValue;
-      switch (type) {
-        case GCOV_BRANCH_NOTEXEC:
-          takenValue = 0;
-          break;
-        case GCOV_BRANCH_NOTTAKEN:
-          takenValue = 1;
-          break;
-        case GCOV_BRANCH_TAKEN:
-          takenValue = 2;
-          break;
-        default:
-          logger.log(Level.WARNING, "gcov info contains invalid line " + line);
-          return false;
+      if (!(type.equals(GCOV_BRANCH_NOTEXEC) || type.equals(GCOV_BRANCH_NOTTAKEN) || type.equals(GCOV_BRANCH_TAKEN))) {
+        logger.log(Level.WARNING, "gcov info contains invalid line " + line);
+        return false;
       }
-      currentSourceFileCoverage.addBranch(lineNr, BranchCoverage.create(lineNr, takenValue));
+      branchValues.put(lineNumber, type);
     } catch (NumberFormatException e) {
       logger.log(Level.WARNING, "gcov info contains invalid line " + line);
       return false;
     }
     return true;
+  }
+
+  private void recordBranchInformation(ListMultimap<Integer, String> branchMap) {
+    for (Entry<Integer, Collection<String>> lineEntry : branchMap.asMap().entrySet()) {
+      int branchNumber = 0;
+      Collection<String> branches = lineEntry.getValue();
+      for (String value : branches) {
+        int execCount = 0;
+        boolean evaluated = false;
+        switch (value) {
+          case GCOV_BRANCH_NOTEXEC:
+            break;
+          case GCOV_BRANCH_NOTTAKEN:
+            evaluated = true;
+            break;
+          case GCOV_BRANCH_TAKEN:
+            evaluated = true;
+            execCount = 1; // we don't have the number of executions recorded, so simply say "1" if the branch was taken
+            break;
+          default:
+            throw new AssertionError("Invalid branch value '" + value + "'");
+        }
+        currentSourceFileCoverage.addBranch(lineEntry.getKey(), BranchCoverage.createWithBranch(lineEntry.getKey(), Integer.toString(branchNumber), evaluated, execCount));
+        branchNumber++;
+      }
+    }
   }
 }

--- a/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/GcovParserTest.java
+++ b/tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator/GcovParserTest.java
@@ -167,21 +167,21 @@ public class GcovParserTest {
 
     assertThat(sourceFileCoverage.getAllBranches())
         .containsExactly(
-            BranchCoverage.create(21, 2),
-            BranchCoverage.create(21, 1),
-            BranchCoverage.create(23, 2),
-            BranchCoverage.create(23, 1),
-            BranchCoverage.create(24, 2),
-            BranchCoverage.create(24, 1),
-            BranchCoverage.create(27, 2),
-            BranchCoverage.create(27, 2),
-            BranchCoverage.create(30, 1),
-            BranchCoverage.create(30, 2),
-            BranchCoverage.create(32, 1),
-            BranchCoverage.create(32, 2),
-            BranchCoverage.create(33, 0),
-            BranchCoverage.create(33, 0),
-            BranchCoverage.create(35, 2),
-            BranchCoverage.create(35, 1));
+            BranchCoverage.createWithBranch(21, "0", true, 1),
+            BranchCoverage.createWithBranch(21, "1", true, 0),
+            BranchCoverage.createWithBranch(23, "0", true, 1),
+            BranchCoverage.createWithBranch(23, "1", true, 0),
+            BranchCoverage.createWithBranch(24, "0", true, 1),
+            BranchCoverage.createWithBranch(24, "1", true, 0),
+            BranchCoverage.createWithBranch(27, "0", true, 1),
+            BranchCoverage.createWithBranch(27, "1", true, 1),
+            BranchCoverage.createWithBranch(30, "0", true, 0),
+            BranchCoverage.createWithBranch(30, "1", true, 1),
+            BranchCoverage.createWithBranch(32, "0", true, 0),
+            BranchCoverage.createWithBranch(32, "1", true, 1),
+            BranchCoverage.createWithBranch(33, "0", false, 0),
+            BranchCoverage.createWithBranch(33, "1", false, 0),
+            BranchCoverage.createWithBranch(35, "0", true, 1),
+            BranchCoverage.createWithBranch(35, "1", true, 0));
   }
 }


### PR DESCRIPTION
We want to emit BRDA branch entries in the coverage lcov files if
possible, as these are what will be expected by other tools (in
particular, genhtml).

This requires inventing branch number identifiers, but that isn't a
big deal.