### PR TITLE
Add channel pool for remote execution to overcome gRPC connections limitation.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -26,6 +26,7 @@ java_library(
         exclude = [
             "ExecutionStatusException.java",
             "ReferenceCountedChannel.java",
+            "ReferenceCountedChannelPool.java",
             "RemoteRetrier.java",
             "RemoteRetrierUtils.java",
             "Retrier.java",
@@ -40,6 +41,7 @@ java_library(
         ":ExecutionStatusException",
         ":ReferenceCountedChannel",
         ":Retrier",
+        "//src/main/java/com/google/devtools/build/lib:build-request-options",
         "//src/main/java/com/google/devtools/build/lib:runtime",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
@@ -121,8 +123,12 @@ java_library(
 
 java_library(
     name = "ReferenceCountedChannel",
-    srcs = ["ReferenceCountedChannel.java"],
+    srcs = [
+        "ReferenceCountedChannel.java",
+        "ReferenceCountedChannelPool.java",
+    ],
     deps = [
+        "//third_party:guava",
         "//third_party:netty",
         "//third_party/grpc:grpc-jar",
     ],

--- a/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannel.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannel.java
@@ -31,20 +31,25 @@ import java.util.concurrent.TimeUnit;
 public class ReferenceCountedChannel extends ManagedChannel implements ReferenceCounted {
 
   private final ManagedChannel channel;
-  private final AbstractReferenceCounted referenceCounted = new AbstractReferenceCounted() {
-    @Override
-    protected void deallocate() {
-      channel.shutdown();
-    }
-
-    @Override
-    public ReferenceCounted touch(Object o) {
-      return this;
-    }
-  };
+  private final AbstractReferenceCounted referenceCounted;
 
   public ReferenceCountedChannel(ManagedChannel channel) {
+    this(channel, new AbstractReferenceCounted() {
+      @Override
+      protected void deallocate() {
+        channel.shutdown();
+      }
+
+      @Override
+      public ReferenceCounted touch(Object o) {
+        return this;
+      }
+    });
+  }
+
+  protected ReferenceCountedChannel(ManagedChannel channel, AbstractReferenceCounted referenceCounted) {
     this.channel = channel;
+    this.referenceCounted = referenceCounted;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannel.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannel.java
@@ -75,8 +75,8 @@ public class ReferenceCountedChannel extends ManagedChannel implements Reference
   }
 
   @Override
-  public boolean awaitTermination(long l, TimeUnit timeUnit) throws InterruptedException {
-    return channel.awaitTermination(l, timeUnit);
+  public boolean awaitTermination(long timeout, TimeUnit timeUnit) throws InterruptedException {
+    return channel.awaitTermination(timeout, timeUnit);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannelPool.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannelPool.java
@@ -1,0 +1,101 @@
+package com.google.devtools.build.lib.remote;
+
+import com.google.common.collect.ImmutableList;
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
+import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.ReferenceCounted;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * <p>See {@link ReferenceCounted} for more information about reference counting.
+ */
+public class ReferenceCountedChannelPool extends ReferenceCountedChannel {
+
+  private final AtomicInteger indexTicker = new AtomicInteger();
+  private final ImmutableList<ManagedChannel> channels;
+
+  public ReferenceCountedChannelPool(ImmutableList<ManagedChannel> channels) {
+    super(channels.get(0), new AbstractReferenceCounted() {
+      @Override
+      protected void deallocate() {
+        for (ManagedChannel channel : channels) {
+          channel.shutdown();
+        }
+      }
+
+      @Override
+      public ReferenceCounted touch(Object o) {
+        return null;
+      }
+    });
+    this.channels = channels;
+  }
+
+  @Override
+  public boolean isShutdown() {
+    for (ManagedChannel channel : channels) {
+      if (!channel.isShutdown()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public boolean isTerminated() {
+    for (ManagedChannel channel : channels) {
+      if (!channel.isTerminated()) {
+        return false;
+      }
+    }
+    return true;  }
+
+  @Override
+  public boolean awaitTermination(long l, TimeUnit timeUnit) throws InterruptedException {
+    long endTimeNanos = System.nanoTime() + timeUnit.toNanos(l);
+    for (ManagedChannel channel : channels) {
+      long awaitTimeNanos = endTimeNanos - System.nanoTime();
+      if (awaitTimeNanos <= 0) {
+        break;
+      }
+      channel.awaitTermination(awaitTimeNanos, TimeUnit.NANOSECONDS);
+    }
+    return isTerminated();
+  }
+
+  @Override
+  public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+      MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+    return getNextChannel().newCall(methodDescriptor, callOptions);
+  }
+
+  @Override
+  public String authority() {
+    // Assume all channels have the same authority.
+    return channels.get(0).authority();
+  }
+
+  /**
+   * Performs a simple round robin on the list of {@link ManagedChannel}s in the {@code channels}
+   * list.
+   *
+   * @return A {@link ManagedChannel} that can be used for a single RPC call.
+   */
+  private ManagedChannel getNextChannel() {
+    return getChannel(indexTicker.getAndIncrement());
+  }
+
+  private ManagedChannel getChannel(int affinity) {
+    int index = affinity % channels.size();
+    index = Math.abs(index);
+    // If index is the most negative int, abs(index) is still negative.
+    if (index < 0) {
+      index = 0;
+    }
+    return channels.get(index);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannelPool.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannelPool.java
@@ -70,11 +70,12 @@ public class ReferenceCountedChannelPool extends ReferenceCountedChannel {
         return false;
       }
     }
-    return true;  }
+    return true;
+  }
 
   @Override
-  public boolean awaitTermination(long l, TimeUnit timeUnit) throws InterruptedException {
-    long endTimeNanos = System.nanoTime() + timeUnit.toNanos(l);
+  public boolean awaitTermination(long timeout, TimeUnit timeUnit) throws InterruptedException {
+    long endTimeNanos = System.nanoTime() + timeUnit.toNanos(timeout);
     for (ManagedChannel channel : channels) {
       long awaitTimeNanos = endTimeNanos - System.nanoTime();
       if (awaitTimeNanos <= 0) {

--- a/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannelPool.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannelPool.java
@@ -1,3 +1,16 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package com.google.devtools.build.lib.remote;
 
 import com.google.common.collect.ImmutableList;
@@ -11,6 +24,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
+ *  A wrapper around a {@link io.grpc.ManagedChannel} exposing a reference count and performing a
+ *  round-robin load balance across a list of channels. When instantiated the reference count is 1.
+ *  {@link ManagedChannel#shutdown()} will be called on the wrapped channel when the reference count
+ *  reaches 0.
+ *
  * <p>See {@link ReferenceCounted} for more information about reference counting.
  */
 public class ReferenceCountedChannelPool extends ReferenceCountedChannel {
@@ -82,6 +100,8 @@ public class ReferenceCountedChannelPool extends ReferenceCountedChannel {
   /**
    * Performs a simple round robin on the list of {@link ManagedChannel}s in the {@code channels}
    * list.
+   *
+   * @see <a href="https://github.com/grpc/grpc/issues/21386#issuecomment-564742173">Suggestion from gRPC team.</a>
    *
    * @return A {@link ManagedChannel} that can be used for a single RPC call.
    */

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -267,9 +267,7 @@ public final class RemoteModule extends BlazeModule {
       // MAX_CONCURRENT_STREAMS which is normally being 100+. We assume 50 concurrent requests for
       // each connection should be fairly well. The number of connections opened by one channel is
       // based on the resolved IPs of that server. We assume servers normally have 2 IPs. So the
-      // number of required channel is calculated as: ceil(jobs / 100).
-      //
-      // TODO(chiwang): Should we use a more intelligent way to calculate poolSize?
+      // number of required channels is calculated as: ceil(jobs / 100).
       poolSize = (int) Math.ceil((double) buildRequestOptions.jobs / 100.0);
     }
     if (enableRemoteExecution) {


### PR DESCRIPTION
This PR add a `ReferenceCountedChannelPool` which will create `poolSize` number of channels and round-robin across them for gRPC requests.

The `poolSize` is calculated as `jobs / 100`.

Fixes #11801.