### PR TITLE
Change disk cache to create sub folders for entries

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
@@ -107,7 +107,7 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
   }
 
   private Path newTempPath() {
-    return diskCache.toPath(UUID.randomUUID().toString(), /* actionResult= */ false);
+    return diskCache.toPathNoSplit(UUID.randomUUID().toString());
   }
 
   private static ListenableFuture<Void> closeStreamOnError(

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskCacheClient.java
@@ -36,7 +36,8 @@ import javax.annotation.Nullable;
 /** A on-disk store for the remote action cache. */
 public class DiskCacheClient implements RemoteCacheClient {
 
-  private static final String ACTION_KEY_PREFIX = "ac_";
+  private static final String AC_DIRECTORY = "ac";
+  private static final String CAS_DIRECTORY = "cas";
 
   private final Path root;
   private final boolean verifyDownloads;
@@ -60,6 +61,7 @@ public class DiskCacheClient implements RemoteCacheClient {
 
   public void captureFile(Path src, Digest digest, boolean isActionCache) throws IOException {
     Path target = toPath(digest.getHash(), isActionCache);
+    target.getParentDirectory().createDirectoryAndParents();
     src.renameTo(target);
   }
 
@@ -109,7 +111,7 @@ public class DiskCacheClient implements RemoteCacheClient {
   public void uploadActionResult(ActionKey actionKey, ActionResult actionResult)
       throws IOException {
     try (InputStream data = actionResult.toByteString().newInput()) {
-      saveFile(getDiskKey(actionKey.getDigest().getHash(), /* actionResult= */ true), data);
+      saveFile(actionKey.getDigest().getHash(), data, /* actionResult= */ true);
     }
   }
 
@@ -119,7 +121,7 @@ public class DiskCacheClient implements RemoteCacheClient {
   @Override
   public ListenableFuture<Void> uploadFile(Digest digest, Path file) {
     try (InputStream in = file.getInputStream()) {
-      saveFile(digest.getHash(), in);
+      saveFile(digest.getHash(), in, /* actionResult= */ false);
     } catch (IOException e) {
       return Futures.immediateFailedFuture(e);
     }
@@ -129,7 +131,7 @@ public class DiskCacheClient implements RemoteCacheClient {
   @Override
   public ListenableFuture<Void> uploadBlob(Digest digest, ByteString data) {
     try (InputStream in = data.newInput()) {
-      saveFile(digest.getHash(), in);
+      saveFile(digest.getHash(), in, /* actionResult= */ false);
     } catch (IOException e) {
       return Futures.immediateFailedFuture(e);
     }
@@ -143,22 +145,25 @@ public class DiskCacheClient implements RemoteCacheClient {
     return Futures.immediateFuture(ImmutableSet.copyOf(digests));
   }
 
+  protected Path toPathNoSplit(String key) {
+    return root.getChild(key);
+  }
+
   protected Path toPath(String key, boolean actionResult) {
-    return root.getChild(getDiskKey(key, actionResult));
+    String cacheFolder = actionResult ? AC_DIRECTORY : CAS_DIRECTORY;
+    // Create the file in a subfolder to bypass possible folder file count limits
+    return root.getChild(cacheFolder).getChild(key.substring(0, 2)).getChild(key);
   }
 
-  private static String getDiskKey(String key, boolean actionResult) {
-    return actionResult ? ACTION_KEY_PREFIX + key : key;
-  }
-
-  private void saveFile(String key, InputStream in) throws IOException {
-    Path target = toPath(key, /* actionResult= */ false);
+  private void saveFile(String key, InputStream in, boolean actionResult) throws IOException {
+    Path target = toPath(key, actionResult);
     if (target.exists()) {
       return;
     }
+    target.getParentDirectory().createDirectoryAndParents();
 
     // Write a temporary file first, and then rename, to avoid data corruption in case of a crash.
-    Path temp = toPath(UUID.randomUUID().toString(), /* actionResult= */ false);
+    Path temp = toPathNoSplit(UUID.randomUUID().toString());
     try (OutputStream out = temp.getOutputStream()) {
       ByteStreams.copy(in, out);
     }


### PR DESCRIPTION
Having all of disk cache in a single folder can cause problems with huge
projects on some filesystems. Splitting the cache entries to a folder
part and a file part to fix this.