### PR TITLE
Allow dot char in workspace name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/WorkspaceGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/WorkspaceGlobals.java
@@ -50,7 +50,7 @@ import javax.annotation.Nullable;
 public class WorkspaceGlobals implements WorkspaceGlobalsApi {
 
   // Must start with a letter and can contain letters, numbers, underscores and hyphens.
-  private static final Pattern LEGAL_WORKSPACE_NAME = Pattern.compile("^\\p{Alpha}[\\w-]*$");
+  private static final Pattern LEGAL_WORKSPACE_NAME = Pattern.compile("^\\p{Alpha}[\\w-\\.]*$");
 
   private final boolean allowOverride;
   private final RuleFactory ruleFactory;


### PR DESCRIPTION
Continuing https://github.com/bazelbuild/bazel/pull/11838 and adresses https://github.com/bazelbuild/bazel/pull/11838#issuecomment-668435204

> The local_repository rule uses this regex, but says it allows a '.' character, which is currently does not:
```local_repository rule //external:shared.name's name field must be a legal workspace name; workspace names may contain only A-Z, a-z, 0-9, '-', '_' and '.'```

cc: @Gromba
