### PR TITLE
Check for errors from config conditions before checking for missing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
@@ -932,12 +932,12 @@ public final class ConfiguredTargetFunction implements SkyFunction {
       aliasPackageValues = env.getValues(aliasPackagesToFetch);
       depsToProcess = aliasDepsToRedo;
     }
-    if (missedValues) {
-      return null;
-    } else if (failWithMessage != null) {
+    if (failWithMessage != null) {
       throw new DependencyEvaluationException(
           new ConfiguredValueCreationException(
               failWithMessage, ctgValue.getConfiguration(), transitiveRootCauses.build()));
+    } else if (missedValues) {
+        return null;
     } else {
       return result;
     }

--- a/src/test/java/com/google/devtools/build/lib/analysis/ConfigurableAttributesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/ConfigurableAttributesTest.java
@@ -498,13 +498,20 @@ public class ConfigurableAttributesTest extends BuildViewTestCase {
   @Test
   public void configKeyNonexistentTarget_otherPackage() throws Exception {
     reporter.removeHandler(failFastHandler); // Expect errors.
+    scratch.file(
+        "conditions/BUILD",
+        "config_setting(",
+        "    name = 'a',",
+        "    values = {'test_arg': 'a'})");
     scratch.file("bar/BUILD");
     scratch.file(
         "foo/BUILD",
         "genrule(",
         "    name = 'g',",
         "    outs = ['g.out'],",
-        "    cmd = select({'//bar:fake': ''})",
+        // With an invalid target and a real target, validate skyframe error handling.
+        // See http://b/162021059 for details.
+        "    cmd = select({'//bar:fake': '', '//conditions:a': ''})",
         ")");
     assertThat(getConfiguredTarget("//foo:g")).isNull();
     assertContainsEvent(


### PR DESCRIPTION
values.

The resolveConfiguredTargetDependencies method currently tracks both
missing values (which will require a skyframe restart) and errors from
dependencies (which should be re-thrown). Unfortunately, it checks this
in the wrong order, which means that when a value is missing and there
is an error, the error will be swallowed and not reported.