### PR TITLE
Implement extra resources for test actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
@@ -152,6 +152,35 @@ public class ExecutionRequirements {
             return null;
           });
 
+  /** How many extra resources an action requires for execution. */
+  public static final ParseableRequirement RESOURCES =
+      ParseableRequirement.create(
+          "resources:<str>:<int>",
+          Pattern.compile("resources:(.+:.+)"),
+          s -> {
+            Preconditions.checkNotNull(s);
+
+            int splitIndex = s.indexOf(":");
+            String resourceCount = s.substring(splitIndex+1);
+            int value;
+            try {
+              value = Integer.parseInt(resourceCount);
+            } catch (NumberFormatException e) {
+              return "can't be parsed as an integer";
+            }
+
+            // De-and-reserialize & compare to only allow canonical integer formats.
+            if (!Integer.toString(value).equals(resourceCount)) {
+              return "must be in canonical format (e.g. '4' instead of '+04')";
+            }
+
+            if (value < 1) {
+              return "can't be zero or negative";
+            }
+
+            return null;
+          });
+
   /** If an action supports running in persistent worker mode. */
   public static final String SUPPORTS_WORKERS = "supports-workers";
 

--- a/src/main/java/com/google/devtools/build/lib/actions/LocalHostResourceFallback.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/LocalHostResourceFallback.java
@@ -27,6 +27,7 @@ public class LocalHostResourceFallback {
       ResourceSet.create(
           3.0 * (Runtime.getRuntime().maxMemory() >> 20),
           Runtime.getRuntime().availableProcessors(),
+          null,
           Integer.MAX_VALUE);
 
   public static ResourceSet getLocalHostResources() {

--- a/src/main/java/com/google/devtools/build/lib/actions/LocalHostResourceManagerDarwin.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/LocalHostResourceManagerDarwin.java
@@ -44,6 +44,7 @@ public class LocalHostResourceManagerDarwin {
       return ResourceSet.create(
           ramMb,
           logicalCpuCount,
+          null,
           Integer.MAX_VALUE);
     } catch (IOException e) {
       return null;

--- a/src/main/java/com/google/devtools/build/lib/actions/LocalHostResourceManagerLinux.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/LocalHostResourceManagerLinux.java
@@ -48,6 +48,7 @@ public class LocalHostResourceManagerLinux {
       return ResourceSet.create(
           ramMb,
           logicalCpuCount,
+          null,
           Integer.MAX_VALUE);
     } catch (IOException e) {
       return null;

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -101,13 +101,16 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -822,10 +825,13 @@ public class ExecutionTool {
     }
     resourceMgr.setUseLocalMemoryEstimate(options.localMemoryEstimate);
 
+    Map<String, Float> extraResources = options.localExtraResources.stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1,v2) -> v1, HashMap::new));
+
     resourceMgr.setAvailableResources(
         ResourceSet.create(
             resources.getMemoryMb(),
             resources.getCpuUsage(),
+            extraResources,
             request.getExecutionOptions().usingLocalTestJobs()
                 ? request.getExecutionOptions().localTestJobs
                 : Integer.MAX_VALUE));

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -352,6 +352,22 @@ public class ExecutionOptions extends OptionsBase {
   public boolean localMemoryEstimate;
 
   @Option(
+      name = "local_extra_resources",
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      allowMultiple = true,
+      help =
+          "Explicitly set the number of extra recourses available to Bazel. "
+            + "Takes in a string-float pair. Can be used multiple times to specify multiple "
+            + "types of extra resources. Bazel will limit concurrently running test actions "
+            + "based on the available extra resources and the extra resources required "
+            + "by the test actions. "
+            + "Note: This is a no-op if --local_resources is set.",
+      converter = Converters.StringToFloatAssignmentConverter.class)
+  public List<Map.Entry<String, Float>> localExtraResources;
+
+  @Option(
       name = "local_test_jobs",
       defaultValue = "auto",
       documentationCategory = OptionDocumentationCategory.TESTING,

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -56,7 +56,8 @@ public final class TargetUtils {
         || tag.startsWith("disable-")
         || tag.startsWith("cpu:")
         || tag.equals(ExecutionRequirements.LOCAL)
-        || tag.equals(ExecutionRequirements.WORKER_KEY_MNEMONIC);
+        || tag.equals(ExecutionRequirements.WORKER_KEY_MNEMONIC)
+        || tag.startsWith("resources:");
   }
 
   private TargetUtils() {} // Uninstantiable.

--- a/src/main/java/com/google/devtools/common/options/Converters.java
+++ b/src/main/java/com/google/devtools/common/options/Converters.java
@@ -458,6 +458,31 @@ public final class Converters {
   }
 
   /**
+   * A converter for variable assignments from the parameter list of a blaze command invocation.
+   * Assignments are expected to have the form "name=value", where names are defined to
+   * be as permissive as possible and the values should be floats.
+   */
+  public static class StringToFloatAssignmentConverter implements Converter<Map.Entry<String, Float>> {
+
+    @Override
+    public Map.Entry<String, Float> convert(String input) throws OptionsParsingException {
+      int pos = input.indexOf("=");
+      if (pos <= 0) {
+        throw new OptionsParsingException(
+            "Variable definitions must be in the form of a 'name=value' assignment");
+      }
+      String name = input.substring(0, pos);
+      float value = Float.parseFloat(input.substring(pos + 1));
+      return Maps.immutableEntry(name, value);
+    }
+
+    @Override
+    public String getTypeDescription() {
+      return "a 'name=value' assignment with second value being a float";
+    }
+  }
+
+  /**
    * Base converter for assignments from a value to a list of values. Both the key type as well as
    * the type for all instances in the list of values are processed via passed converters.
    */

--- a/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
@@ -50,7 +50,7 @@ public class ResourceManagerTest {
   @Before
   public final void configureResourceManager() throws Exception  {
     rm.setAvailableResources(
-        ResourceSet.create(/*memoryMb=*/ 1000, /*cpuUsage=*/ 1, /* localTestCount= */ 2));
+        ResourceSet.create(/*memoryMb=*/ 1000, /*cpuUsage=*/ 1, /*extraResourceUsage*/ null, /* localTestCount= */ 2));
     counter = new AtomicInteger(0);
     sync = new CyclicBarrier(2);
     sync2 = new CyclicBarrier(2);
@@ -59,15 +59,15 @@ public class ResourceManagerTest {
 
   private ResourceHandle acquire(double ram, double cpu, int tests)
       throws InterruptedException {
-    return rm.acquireResources(resourceOwner, ResourceSet.create(ram, cpu, tests));
+    return rm.acquireResources(resourceOwner, ResourceSet.create(ram, cpu, null, tests));
   }
 
   private ResourceHandle acquireNonblocking(double ram, double cpu, int tests) {
-    return rm.tryAcquire(resourceOwner, ResourceSet.create(ram, cpu, tests));
+    return rm.tryAcquire(resourceOwner, ResourceSet.create(ram, cpu, null, tests));
   }
 
   private void release(double ram, double cpu, int tests) {
-    rm.releaseResources(resourceOwner, ResourceSet.create(ram, cpu, tests));
+    rm.releaseResources(resourceOwner, ResourceSet.create(ram, cpu, null, tests));
   }
 
   private void validate(int count) {
@@ -283,7 +283,7 @@ public class ResourceManagerTest {
     // This should process the queue. If the request from above is still present, it will take all
     // the available memory. But it shouldn't.
     rm.setAvailableResources(
-        ResourceSet.create(/*memoryMb=*/ 2000, /*cpuUsage=*/ 1, /* localTestCount= */ 2));
+        ResourceSet.create(/*memoryMb=*/ 2000, /*cpuUsage=*/ 1, /*extraResourceUsage*/ null, /* localTestCount= */ 2));
     TestThread thread2 =
         new TestThread(
             () -> {

--- a/src/test/java/com/google/devtools/build/lib/dynamic/DynamicSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/dynamic/DynamicSpawnStrategyTest.java
@@ -419,7 +419,7 @@ public class DynamicSpawnStrategyTest {
         executionInfo,
         EmptyRunfilesSupplier.INSTANCE,
         action,
-        ResourceSet.create(1, 0, 0));
+        ResourceSet.create(1, 0, null, 0));
   }
 
   /** Constructs a new spawn that can be run locally and remotely with arbitrary settings. */

--- a/src/test/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunnerTest.java
@@ -312,7 +312,7 @@ public class LocalSpawnRunnerTest {
     // Prevent any subprocess execution at all.
     SubprocessBuilder.setDefaultSubprocessFactory(new SubprocessInterceptor());
     resourceManager.setAvailableResources(
-        ResourceSet.create(/*memoryMb=*/1, /*cpuUsage=*/1, /*localTestCount=*/1));
+        ResourceSet.create(/*memoryMb=*/1, /*cpuUsage=*/1, /*extraResourceUsage*/null, /*localTestCount=*/1));
     return new InMemoryFileSystem();
   }
 

--- a/src/test/java/com/google/devtools/build/lib/standalone/StandaloneSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/standalone/StandaloneSpawnStrategyTest.java
@@ -138,7 +138,7 @@ public class StandaloneSpawnStrategyTest {
 
     ResourceManager resourceManager = ResourceManager.instanceForTestingOnly();
     resourceManager.setAvailableResources(
-        ResourceSet.create(/*memoryMb=*/1, /*cpuUsage=*/1, /*localTestCount=*/1));
+        ResourceSet.create(/*memoryMb=*/1, /*cpuUsage=*/1, /*extraResourceUsage*/null, /*localTestCount=*/1));
     Path execRoot = directories.getExecRoot(TestConstants.WORKSPACE_NAME);
     BinTools binTools = BinTools.forIntegrationTesting(directories, ImmutableList.of());
     StandaloneSpawnStrategy strategy =


### PR DESCRIPTION
Adds support for specifying extra resources available for the bazel
invocation and requirement for test actions. Using
--local_extra_resources=\<resource name\>=\<amount of resource\> one can
specify the resources available for tests. Specifying a tag
"resources:\<resource name\>:\<amount of resources\>" for a test action will
tell bazel how much of the said resource this test will require. Bazel
will then limit concurrently running test actions using the same
resource if there isn't enough of said resource available.

This can be used to arbitrate access to additional resources such as GPUs or embedded developer boards.