### PR TITLE
Add embedded jdk support for s390x

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -361,6 +361,15 @@ http_file(
 )
 
 http_file(
+    name = "openjdk_linux_s390x_vanilla",
+    downloaded_file_path="adoptopenjdk-s390x-vanilla.tar.gz",
+    sha256 = "d9b72e87a1d3ebc0c9552f72ae5eb150fffc0298a7cb841f1ce7bfc70dcd1059",
+    urls = [
+        "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz",
+    ],
+)
+
+http_file(
     name = "openjdk_macos",
     downloaded_file_path = "zulu-macos.tar.gz",
     sha256 = "8e283cfd23c7555be8e17295ed76eb8f00324c88ab904b8de37bbe08f90e569b",
@@ -755,6 +764,19 @@ http_archive(
     urls = [
         "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
         "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+    ],
+)
+
+# This must be kept in sync with src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.
+http_archive(
+    name = "remotejdk11_linux_s390x_for_testing",
+    build_file = "@local_jdk//:BUILD.bazel",
+    patch_cmds = EXPORT_WORKSPACE_IN_BUILD_BAZEL_FILE,
+    patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_BAZEL_FILE_WIN,
+    sha256 = "d9b72e87a1d3ebc0c9552f72ae5eb150fffc0298a7cb841f1ce7bfc70dcd1059",
+    strip_prefix = "jdk-11.0.7+10",
+    urls = [
+        "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz",
     ],
 )
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -229,6 +229,9 @@ filegroup(
         "//src/conditions:linux_ppc64le": [
             "@openjdk_linux_ppc64le_vanilla//file",
         ],
+        "//src/conditions:linux_s390x": [
+            "@openjdk_linux_s390x_vanilla//file",
+        ],
         "//conditions:default": [
             "@openjdk_linux_vanilla//file",
         ],
@@ -769,6 +772,7 @@ filegroup(
         "@remotejdk11_linux_aarch64_for_testing//:WORKSPACE",
         "@remotejdk11_linux_for_testing//:WORKSPACE",
         "@remotejdk11_linux_ppc64le_for_testing//:WORKSPACE",
+        "@remotejdk11_linux_s390x_for_testing//:WORKSPACE",
         "@remotejdk11_macos_for_testing//:WORKSPACE",
         "@remotejdk11_win_for_testing//:WORKSPACE",
         "@remotejdk14_linux_for_testing//:WORKSPACE",

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -133,6 +133,18 @@ maybe(
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
     http_archive,
+    name = "remotejdk11_linux_s390x",
+    build_file = "@local_jdk//:BUILD.bazel",
+    sha256 = "d9b72e87a1d3ebc0c9552f72ae5eb150fffc0298a7cb841f1ce7bfc70dcd1059",
+    strip_prefix = "jdk-11.0.7+10",
+    urls = [
+        "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz",
+    ],
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    http_archive,
     name = "remotejdk11_macos",
     build_file = "@local_jdk//:BUILD.bazel",
     sha256 = "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",

--- a/src/minimize_jdk.sh
+++ b/src/minimize_jdk.sh
@@ -31,7 +31,7 @@ fi
 fulljdk=$1
 out=$3
 ARCH=`uname -p`
-if [[ "${ARCH}" == 'ppc64le' ]]; then
+if [[ "${ARCH}" == 'ppc64le'  ]] || [[ "${ARCH}" == 's390x' ]]; then
   FULL_JDK_DIR="jdk*"
   DOCS=""
 else

--- a/src/test/py/bazel/test_base.py
+++ b/src/test/py/bazel/test_base.py
@@ -59,6 +59,7 @@ class TestBase(unittest.TestCase):
       'remotejdk11_linux_for_testing',
       'remotejdk11_linux_aarch64_for_testing',
       'remotejdk11_linux_ppc64le_for_testing',
+      'remotejdk11_linux_s390x_for_testing',
       'remotejdk11_macos_for_testing',
       'remotejdk11_win_for_testing',
       'remotejdk14_linux_for_testing',

--- a/src/test/shell/testenv.sh
+++ b/src/test/shell/testenv.sh
@@ -300,6 +300,7 @@ EOF
         "remotejdk11_linux_for_testing"
         "remotejdk11_linux_aarch64_for_testing"
         "remotejdk11_linux_ppc64le_for_testing"
+        "remotejdk11_linux_s390x_for_testing"
         "remotejdk11_macos_for_testing"
         "remotejdk11_win_for_testing"
         "remotejdk14_linux_for_testing"

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -504,6 +504,7 @@ alias(
             "//src/conditions:linux_aarch64": "@remotejdk11_linux_aarch64//:jdk",
             "//src/conditions:linux_x86_64": "@remotejdk11_linux//:jdk",
             "//src/conditions:linux_ppc64le": "@remotejdk11_linux_ppc64le//:jdk",
+            "//src/conditions:linux_s390x": "@remotejdk11_linux_s390x//:jdk",
         },
         no_match_error = "Could not find a JDK for host execution environment, please explicitly" +
                          " provide one using `--host_javabase.`",


### PR DESCRIPTION
This patch follows a similar approach used in PR
https://github.com/bazelbuild/bazel/pull/11436 to add support
for embedding OpenJDK in bazel on s390x.

Similar to ppc, the openjdk used will be downloadded from adoptopenjdk website.

/cc @philwo 