### PR TITLE
Use CoverageReportGenerator at HEAD in integration tests

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -35,7 +35,8 @@ tasks:
       - "-//src/java_tools/import_deps_checker/..."
       # These tests are not compatible with the gcov version of CentOS 7.
       - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
-      - "-//src/test/shell/bazel:bazel_coverage_cc_test_gcc"
+      - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
+      - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
       - "-//src/test/shell/bazel:bazel_coverage_sh_test"
     include_json_profile:
       - build

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -36,7 +36,8 @@ tasks:
       - "-//src/java_tools/import_deps_checker/..."
       # These tests are not compatible with the gcov version of CentOS 7.
       - "-//src/test/shell/bazel:bazel_cc_code_coverage_test"
-      - "-//src/test/shell/bazel:bazel_coverage_cc_test_gcc"
+      - "-//src/test/shell/bazel:bazel_coverage_cc_released_test_gcc"
+      - "-//src/test/shell/bazel:bazel_coverage_cc_head_test_gcc"
       - "-//src/test/shell/bazel:bazel_coverage_sh_test"
   ubuntu1604:
     shards: 4

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -443,11 +443,11 @@ sh_test(
     name = "bazel_coverage_cc_head_test_gcc",
     srcs = ["bazel_coverage_cc_test_gcc.sh"],
     args = [
-        "tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/coverage_output_generator.zip",
+        "tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/coverage",
         ],
     data = [
         ":test-deps",
-        "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_output_generator_zip",
+        "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_output_generator_repo",
         ],
     tags = [
         "no_windows",
@@ -524,7 +524,7 @@ sh_test(
             # java_tools zip to test
             "src/java_tools_java" + java_version + ".zip",
             # coverage output generator to test
-            "tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/coverage_output_generator.zip",
+            "tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/coverage",
             # --javabase value
         ] + select({
             "//src/conditions:darwin": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
@@ -536,7 +536,7 @@ sh_test(
             ":test-deps",
             "//src:java_tools_java" + java_version + "_zip",
             "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
-            "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_output_generator_zip",
+            "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_output_generator_repo",
         ],
         tags = [
             "no_windows",

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -469,6 +469,7 @@ sh_test(
     args = [
         "@bazel_tools//tools/jdk:toolchain",
         "released",
+        "released",
     ],
     data = [
         ":test-deps",
@@ -482,7 +483,7 @@ sh_test(
 # Test java coverage with the java_toolchain in the released java_tools versions.
 [
     sh_test(
-        name = "bazel_coverage_java_jdk" + java_version + "toolchain_released_test",
+        name = "bazel_coverage_java_jdk" + java_version + "_toolchain_released_test",
         srcs = ["bazel_coverage_java_test.sh"],
         args = select({
             "//src/conditions:darwin": ["@remote_java_tools_javac" + java_version + "_test_darwin//:toolchain"],
@@ -491,6 +492,8 @@ sh_test(
             "//src/conditions:linux_x86_64": ["@remote_java_tools_javac" + java_version + "_test_linux//:toolchain"],
         }) + [
             # java_tools zip to test
+            "released",
+            # coverage_report_generator to test
             "released",
             # --javabase value
         ] + select({
@@ -520,6 +523,8 @@ sh_test(
             "@local_java_tools//:toolchain",
             # java_tools zip to test
             "src/java_tools_java" + java_version + ".zip",
+            # coverage output generator to test
+            "tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/coverage_output_generator.zip",
             # --javabase value
         ] + select({
             "//src/conditions:darwin": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
@@ -531,6 +536,7 @@ sh_test(
             ":test-deps",
             "//src:java_tools_java" + java_version + "_zip",
             "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
+            "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_output_generator_zip",
         ],
         tags = [
             "no_windows",

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -430,9 +430,25 @@ sh_test(
 )
 
 sh_test(
-    name = "bazel_coverage_cc_test_gcc",
+    name = "bazel_coverage_cc_released_test_gcc",
     srcs = ["bazel_coverage_cc_test_gcc.sh"],
+    args = ["released"],
     data = [":test-deps"],
+    tags = [
+        "no_windows",
+    ],
+)
+
+sh_test(
+    name = "bazel_coverage_cc_head_test_gcc",
+    srcs = ["bazel_coverage_cc_test_gcc.sh"],
+    args = [
+        "tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/coverage_output_generator.zip",
+        ],
+    data = [
+        ":test-deps",
+        "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_output_generator_zip",
+        ],
     tags = [
         "no_windows",
     ],

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -556,6 +556,7 @@ sh_test(
         ],
         tags = [
             "no_windows",
+            "manual",
         ],
     )
     for java_version in JAVA_VERSIONS

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -444,7 +444,7 @@ sh_test(
     srcs = ["bazel_coverage_cc_test_gcc.sh"],
     args = [
         "tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/coverage",
-        ],
+    ],
     data = [
         ":test-deps",
         "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_output_generator_repo",
@@ -455,8 +455,24 @@ sh_test(
 )
 
 sh_test(
-    name = "bazel_coverage_cc_test_llvm",
+    name = "bazel_coverage_cc_head_test_llvm",
     srcs = ["bazel_coverage_cc_test_llvm.sh"],
+    args = [
+        "tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/coverage",
+    ],
+    data = [
+        ":test-deps",
+        "//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:coverage_output_generator_repo",
+        ],
+    tags = [
+        "no_windows",
+    ],
+)
+
+sh_test(
+    name = "bazel_coverage_cc_released_test_llvm",
+    srcs = ["bazel_coverage_cc_test_llvm.sh"],
+    args = ["released"],
     data = [":test-deps"],
     tags = [
         "no_windows",

--- a/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_gcc.sh
@@ -21,6 +21,32 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CURRENT_DIR}/../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
+COVERAGE_GENERATOR_ZIP="$1"; shift
+if [[ "${COVERAGE_GENERATOR_ZIP}" != "released" ]]; then
+  if [[ "${COVERAGE_GENERATOR_ZIP}" == file* ]]; then
+    COVERAGE_GENERATOR_ZIP_FILE_URL="${COVERAGE_GENERATOR_ZIP}"
+  else
+    COVERAGE_GENERATOR_ZIP_FILE_URL="file://$(rlocation io_bazel/$COVERAGE_GENERATOR_ZIP)"
+  fi
+fi
+COVERAGE_GENERATOR_ZIP_FILE_URL=${COVERAGE_GENERATOR_ZIP_FILE_URL:-}
+
+function set_up() {
+  if [[ "${COVERAGE_GENERATOR_ZIP_FILE_URL}" ]]; then
+    # there are two targets in the coverage archive: coverate_report_generator and lcov_merge
+    # both are used, both point to the same java binary, but only one can be configured by the user
+    # with the --coverage_report_generator=<target> option
+    # we overwrite the "@remote_coverage_tools" repo so bazel will pick up both targets
+    cat << EOF > WORKSPACE
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "remote_coverage_tools",
+    urls = ["${COVERAGE_GENERATOR_ZIP_FILE_URL}"],
+)
+EOF
+  fi
+}
+
 # Writes the C++ source files and a corresponding BUILD file for which to
 # collect code coverage. The sources are a.cc, a.h and t.cc.
 function setup_a_cc_lib_and_t_cc_test() {

--- a/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
+++ b/src/test/shell/bazel/bazel_coverage_cc_test_llvm.sh
@@ -21,6 +21,12 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CURRENT_DIR}/../integration_test_setup.sh" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
+COVERAGE_GENERATOR_DIR="$1"; shift
+if [[ "${COVERAGE_GENERATOR_DIR}" != "released" ]]; then
+  COVERAGE_GENERATOR_DIR="$(rlocation io_bazel/$COVERAGE_GENERATOR_DIR)"
+  add_to_bazelrc "build --override_repository=remote_coverage_tools=${COVERAGE_GENERATOR_DIR}"
+fi
+
 # Writes the C++ source files and a corresponding BUILD file for which to
 # collect code coverage. The sources are a.cc, a.h and t.cc.
 function setup_a_cc_lib_and_t_cc_test() {

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -35,15 +35,11 @@ if [[ "${JAVA_TOOLS_ZIP}" != "released" ]]; then
 fi
 JAVA_TOOLS_ZIP_FILE_URL=${JAVA_TOOLS_ZIP_FILE_URL:-}
 
-COVERAGE_GENERATOR_ZIP="$1"; shift
-if [[ "${COVERAGE_GENERATOR_ZIP}" != "released" ]]; then
-  if [[ "${COVERAGE_GENERATOR_ZIP}" == file* ]]; then
-    COVERAGE_GENERATOR_ZIP_FILE_URL="${COVERAGE_GENERATOR_ZIP}"
-  else
-    COVERAGE_GENERATOR_ZIP_FILE_URL="file://$(rlocation io_bazel/$COVERAGE_GENERATOR_ZIP)"
-  fi
+COVERAGE_GENERATOR_DIR="$1"; shift
+if [[ "${COVERAGE_GENERATOR_DIR}" != "released" ]]; then
+  COVERAGE_GENERATOR_DIR="$(rlocation io_bazel/$COVERAGE_GENERATOR_DIR)"
+  add_to_bazelrc "build --override_repository=remote_coverage_tools=${COVERAGE_GENERATOR_DIR}"
 fi
-COVERAGE_GENERATOR_ZIP_FILE_URL=${COVERAGE_GENERATOR_ZIP_FILE_URL:-}
 
 if [[ $# -gt 0 ]]; then
     JAVABASE_VALUE="$1"; shift
@@ -67,16 +63,6 @@ EOF
     fi
 
     cat $(rlocation io_bazel/src/test/shell/bazel/testdata/jdk_http_archives) >> WORKSPACE
-
-    if [[ "${COVERAGE_GENERATOR_ZIP_FILE_URL}" ]]; then
-        cat >> WORKSPACE << EOF
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "remote_coverage_tools",
-    urls = ["${COVERAGE_GENERATOR_ZIP_FILE_URL}"],
-  )
-EOF
-    fi
 }
 
 # Asserts if the given expected coverage result is included in the given output

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -35,6 +35,16 @@ if [[ "${JAVA_TOOLS_ZIP}" != "released" ]]; then
 fi
 JAVA_TOOLS_ZIP_FILE_URL=${JAVA_TOOLS_ZIP_FILE_URL:-}
 
+COVERAGE_GENERATOR_ZIP="$1"; shift
+if [[ "${COVERAGE_GENERATOR_ZIP}" != "released" ]]; then
+  if [[ "${COVERAGE_GENERATOR_ZIP}" == file* ]]; then
+    COVERAGE_GENERATOR_ZIP_FILE_URL="${COVERAGE_GENERATOR_ZIP}"
+  else
+    COVERAGE_GENERATOR_ZIP_FILE_URL="file://$(rlocation io_bazel/$COVERAGE_GENERATOR_ZIP)"
+  fi
+fi
+COVERAGE_GENERATOR_ZIP_FILE_URL=${COVERAGE_GENERATOR_ZIP_FILE_URL:-}
+
 if [[ $# -gt 0 ]]; then
     JAVABASE_VALUE="$1"; shift
     add_to_bazelrc "build --javabase=${JAVABASE_VALUE}"
@@ -57,6 +67,16 @@ EOF
     fi
 
     cat $(rlocation io_bazel/src/test/shell/bazel/testdata/jdk_http_archives) >> WORKSPACE
+
+    if [[ "${COVERAGE_GENERATOR_ZIP_FILE_URL}" ]]; then
+        cat >> WORKSPACE << EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "remote_coverage_tools",
+    urls = ["${COVERAGE_GENERATOR_ZIP_FILE_URL}"],
+  )
+EOF
+    fi
 }
 
 # Asserts if the given expected coverage result is included in the given output

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD
@@ -3,6 +3,7 @@ load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 package(
     default_visibility = [
         "//tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator:__pkg__",
+        "//src/test/shell/bazel:__pkg__",
     ],
 )
 

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/BUILD
@@ -3,7 +3,6 @@ load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 package(
     default_visibility = [
         "//tools/test/CoverageOutputGenerator/javatests/com/google/devtools/coverageoutputgenerator:__pkg__",
-        "//src/test/shell/bazel:__pkg__",
     ],
 )
 
@@ -207,4 +206,28 @@ filegroup(
         "BUILD.tools",
     ],
     visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "coverage_lcov_merge_tools",
+    srcs = [":all_lcov_merger_tools_deploy.jar"],
+    outs = ["coverage/all_lcov_merger_tools_deploy.jar"],
+    cmd = "cp $< $@",
+)
+
+genrule(
+    name = "coverage_empty_workspace",
+    outs = ["coverage/WORKSPACE"],
+    cmd = "touch $@",
+)
+
+# Used to act as an override for @remote_coverage_tools in integration tests
+filegroup(
+    name = "coverage_output_generator_repo",
+    data = [
+        ":coverage_empty_workspace",
+        ":coverage_lcov_merge_tools",
+        ":rename_build_tools",
+    ],
+    visibility = ["//src/test/shell/bazel:__pkg__"],
 )


### PR DESCRIPTION
Splits the coverage integration test into versions that test either the
released version of the coverage tool or one built at HEAD.

The java coverage test already has a "head"/"released" split for the
toolchain, which includes the java coverage generator; we include the
HEAD version of the coverage tool in the appropriate test.

We have to disable the java "head" test for the moment because the test
is not compatible with ongoing work that fixes the coverage output output.
The tests will be updated when that work is complete.

Fixes #11604