### PR TITLE
Fix AarResourcesExtractor action to produce consistent zips

### DIFF
--- a/tools/android/aar_native_libs_zip_creator.py
+++ b/tools/android/aar_native_libs_zip_creator.py
@@ -51,7 +51,6 @@ class UnsupportedArchitectureException(Exception):
   """Exception thrown when an AAR does not support the requested CPU."""
   pass
 
-
 def CreateNativeLibsZip(aar, cpu, native_libs_zip):
   native_lib_pattern = re.compile("^jni/.+/.+\\.so$")
   if any(native_lib_pattern.match(filename) for filename in aar.namelist()):
@@ -63,7 +62,15 @@ def CreateNativeLibsZip(aar, cpu, native_libs_zip):
       # Only replaces the first instance of jni, in case the AAR contains
       # something like /jni/x86/jni.so.
       new_filename = lib.replace("jni", "lib", 1)
-      native_libs_zip.writestr(new_filename, aar.read(lib))
+      # To guarantee reproducible zips we must specify a new zipinfo.
+      # From writestr docs: "If its a name, the date and time is set to the current date and time."
+      # which will break the HASH calculation and result in a cache miss.
+      old_zipinfo = aar.getinfo(lib)
+      new_zipinfo = zipfile.ZipInfo(filename = new_filename)
+      new_zipinfo.date_time = old_zipinfo.date_time
+      new_zipinfo.compress_type = old_zipinfo.compress_type
+
+      native_libs_zip.writestr(new_zipinfo, aar.read(lib))
 
 
 def Main(input_aar_path, output_zip_path, cpu, input_aar_path_for_error_msg):

--- a/tools/android/aar_native_libs_zip_creator_test.py
+++ b/tools/android/aar_native_libs_zip_creator_test.py
@@ -17,9 +17,23 @@
 import io
 import unittest
 import zipfile
+import hashlib
+import time
+import tempfile
 
 from tools.android import aar_native_libs_zip_creator
 
+def md5(buf):
+    hash_md5 = hashlib.md5()
+    hash_md5.update(buf)
+    return hash_md5.hexdigest()
+
+def md5FromFile(fname):
+    hash_md5 = hashlib.md5()
+    with open(fname, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5.hexdigest()
 
 class AarNativeLibsZipCreatorTest(unittest.TestCase):
   """Unit tests for aar_native_libs_zip_creator.py."""
@@ -28,7 +42,7 @@ class AarNativeLibsZipCreatorTest(unittest.TestCase):
     aar = zipfile.ZipFile(io.BytesIO(), "w")
     outzip = zipfile.ZipFile(io.BytesIO(), "w")
     aar_native_libs_zip_creator.CreateNativeLibsZip(aar, "x86", outzip)
-    self.assertEquals([], outzip.namelist())
+    self.assertEqual([], outzip.namelist())
 
   def testAarWithMissingLibs(self):
     aar = zipfile.ZipFile(io.BytesIO(), "w")
@@ -47,6 +61,41 @@ class AarNativeLibsZipCreatorTest(unittest.TestCase):
     aar_native_libs_zip_creator.CreateNativeLibsZip(aar, "x86", outzip)
     self.assertIn("lib/x86/foo.so", outzip.namelist())
     self.assertNotIn("lib/armeabi/foo.so", outzip.namelist())
+
+  def testMultipleInvocationConsistency(self):
+      input_aar = tempfile.NamedTemporaryFile(delete=False)
+      aar = zipfile.ZipFile(input_aar.name, "w")
+      aar.writestr(zipfile.ZipInfo(filename="jni/x86/foo.so"), "foo")
+      aar.writestr(zipfile.ZipInfo(filename="jni/x86/bar.so"), "bar")
+      aar.close()
+      input_aar.close()
+      # CreateNativeLibsZip expects a readonly file, this is not required but more correct
+      readonly_aar = zipfile.ZipFile(input_aar.name, "r")
+
+      outfile1 = tempfile.NamedTemporaryFile(delete=False)
+      outzip1 = zipfile.ZipFile(outfile1.name, "w")
+      aar_native_libs_zip_creator.CreateNativeLibsZip(readonly_aar, "x86", outzip1)
+      outfile1.close()
+
+      # Must be more than 1 second because last modified date changes on second basis
+      time.sleep(2)
+
+      outfile2 = tempfile.NamedTemporaryFile(delete=False)
+      outzip2 = zipfile.ZipFile(outfile2.name, "w")
+      aar_native_libs_zip_creator.CreateNativeLibsZip(readonly_aar, "x86", outzip2)
+      outfile2.close()
+
+      self.assertIn("lib/x86/foo.so", outzip1.namelist())
+      self.assertIn("lib/x86/bar.so", outzip1.namelist())
+      self.assertNotEqual(md5(outzip1.read("lib/x86/foo.so")), md5(outzip1.read("lib/x86/bar.so")))
+
+      self.assertIn("lib/x86/foo.so", outzip2.namelist())
+      self.assertIn("lib/x86/bar.so", outzip2.namelist())
+      self.assertNotEqual(md5(outzip1.read("lib/x86/foo.so")), md5(outzip1.read("lib/x86/bar.so")))
+
+      # The hash for the output zips must always match if the inputs match.
+      # Otherwise, there will be a cache miss which will produce poort build times.
+      self.assertEqual(md5FromFile(outfile1.name), md5FromFile(outfile2.name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `aar_native_libs_zip_creator.py` script was producing inconsistent output zips for the same input files due to changing the last modified date of the input files. This resulted in inconsistent cache keys and therefore poor build results.