### PR TITLE
Avoid instrumenting too many packages for test coverage

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/InstrumentationFilterSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/InstrumentationFilterSupport.java
@@ -46,10 +46,7 @@ public final class InstrumentationFilterSupport {
    * 4) Replace all "javatests" directories in packages with "java". Similarly, replace "test/java/"
    *    with "main/java". Also, strip trailing "/internal", "/public", and "/tests" from packages.
    *    (See getInstrumentedPrefix.)
-   * 5) If two packages reside in the same directory, use filter based on the parent directory name
-        instead. Doing so significantly simplifies instrumentation filter in majority of real-life
-        scenarios (in particular when dealing with my/package/... wildcards).
-   * 6) Set --instrumentation_filter default value to instrument everything in those packages.
+   * 5) Set --instrumentation_filter default value to instrument everything in those packages.
    */
   @VisibleForTesting
   public static String computeInstrumentationFilter(
@@ -123,25 +120,6 @@ public final class InstrumentationFilterSupport {
   private static void optimizeFilterSet(SortedSet<String> packageFilters) {
     Iterator<String> iterator = packageFilters.iterator();
     if (iterator.hasNext()) {
-      // Find common parent filters to reduce number of filter expressions. In practice this
-      // still produces nicely constrained instrumentation filter while making final
-      // filter value much more user-friendly - especially in case of /my/package/... wildcards.
-      Set<String> parentFilters = Sets.newTreeSet();
-      String filterString = iterator.next();
-      PathFragment parent = PathFragment.create(filterString).getParentDirectory();
-      String parentPath = (parent == null) ? "" : parent.getPathString();
-      while (iterator.hasNext()) {
-        String current = iterator.next();
-        if (!current.startsWith(filterString) && current.startsWith(parentPath)) {
-          parentFilters.add(parentPath);
-        } else {
-          filterString = current;
-          parent = PathFragment.create(filterString).getParentDirectory();
-          parentPath = (parent == null) ? "" : parent.getPathString();
-        }
-      }
-      packageFilters.addAll(parentFilters);
-
       // Optimize away nested filters.
       iterator = packageFilters.iterator();
       String prev = iterator.next();

--- a/src/main/java/com/google/devtools/build/lib/buildtool/InstrumentationFilterSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/InstrumentationFilterSupport.java
@@ -24,7 +24,6 @@ import com.google.devtools.build.lib.packages.NonconfigurableAttributeMapper;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.packages.TargetUtils;
-import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.stream.Collectors;
 import java.util.Collection;
 import java.util.Iterator;

--- a/src/main/java/com/google/devtools/build/lib/buildtool/InstrumentationFilterSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/InstrumentationFilterSupport.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.buildtool;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.Event;
@@ -26,6 +25,7 @@ import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.packages.TargetUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
+import java.util.stream.Collectors;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
@@ -54,18 +54,13 @@ public final class InstrumentationFilterSupport {
     SortedSet<String> packageFilters = Sets.newTreeSet();
     collectInstrumentedPackages(testTargets, packageFilters);
     optimizeFilterSet(packageFilters);
-
+    // append [/:] only when it's not a top-level target fileter, because "//foo[/:]" matches
+    // everything under //foo and subpackages, but "//[/:]" only matches targets directly under the
+    // top-level package.
     String instrumentationFilter =
-        Joiner.on("[/:],//")
-            .appendTo(new StringBuilder("//"), packageFilters)
-            .append("[/:]")
-            .toString();
-    // Fix up if one of the test targets is a top-level target. "//foo[/:]" matches everything
-    // under //foo and subpackages, but "//[/:]" only matches targets directly under the top-level
-    // package.
-    if (instrumentationFilter.equals("//[/:]")) {
-      instrumentationFilter = "//";
-    }
+        packageFilters.stream()
+            .map(pf -> pf.endsWith("//") ? pf : pf + "[/:]")
+            .collect(Collectors.joining(","));
     if (!packageFilters.isEmpty()) {
       eventHandler.handle(
           Event.info("Using default value for --instrumentation_filter: \""
@@ -80,14 +75,25 @@ public final class InstrumentationFilterSupport {
       Collection<Target> targets, Set<String> packageFilters) {
     for (Target target : targets) {
       // Add package-based filters for every test target.
-      packageFilters.add(getInstrumentedPrefix(target.getLabel().getPackageName()));
+      String workspace = target.getLabel().getWorkspaceName();
+      String pkgPrefix = getInstrumentedPrefix(target.getLabel().getPackageName());
+      if (workspace.length() > 0) {
+        packageFilters.add("@" + workspace + "//" + pkgPrefix);
+      } else {
+        packageFilters.add("^//" + pkgPrefix);
+      }
       if (TargetUtils.isTestSuiteRule(target)) {
         AttributeMap attributes = NonconfigurableAttributeMapper.of((Rule) target);
         // We don't need to handle $implicit_tests attribute since we already added
         // test_suite package to the set.
         for (Label label : attributes.get("tests", BuildType.LABEL_LIST)) {
           // Add package-based filters for all tests in the test suite.
-          packageFilters.add(getInstrumentedPrefix(label.getPackageName()));
+          pkgPrefix = getInstrumentedPrefix(label.getPackageName());
+          if (workspace.length() > 0) {
+            packageFilters.add("@" + workspace + "//" + pkgPrefix);
+          } else {
+            packageFilters.add("^//" + pkgPrefix);
+          }
         }
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/buildtool/InstrumentationFilterSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/InstrumentationFilterSupport.java
@@ -25,7 +25,6 @@ import com.google.devtools.build.lib.packages.NonconfigurableAttributeMapper;
 import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.packages.TargetUtils;
-import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
@@ -56,15 +55,15 @@ public final class InstrumentationFilterSupport {
     optimizeFilterSet(packageFilters);
 
     String instrumentationFilter =
-        Joiner.on("[/:],//")
-            .appendTo(new StringBuilder("//"), packageFilters)
+        Joiner.on("[/:],^//")
+            .appendTo(new StringBuilder("^//"), packageFilters)
             .append("[/:]")
             .toString();
     // Fix up if one of the test targets is a top-level target. "//foo[/:]" matches everything
     // under //foo and subpackages, but "//[/:]" only matches targets directly under the top-level
     // package.
-    if (instrumentationFilter.equals("//[/:]")) {
-      instrumentationFilter = "//";
+    if (instrumentationFilter.equals("^//[/:]")) {
+      instrumentationFilter = "^//";
     }
     if (!packageFilters.isEmpty()) {
       eventHandler.handle(

--- a/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/BUILD
@@ -599,6 +599,21 @@ java_test(
     ],
 )
 
+java_test(
+    name = "InstrumentationFilterTest",
+    srcs = ["InstrumentationFilterTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib:runtime",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/cmdline:cmdline-primitives",
+        "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/packages",
+        "//src/main/java/com/google/devtools/build/lib/packages:build_type",
+        "//src/main/java/com/google/devtools/build/lib/syntax:frontend",
+        "//third_party:junit4",
+    ],
+)
+
 test_suite(
     name = "windows_tests",
     tags = [

--- a/src/test/java/com/google/devtools/build/lib/buildtool/InstrumentationFilterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/InstrumentationFilterTest.java
@@ -1,0 +1,104 @@
+package com.google.devtools.build.lib.buildtool;
+
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
+import com.google.devtools.build.lib.events.EventHandler;
+import com.google.devtools.build.lib.packages.*;
+import com.google.devtools.build.lib.packages.Package;
+import com.google.devtools.build.lib.syntax.Location;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+public class InstrumentationFilterTest {
+  @Test
+  public void testComputeInstrumentationFilter() {
+    List<Target> testTargets =
+        Arrays.asList(
+            new TestTarget("//foo"),
+            new TestTarget("//foo/bar"),
+            new TestTarget("//bar"),
+            new TestTarget("@repo1//foo/bar"));
+    EventHandler eventHandler = event -> {};
+    String filter =
+        InstrumentationFilterSupport.computeInstrumentationFilter(eventHandler, testTargets);
+    assertEquals("@repo1//foo/bar[/:],^//bar[/:],^//foo[/:]", filter);
+
+    testTargets =
+        Arrays.asList(
+            new TestTarget("//"),
+            new TestTarget("@repo1//foo"),
+            new TestTarget("//foo"),
+            new TestTarget("@repo1//"));
+    filter = InstrumentationFilterSupport.computeInstrumentationFilter(eventHandler, testTargets);
+    assertEquals("@repo1//,^//", filter);
+  }
+}
+
+class TestTarget implements Target {
+  String pkg;
+
+  TestTarget(String pkg) {
+    this.pkg = pkg;
+  }
+
+  @Override
+  public Package getPackage() {
+    return null;
+  }
+
+  @Override
+  public String getTargetKind() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Rule getAssociatedRule() {
+    return null;
+  }
+
+  @Override
+  public License getLicense() {
+    return null;
+  }
+
+  @Override
+  public Location getLocation() {
+    return null;
+  }
+
+  @Override
+  public Set<License.DistributionType> getDistributions() {
+    return null;
+  }
+
+  @Override
+  public RuleVisibility getVisibility() {
+    return null;
+  }
+
+  @Override
+  public boolean isConfigurable() {
+    return false;
+  }
+
+  @Override
+  public Label getLabel() {
+    try {
+      return Label.create(this.pkg, "go_default_test");
+    } catch (LabelSyntaxException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/buildtool/InstrumentationFilterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/InstrumentationFilterTest.java
@@ -19,23 +19,15 @@ public class InstrumentationFilterTest {
   public void testComputeInstrumentationFilter() {
     List<Target> testTargets =
         Arrays.asList(
-            new TestTarget("//foo"),
-            new TestTarget("//foo/bar"),
-            new TestTarget("//bar"),
-            new TestTarget("@repo1//foo/bar"));
+            new TestTarget("//foo"), new TestTarget("//foo/bar"), new TestTarget("//bar"));
     EventHandler eventHandler = event -> {};
     String filter =
         InstrumentationFilterSupport.computeInstrumentationFilter(eventHandler, testTargets);
-    assertEquals("@repo1//foo/bar[/:],^//bar[/:],^//foo[/:]", filter);
+    assertEquals("^//bar[/:],^//foo[/:]", filter);
 
-    testTargets =
-        Arrays.asList(
-            new TestTarget("//"),
-            new TestTarget("@repo1//foo"),
-            new TestTarget("//foo"),
-            new TestTarget("@repo1//"));
+    testTargets = Arrays.asList(new TestTarget("//"), new TestTarget("//foo"));
     filter = InstrumentationFilterSupport.computeInstrumentationFilter(eventHandler, testTargets);
-    assertEquals("@repo1//,^//", filter);
+    assertEquals("^//", filter);
   }
 }
 


### PR DESCRIPTION
This PR fixes #11962 by 

* stopping replacing packages with their common parent directories. For example `foo` and `bar/baz` will no longer be replaced with `""`. Finding common parent directories is not necessary even for `//foo/...` patterns, because it will be expanded to several packages, including `//foo`. We just need to collapse children packages into their parent package in the package list.
* Adding `^//` to the beginning of every instrumentation filter, so only the main repo is instrumented.