### PR TITLE
Make processing of paths with tilde consistent between client and server

### DIFF
--- a/src/main/cpp/blaze_util.cc
+++ b/src/main/cpp/blaze_util.cc
@@ -164,6 +164,8 @@ bool IsArg(const string& arg) {
 std::string AbsolutePathFromFlag(const std::string& value) {
   if (value.empty()) {
     return blaze_util::GetCwd();
+  } else if (value.size() >= 1 && value[0] == '~') {
+    return blaze_util::JoinPath(GetHomeDir(), value.substr(1));
   } else {
     return blaze_util::MakeAbsolute(value);
   }

--- a/src/test/cpp/startup_options_test.cc
+++ b/src/test/cpp/startup_options_test.cc
@@ -109,7 +109,7 @@ TEST_F(StartupOptionsTest, OutputRootUseHomeDirectory) {
 
 TEST_F(StartupOptionsTest, OutputUserRootTildeExpansion) {
 #if defined(_WIN32)
-  std::string home = "C:\\nonexistent\\home\\";
+  std::string home = "C:/nonexistent/home/";
 #else
   std::string home = "/nonexistent/home/";
 #endif
@@ -118,41 +118,34 @@ TEST_F(StartupOptionsTest, OutputUserRootTildeExpansion) {
 
   std::string error;
 
-  const std::vector<RcStartupFlag> flags{
+  {
+    const std::vector<RcStartupFlag> flags{
       RcStartupFlag("somewhere", "--output_user_root=~/test"),
-  };
+    };
 
-  const blaze_exit_code::ExitCode ec =
+
+    const blaze_exit_code::ExitCode ec =
       startup_options_->ProcessArgs(flags, &error);
 
-  ASSERT_EQ(blaze_exit_code::SUCCESS, ec)
+    ASSERT_EQ(blaze_exit_code::SUCCESS, ec)
       << "ProcessArgs failed with error " << error;
 
-  EXPECT_EQ(blaze_util::JoinPath(home, "test"), startup_options_->output_user_root);
-}
+    EXPECT_EQ(blaze_util::JoinPath(home, "test"), startup_options_->output_user_root);
+  }
 
-TEST_F(StartupOptionsTest, OutputUserRootSingleTilde) {
-#if defined(_WIN32)
-  std::string home = "C:\\nonexistent\\home";
-#else
-  std::string home = "/nonexistent/home/";
-#endif
-
-  SetEnv("HOME", home);
-
-  std::string error;
-
-  const std::vector<RcStartupFlag> flags{
+  {
+    const std::vector<RcStartupFlag> flags{
       RcStartupFlag("somewhere", "--output_user_root=~"),
-  };
+    };
 
-  const blaze_exit_code::ExitCode ec =
+    const blaze_exit_code::ExitCode ec =
       startup_options_->ProcessArgs(flags, &error);
 
-  ASSERT_EQ(blaze_exit_code::SUCCESS, ec)
+    ASSERT_EQ(blaze_exit_code::SUCCESS, ec)
       << "ProcessArgs failed with error " << error;
 
-  EXPECT_EQ(home, startup_options_->output_user_root);
+    EXPECT_EQ(home, startup_options_->output_user_root);
+  }
 }
 
 TEST_F(StartupOptionsTest, EmptyFlagsAreInvalidTest) {

--- a/src/test/cpp/startup_options_test.cc
+++ b/src/test/cpp/startup_options_test.cc
@@ -107,6 +107,43 @@ TEST_F(StartupOptionsTest, OutputRootUseHomeDirectory) {
 }
 #endif  // __linux
 
+TEST_F(StartupOptionsTest, OutputUserRootTildeExpansion) {
+  SetEnv("HOME", "/nonexistent/home");
+
+  std::string error;
+
+  const std::vector<RcStartupFlag> flags{
+      RcStartupFlag("somewhere", "--output_user_root=~/test"),
+  };
+
+  const blaze_exit_code::ExitCode ec =
+      startup_options_->ProcessArgs(flags, &error);
+
+  ASSERT_EQ(blaze_exit_code::SUCCESS, ec)
+      << "ProcessArgs failed with error " << error;
+
+  EXPECT_EQ("/nonexistent/home/test", startup_options_->output_user_root);
+}
+
+TEST_F(StartupOptionsTest, OutputUserRootSingleTilde) {
+  SetEnv("HOME", "/nonexistent/home");
+
+  std::string error;
+
+  const std::vector<RcStartupFlag> flags{
+      RcStartupFlag("somewhere", "--output_user_root=~"),
+  };
+
+  const blaze_exit_code::ExitCode ec =
+      startup_options_->ProcessArgs(flags, &error);
+
+  ASSERT_EQ(blaze_exit_code::SUCCESS, ec)
+      << "ProcessArgs failed with error " << error;
+
+  EXPECT_EQ("/nonexistent/home/", startup_options_->output_user_root);
+}
+
+
 TEST_F(StartupOptionsTest, EmptyFlagsAreInvalidTest) {
   {
     bool result;

--- a/src/test/cpp/startup_options_test.cc
+++ b/src/test/cpp/startup_options_test.cc
@@ -108,7 +108,13 @@ TEST_F(StartupOptionsTest, OutputRootUseHomeDirectory) {
 #endif  // __linux
 
 TEST_F(StartupOptionsTest, OutputUserRootTildeExpansion) {
-  SetEnv("HOME", "/nonexistent/home");
+#if defined(_WIN32)
+  std::string home = "C:\\nonexistent\\home\\";
+#else
+  std::string home = "/nonexistent/home/";
+#endif
+
+  SetEnv("HOME", home);
 
   std::string error;
 
@@ -122,11 +128,17 @@ TEST_F(StartupOptionsTest, OutputUserRootTildeExpansion) {
   ASSERT_EQ(blaze_exit_code::SUCCESS, ec)
       << "ProcessArgs failed with error " << error;
 
-  EXPECT_EQ("/nonexistent/home/test", startup_options_->output_user_root);
+  EXPECT_EQ(blaze_util::JoinPath(home, "test"), startup_options_->output_user_root);
 }
 
 TEST_F(StartupOptionsTest, OutputUserRootSingleTilde) {
-  SetEnv("HOME", "/nonexistent/home");
+#if defined(_WIN32)
+  std::string home = "C:\\nonexistent\\home";
+#else
+  std::string home = "/nonexistent/home/";
+#endif
+
+  SetEnv("HOME", home);
 
   std::string error;
 
@@ -140,7 +152,7 @@ TEST_F(StartupOptionsTest, OutputUserRootSingleTilde) {
   ASSERT_EQ(blaze_exit_code::SUCCESS, ec)
       << "ProcessArgs failed with error " << error;
 
-  EXPECT_EQ("/nonexistent/home/", startup_options_->output_user_root);
+  EXPECT_EQ(home, startup_options_->output_user_root);
 }
 
 TEST_F(StartupOptionsTest, EmptyFlagsAreInvalidTest) {

--- a/src/test/cpp/startup_options_test.cc
+++ b/src/test/cpp/startup_options_test.cc
@@ -143,7 +143,6 @@ TEST_F(StartupOptionsTest, OutputUserRootSingleTilde) {
   EXPECT_EQ("/nonexistent/home/", startup_options_->output_user_root);
 }
 
-
 TEST_F(StartupOptionsTest, EmptyFlagsAreInvalidTest) {
   {
     bool result;


### PR DESCRIPTION
PathFragmentConverter in Java expands ~ to the user home directory.

Startup arguments that contain paths with `~` processed in client behave strangely compared to arguments processed in Java:

`startup --output_user_root=~/test` actually expands to `WORKSPACE_ROOT/~/test`.

Change AbsolutePathFromFlag to expand `~` suffixes to the user's home directory.