### PR TITLE
Add new target architectures for c++ binaries built on Windows with MSVC

### DIFF
--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -198,7 +198,7 @@ C:\projects\bazel> bazel-bin\examples\cpp\hello-world.exe
 ```
 
 By default the built binaries are targeted to x64 architecture. However, you can specify a different target architecture by setting the ```--cpu``` build option:
-*   Without ```--cpu``` or with ```--cpu=cpu=x64_windows``` targets are built for x64 architecture.
+*   Without ```--cpu``` or with ```--cpu=x64_windows``` targets are built for x64 architecture.
 *   ```--cpu=x64_x86_windows``` builds targets for x86 architecture.
 *   ```--cpu=x64_arm_windows``` builds targets for ARM architecture.
 *   ```--cpu=x64_arm64_windows``` builds targets for ARM64 architecture.

--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -197,6 +197,12 @@ C:\projects\bazel> bazel build //examples/cpp:hello-world
 C:\projects\bazel> bazel-bin\examples\cpp\hello-world.exe
 ```
 
+By default the built binaries are targeted to x64 architecture. However, you can specify a different target architecture by setting the ```--cpu``` build option:
+*   Without ```--cpu``` or with ```--cpu=cpu=x64_windows``` targets are built for x64 architecture.
+*   ```--cpu=x64_x86_windows``` builds targets for x86 architecture.
+*   ```--cpu=x64_arm_windows``` builds targets for ARM architecture.
+*   ```--cpu=x64_arm64_windows``` builds targets for ARM64 architecture.
+
 To build and use Dynamically Linked Libraries (DLL files), see [this
 example](https://github.com/bazelbuild/bazel/tree/master/examples/windows/dll).
 


### PR DESCRIPTION
Adding documentation for the newly supported target architectures for c++ binaries built on Windows with MSVC. Bazel now supports building binaries for x86, ARM and ARM64 architectures besides the default x64.

@meteorcloudy 