### PR TITLE
fix UNC path for Windows/mingw case

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
@@ -22,6 +22,7 @@ import os
 import re
 import shutil
 import subprocess
+import sysconfig
 import tempfile
 import zipfile
 
@@ -37,8 +38,8 @@ def GetWindowsPathWithUNCPrefix(path):
   path = path.strip()
 
   # No need to add prefix for non-Windows platforms.
-  # And \\?\ doesn't work in python 2
-  if not IsWindows() or sys.version_info[0] < 3:
+  # And \\?\ doesn't work in python 2 or on mingw
+  if not IsWindows() or sys.version_info[0] < 3 or sysconfig.get_platform() == 'mingw':
     return path
 
   # Lets start the unicode fun

--- a/src/test/java/com/google/devtools/build/lib/syntax/EvaluationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/syntax/EvaluationTest.java
@@ -137,8 +137,7 @@ public final class EvaluationTest {
 
     class C {
       long run(int n) throws SyntaxError.Exception, EvalException, InterruptedException {
-        Module module =
-            Module.withPredeclared(StarlarkSemantics.DEFAULT, ImmutableMap.of("n", 1000));
+        Module module = Module.withPredeclared(StarlarkSemantics.DEFAULT, ImmutableMap.of("n", n));
         long steps0 = thread.getExecutedSteps();
         EvalUtils.exec(input, FileOptions.DEFAULT, module, thread);
         return thread.getExecutedSteps() - steps0;
@@ -146,15 +145,15 @@ public final class EvaluationTest {
     }
 
     // A thread records the number of computation steps.
-    long steps100 = new C().run(1000);
+    long steps1000 = new C().run(1000);
     long steps10000 = new C().run(10000);
-    double ratio = ((double) steps10000 / (double) steps100) * 100.0;
-    if (ratio < 99 || ratio > 101) {
+    double ratio = (double) steps10000 / (double) steps1000;
+    if (ratio < 9.9 || ratio > 10.1) {
       throw new AssertionError(
           String.format(
-              "computation steps did not increase linearly: f(100)=%d, f(10000)=%d, ratio=%g, want"
-                  + " ~100",
-              steps100, steps10000, ratio));
+              "computation steps did not increase linearly: f(1000)=%d, f(10000)=%d, ratio=%g, want"
+                  + " ~10",
+              steps1000, steps10000, ratio));
     }
 
     // Exceeding the limit causes cancellation.


### PR DESCRIPTION
(There are cases where not a native python installation on Windows can be used but a mingw-python port inside MSYS2 for collaboration with other tools. mingw-python on MSYS2 returns os.name == 'nt' but doesn't support this UNC path pattern.)