### PR TITLE
fix UNC path for Windows/mingw case

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
@@ -22,6 +22,7 @@ import os
 import re
 import shutil
 import subprocess
+import sysconfig
 import tempfile
 import zipfile
 
@@ -37,8 +38,8 @@ def GetWindowsPathWithUNCPrefix(path):
   path = path.strip()
 
   # No need to add prefix for non-Windows platforms.
-  # And \\?\ doesn't work in python 2
-  if not IsWindows() or sys.version_info[0] < 3:
+  # And \\?\ doesn't work in python 2 or on mingw
+  if not IsWindows() or sys.version_info[0] < 3 or sysconfig.get_platform() == 'mingw':
     return path
 
   # Lets start the unicode fun


### PR DESCRIPTION
(There are cases where not a native python installation on Windows can be used but a mingw-python port inside MSYS2 for collaboration with other tools. mingw-python on MSYS2 returns os.name == 'nt' but doesn't support this UNC path pattern.)