### PR TITLE
Add task `kythe_ubuntu2004` to `postsubmit.yml`

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -218,3 +218,13 @@ tasks:
       - "//src:bazel_jdk_minimal"
     include_json_profile:
       - build
+  kythe_ubuntu2004:
+    shell_commands:
+    - sed -i.bak -e 's/^# android_sdk_repository/android_sdk_repository/'
+      -e 's/^# android_ndk_repository/android_ndk_repository/' WORKSPACE
+    - rm -f WORKSPACE.bak
+    index_flags:
+    - "--define=kythe_corpus=github.com/bazelbuild/bazel"
+    index_targets_query: "kind(\"cc_(binary|library|test|proto_library) rule\", ...) union kind(\"java_(binary|import|library|plugin|test|proto_library) rule\", ...) union kind(\"proto_library rule\", ...)"
+    index_upload_policy: Always
+    index_upload_gcs: True


### PR DESCRIPTION
Add task`kythe_ubuntu2004` to generate indexing files with Kythe and upload to GCS automatically.

Must be merged after https://github.com/bazelbuild/continuous-integration/commit/7bb698c41cd6159475154e74c5fab3a38b6106b5 landed.