### PR TITLE
Windows: Make runfiles symlink tree actions depend on the runfiles artifacts.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkTreeAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SymlinkTreeAction.java
@@ -25,11 +25,12 @@ import com.google.devtools.build.lib.actions.ActionResult;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
-import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.util.Fingerprint;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import javax.annotation.Nullable;
 
@@ -106,9 +107,7 @@ public final class SymlinkTreeAction extends AbstractAction {
       boolean skipRunfilesManifests) {
     super(
         owner,
-        skipRunfilesManifests && enableRunfiles && (filesetRoot == null)
-            ? NestedSetBuilder.emptySet(Order.STABLE_ORDER)
-            : NestedSetBuilder.create(Order.STABLE_ORDER, inputManifest),
+        computeInputs(enableRunfiles, skipRunfilesManifests, runfiles, inputManifest),
         ImmutableSet.of(outputManifest),
         env);
     Preconditions.checkArgument(outputManifest.getPath().getBaseName().equals("MANIFEST"));
@@ -122,6 +121,24 @@ public final class SymlinkTreeAction extends AbstractAction {
     this.inprocessSymlinkCreation = inprocessSymlinkCreation;
     this.skipRunfilesManifests = skipRunfilesManifests && enableRunfiles && (filesetRoot == null);
     this.inputManifest = this.skipRunfilesManifests ? null : inputManifest;
+  }
+
+  private static NestedSet<Artifact> computeInputs(
+      boolean enableRunfiles,
+      boolean skipRunfilesManifests,
+      Runfiles runfiles,
+      Artifact inputManifest) {
+    NestedSetBuilder<Artifact> inputs = NestedSetBuilder.<Artifact>stableOrder();
+    if (!skipRunfilesManifests || !enableRunfiles || runfiles == null) {
+      inputs.add(inputManifest);
+    }
+    // All current strategies (in-process and build-runfiles-windows) for
+    // making symlink trees on Windows depend on the target files
+    // existing, so directory or file links can be made as appropriate.
+    if (enableRunfiles && runfiles != null && OS.getCurrent() == OS.WINDOWS) {
+      inputs.addTransitive(runfiles.getAllArtifacts());
+    }
+    return inputs.build();
   }
 
   public Artifact getInputManifest() {


### PR DESCRIPTION
Windows distinguishes between symlinks to files and symlinks to directories. The
code to create symlink trees on Windows thus inspects the targets of the links
to learn what kind of symlink to make. Unfortunately, the symlinking code did
not depend on the link targets actually being created. This race could lead to
non-deterministic and non-functional symlink trees.

Fix this problem by depending on runfiles artifacts in the SymtreeTreeAction
when the host platform is Windows.

It's certainly possible to avoid this os-dependent input dependency—by using
in-memory Artifact state for the in-process implementation and extending the
runfiles manifest format to indicate target type for build-runfiles-windows—but
this commit is the most straightforward change that remediates the serious
correctness issue represented by the previous state.

This topic has a long history. When Windows runfiles trees were actually copies
of artifacts, the "symlink" action obviously had to depend on the origin
artifacts (41f4456ac2348bef66739194853a1ddadcbb887e). That code was removed in
an interregnum period where runfiles trees weren't supported at all on Windows
(0885abd851b17d19661dfbd5459a5b91feb45620). However, the dependency was not
added back when Windows symlinked runfiles trees support was finally added
(b592dbd46d5aae2977b11426850eecb89d94a6cb).

Fixes https://github.com/bazelbuild/bazel/issues/12033.