### PR TITLE
Handling InvalidPathException in repository_ctx

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -654,7 +654,7 @@ public class StarlarkRepositoryContext
       if (fragment.isAbsolute()) {
         // We ignore relative path as they don't mean much here (relative to where? the workspace
         // root?).
-        Path path = outputDirectory.getFileSystem().getPath(fragment).getChild(program);
+        Path path = outputDirectory.getFileSystem().getPath(fragment).getChild(program.trim());
         if (path.exists() && path.isFile(Symlinks.FOLLOW) && path.isExecutable()) {
           return new StarlarkPath(path);
         }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -80,6 +80,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.InvalidPathException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -257,6 +258,10 @@ public class StarlarkRepositoryContext
               "Could not create symlink from " + fromPath + " to " + toPath + ": " + e.getMessage(),
               e),
           Transience.TRANSIENT);
+    } catch (InvalidPathException e) {
+      throw new RepositoryFunctionException(
+          Starlark.errorf("Could not create %s: %s", toPath, e.getMessage()),
+          Transience.PERSISTENT);
     }
   }
 
@@ -301,6 +306,9 @@ public class StarlarkRepositoryContext
       }
     } catch (IOException e) {
       throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+    } catch (InvalidPathException e) {
+      throw new RepositoryFunctionException(
+          Starlark.errorf("Could not create %s: %s", p, e.getMessage()), Transience.PERSISTENT);
     }
   }
 
@@ -342,6 +350,9 @@ public class StarlarkRepositoryContext
       }
     } catch (IOException e) {
       throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+    } catch (InvalidPathException e) {
+      throw new RepositoryFunctionException(
+          Starlark.errorf("Could not create %s: %s", p, e.getMessage()), Transience.PERSISTENT);
     }
   }
 
@@ -361,7 +372,7 @@ public class StarlarkRepositoryContext
   }
 
   // Create parent directories for the given path
-  private void makeDirectories(Path path) throws IOException {
+  private void makeDirectories(Path path) throws IOException, InvalidPathException {
     Path parent = path.getParentDirectory();
     if (parent != null) {
       parent.createDirectoryAndParents();
@@ -390,6 +401,9 @@ public class StarlarkRepositoryContext
       }
     } catch (IOException e) {
       throw new RepositoryFunctionException(e, Transience.TRANSIENT);
+    } catch (InvalidPathException e) {
+      throw new RepositoryFunctionException(
+          Starlark.errorf("Could not create %s: %s", directory, e.getMessage()), Transience.PERSISTENT);
     }
   }
 
@@ -753,6 +767,10 @@ public class StarlarkRepositoryContext
       } else {
         throw new RepositoryFunctionException(e, Transience.TRANSIENT);
       }
+    } catch (InvalidPathException e) {
+      throw new RepositoryFunctionException(
+          Starlark.errorf("Could not create output path %s: %s", outputPath, e.getMessage()),
+          Transience.PERSISTENT);
     }
     if (checksumValidation != null) {
       throw checksumValidation;

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -250,7 +250,7 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
   }
 
   @Override
-  public void createDirectoryAndParents(Path path) throws IOException {
+  public void createDirectoryAndParents(Path path) throws IOException, InvalidPathException {
     java.nio.file.Path nioPath = getNioPath(path);
     try {
       Files.createDirectories(nioPath);

--- a/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
+++ b/src/main/java/com/google/devtools/build/lib/vfs/JavaIoFileSystem.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.LinkOption;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -116,10 +117,12 @@ public class JavaIoFileSystem extends AbstractFileSystemWithCustomStat {
 
   @Override
   protected boolean exists(Path path, boolean followSymlinks) {
-    java.nio.file.Path nioPath = getNioPath(path);
     long startTime = Profiler.nanoTimeMaybe();
     try {
+      java.nio.file.Path nioPath = getNioPath(path);
       return Files.exists(nioPath, linkOpts(followSymlinks));
+    } catch (InvalidPathException e) {
+      return false;
     } finally {
       profiler.logSimpleTask(startTime, ProfilerTask.VFS_STAT, path.toString());
     }


### PR DESCRIPTION
This pull request handles `java.nio.InvalidPathExcception` that may occur while performing `repository_ctx` operations. 

For `repository_ctx.which` operation, it ignores invalid PATH entries and trims the leading and trailing spaces in the program name, so it will not be considered invalid.

Fixes #10481

@meteorcloudy