### PR TITLE
Make --experimental_repo_remote_exec compatible with rbe_autoconfig

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryModule.java
@@ -79,7 +79,6 @@ public class StarlarkRepositoryModule implements RepositoryModuleApi {
     builder.addAttribute(attr("$configure", BOOLEAN).defaultValue(configure).build());
     if (thread.getSemantics().experimentalRepoRemoteExec()) {
       builder.addAttribute(attr("$remotable", BOOLEAN).defaultValue(remotable).build());
-      BaseRuleClasses.execPropertiesAttribute(builder);
     }
     builder.addAttribute(attr("$environ", STRING_LIST).defaultValue(environ).build());
     BaseRuleClasses.nameAttribute(builder);
@@ -97,6 +96,13 @@ public class StarlarkRepositoryModule implements RepositoryModuleApi {
         }
         builder.addAttribute(attrDescriptor.build(attrName));
       }
+    }
+    if (thread.getSemantics().experimentalRepoRemoteExec()) {
+      // Add the 'exec_properties' attribute last. That way it's backwards compatible with
+      // repository rules that already declare 'exec_properties'. In particular
+      // https://github.com/bazelbuild/bazel-toolchains
+      // TODO(buchgr): Remove this backwards compatiblity hack once the feature is marked stable.
+      BaseRuleClasses.addOrOverrideExecPropertiesAttribute(builder);
     }
     builder.setConfiguredTargetFunction(implementation);
     BazelModuleContext bzlModule =

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -1259,6 +1259,10 @@ public class RuleClass {
       return attributes.containsKey(name);
     }
 
+    public Attribute getAttribute(String name) {
+      return attributes.get(name);
+    }
+
     /** Sets the rule implementation function. Meant for Starlark usage. */
     public Builder setConfiguredTargetFunction(StarlarkCallable func) {
       this.configuredTargetFunction = func;


### PR DESCRIPTION
Based on https://github.com/bazelbuild/bazel/pull/11029 by @buchgr

Closes #11029, #12030