### PR TITLE
Support verboseFailures/BTECNF in remote cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BulkTransferException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/BulkTransferException.java
@@ -46,4 +46,9 @@ class BulkTransferException extends IOException {
   boolean onlyCausedByCacheNotFoundException() {
     return allCacheNotFoundException;
   }
+
+  static boolean isOnlyCausedByCacheNotFoundException(Exception e) {
+    return e instanceof BulkTransferException
+        && ((BulkTransferException) e).onlyCausedByCacheNotFoundException();
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -120,6 +120,7 @@ final class RemoteActionContextProvider implements ExecutorLifecycleListener {
         new RemoteSpawnCache(
             env.getExecRoot(),
             checkNotNull(env.getOptions().getOptions(RemoteOptions.class)),
+            checkNotNull(env.getOptions().getOptions(ExecutionOptions.class)).verboseFailures,
             cache,
             env.getBuildRequestId(),
             env.getCommandId().toString(),

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -116,9 +116,8 @@ public class RemoteSpawnRunner implements SpawnRunner {
   private static final String VIOLATION_TYPE_MISSING = "MISSING";
 
   private static boolean retriableExecErrors(Exception e) {
-    if (e instanceof BulkTransferException) {
-      BulkTransferException bulkTransferException = (BulkTransferException) e;
-      return bulkTransferException.onlyCausedByCacheNotFoundException();
+    if (BulkTransferException.isOnlyCausedByCacheNotFoundException(e)) {
+      return true;
     }
     if (!RemoteRetrierUtils.causedByStatus(e, Code.FAILED_PRECONDITION)) {
       return false;
@@ -613,11 +612,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
   private SpawnResult handleError(
       IOException exception, FileOutErr outErr, ActionKey actionKey, SpawnExecutionContext context)
       throws ExecException, InterruptedException, IOException {
-    boolean remoteCacheFailed = false;
-    if (exception instanceof BulkTransferException) {
-      BulkTransferException e = (BulkTransferException) exception;
-      remoteCacheFailed = e.onlyCausedByCacheNotFoundException();
-    }
+    boolean remoteCacheFailed = BulkTransferException.isOnlyCausedByCacheNotFoundException(exception);
     if (exception.getCause() instanceof ExecutionStatusException) {
       ExecutionStatusException e = (ExecutionStatusException) exception.getCause();
       if (e.getResponse() != null) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -201,6 +201,7 @@ public class RemoteSpawnCacheTest {
     return new RemoteSpawnCache(
         execRoot,
         options,
+        /* verboseFailures=*/ true,
         remoteCache,
         "build-req-id",
         "command-id",


### PR DESCRIPTION
The RemoteSpawnCache should respect the verbose_failures option
consistent with RemoteSpawnRunner's behavior, and it should ignore
(per existing behavior) a CacheNotFound-only BulkTransferException.
Refactored the instance check for IOException into a utility method on
BulkTransferException.