### PR TITLE
Add support to crosstool for darwin_arm64(e)

### DIFF
--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -65,6 +65,18 @@ config_setting(
 )
 
 config_setting(
+    name = "darwin_arm64",
+    values = {"cpu": "darwin_arm64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_arm64e",
+    values = {"cpu": "darwin_arm64e"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "iphonesdk",
     values = {"define": "IPHONE_SDK=1"},
     visibility = ["//visibility:public"],

--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -53,6 +53,18 @@ config_setting(
 )
 
 config_setting(
+    name = "darwin_arm64",
+    values = {"cpu": "darwin_arm64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_arm64e",
+    values = {"cpu": "darwin_arm64e"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "windows",
     values = {"cpu": "x64_windows"},
     visibility = ["//visibility:public"],

--- a/src/main/cpp/BUILD
+++ b/src/main/cpp/BUILD
@@ -28,6 +28,14 @@ cc_library(
             "blaze_util_darwin.cc",
             "blaze_util_posix.cc",
         ],
+        "//src/conditions:darwin_arm64": [
+            "blaze_util_darwin.cc",
+            "blaze_util_posix.cc",
+        ],
+        "//src/conditions:darwin_arm64e": [
+            "blaze_util_darwin.cc",
+            "blaze_util_posix.cc",
+        ],
         "//src/conditions:freebsd": [
             "blaze_util_bsd.cc",
             "blaze_util_posix.cc",
@@ -53,6 +61,12 @@ cc_library(
             "-framework CoreFoundation",
         ],
         "//src/conditions:darwin_x86_64": [
+            "-framework CoreFoundation",
+        ],
+        "//src/conditions:darwin_arm64": [
+            "-framework CoreFoundation",
+        ],
+        "//src/conditions:darwin_arm64e": [
             "-framework CoreFoundation",
         ],
         "//src/conditions:freebsd": [
@@ -115,6 +129,10 @@ cc_binary(
         "//src/conditions:darwin": [
         ],
         "//src/conditions:darwin_x86_64": [
+        ],
+        "//src/conditions:darwin_arm64": [
+        ],
+        "//src/conditions:darwin_arm64e": [
         ],
         "//src/conditions:freebsd": [
             "-lprocstat",

--- a/src/main/tools/BUILD
+++ b/src/main/tools/BUILD
@@ -75,6 +75,8 @@ cc_binary(
     srcs = select({
         "//src/conditions:darwin": ["dummy-sandbox.c"],
         "//src/conditions:darwin_x86_64": ["dummy-sandbox.c"],
+        "//src/conditions:darwin_arm64": ["dummy-sandbox.c"],
+        "//src/conditions:darwin_arm64e": ["dummy-sandbox.c"],
         "//src/conditions:freebsd": ["dummy-sandbox.c"],
         "//src/conditions:openbsd": ["dummy-sandbox.c"],
         "//src/conditions:windows": ["dummy-sandbox.c"],
@@ -91,6 +93,8 @@ cc_binary(
     deps = select({
         "//src/conditions:darwin": [],
         "//src/conditions:darwin_x86_64": [],
+        "//src/conditions:darwin_arm64": [],
+        "//src/conditions:darwin_arm64e": [],
         "//src/conditions:freebsd": [],
         "//src/conditions:openbsd": [],
         "//src/conditions:windows": [],

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -368,6 +368,16 @@ config_setting(
 )
 
 config_setting(
+    name = "darwin_arm64",
+    values = {"cpu": "darwin_arm64"},
+)
+
+config_setting(
+    name = "darwin_arm64e",
+    values = {"cpu": "darwin_arm64e"},
+)
+
+config_setting(
     name = "windows",
     values = {"cpu": "x64_windows"},
 )
@@ -398,6 +408,8 @@ alias(
         ":linux_x86_64": "java_tools/src/tools/singlejar/singlejar_local",
         ":darwin": "java_tools/src/tools/singlejar/singlejar_local",
         ":darwin_x86_64": "java_tools/src/tools/singlejar/singlejar_local",
+        ":darwin_arm64": "java_tools/src/tools/singlejar/singlejar_local",
+        ":darwin_arm64e": "java_tools/src/tools/singlejar/singlejar_local",
         ":windows": "java_tools/src/tools/singlejar/singlejar_local.exe",
         "//conditions:default": "singlejar_cc_bin",
     }),
@@ -425,6 +437,8 @@ alias(
         ":linux_x86_64": ":ijar_prebuilt_binary",
         ":darwin": ":ijar_prebuilt_binary",
         ":darwin_x86_64": ":ijar_prebuilt_binary",
+        ":darwin_arm64": ":ijar_prebuilt_binary",
+        ":darwin_arm64e": ":ijar_prebuilt_binary",
         ":windows": ":ijar_prebuilt_binary",
         "//conditions:default": ":ijar_cc_binary",
     }),

--- a/tools/osx/BUILD
+++ b/tools/osx/BUILD
@@ -27,12 +27,16 @@ genrule(
     srcs = select({
         ":darwin": ["xcode_locator.m"],
         ":darwin_x86_64": ["xcode_locator.m"],
+        ":darwin_arm64": ["xcode_locator.m"],
+        ":darwin_arm64e": ["xcode_locator.m"],
         "//conditions:default": ["xcode_locator_stub.sh"],
     }),
     outs = ["xcode-locator"],
     cmd = select({
         ":darwin": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
         ":darwin_x86_64": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
+        ":darwin_arm64": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
+        ":darwin_arm64e": DARWIN_XCODE_LOCATOR_COMPILE_COMMAND,
         "//conditions:default": "cp $< $@",
     }),
     local = 1,
@@ -49,6 +53,18 @@ config_setting(
 config_setting(
     name = "darwin_x86_64",
     values = {"cpu": "darwin_x86_64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_arm64",
+    values = {"cpu": "darwin_arm64"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_arm64e",
+    values = {"cpu": "darwin_arm64e"},
     visibility = ["//visibility:public"],
 )
 

--- a/tools/osx/crosstool/BUILD.toolchains
+++ b/tools/osx/crosstool/BUILD.toolchains
@@ -2,17 +2,22 @@ package(default_visibility = ["//visibility:public"])
 
 load(":osx_archs.bzl", "OSX_TOOLS_ARCHS", "OSX_TOOLS_CONSTRAINTS")
 
+OSX_DEVELOPER_PLATFORM_CPUS = [
+    "aarch64",
+    "x86_64",
+]
+
 [
     toolchain(
-        name = "cc-toolchain-" + arch,
+        name = "cc-toolchain-" + arch + "-" + cpu,
         exec_compatible_with = [
             # These only execute on macOS.
             "@platforms//os:osx",
-            "@platforms//cpu:x86_64",
+            "@platforms//cpu:" + cpu,
         ],
         target_compatible_with = OSX_TOOLS_CONSTRAINTS[arch],
         toolchain = "@local_config_cc//:cc-compiler-" + arch,
         toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
     )
-    for arch in OSX_TOOLS_ARCHS
+    for arch in OSX_TOOLS_ARCHS for cpu in OSX_DEVELOPER_PLATFORM_CPUS
 ]

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -57,6 +57,10 @@ def _deterministic_libtool_flags(ctx):
 def _impl(ctx):
     if (ctx.attr.cpu == "darwin_x86_64"):
         toolchain_identifier = "darwin_x86_64"
+    elif (ctx.attr.cpu == "darwin_arm64"):
+        toolchain_identifier = "darwin_arm64"
+    elif (ctx.attr.cpu == "darwin_arm64e"):
+        toolchain_identifier = "darwin_arm64e"
     elif (ctx.attr.cpu == "ios_arm64"):
         toolchain_identifier = "ios_arm64"
     elif (ctx.attr.cpu == "ios_arm64e"):
@@ -87,6 +91,8 @@ def _impl(ctx):
     if (ctx.attr.cpu == "armeabi-v7a"):
         host_system_name = "armeabi-v7a"
     elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -124,6 +130,10 @@ def _impl(ctx):
         target_system_name = "x86_64-apple-ios"
     elif (ctx.attr.cpu == "darwin_x86_64"):
         target_system_name = "x86_64-apple-macosx"
+    elif (ctx.attr.cpu == "darwin_arm64"):
+        target_system_name = "arm64-apple-macosx"
+    elif (ctx.attr.cpu == "darwin_arm64e"):
+        target_system_name = "arm64e-apple-macosx"
     elif (ctx.attr.cpu == "tvos_x86_64"):
         target_system_name = "x86_64-apple-tvos"
     elif (ctx.attr.cpu == "watchos_x86_64"):
@@ -135,6 +145,10 @@ def _impl(ctx):
         target_cpu = "armeabi-v7a"
     elif (ctx.attr.cpu == "darwin_x86_64"):
         target_cpu = "darwin_x86_64"
+    elif (ctx.attr.cpu == "darwin_arm64"):
+        target_cpu = "darwin_arm64"
+    elif (ctx.attr.cpu == "darwin_arm64e"):
+        target_cpu = "darwin_arm64e"
     elif (ctx.attr.cpu == "ios_arm64"):
         target_cpu = "ios_arm64"
     elif (ctx.attr.cpu == "ios_arm64e"):
@@ -168,7 +182,9 @@ def _impl(ctx):
           ctx.attr.cpu == "ios_i386" or
           ctx.attr.cpu == "ios_x86_64"):
         target_libc = "ios"
-    elif (ctx.attr.cpu == "darwin_x86_64"):
+    elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e"):
         target_libc = "macosx"
     elif (ctx.attr.cpu == "tvos_arm64" or
           ctx.attr.cpu == "tvos_x86_64"):
@@ -187,7 +203,9 @@ def _impl(ctx):
         abi_version = "armeabi-v7a"
     elif (ctx.attr.cpu == "darwin_x86_64"):
         abi_version = "darwin_x86_64"
-    elif (ctx.attr.cpu == "ios_arm64" or
+    elif (ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
+          ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
           ctx.attr.cpu == "ios_i386" or
@@ -206,7 +224,9 @@ def _impl(ctx):
         abi_libc_version = "armeabi-v7a"
     elif (ctx.attr.cpu == "darwin_x86_64"):
         abi_libc_version = "darwin_x86_64"
-    elif (ctx.attr.cpu == "ios_arm64" or
+    elif (ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
+          ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
           ctx.attr.cpu == "ios_i386" or
@@ -320,6 +340,8 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -419,7 +441,8 @@ def _impl(ctx):
             ],
         )
     elif (ctx.attr.cpu == "ios_arm64" or
-          ctx.attr.cpu == "tvos_arm64"):
+          ctx.attr.cpu == "tvos_arm64" or
+          ctx.attr.cpu == "darwin_arm64"):
         objc_compile_action = action_config(
             action_name = ACTION_NAMES.objc_compile,
             flag_sets = [
@@ -451,7 +474,8 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "ios_arm64e"):
+    elif (ctx.attr.cpu == "ios_arm64e" or
+          ctx.attr.cpu == "darwin_arm64e"):
         objc_compile_action = action_config(
             action_name = ACTION_NAMES.objc_compile,
             flag_sets = [
@@ -776,7 +800,8 @@ def _impl(ctx):
             ],
         )
     elif (ctx.attr.cpu == "ios_arm64" or
-          ctx.attr.cpu == "tvos_arm64"):
+          ctx.attr.cpu == "tvos_arm64" or
+          ctx.attr.cpu == "darwin_arm64"):
         objcpp_executable_action = action_config(
             action_name = "objc++-executable",
             flag_sets = [
@@ -838,7 +863,8 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "ios_arm64e"):
+    elif (ctx.attr.cpu == "ios_arm64e" or
+          ctx.attr.cpu == "darwin_arm64e"):
         objcpp_executable_action = action_config(
             action_name = "objc++-executable",
             flag_sets = [
@@ -1184,6 +1210,8 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -1264,6 +1292,8 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -1325,6 +1355,8 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -1440,7 +1472,8 @@ def _impl(ctx):
             ],
         )
     elif (ctx.attr.cpu == "ios_arm64" or
-          ctx.attr.cpu == "tvos_arm64"):
+          ctx.attr.cpu == "tvos_arm64" or
+          ctx.attr.cpu == "darwin_arm64"):
         objcpp_compile_action = action_config(
             action_name = ACTION_NAMES.objcpp_compile,
             flag_sets = [
@@ -1475,7 +1508,8 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "ios_arm64e"):
+    elif (ctx.attr.cpu == "ios_arm64e" or
+          ctx.attr.cpu == "darwin_arm64e"):
         objcpp_compile_action = action_config(
             action_name = ACTION_NAMES.objcpp_compile,
             flag_sets = [
@@ -1718,6 +1752,8 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -1777,6 +1813,8 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -1874,7 +1912,8 @@ def _impl(ctx):
             ],
         )
     elif (ctx.attr.cpu == "ios_arm64" or
-          ctx.attr.cpu == "tvos_arm64"):
+          ctx.attr.cpu == "tvos_arm64" or
+          ctx.attr.cpu == "darwin_arm64"):
         objc_archive_action = action_config(
             action_name = "objc-archive",
             flag_sets = [
@@ -1905,7 +1944,8 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "ios_arm64e"):
+    elif (ctx.attr.cpu == "ios_arm64e" or
+          ctx.attr.cpu == "darwin_arm64e"):
         objc_archive_action = action_config(
             action_name = "objc-archive",
             flag_sets = [
@@ -2200,7 +2240,8 @@ def _impl(ctx):
             ],
         )
     elif (ctx.attr.cpu == "ios_arm64" or
-          ctx.attr.cpu == "tvos_arm64"):
+          ctx.attr.cpu == "tvos_arm64" or
+          ctx.attr.cpu == "darwin_arm64"):
         objc_executable_action = action_config(
             action_name = "objc-executable",
             flag_sets = [
@@ -2266,7 +2307,8 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "ios_arm64e"):
+    elif (ctx.attr.cpu == "ios_arm64e" or
+          ctx.attr.cpu == "darwin_arm64e"):
         objc_executable_action = action_config(
             action_name = "objc-executable",
             flag_sets = [
@@ -2631,6 +2673,8 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -2716,6 +2760,8 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -2779,6 +2825,8 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -3105,6 +3153,8 @@ def _impl(ctx):
             ],
         )
     elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_x86_64" or
           ctx.attr.cpu == "tvos_x86_64" or
           ctx.attr.cpu == "watchos_x86_64"):
@@ -3158,6 +3208,8 @@ def _impl(ctx):
             tools = [tool(path = "/bin/false")],
         )
     elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -3218,7 +3270,9 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "darwin_x86_64"):
+    elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e"):
         apply_default_compiler_flags_feature = feature(
             name = "apply_default_compiler_flags",
             flag_sets = [
@@ -3352,6 +3406,8 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -3445,6 +3501,8 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -3527,7 +3585,9 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "darwin_x86_64"):
+    elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e"):
         contains_objc_source_feature = feature(
             name = "contains_objc_source",
             flag_sets = [
@@ -3813,6 +3873,78 @@ def _impl(ctx):
                 ),
             ],
         )
+    elif (ctx.attr.cpu == "darwin_arm64"):
+        default_link_flags_feature = feature(
+            name = "default_link_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = all_link_actions +
+                              ["objc-executable", "objc++-executable"],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-no-canonical-prefixes",
+                                "-target",
+                                "arm64-apple-macosx",
+                            ],
+                        ),
+                    ],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_dynamic_library,
+                        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ],
+                    flag_groups = [flag_group(flags = ["-undefined", "dynamic_lookup"])],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_executable,
+                        "objc-executable",
+                        "objc++-executable",
+                    ],
+                    flag_groups = [flag_group(flags = ["-undefined", "dynamic_lookup"])],
+                    with_features = [with_feature_set(features = ["dynamic_linking_mode"])],
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "darwin_arm64e"):
+        default_link_flags_feature = feature(
+            name = "default_link_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = all_link_actions +
+                              ["objc-executable", "objc++-executable"],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-no-canonical-prefixes",
+                                "-target",
+                                "arm64e-apple-macos",
+                            ],
+                        ),
+                    ],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_dynamic_library,
+                        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ],
+                    flag_groups = [flag_group(flags = ["-undefined", "dynamic_lookup"])],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_executable,
+                        "objc-executable",
+                        "objc++-executable",
+                    ],
+                    flag_groups = [flag_group(flags = ["-undefined", "dynamic_lookup"])],
+                    with_features = [with_feature_set(features = ["dynamic_linking_mode"])],
+                ),
+            ],
+        )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "watchos_arm64_32" or
           ctx.attr.cpu == "watchos_x86_64"):
@@ -4056,7 +4188,9 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "darwin_x86_64"):
+    elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e"):
         version_min_feature = feature(
             name = "version_min",
             flag_sets = [
@@ -4451,7 +4585,9 @@ def _impl(ctx):
                 ),
             ],
         )
-    elif (ctx.attr.cpu == "darwin_x86_64"):
+    elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e"):
         apply_implicit_frameworks_feature = feature(
             name = "apply_implicit_frameworks",
             flag_sets = [
@@ -4963,6 +5099,68 @@ def _impl(ctx):
                 ),
             ],
         )
+    elif (ctx.attr.cpu == "darwin_arm64"):
+        unfiltered_compile_flags_feature = feature(
+            name = "unfiltered_compile_flags",
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.linkstamp_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-no-canonical-prefixes",
+                                "-Wno-builtin-macro-redefined",
+                                "-D__DATE__=\"redacted\"",
+                                "-D__TIMESTAMP__=\"redacted\"",
+                                "-D__TIME__=\"redacted\"",
+                                "-target",
+                                "arm64-apple-macosx",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "darwin_arm64e"):
+        unfiltered_compile_flags_feature = feature(
+            name = "unfiltered_compile_flags",
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.linkstamp_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-no-canonical-prefixes",
+                                "-Wno-builtin-macro-redefined",
+                                "-D__DATE__=\"redacted\"",
+                                "-D__TIMESTAMP__=\"redacted\"",
+                                "-D__TIME__=\"redacted\"",
+                                "-target",
+                                "arm64e-apple-macosx",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64"):
         unfiltered_compile_flags_feature = feature(
@@ -5121,6 +5319,8 @@ def _impl(ctx):
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
           ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -5327,6 +5527,8 @@ def _impl(ctx):
             ],
         )
     elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_armv7" or
           ctx.attr.cpu == "ios_i386" or
@@ -5513,7 +5715,9 @@ def _impl(ctx):
         ],
     )
 
-    if (ctx.attr.cpu == "darwin_x86_64"):
+    # Kernel extensions for Apple Silicon are arm64e.
+    if (ctx.attr.cpu == "darwin_x86_64" or
+        ctx.attr.cpu == "darwin_arm64e"):
         kernel_extension_feature = feature(
             name = "kernel_extension",
             flag_sets = [
@@ -5535,6 +5739,7 @@ def _impl(ctx):
             ],
         )
     elif (ctx.attr.cpu == "armeabi-v7a" or
+          ctx.attr.cpu == "darwin_arm64" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or
@@ -5653,7 +5858,9 @@ def _impl(ctx):
         provides = ["profile"],
     )
 
-    if (ctx.attr.cpu == "darwin_x86_64"):
+    if (ctx.attr.cpu == "darwin_x86_64" or
+        ctx.attr.cpu == "darwin_arm64" or
+        ctx.attr.cpu == "darwin_arm64e"):
         link_cocoa_feature = feature(
             name = "link_cocoa",
             flag_sets = [
@@ -5730,7 +5937,9 @@ def _impl(ctx):
         ctx.attr.cpu == "tvos_arm64" or
         ctx.attr.cpu == "watchos_arm64_32" or
         ctx.attr.cpu == "watchos_armv7k" or
-        ctx.attr.cpu == "darwin_x86_64"):
+        ctx.attr.cpu == "darwin_x86_64" or
+        ctx.attr.cpu == "darwin_arm64" or
+        ctx.attr.cpu == "darwin_arm64e"):
         bitcode_embedded_feature = feature(
             name = "bitcode_embedded",
             flag_sets = [
@@ -5874,7 +6083,9 @@ def _impl(ctx):
             compiler_output_flags_feature,
             objcopy_embed_flags_feature,
         ]
-    elif (ctx.attr.cpu == "darwin_x86_64"):
+    elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e"):
         features = [
             fastbuild_feature,
             no_legacy_features_feature,
@@ -6049,6 +6260,8 @@ def _impl(ctx):
             "strip": "/bin/false",
         }
     elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e" or
           ctx.attr.cpu == "ios_arm64" or
           ctx.attr.cpu == "ios_arm64e" or
           ctx.attr.cpu == "ios_armv7" or

--- a/tools/osx/crosstool/osx_archs.bzl
+++ b/tools/osx/crosstool/osx_archs.bzl
@@ -16,6 +16,8 @@
 # List of architectures supported by osx crosstool.
 OSX_TOOLS_NON_DEVICE_ARCHS = [
     "darwin_x86_64",
+    "darwin_arm64",
+    "darwin_arm64e",
     "ios_i386",
     "ios_x86_64",
     "watchos_i386",
@@ -38,6 +40,8 @@ OSX_TOOLS_ARCHS = [
 # TODO(apple-rules): Add constraints for watchos and tvos.
 OSX_TOOLS_CONSTRAINTS = {
     "darwin_x86_64": ["@platforms//os:osx", "@platforms//cpu:x86_64"],
+    "darwin_arm64": ["@platforms//os:osx", "@platforms//cpu:aarch64"],
+    "darwin_arm64e": ["@platforms//os:osx", "@platforms//cpu:aarch64"],
     "ios_i386": ["@platforms//os:ios", "@platforms//cpu:x86_32"],
     "ios_x86_64": ["@platforms//os:ios", "@platforms//cpu:x86_64"],
     "watchos_i386": ["@platforms//os:ios", "@platforms//cpu:x86_32"],


### PR DESCRIPTION
This adds support for darwin_arm64(e) to the crosstool.

`bazel build examples/cpp:hello-world --cpu=darwin_arm64 --xcode_version=12`

should function on both a intel and arm64 mac. Note that bazel still runs in emulation on arm64 mac until we have an arm64 darwin jdk.

Fix for #11628