### PR TITLE
Update py_runtime_pair to properly declare config transitions.

### DIFF
--- a/tools/python/toolchain.bzl
+++ b/tools/python/toolchain.bzl
@@ -42,11 +42,11 @@ def _py_runtime_pair_impl(ctx):
 py_runtime_pair = rule(
     implementation = _py_runtime_pair_impl,
     attrs = {
-        "py2_runtime": attr.label(providers = [PyRuntimeInfo], doc = """\
+        "py2_runtime": attr.label(providers = [PyRuntimeInfo], cfg = "exec", doc = """\
 The runtime to use for Python 2 targets. Must have `python_version` set to
 `PY2`.
 """),
-        "py3_runtime": attr.label(providers = [PyRuntimeInfo], doc = """\
+        "py3_runtime": attr.label(providers = [PyRuntimeInfo], cfg = "exec", doc = """\
 The runtime to use for Python 3 targets. Must have `python_version` set to
 `PY3`.
 """),


### PR DESCRIPTION
This is phase 1 of of the switch to toolchain transitions. See #11584 for details.