### PR TITLE
Update Python rules to use the toolchain transition

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPyRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPyRuleClasses.java
@@ -236,6 +236,7 @@ public final class BazelPyRuleClasses {
               attr("$py_toolchain_type", NODEP_LABEL)
                   .value(env.getToolsLabel("//tools/python:toolchain_type")))
           .addRequiredToolchains(env.getToolsLabel("//tools/python:toolchain_type"))
+          .useToolchainTransition(true)
           .build();
     }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/python/PythonToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/python/PythonToolchainTest.java
@@ -73,6 +73,7 @@ public class PythonToolchainTest extends BuildViewTestCase {
         "myrule = rule(",
         "    implementation = _myrule_impl,",
         "    toolchains = ['" + TOOLCHAIN_TYPE + "'],",
+        "    incompatible_use_toolchain_transition = True,",
         ")");
     // A toolchain implementation and an instance of the rule that will use it.
     scratch.file(

--- a/tools/python/toolchain.bzl
+++ b/tools/python/toolchain.bzl
@@ -42,11 +42,11 @@ def _py_runtime_pair_impl(ctx):
 py_runtime_pair = rule(
     implementation = _py_runtime_pair_impl,
     attrs = {
-        "py2_runtime": attr.label(providers = [PyRuntimeInfo], doc = """\
+        "py2_runtime": attr.label(providers = [PyRuntimeInfo], cfg = "exec", doc = """\
 The runtime to use for Python 2 targets. Must have `python_version` set to
 `PY2`.
 """),
-        "py3_runtime": attr.label(providers = [PyRuntimeInfo], doc = """\
+        "py3_runtime": attr.label(providers = [PyRuntimeInfo], cfg = "exec", doc = """\
 The runtime to use for Python 3 targets. Must have `python_version` set to
 `PY3`.
 """),


### PR DESCRIPTION
Builds on #12038, must be submitted after.

This also requires a full downstream test and probably some internal work as well.