### PR TITLE
Fix flaky test caused by incorrectly handled method reference

### DIFF
--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -617,7 +617,47 @@ EOF
   bazel coverage --test_output=all --test_arg=--nooutputredirect \
       --instrumentation_filter=//java/cov javatests/cov:CovTest >"${TEST_log}"
   local coverage_file_path="$( get_coverage_file_path_from_test_log )"
-  assert_coverage_result "java/cov/Cov.java" ${coverage_file_path}
+
+  local expected_result_cov="SF:java/cov/Cov.java
+FN:2,cov/Cov::<init> ()V
+FN:4,cov/Cov::main ([Ljava/lang/String;)V
+FNDA:0,cov/Cov::<init> ()V
+FNDA:2,cov/Cov::main ([Ljava/lang/String;)V
+FNF:2
+FNH:1
+BRDA:4,0,0,0
+BRDA:4,0,1,2
+BRDA:5,0,0,1
+BRDA:5,0,1,1
+BRF:4
+BRH:3
+DA:2,0
+DA:4,2
+DA:5,2
+DA:6,1
+DA:8,1
+DA:11,2
+LH:5
+LF:6
+end_of_record"
+
+  local expected_result_random="SF:java/cov/RandomBinary.java
+FN:2,cov/RandomBinary::<init> ()V
+FN:4,cov/RandomBinary::main ([Ljava/lang/String;)V
+FNDA:0,cov/RandomBinary::<init> ()V
+FNDA:0,cov/RandomBinary::main ([Ljava/lang/String;)V
+FNF:2
+FNH:0
+DA:2,0
+DA:4,0
+LH:0
+LF:2
+end_of_record"
+
+  # we do not assert the order of the source files in the coverage report
+  # only that they are both included and correctly merged
+  assert_coverage_result "$expected_result_cov" ${coverage_file_path}
+  assert_coverage_result "$expected_result_random" ${coverage_file_path}
 }
 
 run_suite "test tests"

--- a/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
+++ b/tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator/Main.java
@@ -351,7 +351,7 @@ public class Main {
             () ->
                 partitions.parallelStream()
                     .map((p) -> parseFilesSequentially(p, parser))
-                    .reduce(Coverage::mergeUnchecked)
+                    .reduce((c1, c2) -> Coverage.mergeUnchecked(c1, c2))
                     .orElse(Coverage.create()))
         .get();
   }


### PR DESCRIPTION
For reasons that are not entirely clear to me, using a method reference
to a variadic function as a BinaryOperator in a reduce call does not
seem to work reliably, at least on the version of Java used in RBE.
In this instance, the merge function will only receive a single argument

e.g.
[a, b, c].stream().reduce(...) results in "c" rather than "a * b * c"

Replacing the reference with a lambda that passes the arguments
explicitly avoids this. Wrapping the call in another variadic function
within the same class also works, but just looks weird and is more code
that shouldn't need to exist in the first place.

The original flaky test is made stricter so this issue could be exposed
consistently, at least on RBE.