### PR TITLE
compile.sh: Rename env var DISTRIBUTION to BAZEL_DISTRIBUTION

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -19,7 +19,7 @@
 if [ -d derived/jars ]; then
   ADDITIONAL_JARS=derived/jars
 else
-  DISTRIBUTION=${DISTRIBUTION:-debian}
+  DISTRIBUTION=${BAZEL_DISTRIBUTION:-debian}
   ADDITIONAL_JARS="$(grep -o '".*\.jar"' tools/distributions/${DISTRIBUTION}/${DISTRIBUTION}_java.BUILD | sed 's/"//g' | sed 's|^|/usr/share/java/|g')"
 fi
 


### PR DESCRIPTION
In the Debian build environment, the DISTRIBUTION env var may be used for
other purpose, so we rename the env var name to avoid conflict.