### PR TITLE
Fall back to building without remote if remote server is inaccessible before build.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -47,6 +47,7 @@ import com.google.devtools.build.lib.buildtool.BuildRequestOptions;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Reporter;
+import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.ExecutorBuilder;
 import com.google.devtools.build.lib.exec.ModuleActionContextRegistry;
 import com.google.devtools.build.lib.exec.SpawnStrategyRegistry;
@@ -154,7 +155,7 @@ public final class RemoteModule extends BlazeModule {
       CommandEnvironment env,
       DigestUtil digestUtil,
       ServerCapabilitiesRequirement requirement)
-      throws AbruptExitException {
+      throws AbruptExitException, IOException {
     RemoteServerCapabilities rsc =
         new RemoteServerCapabilities(
             remoteOptions.remoteInstanceName,
@@ -165,12 +166,6 @@ public final class RemoteModule extends BlazeModule {
     ServerCapabilities capabilities = null;
     try {
       capabilities = rsc.get(env.getCommandId().toString(), env.getBuildRequestId());
-    } catch (IOException e) {
-      env.getReporter().handle(Event.error(Throwables.getStackTraceAsString(e)));
-      throw createExitException(
-          "Failed to query remote execution capabilities: " + Utils.grpcAwareErrorMessage(e),
-          ExitCode.REMOTE_ERROR,
-          Code.CAPABILITIES_QUERY_FAILURE);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       return;
@@ -200,6 +195,10 @@ public final class RemoteModule extends BlazeModule {
     AuthAndTLSOptions authAndTlsOptions = env.getOptions().getOptions(AuthAndTLSOptions.class);
     DigestHashFunction hashFn = env.getRuntime().getFileSystem().getDigestFunction();
     DigestUtil digestUtil = new DigestUtil(hashFn);
+
+    ExecutionOptions executionOptions = Preconditions
+        .checkNotNull(env.getOptions().getOptions(ExecutionOptions.class));
+    boolean verboseFailures = executionOptions.verboseFailures;
 
     boolean enableDiskCache = RemoteCacheClientFactory.isDiskCache(remoteOptions);
     boolean enableHttpCache = RemoteCacheClientFactory.isHttpCache(remoteOptions);
@@ -395,15 +394,43 @@ public final class RemoteModule extends BlazeModule {
     // If they point to different endpoints, we check the endpoint with execution or cache
     // capabilities respectively.
     if (execChannel != null) {
-      if (cacheChannel != execChannel) {
-        verifyServerCapabilities(
-            remoteOptions,
-            execChannel,
-            credentials,
-            retrier,
-            env,
-            digestUtil,
-            ServerCapabilitiesRequirement.EXECUTION);
+      try {
+        if (cacheChannel != execChannel) {
+          verifyServerCapabilities(
+              remoteOptions,
+              execChannel,
+              credentials,
+              retrier,
+              env,
+              digestUtil,
+              ServerCapabilitiesRequirement.EXECUTION);
+          verifyServerCapabilities(
+              remoteOptions,
+              cacheChannel,
+              credentials,
+              retrier,
+              env,
+              digestUtil,
+              ServerCapabilitiesRequirement.CACHE);
+        } else {
+          verifyServerCapabilities(
+              remoteOptions,
+              execChannel,
+              credentials,
+              retrier,
+              env,
+              digestUtil,
+              ServerCapabilitiesRequirement.EXECUTION_AND_CACHE);
+        }
+      } catch (IOException e) {
+        env.getReporter().handle(Event.error(Throwables.getStackTraceAsString(e)));
+        throw createExitException(
+            "Failed to query remote execution capabilities: " + Utils.grpcAwareErrorMessage(e),
+            ExitCode.REMOTE_ERROR,
+            Code.CAPABILITIES_QUERY_FAILURE);
+      }
+    } else {
+      try {
         verifyServerCapabilities(
             remoteOptions,
             cacheChannel,
@@ -412,25 +439,14 @@ public final class RemoteModule extends BlazeModule {
             env,
             digestUtil,
             ServerCapabilitiesRequirement.CACHE);
-      } else {
-        verifyServerCapabilities(
-            remoteOptions,
-            execChannel,
-            credentials,
-            retrier,
-            env,
-            digestUtil,
-            ServerCapabilitiesRequirement.EXECUTION_AND_CACHE);
+      } catch (IOException e) {
+        if (verboseFailures) {
+          env.getReporter().handle(Event.warn(Throwables.getStackTraceAsString(e)));
+        }
+        env.getReporter().handle(Event
+            .warn("Failed to query remote cache capabilities: " + Utils.grpcAwareErrorMessage(e)));
+        return;
       }
-    } else {
-      verifyServerCapabilities(
-          remoteOptions,
-          cacheChannel,
-          credentials,
-          retrier,
-          env,
-          digestUtil,
-          ServerCapabilitiesRequirement.CACHE);
     }
 
     ByteStreamUploader uploader =
@@ -852,5 +868,10 @@ public final class RemoteModule extends BlazeModule {
   @VisibleForTesting
   void setChannelFactory(ChannelFactory channelFactory) {
     this.channelFactory = channelFactory;
+  }
+
+  @VisibleForTesting
+  RemoteActionContextProvider getActionContextProvider() {
+    return actionContextProvider;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -435,15 +435,18 @@ public final class RemoteModule extends BlazeModule {
             ServerCapabilitiesRequirement.CACHE);
       }
     } catch (IOException e) {
-      if (verboseFailures) {
-        env.getReporter().handle(Event.error(Throwables.getStackTraceAsString(e)));
-      }
       String errorMessage =
           "Failed to query remote execution capabilities: " + Utils.grpcAwareErrorMessage(e);
       if (remoteOptions.remoteLocalFallback) {
+        if (verboseFailures) {
+          errorMessage += System.lineSeparator() + Throwables.getStackTraceAsString(e);
+        }
         env.getReporter().handle(Event.warn(errorMessage));
         return;
       } else {
+        if (verboseFailures) {
+          env.getReporter().handle(Event.error(Throwables.getStackTraceAsString(e)));
+        }
         throw createExitException(
             errorMessage,
             ExitCode.REMOTE_ERROR,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -196,9 +196,11 @@ public final class RemoteModule extends BlazeModule {
     DigestHashFunction hashFn = env.getRuntime().getFileSystem().getDigestFunction();
     DigestUtil digestUtil = new DigestUtil(hashFn);
 
-    ExecutionOptions executionOptions = Preconditions
-        .checkNotNull(env.getOptions().getOptions(ExecutionOptions.class));
-    boolean verboseFailures = executionOptions.verboseFailures;
+    boolean verboseFailures = false;
+    ExecutionOptions executionOptions = env.getOptions().getOptions(ExecutionOptions.class);
+    if (executionOptions != null) {
+      verboseFailures = executionOptions.verboseFailures;
+    }
 
     boolean enableDiskCache = RemoteCacheClientFactory.isDiskCache(remoteOptions);
     boolean enableHttpCache = RemoteCacheClientFactory.isHttpCache(remoteOptions);


### PR DESCRIPTION
In the case where gRPC remote mode is enabled (gRPC remote cache or remote execution), Bazel will check the server capabilities [before a build](https://github.com/bazelbuild/bazel/blob/0cb411b525cba2d9d5ac854e679e5b115151035c/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java#L426). If the server is inaccessible at that time, the build fails. (Bazel won't check the connection to the server at that time for HTTP remote cache.)

There were some discussion at #2964 and some fixes are landed already but are for the case where remote server is inaccessible during the build.

This PR addresses above issue by falling back to building without remote cache/execution if `--remote_local_fallback` is set.

Fixes #11989.