### PR TITLE
Update android_sdk_repository to create a valid, but useless, repository

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
@@ -106,12 +106,10 @@ public class AndroidSdkRepositoryFunction extends AndroidRepositoryFunction {
       androidSdkPath =
           fs.getPath(getAndroidHomeEnvironmentVar(directories.getWorkspace(), environ));
     } else {
-      throw new RepositoryFunctionException(
-          new EvalException(
-              rule.getLocation(),
-              "Either the path attribute of android_sdk_repository or the ANDROID_HOME environment "
-                  + "variable must be set."),
-          Transience.PERSISTENT);
+      // Write an empty BUILD file that declares errors when referred to.
+      String buildFile = getStringResource("android_sdk_repository_empty_template.txt");
+      writeBuildFile(outputDirectory, buildFile);
+      return RepositoryDirectoryValue.builder().setPath(outputDirectory);
     }
 
     if (!symlinkLocalRepositoryContents(outputDirectory, androidSdkPath, userDefinedPath)) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryRule.java
@@ -41,8 +41,7 @@ public class AndroidSdkRepositoryRule implements RuleDefinition {
     builder.put("android/d8_jar_import", Label.parseAbsoluteUnchecked(prefix + "d8_jar_import"));
     builder.put("android/dx_jar_import", Label.parseAbsoluteUnchecked(prefix + "dx_jar_import"));
     builder.put("android_sdk_for_testing", Label.parseAbsoluteUnchecked(prefix + "files"));
-    builder.put(
-        "has_androidsdk", Label.parseAbsoluteUnchecked("@bazel_tools//tools/android:always_true"));
+    builder.put("has_androidsdk", Label.parseAbsoluteUnchecked(prefix + "has_androidsdk"));
     return builder.build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_empty_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_empty_template.txt
@@ -1,0 +1,44 @@
+package(default_visibility = ["//visibility:public"])
+
+# android_sdk_repository was used without a valid Android SDK being set.
+# Either the path attribute of android_sdk_repository or the ANDROID_HOME
+# environment variable must be set.
+# This is a minimal BUILD file to allow non-Android builds to continue.
+
+alias(
+    name = "has_androidsdk",
+    actual = "@bazel_tools//tools/android:always_false",
+)
+
+filegroup(
+    name = "files",
+    srcs = [":error_message"],
+)
+
+filegroup(
+    name = "sdk",
+    srcs = [":error_message"],
+)
+
+filegroup(
+    name = "d8_jar_import",
+    srcs = [":error_message"],
+)
+
+filegroup(
+    name = "dx_jar_import",
+    srcs = [":error_message"],
+)
+
+genrule(
+    name = "invalid_android_sdk_repository_error",
+    outs = [
+        "error_message",
+        "error_message.jar",
+    ],
+    cmd = """echo \
+    android_sdk_repository was used without a valid Android SDK being set. \
+    Either the path attribute of android_sdk_repository or the ANDROID_HOME \
+    environment variable must be set. ; \
+    exit 1 """,
+)

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
@@ -5,6 +5,11 @@ load(
     "create_android_sdk_rules",
     "create_system_images_filegroups")
 
+alias(
+    name = "has_androidsdk",
+    actual = "@bazel_tools//tools/android:always_true",
+)
+
 create_android_sdk_rules(
     name = "%repository_name%",
     build_tools_version = "%build_tools_version%",

--- a/tools/android/BUILD.tools
+++ b/tools/android/BUILD.tools
@@ -460,8 +460,9 @@ genrule(
 # //external:has_androidsdk is bound to either
 # @bazel_tools//tools/android:always_true or
 # @bazel_tools//tools/android:always_false depending on whether
-# android_sdk_repository has run. This allows targets to depend on targets from
-# @androidsdk if and only if the user has an android_sdk_repository set up.
+# android_sdk_repository has run and is valid. This allows targets to depend on
+# targets from @androidsdk if and only if the user has an
+# android_sdk_repository set up.
 
 config_feature_flag(
     name = "true",


### PR DESCRIPTION
if the SDK doesn't actually exist.

This allows non-Android builds to proceed but will fail building android
code.

Fixes #12069.