### PR TITLE
Force /usr/bin/python2.7 on macOS

### DIFF
--- a/tools/objc/libtool.sh
+++ b/tools/objc/libtool.sh
@@ -62,6 +62,11 @@ function hash_objfile() {
   echo "$SYMLINK_NAME"
 }
 
+python_executable=/usr/bin/python2.7
+if [[ ! -x "$python_executable" ]]; then
+  python_executable=python
+fi
+
 ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -82,7 +87,7 @@ while [[ $# -gt 0 ]]; do
       HASHED_FILELIST="${ARG%.objlist}_hashes.objlist"
       rm -f "${HASHED_FILELIST}"
       # Use python helper script for fast md5 calculation of many strings.
-      python "${MY_LOCATION}/make_hashed_objlist.py" \
+      "$python_executable" "${MY_LOCATION}/make_hashed_objlist.py" \
         "${ARG}" "${HASHED_FILELIST}" "${TEMPDIR}"
       ARGS+=("${HASHED_FILELIST}")
       ;;


### PR DESCRIPTION
Because of this issue https://github.com/bazelbuild/bazel/issues/12049
this call to python doesn't respect the PATH users invoke bazel with.
Because the default shell path contains /usr/local/bin, this `python`
could end up being from homebrew. Homebrew's python installations are
easily borked which leads to hashlib being unusable:

https://discuss.bitrise.io/t/broken-python-2-7-hashlib-in-new-xcode-10-3-x-mojave-stack/11401/7

This changes this use case to a path that always exists (at least for
now) on macOS, and only falls back to the bare executable if it doesn't.
Ideally this would utilize the python version from the toolchain
instead.