### PR TITLE
Set a default value for --host_crosstool_top

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -560,21 +560,35 @@ public class CppOptions extends FragmentOptions {
               + "except bar.o.")
   public List<PerLabelOptions> perFileLtoBackendOpts;
 
+  /** See {@link #hostCrosstoolTop} documentation. * */
+  private static final String HOST_CROSSTOOL_TOP_NOT_YET_SET = "HOST CROSSTOOL TOP NOT YET SET";
+
+  /**
+   * The value of "--crosstool_top" to use for building tools.
+   *
+   * <p>We want to make sure this stays bound to the top-level configuration when not explicitly set
+   * (as opposed to a configuration that comes out of a transition). Otherwise we risk using the
+   * wrong crosstool (i.e., trying to build tools with an Android-specific crosstool).
+   *
+   * <p>To accomplish this, we initialize this to a special value that means "I haven't been set
+   * yet" and use {@link #getNormalized} to rewrite it to {@link #hostCrosstoolTop} <b>only</b> from
+   * that default. Blaze always evaluates top-level configurations first, so they'll trigger this.
+   * But no followup transitions can.
+   */
   @Option(
-    name = "host_crosstool_top",
-    defaultValue = "null",
-    converter = LabelConverter.class,
-    documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
-    effectTags = {
-      OptionEffectTag.LOADING_AND_ANALYSIS,
-      OptionEffectTag.CHANGES_INPUTS,
-      OptionEffectTag.AFFECTS_OUTPUTS
-    },
-    help =
-        "By default, the --crosstool_top and --compiler options are also used "
-            + "for the host configuration. If this flag is provided, Bazel uses the default libc "
-            + "and compiler for the given crosstool_top."
-  )
+      name = "host_crosstool_top",
+      defaultValue = HOST_CROSSTOOL_TOP_NOT_YET_SET,
+      converter = LabelConverter.class,
+      documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
+      effectTags = {
+        OptionEffectTag.LOADING_AND_ANALYSIS,
+        OptionEffectTag.CHANGES_INPUTS,
+        OptionEffectTag.AFFECTS_OUTPUTS
+      },
+      help =
+          "By default, the --crosstool_top and --compiler options are also used "
+              + "for the host configuration. If this flag is provided, Bazel uses the default libc "
+              + "and compiler for the given crosstool_top.")
   public Label hostCrosstoolTop;
 
   @Option(
@@ -1004,10 +1018,20 @@ public class CppOptions extends FragmentOptions {
   /** See {@link #targetLibcTopLabel} documentation. * */
   @Override
   public FragmentOptions getNormalized() {
+    CppOptions newOptions = (CppOptions) this.clone();
+    boolean changed = false;
     if (targetLibcTopLabel != null
         && targetLibcTopLabel.getName().equals(TARGET_LIBC_TOP_NOT_YET_SET)) {
-      CppOptions newOptions = (CppOptions) this.clone();
       newOptions.targetLibcTopLabel = libcTopLabel;
+      changed = true;
+    }
+    if (hostCrosstoolTop != null
+        && hostCrosstoolTop.getName().equals(HOST_CROSSTOOL_TOP_NOT_YET_SET)) {
+      // Default to the initial target crosstoolTop.
+      newOptions.hostCrosstoolTop = crosstoolTop;
+      changed = true;
+    }
+    if (changed) {
       return newOptions;
     }
     return this;
@@ -1017,14 +1041,8 @@ public class CppOptions extends FragmentOptions {
   public FragmentOptions getHost() {
     CppOptions host = (CppOptions) getDefault();
 
-    // The crosstool options are partially copied from the target configuration.
-    if (hostCrosstoolTop == null) {
-      host.cppCompiler = cppCompiler;
-      host.crosstoolTop = crosstoolTop;
-    } else {
-      host.crosstoolTop = hostCrosstoolTop;
-      host.cppCompiler = hostCppCompiler;
-    }
+    host.crosstoolTop = hostCrosstoolTop;
+    host.cppCompiler = hostCppCompiler;
 
     // hostLibcTop doesn't default to the target's libcTop.
     // Only an explicit command-line option will change it.

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -560,9 +560,6 @@ public class CppOptions extends FragmentOptions {
               + "except bar.o.")
   public List<PerLabelOptions> perFileLtoBackendOpts;
 
-  /** See {@link #hostCrosstoolTop} documentation. * */
-  private static final String HOST_CROSSTOOL_TOP_NOT_YET_SET = "HOST CROSSTOOL TOP NOT YET SET";
-
   /**
    * The value of "--crosstool_top" to use for building tools.
    *
@@ -570,14 +567,13 @@ public class CppOptions extends FragmentOptions {
    * (as opposed to a configuration that comes out of a transition). Otherwise we risk using the
    * wrong crosstool (i.e., trying to build tools with an Android-specific crosstool).
    *
-   * <p>To accomplish this, we initialize this to a special value that means "I haven't been set
-   * yet" and use {@link #getNormalized} to rewrite it to {@link #hostCrosstoolTop} <b>only</b> from
-   * that default. Blaze always evaluates top-level configurations first, so they'll trigger this.
-   * But no followup transitions can.
+   * <p>To accomplish this, we initialize this to null and, if it isn't explicitly set, use {@link
+   * #getNormalized} to rewrite it to {@link #crosstoolTop}. Blaze always evaluates top-level
+   * configurations first, so they'll trigger this. But no followup transitions can.
    */
   @Option(
       name = "host_crosstool_top",
-      defaultValue = HOST_CROSSTOOL_TOP_NOT_YET_SET,
+      defaultValue = "null",
       converter = LabelConverter.class,
       documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
       effectTags = {
@@ -1025,8 +1021,7 @@ public class CppOptions extends FragmentOptions {
       newOptions.targetLibcTopLabel = libcTopLabel;
       changed = true;
     }
-    if (hostCrosstoolTop != null
-        && hostCrosstoolTop.getName().equals(HOST_CROSSTOOL_TOP_NOT_YET_SET)) {
+    if (hostCrosstoolTop == null) {
       // Default to the initial target crosstoolTop.
       newOptions.hostCrosstoolTop = crosstoolTop;
       changed = true;

--- a/src/test/shell/integration/cpp_test.sh
+++ b/src/test/shell/integration/cpp_test.sh
@@ -239,7 +239,7 @@ def toolchains(id):
     native.cc_toolchain_suite(
         name = "%s" % id,
         toolchains = {
-            "k8": ":cc-toolchain-%s" % id,
+            "fake": ":cc-toolchain-%s" % id,
         },
     )
 
@@ -361,7 +361,10 @@ tool = rule(
 EOF
 
 
-  bazel build --crosstool_top=//$pkg/toolchain:alpha //$pkg:outer >& $TEST_log || fail "build failed"
+  bazel build \
+    --cpu=fake --host_cpu=fake \
+    --crosstool_top=//$pkg/toolchain:alpha \
+    //$pkg:outer >& $TEST_log || fail "build failed"
   expect_log "Outer //$pkg:outer found cc toolchain toolchain-alpha"
   expect_log "Inner //$pkg:inner found cc toolchain toolchain-beta"
   expect_log "Tool //$pkg:tool found cc toolchain toolchain-alpha"

--- a/src/test/shell/integration/cpp_test.sh
+++ b/src/test/shell/integration/cpp_test.sh
@@ -156,4 +156,215 @@ EOF
   expect_not_log "Compiling $pkg/a.cc"
 }
 
+# host_crosstool_top should default to the initial value of crosstool_top,
+# not the value after a transition.
+function test_default_host_crosstool_top() {
+  local -r pkg=$FUNCNAME
+
+  # Define two different toolchain suites to use with crosstool_top.
+  mkdir -p $pkg/toolchain
+  cat >> $pkg/toolchain/BUILD <<EOF
+package(default_visibility = ["//visibility:public"])
+
+load(":toolchain.bzl", "toolchains")
+
+cc_library(
+    name = "malloc",
+)
+
+filegroup(
+    name = "empty",
+    srcs = [],
+)
+
+[toolchains(id) for id in [
+    "alpha",
+    "beta",
+]]
+EOF
+  cat >> $pkg/toolchain/toolchain.bzl <<EOF
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "action_config",
+    "flag_group",
+    "flag_set",
+    "make_variable",
+)
+
+def _get_make_variables():
+    return []
+
+def _get_action_configs():
+    return []
+
+def _impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(out, "Fake executable")
+    return [
+        cc_common.create_cc_toolchain_config_info(
+            ctx = ctx,
+            target_cpu = ctx.attr.cpu,
+            compiler = ctx.attr.compiler,
+            toolchain_identifier = ctx.attr.toolchain_identifier,
+            host_system_name = ctx.attr.host_system_name,
+            target_system_name = ctx.attr.target_system_name,
+            target_libc = ctx.attr.target_libc,
+            abi_version = ctx.attr.abi_version,
+            abi_libc_version = ctx.attr.abi_libc_version,
+            action_configs = _get_action_configs(),
+            make_variables = _get_make_variables(),
+        ),
+        DefaultInfo(
+            executable = out,
+        ),
+    ]
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {
+        "cpu": attr.string(mandatory = True),
+        "compiler": attr.string(mandatory = True),
+        "toolchain_identifier": attr.string(mandatory = True),
+        "host_system_name": attr.string(mandatory = True),
+        "target_system_name": attr.string(mandatory = True),
+        "target_libc": attr.string(mandatory = True),
+        "abi_version": attr.string(mandatory = True),
+        "abi_libc_version": attr.string(mandatory = True),
+    },
+    provides = [CcToolchainConfigInfo],
+    executable = True,
+)
+
+def toolchains(id):
+    native.cc_toolchain_suite(
+        name = "%s" % id,
+        toolchains = {
+            "k8": ":cc-toolchain-%s" % id,
+        },
+    )
+
+    name = "toolchain-%s" % id
+    cc_toolchain_config(
+        name = "cc-toolchain-config-%s" % id,
+        abi_libc_version = name,
+        abi_version = name,
+        compiler = name,
+        cpu = name,
+        host_system_name = name,
+        target_libc = name,
+        target_system_name = name,
+        toolchain_identifier = name,
+    )
+
+    native.cc_toolchain(
+        name = "cc-toolchain-%s" % id,
+        all_files = ":empty",
+        ar_files = ":empty",
+        as_files = ":empty",
+        compiler_files = ":empty",
+        dwp_files = ":empty",
+        linker_files = ":empty",
+        objcopy_files = ":empty",
+        strip_files = ":empty",
+        toolchain_config = ":cc-toolchain-config-%s" % id,
+        toolchain_identifier = name,
+    )
+EOF
+
+  # Create an outer target, which uses a transition to depend on an inner.
+  # The inner then depends on a tool in the exec configuration.
+  # Even though te outer->inner dependency changes the value of crosstool_top,
+  # the tool should use the initial crosstool.
+  cat >> $pkg/BUILD <<EOF
+load(":display.bzl", "inner", "outer", "tool")
+
+outer(
+    name = "outer",
+    inner = ":inner",
+)
+
+inner(
+    name = "inner",
+    tool = ":tool",
+)
+
+tool(name = "tool")
+EOF
+  cat >> $pkg/display.bzl <<EOF
+def find_cc_toolchain(ctx):
+    return ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
+
+# Custom transition to change the crosstool.
+def _crosstool_transition_impl(settings, attr):
+    _ignore = (settings, attr)
+    return {"//command_line_option:crosstool_top": "//${pkg}/toolchain:beta"}
+
+crosstool_transition = transition(
+    implementation = _crosstool_transition_impl,
+    inputs = [],
+    outputs = ["//command_line_option:crosstool_top"],
+)
+
+# Outer display rule.
+def _outer_impl(ctx):
+    cc_toolchain = find_cc_toolchain(ctx)
+    print("Outer %s found cc toolchain %s" % (ctx.label, cc_toolchain.target_gnu_system_name))
+    pass
+
+outer = rule(
+    implementation = _outer_impl,
+    attrs = {
+        "inner": attr.label(mandatory = True, cfg = crosstool_transition),
+        "_cc_toolchain": attr.label(
+            default = Label(
+                "@bazel_tools//tools/cpp:current_cc_toolchain",
+            ),
+        ),
+        "_whitelist_function_transition": attr.label(default = "@bazel_tools//tools/whitelists/function_transition_whitelist"),
+    },
+)
+
+# Inner display rule.
+def _inner_impl(ctx):
+    cc_toolchain = find_cc_toolchain(ctx)
+    print("Inner %s found cc toolchain %s" % (ctx.label, cc_toolchain.target_gnu_system_name))
+    pass
+
+inner = rule(
+    implementation = _inner_impl,
+    attrs = {
+        "tool": attr.label(mandatory = True, cfg = "exec"),
+        "_cc_toolchain": attr.label(
+            default = Label(
+                "@bazel_tools//tools/cpp:current_cc_toolchain",
+            ),
+        ),
+    },
+)
+
+# Tool rule.
+def _tool_impl(ctx):
+    cc_toolchain = find_cc_toolchain(ctx)
+    print("Tool %s found cc toolchain %s" % (ctx.label, cc_toolchain.target_gnu_system_name))
+    pass
+
+tool = rule(
+    implementation = _tool_impl,
+    attrs = {
+        "_cc_toolchain": attr.label(
+            default = Label(
+                "@bazel_tools//tools/cpp:current_cc_toolchain",
+            ),
+        ),
+    },
+)
+EOF
+
+
+  bazel build --crosstool_top=//$pkg/toolchain:alpha //$pkg:outer >& $TEST_log || fail "build failed"
+  expect_log "Outer //$pkg:outer found cc toolchain toolchain-alpha"
+  expect_log "Inner //$pkg:inner found cc toolchain toolchain-beta"
+  expect_log "Tool //$pkg:tool found cc toolchain toolchain-alpha"
+}
+
 run_suite "Tests for Bazel's C++ rules"


### PR DESCRIPTION
Previously it was unset and defaulted to --crosstool_top in whatever configuration was being used, but that
doesn't make sense for android/apple/etc builds.

Instead we use getNormalized to set --host_crosstool_top in the target configuration.