### PR TITLE
Add coverage stubs back

### DIFF
--- a/tools/objc/BUILD
+++ b/tools/objc/BUILD
@@ -15,6 +15,16 @@ sh_binary(
     srcs = [":xcrunwrapper.sh"],
 )
 
+filegroup(
+    name = "gcov",
+    srcs = [":gcov_stub"],
+)
+
+filegroup(
+    name = "mcov",
+    srcs = [":mcov_stub"],
+)
+
 xcode_config(
     name = "host_xcodes",
 )

--- a/tools/objc/gcov_stub
+++ b/tools/objc/gcov_stub
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+(
+  printf 'Bazel does not yet support coverage.\n'
+) >&2
+
+exit 1

--- a/tools/objc/mcov_stub
+++ b/tools/objc/mcov_stub
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+(
+  printf 'Bazel does not yet support coverage.\n'
+) >&2
+
+exit 1


### PR DESCRIPTION
This is a partial revert of f8b51ffc2a8a953f64657ae4a21c9e1f1793dae2

These stubs are unused publicly, but were just removed from rules_apple.
https://github.com/bazelbuild/rules_apple//commit/9822cfe2cf5347198413bd7427adb51c9d0179a5

This means any projects using rules_apple without this commit (likely
everything at least until we cut a new release) would be broken without
these when running tests.

There really isn't a good way to do this change since it will force all
rules_apple consumers to upgrade. We can do that in the future, but it's
also very minor so it likely isn't worth breaking everyone for.

https://github.com/bazelbuild/bazel/issues/12102