### PR TITLE
Add CallCredentialsProvider and refresh credentials in ByteStreamUploader

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/BUILD
@@ -12,6 +12,7 @@ java_library(
     name = "authandtls",
     srcs = glob(["*.java"]),
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:auth",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/authandtls/CallCredentialsProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/CallCredentialsProvider.java
@@ -1,0 +1,59 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.authandtls;
+
+import io.grpc.CallCredentials;
+import java.io.IOException;
+import javax.annotation.Nullable;
+
+/**
+ * Interface for providing {@link CallCredentials}.
+ */
+public interface CallCredentialsProvider {
+  /**
+   * @return the current {@link CallCredentials}. May be {@code null}, in which case no
+   *     authentication is required
+   */
+  @Nullable
+  CallCredentials getCallCredentials();
+
+  /**
+   * Refresh the authorization data, discarding any cached state.
+   *
+   * <p> For use by the transport to allow retry after getting an error indicating there may be
+   * invalid tokens or other cached state.
+   *
+   * @throws IOException if there was an error getting up-to-date access.
+   */
+  void refresh() throws IOException;
+
+  /** A no-op implementation that has no credentials and performs no refreshes. */
+  public static class NoCredentials implements CallCredentialsProvider {
+
+    @Nullable
+    @Override
+    public CallCredentials getCallCredentials() {
+      return null;
+    }
+
+    @Override
+    public void refresh() throws IOException {
+
+    }
+  }
+
+  public static CallCredentialsProvider NO_CREDENTIALS = new NoCredentials();
+
+}

--- a/src/main/java/com/google/devtools/build/lib/authandtls/CallCredentialsProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/CallCredentialsProvider.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 import javax.annotation.Nullable;
 
 /**
- * Interface for providing {@link CallCredentials}.
+ * Interface for providing {@link CallCredentials}. Implementations must be thread-safe.
  */
 public interface CallCredentialsProvider {
   /**

--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthCallCredentialsProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthCallCredentialsProvider.java
@@ -1,0 +1,48 @@
+package com.google.devtools.build.lib.authandtls;
+
+import com.google.auth.Credentials;
+import com.google.common.base.Preconditions;
+import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
+import io.grpc.CallCredentials;
+import io.grpc.auth.MoreCallCredentials;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@ThreadSafe
+public class GoogleAuthCallCredentialsProvider implements CallCredentialsProvider {
+
+  private final Credentials credentials;
+
+  private CallCredentials callCredentials;
+  private long lastRefreshTime;
+
+  public GoogleAuthCallCredentialsProvider(Credentials credentials) {
+    Preconditions.checkNotNull(credentials, "credentials");
+    this.credentials = credentials;
+
+    callCredentials = MoreCallCredentials.from(credentials);
+  }
+
+  @Override
+  public CallCredentials getCallCredentials() {
+    synchronized (this) {
+      return callCredentials;
+    }
+  }
+
+  @Override
+  public void refresh() throws IOException {
+    synchronized (this) {
+      long now = System.currentTimeMillis();
+      // Call credentials.refresh() at most once per second. The one second was arbitrarily chosen,
+      // as a small enough value that we don't expect to interfere with actual token lifetimes, but
+      // it should just make sure that potentially hundreds of threads don't call this method
+      // at the same time.
+      if ((now - lastRefreshTime) > TimeUnit.SECONDS.toMillis(1)) {
+        lastRefreshTime = now;
+        credentials.refresh();
+        callCredentials = MoreCallCredentials.from(this.credentials);
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthCallCredentialsProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthCallCredentialsProvider.java
@@ -19,15 +19,12 @@ public class GoogleAuthCallCredentialsProvider implements CallCredentialsProvide
   public GoogleAuthCallCredentialsProvider(Credentials credentials) {
     Preconditions.checkNotNull(credentials, "credentials");
     this.credentials = credentials;
-
     callCredentials = MoreCallCredentials.from(credentials);
   }
 
   @Override
   public CallCredentials getCallCredentials() {
-    synchronized (this) {
-      return callCredentials;
-    }
+    return callCredentials;
   }
 
   @Override
@@ -41,7 +38,6 @@ public class GoogleAuthCallCredentialsProvider implements CallCredentialsProvide
       if ((now - lastRefreshTime) > TimeUnit.SECONDS.toMillis(1)) {
         lastRefreshTime = now;
         credentials.refresh();
-        callCredentials = MoreCallCredentials.from(this.credentials);
       }
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -195,14 +195,23 @@ public final class GoogleAuthUtils {
     return null;
   }
 
+  public static CallCredentialsProvider newCallCredentialsProvider(AuthAndTLSOptions options)
+      throws IOException {
+    Credentials creds = newCredentials(options);
+    if (creds != null) {
+      return new GoogleAuthCallCredentialsProvider(creds);
+    }
+    return CallCredentialsProvider.NO_CREDENTIALS;
+  }
+
   @VisibleForTesting
-  public static CallCredentials newCallCredentials(
+  public static CallCredentialsProvider newCallCredentialsProvider(
       @Nullable InputStream credentialsFile, List<String> authScope) throws IOException {
     Credentials creds = newCredentials(credentialsFile, authScope);
     if (creds != null) {
-      return MoreCallCredentials.from(creds);
+      return new GoogleAuthCallCredentialsProvider(creds);
     }
-    return null;
+    return CallCredentialsProvider.NO_CREDENTIALS;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -33,9 +33,9 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ProgressiveBackoff;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
-import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -74,7 +74,7 @@ class ByteStreamUploader extends AbstractReferenceCounted {
 
   private final String instanceName;
   private final ReferenceCountedChannel channel;
-  private final CallCredentials callCredentials;
+  private final CallCredentialsProvider callCredentialsProvider;
   private final long callTimeoutSecs;
   private final RemoteRetrier retrier;
 
@@ -96,8 +96,7 @@ class ByteStreamUploader extends AbstractReferenceCounted {
    * @param instanceName the instance name to be prepended to resource name of the {@code Write}
    *     call. See the {@code ByteStream} service definition for details
    * @param channel the {@link io.grpc.Channel} to use for calls
-   * @param callCredentials the credentials to use for authentication. May be {@code null}, in which
-   *     case no authentication is performed
+   * @param callCredentialsProvider the credentials provider to use for authentication.
    * @param callTimeoutSecs the timeout in seconds after which a {@code Write} gRPC call must be
    *     complete. The timeout resets between retries
    * @param retrier the {@link RemoteRetrier} whose backoff strategy to use for retry timings.
@@ -105,14 +104,14 @@ class ByteStreamUploader extends AbstractReferenceCounted {
   public ByteStreamUploader(
       @Nullable String instanceName,
       ReferenceCountedChannel channel,
-      @Nullable CallCredentials callCredentials,
+      CallCredentialsProvider callCredentialsProvider,
       long callTimeoutSecs,
       RemoteRetrier retrier) {
     checkArgument(callTimeoutSecs > 0, "callTimeoutSecs must be gt 0.");
 
     this.instanceName = instanceName;
     this.channel = channel;
-    this.callCredentials = callCredentials;
+    this.callCredentialsProvider = callCredentialsProvider;
     this.callTimeoutSecs = callTimeoutSecs;
     this.retrier = retrier;
   }
@@ -267,7 +266,7 @@ class ByteStreamUploader extends AbstractReferenceCounted {
     }
   }
 
-  private static String uploadResourceName(
+  private static String buildUploadResourceName(
       String instanceName, UUID uuid, HashCode hash, long size) {
     String resourceName = format("uploads/%s/blobs/%s/%d", uuid, hash, size);
     if (!Strings.isNullOrEmpty(instanceName)) {
@@ -276,7 +275,7 @@ class ByteStreamUploader extends AbstractReferenceCounted {
     return resourceName;
   }
 
-  /** Starts a file upload an returns a future representing the upload. */
+  /** Starts a file upload and returns a future representing the upload. */
   private ListenableFuture<Void> startAsyncUpload(HashCode hash, Chunker chunker) {
     try {
       chunker.reset();
@@ -285,9 +284,9 @@ class ByteStreamUploader extends AbstractReferenceCounted {
     }
 
     UUID uploadId = UUID.randomUUID();
-    String resourceName = uploadResourceName(instanceName, uploadId, hash, chunker.getSize());
+    String resourceName = buildUploadResourceName(instanceName, uploadId, hash, chunker.getSize());
     AsyncUpload newUpload =
-        new AsyncUpload(channel, callCredentials, callTimeoutSecs, retrier, resourceName, chunker);
+        new AsyncUpload(channel, callCredentialsProvider, callTimeoutSecs, retrier, resourceName, chunker);
     ListenableFuture<Void> currUpload = newUpload.start();
     currUpload.addListener(
         () -> {
@@ -323,7 +322,7 @@ class ByteStreamUploader extends AbstractReferenceCounted {
   private static class AsyncUpload {
 
     private final Channel channel;
-    private final CallCredentials callCredentials;
+    private final CallCredentialsProvider callCredentialsProvider;
     private final long callTimeoutSecs;
     private final Retrier retrier;
     private final String resourceName;
@@ -333,13 +332,13 @@ class ByteStreamUploader extends AbstractReferenceCounted {
 
     AsyncUpload(
         Channel channel,
-        CallCredentials callCredentials,
+        CallCredentialsProvider callCredentialsProvider,
         long callTimeoutSecs,
         Retrier retrier,
         String resourceName,
         Chunker chunker) {
       this.channel = channel;
-      this.callCredentials = callCredentials;
+      this.callCredentialsProvider = callCredentialsProvider;
       this.callTimeoutSecs = callTimeoutSecs;
       this.retrier = retrier;
       this.resourceName = resourceName;
@@ -350,15 +349,26 @@ class ByteStreamUploader extends AbstractReferenceCounted {
       Context ctx = Context.current();
       ProgressiveBackoff progressiveBackoff = new ProgressiveBackoff(retrier::newBackoff);
       AtomicLong committedOffset = new AtomicLong(0);
+
+      ListenableFuture<Void> callFuture = callAndQueryOnFailureWithRetrier(ctx, committedOffset, progressiveBackoff);
+
+      callFuture = Futures.catchingAsync(
+          callFuture,
+          Exception.class,
+          (e) -> {
+            Status status = Status.fromThrowable(e);
+            if (status != null && status.getCode() == Code.UNAUTHENTICATED) {
+              callCredentialsProvider.refresh();
+              return callAndQueryOnFailureWithRetrier(ctx, committedOffset, progressiveBackoff);
+            } else {
+              return Futures.immediateFailedFuture(e);
+            }
+          },
+          MoreExecutors.directExecutor()
+      );
+
       return Futures.transformAsync(
-          retrier.executeAsync(
-              () -> {
-                if (committedOffset.get() < chunker.getSize()) {
-                  return ctx.call(() -> callAndQueryOnFailure(committedOffset, progressiveBackoff));
-                }
-                return Futures.immediateFuture(null);
-              },
-              progressiveBackoff),
+          callFuture,
           (result) -> {
             long committedSize = committedOffset.get();
             long expected = chunker.getSize();
@@ -376,8 +386,19 @@ class ByteStreamUploader extends AbstractReferenceCounted {
     private ByteStreamFutureStub bsFutureStub() {
       return ByteStreamGrpc.newFutureStub(channel)
           .withInterceptors(TracingMetadataUtils.attachMetadataFromContextInterceptor())
-          .withCallCredentials(callCredentials)
+          .withCallCredentials(callCredentialsProvider.getCallCredentials())
           .withDeadlineAfter(callTimeoutSecs, SECONDS);
+    }
+
+    private ListenableFuture<Void> callAndQueryOnFailureWithRetrier(Context ctx, AtomicLong committedOffset, ProgressiveBackoff progressiveBackoff) {
+      return retrier.executeAsync(
+          () -> {
+            if (committedOffset.get() < chunker.getSize()) {
+              return ctx.call(() -> callAndQueryOnFailure(committedOffset, progressiveBackoff));
+            }
+            return Futures.immediateFuture(null);
+          },
+          progressiveBackoff);
     }
 
     private ListenableFuture<Void> callAndQueryOnFailure(
@@ -456,7 +477,7 @@ class ByteStreamUploader extends AbstractReferenceCounted {
     private ListenableFuture<Void> call(AtomicLong committedOffset) {
       CallOptions callOptions =
           CallOptions.DEFAULT
-              .withCallCredentials(callCredentials)
+              .withCallCredentials(callCredentialsProvider.getCallCredentials())
               .withDeadlineAfter(callTimeoutSecs, SECONDS);
       call = channel.newCall(ByteStreamGrpc.getWriteMethod(), callOptions);
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.analysis.test.TestProvider;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
+import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.authandtls.GoogleAuthUtils;
 import com.google.devtools.build.lib.bazel.repository.downloader.Downloader;
 import com.google.devtools.build.lib.buildeventstream.BuildEventArtifactUploader;
@@ -373,13 +374,16 @@ public final class RemoteModule extends BlazeModule {
       }
     }
 
-    CallCredentials credentials;
+    CallCredentialsProvider callCredentialsProvider;
     try {
-      credentials = GoogleAuthUtils.newCallCredentials(authAndTlsOptions);
+      callCredentialsProvider = GoogleAuthUtils.newCallCredentialsProvider(authAndTlsOptions);
     } catch (IOException e) {
       handleInitFailure(env, e, Code.CREDENTIALS_INIT_FAILURE);
       return;
     }
+
+    CallCredentials credentials = callCredentialsProvider.getCallCredentials();
+
     RemoteRetrier retrier =
         new RemoteRetrier(
             remoteOptions,
@@ -437,7 +441,7 @@ public final class RemoteModule extends BlazeModule {
         new ByteStreamUploader(
             remoteOptions.remoteInstanceName,
             cacheChannel.retain(),
-            credentials,
+            callCredentialsProvider,
             remoteOptions.remoteTimeout.getSeconds(),
             retrier);
 

--- a/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Retrier.java
@@ -278,14 +278,18 @@ public class Retrier {
 
   private <T> ListenableFuture<T> onExecuteAsyncFailure(
       Exception t, AsyncCallable<T> call, Backoff backoff) {
-    long waitMillis = backoff.nextDelayMillis();
-    if (waitMillis >= 0 && isRetriable(t)) {
-      try {
-        return Futures.scheduleAsync(
-            () -> executeAsync(call, backoff), waitMillis, TimeUnit.MILLISECONDS, retryService);
-      } catch (RejectedExecutionException e) {
-        // May be thrown by .scheduleAsync(...) if i.e. the executor is shutdown.
-        return Futures.immediateFailedFuture(new IOException(e));
+    if (isRetriable(t)) {
+      long waitMillis = backoff.nextDelayMillis();
+      if (waitMillis >= 0) {
+        try {
+          return Futures.scheduleAsync(
+              () -> executeAsync(call, backoff), waitMillis, TimeUnit.MILLISECONDS, retryService);
+        } catch (RejectedExecutionException e) {
+          // May be thrown by .scheduleAsync(...) if i.e. the executor is shutdown.
+          return Futures.immediateFailedFuture(new IOException(e));
+        }
+      } else {
+        return Futures.immediateFailedFuture(t);
       }
     } else {
       return Futures.immediateFailedFuture(t);

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -40,6 +40,7 @@ import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FileArtifactValue.RemoteFileArtifactValue;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
+import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent.LocalFile;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent.LocalFile.LocalFileType;
 import com.google.devtools.build.lib.buildeventstream.PathConverter;
@@ -167,7 +168,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channel);
     ByteStreamUploader uploader =
-        new ByteStreamUploader("instance", refCntChannel, null, 3, retrier);
+        new ByteStreamUploader("instance", refCntChannel, CallCredentialsProvider.NO_CREDENTIALS, 3, retrier);
     ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(uploader);
 
     PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
@@ -252,7 +253,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channel);
     ByteStreamUploader uploader =
-        new ByteStreamUploader("instance", refCntChannel, null, 3, retrier);
+        new ByteStreamUploader("instance", refCntChannel, CallCredentialsProvider.NO_CREDENTIALS, 3, retrier);
     ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(uploader);
 
     ExecutionException e =

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import build.bazel.remote.execution.v2.Digest;
@@ -33,12 +34,14 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
+import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.TestUtils;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.protobuf.ByteString;
 import io.grpc.BindableService;
+import io.grpc.CallCredentials;
 import io.grpc.Context;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
@@ -72,6 +75,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -146,7 +150,7 @@ public class ByteStreamUploaderTest {
         new ByteStreamUploader(
             INSTANCE_NAME,
             new ReferenceCountedChannel(channel),
-            null, /* timeout seconds */
+            CallCredentialsProvider.NO_CREDENTIALS, /* timeout seconds */
             60,
             retrier);
 
@@ -223,7 +227,8 @@ public class ByteStreamUploaderTest {
         TestUtils.newRemoteRetrier(() -> mockBackoff, (e) -> true, retryService);
     ByteStreamUploader uploader =
         new ByteStreamUploader(
-            INSTANCE_NAME, new ReferenceCountedChannel(channel), null, 3, retrier);
+            INSTANCE_NAME, new ReferenceCountedChannel(channel),
+            CallCredentialsProvider.NO_CREDENTIALS, 3, retrier);
 
     byte[] blob = new byte[CHUNK_SIZE * 2 + 1];
     new Random().nextBytes(blob);
@@ -339,7 +344,8 @@ public class ByteStreamUploaderTest {
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ByteStreamUploader uploader =
         new ByteStreamUploader(
-            INSTANCE_NAME, new ReferenceCountedChannel(channel), null, 1, retrier);
+            INSTANCE_NAME, new ReferenceCountedChannel(channel),
+            CallCredentialsProvider.NO_CREDENTIALS, 1, retrier);
 
     byte[] blob = new byte[CHUNK_SIZE * 2 + 1];
     new Random().nextBytes(blob);
@@ -397,7 +403,8 @@ public class ByteStreamUploaderTest {
         TestUtils.newRemoteRetrier(() -> mockBackoff, (e) -> true, retryService);
     ByteStreamUploader uploader =
         new ByteStreamUploader(
-            INSTANCE_NAME, new ReferenceCountedChannel(channel), null, 3, retrier);
+            INSTANCE_NAME, new ReferenceCountedChannel(channel),
+            CallCredentialsProvider.NO_CREDENTIALS, 3, retrier);
 
     byte[] blob = new byte[CHUNK_SIZE * 2 + 1];
     new Random().nextBytes(blob);
@@ -467,7 +474,8 @@ public class ByteStreamUploaderTest {
         TestUtils.newRemoteRetrier(() -> mockBackoff, (e) -> true, retryService);
     ByteStreamUploader uploader =
         new ByteStreamUploader(
-            INSTANCE_NAME, new ReferenceCountedChannel(channel), null, 3, retrier);
+            INSTANCE_NAME, new ReferenceCountedChannel(channel),
+            CallCredentialsProvider.NO_CREDENTIALS, 3, retrier);
 
     byte[] blob = new byte[CHUNK_SIZE * 2 + 1];
     new Random().nextBytes(blob);
@@ -504,7 +512,8 @@ public class ByteStreamUploaderTest {
         TestUtils.newRemoteRetrier(() -> mockBackoff, (e) -> true, retryService);
     ByteStreamUploader uploader =
         new ByteStreamUploader(
-            INSTANCE_NAME, new ReferenceCountedChannel(channel), null, 3, retrier);
+            INSTANCE_NAME, new ReferenceCountedChannel(channel),
+            CallCredentialsProvider.NO_CREDENTIALS, 3, retrier);
 
     byte[] blob = new byte[CHUNK_SIZE * 2 + 1];
     new Random().nextBytes(blob);
@@ -547,7 +556,7 @@ public class ByteStreamUploaderTest {
         new ByteStreamUploader(
             INSTANCE_NAME,
             new ReferenceCountedChannel(channel),
-            null, /* timeout seconds */
+            CallCredentialsProvider.NO_CREDENTIALS, /* timeout seconds */
             60,
             retrier);
 
@@ -585,7 +594,7 @@ public class ByteStreamUploaderTest {
         new ByteStreamUploader(
             INSTANCE_NAME,
             new ReferenceCountedChannel(channel),
-            null, /* timeout seconds */
+            CallCredentialsProvider.NO_CREDENTIALS, /* timeout seconds */
             60,
             retrier);
 
@@ -702,7 +711,7 @@ public class ByteStreamUploaderTest {
                 InProcessChannelBuilder.forName("Server for " + this.getClass())
                     .intercept(MetadataUtils.newAttachHeadersInterceptor(metadata))
                     .build()),
-            null, /* timeout seconds */
+            CallCredentialsProvider.NO_CREDENTIALS, /* timeout seconds */
             60,
             retrier);
 
@@ -765,7 +774,7 @@ public class ByteStreamUploaderTest {
         new ByteStreamUploader(
             INSTANCE_NAME,
             new ReferenceCountedChannel(channel),
-            null, /* timeout seconds */
+            CallCredentialsProvider.NO_CREDENTIALS, /* timeout seconds */
             60,
             retrier);
 
@@ -833,7 +842,7 @@ public class ByteStreamUploaderTest {
         new ByteStreamUploader(
             INSTANCE_NAME,
             new ReferenceCountedChannel(channel),
-            null, /* timeout seconds */
+            CallCredentialsProvider.NO_CREDENTIALS, /* timeout seconds */
             60,
             retrier);
 
@@ -868,7 +877,7 @@ public class ByteStreamUploaderTest {
         new ByteStreamUploader(
             INSTANCE_NAME,
             new ReferenceCountedChannel(channel),
-            null, /* timeout seconds */
+            CallCredentialsProvider.NO_CREDENTIALS, /* timeout seconds */
             60,
             retrier);
 
@@ -935,7 +944,7 @@ public class ByteStreamUploaderTest {
         new ByteStreamUploader(
             INSTANCE_NAME,
             new ReferenceCountedChannel(channel),
-            null, /* timeout seconds */
+            CallCredentialsProvider.NO_CREDENTIALS, /* timeout seconds */
             60,
             retrier);
 
@@ -975,7 +984,7 @@ public class ByteStreamUploaderTest {
         new ByteStreamUploader(
             /* instanceName */ null,
             new ReferenceCountedChannel(channel),
-            null, /* timeout seconds */
+            CallCredentialsProvider.NO_CREDENTIALS, /* timeout seconds */
             60,
             retrier);
 
@@ -1022,7 +1031,7 @@ public class ByteStreamUploaderTest {
         new ByteStreamUploader(
             /* instanceName */ null,
             new ReferenceCountedChannel(channel),
-            null, /* timeout seconds */
+            CallCredentialsProvider.NO_CREDENTIALS, /* timeout seconds */
             60,
             retrier);
 
@@ -1060,7 +1069,7 @@ public class ByteStreamUploaderTest {
         new ByteStreamUploader(
             INSTANCE_NAME,
             new ReferenceCountedChannel(channel),
-            null, /* timeout seconds */
+            CallCredentialsProvider.NO_CREDENTIALS, /* timeout seconds */
             60,
             retrier);
 
@@ -1141,7 +1150,7 @@ public class ByteStreamUploaderTest {
         new ByteStreamUploader(
             INSTANCE_NAME,
             new ReferenceCountedChannel(channel),
-            null, /* timeout seconds */
+            CallCredentialsProvider.NO_CREDENTIALS, /* timeout seconds */
             60,
             retrier);
 
@@ -1190,6 +1199,152 @@ public class ByteStreamUploaderTest {
     uploader.uploadBlob(hash, chunker, false);
 
     assertThat(numUploads.get()).isEqualTo(1);
+
+    // This test should not have triggered any retries.
+    Mockito.verifyZeroInteractions(mockBackoff);
+
+    blockUntilInternalStateConsistent(uploader);
+
+    withEmptyMetadata.detach(prevContext);
+  }
+
+  @Test
+  public void unauthenticatedErrorShouldNotBeRetried() throws Exception {
+    Context prevContext = withEmptyMetadata.attach();
+    RemoteRetrier retrier =
+        TestUtils
+            .newRemoteRetrier(() -> mockBackoff, RemoteRetrier.RETRIABLE_GRPC_ERRORS, retryService);
+
+    AtomicInteger refreshTimes = new AtomicInteger();
+    CallCredentialsProvider callCredentialsProvider = new CallCredentialsProvider() {
+      @Nullable
+      @Override
+      public CallCredentials getCallCredentials() {
+        return null;
+      }
+
+      @Override
+      public void refresh() throws IOException {
+        refreshTimes.incrementAndGet();
+      }
+    };
+    ByteStreamUploader uploader =
+        new ByteStreamUploader(
+            INSTANCE_NAME,
+            new ReferenceCountedChannel(channel),
+            callCredentialsProvider, /* timeout seconds */
+            60,
+            retrier);
+
+    byte[] blob = new byte[CHUNK_SIZE * 2 + 1];
+    new Random().nextBytes(blob);
+
+    Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
+    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+
+    AtomicInteger numUploads = new AtomicInteger();
+    serviceRegistry.addService(new ByteStreamImplBase() {
+      @Override
+      public StreamObserver<WriteRequest> write(StreamObserver<WriteResponse> streamObserver) {
+        numUploads.incrementAndGet();
+
+        streamObserver.onError(Status.UNAUTHENTICATED.asException());
+        return new NoopStreamObserver();
+      }
+    });
+
+    assertThrows(IOException.class, () -> {
+      uploader.uploadBlob(hash, chunker, true);
+    });
+
+    assertThat(refreshTimes.get()).isEqualTo(1);
+    assertThat(numUploads.get()).isEqualTo(2);
+
+    // This test should not have triggered any retries.
+    Mockito.verifyZeroInteractions(mockBackoff);
+
+    blockUntilInternalStateConsistent(uploader);
+
+    withEmptyMetadata.detach(prevContext);
+  }
+
+  @Test
+  public void shouldRefreshCredentialsOnAuthenticationError() throws Exception {
+    Context prevContext = withEmptyMetadata.attach();
+    RemoteRetrier retrier =
+        TestUtils
+            .newRemoteRetrier(() -> mockBackoff, RemoteRetrier.RETRIABLE_GRPC_ERRORS, retryService);
+
+    AtomicInteger refreshTimes = new AtomicInteger();
+    CallCredentialsProvider callCredentialsProvider = new CallCredentialsProvider() {
+      @Nullable
+      @Override
+      public CallCredentials getCallCredentials() {
+        return null;
+      }
+
+      @Override
+      public void refresh() throws IOException {
+        refreshTimes.incrementAndGet();
+      }
+    };
+    ByteStreamUploader uploader =
+        new ByteStreamUploader(
+            INSTANCE_NAME,
+            new ReferenceCountedChannel(channel),
+            callCredentialsProvider, /* timeout seconds */
+            60,
+            retrier);
+
+    byte[] blob = new byte[CHUNK_SIZE * 2 + 1];
+    new Random().nextBytes(blob);
+
+    Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
+    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+
+    AtomicInteger numUploads = new AtomicInteger();
+    serviceRegistry.addService(new ByteStreamImplBase() {
+      @Override
+      public StreamObserver<WriteRequest> write(StreamObserver<WriteResponse> streamObserver) {
+        numUploads.incrementAndGet();
+
+        if (refreshTimes.get() == 0) {
+          streamObserver.onError(Status.UNAUTHENTICATED.asException());
+          return new NoopStreamObserver();
+        }
+
+        return new StreamObserver<WriteRequest>() {
+          long nextOffset = 0;
+
+          @Override
+          public void onNext(WriteRequest writeRequest) {
+            nextOffset += writeRequest.getData().size();
+            boolean lastWrite = blob.length == nextOffset;
+            assertThat(writeRequest.getFinishWrite()).isEqualTo(lastWrite);
+          }
+
+          @Override
+          public void onError(Throwable throwable) {
+            fail("onError should never be called.");
+          }
+
+          @Override
+          public void onCompleted() {
+            assertThat(nextOffset).isEqualTo(blob.length);
+
+            WriteResponse response =
+                WriteResponse.newBuilder().setCommittedSize(nextOffset).build();
+            streamObserver.onNext(response);
+            streamObserver.onCompleted();
+          }
+        };
+      }
+    });
+
+    uploader.uploadBlob(hash, chunker, true);
+
+    assertThat(refreshTimes.get()).isEqualTo(1);
+    assertThat(numUploads.get()).isEqualTo(2);
 
     // This test should not have triggered any retries.
     Mockito.verifyZeroInteractions(mockBackoff);

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -55,6 +55,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
+import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.authandtls.GoogleAuthUtils;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ExponentialBackoff;
@@ -210,10 +211,11 @@ public class GrpcCacheClientTest {
     Scratch scratch = new Scratch();
     scratch.file(authTlsOptions.googleCredentials, new JacksonFactory().toString(json));
 
-    CallCredentials creds;
+    CallCredentialsProvider callCredentialsProvider;
     try (InputStream in = scratch.resolve(authTlsOptions.googleCredentials).getInputStream()) {
-      creds = GoogleAuthUtils.newCallCredentials(in, authTlsOptions.googleAuthScopes);
+      callCredentialsProvider = GoogleAuthUtils.newCallCredentialsProvider(in, authTlsOptions.googleAuthScopes);
     }
+    CallCredentials creds = callCredentialsProvider.getCallCredentials();
 
     RemoteRetrier retrier =
         TestUtils.newRemoteRetrier(
@@ -229,7 +231,7 @@ public class GrpcCacheClientTest {
         new ByteStreamUploader(
             remoteOptions.remoteInstanceName,
             channel.retain(),
-            creds,
+            callCredentialsProvider,
             remoteOptions.remoteTimeout.getSeconds(),
             retrier);
     return new GrpcCacheClient(

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
@@ -61,6 +61,7 @@ import com.google.devtools.build.lib.actions.SimpleSpawn;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
+import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.authandtls.GoogleAuthUtils;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -259,13 +260,14 @@ public class GrpcRemoteExecutionClientTest {
                 .build());
     GrpcRemoteExecutor executor =
         new GrpcRemoteExecutor(channel.retain(), null, retrier, remoteOptions);
-    CallCredentials creds =
-        GoogleAuthUtils.newCallCredentials(Options.getDefaults(AuthAndTLSOptions.class));
+    CallCredentialsProvider callCredentialsProvider = GoogleAuthUtils
+        .newCallCredentialsProvider(Options.getDefaults(AuthAndTLSOptions.class));
+    CallCredentials creds = callCredentialsProvider.getCallCredentials();
     ByteStreamUploader uploader =
         new ByteStreamUploader(
             remoteOptions.remoteInstanceName,
             channel.retain(),
-            creds,
+            callCredentialsProvider,
             remoteOptions.remoteTimeout.getSeconds(),
             retrier);
     GrpcCacheClient cacheProtocol =


### PR DESCRIPTION
Users may get authentication error in the mid of a long remote build due to credentials timeout. This PR:
1. Add `CallCredentialsProvider` which can be used by gRPC clients to refresh credentials.
2. Update `ByteStreamUploader.java` to use the provider and refresh credentials on authentication error.

The next step would be updating other places where using `CallCrendentials` currently (e.g. `RemoteCacheClient.java`) to use this provider and refresh credentials when necessary.
