### PR TITLE
HttpCacheClient: make upload async

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -616,8 +616,9 @@ public final class HttpCacheClient implements RemoteCacheClient {
                               } catch (IOException e) {
                                 result.setException(e);
                               }
+                            } else {
+                              result.setException(cause);
                             }
-                            result.setException(cause);
                           }
                         });
               });

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -375,20 +375,20 @@ public final class HttpCacheClient implements RemoteCacheClient {
 
               try {
                 Channel ch = channelAcquired.getNow();
-                ChannelPipeline p = ch.pipeline();
+                ChannelPipeline pipeline = ch.pipeline();
 
-                if (!isChannelPipelineEmpty(p)) {
+                if (!isChannelPipelineEmpty(pipeline)) {
                   channelReady.setFailure(
                       new IllegalStateException("Channel pipeline is not empty."));
                   return;
                 }
-                p.addFirst(
+                pipeline.addFirst(
                     "timeout-handler",
                     new IdleTimeoutHandler(timeoutSeconds, ReadTimeoutException.INSTANCE));
-                p.addLast(new HttpClientCodec());
-                p.addLast("inflater", new HttpContentDecompressor());
+                pipeline.addLast(new HttpClientCodec());
+                pipeline.addLast("inflater", new HttpContentDecompressor());
                 synchronized (credentialsLock) {
-                  p.addLast(new HttpDownloadHandler(creds, extraHttpHeaders));
+                  pipeline.addLast(new HttpDownloadHandler(creds, extraHttpHeaders));
                 }
 
                 if (!ch.eventLoop().inEventLoop()) {


### PR DESCRIPTION
This matches the behavior for download, and improves performance for actions
with a lot of outputs.

The code was already using futures in the API and in the implementation,
but the glue code blocked on the internal future and returned an immediate
future to the caller, rather than doing it async.

Fixes #6091.

Change-Id: I3151aa96b879323e0000d3209f6b9bc8be0066d4