### PR TITLE
Remove :zip_headers duplication in //tools/jdk:combiners

### DIFF
--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -738,7 +738,6 @@ cc_library(
     hdrs = [
         "java_tools/src/tools/singlejar/combiners.h",
         ":transient_bytes",
-        ":zip_headers",
     ],
     copts = SUPRESSED_WARNINGS,
     strip_include_prefix = "java_tools",


### PR DESCRIPTION
The PR fixes the following warning
```
WARNING: /***/external/remote_java_tools_linux/BUILD:671:11: in hdrs attribute of cc_library rule @remote_java_tools_linux//:combiners: Artifact 'external/remote_java_tools_linux/java_tools/src/tools/singlejar/zip_headers.h' is duplicated (through '@remote_java_tools_linux//:transient_bytes' and '@remote_java_tools_linux//:zip_headers'). Since this rule was created by the macro 'cc_library', the error might have been caused by the macro implementation
```