### PR TITLE
docfix: Replace Skydoc reference with Stardoc, as former is deprecated

### DIFF
--- a/site/docs/skylark/deploying.md
+++ b/site/docs/skylark/deploying.md
@@ -261,7 +261,7 @@ it to [ci.bazel.build](http://ci.bazel.build).
 
 ## Documentation
 
-See the [Skydoc documentation](https://github.com/bazelbuild/skydoc) for
+See the [Stardoc documentation](https://github.com/bazelbuild/stardoc) for
 instructions on how to comment your rules so that documentation can be generated
 automatically.
 


### PR DESCRIPTION
I just followed the Skydoc link from https://docs.bazel.build/versions/master/skylark/deploying.html#documentation and see that Skydoc is "heavily deprecated" in favour of Stardoc, so I'm not sure if Skydoc should still be referenced in the latest Bazel  documentation.