### PR TITLE
Add --host_action_env option

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -358,9 +358,9 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
           documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
           effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
           help =
-                  "Specifies the set of environment variables available to actions with host configuration. "
-                          + "Variables can be either specified by name, in which case the value will be "
-                          + "taken from the invocation environment, or by the name=value pair which sets "
+                  "Specifies the set of environment variables available to actions with host or execution "
+                          + "configurations. Variables can be either specified by name, in which case the value "
+                          + "will be taken from the invocation environment, or by the name=value pair which sets "
                           + "the value independent of the invocation environment. This option can be used "
                           + "multiple times; for options given for the same variable, the latest wins, options "
                           + "for different variables accumulate.")

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -342,7 +342,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
       help =
-          "Specifies the set of environment variables available to actions performed using target configuration. "
+          "Specifies the set of environment variables available to actions with target configuration. "
               + "Variables can be either specified by name, in which case the value will be "
               + "taken from the invocation environment, or by the name=value pair which sets "
               + "the value independent of the invocation environment. This option can be used "
@@ -358,7 +358,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
           documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
           effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
           help =
-                  "Specifies the set of environment variables available to actions performed using host configuration. "
+                  "Specifies the set of environment variables available to actions with host configuration. "
                           + "Variables can be either specified by name, in which case the value will be "
                           + "taken from the invocation environment, or by the name=value pair which sets "
                           + "the value independent of the invocation environment. This option can be used "

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -342,13 +342,29 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
       help =
-          "Specifies the set of environment variables available to actions. "
+          "Specifies the set of environment variables available to actions performed using target configuration. "
               + "Variables can be either specified by name, in which case the value will be "
               + "taken from the invocation environment, or by the name=value pair which sets "
               + "the value independent of the invocation environment. This option can be used "
               + "multiple times; for options given for the same variable, the latest wins, options "
               + "for different variables accumulate.")
   public List<Map.Entry<String, String>> actionEnvironment;
+
+  @Option(
+          name = "host_action_env",
+          converter = Converters.OptionalAssignmentConverter.class,
+          allowMultiple = true,
+          defaultValue = "null",
+          documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+          effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
+          help =
+                  "Specifies the set of environment variables available to actions performed using host configuration. "
+                          + "Variables can be either specified by name, in which case the value will be "
+                          + "taken from the invocation environment, or by the name=value pair which sets "
+                          + "the value independent of the invocation environment. This option can be used "
+                          + "multiple times; for options given for the same variable, the latest wins, options "
+                          + "for different variables accumulate.")
+  public List<Map.Entry<String, String>> hostActionEnvironment;
 
   @Option(
       name = "repo_env",
@@ -956,6 +972,9 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
     // Save host options in case of a further exec->host transition.
     host.hostCpu = hostCpu;
     host.hostCompilationMode = hostCompilationMode;
+
+    // Pass host action environment variables
+    host.actionEnvironment = hostActionEnvironment;
 
     return host;
   }


### PR DESCRIPTION
This PR adds `--host_action_env` option to specify a set of environment variables to be added to the host configuration. The variables specified by this option are only added to host configuration while those specified by `--action_env` are only included in the target configuration.

Fixes: #4008