### PR TITLE
Add binary support for s390x

### DIFF
--- a/scripts/kokoro/release/build_linux.sh
+++ b/scripts/kokoro/release/build_linux.sh
@@ -18,6 +18,36 @@ set -e
 set -x
 
 RELEASE_NAME=${RELEASE_NAME:-unknown}
+CURDIR="$(pwd)"
+MACHINE_ARCH=`uname -m`
+
+if [ ${MACHINE_ARCH} == 's390x' ]; then
+
+# Install dependencies
+sudo apt-get update
+sudo apt-get install -y wget curl openjdk-11-jdk unzip patch build-essential zip python3 git libapr1
+
+sudo ln -sf /usr/bin/python3 /usr/bin/python
+
+# Bootstrap bazel
+mkdir bazel-bootstrap && cd bazel-bootstrap
+wget https://github.com/bazelbuild/bazel/releases/download/"${RELEASE_NAME}"/bazel-"${RELEASE_NAME}"-dist.zip
+unzip bazel-"${RELEASE_NAME}"-dist.zip
+chmod -R +w .
+env EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" bash ./compile.sh
+export PATH=$PATH:$CURDIR/bazel-bootstrap/output/
+
+# Compile imtermediate Binary
+cd $CURDIR
+bazel build --host_javabase=@local_jdk//:jdk --sandbox_tmpfs_path=/tmp //:bazel-distfile
+cd $CURDIR
+mkdir bazel-temp && cd bazel-temp
+unzip $CURDIR/bazel-bin/bazel-distfile.zip
+bash ./compile.sh
+cd $CURDIR
+mkdir output
+cp "bazel-temp/output/bazel" output/bazel
+else
 
 # Get Bazelisk
 mkdir -p /tmp/tool
@@ -28,7 +58,27 @@ chmod +x "${BAZELISK}"
 "${BAZELISK}" build --sandbox_tmpfs_path=/tmp //src:bazel
 mkdir output
 cp bazel-bin/src/bazel output/bazel
+fi
 
+if [ ${MACHINE_ARCH} == 's390x' ]; then
+
+output/bazel build \
+    -c opt \
+    --stamp \
+    --sandbox_tmpfs_path=/tmp \
+    --embed_label "${RELEASE_NAME}" \
+    --workspace_status_command=scripts/ci/build_status_command.sh \
+      //:bazel-distfile
+# Compile s390x Binary
+cd $CURDIR
+mkdir bazel-s390x && cd bazel-s390x
+unzip $CURDIR/bazel-bin/bazel-distfile.zip
+env EMBED_LABEL="${RELEASE_NAME}" bash ./compile.sh
+cd $CURDIR
+
+mkdir artifacts
+cp bazel-s390x/output/bazel "artifacts/bazel-${RELEASE_NAME}-linux-s390x"
+else
 output/bazel build \
     -c opt \
     --stamp \
@@ -50,3 +100,4 @@ cp "bazel-bin/scripts/packages/debian/bazel.dsc" "artifacts/bazel_${RELEASE_NAME
 cp "bazel-bin/scripts/packages/debian/bazel.tar.gz" "artifacts/bazel_${RELEASE_NAME}.tar.gz"
 cp "bazel-bin/bazel-distfile.zip" "artifacts/bazel-${RELEASE_NAME}-dist.zip"
 
+fi


### PR DESCRIPTION
This patch changes the script in scripts/kokoro/release/build_linux.sh
to allow building bazel binary on a s390x machine. I've also executed this script on x86 to ensure no regressions. 

To execute this script, the following command works on a s390x machine with this PR:

```
export RELEASE_NAME=3.5.0 
./scripts/kokoro/release/build_linux.sh 
```

Lastly, this patch hopes to achieve a similar thing as https://github.com/bazelbuild/bazel/issues/8833 to add Bazel binary for s390x architecture. Though I wasn't able to find too many relevant information on how this was done for arm architecture, so any pointers or guidance will be super helpful. Hardware/VM access can also be provided if needed.  Happy to discuss and make changes. Thanks!