### PR TITLE
Make gcno-files available in CcCompilationOutputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java
@@ -1960,10 +1960,8 @@ public final class CcCompilationHelper {
           CppHelper.getArtifactNameForCategory(
               ccToolchain, ArtifactCategory.COVERAGE_DATA_FILE, picOutputBase);
       Artifact gcnoFile =
-          enableCoverage
-              ? CppHelper.getCompileOutputArtifact(
-                  actionConstructionContext, label, gcnoFileName, configuration)
-              : null;
+          CppHelper.getCompileOutputArtifact(
+              actionConstructionContext, label, gcnoFileName, configuration);
       Artifact dwoFile =
           generateDwo && !bitcodeOutput ? getDwoFile(picBuilder.getOutputFile()) : null;
       Artifact ltoIndexingFile =
@@ -2032,10 +2030,8 @@ public final class CcCompilationHelper {
 
       // Create no-PIC compile actions
       Artifact gcnoFile =
-          enableCoverage
-              ? CppHelper.getCompileOutputArtifact(
-                  actionConstructionContext, label, gcnoFileName, configuration)
-              : null;
+          CppHelper.getCompileOutputArtifact(
+              actionConstructionContext, label, gcnoFileName, configuration);
 
       Artifact noPicDwoFile = generateDwo && !bitcodeOutput ? getDwoFile(noPicOutputFile) : null;
       Artifact ltoIndexingFile = bitcodeOutput ? getLtoIndexingFile(builder.getOutputFile()) : null;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationOutputs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationOutputs.java
@@ -182,13 +182,11 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
 
   @Override
   public Sequence<Artifact> getStarlarkGcnoFiles(StarlarkThread thread) throws EvalException {
-    CcModule.checkPrivateStarlarkificationAllowlist(thread);
     return StarlarkList.immutableCopyOf(getGcnoFiles());
   }
 
   @Override
   public Sequence<Artifact> getStarlarkPicGcnoFiles(StarlarkThread thread) throws EvalException {
-    CcModule.checkPrivateStarlarkificationAllowlist(thread);
     return StarlarkList.immutableCopyOf(getPicGcnoFiles());
   }
 


### PR DESCRIPTION
This is needed to do custom code coverage rules.