### PR TITLE
Add .netrc support for remote build

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/authandtls/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/BUILD
@@ -15,6 +15,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:auth",
+        "//third_party:auto_value",
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party:netty",

--- a/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/GoogleAuthUtils.java
@@ -198,6 +198,10 @@ public final class GoogleAuthUtils {
   public static CallCredentialsProvider newCallCredentialsProvider(AuthAndTLSOptions options)
       throws IOException {
     Credentials creds = newCredentials(options);
+    return newCallCredentialsProvider(creds);
+  }
+
+  public static CallCredentialsProvider newCallCredentialsProvider(@Nullable Credentials creds) {
     if (creds != null) {
       return new GoogleAuthCallCredentialsProvider(creds);
     }
@@ -208,10 +212,7 @@ public final class GoogleAuthUtils {
   public static CallCredentialsProvider newCallCredentialsProvider(
       @Nullable InputStream credentialsFile, List<String> authScope) throws IOException {
     Credentials creds = newCredentials(credentialsFile, authScope);
-    if (creds != null) {
-      return new GoogleAuthCallCredentialsProvider(creds);
-    }
-    return CallCredentialsProvider.NO_CREDENTIALS;
+    return newCallCredentialsProvider(creds);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/authandtls/Netrc.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/Netrc.java
@@ -83,5 +83,15 @@ public class Netrc {
     abstract String login();
     abstract String password();
     abstract String account();
+
+    @Override
+    public String toString() {
+      return "Credential{"
+          + "machine=" + machine() + ", "
+          + "login=" + login() + ", "
+          + "password=<password>" + ", "
+          + "account=" + account()
+          + "}";
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/authandtls/Netrc.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/Netrc.java
@@ -1,0 +1,85 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.authandtls;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.annotation.Nullable;
+
+public class Netrc {
+
+  @Nullable
+  private final Credential defaultCredential;
+  private final ImmutableMap<String, Credential> credentials;
+
+  public static Netrc fromStream(InputStream inputStream) throws IOException  {
+    return NetrcParser.parseAndClose(inputStream);
+  }
+
+  public Netrc(@Nullable Credential defaultCredential, ImmutableMap<String, Credential> credentials) {
+    this.defaultCredential = defaultCredential;
+    this.credentials = credentials;
+  }
+
+  @Nullable
+  public Credential getCredential(String machine) {
+    return credentials.getOrDefault(machine, defaultCredential);
+  }
+
+  @VisibleForTesting
+  @Nullable
+  Credential getDefaultCredential() {
+    return defaultCredential;
+  }
+
+  @VisibleForTesting
+  ImmutableMap<String, Credential> getCredentials() {
+    return credentials;
+  }
+
+  @AutoValue
+  public static abstract class Credential {
+    public static Builder builder(String machine) {
+      return new AutoValue_Netrc_Credential.Builder().setMachine(machine);
+    }
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+      public abstract String machine();
+      public abstract Builder setMachine(String machine);
+
+      public abstract String login();
+      public abstract Builder setLogin(String value);
+
+      public abstract String password();
+      public abstract Builder setPassword(String value);
+
+      public abstract String account();
+      public abstract Builder setAccount(String value);
+
+      public abstract Credential build();
+    }
+
+    abstract String machine();
+    @Nullable
+    abstract String login();
+    @Nullable
+    abstract String password();
+    @Nullable
+    abstract String account();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/authandtls/Netrc.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/Netrc.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import javax.annotation.Nullable;
 
+/** The content of a .netrc file. */
 public class Netrc {
-
   @Nullable
   private final Credential defaultCredential;
   private final ImmutableMap<String, Credential> credentials;

--- a/src/main/java/com/google/devtools/build/lib/authandtls/Netrc.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/Netrc.java
@@ -53,8 +53,13 @@ public class Netrc {
 
   @AutoValue
   public static abstract class Credential {
+
     public static Builder builder(String machine) {
-      return new AutoValue_Netrc_Credential.Builder().setMachine(machine);
+      return new AutoValue_Netrc_Credential.Builder()
+          .setMachine(machine)
+          .setLogin("")
+          .setPassword("")
+          .setAccount("");
     }
 
     @AutoValue.Builder
@@ -75,11 +80,8 @@ public class Netrc {
     }
 
     abstract String machine();
-    @Nullable
     abstract String login();
-    @Nullable
     abstract String password();
-    @Nullable
     abstract String account();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/authandtls/NetrcCredentials.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/NetrcCredentials.java
@@ -1,3 +1,16 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package com.google.devtools.build.lib.authandtls;
 
 import com.google.auth.Credentials;
@@ -10,8 +23,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Subclass of {@link Credentials} which uses username and password from {@link Netrc} to provide
+ * request metadata.
+ */
 public class NetrcCredentials extends Credentials {
-
   private final Netrc netrc;
 
   public NetrcCredentials(Netrc netrc) {
@@ -51,6 +67,5 @@ public class NetrcCredentials extends Credentials {
 
   @Override
   public void refresh() throws IOException {
-
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/authandtls/NetrcCredentials.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/NetrcCredentials.java
@@ -1,0 +1,56 @@
+package com.google.devtools.build.lib.authandtls;
+
+import com.google.auth.Credentials;
+import com.google.devtools.build.lib.authandtls.Netrc.Credential;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class NetrcCredentials extends Credentials {
+
+  private final Netrc netrc;
+
+  public NetrcCredentials(Netrc netrc) {
+    this.netrc = netrc;
+  }
+
+  @Override
+  public String getAuthenticationType() {
+    return "netrc";
+  }
+
+  @Override
+  public Map<String, List<String>> getRequestMetadata(URI uri) throws IOException {
+    Credential credential = netrc.getCredential(uri.getHost());
+    if (credential != null) {
+      String credentialString = credential.login() + ":" + credential.password();
+      String token = "Basic " + Base64.getEncoder()
+          .encodeToString(credentialString.getBytes(StandardCharsets.UTF_8));
+      return Collections.singletonMap(
+          "Authorization",
+          Collections.singletonList(token)
+      );
+    } else {
+      return Collections.emptyMap();
+    }
+  }
+
+  @Override
+  public boolean hasRequestMetadata() {
+    return true;
+  }
+
+  @Override
+  public boolean hasRequestMetadataOnly() {
+    return true;
+  }
+
+  @Override
+  public void refresh() throws IOException {
+
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/authandtls/NetrcParser.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/NetrcParser.java
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
  * A parser used to parse .netrc content.
  *
  * @see <a href="https://man.cx/netrc(4)">netrc − file for ftp remote login data</a>
+ * @see <a href="https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/repo/utils.bzl#L203-L204">Starlark netrc parser</a>
  *
  */
 public class NetrcParser {

--- a/src/main/java/com/google/devtools/build/lib/authandtls/NetrcParser.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/NetrcParser.java
@@ -31,7 +31,12 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
-/** A parser used to parse .netrc content */
+/**
+ * A parser used to parse .netrc content.
+ *
+ * @see <a href="https://man.cx/netrc(4)">netrc − file for ftp remote login data</a>
+ *
+ */
 public class NetrcParser {
   private final static String MACHINE = "machine";
   private final static String MACDEF = "macdef";

--- a/src/main/java/com/google/devtools/build/lib/authandtls/NetrcParser.java
+++ b/src/main/java/com/google/devtools/build/lib/authandtls/NetrcParser.java
@@ -1,0 +1,238 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.authandtls;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.authandtls.Netrc.Credential;
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/** A parser used to parse .netrc content */
+public class NetrcParser {
+  private final static String MACHINE = "machine";
+  private final static String MACDEF = "macdef";
+  private final static String DEFAULT = "default";
+  private final static String LOGIN = "login";
+  private final static String PASSWORD = "password";
+  private final static String ACCOUNT = "account";
+
+  private enum TokenKind {
+    NEWLINE,
+    ITEM
+  }
+
+  private static class Token {
+    static Token newline() {
+      Token token = new Token();
+      token.kind = TokenKind.NEWLINE;
+      return token;
+    }
+
+    static Token item(String item) {
+      Preconditions.checkNotNull(item, "item");
+      Token token = new Token();
+      token.kind = TokenKind.ITEM;
+      token.item = item;
+      return token;
+    }
+
+    private TokenKind kind;
+    @Nullable
+    private String item;
+
+    @Nullable
+    String getItem() {
+      if (kind == TokenKind.ITEM) {
+        return item;
+      } else {
+        return null;
+      }
+    }
+  }
+
+  private static class TokenStream implements Closeable {
+    private final BufferedReader bufferedReader;
+    private final Deque<Token> tokens = new ArrayDeque<>();
+
+    TokenStream(InputStream inputStream) throws IOException {
+      bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+
+      processLine();
+    }
+
+    @Override
+    public void close() throws IOException {
+      bufferedReader.close();
+    }
+
+    private void processLine() throws IOException {
+      String line = bufferedReader.readLine();
+      if (line == null) { return; }
+      List<Token> newTokens = Arrays.stream(line.split("\\s+"))
+          .filter(s -> !Strings.isNullOrEmpty(s)).map(
+              Token::item).collect(Collectors.toList());
+      tokens.addAll(newTokens);
+      tokens.add(Token.newline());
+    }
+
+    void addFirst(Token token) {
+      tokens.addFirst(token);
+    }
+
+    public boolean hasNext() {
+      return !tokens.isEmpty();
+    }
+
+    public Token next() throws IOException {
+      Token token = tokens.removeFirst();
+      if (tokens.isEmpty()) {
+        processLine();
+      }
+      return token;
+    }
+  }
+
+  public static Netrc parseAndClose(InputStream inputStream) throws IOException {
+    try (TokenStream tokenStream = new TokenStream(inputStream)) {
+      return parse(tokenStream);
+    }
+  }
+
+  private static Netrc parse(TokenStream tokenStream) throws IOException {
+    Credential defaultCredential = null;
+    Map<String, Credential> credentialMap = new HashMap<>();
+
+    boolean done = false;
+    while (!done && tokenStream.hasNext()) {
+      Token token = tokenStream.next();
+      switch (token.kind) {
+        case ITEM: {
+          String item = token.getItem();
+          Preconditions.checkState(item != null);
+          switch (item) {
+            case MACHINE: {
+              String machine = nextItem(tokenStream);
+              Credential.Builder builder = Credential.builder(machine);
+              parseCredentialForMachine(tokenStream, builder);
+              credentialMap.put(machine, builder.build());
+              break;
+            }
+            case DEFAULT: {
+              Credential.Builder builder = Credential.builder("default");
+              parseCredentialForMachine(tokenStream, builder);
+              defaultCredential = builder.build();
+              // There can be only one default token, and it must be after all machine tokens.
+              done = true;
+              break;
+            }
+            case MACDEF: {
+              skipMacdef(tokenStream);
+              break;
+            }
+            default: {
+              throw new IOException("Unexpected token: " + item);
+            }
+          }
+        }
+        case NEWLINE: {
+          break;
+        }
+      }
+    }
+
+    return new Netrc(defaultCredential, ImmutableMap.copyOf(credentialMap));
+  }
+
+  private static String nextItem(TokenStream tokenStream) throws IOException {
+    while (tokenStream.hasNext()) {
+      Token token = tokenStream.next();
+      switch (token.kind) {
+        case ITEM: {
+          String item = token.getItem();
+          Preconditions.checkState(item != null);
+          return item;
+        }
+        case NEWLINE: {
+          break;
+        }
+      }
+    }
+
+    throw new IOException("Unexpected EOF");
+  }
+
+  /** Parse credentials for a given machine from token stream. */
+  private static void parseCredentialForMachine(TokenStream tokenStream, Credential.Builder builder) throws IOException {
+    boolean done = false;
+    while (!done && tokenStream.hasNext()) {
+      Token token = tokenStream.next();
+      switch (token.kind) {
+        case ITEM: {
+          String item = token.getItem();
+          Preconditions.checkState(item != null);
+          switch (item) {
+            case LOGIN:
+              builder.setLogin(nextItem(tokenStream));
+              break;
+            case PASSWORD:
+              builder.setPassword(nextItem(tokenStream));
+              break;
+            case ACCOUNT:
+              builder.setAccount(nextItem(tokenStream));
+              break;
+            case MACDEF:
+            case MACHINE:
+            case DEFAULT:
+              tokenStream.addFirst(token);
+              done = true;
+              break;
+            default:
+              throw new IOException("Unexpected item: " + item);
+          }
+        }
+        case NEWLINE: {
+          break;
+        }
+      }
+    }
+  }
+
+  private static void skipMacdef(TokenStream tokenStream) throws IOException {
+    int numNewlines = 0;
+    while (tokenStream.hasNext()) {
+      Token token = tokenStream.next();
+      if (token.kind == TokenKind.NEWLINE) {
+        ++numNewlines;
+      } else {
+        numNewlines = 0;
+      }
+      if (numNewlines >= 2) {
+        break;
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -952,8 +952,15 @@ public final class RemoteModule extends BlazeModule {
   private Credentials newCredentialsFromNetrc(CommandEnvironment env) throws IOException {
     String netrcFileString = env.getClientEnv().get("NETRC");
     if (netrcFileString == null) {
-      netrcFileString = env.getClientEnv().get("HOME") + "/.netrc";
+      String home = env.getClientEnv().get("HOME");
+      if (home != null) {
+        netrcFileString = home + "/.netrc";
+      }
     }
+    if (netrcFileString == null) {
+      return null;
+    }
+
     Path netrcFile = env.getRuntime().getFileSystem().getPath(netrcFileString);
     if (netrcFile.exists()) {
       try {

--- a/src/test/java/com/google/devtools/build/lib/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/BUILD
@@ -14,6 +14,7 @@ filegroup(
     srcs = glob(["**"]) + [
         "//src/test/java/com/google/devtools/build/lib/actions:srcs",
         "//src/test/java/com/google/devtools/build/lib/analysis:srcs",
+        "//src/test/java/com/google/devtools/build/lib/authandtls:srcs",
         "//src/test/java/com/google/devtools/build/lib/bazel:srcs",
         "//src/test/java/com/google/devtools/build/lib/blackbox:srcs",
         "//src/test/java/com/google/devtools/build/lib/buildeventservice:srcs",

--- a/src/test/java/com/google/devtools/build/lib/authandtls/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/BUILD
@@ -1,0 +1,29 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+package(
+    default_testonly = 1,
+    default_visibility = ["//src:__subpackages__"],
+)
+
+filegroup(
+    name = "srcs",
+    testonly = 0,
+    srcs = glob(["**"]),
+    visibility = ["//src/test/java/com/google/devtools/build/lib:__pkg__"],
+)
+
+java_test(
+    name = "AuthAndTLSTestSuite",
+    srcs = glob(["*.java"]),
+    test_class = "com.google.devtools.build.lib.AllTests",
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/authandtls",
+        "//src/test/java/com/google/devtools/build/lib:test_runner",
+        "//src/test/java/com/google/devtools/build/lib/testutil",
+        "//src/test/java/com/google/devtools/build/lib/testutil:JunitUtils",
+        "//src/test/java/com/google/devtools/build/lib/testutil:TestUtils",
+        "//third_party:junit4",
+        "//third_party:mockito",
+        "//third_party:truth",
+    ],
+)

--- a/src/test/java/com/google/devtools/build/lib/authandtls/NetrcCredentialsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/NetrcCredentialsTest.java
@@ -1,0 +1,146 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.authandtls;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.authandtls.Netrc.Credential;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link NetrcCredentials}.
+ */
+@RunWith(JUnit4.class)
+public class NetrcCredentialsTest {
+
+  private final static String fooMachine = "foo.example.org";
+  private final static Credential fooCredential = Credential.builder(fooMachine)
+      .setLogin("foouser")
+      .setPassword("foopass").build();
+  private final static String barMachine = "bar.example.org";
+  private final static Credential defaultCredential = Credential.builder("default")
+      .setLogin("defaultuser")
+      .setPassword("defaultpass").build();
+
+  @Test
+  public void shouldWorkWithEmptyNetrc() throws IOException {
+    Netrc netrc = new Netrc(null, ImmutableMap.of());
+    NetrcCredentials netrcCredentials = new NetrcCredentials(netrc);
+
+    Map<String, List<String>> requestMetadata = netrcCredentials
+        .getRequestMetadata(URI.create("https://example.org"));
+
+    assertThat(requestMetadata).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnMatchedAuthorizationHeader() throws IOException {
+    Netrc netrc = new Netrc(null, ImmutableMap.of(fooMachine, fooCredential));
+    NetrcCredentials netrcCredentials = new NetrcCredentials(netrc);
+
+    Map<String, List<String>> fooRequestMetadata = netrcCredentials
+        .getRequestMetadata(URI.create("https://" + fooMachine));
+    Map<String, List<String>> barRequestMetadata = netrcCredentials
+        .getRequestMetadata(URI.create("https://" + barMachine));
+
+    assertThat(fooRequestMetadata)
+        .isEqualTo(requestMetadata(fooCredential.login(), fooCredential.password()));
+    assertThat(barRequestMetadata).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnDefaultAuthorizationHeaderForNonMatched() throws IOException {
+    Netrc netrc = new Netrc(defaultCredential, ImmutableMap.of(fooMachine, fooCredential));
+    NetrcCredentials netrcCredentials = new NetrcCredentials(netrc);
+
+    Map<String, List<String>> fooRequestMetadata = netrcCredentials
+        .getRequestMetadata(URI.create("https://" + fooMachine));
+    Map<String, List<String>> barRequestMetadata = netrcCredentials
+        .getRequestMetadata(URI.create("https://" + barMachine));
+
+    assertThat(fooRequestMetadata)
+        .isEqualTo(requestMetadata(fooCredential.login(), fooCredential.password()));
+    assertThat(barRequestMetadata)
+        .isEqualTo(requestMetadata(defaultCredential.login(), defaultCredential.password()));
+  }
+
+  @Test
+  public void shouldWorkWithEmptyLogin() throws IOException {
+    Netrc netrc = new Netrc(null, ImmutableMap.of(fooMachine,
+        Credential.builder(fooMachine).setPassword(fooCredential.password()).build()));
+    NetrcCredentials netrcCredentials = new NetrcCredentials(netrc);
+
+    Map<String, List<String>> fooRequestMetadata = netrcCredentials
+        .getRequestMetadata(URI.create("https://" + fooMachine));
+
+    assertThat(fooRequestMetadata)
+        .isEqualTo(requestMetadata("", fooCredential.password()));
+  }
+
+  @Test
+  public void shouldWorkWithEmptyPassword() throws IOException {
+    Netrc netrc = new Netrc(null, ImmutableMap
+        .of(fooMachine, Credential.builder(fooMachine).setLogin(fooCredential.login()).build()));
+    NetrcCredentials netrcCredentials = new NetrcCredentials(netrc);
+
+    Map<String, List<String>> fooRequestMetadata = netrcCredentials
+        .getRequestMetadata(URI.create("https://" + fooMachine));
+
+    assertThat(fooRequestMetadata)
+        .isEqualTo(requestMetadata(fooCredential.login(), ""));
+  }
+
+  @Test
+  public void shouldWorkWithEmptyLoginAndPassword() throws IOException {
+    Netrc netrc = new Netrc(null, ImmutableMap
+        .of(fooMachine, Credential.builder(fooMachine).build()));
+    NetrcCredentials netrcCredentials = new NetrcCredentials(netrc);
+
+    Map<String, List<String>> fooRequestMetadata = netrcCredentials
+        .getRequestMetadata(URI.create("https://" + fooMachine));
+
+    assertThat(fooRequestMetadata).isEqualTo(requestMetadata("", ""));
+  }
+
+  private static String basicAuthenticationToken(String username, String password) {
+    StringBuilder sb = new StringBuilder();
+    if (!Strings.isNullOrEmpty(username)) {
+      sb.append(username);
+    }
+    sb.append(":");
+    if (!Strings.isNullOrEmpty(password)) {
+      sb.append(password);
+    }
+    return "Basic " + Base64.getEncoder()
+        .encodeToString(sb.toString().getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static Map<String, List<String>> requestMetadata(String username, String password) {
+    return ImmutableMap.of(
+        "Authorization",
+        ImmutableList.of(basicAuthenticationToken(username, password))
+    );
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/authandtls/NetrcParserTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/NetrcParserTest.java
@@ -1,0 +1,224 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.authandtls;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.authandtls.Netrc.Credential;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link NetrcParser}.
+ */
+@RunWith(JUnit4.class)
+public class NetrcParserTest {
+
+  private final static String fooMachine = "foo.example.org";
+  private final static Credential fooCredential = Credential.builder("foo.example.org")
+      .setLogin("foouser")
+      .setPassword("foopass").build();
+  private final static String barMachine = "bar.example.org";
+  private final static Credential barCredential = Credential.builder("bar.example.org")
+      .setLogin("baruser")
+      .setPassword("barpass").build();
+  private final static Credential defaultCredential = Credential.builder("default")
+      .setLogin("defaultuser")
+      .setPassword("defaultpass").build();
+
+  @Test
+  public void shouldWorkOnEmptyContent() throws IOException {
+    String content = "";
+    InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    Netrc netrc = NetrcParser.parseAndClose(inputStream);
+
+    assertThat(netrc.getDefaultCredential()).isNull();
+    assertThat(netrc.getCredentials()).isEmpty();
+  }
+
+  @Test
+  public void shouldWorkOnEmptyContentWithWhitespaces() throws IOException {
+    String content = "\t \n   \r\n  \n";
+    InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    Netrc netrc = NetrcParser.parseAndClose(inputStream);
+
+    assertThat(netrc.getDefaultCredential()).isNull();
+    assertThat(netrc.getCredentials()).isEmpty();
+  }
+
+  @Test
+  public void shouldWorkWithMultipleMachines() throws IOException {
+    String content =
+        "machine " + fooMachine + " login " + fooCredential.login() + " password " + fooCredential
+            .password() + "\n"
+            + "machine " + barMachine + " login " + barCredential.login() + " password "
+            + barCredential.password();
+    InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    Netrc netrc = NetrcParser.parseAndClose(inputStream);
+
+    ImmutableMap<String, Credential> expectedCredentials = ImmutableMap.of(
+        fooMachine,
+        fooCredential,
+        barMachine,
+        barCredential
+    );
+    assertThat(netrc.getDefaultCredential()).isNull();
+    assertThat(netrc.getCredentials()).isEqualTo(expectedCredentials);
+    assertThat(netrc.getCredential(fooMachine)).isEqualTo(fooCredential);
+    assertThat(netrc.getCredential(barMachine)).isEqualTo(barCredential);
+  }
+
+  @Test
+  public void shouldWorkWithCorrectButBadlyFormattedContent() throws IOException {
+    String content =
+        "machine " + fooMachine + "\r\n   login " + fooCredential.login()
+            + "\n\t\t\t password \t\t\n" + fooCredential
+            .password() + "\n";
+    InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    Netrc netrc = NetrcParser.parseAndClose(inputStream);
+
+    ImmutableMap<String, Credential> expectedCredentials = ImmutableMap.of(
+        fooMachine,
+        fooCredential
+    );
+    assertThat(netrc.getDefaultCredential()).isNull();
+    assertThat(netrc.getCredentials()).isEqualTo(expectedCredentials);
+    assertThat(netrc.getCredential(fooMachine)).isEqualTo(fooCredential);
+  }
+
+  @Test
+  public void shouldSkipMacdef() throws IOException {
+    String content =
+        "macdef init\n"
+            + "\tcd /pub\n"
+            + "\tmget *\n"
+            + "\tquit";
+    InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    Netrc netrc = NetrcParser.parseAndClose(inputStream);
+
+    assertThat(netrc.getDefaultCredential()).isNull();
+    assertThat(netrc.getCredentials()).isEmpty();
+  }
+
+  @Test
+  public void shouldWorkWithMixOfMachinesAndMacdef() throws IOException {
+    String content =
+        "machine " + fooMachine + " login " + fooCredential.login() + " password " + fooCredential
+            .password() + "\n"
+            + "macdef init\n"
+            + "\tcd /pub\n"
+            + "\tmget *\n"
+            + "\tquit\n"
+            + "\n"
+            + "machine " + barMachine + " login " + barCredential.login() + " password "
+            + barCredential.password();
+    InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    Netrc netrc = NetrcParser.parseAndClose(inputStream);
+
+    ImmutableMap<String, Credential> expectedCredentials = ImmutableMap.of(
+        fooMachine,
+        fooCredential,
+        barMachine,
+        barCredential
+    );
+    assertThat(netrc.getDefaultCredential()).isNull();
+    assertThat(netrc.getCredentials()).isEqualTo(expectedCredentials);
+    assertThat(netrc.getCredential(fooMachine)).isEqualTo(fooCredential);
+    assertThat(netrc.getCredential(barMachine)).isEqualTo(barCredential);
+  }
+
+  @Test
+  public void shouldOverrideDuplicatedMachineFields() throws IOException {
+    String content =
+        "machine " + fooMachine + " login overridden_user login " + fooCredential.login()
+            + " password overridden_pass password " + fooCredential
+            .password();
+    InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    Netrc netrc = NetrcParser.parseAndClose(inputStream);
+
+    ImmutableMap<String, Credential> expectedCredentials = ImmutableMap.of(
+        fooMachine,
+        fooCredential
+    );
+    assertThat(netrc.getDefaultCredential()).isNull();
+    assertThat(netrc.getCredentials()).isEqualTo(expectedCredentials);
+    assertThat(netrc.getCredential(fooMachine)).isEqualTo(fooCredential);
+  }
+
+  @Test
+  public void shouldIgnoreMachinesAfterDefault() throws IOException {
+    String content =
+        "machine " + fooMachine + " login " + fooCredential.login() + " password " + fooCredential
+            .password() + "\n"
+            + "default login " + defaultCredential.login() + " password " + defaultCredential
+            .password() + "\n"
+            + "machine " + barMachine + " login " + barCredential.login() + " password "
+            + barCredential.password();
+    InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    Netrc netrc = NetrcParser.parseAndClose(inputStream);
+
+    ImmutableMap<String, Credential> expectedCredentials = ImmutableMap.of(
+        fooMachine,
+        fooCredential
+    );
+    assertThat(netrc.getDefaultCredential()).isEqualTo(defaultCredential);
+    assertThat(netrc.getCredentials()).isEqualTo(expectedCredentials);
+    assertThat(netrc.getCredential(fooMachine)).isEqualTo(fooCredential);
+  }
+
+  @Test
+  public void shouldFailWithBadStartingContent() {
+    String content = "this is not netrc syntax";
+    InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    assertThrows(IOException.class, () -> {
+      NetrcParser.parseAndClose(inputStream);
+    });
+  }
+
+  @Test
+  public void shouldFailWithBadMachine() {
+    String content = "machine this is not netrc syntax";
+    InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    assertThrows(IOException.class, () -> {
+      NetrcParser.parseAndClose(inputStream);
+    });
+  }
+
+  @Test
+  public void shouldFailWithBadDefault() {
+    String content = "default this is not netrc syntax";
+    InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    assertThrows(IOException.class, () -> {
+      NetrcParser.parseAndClose(inputStream);
+    });
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/authandtls/NetrcParserTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/NetrcParserTest.java
@@ -33,11 +33,11 @@ import org.junit.runners.JUnit4;
 public class NetrcParserTest {
 
   private final static String fooMachine = "foo.example.org";
-  private final static Credential fooCredential = Credential.builder("foo.example.org")
+  private final static Credential fooCredential = Credential.builder(fooMachine)
       .setLogin("foouser")
       .setPassword("foopass").build();
   private final static String barMachine = "bar.example.org";
-  private final static Credential barCredential = Credential.builder("bar.example.org")
+  private final static Credential barCredential = Credential.builder(barMachine)
       .setLogin("baruser")
       .setPassword("barpass").build();
   private final static Credential defaultCredential = Credential.builder("default")

--- a/src/test/java/com/google/devtools/build/lib/authandtls/NetrcParserTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/NetrcParserTest.java
@@ -221,4 +221,15 @@ public class NetrcParserTest {
       NetrcParser.parseAndClose(inputStream);
     });
   }
+
+  @Test
+  public void shouldIgnoreComment() throws IOException {
+    String content = "# this is comment";
+    InputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+
+    Netrc netrc = NetrcParser.parseAndClose(inputStream);
+
+    assertThat(netrc.getDefaultCredential()).isNull();
+    assertThat(netrc.getCredentials()).isEmpty();
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/authandtls/NetrcParserTest.java
+++ b/src/test/java/com/google/devtools/build/lib/authandtls/NetrcParserTest.java
@@ -232,4 +232,9 @@ public class NetrcParserTest {
     assertThat(netrc.getDefaultCredential()).isNull();
     assertThat(netrc.getCredentials()).isEmpty();
   }
+
+  @Test
+  public void shouldNotLeakPasswordFromToString() {
+    assertThat(fooCredential.toString()).doesNotContain(fooCredential.password());
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -92,6 +92,7 @@ java_test(
         "//src/test/java/com/google/devtools/build/lib/testutil:JunitUtils",
         "//src/test/java/com/google/devtools/build/lib/testutil:TestUtils",
         "//third_party:api_client",
+        "//third_party:auth",
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:mockito",


### PR DESCRIPTION
This PR enables .netrc support for remote build by default. Existing authentication methods take higher priority than .netrc if they are enabled by flags.

Bazel search for .netrc in the following order:
1. If environment variable `$NETRC` exists, use it as the path to the .netrc file
2. Fallback to `$HOME/.netrc`

If .netrc doesn't exists, Bazel simply go forward without authentication.