### PR TITLE
Add the OS as a field to the configuration

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -667,7 +667,7 @@ public final class RuleContext extends TargetContext
   public Artifact createOutputArtifactScript() {
     Target target = getTarget();
     // TODO(laszlocsomor): Use the execution platform, not the host platform.
-    boolean isExecutedOnWindows = OS.getCurrent() == OS.WINDOWS;
+    boolean isExecutedOnWindows = getHostConfiguration().getOS() == OS.WINDOWS;
 
     String fileExtension = isExecutedOnWindows ? ".cmd" : ".sh";
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfiguration.java
@@ -776,6 +776,10 @@ public class BuildConfiguration implements BuildConfigurationApi {
     return buildOptionsDiff;
   }
 
+  public OS getOS() {
+    return options.getOs();
+  }
+
   public String getCpu() {
     return options.cpu;
   }
@@ -793,7 +797,7 @@ public class BuildConfiguration implements BuildConfigurationApi {
       case NO:
         return false;
       default:
-        return OS.getCurrent() != OS.WINDOWS;
+        return options.getOs() != OS.WINDOWS;
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.EmptyToNullLabelConverter;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.LabelListConverter;
 import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.RegexFilter;
 import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.Converters;
@@ -983,5 +984,9 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
     }
 
     return result;
+  }
+
+  public OS getOs() {
+    return OS.getCurrent();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/OutputDirectories.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/OutputDirectories.java
@@ -117,6 +117,7 @@ public class OutputDirectories {
     }
   }
 
+  private final OS os;
   private final BlazeDirectories directories;
   private final String mnemonic;
   private final String outputDirName;
@@ -136,6 +137,7 @@ public class OutputDirectories {
       CoreOptions options,
       ImmutableSortedMap<Class<? extends Fragment>, Fragment> fragments,
       RepositoryName mainRepositoryName) {
+    this.os = options.getOs();
     this.directories = directories;
     this.mnemonic = buildMnemonic(options, fragments);
     this.outputDirName =
@@ -219,8 +221,7 @@ public class OutputDirectories {
    * the native path separator, i.e., the path separator for the machine that they run on.
    */
   String getHostPathSeparator() {
-    // TODO(bazel-team): Maybe do this in the constructor instead? This isn't serialization-safe.
-    return OS.getCurrent() == OS.WINDOWS ? ";" : ":";
+    return os == OS.WINDOWS ? ";" : ":";
   }
 
   /** Returns the internal directory (used for middlemen) for this build configuration. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/AnalysisTestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/AnalysisTestActionBuilder.java
@@ -36,7 +36,7 @@ public class AnalysisTestActionBuilder {
       AnalysisTestResultInfo infoObject) {
     FileWriteAction action;
     // TODO(laszlocsomor): Use the execution platform, not the host platform.
-    boolean isExecutedOnWindows = OS.getCurrent() == OS.WINDOWS;
+    boolean isExecutedOnWindows = ruleContext.getHostConfiguration().getOS() == OS.WINDOWS;
 
     if (isExecutedOnWindows) {
       StringBuilder sb = new StringBuilder().append("@echo off\n");

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -165,7 +165,7 @@ public final class TestActionBuilder {
     // TODO(laszlocsomor), TODO(ulfjack): `isExecutedOnWindows` should use the execution platform,
     // not the host platform. Once Bazel can tell apart these platforms, fix the right side of this
     // initialization.
-    final boolean isExecutedOnWindows = OS.getCurrent() == OS.WINDOWS;
+    final boolean isExecutedOnWindows = ruleContext.getHostConfiguration().getOS() == OS.WINDOWS;
     final boolean isUsingTestWrapperInsteadOfTestSetupScript = isExecutedOnWindows;
 
     NestedSetBuilder<Artifact> inputsBuilder = NestedSetBuilder.stableOrder();

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestStrategy.java
@@ -165,10 +165,7 @@ public abstract class TestStrategy implements TestActionContext {
   public static ImmutableList<String> expandedArgsFromAction(TestRunnerAction testAction)
       throws CommandLineExpansionException {
     List<String> args = Lists.newArrayList();
-    // TODO(ulfjack): `executedOnWindows` is incorrect for remote execution, where we need to
-    // consider the target configuration, not the machine Bazel happens to run on. Change this to
-    // something like: testAction.getConfiguration().getTargetOS() == OS.WINDOWS
-    final boolean executedOnWindows = (OS.getCurrent() == OS.WINDOWS);
+    final boolean executedOnWindows = testAction.getConfiguration().getOS() == OS.WINDOWS;
 
     Artifact testSetup = testAction.getTestSetupScript();
     args.add(testSetup.getExecPath().getCallablePathString());

--- a/src/main/java/com/google/devtools/build/lib/util/DependencySet.java
+++ b/src/main/java/com/google/devtools/build/lib/util/DependencySet.java
@@ -55,6 +55,7 @@ public final class DependencySet {
    */
   private final Collection<Path> dependencies = new ArrayList<>();
 
+  private final OS os;
   private final Path root;
   private String outputFileName;
 
@@ -72,8 +73,16 @@ public final class DependencySet {
   /**
    * Constructs a new empty DependencySet instance.
    */
-  public DependencySet(Path root) {
+  public DependencySet(OS os, Path root) {
+    this.os = os;
     this.root = root;
+  }
+
+  /**
+   * Constructs a new empty DependencySet instance.
+   */
+  public DependencySet(Path root) {
+    this(OS.getCurrent(), root);
   }
 
   /**


### PR DESCRIPTION
This helps move Bazel towards being able to perform cross-platform builds
with a remote execution system that's running a different OS. This is in
preparation for updating the rule implementations to use the configuration
setting instead of OS.current() directly.

I'm not sure how this interacts with platforms, but this change seems safe
enough.

Progress on #11748.

Change-Id: I20dff1fb332d4567b621d65e43b05a00905f75b0