### PR TITLE
Upgrade remote_java_tools versions (javac 11 to v10.0, javac 14 to v2.0)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -146,9 +146,9 @@ distdir_tar(
     # Keep in sync with the archives fetched as part of building bazel.
     archives = [
         "e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
-        "java_tools_javac11_linux-v9.0.zip",
-        "java_tools_javac11_windows-v9.0.zip",
-        "java_tools_javac11_darwin-v9.0.zip",
+        "java_tools_javac11_linux-v10.0-rc1.zip",
+        "java_tools_javac11_windows-v10.0-rc1.zip",
+        "java_tools_javac11_darwin-v10.0-rc1.zip",
         "coverage_output_generator-v2.4.zip",
         # bazelbuid/stardoc
         "1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz",
@@ -183,9 +183,9 @@ distdir_tar(
     dirname = "derived/distdir",
     sha256 = {
         "e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip": "fe2e04f91ce8c59d49d91b8102edc6627c6fa2906c1b0e7346f01419ec4f419d",
-        "java_tools_javac11_linux-v9.0.zip": "0be37f4227590ecb6bc929a6a7e427c65e6239363e4c3b28b1a211718b9636c9",
-        "java_tools_javac11_windows-v9.0.zip": "14b679e3bf6a7b4aec36dc33f15ad0027aef43f1bc92e1e2f5abf3a93c156bb5",
-        "java_tools_javac11_darwin-v9.0.zip": "567f5fe77e0c561b454930dea412899543849510f48f9c092dfcff8192b4086f",
+        "java_tools_javac11_linux-v10.0-rc1.zip": "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
+        "java_tools_javac11_windows-v10.0-rc1.zip": "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
+        "java_tools_javac11_darwin-v10.0-rc1.zip": "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
         "coverage_output_generator-v2.4.zip": "2fdde0f257c6d2a1b0d9e7e777e2292a9d2a9af79949d04cdb0964bc8b242611",
         # bazelbuild/stardoc
         "1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz": "5a725b777976b77aa122b707d1b6f0f39b6020f66cd427bb111a585599c857b1",
@@ -222,14 +222,14 @@ distdir_tar(
             "https://mirror.bazel.build/github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
             "https://github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
         ],
-        "java_tools_javac11_linux-v9.0.zip": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_linux-v9.0.zip",
+        "java_tools_javac11_linux-v10.0-rc1.zip": [
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
         ],
-        "java_tools_javac11_windows-v9.0.zip": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_windows-v9.0.zip",
+        "java_tools_javac11_windows-v10.0-rc1.zip": [
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
         ],
-        "java_tools_javac11_darwin-v9.0.zip": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_darwin-v9.0.zip",
+        "java_tools_javac11_darwin-v10.0-rc1.zip": [
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
         ],
         "coverage_output_generator-v2.4.zip": [
             "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.4.zip",
@@ -352,7 +352,7 @@ http_file(
 
 http_file(
     name = "openjdk_linux_ppc64le_vanilla",
-    downloaded_file_path="adoptopenjdk-ppc64le-vanilla.tar.gz",
+    downloaded_file_path = "adoptopenjdk-ppc64le-vanilla.tar.gz",
     sha256 = "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
     urls = [
         "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
@@ -362,7 +362,7 @@ http_file(
 
 http_file(
     name = "openjdk_linux_s390x_vanilla",
-    downloaded_file_path="adoptopenjdk-s390x-vanilla.tar.gz",
+    downloaded_file_path = "adoptopenjdk-s390x-vanilla.tar.gz",
     sha256 = "d9b72e87a1d3ebc0c9552f72ae5eb150fffc0298a7cb841f1ce7bfc70dcd1059",
     urls = [
         "https://mirror.bazel.build/github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz",
@@ -527,9 +527,9 @@ http_archive(
 distdir_tar(
     name = "test_WORKSPACE_files",
     archives = [
-        "java_tools_javac11_linux-v9.0.zip",
-        "java_tools_javac11_windows-v9.0.zip",
-        "java_tools_javac11_darwin-v9.0.zip",
+        "java_tools_javac11_linux-v10.0-rc1.zip",
+        "java_tools_javac11_windows-v10.0-rc1.zip",
+        "java_tools_javac11_darwin-v10.0-rc1.zip",
         "coverage_output_generator-v2.4.zip",
         "zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz",
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz",
@@ -557,9 +557,9 @@ distdir_tar(
     ],
     dirname = "test_WORKSPACE/distdir",
     sha256 = {
-        "java_tools_javac11_linux-v9.0.zip": "0be37f4227590ecb6bc929a6a7e427c65e6239363e4c3b28b1a211718b9636c9",
-        "java_tools_javac11_windows-v9.0.zip": "14b679e3bf6a7b4aec36dc33f15ad0027aef43f1bc92e1e2f5abf3a93c156bb5",
-        "java_tools_javac11_darwin-v9.0.zip": "567f5fe77e0c561b454930dea412899543849510f48f9c092dfcff8192b4086f",
+        "java_tools_javac11_linux-v10.0-rc1.zip": "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
+        "java_tools_javac11_windows-v10.0-rc1.zip": "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
+        "java_tools_javac11_darwin-v10.0-rc1.zip": "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
         "coverage_output_generator-v2.4.zip": "2fdde0f257c6d2a1b0d9e7e777e2292a9d2a9af79949d04cdb0964bc8b242611",
         "zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz": "360626cc19063bc411bfed2914301b908a8f77a7919aaea007a977fa8fb3cde1",
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz": "a452f1b9682d9f83c1c14e54d1446e1c51b5173a3a05dcb013d380f9508562e4",
@@ -586,9 +586,9 @@ distdir_tar(
         "9effcbcb27f0a665f9f345030188c0b291e32482.tar.gz": "61d0417abd60e65ed589c9deee7c124fe76a4106831f6ad39464e1525cef1454",
     },
     urls = {
-        "java_tools_javac11_linux-v9.0.zip": ["https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_linux-v9.0.zip"],
-        "java_tools_javac11_windows-v9.0.zip": ["https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_windows-v9.0.zip"],
-        "java_tools_javac11_darwin-v9.0.zip": ["https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_darwin-v9.0.zip"],
+        "java_tools_javac11_linux-v10.0-rc1.zip": ["https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_linux-v10.0-rc1.zip"],
+        "java_tools_javac11_windows-v10.0-rc1.zip": ["https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_windows-v10.0-rc1.zip"],
+        "java_tools_javac11_darwin-v10.0-rc1.zip": ["https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_darwin-v10.0-rc1.zip"],
         "coverage_output_generator-v2.4.zip": ["https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.4.zip"],
         "zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz"],
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.48-ca-jdk11.0.6/zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz"],
@@ -658,15 +658,15 @@ load("//scripts/docs:doc_versions.bzl", "DOC_VERSIONS")
 # Load shared base CSS theme from bazelbuild/bazel-website
 http_archive(
     name = "bazel_website",
-    urls = ["https://github.com/bazelbuild/bazel-website/archive/c174fa288aa079b68416d2ce2cc97268fa172f42.tar.gz"],
-    strip_prefix = "bazel-website-c174fa288aa079b68416d2ce2cc97268fa172f42",
-    sha256 = "a5f531dd1d62e6947dcfc279656ffc2fdf6f447c163914c5eabf7961b4cb6eb4",
     # TODO(https://github.com/bazelbuild/bazel/issues/10793)
     # - Export files from bazel-website's BUILD, instead of doing it here.
     # - Share more common stylesheets, like footer and navbar.
     build_file_content = """
 exports_files(["_sass/style.scss"])
-"""
+""",
+    sha256 = "a5f531dd1d62e6947dcfc279656ffc2fdf6f447c163914c5eabf7961b4cb6eb4",
+    strip_prefix = "bazel-website-c174fa288aa079b68416d2ce2cc97268fa172f42",
+    urls = ["https://github.com/bazelbuild/bazel-website/archive/c174fa288aa079b68416d2ce2cc97268fa172f42.tar.gz"],
 )
 
 # Stardoc recommends declaring its dependencies via "*_dependencies" functions.
@@ -711,13 +711,12 @@ http_archive(
     ],
 )
 
-
 # This must be kept in sync with src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
 http_archive(
     name = "android_tools_for_testing",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "ea5c0589a01e2a9f43c20e5c145d3530e3b3bdbe7322789bc5da38d0ca49b837", # DO_NOT_REMOVE_THIS_ANDROID_TOOLS_UPDATE_MARKER
+    sha256 = "ea5c0589a01e2a9f43c20e5c145d3530e3b3bdbe7322789bc5da38d0ca49b837",  # DO_NOT_REMOVE_THIS_ANDROID_TOOLS_UPDATE_MARKER
     url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc3.tar.gz",
 )
 
@@ -842,10 +841,10 @@ http_archive(
     name = "remote_java_tools_linux_for_testing",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "0be37f4227590ecb6bc929a6a7e427c65e6239363e4c3b28b1a211718b9636c9",
+    sha256 = "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_linux-v9.0.zip",
-        "https://github.com/bazelbuild/java_tools/releases/download/javac11_v9.0/java_tools_javac11_linux-v9.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
+        "https://github.com/bazelbuild/java_tools/release_candidates/download/javac11_v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
     ],
 )
 
@@ -854,10 +853,10 @@ http_archive(
     name = "remote_java_tools_windows_for_testing",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "14b679e3bf6a7b4aec36dc33f15ad0027aef43f1bc92e1e2f5abf3a93c156bb5",
+    sha256 = "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_windows-v9.0.zip",
-        "https://github.com/bazelbuild/java_tools/releases/download/javac11_v9.0/java_tools_javac11_windows-v9.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
+        "https://github.com/bazelbuild/java_tools/release_candidates/download/javac11_v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
     ],
 )
 
@@ -866,10 +865,10 @@ http_archive(
     name = "remote_java_tools_darwin_for_testing",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "567f5fe77e0c561b454930dea412899543849510f48f9c092dfcff8192b4086f",
+    sha256 = "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_darwin-v9.0.zip",
-        "https://github.com/bazelbuild/java_tools/releases/download/javac11_v9.0/java_tools_javac11_darwin-v9.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
+        "https://github.com/bazelbuild/java_tools/release_candidates/download/javac11_v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
     ],
 )
 
@@ -878,9 +877,9 @@ http_archive(
     name = "remote_java_tools_javac11_test_linux",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "0be37f4227590ecb6bc929a6a7e427c65e6239363e4c3b28b1a211718b9636c9",
+    sha256 = "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_linux-v9.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
     ],
 )
 
@@ -889,9 +888,9 @@ http_archive(
     name = "remote_java_tools_javac11_test_windows",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "14b679e3bf6a7b4aec36dc33f15ad0027aef43f1bc92e1e2f5abf3a93c156bb5",
+    sha256 = "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_windows-v9.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
     ],
 )
 
@@ -900,9 +899,9 @@ http_archive(
     name = "remote_java_tools_javac11_test_darwin",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "567f5fe77e0c561b454930dea412899543849510f48f9c092dfcff8192b4086f",
+    sha256 = "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_darwin-v9.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
     ],
 )
 
@@ -911,9 +910,9 @@ http_archive(
     name = "remote_java_tools_javac14_test_linux",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "196128eadc68a55fb42a1f990c84ee816f5b29320a72fe542fcfc4206ac3978a",
+    sha256 = "ed18ff30d6fff6cff341f2153204cbd19b5cbe2a693351c96651d3dd2b6bf0b3",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac14/v1.0/java_tools_javac14_linux-v1.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac14/v2.0/java_tools_javac14_linux-v2.0-rc1.zip",
     ],
 )
 
@@ -922,9 +921,9 @@ http_archive(
     name = "remote_java_tools_javac14_test_windows",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "a6c69fd89b87fccc4c75203be6b407a1ca22cbdb54cffbd445f874281a933149",
+    sha256 = "269d4dcd8fddcd94e7b54908f263f85486375b04d99fd68c75e430a34053c2e4",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac14/v1.0/java_tools_javac14_windows-v1.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac14/v2.0/java_tools_javac14_windows-v2.0-rc1.zip",
     ],
 )
 
@@ -933,9 +932,9 @@ http_archive(
     name = "remote_java_tools_javac14_test_darwin",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "e20f002ceb3f3353d64c022e1f3400d8539ee56ffcfd4a6680d73d6a2cac938b",
+    sha256 = "ceebee0618e838a0aa904f010e382a407e4ef6302d5d35c803e77b29612c3224",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac14/v1.0/java_tools_javac14_darwin-v1.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac14/v2.0/java_tools_javac14_darwin-v2.0-rc1.zip",
     ],
 )
 
@@ -1061,9 +1060,9 @@ register_toolchains("//src/main/res:empty_rc_toolchain")
 # affected by this issue.
 http_archive(
     name = "upb",
-    sha256 = "61d0417abd60e65ed589c9deee7c124fe76a4106831f6ad39464e1525cef1454",
-    patches = ["//third_party/grpc:upb_gcc10_fix.patch"],
     patch_args = ["-p1"],
+    patches = ["//third_party/grpc:upb_gcc10_fix.patch"],
+    sha256 = "61d0417abd60e65ed589c9deee7c124fe76a4106831f6ad39464e1525cef1454",
     strip_prefix = "upb-9effcbcb27f0a665f9f345030188c0b291e32482",
     urls = [
         "https://mirror.bazel.build/github.com/protocolbuffers/upb/archive/9effcbcb27f0a665f9f345030188c0b291e32482.tar.gz",
@@ -1073,26 +1072,30 @@ http_archive(
 
 http_archive(
     name = "com_github_grpc_grpc",
+    patch_args = ["-p1"],
+    patches = ["//third_party/grpc:grpc_1.26.0.patch"],
+    sha256 = "2fcb7f1ab160d6fd3aaade64520be3e5446fc4c6fa7ba6581afdc4e26094bd81",
+    strip_prefix = "grpc-1.26.0",
     urls = [
         "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.26.0.tar.gz",
         "https://github.com/grpc/grpc/archive/v1.26.0.tar.gz",
     ],
-    sha256 = "2fcb7f1ab160d6fd3aaade64520be3e5446fc4c6fa7ba6581afdc4e26094bd81",
-    patches = ["//third_party/grpc:grpc_1.26.0.patch"],
-    patch_args = ["-p1"],
-    strip_prefix = "grpc-1.26.0",
 )
 
 # Projects using gRPC as an external dependency must call both grpc_deps() and
 # grpc_extra_deps().
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
 grpc_deps()
 
 load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+
 grpc_extra_deps()
 
 load("//tools/distributions/debian:deps.bzl", "debian_deps")
+
 debian_deps()
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
 bazel_skylib_workspace()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -146,9 +146,9 @@ distdir_tar(
     # Keep in sync with the archives fetched as part of building bazel.
     archives = [
         "e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
-        "java_tools_javac11_linux-v10.0-rc1.zip",
-        "java_tools_javac11_windows-v10.0-rc1.zip",
-        "java_tools_javac11_darwin-v10.0-rc1.zip",
+        "java_tools_javac11_linux-v10.0.zip",
+        "java_tools_javac11_windows-v10.0.zip",
+        "java_tools_javac11_darwin-v10.0.zip",
         "coverage_output_generator-v2.4.zip",
         # bazelbuid/stardoc
         "1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz",
@@ -183,9 +183,9 @@ distdir_tar(
     dirname = "derived/distdir",
     sha256 = {
         "e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip": "fe2e04f91ce8c59d49d91b8102edc6627c6fa2906c1b0e7346f01419ec4f419d",
-        "java_tools_javac11_linux-v10.0-rc1.zip": "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
-        "java_tools_javac11_windows-v10.0-rc1.zip": "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
-        "java_tools_javac11_darwin-v10.0-rc1.zip": "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
+        "java_tools_javac11_linux-v10.0.zip": "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
+        "java_tools_javac11_windows-v10.0.zip": "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
+        "java_tools_javac11_darwin-v10.0.zip": "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
         "coverage_output_generator-v2.4.zip": "2fdde0f257c6d2a1b0d9e7e777e2292a9d2a9af79949d04cdb0964bc8b242611",
         # bazelbuild/stardoc
         "1ef781ced3b1443dca3ed05dec1989eca1a4e1cd.tar.gz": "5a725b777976b77aa122b707d1b6f0f39b6020f66cd427bb111a585599c857b1",
@@ -222,14 +222,14 @@ distdir_tar(
             "https://mirror.bazel.build/github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
             "https://github.com/google/desugar_jdk_libs/archive/e0b0291b2c51fbe5a7cfa14473a1ae850f94f021.zip",
         ],
-        "java_tools_javac11_linux-v10.0-rc1.zip": [
-            "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
+        "java_tools_javac11_linux-v10.0.zip": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_linux-v10.0.zip",
         ],
-        "java_tools_javac11_windows-v10.0-rc1.zip": [
-            "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
+        "java_tools_javac11_windows-v10.0.zip": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_windows-v10.0.zip",
         ],
-        "java_tools_javac11_darwin-v10.0-rc1.zip": [
-            "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
+        "java_tools_javac11_darwin-v10.0.zip": [
+            "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_darwin-v10.0.zip",
         ],
         "coverage_output_generator-v2.4.zip": [
             "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.4.zip",
@@ -527,9 +527,9 @@ http_archive(
 distdir_tar(
     name = "test_WORKSPACE_files",
     archives = [
-        "java_tools_javac11_linux-v10.0-rc1.zip",
-        "java_tools_javac11_windows-v10.0-rc1.zip",
-        "java_tools_javac11_darwin-v10.0-rc1.zip",
+        "java_tools_javac11_linux-v10.0.zip",
+        "java_tools_javac11_windows-v10.0.zip",
+        "java_tools_javac11_darwin-v10.0.zip",
         "coverage_output_generator-v2.4.zip",
         "zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz",
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz",
@@ -557,9 +557,9 @@ distdir_tar(
     ],
     dirname = "test_WORKSPACE/distdir",
     sha256 = {
-        "java_tools_javac11_linux-v10.0-rc1.zip": "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
-        "java_tools_javac11_windows-v10.0-rc1.zip": "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
-        "java_tools_javac11_darwin-v10.0-rc1.zip": "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
+        "java_tools_javac11_linux-v10.0.zip": "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
+        "java_tools_javac11_windows-v10.0.zip": "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
+        "java_tools_javac11_darwin-v10.0.zip": "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
         "coverage_output_generator-v2.4.zip": "2fdde0f257c6d2a1b0d9e7e777e2292a9d2a9af79949d04cdb0964bc8b242611",
         "zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz": "360626cc19063bc411bfed2914301b908a8f77a7919aaea007a977fa8fb3cde1",
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz": "a452f1b9682d9f83c1c14e54d1446e1c51b5173a3a05dcb013d380f9508562e4",
@@ -586,9 +586,9 @@ distdir_tar(
         "9effcbcb27f0a665f9f345030188c0b291e32482.tar.gz": "61d0417abd60e65ed589c9deee7c124fe76a4106831f6ad39464e1525cef1454",
     },
     urls = {
-        "java_tools_javac11_linux-v10.0-rc1.zip": ["https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_linux-v10.0-rc1.zip"],
-        "java_tools_javac11_windows-v10.0-rc1.zip": ["https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_windows-v10.0-rc1.zip"],
-        "java_tools_javac11_darwin-v10.0-rc1.zip": ["https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_darwin-v10.0-rc1.zip"],
+        "java_tools_javac11_linux-v10.0.zip": ["https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_linux-v10.0.zip"],
+        "java_tools_javac11_windows-v10.0.zip": ["https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_windows-v10.0.zip"],
+        "java_tools_javac11_darwin-v10.0.zip": ["https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_darwin-v10.0.zip"],
         "coverage_output_generator-v2.4.zip": ["https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.4.zip"],
         "zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz"],
         "zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.48-ca-jdk11.0.6/zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz"],
@@ -843,8 +843,8 @@ http_archive(
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
     sha256 = "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
-        "https://github.com/bazelbuild/java_tools/release_candidates/download/javac11_v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_linux-v10.0.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/javac11_v10.0/java_tools_javac11_linux-v10.0.zip",
     ],
 )
 
@@ -855,8 +855,8 @@ http_archive(
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
     sha256 = "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
-        "https://github.com/bazelbuild/java_tools/release_candidates/download/javac11_v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_windows-v10.0.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/javac11_v10.0/java_tools_javac11_windows-v10.0.zip",
     ],
 )
 
@@ -867,8 +867,8 @@ http_archive(
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
     sha256 = "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
-        "https://github.com/bazelbuild/java_tools/release_candidates/download/javac11_v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_darwin-v10.0.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/javac11_v10.0/java_tools_javac11_darwin-v10.0.zip",
     ],
 )
 
@@ -879,7 +879,7 @@ http_archive(
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
     sha256 = "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_linux-v10.0.zip",
     ],
 )
 
@@ -890,7 +890,7 @@ http_archive(
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
     sha256 = "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_windows-v10.0.zip",
     ],
 )
 
@@ -901,7 +901,7 @@ http_archive(
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
     sha256 = "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_darwin-v10.0.zip",
     ],
 )
 
@@ -912,7 +912,7 @@ http_archive(
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
     sha256 = "ed18ff30d6fff6cff341f2153204cbd19b5cbe2a693351c96651d3dd2b6bf0b3",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac14/v2.0/java_tools_javac14_linux-v2.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac14/v2.0/java_tools_javac14_linux-v2.0.zip",
     ],
 )
 
@@ -923,7 +923,7 @@ http_archive(
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
     sha256 = "269d4dcd8fddcd94e7b54908f263f85486375b04d99fd68c75e430a34053c2e4",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac14/v2.0/java_tools_javac14_windows-v2.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac14/v2.0/java_tools_javac14_windows-v2.0.zip",
     ],
 )
 
@@ -934,7 +934,7 @@ http_archive(
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
     sha256 = "ceebee0618e838a0aa904f010e382a407e4ef6302d5d35c803e77b29612c3224",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac14/v2.0/java_tools_javac14_darwin-v2.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac14/v2.0/java_tools_javac14_darwin-v2.0.zip",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -203,10 +203,10 @@ maybe(
 maybe(
     http_archive,
     name = "remote_java_tools_linux",
-    sha256 = "0be37f4227590ecb6bc929a6a7e427c65e6239363e4c3b28b1a211718b9636c9",
+    sha256 = "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_linux-v9.0.zip",
-        "https://github.com/bazelbuild/java_tools/releases/download/javac11_v9.0/java_tools_javac11_linux-v9.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
+        "https://github.com/bazelbuild/java_tools/release_candidates/download/javac11_v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
     ],
 )
 
@@ -214,10 +214,10 @@ maybe(
 maybe(
     http_archive,
     name = "remote_java_tools_windows",
-    sha256 = "14b679e3bf6a7b4aec36dc33f15ad0027aef43f1bc92e1e2f5abf3a93c156bb5",
+    sha256 = "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_windows-v9.0.zip",
-        "https://github.com/bazelbuild/java_tools/releases/download/javac11_v9.0/java_tools_javac11_windows-v9.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
+        "https://github.com/bazelbuild/java_tools/release_candidates/download/javac11_v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
     ],
 )
 
@@ -225,10 +225,10 @@ maybe(
 maybe(
     http_archive,
     name = "remote_java_tools_darwin",
-    sha256 = "567f5fe77e0c561b454930dea412899543849510f48f9c092dfcff8192b4086f",
+    sha256 = "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_darwin-v9.0.zip",
-        "https://github.com/bazelbuild/java_tools/releases/download/javac11_v9.0/java_tools_javac11_darwin-v9.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
+        "https://github.com/bazelbuild/java_tools/release_candidates/download/javac11_v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -205,8 +205,8 @@ maybe(
     name = "remote_java_tools_linux",
     sha256 = "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
-        "https://github.com/bazelbuild/java_tools/release_candidates/download/javac11_v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_linux-v10.0.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/javac11_v10.0/java_tools_javac11_linux-v10.0.zip",
     ],
 )
 
@@ -216,8 +216,8 @@ maybe(
     name = "remote_java_tools_windows",
     sha256 = "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
-        "https://github.com/bazelbuild/java_tools/release_candidates/download/javac11_v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_windows-v10.0.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/javac11_v10.0/java_tools_javac11_windows-v10.0.zip",
     ],
 )
 
@@ -227,8 +227,8 @@ maybe(
     name = "remote_java_tools_darwin",
     sha256 = "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
-        "https://github.com/bazelbuild/java_tools/release_candidates/download/javac11_v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_darwin-v10.0.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/javac11_v10.0/java_tools_javac11_darwin-v10.0.zip",
     ],
 )
 

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -492,7 +492,6 @@ sh_test(
         "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
     ],
     tags = [
-        "manual",
         "no_windows",
     ],
 )
@@ -524,7 +523,6 @@ sh_test(
             "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
         ],
         tags = [
-            "manual",
             "no_windows",
         ],
     )

--- a/src/test/shell/bazel/bazel_coverage_sh_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_sh_test.sh
@@ -150,8 +150,8 @@ FNDA:1,com/google/orange/orangeBin::main ([Ljava/lang/String;)V
 FNF:2
 FNH:1
 DA:3,0
-DA:5,4
-DA:6,2
+DA:5,1
+DA:6,1
 DA:7,1
 LH:3
 LF:4
@@ -163,8 +163,8 @@ FNDA:1,com/google/orange/orangeLib::<init> ()V
 FNDA:1,com/google/orange/orangeLib::print ()V
 FNF:2
 FNH:2
-DA:3,3
-DA:6,3
+DA:3,1
+DA:6,1
 DA:7,1
 LH:3
 LF:3
@@ -533,8 +533,8 @@ FNDA:1,com/google/orange/orangeBin::main ([Ljava/lang/String;)V
 FNF:2
 FNH:1
 DA:2,0
-DA:4,4
-DA:5,2
+DA:4,1
+DA:5,1
 DA:6,1
 LH:3
 LF:4
@@ -548,8 +548,8 @@ FNDA:1,com/google/orange/orangeLib::<init> ()V
 FNDA:1,com/google/orange/orangeLib::print ()V
 FNF:2
 FNH:2
-DA:2,3
-DA:4,3
+DA:2,1
+DA:4,1
 DA:5,1
 LH:3
 LF:3

--- a/src/test/shell/bazel/testdata/jdk_http_archives
+++ b/src/test/shell/bazel/testdata/jdk_http_archives
@@ -2,25 +2,25 @@
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "remote_java_tools_javac11_test_linux",
-    sha256 = "0be37f4227590ecb6bc929a6a7e427c65e6239363e4c3b28b1a211718b9636c9",
+    sha256 = "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
     urls = [
-         "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_linux-v9.0.zip",
+         "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
     ],
 )
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "remote_java_tools_javac11_test_windows",
-    sha256 = "14b679e3bf6a7b4aec36dc33f15ad0027aef43f1bc92e1e2f5abf3a93c156bb5",
+    sha256 = "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_windows-v9.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
     ],
 )
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "remote_java_tools_javac11_test_darwin",
-    sha256 = "567f5fe77e0c561b454930dea412899543849510f48f9c092dfcff8192b4086f",
+    sha256 = "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
     urls = [
-         "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v9.0/java_tools_javac11_darwin-v9.0.zip",
+         "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
     ],
 )
 
@@ -54,25 +54,25 @@ http_archive(
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "remote_java_tools_javac14_test_linux",
-    sha256 = "196128eadc68a55fb42a1f990c84ee816f5b29320a72fe542fcfc4206ac3978a",
+    sha256 = "ed18ff30d6fff6cff341f2153204cbd19b5cbe2a693351c96651d3dd2b6bf0b3",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac14/v1.0/java_tools_javac14_linux-v1.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac14/v2.0/java_tools_javac14_linux-v2.0-rc1.zip",
     ],
 )
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "remote_java_tools_javac14_test_windows",
-    sha256 = "a6c69fd89b87fccc4c75203be6b407a1ca22cbdb54cffbd445f874281a933149",
+    sha256 = "269d4dcd8fddcd94e7b54908f263f85486375b04d99fd68c75e430a34053c2e4",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac14/v1.0/java_tools_javac14_windows-v1.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac14/v2.0/java_tools_javac14_windows-v2.0-rc1.zip",
     ],
 )
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "remote_java_tools_javac14_test_darwin",
-    sha256 = "e20f002ceb3f3353d64c022e1f3400d8539ee56ffcfd4a6680d73d6a2cac938b",
+    sha256 = "ceebee0618e838a0aa904f010e382a407e4ef6302d5d35c803e77b29612c3224",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/javac14/v1.0/java_tools_javac14_darwin-v1.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac14/v2.0/java_tools_javac14_darwin-v2.0-rc1.zip",
     ],
 )
 

--- a/src/test/shell/bazel/testdata/jdk_http_archives
+++ b/src/test/shell/bazel/testdata/jdk_http_archives
@@ -4,7 +4,7 @@ http_archive(
     name = "remote_java_tools_javac11_test_linux",
     sha256 = "69e65353c2cd65780abcbcce4daae973599298273b0f8b4d469eed822cb220d1",
     urls = [
-         "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_linux-v10.0-rc1.zip",
+         "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_linux-v10.0.zip",
     ],
 )
 # This must be kept in sync with the top-level WORKSPACE file.
@@ -12,7 +12,7 @@ http_archive(
     name = "remote_java_tools_javac11_test_windows",
     sha256 = "d2f62af8daa0a3d55789b605f6582e37038329c64843337c71e64515468e55c4",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_windows-v10.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_windows-v10.0.zip",
     ],
 )
 # This must be kept in sync with the top-level WORKSPACE file.
@@ -20,7 +20,7 @@ http_archive(
     name = "remote_java_tools_javac11_test_darwin",
     sha256 = "64e5de2175dfccb96831573946b80d106edf3801d9db38b564514bf3581d466b",
     urls = [
-         "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac11/v10.0/java_tools_javac11_darwin-v10.0-rc1.zip",
+         "https://mirror.bazel.build/bazel_java_tools/releases/javac11/v10.0/java_tools_javac11_darwin-v10.0.zip",
     ],
 )
 
@@ -56,7 +56,7 @@ http_archive(
     name = "remote_java_tools_javac14_test_linux",
     sha256 = "ed18ff30d6fff6cff341f2153204cbd19b5cbe2a693351c96651d3dd2b6bf0b3",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac14/v2.0/java_tools_javac14_linux-v2.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac14/v2.0/java_tools_javac14_linux-v2.0.zip",
     ],
 )
 # This must be kept in sync with the top-level WORKSPACE file.
@@ -64,7 +64,7 @@ http_archive(
     name = "remote_java_tools_javac14_test_windows",
     sha256 = "269d4dcd8fddcd94e7b54908f263f85486375b04d99fd68c75e430a34053c2e4",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac14/v2.0/java_tools_javac14_windows-v2.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac14/v2.0/java_tools_javac14_windows-v2.0.zip",
     ],
 )
 # This must be kept in sync with the top-level WORKSPACE file.
@@ -72,7 +72,7 @@ http_archive(
     name = "remote_java_tools_javac14_test_darwin",
     sha256 = "ceebee0618e838a0aa904f010e382a407e4ef6302d5d35c803e77b29612c3224",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/release_candidates/javac14/v2.0/java_tools_javac14_darwin-v2.0-rc1.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/javac14/v2.0/java_tools_javac14_darwin-v2.0.zip",
     ],
 )
 


### PR DESCRIPTION
Upgrade remote_java_tools versions (javac 11 to v10.0, javac 14 to v2.0)

Fix coverage tests after upgrade of java_tools.
The change in LCOV was made in https://github.com/bazelbuild/bazel/pull/11919, however some of the tests were testing only LCOV formatter packed with java_tools.
