### PR TITLE
Use CallCredentialsProvider and refresh credentials when needed for GrpcCacheClient and GrpcRemoteExecutor

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -36,6 +36,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ProgressiveBackoff;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
+import com.google.devtools.build.lib.remote.util.Utils;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -351,30 +352,18 @@ class ByteStreamUploader extends AbstractReferenceCounted {
       ProgressiveBackoff progressiveBackoff = new ProgressiveBackoff(retrier::newBackoff);
       AtomicLong committedOffset = new AtomicLong(0);
 
-      ListenableFuture<Void> callFuture =
-          callAndQueryOnFailureWithRetrier(ctx, committedOffset, progressiveBackoff);
-
-      callFuture =
-          Futures.catchingAsync(
-              callFuture,
-              Exception.class,
-              (e) -> {
-                Status status = Status.fromThrowable(e);
-                if (status != null
-                    && (status.getCode() == Code.UNAUTHENTICATED
-                        || status.getCode() == Code.PERMISSION_DENIED)) {
-                  try {
-                    callCredentialsProvider.refresh();
-                  } catch (IOException ioe) {
-                    e.addSuppressed(ioe);
-                    return Futures.immediateFailedFuture(e);
-                  }
-                  return callAndQueryOnFailureWithRetrier(ctx, committedOffset, progressiveBackoff);
-                } else {
-                  return Futures.immediateFailedFuture(e);
-                }
-              },
-              MoreExecutors.directExecutor());
+      ListenableFuture<Void> callFuture = Utils.refreshIfUnauthenticatedAsync(
+          () ->
+              retrier.executeAsync(
+                  () -> {
+                    if (committedOffset.get() < chunker.getSize()) {
+                      return ctx
+                          .call(() -> callAndQueryOnFailure(committedOffset, progressiveBackoff));
+                    }
+                    return Futures.immediateFuture(null);
+                  },
+                  progressiveBackoff),
+          callCredentialsProvider);
 
       return Futures.transformAsync(
           callFuture,
@@ -397,18 +386,6 @@ class ByteStreamUploader extends AbstractReferenceCounted {
           .withInterceptors(TracingMetadataUtils.attachMetadataFromContextInterceptor())
           .withCallCredentials(callCredentialsProvider.getCallCredentials())
           .withDeadlineAfter(callTimeoutSecs, SECONDS);
-    }
-
-    private ListenableFuture<Void> callAndQueryOnFailureWithRetrier(
-        Context ctx, AtomicLong committedOffset, ProgressiveBackoff progressiveBackoff) {
-      return retrier.executeAsync(
-          () -> {
-            if (committedOffset.get() < chunker.getSize()) {
-              return ctx.call(() -> callAndQueryOnFailure(committedOffset, progressiveBackoff));
-            }
-            return Futures.immediateFuture(null);
-          },
-          progressiveBackoff);
     }
 
     private ListenableFuture<Void> callAndQueryOnFailure(

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -42,6 +42,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ProgressiveBackoff;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
@@ -53,7 +54,6 @@ import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.protobuf.ByteString;
-import io.grpc.CallCredentials;
 import io.grpc.Context;
 import io.grpc.Status;
 import io.grpc.Status.Code;
@@ -72,7 +72,7 @@ import javax.annotation.Nullable;
 /** A RemoteActionCache implementation that uses gRPC calls to a remote cache server. */
 @ThreadSafe
 public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder {
-  private final CallCredentials credentials;
+  private final CallCredentialsProvider callCredentialsProvider;
   private final ReferenceCountedChannel channel;
   private final RemoteOptions options;
   private final DigestUtil digestUtil;
@@ -85,12 +85,12 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
   @VisibleForTesting
   public GrpcCacheClient(
       ReferenceCountedChannel channel,
-      CallCredentials credentials,
+      CallCredentialsProvider callCredentialsProvider,
       RemoteOptions options,
       RemoteRetrier retrier,
       DigestUtil digestUtil,
       ByteStreamUploader uploader) {
-    this.credentials = credentials;
+    this.callCredentialsProvider = callCredentialsProvider;
     this.channel = channel;
     this.options = options;
     this.digestUtil = digestUtil;
@@ -121,28 +121,28 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
   private ContentAddressableStorageFutureStub casFutureStub() {
     return ContentAddressableStorageGrpc.newFutureStub(channel)
         .withInterceptors(TracingMetadataUtils.attachMetadataFromContextInterceptor())
-        .withCallCredentials(credentials)
+        .withCallCredentials(callCredentialsProvider.getCallCredentials())
         .withDeadlineAfter(options.remoteTimeout.getSeconds(), TimeUnit.SECONDS);
   }
 
   private ByteStreamStub bsAsyncStub() {
     return ByteStreamGrpc.newStub(channel)
         .withInterceptors(TracingMetadataUtils.attachMetadataFromContextInterceptor())
-        .withCallCredentials(credentials)
+        .withCallCredentials(callCredentialsProvider.getCallCredentials())
         .withDeadlineAfter(options.remoteTimeout.getSeconds(), TimeUnit.SECONDS);
   }
 
   private ActionCacheBlockingStub acBlockingStub() {
     return ActionCacheGrpc.newBlockingStub(channel)
         .withInterceptors(TracingMetadataUtils.attachMetadataFromContextInterceptor())
-        .withCallCredentials(credentials)
+        .withCallCredentials(callCredentialsProvider.getCallCredentials())
         .withDeadlineAfter(options.remoteTimeout.getSeconds(), TimeUnit.SECONDS);
   }
 
   private ActionCacheFutureStub acFutureStub() {
     return ActionCacheGrpc.newFutureStub(channel)
         .withInterceptors(TracingMetadataUtils.attachMetadataFromContextInterceptor())
-        .withCallCredentials(credentials)
+        .withCallCredentials(callCredentialsProvider.getCallCredentials())
         .withDeadlineAfter(options.remoteTimeout.getSeconds(), TimeUnit.SECONDS);
   }
 
@@ -216,7 +216,9 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
   private ListenableFuture<FindMissingBlobsResponse> getMissingDigests(
       FindMissingBlobsRequest request) {
     Context ctx = Context.current();
-    return retrier.executeAsync(() -> ctx.call(() -> casFutureStub().findMissingBlobs(request)));
+    return Utils.refreshIfUnauthenticatedAsync(
+        () -> retrier.executeAsync(() -> ctx.call(() -> casFutureStub().findMissingBlobs(request))),
+        callCredentialsProvider);
   }
 
   private ListenableFuture<ActionResult> handleStatus(ListenableFuture<ActionResult> download) {
@@ -242,15 +244,16 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
             .setInlineStdout(inlineOutErr)
             .build();
     Context ctx = Context.current();
-    return retrier.executeAsync(
-        () -> ctx.call(() -> handleStatus(acFutureStub().getActionResult(request))));
+    return Utils.refreshIfUnauthenticatedAsync(() -> retrier.executeAsync(
+        () -> ctx.call(() -> handleStatus(acFutureStub().getActionResult(request)))),
+        callCredentialsProvider);
   }
 
   @Override
   public void uploadActionResult(ActionKey actionKey, ActionResult actionResult)
       throws IOException, InterruptedException {
     try {
-      retrier.execute(
+      Utils.refreshIfUnauthenticated(() -> retrier.execute(
           () ->
               acBlockingStub()
                   .updateActionResult(
@@ -258,7 +261,7 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
                           .setInstanceName(options.remoteInstanceName)
                           .setActionDigest(actionKey.getDigest())
                           .setActionResult(actionResult)
-                          .build()));
+                          .build())), callCredentialsProvider);
     } catch (StatusRuntimeException e) {
       throw new IOException(e);
     }
@@ -287,11 +290,13 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
     Context ctx = Context.current();
     AtomicLong offset = new AtomicLong(0);
     ProgressiveBackoff progressiveBackoff = new ProgressiveBackoff(retrier::newBackoff);
-    return Futures.catchingAsync(
-        retrier.executeAsync(
-            () ->
+    ListenableFuture<Void> downloadFuture = Utils
+        .refreshIfUnauthenticatedAsync(() -> retrier.executeAsync(() ->
                 ctx.call(() -> requestRead(offset, progressiveBackoff, digest, out, hashSupplier)),
-            progressiveBackoff),
+            progressiveBackoff), callCredentialsProvider);
+
+    return Futures.catchingAsync(
+        downloadFuture,
         StatusRuntimeException.class,
         (e) -> Futures.immediateFailedFuture(new IOException(e)),
         MoreExecutors.directExecutor());

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -473,7 +473,7 @@ public final class RemoteModule extends BlazeModule {
     RemoteCacheClient cacheClient =
         new GrpcCacheClient(
             cacheChannel.retain(),
-            credentials,
+            callCredentialsProvider,
             remoteOptions,
             retrier,
             digestUtil,
@@ -500,7 +500,8 @@ public final class RemoteModule extends BlazeModule {
               retryScheduler,
               Retrier.ALLOW_ALL_CALLS);
       GrpcRemoteExecutor remoteExecutor =
-          new GrpcRemoteExecutor(execChannel.retain(), credentials, execRetrier, remoteOptions);
+          new GrpcRemoteExecutor(execChannel.retain(), callCredentialsProvider, execRetrier,
+              remoteOptions);
       execChannel.release();
       RemoteExecutionCache remoteCache =
           new RemoteExecutionCache(cacheClient, remoteOptions, digestUtil);

--- a/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/BUILD
@@ -19,6 +19,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/analysis:blaze_version_info",
+        "//src/main/java/com/google/devtools/build/lib/authandtls",
         "//src/main/java/com/google/devtools/build/lib/concurrent",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
         "//src/main/java/com/google/devtools/build/lib/remote/options",

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -201,6 +201,10 @@ public class Utils {
     }
   }
 
+  /**
+   *  Call an asynchronous code block. If the block throws unauthenticated error, refresh the
+   *  credentials using {@link CallCredentialsProvider} and call it again.
+   */
   public static <V> ListenableFuture<V> refreshIfUnauthenticatedAsync(
       AsyncCallable<V> call, CallCredentialsProvider callCredentialsProvider) {
     try {
@@ -229,6 +233,9 @@ public class Utils {
     }
   }
 
+  /**
+   * Same as {@link #refreshIfUnauthenticatedAsync} but calling a synchronous code block.
+   */
   public static <V> V refreshIfUnauthenticated(Callable<V> call,
       CallCredentialsProvider callCredentialsProvider) throws IOException, InterruptedException {
     try {

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -236,7 +236,7 @@ public class GrpcCacheClientTest {
             remoteOptions.remoteTimeout.getSeconds(),
             retrier);
     return new GrpcCacheClient(
-        channel.retain(), creds, remoteOptions, retrier, DIGEST_UTIL, uploader);
+        channel.retain(), callCredentialsProvider, remoteOptions, retrier, DIGEST_UTIL, uploader);
   }
 
   private static byte[] downloadBlob(GrpcCacheClient cacheClient, Digest digest)

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutionClientTest.java
@@ -259,10 +259,10 @@ public class GrpcRemoteExecutionClientTest {
                 .directExecutor()
                 .build());
     GrpcRemoteExecutor executor =
-        new GrpcRemoteExecutor(channel.retain(), null, retrier, remoteOptions);
+        new GrpcRemoteExecutor(channel.retain(), CallCredentialsProvider.NO_CREDENTIALS, retrier,
+            remoteOptions);
     CallCredentialsProvider callCredentialsProvider =
         GoogleAuthUtils.newCallCredentialsProvider(Options.getDefaults(AuthAndTLSOptions.class));
-    CallCredentials creds = callCredentialsProvider.getCallCredentials();
     ByteStreamUploader uploader =
         new ByteStreamUploader(
             remoteOptions.remoteInstanceName,
@@ -271,7 +271,8 @@ public class GrpcRemoteExecutionClientTest {
             remoteOptions.remoteTimeout.getSeconds(),
             retrier);
     GrpcCacheClient cacheProtocol =
-        new GrpcCacheClient(channel.retain(), creds, remoteOptions, retrier, DIGEST_UTIL, uploader);
+        new GrpcCacheClient(channel.retain(), callCredentialsProvider, remoteOptions, retrier,
+            DIGEST_UTIL, uploader);
     RemoteExecutionCache remoteCache =
         new RemoteExecutionCache(cacheProtocol, remoteOptions, DIGEST_UTIL);
     client =


### PR DESCRIPTION
Follow up on #12106, this PR make changes to `GrpcCacheClient` and `GrpcRemoteExecutor` to use `CallCredentialsProvider` and refresh credentials when needed to avoid unauthenticated error during a long remote build.