### PR TITLE
Fix formatting of output C++ toolchain for macOS.

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -157,15 +157,15 @@ def configure_osx_toolchain(repository_ctx, overriden_tools):
         write_builtin_include_directory_paths(repository_ctx, cc, escaped_include_paths)
         escaped_cxx_include_directories = []
         for path in escaped_include_paths:
-            escaped_cxx_include_directories.append(("        \"%s\"," % path))
+            escaped_cxx_include_directories.append(("            \"%s\"," % path))
         if xcodeloc_err:
-            escaped_cxx_include_directories.append("# Error: " + xcodeloc_err + "\n")
+            escaped_cxx_include_directories.append("            # Error: " + xcodeloc_err)
         repository_ctx.template(
             "BUILD",
             paths["@bazel_tools//tools/osx/crosstool:BUILD.tpl"],
             {
                 "%{cxx_builtin_include_directories}": "\n".join(escaped_cxx_include_directories),
-                "%{tool_paths_overrides}": ",\n        ".join(
+                "%{tool_paths_overrides}": ",\n            ".join(
                     ['"%s": "%s"' % (k, v) for k, v in tool_paths.items()],
                 ),
             },

--- a/tools/osx/crosstool/BUILD.tpl
+++ b/tools/osx/crosstool/BUILD.tpl
@@ -87,7 +87,9 @@ cc_toolchain_suite(
         name = (arch if arch != "armeabi-v7a" else "stub_armeabi-v7a"),
         compiler = "compiler",
         cpu = arch,
-        cxx_builtin_include_directories = [%{cxx_builtin_include_directories}],
+        cxx_builtin_include_directories = [
+%{cxx_builtin_include_directories}
+        ],
         tool_paths_overrides = {%{tool_paths_overrides}},
     )
     for arch in OSX_TOOLS_ARCHS


### PR DESCRIPTION
Previously the generated `external/local_config_cc/BUILD` was a bit off,
which triggerred buildifier when trying to reuse it for a custom
CROSSTOOL.

Before:

```starlark
[
    cc_toolchain_config(
        name = (arch if arch != "armeabi-v7a" else "stub_armeabi-v7a"),
        compiler = "compiler",
        cpu = arch,
        cxx_builtin_include_directories = [        "/Applications/Xcode-11.7.0.app/Contents/Developer",
        "/Applications/Xcode-12.0.0.app/Contents/Developer",
        "/Applications/",],
        tool_paths_overrides = {},
    )
    for arch in OSX_TOOLS_ARCHS
]
```

After:

```starlark
[
    cc_toolchain_config(
        name = (arch if arch != "armeabi-v7a" else "stub_armeabi-v7a"),
        compiler = "compiler",
        cpu = arch,
        cxx_builtin_include_directories = [
            "/Applications/Xcode-11.7.0.app/Contents/Developer",
            "/Applications/Xcode-12.0.0.app/Contents/Developer",
            "/Applications/",
        ],
        tool_paths_overrides = {},
    )
    for arch in OSX_TOOLS_ARCHS
]
```

Tested by running `bazel sync --configure` and checking the contents of
`external/local_config_cc/BUILD`.
