### PR TITLE
update function_transition allowlisting tests to use the new list path

### DIFF
--- a/src/test/shell/bazel/allowlist_test.sh
+++ b/src/test/shell/bazel/allowlist_test.sh
@@ -61,7 +61,7 @@ rule_with_transition = rule(
     implementation = _rule_with_transition_impl,
     attrs = {
         "dep": attr.label(cfg = my_transition),
-        "_whitelist_function_transition": attr.label(default = "@bazel_tools//tools/whitelists/function_transition_whitelist"),
+        "_allowlist_function_transition": attr.label(default = "@bazel_tools//tools/allowlists/function_transition_allowlist"),
     }
 )
 EOF
@@ -130,7 +130,7 @@ rule_with_transition = rule(
     implementation = _rule_with_transition_impl,
     cfg = my_transition,
     attrs = {
-        "_whitelist_function_transition": attr.label(default = "@bazel_tools//tools/whitelists/bad"),
+        "_allowlist_function_transition": attr.label(default = "@bazel_tools//tools/allowlists/bad"),
     }
 )
 EOF
@@ -143,7 +143,7 @@ EOF
 
   bazel build //vinegar --experimental_starlark_config_transitions \
     >& $TEST_log && fail "Expected failure"
-  expect_log "_allowlist_function_transition attribute (@bazel_tools//tools/whitelists/bad:bad)"
+  expect_log "_allowlist_function_transition attribute (@bazel_tools//tools/allowlists/bad:bad)"
   expect_log "does not have the expected value //tools/allowlists/function_transition_allowlist:function_transition_allowlist"
 }
 
@@ -159,17 +159,17 @@ EOF
 #
 # The allowlist for starlark transitions is set to a package group of "//..."
 function test_allowlist_own_rep() {
-  mkdir -p tools/whitelists/function_transition_whitelist
-  cat > tools/whitelists/function_transition_whitelist/BUILD <<EOF
+  mkdir -p tools/allowlists/function_transition_allowlist
+  cat > tools/allowlists/function_transition_allowlist/BUILD <<EOF
 package_group(
-    name = "function_transition_whitelist",
+    name = "function_transition_allowlist",
     packages = ["//vinegar/..."],
 )
 
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
-    visibility = ["//tools/whitelists:__pkg__"],
+    visibility = ["//tools/allowlists:__pkg__"],
 )
 EOF
 
@@ -189,7 +189,7 @@ rule_with_transition = rule(
     implementation = _rule_with_transition_impl,
     attrs = {
         "dep" : attr.label(cfg = my_transition),
-        "_whitelist_function_transition": attr.label(default = "@//tools/whitelists/function_transition_whitelist"),
+        "_allowlist_function_transition": attr.label(default = "@//tools/allowlists/function_transition_allowlist"),
     }
 )
 EOF

--- a/src/test/shell/bazel/platform_mapping_test.sh
+++ b/src/test/shell/bazel/platform_mapping_test.sh
@@ -203,8 +203,8 @@ my_rule = rule(
   implementation = _my_rule_impl,
   attrs = {
       "deps": attr.label_list(cfg = my_transition),
-      "_whitelist_function_transition": attr.label(
-          default = "@//tools/whitelists/function_transition_whitelist"),
+      "_allowlist_function_transition": attr.label(
+          default = "@//tools/allowlists/function_transition_allowlist"),
   }
 )
 EOF
@@ -276,8 +276,8 @@ transitioning_rule = rule(
   implementation = _transitioning_rule_impl,
   attrs = {
       "deps": attr.label_list(cfg = my_transition),
-      "_whitelist_function_transition": attr.label(
-          default = "@//tools/whitelists/function_transition_whitelist"),
+      "_allowlist_function_transition": attr.label(
+          default = "@//tools/allowlists/function_transition_allowlist"),
   }
 )
 

--- a/src/test/shell/integration/cpp_test.sh
+++ b/src/test/shell/integration/cpp_test.sh
@@ -320,7 +320,7 @@ outer = rule(
                 "${TOOLS_REPOSITORY}//tools/cpp:current_cc_toolchain",
             ),
         ),
-        "_whitelist_function_transition": attr.label(default = "${TOOLS_REPOSITORY}//tools/whitelists/function_transition_whitelist"),
+        "_allowlist_function_transition": attr.label(default = "${TOOLS_REPOSITORY}//tools/allowlists/function_transition_allowlist"),
     },
 )
 

--- a/src/test/shell/integration/starlark_configurations_test.sh
+++ b/src/test/shell/integration/starlark_configurations_test.sh
@@ -446,11 +446,11 @@ function test_output_same_config_as_generating_target() {
   local -r pkg=$FUNCNAME
   mkdir -p $pkg
 
-  rm -rf tools/whitelists/function_transition_whitelist
-  mkdir -p tools/whitelists/function_transition_whitelist
-  cat > tools/whitelists/function_transition_whitelist/BUILD <<EOF
+  rm -rf tools/allowlists/function_transition_allowlist
+  mkdir -p tools/allowlists/function_transition_allowlist
+  cat > tools/allowlists/function_transition_allowlist/BUILD <<EOF
 package_group(
-    name = "function_transition_whitelist",
+    name = "function_transition_allowlist",
     packages = [
         "//...",
     ],
@@ -479,7 +479,7 @@ rule_class_transition_rule = rule(
     _rule_class_transition_rule_impl,
     cfg = _rule_class_transition,
     attrs = {
-        "_whitelist_function_transition": attr.label(default = "//tools/whitelists/function_transition_whitelist"),
+        "_allowlist_function_transition": attr.label(default = "//tools/allowlists/function_transition_allowlist"),
     },
     outputs = {"artifact": "%{name}.output"},
 )


### PR DESCRIPTION
Update function_transition allowlisting tests to use //tools/allowlists/function_transition_allowlist

Subtle side effect: This stops doing tests against the legacy location. I don't count
this as a problem because
- the feature is not enabled by default for Bazel.
- keeping the test at the legacy location might give us false positives that we are still using it.