### PR TITLE
add --http_mirror to accelerate http downloads on external repositories

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -302,6 +302,10 @@ public class BazelRepositoryModule extends BlazeModule {
         httpDownloader.setTimeoutScaling(1.0f);
       }
 
+      if (repoOptions.httpMirror != null) {
+        httpDownloader.setMirror(repoOptions.httpMirror);
+      }
+
       if (repoOptions.repositoryOverrides != null) {
         // To get the usual latest-wins semantics, we need a mutable map, as the builder
         // of an immutable map does not allow redefining the values of existing keys.

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -27,6 +27,7 @@ import com.google.devtools.common.options.OptionMetadataTag;
 import com.google.devtools.common.options.OptionsBase;
 import com.google.devtools.common.options.OptionsParsingException;
 import java.util.List;
+import java.net.URL;
 
 /**
  * Command-line options for repositories.
@@ -76,6 +77,15 @@ public class RepositoryOptions extends OptionsBase {
       effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
       help = "Scale all timeouts related to http downloads by the given factor")
   public double httpTimeoutScaling;
+
+  @Option(
+      name = "http_mirror",
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+      converter = OptionsUtils.URLConverter.class,
+      help = "Prefix all urls related to http downloads by the given mirror")
+  public URL httpMirror;
 
   @Option(
     name = "override_repository",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java
@@ -154,17 +154,30 @@ public class HttpDownloader implements Downloader {
   public List<URL> getMirroredUrls(List<URL> urls) throws IOException {
     List<URL> mirroredUrls = new ArrayList<>(urls.size());
     for (URL url : urls) {
+      URL mirroredUrl;
+      try {
+        mirroredUrl = urlToMirroredUrl(url);
+      } catch (MalformedURLException e) {
+        throw new IOException("Bad mirrored URL: " + e.getMessage());
+      }
+
+      mirroredUrls.add(mirroredUrl);
+    }
+    return mirroredUrls;
+  }
+
+  public URL urlToMirroredUrl(URL url) throws MalformedURLException {
       String portStr = "";
       if ( url.getPort() != -1 ) {
         portStr = String.format(":%d", url.getPort());
       }
-      String mirroredUrlStr = mirror.toString().replaceAll("/*$","") + "/" + url.getHost() + portStr + "/" + url.getPath().replaceAll("^/*","");
-      try {
-        mirroredUrls.add(new URL(mirroredUrlStr));
-      } catch (MalformedURLException e) {
-        throw new IOException("Bad mirrored URL: " + mirroredUrlStr);
-      }
-    }
-    return mirroredUrls;
+
+      String mirroredUrlStr = mirror.toString().replaceAll("/*$","")
+                              + "/"
+                              + url.getHost() + portStr
+                              + "/"
+                              + url.getPath().replaceAll("^/*","");
+
+      return new URL(mirroredUrlStr);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/util/OptionsUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/util/OptionsUtils.java
@@ -22,6 +22,8 @@ import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.OptionsParsingException;
 import com.google.devtools.common.options.OptionsParsingResult;
 import com.google.devtools.common.options.ParsedOptionDescription;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 
 /** Blaze-specific option utilities. */
@@ -156,5 +158,27 @@ public final class OptionsUtils {
       path = path.replace("~", StandardSystemProperty.USER_HOME.value());
     }
     return PathFragment.create(path);
+  }
+
+  /** Converter from String to URL. If the input is empty returns {@code null} instead. */
+  public static class URLConverter implements Converter<URL> {
+
+    @Override
+    public URL convert(String input) throws OptionsParsingException {
+      if (input.isEmpty()) {
+        return null;
+      }
+
+      try {
+        return new URL(input);
+      } catch (MalformedURLException e) {
+        throw new OptionsParsingException("Expected url but got '" + input + "'.");
+      }
+    }
+
+    @Override
+    public String getTypeDescription() {
+      return "a url";
+    }
   }
 }


### PR DESCRIPTION
Every time we build our projects by Bazel from a clean environment(ci for example), it will cost a lot of time to download the external artifacts(sometimes it even breaks because of network jitters). So I think it will be better for Bazel to support something like the [GOPROXY](https://proxy.golang.org/) so that we can maintain our own mirrored external artifacts and speed up the building process.

According to @philwo's great advice, it is better to use repository options to implement it.

Thank you for your help, @philwo, PTAL:)