### PR TITLE
Add symlink_outputs support to Bazel/Ninja executor

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraph.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraph.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.bazel.rules.ninja.actions;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -53,7 +52,6 @@ import com.google.devtools.build.skyframe.SkyFunction.Environment;
 import com.google.devtools.build.skyframe.SkyKey;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
@@ -87,8 +85,6 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
         PathFragment.create(ruleContext.attributes().get("working_directory", Type.STRING));
     List<String> outputRootInputs =
         ruleContext.attributes().get("output_root_inputs", Type.STRING_LIST);
-    List<String> outputRootSymlinks =
-        ruleContext.attributes().get("output_root_symlinks", Type.STRING_LIST);
 
     Environment env = ruleContext.getAnalysisEnvironment().getSkyframeEnv();
     establishDependencyOnNinjaFiles(env, mainArtifact, ninjaSrcs);
@@ -126,18 +122,13 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
                   childNinjaFiles,
                   ownerTargetName)
               .pipeline(mainArtifact.getPath());
-      targetsPreparer.process(ninjaTargets);
+      targetsPreparer.prepareTargets(ninjaTargets);
 
       NestedSet<Artifact> outputRootInputsSymlinks =
           createSymlinkActions(ruleContext, sourceRoot, outputRootInputs, artifactsHelper);
       if (ruleContext.hasErrors()) {
         return null;
       }
-
-      ImmutableSortedSet<PathFragment> outputRootSymlinksPathFragments =
-          outputRootSymlinks.stream()
-              .map(PathFragment::create)
-              .collect(toImmutableSortedSet(Comparator.comparing(PathFragment::getPathString)));
 
       ImmutableSet<PathFragment> outputRootInputsSymlinksPathFragments =
           outputRootInputsSymlinks.toList().stream()
@@ -150,7 +141,7 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
               workingDirectory,
               targetsPreparer.getTargetsMap(),
               targetsPreparer.getPhonyTargetsMap(),
-              outputRootSymlinksPathFragments,
+              targetsPreparer.getSymlinkOutputs(),
               outputRootInputsSymlinksPathFragments);
 
       return new RuleConfiguredTargetBuilder(ruleContext)
@@ -209,6 +200,7 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
   private static class TargetsPreparer {
     private ImmutableSortedMap<PathFragment, NinjaTarget> targetsMap;
     private ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap;
+    private ImmutableSet<PathFragment> symlinkOutputs;
 
     public ImmutableSortedMap<PathFragment, NinjaTarget> getTargetsMap() {
       return targetsMap;
@@ -218,20 +210,41 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
       return phonyTargetsMap;
     }
 
-    void process(List<NinjaTarget> ninjaTargets) throws GenericParsingException {
+    public ImmutableSet<PathFragment> getSymlinkOutputs() {
+      return symlinkOutputs;
+    }
+
+    void prepareTargets(List<NinjaTarget> ninjaTargets) throws GenericParsingException {
       ImmutableSortedMap.Builder<PathFragment, NinjaTarget> targetsMapBuilder =
           ImmutableSortedMap.naturalOrder();
       ImmutableSortedMap.Builder<PathFragment, NinjaTarget> phonyTargetsBuilder =
           ImmutableSortedMap.naturalOrder();
-      separatePhonyTargets(ninjaTargets, targetsMapBuilder, phonyTargetsBuilder);
+      ImmutableSet.Builder<PathFragment> symlinkOutputsBuilder = ImmutableSet.builder();
+      categorizeTargetsAndOutputs(
+          ninjaTargets,
+          targetsMapBuilder,
+          phonyTargetsBuilder,
+          symlinkOutputsBuilder);
       targetsMap = targetsMapBuilder.build();
       phonyTargetsMap = NinjaPhonyTargetsUtil.getPhonyPathsMap(phonyTargetsBuilder.build());
+      symlinkOutputs = symlinkOutputsBuilder.build();
     }
 
-    private static void separatePhonyTargets(
+    /**
+     * Iterate over all parsed Ninja targets into phony and non-phony targets in a single pass,
+     * and run validations along the way. For non-phony targets, also extract the symlink_outputs
+     * for registering symlink artifacts in actions later on, in ninja_build.
+     *
+     * @param ninjaTargets list of all parsed Ninja targets
+     * @param targetsBuilder builder for map of path fragments to the non-phony targets
+     * @param phonyTargetsBuilder builder for map of path fragments to the phony targets
+     * @param symlinkOutputsBuilder builder for set of declared symlink outputs
+     */
+    private static void categorizeTargetsAndOutputs(
         List<NinjaTarget> ninjaTargets,
         ImmutableSortedMap.Builder<PathFragment, NinjaTarget> targetsBuilder,
-        ImmutableSortedMap.Builder<PathFragment, NinjaTarget> phonyTargetsBuilder)
+        ImmutableSortedMap.Builder<PathFragment, NinjaTarget> phonyTargetsBuilder,
+        ImmutableSet.Builder<PathFragment> symlinkOutputsBuilder)
         throws GenericParsingException {
       for (NinjaTarget target : ninjaTargets) {
         if ("phony".equals(target.getRuleName())) {
@@ -250,6 +263,7 @@ public class NinjaGraph implements RuleConfiguredTargetFactory {
           for (PathFragment output : target.getAllOutputs()) {
             targetsBuilder.put(output, target);
           }
+          symlinkOutputsBuilder.addAll(target.getAllSymlinkOutputs());
         }
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphProvider.java
@@ -32,7 +32,7 @@ public final class NinjaGraphProvider implements TransitiveInfoProvider {
   private final PathFragment workingDirectory;
   private final ImmutableSortedMap<PathFragment, NinjaTarget> targetsMap;
   private final ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap;
-  private final ImmutableSortedSet<PathFragment> outputRootSymlinks;
+  private final ImmutableSet<PathFragment> outputRootSymlinks;
   private final ImmutableSet<PathFragment> outputRootInputsSymlinks;
 
   public NinjaGraphProvider(
@@ -40,7 +40,7 @@ public final class NinjaGraphProvider implements TransitiveInfoProvider {
       PathFragment workingDirectory,
       ImmutableSortedMap<PathFragment, NinjaTarget> targetsMap,
       ImmutableSortedMap<PathFragment, PhonyTarget> phonyTargetsMap,
-      ImmutableSortedSet<PathFragment> outputRootSymlinks,
+      ImmutableSet<PathFragment> outputRootSymlinks,
       ImmutableSet<PathFragment> outputRootInputsSymlinks) {
 
     this.outputRoot = outputRoot;
@@ -68,7 +68,7 @@ public final class NinjaGraphProvider implements TransitiveInfoProvider {
   }
 
   /** Output paths under output_root, that should be treated as symlink artifacts. */
-  public ImmutableSortedSet<PathFragment> getOutputRootSymlinks() {
+  public ImmutableSet<PathFragment> getOutputRootSymlinks() {
     return outputRootSymlinks;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphRule.java
@@ -78,14 +78,6 @@ public class NinjaGraphRule implements RuleDefinition {
                         + " <execroot>/<output_root> will be a separate directory, not a"
                         + " symlink.</p>"))
         .add(
-            attr("output_root_symlinks", STRING_LIST)
-                .value(ImmutableList.of())
-                .setDoc(
-                    "<p>Output paths under output_root, that should be treated as symlink"
-                        + " artifacts.</p><p>In combination with"
-                        + " --experimental_allow_unresolved_symlinks flag, this allows Ninja"
-                        + " actions to create symlinks, not pointing to the existing file.</p>"))
-        .add(
             attr("working_directory", STRING)
                 .value("")
                 .setDoc(

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaRuleVariable.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaRuleVariable.java
@@ -28,6 +28,7 @@ public enum NinjaRuleVariable {
   RESTAT,
   RSPFILE,
   RSPFILE_CONTENT,
+  SYMLINK_OUTPUTS,
   POOL;
 
   public String lowerCaseName() {

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/parser/NinjaTarget.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.collect.ImmutableSortedKeyListMultimap;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.Immutable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -145,10 +146,24 @@ public final class NinjaTarget {
         targetHasDescription = true;
       }
 
+      // symlink_outputs are taken from the "build" statement (instead of the referenced rule)
+      // if it's available.
+      boolean targetHasSymlinkOutputs = false;
+      String symlinkOutputs = targetVariables.get("symlink_outputs");
+      if (symlinkOutputs != null) {
+        builder.put(
+            NinjaRuleVariable.SYMLINK_OUTPUTS, NinjaVariableValue.createPlainText(symlinkOutputs));
+        targetHasSymlinkOutputs = true;
+      }
+
       for (Map.Entry<NinjaRuleVariable, NinjaVariableValue> entry : ruleVariables.entrySet()) {
         NinjaRuleVariable type = entry.getKey();
-        if (type.equals(NinjaRuleVariable.DESCRIPTION) && targetHasDescription) {
-          // Don't use the rule description, as the target defined a specific description.
+
+        // Don't use the rule variable if the same variable is defined in the build statement.
+        if (type == NinjaRuleVariable.DESCRIPTION && targetHasDescription) {
+          continue;
+        }
+        if (type == NinjaRuleVariable.SYMLINK_OUTPUTS && targetHasSymlinkOutputs) {
           continue;
         }
         NinjaVariableValue reducedValue =
@@ -221,6 +236,17 @@ public final class NinjaTarget {
 
   public Collection<PathFragment> getAllOutputs() {
     return outputs.values();
+  }
+
+  public Collection<PathFragment> getAllSymlinkOutputs() {
+    String symlinkOutputs = computeRuleVariables().get(NinjaRuleVariable.SYMLINK_OUTPUTS);
+    if (symlinkOutputs == null) {
+      return ImmutableSet.of();
+    } else {
+      return Arrays.stream(
+          symlinkOutputs.split(" "))
+          .map(PathFragment::create).collect(Collectors.toSet());
+    }
   }
 
   public Collection<PathFragment> getAllInputs() {

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaBuildTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaBuildTest.java
@@ -500,6 +500,7 @@ public class NinjaBuildTest extends BuildViewTestCase {
         "build_config/build.ninja",
         "rule symlink_rule",
         "  command = ln -s fictive-file ${out}",
+        "  symlink_outputs = $out",
         "build dangling_symlink: symlink_rule");
 
     ConfiguredTarget configuredTarget =
@@ -508,8 +509,7 @@ public class NinjaBuildTest extends BuildViewTestCase {
             "ninja_target",
             "ninja_graph(name = 'graph', output_root = 'build_config',",
             " working_directory = 'build_config',",
-            " main = 'build_config/build.ninja',",
-            " output_root_symlinks = ['dangling_symlink'])",
+            " main = 'build_config/build.ninja')",
             "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
             " output_groups= {'main': ['dangling_symlink']})");
     assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
@@ -541,6 +541,7 @@ public class NinjaBuildTest extends BuildViewTestCase {
         "rule cat",
         "  command = cat ${in} > ${out}",
         "build dangling_symlink: symlink_rule",
+        "  symlink_outputs = dangling_symlink",
         "build mybuild: cat dangling_symlink");
 
     ConfiguredTarget configuredTarget =
@@ -549,8 +550,7 @@ public class NinjaBuildTest extends BuildViewTestCase {
             "ninja_target",
             "ninja_graph(name = 'graph', output_root = 'build_config',",
             " working_directory = 'build_config',",
-            " main = 'build_config/build.ninja',",
-            " output_root_symlinks = ['dangling_symlink'])",
+            " main = 'build_config/build.ninja')",
             "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
             " output_groups= {'main': ['mybuild']})");
     assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);


### PR DESCRIPTION
Add support for symlink_outputs to Bazel, and delete output_root_symlinks attribute from ninja_graph.

The internal wiring to create Symlink SpecialArtifacts didn't really change much -- instead of receiving the hardcoded list from output_root_symlinks, it now receives the list of PathFragments from the parser.