### PR TITLE
Fix broken docs build due to non-ASCII character

### DIFF
--- a/site/_sass/be.scss
+++ b/site/_sass/be.scss
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 // Build Encyclopedia and Starlark Library
 
 pre.rule-signature {


### PR DESCRIPTION
Seen in GCB:

```
Step #2:   Conversion error: Jekyll::Converters::Scss encountered an error while converting 'css/main.scss':
Step #2:                     Invalid US-ASCII character "\xC2" on line 68
Step #2: jekyll 3.8.7 | Error:  Invalid US-ASCII character "\xC2" on line 68
```

This should fix it.