### PR TITLE
Improve toolchain resolution debug

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionFunction.java
@@ -161,7 +161,7 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
 
         debugMessage(
             eventHandler,
-            "  Type %s: target %s: execution %s: Selected toolchain %s",
+            "  Type %s: target platform %s: execution %s: Selected toolchain %s",
             toolchainTypeLabel,
             targetPlatform.label(),
             executionPlatformKey.getLabel(),
@@ -174,7 +174,7 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
 
     ImmutableMap<ConfiguredTargetKey, Label> resolvedToolchainLabels = builder.build();
     if (toolchainType == null || resolvedToolchainLabels.isEmpty()) {
-      debugMessage(eventHandler, "  Type %s: target %s: No toolchains found.", toolchainTypeLabel,
+      debugMessage(eventHandler, "  Type %s: target platform %s: No toolchains found.", toolchainTypeLabel,
           targetPlatform.label());
       throw new ToolchainResolutionFunctionException(
           new NoToolchainFoundException(toolchainTypeLabel));
@@ -206,7 +206,8 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
       ConstraintCollection toolchainConstraints,
       String platformType,
       PlatformInfo platform,
-      Label toolchainTypeLabel, Label toolchainLabel) {
+      Label toolchainTypeLabel,
+      Label toolchainLabel) {
 
     // Check every constraint_setting in either the toolchain or the platform.
     ImmutableSet<ConstraintSettingInfo> mismatchSettings =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunction.java
@@ -133,7 +133,8 @@ public class ToolchainResolutionFunction implements SkyFunction {
             .handle(
                 Event.info(
                     String.format(
-                        "ToolchainResolution: Selected execution platform %s, %s",
+                        "ToolchainResolution: Target %s: Selected execution platform %s, %s",
+                        unloadedToolchainContext.targetPlatform().label(),
                         unloadedToolchainContext.executionPlatform().label(), selectedToolchains)));
       }
       return unloadedToolchainContext;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunction.java
@@ -133,7 +133,7 @@ public class ToolchainResolutionFunction implements SkyFunction {
             .handle(
                 Event.info(
                     String.format(
-                        "ToolchainResolution: Target %s: Selected execution platform %s, %s",
+                        "ToolchainResolution: Target platform %s: Selected execution platform %s, %s",
                         unloadedToolchainContext.targetPlatform().label(),
                         unloadedToolchainContext.executionPlatform().label(), selectedToolchains)));
       }

--- a/src/test/shell/bazel/toolchain_test.sh
+++ b/src/test/shell/bazel/toolchain_test.sh
@@ -533,8 +533,8 @@ EOF
     --toolchain_resolution_debug \
     --incompatible_auto_configure_host_platform \
     //demo:use &> $TEST_log || fail "Build failed"
-  expect_log 'ToolchainResolution:   Type //toolchain:test_toolchain: target @local_config_platform//.*: execution @local_config_platform//:host: Selected toolchain //:test_toolchain_impl_1'
-  expect_log 'ToolchainResolution: Target @local_config_platform//.*: Selected execution platform @local_config_platform//:host, type //toolchain:test_toolchain -> toolchain //:test_toolchain_impl_1'
+  expect_log 'ToolchainResolution:   Type //toolchain:test_toolchain: target platform @local_config_platform//.*: execution @local_config_platform//:host: Selected toolchain //:test_toolchain_impl_1'
+  expect_log 'ToolchainResolution: Target platform @local_config_platform//.*: Selected execution platform @local_config_platform//:host, type //toolchain:test_toolchain -> toolchain //:test_toolchain_impl_1'
   expect_log 'Using toolchain: rule message: "this is the rule", toolchain extra_str: "foo from test_toolchain"'
 }
 

--- a/src/test/shell/bazel/toolchain_test.sh
+++ b/src/test/shell/bazel/toolchain_test.sh
@@ -533,9 +533,8 @@ EOF
     --toolchain_resolution_debug \
     --incompatible_auto_configure_host_platform \
     //demo:use &> $TEST_log || fail "Build failed"
-  expect_log 'ToolchainResolution: Looking for toolchain of type //toolchain:test_toolchain'
-  expect_log 'ToolchainResolution:   For toolchain type //toolchain:test_toolchain, possible execution platforms and toolchains: {@local_config_platform//:host -> //:test_toolchain_impl_1}'
-  expect_log 'ToolchainResolution: Selected execution platform @local_config_platform//:host, type //toolchain:test_toolchain -> toolchain //:test_toolchain_impl_1'
+  expect_log 'ToolchainResolution:   Type //toolchain:test_toolchain: target @local_config_platform//.*: execution @local_config_platform//:host: Selected toolchain //:test_toolchain_impl_1'
+  expect_log 'ToolchainResolution: Target @local_config_platform//.*: Selected execution platform @local_config_platform//:host, type //toolchain:test_toolchain -> toolchain //:test_toolchain_impl_1'
   expect_log 'Using toolchain: rule message: "this is the rule", toolchain extra_str: "foo from test_toolchain"'
 }
 
@@ -914,7 +913,7 @@ EOF
     --extra_execution_platforms=//platform:test_platform \
     --toolchain_resolution_debug \
     //demo:target &> $TEST_log || fail "Build failed"
-  expect_log "ToolchainResolution: Selected execution platform //platform:test_platform"
+  expect_log "Selected execution platform //platform:test_platform"
 }
 
 


### PR DESCRIPTION
When multiple toolchain types are resolved, skyframe functions run in parallel and the debug output is often hard to follow. Adding type of toolchain to each message makes it possible to analyse the results better.

Also after a execution transition, target changes. Added target label to the message, to be able to tell for which target toolchain was selected.

Removing initial messages "Looking for toolchain of type...", "Considering toolchain...". With additional fields displayed they become obsolete.

Condensing 'rejection explanation', i.e. which values are mismatched, into a single line.

#7713, b/126375095: there is still some duplications in ToolchainResolutionFunction:125, which I didn't remove because some tests depend on it (when specifying extra_toolchains)

b/117279695 is fixed with this