### PR TITLE
Use git protocol v2 for shallow git_repository fetches

### DIFF
--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -173,7 +173,7 @@ def _git_maybe_shallow(ctx, git_repo, command, *args):
     start = ["git", command]
     args_list = list(args)
     if git_repo.shallow:
-        st = _execute(ctx, git_repo, start + [git_repo.shallow] + args_list)
+        st = _execute(ctx, git_repo, ["git", "-c", "protocol.version=2", command, git_repo.shallow] + args_list)
         if st.return_code == 0:
             return st
     return _execute(ctx, git_repo, start + args_list)


### PR DESCRIPTION
Without this, the git fetch was failing for me. I believe git operations run with protocol v2 should work seamlessly with other git operations, but I'm not an expert. v2 is the default in git 2.26+, but e.g. MacOS isn't there yet. The global config analogy would be `git config --global protocol.version 2`.