### PR TITLE
Add Java constraint settings.

### DIFF
--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -443,6 +443,7 @@ filegroup(
         "proguard_whitelister_test_input.pgcfg",
         "remote_java_tools_aliases.bzl",
         "toolchain_utils.bzl",
+        "//tools/jdk/constraints:srcs",
     ],
 )
 

--- a/tools/jdk/constraints/BUILD
+++ b/tools/jdk/constraints/BUILD
@@ -1,0 +1,116 @@
+# Standard constraint_settings and constraint_values for Java.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+filegroup(
+    name = "srcs",
+    srcs = ["BUILD"],
+)
+
+constraint_setting(name = "runtime")
+
+constraint_value(
+    name = "jdk8",
+    constraint_setting = ":runtime",
+)
+
+constraint_value(
+    name = "jdk9",
+    constraint_setting = ":runtime",
+)
+
+constraint_value(
+    name = "jdk10",
+    constraint_setting = ":runtime",
+)
+
+constraint_value(
+    name = "jdk11",
+    constraint_setting = ":runtime",
+)
+
+constraint_value(
+    name = "jdk12",
+    constraint_setting = ":runtime",
+)
+
+constraint_value(
+    name = "jdk13",
+    constraint_setting = ":runtime",
+)
+
+constraint_value(
+    name = "jdk14",
+    constraint_setting = ":runtime",
+)
+
+constraint_value(
+    name = "jdk15",
+    constraint_setting = ":runtime",
+)
+
+constraint_setting(name = "language")
+
+constraint_value(
+    name = "java7",
+    constraint_setting = ":language",
+)
+
+constraint_value(
+    name = "java8",
+    constraint_setting = ":language",
+)
+
+constraint_value(
+    name = "java9",
+    constraint_setting = ":language",
+)
+
+constraint_value(
+    name = "java10",
+    constraint_setting = ":language",
+)
+
+constraint_value(
+    name = "java11",
+    constraint_setting = ":language",
+)
+
+constraint_value(
+    name = "java12",
+    constraint_setting = ":language",
+)
+
+constraint_value(
+    name = "java13",
+    constraint_setting = ":language",
+)
+
+constraint_value(
+    name = "java14",
+    constraint_setting = ":language",
+)
+
+constraint_value(
+    name = "java15",
+    constraint_setting = ":language",
+)
+
+constraint_setting(name = "location")
+
+constraint_value(
+    name = "local",
+    constraint_setting = ":location",
+)
+
+constraint_value(
+    name = "absolute",
+    constraint_setting = ":location",
+)
+
+constraint_value(
+    name = "remote",
+    constraint_setting = ":location",
+)

--- a/tools/jdk/constraints/BUILD
+++ b/tools/jdk/constraints/BUILD
@@ -51,53 +51,6 @@ constraint_value(
     constraint_setting = ":runtime",
 )
 
-constraint_setting(name = "language")
-
-constraint_value(
-    name = "java7",
-    constraint_setting = ":language",
-)
-
-constraint_value(
-    name = "java8",
-    constraint_setting = ":language",
-)
-
-constraint_value(
-    name = "java9",
-    constraint_setting = ":language",
-)
-
-constraint_value(
-    name = "java10",
-    constraint_setting = ":language",
-)
-
-constraint_value(
-    name = "java11",
-    constraint_setting = ":language",
-)
-
-constraint_value(
-    name = "java12",
-    constraint_setting = ":language",
-)
-
-constraint_value(
-    name = "java13",
-    constraint_setting = ":language",
-)
-
-constraint_value(
-    name = "java14",
-    constraint_setting = ":language",
-)
-
-constraint_value(
-    name = "java15",
-    constraint_setting = ":language",
-)
-
 constraint_setting(name = "location")
 
 constraint_value(

--- a/tools/jdk/java_toolchain_alias.bzl
+++ b/tools/jdk/java_toolchain_alias.bzl
@@ -67,7 +67,7 @@ java_host_runtime_alias = rule(
                 java_common.JavaRuntimeInfo,
                 platform_common.TemplateVariableInfo,
             ],
-            cfg = "host",
+            cfg = "exec",
         ),
     },
 )


### PR DESCRIPTION
The constraint setting are copied from rules_java, with added new versions of JDKs and added constraint for JDK location (local, absolute, remote) - with which we can 'tag' the toolchains more precisely - i.e. allowing the user to select arbitrary java toolchain that is defined by default.

Duplication of constraints with rules_java is generally not a good idea. However the rules_java has been last updated in bazel at commit https://github.com/bazelbuild/rules_java/commit/7cf3cefd652008d0a64a419c34c13bdca6c8f178.

Comparison https://github.com/bazelbuild/rules_java/compare/7cf3cefd652008d0a64a419c34c13bdca6c8f178...HEAD
shows that since then dependency to bazel_federation was added, and also references to remote_java releases (which are stale). At this point of time release of rules_java would potentially cause more problems than duplication of those constraints (which are not yet used in Bazel).