### PR TITLE
Add undeclared ninja file path in exception message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/pipeline/NinjaPipelineImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/pipeline/NinjaPipelineImpl.java
@@ -175,8 +175,8 @@ public class NinjaPipelineImpl implements NinjaPipeline {
     if (!this.includedOrSubninjaFiles.contains(childPath)) {
       throw new GenericParsingException(
           String.format(
-              "Ninja file requested from '%s' " + "not declared in 'srcs' attribute of '%s'.",
-              parentNinjaFileName, this.ownerTargetName));
+              "Ninja file '%s' requested from '%s' not declared in 'ninja_srcs' attribute of '%s'.",
+              rawText, parentNinjaFileName, this.ownerTargetName));
     }
     return childPath;
   }

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaPipelineTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaPipelineTest.java
@@ -228,8 +228,8 @@ public class NinjaPipelineTest {
     assertThat(exception)
         .hasMessageThat()
         .isEqualTo(
-            "Ninja file requested from 'test.ninja' "
-                + "not declared in 'srcs' attribute of 'ninja_target'.");
+            "Ninja file 'subfile.ninja' requested from 'test.ninja' "
+                + "not declared in 'ninja_srcs' attribute of 'ninja_target'.");
   }
 
   @Test


### PR DESCRIPTION
When a ninja file includes another ninja file it's needs to be declared
to the ninja_graph rule, otherwise an exeception is thrown.

This patch adds information of which file were not declared to the
exception error message which could be handy for trouble-shooting.