### PR TITLE
Validate the types of sequence inputs to JavaInfo

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfo.java
@@ -425,8 +425,10 @@ public final class JavaInfo extends NativeInfo implements JavaInfoApi<Artifact> 
     }
 
     private void checkSequenceOfJavaInfo(Sequence<?> seq, String field) throws EvalException {
-      if (seq.stream().anyMatch(v -> !(v instanceof JavaInfo))) {
-        throw Starlark.errorf("Expected 'sequence of JavaInfo' for '%s'", field);
+      for (Object v : seq) {
+        if (!(v instanceof JavaInfo)) {
+          throw Starlark.errorf("Expected 'sequence of JavaInfo' for '%s'", field);
+        }
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfo.java
@@ -424,6 +424,12 @@ public final class JavaInfo extends NativeInfo implements JavaInfoApi<Artifact> 
       super(STARLARK_NAME, JavaInfo.class);
     }
 
+    private void checkSequenceOfJavaInfo(Sequence<?> seq, String field) throws EvalException {
+      if (seq.stream().anyMatch(v -> !(v instanceof JavaInfo))) {
+        throw Starlark.errorf("Expected 'sequence of JavaInfo' for '%s'", field);
+      }
+    }
+
     @Override
     @SuppressWarnings({"unchecked"})
     public JavaInfo javaInfo(
@@ -444,6 +450,9 @@ public final class JavaInfo extends NativeInfo implements JavaInfoApi<Artifact> 
       if (compileJar == null) {
         throw Starlark.errorf("Expected 'File' for 'compile_jar', found 'None'");
       }
+      checkSequenceOfJavaInfo(deps, "deps");
+      checkSequenceOfJavaInfo(runtimeDeps, "runtime_deps");
+      checkSequenceOfJavaInfo(exports, "exports");
       return JavaInfoBuildHelper.getInstance()
           .createJavaInfo(
               outputJar,

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
@@ -1373,6 +1373,35 @@ public class JavaStarlarkApiTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testJavaInfoSequenceParametersTypeChecked() throws Exception {
+    scratch.file("foo/bad_rules.bzl",
+            "def make_file(ctx):",
+            "  f = ctx.actions.declare_file('out')",
+            "  ctx.actions.write(f, 'out')",
+            "  return f",
+            "def _deps_impl(ctx):",
+            "  f = make_file(ctx)",
+            "  return JavaInfo(output_jar=f, compile_jar=f, deps=[f])",
+            "def _runtime_deps_impl(ctx):",
+            "  f = make_file(ctx)",
+            "  return JavaInfo(output_jar=f, compile_jar=f, runtime_deps=[f])",
+            "def _exports_impl(ctx):",
+            "  f = make_file(ctx)",
+            "  return JavaInfo(output_jar=f, compile_jar=f, runtime_deps=[f])",
+            "bad_deps = rule(_deps_impl)",
+            "bad_runtime_deps = rule(_runtime_deps_impl)",
+            "bad_exports = rule(_exports_impl)");
+    scratch.file("foo/BUILD",
+            "load(':bad_rules.bzl', 'bad_deps', 'bad_runtime_deps', 'bad_exports')",
+            "bad_deps(name='bad_deps')",
+            "bad_runtime_deps(name='bad_runtime_deps')",
+            "bad_exports(name='bad_exports')");
+    checkError("//foo:bad_deps", "Expected 'sequence of JavaInfo'");
+    checkError("//foo:bad_runtime_deps", "Expected 'sequence of JavaInfo'");
+    checkError("//foo:bad_exports", "Expected 'sequence of JavaInfo'");
+  }
+
+  @Test
   public void javaInfoSourceJarsExposed() throws Exception {
     scratch.file(
         "foo/extension.bzl",


### PR DESCRIPTION
Starlark does not check the types of generic parameters (e.g.
Sequence<T>), so we must do this manually so as to raise a neater error
message.

Fixes #11457