### PR TITLE
Fix multiplex worker deadlock

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/Worker.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/Worker.java
@@ -155,7 +155,7 @@ class Worker {
         : Optional.empty();
   }
 
-  void putRequest(WorkRequest request) throws IOException {
+  void putRequest(WorkRequest request) throws InterruptedException, IOException {
     workerProtocol.putRequest(request);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkerTest.java
@@ -203,7 +203,7 @@ public final class WorkerTest {
   }
 
   @Test
-  public void testPutRequest_success() throws IOException {
+  public void testPutRequest_success() throws InterruptedException, IOException {
     WorkRequest request = WorkRequest.getDefaultInstance();
 
     TestWorker testWorker = createTestWorker(new byte[0], PROTO);
@@ -227,7 +227,7 @@ public final class WorkerTest {
   }
 
   @Test
-  public void testPutRequest_json_success() throws IOException {
+  public void testPutRequest_json_success() throws InterruptedException, IOException {
     TestWorker testWorker = createTestWorker(new byte[0], JSON);
     testWorker.putRequest(WorkRequest.getDefaultInstance());
 
@@ -245,7 +245,7 @@ public final class WorkerTest {
   }
 
   @Test
-  public void testPutRequest_json_populatedFields_success() throws IOException {
+  public void testPutRequest_json_populatedFields_success() throws InterruptedException, IOException {
     WorkRequest request =
         WorkRequest.newBuilder()
             .addArguments("testRequest")


### PR DESCRIPTION
We often were experiencing deadlocks after terminating or failing a build that uses multiplex workers. Our cause seems to be an interrupted exception being swallowed during [worker.putRequest](https://github.com/bazelbuild/bazel/blob/360265b2664971b42b8e0da451581a9af5890fc4/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java#L452) causing [worker.getResponse](https://github.com/bazelbuild/bazel/blob/360265b2664971b42b8e0da451581a9af5890fc4/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java#L467) to wait indefinitely.

I believe this fixes #10288 but I'm not 100% sure this is the only scenario. The issue is also mentioned at https://docs.bazel.build/versions/2.1.0/multiplex-worker.html in the warning section.