### PR TITLE
Move default_java_toolchain definitions into java_tools repository

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -657,9 +657,12 @@ JAVA_VERSIONS = ("11",)
 [
     genrule(
         name = "java_tools_java" + java_version + "_build_zip",
-        srcs = ["remote_java_tools_java" + java_version + "/BUILD"],
+        srcs = [
+            "remote_java_tools_java" + java_version + "/BUILD",
+            "//tools/jdk:java_toolchain_default.bzl",
+        ],
         outs = ["java_tools_java_" + java_version + "_build.zip"],
-        cmd = "zip -jX $@ $<",
+        cmd = "zip -jX $@ $(SRCS)",
     )
     for java_version in JAVA_VERSIONS
 ]

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -440,6 +440,7 @@ filegroup(
         "default_java_toolchain.bzl",
         "fail_rule.bzl",
         "java_toolchain_alias.bzl",
+        "java_toolchain_default.bzl",
         "jdk.BUILD",
         "local_java_repository.bzl",
         "nosystemjdk/README",

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -55,16 +55,21 @@ toolchain(
 
 java_runtime(name = "dummy_java_runtime")
 
+# Points to toolchain[":runtime_toolchain_type"] (was :legacy_current_java_runtime)
 java_runtime_alias(name = "current_java_runtime")
 
+# Host configuration of ":current_java_runtime"
 java_host_runtime_alias(name = "current_host_java_runtime")
 
+# Points to toolchain[":toolchain_type"] (was :legacy_current_java_toolchain)
 java_toolchain_alias(name = "current_java_toolchain")
 
 # This exists to support the migration to toolchain resolution.
 # TODO(cushon): delete once the migration is complete.
+# Points to --javabase/--host_javabase, defaults ":jdk"/":remote_jdk11"
 legacy_java_runtime_alias(name = "legacy_current_java_runtime")
 
+# Points to --java_toolchain/--host_java_toolchain, defaults ":toolchain"/":remote_toolchain"
 legacy_java_toolchain_alias(name = "legacy_current_java_toolchain")
 
 # Used to set --host_javabase or --javabase to a local JDK without having to define

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -19,7 +19,6 @@ SUPRESSED_WARNINGS = select({
 
 java_toolchain_default(
     name = "toolchain",
-    jacocorunner = ":jacoco_coverage_runner_filegroup",
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
         # G1 collector and having compact strings enabled.
@@ -97,7 +96,6 @@ RELEASES = (8, 9, 10, 11)
 # A toolchain that targets java 11.
 java_toolchain_default(
     name = "toolchain_jdk_11",
-    jacocorunner = ":jacoco_coverage_runner_filegroup",
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
         # G1 collector and having compact strings enabled.
@@ -111,7 +109,6 @@ java_toolchain_default(
 # A toolchain that targets java 14.
 java_toolchain_nojavac(
     name = "toolchain_jdk_14",
-    jacocorunner = ":jacoco_coverage_runner_filegroup",
     source_version = "14",
     target_version = "14",
 )
@@ -119,7 +116,6 @@ java_toolchain_nojavac(
 # A toolchain that targets java 15.
 java_toolchain_nojavac(
     name = "toolchain_jdk_15",
-    jacocorunner = ":jacoco_coverage_runner_filegroup",
     source_version = "15",
     target_version = "15",
 )
@@ -132,7 +128,6 @@ java_toolchain_nojavac(
 java_toolchain_default(
     name = "prebuilt_toolchain",
     ijar = [":ijar_prebuilt_binary"],
-    jacocorunner = ":jacoco_coverage_runner_filegroup",
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
         # G1 collector and having compact strings enabled.

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -97,6 +97,14 @@ java_toolchain_nojavac(
     target_version = "14",
 )
 
+# A toolchain that targets java 15.
+java_toolchain_nojavac(
+    name = "toolchain_jdk_15",
+    jacocorunner = ":jacoco_coverage_runner_filegroup",
+    source_version = "15",
+    target_version = "15",
+)
+
 # The new toolchain is using all the pre-built tools, including
 # singlejar and ijar, even on remote execution. This toolchain
 # should be used only when host and execution platform are the

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -35,8 +35,18 @@ java_toolchain_default(
     target_version = "8",
 )
 
+# Default to the Java 8 language level.
+# TODO(cushon): consider if/when we should increment this?
 java_toolchain_default(
     name = "legacy_toolchain",
+    source_version = "8",
+    target_version = "8",
+)
+
+# Needed for openbsd
+java_toolchain_default(
+    name = "legacy_toolchain_jvm8",
+    jvm_opts = JDK8_JVM_OPTS,
     source_version = "8",
     target_version = "8",
 )
@@ -67,10 +77,19 @@ java_toolchain_default(
 RELEASES = (8, 9, 10, 11)
 
 [
-    java_toolchain_default(
-        name = "toolchain_java%d" % release,
-        source_version = "%s" % release,
-        target_version = "%s" % release,
+    (
+        java_toolchain_default(
+            name = "toolchain_java%d" % release,
+            source_version = "%s" % release,
+            target_version = "%s" % release,
+        ),
+        # Needed for openbsd
+        java_toolchain_default(
+            name = "toolchain_java%d_jvm8" % release,
+            jvm_opts = JDK8_JVM_OPTS,
+            source_version = "%s" % release,
+            target_version = "%s" % release,
+        ),
     )
     for release in RELEASES
 ]

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -7,7 +7,7 @@ licenses(["notice"])  # Apache 2.0
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library")
 load("@rules_java//java:defs.bzl", "java_binary", "java_import", "java_toolchain")
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load(":java_toolchain_default.bzl", "JDK8_JVM_OPTS", "JDK9_JVM_OPTS", "java_toolchain_default", "java_toolchain_nojavac")
+load(":java_toolchain_default.bzl", "JDK9_JVM_OPTS", "java_toolchain_default")
 
 SUPRESSED_WARNINGS = select({
     ":windows": [],
@@ -19,17 +19,26 @@ SUPRESSED_WARNINGS = select({
 
 java_toolchain_default(
     name = "toolchain",
+    javac = [":javac_jar"],
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
         # G1 collector and having compact strings enabled.
         "-XX:+UseParallelOldGC",
         "-XX:-CompactStrings",
+        # override the javac in the JDK.
+        "--patch-module=java.compiler=$(location :java_compiler_jar)",
+        "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
     ] + JDK9_JVM_OPTS,
+    tools = [
+        ":java_compiler_jar",
+        ":jdk_compiler_jar",
+    ],
 )
 
 java_toolchain_default(
     name = "toolchain_hostjdk8",
-    jvm_opts = JDK8_JVM_OPTS,
+    javac = [":javac_jar"],
+    jvm_opts = ["-Xbootclasspath/p:$(location :javac_jar)"],
     source_version = "8",
     target_version = "8",
 )
@@ -38,14 +47,25 @@ java_toolchain_default(
 # TODO(cushon): consider if/when we should increment this?
 java_toolchain_default(
     name = "legacy_toolchain",
+    javac = [":javac_jar"],
+    jvm_opts = [
+        # override the javac in the JDK.
+        "--patch-module=java.compiler=$(location :java_compiler_jar)",
+        "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
+    ] + JDK9_JVM_OPTS,
     source_version = "8",
     target_version = "8",
+    tools = [
+        ":java_compiler_jar",
+        ":jdk_compiler_jar",
+    ],
 )
 
-# Needed for openbsd
+# Needed for openbsd / JVM8
 java_toolchain_default(
     name = "legacy_toolchain_jvm8",
-    jvm_opts = JDK8_JVM_OPTS,
+    javac = [":javac_jar"],
+    jvm_opts = ["-Xbootclasspath/p:$(location :javac_jar)"],
     source_version = "8",
     target_version = "8",
 )
@@ -79,13 +99,26 @@ RELEASES = (8, 9, 10, 11)
     (
         java_toolchain_default(
             name = "toolchain_java%d" % release,
+            javac = [":javac_jar"],
+            jvm_opts = [
+                # override the javac in the JDK.
+                "--patch-module=java.compiler=$(location :java_compiler_jar)",
+                "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
+            ] + JDK9_JVM_OPTS,
             source_version = "%s" % release,
             target_version = "%s" % release,
+            tools = [
+                ":java_compiler_jar",
+                ":jdk_compiler_jar",
+            ],
         ),
-        # Needed for openbsd
+        # Needed for openbsd / JVM8
         java_toolchain_default(
             name = "toolchain_java%d_jvm8" % release,
-            jvm_opts = JDK8_JVM_OPTS,
+            javac = [":javac_jar"],
+            jvm_opts = [
+                "-Xbootclasspath/p:$(location :javac_jar)",
+            ],
             source_version = "%s" % release,
             target_version = "%s" % release,
         ),
@@ -96,25 +129,33 @@ RELEASES = (8, 9, 10, 11)
 # A toolchain that targets java 11.
 java_toolchain_default(
     name = "toolchain_jdk_11",
+    javac = [":javac_jar"],
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
         # G1 collector and having compact strings enabled.
         "-XX:+UseParallelOldGC",
         "-XX:-CompactStrings",
+        # override the javac in the JDK.
+        "--patch-module=java.compiler=$(location :java_compiler_jar)",
+        "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
     ] + JDK9_JVM_OPTS,
     source_version = "11",
     target_version = "11",
+    tools = [
+        ":java_compiler_jar",
+        ":jdk_compiler_jar",
+    ],
 )
 
 # A toolchain that targets java 14.
-java_toolchain_nojavac(
+java_toolchain_default(
     name = "toolchain_jdk_14",
     source_version = "14",
     target_version = "14",
 )
 
 # A toolchain that targets java 15.
-java_toolchain_nojavac(
+java_toolchain_default(
     name = "toolchain_jdk_15",
     source_version = "15",
     target_version = "15",
@@ -128,13 +169,21 @@ java_toolchain_nojavac(
 java_toolchain_default(
     name = "prebuilt_toolchain",
     ijar = [":ijar_prebuilt_binary"],
+    javac = [":javac_jar"],
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
         # G1 collector and having compact strings enabled.
         "-XX:+UseParallelOldGC",
         "-XX:-CompactStrings",
+        # override the javac in the JDK.
+        "--patch-module=java.compiler=$(location :java_compiler_jar)",
+        "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
     ] + JDK9_JVM_OPTS,
     singlejar = [":prebuilt_singlejar"],
+    tools = [
+        ":java_compiler_jar",
+        ":jdk_compiler_jar",
+    ],
 )
 
 filegroup(

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -52,18 +52,18 @@ java_toolchain_default(
 
 # The 'vanilla' toolchain is an unsupported alternative to the default.
 #
-# It does not provider any of the following features:
+# It does not provide any of the following features:
 #   * Error Prone
 #   * Strict Java Deps
 #   * Header Compilation
 #   * Reduced Classpath Optimization
 #
-# It uses the version of javac from the `--host_javabase` instead of the
-# embedded javac, which may not be source- or bug-compatible with the embedded
-# javac.
+# It uses the version of internal javac from the `--host_javabase` JDK instead
+# of providing a javac. Internal javac may not be source- or bug-compatible with
+# the javac that is provided with other toolchains.
 #
 # However it does allow using a wider range of `--host_javabase`s, including
-# versions newer than the current embedded JDK.
+# versions newer than the current JDK.
 java_toolchain_default(
     name = "toolchain_vanilla",
     forcibly_disable_header_compilation = True,

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -1,4 +1,5 @@
 package(default_visibility = ["//visibility:public"])
+
 exports_files(glob(["**/*.jar"]))
 
 licenses(["notice"])  # Apache 2.0
@@ -6,6 +7,7 @@ licenses(["notice"])  # Apache 2.0
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library")
 load("@rules_java//java:defs.bzl", "java_binary", "java_import", "java_toolchain")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load(":java_toolchain_default.bzl", "JDK8_JVM_OPTS", "JDK9_JVM_OPTS", "java_toolchain_default", "java_toolchain_nojavac")
 
 SUPRESSED_WARNINGS = select({
     ":windows": [],
@@ -15,145 +17,82 @@ SUPRESSED_WARNINGS = select({
     ],
 })
 
-java_toolchain(
+java_toolchain_default(
     name = "toolchain",
-    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
-    forcibly_disable_header_compilation = 0,
-    genclass = [":GenClass"],
-    header_compiler = [":Turbine"],
-    header_compiler_direct = [":TurbineDirect"],
-    ijar = [":ijar"],
     jacocorunner = ":jacoco_coverage_runner_filegroup",
-    javabuilder = [":JavaBuilder"],
-    javac = [":javac_jar"],
-    javac_supports_workers = 1,
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
         # G1 collector and having compact strings enabled.
         "-XX:+UseParallelOldGC",
         "-XX:-CompactStrings",
-        # Allow JavaBuilder to access internal javac APIs.
-        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-        "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-
-        # override the javac in the JDK.
-        "--patch-module=java.compiler=$(location :java_compiler_jar)",
-        "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
-
-        # quiet warnings from com.google.protobuf.UnsafeUtil,
-        # see: https://github.com/google/protobuf/issues/3781
-        # and: https://github.com/bazelbuild/bazel/issues/5599
-        "--add-opens=java.base/java.nio=ALL-UNNAMED",
-        "--add-opens=java.base/java.lang=ALL-UNNAMED",
-    ],
-    misc = [
-        "-XDskipDuplicateBridges=true",
-        "-g",
-        "-parameters",
-    ],
-    singlejar = [":singlejar"],
-    source_version = "8",
-    target_version = "8",
-    tools = [
-        ":java_compiler_jar",
-        ":jdk_compiler_jar",
-    ],
+    ] + JDK9_JVM_OPTS,
 )
 
+java_toolchain_default(
+    name = "toolchain_hostjdk8",
+    jvm_opts = JDK8_JVM_OPTS,
+    source_version = "8",
+    target_version = "8",
+)
+
+java_toolchain_default(
+    name = "legacy_toolchain",
+    source_version = "8",
+    target_version = "8",
+)
+
+# The 'vanilla' toolchain is an unsupported alternative to the default.
+#
+# It does not provider any of the following features:
+#   * Error Prone
+#   * Strict Java Deps
+#   * Header Compilation
+#   * Reduced Classpath Optimization
+#
+# It uses the version of javac from the `--host_javabase` instead of the
+# embedded javac, which may not be source- or bug-compatible with the embedded
+# javac.
+#
+# However it does allow using a wider range of `--host_javabase`s, including
+# versions newer than the current embedded JDK.
+java_toolchain_default(
+    name = "toolchain_vanilla",
+    forcibly_disable_header_compilation = True,
+    javabuilder = [":vanillajavabuilder"],
+    jvm_opts = [],
+    source_version = "",
+    target_version = "",
+)
+
+RELEASES = (8, 9, 10, 11)
+
+[
+    java_toolchain_default(
+        name = "toolchain_java%d" % release,
+        source_version = "%s" % release,
+        target_version = "%s" % release,
+    )
+    for release in RELEASES
+]
+
 # A toolchain that targets java 11.
-java_toolchain(
+java_toolchain_default(
     name = "toolchain_jdk_11",
-    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
-    forcibly_disable_header_compilation = 0,
-    genclass = [":GenClass"],
-    header_compiler = [":Turbine"],
-    header_compiler_direct = [":TurbineDirect"],
-    ijar = [":ijar"],
     jacocorunner = ":jacoco_coverage_runner_filegroup",
-    javabuilder = [":JavaBuilder"],
-    javac = [":javac_jar"],
-    javac_supports_workers = 1,
     jvm_opts = [
-        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance
-        # when using G1 collector and having compact strings enabled.
+        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
+        # G1 collector and having compact strings enabled.
         "-XX:+UseParallelOldGC",
         "-XX:-CompactStrings",
-
-        # Allow JavaBuilder to access internal javac APIs.
-        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-        "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-
-        # override the javac in the JDK.
-        "--patch-module=java.compiler=$(location :java_compiler_jar)",
-        "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
-
-        # quiet warnings from com.google.protobuf.UnsafeUtil,
-        # see: https://github.com/google/protobuf/issues/3781
-        # and: https://github.com/bazelbuild/bazel/issues/5599
-        "--add-opens=java.base/java.nio=ALL-UNNAMED",
-        "--add-opens=java.base/java.lang=ALL-UNNAMED",
-    ],
-    misc = [
-        "-XDskipDuplicateBridges=true",
-        "-g",
-        "-parameters",
-    ],
-    singlejar = [":singlejar"],
+    ] + JDK9_JVM_OPTS,
     source_version = "11",
     target_version = "11",
-    tools = [
-        ":java_compiler_jar",
-        ":jdk_compiler_jar",
-    ],
 )
 
 # A toolchain that targets java 14.
-java_toolchain(
+java_toolchain_nojavac(
     name = "toolchain_jdk_14",
-    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
-    forcibly_disable_header_compilation = 0,
-    genclass = [":GenClass"],
-    header_compiler = [":Turbine"],
-    header_compiler_direct = [":TurbineDirect"],
-    ijar = [":ijar"],
     jacocorunner = ":jacoco_coverage_runner_filegroup",
-    javabuilder = [":JavaBuilder"],
-    javac_supports_workers = 1,
-    jvm_opts = [
-        # Allow JavaBuilder to access internal javac APIs.
-        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-        "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-
-        # quiet warnings from com.google.protobuf.UnsafeUtil,
-        # see: https://github.com/google/protobuf/issues/3781
-        # and: https://github.com/bazelbuild/bazel/issues/5599
-        "--add-opens=java.base/java.nio=ALL-UNNAMED",
-        "--add-opens=java.base/java.lang=ALL-UNNAMED",
-    ],
-    misc = [
-        "-XDskipDuplicateBridges=true",
-        "-g",
-        "-parameters",
-    ],
-    singlejar = [":singlejar"],
     source_version = "14",
     target_version = "14",
 )
@@ -163,55 +102,17 @@ java_toolchain(
 # should be used only when host and execution platform are the
 # same, otherwise the binaries will not work on the execution
 # platform.
-java_toolchain(
+java_toolchain_default(
     name = "prebuilt_toolchain",
-    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
-    forcibly_disable_header_compilation = 0,
-    genclass = [":GenClass"],
-    header_compiler = [":Turbine"],
-    header_compiler_direct = [":TurbineDirect"],
     ijar = [":ijar_prebuilt_binary"],
     jacocorunner = ":jacoco_coverage_runner_filegroup",
-    javabuilder = [":JavaBuilder"],
-    javac = [":javac_jar"],
-    javac_supports_workers = 1,
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
         # G1 collector and having compact strings enabled.
         "-XX:+UseParallelOldGC",
         "-XX:-CompactStrings",
-        # Allow JavaBuilder to access internal javac APIs.
-        "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-        "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-        "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-
-        # override the javac in the JDK.
-        "--patch-module=java.compiler=$(location :java_compiler_jar)",
-        "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
-
-        # quiet warnings from com.google.protobuf.UnsafeUtil,
-        # see: https://github.com/google/protobuf/issues/3781
-        # and: https://github.com/bazelbuild/bazel/issues/5599
-        "--add-opens=java.base/java.nio=ALL-UNNAMED",
-        "--add-opens=java.base/java.lang=ALL-UNNAMED",
-    ],
-    misc = [
-        "-XDskipDuplicateBridges=true",
-        "-g",
-        "-parameters",
-    ],
+    ] + JDK9_JVM_OPTS,
     singlejar = [":prebuilt_singlejar"],
-    source_version = "8",
-    target_version = "8",
-    tools = [
-        ":java_compiler_jar",
-        ":jdk_compiler_jar",
-    ],
 )
 
 filegroup(

--- a/tools/jdk/java_toolchain_default.bzl
+++ b/tools/jdk/java_toolchain_default.bzl
@@ -54,7 +54,7 @@ _BASE_TOOLCHAIN_CONFIGURATION = dict(
     javabuilder = [":JavaBuilder"],
     javac_supports_workers = True,
     jacocorunner = ":jacoco_coverage_runner_filegroup",
-    misc = DEFAULT_JAVACOPTS,
+    misc = _DEFAULT_JAVACOPTS,
     singlejar = [":singlejar"],
     # Code to enumerate target JVM boot classpath uses host JVM. Because
     # java_runtime-s are involved, its implementation is in @bazel_tools.
@@ -63,7 +63,7 @@ _BASE_TOOLCHAIN_CONFIGURATION = dict(
     target_version = "8",
 )
 
-JDK9_JVM_OPTS = BASE_JDK9_JVM_OPTS + [
+JDK9_JVM_OPTS = _BASE_JDK9_JVM_OPTS + [
     # override the javac in the JDK.
     "--patch-module=java.compiler=$(location :java_compiler_jar)",
     "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
@@ -76,7 +76,7 @@ _DEFAULT_TOOLCHAIN_CONFIGURATION = dict(
         ":jdk_compiler_jar",
     ],
     jvm_opts = JDK9_JVM_OPTS,
-    **BASE_TOOLCHAIN_CONFIGURATION
+    **_BASE_TOOLCHAIN_CONFIGURATION
 )
 
 def java_toolchain_default(name, **kwargs):

--- a/tools/jdk/java_toolchain_default.bzl
+++ b/tools/jdk/java_toolchain_default.bzl
@@ -107,7 +107,7 @@ NOJAVAC_TOOLCHAIN_CONFIGURATION = {
     "jvm_opts": JDK_NOJAVAC_JVM_OPTS,
     "misc": DEFAULT_JAVACOPTS,
     "singlejar": [":singlejar"],
-    "bootclasspath": [":platformclasspath"],
+    "bootclasspath": ["@bazel_tools//tools/jdk:platformclasspath"],
     "source_version": "8",
     "target_version": "8",
 }

--- a/tools/jdk/java_toolchain_default.bzl
+++ b/tools/jdk/java_toolchain_default.bzl
@@ -20,12 +20,8 @@ _DEFAULT_JAVACOPTS = [
     "-parameters",
 ]
 
-JDK8_JVM_OPTS = [
-    "-Xbootclasspath/p:$(location :javac_jar)",
-]
-
 # JVM options, without patching java.compiler and jdk.compiler modules.
-_BASE_JDK9_JVM_OPTS = [
+JDK9_JVM_OPTS = [
     # Allow JavaBuilder to access internal javac APIs.
     "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
     "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
@@ -54,6 +50,7 @@ _BASE_TOOLCHAIN_CONFIGURATION = dict(
     javabuilder = [":JavaBuilder"],
     javac_supports_workers = True,
     jacocorunner = ":jacoco_coverage_runner_filegroup",
+    jvm_opts = JDK9_JVM_OPTS,
     misc = _DEFAULT_JAVACOPTS,
     singlejar = [":singlejar"],
     # Code to enumerate target JVM boot classpath uses host JVM. Because
@@ -63,39 +60,10 @@ _BASE_TOOLCHAIN_CONFIGURATION = dict(
     target_version = "8",
 )
 
-JDK9_JVM_OPTS = _BASE_JDK9_JVM_OPTS + [
-    # override the javac in the JDK.
-    "--patch-module=java.compiler=$(location :java_compiler_jar)",
-    "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
-]
-
-_DEFAULT_TOOLCHAIN_CONFIGURATION = dict(
-    javac = [":javac_jar"],
-    tools = [
-        ":java_compiler_jar",
-        ":jdk_compiler_jar",
-    ],
-    jvm_opts = JDK9_JVM_OPTS,
-    **_BASE_TOOLCHAIN_CONFIGURATION
-)
-
 def java_toolchain_default(name, **kwargs):
     """Defines a java_toolchain with appropriate defaults for Bazel."""
 
-    toolchain_args = dict(_DEFAULT_TOOLCHAIN_CONFIGURATION)
-    toolchain_args.update(kwargs)
-    native.java_toolchain(
-        name = name,
-        **toolchain_args
-    )
-
-def java_toolchain_nojavac(name, **kwargs):
-    """Defines a java_toolchain without overriding javac for Bazel."""
-
-    toolchain_args = dict(
-        jvm_opts = _BASE_JDK9_JVM_OPTS,
-        **_BASE_TOOLCHAIN_CONFIGURATION
-    )
+    toolchain_args = dict(_BASE_TOOLCHAIN_CONFIGURATION)
     toolchain_args.update(kwargs)
     native.java_toolchain(
         name = name,

--- a/tools/jdk/java_toolchain_default.bzl
+++ b/tools/jdk/java_toolchain_default.bzl
@@ -52,6 +52,7 @@ DEFAULT_TOOLCHAIN_CONFIGURATION = {
     "header_compiler": [":Turbine"],
     "header_compiler_direct": [":TurbineDirect"],
     "ijar": [":ijar"],
+    "jacocorunner": ":jacoco_coverage_runner_filegroup",
     "javabuilder": [":JavaBuilder"],
     "javac": [":javac_jar"],
     "tools": [

--- a/tools/jdk/java_toolchain_default.bzl
+++ b/tools/jdk/java_toolchain_default.bzl
@@ -14,7 +14,7 @@
 
 """Bazel rules for creating Java toolchains."""
 
-DEFAULT_JAVACOPTS = [
+_DEFAULT_JAVACOPTS = [
     "-XDskipDuplicateBridges=true",
     "-g",
     "-parameters",
@@ -25,7 +25,7 @@ JDK8_JVM_OPTS = [
 ]
 
 # JVM options, without patching java.compiler and jdk.compiler modules.
-BASE_JDK9_JVM_OPTS = [
+_BASE_JDK9_JVM_OPTS = [
     # Allow JavaBuilder to access internal javac APIs.
     "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
     "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
@@ -44,8 +44,8 @@ BASE_JDK9_JVM_OPTS = [
 ]
 
 # java_toolchain parameters without specifying javac, java.compiler,
-# and jdk.compiler module
-BASE_TOOLCHAIN_CONFIGURATION = dict(
+# jdk.compiler module, and jvm_opts
+_BASE_TOOLCHAIN_CONFIGURATION = dict(
     forcibly_disable_header_compilation = False,
     genclass = [":GenClass"],
     header_compiler = [":Turbine"],
@@ -54,7 +54,6 @@ BASE_TOOLCHAIN_CONFIGURATION = dict(
     javabuilder = [":JavaBuilder"],
     javac_supports_workers = True,
     jacocorunner = ":jacoco_coverage_runner_filegroup",
-    jvm_opts = BASE_JDK9_JVM_OPTS,
     misc = DEFAULT_JAVACOPTS,
     singlejar = [":singlejar"],
     # Code to enumerate target JVM boot classpath uses host JVM. Because
@@ -70,7 +69,7 @@ JDK9_JVM_OPTS = BASE_JDK9_JVM_OPTS + [
     "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
 ]
 
-DEFAULT_TOOLCHAIN_CONFIGURATION = dict(
+_DEFAULT_TOOLCHAIN_CONFIGURATION = dict(
     javac = [":javac_jar"],
     tools = [
         ":java_compiler_jar",
@@ -83,7 +82,7 @@ DEFAULT_TOOLCHAIN_CONFIGURATION = dict(
 def java_toolchain_default(name, **kwargs):
     """Defines a java_toolchain with appropriate defaults for Bazel."""
 
-    toolchain_args = dict(DEFAULT_TOOLCHAIN_CONFIGURATION)
+    toolchain_args = dict(_DEFAULT_TOOLCHAIN_CONFIGURATION)
     toolchain_args.update(kwargs)
     native.java_toolchain(
         name = name,
@@ -93,7 +92,10 @@ def java_toolchain_default(name, **kwargs):
 def java_toolchain_nojavac(name, **kwargs):
     """Defines a java_toolchain without overriding javac for Bazel."""
 
-    toolchain_args = dict(BASE_TOOLCHAIN_CONFIGURATION)
+    toolchain_args = dict(
+        jvm_opts = _BASE_JDK9_JVM_OPTS,
+        **_BASE_TOOLCHAIN_CONFIGURATION
+    )
     toolchain_args.update(kwargs)
     native.java_toolchain(
         name = name,

--- a/tools/jdk/java_toolchain_default.bzl
+++ b/tools/jdk/java_toolchain_default.bzl
@@ -1,0 +1,122 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bazel rules for creating Java toolchains."""
+
+JDK8_JVM_OPTS = [
+    "-Xbootclasspath/p:$(location :javac_jar)",
+]
+
+JDK9_JVM_OPTS = [
+    # Allow JavaBuilder to access internal javac APIs.
+    "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+
+    # override the javac in the JDK.
+    "--patch-module=java.compiler=$(location :java_compiler_jar)",
+    "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
+
+    # quiet warnings from com.google.protobuf.UnsafeUtil,
+    # see: https://github.com/google/protobuf/issues/3781
+    # and: https://github.com/bazelbuild/bazel/issues/5599
+    "--add-opens=java.base/java.nio=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+]
+
+DEFAULT_JAVACOPTS = [
+    "-XDskipDuplicateBridges=true",
+    "-g",
+    "-parameters",
+]
+
+DEFAULT_TOOLCHAIN_CONFIGURATION = {
+    "forcibly_disable_header_compilation": 0,
+    "genclass": [":GenClass"],
+    "header_compiler": [":Turbine"],
+    "header_compiler_direct": [":TurbineDirect"],
+    "ijar": [":ijar"],
+    "javabuilder": [":JavaBuilder"],
+    "javac": [":javac_jar"],
+    "tools": [
+        ":java_compiler_jar",
+        ":jdk_compiler_jar",
+    ],
+    "javac_supports_workers": 1,
+    "jvm_opts": JDK9_JVM_OPTS,
+    "misc": DEFAULT_JAVACOPTS,
+    "singlejar": [":singlejar"],
+    "bootclasspath": ["@bazel_tools//tools/jdk:platformclasspath"],
+    "source_version": "8",
+    "target_version": "8",
+}
+
+def java_toolchain_default(name, **kwargs):
+    """Defines a java_toolchain with appropriate defaults for Bazel."""
+
+    toolchain_args = dict(DEFAULT_TOOLCHAIN_CONFIGURATION)
+    toolchain_args.update(kwargs)
+    native.java_toolchain(
+        name = name,
+        **toolchain_args
+    )
+
+JDK_NOJAVAC_JVM_OPTS = [
+    # Allow JavaBuilder to access internal javac APIs.
+    "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+
+    # quiet warnings from com.google.protobuf.UnsafeUtil,
+    # see: https://github.com/google/protobuf/issues/3781
+    # and: https://github.com/bazelbuild/bazel/issues/5599
+    "--add-opens=java.base/java.nio=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+]
+
+NOJAVAC_TOOLCHAIN_CONFIGURATION = {
+    "forcibly_disable_header_compilation": 0,
+    "genclass": [":GenClass"],
+    "header_compiler": [":Turbine"],
+    "header_compiler_direct": [":TurbineDirect"],
+    "ijar": [":ijar"],
+    "javabuilder": [":JavaBuilder"],
+    "javac_supports_workers": 1,
+    "jvm_opts": JDK_NOJAVAC_JVM_OPTS,
+    "misc": DEFAULT_JAVACOPTS,
+    "singlejar": [":singlejar"],
+    "bootclasspath": [":platformclasspath"],
+    "source_version": "8",
+    "target_version": "8",
+}
+
+def java_toolchain_nojavac(name, **kwargs):
+    """Defines a java_toolchain without overriding javac for Bazel."""
+
+    toolchain_args = dict(NOJAVAC_TOOLCHAIN_CONFIGURATION)
+    toolchain_args.update(kwargs)
+    native.java_toolchain(
+        name = name,
+        **toolchain_args
+    )


### PR DESCRIPTION
default_java_toolchain macro is handy to define toolchains in //tools/jvm/BUILD without making a release of java_tools.

However default_java_toolchain heavily relies on selects by operating system to pick the right parts from the right java_tools. This indirection is removed by putting definition directly into java_tools.

This is the first part. After java_tools release, default_java_toolchain and remote_java_tools_java_import can be removed.