### PR TITLE
Add executable_use_pic to Starlark CcLinkingOutputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
@@ -771,6 +771,7 @@ public final class CcLinkingHelper {
     CppLinkAction dynamicLinkAction = dynamicLinkActionBuilder.build();
     if (dynamicLinkType.isExecutable()) {
       ccLinkingOutputs.setExecutable(linkerOutput);
+      ccLinkingOutputs.setExecutableUsePic(usePic);
     }
     actionConstructionContext.registerAction(dynamicLinkAction);
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingOutputs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingOutputs.java
@@ -30,6 +30,7 @@ public class CcLinkingOutputs implements CcLinkingOutputsApi<Artifact> {
 
   @Nullable private final LibraryToLink libraryToLink;
   @Nullable private final Artifact executable;
+  @Nullable private final Boolean executableUsePic;
 
   private final ImmutableList<LtoBackendArtifacts> allLtoArtifacts;
   private final ImmutableList<Artifact> linkActionInputs;
@@ -37,10 +38,12 @@ public class CcLinkingOutputs implements CcLinkingOutputsApi<Artifact> {
   private CcLinkingOutputs(
       LibraryToLink libraryToLink,
       Artifact executable,
+      Boolean executableUsePic,
       ImmutableList<LtoBackendArtifacts> allLtoArtifacts,
       ImmutableList<Artifact> linkActionInputs) {
     this.libraryToLink = libraryToLink;
     this.executable = executable;
+    this.executableUsePic = executableUsePic;
     this.allLtoArtifacts = allLtoArtifacts;
     this.linkActionInputs = linkActionInputs;
   }
@@ -55,6 +58,12 @@ public class CcLinkingOutputs implements CcLinkingOutputsApi<Artifact> {
   @Nullable
   public Artifact getExecutable() {
     return executable;
+  }
+
+  @Override
+  @Nullable
+  public Boolean getExecutableUsePic() {
+    return executableUsePic;
   }
 
   public ImmutableList<LtoBackendArtifacts> getAllLtoArtifacts() {
@@ -109,6 +118,7 @@ public class CcLinkingOutputs implements CcLinkingOutputsApi<Artifact> {
   public static final class Builder {
     private LibraryToLink libraryToLink;
     private Artifact executable;
+    private Boolean executableUsePic;
 
     private Builder() {
       // private to avoid class initialization deadlock between this class and its outer class
@@ -122,7 +132,7 @@ public class CcLinkingOutputs implements CcLinkingOutputsApi<Artifact> {
 
     public CcLinkingOutputs build() {
       return new CcLinkingOutputs(
-          libraryToLink, executable, allLtoArtifacts.build(), linkActionInputs.build());
+          libraryToLink, executable, executableUsePic, allLtoArtifacts.build(), linkActionInputs.build());
     }
 
     public Builder setLibraryToLink(LibraryToLink libraryToLink) {
@@ -132,6 +142,11 @@ public class CcLinkingOutputs implements CcLinkingOutputsApi<Artifact> {
 
     public Builder setExecutable(Artifact executable) {
       this.executable = executable;
+      return this;
+    }
+
+    public Builder setExecutableUsePic(boolean executableUsePic) {
+      this.executableUsePic = Boolean.valueOf(executableUsePic);
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcLinkingOutputsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcLinkingOutputsApi.java
@@ -44,4 +44,13 @@ public interface CcLinkingOutputsApi<FileT extends FileApi> extends StarlarkValu
       doc = "<a href='File.html'><code>File</code></a> object representing the linked executable.",
       documented = true)
   FileT getExecutable();
+
+  @StarlarkMethod(
+      name = "executable_use_pic",
+      structField = true,
+      allowReturnNones = true,
+      doc = "<a href='bool.html'><code>bool</code></a> set to True if linker was requested to use pic objects,"
+                + " None if not known.",
+      documented = true)
+  Boolean getExecutableUsePic();
 }


### PR DESCRIPTION
This makes it possible for Starlark code to know if an executable is
linked using pic objects or not.

Needed for instance to choose correct gcno-files in a clean way for custom
code coverare rules.