### PR TITLE
Arm64 installation instructions

### DIFF
--- a/site/docs/install-redhat.md
+++ b/site/docs/install-redhat.md
@@ -15,6 +15,8 @@ The commands below must be run either via `sudo` or while logged in as `root`.
 Add `--allowerasing` when installing an upgrade from a previous major
 version of the Bazel package.
 
+[The Bazelisk installer](install-bazelisk.md) is an alternative to package installation.
+
 ## Installing on Fedora 25+
 
 1. The [DNF](https://fedoraproject.org/wiki/DNF) package manager can install

--- a/site/docs/install-ubuntu.md
+++ b/site/docs/install-ubuntu.md
@@ -21,6 +21,10 @@ Install Bazel on Ubuntu using one of the following methods:
 *   [Use the binary installer](#install-with-installer-ubuntu)
 *   [Compile Bazel from source](install-compile-source.md)
 
+**Note:** For Arm-based systems, the APT repository does not contain an `arm64`
+release, and there is no binary installer available. Either use Bazelisk or
+compile from source.
+
 Bazel comes with two completion scripts. After installing Bazel, you can:
 
 *   Access the [bash completion script](completion.md#bash)


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/11994.

Looks like a simple note is all that's needed now for installing on Ubuntu.

Also, I noticed the Fedora/CentOS instructions don't work on Amazon Linux 2, so I added a reference to Bazelisk - let me know what you think. Could call out AL2 specifically.