### PR TITLE
[1/3] Bump grpc from 1.26.0 to 1.31.1

### DIFF
--- a/third_party/grpc/BUILD
+++ b/third_party/grpc/BUILD
@@ -18,7 +18,7 @@ load("//tools/distributions:distribution_rules.bzl", "distrib_java_import", "dis
 
 licenses(["notice"])  # Apache v2
 
-exports_files(["grpc_1.26.0.patch", "upb_gcc10_fix.patch"])
+exports_files(["grpc_1.26.0.patch", "upb_gcc10_fix.patch", "grpc_1.31.1.patch"])
 
 package(default_visibility = ["//visibility:public"])
 

--- a/third_party/grpc/README.bazel.md
+++ b/third_party/grpc/README.bazel.md
@@ -1,18 +1,18 @@
 # How to update the C++ sources of gRPC:
 
 1. Update the gRPC definitions in WORKSPACE file, currently we use 
-   https://github.com/grpc/grpc/archive/v1.26.0.tar.gz
+   https://github.com/grpc/grpc/archive/v1.31.1.tar.gz
 2. Update the gRPC patch file if necessary, it mostly helps avoid unnecessary dependencies.
 3. Update third_party/grpc/BUILD to redirect targets to @com_github_grpc_grpc if necessary.
 
 # How to update the BUILD/bzl sources of gRPC:
 
 1. `git clone http://github.com/grpc/grpc.git` in a convenient directory
-2. `git checkout <tag>` (current is `v1.26.0`, commithash `de893acb`)
+2. `git checkout <tag>` (current is `v1.31.1`, commithash `7d7e456762`)
 3. `mkdir -p third_party/grpc/bazel`
 4. `cp <gRPC git tree>/bazel/{BUILD,cc_grpc_library.bzl,generate_cc.bzl,protobuf.bzl} third_party/grpc/bazel`
 5. In the `third_party/grpc` directory, apply local patches:
-   `patch -p3 < bazel.patch`
+   `patch -p3 < bazel_1.31.1.patch`
 
 # How to update the Java plugin:
 

--- a/third_party/grpc/bazel/generate_cc.bzl
+++ b/third_party/grpc/bazel/generate_cc.bzl
@@ -4,6 +4,7 @@ This is an internal rule used by cc_grpc_library, and shouldn't be used
 directly.
 """
 
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load(
     ":protobuf.bzl",
     "get_include_directory",

--- a/third_party/grpc/bazel/protobuf.bzl
+++ b/third_party/grpc/bazel/protobuf.bzl
@@ -1,5 +1,7 @@
 """Utility functions for generating protobuf code."""
 
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
+
 _PROTO_EXTENSION = ".proto"
 _VIRTUAL_IMPORTS = "/_virtual_imports/"
 

--- a/third_party/grpc/bazel_1.31.1.patch
+++ b/third_party/grpc/bazel_1.31.1.patch
@@ -57,6 +57,7 @@ index dea493eaf2..0470a294fc 100644
 @@ -1,105 +1,58 @@
  """Generates and compiles C++ grpc stubs from proto_library rules."""
  
+-load("@rules_proto//proto:defs.bzl", "proto_library")
 -load("//bazel:generate_cc.bzl", "generate_cc")
 -load("//bazel:protobuf.bzl", "well_known_proto_libs")
 +load(":generate_cc.bzl", "generate_cc")
@@ -137,8 +138,7 @@ index dea493eaf2..0470a294fc 100644
 -        proto_deps += [dep.split(":")[0] + ":" + "_" + dep.split(":")[1] + "_only" for dep in deps if dep.find(":") != -1]
 -        if well_known_protos:
 -            proto_deps += well_known_proto_libs()
--
--        native.proto_library(
+-        proto_library(
 -            name = proto_target,
 -            srcs = srcs,
 -            deps = proto_deps,

--- a/third_party/grpc/grpc_1.31.1.patch
+++ b/third_party/grpc/grpc_1.31.1.patch
@@ -1,0 +1,90 @@
+commit bb0d04663c7dc6c0096f8717cb4ec26330a5ae40
+Author: Yun Peng <pcloudy@google.com>
+Date:   Wed Jun 3 15:35:31 2020 +0200
+
+    Patch grpc v1.26.0 for Bazel build
+    
+    - Avoid loading dependencies that're not needed for the gRPC C++
+    libraries
+    - Add bazel mirror URL for upb and cares
+    - Redirect zlib to @//third_party/zlib
+
+diff --git a/bazel/grpc_build_system.bzl b/bazel/grpc_build_system.bzl
+index 7bb6b8bdb9..7644107b70 100644
+--- a/bazel/grpc_build_system.bzl
++++ b/bazel/grpc_build_system.bzl
+@@ -25,7 +25,7 @@
+ 
+ load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+ load("@upb//bazel:upb_proto_library.bzl", "upb_proto_library")
+-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
++# load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+ 
+ # The set of pollers to test against if a test exercises polling
+ POLLERS = ["epollex", "epoll1", "poll"]
+@@ -181,13 +181,13 @@ def ios_cc_test(
+             testonly = 1,
+         )
+         ios_test_deps = [ios_test_adapter, ":" + test_lib_ios]
+-        ios_unit_test(
+-            name = name + "_on_ios",
+-            size = kwargs.get("size"),
+-            tags = ios_tags,
+-            minimum_os_version = "9.0",
+-            deps = ios_test_deps,
+-        )
++        # ios_unit_test(
++        #     name = name + "_on_ios",
++        #     size = kwargs.get("size"),
++        #     tags = ios_tags,
++        #     minimum_os_version = "9.0",
++        #     deps = ios_test_deps,
++        # )
+ 
+ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data = [], uses_polling = True, language = "C++", size = "medium", timeout = None, tags = [], exec_compatible_with = [], exec_properties = {}, shard_count = None, flaky = None):
+     copts = if_mac(["-DGRPC_CFSTREAM"])
+diff --git a/bazel/grpc_deps.bzl b/bazel/grpc_deps.bzl
+index 09fcad95a2..9b737e5deb 100644
+--- a/bazel/grpc_deps.bzl
++++ b/bazel/grpc_deps.bzl
+@@ -33,7 +33,7 @@ def grpc_deps():
+ 
+     native.bind(
+         name = "madler_zlib",
+-        actual = "@zlib//:zlib",
++        actual = "@//third_party/zlib",
+     )
+ 
+     native.bind(
+diff --git a/bazel/grpc_extra_deps.bzl b/bazel/grpc_extra_deps.bzl
+index 4c1dfad2e8..f63c54ddef 100644
+--- a/bazel/grpc_extra_deps.bzl
++++ b/bazel/grpc_extra_deps.bzl
+@@ -1,11 +1,6 @@
+ """Loads the dependencies necessary for the external repositories defined in grpc_deps.bzl."""
+ 
+-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+ load("@upb//bazel:workspace_deps.bzl", "upb_deps")
+-load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
+-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+-load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+-load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
+ 
+ def grpc_extra_deps():
+     """Loads the extra dependencies.
+@@ -26,15 +21,5 @@ def grpc_extra_deps():
+     grpc_extra_deps()
+     ```
+     """
+-    protobuf_deps()
+-
+     upb_deps()
+ 
+-    api_dependencies()
+-
+-    go_rules_dependencies()
+-    go_register_toolchains()
+-
+-    apple_rules_dependencies()
+-
+-    apple_support_dependencies()


### PR DESCRIPTION
PART 1: prepare third_party/grpc files for new version
Composed PR: https://github.com/bazelbuild/bazel/pull/12226
Note: generate_cc.bzl and protobuf.bzl are modified in place and
already affect the build. But the change seems to be harmless
(adding explicit ProtoInfo load from @rules_proto).

Fixes having external dependencies without checksum
- boringssl (each download was timestamped, but otherwise stable)
- bazel_skylark was overriden to be master (sic!)

There doesn't seem to be many breaking/big changes up to grpc 1.31.1
- removal of xds-experimental URI scheme
- removal of MAX_EPOLL_EVENTS_HANDLED_EACH_POLL_CALL
- enable TLS 1.3 in the C-core and all wrapped languages
- some of bazel-related patches got merged in
https://github.com/grpc/grpc/releases

How to check whether certain dependency has a checksum
bazel query //external:bazel_skylib --output build
bazel query //external:boringssl --output build

How to find (almost?) all problematic dependencies
compare output of
bazel query 'kind(http_archive, //external:all) + kind(http_file, //external:all) + kind(distdir_tar, //external:all)' --output xml | xq '.query.rule[] | ."@name"'
vs
bazel query 'kind(http_archive, //external:all) + kind(http_file, //external:all) + kind(distdir_tar, //external:all)' --output xml | xq '.query.rule[] | select (.string[]."@name" | contains("sha256")) | ."@name"'

Note that it looks for string sha256 and misses dict sha256 for
distdir_tar rules - those are false positive currently.