### PR TITLE
[WIP] Update Java rules to use the toolchain transition.

### DIFF
--- a/tools/jdk/java_toolchain_alias.bzl
+++ b/tools/jdk/java_toolchain_alias.bzl
@@ -92,6 +92,7 @@ java_toolchain_alias = rule(
             default = Label("@bazel_tools//tools/jdk:legacy_current_java_toolchain"),
         ),
     },
+    incompatible_use_toolchain_transition = True,
 )
 
 # Add aliases for the legacy native rules to allow referring to both versions in @bazel_tools//tools/jdk


### PR DESCRIPTION
This is phase 2 of of the switch to toolchain transitions. See https://github.com/bazelbuild/bazel/issues/11584 for details.

PiperOrigin-RevId: 316094950
Change-Id: I01002a9c012209434928ac8afb58a52c836e727e