### PR TITLE
TestTargetProperties: fix typo in cpu reservation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
@@ -149,7 +149,7 @@ public class TestTargetProperties {
 
     ResourceSet testResourcesFromSize = TestTargetProperties.getResourceSetFromSize(size);
 
-    // Tests can override their CPU reservation with a "cpus:<n>" tag.
+    // Tests can override their CPU reservation with a "cpu:<n>" tag.
     ResourceSet testResourcesFromTag = null;
     for (String tag : executionInfo.keySet()) {
       try {


### PR DESCRIPTION
This is just a comment fix, but as I was looking through the code
to see how this tag is implemented, the difference between this
comment and the [documented syntax](https://docs.bazel.build/versions/master/test-encyclopedia.html#other-resources)
confused me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bazelbuild/bazel/12243)
<!-- Reviewable:end -->
