### PR TITLE
Add a fake option for the gfm_quirks option so that it isn't read as

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -3,6 +3,8 @@ markdown: kramdown
 kramdown:
   syntax_highlighter: rouge
   toc_levels: "2,3"
+  gfm_quirks:
+    - fake_to_fix_options_parsing
 highlighter: rouge
 
 paginate: 10


### PR DESCRIPTION
being empty.

This fixes #12245.