### PR TITLE
Ensure BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN does not break builds

### DIFF
--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -923,6 +923,10 @@ cc_binary(
   srcs = ["ok.cc"],
 )
 EOF
+  # As long as the default workspace suffix runs cc_configure the local_config_cc toolchain suite will be evaluated.
+  # Ensure the fake cc_toolchain_suite target doesn't have any errors.
+  BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel build '@local_config_cc//:toolchain' &>/dev/null || \
+    fail "Fake toolchain target causes analysis errors"
 
   # This only shows reliably for query due to ordering issues in how Bazel shows
   # errors.

--- a/tools/cpp/BUILD.empty.tpl
+++ b/tools/cpp/BUILD.empty.tpl
@@ -15,6 +15,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+load("@rules_cc//cc:defs.bzl", "cc_toolchain_suite", "cc_toolchain")
 
 cc_library(
     name = "malloc",
@@ -28,8 +29,8 @@ filegroup(
 cc_toolchain_suite(
     name = "toolchain",
     toolchains = {
-        "local|local": ":local",
-        "local": ":local",
+        "%{cpu}|local": ":local",
+        "%{cpu}": ":local",
     },
 )
 

--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -97,11 +97,13 @@ def cc_autoconf_impl(repository_ctx, overriden_tools = dict()):
     cpu_value = get_cpu_value(repository_ctx)
     if "BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN" in env and env["BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN"] == "1":
         paths = resolve_labels(repository_ctx, [
-            "@bazel_tools//tools/cpp:BUILD.empty",
+            "@bazel_tools//tools/cpp:BUILD.empty.tpl",
             "@bazel_tools//tools/cpp:empty_cc_toolchain_config.bzl",
         ])
         repository_ctx.symlink(paths["@bazel_tools//tools/cpp:empty_cc_toolchain_config.bzl"], "cc_toolchain_config.bzl")
-        repository_ctx.symlink(paths["@bazel_tools//tools/cpp:BUILD.empty"], "BUILD")
+        repository_ctx.template("BUILD", paths["@bazel_tools//tools/cpp:BUILD.empty.tpl"], {
+            "%{cpu}": get_cpu_value(repository_ctx),
+        })
     elif cpu_value == "freebsd" or cpu_value == "openbsd":
         paths = resolve_labels(repository_ctx, [
             "@bazel_tools//tools/cpp:BUILD.static.bsd",


### PR DESCRIPTION
The workspace prefix calls `cc_configure` which causes the toolchain in `@local_config_cc` to be evaluated.

Currently the evaluation of `@local_config_cc//:toolchain` with toolchain detection turned off causes an error in CcToolchainSuite due to none of the cpu labels matching the local host cpu.

This patch fixes this issue by templating the cpu label to the host cpu in `cc_autoconf` when `BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN` is true. 

Addresses https://github.com/bazelbuild/bazel/issues/10756