### PR TITLE
Export `.bzl` files in `@bazel_tools//tools/...`

### DIFF
--- a/tools/build_defs/repo/BUILD
+++ b/tools/build_defs/repo/BUILD
@@ -4,6 +4,8 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 licenses(["notice"])  # Apache 2.0
 
+exports_files(glob(["*.bzl"]))
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),

--- a/tools/build_defs/repo/BUILD.repo
+++ b/tools/build_defs/repo/BUILD.repo
@@ -1,3 +1,5 @@
+exports_files(glob(["*.bzl"]))
+
 filegroup(
     name = "bzl_srcs",
     srcs = glob(["*.bzl"]),

--- a/tools/cpp/BUILD
+++ b/tools/cpp/BUILD
@@ -16,6 +16,8 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+exports_files(glob(["*.bzl"]))
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]) + [

--- a/tools/osx/BUILD
+++ b/tools/osx/BUILD
@@ -24,6 +24,7 @@ filegroup(
 
 exports_files([
     "xcode_locator.m",
+    "xcode_configure.bzl",
 ])
 
 DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """


### PR DESCRIPTION
With this change it is now possible to create a `bzl_library` entry that has a `deps` entry for all its inputs.