### PR TITLE
Try disabling grpc server auto flow control

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
@@ -390,7 +390,7 @@ public class GrpcServerImpl extends CommandServerGrpc.CommandServerImplBase impl
       server =
           NettyServerBuilder.forAddress(address).addService(this).directExecutor()
               // disable auto flow control https://github.com/bazelbuild/bazel/issues/12264
-              .flowControlWindow(NettyServerBuilder.DEFAULT_FLOW_CONTROL_WINDOW);
+              .flowControlWindow(NettyServerBuilder.DEFAULT_FLOW_CONTROL_WINDOW)
 	      .build().start();
     } catch (IOException ipv6Exception) {
       address = new InetSocketAddress("127.0.0.1", port);

--- a/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
@@ -400,7 +400,7 @@ public class GrpcServerImpl extends CommandServerGrpc.CommandServerImplBase impl
                 .addService(this)
                 .directExecutor()
                 // disable auto flow control https://github.com/bazelbuild/bazel/issues/12264
-                .flowControlWindow(NettyServerBuilder.DEFAULT_FLOW_CONTROL_WINDOW);
+                .flowControlWindow(NettyServerBuilder.DEFAULT_FLOW_CONTROL_WINDOW)
                 .build()
                 .start();
       } catch (IOException ipv4Exception) {

--- a/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java
@@ -388,7 +388,10 @@ public class GrpcServerImpl extends CommandServerGrpc.CommandServerImplBase impl
         throw new IOException("ipv6 is not preferred on the system.");
       }
       server =
-          NettyServerBuilder.forAddress(address).addService(this).directExecutor().build().start();
+          NettyServerBuilder.forAddress(address).addService(this).directExecutor()
+              // disable auto flow control https://github.com/bazelbuild/bazel/issues/12264
+              .flowControlWindow(NettyServerBuilder.DEFAULT_FLOW_CONTROL_WINDOW);
+	      .build().start();
     } catch (IOException ipv6Exception) {
       address = new InetSocketAddress("127.0.0.1", port);
       try {
@@ -396,6 +399,8 @@ public class GrpcServerImpl extends CommandServerGrpc.CommandServerImplBase impl
             NettyServerBuilder.forAddress(address)
                 .addService(this)
                 .directExecutor()
+                // disable auto flow control https://github.com/bazelbuild/bazel/issues/12264
+                .flowControlWindow(NettyServerBuilder.DEFAULT_FLOW_CONTROL_WINDOW);
                 .build()
                 .start();
       } catch (IOException ipv4Exception) {

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorker.java
@@ -168,6 +168,9 @@ public final class RemoteWorker {
       logger.atInfo().log("Execution disabled, only serving cache requests");
     }
 
+    // disable auto flow control https://github.com/bazelbuild/bazel/issues/12264
+    b.flowControlWindow(NettyServerBuilder.DEFAULT_FLOW_CONTROL_WINDOW);
+
     Server server = b.build();
     logger.atInfo().log("Starting gRPC server on port %d", workerOptions.listenPort);
     server.start();


### PR DESCRIPTION
Was turned on by default during 1.26.0->1.31.1 grpc-java bump
It seems that it may be causing errors in RBE:

io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: Bandwidth exhausted
HTTP/2 error code: ENHANCE_YOUR_CALM
Received Goaway
too_many_pings

https://github.com/bazelbuild/bazel/issues/12264
https://github.com/grpc/grpc-java/pull/7302