### PR TITLE
Fix sleep-process not killed at exit in test-setup.sh

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -361,7 +361,7 @@ wait $childPid
 # By this point, we have everything we're willing to wait for. Tidy up our own
 # processes and move on.
 kill_group SIGKILL $childPid
-kill -SIGKILL $cleanupPid &> /dev/null
+kill_group SIGKILL $cleanupPid &> /dev/null
 wait $cleanupPid
 
 for signal in $signals; do


### PR DESCRIPTION
When sending the kill-signal to cleanupPid only
the subshell is killed but the spawned sleep
process within that shell remains and will remain
up to 10 seconds after the test has finished.

This is especially troublesome in the case of running
the test from a nfs-mount since the sleep process
may inherit file-descriptors to files within the
nfs-mount which could then not be removed until the
sleep process has exited.