### PR TITLE
CC rules should use cc_configure.WORKSPACE again.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
+import com.google.devtools.build.lib.bazel.rules.cpp.BazelCppRuleClasses;
 import com.google.devtools.build.lib.bazel.rules.sh.BazelShRuleClasses;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.rules.cpp.CcSkyframeFdoSupportFunction;
@@ -458,6 +459,8 @@ public class BazelRulesModule extends BlazeModule {
     try {
       // Load auto-configuration files, it is made outside of the rule class provider so that it
       // will not be loaded for our Java tests.
+      builder.addWorkspaceFileSuffix(
+          ResourceFileLoader.loadResource(BazelCppRuleClasses.class, "cc_configure.WORKSPACE"));
       builder.addWorkspaceFileSuffix(
           ResourceFileLoader.loadResource(BazelRulesModule.class, "xcode_configure.WORKSPACE"));
       builder.addWorkspaceFileSuffix(

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/CcRules.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/CcRules.java
@@ -99,6 +99,8 @@ public class CcRules implements RuleSet {
 
     try {
       builder.addWorkspaceFileSuffix(
+          ResourceFileLoader.loadResource(BazelCppRuleClasses.class, "cc_configure.WORKSPACE"));
+      builder.addWorkspaceFileSuffix(
           ResourceFileLoader.loadResource(JavaRules.class, "coverage.WORKSPACE"));
     } catch (IOException e) {
       throw new IllegalStateException(e);

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/CcRules.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/CcRules.java
@@ -99,8 +99,6 @@ public class CcRules implements RuleSet {
 
     try {
       builder.addWorkspaceFileSuffix(
-          ResourceFileLoader.loadResource(BazelCppRuleClasses.class, "cc_configure.WORKSPACE"));
-      builder.addWorkspaceFileSuffix(
           ResourceFileLoader.loadResource(JavaRules.class, "coverage.WORKSPACE"));
     } catch (IOException e) {
       throw new IllegalStateException(e);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/WorkspaceFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/WorkspaceFileFunction.java
@@ -169,19 +169,8 @@ public class WorkspaceFileFunction implements SkyFunction {
       String suffix;
       if (resolvedFile.isPresent()) {
         suffix = "";
-      } else if (!ruleClassProvider.getDefaultWorkspaceSuffix().contains("sh_configure")) {
-        // It might look fragile to check for sh_configure in the WORKSPACE file,
-        // but it turns out it's the best approximation.
-        // The problem is that some tests want the ruleClassProvider
-        // together with logic from BazelRulesModule,
-        // whereas some tests want only the BazelRuleClassProvider,
-        // and some only a subset of that.
-        suffix = ruleClassProvider.getDefaultWorkspaceSuffix();
       } else {
-        suffix =
-            ruleClassProvider.getDefaultWorkspaceSuffix()
-                + "\nload('@bazel_tools//tools/cpp:cc_configure.bzl', 'cc_configure')\n\n"
-                + "cc_configure()";
+        suffix = ruleClassProvider.getDefaultWorkspaceSuffix();
       }
 
       file =


### PR DESCRIPTION
This removes a hack that was intended to support
--incompatible_use_cc_configure_from_rules_cc but which was never
enabled.