### PR TITLE
Load rules_cc from cc_configure.WORKSPACE.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -503,6 +503,8 @@ http_archive(
     ],
 )
 
+# This must be kept in sync with src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE.
+# This must be kept in sync with src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/cc_configure.WORKSPACE.
 http_archive(
     name = "rules_cc",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/cc_configure.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/cc_configure.WORKSPACE
@@ -1,3 +1,17 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_configure")
+
+# rules_cc is used in @bazel_tools//tools/cpp, so must be loaded here.
+maybe(
+    http_archive,
+    "rules_cc",
+    sha256 = "1d4dbbd1e1e9b57d40bb0ade51c9e882da7658d5bfbf22bbd15b68e7879d761f",
+    strip_prefix = "rules_cc-8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0.zip",
+        "https://github.com/bazelbuild/rules_cc/archive/8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0.zip",
+    ],
+)
 
 cc_configure()


### PR DESCRIPTION
rules_cc is referenced from @bazel_tools//tools/cpp, and was previously only working by accident (because it is also loaded from jdk.WORKSPACE).
