### PR TITLE
Add relative_ast_path_feature

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5218,6 +5218,24 @@ def _impl(ctx):
         ],
     )
 
+    relative_ast_path_feature = feature(
+        name = "relative_ast_path",
+        env_sets = [
+            env_set(
+                actions = all_link_actions + [
+                    "objc-executable",
+                    "objc++-executable",
+                ],
+                env_entries = [
+                    env_entry(
+                        key = "RELATIVE_AST_PATH",
+                        value = "true",
+                    ),
+                ],
+            ),
+        ],
+    )
+
     archiver_flags_feature = feature(
         name = "archiver_flags",
         flag_sets = [
@@ -6090,6 +6108,7 @@ def _impl(ctx):
             objc_arc_feature,
             no_objc_arc_feature,
             apple_env_feature,
+            relative_ast_path_feature,
             user_link_flags_feature,
             default_link_flags_feature,
             version_min_feature,
@@ -6165,6 +6184,7 @@ def _impl(ctx):
             objc_arc_feature,
             no_objc_arc_feature,
             apple_env_feature,
+            relative_ast_path_feature,
             user_link_flags_feature,
             default_link_flags_feature,
             version_min_feature,
@@ -6240,6 +6260,7 @@ def _impl(ctx):
             objc_arc_feature,
             no_objc_arc_feature,
             apple_env_feature,
+            relative_ast_path_feature,
             user_link_flags_feature,
             default_link_flags_feature,
             version_min_feature,

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5223,8 +5223,8 @@ def _impl(ctx):
         env_sets = [
             env_set(
                 actions = all_link_actions + [
-                    "objc-executable",
-                    "objc++-executable",
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
                 ],
                 env_entries = [
                     env_entry(

--- a/tools/osx/crosstool/wrapped_clang.cc
+++ b/tools/osx/crosstool/wrapped_clang.cc
@@ -201,6 +201,7 @@ int main(int argc, char *argv[]) {
     abort();
   }
 
+  bool relative_ast_path = getenv("RELATIVE_AST_PATH") != nullptr;
   for (int i = 1; i < argc; i++) {
     std::string arg(argv[i]);
 
@@ -228,7 +229,7 @@ int main(int argc, char *argv[]) {
     // Make the `add_ast_path` options used to embed Swift module references
     // absolute to enable Swift debugging without dSYMs: see
     // https://forums.swift.org/t/improving-swift-lldb-support-for-path-remappings/22694
-    if (StripPrefixStringIfPresent(&arg, kAddASTPathPrefix)) {
+    if (!relative_ast_path && StripPrefixStringIfPresent(&arg, kAddASTPathPrefix)) {
       // Only modify relative paths.
       if (!StartsWith(arg, "/")) {
         arg = std::string(kAddASTPathPrefix) +

--- a/tools/osx/crosstool/wrapped_clang_test.sh
+++ b/tools/osx/crosstool/wrapped_clang_test.sh
@@ -58,6 +58,12 @@ function test_add_ast_path_remapping() {
   expect_log "-Wl,-add_ast_path,${PWD}/foo" "Expected add_ast_path to be remapped."
 }
 
+function test_disable_add_ast_path_remapping() {
+  env RELATIVE_AST_PATH=isset DEVELOPER_DIR=dummy SDKROOT=a \
+      "${WRAPPED_CLANG}" "-Wl,-add_ast_path,relative/foo" >$TEST_log || fail "wrapped_clang failed";
+  expect_log "-Wl,-add_ast_path,relative/foo" "Expected add_ast_path to not be remapped."
+}
+
 # Test that __BAZEL_XCODE_DEVELOPER_DIR__ is remapped properly.
 function test_developer_dir_remapping() {
   env DEVELOPER_DIR=mydir SDKROOT=a \


### PR DESCRIPTION
This feature applies for darwin builds to disable absolutizing
swiftmodule paths to link commands. Previously these paths were
absolutized to support debugging. This is not required if users change
the pwd of their debugger so that the relative paths are valid. Since we
don't have a way to force that on users, absolutizing them is still the
default, but users who configure that can enable this feature to improve
hermeticity of their builds.

RELNOTES: Add `relative_ast_path` feature for darwin builds to relativize swiftmodule paths for debugging