### PR TITLE
starlark: dedent continued function param lines

### DIFF
--- a/src/test/java/com/google/devtools/build/skydoc/testdata/function_basic_test/golden.txt
+++ b/src/test/java/com/google/devtools/build/skydoc/testdata/function_basic_test/golden.txt
@@ -103,6 +103,47 @@ Use literally anything but this function.
 
 
 
+<a name="#param_doc_multiline"></a>
+
+## param_doc_multiline
+
+<pre>
+param_doc_multiline(<a href="#param_doc_multiline-complex">complex</a>)
+</pre>
+
+Has a complex parameter.
+
+### Parameters
+
+<table class="params-table">
+  <colgroup>
+    <col class="col-param" />
+    <col class="col-description" />
+  </colgroup>
+  <tbody>
+    <tr id="param_doc_multiline-complex">
+      <td><code>complex</code></td>
+      <td>
+        required.
+        <p>
+          A parameter with some non-obvious behavior.
+
+For example, it does things that require **multiple paragraphs** to explain.
+
+Note: we should preserve the nested indent in the following code:
+
+```json
+{
+    "key": "value"
+}
+```
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
 <a name="#returns_a_thing"></a>
 
 ## returns_a_thing

--- a/src/test/java/com/google/devtools/build/skydoc/testdata/function_basic_test/golden.txt
+++ b/src/test/java/com/google/devtools/build/skydoc/testdata/function_basic_test/golden.txt
@@ -128,7 +128,7 @@ Has a complex parameter.
         <p>
           A parameter with some non-obvious behavior.
 
-For example, it does things that require **multiple paragraphs** to explain.
+ For example, it does things that require **multiple paragraphs** to explain.
 
 Note: we should preserve the nested indent in the following code:
 

--- a/src/test/java/com/google/devtools/build/skydoc/testdata/function_basic_test/input.bzl
+++ b/src/test/java/com/google/devtools/build/skydoc/testdata/function_basic_test/input.bzl
@@ -54,3 +54,22 @@ def deprecated_do_not_use():
 
 def undocumented_function(a, b, c):
     pass
+
+def param_doc_multiline(complex):
+    """Has a complex parameter.
+
+    Args:
+        complex: A parameter with some non-obvious behavior.
+
+            For example, it does things that require **multiple paragraphs** to explain.
+
+           Note: we should preserve the nested indent in the following code:
+
+           ```json
+           {
+               "key": "value"
+           }
+           ```
+    """
+    pass
+

--- a/src/test/java/com/google/devtools/build/skydoc/testdata/pure_markdown_template_test/golden.txt
+++ b/src/test/java/com/google/devtools/build/skydoc/testdata/pure_markdown_template_test/golden.txt
@@ -56,7 +56,7 @@ Small example of function using a markdown template.
 | Name  | Description | Default Value |
 | :-------------: | :-------------: | :-------------: |
 | <a name="example_function-foo"></a>foo |  This parameter does foo related things.   |  none |
-| <a name="example_function-bar"></a>bar |  This parameter does bar related things.   |  <code>"bar"</code> |
+| <a name="example_function-bar"></a>bar |  This parameter does bar related things.<br><br>For example, it does things that require **multiple paragraphs** to explain.<br><br>Note: we should preserve the nested indent in the following code:<br><br><pre><code>json {     "key": "value" } </code></pre>   |  <code>"bar"</code> |
 
 
 <a name="#example_aspect"></a>

--- a/src/test/java/com/google/devtools/build/skydoc/testdata/pure_markdown_template_test/input.bzl
+++ b/src/test/java/com/google/devtools/build/skydoc/testdata/pure_markdown_template_test/input.bzl
@@ -9,13 +9,13 @@ def example_function(foo, bar = "bar"):
 
             For example, it does things that require **multiple paragraphs** to explain.
 
-           Note: we should preserve the nested indent in the following code:
+            Note: we should preserve the nested indent in the following code:
 
-           ```json
-           {
-               "key": "value"
-           }
-           ```
+            ```json
+            {
+                "key": "value"
+            }
+            ```
     """
     pass
 

--- a/src/test/java/com/google/devtools/build/skydoc/testdata/pure_markdown_template_test/input.bzl
+++ b/src/test/java/com/google/devtools/build/skydoc/testdata/pure_markdown_template_test/input.bzl
@@ -6,6 +6,16 @@ def example_function(foo, bar = "bar"):
     Args:
         foo: This parameter does foo related things.
         bar: This parameter does bar related things.
+
+            For example, it does things that require **multiple paragraphs** to explain.
+
+           Note: we should preserve the nested indent in the following code:
+
+           ```json
+           {
+               "key": "value"
+           }
+           ```
     """
     pass
 

--- a/src/tools/starlark/java/com/google/devtools/starlark/common/DocstringUtils.java
+++ b/src/tools/starlark/java/com/google/devtools/starlark/common/DocstringUtils.java
@@ -479,23 +479,25 @@ public final class DocstringUtils {
     /** Parses additional lines that can come after "param: foo" in an 'Args' section. */
     private void parseContinuedParamDescription(
         int baselineIndentation, StringBuilder description) {
-      // continuations are de-dented to the minimum value seen
+      // Two iterations: first buffer lines and find the minimal indent, then trim to the min
+      List<String> buffer = new ArrayList();
       int continuationIndentation = Integer.MAX_VALUE;
       while (nextLine()) {
-        if (line.isEmpty()) {
-          description.append('\n');
-          continue;
+        if (!line.isEmpty()) {
+          if (getIndentation(line) <= baselineIndentation) {
+            break;
+          }
+          continuationIndentation = Math.min(getIndentation(line), continuationIndentation);
         }
-        int lineIndentation = getIndentation(line);
-        if (lineIndentation <= baselineIndentation) {
-          break;
-        }
-        if (lineIndentation < continuationIndentation) {
-          continuationIndentation = lineIndentation;
-        }
-        String trimmedLine = line.substring(continuationIndentation);
+        buffer.add(line);
+      }
+
+      for (String bufLine: buffer) {
         description.append('\n');
-        description.append(trimmedLine);
+        if (!bufLine.isEmpty()) {
+          String trimmedLine = bufLine.substring(continuationIndentation);
+          description.append(trimmedLine);
+        }
       }
     }
 

--- a/src/tools/starlark/java/com/google/devtools/starlark/common/DocstringUtils.java
+++ b/src/tools/starlark/java/com/google/devtools/starlark/common/DocstringUtils.java
@@ -479,15 +479,21 @@ public final class DocstringUtils {
     /** Parses additional lines that can come after "param: foo" in an 'Args' section. */
     private void parseContinuedParamDescription(
         int baselineIndentation, StringBuilder description) {
+      // continuations are de-dented to the minimum value seen
+      int continuationIndentation = Integer.MAX_VALUE;
       while (nextLine()) {
         if (line.isEmpty()) {
           description.append('\n');
           continue;
         }
-        if (getIndentation(line) <= baselineIndentation) {
+        int lineIndentation = getIndentation(line);
+        if (lineIndentation <= baselineIndentation) {
           break;
         }
-        String trimmedLine = line.substring(baselineIndentation);
+        if (lineIndentation < continuationIndentation) {
+          continuationIndentation = lineIndentation;
+        }
+        String trimmedLine = line.substring(continuationIndentation);
         description.append('\n');
         description.append(trimmedLine);
       }


### PR DESCRIPTION
This allows multi-line parameter documentation under Args: without extra indents.
Fixes https://github.com/bazelbuild/stardoc/issues/74