### PR TITLE
Add package_metrics.proto to bootstrap protos list

### DIFF
--- a/scripts/bootstrap/compile.sh
+++ b/scripts/bootstrap/compile.sh
@@ -25,7 +25,7 @@ fi
 
 # Parse third_party/googleapis/BUILD.bazel to find the proto files we need to compile from googleapis
 GOOGLE_API_PROTOS="$(grep -o '".*\.proto"' third_party/googleapis/BUILD.bazel | sed 's/"//g' | sed 's|^|third_party/googleapis/|g')"
-PROTO_FILES=$(find third_party/remoteapis ${GOOGLE_API_PROTOS} third_party/pprof src/main/protobuf src/main/java/com/google/devtools/build/lib/buildeventstream/proto src/main/java/com/google/devtools/build/skyframe src/main/java/com/google/devtools/build/lib/skyframe/proto src/main/java/com/google/devtools/build/lib/bazel/debug src/main/java/com/google/devtools/build/lib/starlarkdebug/proto -name "*.proto")
+PROTO_FILES=$(find third_party/remoteapis ${GOOGLE_API_PROTOS} third_party/pprof src/main/protobuf src/main/java/com/google/devtools/build/lib/buildeventstream/proto src/main/java/com/google/devtools/build/skyframe src/main/java/com/google/devtools/build/lib/skyframe/proto src/main/java/com/google/devtools/build/lib/bazel/debug src/main/java/com/google/devtools/build/lib/starlarkdebug/proto src/main/java/com/google/devtools/build/lib/packages/metrics/package_metrics.proto -name "*.proto")
 LIBRARY_JARS=$(find $ADDITIONAL_JARS third_party -name '*.jar' | grep -Fv JavaBuilder | grep -Fv third_party/guava/guava | grep -ve 'third_party/grpc/grpc.*jar' | tr "\n" " ")
 GRPC_JAVA_VERSION=1.32.2
 GRPC_LIBRARY_JARS=$(find third_party/grpc -name '*.jar' | grep -e ".*${GRPC_JAVA_VERSION}.*jar" | tr "\n" " ")


### PR DESCRIPTION
Without it non-dist non-bazel bootstrapping fails with messages like
following:
```
src/main/java/com/google/devtools/build/lib/packages/metrics/CompletePackageMetricsRecorder.java:30: error: cannot find symbol
  private final HashMap<PackageIdentifier, PackageMetrics> metrics = new HashMap<>();
                                           ^
  symbol:   class PackageMetrics
  location: class CompletePackageMetricsRecorder
```

Another option could be to move it under src/main/protobuf.
Note that there are more protos currently under src/main/java, but
it seems like not all of them are needed for bootstrap compilation.
$ find src/main/java/ -name "*.proto"
src/main/java/com/google/devtools/build/skyframe/graph_inconsistency.proto
src/main/java/com/google/devtools/build/skydoc/rendering/proto/stardoc_output.proto
src/main/java/com/google/devtools/build/lib/skyframe/proto/action_rewind_event.proto
src/main/java/com/google/devtools/build/lib/starlarkdebug/proto/starlark_debugging.proto
src/main/java/com/google/devtools/build/lib/packages/metrics/package_metrics.proto
src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto
src/main/java/com/google/devtools/build/lib/bazel/debug/workspace_log.proto