### PR TITLE
Improve cquery speed by caching Skyframe calls

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryThreadsafeCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryThreadsafeCallback.java
@@ -20,6 +20,7 @@ import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.query2.NamedThreadSafeOutputFormatterCallback;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccessor;
+import com.google.devtools.build.lib.skyframe.BuildConfigurationValue;
 import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -27,7 +28,9 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -45,7 +48,10 @@ public abstract class CqueryThreadsafeCallback
   protected final CqueryOptions options;
   protected OutputStream outputStream;
   protected Writer printStream;
-  protected final SkyframeExecutor skyframeExecutor;
+  // Skyframe calls incur a performance cost, even on cache hits. Consider this before exposing
+  // direct executor access to child classes.
+  private final SkyframeExecutor skyframeExecutor;
+  private final Map<BuildConfigurationValue.Key, BuildConfiguration> configCache = new HashMap<>();
   protected final ConfiguredTargetAccessor accessor;
 
   private final List<String> result = new ArrayList<>();
@@ -88,6 +94,14 @@ public abstract class CqueryThreadsafeCallback
     }
   }
 
+  protected BuildConfiguration getConfiguration(BuildConfigurationValue.Key configKey) {
+    // Experiments querying:
+    //     cquery --output=graph "deps(//src:main/java/com/google/devtools/build/lib:runtime)"
+    // 10 times on a warm Blaze instance show 7% less total query time when using this cache vs.
+    // calling Skyframe directly (and relying on Skyframe's cache).
+    return configCache.computeIfAbsent(
+        configKey, key -> skyframeExecutor.getConfiguration(eventHandler, key));
+  }
   /**
    * Returns a user-friendly configuration identifier as a prefix of <code>fullId</code>.
    *

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryThreadsafeCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryThreadsafeCallback.java
@@ -28,9 +28,9 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 
 /**
@@ -51,7 +51,7 @@ public abstract class CqueryThreadsafeCallback
   // Skyframe calls incur a performance cost, even on cache hits. Consider this before exposing
   // direct executor access to child classes.
   private final SkyframeExecutor skyframeExecutor;
-  private final Map<BuildConfigurationValue.Key, BuildConfiguration> configCache = new HashMap<>();
+  private final Map<BuildConfigurationValue.Key, BuildConfiguration> configCache = new ConcurrentHashMap<>();
   protected final ConfiguredTargetAccessor accessor;
 
   private final List<String> result = new ArrayList<>();

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
@@ -61,13 +61,7 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
           // hashes.
           ConfiguredTarget ct = node.getLabel();
           return String.format(
-              "%s (%s)",
-              ct.getLabel(),
-              // TODO(gregce): Even if getConfiguration is a cache hit this has overhead, especially
-              // when called many times on the same configuration in the same query. Investigate the
-              // performance impact and apply a cache if measurements justify it (also in other
-              // callbacks that do this).
-              shortId(skyframeExecutor.getConfiguration(eventHandler, ct.getConfigurationKey())));
+              "%s (%s)", ct.getLabel(), shortId(getConfiguration(ct.getConfigurationKey())));
         }
 
         @Override

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/LabelAndConfigurationOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/LabelAndConfigurationOutputFormatterCallback.java
@@ -15,7 +15,6 @@ package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.RequiredConfigFragmentsProvider;
-import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.analysis.config.CoreOptions.IncludeConfigFragmentsEnum;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.packages.Target;
@@ -46,8 +45,6 @@ public class LabelAndConfigurationOutputFormatterCallback extends CqueryThreadsa
   @Override
   public void processOutput(Iterable<ConfiguredTarget> partialResult) {
     for (ConfiguredTarget configuredTarget : partialResult) {
-      BuildConfiguration config =
-          skyframeExecutor.getConfiguration(eventHandler, configuredTarget.getConfigurationKey());
       StringBuilder output = new StringBuilder();
       if (showKind) {
         Target actualTarget = accessor.getTargetFromConfiguredTarget(configuredTarget);
@@ -57,7 +54,7 @@ public class LabelAndConfigurationOutputFormatterCallback extends CqueryThreadsa
           output
               .append(configuredTarget.getOriginalLabel())
               .append(" (")
-              .append(shortId(config))
+              .append(shortId(getConfiguration(configuredTarget.getConfigurationKey())))
               .append(")");
 
       if (options.showRequiredConfigFragments != IncludeConfigFragmentsEnum.OFF) {

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallback.java
@@ -63,6 +63,7 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
 
   private final OutputType outputType;
   private final AspectResolver resolver;
+  private final SkyframeExecutor skyframeExecutor;
   private final JsonFormat.Printer jsonPrinter = JsonFormat.printer();
 
   private AnalysisProtos.CqueryResult.Builder protoResult;
@@ -79,6 +80,7 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
       OutputType outputType) {
     super(eventHandler, options, out, skyframeExecutor, accessor);
     this.outputType = outputType;
+    this.skyframeExecutor = skyframeExecutor;
     this.resolver = resolver;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
@@ -63,8 +63,7 @@ public class StarlarkOutputFormatterCallback extends CqueryThreadsafeCallback {
           @Param(name = "target"),
         })
     public Object buildOptions(ConfiguredTarget target) {
-      BuildConfiguration config =
-          skyframeExecutor.getConfiguration(eventHandler, target.getConfigurationKey());
+      BuildConfiguration config = getConfiguration(target.getConfigurationKey());
 
       if (config == null) {
         // config is null for input file configured targets.

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
@@ -106,9 +106,7 @@ class TransitionsOutputFormatterCallback extends CqueryThreadsafeCallback {
                 ct.getOriginalLabel(), accessor.getTargetFromConfiguredTarget(ct)));
     for (ConfiguredTarget configuredTarget : partialResult) {
       Target target = partialResultMap.get(configuredTarget.getOriginalLabel());
-      BuildConfiguration config =
-          skyframeExecutor.getConfiguration(
-              eventHandler, configuredTarget.getConfigurationKey());
+      BuildConfiguration config = getConfiguration(configuredTarget.getConfigurationKey());
       addResult(
           getRuleClassTransition(configuredTarget, target)
               + String.format("%s (%s)", configuredTarget.getOriginalLabel(), shortId(config)));


### PR DESCRIPTION
Calling Skyframe adds a performance cost even when hitting the Skyframe
cache. This change adds a local cache for retrieving configurations.

Experiments show about a 7% reduction in query time on `--output=graph` (see code comments).

Followup to
https://github.com/bazelbuild/bazel/pull/12248/files/939e4cadf7a49a316017d207bd4504ac0c10373c#r503552367.

