### PR TITLE
Improve error reporting from repository functions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/NewLocalRepositoryFunction.java
@@ -55,7 +55,7 @@ public class NewLocalRepositoryFunction extends RepositoryFunction {
       Environment env,
       Map<String, String> markerData,
       SkyKey key)
-      throws SkyFunctionException, InterruptedException {
+      throws InterruptedException, RepositoryFunctionException {
 
     NewRepositoryFileHandler fileHandler = new NewRepositoryFileHandler(directories.getWorkspace());
     if (!fileHandler.prepareFile(rule, env)) {

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -114,18 +114,9 @@ public abstract class RepositoryFunction {
     public RepositoryFunctionException(EvalException cause, Transience transience) {
       super(cause, transience);
     }
-  }
-  /**
-   * Exception thrown when something a repository rule cannot be found.
-   */
-  public static final class RepositoryNotFoundException extends RepositoryFunctionException {
 
-    public RepositoryNotFoundException(String repositoryName) {
-      super(
-          new BuildFileContainsErrorsException(
-              LabelConstants.EXTERNAL_PACKAGE_IDENTIFIER,
-              "The repository named '" + repositoryName + "' could not be resolved"),
-          Transience.PERSISTENT);
+    public RepositoryFunctionException(ExternalPackageException e) {
+      super(e.getCause(), e.isTransient() ? Transience.TRANSIENT : Transience.PERSISTENT);
     }
   }
 
@@ -180,7 +171,7 @@ public abstract class RepositoryFunction {
       Environment env,
       Map<String, String> markerData,
       SkyKey key)
-      throws SkyFunctionException, InterruptedException;
+      throws InterruptedException, RepositoryFunctionException;
 
   @SuppressWarnings("unchecked")
   private static Iterable<String> getEnviron(Rule rule) {

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryFunctionTest.java
@@ -61,7 +61,7 @@ public class RepositoryFunctionTest extends BuildViewTestCase {
         SkyFunction.Environment env,
         Map<String, String> markerData,
         SkyKey key)
-        throws SkyFunctionException, InterruptedException {
+        throws InterruptedException {
       return null;
     }
 


### PR DESCRIPTION
Use more specific exception types, and don't blindly rethrow other
SkyFunctions' exception types.

Part of #12303.