### PR TITLE
Add support for AArch64 release artifacts

### DIFF
--- a/scripts/kokoro/release/build_linux.sh
+++ b/scripts/kokoro/release/build_linux.sh
@@ -18,11 +18,18 @@ set -e
 set -x
 
 RELEASE_NAME=${RELEASE_NAME:-unknown}
+ARCHITECTURE=`uname -m`
+
+if [ $ARCHITECTURE = "aarch64" ]; then
+    BAZELISK_EXT="arm64"
+else
+    BAZELISK_EXT="amd64"
+fi
 
 # Get Bazelisk
 mkdir -p /tmp/tool
 BAZELISK="/tmp/tool/bazelisk"
-wget -q https://github.com/bazelbuild/bazelisk/releases/download/v1.2.1/bazelisk-linux-amd64 -O "${BAZELISK}"
+wget -q https://github.com/bazelbuild/bazelisk/releases/download/v1.7.2/bazelisk-linux-"${BAZELISK_EXT}" -O "${BAZELISK}"
 chmod +x "${BAZELISK}"
 
 "${BAZELISK}" build --sandbox_tmpfs_path=/tmp //src:bazel
@@ -43,10 +50,13 @@ output/bazel build \
     bazel-distfile.zip
 
 mkdir artifacts
-cp "bazel-bin/src/bazel" "artifacts/bazel-${RELEASE_NAME}-linux-x86_64"
-cp "bazel-bin/scripts/packages/with-jdk/install.sh" "artifacts/bazel-${RELEASE_NAME}-installer-linux-x86_64.sh"
-cp "bazel-bin/scripts/packages/debian/bazel-debian.deb" "artifacts/bazel_${RELEASE_NAME}-linux-x86_64.deb"
-cp "bazel-bin/scripts/packages/debian/bazel.dsc" "artifacts/bazel_${RELEASE_NAME}.dsc"
-cp "bazel-bin/scripts/packages/debian/bazel.tar.gz" "artifacts/bazel_${RELEASE_NAME}.tar.gz"
-cp "bazel-bin/bazel-distfile.zip" "artifacts/bazel-${RELEASE_NAME}-dist.zip"
+cp "bazel-bin/src/bazel" "artifacts/bazel-${RELEASE_NAME}-linux-${ARCHITECTURE}"
+cp "bazel-bin/scripts/packages/with-jdk/install.sh" "artifacts/bazel-${RELEASE_NAME}-installer-linux-${ARCHITECTURE}.sh"
+cp "bazel-bin/scripts/packages/debian/bazel-debian.deb" "artifacts/bazel_${RELEASE_NAME}-linux-${ARCHITECTURE}.deb"
+
+if [ $ARCHITECTURE = "x86_64" ]; then
+    cp "bazel-bin/scripts/packages/debian/bazel.dsc" "artifacts/bazel_${RELEASE_NAME}.dsc"
+    cp "bazel-bin/scripts/packages/debian/bazel.tar.gz" "artifacts/bazel_${RELEASE_NAME}.tar.gz"
+    cp "bazel-bin/bazel-distfile.zip" "artifacts/bazel-${RELEASE_NAME}-dist.zip"
+fi
 

--- a/scripts/kokoro/release/build_macos.sh
+++ b/scripts/kokoro/release/build_macos.sh
@@ -22,7 +22,7 @@ RELEASE_NAME=${RELEASE_NAME:-unknown}
 # Get Bazelisk
 mkdir -p /tmp/tool
 BAZELISK="/tmp/tool/bazelisk"
-wget https://github.com/bazelbuild/bazelisk/releases/download/v1.2.1/bazelisk-darwin-amd64 -O "${BAZELISK}"
+wget https://github.com/bazelbuild/bazelisk/releases/download/v1.7.2/bazelisk-darwin-amd64 -O "${BAZELISK}"
 chmod +x "${BAZELISK}"
 
 # Switch to Xcode 10.3

--- a/scripts/kokoro/release/build_windows.bat
+++ b/scripts/kokoro/release/build_windows.bat
@@ -18,7 +18,7 @@ if not defined RELEASE_NAME (
 
 mkdir T:\tmp\tool
 set BAZELISK=T:\tmp\tool\bazelisk.exe
-powershell /c "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object Net.WebClient).DownloadFile('https://github.com/bazelbuild/bazelisk/releases/download/v1.2.1/bazelisk-windows-amd64.exe', '%BAZELISK%')"
+powershell /c "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object Net.WebClient).DownloadFile('https://github.com/bazelbuild/bazelisk/releases/download/v1.7.2/bazelisk-windows-amd64.exe', '%BAZELISK%')"
 
 set PATH=C:\python37;%PATH%
 


### PR DESCRIPTION
kokoro scripts are updated to support:

1. bazelisk v1.7.2
2. AArch64 release artifacts