### PR TITLE
Reduce platform dependant selects in //tools/jdk/BUILD

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/BazelAndroidLocalTestRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/BazelAndroidLocalTestRule.java
@@ -42,7 +42,7 @@ import com.google.devtools.build.lib.rules.java.JavaSemantics;
 /** Rule definition for Bazel android_local_test */
 public class BazelAndroidLocalTestRule implements RuleDefinition {
 
-  protected static final String JUNIT_TESTRUNNER = "//tools/jdk:TestRunner_deploy.jar";
+  protected static final String JUNIT_TESTRUNNER = "//tools/jdk:TestRunner";
 
   private static final ImmutableCollection<String> ALLOWED_RULES_IN_DEPS =
       ImmutableSet.of(

--- a/src/test/shell/bazel/bazel_example_test.sh
+++ b/src/test/shell/bazel/bazel_example_test.sh
@@ -91,7 +91,6 @@ function test_java_test() {
   local java_native_main=//examples/java-native/src/main/java/com/example/myproject
 
   assert_build "-- //examples/java-native/... -${java_native_main}:hello-error-prone"
-  JAVA_VERSION="1.$(bazel query  --output=build '@bazel_tools//tools/jdk:legacy_toolchain' | grep source_version | cut -d '"' -f 2)"
   assert_test_ok "${java_native_tests}:hello"
   assert_test_ok "${java_native_tests}:custom"
   assert_test_fails "${java_native_tests}:fail"

--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -59,6 +59,7 @@ fi
 
 
 function test_default_java_toolchain_target_version() {
+  setup_bazelrc
   mkdir -p java/main
   cat >java/main/BUILD <<EOF
 java_binary(

--- a/src/test/shell/integration/bazel_java_test.sh
+++ b/src/test/shell/integration/bazel_java_test.sh
@@ -93,7 +93,7 @@ default_java_toolchain(
     # Implicitly use the host_javabase bootclasspath, since the target doesn't
     # exist in this test.
     bootclasspath = [],
-    javabuilder = ["@bazel_tools//tools/jdk:vanillajavabuilder"],
+    javabuilder = ["//:VanillaJavaBuilder"],
     jvm_opts = [],
     visibility = ["//visibility:public"],
 )

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -264,7 +264,6 @@ alias(
     name = "toolchain_hostjdk8",
     actual = select({
         "//src/conditions:darwin": "@remote_java_tools_darwin//:toolchain_hostjdk8",
-        "//src/conditions:darwin_x86_64": "@remote_java_tools_darwin//:toolchain_hostjdk8",
         "//src/conditions:windows": "@remote_java_tools_windows//:toolchain_hostjdk8",
         "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:toolchain_hostjdk8",
     }),
@@ -307,7 +306,6 @@ alias(
     name = "toolchain_vanilla",
     actual = select({
         "//src/conditions:darwin": "@remote_java_tools_darwin//:toolchain_vanilla",
-        "//src/conditions:darwin_x86_64": "@remote_java_tools_darwin//:toolchain_vanilla",
         "//src/conditions:windows": "@remote_java_tools_windows//:toolchain_vanilla",
         "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:toolchain_vanilla",
     }),
@@ -320,7 +318,6 @@ RELEASES = (8, 9, 10, 11)
         name = "toolchain_java%d" % release,
         actual = select({
             "//src/conditions:darwin": "@remote_java_tools_darwin//:toolchain_java%d" % release,
-            "//src/conditions:darwin_x86_64": "@remote_java_tools_darwin//:toolchain_java%d" % release,
             "//src/conditions:windows": "@remote_java_tools_windows//:toolchain_java%d" % release,
             "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:toolchain_java%d" % release,
         }),

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -197,7 +197,17 @@ remote_java_tools_java_import(
 )
 
 remote_java_tools_java_import(
+    name = "JacocoCoverage",
+    target = ":java_tools/JacocoCoverage_jarjar_deploy.jar",
+)
+
+remote_java_tools_java_import(
     name = "TestRunner",
+    target = ":java_tools/Runner_deploy.jar",
+)
+
+remote_java_tools_filegroup(
+    name = "TestRunner_deploy.jar",
     target = ":java_tools/Runner_deploy.jar",
 )
 

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -1,9 +1,7 @@
 load("@rules_java//java:defs.bzl", "java_import", "java_runtime", "java_toolchain")
 load(
-    "//tools/jdk:default_java_toolchain.bzl",
-    "JDK8_JVM_OPTS",
+    "//tools/jdk:utils.bzl",
     "bootclasspath",
-    "default_java_toolchain",
     "java_runtime_files",
 )
 load(
@@ -180,14 +178,6 @@ alias(
     actual = "@local_jdk//:javadoc",
 )
 
-# On Windows, executables end in ".exe", but the label we reach it through
-# must be platform-independent. Thus, we create a little filegroup that
-# contains the appropriate platform-dependent file.
-remote_java_tools_filegroup(
-    name = "ijar",
-    target = ":ijar",
-)
-
 # On Windows, Java implementation of singlejar is used. We create a little
 # filegroup that contains the appropriate platform-dependent file.
 # Once https://github.com/bazelbuild/bazel/issues/2241 is fixed (that is,
@@ -201,88 +191,13 @@ remote_java_tools_filegroup(
 
 exports_files(["BUILD.java_tools"])
 
-remote_java_tools_filegroup(
-    name = "genclass",
-    target = ":GenClass",
-)
-
-remote_java_tools_filegroup(
-    name = "GenClass_deploy.jar",
-    target = ":java_tools/GenClass_deploy.jar",
-)
-
-remote_java_tools_filegroup(
-    name = "bazel-singlejar_deploy.jar",
-    target = ":java_tools/bazel-singlejar_deploy.jar",
-)
-
-remote_java_tools_filegroup(
-    name = "turbine",
-    target = ":Turbine",
-)
-
-remote_java_tools_filegroup(
-    name = "turbine_deploy.jar",
-    target = ":java_tools/turbine_deploy.jar",
-)
-
-remote_java_tools_filegroup(
-    name = "turbine_direct",
-    target = ":TurbineDirect",
-)
-
-remote_java_tools_filegroup(
-    name = "turbine_direct_binary_deploy.jar",
-    target = ":java_tools/turbine_direct_binary_deploy.jar",
-)
-
-remote_java_tools_filegroup(
-    name = "javabuilder",
-    target = ":JavaBuilder",
-)
-
-remote_java_tools_filegroup(
-    name = "JavaBuilder_deploy.jar",
-    target = ":java_tools/JavaBuilder_deploy.jar",
-)
-
-remote_java_tools_filegroup(
-    name = "vanillajavabuilder",
-    target = ":VanillaJavaBuilder",
-)
-
-remote_java_tools_filegroup(
-    name = "javac_jar",
-    target = ":javac_jar",
-)
-
-remote_java_tools_filegroup(
-    name = "jdk_compiler_jar",
-    target = ":jdk_compiler_jar",
-)
-
-remote_java_tools_filegroup(
-    name = "java_compiler_jar",
-    target = ":java_compiler_jar",
-)
-
 remote_java_tools_java_import(
     name = "JacocoCoverageRunner",
     target = ":java_tools/JacocoCoverage_jarjar_deploy.jar",
 )
 
 remote_java_tools_java_import(
-    name = "JacocoCoverage",
-    target = ":java_tools/JacocoCoverage_jarjar_deploy.jar",
-)
-
-remote_java_tools_java_import(
     name = "TestRunner",
-    target = ":java_tools/Runner_deploy.jar",
-)
-
-remote_java_tools_filegroup(
-    name = "TestRunner_deploy.jar",
     target = ":java_tools/Runner_deploy.jar",
 )
 
@@ -345,19 +260,14 @@ bootclasspath(
     target_javabase = "current_java_runtime",
 )
 
-default_java_toolchain(
+alias(
     name = "toolchain_hostjdk8",
-    jvm_opts = JDK8_JVM_OPTS,
-    source_version = "8",
-    target_version = "8",
-)
-
-# Default to the Java 8 language level.
-# TODO(cushon): consider if/when we should increment this?
-default_java_toolchain(
-    name = "legacy_toolchain",
-    source_version = "8",
-    target_version = "8",
+    actual = select({
+        "//src/conditions:darwin": "@remote_java_tools_darwin//:toolchain_hostjdk8",
+        "//src/conditions:darwin_x86_64": "@remote_java_tools_darwin//:toolchain_hostjdk8",
+        "//src/conditions:windows": "@remote_java_tools_windows//:toolchain_hostjdk8",
+        "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:toolchain_hostjdk8",
+    }),
 )
 
 alias(
@@ -366,7 +276,6 @@ alias(
         "//src/conditions:darwin": "@remote_java_tools_darwin//:toolchain",
         "//src/conditions:windows": "@remote_java_tools_windows//:toolchain",
         "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:toolchain",
-        "//conditions:default": "@bazel_tools//tools/jdk:legacy_toolchain",
     }),
 )
 
@@ -376,7 +285,7 @@ alias(
         "//src/conditions:darwin": "@remote_java_tools_darwin//:toolchain",
         "//src/conditions:windows": "@remote_java_tools_windows//:toolchain",
         "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:toolchain",
-        "//conditions:default": "@bazel_tools//tools/jdk:legacy_toolchain",
+        "//conditions:default": "@remote_java_tools_linux//:toolchain",
     }),
 )
 
@@ -394,22 +303,27 @@ alias(
 #
 # However it does allow using a wider range of `--host_javabase`s, including
 # versions newer than the current embedded JDK.
-default_java_toolchain(
+alias(
     name = "toolchain_vanilla",
-    forcibly_disable_header_compilation = True,
-    javabuilder = [":vanillajavabuilder"],
-    jvm_opts = [],
-    source_version = "",
-    target_version = "",
+    actual = select({
+        "//src/conditions:darwin": "@remote_java_tools_darwin//:toolchain_vanilla",
+        "//src/conditions:darwin_x86_64": "@remote_java_tools_darwin//:toolchain_vanilla",
+        "//src/conditions:windows": "@remote_java_tools_windows//:toolchain_vanilla",
+        "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:toolchain_vanilla",
+    }),
 )
 
 RELEASES = (8, 9, 10, 11)
 
 [
-    default_java_toolchain(
+    alias(
         name = "toolchain_java%d" % release,
-        source_version = "%s" % release,
-        target_version = "%s" % release,
+        actual = select({
+            "//src/conditions:darwin": "@remote_java_tools_darwin//:toolchain_java%d" % release,
+            "//src/conditions:darwin_x86_64": "@remote_java_tools_darwin//:toolchain_java%d" % release,
+            "//src/conditions:windows": "@remote_java_tools_windows//:toolchain_java%d" % release,
+            "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:toolchain_java%d" % release,
+        }),
     )
     for release in RELEASES
 ]
@@ -433,6 +347,7 @@ filegroup(
         "proguard_whitelister_test_input.pgcfg",
         "remote_java_tools_aliases.bzl",
         "toolchain_utils.bzl",
+        "utils.bzl",
     ],
 )
 

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -12,18 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Bazel rules for creating Java toolchains."""
+"""Deprecated: Bazel rules for creating Java toolchains. Use java_toolchain_default.bzl."""
 
 load("@remote_java_tools_darwin//:java_toolchain_default.bzl", java_toolchain_default_macos = "java_toolchain_default")
 load("@remote_java_tools_windows//:java_toolchain_default.bzl", java_toolchain_default_windows = "java_toolchain_default")
 load("@remote_java_tools_linux//:java_toolchain_default.bzl", "JAVABUILDER_TOOLCHAIN_CONFIGURATION", java_toolchain_default_linux = "java_toolchain_default")
 
 def default_java_toolchain(name, configuration = JAVABUILDER_TOOLCHAIN_CONFIGURATION, **kwargs):
-    """Defines a remote java_toolchain with appropriate defaults for Bazel."""
+    """Deprecated: Defines a remote java_toolchain with appropriate defaults for Bazel.
 
-    java_toolchain_default_macos(name + "_darwin", configuration = JAVABUILDER_TOOLCHAIN_CONFIGURATION, **kwargs)
-    java_toolchain_default_windows(name + "_windows", configuration = JAVABUILDER_TOOLCHAIN_CONFIGURATION, **kwargs)
-    java_toolchain_default_linux(name + "_linux", configuration = JAVABUILDER_TOOLCHAIN_CONFIGURATION, **kwargs)
+    Use use java_toolchain_default instead."""
+
+    java_toolchain_default_macos(name + "_darwin", configuration = configuration, **kwargs)
+    java_toolchain_default_windows(name + "_windows", configuration = configuration, **kwargs)
+    java_toolchain_default_linux(name + "_linux", configuration = configuration, **kwargs)
 
     native.alias(
         name = name,

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -14,175 +14,29 @@
 
 """Bazel rules for creating Java toolchains."""
 
-load("@rules_java//java:defs.bzl", "java_toolchain")
+load("@remote_java_tools_darwin//:java_toolchain_default.bzl", java_toolchain_default_macos = "java_toolchain_default")
+load("@remote_java_tools_windows//:java_toolchain_default.bzl", java_toolchain_default_windows = "java_toolchain_default")
+load("@remote_java_tools_linux//:java_toolchain_default.bzl", "JAVABUILDER_TOOLCHAIN_CONFIGURATION", java_toolchain_default_linux = "java_toolchain_default")
 
-JDK8_JVM_OPTS = [
-    "-Xbootclasspath/p:$(location @bazel_tools//tools/jdk:javac_jar)",
-]
-
-JDK9_JVM_OPTS = [
-    # Allow JavaBuilder to access internal javac APIs.
-    "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-    "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-    "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-    "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-    "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-    "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-    "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-    "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-
-    # override the javac in the JDK.
-    "--patch-module=java.compiler=$(location @bazel_tools//tools/jdk:java_compiler_jar)",
-    "--patch-module=jdk.compiler=$(location @bazel_tools//tools/jdk:jdk_compiler_jar)",
-
-    # quiet warnings from com.google.protobuf.UnsafeUtil,
-    # see: https://github.com/google/protobuf/issues/3781
-    # and: https://github.com/bazelbuild/bazel/issues/5599
-    "--add-opens=java.base/java.nio=ALL-UNNAMED",
-    "--add-opens=java.base/java.lang=ALL-UNNAMED",
-]
-
-DEFAULT_JAVACOPTS = [
-    "-XDskipDuplicateBridges=true",
-    "-XDcompilePolicy=simple",
-    "-g",
-    "-parameters",
-]
-
-DEFAULT_TOOLCHAIN_CONFIGURATION = {
-    "forcibly_disable_header_compilation": 0,
-    "genclass": ["@bazel_tools//tools/jdk:genclass"],
-    "header_compiler": ["@bazel_tools//tools/jdk:turbine_direct"],
-    "header_compiler_direct": ["@bazel_tools//tools/jdk:turbine_direct"],
-    "ijar": ["@bazel_tools//tools/jdk:ijar"],
-    "javabuilder": ["@bazel_tools//tools/jdk:javabuilder"],
-    "tools": [
-        "@bazel_tools//tools/jdk:javac_jar",
-        "@bazel_tools//tools/jdk:java_compiler_jar",
-        "@bazel_tools//tools/jdk:jdk_compiler_jar",
-    ],
-    "javac_supports_workers": 1,
-    "jvm_opts": select({
-        "@bazel_tools//src/conditions:openbsd": JDK8_JVM_OPTS,
-        "//conditions:default": JDK9_JVM_OPTS,
-    }),
-    "misc": DEFAULT_JAVACOPTS,
-    "singlejar": ["@bazel_tools//tools/jdk:singlejar"],
-    "bootclasspath": ["@bazel_tools//tools/jdk:platformclasspath"],
-    "source_version": "8",
-    "target_version": "8",
-}
-
-def default_java_toolchain(name, **kwargs):
+def default_java_toolchain(name, configuration = JAVABUILDER_TOOLCHAIN_CONFIGURATION, **kwargs):
     """Defines a remote java_toolchain with appropriate defaults for Bazel."""
 
-    toolchain_args = dict(DEFAULT_TOOLCHAIN_CONFIGURATION)
-    toolchain_args.update(kwargs)
-    java_toolchain(
+    java_toolchain_default_macos(name + "_darwin", configuration = JAVABUILDER_TOOLCHAIN_CONFIGURATION, **kwargs)
+    java_toolchain_default_windows(name + "_windows", configuration = JAVABUILDER_TOOLCHAIN_CONFIGURATION, **kwargs)
+    java_toolchain_default_linux(name + "_linux", configuration = JAVABUILDER_TOOLCHAIN_CONFIGURATION, **kwargs)
+
+    native.alias(
         name = name,
-        **toolchain_args
-    )
-
-def java_runtime_files(name, srcs):
-    """Copies the given sources out of the current Java runtime."""
-
-    native.filegroup(
-        name = name,
-        srcs = srcs,
-    )
-    for src in srcs:
-        native.genrule(
-            name = "gen_%s" % src,
-            srcs = ["@bazel_tools//tools/jdk:current_java_runtime"],
-            toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
-            cmd = "cp $(JAVABASE)/%s $@" % src,
-            outs = [src],
-        )
-
-def _bootclasspath_impl(ctx):
-    host_javabase = ctx.attr.host_javabase[java_common.JavaRuntimeInfo]
-
-    # explicitly list output files instead of using TreeArtifact to work around
-    # https://github.com/bazelbuild/bazel/issues/6203
-    classes = [
-        "DumpPlatformClassPath.class",
-    ]
-
-    class_outputs = [
-        ctx.actions.declare_file("%s_classes/%s" % (ctx.label.name, clazz))
-        for clazz in classes
-    ]
-
-    args = ctx.actions.args()
-    args.add("-source")
-    args.add("8")
-    args.add("-target")
-    args.add("8")
-    args.add("-Xlint:-options")
-    args.add("-cp")
-    args.add("%s/lib/tools.jar" % host_javabase.java_home)
-    args.add("-d")
-    args.add(class_outputs[0].dirname)
-    args.add(ctx.file.src)
-
-    ctx.actions.run(
-        executable = "%s/bin/javac" % host_javabase.java_home,
-        inputs = [ctx.file.src] + ctx.files.host_javabase,
-        outputs = class_outputs,
-        arguments = [args],
-    )
-
-    bootclasspath = ctx.outputs.output_jar
-
-    inputs = class_outputs + ctx.files.host_javabase
-
-    args = ctx.actions.args()
-    args.add("-XX:+IgnoreUnrecognizedVMOptions")
-    args.add("--add-exports=jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED")
-    args.add_joined(
-        "-cp",
-        [class_outputs[0].dirname, "%s/lib/tools.jar" % host_javabase.java_home],
-        join_with = ctx.configuration.host_path_separator,
-    )
-    args.add("DumpPlatformClassPath")
-    args.add(bootclasspath)
-
-    if ctx.attr.target_javabase:
-        inputs.extend(ctx.files.target_javabase)
-        args.add(ctx.attr.target_javabase[java_common.JavaRuntimeInfo].java_home)
-
-    ctx.actions.run(
-        executable = str(host_javabase.java_executable_exec_path),
-        inputs = inputs,
-        outputs = [bootclasspath],
-        arguments = [args],
-    )
-    return [
-        DefaultInfo(files = depset([bootclasspath])),
-        OutputGroupInfo(jar = [bootclasspath]),
-    ]
-
-_bootclasspath = rule(
-    implementation = _bootclasspath_impl,
-    attrs = {
-        "host_javabase": attr.label(
-            cfg = "host",
-            providers = [java_common.JavaRuntimeInfo],
-        ),
-        "src": attr.label(
-            cfg = "host",
-            allow_single_file = True,
-        ),
-        "target_javabase": attr.label(
-            providers = [java_common.JavaRuntimeInfo],
-        ),
-        "output_jar": attr.output(mandatory = True),
-    },
-)
-
-def bootclasspath(name, **kwargs):
-    _bootclasspath(
-        name = name,
-        output_jar = name + ".jar",
-        **kwargs
+        actual = select({
+            "@bazel_tools//src/conditions:linux_x86_64": name + "_linux",
+            "@bazel_tools//src/conditions:darwin": name + "_darwin",
+            "@bazel_tools//src/conditions:darwin_x86_64": name + "_darwin",
+            "@bazel_tools//src/conditions:windows": name + "_windows",
+            # On different platforms the linux repository can be used.
+            # The deploy jars inside the linux repository are platform-agnostic.
+            # The ijar target inside the repository identifies the different
+            # platform and builds ijar from source instead of returning the
+            # precompiled binary.
+            "//conditions:default": name + "_linux",
+        }),
     )

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -30,7 +30,6 @@ def default_java_toolchain(name, configuration = JAVABUILDER_TOOLCHAIN_CONFIGURA
         actual = select({
             "@bazel_tools//src/conditions:linux_x86_64": name + "_linux",
             "@bazel_tools//src/conditions:darwin": name + "_darwin",
-            "@bazel_tools//src/conditions:darwin_x86_64": name + "_darwin",
             "@bazel_tools//src/conditions:windows": name + "_windows",
             # On different platforms the linux repository can be used.
             # The deploy jars inside the linux repository are platform-agnostic.

--- a/tools/jdk/utils.bzl
+++ b/tools/jdk/utils.bzl
@@ -1,0 +1,117 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def java_runtime_files(name, srcs):
+    """Copies the given sources out of the current Java runtime."""
+
+    native.filegroup(
+        name = name,
+        srcs = srcs,
+    )
+    for src in srcs:
+        native.genrule(
+            name = "gen_%s" % src,
+            srcs = ["@bazel_tools//tools/jdk:current_java_runtime"],
+            toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+            cmd = "cp $(JAVABASE)/%s $@" % src,
+            outs = [src],
+        )
+
+def _bootclasspath_impl(ctx):
+    host_javabase = ctx.attr.host_javabase[java_common.JavaRuntimeInfo]
+
+    # explicitly list output files instead of using TreeArtifact to work around
+    # https://github.com/bazelbuild/bazel/issues/6203
+    classes = [
+        "DumpPlatformClassPath.class",
+    ]
+
+    class_outputs = [
+        ctx.actions.declare_file("%s_classes/%s" % (ctx.label.name, clazz))
+        for clazz in classes
+    ]
+
+    args = ctx.actions.args()
+    args.add("-source")
+    args.add("8")
+    args.add("-target")
+    args.add("8")
+    args.add("-Xlint:-options")
+    args.add("-cp")
+    args.add("%s/lib/tools.jar" % host_javabase.java_home)
+    args.add("-d")
+    args.add(class_outputs[0].dirname)
+    args.add(ctx.file.src)
+
+    ctx.actions.run(
+        executable = "%s/bin/javac" % host_javabase.java_home,
+        inputs = [ctx.file.src] + ctx.files.host_javabase,
+        outputs = class_outputs,
+        arguments = [args],
+    )
+
+    bootclasspath = ctx.outputs.output_jar
+
+    inputs = class_outputs + ctx.files.host_javabase
+
+    args = ctx.actions.args()
+    args.add("-XX:+IgnoreUnrecognizedVMOptions")
+    args.add("--add-exports=jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED")
+    args.add_joined(
+        "-cp",
+        [class_outputs[0].dirname, "%s/lib/tools.jar" % host_javabase.java_home],
+        join_with = ctx.configuration.host_path_separator,
+    )
+    args.add("DumpPlatformClassPath")
+    args.add(bootclasspath)
+
+    if ctx.attr.target_javabase:
+        inputs.extend(ctx.files.target_javabase)
+        args.add(ctx.attr.target_javabase[java_common.JavaRuntimeInfo].java_home)
+
+    ctx.actions.run(
+        executable = str(host_javabase.java_executable_exec_path),
+        inputs = inputs,
+        outputs = [bootclasspath],
+        arguments = [args],
+    )
+    return [
+        DefaultInfo(files = depset([bootclasspath])),
+        OutputGroupInfo(jar = [bootclasspath]),
+    ]
+
+_bootclasspath = rule(
+    implementation = _bootclasspath_impl,
+    attrs = {
+        "host_javabase": attr.label(
+            cfg = "host",
+            providers = [java_common.JavaRuntimeInfo],
+        ),
+        "src": attr.label(
+            cfg = "host",
+            allow_single_file = True,
+        ),
+        "target_javabase": attr.label(
+            providers = [java_common.JavaRuntimeInfo],
+        ),
+        "output_jar": attr.output(mandatory = True),
+    },
+)
+
+def bootclasspath(name, **kwargs):
+    _bootclasspath(
+        name = name,
+        output_jar = name + ".jar",
+        **kwargs
+    )


### PR DESCRIPTION
Macro `default_java_toolchain` used to create a `java_toolchain` rule with each attribute set using a platform dependent select. For example `ijar` attribute was set to `//tools/jdk:ijar`, which was a macro `remote_java_tools_filegroup`. That macro contains a `select` choosing the right `@remote_java_tools` repository.

With Java toolchainisation this become a fragile mechanism (selects need to match the toolchain...), which would be hard to maintain.

In previous commits `java_toolchain_default` was implemented, which is part of each `java_tools` repository and does not use any `selects`.

For backward compatibility `default_java_toolchain` was reimplemented to invoke `java_toolchain_default`. Implementation is not perfect, because it load 3 java_tools repositories (linux,darwin,windows). Not to invoke this misfeature, some macros were moved into `utils.bzl`. The use of `default_java_toolchain` should be discouraged.

`remote_java_tools_filegroup/import` targets in `//tools/jdk/BUILD` that were previous used only by `default_java_toolchain` were removed.

`default_java_toolchain` targets in `//tools/jdk/BUILD` were replaced with select aliases. Those will be removed when Java toolchainsation is complete.

`legacy_toolchain` was removed as a fall-back - it was an awkard one - going from Java 11 to Java 8 language level.
