### PR TITLE
Allow Jacoco Coverage to work with classpath jar.

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoCoverageRunner.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoCoverageRunner.java
@@ -349,21 +349,20 @@ public class JacocoCoverageRunner {
   private static URL[] getUrls(ClassLoader classLoader, boolean wasWrappedJar) {
     URL[] urls = getClassLoaderUrls(classLoader);
     // If the classpath was too long then a temporary top-level jar is created containing nothing but a manifest with
-    // the original classpath. For the moment, we just assume it's made up of URLs to other jars and extract them.
-    if (urls != null) {
-      if (wasWrappedJar && urls.length == 1) {
-        try {
-          String jarClassPath =
-              new JarInputStream(urls[0].openStream()).getManifest().getMainAttributes().getValue("Class-Path");
-          String[] urlStrings = jarClassPath.split(" ");
-          URL[] newUrls = new URL[urlStrings.length];
-          for (int i = 0; i < urlStrings.length; i++) {
-            newUrls[i] = new URL(urlStrings[i]);
-          }
-          return newUrls;
-        } catch (Exception e) {
-         return null;
+    // the original classpath. Those are the URLs we are looking for.
+    if (wasWrappedJar && urls != null && urls.length == 1) {
+      try {
+        String jarClassPath =
+            new JarInputStream(urls[0].openStream()).getManifest().getMainAttributes().getValue("Class-Path");
+        String[] urlStrings = jarClassPath.split(" ");
+        URL[] newUrls = new URL[urlStrings.length];
+        for (int i = 0; i < urlStrings.length; i++) {
+          newUrls[i] = new URL(urlStrings[i]);
         }
+        return newUrls;
+      } catch (Exception e) {
+        e.printStackTrace();
+        return null;
       }
     }
     return urls;

--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoCoverageRunner.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoCoverageRunner.java
@@ -46,6 +46,7 @@ import java.util.TreeMap;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 import org.jacoco.agent.rt.IAgent;
 import org.jacoco.agent.rt.RT;
@@ -345,7 +346,30 @@ public class JacocoCoverageRunner {
     return convertedMetadataFiles.build();
   }
 
-  private static URL[] getUrls(ClassLoader classLoader) {
+  private static URL[] getUrls(ClassLoader classLoader, boolean wasWrappedJar) {
+    URL[] urls = getClassLoaderUrls(classLoader);
+    // If the classpath was too long then a temporary top-level jar is created containing nothing but a manifest with
+    // the original classpath. For the moment, we just assume it's made up of URLs to other jars and extract them.
+    if (urls != null) {
+      if (wasWrappedJar && urls.length == 1) {
+        try {
+          String jarClassPath =
+              new JarInputStream(urls[0].openStream()).getManifest().getMainAttributes().getValue("Class-Path");
+          String[] urlStrings = jarClassPath.split(" ");
+          URL[] newUrls = new URL[urlStrings.length];
+          for (int i = 0; i < urlStrings.length; i++) {
+            newUrls[i] = new URL(urlStrings[i]);
+          }
+          return newUrls;
+        } catch (Exception e) {
+         return null;
+        }
+      }
+    }
+    return urls;
+  }
+
+  private static URL[] getClassLoaderUrls(ClassLoader classLoader) {
     if (classLoader instanceof URLClassLoader) {
       return ((URLClassLoader) classLoader).getURLs();
     }
@@ -377,13 +401,15 @@ public class JacocoCoverageRunner {
 
   public static void main(String[] args) throws Exception {
     String metadataFile = System.getenv("JACOCO_METADATA_JAR");
+    String jarWrappedValue = System.getenv("JACOCO_IS_JAR_WRAPPED");
+    boolean wasWrappedJar = jarWrappedValue != null ? !jarWrappedValue.equals("0") : false;
 
     File[] metadataFiles = null;
     int deployJars = 0;
     final HashMap<String, byte[]> uninstrumentedClasses = new HashMap<>();
     ImmutableSet.Builder<String> pathsForCoverageBuilder = new ImmutableSet.Builder<>();
     ClassLoader classLoader = ClassLoader.getSystemClassLoader();
-    URL[] urls = getUrls(classLoader);
+    URL[] urls = getUrls(classLoader, wasWrappedJar);
     if (urls != null) {
       metadataFiles = new File[urls.length];
       for (int i = 0; i < urls.length; i++) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -258,6 +258,7 @@ export CLASSLOADER_PREFIX_PATH="${RUNPATH}"
 %set_jacoco_metadata%
 %set_jacoco_main_class%
 %set_jacoco_java_runfiles_root%
+export JACOCO_IS_JAR_WRAPPED=0
 
 if [[ -n "$JVM_DEBUG_PORT" ]]; then
   JVM_DEBUG_SUSPEND=${DEFAULT_JVM_DEBUG_SUSPEND:-"y"}
@@ -359,6 +360,7 @@ if [ -z "$CLASSPATH_LIMIT" ]; then
 fi
 
 if (("${#CLASSPATH}" > ${CLASSPATH_LIMIT})); then
+  export JACOCO_IS_JAR_WRAPPED=1
   create_and_run_classpath_jar
 else
   exec $JAVABIN -classpath $CLASSPATH "${ARGS[@]}"


### PR DESCRIPTION
If the classpath for a java binary exceeds the limits specified, a
separate jar is created at runtime to contain the classpath and is the
target of execution. The JacocoRunner could not handle this case, only
inspecting the wrapping jar.

This change adds code to extract the objects in the original classpath
and pass them to the original handling code.

Fixes #11847