### PR TITLE
Ninja symlink outputs: fix working_dir and output_root path handling

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphArtifactsHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions/NinjaGraphArtifactsHelper.java
@@ -92,7 +92,8 @@ class NinjaGraphArtifactsHelper {
               pathRelativeToWorkingDirectory));
     }
     // If the path was declared as output symlink, create a symlink artifact.
-    if (symlinkOutputs.contains(execPath.relativeTo(outputRootPath))) {
+    // symlink_outputs are always declared as relative to working directory.
+    if (symlinkOutputs.contains(pathRelativeToWorkingDirectory)) {
       return ruleContext
           .getAnalysisEnvironment()
           .getSymlinkArtifact(execPath.relativeTo(outputRootPath), derivedOutputRoot);
@@ -113,7 +114,7 @@ class NinjaGraphArtifactsHelper {
     if (execPath.startsWith(outputRootPath)) {
       // In the output directory, so it is either marked as a symlink_output from Ninja, or
       // it is a derived artifact.
-      if (symlinkOutputs.contains(execPath.relativeTo(outputRootPath))) {
+      if (symlinkOutputs.contains(workingDirectoryPath)) {
         return ruleContext
             .getAnalysisEnvironment()
             .getSymlinkArtifact(execPath.relativeTo(outputRootPath), derivedOutputRoot);

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaBuildTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/ninja/NinjaBuildTest.java
@@ -493,7 +493,48 @@ public class NinjaBuildTest extends BuildViewTestCase {
   }
 
   @Test
-  public void testCreateOutputSymlinkArtifacts() throws Exception {
+  public void testCreateOutputSymlinkArtifactsInTopLevelDirectory() throws Exception {
+    // output root: <cwd>/out/
+    // working directory: <cwd>
+    rewriteWorkspace(
+            "workspace(name = 'test')", "toplevel_output_directories(paths = ['out'])");
+
+    scratch.file(
+            "out/build.ninja",
+            "rule symlink_rule",
+            "  command = ln -s fictive-file ${out}",
+            "  symlink_outputs = $out",
+            "build out/dangling_symlink: symlink_rule");
+
+    ConfiguredTarget configuredTarget =
+            scratchConfiguredTarget(
+                    "",
+                    "ninja_target",
+                    "ninja_graph(name = 'graph', output_root = 'out',",
+                    " main = 'out/build.ninja')",
+                    "ninja_build(name = 'ninja_target', ninja_graph = 'graph',",
+                    " output_groups= {'main': ['out/dangling_symlink']})");
+    assertThat(configuredTarget).isInstanceOf(RuleConfiguredTarget.class);
+    RuleConfiguredTarget ninjaConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
+    ImmutableList<ActionAnalysisMetadata> actions = ninjaConfiguredTarget.getActions();
+    assertThat(actions).hasSize(1);
+
+    ActionAnalysisMetadata action = Iterables.getOnlyElement(actions);
+    Artifact primaryOutput = action.getPrimaryOutput();
+    assertThat(primaryOutput.isSymlink()).isTrue();
+    assertThat(action).isInstanceOf(NinjaAction.class);
+
+    List<CommandLineAndParamFileInfo> commandLines =
+            ((NinjaAction) action).getCommandLines().getCommandLines();
+    assertThat(commandLines).hasSize(1);
+    assertThat(commandLines.get(0).commandLine.toString())
+            .endsWith("ln -s fictive-file out/dangling_symlink");
+  }
+
+  @Test
+  public void testCreateOutputSymlinkArtifactsInWorkingDirectory() throws Exception {
+    // output root: <cwd>/build_config
+    // working directory: <cwd>/build_config
     rewriteWorkspace(
         "workspace(name = 'test')", "toplevel_output_directories(paths = ['build_config'])");
 


### PR DESCRIPTION
symlink_outputs in Ninja files are always created relative to the working directory. If the working directory is /path/to/foo, and the output root is /path/to/foo/out, the symlink_outputs values in the Ninja file will be "out/path/to/symlink".

Currently, the code that creates symlink artifacts tries to get the relative path of the symlink from the output root ("out/path/to/symlink".relativeTo("out") == "path/to/symlink"), and tries to find that in a set of paths that *do* contain the output root as the prefix ("out/path/to/symlink"), since the set contains path relative to the *working directory*. This causes failures.

Instead, use the path relative to the working directory while checking the symlink outputs set instead, preserving the output root path prefix.

Added a test case where the working dir is the top level directory, and "out" as the toplevel_output_directory and ninja_graph.output_root, emulating the environment where this bug was found.