### PR TITLE
Add libraries to allowed macOS include directories

### DIFF
--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -169,6 +169,7 @@ cc_autoconf = repository_rule(
         "GCOV",
         "HOMEBREW_RUBY_PATH",
         "SYSTEMROOT",
+        "USER",
     ] + MSVC_ENVVARS,
     implementation = cc_autoconf_impl,
     configure = True,

--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -38,12 +38,20 @@ def _get_escaped_xcode_cxx_inc_directories(repository_ctx, cc, xcode_toolchains)
       include_paths: A list of builtin include paths.
     """
 
-    include_dirs = []
+    # Assume that everything is managed by Xcode / toolchain installations
+    include_dirs = [
+        "/Applications/",
+        "/Library/",
+    ]
+
+    user = repository_ctx.os.environ.get("USER")
+    if user:
+        include_dirs.append("/Users/{}/Library/".format(user))
+
+    # Include extra Xcode paths in case they're installed on other volumes
     for toolchain in xcode_toolchains:
         include_dirs.append(escape_string(toolchain.developer_dir))
 
-    # Assume that all paths that point to /Applications/ are built in include paths
-    include_dirs.append("/Applications/")
     return include_dirs
 
 def compile_cc_file(repository_ctx, src_name, out_name):


### PR DESCRIPTION
This adds macOS `/Library` and `/Users/$USER/Library` to allowed include
paths. In macOS workflows most system headers are included in the Xcode
toolchains, which were already covered in this logic. The only exception
is custom `xctoolchains`, which can be used for custom Swift compilers
(among other things). These toolchains are either installed globally in
`/Library`, or without root they can be installed in the user's
`~/Library`. This adds those paths since they can safely be referenced
by passing `--action_env=TOOLCHAINS=toolchain_id` which will be picked
up by invocations of `xcrun`.
