### PR TITLE
Fix output=locations display source file location

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/FormatUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/FormatUtils.java
@@ -59,6 +59,27 @@ class FormatUtils {
    */
   static String getLocation(Target target, boolean relative) {
     Location loc = target.getLocation();
+
+    if (relative) {
+      loc = getRootRelativeLocation(loc, target.getPackage());
+    }
+    return loc.toString();
+  }
+
+  /**
+   * Returns the target location string, optionally relative to its package's source root directory
+   * and optionally to display the location of source files.
+   *
+   * @param relative flag to display the location relative to its package's source root directory.
+   * @param displaySourceFileLocation flag to display the location of line 1 of the actual source
+   *    file instead of its location in the BUILD file.
+   */
+  static String getLocation(Target target, boolean relative, boolean displaySourceFileLocation) {
+    Location loc = target.getLocation();
+    if (target instanceof InputFile && displaySourceFileLocation) {
+      PathFragment packageDir = target.getPackage().getPackageDirectory().asFragment();
+      loc = Location.fromFileLineColumn(packageDir.getRelative(target.getName()).toString(), 1, 1);
+    }
     if (relative) {
       loc = getRootRelativeLocation(loc, target.getPackage());
     }
@@ -80,31 +101,5 @@ class FormatUtils {
       }
     }
     return location;
-  }
-
-  /**
-   * Returns the target label string. For {@link InputFile} targets, displays the location of line 1
-   * of the actual source file by default.
-   *
-   * @param target the target to get the label from
-   * @param displaySourceFileLocation displays the location of line 1 of the actual source file
-   *     instead of its target if true.
-   * @param relativeLocations displays the location of the source file relative to its package's
-   *     source root directory
-   */
-  static String getLabel(
-      Target target, boolean displaySourceFileLocation, boolean relativeLocations) {
-    if (!(target instanceof InputFile) || !displaySourceFileLocation) {
-      return target.getLabel().getDefaultCanonicalForm();
-    }
-
-    // Default behaviour for source files without the incompatible_display_source_file_location flag
-    PathFragment packageDir = target.getPackage().getPackageDirectory().asFragment();
-    Location sourceFileLoc =
-        Location.fromFileLineColumn(packageDir.getRelative(target.getName()).toString(), 1, 1);
-    if (relativeLocations) {
-      sourceFileLoc = getRootRelativeLocation(sourceFileLoc, target.getPackage());
-    }
-    return sourceFileLoc.toString();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/LocationOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/LocationOutputFormatter.java
@@ -83,11 +83,11 @@ class LocationOutputFormatter extends AbstractUnorderedFormatter {
         final String lineTerm = options.getLineTerminator();
         for (Target target : partialResult) {
           writer
-              .append(FormatUtils.getLocation(target, relativeLocations))
+              .append(FormatUtils.getLocation(target, relativeLocations, displaySourceFileLocation))
               .append(": ")
               .append(target.getTargetKind())
               .append(" ")
-              .append(FormatUtils.getLabel(target, displaySourceFileLocation, relativeLocations))
+              .append(target.getLabel().getDefaultCanonicalForm())
               .append(lineTerm);
         }
       }


### PR DESCRIPTION
This PR is a patch to fix this [commit](https://github.com/bazelbuild/bazel/commit/f00f911b7eff7057da804f7a058da605c577fb4a) after being brought up [here](https://github.com/bazelbuild/bazel/issues/12322#issuecomment-713742386). 

The goal of this PR is to align the output of `--output=location` with its current definition in the [documentation](https://docs.bazel.build/versions/master/query.html#output-location). With the flag `--output=location`, source files are supposed to output "the location of line 1 of the actual file" but only displayed its location in the BUILD file prior to the commit.

**Expected behavior by definition:**
```
bazel query bazeltest:main.py --output=location
/home/tanzhengwei/bazeltest/main.py:1:1: source file //bazeltest:main.py
```

The previous [commit](https://github.com/bazelbuild/bazel/commit/f00f911b7eff7057da804f7a058da605c577fb4a) wrongly modified the output to the following (with the `--incompatible_display_source_file_location` flag):
```
bazel query bazeltest:main.py --output=location --incompatible_display_source_file_location
/home/tanzhengwei/bazeltest/BUILD:1:10: source file /home/tanzhengwei/bazeltest/main.py:1:1
```

This PR fixes it to output to the correct implementation (with the `--incompatible_display_source_file_location` flag):
```
bazel query bazeltest:main.py --output=location --incompatible_display_source_file_location
/home/tanzhengwei/bazeltest/main.py:1:1: source file //bazeltest:main.py
```