### PR TITLE
Set java_runtime on java_toolchains.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -637,6 +637,14 @@ JAVA_VERSIONS = ("11",)
     for java_version in JAVA_VERSIONS
 ]
 
+_PLATFORM = select({
+    "//src/conditions:darwin": "macos",
+    "//src/conditions:darwin_x86_64": "macos",
+    "//src/conditions:windows": "win",
+    "//src/conditions:linux_x86_64": "linux",
+    "//conditions:default": "linux",
+})
+
 [
     # The java_tools releases can have BUILD files that vary depending on the
     # javac version they embed. Currently the only difference is in the
@@ -648,7 +656,7 @@ JAVA_VERSIONS = ("11",)
         name = "create_java_tools_build_java" + java_version,
         srcs = ["//tools/jdk:BUILD.java_tools"],
         outs = ["remote_java_tools_java" + java_version + "/BUILD"],
-        cmd = "sed 's/JAVA_LANGUAGE_LEVEL/" + java_version + "/g' $< > $@",
+        cmd = "sed 's/JAVA_LANGUAGE_LEVEL/" + java_version + "/g; s/PLATFORM/" + _PLATFORM + "/g' $< > $@",
     )
     for java_version in JAVA_VERSIONS
 ]

--- a/src/BUILD
+++ b/src/BUILD
@@ -646,12 +646,12 @@ _PLATFORM = select({
 })
 
 [
-    # The java_tools releases can have BUILD files that vary depending on the
-    # javac version they embed. Currently the only difference is in the
-    # java_toolchain source version which has to be 14 for javac 14 to be able
-    # to build new Java 14 features. This is not used atm, as the toolchain for
-    # javac 14 was duplicated, but it might be used in future Bazel releases to
-    # support new javac release, so that we preserve this step for now.
+    # Currently a single release of java_tools contains java_toolchains for
+    # Java 8 to 11 (using remote_jdk11 with patched javac), and Java 14 and 15
+    # (using corresponding remote_jdk). All toolchains use JavaBuilder.
+    # The java_tools are released for three platforms: linux, macos and
+    # windows. Each release is bound to the remote_jdks for the corresponding
+    # platform.
     genrule(
         name = "create_java_tools_build_java" + java_version,
         srcs = ["//tools/jdk:BUILD.java_tools"],

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -19,6 +19,7 @@ SUPRESSED_WARNINGS = select({
 
 java_toolchain_default(
     name = "toolchain",
+    java_runtime = "@remotejdk11_PLATFORM//:jdk",
     javac = [":javac_jar"],
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
@@ -35,70 +36,13 @@ java_toolchain_default(
     ],
 )
 
-java_toolchain_default(
-    name = "toolchain_hostjdk8",
-    javac = [":javac_jar"],
-    jvm_opts = ["-Xbootclasspath/p:$(location :javac_jar)"],
-    source_version = "8",
-    target_version = "8",
-)
-
-# Default to the Java 8 language level.
-# TODO(cushon): consider if/when we should increment this?
-java_toolchain_default(
-    name = "legacy_toolchain",
-    javac = [":javac_jar"],
-    jvm_opts = [
-        # override the javac in the JDK.
-        "--patch-module=java.compiler=$(location :java_compiler_jar)",
-        "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
-    ] + JDK9_JVM_OPTS,
-    source_version = "8",
-    target_version = "8",
-    tools = [
-        ":java_compiler_jar",
-        ":jdk_compiler_jar",
-    ],
-)
-
-# Needed for openbsd / JVM8
-java_toolchain_default(
-    name = "legacy_toolchain_jvm8",
-    javac = [":javac_jar"],
-    jvm_opts = ["-Xbootclasspath/p:$(location :javac_jar)"],
-    source_version = "8",
-    target_version = "8",
-)
-
-# The 'vanilla' toolchain is an unsupported alternative to the default.
-#
-# It does not provide any of the following features:
-#   * Error Prone
-#   * Strict Java Deps
-#   * Header Compilation
-#   * Reduced Classpath Optimization
-#
-# It uses the version of internal javac from the `--host_javabase` JDK instead
-# of providing a javac. Internal javac may not be source- or bug-compatible with
-# the javac that is provided with other toolchains.
-#
-# However it does allow using a wider range of `--host_javabase`s, including
-# versions newer than the current JDK.
-java_toolchain_default(
-    name = "toolchain_vanilla",
-    forcibly_disable_header_compilation = True,
-    javabuilder = [":vanillajavabuilder"],
-    jvm_opts = [],
-    source_version = "",
-    target_version = "",
-)
-
 RELEASES = (8, 9, 10, 11)
 
 [
     (
         java_toolchain_default(
             name = "toolchain_java%d" % release,
+            java_runtime = "@remotejdk11_PLATFORM//:jdk",
             javac = [":javac_jar"],
             jvm_opts = [
                 # override the javac in the JDK.
@@ -111,45 +55,15 @@ RELEASES = (8, 9, 10, 11)
                 ":java_compiler_jar",
                 ":jdk_compiler_jar",
             ],
-        ),
-        # Needed for openbsd / JVM8
-        java_toolchain_default(
-            name = "toolchain_java%d_jvm8" % release,
-            javac = [":javac_jar"],
-            jvm_opts = [
-                "-Xbootclasspath/p:$(location :javac_jar)",
-            ],
-            source_version = "%s" % release,
-            target_version = "%s" % release,
-        ),
+        )
     )
     for release in RELEASES
 ]
 
-# A toolchain that targets java 11.
-java_toolchain_default(
-    name = "toolchain_jdk_11",
-    javac = [":javac_jar"],
-    jvm_opts = [
-        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
-        # G1 collector and having compact strings enabled.
-        "-XX:+UseParallelOldGC",
-        "-XX:-CompactStrings",
-        # override the javac in the JDK.
-        "--patch-module=java.compiler=$(location :java_compiler_jar)",
-        "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
-    ] + JDK9_JVM_OPTS,
-    source_version = "11",
-    target_version = "11",
-    tools = [
-        ":java_compiler_jar",
-        ":jdk_compiler_jar",
-    ],
-)
-
 # A toolchain that targets java 14.
 java_toolchain_default(
     name = "toolchain_jdk_14",
+    java_runtime = "@remotejdk14_PLATFORM//:jdk",
     source_version = "14",
     target_version = "14",
 )
@@ -157,6 +71,7 @@ java_toolchain_default(
 # A toolchain that targets java 15.
 java_toolchain_default(
     name = "toolchain_jdk_15",
+    java_runtime = "@remotejdk15_PLATFORM//:jdk",
     source_version = "15",
     target_version = "15",
 )
@@ -169,6 +84,7 @@ java_toolchain_default(
 java_toolchain_default(
     name = "prebuilt_toolchain",
     ijar = [":ijar_prebuilt_binary"],
+    java_runtime = "@remotejdk11_PLATFORM//:jdk",
     javac = [":javac_jar"],
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -39,23 +39,21 @@ java_toolchain_default(
 RELEASES = (8, 9, 10, 11)
 
 [
-    (
-        java_toolchain_default(
-            name = "toolchain_java%d" % release,
-            java_runtime = "@remotejdk11_PLATFORM//:jdk",
-            javac = [":javac_jar"],
-            jvm_opts = [
-                # override the javac in the JDK.
-                "--patch-module=java.compiler=$(location :java_compiler_jar)",
-                "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
-            ] + JDK9_JVM_OPTS,
-            source_version = "%s" % release,
-            target_version = "%s" % release,
-            tools = [
-                ":java_compiler_jar",
-                ":jdk_compiler_jar",
-            ],
-        )
+    java_toolchain_default(
+        name = "toolchain_java%d" % release,
+        java_runtime = "@remotejdk11_PLATFORM//:jdk",
+        javac = [":javac_jar"],
+        jvm_opts = [
+            # override the javac in the JDK.
+            "--patch-module=java.compiler=$(location :java_compiler_jar)",
+            "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
+        ] + JDK9_JVM_OPTS,
+        source_version = "%s" % release,
+        target_version = "%s" % release,
+        tools = [
+            ":java_compiler_jar",
+            ":jdk_compiler_jar",
+        ],
     )
     for release in RELEASES
 ]


### PR DESCRIPTION
Toolchains that don't have java_runtime in a remote repository (toolchain_hostjdk8, legacy_toolchain, ...) were removed. They are better defined using java_toolchain_default, next to the rules defining local JDK.