### PR TITLE
Allow remapping of __BAZEL_EXECUTION_ROOT__ to execution root in wrapped_clang

### DIFF
--- a/tools/osx/crosstool/wrapped_clang.cc
+++ b/tools/osx/crosstool/wrapped_clang.cc
@@ -223,6 +223,7 @@ int main(int argc, char *argv[]) {
     if (arg.compare("OSO_PREFIX_MAP_PWD") == 0) {
       arg = "-Wl,-oso_prefix," + std::string(cwd.get()) + "/";
     }
+    FindAndReplace("__BAZEL_EXECUTION_ROOT__", std::string(cwd.get()), &arg);
     FindAndReplace("__BAZEL_XCODE_DEVELOPER_DIR__", developer_dir, &arg);
     FindAndReplace("__BAZEL_XCODE_SDKROOT__", sdk_root, &arg);
 

--- a/tools/osx/crosstool/wrapped_clang_test.sh
+++ b/tools/osx/crosstool/wrapped_clang_test.sh
@@ -64,6 +64,14 @@ function test_disable_add_ast_path_remapping() {
   expect_log "-Wl,-add_ast_path,relative/foo" "Expected add_ast_path to not be remapped."
 }
 
+# Test that __BAZEL_EXECUTION_ROOT__ is remapped properly.
+function test_absolute_path_resolution() {
+  env DEVELOPER_DIR=dummy SDKROOT=a \
+      "${WRAPPED_CLANG}" "-fuse-ld=__BAZEL_EXECUTION_ROOT__/foo" \
+      >$TEST_log || fail "wrapped_clang failed";
+  expect_log "-fuse-ld=${PWD}/foo" "Expected execution root to be remapped."
+}
+
 # Test that __BAZEL_XCODE_DEVELOPER_DIR__ is remapped properly.
 function test_developer_dir_remapping() {
   env DEVELOPER_DIR=mydir SDKROOT=a \


### PR DESCRIPTION
Some clang flags requires the file path passed to it to be an absolute
path (for instance, the `-fuse-ld` flag).

Currently, in order to use those flags, we would need to either:
- Expand the location of the file before it is passed to wrapped_clang,
  which breaks reproducibility, since the absolute path would go into a
  cache key.
- Place the file at a global path (for example, `/tmp/my-linker`), and
  make that available to the build, which breaks hermeticity.

This change adds a new shared secret, `__BAZEL_EXECUTION_ROOT__`, so
that rule authors can use it as a prefix to paths that they want to be
expanded properly.