### PR TITLE
Make bazel-toolchains compatible with Incompatible Target Skipping (part 2)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -440,6 +440,8 @@ http_archive(
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
         "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
     ],
+    patches = ["@//third_party:bazel_toolchains/0001-Rename-target_compatible_with-to-internal_target_com.patch"],
+    patch_args = ["-p1"],
 )
 
 load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")


### PR DESCRIPTION
This is a follow-up to #12336. It makes use of the .patch file to make
the 3.1 version of bazel-toolchains compatible with Incompatible
Target Skipping.