### PR TITLE
Enable debug_prefix_map_pwd_is_dot feature by default on macOS

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5356,6 +5356,7 @@ def _impl(ctx):
 
     debug_prefix_map_pwd_is_dot_feature = feature(
         name = "debug_prefix_map_pwd_is_dot",
+        enabled = True,
         flag_sets = [
             flag_set(
                 actions = [


### PR DESCRIPTION
This feature improves hermeticity of binaries, and shouldn't have impact
on debugging.

RELNOTES: Enable debug_prefix_map_pwd_is_dot feature by default on macOS, this passes `-fdebug-prefix-map=$PWD=.` for every compile to remove absolute paths from debug info.