### PR TITLE
script: improve bazel upgrade experience

### DIFF
--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -203,11 +203,11 @@ if [[ ! -x $BAZEL_REAL ]]; then
     if [[ -x $(command -v curl) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"
-      echo "  (cd \"${wrapper_dir}\" && curl -fLO https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
+      echo "  pushd `pwd` && (cd \"${wrapper_dir}\" && curl -fLO https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name}) && popd") 2>&1
     elif [[ -x $(command -v wget) && -w $wrapper_dir ]]; then
       (echo ""
       echo "You can download the required version directly using this command:"
-      echo "  (cd \"${wrapper_dir}\" && wget https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name})") 2>&1
+      echo "  pushd `pwd` && (cd \"${wrapper_dir}\" && wget https://releases.bazel.build/${bazel_version}/release/${long_binary_name} && chmod +x ${long_binary_name}) && popd") 2>&1
     else
       (echo ""
       echo "Please put the downloaded Bazel binary into this location:"


### PR DESCRIPTION
After this change, the current directory would be preserved, no need to manually `cd` anymore.

Otherwise, the dir would be `~/.bazel/bin`