### PR TITLE
Implement com.google.devtools.build.lib.rules.apple.DottedVersion$Option toString()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/DottedVersion.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/DottedVersion.java
@@ -117,6 +117,11 @@ public final class DottedVersion implements DottedVersionApi<DottedVersion> {
 
       return version.stringRepresentation.equals(((Option) o).version.stringRepresentation);
     }
+
+    @Override
+    public String toString() {
+      return version.toString();
+    }
   }
 
   public static DottedVersion maybeUnwrap(DottedVersion.Option option) {


### PR DESCRIPTION
This way, the string value shows up when running bazel config, instead of values such as `com.google.devtools.build.lib.rules.apple.DottedVersion$Option@1703e2`