### PR TITLE
Prevent a null IgnoredPackagePrefixesValue from crashing Bazel with cquery/aquery

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
@@ -230,9 +230,11 @@ public abstract class PostAnalysisQueryEnvironment<T> extends AbstractBlazeQuery
 
   public ImmutableSet<PathFragment> getIgnoredPackagePrefixesPathFragments()
       throws InterruptedException {
-    return ((IgnoredPackagePrefixesValue)
-            walkableGraphSupplier.get().getValue(IgnoredPackagePrefixesValue.key()))
-        .getPatterns();
+     IgnoredPackagePrefixesValue ignoredPackagePrefixesValue = (IgnoredPackagePrefixesValue)
+            walkableGraphSupplier.get().getValue(IgnoredPackagePrefixesValue.key());
+     return ignoredPackagePrefixesValue == null
+         ? ImmutableSet.of()
+         : ignoredPackagePrefixesValue.getPatterns();
   }
 
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/PostAnalysisQueryEnvironment.java
@@ -230,7 +230,8 @@ public abstract class PostAnalysisQueryEnvironment<T> extends AbstractBlazeQuery
 
   public ImmutableSet<PathFragment> getIgnoredPackagePrefixesPathFragments()
       throws InterruptedException {
-     IgnoredPackagePrefixesValue ignoredPackagePrefixesValue = (IgnoredPackagePrefixesValue)
+     IgnoredPackagePrefixesValue ignoredPackagePrefixesValue =
+         (IgnoredPackagePrefixesValue)
             walkableGraphSupplier.get().getValue(IgnoredPackagePrefixesValue.key());
      return ignoredPackagePrefixesValue == null
          ? ImmutableSet.of()


### PR DESCRIPTION
Related: #12303 