### PR TITLE
Switch to -fdebug-compilation-dir

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5370,7 +5370,7 @@ def _impl(ctx):
                     ACTION_NAMES.objc_compile,
                     ACTION_NAMES.objcpp_compile,
                 ],
-                flag_groups = [flag_group(flags = ["DEBUG_PREFIX_MAP_PWD=."])],
+                flag_groups = [flag_group(flags = ["-fdebug-compilation-dir", "."])],
             ),
         ],
     )

--- a/tools/osx/crosstool/wrapped_clang.cc
+++ b/tools/osx/crosstool/wrapped_clang.cc
@@ -217,9 +217,6 @@ int main(int argc, char *argv[]) {
       std::ofstream bitcode_symbol_map_file(bitcode_symbol_map);
       arg = bitcode_symbol_map;
     }
-    if (SetArgIfFlagPresent(arg, "DEBUG_PREFIX_MAP_PWD", &dest_dir)) {
-      arg = "-fdebug-prefix-map=" + std::string(cwd.get()) + "=" + dest_dir;
-    }
     if (arg.compare("OSO_PREFIX_MAP_PWD") == 0) {
       arg = "-Wl,-oso_prefix," + std::string(cwd.get()) + "/";
     }


### PR DESCRIPTION
This removes some argument parsing from wrapped_clang. This flag was
introduced in clang 9.