### PR TITLE
Remove C++ linking from oso_prefix feature for now

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5721,8 +5721,7 @@ def _impl(ctx):
         name = "oso_prefix_is_pwd",
         flag_sets = [
             flag_set(
-                actions = all_link_actions +
-                          ["objc-executable", "objc++-executable"],
+                actions = ["objc-executable", "objc++-executable"],
                 flag_groups = [flag_group(flags = ["OSO_PREFIX_MAP_PWD"])],
             ),
         ],


### PR DESCRIPTION
Currently in the macOS toolchain C++ linking goes through
`cc_wrapper.sh`, not `wrapped_clang`. I didn't add the handling to
`cc_wrapper` for this argument. These wrappers will likely go away soon,
when they do we should probably make them route to wrapped_clang
instead, in which case we could revert this.

https://github.com/bazelbuild/bazel/pull/12304