### PR TITLE
Report error when fetching repository in RepositoryDelegatorFunction

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/BUILD
@@ -424,6 +424,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/repository:external_rule_not_found_exception",
         "//src/main/java/com/google/devtools/build/lib/repository:repository_failed_event",
         "//src/main/java/com/google/devtools/build/lib/skyframe:action_environment_function",
+        "//src/main/java/com/google/devtools/build/lib/skyframe:already_reported_exception",
         "//src/main/java/com/google/devtools/build/lib/skyframe:managed_directories_knowledge",
         "//src/main/java/com/google/devtools/build/lib/skyframe:package_lookup_function",
         "//src/main/java/com/google/devtools/build/lib/skyframe:package_lookup_value",

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -350,6 +350,7 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
       // Upon an exceptional exit, the fetching of that repository is over as well.
       env.getListener().post(new RepositoryFetching(repositoryName, true));
       env.getListener().post(new RepositoryFailedEvent(repositoryName, e.getMessage()));
+      env.getListener().handle(Event.error("Error fetching repository: " + e.getMessage()));
       throw e;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryFunction.java
@@ -136,7 +136,7 @@ public abstract class RepositoryFunction {
       super(e.getMessage(), e.getCause());
       checkState(e instanceof NoSuchPackageException
           || e instanceof IOException || e instanceof EvalException
-          || e instanceof ExternalPackageException);
+          || e instanceof ExternalPackageException, e);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/AlreadyReportedException.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AlreadyReportedException.java
@@ -1,0 +1,11 @@
+package com.google.devtools.build.lib.skyframe;
+
+/**
+ * A marker class for exceptions that are already reported. Once caught, these exceptions shouldn't
+ * be reported again.
+ */
+public class AlreadyReportedException extends Exception {
+  public AlreadyReportedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -1742,6 +1742,7 @@ java_library(
     name = "package_lookup_function",
     srcs = ["PackageLookupFunction.java"],
     deps = [
+        ":already_reported_exception",
         ":file_symlink_exception",
         ":ignored_package_prefixes_value",
         ":local_repository_lookup_value",
@@ -2800,4 +2801,10 @@ java_library(
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//third_party:jsr305",
     ],
+)
+
+java_library(
+    name = "already_reported_exception",
+    srcs = ["AlreadyReportedException.java"],
+    deps = [],
 )

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -2806,5 +2806,4 @@ java_library(
 java_library(
     name = "already_reported_exception",
     srcs = ["AlreadyReportedException.java"],
-    deps = [],
 )

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PackageLookupFunction.java
@@ -330,14 +330,14 @@ public class PackageLookupFunction implements SkyFunction {
     RepositoryValue repositoryValue;
     try {
       repositoryValue = (RepositoryValue) env.getValueOrThrow(
-          repositoryKey, NoSuchPackageException.class, IOException.class, EvalException.class);
+          repositoryKey, NoSuchPackageException.class, IOException.class, EvalException.class, AlreadyReportedException.class);
       if (repositoryValue == null) {
         return null;
       }
     } catch (NoSuchPackageException e) {
       throw new PackageLookupFunctionException(new BuildFileNotFoundException(id, e.getMessage()),
           Transience.PERSISTENT);
-    } catch (IOException | EvalException e) {
+    } catch (IOException | EvalException | AlreadyReportedException e) {
       throw new PackageLookupFunctionException(
           new RepositoryFetchException(id, e.getMessage()), Transience.PERSISTENT);
     }

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryTest.java
@@ -211,6 +211,7 @@ public class AndroidNdkRepositoryTest extends BuildViewTestCase {
         "    path = '/ndk',",
         ")");
     invalidatePackages(false);
+    reporter.removeHandler(failFastHandler);
     RepositoryFetchException e =
         assertThrows(RepositoryFetchException.class, () -> getTarget("@androidndk//:files"));
     assertThat(e)

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryTest.java
@@ -288,6 +288,7 @@ public class AndroidSdkRepositoryTest extends BuildViewTestCase {
         "    build_tools_version = '26.0.1',",
         ")");
     invalidatePackages();
+    reporter.removeHandler(failFastHandler);
 
     try {
       getTarget("@androidsdk//:files");
@@ -332,6 +333,7 @@ public class AndroidSdkRepositoryTest extends BuildViewTestCase {
         "    path = '/sdk',",
         ")");
     invalidatePackages();
+    reporter.removeHandler(failFastHandler);
 
     try {
       getTarget("@androidsdk//:files");
@@ -355,6 +357,7 @@ public class AndroidSdkRepositoryTest extends BuildViewTestCase {
         "    path = '/sdk',",
         ")");
     invalidatePackages();
+    reporter.removeHandler(failFastHandler);
 
     try {
       getTarget("@androidsdk//:files");

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -39,6 +39,7 @@ import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.WorkspaceFileValue;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue.SuccessfulRepositoryDirectoryValue;
+import com.google.devtools.build.lib.rules.repository.RepositoryFunction.AlreadyReportedRepositoryAccessException;
 import com.google.devtools.build.lib.skyframe.BazelSkyframeExecutorConstants;
 import com.google.devtools.build.lib.skyframe.BzlCompileFunction;
 import com.google.devtools.build.lib.skyframe.BzlLoadFunction;
@@ -397,7 +398,8 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
     EvaluationResult<SkyValue> result = driver.evaluate(ImmutableList.of(key), evaluationContext);
 
     assertThat(result.hasError()).isTrue();
-    assertThat(result.getError().getException() instanceof IOException).isTrue();
+    assertThat(
+        result.getError().getException() instanceof AlreadyReportedRepositoryAccessException).isTrue();
     assertThat(eventHandler.hasErrors()).isTrue();
     assertThat(eventHandler.getEvents().size()).isEqualTo(1);
   }


### PR DESCRIPTION
Printing the error in `RepositoryDelegatorFunction` should provide enough context for the users, in case of an error.

What it looks like now:

```
[14:54:32] leba@leba:~/src/error_demo$ /tmp/bazel build --keep_going //:sample --extra_toolchains=@broken//...
ERROR: Error fetching repository: java.io.IOException: broken_repo rule //external:broken must create a directory
WARNING: errors encountered while analyzing target '//:sample': it will not be built
INFO: Analyzed target //:sample (0 packages loaded, 0 targets configured).
INFO: Found 0 targets...
ERROR: command succeeded, but not all targets were analyzed
INFO: Elapsed time: 0.168s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
FAILED: Build did NOT complete successfully

[15:38:18] leba@leba:~/src/error_demo$ /tmp/bazel build --nokeep_going //:sample --extra_toolchains=@broken//...
ERROR: Error fetching repository: java.io.IOException: broken_repo rule //external:broken must create a directory
ERROR: Analysis of target '//:sample' failed; build aborted: broken_repo rule //external:broken must create a directory
INFO: Elapsed time: 0.104s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
```

Fixes #12303 