### PR TITLE
Fix incompatible target skipping for skylib's analysistest

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/RuleContextConstraintSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/RuleContextConstraintSemantics.java
@@ -43,6 +43,7 @@ import com.google.devtools.build.lib.analysis.constraints.EnvironmentCollection.
 import com.google.devtools.build.lib.analysis.constraints.SupportedEnvironmentsProvider.RemovedEnvironmentCulprit;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformProviderUtils;
+import com.google.devtools.build.lib.analysis.test.AnalysisTestResultInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -966,6 +967,15 @@ public class RuleContextConstraintSemantics implements ConstraintSemantics<RuleC
     } else {
       throw new IllegalArgumentException(
           "Both violatedConstraints and targetsResponsibleForIncompatibility are null");
+    }
+
+    // If this is an analysis test, RuleConfiguredTargetBuilder performs some additional sanity
+    // checks. Satisfy them with an appropriate provider.
+    if (ruleContext.getRule().isAnalysisTest()) {
+      builder.addNativeDeclaredProvider(
+          new AnalysisTestResultInfo(
+              /*success=*/ false,
+              "This test is incompatible and should not have been run. Please file a bug upstream."));
     }
 
     builder.add(RunfilesProvider.class, RunfilesProvider.simple(runfiles));


### PR DESCRIPTION
In #12366, Keith Smiley (@keith) reported that he was having trouble
using the new `target_compatible_with` attribute in `rules_swift`.
Specifically, setting it on an `analysistest` test target was giving
him the following error:

    ERROR: /workdir/test/BUILD:13:29: in coverage_xcode_prefix_map_test rule //test:coverage_settings_xcode_prefix_map: rules with analysis_test=true must return an instance of AnalysisTestResultInfo
    ERROR: Analysis of target '//test:coverage_settings_xcode_prefix_map' failed; build aborted: Analysis of target '//test:coverage_settings_xcode_prefix_map' failed

This was caused by the fact that for incompatible targets we create a
dummy `ConfiguredTarget` that only provides the bare minimum to make
the rest of bazel happy before it gets skipped. It turns out that
`analysistest` rules have additional checks that need to be satisfied.
This patch aims to satisfy those additional checks without impacting
functionality.

Fixes #12366