### PR TITLE
Extract RemoteExecutionClient from GrpcRemoteExecutor

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java
@@ -22,6 +22,8 @@ import build.bazel.remote.execution.v2.WaitExecutionRequest;
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
+import com.google.devtools.build.lib.remote.common.OperationObserver;
+import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.longrunning.Operation;
@@ -36,7 +38,7 @@ import javax.annotation.Nullable;
 
 /** A remote work executor that uses gRPC for communicating the work, inputs and outputs. */
 @ThreadSafe
-class GrpcRemoteExecutor {
+class GrpcRemoteExecutor implements RemoteExecutionClient {
 
   private final ReferenceCountedChannel channel;
   private final CallCredentialsProvider callCredentialsProvider;
@@ -84,15 +86,6 @@ class GrpcRemoteExecutor {
     return null;
   }
 
-  interface ExecuteOperationUpdateReceiver {
-    void onNextOperation(Operation o) throws IOException;
-  }
-
-  public ExecuteResponse executeRemotely(ExecuteRequest request)
-      throws IOException, InterruptedException {
-    return executeRemotely(request, null);
-  }
-
   /* Execute has two components: the Execute call and (optionally) the WaitExecution call.
    * This is the simple flow without any errors:
    *
@@ -111,8 +104,9 @@ class GrpcRemoteExecutor {
    *   are completed and failed; however, some of these errors may be retriable. These errors should
    *   trigger a retry of the Execute call, resulting in a new Operation.
    * */
+  @Override
   public ExecuteResponse executeRemotely(
-      ExecuteRequest request, ExecuteOperationUpdateReceiver receiver)
+      ExecuteRequest request, OperationObserver observer)
       throws IOException, InterruptedException {
     // Execute has two components: the Execute call and (optionally) the WaitExecution call.
     // This is the simple flow without any errors:
@@ -184,9 +178,7 @@ class GrpcRemoteExecutor {
                           //      action is accepted by the server and will be executed ASAP;
                           //   3. Server may execute the action silently and send a reply once it is
                           // done.
-                          if (receiver != null) {
-                            receiver.onNextOperation(o);
-                          }
+                          observer.onNext(o);
 
                           ExecuteResponse r = getOperationResponse(o);
                           if (r != null) {
@@ -233,6 +225,7 @@ class GrpcRemoteExecutor {
     }
   }
 
+  @Override
   public void close() {
     if (closed.getAndSet(true)) {
       return;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.exec.ExecutorLifecycleListener;
 import com.google.devtools.build.lib.exec.ModuleActionContextRegistry;
 import com.google.devtools.build.lib.exec.SpawnCache;
 import com.google.devtools.build.lib.exec.SpawnStrategyRegistry;
+import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
@@ -38,7 +39,7 @@ final class RemoteActionContextProvider implements ExecutorLifecycleListener {
 
   private final CommandEnvironment env;
   private final RemoteCache cache;
-  @Nullable private final GrpcRemoteExecutor executor;
+  @Nullable private final RemoteExecutionClient executor;
   @Nullable private final ListeningScheduledExecutorService retryScheduler;
   private final DigestUtil digestUtil;
   @Nullable private final Path logDir;
@@ -47,7 +48,7 @@ final class RemoteActionContextProvider implements ExecutorLifecycleListener {
   private RemoteActionContextProvider(
       CommandEnvironment env,
       RemoteCache cache,
-      @Nullable GrpcRemoteExecutor executor,
+      @Nullable RemoteExecutionClient executor,
       @Nullable ListeningScheduledExecutorService retryScheduler,
       DigestUtil digestUtil,
       @Nullable Path logDir) {
@@ -71,7 +72,7 @@ final class RemoteActionContextProvider implements ExecutorLifecycleListener {
   public static RemoteActionContextProvider createForRemoteExecution(
       CommandEnvironment env,
       RemoteExecutionCache cache,
-      GrpcRemoteExecutor executor,
+      RemoteExecutionClient executor,
       ListeningScheduledExecutorService retryScheduler,
       DigestUtil digestUtil,
       Path logDir) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
@@ -28,7 +28,9 @@ import com.google.devtools.build.lib.analysis.platform.PlatformUtils;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
+import com.google.devtools.build.lib.remote.common.OperationObserver;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
+import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.remote.util.Utils;
@@ -45,7 +47,7 @@ import java.util.Map;
 public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor {
 
   private final RemoteExecutionCache remoteCache;
-  private final GrpcRemoteExecutor remoteExecutor;
+  private final RemoteExecutionClient remoteExecutor;
   private final DigestUtil digestUtil;
   private final Context requestCtx;
 
@@ -54,7 +56,7 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
 
   public RemoteRepositoryRemoteExecutor(
       RemoteExecutionCache remoteCache,
-      GrpcRemoteExecutor remoteExecutor,
+      RemoteExecutionClient remoteExecutor,
       DigestUtil digestUtil,
       Context requestCtx,
       String remoteInstanceName,
@@ -139,7 +141,8 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
                   .setSkipCacheLookup(!acceptCached)
                   .build();
 
-          ExecuteResponse response = remoteExecutor.executeRemotely(executeRequest);
+          ExecuteResponse response = remoteExecutor
+              .executeRemotely(executeRequest, OperationObserver.NO_OP);
           actionResult = response.getResult();
         }
       }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorFactory.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote;
 
+import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutorFactory;
@@ -22,7 +23,7 @@ import io.grpc.Context;
 class RemoteRepositoryRemoteExecutorFactory implements RepositoryRemoteExecutorFactory {
 
   private final RemoteExecutionCache remoteExecutionCache;
-  private final GrpcRemoteExecutor remoteExecutor;
+  private final RemoteExecutionClient remoteExecutor;
   private final DigestUtil digestUtil;
   private final Context requestCtx;
 
@@ -31,7 +32,7 @@ class RemoteRepositoryRemoteExecutorFactory implements RepositoryRemoteExecutorF
 
   RemoteRepositoryRemoteExecutorFactory(
       RemoteExecutionCache remoteExecutionCache,
-      GrpcRemoteExecutor remoteExecutor,
+      RemoteExecutionClient remoteExecutor,
       DigestUtil digestUtil,
       Context requestCtx,
       String remoteInstanceName,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -66,8 +66,9 @@ import com.google.devtools.build.lib.exec.SpawnRunner;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
-import com.google.devtools.build.lib.remote.GrpcRemoteExecutor.ExecuteOperationUpdateReceiver;
+import com.google.devtools.build.lib.remote.common.OperationObserver;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
+import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
@@ -152,7 +153,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
 
   @Nullable private final Reporter cmdlineReporter;
   private final RemoteExecutionCache remoteCache;
-  @Nullable private final GrpcRemoteExecutor remoteExecutor;
+  @Nullable private final RemoteExecutionClient remoteExecutor;
   private final RemoteRetrier retrier;
   private final String buildRequestId;
   private final String commandId;
@@ -177,7 +178,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
       String buildRequestId,
       String commandId,
       RemoteExecutionCache remoteCache,
-      GrpcRemoteExecutor remoteExecutor,
+      RemoteExecutionClient remoteExecutor,
       ListeningScheduledExecutorService retryService,
       DigestUtil digestUtil,
       Path logDir,
@@ -202,7 +203,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
     return "remote";
   }
 
-  class ExecutingStatusReporter implements ExecuteOperationUpdateReceiver {
+  class ExecutingStatusReporter implements OperationObserver {
     private boolean reportedExecuting = false;
     private final SpawnExecutionContext context;
 
@@ -211,7 +212,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
     }
 
     @Override
-    public void onNextOperation(Operation o) throws IOException {
+    public void onNext(Operation o) throws IOException {
       if (!reportedExecuting) {
         if (o.getMetadata().is(ExecuteOperationMetadata.class)) {
           ExecuteOperationMetadata metadata =

--- a/src/main/java/com/google/devtools/build/lib/remote/common/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BUILD
@@ -17,6 +17,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//third_party:guava",
         "//third_party/protobuf:protobuf_java",
+        "@googleapis//:google_longrunning_operations_java_proto",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/remote/common/OperationObserver.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/OperationObserver.java
@@ -1,0 +1,28 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.common;
+
+import com.google.longrunning.Operation;
+import java.io.IOException;
+
+/**
+ * Receives {@link Operation} updates from an stream of messages.
+ */
+public interface OperationObserver {
+  /** Receives a value from the stream. */
+  void onNext(Operation o) throws IOException;
+
+  /** A no-op implementation */
+  OperationObserver NO_OP = o -> {};
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteExecutionClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteExecutionClient.java
@@ -1,0 +1,37 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.common;
+
+import build.bazel.remote.execution.v2.ExecuteRequest;
+import build.bazel.remote.execution.v2.ExecuteResponse;
+import java.io.IOException;
+
+/**
+ * An interface for a remote execution protocol.
+ *
+ * <p>Implementations must be thread-safe.
+ */
+public interface RemoteExecutionClient {
+
+  /**
+   * Execute an action remotely using Remote Execution API.
+   */
+  ExecuteResponse executeRemotely(ExecuteRequest request, OperationObserver observer)
+      throws IOException, InterruptedException;
+
+  /**
+   * Close resources associated with the remote execution client.
+   */
+  void close();
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorTest.java
@@ -26,6 +26,7 @@ import build.bazel.remote.execution.v2.ExecuteResponse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor.ExecutionResult;
 import com.google.devtools.build.lib.vfs.DigestHashFunction;
@@ -49,7 +50,7 @@ public class RemoteRepositoryRemoteExecutorTest {
 
   @Mock public RemoteExecutionCache remoteCache;
 
-  @Mock public GrpcRemoteExecutor remoteExecutor;
+  @Mock public RemoteExecutionClient remoteExecutor;
 
   private RemoteRepositoryRemoteExecutor repoExecutor;
 
@@ -88,7 +89,7 @@ public class RemoteRepositoryRemoteExecutorTest {
     // Assert
     verify(remoteCache).downloadActionResult(any(), anyBoolean());
     // Don't fallback to execution
-    verify(remoteExecutor, never()).executeRemotely(any());
+    verify(remoteExecutor, never()).executeRemotely(any(), any());
 
     assertThat(executionResult.exitCode()).isEqualTo(0);
   }
@@ -103,7 +104,7 @@ public class RemoteRepositoryRemoteExecutorTest {
         .thenReturn(cachedResult);
 
     ExecuteResponse response = ExecuteResponse.newBuilder().setResult(cachedResult).build();
-    when(remoteExecutor.executeRemotely(any())).thenReturn(response);
+    when(remoteExecutor.executeRemotely(any(), any())).thenReturn(response);
 
     // Act
     ExecutionResult executionResult =
@@ -118,7 +119,7 @@ public class RemoteRepositoryRemoteExecutorTest {
     // Assert
     verify(remoteCache).downloadActionResult(any(), anyBoolean());
     // Fallback to execution
-    verify(remoteExecutor).executeRemotely(any());
+    verify(remoteExecutor).executeRemotely(any(), any());
 
     assertThat(executionResult.exitCode()).isEqualTo(1);
   }
@@ -140,7 +141,7 @@ public class RemoteRepositoryRemoteExecutorTest {
         .thenReturn(cachedResult);
 
     ExecuteResponse response = ExecuteResponse.newBuilder().setResult(cachedResult).build();
-    when(remoteExecutor.executeRemotely(any())).thenReturn(response);
+    when(remoteExecutor.executeRemotely(any(), any())).thenReturn(response);
 
     // Act
     ExecutionResult executionResult =


### PR DESCRIPTION
This step is necessary to support experimenting with other remote execution client implementations.