### PR TITLE
Remove superfluous bazel_toolchains patch

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -432,10 +432,8 @@ http_file(
 
 http_archive(
     name = "bazel_toolchains",
-    patch_args = ["-p1"],
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    patches = ["@//third_party:bazel_toolchains/0001-Rename-target_compatible_with-to-internal_target_com.patch"],
     sha256 = "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
     strip_prefix = "bazel-toolchains-3.1.0",
     urls = [


### PR DESCRIPTION
This is effectively a revert of
8946cc1746f4092d86380a23b0ac8b2d8699d3fc.

I originally needed to rename an attribute in `bazel_toolchains` for
22b4dbcaf05756d506de346728db3846da56b775. The `target_compatible_with`
attribute used in one of the repository rules clashed with the
attribute I added in the Incompatible Target Skipping patch. Once we
merged 22b4dbcaf05756d506de346728db3846da56b775 we realized that we
broke a bunch of projects because they pulled in unpatched versions of
`bazel_toolchains`.

John Cater (@katre) noticed that we can fix everything by making the
new attribute not apply to repository rules. He submitted
775a979bde21a71ddf04f67b865e8c43a29f702a to fix this.

That means that the original patch I added is actually not needed
anymore.

A follow-up patch will delete the .patch file from the source tree.