### PR TITLE
Retrieve ijar from java_toolchain instead of using remote_java_tools.

### DIFF
--- a/tools/android/BUILD.tools
+++ b/tools/android/BUILD.tools
@@ -1,5 +1,6 @@
-load("//tools/python:private/defs.bzl", "py_library", "py_binary")
+load("//tools/python:private/defs.bzl", "py_binary", "py_library")
 load("//tools/python:private/version.bzl", "PY_BINARY_VERSION")
+load(":defs.bzl", "run_ijar")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -106,7 +107,7 @@ alias(
         "use_d8_dexmerger": ":d8_dexmerger",
         "use_dx_dexmerger": "//src/tools/android/java/com/google/devtools/build/android/dexer:DexFileMerger",
         "//conditions:default": "//src/tools/android/java/com/google/devtools/build/android/dexer:DexFileMerger",
-    })
+    }),
 )
 
 alias(
@@ -167,12 +168,9 @@ java_import(
     visibility = ["//visibility:public"],
 )
 
-genrule(
+run_ijar(
     name = "ijar_desugared_java8_legacy_libs",
-    srcs = ["desugared_java8_legacy_libs"],
-    outs = ["desugared_java8_legacy_libs-ijar.jar"],
-    cmd = "$(location @bazel_tools//tools/jdk:ijar) $< $@",
-    tools = ["@bazel_tools//tools/jdk:ijar"],
+    jar = "desugared_java8_legacy_libs.jar",
     visibility = ["//visibility:private"],
 )
 
@@ -302,8 +300,8 @@ py_binary(
     srcs = ["incremental_install.py"],
     python_version = PY_BINARY_VERSION,
     deps = [
-        "//third_party/py/concurrent:futures",
         "//third_party/py/abseil",
+        "//third_party/py/concurrent:futures",
     ],
 )
 

--- a/tools/android/defs.bzl
+++ b/tools/android/defs.bzl
@@ -1,0 +1,18 @@
+def _run_ijar(ctx):
+    ijar_jar = java_common.run_ijar(
+        ctx.actions,
+        jar = ctx.file.jar,
+        java_toolchain = ctx.attr._java_toolchain[java_common.JavaToolchainInfo],
+    )
+    return [DefaultInfo(files = depset([ijar_jar]))]
+
+run_ijar = rule(
+    implementation = _run_ijar,
+    attrs = {
+        "jar": attr.label(mandatory = True, allow_single_file = True),
+        "_java_toolchain": attr.label(
+            default = "//tools/jdk:current_java_toolchain",
+            providers = [java_common.JavaRuntimeInfo],
+        ),
+    },
+)

--- a/tools/android/defs.bzl
+++ b/tools/android/defs.bzl
@@ -1,3 +1,19 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provides a rule to run ijar from java_toolchain."""
+
 def _run_ijar(ctx):
     ijar_jar = java_common.run_ijar(
         ctx.actions,
@@ -8,6 +24,7 @@ def _run_ijar(ctx):
 
 run_ijar = rule(
     implementation = _run_ijar,
+    doc = "Runs ijar over the given jar.",
     attrs = {
         "jar": attr.label(mandatory = True, allow_single_file = True),
         "_java_toolchain": attr.label(


### PR DESCRIPTION
Android tools depend on using ijar directly, which is provided in tools/jdk/BUILD using remote_java_tools macro.
Remote_java_tools uses selects to produce an archive name (java_lang_tools_linux, ..) and grab a tool out of it. The selected archive name needs to match the one toolchains will resolve to. 

Instead of ijar is already among things provided by java_toolchain and we can obtain it directly from the toolchain. The right way to do it is using already provided java_common.run_ijar.