### PR TITLE
Resolve labels in java_toolchain_default relative to java_tools repo

### DIFF
--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -213,4 +213,28 @@ EOF
   bazel build @local_java_tools//:ijar_cc_binary || fail "ijar failed to build"
 }
 
+
+function test_java_toolchain_default() {
+  local java_tools_rlocation=$(rlocation io_bazel/src/java_tools_${JAVA_TOOLS_JAVA_VERSION}.zip)
+  local java_tools_zip_file_url="file://${java_tools_rlocation}"
+  if "$is_windows"; then
+        java_tools_zip_file_url="file:///${java_tools_rlocation}"
+  fi
+  cat > WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "local_java_tools",
+    urls = ["${java_tools_zip_file_url}"]
+)
+EOF
+  cat > BUILD <<EOF
+load("@local_java_tools//:java_toolchain_default.bzl", "java_toolchain_default")
+java_toolchain_default(
+  name = "vanilla",
+  javabuilder = ["//:VanillaJavaBuilder"],
+)
+EOF
+  bazel build //:vanilla || fail "java_toolchain_default target failed to build"
+}
+
 run_suite "Java tools archive tests"

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -19,7 +19,7 @@ SUPRESSED_WARNINGS = select({
 
 java_toolchain_default(
     name = "toolchain",
-    javac = [":javac_jar"],
+    javac = ["//:javac_jar"],
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
         # G1 collector and having compact strings enabled.
@@ -30,14 +30,14 @@ java_toolchain_default(
         "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
     ] + JDK9_JVM_OPTS,
     tools = [
-        ":java_compiler_jar",
-        ":jdk_compiler_jar",
+        "//:java_compiler_jar",
+        "//:jdk_compiler_jar",
     ],
 )
 
 java_toolchain_default(
     name = "toolchain_hostjdk8",
-    javac = [":javac_jar"],
+    javac = ["//:javac_jar"],
     jvm_opts = ["-Xbootclasspath/p:$(location :javac_jar)"],
     source_version = "8",
     target_version = "8",
@@ -47,7 +47,7 @@ java_toolchain_default(
 # TODO(cushon): consider if/when we should increment this?
 java_toolchain_default(
     name = "legacy_toolchain",
-    javac = [":javac_jar"],
+    javac = ["//:javac_jar"],
     jvm_opts = [
         # override the javac in the JDK.
         "--patch-module=java.compiler=$(location :java_compiler_jar)",
@@ -56,15 +56,15 @@ java_toolchain_default(
     source_version = "8",
     target_version = "8",
     tools = [
-        ":java_compiler_jar",
-        ":jdk_compiler_jar",
+        "//:java_compiler_jar",
+        "//:jdk_compiler_jar",
     ],
 )
 
 # Needed for openbsd / JVM8
 java_toolchain_default(
     name = "legacy_toolchain_jvm8",
-    javac = [":javac_jar"],
+    javac = ["//:javac_jar"],
     jvm_opts = ["-Xbootclasspath/p:$(location :javac_jar)"],
     source_version = "8",
     target_version = "8",
@@ -87,7 +87,7 @@ java_toolchain_default(
 java_toolchain_default(
     name = "toolchain_vanilla",
     forcibly_disable_header_compilation = True,
-    javabuilder = [":vanillajavabuilder"],
+    javabuilder = ["//:vanillajavabuilder"],
     jvm_opts = [],
     source_version = "",
     target_version = "",
@@ -99,7 +99,7 @@ RELEASES = (8, 9, 10, 11)
     (
         java_toolchain_default(
             name = "toolchain_java%d" % release,
-            javac = [":javac_jar"],
+            javac = ["//:javac_jar"],
             jvm_opts = [
                 # override the javac in the JDK.
                 "--patch-module=java.compiler=$(location :java_compiler_jar)",
@@ -108,14 +108,14 @@ RELEASES = (8, 9, 10, 11)
             source_version = "%s" % release,
             target_version = "%s" % release,
             tools = [
-                ":java_compiler_jar",
-                ":jdk_compiler_jar",
+                "//:java_compiler_jar",
+                "//:jdk_compiler_jar",
             ],
         ),
         # Needed for openbsd / JVM8
         java_toolchain_default(
             name = "toolchain_java%d_jvm8" % release,
-            javac = [":javac_jar"],
+            javac = ["//:javac_jar"],
             jvm_opts = [
                 "-Xbootclasspath/p:$(location :javac_jar)",
             ],
@@ -129,7 +129,7 @@ RELEASES = (8, 9, 10, 11)
 # A toolchain that targets java 11.
 java_toolchain_default(
     name = "toolchain_jdk_11",
-    javac = [":javac_jar"],
+    javac = ["//:javac_jar"],
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
         # G1 collector and having compact strings enabled.
@@ -142,8 +142,8 @@ java_toolchain_default(
     source_version = "11",
     target_version = "11",
     tools = [
-        ":java_compiler_jar",
-        ":jdk_compiler_jar",
+        "//:java_compiler_jar",
+        "//:jdk_compiler_jar",
     ],
 )
 
@@ -168,8 +168,8 @@ java_toolchain_default(
 # platform.
 java_toolchain_default(
     name = "prebuilt_toolchain",
-    ijar = [":ijar_prebuilt_binary"],
-    javac = [":javac_jar"],
+    ijar = ["//:ijar_prebuilt_binary"],
+    javac = ["//:javac_jar"],
     jvm_opts = [
         # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
         # G1 collector and having compact strings enabled.
@@ -179,10 +179,10 @@ java_toolchain_default(
         "--patch-module=java.compiler=$(location :java_compiler_jar)",
         "--patch-module=jdk.compiler=$(location :jdk_compiler_jar)",
     ] + JDK9_JVM_OPTS,
-    singlejar = [":prebuilt_singlejar"],
+    singlejar = ["//:prebuilt_singlejar"],
     tools = [
-        ":java_compiler_jar",
-        ":jdk_compiler_jar",
+        "//:java_compiler_jar",
+        "//:jdk_compiler_jar",
     ],
 )
 

--- a/tools/jdk/java_toolchain_default.bzl
+++ b/tools/jdk/java_toolchain_default.bzl
@@ -87,9 +87,9 @@ _LABELS = [
 
 # Converts values to labels, so that they are resolved relative to this java_tools repository
 def _to_label(k, v):
-    if k in _LABELS:
+    if k in _LABELS and type(v) == type(Label("//a")):
         return Label(v)
-    if k in _LABEL_LISTS:
+    if k in _LABEL_LISTS and type(v) == type([Label("//a")]):
         return [Label(l) for l in v]
     return v
 
@@ -97,7 +97,7 @@ def java_toolchain_default(name, **kwargs):
     """Defines a java_toolchain with appropriate defaults for Bazel."""
 
     toolchain_args = dict(_BASE_TOOLCHAIN_CONFIGURATION)
-    toolchain_args.update({k: _to_label(k, v) for k, v in kwargs})
+    toolchain_args.update({k: _to_label(k, v) for k, v in kwargs.items()})
     native.java_toolchain(
         name = name,
         **toolchain_args

--- a/tools/jdk/java_toolchain_default.bzl
+++ b/tools/jdk/java_toolchain_default.bzl
@@ -61,11 +61,43 @@ _BASE_TOOLCHAIN_CONFIGURATION = dict(
     target_version = "8",
 )
 
+_LABEL_LISTS = [
+    "bootclasspath",
+    "extclasspath",
+    "javac",
+    "tools",
+    "javabuilder",
+    "singlejar",
+    "genclass",
+    "resourcejar",
+    "ijar",
+    "header_compiler",
+    "header_compiler_direct",
+    "package_configuration",
+]
+
+_LABELS = [
+    "timezone_data",
+    "oneversion",
+    "oneversion_whitelist",
+    "jacocorunner",
+    "proguard_allowlister",
+    "java_runtime",
+]
+
+# Converts values to labels, so that they are resolved relative to this java_tools repository
+def _to_label(k, v):
+    if k in _LABELS:
+        return Label(v)
+    if k in _LABEL_LISTS:
+        return [Label(l) for l in v]
+    return v
+
 def java_toolchain_default(name, **kwargs):
     """Defines a java_toolchain with appropriate defaults for Bazel."""
 
     toolchain_args = dict(_BASE_TOOLCHAIN_CONFIGURATION)
-    toolchain_args.update(kwargs)
+    toolchain_args.update({k: _to_label(k, v) for k, v in kwargs})
     native.java_toolchain(
         name = name,
         **toolchain_args


### PR DESCRIPTION
Usecase for `java_toolchain_default` is:
```
load("@remote_java_tools_linux//:java_toolchain_default.bzl", "java_toolchain_default)
java_toolchain_default(
  name = "mytoolchain",
  javabuilder = ["//:VanillaJavaBuilder"],
)
```

In order to make the use easier, we need to resolve labels relatively to current repo. Otherwise the user would need to specify `javabuilder = ["@remote_java_tools_linux//:VanillaJavaBuilder"]`.