### PR TITLE
Use selects based on constraint_values in java_tools.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,8 +78,8 @@ list_source_repository(name = "local_bazel_source_list")
 #   2. Set the $ANDROID_HOME and $ANDROID_NDK_HOME environment variables
 #   3. Uncomment the two lines below
 #
-# android_sdk_repository(name = "androidsdk")
-# android_ndk_repository(name = "androidndk")
+android_sdk_repository(name = "androidsdk")
+android_ndk_repository(name = "androidndk")
 
 # In order to run //src/test/shell/bazel:maven_skylark_test, follow the
 # instructions above for the Android integration tests and uncomment the

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,8 +78,8 @@ list_source_repository(name = "local_bazel_source_list")
 #   2. Set the $ANDROID_HOME and $ANDROID_NDK_HOME environment variables
 #   3. Uncomment the two lines below
 #
-android_sdk_repository(name = "androidsdk")
-android_ndk_repository(name = "androidndk")
+# android_sdk_repository(name = "androidsdk")
+# android_ndk_repository(name = "androidndk")
 
 # In order to run //src/test/shell/bazel:maven_skylark_test, follow the
 # instructions above for the Android integration tests and uncomment the

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -326,43 +326,28 @@ config_setting(
 
 config_setting(
     name = "linux_x86_64",
-    values = {"cpu": "k8"},
+    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:x86_64" ],
 )
 
 config_setting(
     name = "darwin",
-    values = {"cpu": "darwin"},
-)
-
-config_setting(
-    name = "darwin_x86_64",
-    values = {"cpu": "darwin_x86_64"},
-)
-
-config_setting(
-    name = "darwin_arm64",
-    values = {"cpu": "darwin_arm64"},
-)
-
-config_setting(
-    name = "darwin_arm64e",
-    values = {"cpu": "darwin_arm64e"},
+    constraint_values = [ "@platforms//os:macos"],
 )
 
 config_setting(
     name = "windows",
-    values = {"cpu": "x64_windows"},
+    constraint_values = [ "@platforms//os:windows" ],
 )
 
 config_setting(
     name = "freebsd",
-    values = {"cpu": "freebsd"},
+    constraint_values = [ "@platforms//os:freebsd" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "openbsd",
-    values = {"cpu": "openbsd"},
+    constraint_values = [ "@platforms//os:openbsd" ],
     visibility = ["//visibility:public"],
 )
 
@@ -379,9 +364,6 @@ alias(
     actual = select({
         ":linux_x86_64": "java_tools/src/tools/singlejar/singlejar_local",
         ":darwin": "java_tools/src/tools/singlejar/singlejar_local",
-        ":darwin_x86_64": "java_tools/src/tools/singlejar/singlejar_local",
-        ":darwin_arm64": "java_tools/src/tools/singlejar/singlejar_local",
-        ":darwin_arm64e": "java_tools/src/tools/singlejar/singlejar_local",
         ":windows": "java_tools/src/tools/singlejar/singlejar_local.exe",
         "//conditions:default": "singlejar_cc_bin",
     }),
@@ -408,9 +390,6 @@ alias(
     actual = select({
         ":linux_x86_64": ":ijar_prebuilt_binary",
         ":darwin": ":ijar_prebuilt_binary",
-        ":darwin_x86_64": ":ijar_prebuilt_binary",
-        ":darwin_arm64": ":ijar_prebuilt_binary",
-        ":darwin_arm64e": ":ijar_prebuilt_binary",
         ":windows": ":ijar_prebuilt_binary",
         "//conditions:default": ":ijar_cc_binary",
     }),

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -330,8 +330,18 @@ config_setting(
 )
 
 config_setting(
-    name = "darwin",
-    constraint_values = [ "@platforms//os:macos"],
+    name = "darwin_x86_64",
+    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:x86_64" ],
+)
+
+config_setting(
+    name = "darwin_arm64",
+    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:arm64" ],
+)
+
+config_setting(
+    name = "darwin_arm64e",
+    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:arm64e" ],
 )
 
 config_setting(
@@ -363,7 +373,9 @@ alias(
     name = "singlejar_prebuilt_or_cc_binary",
     actual = select({
         ":linux_x86_64": "java_tools/src/tools/singlejar/singlejar_local",
-        ":darwin": "java_tools/src/tools/singlejar/singlejar_local",
+        ":darwin_x86_64": "java_tools/src/tools/singlejar/singlejar_local",
+        ":darwin_arm64": "java_tools/src/tools/singlejar/singlejar_local",
+        ":darwin_arm64e": "java_tools/src/tools/singlejar/singlejar_local",
         ":windows": "java_tools/src/tools/singlejar/singlejar_local.exe",
         "//conditions:default": "singlejar_cc_bin",
     }),
@@ -389,7 +401,9 @@ alias(
     name = "prebuilt_binary_or_cc_binary",
     actual = select({
         ":linux_x86_64": ":ijar_prebuilt_binary",
-        ":darwin": ":ijar_prebuilt_binary",
+        ":darwin_x86_64": ":ijar_prebuilt_binary",
+        ":darwin_arm64": ":ijar_prebuilt_binary",
+        ":darwin_arm64e": ":ijar_prebuilt_binary",
         ":windows": ":ijar_prebuilt_binary",
         "//conditions:default": ":ijar_cc_binary",
     }),


### PR DESCRIPTION
This makes them consistent with platformization which works on OS and CPU constraints from @platforms.

Flag --cpu=darwin maps on Bazel to macos+x86_64, internally --cpu=darwin_x86_64 is used. With platforms, those become a single config_setting.

I didn't combine together other darwin config_settings (dropping cpu), because of possible combination macos+ppc.