### PR TITLE
Use constraints in global conditions instead of configuration flags.

### DIFF
--- a/scripts/packages/BUILD
+++ b/scripts/packages/BUILD
@@ -29,11 +29,6 @@ filegroup(
             ":without-jdk/install.sh",
             ":generate-package-info",
         ],
-        "//src/conditions:darwin_x86_64": [
-            ":with-jdk/install.sh",
-            ":without-jdk/install.sh",
-            ":generate-package-info",
-        ],
         "//conditions:default": [
             ":with-jdk/install.sh",
             ":without-jdk/install.sh",

--- a/src/BUILD
+++ b/src/BUILD
@@ -24,7 +24,6 @@ md5_cmd = "set -e -o pipefail && %s $(SRCS) | %s | %s > $@"
     outs = ["install_base_key" + suffix],
     cmd = select({
         "//src/conditions:darwin": md5_cmd % ("/sbin/md5", "/sbin/md5", "head -c 32"),
-        "//src/conditions:darwin_x86_64": md5_cmd % ("/sbin/md5", "/sbin/md5", "head -c 32"),
         "//src/conditions:freebsd": md5_cmd % ("/sbin/md5", "/sbin/md5", "head -c 32"),
         # We avoid using the `head` tool's `-c` option, since it does not exist
         # on OpenBSD.
@@ -133,9 +132,6 @@ JAVA_TOOLS = [
                "//src/conditions:darwin": [
                    ":darwin_tools",
                ],
-               "//src/conditions:darwin_x86_64": [
-                   ":darwin_tools",
-               ],
                "//conditions:default": [
                    ":dummy_darwin_tools",
                ],
@@ -173,9 +169,6 @@ filegroup(
         "//src/conditions:darwin": [
             "@openjdk_macos//file",
         ],
-        "//src/conditions:darwin_x86_64": [
-            "@openjdk_macos//file",
-        ],
         "//src/conditions:windows": [
             "@openjdk_win//file",
         ],
@@ -195,9 +188,6 @@ filegroup(
         "//src/conditions:darwin": [
             "@openjdk_macos_minimal//file",
         ],
-        "//src/conditions:darwin_x86_64": [
-            "@openjdk_macos_minimal//file",
-        ],
         "//src/conditions:windows": [
             "@openjdk_win_minimal//file",
         ],
@@ -215,9 +205,6 @@ filegroup(
     name = "embedded_jdk_vanilla",
     srcs = select({
         "//src/conditions:darwin": [
-            "@openjdk_macos_vanilla//file",
-        ],
-        "//src/conditions:darwin_x86_64": [
             "@openjdk_macos_vanilla//file",
         ],
         "//src/conditions:windows": [
@@ -625,9 +612,8 @@ JAVA_VERSIONS = ("11",)
             "--platform",
         ] + select({
             "//src/conditions:darwin": ["darwin"],
-            "//src/conditions:darwin_x86_64": ["darwin_x86_64"],
             "//src/conditions:windows": ["windows"],
-            "//src/conditions:linux_x86_64": ["linux"],
+            "//src/conditions:linux": ["linux"],
             "//conditions:default": ["unknown"],
         }),
         data = [":java_tools_dist_java" + java_version],
@@ -716,9 +702,8 @@ JAVA_VERSIONS = ("11",)
             "--platform",
         ] + select({
             "//src/conditions:darwin": ["darwin"],
-            "//src/conditions:darwin_x86_64": ["darwin_x86_64"],
             "//src/conditions:windows": ["windows"],
-            "//src/conditions:linux_x86_64": ["linux"],
+            "//src/conditions:linux": ["linux"],
             "//conditions:default": ["unknown"],
         }),
         data = [":java_tools_java" + java_version + "_zip"],

--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -55,10 +55,9 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
-# TODO: fix where use points and remove cpu
 config_setting(
     name = "darwin",
-    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:x86_64" ],
+    constraint_values = [ "@platforms//os:macos" ],
     visibility = ["//visibility:public"],
 )
 

--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -13,66 +13,69 @@ filegroup(
     visibility = ["//src:__pkg__"],
 )
 
-# There is no config_setting for "linux".
-# See https://github.com/bazelbuild/bazel/issues/11107
+config_setting(
+    name = "linux",
+    constraint_values = [ "@platforms//os:linux" ],
+    visibility = ["//visibility:public"],
+)
 
 config_setting(
     name = "linux_aarch64",
-    values = {"cpu": "aarch64"},
+    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:aarch64" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_arm",
-    values = {"cpu": "arm"},
+    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:arm" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_ppc",
-    values = {"cpu": "ppc"},
+    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:ppc" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_ppc64le",
-    values = {"cpu": "ppc"},
+    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:ppc" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_s390x",
-    values = {"cpu": "s390x"},
+    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:s390x" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_x86_64",
-    values = {"cpu": "k8"},
+    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:x86_64" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "darwin",
-    values = {"cpu": "darwin"},
+    constraint_values = [ "@platforms//os:macos" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "darwin_x86_64",
-    values = {"cpu": "darwin_x86_64"},
+    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:x86_64" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "darwin_arm64",
-    values = {"cpu": "darwin_arm64"},
+    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:arm64" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "darwin_arm64e",
-    values = {"cpu": "darwin_arm64e"},
+    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:arm64e" ],
     visibility = ["//visibility:public"],
 )
 
@@ -84,25 +87,25 @@ config_setting(
 
 config_setting(
     name = "freebsd",
-    values = {"cpu": "freebsd"},
+    constraint_values = [ "@platforms//os:freebsd"],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "openbsd",
-    values = {"cpu": "openbsd"},
+    constraint_values = [ "@platforms//os:openbsd"],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "windows",
-    values = {"cpu": "x64_windows"},
+    constraint_values = [ "@platforms//os:windows"],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "arm",
-    values = {"cpu": "arm"},
+    constraint_values = [ "@platforms//cpu:arm"],
     visibility = ["//visibility:public"],
 )
 

--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -55,9 +55,10 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+# TODO: fix where use points and remove cpu
 config_setting(
     name = "darwin",
-    constraint_values = [ "@platforms//os:macos" ],
+    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:x86_64" ],
     visibility = ["//visibility:public"],
 )
 

--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -1,102 +1,79 @@
 config_setting(
     name = "freebsd",
-    values = {"cpu": "freebsd"},
+    constraint_values = [ "@platforms//os:freebsd"],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "openbsd",
-    values = {"cpu": "openbsd"},
+    constraint_values = [ "@platforms//os:openbsd"],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "darwin",
-    values = {"cpu": "darwin"},
+    constraint_values = [ "@platforms//os:macos" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_ppc",
-    values = {"cpu": "ppc"},
+    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:ppc" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_ppc64le",
-    values = {"cpu": "ppc"},
+    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:ppc" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_s390x",
-    values = {"cpu": "s390x"},
+    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:s390x" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_x86_64",
-    values = {"cpu": "k8"},
+    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:x86_64" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_aarch64",
-    values = {"cpu": "aarch64"},
+    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:aarch64" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "darwin_x86_64",
-    values = {"cpu": "darwin_x86_64"},
+    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:x86_64" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "darwin_arm64",
-    values = {"cpu": "darwin_arm64"},
+    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:arm64" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "darwin_arm64e",
-    values = {"cpu": "darwin_arm64e"},
+    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:arm64e" ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "windows",
-    values = {"cpu": "x64_windows"},
+    constraint_values = [ "@platforms//os:windows"],
     visibility = ["//visibility:public"],
 )
 
-config_setting(
-    name = "windows_msvc",
-    values = {"cpu": "x64_windows_msvc"},
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "windows_msys",
-    values = {"cpu": "x64_windows_msys"},
-    visibility = ["//visibility:public"],
-)
-
+# TODO: figure out how to base this selection on constraints
 config_setting(
     name = "host_windows",
     values = {"host_cpu": "x64_windows"},
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "host_windows_msvc",
-    values = {"host_cpu": "x64_windows_msvc"},
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "host_windows_msys",
-    values = {"host_cpu": "x64_windows_msys"},
     visibility = ["//visibility:public"],
 )
 

--- a/src/main/cpp/BUILD
+++ b/src/main/cpp/BUILD
@@ -24,18 +24,6 @@ cc_library(
             "blaze_util_darwin.cc",
             "blaze_util_posix.cc",
         ],
-        "//src/conditions:darwin_x86_64": [
-            "blaze_util_darwin.cc",
-            "blaze_util_posix.cc",
-        ],
-        "//src/conditions:darwin_arm64": [
-            "blaze_util_darwin.cc",
-            "blaze_util_posix.cc",
-        ],
-        "//src/conditions:darwin_arm64e": [
-            "blaze_util_darwin.cc",
-            "blaze_util_posix.cc",
-        ],
         "//src/conditions:freebsd": [
             "blaze_util_bsd.cc",
             "blaze_util_posix.cc",
@@ -58,15 +46,6 @@ cc_library(
     ],
     linkopts = select({
         "//src/conditions:darwin": [
-            "-framework CoreFoundation",
-        ],
-        "//src/conditions:darwin_x86_64": [
-            "-framework CoreFoundation",
-        ],
-        "//src/conditions:darwin_arm64": [
-            "-framework CoreFoundation",
-        ],
-        "//src/conditions:darwin_arm64e": [
             "-framework CoreFoundation",
         ],
         "//src/conditions:freebsd": [
@@ -127,12 +106,6 @@ cc_binary(
     }),
     linkopts = select({
         "//src/conditions:darwin": [
-        ],
-        "//src/conditions:darwin_x86_64": [
-        ],
-        "//src/conditions:darwin_arm64": [
-        ],
-        "//src/conditions:darwin_arm64e": [
         ],
         "//src/conditions:freebsd": [
             "-lprocstat",

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
@@ -70,7 +70,6 @@ filegroup(
     name = "qemu2_x86",
     srcs = ["emulator/emulator"] + select({
         "@bazel_tools//src/conditions:darwin": ["emulator/qemu/darwin-x86_64/qemu-system-i386"],
-        "@bazel_tools//src/conditions:darwin_x86_64": ["emulator/qemu/darwin-x86_64/qemu-system-i386"],
         "//conditions:default": ["emulator/qemu/linux-x86_64/qemu-system-i386"],
     }),
 )

--- a/src/main/java/net/starlark/java/eval/BUILD
+++ b/src/main/java/net/starlark/java/eval/BUILD
@@ -95,13 +95,7 @@ cc_binary(
     name = "libcpu_profiler.so",
     srcs = select({
         "//src/conditions:darwin": ["cpu_profiler_posix.cc"],
-        # There is no config_setting for Linux.
-        # See https://github.com/bazelbuild/bazel/issues/11107
-        "//src/conditions:linux_aarch64": ["cpu_profiler_posix.cc"],
-        "//src/conditions:linux_arm": ["cpu_profiler_posix.cc"],
-        "//src/conditions:linux_ppc": ["cpu_profiler_posix.cc"],
-        "//src/conditions:linux_s390x": ["cpu_profiler_posix.cc"],
-        "//src/conditions:linux_x86_64": ["cpu_profiler_posix.cc"],
+        "//src/conditions:linux": ["cpu_profiler_posix.cc"],
         "//conditions:default": ["cpu_profiler_unimpl.cc"],
     }),
     linkshared = 1,

--- a/src/main/native/BUILD
+++ b/src/main/native/BUILD
@@ -4,7 +4,6 @@ genrule(
     name = "copy_link_jni_md_header",
     srcs = select({
         "//src/conditions:darwin": ["//tools/jdk:jni_md_header-darwin"],
-        "//src/conditions:darwin_x86_64": ["//tools/jdk:jni_md_header-darwin"],
         "//src/conditions:freebsd": ["//tools/jdk:jni_md_header-freebsd"],
         "//src/conditions:openbsd": ["//tools/jdk:jni_md_header-openbsd"],
         "//src/conditions:windows": ["//tools/jdk:jni_md_header-windows"],
@@ -27,10 +26,6 @@ filegroup(
     name = "jni_os",
     srcs = select({
         "//src/conditions:darwin": [
-            "unix_jni_darwin.cc",
-            "fsevents.cc",
-        ],
-        "//src/conditions:darwin_x86_64": [
             "unix_jni_darwin.cc",
             "fsevents.cc",
         ],
@@ -69,7 +64,6 @@ cc_binary(
     includes = ["."],  # For jni headers.
     linkopts = select({
         "//src/conditions:darwin": ["-framework CoreServices"],
-        "//src/conditions:darwin_x86_64": ["-framework CoreServices"],
         "//conditions:default": [],
     }),
     linkshared = 1,

--- a/src/main/tools/BUILD
+++ b/src/main/tools/BUILD
@@ -74,9 +74,6 @@ cc_binary(
     name = "linux-sandbox",
     srcs = select({
         "//src/conditions:darwin": ["dummy-sandbox.c"],
-        "//src/conditions:darwin_x86_64": ["dummy-sandbox.c"],
-        "//src/conditions:darwin_arm64": ["dummy-sandbox.c"],
-        "//src/conditions:darwin_arm64e": ["dummy-sandbox.c"],
         "//src/conditions:freebsd": ["dummy-sandbox.c"],
         "//src/conditions:openbsd": ["dummy-sandbox.c"],
         "//src/conditions:windows": ["dummy-sandbox.c"],
@@ -92,9 +89,6 @@ cc_binary(
     linkopts = ["-lm"],
     deps = select({
         "//src/conditions:darwin": [],
-        "//src/conditions:darwin_x86_64": [],
-        "//src/conditions:darwin_arm64": [],
-        "//src/conditions:darwin_arm64e": [],
         "//src/conditions:freebsd": [],
         "//src/conditions:openbsd": [],
         "//src/conditions:windows": [],

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -26,8 +26,7 @@ NATIVE_SSL_TEST = ["NativeSslTest.java"]
 NATIVE_SSL_TEST_MAYBE = select({
     "//src/conditions:windows": NATIVE_SSL_TEST,
     "//src/conditions:darwin": NATIVE_SSL_TEST,
-    "//src/conditions:darwin_x86_64": NATIVE_SSL_TEST,
-    "//src/conditions:linux_x86_64": NATIVE_SSL_TEST,
+    "//src/conditions:linux": NATIVE_SSL_TEST,
     "//conditions:default": [],
 })
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -72,10 +72,6 @@ java_test(
             ["*.java"],
             exclude = CROSS_PLATFORM_WINDOWS_TESTS,
         ),
-        "//src/conditions:darwin_x86_64": glob(
-            ["*.java"],
-            exclude = CROSS_PLATFORM_WINDOWS_TESTS,
-        ),
         "//conditions:default": glob(
             ["*.java"],
             exclude = ["MacOSXFsEventsDiffAwarenessTest.java"] + CROSS_PLATFORM_WINDOWS_TESTS,
@@ -90,11 +86,6 @@ java_test(
     ],
     deps = select({
         "//src/conditions:darwin": [
-            "//src/main/java/com/google/devtools/build/lib/skyframe:incompatible_view_exception",
-            "//src/main/java/com/google/devtools/build/lib/skyframe:local_diff_awareness",
-            "//src/main/java/com/google/devtools/build/lib/testing/common:fake-options",
-        ],
-        "//src/conditions:darwin_x86_64": [
             "//src/main/java/com/google/devtools/build/lib/skyframe:incompatible_view_exception",
             "//src/main/java/com/google/devtools/build/lib/skyframe:local_diff_awareness",
             "//src/main/java/com/google/devtools/build/lib/testing/common:fake-options",

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -189,9 +189,8 @@ sh_test(
     ] + select({
         # --javabase and --host_javabase values
         "//src/conditions:darwin": ["@openjdk14_darwin_archive//:runtime"],
-        "//src/conditions:darwin_x86_64": ["@openjdk14_darwin_archive//:runtime"],
         "//src/conditions:windows": ["@openjdk14_windows_archive//:runtime"],
-        "//src/conditions:linux_x86_64": ["@openjdk14_linux_archive//:runtime"],
+        "//src/conditions:linux": ["@openjdk14_linux_archive//:runtime"],
     }),
     data = [
         ":test-deps",
@@ -213,9 +212,8 @@ sh_test(
     ] + select({
         # --javabase and --host_javabase values
         "//src/conditions:darwin": ["@openjdk15_darwin_archive//:runtime"],
-        "//src/conditions:darwin_x86_64": ["@openjdk15_darwin_archive//:runtime"],
         "//src/conditions:windows": ["@openjdk15_windows_archive//:runtime"],
-        "//src/conditions:linux_x86_64": ["@openjdk15_linux_archive//:runtime"],
+        "//src/conditions:linux": ["@openjdk15_linux_archive//:runtime"],
     }),
     data = [
         ":test-deps",
@@ -260,9 +258,8 @@ JAVA_VERSIONS = ("11", "14", "15")
             # --javabase value
         ] + select({
             "//src/conditions:darwin": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
-            "//src/conditions:darwin_x86_64": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
             "//src/conditions:windows": ["@openjdk" + java_version + "_windows_archive//:runtime"],
-            "//src/conditions:linux_x86_64": ["@openjdk" + java_version + "_linux_archive//:runtime"],
+            "//src/conditions:linux": ["@openjdk" + java_version + "_linux_archive//:runtime"],
         }),
         data = [
             ":test-deps",
@@ -289,9 +286,8 @@ JAVA_VERSIONS = ("11", "14", "15")
             # --javabase value
         ] + select({
             "//src/conditions:darwin": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
-            "//src/conditions:darwin_x86_64": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
             "//src/conditions:windows": ["@openjdk" + java_version + "_windows_archive//:runtime"],
-            "//src/conditions:linux_x86_64": ["@openjdk" + java_version + "_linux_archive//:runtime"],
+            "//src/conditions:linux": ["@openjdk" + java_version + "_linux_archive//:runtime"],
         }),
         data = [
             ":test-deps",
@@ -318,9 +314,8 @@ JAVA_VERSIONS = ("11", "14", "15")
             # --javabase value
         ] + select({
             "//src/conditions:darwin": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
-            "//src/conditions:darwin_x86_64": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
             "//src/conditions:windows": ["@openjdk" + java_version + "_windows_archive//:runtime"],
-            "//src/conditions:linux_x86_64": ["@openjdk" + java_version + "_linux_archive//:runtime"],
+            "//src/conditions:linux": ["@openjdk" + java_version + "_linux_archive//:runtime"],
         }),
         data = [
             ":test-deps",
@@ -521,9 +516,8 @@ sh_test(
         srcs = ["bazel_coverage_java_test.sh"],
         args = select({
             "//src/conditions:darwin": ["@remote_java_tools_javac11_test_darwin//:toolchain"],
-            "//src/conditions:darwin_x86_64": ["@remote_java_tools_javac11_test_darwin//:toolchain"],
             "//src/conditions:windows": ["@remote_java_tools_javac11_test_windows//:toolchain"],
-            "//src/conditions:linux_x86_64": ["@remote_java_tools_javac11_test_linux//:toolchain"],
+            "//src/conditions:linux": ["@remote_java_tools_javac11_test_linux//:toolchain"],
         }) + [
             # java_tools zip to test
             "released",
@@ -532,9 +526,8 @@ sh_test(
             # --javabase value
         ] + select({
             "//src/conditions:darwin": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
-            "//src/conditions:darwin_x86_64": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
             "//src/conditions:windows": ["@openjdk" + java_version + "_windows_archive//:runtime"],
-            "//src/conditions:linux_x86_64": ["@openjdk" + java_version + "_linux_archive//:runtime"],
+            "//src/conditions:linux": ["@openjdk" + java_version + "_linux_archive//:runtime"],
         }),
         data = [
             ":test-deps",
@@ -562,9 +555,8 @@ sh_test(
             # --javabase value
         ] + select({
             "//src/conditions:darwin": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
-            "//src/conditions:darwin_x86_64": ["@openjdk" + java_version + "_darwin_archive//:runtime"],
             "//src/conditions:windows": ["@openjdk" + java_version + "_windows_archive//:runtime"],
-            "//src/conditions:linux_x86_64": ["@openjdk" + java_version + "_linux_archive//:runtime"],
+            "//src/conditions:linux": ["@openjdk" + java_version + "_linux_archive//:runtime"],
         }),
         data = [
             ":test-deps",

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -134,12 +134,14 @@ java_runtime_files(
 # See test_jni in third_party/bazel/src/test/shell/bazel/bazel_java_test.sh for
 # an example of using Bazel to build a Java program that calls a C function.
 #
-# TODO(adonovan): add cases for //src/conditions:linux_arm when released in Bazel.
-# TODO(adonovan): why is there no //src/conditions target meaning "just linux"?
+# TODO(ilist): use //src:condition:linux when released in Bazel
 cc_library(
     name = "jni",
     hdrs = [":jni_header"] + select({
-        "//src/conditions:linux": [":jni_md_header-linux"],
+        "//src/conditions:linux_aarch64": [":jni_md_header-linux"],
+        "//src/conditions:linux_ppc64le": [":jni_md_header-linux"],
+        "//src/conditions:linux_s390x": [":jni_md_header-linux"],
+        "//src/conditions:linux_x86_64": [":jni_md_header-linux"],
         "//src/conditions:darwin": [":jni_md_header-darwin"],
         "//src/conditions:freebsd": [":jni_md_header-freebsd"],
         "//src/conditions:openbsd": [":jni_md_header-openbsd"],
@@ -147,7 +149,10 @@ cc_library(
         "//conditions:default": [],
     }),
     includes = ["include"] + select({
-        "//src/conditions:linux": ["include/linux"],
+        "//src/conditions:linux_aarch64": ["include/linux"],
+        "//src/conditions:linux_ppc64le": ["include/linux"],
+        "//src/conditions:linux_s390x": ["include/linux"],
+        "//src/conditions:linux_x86_64": ["include/linux"],
         "//src/conditions:darwin": ["include/darwin"],
         "//src/conditions:freebsd": ["include/freebsd"],
         "//src/conditions:openbsd": ["include/openbsd"],
@@ -287,7 +292,7 @@ alias(
     actual = select({
         "//src/conditions:darwin": "@remote_java_tools_darwin//:proguard",
         "//src/conditions:windows": "@remote_java_tools_windows//:proguard",
-        "//src/conditions:linux": "@remote_java_tools_linux//:proguard",
+        "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:proguard",
         # On different platforms the linux repository can be used because the
         # proguard deploy jar is platform-agnostic.
         "//conditions:default": "@remote_java_tools_linux//:proguard",
@@ -372,7 +377,7 @@ alias(
     actual = select({
         "//src/conditions:darwin": "@remote_java_tools_darwin//:toolchain",
         "//src/conditions:windows": "@remote_java_tools_windows//:toolchain",
-        "//src/conditions:linux": "@remote_java_tools_linux//:toolchain",
+        "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:toolchain",
         "//conditions:default": "@bazel_tools//tools/jdk:legacy_toolchain",
     }),
 )
@@ -382,7 +387,7 @@ alias(
     actual = select({
         "//src/conditions:darwin": "@remote_java_tools_darwin//:toolchain",
         "//src/conditions:windows": "@remote_java_tools_windows//:toolchain",
-        "//src/conditions:linux": "@remote_java_tools_linux//:toolchain",
+        "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:toolchain",
         "//conditions:default": "@bazel_tools//tools/jdk:legacy_toolchain",
     }),
 )

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -139,10 +139,7 @@ java_runtime_files(
 cc_library(
     name = "jni",
     hdrs = [":jni_header"] + select({
-        "//src/conditions:linux_aarch64": [":jni_md_header-linux"],
-        "//src/conditions:linux_ppc64le": [":jni_md_header-linux"],
-        "//src/conditions:linux_s390x": [":jni_md_header-linux"],
-        "//src/conditions:linux_x86_64": [":jni_md_header-linux"],
+        "//src/conditions:linux": [":jni_md_header-linux"],
         "//src/conditions:darwin": [":jni_md_header-darwin"],
         "//src/conditions:freebsd": [":jni_md_header-freebsd"],
         "//src/conditions:openbsd": [":jni_md_header-openbsd"],
@@ -150,10 +147,7 @@ cc_library(
         "//conditions:default": [],
     }),
     includes = ["include"] + select({
-        "//src/conditions:linux_aarch64": ["include/linux"],
-        "//src/conditions:linux_ppc64le": ["include/linux"],
-        "//src/conditions:linux_s390x": ["include/linux"],
-        "//src/conditions:linux_x86_64": ["include/linux"],
+        "//src/conditions:linux": ["include/linux"],
         "//src/conditions:darwin": ["include/darwin"],
         "//src/conditions:freebsd": ["include/freebsd"],
         "//src/conditions:openbsd": ["include/openbsd"],
@@ -292,9 +286,8 @@ alias(
     name = "proguard",
     actual = select({
         "//src/conditions:darwin": "@remote_java_tools_darwin//:proguard",
-        "//src/conditions:darwin_x86_64": "@remote_java_tools_darwin//:proguard",
         "//src/conditions:windows": "@remote_java_tools_windows//:proguard",
-        "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:proguard",
+        "//src/conditions:linux": "@remote_java_tools_linux//:proguard",
         # On different platforms the linux repository can be used because the
         # proguard deploy jar is platform-agnostic.
         "//conditions:default": "@remote_java_tools_linux//:proguard",
@@ -378,9 +371,8 @@ alias(
     name = "toolchain",
     actual = select({
         "//src/conditions:darwin": "@remote_java_tools_darwin//:toolchain",
-        "//src/conditions:darwin_x86_64": "@remote_java_tools_darwin//:toolchain",
         "//src/conditions:windows": "@remote_java_tools_windows//:toolchain",
-        "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:toolchain",
+        "//src/conditions:linux": "@remote_java_tools_linux//:toolchain",
         "//conditions:default": "@bazel_tools//tools/jdk:legacy_toolchain",
     }),
 )
@@ -389,9 +381,8 @@ alias(
     name = "remote_toolchain",
     actual = select({
         "//src/conditions:darwin": "@remote_java_tools_darwin//:toolchain",
-        "//src/conditions:darwin_x86_64": "@remote_java_tools_darwin//:toolchain",
         "//src/conditions:windows": "@remote_java_tools_windows//:toolchain",
-        "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:toolchain",
+        "//src/conditions:linux": "@remote_java_tools_linux//:toolchain",
         "//conditions:default": "@bazel_tools//tools/jdk:legacy_toolchain",
     }),
 )
@@ -508,7 +499,6 @@ alias(
     actual = select(
         {
             "//src/conditions:darwin": "@remotejdk11_macos//:jdk",
-            "//src/conditions:darwin_x86_64": "@remotejdk11_macos//:jdk",
             "//src/conditions:windows": "@remotejdk11_win//:jdk",
             "//src/conditions:linux_aarch64": "@remotejdk11_linux_aarch64//:jdk",
             "//src/conditions:linux_x86_64": "@remotejdk11_linux//:jdk",

--- a/tools/jdk/remote_java_tools_aliases.bzl
+++ b/tools/jdk/remote_java_tools_aliases.bzl
@@ -16,9 +16,10 @@
 
 load("@rules_java//java:defs.bzl", "java_import")
 
+# TODO(ilist) use //src/conditions:linux after Bazel release
 def _get_args(target, attr, **kwargs):
     workspace_target_dict = {
-        "//src/conditions:linux": ["@remote_java_tools_linux//" + target],
+        "//src/conditions:linux_x86_64": ["@remote_java_tools_linux//" + target],
         "//src/conditions:darwin": ["@remote_java_tools_darwin//" + target],
         "//src/conditions:windows": ["@remote_java_tools_windows//" + target],
         # On different platforms the linux repository can be used.

--- a/tools/jdk/remote_java_tools_aliases.bzl
+++ b/tools/jdk/remote_java_tools_aliases.bzl
@@ -18,9 +18,8 @@ load("@rules_java//java:defs.bzl", "java_import")
 
 def _get_args(target, attr, **kwargs):
     workspace_target_dict = {
-        "//src/conditions:linux_x86_64": ["@remote_java_tools_linux//" + target],
+        "//src/conditions:linux": ["@remote_java_tools_linux//" + target],
         "//src/conditions:darwin": ["@remote_java_tools_darwin//" + target],
-        "//src/conditions:darwin_x86_64": ["@remote_java_tools_darwin//" + target],
         "//src/conditions:windows": ["@remote_java_tools_windows//" + target],
         # On different platforms the linux repository can be used.
         # The deploy jars inside the linux repository are platform-agnostic.


### PR DESCRIPTION
I changed configuration settings in //src/conditions to use constraints instead of flags and then fixed some places where this is used.

I fixed uses of darwin and darwin_x86_64, which using flags I believe is the same thing and using constraints actually becomes different.

Added config_setting for linux. Used it where it makes sense. It cannot be used in tools/jdk/..., because it somehow gets new @bazel_tools and old @bazel_tools/constraints.

This might break users of remote execution or cross compiling. The users working on a single platform should be safe.