### PR TITLE
Make runfiles-windows.cc not crash on dangling dummy_link

### DIFF
--- a/src/main/tools/build-runfiles-windows.cc
+++ b/src/main/tools/build-runfiles-windows.cc
@@ -255,19 +255,20 @@ class RunfilesCreator {
     }
     wstring dummy_link = runfiles_base_dir + L"\\dummy_link";
     wstring dummy_target = runfiles_base_dir + L"\\dummy_target";
-
+    
     // Try creating symlink with admin privilege
-    if (!CreateSymbolicLinkW(dummy_link.c_str(), dummy_target.c_str(), 0)) {
-      // on a rare occasion the dummy_link may exist from a previous run
-      if (GetLastError() == ERROR_ALREADY_EXISTS) {
-        wstring target, werror;
-        // only die when we cannot ensure this is a symlink
-        if (!ReadSymlink(dummy_link, &target, &werror)) {
-          die(L"The dummy_link exists but is not a symlink: %hs", werror.c_str());
-        }
-      }
-      // If we couldn't create symlink, print out an error message and exit.
-      else if (GetLastError() == ERROR_PRIVILEGE_NOT_HELD) {
+    bool created = CreateSymbolicLinkW(dummy_link.c_str(), dummy_target.c_str(), 0);
+
+    // on a rare occasion the dummy_link may exist from a previous run
+    // retry after deleting the existing link
+    if (!created && GetLastError() == ERROR_ALREADY_EXISTS) {
+      DeleteFileOrDie(dummy_link);
+      created = CreateSymbolicLinkW(dummy_link.c_str(), dummy_target.c_str(), 0);
+    }
+
+    // If we couldn't create symlink, print out an error message and exit.
+    if (!created) {
+      if (GetLastError() == ERROR_PRIVILEGE_NOT_HELD) {
         die(L"CreateSymbolicLinkW failed:\n%hs\n",
             "Bazel needs to create symlink for building runfiles tree.\n"
             "Creating symlink on Windows requires either of the following:\n"


### PR DESCRIPTION
Since upgrading to bazel 3.6 we were experiencing similar issues to #11779. Occasionally a dangling dummy_link would exist (I think when the create runfiles process was terminated early) causing the next invocation to crash. This change handles the already exists error and continues execution in case the dummy_link is recognized as a symlink.