### PR TITLE
Use constraints in global conditions instead of configuration flags (third_party/BUILD).

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -552,7 +552,6 @@ java_import(
 UNNECESSARY_DYNAMIC_LIBRARIES = select({
     "//src/conditions:windows": "*.so *.jnilib",
     "//src/conditions:darwin": "*.so *.dll",
-    "//src/conditions:darwin_x86_64": "*.so *.dll",
     "//src/conditions:linux_x86_64": "*.jnilib *.dll",
     # The .so file is an x86 one, so we can just remove it if the CPU is not x86
     "//src/conditions:arm": "*.so *.jnilib *.dll",


### PR DESCRIPTION
This is part of https://github.com/bazelbuild/bazel/pull/12427, that
changes third_party/BUILD file.