### PR TITLE
 Handle empty argument in repository_ctx.which()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -651,7 +651,10 @@ public class StarlarkRepositoryContext
     env.getListener().post(w);
     if (program.contains("/") || program.contains("\\")) {
       throw Starlark.errorf(
-          "Program argument of which() may not contains a / or a \\ ('%s' given)", program);
+          "Program argument of which() may not contain a / or a \\ ('%s' given)", program);
+    }
+    if (program.length() == 0) {
+      throw Starlark.errorf("Program argument of which() may not be empty");
     }
     try {
       StarlarkPath commandPath = findCommandOnPath(program);


### PR DESCRIPTION
This PR handles empty program name in repository_ctx.which() to fix #12216