### PR TITLE
Fix prose reference to user_link_flags field type

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java
@@ -661,7 +661,7 @@ public interface CcModuleApi<
             allowedTypes = {@ParamType(type = NoneType.class), @ParamType(type = Depset.class)}),
         @Param(
             name = "user_link_flags",
-            doc = "List of user link flags passed as strings.",
+            doc = "Depset of user link flags passed as strings.",
             positional = false,
             named = true,
             defaultValue = "None",


### PR DESCRIPTION
The create_linker_input method takes None or a Depset for its linker
flags, but the docstring said List.