### PR TITLE
Remove -no_dead_strip_inits_and_terms ld64 option

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
@@ -1113,7 +1113,7 @@ public class CompilationSupport {
    * <p>When Bazel flags {@code --compilation_mode=opt} and {@code --objc_enable_binary_stripping}
    * are specified, additional optimizations will be performed on the linked binary: all-symbol
    * stripping (using {@code /usr/bin/strip}) and dead-code stripping (using linker flags: {@code
-   * -dead_strip} and {@code -no_dead_strip_inits_and_terms}).
+   * -dead_strip}).
    *
    * @param objcProvider common information about this rule's attributes and its dependencies
    * @param j2ObjcMappingFileProvider contains mapping files for j2objc transpilation

--- a/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
@@ -7484,7 +7484,7 @@ def _impl(ctx):
                 actions = _ALL_LINK_ACTIONS,
                 flag_groups = [
                     flag_group(
-                        flags = ["-dead_strip", "-no_dead_strip_inits_and_terms"],
+                        flags = ["-dead_strip"],
                     ),
                 ],
                 with_features = [with_feature_set(features = ["is_not_test_target"])],

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5710,7 +5710,7 @@ def _impl(ctx):
                           ["objc-executable", "objc++-executable"],
                 flag_groups = [
                     flag_group(
-                        flags = ["-dead_strip", "-no_dead_strip_inits_and_terms"],
+                        flags = ["-dead_strip"],
                     ),
                 ],
             ),


### PR DESCRIPTION
This option is explicitly mentioned as obsolete in the man page. As far
back as Xcode 9 it was a alias for `-dead_strip`:

https://github.com/keith/ld64/blob/40383cc964a1c9993000c2fdd50ecf25802df668/src/ld/Options.cpp#L3090-L3095