### PR TITLE
Retrieve singlejar from java_toolchain instead of using remote_java_tools.

### DIFF
--- a/tools/android/BUILD.tools
+++ b/tools/android/BUILD.tools
@@ -1,6 +1,6 @@
 load("//tools/python:private/defs.bzl", "py_binary", "py_library")
 load("//tools/python:private/version.bzl", "PY_BINARY_VERSION")
-load(":defs.bzl", "run_ijar")
+load(":defs.bzl", "run_ijar", "run_singlejar")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -142,22 +142,16 @@ filegroup(
 
 # javac needs this Jar to compile lambdas, method references, and type annotations.
 # These classes are not part of the android.jar.
-genrule(
+run_singlejar(
     name = "gen_java_base_extras_jar",
     srcs = [
         "@bazel_tools//tools/jdk:platformclasspath",
     ],
-    outs = ["java_base_extras.jar"],
-    cmd = """
-    $(location @bazel_tools//tools/jdk:singlejar) \
-        --exclude_build_data \
-        --dont_change_compression \
-        --sources  $(location @bazel_tools//tools/jdk:platformclasspath) \
-        --include_prefixes "java/lang/invoke/" \
-        --include_prefixes "java/lang/annotation/" \
-        --normalize \
-        --output $@""",
-    tools = ["@bazel_tools//tools/jdk:singlejar"],
+    out = "java_base_extras.jar",
+    include_prefixes = [
+        "java/lang/invoke/",
+        "java/lang/annotation/",
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/tools/android/defs.bzl
+++ b/tools/android/defs.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Provides a rule to run ijar from java_toolchain."""
+"""Provides rules to run ijar and single_jar from java_toolchain."""
 
 def _run_ijar(ctx):
     ijar_jar = java_common.run_ijar(
@@ -27,6 +27,37 @@ run_ijar = rule(
     doc = "Runs ijar over the given jar.",
     attrs = {
         "jar": attr.label(mandatory = True, allow_single_file = True),
+        "_java_toolchain": attr.label(
+            default = "//tools/jdk:current_java_toolchain",
+            providers = [java_common.JavaRuntimeInfo],
+        ),
+    },
+)
+
+def _run_singlejar(ctx):
+    args = ctx.actions.args()
+    args.add("--exclude_build_data")
+    args.add("--dont_change_compression")
+    args.add_all("--sources", ctx.files.srcs)
+    args.add_all("--include_prefixes", ctx.attr.include_prefixes)
+    args.add("--normalize")
+    args.add("--output", ctx.outputs.out)
+    ctx.actions.run(
+        inputs = ctx.files.srcs,
+        outputs = [ctx.outputs.out],
+        executable = ctx.attr._java_toolchain[java_common.JavaToolchainInfo].single_jar,
+        arguments = [args],
+    )
+
+    return [DefaultInfo(files = depset([ctx.outputs.out]))]
+
+run_singlejar = rule(
+    implementation = _run_singlejar,
+    doc = "Runs singlejar over the given files.",
+    attrs = {
+        "srcs": attr.label_list(mandatory = True),
+        "out": attr.output(mandatory = True),
+        "include_prefixes": attr.string_list(),
         "_java_toolchain": attr.label(
             default = "//tools/jdk:current_java_toolchain",
             providers = [java_common.JavaRuntimeInfo],


### PR DESCRIPTION
Android tools depend on using singlejar directly, which is provided in tools/jdk/BUILD via remote_java_tools macro.
Remote_java_tools uses selects to produce an archive name (java_lang_tools_linux, ..) and grab a tool out of it. The selected archive name needs to match the one toolchains will resolve to.

Instead of singlejar is already among things provided by java_toolchain and we can obtain it directly from the toolchain.