### PR TITLE
Fix NPE with netrc and disk cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -1019,7 +1019,8 @@ public final class RemoteModule extends BlazeModule {
         env.getReporter().handle(Event.warn(e.getMessage()));
       }
 
-      if (creds != null && Ascii.toLowerCase(remoteOptions.remoteCache).startsWith("http://")) {
+      if (creds != null && remoteOptions.remoteCache != null &&
+              Ascii.toLowerCase(remoteOptions.remoteCache).startsWith("http://")) {
         env.getReporter()
             .handle(
                 Event.warn(


### PR DESCRIPTION
If you had a netrc file and were using a disk cache with no remote
cache, this would crash.

This was introduced by https://github.com/bazelbuild/bazel/pull/12130