### PR TITLE
Fix the asynchronous cleaning of readonly directories.

### DIFF
--- a/src/test/py/bazel/bazel_clean_test.py
+++ b/src/test/py/bazel/bazel_clean_test.py
@@ -14,6 +14,7 @@
 
 import os
 import re
+import time
 import unittest
 from src.test.py.bazel import test_base
 
@@ -70,7 +71,7 @@ class BazelCleanTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
     matcher = self._findMatch(' moved to (.*) for deletion', stderr)
     self.assertTrue(matcher, stderr)
-    first_temp = matcher.group(0)
+    first_temp = matcher.group(1)
     self.assertTrue(first_temp, stderr)
     # Now do it again (we need to build to recreate exec root).
     self.RunBazel(['build'])
@@ -78,10 +79,34 @@ class BazelCleanTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
     matcher = self._findMatch(' moved to (.*) for deletion', stderr)
     self.assertTrue(matcher, stderr)
-    second_temp = matcher.group(0)
+    second_temp = matcher.group(1)
     self.assertTrue(second_temp, stderr)
     # Two directories should be different.
     self.assertNotEqual(second_temp, first_temp, stderr)
+
+  @unittest.skipIf(not test_base.TestBase.IsLinux(),
+                   'Async clean only supported on Linux')
+  def testBazelAsyncCleanWithReadonlyDirectories(self):
+    self.ScratchFile('WORKSPACE')
+    exit_code, _, stderr = self.RunBazel(['build'])
+    self.AssertExitCode(exit_code, 0, stderr)
+    exit_code, stdout, stderr = self.RunBazel(['info', 'execution_root'])
+    self.AssertExitCode(exit_code, 0, stderr)
+    execroot = stdout[0]
+    readonly_dir = os.path.join(execroot, "readonly")
+    os.mkdir(readonly_dir)
+    open(os.path.join(readonly_dir, "somefile"), "wb").close()
+    os.chmod(readonly_dir, 0o555)
+    exit_code, _, stderr = self.RunBazel(['clean', '--async'])
+    matcher = self._findMatch(' moved to (.*) for deletion', stderr)
+    self.assertTrue(matcher, stderr)
+    temp = matcher.group(1)
+    for i in range(50):
+      if not os.path.isdir(temp):
+        break
+      time.sleep(.1)
+    else:
+      self.fail("temporary directory not removed: {!r}".format(stderr))
 
   def _findMatch(self, pattern, items):
     r = re.compile(pattern)


### PR DESCRIPTION
Previously, clean --async would silently fail to remove files in read-only
directories. Such directories arise from tree artifacts or unsandboxed actions
writing junk into the output tree. This change makes sure all directories can be
edited before executing the "rm -rf".

The limits of shelling out come into relief in this CL. A more solid approach
would be daemonizing a native utility that executes the code backing the VFS's
Path.deleteTreesBelow method. That would ensure synchronous and asynchronous
cleans have the same erasure capabilities and pave the way for cross-platform
--async support. This CL takes a small step in that direction by replacing
arcane shell daemonization with Bazel's daemonize tool.

Fixes https://github.com/bazelbuild/bazel/issues/12125.