### PR TITLE
Bump rules_cc to support llvm 11.0.0 clang-cl compiler on Windows

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/cc_configure.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/cc_configure.WORKSPACE
@@ -6,11 +6,11 @@ load("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_configure")
 maybe(
     http_archive,
     "rules_cc",
-    sha256 = "1d4dbbd1e1e9b57d40bb0ade51c9e882da7658d5bfbf22bbd15b68e7879d761f",
-    strip_prefix = "rules_cc-8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0",
+    sha256 = "d0c573b94a6ef20ef6ff20154a23d0efcb409fb0e1ff0979cec318dfe42f0cdd",
+    strip_prefix = "rules_cc-b1c40e1de81913a3c40e5948f78719c28152486d",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0.zip",
-        "https://github.com/bazelbuild/rules_cc/archive/8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/b1c40e1de81913a3c40e5948f78719c28152486d.zip",
+        "https://github.com/bazelbuild/rules_cc/archive/b1c40e1de81913a3c40e5948f78719c28152486d.zip",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -207,11 +207,11 @@ maybe(
 maybe(
     http_archive,
     "rules_cc",
-    sha256 = "1d4dbbd1e1e9b57d40bb0ade51c9e882da7658d5bfbf22bbd15b68e7879d761f",
-    strip_prefix = "rules_cc-8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0",
+    sha256 = "d0c573b94a6ef20ef6ff20154a23d0efcb409fb0e1ff0979cec318dfe42f0cdd",
+    strip_prefix = "rules_cc-b1c40e1de81913a3c40e5948f78719c28152486d",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0.zip",
-        "https://github.com/bazelbuild/rules_cc/archive/8bd6cd75d03c01bb82561a96d9c1f9f7157b13d0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/b1c40e1de81913a3c40e5948f78719c28152486d.zip",
+        "https://github.com/bazelbuild/rules_cc/archive/b1c40e1de81913a3c40e5948f78719c28152486d.zip",
     ],
 )
 


### PR DESCRIPTION
The clang-cl compiler version 11.0.0 number was missing a trailing whitespace that bazel rules_cc expected.

This commit picks up the most recent commit of rules_cc.

We would appreciate seeing this backported to 3.7.1 prior to the 4.0.0 release, since it represented a showstopper and has no side effects to users of earlier clang-cl compilers.

Signed-off-by: William A Rowe Jr <wrowe@vmware.com>