### PR TITLE
Disable rename DLL when using win_def_file

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -327,11 +327,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
     if (ruleContext.getRule().getImplicitOutputsFunction() != ImplicitOutputsFunction.NONE
         || !ccCompilationOutputs.isEmpty()) {
       if (featureConfiguration.isEnabled(CppRuleClasses.TARGETS_WINDOWS)) {
-        Artifact customDefFile = common.getWinDefFile();
-        String dllNameSuffix =
-            customDefFile != null
-                ? CppHelper.getDLLHashSuffix(ruleContext, featureConfiguration)
-                : "";
+        String dllNameSuffix = CppHelper.getDLLHashSuffix(ruleContext, featureConfiguration);
         linkingHelper.setLinkedDLLNameSuffix(dllNameSuffix);
         Artifact generatedDefFile = null;
 
@@ -355,7 +351,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
         }
         linkingHelper.setDefFile(
             CppHelper.getWindowsDefFileForLinking(
-                ruleContext, customDefFile, generatedDefFile, featureConfiguration));
+                ruleContext, common.getWinDefFile(), generatedDefFile, featureConfiguration));
       }
       ccLinkingOutputs = linkingHelper.link(ccCompilationOutputs);
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -327,7 +327,11 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
     if (ruleContext.getRule().getImplicitOutputsFunction() != ImplicitOutputsFunction.NONE
         || !ccCompilationOutputs.isEmpty()) {
       if (featureConfiguration.isEnabled(CppRuleClasses.TARGETS_WINDOWS)) {
-        String dllNameSuffix = CppHelper.getDLLHashSuffix(ruleContext, featureConfiguration);
+        Artifact customDefFile = common.getWinDefFile();
+        String dllNameSuffix =
+            customDefFile != null
+                ? CppHelper.getDLLHashSuffix(ruleContext, featureConfiguration)
+                : "";
         linkingHelper.setLinkedDLLNameSuffix(dllNameSuffix);
         Artifact generatedDefFile = null;
 
@@ -351,7 +355,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
         }
         linkingHelper.setDefFile(
             CppHelper.getWindowsDefFileForLinking(
-                ruleContext, common.getWinDefFile(), generatedDefFile, featureConfiguration));
+                ruleContext, customDefFile, generatedDefFile, featureConfiguration));
       }
       ccLinkingOutputs = linkingHelper.link(ccCompilationOutputs);
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -950,7 +950,7 @@ public class CppHelper {
     if (cppOptions.renameDLL
         && cppOptions.dynamicMode != DynamicMode.OFF
         && featureConfiguration.isEnabled(CppRuleClasses.TARGETS_WINDOWS)
-        && ruleContext.isAttrDefined("win_def_file", LABEL)) {
+        && !ruleContext.isAttrDefined("win_def_file", LABEL)) {
       Fingerprint digest = new Fingerprint();
       digest.addString(ruleContext.getRepository().getName());
       digest.addPath(ruleContext.getPackageDirectory());

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -949,7 +949,8 @@ public class CppHelper {
             ruleContext.getConfiguration().getOptions().get(CppOptions.class));
     if (cppOptions.renameDLL
         && cppOptions.dynamicMode != DynamicMode.OFF
-        && featureConfiguration.isEnabled(CppRuleClasses.TARGETS_WINDOWS)) {
+        && featureConfiguration.isEnabled(CppRuleClasses.TARGETS_WINDOWS)
+        && ruleContext.isAttrDefined("win_def_file", LABEL)) {
       Fingerprint digest = new Fingerprint();
       digest.addString(ruleContext.getRepository().getName());
       digest.addPath(ruleContext.getPackageDirectory());

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -950,7 +950,10 @@ public class CppHelper {
     if (cppOptions.renameDLL
         && cppOptions.dynamicMode != DynamicMode.OFF
         && featureConfiguration.isEnabled(CppRuleClasses.TARGETS_WINDOWS)
-        && !ruleContext.isAttrDefined("win_def_file", LABEL)) {
+        && (!ruleContext.isAttrDefined("win_def_file", LABEL) || 
+        ruleContext.getPrerequisiteArtifact("win_def_file") == null)) {
+      // Because the custom DEF file in `win_def_file` does not contain the suffix of the DLL, we
+      // should not calculate _{hash} when `win_def_file` is used.
       Fingerprint digest = new Fingerprint();
       digest.addString(ruleContext.getRepository().getName());
       digest.addPath(ruleContext.getPackageDirectory());

--- a/src/test/py/bazel/bazel_windows_cpp_test.py
+++ b/src/test/py/bazel/bazel_windows_cpp_test.py
@@ -635,6 +635,7 @@ class BazelWindowsCppTest(test_base.TestBase):
 
     # Test exporting symbols using custom DEF file in cc_library.
     # Auto-generating DEF file should be disabled when custom DEF file specified
+    # Rename DLL shoud be disabled when when custom DEF file specified
     exit_code, _, stderr = self.RunBazel([
         'build', '//:lib', '-s', '--output_groups=dynamic_library',
         '--features=windows_export_all_symbols'
@@ -644,8 +645,10 @@ class BazelWindowsCppTest(test_base.TestBase):
     bazel_bin = self.getBazelInfo('bazel-bin')
     lib_if = os.path.join(bazel_bin, 'lib.if.lib')
     lib_def = os.path.join(bazel_bin, 'lib.gen.def')
+    lib_dll = os.path.join(bazel_bin, 'lib.dll')
     self.assertTrue(os.path.exists(lib_if))
     self.assertFalse(os.path.exists(lib_def))
+    self.assertTrue(os.path.exists(lib_dll))
 
     # Test specifying DEF file in cc_binary
     exit_code, _, stderr = self.RunBazel(['build', '//:lib_dy.dll', '-s'])


### PR DESCRIPTION
We should not rename the `*.dll` in `cc_library` when `win_def_file` is specified. Part of #11600 https://github.com/bazelbuild/bazel/issues/11600#issuecomment-645234548 

cc @meteorcloudy 