### PR TITLE
docs: remove stray code fence causing incorrect formatting

### DIFF
--- a/site/docs/configurable-attributes.md
+++ b/site/docs/configurable-attributes.md
@@ -521,7 +521,6 @@ It's an error for multiple conditions to match unless one is an unambiguous
 If you need a `select` branch to match when multiple conditions match, use the
 [Skylib](https://github.com/bazelbuild/bazel-skylib) macro
 [config_setting_group](https://github.com/bazelbuild/bazel-skylib/blob/master/docs/selects_doc.md#selectsconfig_setting_group):
-```
 
 ```python
 config_setting(
@@ -542,7 +541,7 @@ sh_binary(
     deps = select({
         ":config1_and_2": [":standard_lib"],
         "//conditions:default": [":other_lib"],
-        }),
+    }),
 )
 ```
 


### PR DESCRIPTION
Removes a stray code fence that causes the block to render incorrectly in https://docs.bazel.build/versions/master/configurable-attributes.html#and-chaining