### PR TITLE
Starlark: optimize 64-bit integer negation

### DIFF
--- a/src/main/java/net/starlark/java/eval/StarlarkInt.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkInt.java
@@ -618,6 +618,13 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
       return StarlarkInt.of(-xl);
     }
 
+    if (x instanceof Int64) {
+      long xl = ((Int64) x).v;
+      if (xl != Long.MIN_VALUE) {
+        return StarlarkInt.of(-xl);
+      }
+    }
+
     BigInteger xbig = x.toBigInteger();
     BigInteger ybig = xbig.negate();
     return StarlarkInt.of(ybig);

--- a/src/test/java/net/starlark/java/eval/testdata/int.star
+++ b/src/test/java/net/starlark/java/eval/testdata/int.star
@@ -139,10 +139,20 @@ compound()
 
 # unary operators
 
+assert_eq(+0, 0)
 assert_eq(+4, 4)
-assert_eq(-4, -4)
-assert_eq(++4, 4)
 assert_eq(+-4, -4)
+
+assert_eq(-0, 0)
+assert_eq(-4, 0 - 4)
+assert_eq(-(0 - 4), 4)
+assert_eq(-minint, 0 - minint)
+assert_eq(-maxint, 0 - maxint)
+assert_eq(-minlong, 0 - minlong)
+assert_eq(-maxlong, 0 - maxlong)
+
+assert_eq(++4, 4)
+assert_eq(+-4, 0 - 4)
 assert_eq(-+-4, 4)
 
 ---


### PR DESCRIPTION
Perform negation of 64-bit integer without roundtrip to `BigInteger`.

Not a big deal, but it may be a performance issue in certain cases.