### PR TITLE
Fix action cache checking for missing constant-metadata artifacts.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionCacheCheckerTest.java
@@ -21,6 +21,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.ActionCacheChecker.Token;
 import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
+import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
+import com.google.devtools.build.lib.actions.Artifact.SpecialArtifactType;
 import com.google.devtools.build.lib.actions.cache.ActionCache;
 import com.google.devtools.build.lib.actions.cache.CompactPersistentActionCache;
 import com.google.devtools.build.lib.actions.cache.MetadataHandler;
@@ -39,10 +41,13 @@ import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.testutil.ManualClock;
 import com.google.devtools.build.lib.testutil.Scratch;
 import com.google.devtools.build.lib.util.Fingerprint;
+import com.google.devtools.build.lib.vfs.DigestHashFunction;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.lib.vfs.Root;
+import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -353,6 +358,31 @@ public class ActionCacheCheckerTest {
             .set(MissReason.DIFFERENT_DEPS, 1)
             .set(MissReason.DIFFERENT_FILES, 1)
             .build());
+  }
+
+  @Test
+  public void testDeletedConstantMetadataOutputCausesReexecution() throws Exception {
+    SpecialArtifact output =
+        new Artifact.SpecialArtifact(
+            ArtifactRoot.asDerivedRoot(
+                new InMemoryFileSystem(DigestHashFunction.SHA256).getPath("/output"), "bin"),
+            PathFragment.create("bin/dummy"),
+            ActionsTestUtil.NULL_ARTIFACT_OWNER,
+            SpecialArtifactType.CONSTANT_METADATA);
+    output.getPath().getParentDirectory().createDirectoryAndParents();
+    Action action = new NullAction(output);
+    runAction(action);
+    output.getPath().delete();
+    assertThat(
+            cacheChecker.getTokenIfNeedToExecute(
+                action,
+                null,
+                ImmutableMap.<String, String>of(),
+                null,
+                new FakeMetadataHandler(),
+                null,
+                ImmutableMap.<String, String>of()))
+        .isNotNull();
   }
 
   /** A {@link CompactPersistentActionCache} that allows injecting corruption for testing. */


### PR DESCRIPTION
There were two bugs:
- getMetadataOrConstant always returned a non-null metadata for constant-metadata artifacts. But, it should return null if the artifact is missing.
- ConstantMetadataValue was indistinguishable from null in a digest map because ConstantMetadataValue's digest was a 0-length array.