### PR TITLE
Accept proto_library as //tools/objc:protobuf_well_known_types

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/BUILD
@@ -38,6 +38,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/split_transition",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/transition_factory",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
+        "//src/main/java/com/google/devtools/build/lib/analysis:file_provider",
         "//src/main/java/com/google/devtools/build/lib/analysis:platform_options",
         "//src/main/java/com/google/devtools/build/lib/analysis:rule_definition_environment",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/instrumented_files_info",

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ProtoAttributes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ProtoAttributes.java
@@ -23,8 +23,10 @@ import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.analysis.FileProvider;
 import com.google.devtools.build.lib.analysis.PrerequisiteArtifacts;
 import com.google.devtools.build.lib.analysis.RuleContext;
+import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.rules.proto.ProtoInfo;
@@ -86,7 +88,17 @@ final class ProtoAttributes {
 
   /** Returns the list of well known type protos. */
   NestedSet<Artifact> getWellKnownTypeProtos() {
-    return PrerequisiteArtifacts.nestedSet(ruleContext, ObjcRuleClasses.PROTOBUF_WELL_KNOWN_TYPES);
+    NestedSetBuilder<Artifact> wellKnownTypeProtos = NestedSetBuilder.stableOrder();
+    for (TransitiveInfoCollection protos :
+             ruleContext.getPrerequisites(ObjcRuleClasses.PROTOBUF_WELL_KNOWN_TYPES)) {
+      ProtoInfo protoInfo = protos.get(ProtoInfo.PROVIDER);
+      if (protoInfo != null) {
+        wellKnownTypeProtos.addTransitive(protoInfo.getTransitiveProtoSources());
+      } else {
+        wellKnownTypeProtos.addTransitive(protos.getProvider(FileProvider.class).getFilesToBuild());
+      }
+    }
+    return wellKnownTypeProtos.build();
   }
 
   /** Returns the list of proto files to compile. */


### PR DESCRIPTION
Part of the migration of Protobuf rules/aspects to `ProtoSource`.
A future change will make `ProtoInfo` mandatory (similar to what was
done for `proto_lang_toolchain`).

Note that this is for Obj-C Protobuf rules which don't exist in Bazel.

Updates #10005