### PR TITLE
Starlark: perform object validity assertions only when property is set

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkInfo.java
@@ -83,7 +83,7 @@ public final class StarlarkInfo extends StructImpl implements HasBinary {
     int i = 0;
     for (Map.Entry<String, Object> e : values.entrySet()) {
       table[i] = e.getKey();
-      table[n + i] = Starlark.checkValid(e.getValue());
+      table[n + i] = Starlark.checkValidIfAssertionsEnabled(e.getValue());
       i++;
     }
     // Sort keys, permuting values in parallel.

--- a/src/main/java/net/starlark/java/eval/Dict.java
+++ b/src/main/java/net/starlark/java/eval/Dict.java
@@ -408,8 +408,8 @@ public final class Dict<K, V>
     Dict<K, V> dict = new Dict<>(mu);
     for (Map.Entry<? extends K, ? extends V> e : m.entrySet()) {
       dict.contents.put(
-          Starlark.checkValid(e.getKey()), //
-          Starlark.checkValid(e.getValue()));
+          Starlark.checkValidIfAssertionsEnabled(e.getKey()), //
+          Starlark.checkValidIfAssertionsEnabled(e.getValue()));
     }
     return dict;
   }
@@ -430,8 +430,8 @@ public final class Dict<K, V>
 
     /** Adds an entry (k, v) to the builder, overwriting any previous entry with the same key . */
     public Builder<K, V> put(K k, V v) {
-      items.add(Starlark.checkValid(k));
-      items.add(Starlark.checkValid(v));
+      items.add(Starlark.checkValidIfAssertionsEnabled(k));
+      items.add(Starlark.checkValidIfAssertionsEnabled(v));
       return this;
     }
 
@@ -486,6 +486,9 @@ public final class Dict<K, V>
    * @throws EvalException if the key is invalid or the dict is frozen
    */
   public void putEntry(K key, V value) throws EvalException {
+    Starlark.checkValidIfAssertionsEnabled(key);
+    Starlark.checkValidIfAssertionsEnabled(value);
+
     Starlark.checkMutable(this);
     Starlark.checkHashable(key);
     contents.put(key, value);
@@ -502,6 +505,7 @@ public final class Dict<K, V>
     for (Map.Entry<K2, V2> e : map.entrySet()) {
       K2 k = e.getKey();
       Starlark.checkHashable(k);
+      Starlark.checkValidIfAssertionsEnabled(e.getValue());
       contents.put(k, e.getValue());
     }
   }

--- a/src/main/java/net/starlark/java/eval/StarlarkList.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkList.java
@@ -161,14 +161,8 @@ public final class StarlarkList<E> extends AbstractList<E>
     }
 
     Object[] array = Iterables.toArray(elems, Object.class);
-    checkElemsValid(array);
+    Starlark.checkValidElementsIfAssertionsEnabled(array);
     return wrap(mutability, array);
-  }
-
-  private static void checkElemsValid(Object[] elems) {
-    for (Object elem : elems) {
-      Starlark.checkValid(elem);
-    }
   }
 
   /**
@@ -183,13 +177,13 @@ public final class StarlarkList<E> extends AbstractList<E>
    * mutability} is null, the list is immutable.
    */
   public static <T> StarlarkList<T> of(@Nullable Mutability mutability, T... elems) {
-    checkElemsValid(elems);
+    Starlark.checkValidElementsIfAssertionsEnabled(elems);
     return wrap(mutability, Arrays.copyOf(elems, elems.length));
   }
 
   /** Returns an immutable {@code StarlarkList} with the given items. */
   public static <T> StarlarkList<T> immutableOf(T... elems) {
-    checkElemsValid(elems);
+    Starlark.checkValidElementsIfAssertionsEnabled(elems);
     return wrap(null, Arrays.copyOf(elems, elems.length));
   }
 
@@ -334,6 +328,7 @@ public final class StarlarkList<E> extends AbstractList<E>
    * @param element the element to add
    */
   public void addElement(E element) throws EvalException {
+    Starlark.checkValidIfAssertionsEnabled(element);
     Starlark.checkMutable(this);
     grow(size + 1);
     elems[size++] = element;
@@ -346,6 +341,7 @@ public final class StarlarkList<E> extends AbstractList<E>
    * @param element the element to add
    */
   public void addElementAt(int index, E element) throws EvalException {
+    Starlark.checkValidIfAssertionsEnabled(element);
     Starlark.checkMutable(this);
     grow(size + 1);
     System.arraycopy(elems, index, elems, index + 1, size - index);
@@ -359,6 +355,7 @@ public final class StarlarkList<E> extends AbstractList<E>
    * @param elements the elements to add
    */
   public void addElements(Iterable<? extends E> elements) throws EvalException {
+    Starlark.checkValidElementsIfAssertionsEnabled(elements);
     Starlark.checkMutable(this);
     if (elements instanceof StarlarkList) {
       StarlarkList<?> that = (StarlarkList) elements;
@@ -404,6 +401,7 @@ public final class StarlarkList<E> extends AbstractList<E>
               + "It is an error if there is no such item.",
       parameters = {@Param(name = "x", doc = "The object to remove.")})
   public NoneType removeElement(Object x) throws EvalException {
+    Starlark.checkValidIfAssertionsEnabled(x);
     for (int i = 0; i < size; i++) {
       if (elems[i].equals(x)) {
         removeElementAt(i);
@@ -418,6 +416,7 @@ public final class StarlarkList<E> extends AbstractList<E>
    * index < size()}.
    */
   public void setElementAt(int index, E value) throws EvalException {
+    Starlark.checkValidIfAssertionsEnabled(value);
     Starlark.checkMutable(this);
     Preconditions.checkArgument(index < size);
     elems[index] = value;

--- a/src/main/java/net/starlark/java/eval/Tuple.java
+++ b/src/main/java/net/starlark/java/eval/Tuple.java
@@ -60,6 +60,7 @@ public final class Tuple extends AbstractList<Object>
 
   /** Returns a Tuple that wraps the specified array, which must not be subsequently modified. */
   static Tuple wrap(Object[] array) {
+    Starlark.checkValidElementsIfAssertionsEnabled(array);
     return array.length == 0 ? empty() : new Tuple(array);
   }
 
@@ -68,6 +69,7 @@ public final class Tuple extends AbstractList<Object>
     if (seq instanceof Tuple) {
       return (Tuple) seq;
     }
+    Starlark.checkValidElementsIfAssertionsEnabled(seq);
     return wrap(Iterables.toArray(seq, Object.class));
   }
 
@@ -76,6 +78,7 @@ public final class Tuple extends AbstractList<Object>
     if (elems.length == 0) {
       return empty();
     }
+    Starlark.checkValidElementsIfAssertionsEnabled(elems);
     return new Tuple(Arrays.copyOf(elems, elems.length));
   }
 
@@ -186,6 +189,8 @@ public final class Tuple extends AbstractList<Object>
    */
   // TODO(adonovan): move this somewhere more appropriate.
   static <T> ImmutableList<T> wrapImmutable(Object[] array) {
+    Starlark.checkValidElementsIfAssertionsEnabled(array);
+
     // Construct an ImmutableList that shares the array.
     // ImmutableList relies on the implementation of Collection.toArray
     // not subsequently modifying the returned array.

--- a/src/test/java/net/starlark/java/eval/BUILD
+++ b/src/test/java/net/starlark/java/eval/BUILD
@@ -39,6 +39,9 @@ java_test(
         "//third_party:junit4",
         "//third_party:truth",
     ],
+    jvm_flags = [
+        "-Dstarlark.assertValid=true",
+    ],
 )
 
 # Script-based tests of the Starlark interpreter.

--- a/src/test/java/net/starlark/java/eval/EvalUtilsTest.java
+++ b/src/test/java/net/starlark/java/eval/EvalUtilsTest.java
@@ -44,7 +44,7 @@ public final class EvalUtilsTest {
   public void testDataTypeNames() throws Exception {
     assertThat(Starlark.type("foo")).isEqualTo("string");
     assertThat(Starlark.type(StarlarkInt.of(3))).isEqualTo("int");
-    assertThat(Starlark.type(Tuple.of(1, 2, 3))).isEqualTo("tuple");
+    assertThat(Starlark.type(Tuple.of(StarlarkInt.of(1), StarlarkInt.of(2), StarlarkInt.of(3)))).isEqualTo("tuple");
     assertThat(Starlark.type(StarlarkList.empty())).isEqualTo("list");
     assertThat(Starlark.type(Dict.empty())).isEqualTo("dict");
     assertThat(Starlark.type(Starlark.NONE)).isEqualTo("NoneType");

--- a/src/test/java/net/starlark/java/eval/StarlarkEvaluationTest.java
+++ b/src/test/java/net/starlark/java/eval/StarlarkEvaluationTest.java
@@ -1433,6 +1433,9 @@ public final class StarlarkEvaluationTest {
 
   @Test
   public void testFieldReturnsNonStarlarkValue() throws Exception {
+    // `-Dstarlark.assertValid=true` must be specified when running tests
+    assertThat(Starlark.ASSERT_VALID).isTrue();
+
     ev.update("s", new SimpleStruct(ImmutableMap.of("bad", new StringBuilder())));
     RuntimeException e = assertThrows(RuntimeException.class, () -> ev.eval("s.bad"));
     assertThat(e)


### PR DESCRIPTION
Only when JVM arg `-Dstarlark.assertValid=true` is set, Starlark
interpreter checks only valid objects (`Boolean`, `String`,
`StarlarkValue`) cross public API border.

This PR implements first prosal from #12481:

* There are inconsistencies in public API, some API validate the objects, other don't
* Code inside Starlark still performs object validity checks needlessly

The proposal is to remove all validity checks by default, and enable
a lot more checks when assertions enable.

See the issue #12481 for possible alternatives.