### PR TITLE
Starlark: microoptimize str[index]

### DIFF
--- a/src/main/java/net/starlark/java/eval/EvalUtils.java
+++ b/src/main/java/net/starlark/java/eval/EvalUtils.java
@@ -443,7 +443,7 @@ final class EvalUtils {
       String string = (String) object;
       int index = Starlark.toInt(key, "string index");
       index = getSequenceIndex(index, string.length());
-      return string.substring(index, index + 1);
+      return StringModule.memoizedCharToString(string.charAt(index));
     } else {
       throw Starlark.errorf(
           "type '%s' has no operator [](%s)", Starlark.type(object), Starlark.type(key));


### PR DESCRIPTION
Preallocate single-char ASCII strings.

```
def test():
    for i in range(1000000):
        s = "abcdefghijklmnopqrstuvwxyz"
        for j in range(len(s)):
            s[j]

test()
```

```
A: N=48, r=3.896+-0.475
B: N=48, r=3.516+-0.571
B/A: 0.902
```