### PR TITLE
Remove jarjar from java_tools.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -549,7 +549,6 @@ JAVA_TOOLS_DEPLOY_JARS = [
     "//src/java_tools/buildjar/java/com/google/devtools/build/java/turbine:turbine_direct_binary_deploy.jar",
     "//src/java_tools/junitrunner/java/com/google/testing/coverage:JacocoCoverage_jarjar_deploy.jar",
     "//src/java_tools/junitrunner/java/com/google/testing/junit/runner:Runner_deploy.jar",
-    "//third_party/jarjar:jarjar_command_deploy.jar",
 ] + select({
     "//src/conditions:arm": ["//src/java_tools/singlejar/java/com/google/devtools/build/singlejar:bazel-singlejar_deploy.jar"],
     "//conditions:default": [],
@@ -582,7 +581,6 @@ JAVA_VERSIONS = ("11",)
             "//src/tools/singlejar:embedded_java_tools",
             "//third_party/checker_framework_dataflow:srcs",
             "//third_party/checker_framework_javacutil:srcs",
-            "//third_party/jarjar:srcs",
             "//third_party/ijar:transitive_sources",
             "//third_party/java/jacoco:transitive_sources",
             "//third_party/java/proguard:srcs",

--- a/src/test/shell/bazel/bazel_java_tools_dist_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_dist_test.sh
@@ -140,11 +140,6 @@ function test_java_tools_has_javac() {
   expect_path_in_java_tools "javac-9+181-r4173-1.srcjar"
 }
 
-function test_java_tools_has_jarjar() {
-  expect_path_in_java_tools "third_party/jarjar"
-  expect_path_in_java_tools "third_party/jarjar/java/com/tonicsystems/jarjar"
-}
-
 # TOODO(iirina): Re-enable this and update jacoco version after #8376 is merged.
 function DISABLED_test_java_tools_has_jacocoagent() {
   expect_path_in_java_tools "third_party/java/jacoco/org.jacoco.agent-0.7.5.201505241946-src.jar"

--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -147,10 +147,6 @@ function test_java_tools_has_javac() {
   expect_path_in_java_tools "java_tools/javac-9+181-r4173-1.jar"
 }
 
-function test_java_tools_has_jarjar() {
-  expect_path_in_java_tools "java_tools/jarjar_command_deploy.jar"
-}
-
 function test_java_tools_has_Jacoco() {
   expect_path_in_java_tools "java_tools/JacocoCoverage_jarjar_deploy.jar"
 }

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -478,11 +478,6 @@ py_test(
     ],
 )
 
-remote_java_tools_java_import(
-    name = "JarJar",
-    target = ":JarJar",
-)
-
 test_suite(
     name = "windows_tests",
     tags = [

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -139,11 +139,6 @@ filegroup(
 )
 
 filegroup(
-    name = "JarJar",
-    srcs = ["java_tools/jarjar_command_deploy.jar"],
-)
-
-filegroup(
     name = "Turbine",
     srcs = ["java_tools/turbine_deploy.jar"],
 )
@@ -494,13 +489,6 @@ cc_library(
         "java_tools/src/main/native/windows/file.h",
         "java_tools/src/main/native/windows/util.h",
     ],
-    strip_include_prefix = "java_tools",
-)
-
-cc_library(
-    name = "lib-util",
-    srcs = ["java_tools/src/main/native/windows/util.cc"],
-    hdrs = ["java_tools/src/main/native/windows/util.h"],
     strip_include_prefix = "java_tools",
 )
 


### PR DESCRIPTION
Jarjar is an advanced processor of jar files. It can rename classes consistently within a .jar file. It is used in Jacoco deployment, renaming package of 'asm' dependency in the Jacoco deployment jar. This is done so that 'asm' does not clash with another version of asm that might be used in the target being "code coveraged".

After the deployment of java_tools, jarjar is not used by Bazel itself. There might be downstream projects using jarjar from java_tools. However it is a much better idea to remove jarjar from java_tools interface, and that downstream projects depend on it directly.