### PR TITLE
Stop profilers in clean command test.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeCommandDispatcher.java
@@ -44,6 +44,7 @@ import com.google.devtools.build.lib.events.ExtendedEventHandler.Postable;
 import com.google.devtools.build.lib.events.PrintingEventHandler;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.events.StoredEventHandler;
+import com.google.devtools.build.lib.profiler.MemoryProfiler;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.runtime.proto.InvocationPolicyOuterClass.InvocationPolicy;
@@ -621,6 +622,14 @@ public class BlazeCommandDispatcher implements CommandDispatcher {
           logger.atWarning().log("afterCommand yielded different result: %s %s", result, newResult);
         }
       }
+
+      try {
+        Profiler.instance().stop();
+        MemoryProfiler.instance().stop();
+      } catch (IOException e) {
+        env.getReporter().handle(Event.error("Error while writing profile file: " + e.getMessage()));
+      }
+
       // Swallow IOException, as we are already in a finally clause
       Flushables.flushQuietly(outErr.getOutputStream());
       Flushables.flushQuietly(outErr.getErrorStream());

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -677,13 +677,6 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
       }
     }
 
-    try {
-      Profiler.instance().stop();
-      MemoryProfiler.instance().stop();
-    } catch (IOException e) {
-      env.getReporter().handle(Event.error("Error while writing profile file: " + e.getMessage()));
-    }
-
     env.getReporter().clearEventBus();
     retainedHeapLimiter.resetEventHandler();
     actionKeyContext.clear();


### PR DESCRIPTION
This became necessary after d5f96eb44a1fd70048a6bfb42b3e0f308b2dcb88
changed how we handle crashes.

```
bazel test --test_output=streamed --test_filter=CleanCommandRecommendsAsyncTest //src/test/java/com/google/devtools/build/lib:runtime-tests
```
passes now.