### PR TITLE
Starlark: more 64-bit integer operations without round-trip to BigInteger

### DIFF
--- a/src/test/java/net/starlark/java/eval/testdata/bench_int.star
+++ b/src/test/java/net/starlark/java/eval/testdata/bench_int.star
@@ -1,0 +1,25 @@
+_11 = 1 << 11        # 32-bit integer
+_33 = 1 << 33        # 64-bit integer
+_ml = (1 << 63) - 1  # maxlong
+_66 = 1 << 66        # BigInteger
+
+def bench_add_32(b):
+    for _ in range(b.n):
+        (_11 + _11, _11 + _11, _11 + _11, _11 + _11, _11 + _11,
+            _11 + _11, _11 + _11, _11 + _11, _11 + _11, _11 + _11)
+
+def bench_add_64(b):
+    for _ in range(b.n):
+        (_33 + _33, _33 + _33, _33 + _33, _33 + _33, _33 + _33,
+            _33 + _33, _33 + _33, _33 + _33, _33 + _33, _33 + _33)
+
+# 64 bit addition overflows
+def bench_add_64_overfl(b):
+    for _ in range(b.n):
+        (_ml + _ml, _ml + _ml, _ml + _ml, _ml + _ml, _ml + _ml,
+            _ml + _ml, _ml + _ml, _ml + _ml, _ml + _ml, _ml + _ml)
+
+def bench_add_bigint(b):
+    for _ in range(b.n):
+        (_66 + _66, _66 + _66, _66 + _66, _66 + _66, _66 + _66,
+            _66 + _66, _66 + _66, _66 + _66, _66 + _66, _66 + _66)


### PR DESCRIPTION
Implement faster integer operations for integers within signed 64-bit range:
* comparison
* addition
* subtraction

Note JDK has `Math.addExact` function; it cannot cannot be used
directly, because thrown exception on overflow results in high
performance slowdown (about 3x on my laptop) because stack trace
is collected on overflow.

64-bit integer benchmark is significantly faster:

```
def test():
    x = 0
    y = 1 << 33  # 64-bit
    for i in range(10000000):
        x += y + y + y + y + y + y + y + y + y + y

    if x >= 1 << 63:
        fail()

test()
```

```
A: N=6, r=4.046+-0.074
B: N=6, r=3.061+-0.128
B/A: 0.757
```

BigInteger benchmark slightly slower:

```
def test():
    x = 0
    y = 1 << 66  # BigInteger
    for i in range(10000000):
        x += y + y + y + y + y + y + y + y + y + y

test()
```

```
A: N=15, r=4.514+-0.149
B: N=15, r=4.588+-0.155
B/A: 1.016
```

And finally, 64-bit addition with overflow is also slightly slower:

```
def test():
    x = 0
    ml = (1<<63) - 1 # maxlong
    for i in range(2000000):
        x += (int(not (ml + ml)) + int(not (ml + ml)) + int(not (ml + ml)) + int(not (ml + ml))
            + int(not (ml + ml)) + int(not (ml + ml)) + int(not (ml + ml)) + int(not (ml + ml)))

test()
```

```
A: N=126, r=4.089+-0.286
B: N=126, r=4.109+-0.256
B/A: 1.005
```

Follow-up to #12475 (optimize 64-bit integer negation).