### PR TITLE
[WIP] Retain the ConfiguredTargetKey during cquery analysis

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/CqueryBuildTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/CqueryBuildTool.java
@@ -14,11 +14,11 @@
 package com.google.devtools.build.lib.buildtool;
 
 import com.google.common.collect.ImmutableList;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment.TopLevelConfigurations;
 import com.google.devtools.build.lib.query2.cquery.ConfiguredTargetQueryEnvironment;
 import com.google.devtools.build.lib.query2.cquery.CqueryOptions;
+import com.google.devtools.build.lib.query2.cquery.KeyedConfiguredTarget;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
 import com.google.devtools.build.lib.query2.engine.QueryExpression;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
@@ -27,7 +27,7 @@ import com.google.devtools.build.skyframe.WalkableGraph;
 import java.util.Collection;
 
 /** A version of {@link BuildTool} that handles all cquery work. */
-public final class CqueryBuildTool extends PostAnalysisQueryBuildTool<ConfiguredTarget> {
+public final class CqueryBuildTool extends PostAnalysisQueryBuildTool<KeyedConfiguredTarget> {
 
   public CqueryBuildTool(CommandEnvironment env, QueryExpression queryExpression) {
     super(env, queryExpression);

--- a/src/main/java/com/google/devtools/build/lib/query2/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/query2/BUILD
@@ -107,6 +107,7 @@ java_library(
         "//src/main/protobuf:analysis_java_proto",
         "//src/main/protobuf:build_java_proto",
         "//src/main/protobuf:failure_details_java_proto",
+        "//third_party:auto_value",
         "//third_party:flogger",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/query2/ConfiguredTargetValueAccessor.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/ConfiguredTargetValueAccessor.java
@@ -138,8 +138,8 @@ public class ConfiguredTargetValueAccessor implements TargetAccessor<ConfiguredT
   }
 
   private Target getTargetFromConfiguredTargetValue(ConfiguredTargetValue configuredTargetValue) {
-    return ConfiguredTargetAccessor.getTargetFromConfiguredTarget(
-        configuredTargetValue.getConfiguredTarget(), walkableGraph);
+    return ConfiguredTargetAccessor.getTarget(
+        configuredTargetValue.getConfiguredTarget().getOriginalLabel(), walkableGraph);
   }
 
   /** Returns the AspectValues that are attached to the given configuredTarget. */

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfigFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfigFunction.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.common.collect.ImmutableList;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.query2.common.AbstractBlazeQueryEnvironment;
 import com.google.devtools.build.lib.query2.engine.Callback;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment;
@@ -84,8 +83,8 @@ public final class ConfigFunction implements QueryFunction {
         ((ConfiguredTargetQueryEnvironment) env)
             .getConfiguredTargetsForConfigFunction(
                 targetExpression.toString(),
-                (ThreadSafeMutableSet<ConfiguredTarget>) targets.getIfSuccessful(),
+                (ThreadSafeMutableSet<KeyedConfiguredTarget>) targets.getIfSuccessful(),
                 configuration,
-                (Callback<ConfiguredTarget>) callback));
+                (Callback<KeyedConfiguredTarget>) callback));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetAccessor.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetAccessor.java
@@ -75,12 +75,12 @@ public class ConfiguredTargetAccessor implements TargetAccessor<KeyedConfiguredT
 
   @Override
   public String getLabel(KeyedConfiguredTarget target) {
-    return target.label().toString();
+    return target.originalLabel().toString();
   }
 
   @Override
   public String getPackage(KeyedConfiguredTarget target) {
-    return target.label().getPackageIdentifier().getPackageFragment().toString();
+    return target.originalLabel().getPackageIdentifier().getPackageFragment().toString();
   }
 
   @Override
@@ -121,7 +121,7 @@ public class ConfiguredTargetAccessor implements TargetAccessor<KeyedConfiguredT
     Multimap<Label, KeyedConfiguredTarget> depsByLabel =
         Multimaps.index(
             queryEnvironment.getFwdDeps(ImmutableList.of(actualConfiguredTarget)),
-            KeyedConfiguredTarget::label);
+            KeyedConfiguredTarget::originalLabel);
 
     Rule rule = (Rule) getTarget(actualConfiguredTarget);
     ImmutableMap<Label, ConfigMatchingProvider> configConditions =
@@ -178,7 +178,7 @@ public class ConfiguredTargetAccessor implements TargetAccessor<KeyedConfiguredT
     Target target = null;
     try {
       // Dereference any aliases that might be present.
-      Label label = configuredTarget.label();
+      Label label = configuredTarget.actualLabel();
       target =
           ((PackageValue) walkableGraph.getValue(PackageValue.key(label.getPackageIdentifier())))
               .getPackage()

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetAccessor.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetAccessor.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.PlatformConfiguration;
 import com.google.devtools.build.lib.analysis.ToolchainCollection;
 import com.google.devtools.build.lib.analysis.ToolchainContext;
@@ -53,11 +52,11 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * A {@link TargetAccessor} for {@link ConfiguredTarget} objects.
+ * A {@link TargetAccessor} for {@link KeyedConfiguredTarget} objects.
  *
  * <p>Incomplete; we'll implement getVisibility when needed.
  */
-public class ConfiguredTargetAccessor implements TargetAccessor<ConfiguredTarget> {
+public class ConfiguredTargetAccessor implements TargetAccessor<KeyedConfiguredTarget> {
 
   private final WalkableGraph walkableGraph;
   private final ConfiguredTargetQueryEnvironment queryEnvironment;
@@ -69,62 +68,64 @@ public class ConfiguredTargetAccessor implements TargetAccessor<ConfiguredTarget
   }
 
   @Override
-  public String getTargetKind(ConfiguredTarget target) {
-    Target actualTarget = getTargetFromConfiguredTarget(target);
+  public String getTargetKind(KeyedConfiguredTarget target) {
+    Target actualTarget = getTarget(target);
     return actualTarget.getTargetKind();
   }
 
   @Override
-  public String getLabel(ConfiguredTarget target) {
-    return target.getLabel().toString();
+  public String getLabel(KeyedConfiguredTarget target) {
+    return target.label().toString();
   }
 
   @Override
-  public String getPackage(ConfiguredTarget target) {
-    return target.getLabel().getPackageIdentifier().getPackageFragment().toString();
+  public String getPackage(KeyedConfiguredTarget target) {
+    return target.label().getPackageIdentifier().getPackageFragment().toString();
   }
 
   @Override
-  public boolean isRule(ConfiguredTarget target) {
-    Target actualTarget = getTargetFromConfiguredTarget(target);
+  public boolean isRule(KeyedConfiguredTarget target) {
+    Target actualTarget = getTarget(target);
     return actualTarget instanceof Rule;
   }
 
   @Override
-  public boolean isTestRule(ConfiguredTarget target) {
-    Target actualTarget = getTargetFromConfiguredTarget(target);
+  public boolean isTestRule(KeyedConfiguredTarget target) {
+    Target actualTarget = getTarget(target);
     return TargetUtils.isTestRule(actualTarget);
   }
 
   @Override
-  public boolean isTestSuite(ConfiguredTarget target) {
-    Target actualTarget = getTargetFromConfiguredTarget(target);
+  public boolean isTestSuite(KeyedConfiguredTarget target) {
+    Target actualTarget = getTarget(target);
     return TargetUtils.isTestSuiteRule(actualTarget);
   }
 
   @Override
-  public List<ConfiguredTarget> getPrerequisites(
+  public List<KeyedConfiguredTarget> getPrerequisites(
       QueryExpression caller,
-      ConfiguredTarget configuredTarget,
+      KeyedConfiguredTarget configuredTarget,
       String attrName,
       String errorMsgPrefix)
       throws QueryException, InterruptedException {
-    ConfiguredTarget actualConfiguredTarget = configuredTarget.getActual();
+    KeyedConfiguredTarget actualConfiguredTarget =
+        KeyedConfiguredTarget.create(
+            configuredTarget.key(), configuredTarget.configuredTarget().getActual());
 
     Preconditions.checkArgument(
-        isRule(actualConfiguredTarget),
+        isRule(configuredTarget),
         "%s %s is not a rule configured target",
         errorMsgPrefix,
-        getLabel(actualConfiguredTarget));
+        getLabel(configuredTarget));
 
-    Multimap<Label, ConfiguredTarget> depsByLabel =
+    Multimap<Label, KeyedConfiguredTarget> depsByLabel =
         Multimaps.index(
             queryEnvironment.getFwdDeps(ImmutableList.of(actualConfiguredTarget)),
-            ConfiguredTarget::getLabel);
+            KeyedConfiguredTarget::label);
 
-    Rule rule = (Rule) getTargetFromConfiguredTarget(actualConfiguredTarget);
+    Rule rule = (Rule) getTarget(actualConfiguredTarget);
     ImmutableMap<Label, ConfigMatchingProvider> configConditions =
-        ((RuleConfiguredTarget) actualConfiguredTarget).getConfigConditions();
+        ((RuleConfiguredTarget) actualConfiguredTarget.configuredTarget()).getConfigConditions();
     ConfiguredAttributeMapper attributeMapper =
         ConfiguredAttributeMapper.of(rule, configConditions);
     if (!attributeMapper.has(attrName)) {
@@ -135,49 +136,64 @@ public class ConfiguredTargetAccessor implements TargetAccessor<ConfiguredTarget
               errorMsgPrefix, actualConfiguredTarget, rule.getRuleClass(), attrName),
           ConfigurableQuery.Code.ATTRIBUTE_MISSING);
     }
-    ImmutableList.Builder<ConfiguredTarget> toReturn = ImmutableList.builder();
+    ImmutableList.Builder<KeyedConfiguredTarget> toReturn = ImmutableList.builder();
     attributeMapper.visitLabels(attributeMapper.getAttributeDefinition(attrName)).stream()
         .forEach(depEdge -> toReturn.addAll(depsByLabel.get(depEdge.getLabel())));
     return toReturn.build();
   }
 
   @Override
-  public List<String> getStringListAttr(ConfiguredTarget target, String attrName) {
-    Target actualTarget = getTargetFromConfiguredTarget(target);
+  public List<String> getStringListAttr(KeyedConfiguredTarget target, String attrName) {
+    Target actualTarget = getTarget(target);
     return TargetUtils.getStringListAttr(actualTarget, attrName);
   }
 
   @Override
-  public String getStringAttr(ConfiguredTarget target, String attrName) {
-    Target actualTarget = getTargetFromConfiguredTarget(target);
+  public String getStringAttr(KeyedConfiguredTarget target, String attrName) {
+    Target actualTarget = getTarget(target);
     return TargetUtils.getStringAttr(actualTarget, attrName);
   }
 
   @Override
-  public Iterable<String> getAttrAsString(ConfiguredTarget target, String attrName) {
-    Target actualTarget = getTargetFromConfiguredTarget(target);
+  public Iterable<String> getAttrAsString(KeyedConfiguredTarget target, String attrName) {
+    Target actualTarget = getTarget(target);
     return TargetUtils.getAttrAsString(actualTarget, attrName);
   }
 
   @Override
-  public ImmutableSet<QueryVisibility<ConfiguredTarget>> getVisibility(
-      QueryExpression caller, ConfiguredTarget from) throws QueryException {
+  public ImmutableSet<QueryVisibility<KeyedConfiguredTarget>> getVisibility(
+      QueryExpression caller, KeyedConfiguredTarget from) throws QueryException {
     // TODO(bazel-team): implement this if needed.
     throw new QueryException(
         "visible() is not supported on configured targets",
         ConfigurableQuery.Code.VISIBLE_FUNCTION_NOT_SUPPORTED);
   }
 
-  public Target getTargetFromConfiguredTarget(ConfiguredTarget configuredTarget) {
-    return getTargetFromConfiguredTarget(configuredTarget, walkableGraph);
+  public Target getTarget(KeyedConfiguredTarget configuredTarget) {
+    return getTarget(configuredTarget, walkableGraph);
   }
 
-  public static Target getTargetFromConfiguredTarget(
-      ConfiguredTarget configuredTarget, WalkableGraph walkableGraph) {
+  public static Target getTarget(
+      KeyedConfiguredTarget configuredTarget, WalkableGraph walkableGraph) {
     Target target = null;
     try {
       // Dereference any aliases that might be present.
-      Label label = configuredTarget.getOriginalLabel();
+      Label label = configuredTarget.label();
+      target =
+          ((PackageValue) walkableGraph.getValue(PackageValue.key(label.getPackageIdentifier())))
+              .getPackage()
+              .getTarget(label.getName());
+    } catch (NoSuchTargetException e) {
+      throw new IllegalStateException("Unable to get target from package in accessor.", e);
+    } catch (InterruptedException e2) {
+      throw new IllegalStateException("Thread interrupted in the middle of getting a Target.", e2);
+    }
+    return target;
+  }
+
+  public static Target getTarget(Label label, WalkableGraph walkableGraph) {
+    Target target = null;
+    try {
       target =
           ((PackageValue) walkableGraph.getValue(PackageValue.key(label.getPackageIdentifier())))
               .getPackage()
@@ -198,7 +214,9 @@ public class ConfiguredTargetAccessor implements TargetAccessor<ConfiguredTarget
                 walkableGraph.getValue(
                     ConfiguredTargetKey.builder()
                         .setLabel(oct.getGeneratingRule().getLabel())
-                        .setConfiguration(queryEnvironment.getConfiguration(oct))
+                        .setConfiguration(
+                            queryEnvironment.getConfiguration(
+                                KeyedConfiguredTarget.create(null, oct)))
                         .build()))
             .getConfiguredTarget();
   }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
@@ -460,7 +460,7 @@ public class ConfiguredTargetQueryEnvironment
   @Override
   public Label getCorrectLabel(KeyedConfiguredTarget target) {
     // Dereference any aliases that might be present.
-    return target.configuredTarget().getOriginalLabel();
+    return target.actualLabel();
   }
 
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryThreadsafeCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryThreadsafeCallback.java
@@ -15,7 +15,6 @@ package com.google.devtools.build.lib.query2.cquery;
 
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.query2.NamedThreadSafeOutputFormatterCallback;
@@ -42,7 +41,7 @@ import javax.annotation.Nullable;
  * on completeness, should output full configuration checksums.
  */
 public abstract class CqueryThreadsafeCallback
-    extends NamedThreadSafeOutputFormatterCallback<ConfiguredTarget> {
+    extends NamedThreadSafeOutputFormatterCallback<KeyedConfiguredTarget> {
 
   protected final ExtendedEventHandler eventHandler;
   protected final CqueryOptions options;
@@ -63,7 +62,7 @@ public abstract class CqueryThreadsafeCallback
       CqueryOptions options,
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
-      TargetAccessor<ConfiguredTarget> accessor) {
+      TargetAccessor<KeyedConfiguredTarget> accessor) {
     this.eventHandler = eventHandler;
     this.options = options;
     if (out != null) {

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
@@ -48,8 +48,8 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
         private final Comparator<KeyedConfiguredTarget> configuredTargetOrdering =
             (ct1, ct2) -> {
               // Order graph output first by target label, then by configuration hash.
-              Label label1 = ct1.label();
-              Label label2 = ct2.label();
+              Label label1 = ct1.originalLabel();
+              Label label2 = ct2.originalLabel();
               return label1.equals(label2)
                   ? ct1.configurationChecksum().compareTo(ct2.configurationChecksum())
                   : label1.compareTo(label2);
@@ -61,7 +61,7 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
           // hashes.
           KeyedConfiguredTarget ct = node.getLabel();
           return String.format(
-              "%s (%s)", ct.label(), shortId(getConfiguration(ct.configurationKey())));
+              "%s (%s)", ct.originalLabel(), shortId(getConfiguration(ct.configurationKey())));
         }
 
         @Override

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.graph.Digraph;
@@ -37,35 +36,36 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
   /** Interface for finding a configured target's direct dependencies. */
   @FunctionalInterface
   public interface DepsRetriever {
-    Iterable<ConfiguredTarget> getDirectDeps(ConfiguredTarget taget) throws InterruptedException;
+    Iterable<KeyedConfiguredTarget> getDirectDeps(KeyedConfiguredTarget taget)
+        throws InterruptedException;
   }
 
   private final DepsRetriever depsRetriever;
 
-  private final GraphOutputWriter.NodeReader<ConfiguredTarget> nodeReader =
-      new NodeReader<ConfiguredTarget>() {
+  private final GraphOutputWriter.NodeReader<KeyedConfiguredTarget> nodeReader =
+      new NodeReader<KeyedConfiguredTarget>() {
 
-        private final Comparator<ConfiguredTarget> configuredTargetOrdering =
+        private final Comparator<KeyedConfiguredTarget> configuredTargetOrdering =
             (ct1, ct2) -> {
               // Order graph output first by target label, then by configuration hash.
-              Label label1 = ct1.getLabel();
-              Label label2 = ct2.getLabel();
+              Label label1 = ct1.label();
+              Label label2 = ct2.label();
               return label1.equals(label2)
-                  ? ct1.getConfigurationChecksum().compareTo(ct2.getConfigurationChecksum())
+                  ? ct1.configurationChecksum().compareTo(ct2.configurationChecksum())
                   : label1.compareTo(label2);
             };
 
         @Override
-        public String getLabel(Node<ConfiguredTarget> node) {
+        public String getLabel(Node<KeyedConfiguredTarget> node) {
           // Node payloads are ConfiguredTargets. Output node labels are target labels + config
           // hashes.
-          ConfiguredTarget ct = node.getLabel();
+          KeyedConfiguredTarget ct = node.getLabel();
           return String.format(
-              "%s (%s)", ct.getLabel(), shortId(getConfiguration(ct.getConfigurationKey())));
+              "%s (%s)", ct.label(), shortId(getConfiguration(ct.configurationKey())));
         }
 
         @Override
-        public Comparator<ConfiguredTarget> comparator() {
+        public Comparator<KeyedConfiguredTarget> comparator() {
           return configuredTargetOrdering;
         }
       };
@@ -75,30 +75,31 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
       CqueryOptions options,
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
-      TargetAccessor<ConfiguredTarget> accessor,
+      TargetAccessor<KeyedConfiguredTarget> accessor,
       DepsRetriever depsRetriever) {
     super(eventHandler, options, out, skyframeExecutor, accessor);
     this.depsRetriever = depsRetriever;
   }
 
   @Override
-  public void processOutput(Iterable<ConfiguredTarget> partialResult) throws InterruptedException {
+  public void processOutput(Iterable<KeyedConfiguredTarget> partialResult)
+      throws InterruptedException {
     // Transform the cquery-backed graph into a Digraph to make it suitable for GraphOutputWriter.
     // Note that this involves an extra iteration over the entire query result subgraph. We could
     // conceptually merge transformation and output writing into the same iteration if needed.
-    Digraph<ConfiguredTarget> graph = new Digraph<>();
-    ImmutableSet<ConfiguredTarget> allNodes = ImmutableSet.copyOf(partialResult);
-    for (ConfiguredTarget configuredTarget : partialResult) {
-      Node<ConfiguredTarget> node = graph.createNode(configuredTarget);
-      for (ConfiguredTarget dep : depsRetriever.getDirectDeps(configuredTarget)) {
+    Digraph<KeyedConfiguredTarget> graph = new Digraph<>();
+    ImmutableSet<KeyedConfiguredTarget> allNodes = ImmutableSet.copyOf(partialResult);
+    for (KeyedConfiguredTarget configuredTarget : partialResult) {
+      Node<KeyedConfiguredTarget> node = graph.createNode(configuredTarget);
+      for (KeyedConfiguredTarget dep : depsRetriever.getDirectDeps(configuredTarget)) {
         if (allNodes.contains(dep)) {
-          Node<ConfiguredTarget> depNode = graph.createNode(dep);
+          Node<KeyedConfiguredTarget> depNode = graph.createNode(dep);
           graph.addEdge(node, depNode);
         }
       }
     }
 
-    GraphOutputWriter<ConfiguredTarget> graphWriter =
+    GraphOutputWriter<KeyedConfiguredTarget> graphWriter =
         new GraphOutputWriter<>(
             nodeReader,
             options.getLineTerminator(),

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/KeyedConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/KeyedConfiguredTarget.java
@@ -1,0 +1,34 @@
+package com.google.devtools.build.lib.query2.cquery;
+
+import com.google.auto.value.AutoValue;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.skyframe.BuildConfigurationValue;
+import com.google.devtools.build.lib.skyframe.ConfiguredTargetKey;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class KeyedConfiguredTarget {
+
+  public static KeyedConfiguredTarget create(
+      ConfiguredTargetKey key, ConfiguredTarget configuredTarget) {
+    return new AutoValue_KeyedConfiguredTarget(key, configuredTarget);
+  }
+
+  @Nullable
+  public abstract ConfiguredTargetKey key();
+
+  public abstract ConfiguredTarget configuredTarget();
+
+  public Label label() {
+    return configuredTarget().getOriginalLabel();
+  }
+
+  public BuildConfigurationValue.Key configurationKey() {
+    return configuredTarget().getConfigurationKey();
+  }
+
+  public String configurationChecksum() {
+    return configuredTarget().getConfigurationChecksum();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/KeyedConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/KeyedConfiguredTarget.java
@@ -20,8 +20,12 @@ public abstract class KeyedConfiguredTarget {
 
   public abstract ConfiguredTarget configuredTarget();
 
-  public Label label() {
+  public Label originalLabel() {
     return configuredTarget().getOriginalLabel();
+  }
+
+  public Label actualLabel() {
+    return configuredTarget().getActual().getLabel();
   }
 
   public BuildConfigurationValue.Key configurationKey() {

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/LabelAndConfigurationOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/LabelAndConfigurationOutputFormatterCallback.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.query2.cquery;
 
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.RequiredConfigFragmentsProvider;
 import com.google.devtools.build.lib.analysis.config.CoreOptions.IncludeConfigFragmentsEnum;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
@@ -31,7 +30,7 @@ public class LabelAndConfigurationOutputFormatterCallback extends CqueryThreadsa
       CqueryOptions options,
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
-      TargetAccessor<ConfiguredTarget> accessor,
+      TargetAccessor<KeyedConfiguredTarget> accessor,
       boolean showKind) {
     super(eventHandler, options, out, skyframeExecutor, accessor);
     this.showKind = showKind;
@@ -43,23 +42,23 @@ public class LabelAndConfigurationOutputFormatterCallback extends CqueryThreadsa
   }
 
   @Override
-  public void processOutput(Iterable<ConfiguredTarget> partialResult) {
-    for (ConfiguredTarget configuredTarget : partialResult) {
+  public void processOutput(Iterable<KeyedConfiguredTarget> partialResult) {
+    for (KeyedConfiguredTarget configuredTarget : partialResult) {
       StringBuilder output = new StringBuilder();
       if (showKind) {
-        Target actualTarget = accessor.getTargetFromConfiguredTarget(configuredTarget);
+        Target actualTarget = accessor.getTarget(configuredTarget);
         output = output.append(actualTarget.getTargetKind()).append(" ");
       }
       output =
           output
-              .append(configuredTarget.getOriginalLabel())
+              .append(configuredTarget.label())
               .append(" (")
-              .append(shortId(getConfiguration(configuredTarget.getConfigurationKey())))
+              .append(shortId(getConfiguration(configuredTarget.configurationKey())))
               .append(")");
 
       if (options.showRequiredConfigFragments != IncludeConfigFragmentsEnum.OFF) {
         RequiredConfigFragmentsProvider configFragmentsProvider =
-            configuredTarget.getProvider(RequiredConfigFragmentsProvider.class);
+            configuredTarget.configuredTarget().getProvider(RequiredConfigFragmentsProvider.class);
         String requiredFragmentsOutput =
             configFragmentsProvider != null
                 ? String.join(", ", configFragmentsProvider.getRequiredConfigFragments())

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/LabelAndConfigurationOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/LabelAndConfigurationOutputFormatterCallback.java
@@ -51,7 +51,7 @@ public class LabelAndConfigurationOutputFormatterCallback extends CqueryThreadsa
       }
       output =
           output
-              .append(configuredTarget.label())
+              .append(configuredTarget.originalLabel())
               .append(" (")
               .append(shortId(getConfiguration(configuredTarget.configurationKey())))
               .append(")");

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
@@ -245,7 +245,7 @@ public class StarlarkOutputFormatterCallback extends CqueryThreadsafeCallback {
             Event.error(
                 String.format(
                     "Starlark evaluation error for %s: %s",
-                    target.label(), ex.getMessageWithStack())));
+                    target.originalLabel(), ex.getMessageWithStack())));
         continue;
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
@@ -140,7 +140,7 @@ public class StarlarkOutputFormatterCallback extends CqueryThreadsafeCallback {
       CqueryOptions options,
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
-      TargetAccessor<ConfiguredTarget> accessor)
+      TargetAccessor<KeyedConfiguredTarget> accessor)
       throws QueryException, InterruptedException {
     super(eventHandler, options, out, skyframeExecutor, accessor);
 
@@ -226,15 +226,18 @@ public class StarlarkOutputFormatterCallback extends CqueryThreadsafeCallback {
   }
 
   @Override
-  public void processOutput(Iterable<ConfiguredTarget> partialResult) throws InterruptedException {
-    for (ConfiguredTarget target : partialResult) {
+  public void processOutput(Iterable<KeyedConfiguredTarget> partialResult)
+      throws InterruptedException {
+    for (KeyedConfiguredTarget target : partialResult) {
       try {
         StarlarkThread thread =
             new StarlarkThread(Mutability.create("cquery evaluation"), StarlarkSemantics.DEFAULT);
         thread.setMaxExecutionSteps(500_000L);
 
         // Invoke formatFn with `target` argument.
-        Object result = Starlark.fastcall(thread, this.formatFn, new Object[] {target}, NO_ARGS);
+        Object result =
+            Starlark.fastcall(
+                thread, this.formatFn, new Object[] {target.configuredTarget()}, NO_ARGS);
 
         addResult(Starlark.str(result));
       } catch (EvalException ex) {
@@ -242,7 +245,7 @@ public class StarlarkOutputFormatterCallback extends CqueryThreadsafeCallback {
             Event.error(
                 String.format(
                     "Starlark evaluation error for %s: %s",
-                    target.getLabel(), ex.getMessageWithStack())));
+                    target.label(), ex.getMessageWithStack())));
         continue;
       }
     }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
@@ -100,13 +100,13 @@ class TransitionsOutputFormatterCallback extends CqueryThreadsafeCallback {
                   + " flag explicitly to 'lite' or 'full'"));
       return;
     }
-    partialResult.forEach(ct -> partialResultMap.put(ct.label(), accessor.getTarget(ct)));
+    partialResult.forEach(ct -> partialResultMap.put(ct.originalLabel(), accessor.getTarget(ct)));
     for (KeyedConfiguredTarget configuredTarget : partialResult) {
-      Target target = partialResultMap.get(configuredTarget.label());
+      Target target = partialResultMap.get(configuredTarget.originalLabel());
       BuildConfiguration config = getConfiguration(configuredTarget.configurationKey());
       addResult(
           getRuleClassTransition(configuredTarget, target)
-              + String.format("%s (%s)", configuredTarget.label(), shortId(config)));
+              + String.format("%s (%s)", configuredTarget.originalLabel(), shortId(config)));
       if (!(configuredTarget.configuredTarget() instanceof RuleConfiguredTarget)) {
         continue;
       }

--- a/src/main/java/com/google/devtools/build/lib/query2/engine/KeyExtractor.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/engine/KeyExtractor.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
  * <p>Depending on the choice of {@code K}, this enables potential memory optimizations.
  */
 @ThreadSafe
+@FunctionalInterface
 public interface KeyExtractor<T, K> {
   /** Extracts an unique key that can be used to dedupe the given {@code element}. */
   K extractKey(T element);

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
@@ -69,6 +69,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/packages",
+        "//src/main/java/com/google/devtools/build/lib/query2",
         "//src/main/java/com/google/devtools/build/lib/query2/engine",
         "//src/main/java/com/google/devtools/build/lib/util:filetype",
         "//src/main/java/com/google/devtools/build/lib/vfs",

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/BuildOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/BuildOutputFormatterCallbackTest.java
@@ -19,7 +19,6 @@ import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
 import static com.google.devtools.build.lib.packages.BuildType.OUTPUT;
 
 import com.google.common.eventbus.EventBus;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.MockRule;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Reporter;
@@ -74,7 +73,7 @@ public class BuildOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
     Set<String> targetPatternSet = new LinkedHashSet<>();
     expression.collectTargetPatterns(targetPatternSet);
     helper.setQuerySettings(Setting.NO_IMPLICIT_DEPS);
-    PostAnalysisQueryEnvironment<ConfiguredTarget> env =
+    PostAnalysisQueryEnvironment<KeyedConfiguredTarget> env =
         ((ConfiguredTargetQueryHelper) helper).getPostAnalysisQueryEnvironment(targetPatternSet);
 
     ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryHelper.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.common.collect.ImmutableList;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.AnalysisTestCase;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment.TopLevelConfigurations;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
@@ -31,7 +30,7 @@ import java.util.Collection;
  * AnalysisTestCase} must be run manually. @BeforeClass and @AfterClass are completely ignored for
  * now.
  */
-public class ConfiguredTargetQueryHelper extends PostAnalysisQueryHelper<ConfiguredTarget> {
+public class ConfiguredTargetQueryHelper extends PostAnalysisQueryHelper<KeyedConfiguredTarget> {
   @Override
   protected ConfiguredTargetQueryEnvironment getPostAnalysisQueryEnvironment(
       WalkableGraph walkableGraph,
@@ -54,7 +53,7 @@ public class ConfiguredTargetQueryHelper extends PostAnalysisQueryHelper<Configu
   }
 
   @Override
-  public String getLabel(ConfiguredTarget target) {
-    return target.getLabel().toString();
+  public String getLabel(KeyedConfiguredTarget target) {
+    return target.label().toString();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryHelper.java
@@ -54,6 +54,6 @@ public class ConfiguredTargetQueryHelper extends PostAnalysisQueryHelper<KeyedCo
 
   @Override
   public String getLabel(KeyedConfiguredTarget target) {
-    return target.label().toString();
+    return target.originalLabel().toString();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQuerySemanticsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQuerySemanticsTest.java
@@ -197,7 +197,8 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
         "rule_with_dep(name = 'actual', dep = ':dep')",
         "rule_with_dep(name = 'dep')");
 
-    KeyedConfiguredTarget dep = Iterables.getOnlyElement(eval("labels('dep', '//test:alias')"));
+    Set<KeyedConfiguredTarget> results = eval("labels('dep', '//test:alias')");
+    KeyedConfiguredTarget dep = Iterables.getOnlyElement(results);
     assertThat(dep.originalLabel()).isEqualTo(Label.parseAbsoluteUnchecked("//test:dep"));
   }
 
@@ -229,7 +230,7 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
     KeyedConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
     // Note: {@link AliasConfiguredTarget#getLabel} returns the label of the "actual" value not the
     // label of the alias.
-    assertThat(other.originalLabel()).isEqualTo(myRule.originalLabel());
+    assertThat(other.actualLabel()).isEqualTo(myRule.actualLabel());
 
     // Regression test for b/73496081 in which alias-ed configured targets were skipping filtering.
     helper.setQuerySettings(Setting.ONLY_TARGET_DEPS, Setting.NO_IMPLICIT_DEPS);

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQuerySemanticsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQuerySemanticsTest.java
@@ -198,7 +198,7 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
         "rule_with_dep(name = 'dep')");
 
     KeyedConfiguredTarget dep = Iterables.getOnlyElement(eval("labels('dep', '//test:alias')"));
-    assertThat(dep.label()).isEqualTo(Label.parseAbsoluteUnchecked("//test:dep"));
+    assertThat(dep.originalLabel()).isEqualTo(Label.parseAbsoluteUnchecked("//test:dep"));
   }
 
   @Test
@@ -229,7 +229,7 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
     KeyedConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
     // Note: {@link AliasConfiguredTarget#getLabel} returns the label of the "actual" value not the
     // label of the alias.
-    assertThat(other.label()).isEqualTo(myRule.label());
+    assertThat(other.originalLabel()).isEqualTo(myRule.originalLabel());
 
     // Regression test for b/73496081 in which alias-ed configured targets were skipping filtering.
     helper.setQuerySettings(Setting.ONLY_TARGET_DEPS, Setting.NO_IMPLICIT_DEPS);
@@ -413,7 +413,7 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
     assertThat(result).hasSize(2);
 
     ImmutableList<KeyedConfiguredTarget> stableOrderList = ImmutableList.copyOf(result);
-    int myDepIndex = stableOrderList.get(0).label().toString().equals("//test:mydep") ? 0 : 1;
+    int myDepIndex = stableOrderList.get(0).originalLabel().toString().equals("//test:mydep") ? 0 : 1;
     BuildConfiguration myDepConfig = getConfiguration(stableOrderList.get(myDepIndex));
     BuildConfiguration stringFlagConfig = getConfiguration(stableOrderList.get(1 - myDepIndex));
 
@@ -507,7 +507,7 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
 
     Iterator<KeyedConfiguredTarget> resultIterator = result.iterator();
     KeyedConfiguredTarget first = resultIterator.next();
-    if (first.label().toString().equals("//test:foo.java")) {
+    if (first.originalLabel().toString().equals("//test:foo.java")) {
       assertThat(getConfiguration(first)).isNull();
       assertThat(getConfiguration(resultIterator.next())).isNotNull();
     } else {
@@ -537,7 +537,7 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
     // not the one down this dependency path.
     helper.setUniverseScope("//test:buildme");
     Set<KeyedConfiguredTarget> result = eval("somepath(//test:buildme, //test:mydep)");
-    assertThat(result.stream().map(ct -> ct.label().toString()).collect(Collectors.toList()))
+    assertThat(result.stream().map(ct -> ct.originalLabel().toString()).collect(Collectors.toList()))
         .contains("//test:mydep");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQuerySemanticsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQuerySemanticsTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.BuildOptionsView;
@@ -120,24 +119,24 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
     setUpLabelsFunctionTests();
 
     // Test that this retrieves the correctly configured version(s) of the dep(s).
-    ConfiguredTarget patchDep =
+    KeyedConfiguredTarget patchDep =
         Iterables.getOnlyElement(eval("labels('patch_dep', //test:my_rule)"));
-    ConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
-    String targetConfiguration = myRule.getConfigurationChecksum();
-    assertThat(patchDep.getConfigurationChecksum()).doesNotMatch(targetConfiguration);
+    KeyedConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
+    String targetConfiguration = myRule.configurationChecksum();
+    assertThat(patchDep.configurationChecksum()).doesNotMatch(targetConfiguration);
   }
 
   @Test
   public void testLabelsFunction_splitTransitionAttribute() throws Exception {
     setUpLabelsFunctionTests();
 
-    ConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
-    String targetConfiguration = myRule.getConfigurationChecksum();
+    KeyedConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
+    String targetConfiguration = myRule.configurationChecksum();
 
-    Collection<ConfiguredTarget> splitDeps = eval("labels('split_dep', //test:my_rule)");
+    Collection<KeyedConfiguredTarget> splitDeps = eval("labels('split_dep', //test:my_rule)");
     assertThat(splitDeps).hasSize(2);
-    for (ConfiguredTarget ct : splitDeps) {
-      assertThat(ct.getConfigurationChecksum()).doesNotMatch(targetConfiguration);
+    for (KeyedConfiguredTarget ct : splitDeps) {
+      assertThat(ct.configurationChecksum()).doesNotMatch(targetConfiguration);
     }
   }
 
@@ -145,14 +144,14 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
   public void testLabelsFunction_labelListAttribute() throws Exception {
     setUpLabelsFunctionTests();
 
-    ConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
-    String targetConfiguration = myRule.getConfigurationChecksum();
+    KeyedConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
+    String targetConfiguration = myRule.configurationChecksum();
 
     // Test that this works for label_lists as well.
-    Set<ConfiguredTarget> deps = eval("labels('patch_dep_list', //test:my_rule)");
+    Set<KeyedConfiguredTarget> deps = eval("labels('patch_dep_list', //test:my_rule)");
     assertThat(deps).hasSize(2);
-    for (ConfiguredTarget ct : deps) {
-      assertThat(ct.getConfigurationChecksum()).doesNotMatch(targetConfiguration);
+    for (KeyedConfiguredTarget ct : deps) {
+      assertThat(ct.configurationChecksum()).doesNotMatch(targetConfiguration);
     }
   }
 
@@ -160,8 +159,8 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
   public void testLabelsFunction_errorsOnBadAttribute() throws Exception {
     setUpLabelsFunctionTests();
 
-    ConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
-    String targetConfiguration = myRule.getConfigurationChecksum();
+    KeyedConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
+    String targetConfiguration = myRule.configurationChecksum();
 
     // Test that the proper error is thrown when requesting an attribute that doesn't exist.
     EvalThrowsResult evalThrowsResult = evalThrows("labels('fake_attr', //test:my_rule)", true);
@@ -169,7 +168,7 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
     assertThat(evalThrowsResult.getMessage())
         .isEqualTo(
             String.format(
-                "in 'fake_attr' of rule //test:my_rule:  ConfiguredTarget(//test:my_rule, %s) "
+                "in 'fake_attr' of rule //test:my_rule:  //test:my_rule (%s) "
                     + "of type rule_with_transitions does not have attribute 'fake_attr'",
                 targetConfiguration));
   }
@@ -198,8 +197,8 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
         "rule_with_dep(name = 'actual', dep = ':dep')",
         "rule_with_dep(name = 'dep')");
 
-    ConfiguredTarget dep = Iterables.getOnlyElement(eval("labels('dep', '//test:alias')"));
-    assertThat(dep.getLabel()).isEqualTo(Label.parseAbsoluteUnchecked("//test:dep"));
+    KeyedConfiguredTarget dep = Iterables.getOnlyElement(eval("labels('dep', '//test:alias')"));
+    assertThat(dep.label()).isEqualTo(Label.parseAbsoluteUnchecked("//test:dep"));
   }
 
   @Test
@@ -226,11 +225,11 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
         "alias(name = 'other_impl_dep', actual = 'impl_dep')",
         "simple_rule(name='impl_dep')");
 
-    ConfiguredTarget other = Iterables.getOnlyElement(eval("//test:other_my_rule"));
-    ConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
+    KeyedConfiguredTarget other = Iterables.getOnlyElement(eval("//test:other_my_rule"));
+    KeyedConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
     // Note: {@link AliasConfiguredTarget#getLabel} returns the label of the "actual" value not the
     // label of the alias.
-    assertThat(other.getLabel()).isEqualTo(myRule.getLabel());
+    assertThat(other.label()).isEqualTo(myRule.label());
 
     // Regression test for b/73496081 in which alias-ed configured targets were skipping filtering.
     helper.setQuerySettings(Setting.ONLY_TARGET_DEPS, Setting.NO_IMPLICIT_DEPS);
@@ -251,7 +250,7 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
 
     writeFile("test/BUILD", "rule_class_transition(name='rule_class')");
 
-    Set<ConfiguredTarget> ruleClass = eval("//test:rule_class");
+    Set<KeyedConfiguredTarget> ruleClass = eval("//test:rule_class");
     TestOptions testOptions =
         getConfiguration(Iterables.getOnlyElement(ruleClass)).getOptions().get(TestOptions.class);
     assertThat(testOptions.testArguments).containsExactly("SET BY PATCH");
@@ -410,11 +409,11 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
     // setting --universe_scope we ensure only the transitioned version exists.
     helper.setUniverseScope("//test:buildme");
     helper.setQuerySettings(Setting.ONLY_TARGET_DEPS, Setting.NO_IMPLICIT_DEPS);
-    Set<ConfiguredTarget> result = eval("deps(//test:buildme, 1)");
+    Set<KeyedConfiguredTarget> result = eval("deps(//test:buildme, 1)");
     assertThat(result).hasSize(2);
 
-    ImmutableList<ConfiguredTarget> stableOrderList = ImmutableList.copyOf(result);
-    int myDepIndex = stableOrderList.get(0).getLabel().toString().equals("//test:mydep") ? 0 : 1;
+    ImmutableList<KeyedConfiguredTarget> stableOrderList = ImmutableList.copyOf(result);
+    int myDepIndex = stableOrderList.get(0).label().toString().equals("//test:mydep") ? 0 : 1;
     BuildConfiguration myDepConfig = getConfiguration(stableOrderList.get(myDepIndex));
     BuildConfiguration stringFlagConfig = getConfiguration(stableOrderList.get(1 - myDepIndex));
 
@@ -437,11 +436,12 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
     createConfigRulesAndBuild();
     writeFile("mytest/BUILD", "simple_rule(name = 'mytarget')");
 
-    Set<ConfiguredTarget> result = eval("//mytest:mytarget");
+    Set<KeyedConfiguredTarget> result = eval("//mytest:mytarget");
     String configHash = getConfiguration(Iterables.getOnlyElement(result)).checksum();
     String hashPrefix = configHash.substring(0, configHash.length() / 2);
 
-    Set<ConfiguredTarget> resultFromPrefix = eval("config(//mytest:mytarget," + hashPrefix + ")");
+    Set<KeyedConfiguredTarget> resultFromPrefix =
+        eval("config(//mytest:mytarget," + hashPrefix + ")");
     assertThat(resultFromPrefix).containsExactlyElementsIn(result);
   }
 
@@ -450,7 +450,7 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
     createConfigRulesAndBuild();
     writeFile("mytest/BUILD", "simple_rule(name = 'mytarget')");
 
-    Set<ConfiguredTarget> result = eval("//mytest:mytarget");
+    Set<KeyedConfiguredTarget> result = eval("//mytest:mytarget");
     String configHash = getConfiguration(Iterables.getOnlyElement(result)).checksum();
     String rightPrefix = configHash.substring(0, configHash.length() / 2);
     char lastChar = rightPrefix.charAt(rightPrefix.length() - 1);
@@ -501,13 +501,13 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
   public void testMultipleTopLevelConfigurations_nullConfigs() throws Exception {
     writeFile("test/BUILD", "java_library(name='my_java',", "  srcs = ['foo.java'],", ")");
 
-    Set<ConfiguredTarget> result = eval("//test:my_java+//test:foo.java");
+    Set<KeyedConfiguredTarget> result = eval("//test:my_java+//test:foo.java");
 
     assertThat(result).hasSize(2);
 
-    Iterator<ConfiguredTarget> resultIterator = result.iterator();
-    ConfiguredTarget first = resultIterator.next();
-    if (first.getLabel().toString().equals("//test:foo.java")) {
+    Iterator<KeyedConfiguredTarget> resultIterator = result.iterator();
+    KeyedConfiguredTarget first = resultIterator.next();
+    if (first.label().toString().equals("//test:foo.java")) {
       assertThat(getConfiguration(first)).isNull();
       assertThat(getConfiguration(resultIterator.next())).isNotNull();
     } else {
@@ -536,8 +536,8 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
     // cases cquery prefers the top-level configured one, which won't produce a match since that's
     // not the one down this dependency path.
     helper.setUniverseScope("//test:buildme");
-    Set<ConfiguredTarget> result = eval("somepath(//test:buildme, //test:mydep)");
-    assertThat(result.stream().map(ct -> ct.getLabel().toString()).collect(Collectors.toList()))
+    Set<KeyedConfiguredTarget> result = eval("somepath(//test:buildme, //test:mydep)");
+    assertThat(result.stream().map(ct -> ct.label().toString()).collect(Collectors.toList()))
         .contains("//test:mydep");
   }
 
@@ -582,7 +582,7 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
         "simple_rule(name='foo', deps = [':bar'])",
         "simple_rule(name='bar')");
 
-    Set<ConfiguredTarget> result =
+    Set<KeyedConfiguredTarget> result =
         eval("somepath(//test:top, filter(//test:bar, deps(//test:top)))");
     assertThat(result).isNotEmpty();
   }
@@ -602,7 +602,7 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
         "simple_rule(name = 'simple')");
 
     helper.setUniverseScope("//test:transitioner,//test:simple");
-    Set<ConfiguredTarget> result = eval("//test:simple");
+    Set<KeyedConfiguredTarget> result = eval("//test:simple");
     assertThat(result.size()).isEqualTo(2);
   }
 
@@ -624,7 +624,7 @@ public class ConfiguredTargetQuerySemanticsTest extends ConfiguredTargetQueryTes
         "simple_rule(name = 'simple')");
 
     helper.setUniverseScope("//test:transitioner,//test:simple");
-    Set<ConfiguredTarget> result = eval("config(//test:simple, target)");
+    Set<KeyedConfiguredTarget> result = eval("config(//test:simple, target)");
     assertThat(result.size()).isEqualTo(1);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.BuildOptionsView;
@@ -39,10 +38,11 @@ import org.junit.runners.JUnit4;
 
 /** Tests for {@link ConfiguredTargetQueryEnvironment}. */
 @RunWith(JUnit4.class)
-public abstract class ConfiguredTargetQueryTest extends PostAnalysisQueryTest<ConfiguredTarget> {
+public abstract class ConfiguredTargetQueryTest
+    extends PostAnalysisQueryTest<KeyedConfiguredTarget> {
 
   @Override
-  protected QueryHelper<ConfiguredTarget> createQueryHelper() {
+  protected QueryHelper<KeyedConfiguredTarget> createQueryHelper() {
     if (helper != null) {
       getHelper().cleanUp();
     }
@@ -62,10 +62,10 @@ public abstract class ConfiguredTargetQueryTest extends PostAnalysisQueryTest<Co
   }
 
   @Override
-  protected final BuildConfiguration getConfiguration(ConfiguredTarget ct) {
+  protected final BuildConfiguration getConfiguration(KeyedConfiguredTarget ct) {
     return getHelper()
         .getSkyframeExecutor()
-        .getConfiguration(getHelper().getReporter(), ct.getConfigurationKey());
+        .getConfiguration(getHelper().getReporter(), ct.configurationKey());
   }
 
   /** SplitTransition on --test_arg */
@@ -98,13 +98,13 @@ public abstract class ConfiguredTargetQueryTest extends PostAnalysisQueryTest<Co
   public void testMultipleTopLevelConfigurations_nullConfigs() throws Exception {
     writeFile("test/BUILD", "java_library(name='my_java',", "  srcs = ['foo.java'],", ")");
 
-    Set<ConfiguredTarget> result = eval("//test:my_java+//test:foo.java");
+    Set<KeyedConfiguredTarget> result = eval("//test:my_java+//test:foo.java");
 
     assertThat(result).hasSize(2);
 
-    Iterator<ConfiguredTarget> resultIterator = result.iterator();
-    ConfiguredTarget first = resultIterator.next();
-    if (first.getLabel().toString().equals("//test:foo.java")) {
+    Iterator<KeyedConfiguredTarget> resultIterator = result.iterator();
+    KeyedConfiguredTarget first = resultIterator.next();
+    if (first.label().toString().equals("//test:foo.java")) {
       assertThat(getConfiguration(first)).isNull();
       assertThat(getConfiguration(resultIterator.next())).isNotNull();
     } else {

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryTest.java
@@ -104,7 +104,7 @@ public abstract class ConfiguredTargetQueryTest
 
     Iterator<KeyedConfiguredTarget> resultIterator = result.iterator();
     KeyedConfiguredTarget first = resultIterator.next();
-    if (first.label().toString().equals("//test:foo.java")) {
+    if (first.originalLabel().toString().equals("//test:foo.java")) {
       assertThat(getConfiguration(first)).isNull();
       assertThat(getConfiguration(resultIterator.next())).isNotNull();
     } else {

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallbackTest.java
@@ -17,7 +17,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.eventbus.EventBus;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment;
@@ -70,7 +69,7 @@ public class GraphOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
     Set<String> targetPatternSet = new LinkedHashSet<>();
     expression.collectTargetPatterns(targetPatternSet);
     helper.setQuerySettings(Setting.NO_IMPLICIT_DEPS);
-    PostAnalysisQueryEnvironment<ConfiguredTarget> env =
+    PostAnalysisQueryEnvironment<KeyedConfiguredTarget> env =
         ((ConfiguredTargetQueryHelper) helper).getPostAnalysisQueryEnvironment(targetPatternSet);
 
     ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
@@ -20,7 +20,6 @@ import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
 import com.google.common.collect.Iterables;
 import com.google.common.eventbus.EventBus;
 import com.google.devtools.build.lib.analysis.AnalysisProtos;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.TransitionFactories;
 import com.google.devtools.build.lib.analysis.util.MockRule;
 import com.google.devtools.build.lib.events.Event;
@@ -144,10 +143,10 @@ public class ProtoOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
     // Assert checksum from proto is proper checksum.
     AnalysisProtos.ConfiguredTarget myRuleProto =
         Iterables.getOnlyElement(getOutput("//test:my_rule").getResultsList());
-    ConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
+    KeyedConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
 
     assertThat(myRuleProto.getConfiguration().getChecksum())
-        .isEqualTo(myRule.getConfigurationChecksum());
+        .isEqualTo(myRule.configurationChecksum());
 
     // Assert checksum for two configured targets in proto are not the same.
     List<AnalysisProtos.ConfiguredTarget> protoDeps =
@@ -216,7 +215,7 @@ public class ProtoOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
     Set<String> targetPatternSet = new LinkedHashSet<>();
     expression.collectTargetPatterns(targetPatternSet);
     helper.setQuerySettings(Setting.NO_IMPLICIT_DEPS);
-    PostAnalysisQueryEnvironment<ConfiguredTarget> env =
+    PostAnalysisQueryEnvironment<KeyedConfiguredTarget> env =
         ((ConfiguredTargetQueryHelper) helper).getPostAnalysisQueryEnvironment(targetPatternSet);
 
     ProtoOutputFormatterCallback callback =

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterTest.java
@@ -20,7 +20,6 @@ import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
 
 import com.google.common.eventbus.EventBus;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.TransitionFactories;
 import com.google.devtools.build.lib.analysis.config.transitions.NoTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
@@ -212,7 +211,7 @@ public class TransitionsOutputFormatterTest extends ConfiguredTargetQueryTest {
     Set<String> targetPatternSet = new LinkedHashSet<>();
     expression.collectTargetPatterns(targetPatternSet);
     helper.setQuerySettings(Setting.NO_IMPLICIT_DEPS);
-    PostAnalysisQueryEnvironment<ConfiguredTarget> env =
+    PostAnalysisQueryEnvironment<KeyedConfiguredTarget> env =
         ((ConfiguredTargetQueryHelper) helper).getPostAnalysisQueryEnvironment(targetPatternSet);
     options.transitions = verbosity;
     // TODO(juliexxia): Test late-bound attributes.


### PR DESCRIPTION
This addresses the problem from #11993 that the SkyKey for configured targets was previously being dropped and incorrectly re-built.