### PR TITLE
Starlark: dict.popitem without hashmap lookup

### DIFF
--- a/src/main/java/net/starlark/java/eval/Dict.java
+++ b/src/main/java/net/starlark/java/eval/Dict.java
@@ -230,20 +230,21 @@ public final class Dict<K, V>
   @StarlarkMethod(
       name = "popitem",
       doc =
-          "Remove and return an arbitrary <code>(key, value)</code> pair from the dictionary. "
+          "Remove and return the first <code>(key, value)</code> pair from the dictionary. "
               + "<code>popitem()</code> is useful to destructively iterate over a dictionary, "
               + "as often used in set algorithms. "
-              + "If the dictionary is empty, calling <code>popitem()</code> fails. "
-              + "It is deterministic which pair is returned.",
-      useStarlarkThread = true)
-  public Tuple popitem(StarlarkThread thread) throws EvalException {
+              + "If the dictionary is empty, calling <code>popitem()</code> fails.")
+  public Tuple popitem() throws EvalException {
     if (isEmpty()) {
       throw Starlark.errorf("popitem(): dictionary is empty");
     }
-    Object key = keySet().iterator().next();
-    Object value = get(key);
-    removeEntry(key);
-    return Tuple.pair(key, value);
+
+    Starlark.checkMutable(this);
+
+    Iterator<Entry<K, V>> iterator = contents.entrySet().iterator();
+    Entry<K, V> entry = iterator.next();
+    iterator.remove();
+    return Tuple.pair(entry.getKey(), entry.getValue());
   }
 
   @StarlarkMethod(

--- a/src/test/java/net/starlark/java/eval/testdata/bench_dict.star
+++ b/src/test/java/net/starlark/java/eval/testdata/bench_dict.star
@@ -1,0 +1,7 @@
+_d = {x: x for x in range(10)}
+
+def bench_popitem(b):
+    for _ in range(b.n):
+        d = dict(_d)
+        for _j in range(10):
+            d.popitem()


### PR DESCRIPTION
Benchmarks becomes about 7% faster.

Not critical optimization, since Starlark doesn't have a while loop,
but still better have it fixed.

Also removes unused `StarlarkThread` parameter.