### PR TITLE
Take no action to prefetch empty artifacts.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.actions.ActionInputPrefetcher;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
+import com.google.devtools.build.lib.actions.cache.VirtualActionInput.EmptyActionInput;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
@@ -94,9 +95,11 @@ class RemoteActionInputFetcher implements ActionInputPrefetcher {
       Map<Path, ListenableFuture<Void>> downloadsToWaitFor = new HashMap<>();
       for (ActionInput input : inputs) {
         if (input instanceof VirtualActionInput) {
-          VirtualActionInput virtualActionInput = (VirtualActionInput) input;
-          Path outputPath = execRoot.getRelative(virtualActionInput.getExecPath());
-          SandboxHelpers.atomicallyWriteVirtualInput(virtualActionInput, outputPath, ".remote");
+          if (!(input instanceof EmptyActionInput)) {
+            VirtualActionInput virtualActionInput = (VirtualActionInput) input;
+            Path outputPath = execRoot.getRelative(virtualActionInput.getExecPath());
+            SandboxHelpers.atomicallyWriteVirtualInput(virtualActionInput, outputPath, ".remote");
+          }
         } else {
           FileArtifactValue metadata = metadataProvider.getMetadata(input);
           if (metadata == null || !metadata.isRemote()) {


### PR DESCRIPTION
Previously, Bazel would attempt to overwrite /dev/null.