### PR TITLE
Starlark: optimze list(list)

### DIFF
--- a/src/main/java/net/starlark/java/eval/Starlark.java
+++ b/src/main/java/net/starlark/java/eval/Starlark.java
@@ -238,6 +238,8 @@ public final class Starlark {
     throw errorf("type '%s' is not iterable", type(x));
   }
 
+  private static final Object[] EMPTY_ARRAY = {};
+
   /**
    * Returns a new array of class Object[] containing the elements of Starlark iterable value {@code
    * x}. A Starlark value is iterable if it implements {@link StarlarkIterable}.
@@ -245,7 +247,9 @@ public final class Starlark {
   public static Object[] toArray(Object x) throws EvalException {
     // Specialize Sequence and Dict to avoid allocation and/or indirection.
     if (x instanceof Sequence) {
-      return ((Sequence<?>) x).toArray(new Object[((Sequence) x).size()]);
+      // Returned array type must be exactly Object[], not Object[] subclass,
+      // so calling `toArray()` is not enough.
+      return ((Sequence<?>) x).toArray(EMPTY_ARRAY);
     } else if (x instanceof Dict) {
       return ((Dict<?, ?>) x).keySet().toArray();
     } else {

--- a/src/main/java/net/starlark/java/eval/StarlarkList.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkList.java
@@ -535,4 +535,16 @@ public final class StarlarkList<E> extends AbstractList<E>
   public Object[] toArray() {
     return size != 0 ? Arrays.copyOf(elems, size, Object[].class) : EMPTY_ARRAY;
   }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> T[] toArray(T[] a) {
+    if (a.length < size) {
+      return (T[]) Arrays.copyOf(elems, size, a.getClass());
+    } else {
+      System.arraycopy(elems, 0, a, 0, size);
+      Arrays.fill(a, size, a.length, null);
+      return a;
+    }
+  }
 }

--- a/src/main/java/net/starlark/java/eval/Tuple.java
+++ b/src/main/java/net/starlark/java/eval/Tuple.java
@@ -153,6 +153,18 @@ public final class Tuple extends AbstractList<Object>
     return elems.length != 0 ? Arrays.copyOf(elems, elems.length, Object[].class) : elems;
   }
 
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> T[] toArray(T[] a) {
+    if (a.length < size()) {
+      return (T[]) Arrays.copyOf(elems, elems.length, a.getClass());
+    } else {
+      System.arraycopy(elems, 0, a, 0, elems.length);
+      Arrays.fill(a, elems.length, a.length, null);
+      return a;
+    }
+  }
+
   @Override
   public void repr(Printer printer) {
     printer.append('(');

--- a/src/test/java/net/starlark/java/eval/BUILD
+++ b/src/test/java/net/starlark/java/eval/BUILD
@@ -22,6 +22,7 @@ java_test(
         "MethodLibraryTest.java",
         "MutabilityTest.java",
         "PrinterTest.java",
+        "TupleTest.java",
         "StarlarkAnnotationsTest.java",
         "StarlarkEvaluationTest.java",
         "StarlarkFlagGuardingTest.java",

--- a/src/test/java/net/starlark/java/eval/EvalTests.java
+++ b/src/test/java/net/starlark/java/eval/EvalTests.java
@@ -32,5 +32,6 @@ import org.junit.runners.Suite;
   StarlarkMutableTest.class,
   StarlarkThreadDebuggingTest.class,
   StarlarkThreadTest.class,
+  TupleTest.class,
 })
 public class EvalTests {}

--- a/src/test/java/net/starlark/java/eval/TupleTest.java
+++ b/src/test/java/net/starlark/java/eval/TupleTest.java
@@ -1,0 +1,45 @@
+package net.starlark.java.eval;
+
+import org.junit.Test;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class TupleTest {
+  @Test
+  public void testToArrayWithObjectArrayParam() throws Exception {
+    for (int i = 0; i != 10; ++i) {
+      Tuple tuple = Tuple.of(IntStream.range(0, 10).mapToObj(Integer::toString).toArray());
+      for (int arrayLength : new int[] { 0, tuple.size() / 2, tuple.size(), tuple.size() * 2 }) {
+        for (Class<?> arrayElementClass : new Class[] { Object.class, String.class }) {
+          Object[] input = (Object[]) Array.newInstance(arrayElementClass, arrayLength);
+          Arrays.fill(input, "x");
+
+          Object[] output = tuple.toArray(input);
+          assertThat(input.getClass()).isEqualTo(output.getClass());
+          if (input.length < tuple.size()) {
+            // assert input is unchanged
+            for (Object o : input) {
+              assertThat(o).isEqualTo("x");
+            }
+
+            Object[] expected = IntStream.range(0, tuple.size()).mapToObj(Integer::toString).toArray();
+            assertThat(output).isEqualTo(expected);
+          } else {
+            assertThat(output).isSameInstanceAs(input);
+            for (int j = 0; j != output.length; ++j) {
+              if (j < tuple.size()) {
+                assertThat(output[j]).isEqualTo(Integer.toString(j));
+              } else {
+                assertThat(output[j]).isNull();
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/net/starlark/java/eval/testdata/bench_list.star
+++ b/src/test/java/net/starlark/java/eval/testdata/bench_list.star
@@ -1,4 +1,5 @@
 _list1000 = list(range(1000))
+_list10 = list(range(10))
 
 def bench_extend(b):
     "Extends an empty list by 1000 items."
@@ -12,3 +13,8 @@ def bench_append(b):
         x = []
         for y in _list1000:
             x.append(y)
+
+def bench_list_list(b):
+    "list([10 elements])"
+    for _ in range(b.n):
+        list(_list10)


### PR DESCRIPTION
`toArray()` is more efficient than `toArray(new Object[size()])`,
so switch to `toArray()` in `Starlark.toArray(..)`.

```
A: N=23 r=8.124+-0.325 se=0.069
B: N=23 r=6.613+-0.391 se=0.083
B/A: 0.814
```

for a benchmark

```
l = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
for i in range(50000000):
    list(l)
```

Or for bundled benchmark:

```
benchmark                   ops     cpu/op    wall/op   steps/op   alloc/op
# before
bench_list_list        67108863      209ns      208ns          4       255B
# after
bench_list_list        67108863      174ns      173ns          4       223B
```