### PR TITLE
Starlark: specialize &, |, ^, ~ for 64-bit integers

### DIFF
--- a/src/main/java/net/starlark/java/eval/StarlarkInt.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkInt.java
@@ -598,10 +598,12 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
 
   /** Returns x ^ y. */
   public static StarlarkInt xor(StarlarkInt x, StarlarkInt y) {
-    if (x instanceof Int32 && y instanceof Int32) {
-      long xl = ((Int32) x).v;
-      long yl = ((Int32) y).v;
+    try {
+      long xl = x.toLongFast();
+      long yl = y.toLongFast();
       return StarlarkInt.of(xl ^ yl);
+    } catch (Overflow unused) {
+      /* fall through */
     }
 
     BigInteger xbig = x.toBigInteger();
@@ -612,10 +614,12 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
 
   /** Returns x | y. */
   public static StarlarkInt or(StarlarkInt x, StarlarkInt y) {
-    if (x instanceof Int32 && y instanceof Int32) {
-      long xl = ((Int32) x).v;
-      long yl = ((Int32) y).v;
+    try {
+      long xl = x.toLongFast();
+      long yl = y.toLongFast();
       return StarlarkInt.of(xl | yl);
+    } catch (Overflow unused) {
+      /* fall through */
     }
 
     BigInteger xbig = x.toBigInteger();
@@ -626,10 +630,12 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
 
   /** Returns x & y. */
   public static StarlarkInt and(StarlarkInt x, StarlarkInt y) {
-    if (x instanceof Int32 && y instanceof Int32) {
-      long xl = ((Int32) x).v;
-      long yl = ((Int32) y).v;
+    try {
+      long xl = x.toLongFast();
+      long yl = y.toLongFast();
       return StarlarkInt.of(xl & yl);
+    } catch (Overflow unused) {
+      /* fall through */
     }
 
     BigInteger xbig = x.toBigInteger();
@@ -640,9 +646,11 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
 
   /** Returns ~x. */
   public static StarlarkInt bitnot(StarlarkInt x) {
-    if (x instanceof Int32) {
-      long xl = ((Int32) x).v;
+    try {
+      long xl = x.toLongFast();
       return StarlarkInt.of(~xl);
+    } catch (Overflow unused) {
+      /* fall through */
     }
 
     BigInteger xbig = x.toBigInteger();

--- a/src/test/java/net/starlark/java/eval/testdata/int.star
+++ b/src/test/java/net/starlark/java/eval/testdata/int.star
@@ -173,12 +173,6 @@ assert_eq(++4, 4)
 assert_eq(+-4, 0 - 4)
 assert_eq(-+-4, 4)
 
----
-1 // 0  ### integer division by zero
----
-1 % 0  ### integer modulo by zero
----
-
 # bitwise
 
 def f():
@@ -196,6 +190,32 @@ def f():
   assert_eq(x, 1)
 
 f()
+
+assert_eq(minint & -1, minint)
+assert_eq(maxint & -1, maxint)
+assert_eq(minlong & -1, minlong)
+assert_eq(maxlong & -1, maxlong)
+
+assert_eq(minint | -1, -1)
+assert_eq(maxint | -1, -1)
+assert_eq(minlong | -1, -1)
+assert_eq(maxlong | -1, -1)
+
+assert_eq(minint ^ -1, maxint)
+assert_eq(maxint ^ -1, minint)
+assert_eq(minlong ^ -1, maxlong)
+assert_eq(maxlong ^ -1, minlong)
+
+assert_eq(~minint, maxint)
+assert_eq(~maxint, minint)
+assert_eq(~minlong, maxlong)
+assert_eq(~maxlong, minlong)
+
+---
+1 // 0  ### integer division by zero
+---
+1 % 0  ### integer modulo by zero
+
 ---
 assert_eq(1 | 2, 3)
 assert_eq(3 | 6, 7)


### PR DESCRIPTION
Follow-up to #12498 (64-bit integer operations without round-trip
to BigInteger).