### PR TITLE
Starlark: dict.pop should fail when frozen or when key is not hashable

### DIFF
--- a/src/main/java/net/starlark/java/eval/Dict.java
+++ b/src/main/java/net/starlark/java/eval/Dict.java
@@ -215,11 +215,14 @@ public final class Dict<K, V>
       },
       useStarlarkThread = true)
   public Object pop(Object key, Object defaultValue, StarlarkThread thread) throws EvalException {
-    Object value = get(key);
+    Starlark.checkMutable(this);
+    Object value = contents.remove(key);
     if (value != null) {
-      removeEntry(key);
       return value;
     }
+
+    Starlark.checkHashable(key);
+
     if (defaultValue != Starlark.UNBOUND) {
       return defaultValue;
     }

--- a/src/test/java/net/starlark/java/eval/ScriptTest.java
+++ b/src/test/java/net/starlark/java/eval/ScriptTest.java
@@ -108,6 +108,21 @@ public final class ScriptTest {
     return new MutableStruct(kwargs);
   }
 
+  @StarlarkMethod(
+      name = "freeze",
+      documented = false,
+      parameters = {
+        @Param(name = "x"),
+      }
+  )
+  public void freeze(Object x) throws EvalException {
+    if (x instanceof Mutability.Freezable) {
+      ((Mutability.Freezable) x).unsafeShallowFreeze();
+    } else {
+      throw Starlark.errorf("Value is not freezable: %s", Starlark.type(x));
+    }
+  }
+
   private static boolean ok = true;
 
   public static void main(String[] args) throws Exception {
@@ -167,7 +182,7 @@ public final class ScriptTest {
 
         StarlarkSemantics semantics = StarlarkSemantics.DEFAULT;
         Module module = Module.withPredeclared(semantics, predeclared.build());
-        try (Mutability mu = Mutability.create("test")) {
+        try (Mutability mu = Mutability.createAllowingShallowFreeze("test")) {
           StarlarkThread thread = new StarlarkThread(mu, semantics);
           thread.setThreadLocal(Reporter.class, ScriptTest::reportError);
           Starlark.execFile(input, FileOptions.DEFAULT, module, thread);

--- a/src/test/java/net/starlark/java/eval/testdata/dict.star
+++ b/src/test/java/net/starlark/java/eval/testdata/dict.star
@@ -43,6 +43,12 @@ dict().popitem() ### dictionary is empty
 ---
 dict(a=2).pop('z') ### KeyError: "z"
 ---
+d = {}
+freeze(d)
+d.pop("nonexistent", "default") ### trying to mutate a frozen dict value
+---
+{}.pop([], 1) ### unhashable type: 'list'
+---
 
 # update
 


### PR DESCRIPTION
... even if default value is provided.

[Starlark spec] says:

> `pop` fails if `key` is unhashable, or the dictionary is frozen or
> has active iterators.

It is not crystal clear how to interpet it.

My understanding is: if `dict` is frozen or key is not hashable,
`pop` must fail, even if default value is provided.

Similarly to how `list.extend([])` (extend with empty list) fails
if the list is frozen.

This PR should also make `dict.pop` a little faster.

[Starlark spec]: https://github.com/bazelbuild/starlark/blob/master/spec.md#dictpop