### PR TITLE
Starlark: intern dot-expression RHS identifiers globally

### DIFF
--- a/src/main/java/net/starlark/java/eval/CallUtils.java
+++ b/src/main/java/net/starlark/java/eval/CallUtils.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.StarlarkAnnotations;
 import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.syntax.StarlarkStringInterner;
 
 /** Helper functions for StarlarkMethod-annotated fields and methods. */
 final class CallUtils {
@@ -132,11 +133,15 @@ final class CallUtils {
         continue;
       }
 
+      // Identifiers are interned int parser, intern them here too
+      // to speed up lookup in dot expressions.
+      String name = StarlarkStringInterner.intern(callable.name());
+
       // regular method
-      methods.put(callable.name(), descriptor);
+      methods.put(name, descriptor);
 
       // field method?
-      if (descriptor.isStructField() && fields.put(callable.name(), descriptor) != null) {
+      if (descriptor.isStructField() && fields.put(name, descriptor) != null) {
         // TODO(b/72113542): Validate with annotation processor instead of at runtime.
         throw new IllegalArgumentException(
             String.format(

--- a/src/main/java/net/starlark/java/syntax/BUILD
+++ b/src/main/java/net/starlark/java/syntax/BUILD
@@ -32,6 +32,7 @@ java_library(
         "FlowStatement.java",
         "ForStatement.java",
         "Identifier.java",
+        "StarlarkStringInterner.java",
         "IfStatement.java",
         "IndexExpression.java",
         "IntLiteral.java",

--- a/src/main/java/net/starlark/java/syntax/Parser.java
+++ b/src/main/java/net/starlark/java/syntax/Parser.java
@@ -422,6 +422,7 @@ final class Parser {
     expr = parseTest();
     if (expr instanceof Identifier) {
       Identifier id = (Identifier) expr;
+      id = new Identifier(locs, internGlobally(id.getName()), id.getStartOffset());
       // parse a named argument
       if (token.kind == TokenKind.EQUALS) {
         nextToken();
@@ -455,7 +456,7 @@ final class Parser {
     }
 
     // name=default
-    Identifier id = parseIdent(false);
+    Identifier id = parseIdent(true);
     if (token.kind == TokenKind.EQUALS) {
       nextToken(); // TODO: save token pos?
       Expression expr = parseTest();

--- a/src/main/java/net/starlark/java/syntax/StarlarkStringInterner.java
+++ b/src/main/java/net/starlark/java/syntax/StarlarkStringInterner.java
@@ -1,0 +1,21 @@
+package net.starlark.java.syntax;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+
+/**
+ * Common place to intern strings in Starlark interpreter.
+ *
+ * <p>Interned strings are much faster to lookup, which is important, for example, when evaluating
+ * expression {@code foo.bar}.
+ */
+public class StarlarkStringInterner {
+  private StarlarkStringInterner() {}
+
+  private static final Interner<String> INTERNER = Interners.newWeakInterner();
+
+  /** Weak intern the string. */
+  public static String intern(String string) {
+    return INTERNER.intern(string);
+  }
+}

--- a/src/test/java/net/starlark/java/eval/testdata/bench_dot_expr.star
+++ b/src/test/java/net/starlark/java/eval/testdata/bench_dot_expr.star
@@ -1,0 +1,15 @@
+def bench_dot_expr_native(b):
+    "Benchmark dot-expression performance for native methods"
+    for _ in range(b.n):
+        # Use several different object types and and identifiers
+        # to make benchmark results more stable.
+        "abc".startswith
+        [].append
+        "cde".endswith
+        [].extend
+        {}.pop
+        "fg".rsplit
+        [].pop
+        "".lower
+        "".lstrip
+        [].remove


### PR DESCRIPTION
Indentifiers are interned in two places:
* when parsing dot-expression RHS
* in `CallUtils` map keys

Thus when evaluating dot expression (`foo.bar`), `bar` is interned
and lookup is faster: `String.equals` performs the identity comparison
before falling back to the comparison of contents.

This PR does interning conservatively: it only interns identifiers
from RHS of dot expression, but no other identifiers.

Other identifiers, and even string literals could be interned to
get performance gain. Consider this example:

```
def my_cc_library_wrapper(**kwargs):
  internal = kwargs.pop("is_internal_library", False)
  if internal:
    local_defs = kwargs.pop("local_defines", []) + ["-DINTERNAL"]
    kwargs["local_defines"] = local_defs
  cc_library(**kwargs)

my_cc_library_wrapper(..., is_internal_library = True)
```

Here we lookup by literal "is_internal_library" which is specified
as a named argument "is_internal_library" in another file: if both
strings were interned, lookup would be faster.

But interning everything may have dire performance implications.
Can be done later.

From my experiments running profiler, attribute lookup is one of
significant bottlenecks of the Starlark interpreter.

Benchmark:

```
def test():
    for _ in range(50000000):
        "abc".startswith
        [].append
        "cde".endswith
        [].extend
        {}.pop
        "fg".rsplit
        [].pop

test()
```

Output is:

```
A: N=27 r=13.546+-0.785 se=0.153
B: N=27 r=11.838+-0.965 se=0.189
B/A: 0.874
```

Or with include benchmark (best of 10 runs 10 seconds each):

```
benchmark                   ops     cpu/op    wall/op   steps/op   alloc/op
# before
bench_dot_expr_native   33554431      353ns      351ns         30       529B
# after
bench_dot_expr_native   67108863      298ns      297ns         30       288B
```