### PR TITLE
Handle escaping command arguments in cmd_bat

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/windows/WindowsSubprocessFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/windows/WindowsSubprocessFactory.java
@@ -39,7 +39,7 @@ public class WindowsSubprocessFactory implements SubprocessFactory {
 
     // DO NOT quote argv0, createProcess will do it for us.
     String argv0 = processArgv0(argv.get(0));
-    String argvRest = argv.size() > 1 ? escapeArgvRest(argv.subList(1, argv.size())) : "";
+    String argvRest = argv.size() > 1 ? escapeArgvRest(argv.subList(1, argv.size()), (argv0 == "cmd.exe")) : "";
     byte[] env = convertEnvToNative(builder.getEnv());
 
     String stdoutPath = getRedirectPath(builder.getStdout(), builder.getStdoutFile());
@@ -68,7 +68,7 @@ public class WindowsSubprocessFactory implements SubprocessFactory {
         builder.getTimeoutMillis());
   }
 
-  private String escapeArgvRest(List<String> argv) {
+  private String escapeArgvRest(List<String> argv, boolean isCmd) {
     StringBuilder result = new StringBuilder();
     boolean first = true;
     for (String arg : argv) {
@@ -77,7 +77,12 @@ public class WindowsSubprocessFactory implements SubprocessFactory {
       } else {
         result.append(" ");
       }
-      result.append(ShellUtils.windowsEscapeArg(arg));
+      if (isCmd) {
+        result.append(arg);
+      }
+      else {
+        result.append(ShellUtils.windowsEscapeArg(arg));
+      }
     }
     return result.toString();
   }

--- a/src/test/py/bazel/genrule_test.py
+++ b/src/test/py/bazel/genrule_test.py
@@ -148,6 +148,55 @@ class GenRuleTest(test_base.TestBase):
         'The term \'command_not_exist\' is not recognized as the name of a cmdlet',
         ''.join(stderr))
 
+  def testCopyWithSpacesWithBatch(self):
+    if not self.IsWindows():
+      return
+    self.ScratchFile('WORKSPACE')
+    self.ScratchFile('foo/BUILD', [
+        'genrule(',
+        '  name = "xx",',
+        '  srcs = ["hello source"],',
+        '  outs = ["hello copied"],',
+        '  cmd_bat = "echo copy \\"$<\\" \\"$@\\"",',
+        ')',
+    ])
+    self.ScratchFile('foo/hello source', ['hello world'])
+
+    exit_code, stdout, stderr = self.RunBazel(['info', 'bazel-bin'])
+    self.AssertExitCode(exit_code, 0, stderr)
+    bazel_bin = stdout[0]
+
+    exit_code, _, stderr = self.RunBazel(['build', '//foo:xx', '--verbose_failures'])
+    self.AssertExitCode(exit_code, 0, stderr)
+
+    copied = os.path.join(bazel_bin, 'foo', 'hello copied')
+    self.assertTrue(os.path.exists(copied))
+    self.AssertFileContentContains(copied, 'hello world')
+
+  def testCopyWithSpacesWithPowershell(self):
+    if not self.IsWindows():
+      return
+    self.ScratchFile('WORKSPACE')
+    self.ScratchFile('foo/BUILD', [
+        'genrule(',
+        '  name = "x",',
+        '  srcs = ["hello source"],',
+        '  outs = ["hello copied"],',
+        '  cmd_ps = "cp \\"$<\\" \\"$@\\"",',
+        ')',
+    ])
+    self.ScratchFile('foo/hello source', ['hello world'])
+
+    exit_code, stdout, stderr = self.RunBazel(['info', 'bazel-bin'])
+    self.AssertExitCode(exit_code, 0, stderr)
+    bazel_bin = stdout[0]
+
+    exit_code, _, stderr = self.RunBazel(['build', '//foo:x'])
+    self.AssertExitCode(exit_code, 0, stderr)
+
+    copied = os.path.join(bazel_bin, 'foo', 'hello copied')
+    self.assertTrue(os.path.exists(copied))
+    self.AssertFileContentContains(copied, 'hello world')
 
 if __name__ == '__main__':
   unittest.main()

--- a/src/test/py/bazel/genrule_test.py
+++ b/src/test/py/bazel/genrule_test.py
@@ -154,10 +154,10 @@ class GenRuleTest(test_base.TestBase):
     self.ScratchFile('WORKSPACE')
     self.ScratchFile('foo/BUILD', [
         'genrule(',
-        '  name = "xx",',
+        '  name = "x",',
         '  srcs = ["hello source"],',
         '  outs = ["hello copied"],',
-        '  cmd_bat = "echo copy \\"$<\\" \\"$@\\"",',
+        '  cmd_bat = "copy \\"$<\\" \\"$@\\"",',
         ')',
     ])
     self.ScratchFile('foo/hello source', ['hello world'])
@@ -166,7 +166,7 @@ class GenRuleTest(test_base.TestBase):
     self.AssertExitCode(exit_code, 0, stderr)
     bazel_bin = stdout[0]
 
-    exit_code, _, stderr = self.RunBazel(['build', '//foo:xx', '--verbose_failures'])
+    exit_code, _, stderr = self.RunBazel(['build', '//foo:x'])
     self.AssertExitCode(exit_code, 0, stderr)
 
     copied = os.path.join(bazel_bin, 'foo', 'hello copied')


### PR DESCRIPTION
This pull request stops arguments escaping for commands run using cmd.exe since the result of `ShellUtils.windowsEscapeArg()` method is not accepted by cmd.exe.

Fixes: #11975