### PR TITLE
[Bazel] Fix mobile-install for python2

### DIFF
--- a/tools/android/build_incremental_dexmanifest.py
+++ b/tools/android/build_incremental_dexmanifest.py
@@ -32,7 +32,7 @@ or
 
 import hashlib
 import os
-from queue import Queue
+import Queue
 import shutil
 import sys
 import tempfile

--- a/tools/android/build_incremental_dexmanifest.py
+++ b/tools/android/build_incremental_dexmanifest.py
@@ -33,9 +33,11 @@ or
 import hashlib
 import os
 try:
-    from Queue import Queue
+  # python2 without compatibility package
+  from Queue import Queue
 except ImportError:
-    import queue as Queue
+  # python3
+  from queue import Queue
 import shutil
 import sys
 import tempfile

--- a/tools/android/build_incremental_dexmanifest.py
+++ b/tools/android/build_incremental_dexmanifest.py
@@ -32,7 +32,10 @@ or
 
 import hashlib
 import os
-from Queue import Queue
+try:
+    from Queue import Queue
+except ImportError:
+    import queue as Queue
 import shutil
 import sys
 import tempfile

--- a/tools/android/build_incremental_dexmanifest.py
+++ b/tools/android/build_incremental_dexmanifest.py
@@ -32,7 +32,7 @@ or
 
 import hashlib
 import os
-import Queue
+from Queue import Queue
 import shutil
 import sys
 import tempfile


### PR DESCRIPTION
**Background**
Fix issue introduced by https://github.com/bazelbuild/bazel/commit/1049fe89f12cfcae00902fbae6f6a5f1bc0b3a33
It turns out the queue module name is inconsistent across different python versions. We found that:
* On some macos system:
  - python2 contains both queue and Queue module. All python2 contains Queue module
  - python3 only contains queue module
* On some Linux system
  - python2 contains only Queue module. 
  - python3 only contains queue module 

Therefore, some developers are seeing `ImportError: No module named queue` errors locally on linux machine after using mobile-install. 

**Change**
Import correct Queue module instead

**Test**
Local test pass