### PR TITLE
Detect ar executable on Linux.

### DIFF
--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -357,6 +357,14 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
         warn = True,
         silent = True,
     )
+    overriden_tools["ar"] = _find_generic(
+        repository_ctx,
+        "ar",
+        "AR",
+        overriden_tools,
+        warn = True,
+        silent = True,
+    )
     if darwin:
         overriden_tools["gcc"] = "cc_wrapper.sh"
         overriden_tools["ar"] = "/usr/bin/libtool"


### PR DESCRIPTION
This commit makes it possible for the default linux toolchain to detect the ar executable.
This is necessary for rules_foreign_cc as some of their rules depend on ar.

Tested: Manually