### PR TITLE
Add --{no,}autodetect_server_javabase.

### DIFF
--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -2838,7 +2838,7 @@ adb -s deadbeef install ...
 <h4 id='flag--autodetect_server_javabase'><code class='flag'>--autodetect_server_javabase</code></h4>
 <p>
   This option causes Bazel to automatically search for an installed JDK on startup,
-  and to fall back to the installed JRE if the embedded JRE isn't available. 
+  and to fall back to the installed JRE if the embedded JRE isn't available.
   <code>--explicit_server_javabase</code> can be used to pick an explicit JRE to
   run bazel with.
 </p>

--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -2835,6 +2835,14 @@ adb -s deadbeef install ...
   subprocesses of Bazel: applications, tests, tools, etc.)
 </p>
 
+<h4 id='flag--autodetect_server_javabase'><code class='flag'>--autodetect_server_javabase</code></h4>
+<p>
+  This option causes Bazel to automatically search for an installed JDK on startup,
+  and to fall back to the installed JRE if the embedded JRE isn't available. 
+  <code>--explicit_server_javabase</code> can be used to pick an explicit JRE to
+  run bazel with.
+</p>
+
 <h4 id='flag--batch'><code class='flag'>--batch</code></h4>
 
 <p>

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -457,7 +457,9 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
                    startup_options.output_base.AsCommandLineArgument());
   result.push_back("--workspace_directory=" +
                    blaze_util::ConvertPath(workspace));
-  result.push_back("--default_system_javabase=" + GetSystemJavabase());
+  if (startup_options.autodetect_server_javabase) {
+    result.push_back("--default_system_javabase=" + GetSystemJavabase());
+  }
 
   if (!startup_options.server_jvm_out.IsEmpty()) {
     result.push_back("--server_jvm_out=" +

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -71,6 +71,7 @@ StartupOptions::StartupOptions(const string &product_name,
       ignore_all_rc_files(false),
       block_for_lock(true),
       host_jvm_debug(false),
+      autodetect_server_javabase(true),
       batch(false),
       batch_cpu_scheduling(false),
       io_nice_level(-1),
@@ -135,6 +136,8 @@ StartupOptions::StartupOptions(const string &product_name,
   RegisterNullaryStartupFlag("fatal_event_bus_exceptions",
                              &fatal_event_bus_exceptions);
   RegisterNullaryStartupFlag("host_jvm_debug", &host_jvm_debug);
+  RegisterNullaryStartupFlag("autodetect_server_javabase",
+                             &autodetect_server_javabase);
   RegisterNullaryStartupFlag("idle_server_tasks", &idle_server_tasks);
   RegisterNullaryStartupFlag("incompatible_enable_execution_transition",
                              &incompatible_enable_execution_transition);
@@ -481,6 +484,10 @@ StartupOptions::GetServerJavabaseAndType() const {
       // 2) Use a bundled JVM if we have one.
       default_server_javabase_ = std::pair<blaze_util::Path, JavabaseType>(
           bundled_jre_path, JavabaseType::EMBEDDED);
+    } else if (!autodetect_server_javabase) {
+      BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
+          << "Could not find embedded or explicit server javabase, and "
+             "--noautodetect_server_javabase is set.";
     } else {
       // 3) Otherwise fall back to using the default system JVM.
       blaze_util::Path system_javabase = GetSystemJavabase();

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -165,6 +165,8 @@ class StartupOptions {
 
   bool host_jvm_debug;
 
+  bool autodetect_server_javabase;
+
   std::string host_jvm_profile;
 
   std::vector<std::string> host_jvm_args;

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
@@ -493,4 +493,14 @@ public class BlazeServerStartupOptions extends OptionsBase {
               + "extended attribute is checked on all source files and output files, meaning "
               + "that it causes a significant number of invocations of the getxattr() system call.")
   public String unixDigestHashAttributeName;
+
+  @Option(
+      name = "autodetect_server_javabase",
+      defaultValue = "true", // NOTE: only for documentation, value never passed to the server.
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS, OptionEffectTag.LOSES_INCREMENTAL_STATE},
+      help =
+          "When --noautodetect_server_javabase is passed, Bazel does not fall back to the local "
+              + "JDK for running the bazel server and instead exits.")
+  public boolean autodetectServerJavabase;
 }

--- a/src/test/cpp/bazel_startup_options_test.cc
+++ b/src/test/cpp/bazel_startup_options_test.cc
@@ -100,6 +100,7 @@ TEST_F(BazelStartupOptionsTest, ValidStartupFlags) {
   ExpectValidNullaryOption(options, "fatal_event_bus_exceptions");
   ExpectValidNullaryOption(options, "home_rc");
   ExpectValidNullaryOption(options, "host_jvm_debug");
+  ExpectValidNullaryOption(options, "autodetect_server_javabase");
   ExpectValidNullaryOption(options, "ignore_all_rc_files");
   ExpectValidNullaryOption(options, "incompatible_enable_execution_transition");
   ExpectValidNullaryOption(options, "master_bazelrc");

--- a/src/test/shell/BUILD
+++ b/src/test/shell/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:private"])
 exports_files([
     "bin/bazel",
     "bin/bazel_jdk_minimal",
+    "bin/bazel_nojdk",
     "testenv.sh",
     "integration_test_setup.sh",
     "sandboxing_test_utils.sh",

--- a/src/test/shell/bin/bazel
+++ b/src/test/shell/bin/bazel
@@ -18,6 +18,13 @@
 # affect all our integration tests.
 #
 bazel_bin=$(rlocation io_bazel/src/bazel)
+
+# One test uses bazel_nojdk instead.  If bazel_bin is empty, try that.
+if [[ -z "${bazel_bin}" ]];
+then
+  bazel_bin=$(rlocation io_bazel/src/bazel_nojdk)
+fi
+
 # unset runfiles environment so that the "inner bazel"
 # has to detect its own runfiles
 unset RUNFILES_DIR

--- a/src/test/shell/bin/bazel_nojdk
+++ b/src/test/shell/bin/bazel_nojdk
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2016 The Bazel Authors. All rights reserved.
+# Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,5 @@
 # Wrapper script to run bazel in the tests. Any change to this file will
 # affect all our integration tests.
 #
-bazel_bin=$(rlocation io_bazel/src/bazel)
-# unset runfiles environment so that the "inner bazel"
-# has to detect its own runfiles
-unset RUNFILES_DIR
-unset RUNFILES_MANIFEST_FILE
-unset RUNFILES_MANIFEST_ONLY
-exec $bazel_bin --bazelrc=$TEST_TMPDIR/bazelrc "$@"
+exec $(rlocation io_bazel/src/bazel_nojdk) \
+  --bazelrc=$TEST_TMPDIR/bazelrc "$@"

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -186,6 +186,18 @@ sh_test(
 )
 
 sh_test(
+    name = "nojdk_startup_options_test",
+    size = "medium",
+    srcs = ["nojdk_startup_options_test.sh"],
+    data = [
+        "//src:bazel_nojdk",
+        "//src/test/shell:bin/bazel",
+        "//src/test/shell/bazel:test-deps-wo-bazel",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+sh_test(
     name = "run_test",
     size = "medium",
     srcs = ["run_test.sh"],

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -26,6 +26,16 @@ filegroup(
     ],
 )
 
+filegroup(
+    name = "test-deps-nojdk",
+    testonly = 1,
+    srcs = [
+        "//src:bazel-bin_nojdk",
+        "//src/test/shell:bin/bazel_nojdk",
+        "//src/test/shell/bazel:test-deps-wo-bazel",
+    ],
+)
+
 sh_test(
     name = "progress_reporting_test",
     size = "large",
@@ -190,9 +200,7 @@ sh_test(
     size = "medium",
     srcs = ["nojdk_startup_options_test.sh"],
     data = [
-        "//src:bazel_nojdk",
-        "//src/test/shell:bin/bazel",
-        "//src/test/shell/bazel:test-deps-wo-bazel",
+        ":test-deps-nojdk",
         "@bazel_tools//tools/bash/runfiles",
     ],
 )

--- a/src/test/shell/integration/BUILD
+++ b/src/test/shell/integration/BUILD
@@ -203,6 +203,8 @@ sh_test(
         ":test-deps-nojdk",
         "@bazel_tools//tools/bash/runfiles",
     ],
+    # Windows doesn't support sandboxing, which BAZEL_SUFFIX needs.
+    tags = ["no_windows"],
 )
 
 sh_test(

--- a/src/test/shell/integration/nojdk_startup_options_test.sh
+++ b/src/test/shell/integration/nojdk_startup_options_test.sh
@@ -38,6 +38,10 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
+# We don't want to use the cached, extracted bazel.  It will have a different
+# sha1 and fail the test.  The 2 version commands below are cheap.
+unset TEST_INSTALL_BASE
+
 export BAZEL_SUFFIX="_nojdk"
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }

--- a/src/test/shell/integration/nojdk_startup_options_test.sh
+++ b/src/test/shell/integration/nojdk_startup_options_test.sh
@@ -38,6 +38,10 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
+# We don't want to use the cached, extracted bazel.  It will have a different
+# sha1 and fail the test.  The 2 version commands below are cheap.
+unset TEST_INSTALL_BASE
+
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 

--- a/src/test/shell/integration/nojdk_startup_options_test.sh
+++ b/src/test/shell/integration/nojdk_startup_options_test.sh
@@ -38,10 +38,7 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
-# We don't want to use the cached, extracted bazel.  It will have a different
-# sha1 and fail the test.  The 2 version commands below are cheap.
-unset TEST_INSTALL_BASE
-
+export BAZEL_SUFFIX="_nojdk"
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 

--- a/src/test/shell/integration/nojdk_startup_options_test.sh
+++ b/src/test/shell/integration/nojdk_startup_options_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2016 The Bazel Authors. All rights reserved.
+# Copyright 2020 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Test of Bazel's startup option handling.
+# Test of Bazel's startup option handling cof the nojdk version.
 
 # --- begin runfiles.bash initialization ---
 set -euo pipefail
@@ -55,31 +55,15 @@ if "$is_windows"; then
   export MSYS2_ARG_CONV_EXCL="*"
 fi
 
-function test_different_startup_options() {
-  pid=$(bazel --nobatch info server_pid 2> $TEST_log)
-  [[ -n $pid ]] || fail "Couldn't run ${PRODUCT_NAME}"
-  newpid=$(bazel --batch info server_pid 2> $TEST_log)
-  expect_log "WARNING: Running B\\(azel\\|laze\\) server needs to be killed, because the startup options are different."
-  [[ "$newpid" != "$pid" ]] || fail "pid $pid was the same!"
-  if ! "$is_windows"; then
-    # On Windows: the kill command of MSYS doesn't work for Windows PIDs.
-    kill -0 $pid 2> /dev/null && fail "$pid not dead" || true
-    kill -0 $newpid 2> /dev/null && fail "$newpid not dead" || true
-  fi
-}
-
-# Regression test for Issue #1659
-function test_command_args_are_not_parsed_as_startup_args() {
-  bazel info --bazelrc=bar &> $TEST_log && fail "Should fail"
-  expect_log "Unrecognized option: --bazelrc=bar"
-  expect_not_log "Error: Unable to read .bazelrc file"
-}
-
-# Test that normal bazel works with and without --autodetect_server_javabase
-# because it has an embedded JRE.
+# Test that nojdk bazel works with --autodetect_server_javabase
 function test_autodetect_server_javabase() {
   bazel --autodetect_server_javabase version &> $TEST_log || fail "Should pass"
-  bazel --noautodetect_server_javabase version &> $TEST_log || fail "Should pass"
+}
+
+# Test that nojdk bazel fails with --noautodetect_server_javabase
+function test_noautodetect_server_javabase() {
+  bazel --noautodetect_server_javabase version &> $TEST_log && fail "Should fail"
+  expect_log "FATAL: Could not find embedded or explicit server javabase, and --noautodetect_server_javabase is set."
 }
 
 run_suite "${PRODUCT_NAME} startup options test"

--- a/src/test/shell/integration/startup_options_test.sh
+++ b/src/test/shell/integration/startup_options_test.sh
@@ -75,4 +75,10 @@ function test_command_args_are_not_parsed_as_startup_args() {
   expect_not_log "Error: Unable to read .bazelrc file"
 }
 
+# Test that normal bazel works with and without --autodetect_server_javabase
+function test_autodetect_server_javabase() {
+  bazel --autodetect_server_javabase version &> $TEST_log || fail "Should pass"
+  bazel --noautodetect_server_javabase version &> $TEST_log || fail "Should pass"
+}
+
 run_suite "${PRODUCT_NAME} startup options test"


### PR DESCRIPTION
We want bazel to fail to start instead of falling back to a host
JRE/JDK.  We are using a hermetic JDK and the embedded JRE, so there
should be no need to use anything from the host.  We've debugged enough
cases so far where the host installed JDK was buggy and causing random
crashes on specific machines.

Fixes: #12451