### PR TITLE
Starlark: use jline in REPL

### DIFF
--- a/src/main/java/net/starlark/java/cmd/BUILD
+++ b/src/main/java/net/starlark/java/cmd/BUILD
@@ -28,5 +28,7 @@ java_binary(
     deps = [
         "//src/main/java/net/starlark/java/eval",
         "//src/main/java/net/starlark/java/syntax",
+        "//third_party:jline-reader",
+        "//third_party:jsr305",
     ],
 )


### PR DESCRIPTION
Support two basic and the most common use cases:
* show previous line when on UP
* restore history on restart

There is not specific reason to use jline instead of some other library
other than the fact I was using jline as long as [13 years ago](https://git.io/JkXJl).

Using basic version of jline (without native bindings). This version
should work as dumb on Windows.

REPL also works as dumb when stdin is not a terminal on macOS:

```
$ cat | bazel run //src/main/java/net/starlark/java/cmd:starlark
...
Welcome to Starlark (java.starlark.net)
Nov 24, 2020 6:49:46 AM org.jline.utils.Log logr
WARNING: Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)
...
>> 1 + 1
..
2
>>
>> ^[[A^[[A^[[A   <-- when <UP> is pressed
```

There's one major drawback of jline: it visibly blinks when displaying
a prompt: first it displays a cursor in the beginning on the line,
and after a split second it displays a prompt and shifted cursor.
When you notice it, you cannot unnotice it.

jline jars are downloaded from the
[maven repo](https://repo1.maven.org/maven2/org/jline/).