### PR TITLE
Change ConfiguredTargetQuery to use KeyedConfiguredTarget as a value.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/CqueryBuildTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/CqueryBuildTool.java
@@ -14,11 +14,11 @@
 package com.google.devtools.build.lib.buildtool;
 
 import com.google.common.collect.ImmutableList;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment.TopLevelConfigurations;
 import com.google.devtools.build.lib.query2.cquery.ConfiguredTargetQueryEnvironment;
 import com.google.devtools.build.lib.query2.cquery.CqueryOptions;
+import com.google.devtools.build.lib.query2.cquery.KeyedConfiguredTarget;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
 import com.google.devtools.build.lib.query2.engine.QueryExpression;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
@@ -27,7 +27,7 @@ import com.google.devtools.build.skyframe.WalkableGraph;
 import java.util.Collection;
 
 /** A version of {@link BuildTool} that handles all cquery work. */
-public final class CqueryBuildTool extends PostAnalysisQueryBuildTool<ConfiguredTarget> {
+public final class CqueryBuildTool extends PostAnalysisQueryBuildTool<KeyedConfiguredTarget> {
 
   public CqueryBuildTool(CommandEnvironment env, QueryExpression queryExpression) {
     super(env, queryExpression);

--- a/src/main/java/com/google/devtools/build/lib/query2/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/query2/BUILD
@@ -110,6 +110,7 @@ java_library(
         "//src/main/protobuf:analysis_java_proto",
         "//src/main/protobuf:build_java_proto",
         "//src/main/protobuf:failure_details_java_proto",
+        "//third_party:auto_value",
         "//third_party:flogger",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfigFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfigFunction.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.common.collect.ImmutableList;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.query2.common.AbstractBlazeQueryEnvironment;
 import com.google.devtools.build.lib.query2.engine.Callback;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment;
@@ -60,7 +59,7 @@ public final class ConfigFunction implements QueryFunction {
 
   /**
    * This function is only viable with ConfiguredTargetQueryEnvironment which extends {@link
-   * AbstractBlazeQueryEnvironment <ConfiguredTarget>}
+   * AbstractBlazeQueryEnvironment <KeyedConfiguredTarget>}
    */
   @Override
   @SuppressWarnings("unchecked")
@@ -84,8 +83,8 @@ public final class ConfigFunction implements QueryFunction {
         ((ConfiguredTargetQueryEnvironment) env)
             .getConfiguredTargetsForConfigFunction(
                 targetExpression.toString(),
-                (ThreadSafeMutableSet<ConfiguredTarget>) targets.getIfSuccessful(),
+                (ThreadSafeMutableSet<KeyedConfiguredTarget>) targets.getIfSuccessful(),
                 configuration,
-                (Callback<ConfiguredTarget>) callback));
+                (Callback<KeyedConfiguredTarget>) callback));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetAccessor.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetAccessor.java
@@ -178,6 +178,7 @@ public class ConfiguredTargetAccessor implements TargetAccessor<KeyedConfiguredT
   /** Returns the rule that generates the given output file. */
   RuleConfiguredTarget getGeneratingConfiguredTarget(KeyedConfiguredTarget kct)
       throws InterruptedException {
+    Preconditions.checkArgument(kct.getConfiguredTarget() instanceof OutputFileConfiguredTarget);
     return (RuleConfiguredTarget)
         ((ConfiguredTargetValue)
                 walkableGraph.getValue(

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
@@ -73,7 +73,7 @@ import javax.annotation.Nullable;
  * comments on {@link PostAnalysisQueryEnvironment#targetifyValues} and b/163052263 for details.
  */
 public class ConfiguredTargetQueryEnvironment
-    extends PostAnalysisQueryEnvironment<ConfiguredTarget> {
+    extends PostAnalysisQueryEnvironment<KeyedConfiguredTarget> {
   /** Common query functions and cquery specific functions. */
   public static final ImmutableList<QueryFunction> FUNCTIONS = populateFunctions();
   /** Cquery specific functions. */
@@ -81,7 +81,8 @@ public class ConfiguredTargetQueryEnvironment
 
   private CqueryOptions cqueryOptions;
 
-  private final KeyExtractor<ConfiguredTarget, ConfiguredTargetKey> configuredTargetKeyExtractor;
+  private final KeyExtractor<KeyedConfiguredTarget, ConfiguredTargetKey>
+      configuredTargetKeyExtractor;
 
   private final ConfiguredTargetAccessor accessor;
 
@@ -103,7 +104,8 @@ public class ConfiguredTargetQueryEnvironment
   private final ImmutableMap<String, BuildConfiguration> transitiveConfigurations;
 
   @Override
-  protected KeyExtractor<ConfiguredTarget, ConfiguredTargetKey> getConfiguredTargetKeyExtractor() {
+  protected KeyExtractor<KeyedConfiguredTarget, ConfiguredTargetKey>
+      getConfiguredTargetKeyExtractor() {
     return configuredTargetKeyExtractor;
   }
 
@@ -130,12 +132,7 @@ public class ConfiguredTargetQueryEnvironment
         walkableGraphSupplier,
         settings);
     this.accessor = new ConfiguredTargetAccessor(walkableGraphSupplier.get(), this);
-    this.configuredTargetKeyExtractor =
-        element ->
-            ConfiguredTargetKey.builder()
-                .setConfiguredTarget(element)
-                .setConfigurationKey(element.getConfigurationKey())
-                .build();
+    this.configuredTargetKeyExtractor = KeyedConfiguredTarget::getConfiguredTargetKey;
     this.transitiveConfigurations =
         getTransitiveConfigurations(transitiveConfigurationKeys, walkableGraphSupplier.get());
   }
@@ -201,9 +198,9 @@ public class ConfiguredTargetQueryEnvironment
   }
 
   @Override
-  public ImmutableList<NamedThreadSafeOutputFormatterCallback<ConfiguredTarget>>
+  public ImmutableList<NamedThreadSafeOutputFormatterCallback<KeyedConfiguredTarget>>
       getDefaultOutputFormatters(
-          TargetAccessor<ConfiguredTarget> accessor,
+          TargetAccessor<KeyedConfiguredTarget> accessor,
           ExtendedEventHandler eventHandler,
           OutputStream out,
           SkyframeExecutor skyframeExecutor,
@@ -258,7 +255,7 @@ public class ConfiguredTargetQueryEnvironment
             out,
             skyframeExecutor,
             accessor,
-            ct -> getFwdDeps(ImmutableList.of(ct))),
+            kct -> getFwdDeps(ImmutableList.of(kct))),
         new StarlarkOutputFormatterCallback(
             eventHandler, cqueryOptions, out, skyframeExecutor, accessor));
   }
@@ -275,7 +272,7 @@ public class ConfiguredTargetQueryEnvironment
 
   @Override
   public QueryTaskFuture<Void> getTargetsMatchingPattern(
-      QueryExpression owner, String pattern, Callback<ConfiguredTarget> callback) {
+      QueryExpression owner, String pattern, Callback<KeyedConfiguredTarget> callback) {
     TargetPattern patternToEval;
     try {
       patternToEval = getPattern(pattern);
@@ -302,7 +299,7 @@ public class ConfiguredTargetQueryEnvironment
                   /* excludedSubdirectories= */ ImmutableSet.of(),
                   (Callback<Target>)
                       partialResult -> {
-                        List<ConfiguredTarget> transformedResult = new ArrayList<>();
+                        List<KeyedConfiguredTarget> transformedResult = new ArrayList<>();
                         for (Target target : partialResult) {
                           transformedResult.addAll(
                               getConfiguredTargetsForConfigFunction(target.getLabel()));
@@ -323,7 +320,7 @@ public class ConfiguredTargetQueryEnvironment
    * null.
    */
   @Nullable
-  private ConfiguredTarget getConfiguredTarget(Label label, BuildConfiguration configuration)
+  private KeyedConfiguredTarget getConfiguredTarget(Label label, BuildConfiguration configuration)
       throws InterruptedException {
     return getValueFromKey(
         ConfiguredTargetKey.builder().setLabel(label).setConfiguration(configuration).build());
@@ -331,9 +328,11 @@ public class ConfiguredTargetQueryEnvironment
 
   @Override
   @Nullable
-  protected ConfiguredTarget getValueFromKey(SkyKey key) throws InterruptedException {
+  protected KeyedConfiguredTarget getValueFromKey(SkyKey key) throws InterruptedException {
     ConfiguredTargetValue value = getConfiguredTargetValue(key);
-    return value == null ? null : value.getConfiguredTarget();
+    return value == null
+        ? null
+        : KeyedConfiguredTarget.create((ConfiguredTargetKey) key, value.getConfiguredTarget());
   }
 
   /**
@@ -341,16 +340,16 @@ public class ConfiguredTargetQueryEnvironment
    *
    * <p>If there are no matches, returns an empty list.
    */
-  private List<ConfiguredTarget> getConfiguredTargetsForConfigFunction(Label label)
+  private List<KeyedConfiguredTarget> getConfiguredTargetsForConfigFunction(Label label)
       throws InterruptedException {
-    ImmutableList.Builder<ConfiguredTarget> ans = ImmutableList.builder();
+    ImmutableList.Builder<KeyedConfiguredTarget> ans = ImmutableList.builder();
     for (BuildConfiguration config : transitiveConfigurations.values()) {
-      ConfiguredTarget ct = getConfiguredTarget(label, config);
-      if (ct != null) {
-        ans.add(ct);
+      KeyedConfiguredTarget kct = getConfiguredTarget(label, config);
+      if (kct != null) {
+        ans.add(kct);
       }
     }
-    ConfiguredTarget nullConfiguredTarget = getNullConfiguredTarget(label);
+    KeyedConfiguredTarget nullConfiguredTarget = getNullConfiguredTarget(label);
     if (nullConfiguredTarget != null) {
       ans.add(nullConfiguredTarget);
     }
@@ -372,28 +371,28 @@ public class ConfiguredTargetQueryEnvironment
    */
   QueryTaskCallable<Void> getConfiguredTargetsForConfigFunction(
       String pattern,
-      ThreadSafeMutableSet<ConfiguredTarget> targets,
+      ThreadSafeMutableSet<KeyedConfiguredTarget> targets,
       String configPrefix,
-      Callback<ConfiguredTarget> callback) {
+      Callback<KeyedConfiguredTarget> callback) {
     // There's no technical reason other callers beside ConfigFunction can't call this. But they'd
     // need to adjust the error messaging below to not make it config()-specific. Please don't just
     // remove that line: the counter-priority is making error messages as clear, precise, and
     // actionable as possible.
     return () -> {
-      List<ConfiguredTarget> transformedResult = new ArrayList<>();
+      List<KeyedConfiguredTarget> transformedResult = new ArrayList<>();
       boolean userFriendlyConfigName = true;
-      for (ConfiguredTarget target : targets) {
+      for (KeyedConfiguredTarget target : targets) {
         Label label = getCorrectLabel(target);
-        ConfiguredTarget configuredTarget;
+        KeyedConfiguredTarget keyedConfiguredTarget;
         switch (configPrefix) {
           case "host":
-            configuredTarget = getHostConfiguredTarget(label);
+            keyedConfiguredTarget = getHostConfiguredTarget(label);
             break;
           case "target":
-            configuredTarget = getTargetConfiguredTarget(label);
+            keyedConfiguredTarget = getTargetConfiguredTarget(label);
             break;
           case "null":
-            configuredTarget = getNullConfiguredTarget(label);
+            keyedConfiguredTarget = getNullConfiguredTarget(label);
             break;
           default:
             ImmutableList<String> matchingConfigs =
@@ -401,7 +400,7 @@ public class ConfiguredTargetQueryEnvironment
                     .filter(fullConfig -> fullConfig.startsWith(configPrefix))
                     .collect(ImmutableList.toImmutableList());
             if (matchingConfigs.size() == 1) {
-              configuredTarget =
+              keyedConfiguredTarget =
                   getConfiguredTarget(
                       label,
                       Verify.verifyNotNull(transitiveConfigurations.get(matchingConfigs.get(0))));
@@ -435,8 +434,8 @@ public class ConfiguredTargetQueryEnvironment
                   ConfigurableQuery.Code.INCORRECT_CONFIG_ARGUMENT_ERROR);
             }
         }
-        if (configuredTarget != null) {
-          transformedResult.add(configuredTarget);
+        if (keyedConfiguredTarget != null) {
+          transformedResult.add(keyedConfiguredTarget);
         }
       }
       if (transformedResult.isEmpty()) {
@@ -459,25 +458,26 @@ public class ConfiguredTargetQueryEnvironment
    * the "actual" target instead of the alias target. Grr.
    */
   @Override
-  public Label getCorrectLabel(ConfiguredTarget target) {
+  public Label getCorrectLabel(KeyedConfiguredTarget target) {
     // Dereference any aliases that might be present.
-    return target.getOriginalLabel();
+    return target.getConfiguredTarget().getOriginalLabel();
   }
 
   @Nullable
   @Override
-  protected ConfiguredTarget getHostConfiguredTarget(Label label) throws InterruptedException {
+  protected KeyedConfiguredTarget getHostConfiguredTarget(Label label) throws InterruptedException {
     return getConfiguredTarget(label, hostConfiguration);
   }
 
   @Nullable
   @Override
-  protected ConfiguredTarget getTargetConfiguredTarget(Label label) throws InterruptedException {
+  protected KeyedConfiguredTarget getTargetConfiguredTarget(Label label)
+      throws InterruptedException {
     if (topLevelConfigurations.isTopLevelTarget(label)) {
       return getConfiguredTarget(
           label, topLevelConfigurations.getConfigurationForTopLevelTarget(label));
     } else {
-      ConfiguredTarget toReturn;
+      KeyedConfiguredTarget toReturn;
       for (BuildConfiguration configuration : topLevelConfigurations.getConfigurations()) {
         toReturn = getConfiguredTarget(label, configuration);
         if (toReturn != null) {
@@ -490,22 +490,22 @@ public class ConfiguredTargetQueryEnvironment
 
   @Nullable
   @Override
-  protected ConfiguredTarget getNullConfiguredTarget(Label label) throws InterruptedException {
+  protected KeyedConfiguredTarget getNullConfiguredTarget(Label label) throws InterruptedException {
     return getConfiguredTarget(label, null);
   }
 
   @Nullable
   @Override
-  protected RuleConfiguredTarget getRuleConfiguredTarget(ConfiguredTarget configuredTarget) {
-    if (configuredTarget instanceof RuleConfiguredTarget) {
-      return (RuleConfiguredTarget) configuredTarget;
+  protected RuleConfiguredTarget getRuleConfiguredTarget(KeyedConfiguredTarget configuredTarget) {
+    if (configuredTarget.getConfiguredTarget() instanceof RuleConfiguredTarget) {
+      return (RuleConfiguredTarget) configuredTarget.getConfiguredTarget();
     }
     return null;
   }
 
   @Nullable
   @Override
-  protected BuildConfiguration getConfiguration(ConfiguredTarget target) {
+  protected BuildConfiguration getConfiguration(KeyedConfiguredTarget target) {
     try {
       return target.getConfigurationKey() == null
           ? null
@@ -517,18 +517,15 @@ public class ConfiguredTargetQueryEnvironment
   }
 
   @Override
-  protected ConfiguredTargetKey getSkyKey(ConfiguredTarget target) {
-    return ConfiguredTargetKey.builder()
-        .setConfiguredTarget(target)
-        .setConfiguration(getConfiguration(target))
-        .build();
+  protected ConfiguredTargetKey getSkyKey(KeyedConfiguredTarget target) {
+    return target.getConfiguredTargetKey();
   }
 
   @Override
-  public ThreadSafeMutableSet<ConfiguredTarget> createThreadSafeMutableSet() {
+  public ThreadSafeMutableSet<KeyedConfiguredTarget> createThreadSafeMutableSet() {
     return new ThreadSafeMutableKeyExtractorBackedSetImpl<>(
         configuredTargetKeyExtractor,
-        ConfiguredTarget.class,
+        KeyedConfiguredTarget.class,
         SkyQueryEnvironment.DEFAULT_THREAD_COUNT);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryThreadsafeCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryThreadsafeCallback.java
@@ -15,7 +15,6 @@ package com.google.devtools.build.lib.query2.cquery;
 
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.query2.NamedThreadSafeOutputFormatterCallback;
@@ -42,7 +41,7 @@ import javax.annotation.Nullable;
  * on completeness, should output full configuration checksums.
  */
 public abstract class CqueryThreadsafeCallback
-    extends NamedThreadSafeOutputFormatterCallback<ConfiguredTarget> {
+    extends NamedThreadSafeOutputFormatterCallback<KeyedConfiguredTarget> {
 
   protected final ExtendedEventHandler eventHandler;
   protected final CqueryOptions options;
@@ -63,7 +62,7 @@ public abstract class CqueryThreadsafeCallback
       CqueryOptions options,
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
-      TargetAccessor<ConfiguredTarget> accessor) {
+      TargetAccessor<KeyedConfiguredTarget> accessor) {
     this.eventHandler = eventHandler;
     this.options = options;
     if (out != null) {

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.graph.Digraph;
@@ -37,15 +36,16 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
   /** Interface for finding a configured target's direct dependencies. */
   @FunctionalInterface
   public interface DepsRetriever {
-    Iterable<ConfiguredTarget> getDirectDeps(ConfiguredTarget taget) throws InterruptedException;
+    Iterable<KeyedConfiguredTarget> getDirectDeps(KeyedConfiguredTarget taget)
+        throws InterruptedException;
   }
 
   private final DepsRetriever depsRetriever;
 
-  private final GraphOutputWriter.NodeReader<ConfiguredTarget> nodeReader =
-      new NodeReader<ConfiguredTarget>() {
+  private final GraphOutputWriter.NodeReader<KeyedConfiguredTarget> nodeReader =
+      new NodeReader<KeyedConfiguredTarget>() {
 
-        private final Comparator<ConfiguredTarget> configuredTargetOrdering =
+        private final Comparator<KeyedConfiguredTarget> configuredTargetOrdering =
             (ct1, ct2) -> {
               // Order graph output first by target label, then by configuration hash.
               Label label1 = ct1.getLabel();
@@ -56,16 +56,16 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
             };
 
         @Override
-        public String getLabel(Node<ConfiguredTarget> node) {
+        public String getLabel(Node<KeyedConfiguredTarget> node) {
           // Node payloads are ConfiguredTargets. Output node labels are target labels + config
           // hashes.
-          ConfiguredTarget ct = node.getLabel();
+          KeyedConfiguredTarget kct = node.getLabel();
           return String.format(
-              "%s (%s)", ct.getLabel(), shortId(getConfiguration(ct.getConfigurationKey())));
+              "%s (%s)", kct.getLabel(), shortId(getConfiguration(kct.getConfigurationKey())));
         }
 
         @Override
-        public Comparator<ConfiguredTarget> comparator() {
+        public Comparator<KeyedConfiguredTarget> comparator() {
           return configuredTargetOrdering;
         }
       };
@@ -75,30 +75,31 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
       CqueryOptions options,
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
-      TargetAccessor<ConfiguredTarget> accessor,
+      TargetAccessor<KeyedConfiguredTarget> accessor,
       DepsRetriever depsRetriever) {
     super(eventHandler, options, out, skyframeExecutor, accessor);
     this.depsRetriever = depsRetriever;
   }
 
   @Override
-  public void processOutput(Iterable<ConfiguredTarget> partialResult) throws InterruptedException {
+  public void processOutput(Iterable<KeyedConfiguredTarget> partialResult)
+      throws InterruptedException {
     // Transform the cquery-backed graph into a Digraph to make it suitable for GraphOutputWriter.
     // Note that this involves an extra iteration over the entire query result subgraph. We could
     // conceptually merge transformation and output writing into the same iteration if needed.
-    Digraph<ConfiguredTarget> graph = new Digraph<>();
-    ImmutableSet<ConfiguredTarget> allNodes = ImmutableSet.copyOf(partialResult);
-    for (ConfiguredTarget configuredTarget : partialResult) {
-      Node<ConfiguredTarget> node = graph.createNode(configuredTarget);
-      for (ConfiguredTarget dep : depsRetriever.getDirectDeps(configuredTarget)) {
+    Digraph<KeyedConfiguredTarget> graph = new Digraph<>();
+    ImmutableSet<KeyedConfiguredTarget> allNodes = ImmutableSet.copyOf(partialResult);
+    for (KeyedConfiguredTarget configuredTarget : partialResult) {
+      Node<KeyedConfiguredTarget> node = graph.createNode(configuredTarget);
+      for (KeyedConfiguredTarget dep : depsRetriever.getDirectDeps(configuredTarget)) {
         if (allNodes.contains(dep)) {
-          Node<ConfiguredTarget> depNode = graph.createNode(dep);
+          Node<KeyedConfiguredTarget> depNode = graph.createNode(dep);
           graph.addEdge(node, depNode);
         }
       }
     }
 
-    GraphOutputWriter<ConfiguredTarget> graphWriter =
+    GraphOutputWriter<KeyedConfiguredTarget> graphWriter =
         new GraphOutputWriter<>(
             nodeReader,
             options.getLineTerminator(),

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/KeyedConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/KeyedConfiguredTarget.java
@@ -1,0 +1,68 @@
+package com.google.devtools.build.lib.query2.cquery;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.skyframe.BuildConfigurationValue;
+import com.google.devtools.build.lib.skyframe.ConfiguredTargetKey;
+import javax.annotation.Nullable;
+
+/**
+ * A representation of a ConfiguredTargetKey and the ConfiguredTarget that it points to, for use in
+ * configured target queries.
+ */
+@AutoValue
+public abstract class KeyedConfiguredTarget {
+
+  /** Returns a new KeyedConfiguredTarget for the given data. */
+  public static KeyedConfiguredTarget create(
+      ConfiguredTargetKey configuredTargetKey, ConfiguredTarget configuredTarget) {
+    return new AutoValue_KeyedConfiguredTarget(configuredTargetKey, configuredTarget);
+  }
+
+  /** Returns the key for this KeyedConfiguredTarget. */
+  @Nullable
+  public abstract ConfiguredTargetKey getConfiguredTargetKey();
+
+  /** Returns the ConfiguredTarget for this KeyedConfiguredTarget. */
+  public abstract ConfiguredTarget getConfiguredTarget();
+
+  /** Returns the original (pre-alias) label for the underlying ConfiguredTarget. */
+  public Label getLabel() {
+    return getConfiguredTarget().getOriginalLabel();
+  }
+
+  /** Returns the configuration key used for this KeyedConfiguredTarget. */
+  @Nullable
+  public BuildConfigurationValue.Key getConfigurationKey() {
+    return getConfiguredTarget().getConfigurationKey();
+  }
+
+  /** Returns the configuration checksum in use for this KeyedConfiguredTarget. */
+  @Nullable
+  public String getConfigurationChecksum() {
+    return getConfigurationKey() == null
+        ? null
+        : getConfigurationKey().getOptionsDiff().getChecksum();
+  }
+
+  /**
+   * The configuration conditions that trigger this configured target's configurable attributes. For
+   * targets that do not support configurable attributes, this will be an empty map.
+   */
+  public ImmutableMap<Label, ConfigMatchingProvider> getConfigConditions() {
+    return getConfiguredTarget().getConfigConditions();
+  }
+
+  /** Returns a KeyedConfiguredTarget instance that resolves aliases. */
+  public KeyedConfiguredTarget getActual() {
+    ConfiguredTarget actual = getConfiguredTarget().getActual();
+    ConfiguredTargetKey actualKey =
+        this.getConfiguredTargetKey() == null
+            ? null
+            : this.getConfiguredTargetKey().toBuilder().setLabel(actual.getLabel()).build();
+    return KeyedConfiguredTarget.create(actualKey, actual);
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/LabelAndConfigurationOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/LabelAndConfigurationOutputFormatterCallback.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.google.devtools.build.lib.query2.cquery;
 
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.RequiredConfigFragmentsProvider;
 import com.google.devtools.build.lib.analysis.config.CoreOptions.IncludeConfigFragmentsEnum;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
@@ -31,7 +30,7 @@ public class LabelAndConfigurationOutputFormatterCallback extends CqueryThreadsa
       CqueryOptions options,
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
-      TargetAccessor<ConfiguredTarget> accessor,
+      TargetAccessor<KeyedConfiguredTarget> accessor,
       boolean showKind) {
     super(eventHandler, options, out, skyframeExecutor, accessor);
     this.showKind = showKind;
@@ -43,23 +42,25 @@ public class LabelAndConfigurationOutputFormatterCallback extends CqueryThreadsa
   }
 
   @Override
-  public void processOutput(Iterable<ConfiguredTarget> partialResult) {
-    for (ConfiguredTarget configuredTarget : partialResult) {
+  public void processOutput(Iterable<KeyedConfiguredTarget> partialResult) {
+    for (KeyedConfiguredTarget keyedConfiguredTarget : partialResult) {
       StringBuilder output = new StringBuilder();
       if (showKind) {
-        Target actualTarget = accessor.getTargetFromConfiguredTarget(configuredTarget);
+        Target actualTarget = accessor.getTarget(keyedConfiguredTarget);
         output = output.append(actualTarget.getTargetKind()).append(" ");
       }
       output =
           output
-              .append(configuredTarget.getOriginalLabel())
+              .append(keyedConfiguredTarget.getLabel())
               .append(" (")
-              .append(shortId(getConfiguration(configuredTarget.getConfigurationKey())))
+              .append(shortId(getConfiguration(keyedConfiguredTarget.getConfigurationKey())))
               .append(")");
 
       if (options.showRequiredConfigFragments != IncludeConfigFragmentsEnum.OFF) {
         RequiredConfigFragmentsProvider configFragmentsProvider =
-            configuredTarget.getProvider(RequiredConfigFragmentsProvider.class);
+            keyedConfiguredTarget
+                .getConfiguredTarget()
+                .getProvider(RequiredConfigFragmentsProvider.class);
         String requiredFragmentsOutput =
             configFragmentsProvider != null
                 ? String.join(", ", configFragmentsProvider.getRequiredConfigFragments())

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
@@ -81,7 +81,7 @@ class TransitionsOutputFormatterCallback extends CqueryThreadsafeCallback {
       CqueryOptions options,
       OutputStream out,
       SkyframeExecutor skyframeExecutor,
-      TargetAccessor<ConfiguredTarget> accessor,
+      TargetAccessor<KeyedConfiguredTarget> accessor,
       BuildConfiguration hostConfiguration,
       @Nullable TransitionFactory<Rule> trimmingTransitionFactory) {
     super(eventHandler, options, out, skyframeExecutor, accessor);
@@ -91,7 +91,8 @@ class TransitionsOutputFormatterCallback extends CqueryThreadsafeCallback {
   }
 
   @Override
-  public void processOutput(Iterable<ConfiguredTarget> partialResult) throws InterruptedException {
+  public void processOutput(Iterable<KeyedConfiguredTarget> partialResult)
+      throws InterruptedException {
     CqueryOptions.Transitions verbosity = options.transitions;
     if (verbosity.equals(CqueryOptions.Transitions.NONE)) {
       eventHandler.handle(
@@ -100,22 +101,21 @@ class TransitionsOutputFormatterCallback extends CqueryThreadsafeCallback {
                   + " flag explicitly to 'lite' or 'full'"));
       return;
     }
-    partialResult.forEach(
-        ct ->
-            partialResultMap.put(
-                ct.getOriginalLabel(), accessor.getTargetFromConfiguredTarget(ct)));
-    for (ConfiguredTarget configuredTarget : partialResult) {
-      Target target = partialResultMap.get(configuredTarget.getOriginalLabel());
-      BuildConfiguration config = getConfiguration(configuredTarget.getConfigurationKey());
+    partialResult.forEach(kct -> partialResultMap.put(kct.getLabel(), accessor.getTarget(kct)));
+    for (KeyedConfiguredTarget keyedConfiguredTarget : partialResult) {
+      Target target = partialResultMap.get(keyedConfiguredTarget.getLabel());
+      BuildConfiguration config = getConfiguration(keyedConfiguredTarget.getConfigurationKey());
       addResult(
-          getRuleClassTransition(configuredTarget, target)
-              + String.format("%s (%s)", configuredTarget.getOriginalLabel(), shortId(config)));
-      if (!(configuredTarget instanceof RuleConfiguredTarget)) {
+          getRuleClassTransition(keyedConfiguredTarget.getConfiguredTarget(), target)
+              + String.format(
+                  "%s (%s)",
+                  keyedConfiguredTarget.getConfiguredTarget().getOriginalLabel(), shortId(config)));
+      if (!(keyedConfiguredTarget.getConfiguredTarget() instanceof RuleConfiguredTarget)) {
         continue;
       }
       OrderedSetMultimap<DependencyKind, DependencyKey> deps;
       ImmutableMap<Label, ConfigMatchingProvider> configConditions =
-          configuredTarget.getConfigConditions();
+          keyedConfiguredTarget.getConfigConditions();
 
       // Get a ToolchainContext to use for dependency resolution.
       ToolchainCollection<ToolchainContext> toolchainContexts =

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetKey.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetKey.java
@@ -56,6 +56,13 @@ public class ConfiguredTargetKey implements ActionLookupKey {
     return interner.intern(new ConfiguredTargetKey(label, configurationKey));
   }
 
+  public Builder toBuilder() {
+    return builder()
+        .setConfigurationKey(getConfigurationKey())
+        .setLabel(getLabel())
+        .setToolchainContextKey(getToolchainContextKey());
+  }
+
   @Override
   public final Label getLabel() {
     return label;
@@ -67,7 +74,7 @@ public class ConfiguredTargetKey implements ActionLookupKey {
   }
 
   @Nullable
-  final BuildConfigurationValue.Key getConfigurationKey() {
+  public final BuildConfigurationValue.Key getConfigurationKey() {
     return configurationKey;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/BUILD
@@ -69,6 +69,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/packages",
+        "//src/main/java/com/google/devtools/build/lib/query2",
         "//src/main/java/com/google/devtools/build/lib/query2/engine",
         "//src/main/java/com/google/devtools/build/lib/util:filetype",
         "//src/main/java/com/google/devtools/build/lib/vfs",

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/BuildOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/BuildOutputFormatterCallbackTest.java
@@ -19,7 +19,6 @@ import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
 import static com.google.devtools.build.lib.packages.BuildType.OUTPUT;
 
 import com.google.common.eventbus.EventBus;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.MockRule;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Reporter;
@@ -74,7 +73,7 @@ public class BuildOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
     Set<String> targetPatternSet = new LinkedHashSet<>();
     expression.collectTargetPatterns(targetPatternSet);
     helper.setQuerySettings(Setting.NO_IMPLICIT_DEPS);
-    PostAnalysisQueryEnvironment<ConfiguredTarget> env =
+    PostAnalysisQueryEnvironment<KeyedConfiguredTarget> env =
         ((ConfiguredTargetQueryHelper) helper).getPostAnalysisQueryEnvironment(targetPatternSet);
 
     ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryHelper.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryHelper.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.common.collect.ImmutableList;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.AnalysisTestCase;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment.TopLevelConfigurations;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.QueryFunction;
@@ -31,7 +30,7 @@ import java.util.Collection;
  * AnalysisTestCase} must be run manually. @BeforeClass and @AfterClass are completely ignored for
  * now.
  */
-public class ConfiguredTargetQueryHelper extends PostAnalysisQueryHelper<ConfiguredTarget> {
+public class ConfiguredTargetQueryHelper extends PostAnalysisQueryHelper<KeyedConfiguredTarget> {
   @Override
   protected ConfiguredTargetQueryEnvironment getPostAnalysisQueryEnvironment(
       WalkableGraph walkableGraph,
@@ -54,7 +53,7 @@ public class ConfiguredTargetQueryHelper extends PostAnalysisQueryHelper<Configu
   }
 
   @Override
-  public String getLabel(ConfiguredTarget target) {
-    return target.getLabel().toString();
+  public String getLabel(KeyedConfiguredTarget target) {
+    return target.getConfiguredTarget().getLabel().toString();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.BuildOptionsView;
@@ -39,10 +38,11 @@ import org.junit.runners.JUnit4;
 
 /** Tests for {@link ConfiguredTargetQueryEnvironment}. */
 @RunWith(JUnit4.class)
-public abstract class ConfiguredTargetQueryTest extends PostAnalysisQueryTest<ConfiguredTarget> {
+public abstract class ConfiguredTargetQueryTest
+    extends PostAnalysisQueryTest<KeyedConfiguredTarget> {
 
   @Override
-  protected QueryHelper<ConfiguredTarget> createQueryHelper() {
+  protected QueryHelper<KeyedConfiguredTarget> createQueryHelper() {
     if (helper != null) {
       getHelper().cleanUp();
     }
@@ -62,10 +62,10 @@ public abstract class ConfiguredTargetQueryTest extends PostAnalysisQueryTest<Co
   }
 
   @Override
-  protected final BuildConfiguration getConfiguration(ConfiguredTarget ct) {
+  protected final BuildConfiguration getConfiguration(KeyedConfiguredTarget kct) {
     return getHelper()
         .getSkyframeExecutor()
-        .getConfiguration(getHelper().getReporter(), ct.getConfigurationKey());
+        .getConfiguration(getHelper().getReporter(), kct.getConfigurationKey());
   }
 
   /** SplitTransition on --test_arg */
@@ -98,12 +98,12 @@ public abstract class ConfiguredTargetQueryTest extends PostAnalysisQueryTest<Co
   public void testMultipleTopLevelConfigurations_nullConfigs() throws Exception {
     writeFile("test/BUILD", "java_library(name='my_java',", "  srcs = ['foo.java'],", ")");
 
-    Set<ConfiguredTarget> result = eval("//test:my_java+//test:foo.java");
+    Set<KeyedConfiguredTarget> result = eval("//test:my_java+//test:foo.java");
 
     assertThat(result).hasSize(2);
 
-    Iterator<ConfiguredTarget> resultIterator = result.iterator();
-    ConfiguredTarget first = resultIterator.next();
+    Iterator<KeyedConfiguredTarget> resultIterator = result.iterator();
+    KeyedConfiguredTarget first = resultIterator.next();
     if (first.getLabel().toString().equals("//test:foo.java")) {
       assertThat(getConfiguration(first)).isNull();
       assertThat(getConfiguration(resultIterator.next())).isNotNull();

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallbackTest.java
@@ -17,7 +17,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.eventbus.EventBus;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment;
@@ -70,7 +69,7 @@ public class GraphOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
     Set<String> targetPatternSet = new LinkedHashSet<>();
     expression.collectTargetPatterns(targetPatternSet);
     helper.setQuerySettings(Setting.NO_IMPLICIT_DEPS);
-    PostAnalysisQueryEnvironment<ConfiguredTarget> env =
+    PostAnalysisQueryEnvironment<KeyedConfiguredTarget> env =
         ((ConfiguredTargetQueryHelper) helper).getPostAnalysisQueryEnvironment(targetPatternSet);
 
     ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
@@ -20,7 +20,6 @@ import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
 import com.google.common.collect.Iterables;
 import com.google.common.eventbus.EventBus;
 import com.google.devtools.build.lib.analysis.AnalysisProtos;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.TransitionFactories;
 import com.google.devtools.build.lib.analysis.util.MockRule;
 import com.google.devtools.build.lib.events.Event;
@@ -144,7 +143,7 @@ public class ProtoOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
     // Assert checksum from proto is proper checksum.
     AnalysisProtos.ConfiguredTarget myRuleProto =
         Iterables.getOnlyElement(getOutput("//test:my_rule").getResultsList());
-    ConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
+    KeyedConfiguredTarget myRule = Iterables.getOnlyElement(eval("//test:my_rule"));
 
     assertThat(myRuleProto.getConfiguration().getChecksum())
         .isEqualTo(myRule.getConfigurationChecksum());
@@ -216,7 +215,7 @@ public class ProtoOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
     Set<String> targetPatternSet = new LinkedHashSet<>();
     expression.collectTargetPatterns(targetPatternSet);
     helper.setQuerySettings(Setting.NO_IMPLICIT_DEPS);
-    PostAnalysisQueryEnvironment<ConfiguredTarget> env =
+    PostAnalysisQueryEnvironment<KeyedConfiguredTarget> env =
         ((ConfiguredTargetQueryHelper) helper).getPostAnalysisQueryEnvironment(targetPatternSet);
 
     ProtoOutputFormatterCallback callback =

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterTest.java
@@ -20,7 +20,6 @@ import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
 
 import com.google.common.eventbus.EventBus;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
-import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.config.TransitionFactories;
 import com.google.devtools.build.lib.analysis.config.transitions.NoTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
@@ -212,7 +211,7 @@ public class TransitionsOutputFormatterTest extends ConfiguredTargetQueryTest {
     Set<String> targetPatternSet = new LinkedHashSet<>();
     expression.collectTargetPatterns(targetPatternSet);
     helper.setQuerySettings(Setting.NO_IMPLICIT_DEPS);
-    PostAnalysisQueryEnvironment<ConfiguredTarget> env =
+    PostAnalysisQueryEnvironment<KeyedConfiguredTarget> env =
         ((ConfiguredTargetQueryHelper) helper).getPostAnalysisQueryEnvironment(targetPatternSet);
     options.transitions = verbosity;
     // TODO(juliexxia): Test late-bound attributes.

--- a/src/test/shell/bazel/toolchain_transition_test.sh
+++ b/src/test/shell/bazel/toolchain_transition_test.sh
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 # Test the toolchain transition.
-#
 
 # Load the test setup defined in the parent directory
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -353,6 +352,31 @@ EOF
   # The toolchain's dependencies should use alpha for exec.
   # Make sure the exec platform does not propagate to further dependencies.
   expect_log 'extra_lib: message: extra_lib foo, target_dep: target, tool_dep: exec-alpha'
+}
+
+function test_toolchain_transition_cquery() {
+  write_constraints
+  write_platforms
+  write_toolchains
+  write_rule
+
+  cat >BUILD.bazel <<EOF
+package(default_visibility = ["//visibility:public"])
+
+load("//rule:rule.bzl", "sample")
+
+sample(
+    name = "sample",
+    message = "Hello",
+)
+EOF
+
+  bazel cquery \
+    --platforms=//platform:target \
+    --host_platform=//platform:host \
+     'deps(//:sample)' &> $TEST_log || fail "Build failed"
+
+  expect_not_log "Targets were missing from graph"
 }
 
 run_suite "toolchain transition tests"

--- a/src/test/shell/bazel/toolchain_transition_test.sh
+++ b/src/test/shell/bazel/toolchain_transition_test.sh
@@ -354,6 +354,9 @@ EOF
   expect_log 'extra_lib: message: extra_lib foo, target_dep: target, tool_dep: exec-alpha'
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/11993
+# This was causing cquery to not correctly generate ConfiguredTargetKeys for
+# toolchains, leading to the message "Targets were missing from graph"
 function test_toolchain_transition_cquery() {
   write_constraints
   write_platforms


### PR DESCRIPTION
This will allow us to keep the configured target key between lookup rounds.

Fixes #11993.
