### PR TITLE
Clean up ConfiguredTargetValueAccessor and ConfiguredTargetAccessor

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphQueryEnvironment.java
@@ -30,7 +30,6 @@ import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.pkgcache.PackageManager;
 import com.google.devtools.build.lib.pkgcache.PathPackageLocator;
-import com.google.devtools.build.lib.query2.ConfiguredTargetValueAccessor;
 import com.google.devtools.build.lib.query2.NamedThreadSafeOutputFormatterCallback;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment;
 import com.google.devtools.build.lib.query2.SkyQueryEnvironment;
@@ -102,7 +101,7 @@ public class ActionGraphQueryEnvironment
                 .build();
     this.accessor =
         new ConfiguredTargetValueAccessor(
-            walkableGraphSupplier.get(), this.configuredTargetKeyExtractor);
+            walkableGraphSupplier.get(), this::getTarget, this.configuredTargetKeyExtractor);
   }
 
   public ActionGraphQueryEnvironment(

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/AqueryThreadsafeCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/AqueryThreadsafeCallback.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.query2.aquery;
 
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
-import com.google.devtools.build.lib.query2.ConfiguredTargetValueAccessor;
 import com.google.devtools.build.lib.query2.NamedThreadSafeOutputFormatterCallback;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccessor;
 import com.google.devtools.build.lib.skyframe.ConfiguredTargetValue;

--- a/src/main/java/com/google/devtools/build/lib/query2/engine/QueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/engine/QueryEnvironment.java
@@ -17,7 +17,9 @@ import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
+import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import java.util.Collection;
 import java.util.List;
@@ -157,6 +159,11 @@ public interface QueryEnvironment<T> {
 
     /** Returns the argument index of the expression that is used as the input to be filtered. */
     public abstract int getExpressionToFilterIndex();
+  }
+
+  @FunctionalInterface
+  interface TargetLookup {
+    Target getTarget(Label label) throws TargetNotFoundException, InterruptedException;
   }
 
   /**


### PR DESCRIPTION
- Fix looking up a target from the walkable graph.
  - This prevents ConfiguredTargetValueAccessor from needing to look into
    ConfiguredTargetAccessor.
  - And removes duplicated code.
- Move CTVA into the correct package.

Part of #11993.