### PR TITLE
Move getConfigConditions into ConfiguredTarget.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -696,6 +696,7 @@ java_library(
     name = "configured_target",
     srcs = ["ConfiguredTarget.java"],
     deps = [
+        ":config/config_matching_provider",
         ":transitive_info_collection",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/cmdline",

--- a/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/ConfiguredTarget.java
@@ -15,7 +15,9 @@
 package com.google.devtools.build.lib.analysis;
 
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.Artifact.SourceArtifact;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.skyframe.BuildConfigurationValue;
 import javax.annotation.Nullable;
@@ -90,5 +92,13 @@ public interface ConfiguredTarget extends TransitiveInfoCollection, Structure {
    */
   default Label getOriginalLabel() {
     return getLabel();
+  }
+
+  /**
+   * The configuration conditions that trigger this configured target's configurable attributes. For
+   * targets that do not support configurable attributes, this will be an empty map.
+   */
+  default ImmutableMap<Label, ConfigMatchingProvider> getConfigConditions() {
+    return ImmutableMap.of();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -1711,7 +1711,7 @@ public final class RuleContext extends TargetContext
     private final PrerequisiteValidator prerequisiteValidator;
     private final RuleErrorConsumer reporter;
     private OrderedSetMultimap<Attribute, ConfiguredTargetAndData> prerequisiteMap;
-    private ImmutableMap<Label, ConfigMatchingProvider> configConditions;
+    private ImmutableMap<Label, ConfigMatchingProvider> configConditions = ImmutableMap.of();
     private NestedSet<PackageGroupContents> visibility;
     private ImmutableMap<String, Attribute> aspectAttributes;
     private ImmutableList<Aspect> aspects;

--- a/src/main/java/com/google/devtools/build/lib/analysis/TargetCompleteEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/TargetCompleteEvent.java
@@ -183,7 +183,7 @@ public final class TargetCompleteEvent
       AttributeMap attributes =
           ConfiguredAttributeMapper.of(
               (Rule) targetAndData.getTarget(),
-              ((RuleConfiguredTarget) targetAndData.getConfiguredTarget()).getConfigConditions());
+              targetAndData.getConfiguredTarget().getConfigConditions());
       // Every build rule (implicitly) has a "tags" attribute. However other rule configured targets
       // are repository rules (which don't have a tags attribute); morevoer, thanks to the virtual
       // "external" package, they are user visible as targets and can create a completed event as

--- a/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/RuleConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/RuleConfiguredTarget.java
@@ -154,9 +154,8 @@ public final class RuleConfiguredTarget extends AbstractConfiguredTarget {
     }
   }
 
-  /**
-   * The configuration conditions that trigger this rule's configurable attributes.
-   */
+  /** The configuration conditions that trigger this rule's configurable attributes. */
+  @Override
   public ImmutableMap<Label, ConfigMatchingProvider> getConfigConditions() {
     return configConditions;
   }

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/BuildOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/BuildOutputFormatterCallback.java
@@ -14,11 +14,9 @@
 
 package com.google.devtools.build.lib.query2.cquery;
 
-import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.configuredtargets.OutputFileConfiguredTarget;
-import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.ConfiguredAttributeMapper;
@@ -30,7 +28,6 @@ import com.google.devtools.build.lib.query2.query.output.BuildOutputFormatter;
 import com.google.devtools.build.lib.query2.query.output.BuildOutputFormatter.AttributeReader;
 import com.google.devtools.build.lib.query2.query.output.BuildOutputFormatter.TargetOutputter;
 import com.google.devtools.build.lib.query2.query.output.PossibleAttributeValues;
-import com.google.devtools.build.lib.rules.AliasConfiguredTarget;
 import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -77,9 +74,6 @@ class BuildOutputFormatterCallback extends CqueryThreadsafeCallback {
     Rule associatedRule = accessor.getTargetFromConfiguredTarget(ct).getAssociatedRule();
     if (associatedRule == null) {
       return null;
-    } else if (ct instanceof AliasConfiguredTarget) {
-      return ConfiguredAttributeMapper.of(
-          associatedRule, ((AliasConfiguredTarget) ct).getConfigConditions());
     } else if (ct instanceof OutputFileConfiguredTarget) {
       return ConfiguredAttributeMapper.of(
           associatedRule,
@@ -87,9 +81,7 @@ class BuildOutputFormatterCallback extends CqueryThreadsafeCallback {
               .getGeneratingConfiguredTarget((OutputFileConfiguredTarget) ct)
               .getConfigConditions());
     } else {
-      Verify.verify(ct instanceof RuleConfiguredTarget);
-      return ConfiguredAttributeMapper.of(
-          associatedRule, ((RuleConfiguredTarget) ct).getConfigConditions());
+      return ConfiguredAttributeMapper.of(associatedRule, ct.getConfigConditions());
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetAccessor.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetAccessor.java
@@ -124,7 +124,7 @@ public class ConfiguredTargetAccessor implements TargetAccessor<ConfiguredTarget
 
     Rule rule = (Rule) getTargetFromConfiguredTarget(actualConfiguredTarget);
     ImmutableMap<Label, ConfigMatchingProvider> configConditions =
-        ((RuleConfiguredTarget) actualConfiguredTarget).getConfigConditions();
+        actualConfiguredTarget.getConfigConditions();
     ConfiguredAttributeMapper attributeMapper =
         ConfiguredAttributeMapper.of(rule, configConditions);
     if (!attributeMapper.has(attrName)) {

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
@@ -115,7 +115,7 @@ class TransitionsOutputFormatterCallback extends CqueryThreadsafeCallback {
       }
       OrderedSetMultimap<DependencyKind, DependencyKey> deps;
       ImmutableMap<Label, ConfigMatchingProvider> configConditions =
-          ((RuleConfiguredTarget) configuredTarget).getConfigConditions();
+          configuredTarget.getConfigConditions();
 
       // Get a ToolchainContext to use for dependency resolution.
       ToolchainCollection<ToolchainContext> toolchainContexts =

--- a/src/main/java/com/google/devtools/build/lib/rules/AliasConfiguredTarget.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/AliasConfiguredTarget.java
@@ -84,6 +84,7 @@ public final class AliasConfiguredTarget implements ConfiguredTarget, Structure 
     return true; // immutable and Starlark-hashable
   }
 
+  @Override
   public ImmutableMap<Label, ConfigMatchingProvider> getConfigConditions() {
     return configConditions;
   }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/PrintActionCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/PrintActionCommand.java
@@ -28,7 +28,6 @@ import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.FileProvider;
 import com.google.devtools.build.lib.analysis.OutputGroupInfo;
 import com.google.devtools.build.lib.analysis.PrintActionVisitor;
-import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
 import com.google.devtools.build.lib.buildtool.BuildRequest;
 import com.google.devtools.build.lib.buildtool.BuildResult;
 import com.google.devtools.build.lib.buildtool.BuildTool;
@@ -389,7 +388,6 @@ public final class PrintActionCommand implements BlazeCommand {
 
       // C++ header files show up in the dependency on the Target, but not the ConfiguredTarget, so
       // we also check the target's header files there.
-      RuleConfiguredTarget ruleConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
       Rule rule;
       try {
         rule =
@@ -404,7 +402,7 @@ public final class PrintActionCommand implements BlazeCommand {
       }
 
       List<Label> hdrs =
-          ConfiguredAttributeMapper.of(rule, ruleConfiguredTarget.getConfigConditions())
+          ConfiguredAttributeMapper.of(rule, configuredTarget.getConfigConditions())
               .get("hdrs", BuildType.LABEL_LIST);
       if (hdrs != null) {
         for (Label hdrLabel : hdrs) {

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
@@ -1660,8 +1660,7 @@ public abstract class BuildViewTestCase extends FoundationTestCase {
   protected static ConfiguredAttributeMapper getMapperFromConfiguredTargetAndTarget(
       ConfiguredTargetAndData ctad) {
     return ConfiguredAttributeMapper.of(
-        (Rule) ctad.getTarget(),
-        ((RuleConfiguredTarget) ctad.getConfiguredTarget()).getConfigConditions());
+        (Rule) ctad.getTarget(), ctad.getConfiguredTarget().getConfigConditions());
   }
 
   public static Label makeLabel(String label) {


### PR DESCRIPTION
Uses a default value for non-alias and non-rule CTs.

This alloows removing many instanceof/cast checks when getting config
conditions.

Part of the work on #11993.