### PR TITLE
Separate ijar sources from deployment zip.

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -676,7 +676,6 @@ JAVA_VERSIONS = ("11",)
             ":jars_java_tools_java" + java_version + ".zip",
             "//src/tools/singlejar:singlejar_transitive_zip",
             "//third_party/ijar:ijar_transitive_zip",
-            "//third_party/ijar:ijar_deploy_zip",
             "//third_party/java/jacoco:jacoco_jars_zip",
             "//third_party/java/proguard:proguard_zip",
         ],

--- a/src/BUILD
+++ b/src/BUILD
@@ -676,6 +676,7 @@ JAVA_VERSIONS = ("11",)
             ":jars_java_tools_java" + java_version + ".zip",
             "//src/tools/singlejar:singlejar_transitive_zip",
             "//third_party/ijar:ijar_transitive_zip",
+            "//third_party/ijar:ijar_deploy_zip",
             "//third_party/java/jacoco:jacoco_jars_zip",
             "//third_party/java/proguard:proguard_zip",
         ],

--- a/third_party/ijar/BUILD
+++ b/third_party/ijar/BUILD
@@ -136,14 +136,23 @@ genrule(
 )
 
 genrule(
+    name = "ijar_deploy_zip",
+    srcs = [
+        ":ijar",
+        ":zipper",
+    ],
+    outs = ["ijar_deploy.zip"],
+    cmd = "$(location //src:zip_files) ijar $@ $(SRCS)",
+    tools = ["//src:zip_files"],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
     name = "ijar_srcs_zip",
     srcs = glob(
         ["**"],
         exclude = ["BUILD"],
-    ) + [
-        ":ijar",
-        ":zipper",
-    ],
+    ),
     outs = ["ijar_srcs.zip"],
     cmd = "$(location //src:zip_files) ijar $@ $(SRCS)",
     tools = ["//src:zip_files"],

--- a/third_party/ijar/BUILD
+++ b/third_party/ijar/BUILD
@@ -130,7 +130,7 @@ genrule(
         "//src:zlib_zip",
         "//src/main/cpp/util:cpp_util_with_deps_zip",
     ],
-    outs = ["ijar_srcs_with_deps.zip"],
+    outs = ["ijar_with_deps.zip"],
     cmd = "$(location //src:merge_zip_files) - $@ $(SRCS)",
     tools = ["//src:merge_zip_files"],
     visibility = ["//visibility:public"],

--- a/third_party/ijar/BUILD
+++ b/third_party/ijar/BUILD
@@ -126,6 +126,20 @@ genrule(
     name = "ijar_transitive_zip",
     srcs = [
         ":ijar_srcs_zip",
+        ":ijar_deploy_zip",
+        "//src:zlib_zip",
+        "//src/main/cpp/util:cpp_util_with_deps_zip",
+    ],
+    outs = ["ijar_srcs_with_deps.zip"],
+    cmd = "$(location //src:merge_zip_files) - $@ $(SRCS)",
+    tools = ["//src:merge_zip_files"],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "ijar_transitive_srcs_zip",
+    srcs = [
+        ":ijar_srcs_zip",
         "//src:zlib_zip",
         "//src/main/cpp/util:cpp_util_with_deps_zip",
     ],


### PR DESCRIPTION
This is a github only patch from PR https://github.com/bazelbuild/bazel/pull/12546. Needs to go in first.