### PR TITLE
Fix a couple of bugs with Incompatible Target Skipping

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java
@@ -54,6 +54,7 @@ import com.google.devtools.build.lib.analysis.config.FragmentCollection;
 import com.google.devtools.build.lib.analysis.config.transitions.ConfigurationTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.NoTransition;
 import com.google.devtools.build.lib.analysis.constraints.ConstraintSemantics;
+import com.google.devtools.build.lib.analysis.constraints.RuleContextConstraintSemantics;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.analysis.stringtemplate.TemplateContext;
@@ -2306,6 +2307,14 @@ public final class RuleContext extends TargetContext
 
     private void validateDirectPrerequisite(
         Attribute attribute, ConfiguredTargetAndData prerequisite) {
+      if (RuleContextConstraintSemantics.checkForIncompatibility(prerequisite.getConfiguredTarget())
+          .isIncompatible()) {
+        // If the prerequisite is incompatible (e.g. has an incompatible provider), we pretend that
+        // there is no further validation needed. Otherwise, it would be difficult to make the
+        // incompatible target satisfy things like required providers and file extensions.
+        return;
+      }
+
       validateDirectPrerequisiteType(prerequisite, attribute);
       validateDirectPrerequisiteFileTypes(prerequisite, attribute);
       if (attribute.performPrereqValidatorCheck()) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/RuleContextConstraintSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/RuleContextConstraintSemantics.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.analysis.constraints;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Streams.stream;
 
+import com.google.auto.value.AutoValue;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
@@ -831,6 +832,45 @@ public class RuleContextConstraintSemantics implements ConstraintSemantics<RuleC
   }
 
   /**
+   * Provides information about a target's incompatibility.
+   *
+   * <p>After calling {@code checkForIncompatibility()}, the {@code isIncompatible} getter tells you
+   * whether the target is incompatible. If the target is incompatible, then {@code
+   * underlyingTarget} tells you which underlying target provided the incompatibility. For the vast
+   * majority of targets this is the same one passed to {@code checkForIncompatibility()}. In some
+   * instances like {@link OutputFileConfiguredTarget}, however, the {@code underlyingTarget} is the
+   * rule that generated the file.
+   */
+  @AutoValue
+  public abstract static class IncompatibleCheckResult {
+    private static IncompatibleCheckResult create(
+        boolean isIncompatible, ConfiguredTarget underlyingTarget) {
+      return new AutoValue_RuleContextConstraintSemantics_IncompatibleCheckResult(
+          isIncompatible, underlyingTarget);
+    }
+
+    public abstract boolean isIncompatible();
+
+    public abstract ConfiguredTarget underlyingTarget();
+  };
+
+  /**
+   * Checks whether the target is incompatible.
+   *
+   * <p>See the documentation for {@link RuleContextConstraintSemantics.IncompatibleCheckResult} for
+   * more information.
+   */
+  public static IncompatibleCheckResult checkForIncompatibility(ConfiguredTarget target) {
+    if (target instanceof OutputFileConfiguredTarget) {
+      // For generated files, we want to query the generating rule for providers. genrule() for
+      // example doesn't attach providers like IncompatiblePlatformProvider to its outputs.
+      target = ((OutputFileConfiguredTarget) target).getGeneratingRule();
+    }
+    return IncompatibleCheckResult.create(
+        target.getProvider(IncompatiblePlatformProvider.class) != null, target);
+  }
+
+  /**
    * Creates an incompatible {@link ConfiguredTarget} if the corresponding rule is incompatible.
    *
    * <p>Returns null if the target is not incompatible.
@@ -870,22 +910,12 @@ public class RuleContextConstraintSemantics implements ConstraintSemantics<RuleC
     }
 
     // This is incompatible if one of the dependencies is as well.
-    ImmutableList.Builder<ConfiguredTarget> incompatibleDependenciesBuilder =
-        ImmutableList.builder();
-    for (ConfiguredTargetAndData infoCollection : prerequisiteMap.values()) {
-      ConfiguredTarget dependency = infoCollection.getConfiguredTarget();
-      if (dependency instanceof OutputFileConfiguredTarget) {
-        // For generated files, we want to query the generating rule for providers. genrule() for
-        // example doesn't attach providers like IncompatiblePlatformProvider to its outputs.
-        dependency = ((OutputFileConfiguredTarget) dependency).getGeneratingRule();
-      }
-      if (dependency.getProvider(IncompatiblePlatformProvider.class) != null) {
-        incompatibleDependenciesBuilder.add(dependency);
-      }
-    }
-
     ImmutableList<ConfiguredTarget> incompatibleDependencies =
-        incompatibleDependenciesBuilder.build();
+        stream(prerequisiteMap.values())
+            .map(value -> checkForIncompatibility(value.getConfiguredTarget()))
+            .filter(result -> result.isIncompatible())
+            .map(result -> result.underlyingTarget())
+            .collect(toImmutableList());
     if (!incompatibleDependencies.isEmpty()) {
       return createIncompatibleConfiguredTarget(ruleContext, incompatibleDependencies, null);
     }
@@ -987,7 +1017,7 @@ public class RuleContextConstraintSemantics implements ConstraintSemantics<RuleC
           new FailAction(
               ruleContext.getActionOwner(),
               outputArtifacts,
-              "Can't build this. This target is incompatible.",
+              "Can't build this. This target is incompatible. Please file a bug upstream.",
               Code.CANT_BUILD_INCOMPATIBLE_TARGET));
     }
     return builder.build();

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/TopLevelConstraintSemantics.java
@@ -123,11 +123,11 @@ public class TopLevelConstraintSemantics {
     ImmutableSet.Builder<ConfiguredTarget> incompatibleButRequestedTargets = ImmutableSet.builder();
 
     for (ConfiguredTarget target : topLevelTargets) {
-      IncompatiblePlatformProvider incompatibleProvider =
-          target.getProvider(IncompatiblePlatformProvider.class);
+      RuleContextConstraintSemantics.IncompatibleCheckResult result =
+          RuleContextConstraintSemantics.checkForIncompatibility(target);
 
       // Move on to the next target if this one is compatible.
-      if (incompatibleProvider == null) {
+      if (!result.isIncompatible()) {
         continue;
       }
 
@@ -143,7 +143,9 @@ public class TopLevelConstraintSemantics {
               String.format(
                   TARGET_INCOMPATIBLE_ERROR_TEMPLATE,
                   target.getLabel().toString(),
-                  reportOnIncompatibility(target));
+                  // We need access to the provider so we pass in the underlying target here that is
+                  // responsible for the incompatibility.
+                  reportOnIncompatibility(result.underlyingTarget()));
           throw new ViewCreationFailedException(
               targetIncompatibleMessage,
               FailureDetail.newBuilder()


### PR DESCRIPTION
While adding `target_compatible_with` attributes in the FRC team 971's
code base I came across bug #12553. It wasn't possible to make a
Python target depend on another incompatible Python target.

This patch fixes that issue by teaching `RuleContext` about
incompatible prerequisites. This also fixes an issue with the
validation of file extensions.

It's possible that `validateDirectPrerequisite()` skips a bit too much
validation. It was unfortunately the cleanest way I could think of.

I struggled a bit to come up with what ended up becoming
`RuleContextConstraintSemantics.IncompatibleCheckResult`. The purpose
of that class is to centralize the logic for checking for
`OutputFileConfiguredTarget` dependencies. Such dependencies need a
bit of special logic in order to find `IncompatiblePlatformProvider`
instances. When I implemented this patch, I realized that the
`TopLevelConstraintSemantics` logic had a very similar problem. It
didn't deal with the `OutputFileConfiguredTarget` problem at all. I
took the liberty of fixing that issue in this patch also because it
nicely re-used the same new helper.

I could not figure out a good way to avoid making `RuleContext` depend
on `RuleContextConstraintSemantics`.

Fixes #12553