### PR TITLE
Use write result for pid done signal

### DIFF
--- a/src/main/tools/daemonize.c
+++ b/src/main/tools/daemonize.c
@@ -39,6 +39,7 @@
 
 #include <assert.h>
 #include <err.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
 #include <inttypes.h>
@@ -95,6 +96,9 @@ static void WritePidFile(pid_t pid, const char* pid_path, int pid_done_fd) {
   int ret = 0;
   while (ret == 0) {
     ret = write(pid_done_fd, &dummy, sizeof(dummy));
+    if (ret == -1 && errno == EINTR) {
+      ret = 0;
+    }
   }
   if (ret != 1) {
     err(EXIT_FAILURE, "Failed to signal pid done");

--- a/src/main/tools/daemonize.c
+++ b/src/main/tools/daemonize.c
@@ -92,7 +92,13 @@ static void WritePidFile(pid_t pid, const char* pid_path, int pid_done_fd) {
   fclose(pid_file);
 
   char dummy = '\0';
-  write(pid_done_fd, &dummy, sizeof(dummy));
+  int ret = 0;
+  while (ret == 0) {
+    ret = write(pid_done_fd, &dummy, sizeof(dummy));
+  }
+  if (ret != 1) {
+    err(EXIT_FAILURE, "Failed to signal pid done");
+  }
   close(pid_done_fd);
 }
 


### PR DESCRIPTION
Prevent warnings during build for a signal write to indicate that the
pid file has been created. This is a warning under -Wunused-result on
linux.