### PR TITLE
Include the product version as an alias when generating xcode_version targets

### DIFF
--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -74,7 +74,7 @@ def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir)
     build_contents += "xcode_version(\n  name = '%s'," % name
     build_contents += "\n  version = '%s'," % version
     if aliases:
-        build_contents += "\n  aliases = [%s]," % " ,".join(decorated_aliases)
+        build_contents += "\n  aliases = [%s]," % ", ".join(decorated_aliases)
     if ios_sdk_version:
         build_contents += "\n  default_ios_sdk_version = '%s'," % ios_sdk_version
     if tvos_sdk_version:
@@ -231,7 +231,7 @@ def _darwin_build_file(repository_ctx):
         if (version.startswith(default_xcode_version) and
             version.endswith(default_xcode_build_version)):
             default_xcode_target = target_label
-    buildcontents += "xcode_config(name = 'host_xcodes',"
+    buildcontents += "xcode_config(\n  name = 'host_xcodes',"
     if target_names:
         buildcontents += "\n  versions = [%s]," % ", ".join(target_names)
     if not default_xcode_target and target_names:
@@ -242,7 +242,7 @@ def _darwin_build_file(repository_ctx):
         buildcontents += "\n  default = %s," % default_xcode_target
 
     buildcontents += "\n)\n"
-    buildcontents += "available_xcodes(name = 'host_available_xcodes',"
+    buildcontents += "available_xcodes(\n  name = 'host_available_xcodes',"
     if target_names:
         buildcontents += "\n  versions = [%s]," % ", ".join(target_names)
     if default_xcode_target:

--- a/tools/osx/xcode_locator.m
+++ b/tools/osx/xcode_locator.m
@@ -80,8 +80,8 @@ static void AddEntryToDictionary(
     subversion = [subversion substringToIndex:range.location];
     XcodeVersionEntry *subversionEntry = dict[subversion];
     if (subversionEntry) {
-      BOOL atLeastAsLarge = ([subversionEntry.version compare:entry.version]
-                             == NSOrderedDescending);
+      BOOL atLeastAsLarge = ([subversionEntry.version compare:entry.version
+                                                      options:NSNumericSearch] != NSOrderedDescending);
       if (inApplications && atLeastAsLarge) {
         dict[subversion] = entry;
       }

--- a/tools/osx/xcode_locator.m
+++ b/tools/osx/xcode_locator.m
@@ -32,14 +32,16 @@
 // to the appplication.
 @interface XcodeVersionEntry : NSObject
 @property(readonly) NSString *version;
+@property(readonly) NSString *productVersion;
 @property(readonly) NSURL *url;
 @end
 
 @implementation XcodeVersionEntry
 
-- (id)initWithVersion:(NSString *)version url:(NSURL *)url {
+- (id)initWithVersion:(NSString *)version productVersion:(NSString *)productVersion url:(NSURL *)url {
   if ((self = [super init])) {
     _version = version;
+    _productVersion = productVersion;
     _url = url;
   }
   return self;
@@ -67,11 +69,15 @@ static void AddEntryToDictionary(
   NSMutableDictionary<NSString *, XcodeVersionEntry *> *dict) {
   BOOL inApplications = [entry.url.path hasPrefix:@"/Applications/"];
   NSString *entryVersion = entry.version;
+  NSString *entryProductVersion = entry.productVersion;
   NSString *subversion = entryVersion;
   if (dict[entryVersion] && !inApplications) {
     return;
   }
   dict[entryVersion] = entry;
+  if (entryProductVersion) {
+    dict[entryProductVersion] = entry;
+  }
   while (YES) {
     NSRange range = [subversion rangeOfString:@"." options:NSBackwardsSearch];
     if (range.length == 0 || range.location == 0) {
@@ -187,6 +193,7 @@ static NSMutableDictionary<NSString *, XcodeVersionEntry *> *FindXcodes()
         [url URLByAppendingPathComponent:@"Contents/Developer"];
     XcodeVersionEntry *entry =
         [[XcodeVersionEntry alloc] initWithVersion:expandedVersion
+                                    productVersion:productVersion
                                                url:developerDir];
     AddEntryToDictionary(entry, dict);
   }


### PR DESCRIPTION
This allows passing `--xcode_version=$XCODE_PRODUCT_BUILD_VERSION` in the context of an Xcode shell script build phase