### PR TITLE
Let --remote_download_symlink_template use hard links

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -469,19 +469,19 @@ public final class RemoteOptions extends OptionsBase {
   public boolean remoteVerifyDownloads;
 
   @Option(
-      name = "remote_download_symlink_template",
+      name = "remote_download_hard_link_template",
       defaultValue = "",
       category = "remote",
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
-          "Instead of downloading remote build outputs to the local machine, create symbolic "
-              + "links. The target of the symbolic links can be specified in the form of a "
+          "Instead of downloading remote build outputs to the local machine, create hard "
+              + "links. The target of the hard links can be specified in the form of a "
               + "template string. This template string may contain {hash} and {size_bytes} that "
               + "expand to the hash of the object and the size in bytes, respectively. "
-              + "These symbolic links may, for example, point to a FUSE file system "
+              + "These hard links may, for example, be stored in a FUSE file system "
               + "that loads objects from the CAS on demand.")
-  public String remoteDownloadSymlinkTemplate;
+  public String remoteDownloadHardLinkTemplate;
 
   // The below options are not configurable by users, only tests.
   // This is part of the effort to reduce the overall number of flags.


### PR DESCRIPTION
In an attempt to achieve 'Builds without the Bytes' without losing
access to build outputs, I am experimenting with a FUSE file system that
gives access to objects stored in the CAS. In PR #11703, I added a
command line flag to let Bazel emit symbolic links pointing into this
FUSE file system, as opposed to downloading files into the exec root.

Though this change has allowed me to get quite a lot of stuff working,
there are also many build actions that break. For example, Python calls
realpath(argv[0]) to figure out its installation path. Because the FUSE
file system does not mimic the execroot, Python won't be able to find
its site packages. Similar problems hold with shared library resolution
in general.

This is why I think the only proper way we can get this to work is by
using hard links instead of symbolic links. That way the usual file
hierarchy remains intact. This change renames the
--remote_download_symlink_template flag to
--remote_download_hard_link_template and changes the code to create hard
links instead.

When used in combination with --exec_root_base (#12558), it's now
possible to let Bazel construct an exec root that does not have any
additional indirection through symbolic links, thereby keeping programs
that do symlink expansion happy.