### PR TITLE
Starlark: faster str(int)

### DIFF
--- a/src/main/java/net/starlark/java/eval/Printer.java
+++ b/src/main/java/net/starlark/java/eval/Printer.java
@@ -64,6 +64,18 @@ public class Printer {
     return this;
   }
 
+  /** Appends an integer to the printer's buffer */
+  public final Printer append(int i) {
+    buffer.append(i);
+    return this;
+  }
+
+  /** Appends a long integer to the printer's buffer */
+  public final Printer append(long l) {
+    buffer.append(l);
+    return this;
+  }
+
   /**
    * Appends a list to the printer's buffer. List elements are rendered with {@code repr}.
    *

--- a/src/main/java/net/starlark/java/eval/StarlarkInt.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkInt.java
@@ -204,6 +204,11 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
     }
 
     @Override
+    public void repr(Printer printer) {
+      printer.append(v);
+    }
+
+    @Override
     public int hashCode() {
       return 0x316c5239 * Integer.hashCode(v) ^ 0x67c4a7d5;
     }
@@ -249,6 +254,11 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
     }
 
     @Override
+    public void repr(Printer printer) {
+      printer.append(v);
+    }
+
+    @Override
     public int hashCode() {
       return 0x67c4a7d5 * Long.hashCode(v) ^ 0xee914a1b;
     }
@@ -284,6 +294,11 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
     }
 
     @Override
+    public void repr(Printer printer) {
+      printer.append(v.toString());
+    }
+
+    @Override
     public int hashCode() {
       return 0xee914a1b * v.hashCode() ^ 0x6406918f;
     }
@@ -314,9 +329,7 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
   }
 
   @Override
-  public void repr(Printer printer) {
-    printer.append(toString());
-  }
+  public abstract void repr(Printer printer);
 
   /** Returns the signed int32 value of this StarlarkInt, or fails if not exactly representable. */
   public int toInt(String what) throws EvalException {


### PR DESCRIPTION
For this benchmark:

```
def test():
    for x in range(30000000):
        str(17)

test()
```

```
A: n=40 mean=4.992 std=0.231 se=0.036 min=4.725 med=4.923
B: n=40 mean=4.684 std=0.235 se=0.037 min=4.447 med=4.606
B/A: 0.938 0.918..0.959 (95% conf)
```

`str.format` and `str %` should also be a little faster for integer
arguments.