### PR TITLE
Migrate some uses of NestedSet#forEachElement to NestedSetVisitor

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSetVisitor.java
+++ b/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSetVisitor.java
@@ -40,6 +40,20 @@ public final class NestedSetVisitor<E> {
     void accept(E arg);
   }
 
+  /**
+   * Transitively visit a nested set.
+   *
+   * @param nestedSet The {@link NestedSet} to traverse.
+   * @param callback A function called for each element in the {@link NestedSet}.
+   * @param <T>
+   * @throws InterruptedException
+   */
+  public static <T> void traverseNestedSet(NestedSet<T> nestedSet, Receiver<T> callback)
+      throws InterruptedException {
+    NestedSetVisitor<T> visitor = new NestedSetVisitor<>(callback, new VisitedState<>());
+    visitor.visit(nestedSet);
+  }
+
   private final Receiver<E> callback;
 
   private final VisitedState<E> visited;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
@@ -63,6 +63,7 @@ import com.google.devtools.build.lib.causes.LoadingFailedCause;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetVisitor;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventKind;
@@ -1096,10 +1097,11 @@ public final class ConfiguredTargetFunction implements SkyFunction {
             .build());
   }
 
-  static DetailedExitCode getPrioritizedDetailedExitCode(NestedSet<Cause> causes) {
+  static DetailedExitCode getPrioritizedDetailedExitCode(NestedSet<Cause> causes)
+      throws InterruptedException {
     DetailedExitCode[] prioritizedDetailedExitCodeWrapper = {null};
-    causes.forEachElement(
-        o -> true,
+    NestedSetVisitor.traverseNestedSet(
+        causes,
         c ->
             prioritizedDetailedExitCodeWrapper[0] =
                 DetailedExitCodeComparator.chooseMoreImportantWithFirstIfTie(

--- a/src/test/java/com/google/devtools/build/lib/analysis/TargetCompleteEventTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/TargetCompleteEventTest.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.buildeventstream.BuildEvent.LocalFile.Local
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos.File;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetVisitor;
 import com.google.devtools.build.lib.skyframe.ConfiguredTargetAndData;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -102,8 +103,8 @@ public class TargetCompleteEventTest extends AnalysisTestCase {
     ArrayList<File> fileProtos = new ArrayList<>();
     ReportedArtifacts reportedArtifacts = event.reportedArtifacts();
     for (NestedSet<Artifact> artifactSet : reportedArtifacts.artifacts) {
-      artifactSet.forEachElement(
-          o -> true,
+      NestedSetVisitor.traverseNestedSet(
+          artifactSet,
           a -> fileProtos.add(newFileFromArtifact(null, a, PathFragment.EMPTY_FRAGMENT).build()));
     }
     // Bytes are the same but the encoding is actually UTF-8 as required of a protobuf string.


### PR DESCRIPTION
These were the only 2 uses of NestedSet#forEachElement in Bazel.

No functional change intended.