### PR TITLE
Add toolchain definitions for Java.

### DIFF
--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -38,7 +38,7 @@ _BAZEL_ARGS="--spawn_strategy=standalone \
       --distdir=derived/distdir \
       --java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \
       --host_java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \
-      --extra_toolchains=//src/java_tools/buildjar:bootstrap_toolchain_toolchain \
+      --extra_toolchains=//src/java_tools/buildjar:bootstrap_toolchain_definition \
       ${DIST_BOOTSTRAP_ARGS:-} \
       ${EXTRA_BAZEL_ARGS:-}"
 

--- a/scripts/bootstrap/bootstrap.sh
+++ b/scripts/bootstrap/bootstrap.sh
@@ -38,6 +38,7 @@ _BAZEL_ARGS="--spawn_strategy=standalone \
       --distdir=derived/distdir \
       --java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \
       --host_java_toolchain=//src/java_tools/buildjar:bootstrap_toolchain \
+      --extra_toolchains=//src/java_tools/buildjar:bootstrap_toolchain_toolchain \
       ${DIST_BOOTSTRAP_ARGS:-} \
       ${EXTRA_BAZEL_ARGS:-}"
 

--- a/src/java_tools/buildjar/BUILD
+++ b/src/java_tools/buildjar/BUILD
@@ -1,4 +1,5 @@
-load("@rules_java//java:defs.bzl", "java_binary", "java_toolchain")
+load("@rules_java//java:defs.bzl", "java_binary")
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
 
 # Description:
 # JavaBuilder and java tools used by Bazel
@@ -55,7 +56,7 @@ filegroup(
 )
 
 # This toolchain is used to bootstrap Bazel.
-java_toolchain(
+default_java_toolchain(
     name = "bootstrap_toolchain",
     bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath.jar"],
     genclass = ["bootstrap_genclass_deploy.jar"],

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/jdk.WORKSPACE
@@ -1,9 +1,11 @@
 # External dependencies for the java_* rules.
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_tools//tools/jdk:local_java_repository.bzl", "local_java_repository")
+load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
 
-local_java_repository(
+maybe(
+    local_java_repository,
     name = "local_jdk",
     java_home = DEFAULT_SYSTEM_JAVABASE,
 )
@@ -16,147 +18,195 @@ local_java_repository(
 
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
-    http_archive,
+    remote_java_repository,
     name = "remotejdk11_linux",
-    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
     sha256 = "360626cc19063bc411bfed2914301b908a8f77a7919aaea007a977fa8fb3cde1",
     strip_prefix = "zulu11.37.17-ca-jdk11.0.6-linux_x64",
     urls = [
         "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz",
     ],
+    version = "11",
 )
 
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
-    http_archive,
+    remote_java_repository,
     name = "remotejdk11_linux_aarch64",
-    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
     sha256 = "a452f1b9682d9f83c1c14e54d1446e1c51b5173a3a05dcb013d380f9508562e4",
     strip_prefix = "zulu11.37.48-ca-jdk11.0.6-linux_aarch64",
     urls = [
         "https://mirror.bazel.build/openjdk/azul-zulu11.37.48-ca-jdk11.0.6/zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz",
     ],
+    version = "11",
 )
 
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
-    http_archive,
+    remote_java_repository,
     name = "remotejdk11_linux_ppc64le",
-    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:ppc",
+    ],
     sha256 = "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
     strip_prefix = "jdk-11.0.7+10",
     urls = [
         "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
         "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
     ],
+    version = "11",
 )
 
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
-    http_archive,
+    remote_java_repository,
     name = "remotejdk11_linux_s390x",
-    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:s390x",
+    ],
     sha256 = "d9b72e87a1d3ebc0c9552f72ae5eb150fffc0298a7cb841f1ce7bfc70dcd1059",
     strip_prefix = "jdk-11.0.7+10",
     urls = [
         "https://mirror.bazel.build/github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz",
         "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz",
     ],
+    version = "11",
 )
 
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
-    http_archive,
+    remote_java_repository,
     name = "remotejdk11_macos",
-    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
     sha256 = "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",
     strip_prefix = "zulu11.37.17-ca-jdk11.0.6-macosx_x64",
     urls = [
         "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz",
     ],
+    version = "11",
 )
 
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
-    http_archive,
+    remote_java_repository,
     name = "remotejdk11_win",
-    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
+    exec_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
     sha256 = "a9695617b8374bfa171f166951214965b1d1d08f43218db9a2a780b71c665c18",
     strip_prefix = "zulu11.37.17-ca-jdk11.0.6-win_x64",
     urls = [
         "https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64.zip",
     ],
+    version = "11",
 )
 
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
-    http_archive,
+    remote_java_repository,
     name = "remotejdk14_linux",
-    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
     sha256 = "48bb8947034cd079ad1ef83335e7634db4b12a26743a0dc314b6b861480777aa",
     strip_prefix = "zulu14.28.21-ca-jdk14.0.1-linux_x64",
     urls = [
         "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-linux_x64.tar.gz",
     ],
+    version = "14",
 )
 
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
-    http_archive,
+    remote_java_repository,
     name = "remotejdk14_macos",
-    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
     sha256 = "088bd4d0890acc9f032b738283bf0f26b2a55c50b02d1c8a12c451d8ddf080dd",
     strip_prefix = "zulu14.28.21-ca-jdk14.0.1-macosx_x64",
     urls = ["https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-macosx_x64.tar.gz"],
+    version = "14",
 )
 
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
-    http_archive,
+    remote_java_repository,
     name = "remotejdk14_win",
-    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
+    exec_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
     sha256 = "9cb078b5026a900d61239c866161f0d9558ec759aa15c5b4c7e905370e868284",
     strip_prefix = "zulu14.28.21-ca-jdk14.0.1-win_x64",
     urls = ["https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-win_x64.zip"],
+    version = "14",
 )
 
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
-    http_archive,
+    remote_java_repository,
     name = "remotejdk15_linux",
-    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
-    strip_prefix = "zulu15.27.17-ca-jdk15.0.0-linux_x64",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
     sha256 = "0a38f1138c15a4f243b75eb82f8ef40855afcc402e3c2a6de97ce8235011b1ad",
+    strip_prefix = "zulu15.27.17-ca-jdk15.0.0-linux_x64",
     urls = [
         "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz",
-        "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz"
+        "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz",
     ],
+    version = "15",
 )
 
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
-    http_archive,
+    remote_java_repository,
     name = "remotejdk15_macos",
-    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
-    strip_prefix = "zulu15.27.17-ca-jdk15.0.0-macosx_x64",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
     sha256 = "f80b2e0512d9d8a92be24497334c974bfecc8c898fc215ce0e76594f00437482",
+    strip_prefix = "zulu15.27.17-ca-jdk15.0.0-macosx_x64",
     urls = [
         "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-macosx_x64.tar.gz",
         "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-macosx_x64.tar.gz",
     ],
+    version = "15",
 )
 
 # This must be kept in sync with the top-level WORKSPACE file.
 maybe(
-    http_archive,
+    remote_java_repository,
     name = "remotejdk15_win",
-    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
-    strip_prefix = "zulu15.27.17-ca-jdk15.0.0-win_x64",
+    exec_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
     sha256 = "f535a530151e6c20de8a3078057e332b08887cb3ba1a4735717357e72765cad6",
+    strip_prefix = "zulu15.27.17-ca-jdk15.0.0-win_x64",
     urls = [
         "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-win_x64.zip",
-        "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-win_x64.zip"
+        "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-win_x64.zip",
     ],
+    version = "15",
 )
 
 # This must be kept in sync with the top-level WORKSPACE file.

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -612,7 +612,7 @@ public class JavaOptions extends FragmentOptions {
 
   @Option(
       name = "java_runtime_version",
-      defaultValue = "",
+      defaultValue = "local_jdk",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "The Java runtime version")
@@ -620,7 +620,7 @@ public class JavaOptions extends FragmentOptions {
 
   @Option(
       name = "tool_java_runtime_version",
-      defaultValue = "",
+      defaultValue = "remotejdk_11",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "The Java runtime version used to execute tools during the build")

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -628,7 +628,7 @@ public class JavaOptions extends FragmentOptions {
 
   @Option(
       name = "java_language_version",
-      defaultValue = "",
+      defaultValue = "8",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "The Java language version")
@@ -636,7 +636,7 @@ public class JavaOptions extends FragmentOptions {
 
   @Option(
       name = "tool_java_language_version",
-      defaultValue = "",
+      defaultValue = "8",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help = "The Java language version used to build tools that are executed during a build")

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -434,6 +434,10 @@ public final class BazelAnalysisMock extends AnalysisMock {
         "bazel_tools_workspace/tools/jdk/local_java_repository.bzl",
         "def local_java_repository(**kwargs):",
         "  pass");
+    config.create(
+        "bazel_tools_workspace/tools/jdk/remote_java_repository.bzl",
+        "def remote_java_repository(**kwargs):",
+        "  pass");
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
@@ -261,6 +261,10 @@ public abstract class BuildViewTestCase extends FoundationTestCase {
         "bazel_tools_workspace/tools/jdk/local_java_repository.bzl",
         "def local_java_repository(**kwargs):",
         "  pass");
+    mockToolsConfig.create(
+        "bazel_tools_workspace/tools/jdk/remote_java_repository.bzl",
+        "def remote_java_repository(**kwargs):",
+        "  pass");
     initializeMockClient();
 
     packageOptions = parsePackageOptions();

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/ConfigurationTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/ConfigurationTestCase.java
@@ -126,6 +126,10 @@ public abstract class ConfigurationTestCase extends FoundationTestCase {
         "bazel_tools_workspace/tools/jdk/local_java_repository.bzl",
         "def local_java_repository(**kwargs):",
         "  pass");
+    mockToolsConfig.create(
+        "bazel_tools_workspace/tools/jdk/remote_java_repository.bzl",
+        "def remote_java_repository(**kwargs):",
+        "  pass");
 
     analysisMock.setupMockClient(mockToolsConfig);
     analysisMock.setupMockWorkspaceFiles(directories.getEmbeddedBinariesRoot());

--- a/src/test/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoaderTest.java
@@ -97,6 +97,10 @@ public final class BazelPackageLoaderTest extends AbstractPackageLoaderTest {
         tools.getRelative("tools/jdk/local_java_repository.bzl"),
         "def local_java_repository(**kwargs):",
         "  pass");
+    FileSystemUtils.writeIsoLatin1(
+        tools.getRelative("tools/jdk/remote_java_repository.bzl"),
+        "def remote_java_repository(**kwargs):",
+        "  pass");
   }
 
   private void fetchExternalRepo(RepositoryName externalRepo) {

--- a/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
+++ b/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh
@@ -102,7 +102,7 @@ function test_bootstrap() {
 
     JAVABASE=$(echo reduced*)
 
-    env EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" ./compile.sh \
+    env EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk --tool_java_runtime_version=local_jdk" ./compile.sh \
         || fail "Expected to be able to bootstrap bazel"
     ./output/bazel \
       --server_javabase=$JAVABASE --host_jvm_args=--add-opens=java.base/java.nio=ALL-UNNAMED \

--- a/src/test/shell/bazel/bazel_java14_test.sh
+++ b/src/test/shell/bazel/bazel_java14_test.sh
@@ -125,7 +125,8 @@ public class Javac14Example {
   }
 }
 EOF
-  bazel run java/main:Javac14Example --test_output=all --verbose_failures &>"${TEST_log}"
+  # TODO(ilist): remove tool_java_runtime_version after java_runtime is attached to the toolchain
+  bazel run java/main:Javac14Example --java_language_version=14 --java_runtime_version=14 --tool_java_runtime_version=14 --test_output=all --verbose_failures &>"${TEST_log}"
   expect_log "0"
 }
 

--- a/src/test/shell/bazel/bazel_java15_test.sh
+++ b/src/test/shell/bazel/bazel_java15_test.sh
@@ -125,7 +125,8 @@ public class Javac15Example {
   }
 }
 EOF
-  bazel run java/main:Javac15Example --test_output=all --verbose_failures &>"${TEST_log}"
+  # TODO(ilist): remove tool_java_runtime_version after java_runtime is attached to the toolchain
+  bazel run java/main:Javac15Example --java_language_version=15 --java_runtime_version=15 --tool_java_runtime_version=15 --test_output=all --verbose_failures &>"${TEST_log}"
   expect_log "^Hello,\$"
   expect_log "^World\$"
 }

--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -87,7 +87,7 @@ EOF
       --java_toolchain=//java/main:default_toolchain \
       --javabase=@bazel_tools//tools/jdk:remote_jdk11 \
       --java_runtime_version=11 \
-      --extra_toolchains=//java/main:default_toolchain_toolchain \
+      --extra_toolchains=//java/main:default_toolchain_definition \
       --verbose_failures -s &>"${TEST_log}" \
       || fail "Building with //java/main:default_toolchain failed"
   expect_log "Successfully executed JavaBinary!"

--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -86,6 +86,8 @@ EOF
   bazel run java/main:JavaBinary \
       --java_toolchain=//java/main:default_toolchain \
       --javabase=@bazel_tools//tools/jdk:remote_jdk11 \
+      --java_runtime_version=11 \
+      --extra_toolchains=//java/main:default_toolchain_toolchain \
       --verbose_failures -s &>"${TEST_log}" \
       || fail "Building with //java/main:default_toolchain failed"
   expect_log "Successfully executed JavaBinary!"
@@ -115,6 +117,8 @@ EOF
   bazel run java/main:JavaBinary \
       --java_toolchain=@bazel_tools//tools/jdk:toolchain_java11 \
       --javabase=@bazel_tools//tools/jdk:remote_jdk11 \
+      --java_language_version=11 \
+      --java_runtime_version=11 \
       --verbose_failures -s &>"${TEST_log}" \
       || fail "Building with @bazel_tools//tools/jdk:toolchain_java11 failed"
   expect_log "strip_trailing_java11"

--- a/src/test/shell/integration/bazel_java_test.sh
+++ b/src/test/shell/integration/bazel_java_test.sh
@@ -125,7 +125,7 @@ public class HelloWorld {}
 EOF
 
   # Check that the RHS javabase appears in the launcher.
-  bazel build --java_toolchain=//:toolchain --javabase=@javabase//:jdk --extra_toolchains=//:toolchain_toolchain --java_runtime_version=javabase //java:javabin
+  bazel build --java_toolchain=//:toolchain --javabase=@javabase//:jdk --extra_toolchains=//:toolchain_definition --java_runtime_version=javabase //java:javabin
   cat bazel-bin/java/javabin >& $TEST_log
   expect_log "JAVABIN=.*/javabase/bin/java}"
 

--- a/src/test/shell/integration/bazel_java_test.sh
+++ b/src/test/shell/integration/bazel_java_test.sh
@@ -45,12 +45,12 @@ EOF
 }
 
 function test_host_javabase() {
-  mkdir -p foobar/bin
-  cat << EOF > BUILD
-java_runtime(
+  cat << EOF >> WORKSPACE
+load("@bazel_tools//tools/jdk:local_java_repository.bzl", "local_java_repository")
+local_java_repository(
     name = "host_javabase",
     java_home = "$PWD/foobar",
-    visibility = ["//visibility:public"],
+    version = "11",
 )
 EOF
 
@@ -63,10 +63,13 @@ java_library(
 EOF
   touch java/HelloWorld.java
 
+  mkdir -p foobar/bin
+  touch foobar/bin/java
+
   # We expect the given host_javabase to appear in the command line of
   # java_library actions.
-  bazel aquery --output=text --host_javabase=//:host_javabase //java:javalib >& $TEST_log
-  expect_log "exec .*foobar/bin/java"
+  bazel aquery --output=text --host_javabase=@host_javabase//:jdk --tool_java_runtime_version='host_javabase' //java:javalib >& $TEST_log
+  expect_log "exec external/host_javabase/bin/java"
 
   # If we don't specify anything, we expect the embedded JDK to be used.
   # Note that this will change in the future but is the current state.
@@ -74,9 +77,9 @@ EOF
   expect_not_log "exec external/embedded_jdk/bin/java"
   expect_log "exec external/remotejdk11_.*/bin/java"
 
-  bazel aquery --output=text --host_javabase=//:host_javabase \
+  bazel aquery --output=text --host_javabase=@host_javabase//:jdk --tool_java_runtime_version='host_javabase' \
     //java:javalib >& $TEST_log
-  expect_log "exec .*foobar/bin/java"
+  expect_log "exec external/host_javabase/bin/java"
   expect_not_log "exec external/remotejdk_.*/bin/java"
 
   bazel aquery --output=text \
@@ -85,7 +88,18 @@ EOF
 }
 
 function test_javabase() {
+   cat << EOF >> WORKSPACE
+load("@bazel_tools//tools/jdk:local_java_repository.bzl", "local_java_repository")
+local_java_repository(
+    name = "javabase",
+    java_home = "$PWD/zoo",
+    version = "11",
+)
+EOF
+
   mkdir -p zoo/bin
+  touch zoo/bin/java
+
   cat << EOF > BUILD
 load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
 default_java_toolchain(
@@ -95,11 +109,6 @@ default_java_toolchain(
     bootclasspath = [],
     javabuilder = ["@bazel_tools//tools/jdk:vanillajavabuilder"],
     jvm_opts = [],
-    visibility = ["//visibility:public"],
-)
-java_runtime(
-    name = "javabase",
-    java_home = "$PWD/zoo",
     visibility = ["//visibility:public"],
 )
 EOF
@@ -116,9 +125,9 @@ public class HelloWorld {}
 EOF
 
   # Check that the RHS javabase appears in the launcher.
-  bazel build --java_toolchain=//:toolchain --javabase=//:javabase //java:javabin
+  bazel build --java_toolchain=//:toolchain --javabase=@javabase//:jdk --extra_toolchains=//:toolchain_toolchain --java_runtime_version=javabase //java:javabin
   cat bazel-bin/java/javabin >& $TEST_log
-  expect_log "JAVABIN=.*/zoo/bin/java"
+  expect_log "JAVABIN=.*/javabase/bin/java}"
 
   # Check that we use local_jdk when it's not specified.
   bazel build //java:javabin

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -23,6 +23,7 @@ filegroup(
         "proguard_whitelister.py",
         "proguard_whitelister_test.py",
         "proguard_whitelister_test_input.pgcfg",
+        "remote_java_repository.bzl",
         "toolchain_utils.bzl",
     ],
 )

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -44,14 +44,6 @@ java_toolchain(
     singlejar = [":dummy_binary"],
 )
 
-toolchain(
-    name = "dummy_java_runtime_toolchain",
-    toolchain = ":dummy_java_runtime",
-    toolchain_type = ":runtime_toolchain_type",
-)
-
-java_runtime(name = "dummy_java_runtime")
-
 # Points to toolchain[":runtime_toolchain_type"] (was :legacy_current_java_runtime)
 java_runtime_alias(name = "current_java_runtime")
 

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -28,22 +28,6 @@ toolchain_type(name = "toolchain_type")
 # Used to distinguish toolchains used for Java execution, ie the JavaRuntimeInfo.
 toolchain_type(name = "runtime_toolchain_type")
 
-toolchain(
-    name = "dummy_java_toolchain",
-    toolchain = ":dummy_toolchain",
-    toolchain_type = ":toolchain_type",
-)
-
-cc_binary(name = "dummy_binary")
-
-java_toolchain(
-    name = "dummy_toolchain",
-    genclass = [":dummy_binary"],
-    ijar = [":dummy_binary"],
-    javabuilder = [":dummy_binary"],
-    singlejar = [":dummy_binary"],
-)
-
 # Points to toolchain[":runtime_toolchain_type"] (was :legacy_current_java_runtime)
 java_runtime_alias(name = "current_java_runtime")
 
@@ -375,25 +359,6 @@ default_java_toolchain(
 alias(
     name = "remote_toolchain",
     actual = ":toolchain",
-)
-
-# The 'vanilla' toolchain is an unsupported alternative to the default.
-#
-# It does not provider any of the following features:
-#   * Error Prone
-#   * Strict Java Deps
-#   * Header Compilation
-#   * Reduced Classpath Optimization
-#
-# It uses the version of javac from the `--host_javabase` instead of the
-# embedded javac, which may not be source- or bug-compatible with the embedded
-# javac.
-#
-# However it does allow using a wider range of `--host_javabase`s, including
-# versions newer than the current embedded JDK.
-default_java_toolchain(
-    name = "toolchain_vanilla",
-    configuration = VANILLA_TOOLCHAIN_CONFIGURATION,
 )
 
 RELEASES = (8, 9, 10, 11)

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -152,7 +152,7 @@ def default_java_toolchain(name, configuration = DEFAULT_TOOLCHAIN_CONFIGURATION
         visibility = ["//visibility:private"],
     )
     native.toolchain(
-        name = name + "_toolchain",
+        name = name + "_definition",
         toolchain_type = "@bazel_tools//tools/jdk:toolchain_type",
         target_settings = [name + "_version_setting"],
         toolchain = name,

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -146,6 +146,18 @@ def default_java_toolchain(name, configuration = DEFAULT_TOOLCHAIN_CONFIGURATION
         **toolchain_args
     )
 
+    native.config_setting(
+        name = name + "_version_setting",
+        values = {"java_language_version": toolchain_args["source_version"]},
+        visibility = ["//visibility:private"],
+    )
+    native.toolchain(
+        name = name + "_toolchain",
+        toolchain_type = "@bazel_tools//tools/jdk:toolchain_type",
+        target_settings = [name + "_version_setting"],
+        toolchain = name,
+    )
+
 def java_runtime_files(name, srcs):
     """Copies the given sources out of the current Java runtime."""
 

--- a/tools/jdk/jdk.BUILD
+++ b/tools/jdk/jdk.BUILD
@@ -165,7 +165,7 @@ filegroup(
 #This folder holds security policies
 filegroup(
     name = "jdk-conf",
-    srcs = glob(["conf/**"]),
+    srcs = glob(["conf/**"], allow_empty = True),
 )
 
 filegroup(

--- a/tools/jdk/local_java_repository.bzl
+++ b/tools/jdk/local_java_repository.bzl
@@ -16,17 +16,18 @@
 
 def _detect_java_version(repository_ctx, java_bin):
     properties_out = repository_ctx.execute([java_bin, "-XshowSettings:properties"]).stderr
+    # This returns an indented list of properties separated with newlines:
+    # "  java.vendor.url.bug = ... \n"
+    # "  java.version = 11.0.8\n"
+    # "  java.version.date = 2020-11-05\"
 
-    version_property = "java.version = "
-    versions = [
-        property.lstrip()[len(version_property):].rstrip()
-        for property in properties_out.splitlines()
-        if property.lstrip().startswith(version_property)
-    ]
-    if len(versions) != 1:
+    strip_properties = [property.strip() for property in properties_out.splitlines()]
+    version_property = [property for property in strip_properties if property.startswith("java.version=")]
+    if len(version_property) != 1:
         return "unknown"
 
-    (major, minor, rest) = versions[0].split(".", 2)
+    version_value = version_property[0][len("java.version="):]
+    (major, minor, rest) = version_value.split(".", 2)
 
     if major == "1":  # handles versions below 1.8
         return minor

--- a/tools/jdk/remote_java_repository.bzl
+++ b/tools/jdk/remote_java_repository.bzl
@@ -1,0 +1,88 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules for importing and registering JDKs from http archive.
+
+Rule remote_java_repository imports and registers JDK with the toolchain resolution.
+"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def _toolchain_config_impl(ctx):
+    ctx.file("WORKSPACE", "workspace(name = \"{name}\")\n".format(name = ctx.name))
+    ctx.file("BUILD.bazel", ctx.attr.build_file)
+
+_toolchain_config = repository_rule(
+    local = True,
+    implementation = _toolchain_config_impl,
+    attrs = {
+        "build_file": attr.string(),
+    },
+)
+
+def remote_java_repository(name, version, exec_compatible_with, prefix = "remotejdk", **kwargs):
+    """Imports and registers a JDK from a http archive.
+
+    Toolchain resolution is determined with exec_compatible_with
+    parameter and constrained with --java_runtime_version flag either having value
+    of "version" or "{prefix}_{version}" parameters.
+
+    Args:
+      name: A unique name for this rule.
+      version: Version of the JDK imported.
+      exec_compatible_with: Platform constraints (CPU and OS) for this JDK.
+      prefix: Optional alternative prefix for configuration flag value used to determine this JDK.
+      kwargs: Refer to http_archive documentation
+    """
+    http_archive(
+        name = name,
+        build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
+        **kwargs
+    )
+    _toolchain_config(
+        name = name + "_toolchain_config_repo",
+        build_file = """
+config_setting(
+    name = "prefix_version_setting",
+    values = {{"java_runtime_version": "{prefix}_{version}"}},
+    visibility = ["//visibility:private"],
+)
+config_setting(
+    name = "version_setting",
+    values = {{"java_runtime_version": "{version}"}},
+    visibility = ["//visibility:private"],
+)
+alias(
+    name = "version_or_prefix_version_setting",
+    actual = select({{
+        ":version_setting": ":version_setting",
+        "//conditions:default": ":prefix_version_setting",
+    }}),
+    visibility = ["//visibility:private"],
+)
+toolchain(
+    name = "toolchain",
+    exec_compatible_with = {exec_compatible_with},
+    target_settings = [":version_or_prefix_version_setting"],
+    toolchain_type = "@bazel_tools//tools/jdk:runtime_toolchain_type",
+    toolchain = "{toolchain}",
+)
+""".format(
+            prefix = prefix,
+            version = version,
+            exec_compatible_with = exec_compatible_with,
+            toolchain = "@{repo}//:jdk".format(repo = name),
+        ),
+    )
+    native.register_toolchains("@" + name + "_toolchain_config_repo//:toolchain")


### PR DESCRIPTION
Design document: https://docs.google.com/document/d/1MVbBxbKVKRJJY7DnkptHpvz7ROhyAYy4a-TZ-n7Q0r4/edit

A new macro remote_java_repository is defined, which creates an additional
repository with BUILD file containing toolchain target and registers it.

An additional repository prevents download of all JDKs (even if not
used).

Similarly local_java_repository rule is extended to add toolchain
target. In case the local JDK is not present a fake toolchain is added in
order to provide a nicer error message (without it toolchain resolution
fails without giving a clear message what was wrong).

Default_java_toolchain macro is extended to define toolchain rule as well.

Local JDKs version is autodetected.

Addresses https://github.com/bazelbuild/bazel/issues/4592