### PR TITLE
Fix the classic query package-loading cutoff optimization with external workspaces.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/query/BlazeQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/BlazeQueryEnvironment.java
@@ -184,9 +184,9 @@ public class BlazeQueryEnvironment extends AbstractBlazeQueryEnvironment<Target>
       }
     }
 
-    Set<PathFragment> packages = CompactHashSet.create();
+    Set<PackageIdentifier> packages = CompactHashSet.create();
     for (Target target : targets) {
-      packages.add(target.getLabel().getPackageFragment());
+      packages.add(target.getLabel().getPackageIdentifier());
     }
 
     for (Target target : targets) {
@@ -205,7 +205,7 @@ public class BlazeQueryEnvironment extends AbstractBlazeQueryEnvironment<Target>
       } else if (target instanceof Rule) {
         Rule rule = (Rule) target;
         for (Label label : rule.getLabels(dependencyFilter)) {
-          if (!packages.contains(label.getPackageFragment())) {
+          if (!packages.contains(label.getPackageIdentifier())) {
             continue;  // don't cause additional package loading
           }
           try {

--- a/src/test/shell/integration/bazel_query_test.sh
+++ b/src/test/shell/integration/bazel_query_test.sh
@@ -853,4 +853,20 @@ function test_query_failure_exit_code_behavior() {
   assert_equals 7 "$exit_code"
 }
 
+function test_unnecessary_external_workspaces_not_loaded() {
+  cat > WORKSPACE <<'EOF'
+local_repository(
+    name = "notthere",
+    path = "/nope",
+)
+EOF
+  cat > BUILD <<'EOF'
+filegroup(
+    name = "something",
+    srcs = ["@notthere"],
+)
+EOF
+  bazel query '//:*' || fail "Expected success"
+}
+
 run_suite "${PRODUCT_NAME} query tests"


### PR DESCRIPTION
A package's path fragment is not unambiguous when external workspaces are involved.

Fixes https://github.com/bazelbuild/bazel/issues/12497.