### PR TITLE
Allow G1 for javac workers.

### DIFF
--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -80,11 +80,13 @@ JVM8_TOOLCHAIN_CONFIGURATION = dict(
 
 DEFAULT_TOOLCHAIN_CONFIGURATION = dict(
     jvm_opts = [
-        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
-        # G1 collector and having compact strings enabled.
-        "-XX:+UseParallelOldGC",
+        # Compact strings make JavaBuilder slightly slower.
         "-XX:-CompactStrings",
     ] + JDK9_JVM_OPTS,
+    turbine_jvm_opts = [
+        # Turbine is not a worker and parallel GC is faster for short-lived programs.
+        "-XX:+UseParallelOldGC",
+    ],
     tools = [
         "@remote_java_tools//:java_compiler_jar",
         "@remote_java_tools//:jdk_compiler_jar",
@@ -118,11 +120,13 @@ VANILLA_TOOLCHAIN_CONFIGURATION = dict(
 # platform.
 PREBUILT_TOOLCHAIN_CONFIGURATION = dict(
     jvm_opts = [
-        # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
-        # G1 collector and having compact strings enabled.
-        "-XX:+UseParallelOldGC",
+        # Compact strings make JavaBuilder slightly slower.
         "-XX:-CompactStrings",
     ] + JDK9_JVM_OPTS,
+    turbine_jvm_opts = [
+        # Turbine is not a worker and parallel GC is faster for short-lived programs.
+        "-XX:+UseParallelOldGC",
+    ],
     tools = [
         "@remote_java_tools//:java_compiler_jar",
         "@remote_java_tools//:jdk_compiler_jar",


### PR DESCRIPTION
G1 has a smoother memory profile than parallelGC, which is desirable for workers
that users run locally like javac.

Unfortunately, completely getting rid of the parallelGC option regresses Java
build performance. This is because Turbine does not run as a worker—see
https://github.com/bazelbuild/bazel/issues/8006—and G1 seems to do worse than
parallelGC for short-lived programs. So, I simply moved the parallelGC option to
the Turbine-specific jvm opts.

I ran bazel-bench to test the performance this change building //src:bazel_nojdk:
```
  metric          mean                median          stddev      pval
    wall:  475.842s  ( -0.05%)  474.997s  ( -0.09%)   1.203s     0.00000
     cpu:   73.063s  ( -2.28%)   72.980s  ( -2.21%)   1.499s     0.40000
  system:   19.427s  ( +0.66%)   19.450s  ( +1.09%)   0.111s     0.40000
  memory:   89.667MB ( -0.74%)   90.000MB ( +0.00%)   0.471MB    0.00000
```