### PR TITLE
Starlark: avoid Starlark.fromJava calls for StarlarkValue

### DIFF
--- a/src/main/java/net/starlark/java/eval/Dict.java
+++ b/src/main/java/net/starlark/java/eval/Dict.java
@@ -297,13 +297,12 @@ public final class Dict<K, V>
       },
       extraKeywords = @Param(name = "kwargs", doc = "Dictionary of additional entries."),
       useStarlarkThread = true)
-  public NoneType update(Object pairs, Dict<String, Object> kwargs, StarlarkThread thread)
+  public void update(Object pairs, Dict<String, Object> kwargs, StarlarkThread thread)
       throws EvalException {
     Starlark.checkMutable(this);
     @SuppressWarnings("unchecked")
     Dict<Object, Object> dict = (Dict) this; // see class doc comment
     update("update", dict, pairs, kwargs);
-    return Starlark.NONE;
   }
 
   // Common implementation of dict(pairs, **kwargs) and dict.update(pairs, **kwargs).

--- a/src/main/java/net/starlark/java/eval/MethodLibrary.java
+++ b/src/main/java/net/starlark/java/eval/MethodLibrary.java
@@ -82,7 +82,7 @@ class MethodLibrary {
               + "<pre class=\"language-python\">all([\"hello\", 3, True]) == True\n"
               + "all([-1, 0, 1]) == False</pre>",
       parameters = {@Param(name = "elements", doc = "A string or a collection of elements.")})
-  public Boolean all(Object collection) throws EvalException {
+  public boolean all(Object collection) throws EvalException {
     return !hasElementWithBooleanValue(collection, false);
   }
 
@@ -94,7 +94,7 @@ class MethodLibrary {
               + "<pre class=\"language-python\">any([-1, 0, 1]) == True\n"
               + "any([False, 0, \"\"]) == False</pre>",
       parameters = {@Param(name = "elements", doc = "A string or a collection of elements.")})
-  public Boolean any(Object collection) throws EvalException {
+  public boolean any(Object collection) throws EvalException {
     return hasElementWithBooleanValue(collection, true);
   }
 
@@ -271,7 +271,7 @@ class MethodLibrary {
               + " iterable.",
       parameters = {@Param(name = "x", doc = "The value whose length to report.")},
       useStarlarkThread = true)
-  public Integer len(Object x, StarlarkThread thread) throws EvalException {
+  public int len(Object x, StarlarkThread thread) throws EvalException {
     int len = Starlark.len(x);
     if (len < 0) {
       throw Starlark.errorf("%s is not iterable", Starlark.type(x));
@@ -309,7 +309,7 @@ class MethodLibrary {
               + "empty collection (e.g. <code>()</code>, <code>[]</code>). "
               + "Otherwise, it returns <code>True</code>.",
       parameters = {@Param(name = "x", defaultValue = "False", doc = "The variable to convert.")})
-  public Boolean bool(Object x) throws EvalException {
+  public boolean bool(Object x) throws EvalException {
     return Starlark.truth(x);
   }
 
@@ -536,7 +536,7 @@ class MethodLibrary {
       // promise a specific algorithm. This is in contrast to Java (Object.hashCode()) and
       // Python, which promise stable hashing only within a given execution of the program.
       parameters = {@Param(name = "value", doc = "String value to hash.")})
-  public Integer hash(String value) throws EvalException {
+  public int hash(String value) throws EvalException {
     return value.hashCode();
   }
 
@@ -603,7 +603,7 @@ class MethodLibrary {
         @Param(name = "name", doc = "The name of the attribute.")
       },
       useStarlarkThread = true)
-  public Boolean hasattr(Object obj, String name, StarlarkThread thread) throws EvalException {
+  public boolean hasattr(Object obj, String name, StarlarkThread thread) throws EvalException {
     return Starlark.hasattr(thread.getSemantics(), obj, name);
   }
 
@@ -680,7 +680,7 @@ class MethodLibrary {
               doc =
                   "A list of values, formatted with str and joined with spaces, that appear in the"
                       + " error message."))
-  public NoneType fail(Object msg, Object attr, Tuple args) throws EvalException {
+  public void fail(Object msg, Object attr, Tuple args) throws EvalException {
     List<String> elems = new ArrayList<>();
     // msg acts like a leading element of args.
     if (msg != Starlark.NONE) {
@@ -719,7 +719,7 @@ class MethodLibrary {
       // NB: as compared to Python3, we're missing optional named-only arguments 'end' and 'file'
       extraPositionals = @Param(name = "args", doc = "The objects to print."),
       useStarlarkThread = true)
-  public NoneType print(String sep, Sequence<?> args, StarlarkThread thread) throws EvalException {
+  public void print(String sep, Sequence<?> args, StarlarkThread thread) throws EvalException {
     Printer p = new Printer();
     String separator = "";
     for (Object x : args) {
@@ -734,7 +734,6 @@ class MethodLibrary {
     }
 
     thread.getPrintHandler().print(thread, p.toString());
-    return Starlark.NONE;
   }
 
   @StarlarkMethod(

--- a/src/main/java/net/starlark/java/eval/StarlarkList.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkList.java
@@ -409,11 +409,11 @@ public final class StarlarkList<E> extends AbstractList<E>
           "Removes the first item from the list whose value is x. "
               + "It is an error if there is no such item.",
       parameters = {@Param(name = "x", doc = "The object to remove.")})
-  public NoneType removeElement(Object x) throws EvalException {
+  public void removeElement(Object x) throws EvalException {
     for (int i = 0; i < size; i++) {
       if (elems[i].equals(x)) {
         removeElementAt(i);
-        return Starlark.NONE;
+        return;
       }
     }
     throw Starlark.errorf("item %s not found in list", Starlark.repr(x));
@@ -434,19 +434,17 @@ public final class StarlarkList<E> extends AbstractList<E>
       doc = "Adds an item to the end of the list.",
       parameters = {@Param(name = "item", doc = "Item to add at the end.")})
   @SuppressWarnings("unchecked")
-  public NoneType append(Object item) throws EvalException {
+  public void append(Object item) throws EvalException {
     addElement((E) item); // unchecked
-    return Starlark.NONE;
   }
 
   @StarlarkMethod(name = "clear", doc = "Removes all the elements of the list.")
-  public NoneType clearElements() throws EvalException {
+  public void clearElements() throws EvalException {
     Starlark.checkMutable(this);
     for (int i = 0; i < size; i++) {
       elems[i] = null; // aid GC
     }
     size = 0;
-    return Starlark.NONE;
   }
 
   @StarlarkMethod(
@@ -457,20 +455,18 @@ public final class StarlarkList<E> extends AbstractList<E>
         @Param(name = "item", doc = "The item.")
       })
   @SuppressWarnings("unchecked")
-  public NoneType insert(StarlarkInt index, Object item) throws EvalException {
+  public void insert(StarlarkInt index, Object item) throws EvalException {
     addElementAt(EvalUtils.toIndex(index.toInt("index"), size), (E) item); // unchecked
-    return Starlark.NONE;
   }
 
   @StarlarkMethod(
       name = "extend",
       doc = "Adds all items to the end of the list.",
       parameters = {@Param(name = "items", doc = "Items to add at the end.")})
-  public NoneType extend(Object items) throws EvalException {
+  public void extend(Object items) throws EvalException {
     @SuppressWarnings("unchecked")
     Iterable<? extends E> src = (Iterable<? extends E>) Starlark.toIterable(items);
     addElements(src);
-    return Starlark.NONE;
   }
 
   @StarlarkMethod(
@@ -499,7 +495,7 @@ public final class StarlarkList<E> extends AbstractList<E>
             named = true, // TODO(adonovan): this is wrong
             doc = "The end index of the list portion to inspect.")
       })
-  public Integer index(Object x, Object start, Object end) throws EvalException {
+  public int index(Object x, Object start, Object end) throws EvalException {
     int i = start == Starlark.NONE ? 0 : EvalUtils.toIndex(Starlark.toInt(start, "start"), size);
     int j = end == Starlark.NONE ? size : EvalUtils.toIndex(Starlark.toInt(end, "end"), size);
     for (; i < j; i++) {

--- a/src/main/java/net/starlark/java/eval/StringModule.java
+++ b/src/main/java/net/starlark/java/eval/StringModule.java
@@ -563,7 +563,7 @@ final class StringModule implements StarlarkValue {
             defaultValue = "None",
             doc = "optional position before which to restrict to search.")
       })
-  public Integer rfind(String self, String sub, Object start, Object end) throws EvalException {
+  public int rfind(String self, String sub, Object start, Object end) throws EvalException {
     return stringFind(false, self, sub, start, end);
   }
 
@@ -593,7 +593,7 @@ final class StringModule implements StarlarkValue {
             defaultValue = "None",
             doc = "optional position before which to restrict to search.")
       })
-  public Integer find(String self, String sub, Object start, Object end) throws EvalException {
+  public int find(String self, String sub, Object start, Object end) throws EvalException {
     return stringFind(true, self, sub, start, end);
   }
 
@@ -623,7 +623,7 @@ final class StringModule implements StarlarkValue {
             defaultValue = "None",
             doc = "optional position before which to restrict to search.")
       })
-  public Integer rindex(String self, String sub, Object start, Object end) throws EvalException {
+  public int rindex(String self, String sub, Object start, Object end) throws EvalException {
     int res = stringFind(false, self, sub, start, end);
     if (res < 0) {
       throw Starlark.errorf("substring not found");
@@ -657,7 +657,7 @@ final class StringModule implements StarlarkValue {
             defaultValue = "None",
             doc = "optional position before which to restrict to search.")
       })
-  public Integer index(String self, String sub, Object start, Object end) throws EvalException {
+  public int index(String self, String sub, Object start, Object end) throws EvalException {
     int res = stringFind(true, self, sub, start, end);
     if (res < 0) {
       throw Starlark.errorf("substring not found");
@@ -707,7 +707,7 @@ final class StringModule implements StarlarkValue {
           "Returns True if all characters in the string are alphabetic ([a-zA-Z]) and there is "
               + "at least one character.",
       parameters = {@Param(name = "self", doc = "This string.")})
-  public Boolean isAlpha(String self) throws EvalException {
+  public boolean isAlpha(String self) throws EvalException {
     return matches(self, ALPHA, false);
   }
 
@@ -717,7 +717,7 @@ final class StringModule implements StarlarkValue {
           "Returns True if all characters in the string are alphanumeric ([a-zA-Z0-9]) and there "
               + "is at least one character.",
       parameters = {@Param(name = "self", doc = "This string.")})
-  public Boolean isAlnum(String self) throws EvalException {
+  public boolean isAlnum(String self) throws EvalException {
     return matches(self, ALNUM, false);
   }
 
@@ -727,7 +727,7 @@ final class StringModule implements StarlarkValue {
           "Returns True if all characters in the string are digits ([0-9]) and there is "
               + "at least one character.",
       parameters = {@Param(name = "self", doc = "This string.")})
-  public Boolean isDigit(String self) throws EvalException {
+  public boolean isDigit(String self) throws EvalException {
     return matches(self, DIGIT, false);
   }
 
@@ -737,7 +737,7 @@ final class StringModule implements StarlarkValue {
           "Returns True if all characters are white space characters and the string "
               + "contains at least one character.",
       parameters = {@Param(name = "self", doc = "This string.")})
-  public Boolean isSpace(String self) throws EvalException {
+  public boolean isSpace(String self) throws EvalException {
     return matches(self, SPACE, false);
   }
 
@@ -747,7 +747,7 @@ final class StringModule implements StarlarkValue {
           "Returns True if all cased characters in the string are lowercase and there is "
               + "at least one character.",
       parameters = {@Param(name = "self", doc = "This string.")})
-  public Boolean isLower(String self) throws EvalException {
+  public boolean isLower(String self) throws EvalException {
     // Python also accepts non-cased characters, so we cannot use LOWER.
     return matches(self, UPPER.negate(), true);
   }
@@ -758,7 +758,7 @@ final class StringModule implements StarlarkValue {
           "Returns True if all cased characters in the string are uppercase and there is "
               + "at least one character.",
       parameters = {@Param(name = "self", doc = "This string.")})
-  public Boolean isUpper(String self) throws EvalException {
+  public boolean isUpper(String self) throws EvalException {
     // Python also accepts non-cased characters, so we cannot use UPPER.
     return matches(self, LOWER.negate(), true);
   }
@@ -771,7 +771,7 @@ final class StringModule implements StarlarkValue {
               + "whitespace) and every lowercase character must follow a cased one (e.g. "
               + "uppercase or lowercase).",
       parameters = {@Param(name = "self", doc = "This string.")})
-  public Boolean isTitle(String self) throws EvalException {
+  public boolean isTitle(String self) throws EvalException {
     if (self.isEmpty()) {
       return false;
     }
@@ -856,7 +856,7 @@ final class StringModule implements StarlarkValue {
             defaultValue = "None",
             doc = "optional position before which to restrict to search.")
       })
-  public Integer count(String self, String sub, Object start, Object end) throws EvalException {
+  public int count(String self, String sub, Object start, Object end) throws EvalException {
     long indices = substringIndices(self, start, end);
     if (sub.isEmpty()) {
       return hi(indices) - lo(indices) + 1; // str.length() + 1
@@ -923,7 +923,7 @@ final class StringModule implements StarlarkValue {
             defaultValue = "None",
             doc = "optional position at which to stop comparing.")
       })
-  public Boolean endsWith(String self, Object sub, Object start, Object end) throws EvalException {
+  public boolean endsWith(String self, Object sub, Object start, Object end) throws EvalException {
     long indices = substringIndices(self, start, end);
     if (sub instanceof String) {
       return substringEndsWith(self, lo(indices), hi(indices), (String) sub);
@@ -1004,7 +1004,7 @@ final class StringModule implements StarlarkValue {
             defaultValue = "None",
             doc = "Stop comparing at this position.")
       })
-  public Boolean startsWith(String self, Object sub, Object start, Object end)
+  public boolean startsWith(String self, Object sub, Object start, Object end)
       throws EvalException {
     long indices = substringIndices(self, start, end);
     if (sub instanceof String) {


### PR DESCRIPTION
First commit:

When it is known that method return type is already `StarlarkValue`
or `String`, avoid unnecessary expensive `fromJava` call.

Unfortunately, this optimization makes
[my favorite MethodHandle optimization](https://github.com/bazelbuild/bazel/pull/11747)
somewhat less useful.

```
def foo():
    for i in range(10):
        print(i)
        for j in range(1000):
            for k in range(5000):
                type(1)
foo()
```

On my MacBook Pro Intel(R) Core(TM) i9-9980HK,
openjdk version "11.0.6" 2020-01-14
OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.6+10)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.6+10, mixed mode)

```
A: n=46 mean=7.008 std=0.312 se=0.046 min=6.332 med=7.031
B: n=46 mean=5.893 std=0.337 se=0.050 min=5.352 med=5.847
B/A: 0.841 0.823..0.859 (95% conf)
```

Second commit:

Replace return type `NoneType` with `void`, `Integer` with `int`, `Boolean` with `boolean` to avoid unnecessary runtime checks.