### PR TITLE
fix build bugs in android sample

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -45,3 +45,4 @@ build:macos --macos_minimum_os=10.10
 
 # User-specific .bazelrc
 try-import user.bazelrc
+build --copt="-fdebug-compilation-dir" --copt="/proc/self/cwd"

--- a/.bazelrc
+++ b/.bazelrc
@@ -38,6 +38,10 @@ build:ubuntu1604_java8 --host_platform=//:rbe_ubuntu1604_java8_platform
 build:ubuntu1604_java8 --platforms=//:rbe_ubuntu1604_java8_platform
 build:ubuntu1604_java8 --config=remote_shared
 
+# https://github.com/bazelbuild/intellij/issues/295#issuecomment-729656232
+# Configuration to fix ndk debugging on macos (uncomment this line on macos)
+# build --copt="-fdebug-compilation-dir" --copt="/proc/self/cwd"
+
 # Alias
 build:remote --config=ubuntu1604_java8
 
@@ -45,4 +49,3 @@ build:macos --macos_minimum_os=10.10
 
 # User-specific .bazelrc
 try-import user.bazelrc
-build --copt="-fdebug-compilation-dir" --copt="/proc/self/cwd"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,8 +78,8 @@ list_source_repository(name = "local_bazel_source_list")
 #   2. Set the $ANDROID_HOME and $ANDROID_NDK_HOME environment variables
 #   3. Uncomment the two lines below
 #
-# android_sdk_repository(name = "androidsdk")
-# android_ndk_repository(name = "androidndk")
+android_sdk_repository(name = "androidsdk")
+android_ndk_repository(name = "androidndk")
 
 # In order to run //src/test/shell/bazel:maven_skylark_test, follow the
 # instructions above for the Android integration tests and uncomment the
@@ -167,7 +167,7 @@ distdir_tar(
         # bazelbuild/rules_cc
         "b1c40e1de81913a3c40e5948f78719c28152486d.zip",
         # bazelbuild/bazel-toolchains
-        "bazel-toolchains-3.1.0.tar.gz",
+        "bazel-toolchains-3.7.1.tar.gz",
         # bazelbuild/rules_pkg
         "rules_pkg-0.2.4.tar.gz",
         # bazelbuild/rules_proto
@@ -209,7 +209,7 @@ distdir_tar(
         # bazelbuild/rules_cc
         "b1c40e1de81913a3c40e5948f78719c28152486d.zip": "d0c573b94a6ef20ef6ff20154a23d0efcb409fb0e1ff0979cec318dfe42f0cdd",
         # bazelbuild/bazel-toolchains
-        "bazel-toolchains-3.1.0.tar.gz": "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
+        "bazel-toolchains-3.7.1.tar.gz": "8c9728dc1bb3e8356b344088dfd10038984be74e1c8d6e92dbb05f21cabbb8e4",
         # bazelbuild/rules_pkg
         "rules_pkg-0.2.4.tar.gz": "4ba8f4ab0ff85f2484287ab06c0d871dcb31cc54d439457d28fd4ae14b18450a",
         # bazelbuild/rules_proto
@@ -283,9 +283,9 @@ distdir_tar(
             "https://github.com/bazelbuild/rules_cc/archive/b1c40e1de81913a3c40e5948f78719c28152486d.zip",
         ],
         # bazelbuild/bazel-toolchains
-        "bazel-toolchains-3.1.0.tar.gz": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
+        "bazel-toolchains-3.7.1.tar.gz": [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.7.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.7.1/bazel-toolchains-3.1.0.tar.gz",
         ],
         # bazelbuild/rules_pkg
         "rules_pkg-0.2.4.tar.gz": [
@@ -439,11 +439,11 @@ http_archive(
     name = "bazel_toolchains",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
-    strip_prefix = "bazel-toolchains-3.1.0",
+    sha256 = "8c9728dc1bb3e8356b344088dfd10038984be74e1c8d6e92dbb05f21cabbb8e4",
+    strip_prefix = "bazel-toolchains-3.7.1",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.7.1/bazel-toolchains-3.7.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.7.1/bazel-toolchains-3.7.1.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -167,7 +167,7 @@ distdir_tar(
         # bazelbuild/rules_cc
         "b1c40e1de81913a3c40e5948f78719c28152486d.zip",
         # bazelbuild/bazel-toolchains
-        "bazel-toolchains-3.7.1.tar.gz",
+        "bazel-toolchains-3.1.0.tar.gz",
         # bazelbuild/rules_pkg
         "rules_pkg-0.2.4.tar.gz",
         # bazelbuild/rules_proto
@@ -209,7 +209,7 @@ distdir_tar(
         # bazelbuild/rules_cc
         "b1c40e1de81913a3c40e5948f78719c28152486d.zip": "d0c573b94a6ef20ef6ff20154a23d0efcb409fb0e1ff0979cec318dfe42f0cdd",
         # bazelbuild/bazel-toolchains
-        "bazel-toolchains-3.7.1.tar.gz": "8c9728dc1bb3e8356b344088dfd10038984be74e1c8d6e92dbb05f21cabbb8e4",
+        "bazel-toolchains-3.1.0.tar.gz": "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
         # bazelbuild/rules_pkg
         "rules_pkg-0.2.4.tar.gz": "4ba8f4ab0ff85f2484287ab06c0d871dcb31cc54d439457d28fd4ae14b18450a",
         # bazelbuild/rules_proto
@@ -283,9 +283,9 @@ distdir_tar(
             "https://github.com/bazelbuild/rules_cc/archive/b1c40e1de81913a3c40e5948f78719c28152486d.zip",
         ],
         # bazelbuild/bazel-toolchains
-        "bazel-toolchains-3.7.1.tar.gz": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.7.1.tar.gz",
-            "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.7.1/bazel-toolchains-3.1.0.tar.gz",
+        "bazel-toolchains-3.1.0.tar.gz": [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
         ],
         # bazelbuild/rules_pkg
         "rules_pkg-0.2.4.tar.gz": [
@@ -439,11 +439,11 @@ http_archive(
     name = "bazel_toolchains",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "8c9728dc1bb3e8356b344088dfd10038984be74e1c8d6e92dbb05f21cabbb8e4",
-    strip_prefix = "bazel-toolchains-3.7.1",
+    sha256 = "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
+    strip_prefix = "bazel-toolchains-3.1.0",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.7.1/bazel-toolchains-3.7.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.7.1/bazel-toolchains-3.7.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,8 +78,8 @@ list_source_repository(name = "local_bazel_source_list")
 #   2. Set the $ANDROID_HOME and $ANDROID_NDK_HOME environment variables
 #   3. Uncomment the two lines below
 #
-android_sdk_repository(name = "androidsdk")
-android_ndk_repository(name = "androidndk")
+# android_sdk_repository(name = "androidsdk")
+# android_ndk_repository(name = "androidndk")
 
 # In order to run //src/test/shell/bazel:maven_skylark_test, follow the
 # instructions above for the Android integration tests and uncomment the

--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -1,31 +1,4 @@
-In order to build these examples, add the following two rules to the top-level `WORKSPACE` file (two directories above this file):
-
-```python
-android_sdk_repository(
-    name="androidsdk",
-    path="<full path to your Android SDK>",
-    api_level=<api level>,
-)
-
-android_ndk_repository(
-    name="androidndk",
-    path="<path to your Android NDK>",
-    api_level=<api_level>,
-)
-```
-
-For the `android_sdk_repository` rule, the value of `api_level` corresponds to
-a directory in the SDK containing the specific version of `android.jar` to
-compile against. For example, if `path = "/Users/xyzzy/Library/Android/sdk"` and
-`api_level = 21`, then the directory
-`/Users/xyzzy/Library/Android/sdk/platforms/android-21` must exist.
-
-Similarly, for the `android_ndk_repository` rule, the value of the `api_level`
-attribute corresponds to a directory containing the NDK libraries for that
-API level. For example, if
-`path=/Users/xyzzy/Library/Android/android-ndk-r10e` and
-`api_level=21`, then you your NDK must contain the directory
-`/Users/xyzzy/Library/Android/android-ndk-r10e/platforms/android-21`.
+In order to build these examples, uncomment the two `android_sdk_repository` and `android_ndk_repository` lines in the top-level `WORKSPACE` file (two directories above this file).
 
 The example `android_binary` depends on
 `@androidsdk//com.android.support:appcompat-v7-25.0.0`, so you will need to

--- a/examples/android/java/bazel/AndroidManifest.xml
+++ b/examples/android/java/bazel/AndroidManifest.xml
@@ -5,9 +5,10 @@
 
     <uses-sdk
         android:minSdkVersion="21"
-        android:targetSdkVersion="21" />
+        android:targetSdkVersion="30" />
 
     <application
+        android:debuggable="true"
         android:label="Bazel App"
         android:theme="@style/MyTheme" >
         <activity

--- a/examples/android/java/bazel/AndroidManifest.xml
+++ b/examples/android/java/bazel/AndroidManifest.xml
@@ -8,7 +8,6 @@
         android:targetSdkVersion="30" />
 
     <application
-        android:debuggable="true"
         android:label="Bazel App"
         android:theme="@style/MyTheme" >
         <activity

--- a/examples/android/java/bazel/BUILD
+++ b/examples/android/java/bazel/BUILD
@@ -30,6 +30,8 @@ cc_library(
     name = "jni",
     srcs = ["jni.cc"],
     deps = [":jni_dep"],
+    linkopts = ["-ldl"],
+    alwayslink = True,
 )
 
 cc_library(

--- a/examples/android/java/bazel/BUILD
+++ b/examples/android/java/bazel/BUILD
@@ -30,7 +30,9 @@ cc_library(
     name = "jni",
     srcs = ["jni.cc"],
     deps = [":jni_dep"],
+    # https://github.com/bazelbuild/bazel/issues/6959#issuecomment-449153377
     linkopts = ["-ldl"],
+    # https://github.com/bazelbuild/bazel/issues/10928#issuecomment-597895076
     alwayslink = True,
 )
 


### PR DESCRIPTION
- Add alwayslink otherwise the hello() C symbol is removed because it's not called by any C code.
- Add `-ldl` because libdl is no longer automatically linked.
- Bump target sdk to latest.
- Remove outdated android_sdk_repository instructions from README.
- Add workaround copt flag to fix ndk debugging on mac.