### PR TITLE
Make gcov executable available in Starlark ToolchainInfo

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderHelper.java
@@ -397,6 +397,7 @@ public class CcToolchainProviderHelper {
         .put("ar_executable", getStarlarkValueForTool(Tool.AR, toolPaths))
         .put("strip_executable", getStarlarkValueForTool(Tool.STRIP, toolPaths))
         .put("ld_executable", getStarlarkValueForTool(Tool.LD, toolPaths))
+        .put("gcov_executable", getStarlarkValueForTool(Tool.GCOV, toolPaths))
         .build();
   }
 


### PR DESCRIPTION
This is needed to use gcov in Starlark rules in custom coverage rules.