### PR TITLE
Support symlinks for Android SDK repository

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidRepositoryFunction.java
@@ -83,12 +83,11 @@ abstract class AndroidRepositoryFunction extends RepositoryFunction {
   static final ImmutableSortedSet<Integer> getApiLevels(Dirents platformsDirectories) {
     ImmutableSortedSet.Builder<Integer> apiLevels = ImmutableSortedSet.reverseOrder();
     for (Dirent platformDirectory : platformsDirectories) {
-      if (platformDirectory.getType() != Dirent.Type.DIRECTORY) {
-        continue;
-      }
-      Matcher matcher = PLATFORMS_API_LEVEL_PATTERN.matcher(platformDirectory.getName());
-      if (matcher.matches()) {
-        apiLevels.add(Integer.parseInt(matcher.group(1)));
+      if (platformDirectory.getType() == Dirent.Type.DIRECTORY || platformDirectory.getType() == Dirent.Type.SYMLINK) {
+        Matcher matcher = PLATFORMS_API_LEVEL_PATTERN.matcher(platformDirectory.getName());
+        if (matcher.matches()) {
+          apiLevels.add(Integer.parseInt(matcher.group(1)));
+        }
       }
     }
     return apiLevels.build();


### PR DESCRIPTION
For example, NixOS create a symlink for Android platform like:
```
ls -la /nix/store/azw6n236rgfkbmvfrbak4cnbcd4glbxn-androidsdk/libexec/android-sdk/platforms
total 0
dr-xr-xr-x 2 root root  24 Jan  1  1970 .
dr-xr-xr-x 7 root root 141 Jan  1  1970 ..
lrwxrwxrwx 1 root root  97 Jan  1  1970 android-29 -> /nix/store/2lll753i9y9j37b7mpsz5b81mspmpmnv-platforms-29/libexec/android-sdk/platforms/android-29
```