### PR TITLE
docs: clarify that urls is order sensitive

### DIFF
--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -219,7 +219,7 @@ Each entry must be a file, http or https URL. Redirections are followed.
 Authentication is not supported.
 
 URLs are tried in order until one succeeds, so you should list local mirrors first.
-If all downloads fail the rule will fail.""",
+If all downloads fail, the rule will fail.""",
     ),
     "sha256": attr.string(
         doc = """The expected SHA-256 of the file downloaded.

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -216,7 +216,10 @@ to specify alternative URLs to fetch from.
             """A list of URLs to a file that will be made available to Bazel.
 
 Each entry must be a file, http or https URL. Redirections are followed.
-Authentication is not supported.""",
+Authentication is not supported.
+
+The resolution of this value is read top to bottom, and will fall through if a given
+url fails to fetch the artifact.""",
     ),
     "sha256": attr.string(
         doc = """The expected SHA-256 of the file downloaded.

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -218,8 +218,8 @@ to specify alternative URLs to fetch from.
 Each entry must be a file, http or https URL. Redirections are followed.
 Authentication is not supported.
 
-The resolution of this value is read top to bottom, and will fall through if a given
-url fails to fetch the artifact.""",
+URLs are tried in order until one succeeds, so you should list local mirrors first.
+If all downloads fail the rule will fail.""",
     ),
     "sha256": attr.string(
         doc = """The expected SHA-256 of the file downloaded.


### PR DESCRIPTION
According to https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpDownloader.java#L83-L84, `urls` is order sensitive. Noting it in the docs to make it clear to future users that order matters.