### PR TITLE
Transform roots along with paths during output deletion.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ArtifactPathResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ArtifactPathResolver.java
@@ -37,9 +37,7 @@ public interface ArtifactPathResolver {
    */
   Path convertPath(Path path);
 
-  /**
-   * @return a resolved Rooth corresponding to the given Root.
-   */
+  /** @return a resolved {@link Root} corresponding to the given Root. */
   Root transformRoot(Root root);
 
   ArtifactPathResolver IDENTITY = new IdentityResolver(null);

--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelWorkspaceStatusModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelWorkspaceStatusModule.java
@@ -161,7 +161,7 @@ public class BazelWorkspaceStatusModule extends BlazeModule {
       // The default implementation of this method deletes all output files; override it to keep
       // the old stableStatus around. This way we can reuse the existing file (preserving its mtime)
       // if the contents haven't changed.
-      deleteOutput(pathResolver.toPath(volatileStatus), volatileStatus.getRoot());
+      deleteOutput(volatileStatus, pathResolver);
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/includescanning/SpawnIncludeScanner.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/SpawnIncludeScanner.java
@@ -295,7 +295,11 @@ public class SpawnIncludeScanner {
     Path output = getIncludesOutput(file, actionExecutionContext.getPathResolver(), fileType,
         placeNextToFile);
     if (!inMemoryOutput) {
-      AbstractAction.deleteOutput(output, placeNextToFile ? file.getRoot() : null);
+      AbstractAction.deleteOutput(
+          output,
+          placeNextToFile
+              ? actionExecutionContext.getPathResolver().transformRoot(file.getRoot().getRoot())
+              : null);
       if (!placeNextToFile) {
         output.getParentDirectory().createDirectoryAndParents();
       }
@@ -409,7 +413,11 @@ public class SpawnIncludeScanner {
         getIncludesOutput(
             file, actionExecutionContext.getPathResolver(), fileType, placeNextToFile);
     if (!inMemoryOutput) {
-      AbstractAction.deleteOutput(output, placeNextToFile ? file.getRoot() : null);
+      AbstractAction.deleteOutput(
+          output,
+          placeNextToFile
+              ? actionExecutionContext.getPathResolver().transformRoot(file.getRoot().getRoot())
+              : null);
       if (!placeNextToFile) {
         output.getParentDirectory().createDirectoryAndParents();
       }

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -1667,6 +1667,24 @@ function test_download_toplevel_no_remote_execution() {
       || fail "Failed to run bazel build --remote_download_toplevel"
 }
 
+function test_download_toplevel_can_delete_directory_outputs() {
+  cat > BUILD <<'EOF'
+genrule(
+    name = 'g',
+    outs = ['out'],
+    cmd = "touch $@",
+)
+EOF
+  bazel build
+  mkdir $(bazel info bazel-genfiles)/out
+  touch $(bazel info bazel-genfiles)/out/f
+  bazel build \
+        --remote_download_toplevel \
+        --remote_executor=grpc://localhost:${worker_port} \
+        //:g \
+        || fail "should have worked"
+}
+
 function test_tag_no_remote_cache() {
   mkdir -p a
   cat > a/BUILD <<'EOF'


### PR DESCRIPTION
4009b176cb480eb2f16b86f8d05a2e2beb62f61d resolved output paths but not the related roots.

Fixes https://github.com/bazelbuild/bazel/issues/12678.