### PR TITLE
Starlark: validate generic1 is not specified for parameterless types

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleContextApi.java
@@ -568,7 +568,7 @@ public interface StarlarkRuleContextApi<ConstraintValueT extends ConstraintValue
         @Param(
             name = "transitive_files",
             allowedTypes = {
-              @ParamType(type = Depset.class, generic1 = FileApi.class),
+              @ParamType(type = Depset.class),
               @ParamType(type = NoneType.class),
             },
             defaultValue = "None",

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidAssetsInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidAssetsInfoApi.java
@@ -136,7 +136,7 @@ public interface AndroidAssetsInfoApi<FileT extends FileApi, AssetsT extends Par
               positional = true,
               named = true,
               allowedTypes = {
-                @ParamType(type = Depset.class, generic1 = ParsedAndroidAssetsApi.class)
+                @ParamType(type = Depset.class)
               }),
           @Param(
               name = "transitive_parsed_assets",
@@ -144,26 +144,26 @@ public interface AndroidAssetsInfoApi<FileT extends FileApi, AssetsT extends Par
               positional = true,
               named = true,
               allowedTypes = {
-                @ParamType(type = Depset.class, generic1 = ParsedAndroidAssetsApi.class)
+                @ParamType(type = Depset.class)
               }),
           @Param(
               name = "transitive_assets",
               doc = "A depset of all the assets in the transitive closure.",
               positional = true,
               named = true,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
           @Param(
               name = "transitive_symbols",
               doc = "A depset of all the symbols in the transitive closure.",
               positional = true,
               named = true,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
           @Param(
               name = "transitive_compiled_symbols",
               doc = "A depset of all the compiled symbols in the transitive closure.",
               positional = true,
               named = true,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
         },
         selfCall = true)
     @StarlarkConstructor

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidIdlProviderApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidIdlProviderApi.java
@@ -93,13 +93,13 @@ public interface AndroidIdlProviderApi<FileT extends FileApi> extends StructApi 
               doc = "A depset of strings of all the idl import roots in the transitive closure.",
               positional = true,
               named = false,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = String.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
           @Param(
               name = "transitive_idl_imports",
               doc = "A depset of artifacts of all the idl imports in the transitive closure.",
               positional = true,
               named = false,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
           @Param(
               name = "transitive_idl_jars",
               doc =
@@ -107,7 +107,7 @@ public interface AndroidIdlProviderApi<FileT extends FileApi> extends StructApi 
                       + "transitive closure.",
               positional = true,
               named = false,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
           @Param(
               name = "transitive_idl_preprocessed",
               doc =
@@ -115,7 +115,7 @@ public interface AndroidIdlProviderApi<FileT extends FileApi> extends StructApi 
                       + "closure.",
               positional = true,
               named = false,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
         },
         selfCall = true)
     @StarlarkConstructor

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidLibraryResourceClassJarProviderApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidLibraryResourceClassJarProviderApi.java
@@ -61,7 +61,7 @@ public interface AndroidLibraryResourceClassJarProviderApi<FileT extends FileApi
               doc = "Resource class jars.",
               positional = true,
               named = false,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
         },
         selfCall = true)
     @StarlarkConstructor

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidNativeLibsInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidNativeLibsInfoApi.java
@@ -62,7 +62,7 @@ public interface AndroidNativeLibsInfoApi<FileT extends FileApi> extends StructA
         parameters = {
           @Param(
               name = "native_libs",
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)},
+              allowedTypes = {@ParamType(type = Depset.class)},
               named = true,
               doc = "The native libraries produced by the rule."),
         },

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidResourcesInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidResourcesInfoApi.java
@@ -140,7 +140,7 @@ public interface AndroidResourcesInfoApi<
               positional = true,
               named = true,
               allowedTypes = {
-                @ParamType(type = Depset.class, generic1 = ValidatedAndroidDataApi.class)
+                @ParamType(type = Depset.class)
               }),
           @Param(
               name = "direct_android_resources",
@@ -148,32 +148,32 @@ public interface AndroidResourcesInfoApi<
               positional = true,
               named = true,
               allowedTypes = {
-                @ParamType(type = Depset.class, generic1 = ValidatedAndroidDataApi.class)
+                @ParamType(type = Depset.class)
               }),
           @Param(
               name = "transitive_resources",
               doc = "A depset of Artifacts of Android Resource files in the transitive closure.",
               positional = true,
               named = true,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
           @Param(
               name = "transitive_manifests",
               doc = "A depset of Artifacts of Android Manifests in the transitive closure.",
               positional = true,
               named = true,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
           @Param(
               name = "transitive_aapt2_r_txt",
               doc = "A depset of Artifacts of Android AAPT2 R.txt files in the transitive closure.",
               positional = true,
               named = true,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
           @Param(
               name = "transitive_symbols_bin",
               doc = "A depset of Artifacts of Android symbols files in the transitive closure.",
               positional = true,
               named = true,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
           @Param(
               name = "transitive_compiled_symbols",
               doc =
@@ -181,21 +181,21 @@ public interface AndroidResourcesInfoApi<
                       + "closure.",
               positional = true,
               named = true,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
           @Param(
               // TODO(b/119560471): remove.
               name = "transitive_static_lib",
               doc = "A depset of Artifacts of static lib files in the transitive closure.",
               positional = true,
               named = true,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)},
+              allowedTypes = {@ParamType(type = Depset.class)},
               defaultValue = "unbound"),
           @Param(
               name = "transitive_r_txt",
               doc = "A depset of Artifacts of Android AAPT R.txt files in the transitive closure.",
               positional = true,
               named = true,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)},
+              allowedTypes = {@ParamType(type = Depset.class)},
               defaultValue = "unbound"), // needed to allow removing any earlier parameters.
           // TODO(b/132383435): remove this
           @Param(
@@ -204,7 +204,7 @@ public interface AndroidResourcesInfoApi<
               doc = "A depset of opaque files to trigger resource validation.",
               positional = false,
               named = true,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
         },
         selfCall = true)
     @StarlarkConstructor

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/apple/AppleCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/apple/AppleCommonApi.java
@@ -301,7 +301,7 @@ public interface AppleCommonApi<
         @Param(
             name = "framework_dirs",
             allowedTypes = {
-              @ParamType(type = Depset.class, generic1 = String.class),
+              @ParamType(type = Depset.class),
               @ParamType(type = NoneType.class),
             },
             named = true,
@@ -313,7 +313,7 @@ public interface AppleCommonApi<
         @Param(
             name = "framework_files",
             allowedTypes = {
-              @ParamType(type = Depset.class, generic1 = FileApi.class),
+              @ParamType(type = Depset.class),
               @ParamType(type = NoneType.class),
             },
             named = true,

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/GeneratedExtensionRegistryProviderApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/GeneratedExtensionRegistryProviderApi.java
@@ -84,7 +84,7 @@ public interface GeneratedExtensionRegistryProviderApi<FileT extends FileApi> ex
               doc = "Proto jars used to generate the registry",
               positional = true,
               named = false,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
         },
         selfCall = true)
     @StarlarkConstructor

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaNativeLibraryInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaNativeLibraryInfoApi.java
@@ -73,7 +73,7 @@ public interface JavaNativeLibraryInfoApi<
               doc = "The transitive set of LibraryToLink providers.",
               positional = true,
               named = false,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = LibraryToLinkApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
         },
         selfCall = true)
     @StarlarkConstructor

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/ProguardSpecProviderApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/ProguardSpecProviderApi.java
@@ -50,7 +50,7 @@ public interface ProguardSpecProviderApi<FileT extends FileApi> extends StructAp
               doc = "Transitive proguard specs.",
               positional = true,
               named = false,
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)}),
+              allowedTypes = {@ParamType(type = Depset.class)}),
         },
         selfCall = true)
     @StarlarkConstructor

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/python/PyInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/python/PyInfoApi.java
@@ -87,7 +87,7 @@ public interface PyInfoApi<FileT extends FileApi> extends StarlarkValue {
         parameters = {
           @Param(
               name = "transitive_sources",
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = FileApi.class)},
+              allowedTypes = {@ParamType(type = Depset.class)},
               positional = false,
               named = true,
               doc = "The value for the new object's <code>transitive_sources</code> field."),
@@ -99,7 +99,7 @@ public interface PyInfoApi<FileT extends FileApi> extends StarlarkValue {
               doc = "The value for the new object's <code>uses_shared_libraries</code> field."),
           @Param(
               name = "imports",
-              allowedTypes = {@ParamType(type = Depset.class, generic1 = String.class)},
+              allowedTypes = {@ParamType(type = Depset.class)},
               positional = false,
               named = true,
               defaultValue = "unbound",

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/python/PyRuntimeInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/python/PyRuntimeInfoApi.java
@@ -123,7 +123,7 @@ public interface PyRuntimeInfoApi<FileT extends FileApi> extends StarlarkValue {
           @Param(
               name = "files",
               allowedTypes = {
-                @ParamType(type = Depset.class, generic1 = FileApi.class),
+                @ParamType(type = Depset.class),
                 @ParamType(type = NoneType.class),
               },
               positional = false,

--- a/src/main/java/net/starlark/java/annot/ParamType.java
+++ b/src/main/java/net/starlark/java/annot/ParamType.java
@@ -19,6 +19,9 @@ import java.lang.annotation.RetentionPolicy;
 /** An annotation for parameter types for Starlark built-in functions. */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ParamType {
+  /** Unspecified value for {@link #generic1()}. */
+  enum Unspecified {}
+
   /**
    * The Java class of the type, e.g. {@link String}.class or {@link
    * net.starlark.java.eval.Sequence}.class.
@@ -36,5 +39,5 @@ public @interface ParamType {
    */
   // TODO(adonovan): make this an array---a non-breaking change for most clients---
   // ideally of the same length as the number of type parameters of type().
-  Class<?> generic1() default Object.class;
+  Class<?> generic1() default Unspecified.class;
 }

--- a/src/main/java/net/starlark/java/eval/StringModule.java
+++ b/src/main/java/net/starlark/java/eval/StringModule.java
@@ -903,7 +903,7 @@ final class StringModule implements StarlarkValue {
             name = "sub",
             allowedTypes = {
               @ParamType(type = String.class),
-              @ParamType(type = Tuple.class, generic1 = String.class),
+              @ParamType(type = Tuple.class),
             },
             doc = "The suffix (or tuple of alternative suffixes) to match."),
         @Param(
@@ -984,7 +984,7 @@ final class StringModule implements StarlarkValue {
             name = "sub",
             allowedTypes = {
               @ParamType(type = String.class),
-              @ParamType(type = Tuple.class, generic1 = String.class),
+              @ParamType(type = Tuple.class),
             },
             doc = "The prefix (or tuple of alternative prefixes) to match."),
         @Param(

--- a/src/test/java/net/starlark/java/annot/processor/StarlarkMethodProcessorTest.java
+++ b/src/test/java/net/starlark/java/annot/processor/StarlarkMethodProcessorTest.java
@@ -171,6 +171,16 @@ public final class StarlarkMethodProcessorTest {
   }
 
   @Test
+  public void testParamTypeExtraGenericParam() throws Exception {
+    assertAbout(javaSource())
+        .that(getFile("ParamTypeExtraGenericParam.java"))
+        .processedWith(new StarlarkMethodProcessor())
+        .failsToCompile()
+        .withErrorContaining("type java.lang.String of parameter 'a_parameter' has no type parameters," +
+          " net.starlark.java.eval.StarlarkInt given");
+  }
+
+  @Test
   public void testNonDefaultParamAfterDefault() throws Exception {
     assertAbout(javaSource())
         .that(getFile("NonDefaultParamAfterDefault.java"))

--- a/src/test/java/net/starlark/java/annot/processor/testsources/ParamTypeExtraGenericParam.java
+++ b/src/test/java/net/starlark/java/annot/processor/testsources/ParamTypeExtraGenericParam.java
@@ -1,0 +1,32 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net.starlark.java.annot.processor.testsources;
+
+import net.starlark.java.annot.Param;
+import net.starlark.java.annot.ParamType;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.StarlarkInt;
+
+public class ParamTypeExtraGenericParam {
+  @StarlarkMethod(
+    name = "param_type_extra_generic_param",
+    documented = false,
+    parameters = {
+      @Param(name = "a_parameter", allowedTypes = @ParamType(type = String.class, generic1 = StarlarkInt.class)),
+    })
+  public int param(Object x) {
+    return 42;
+  }
+}


### PR DESCRIPTION
For example this is incorrect:

```
@ParamType(type = Tuple.class, generic1 = String.class)
```

because `String` does not accept type parameters.

Validate it in annotation processor and fix annotations in Bazel sources.