### PR TITLE
Starlark: "fix" RangeList.hashCode

### DIFF
--- a/src/main/java/net/starlark/java/eval/RangeList.java
+++ b/src/main/java/net/starlark/java/eval/RangeList.java
@@ -19,6 +19,7 @@ import com.google.common.collect.UnmodifiableIterator;
 import java.util.AbstractList;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 import net.starlark.java.annot.StarlarkBuiltin;
 
@@ -118,7 +119,13 @@ final class RangeList extends AbstractList<StarlarkInt> implements Sequence<Star
 
   @Override
   public int hashCode() {
-    return 7873 ^ (5557 * start) ^ (3251 * step) ^ (1091 * size);
+    if (size == 0) {
+      return 234982346;
+    } else if (size == 1) {
+      return Integer.hashCode(start);
+    } else {
+      return Objects.hash(start, size, step);
+    }
   }
 
   @Override


### PR DESCRIPTION
```
r1.equals(r2) => r1.hashCode() == r2.hashCode()
```

It is not a big deal because:

* `range` type is not hashable in Starlark
* `RangeList` violates `java.util.List` conventions: `List` objects
  of different types should be equal if their content is equal,
  and `hashCode` should be computed by `hash = 31 * hash + hash(elem)`

but still better fix it.