### PR TITLE
Starlark: dict.setdefault should fail if frozen

### DIFF
--- a/src/main/java/net/starlark/java/eval/Dict.java
+++ b/src/main/java/net/starlark/java/eval/Dict.java
@@ -267,13 +267,11 @@ public final class Dict<K, V>
       })
   @SuppressWarnings("unchecked") // Cast of value to V
   public Object setdefault(K key, Object defaultValue) throws EvalException {
-    // TODO(adonovan): opt: use putIfAbsent to avoid hashing twice.
-    Object value = get(key);
-    if (value != null) {
-      return value;
-    }
-    putEntry(key, (V) defaultValue);
-    return defaultValue;
+    Starlark.checkMutable(this);
+    Starlark.checkHashable(key);
+
+    V prev = contents.putIfAbsent(key, (V) defaultValue);
+    return prev != null ? prev : defaultValue;
   }
 
   @StarlarkMethod(

--- a/src/test/java/net/starlark/java/eval/testdata/dict.star
+++ b/src/test/java/net/starlark/java/eval/testdata/dict.star
@@ -39,6 +39,10 @@ assert_eq(foo.pop('a', 0), 0)
 assert_eq(foo.popitem(), ('b', [1, 2]))
 
 ---
+d = {1: 2}
+freeze(d)
+d.setdefault(1, 2) ### trying to mutate a frozen dict value
+---
 dict().popitem() ### empty dictionary
 ---
 dict(a=2).pop('z') ### KeyError: "z"


### PR DESCRIPTION
... even if `setdefault` call did not update the dict.

This is similar to #12519.