### PR TITLE
Support Shenandoah and ZGC

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/RetainedHeapLimiter.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/RetainedHeapLimiter.java
@@ -242,6 +242,7 @@ final class RetainedHeapLimiter implements NotificationListener {
         || "G1 Old Gen".equals(name)
         || "PS Old Gen".equals(name)
         || "Tenured Gen".equals(name)
-        || "Shenandoah".equals(name);
+        || "Shenandoah".equals(name)
+        || "ZHeap".equals(name);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/RetainedHeapLimiter.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/RetainedHeapLimiter.java
@@ -241,6 +241,7 @@ final class RetainedHeapLimiter implements NotificationListener {
     return "CMS Old Gen".equals(name)
         || "G1 Old Gen".equals(name)
         || "PS Old Gen".equals(name)
-        || "Tenured Gen".equals(name);
+        || "Tenured Gen".equals(name)
+        || "Shenandoah".equals(name);
   }
 }


### PR DESCRIPTION
Bazel currently refuses to start up when JVM is launched with `-XX:+UseShenandoahGC` or
`-XX:+UseZGC`. This can be easily fixed by making `RetainedHeapLimiter` recognize the
memory pool name `Shenandoah` and `ZHeap`.