### PR TITLE
Use release_archive to create java_tools' zips (reenabling tests).

### DIFF
--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -176,8 +176,7 @@ function test_java_tools_has_BUILD() {
   expect_path_in_java_tools "BUILD"
 }
 
-# TODO(ilist): reenable after jacocoagent is patched
-function disable_java_tools_has_jacocoagent() {
+function test_java_tools_has_jacocoagent() {
   expect_path_in_java_tools "java_tools/third_party/java/jacoco/jacocoagent-0.8.3.jar"
   expect_path_in_java_tools "java_tools/third_party/java/jacoco/org.jacoco.agent-0.8.3.jar"
   expect_path_in_java_tools "java_tools/third_party/java/jacoco/org.jacoco.core-0.8.3.jar"
@@ -188,8 +187,7 @@ function disable_java_tools_has_jacocoagent() {
   expect_path_in_java_tools "java_tools/third_party/java/jacoco/LICENSE"
 }
 
-# TODO(ilist): reenable after proguard is patched
-function disable_java_tools_has_proguard() {
+function test_java_tools_has_proguard() {
   expect_path_in_java_tools "java_tools/third_party/java/proguard/proguard.jar"
   expect_path_in_java_tools "java_tools/third_party/java/proguard/GPL.html"
 }


### PR DESCRIPTION
This is third part of https://github.com/bazelbuild/bazel/pull/12615
Second part was https://github.com/bazelbuild/bazel/pull/12628