### PR TITLE
WIP: Build process-wrapper statically

### DIFF
--- a/src/main/tools/BUILD
+++ b/src/main/tools/BUILD
@@ -41,8 +41,10 @@ cc_binary(
     }),
     linkopts = select({
         "//src/conditions:windows": [],
-        "//conditions:default": ["-lm"],
+        "//conditions:default": ["-lm", "-lstdc++", "-lgcc"],
     }),
+    linkstatic = 1,
+    features = ["fully_static_link"],
     deps = select({
         "//src/conditions:windows": [],
         "//conditions:default": [


### PR DESCRIPTION
process-wrapper was built with some system libraries dynamical linked, Bazel fails silently when the required LD_LIBRARY_PATH was not passed to the action.

Fixes https://github.com/bazelbuild/bazel/issues/4137, https://github.com/bazelbuild/bazel/issues/12579
Related: https://github.com/bazelbuild/bazel/issues/12649