### PR TITLE
Remove ABSOLUTE_JAVABASE in Bazel and remove obsolete documentation.

### DIFF
--- a/site/docs/bazel-and-java.md
+++ b/site/docs/bazel-and-java.md
@@ -131,33 +131,6 @@ Similarly for `java_runtime` targets:
 $ bazel query 'kind(java_runtime, @bazel_tools//tools/jdk:all)'
 ```
 
-For example, if you'd like to use a locally installed JDK installed at
-`/usr/lib/jvm/java-13-openjdk`, use the `absolute_javabase` `java_runtime`
-target and the `toolchain_vanilla` `java_toolchain` target, and define
-`ABSOLUTE_JAVABASE` as the absolute path to the JDK.
-
-
-```
-bazel build \
-    --define=ABSOLUTE_JAVABASE=/usr/lib/jvm/java-13-openjdk \
-    --javabase=@bazel_tools//tools/jdk:absolute_javabase \
-    --host_javabase=@bazel_tools//tools/jdk:absolute_javabase \
-    --java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla \
-    --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla \
-    //my/java_13:target
-```
-
-Optionally, you can add the flags into your project's `.bazelrc` file to
-avoid having to specify them every time:
-
-```
-build --define=ABSOLUTE_JAVABASE=/usr/lib/jvm/java-13-openjdk
-build --javabase=@bazel_tools//tools/jdk:absolute_javabase
-build --host_javabase=@bazel_tools//tools/jdk:absolute_javabase
-build --java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla
-build --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_vanilla
-```
-
 You can also write your own `java_runtime` and `java_toolchain` targets. As a
 tip, use `bazel query --output=build @bazel_tools//tools/jdk:all` to see how
 the built-in runtime and toolchain targets are defined.

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -69,16 +69,6 @@ legacy_java_runtime_alias(name = "legacy_current_java_runtime")
 # Points to --java_toolchain/--host_java_toolchain, defaults ":toolchain"/":remote_toolchain"
 legacy_java_toolchain_alias(name = "legacy_current_java_toolchain")
 
-# Used to set --host_javabase or --javabase to a local JDK without having to define
-# a custom java_runtime rule.
-# E.g.:
-# bazel build --host_javabase=@bazel_tools//tools/jdk:absolute_javabase \
-#   --define=ABSOLUTE_JAVABASE=<path to JDK> ...
-java_runtime(
-    name = "absolute_javabase",
-    java_home = "$(ABSOLUTE_JAVABASE)",
-)
-
 # This is necessary to get the *host* Java runtime. Depending on
 # //tools/jdk:current_java_runtime from an attribute with the host transition
 # does not work because the dependency is determined based on the configuration


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/6118.