### PR TITLE
Use configuration flags for //src/conditions:darwin_arm64

### DIFF
--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -103,6 +103,10 @@ config_setting(
     values = {"cpu": "darwin_arm64"},
 )
 
+# Workaround for an issue where the dummy cc toolchain isn't being picked up
+# when cross-compile from darwin_x86_64 to darwin_arm64 cpu.
+# TODO(https://github.com/bazelbuild/bazel/issues/12655): Remove the flag based
+# select when the issue is resolved.
 selects.config_setting_group(
     name = "darwin_arm64",
     match_any = [

--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
@@ -89,8 +91,24 @@ config_setting(
 )
 
 config_setting(
-    name = "darwin_arm64",
+    name = "darwin_arm64_constraint",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
+    name = "darwin_arm64_flag",
     values = {"cpu": "darwin_arm64"},
+)
+
+selects.config_setting_group(
+    name = "darwin_arm64",
+    match_any = [
+        ":darwin_arm64_constraint",
+        ":darwin_arm64_flag",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -90,10 +90,7 @@ config_setting(
 
 config_setting(
     name = "darwin_arm64",
-    constraint_values = [
-        "@platforms//os:macos",
-        "@platforms//cpu:arm64",
-    ],
+    values = {"cpu": "darwin_arm64"},
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Partially reverts 6d637f4165445a0d6644f6e6f8a61b3f1de208d8, to allow
cross-compiling Bazel from darwin_x86_64 to darwin_arm64 with
the `--cpu=darwin_arm64` flag.

The only source that is different between darwin_x86_64 and darwin_arm64
now is the embedded JDK.
