### PR TITLE
[starlark] Force locale en_US in ScriptTest

### DIFF
--- a/src/test/java/net/starlark/java/eval/BUILD
+++ b/src/test/java/net/starlark/java/eval/BUILD
@@ -47,7 +47,10 @@ java_test(
     name = "ScriptTest",
     srcs = ["ScriptTest.java"],
     data = glob(["testdata/*.star"]),
-    jvm_flags = ["-Dfile.encoding=UTF8"],
+    jvm_flags = [
+        "-Duser.language=en_US",
+        "-Dfile.encoding=UTF8",
+    ],
     use_testrunner = False,
     deps = [
         "//src/main/java/net/starlark/java/annot",


### PR DESCRIPTION
Otherwise, the test can fail depending on the default locale of the system
(e.g., for me with locale `de`).

```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //src/test/java/net/starlark/java/eval:ScriptTest
-----------------------------------------------------------------------------
Traceback (most recent call last):
./src/test/java/net/starlark/java/eval/testdata/float.star:53:10: called from <toplevel>
Error: assert_eq: "0,0000000000000000.0" != "0.0"
Traceback (most recent call last):
./src/test/java/net/starlark/java/eval/testdata/float.star:54:10: called from <toplevel>
Error: assert_eq: "0,0000000000000000.0" != "0.0"
Traceback (most recent call last):
./src/test/java/net/starlark/java/eval/testdata/float.star:58:10: called from <toplevel>
Error: assert_eq: "-1,5557538194652854e-61" != "-1.5557538194652854e-61"

...
```