### PR TITLE
Propagate test envs to xml generation action

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -404,7 +404,7 @@ public class StandaloneTestStrategy extends TestStrategy {
     envBuilder.putAll(testEnv).put("TEST_NAME", action.getTestName());
     if (!action.isSharded()) {
       envBuilder.put("TEST_SHARD_INDEX", "0");
-      envBuilder.put("TEST_SHARD_INDEX", "0");
+      envBuilder.put("TEST_TOTAL_SHARDS", "0");
     }
     return new SimpleSpawn(
         action,

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -401,7 +401,12 @@ public class StandaloneTestStrategy extends TestStrategy {
             Long.toString(result.getWallTime().orElse(Duration.ZERO).getSeconds()),
             Integer.toString(result.exitCode()));
     ImmutableMap.Builder<String, String> envBuilder = ImmutableMap.builder();
+    // "PATH" and "TEST_BINARY" are also required, they should always be set in testEnv.
+    Preconditions.checkArgument(testEnv.containsKey("PATH"));
+    Preconditions.checkArgument(testEnv.containsKey("TEST_BINARY"));
     envBuilder.putAll(testEnv).put("TEST_NAME", action.getTestName());
+    // testEnv only contains TEST_SHARD_INDEX and TEST_TOTAL_SHARDS if the test action is sharded,
+    // we need to set the default value when the action isn't sharded.
     if (!action.isSharded()) {
       envBuilder.put("TEST_SHARD_INDEX", "0");
       envBuilder.put("TEST_TOTAL_SHARDS", "0");

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -402,6 +402,10 @@ public class StandaloneTestStrategy extends TestStrategy {
             Integer.toString(result.exitCode()));
     ImmutableMap.Builder<String, String> envBuilder = ImmutableMap.builder();
     envBuilder.put("TEST_NAME", action.getTestName()).putAll(testEnv);
+    if (!action.isSharded()) {
+      envBuilder.put("TEST_SHARD_INDEX", "0");
+      envBuilder.put("TEST_SHARD_INDEX", "0");
+    }
     return new SimpleSpawn(
         action,
         args,

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -401,10 +401,7 @@ public class StandaloneTestStrategy extends TestStrategy {
             Long.toString(result.getWallTime().orElse(Duration.ZERO).getSeconds()),
             Integer.toString(result.exitCode()));
     ImmutableMap.Builder<String, String> envBuilder = ImmutableMap.builder();
-    envBuilder.putAll(testEnv)
-        .put("TEST_SHARD_INDEX", Integer.toString(action.getShardNum()))
-        .put("TEST_TOTAL_SHARDS", Integer.toString(action.getExecutionSettings().getTotalShards()))
-        .put("TEST_NAME", action.getTestName());
+    envBuilder.put("TEST_NAME", action.getTestName()).putAll(testEnv);
     return new SimpleSpawn(
         action,
         args,

--- a/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/StandaloneTestStrategy.java
@@ -401,7 +401,7 @@ public class StandaloneTestStrategy extends TestStrategy {
             Long.toString(result.getWallTime().orElse(Duration.ZERO).getSeconds()),
             Integer.toString(result.exitCode()));
     ImmutableMap.Builder<String, String> envBuilder = ImmutableMap.builder();
-    envBuilder.put("TEST_NAME", action.getTestName()).putAll(testEnv);
+    envBuilder.putAll(testEnv).put("TEST_NAME", action.getTestName());
     if (!action.isSharded()) {
       envBuilder.put("TEST_SHARD_INDEX", "0");
       envBuilder.put("TEST_SHARD_INDEX", "0");


### PR DESCRIPTION
Previously, we hardcode the envs of the xml generation action, which
caused problem for process-wrapper because it's dynamically linked to
some system libraries and the required PATH or LD_LIBRARY_PATH are not
set.

This change propagate the envs we set for the actual test action to the
xml file generation action to make sure the env vars are correctly set and
can also be controlled by --action_env and --test_env.

Fixes https://github.com/bazelbuild/bazel/issues/4137
Fixes https://github.com/bazelbuild/bazel/issues/12579