### PR TITLE
Add windows_msvc back to conditions.

### DIFF
--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -150,6 +150,12 @@ config_setting(
 )
 
 config_setting(
+    name = "windows_msvc",
+    values = {"cpu": "x64_windows_msvc"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "arm",
     constraint_values = ["@platforms//cpu:arm"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This is partial revert of 6d637f4165445a0d6644f6e6f8a61b3f1de208d8.

windows_msvc condition is used downstream by tensorflow via ruy.

The culprit line is in https://github.com/google/ruy/blob/master/ruy/build_defs.bzl#L60 (and #L67,#L77).