### PR TITLE
Starlark: reimplement StarlarkInt.bitnot using BigInteger.not

### DIFF
--- a/src/main/java/net/starlark/java/eval/StarlarkInt.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkInt.java
@@ -667,9 +667,8 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
       /* fall through */
     }
 
-    BigInteger xbig = x.toBigInteger();
-    BigInteger ybig = MINUS1BIG.subtract(xbig);
-    return StarlarkInt.of(ybig);
+    BigInteger xbig = ((Big) x).v;
+    return StarlarkInt.of(xbig.not());
   }
 
   /** Returns -x. */
@@ -690,8 +689,6 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
     BigInteger ybig = xbig.negate();
     return StarlarkInt.of(ybig);
   }
-
-  private static final BigInteger MINUS1BIG = BigInteger.ONE.negate();
 
   /** Reports whether int x exactly equals float y. */
   static boolean intEqualsFloat(StarlarkInt x, StarlarkFloat y) {

--- a/src/test/java/net/starlark/java/eval/testdata/int.star
+++ b/src/test/java/net/starlark/java/eval/testdata/int.star
@@ -216,6 +216,8 @@ assert_eq(~minint, maxint)
 assert_eq(~maxint, minint)
 assert_eq(~minlong, maxlong)
 assert_eq(~maxlong, minlong)
+assert_eq(~(1 << 100), -(1 << 100) - 1)
+assert_eq(~-(1 << 100), (1 << 100) - 1)
 
 ---
 1 // 0  ### integer division by zero


### PR DESCRIPTION
Mostly to avoid questioning why not use `BigInteger.not`.