### PR TITLE
Add windows_msvc back to conditions in bazel_tools.

### DIFF
--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -150,12 +150,6 @@ config_setting(
 )
 
 config_setting(
-    name = "windows_msvc",
-    values = {"cpu": "x64_windows_msvc"},
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
     name = "arm",
     constraint_values = ["@platforms//cpu:arm"],
     visibility = ["//visibility:public"],

--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -1,72 +1,103 @@
 config_setting(
     name = "freebsd",
-    constraint_values = [ "@platforms//os:freebsd"],
+    constraint_values = ["@platforms//os:freebsd"],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "openbsd",
-    constraint_values = [ "@platforms//os:openbsd"],
+    constraint_values = ["@platforms//os:openbsd"],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "darwin",
-    constraint_values = [ "@platforms//os:macos" ],
+    constraint_values = ["@platforms//os:macos"],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_ppc",
-    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:ppc" ],
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:ppc",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_ppc64le",
-    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:ppc" ],
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:ppc",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_s390x",
-    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:s390x" ],
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:s390x",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_x86_64",
-    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:x86_64" ],
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "linux_aarch64",
-    constraint_values = [ "@platforms//os:linux", "@platforms//cpu:aarch64" ],
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "darwin_x86_64",
-    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:x86_64" ],
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "darwin_arm64",
-    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:arm64" ],
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "darwin_arm64e",
-    constraint_values = [ "@platforms//os:macos", "@platforms//cpu:arm64e" ],
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64e",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "windows",
-    constraint_values = [ "@platforms//os:windows"],
+    constraint_values = ["@platforms//os:windows"],
+    visibility = ["//visibility:public"],
+)
+
+# TODO: figure out how to base this selection on constraints
+config_setting(
+    name = "windows_msvc",
+    values = {"cpu": "x64_windows_msvc"},
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
This is partial revert of 6d637f4 and a fix to a06d7e1, which went into wrong file.

windows_msvc condition is used downstream by tensorflow via ruy.

The culprit line is in https://github.com/google/ruy/blob/master/ruy/build_defs.bzl#L60 (and #L67,#L77).