### PR TITLE
Starlark: better errors on integer overflow

### DIFF
--- a/src/main/java/net/starlark/java/eval/StarlarkList.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkList.java
@@ -74,6 +74,11 @@ import net.starlark.java.annot.StarlarkMethod;
 public final class StarlarkList<E> extends AbstractList<E>
     implements Sequence<E>, StarlarkValue, Mutability.Freezable, Comparable<StarlarkList<?>> {
 
+  // It's always possible to overeat in small bites but we'll
+  // try to stop someone swallowing the world in one gulp.
+  static final int MAX_ALLOC = 1 << 30;
+
+
   // The implementation strategy is similar to ArrayList,
   // but without the extra indirection of using ArrayList.
 
@@ -284,9 +289,12 @@ public final class StarlarkList<E> extends AbstractList<E>
       return wrap(mutability, EMPTY_ARRAY);
     }
 
-    // TODO(adonovan): reject unreasonably large n.
     int ni = n.toInt("repeat");
-    Object[] res = new Object[ni * size];
+    long sz = (long) ni * size;
+    if (sz > MAX_ALLOC) {
+      throw Starlark.errorf("excessive repeat (%d * %d elements)", size, ni);
+    }
+    Object[] res = new Object[(int) sz];
     for (int i = 0; i < ni; i++) {
       System.arraycopy(elems, 0, res, i * size, size);
     }
@@ -334,6 +342,15 @@ public final class StarlarkList<E> extends AbstractList<E>
     }
   }
 
+  // Grow capacity enough to insert given number of elements
+  private void growAdditional(int additional) throws EvalException {
+    int mincap = size + additional;
+    if (mincap < 0 || mincap > MAX_ALLOC) {
+      throw Starlark.errorf("excessive capacity requested (%d + %d elements)", size, additional);
+    }
+    grow(mincap);
+  }
+
   /**
    * Appends an element to the end of the list, after validating that mutation is allowed.
    *
@@ -341,7 +358,7 @@ public final class StarlarkList<E> extends AbstractList<E>
    */
   public void addElement(E element) throws EvalException {
     Starlark.checkMutable(this);
-    grow(size + 1);
+    growAdditional(1);
     elems[size++] = element;
   }
 
@@ -353,7 +370,7 @@ public final class StarlarkList<E> extends AbstractList<E>
    */
   public void addElementAt(int index, E element) throws EvalException {
     Starlark.checkMutable(this);
-    grow(size + 1);
+    growAdditional(1);
     System.arraycopy(elems, index, elems, index + 1, size - index);
     elems[index] = element;
     size++;
@@ -369,20 +386,20 @@ public final class StarlarkList<E> extends AbstractList<E>
     if (elements instanceof StarlarkList) {
       StarlarkList<?> that = (StarlarkList) elements;
       // (safe even if this == that)
-      grow(this.size + that.size);
+      growAdditional(that.size);
       System.arraycopy(that.elems, 0, this.elems, this.size, that.size);
       this.size += that.size;
     } else if (elements instanceof Collection) {
       // collection of known size
       Collection<?> that = (Collection) elements;
-      grow(size + that.size());
+      growAdditional(that.size());
       for (Object x : that) {
         elems[size++] = x;
       }
     } else {
       // iterable
       for (Object x : elements) {
-        grow(size + 1);
+        growAdditional(1);
         elems[size++] = x;
       }
     }

--- a/src/main/java/net/starlark/java/eval/Tuple.java
+++ b/src/main/java/net/starlark/java/eval/Tuple.java
@@ -245,9 +245,12 @@ public final class Tuple extends AbstractList<Object>
       return empty();
     }
 
-    // TODO(adonovan): reject unreasonably large n.
     int ni = n.toInt("repeat");
-    Object[] res = new Object[ni * elems.length];
+    long sz = (long) ni * elems.length;
+    if (sz > StarlarkList.MAX_ALLOC) {
+      throw Starlark.errorf("excessive repeat (%d * %d elements)", elems.length, ni);
+    }
+    Object[] res = new Object[(int) sz];
     for (int i = 0; i < ni; i++) {
       System.arraycopy(elems, 0, res, i * elems.length, elems.length);
     }

--- a/src/test/java/net/starlark/java/eval/testdata/list_mutation.star
+++ b/src/test/java/net/starlark/java/eval/testdata/list_mutation.star
@@ -53,6 +53,9 @@ assert_eq(foo, ['a', 'b', 'c', 'd', 'e', 'f', 'g'])
 (1, 2).extend([3, 4]) ### 'tuple' value has no field or method 'extend'
 ---
 [1, 2].extend(3) ### type 'int' is not iterable
+---
+[].extend(range((1 << 31) - 1)) ### excessive capacity requested
+---
 
 # remove
 


### PR DESCRIPTION
Before:

```
>> [1] * (1 << 30) * (1 << 5)
Exception in thread "main" net.starlark.java.eval.Starlark$UncheckedEvalException: java.lang.ArrayIndexOutOfBoundsException: arraycopy: last destination index 1073741824 out of bounds for object array[0] (Starlark stack: [<toplevel>@<stdin>:1:1])
	at net.starlark.java.eval.Starlark.fastcall(Starlark.java:621)
	at net.starlark.java.eval.Starlark.execFileProgram(Starlark.java:892)
...
exit 1
```

Now:

```
>> [1] * (1 << 30) * (1 << 5)
Traceback (most recent call last):
	File "<stdin>", line 1, column 21, in <toplevel>
Error: got 34359738368 for repeat, want value in signed 32-bit range
```