### PR TITLE
Starlark: Sequence.len protocol and fix range is not iterable

### DIFF
--- a/src/main/java/net/starlark/java/eval/MethodLibrary.java
+++ b/src/main/java/net/starlark/java/eval/MethodLibrary.java
@@ -271,12 +271,15 @@ class MethodLibrary {
               + " iterable.",
       parameters = {@Param(name = "x", doc = "The value whose length to report.")},
       useStarlarkThread = true)
-  public int len(Object x, StarlarkThread thread) throws EvalException {
+  public StarlarkInt len(Object x, StarlarkThread thread) throws EvalException {
+    if (x instanceof Sequence) {
+      return ((Sequence) x).len();
+    }
     int len = Starlark.len(x);
     if (len < 0) {
       throw Starlark.errorf("%s is not iterable", Starlark.type(x));
     }
-    return len;
+    return StarlarkInt.of(len);
   }
 
   @StarlarkMethod(

--- a/src/main/java/net/starlark/java/eval/RangeList.java
+++ b/src/main/java/net/starlark/java/eval/RangeList.java
@@ -114,7 +114,22 @@ final class RangeList extends AbstractList<StarlarkInt> implements Sequence<Star
 
   @Override
   public int size() {
+    Preconditions.checkState(size >= 0, "len(%s) = %s", this, len());
     return size;
+  }
+
+  @Override
+  public int lenInt() throws EvalException {
+    if (size >= 0) {
+      return size;
+    } else {
+      throw Starlark.errorf("len(%s) = %s, want value in signed 32-bit range", this, len());
+    }
+  }
+
+  @Override
+  public StarlarkInt len() {
+    return StarlarkInt.of(size & 0xFFFFFFFFL);
   }
 
   @Override

--- a/src/main/java/net/starlark/java/eval/Sequence.java
+++ b/src/main/java/net/starlark/java/eval/Sequence.java
@@ -41,6 +41,28 @@ public interface Sequence<E>
     return !isEmpty();
   }
 
+  /**
+   * The number of elements in the collection.
+   *
+   * @throws IllegalStateException if collection size exceeds int32 range
+   */
+  @Override
+  int size();
+
+  /**
+   * The number of elements in the collection.
+   *
+   * @throws EvalException if collection size exceeds int32 range
+   */
+  default int lenInt() throws EvalException {
+    return size();
+  }
+
+  /** The number of elements in the collection as an arbitrary size integer. */
+  default StarlarkInt len() {
+    return StarlarkInt.of(size());
+  }
+
   /** Returns an ImmutableList object with the current underlying contents of this Sequence. */
   default ImmutableList<E> getImmutableList() {
     return ImmutableList.copyOf(this);

--- a/src/main/java/net/starlark/java/eval/Starlark.java
+++ b/src/main/java/net/starlark/java/eval/Starlark.java
@@ -260,11 +260,11 @@ public final class Starlark {
    * iterable, as if by the Starlark expression {@code len(x)}, or -1 if the value is valid but has
    * no length.
    */
-  public static int len(Object x) {
+  public static int len(Object x) throws EvalException {
     if (x instanceof String) {
       return ((String) x).length();
     } else if (x instanceof Sequence) {
-      return ((Sequence) x).size();
+      return ((Sequence) x).lenInt();
     } else if (x instanceof Dict) {
       return ((Dict) x).size();
     } else if (x instanceof StarlarkIterable) {

--- a/src/test/java/net/starlark/java/eval/EvalUtilsTest.java
+++ b/src/test/java/net/starlark/java/eval/EvalUtilsTest.java
@@ -124,7 +124,7 @@ public final class EvalUtilsTest {
   }
 
   @Test
-  public void testLen() {
+  public void testLen() throws Exception {
     assertThat(Starlark.len("abc")).isEqualTo(3);
     assertThat(Starlark.len(Tuple.of(StarlarkInt.of(1), StarlarkInt.of(2), StarlarkInt.of(3))))
         .isEqualTo(3);

--- a/src/test/java/net/starlark/java/eval/testdata/range.star
+++ b/src/test/java/net/starlark/java/eval/testdata/range.star
@@ -13,6 +13,13 @@ assert_eq(list(range(5, 0, -1)), [5, 4, 3, 2, 1])
 assert_eq(list(range(5, 0, -10)), [5])
 assert_eq(list(range(0, -3, -2)), [0, -2])
 
+int32_range_range = range(-1 << 31, (1 << 31) - 1)
+assert_eq(len(int32_range_range), 4294967295)
+assert_((-1 << 31) - 1 not in int32_range_range)
+assert_(-1 << 31 in int32_range_range)
+assert_((1 << 31) - 2 in int32_range_range)
+assert_((1 << 31) - 1 not in int32_range_range)
+
 ---
 range(2, 3, 0) ### step cannot be 0
 


### PR DESCRIPTION
`range` need to be reimplemented using `StarlarkInt`.  For starters,
we can change the `Sequence` protocol to work with `StarlarkInt`,
not `int`.

This PR adds two operations to `Sequence` interface:
* `int lenInt() throws EvalException`, get size as `int`, throw on overflow
* `StarlarInt len()`, get size as `StarlarkInt`, does not throw

The first operation is used in sequence unpack, e. g. `[a, b] = l`.
The second operation is used in `len(x)` expression.

Before this PR:

```
>> range(-1 << 31, (1 << 31) - 1)
range(-2147483648, 2147483647)
>> len(range(-1 << 31, (1 << 31) - 1))
Traceback (most recent call last):
	File "<stdin>", line 1, column 4, in <toplevel>
Error in len: range is not iterable
```

"range is not iterable" error is reported because `RangeList.size`
returned negative integer.

Now:

```
>> range(-1 << 31, (1 << 31) - 1)
range(-2147483648, 2147483647)
>> len(range(-1 << 31, (1 << 31) - 1))
4294967295
```

We could fix range to explicitly handle size overflow in constructor,
but that's not the point, the point is future extension of range
to work with unbounded integers.