### PR TITLE
Add NONPREBUILT_TOOLCHAIN_CONFIGURATION.

### DIFF
--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -160,4 +160,96 @@ EOF
   expect_log "jacocorunner not set in java_toolchain:"
 }
 
+
+function test_default_java_toolchain_manualConfiguration() {
+  cat > BUILD <<EOF
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
+default_java_toolchain(
+  name = "vanilla",
+  javabuilder = ["//:VanillaJavaBuilder"],
+  jvm_opts = [],
+)
+EOF
+  bazel build //:vanilla || fail "default_java_toolchain target failed to build"
+}
+
+function test_default_java_toolchain_manualConfigurationWithLocation() {
+  cat > BUILD <<EOF
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain", "JDK9_JVM_OPTS")
+default_java_toolchain(
+  name = "toolchain",
+  jvm_opts = [
+      # In JDK9 we have seen a ~30% slow down in JavaBuilder performance when using
+      # G1 collector and having compact strings enabled.
+      "-XX:+UseParallelOldGC",
+      "-XX:-CompactStrings",
+      # override the javac in the JDK.
+      "--patch-module=java.compiler=\$(location @remote_java_tools//:java_compiler_jar)",
+      "--patch-module=jdk.compiler=\$(location @remote_java_tools//:jdk_compiler_jar)",
+  ] + JDK9_JVM_OPTS,
+  tools = [
+      "@remote_java_tools//:java_compiler_jar",
+      "@remote_java_tools//:jdk_compiler_jar",
+    ],
+)
+EOF
+  bazel build //:toolchain || fail "default_java_toolchain target failed to build"
+}
+
+function test_default_java_toolchain_jvm8Toolchain() {
+  cat > BUILD <<EOF
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain", "JVM8_TOOLCHAIN_CONFIGURATION")
+default_java_toolchain(
+  name = "jvm8_toolchain",
+  configuration = JVM8_TOOLCHAIN_CONFIGURATION,
+)
+EOF
+  bazel build //:jvm8_toolchain || fail "default_java_toolchain target failed to build"
+}
+
+function test_default_java_toolchain_javabuilderToolchain() {
+  cat > BUILD <<EOF
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain", "DEFAULT_TOOLCHAIN_CONFIGURATION")
+default_java_toolchain(
+  name = "javabuilder_toolchain",
+  configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,
+)
+EOF
+  bazel build //:javabuilder_toolchain || fail "default_java_toolchain target failed to build"
+}
+
+function test_default_java_toolchain_vanillaToolchain() {
+  cat > BUILD <<EOF
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain", "VANILLA_TOOLCHAIN_CONFIGURATION")
+default_java_toolchain(
+  name = "vanilla_toolchain",
+  configuration = VANILLA_TOOLCHAIN_CONFIGURATION,
+)
+EOF
+  bazel build //:vanilla_toolchain || fail "default_java_toolchain target failed to build"
+}
+
+function test_default_java_toolchain_prebuiltToolchain() {
+  cat > BUILD <<EOF
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain", "PREBUILT_TOOLCHAIN_CONFIGURATION")
+default_java_toolchain(
+  name = "prebuilt_toolchain",
+  configuration = PREBUILT_TOOLCHAIN_CONFIGURATION,
+)
+EOF
+  bazel build //:prebuilt_toolchain || fail "default_java_toolchain target failed to build"
+}
+
+function test_default_java_toolchain_nonprebuiltToolchain() {
+  cat > BUILD <<EOF
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain", "NONPREBUILT_TOOLCHAIN_CONFIGURATION")
+default_java_toolchain(
+  name = "nonprebuilt_toolchain",
+  configuration = NONPREBUILT_TOOLCHAIN_CONFIGURATION,
+)
+EOF
+  bazel build //:nonprebuilt_toolchain || fail "default_java_toolchain target failed to build"
+}
+
+
 run_suite "Java integration tests with default Bazel values"

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -131,6 +131,24 @@ PREBUILT_TOOLCHAIN_CONFIGURATION = dict(
         "@remote_java_tools//:java_compiler_jar",
         "@remote_java_tools//:jdk_compiler_jar",
     ],
+    ijar = ["@remote_java_tools//:ijar_cc_binary"],
+    singlejar = ["@remote_java_tools//:singlejar_cc_bin"],
+)
+
+# The new toolchain is using all the tools from sources.
+NONPREBUILT_TOOLCHAIN_CONFIGURATION = dict(
+    jvm_opts = [
+        # Compact strings make JavaBuilder slightly slower.
+        "-XX:-CompactStrings",
+    ] + JDK9_JVM_OPTS,
+    turbine_jvm_opts = [
+        # Turbine is not a worker and parallel GC is faster for short-lived programs.
+        "-XX:+UseParallelOldGC",
+    ],
+    tools = [
+        "@remote_java_tools//:java_compiler_jar",
+        "@remote_java_tools//:jdk_compiler_jar",
+    ],
     ijar = ["@bazel_tools//tools/jdk:ijar_prebuilt_binary"],
     singlejar = ["@bazel_tools//tools/jdk:prebuilt_singlejar"],
 )


### PR DESCRIPTION
Also re-added all the tests that were remove while splitting java_tools into pure and prebuilt parts.