### PR TITLE
Add the parse_netrc function

### DIFF
--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -213,6 +213,19 @@ def read_netrc(ctx, filename):
       about them
     """
     contents = ctx.read(filename)
+    return parse_netrc(contents, filename)
+
+def parse_netrc(contents, filename=None):
+    """Utility function to parse at least a basic .netrc file.
+
+    Args:
+      contents: input for the parser.
+      filename: filename to use in error messages, if any.
+
+    Returns:
+      dict mapping a machine names to a dict with the information provided
+      about them
+    """
 
     # Parse the file. This is mainly a token-based update of a simple state
     # machine, but we need to keep the line structure to correctly determine
@@ -283,6 +296,8 @@ def read_netrc(ctx, filename):
                     currentmachinename = ""
                     currentmachine = {}
                 else:
+                    if filename == None:
+                        filename = "a .netrc file"
                     fail("Unexpected token '%s' while reading %s" %
                          (token, filename))
     if not currentmachinename == None:


### PR DESCRIPTION
The existing `read_netrc` function can only be used from repository rules.
This makes it harder to e.g. test code that builds on top of `read_netrc`.
The new function is pure and can be easily tested.