### PR TITLE
Update docs to use the @platforms//:incompatible constraint

### DIFF
--- a/site/docs/platforms.md
+++ b/site/docs/platforms.md
@@ -169,25 +169,16 @@ FAILED: Build did NOT complete successfully
 
 ### More expressive constraints
 
-For more flexibility in expressing constraints, create a user-defined
+For more flexibility in expressing constraints, use the
+`@platforms//:incompatible`
 [`constraint_value`](platform.html#constraint_value) that no platform
-satisfies. For example, Put the following somewhere in your project and change
-`//:not_compatible` in the subsequent examples to match your location.
+satisfies.
 
-```python
-constraint_setting(name = "not_compatible_setting")
-
-constraint_value(
-    name = "not_compatible",
-    constraint_setting = ":not_compatible_setting",
-)
-```
-
-Use [`select()`](functions.html#select) in combination with `:not_compatible`
-to express more complicated restrictions. For example, use it to implement
-basic OR logic. The following marks a library compatible with macOS and Linux,
-but no other platforms. Note that an empty constraints list is equivalent to
-"compatible with everything".
+Use [`select()`](functions.html#select) in combination with
+`@platforms//:incompatible` to express more complicated restrictions. For
+example, use it to implement basic OR logic. The following marks a library
+compatible with macOS and Linux, but no other platforms. Note that an empty
+constraints list is equivalent to "compatible with everything".
 
 ```python
 cc_library(
@@ -196,7 +187,7 @@ cc_library(
     target_compatible_with = select({
         "@platforms//os:osx": [],
         "@platforms//os:linux": [],
-        "//conditions:default": ["//:not_compatible"],
+        "//conditions:default": ["@platforms//:incompatible"],
     ],
 )
 ```
@@ -205,9 +196,9 @@ The above can be interpreted as follows:
 
 1. If we are targeting macOS, then this target has no constraints.
 2. If we are targeting Linux, then this target has no constraints.
-3. Otherwise the target has the `:not_compatible` constraint. Because
-   `:not_compatible` is not part of any platforms, the target is deemed
-   incompatible.
+3. Otherwise the target has the `@platforms//:incompatible` constraint. Because
+   `@platforms//:incompatible` is not part of any platform, the target is
+   deemed incompatible.
 
 To make your constraints more readable, use
 [skylib](https://github.com/bazelbuild/bazel-skylib)'s
@@ -221,7 +212,7 @@ cc_library(
     name = "non_arm_lib",
     srcs = "non_arm_lib.cc",
     target_compatible_with = select({
-        "@platforms//cpu:arm": ["//:not_compatible"],
+        "@platforms//cpu:arm": ["@platforms//:incompatible"],
         "//conditions:default": [],
     ],
 )

--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -81,6 +81,8 @@ EOF
 # We're not validating visibility here. Let everything access these targets.
 package(default_visibility = ["//visibility:public"])
 
+# TODO(philsc): Get rid of this and use @platforms//:incomaptible instead.
+# Right now it's problematic because Google CI doesn't support @platforms.
 constraint_setting(name = "not_compatible_setting")
 
 constraint_value(

--- a/src/test/shell/integration/target_compatible_with_test_external_repo.sh
+++ b/src/test/shell/integration/target_compatible_with_test_external_repo.sh
@@ -80,13 +80,6 @@ EOF
 # We're not validating visibility here. Let everything access these targets.
 package(default_visibility = ["//visibility:public"])
 
-constraint_setting(name = "not_compatible_setting")
-
-constraint_value(
-    name = "not_compatible",
-    constraint_setting = ":not_compatible_setting",
-)
-
 constraint_setting(name = "foo_version")
 
 constraint_value(


### PR DESCRIPTION
With e03cb63e059420847d6578d7cbfe93f05615c95e bazel now distributes
the 0.0.2 release of bazelbuild/platforms. This lets us use the
`@platforms//:incompatible` constraint instead of setting up our own.

This patch updates the docs to use the commonly available constraint.

I decided against updating the tests because it causes problems with
Google CI internally. Google CI doesn't have access to external repos.