### PR TITLE
Set java_runtime in toolchain_hostjdk8 to current host JDK.

### DIFF
--- a/src/test/shell/bazel/bazel_example_test.sh
+++ b/src/test/shell/bazel/bazel_example_test.sh
@@ -91,7 +91,6 @@ function test_java_test() {
   local java_native_main=//examples/java-native/src/main/java/com/example/myproject
 
   assert_build "-- //examples/java-native/... -${java_native_main}:hello-error-prone"
-  JAVA_VERSION="1.$(bazel query  --output=build '@bazel_tools//tools/jdk:legacy_toolchain' | grep source_version | cut -d '"' -f 2)"
   assert_test_ok "${java_native_tests}:hello"
   assert_test_ok "${java_native_tests}:custom"
   assert_test_fails "${java_native_tests}:fail"

--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -203,6 +203,7 @@ load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolcha
 default_java_toolchain(
   name = "jvm8_toolchain",
   configuration = JVM8_TOOLCHAIN_CONFIGURATION,
+  java_runtime = "@local_jdk//:jdk",
 )
 EOF
   bazel query //:jvm8_toolchain || fail "default_java_toolchain target failed to build"

--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -226,6 +226,7 @@ load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolcha
 default_java_toolchain(
   name = "vanilla_toolchain",
   configuration = VANILLA_TOOLCHAIN_CONFIGURATION,
+  java_runtime = "@local_jdk//:jdk",
 )
 EOF
   bazel build //:vanilla_toolchain || fail "default_java_toolchain target failed to build"

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -386,6 +386,11 @@ default_java_toolchain(
     target_version = "8",
 )
 
+default_java_toolchain(
+    name = "prebuilt_toolchain",
+    configuration = PREBUILT_TOOLCHAIN_CONFIGURATION,
+)
+
 filegroup(
     name = "bzl_srcs",
     srcs = glob(["*.bzl"]),

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -337,22 +337,6 @@ bootclasspath(
 )
 
 default_java_toolchain(
-    name = "toolchain_hostjdk8",
-    configuration = JVM8_TOOLCHAIN_CONFIGURATION,
-    source_version = "8",
-    target_version = "8",
-)
-
-# Default to the Java 8 language level.
-# TODO(cushon): consider if/when we should increment this?
-default_java_toolchain(
-    name = "legacy_toolchain",
-    configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,
-    source_version = "8",
-    target_version = "8",
-)
-
-default_java_toolchain(
     name = "toolchain",
     configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,
 )
@@ -392,9 +376,14 @@ default_java_toolchain(
     target_version = "15",
 )
 
+# Deprecated, do not use.
+# It will be removed after migration to Java toolchain resolution.
 default_java_toolchain(
-    name = "prebuilt_toolchain",
-    configuration = PREBUILT_TOOLCHAIN_CONFIGURATION,
+    name = "toolchain_hostjdk8",
+    configuration = JVM8_TOOLCHAIN_CONFIGURATION,
+    java_runtime = ":current_host_java_runtime",
+    source_version = "8",
+    target_version = "8",
 )
 
 filegroup(
@@ -468,12 +457,5 @@ java_runtime_version_alias(
         no_match_error = "Could not find a JDK for host execution environment, please explicitly" +
                          " provide one using `--host_javabase.`",
     ),
-    visibility = ["//visibility:public"],
-)
-
-java_runtime_version_alias(
-    name = "jdk_8",
-    runtime_version = "8",
-    selected_java_runtime = ":legacy_current_java_runtime",
     visibility = ["//visibility:public"],
 )

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -134,6 +134,7 @@ PREBUILT_TOOLCHAIN_CONFIGURATION = dict(
     ],
     ijar = ["@remote_java_tools//:ijar_cc_binary"],
     singlejar = ["@remote_java_tools//:singlejar_cc_bin"],
+    java_runtime = "@bazel_tools//tools/jdk:remote_jdk11",
 )
 
 # The new toolchain is using all the tools from sources.
@@ -152,6 +153,7 @@ NONPREBUILT_TOOLCHAIN_CONFIGURATION = dict(
     ],
     ijar = ["@bazel_tools//tools/jdk:ijar_prebuilt_binary"],
     singlejar = ["@bazel_tools//tools/jdk:prebuilt_singlejar"],
+    java_runtime = "@bazel_tools//tools/jdk:remote_jdk11",
 )
 
 def default_java_toolchain(name, configuration = DEFAULT_TOOLCHAIN_CONFIGURATION, **kwargs):

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -71,13 +71,11 @@ _BASE_TOOLCHAIN_CONFIGURATION = dict(
     bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
     source_version = "8",
     target_version = "8",
-    java_runtime = "@bazel_tools//tools/jdk:remote_jdk11",
 )
 
 JVM8_TOOLCHAIN_CONFIGURATION = dict(
     tools = ["@remote_java_tools//:javac_jar"],
     jvm_opts = ["-Xbootclasspath/p:$(location @remote_java_tools//:javac_jar)"],
-    java_runtime = "@bazel_tools//tools/jdk:jdk_8",
 )
 
 DEFAULT_TOOLCHAIN_CONFIGURATION = dict(
@@ -93,6 +91,7 @@ DEFAULT_TOOLCHAIN_CONFIGURATION = dict(
         "@remote_java_tools//:java_compiler_jar",
         "@remote_java_tools//:jdk_compiler_jar",
     ],
+    java_runtime = "@bazel_tools//tools/jdk:remote_jdk11",
 )
 
 # The 'vanilla' toolchain is an unsupported alternative to the default.


### PR DESCRIPTION
Remove jdk_8 alias.

Setting java_runtime to current host JDK is not entirely correct, but all usecases currently use it in such manner.
Previous implementation caused problems, when there was no local jdk version 8.
Toolchain_hostjdk8 should be available only in the migration period and then removed.

Fixes https://github.com/bazelbuild/bazel/issues/12705.