### PR TITLE
Remove {direct,transitive}OriginalSources field from ProtoInfo

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/proto/CcProtoAspect.java
@@ -285,7 +285,7 @@ public abstract class CcProtoAspect extends NativeAspectClass implements Configu
     private boolean areSrcsExcluded() {
       return !new ProtoSourceFileExcludeList(
               ruleContext, getProtoToolchainProvider().forbiddenProtos())
-          .checkSrcs(protoInfo.getOriginalDirectProtoSources(), "cc_proto_library");
+          .checkSrcs(protoInfo.getDirectSources(), "cc_proto_library");
     }
 
     private FeatureConfiguration getFeatureConfiguration() throws RuleErrorException {

--- a/src/main/java/com/google/devtools/build/lib/rules/java/proto/JavaProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/proto/JavaProtoAspect.java
@@ -273,7 +273,7 @@ public class JavaProtoAspect extends NativeAspectClass implements ConfiguredAspe
      * proto_library.
      */
     private boolean shouldGenerateCode() {
-      if (protoInfo.getOriginalDirectProtoSources().isEmpty()) {
+      if (protoInfo.getDirectSources().isEmpty()) {
         return false;
       }
 
@@ -285,7 +285,7 @@ public class JavaProtoAspect extends NativeAspectClass implements ConfiguredAspe
           new ProtoSourceFileExcludeList(ruleContext, forbiddenProtos.build());
 
       return protoExcludeList.checkSrcs(
-          protoInfo.getOriginalDirectProtoSources(), "java_proto_library");
+          protoInfo.getDirectSources(), "java_proto_library");
     }
 
     private void createProtoCompileAction(Artifact sourceJar) {

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCommon.java
@@ -131,19 +131,6 @@ public class ProtoCommon {
     return result.build();
   }
 
-  private static NestedSet<Artifact> computeTransitiveOriginalProtoSources(
-      ImmutableList<ProtoInfo> protoDeps, ImmutableList<Artifact> originalProtoSources) {
-    NestedSetBuilder<Artifact> result = NestedSetBuilder.naiveLinkOrder();
-
-    result.addAll(originalProtoSources);
-
-    for (ProtoInfo dep : protoDeps) {
-      result.addTransitive(dep.getOriginalTransitiveProtoSources());
-    }
-
-    return result.build();
-  }
-
   static NestedSet<Artifact> computeDependenciesDescriptorSets(ImmutableList<ProtoInfo> deps) {
     return computeTransitiveDescriptorSets(null, deps);
   }
@@ -390,8 +377,6 @@ public class ProtoCommon {
     NestedSet<ProtoSource> transitiveSources = computeTransitiveProtoSources(deps, library);
     NestedSet<Artifact> transitiveProtoSources =
         computeTransitiveProtoSourceArtifacts(directSources, deps);
-    NestedSet<Artifact> transitiveOriginalProtoSources =
-        computeTransitiveOriginalProtoSources(deps, originalDirectProtoSources);
     NestedSet<String> transitiveProtoSourceRoots =
         computeTransitiveProtoSourceRoots(deps, directProtoSourceRoot.getSafePathString());
     NestedSet<Artifact> strictImportableProtosForDependents =
@@ -413,7 +398,6 @@ public class ProtoCommon {
         directProtoSourceRoot,
         transitiveSources,
         transitiveProtoSources,
-        transitiveOriginalProtoSources,
         transitiveProtoSourceRoots,
         strictImportableProtosForDependents,
         directDescriptorSet,

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCompileActionBuilder.java
@@ -364,7 +364,7 @@ public class ProtoCompileActionBuilder {
             "--descriptor_set_out=$(OUT)",
             /* pluginExecutable= */ null,
             /* runtime= */ null,
-            /* forbiddenProtos= */ NestedSetBuilder.<Artifact>emptySet(STABLE_ORDER)),
+            /* providedProtoSources= */ ImmutableList.of()),
         outReplacement,
         protocOpts.build());
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoInfo.java
@@ -51,22 +51,11 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
     return builder.build();
   }
 
-  private static ImmutableList<Artifact> extractOriginalProtoSources(
-      ImmutableList<ProtoSource> sources) {
-    ImmutableList.Builder<Artifact> builder = ImmutableList.builder();
-    for (ProtoSource source : sources) {
-      builder.add(source.getOriginalSourceFile());
-    }
-    return builder.build();
-  }
-
   private final ImmutableList<ProtoSource> directSources;
   private final ImmutableList<Artifact> directProtoSources;
-  private final ImmutableList<Artifact> originalDirectProtoSources;
   private final PathFragment directProtoSourceRoot;
   private final NestedSet<ProtoSource> transitiveSources;
   private final NestedSet<Artifact> transitiveProtoSources;
-  private final NestedSet<Artifact> originalTransitiveProtoSources;
   private final NestedSet<String> transitiveProtoSourceRoots;
   private final NestedSet<Artifact> strictImportableProtoSourcesForDependents;
   private final Artifact directDescriptorSet;
@@ -85,7 +74,6 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
       PathFragment directProtoSourceRoot,
       NestedSet<ProtoSource> transitiveSources,
       NestedSet<Artifact> transitiveProtoSources,
-      NestedSet<Artifact> originalTransitiveProtoSources,
       NestedSet<String> transitiveProtoSourceRoots,
       NestedSet<Artifact> strictImportableProtoSourcesForDependents,
       Artifact directDescriptorSet,
@@ -96,11 +84,9 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
       NestedSet<ProtoSource> publicImportSources) {
     this.directSources = directSources;
     this.directProtoSources = extractProtoSources(directSources);
-    this.originalDirectProtoSources = extractOriginalProtoSources(directSources);
     this.directProtoSourceRoot = ProtoCommon.memoryEfficientProtoSourceRoot(directProtoSourceRoot);
     this.transitiveSources = transitiveSources;
     this.transitiveProtoSources = transitiveProtoSources;
-    this.originalTransitiveProtoSources = originalTransitiveProtoSources;
     this.transitiveProtoSourceRoots = transitiveProtoSourceRoots;
     this.strictImportableProtoSourcesForDependents = strictImportableProtoSourcesForDependents;
     this.directDescriptorSet = directDescriptorSet;
@@ -131,16 +117,6 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
   }
 
   /**
-   * The non-virtual proto sources of the {@code proto_library} declaring this provider.
-   *
-   * <p>Different from {@link #getDirectProtoSources()} if a transitive dependency has {@code
-   * import_prefix} or the like.
-   */
-  public ImmutableList<Artifact> getOriginalDirectProtoSources() {
-    return originalDirectProtoSources;
-  }
-
-  /**
    * The source root of the current library.
    *
    * <p>For Bazel, this is always a (logical) prefix of all direct sources. For Blaze, this is
@@ -167,16 +143,6 @@ public final class ProtoInfo extends NativeInfo implements ProtoInfoApi<Artifact
 
   public NestedSet<Artifact> getTransitiveProtoSources() {
     return transitiveProtoSources;
-  }
-
-  /**
-   * The non-virtual transitive proto source files.
-   *
-   * <p>Different from {@link #getTransitiveProtoSources()} if a transitive dependency has {@code
-   * import_prefix} or the like.
-   */
-  public NestedSet<Artifact> getOriginalTransitiveProtoSources() {
-    return originalTransitiveProtoSources;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoLangToolchain.java
@@ -33,10 +33,10 @@ public class ProtoLangToolchain implements RuleConfiguredTargetFactory {
   @Override
   public ConfiguredTarget create(RuleContext ruleContext)
       throws InterruptedException, RuleErrorException, ActionConflictException {
-    NestedSetBuilder<Artifact> forbiddenProtos = NestedSetBuilder.stableOrder();
+    NestedSetBuilder<ProtoSource> providedProtoSources = NestedSetBuilder.stableOrder();
     for (ProtoInfo protoInfo :
         ruleContext.getPrerequisites("blacklisted_protos", ProtoInfo.PROVIDER)) {
-      forbiddenProtos.addTransitive(protoInfo.getOriginalTransitiveProtoSources());
+      providedProtoSources.addTransitive(protoInfo.getTransitiveSources());
     }
 
     return new RuleConfiguredTargetBuilder(ruleContext)
@@ -45,7 +45,14 @@ public class ProtoLangToolchain implements RuleConfiguredTargetFactory {
                 ruleContext.attributes().get("command_line", Type.STRING),
                 ruleContext.getPrerequisite("plugin", FilesToRunProvider.class),
                 ruleContext.getPrerequisite("runtime"),
-                forbiddenProtos.build()))
+                // We intentionally flatten the NestedSet here.
+                //
+                // `providedProtoSources` are read during analysis, so flattening the set here once
+                // avoid flattening it in every `<lang>_proto_aspect` applied to `proto_library`
+                // targets. While this has the potential to use more memory than using a NestedSet,
+                // there are only a few `proto_lang_toolchain` targets in every build, so the impact
+                // on memory consumption should be neglectable.
+                providedProtoSources.build().toList()))
         .setFilesToBuild(NestedSetBuilder.<Artifact>emptySet(STABLE_ORDER))
         .addProvider(RunfilesProvider.simple(Runfiles.EMPTY))
         .build();

--- a/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoSourceFileExcludeList.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoSourceFileExcludeList.java
@@ -20,6 +20,7 @@ import static com.google.devtools.build.lib.packages.BuildType.LABEL_LIST;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.devtools.build.lib.actions.Artifact;
@@ -80,10 +81,19 @@ public class ProtoSourceFileExcludeList {
    * Checks the proto sources for mixing excluded and non-excluded protos in one single
    * proto_library rule. Registers an attribute error if proto mixing is detected.
    *
-   * @param protoFiles the protos to filter.
+   * @param protoSources the protos to filter.
    * @param topLevelProtoRuleName the name of the top-level rule that generates the protos.
    * @return whether the proto sources are clean without mixing.
    */
+  public boolean checkSrcs(ImmutableList<ProtoSource> protoSources, String topLevelProtoRuleName) {
+    ImmutableList.Builder<Artifact> protoFiles = ImmutableList.builder();
+    for (ProtoSource protoSource : protoSources) {
+      protoFiles.add(protoSource.getOriginalSourceFile());
+    }
+    return checkSrcs(protoFiles.build(), topLevelProtoRuleName);
+  }
+
+  @Deprecated
   public boolean checkSrcs(Iterable<Artifact> protoFiles, String topLevelProtoRuleName) {
     List<Artifact> excluded = new ArrayList<>();
     List<Artifact> nonExcluded = new ArrayList<>();

--- a/src/test/java/com/google/devtools/build/lib/rules/proto/ProtoCompileActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/proto/ProtoCompileActionBuilderTest.java
@@ -81,7 +81,6 @@ public class ProtoCompileActionBuilderTest {
         /* directProtoSourceRoot */ PathFragment.EMPTY_FRAGMENT,
         /* transitiveSources */ NestedSetBuilder.wrap(Order.STABLE_ORDER, transitiveProtoSources),
         /* transitiveProtoSources */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
-        /* originalTransitiveProtoSources */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
         /* transitiveProtoSourceRoots */ NestedSetBuilder.emptySet(Order.STABLE_ORDER),
         /* strictImportableProtoSourcesForDependents */ NestedSetBuilder.emptySet(
             Order.STABLE_ORDER),
@@ -107,14 +106,14 @@ public class ProtoCompileActionBuilderTest {
             "--java_out=param1,param2:$(OUT)",
             /* pluginExecutable= */ null,
             /* runtime= */ mock(TransitiveInfoCollection.class),
-            /* forbiddenProtos= */ NestedSetBuilder.emptySet(STABLE_ORDER));
+            /* providedProtoSources= */ ImmutableList.of());
 
     ProtoLangToolchainProvider toolchainWithPlugin =
         ProtoLangToolchainProvider.create(
             "--$(PLUGIN_OUT)=param3,param4:$(OUT)",
             plugin,
             /* runtime= */ mock(TransitiveInfoCollection.class),
-            /* forbiddenProtos= */ NestedSetBuilder.emptySet(STABLE_ORDER));
+            /* providedProtoSources= */ ImmutableList.of());
 
     CustomCommandLine cmdLine =
         createCommandLineFromToolchains(
@@ -177,7 +176,7 @@ public class ProtoCompileActionBuilderTest {
             "--java_out=param1,param2:$(OUT)",
             /* pluginExecutable= */ null,
             /* runtime= */ mock(TransitiveInfoCollection.class),
-            /* forbiddenProtos= */ NestedSetBuilder.emptySet(STABLE_ORDER));
+            /* providedProtoSources= */ ImmutableList.of());
 
     CustomCommandLine cmdLine =
         createCommandLineFromToolchains(
@@ -215,7 +214,7 @@ public class ProtoCompileActionBuilderTest {
             "--java_out=param1,param2:$(OUT)",
             /* pluginExecutable= */ null,
             /* runtime= */ mock(TransitiveInfoCollection.class),
-            /* forbiddenProtos= */ NestedSetBuilder.emptySet(STABLE_ORDER));
+            /* providedProtoSources= */ ImmutableList.of());
 
     CustomCommandLine cmdLine =
         createCommandLineFromToolchains(
@@ -285,7 +284,7 @@ public class ProtoCompileActionBuilderTest {
             "--java_out=param1,param2:$(OUT)",
             /* pluginExecutable= */ null,
             /* runtime= */ mock(TransitiveInfoCollection.class),
-            /* forbiddenProtos= */ NestedSetBuilder.emptySet(STABLE_ORDER));
+            /* providedProtoSources= */ ImmutableList.of());
 
     CustomCommandLine cmdLine =
         createCommandLineFromToolchains(
@@ -319,14 +318,14 @@ public class ProtoCompileActionBuilderTest {
             "dontcare",
             /* pluginExecutable= */ null,
             /* runtime= */ mock(TransitiveInfoCollection.class),
-            /* forbiddenProtos= */ NestedSetBuilder.emptySet(STABLE_ORDER));
+            /* providedProtoSources= */ ImmutableList.of());
 
     ProtoLangToolchainProvider toolchain2 =
         ProtoLangToolchainProvider.create(
             "dontcare",
             /* pluginExecutable= */ null,
             /* runtime= */ mock(TransitiveInfoCollection.class),
-            /* forbiddenProtos= */ NestedSetBuilder.emptySet(STABLE_ORDER));
+            /* providedProtoSources= */ ImmutableList.of());
 
     IllegalStateException e =
         assertThrows(


### PR DESCRIPTION
The information is already part of another field.

Cleanup after #12431 and #10939