### PR TITLE
Starlark: Resolver.resolveFile can be called at most once

### DIFF
--- a/src/main/java/net/starlark/java/syntax/Resolver.java
+++ b/src/main/java/net/starlark/java/syntax/Resolver.java
@@ -982,6 +982,9 @@ public final class Resolver extends NodeVisitor {
    * StarlarkFile#errors}.
    */
   public static void resolveFile(StarlarkFile file, Module module) {
+    Preconditions.checkState(!file.resolveStarted, "StarlarkFile can be resolved only once");
+    file.resolveStarted = true;
+
     Resolver r = new Resolver(file.errors, module, file.getOptions());
     ImmutableList<Statement> stmts = file.getStatements();
 

--- a/src/main/java/net/starlark/java/syntax/StarlarkFile.java
+++ b/src/main/java/net/starlark/java/syntax/StarlarkFile.java
@@ -30,6 +30,7 @@ public final class StarlarkFile extends Node {
   private final FileOptions options;
   private final ImmutableList<Comment> comments;
   final List<SyntaxError> errors; // appended to by Resolver
+  boolean resolveStarted = false; // used by Resolver
 
   // set by resolver
   @Nullable private Resolver.Function resolved;


### PR DESCRIPTION
Calling `resolveFile` second time results in obscure errors like

```
Caused by: java.lang.IllegalStateException
    at com.google.common.base.Preconditions.checkState(Preconditions.java:491)
    at net.starlark.java.syntax.Identifier.setBinding(Identifier.java:65)
    at net.starlark.java.syntax.Resolver.visit(Resolver.java:466)
    at net.starlark.java.syntax.Identifier.accept(Identifier.java:71)
    at net.starlark.java.syntax.NodeVisitor.visit(NodeVisitor.java:23)
    at net.starlark.java.syntax.NodeVisitor.visit(NodeVisitor.java:71)
    at net.starlark.java.syntax.Resolver.visit(Resolver.java:620)
    at net.starlark.java.syntax.CallExpression.accept(CallExpression.java:97)
    at net.starlark.java.syntax.NodeVisitor.visit(NodeVisitor.java:23)
    at net.starlark.java.syntax.NodeVisitor.visit(NodeVisitor.java:125)
    at net.starlark.java.syntax.ExpressionStatement.accept(ExpressionStatement.java:33)
    at net.starlark.java.syntax.NodeVisitor.visit(NodeVisitor.java:23)
    at net.starlark.java.syntax.NodeVisitor.visitAll(NodeVisitor.java:29)
    at net.starlark.java.syntax.Resolver.resolveFile(Resolver.java:1001)
```

Better fail explicitly when API is used incorrectly.