### PR TITLE
Report a warning when using an oldName of a flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -723,8 +723,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
-          "Enable runfiles symlink tree; By default, it's off on Windows, on on other platforms.",
-      oldName = "experimental_enable_runfiles")
+          "Enable runfiles symlink tree; By default, it's off on Windows, on on other platforms.")
   public TriState enableRunfiles;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -723,7 +723,8 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
-          "Enable runfiles symlink tree; By default, it's off on Windows, on on other platforms.")
+          "Enable runfiles symlink tree; By default, it's off on Windows, on on other platforms.",
+      oldName = "experimental_enable_runfiles")
   public TriState enableRunfiles;
 
   @Option(

--- a/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParserImpl.java
@@ -237,6 +237,19 @@ class OptionsParserImpl {
     }
   }
 
+  private void maybeAddOldNameWarning(ParsedOptionDescription parsedOption){
+    // Don't add a warning for old name options set by the invocation policy.
+    if (parsedOption.getPriority().getPriorityCategory().equals(INVOCATION_POLICY)) {
+      return;
+    }
+    String commandLineForm = parsedOption.getCommandLineForm();
+    String oldOptionName = parsedOption.getOptionDefinition().getOldOptionName();
+    String optionName = parsedOption.getOptionDefinition().getOptionName();
+    if(commandLineForm.startsWith(String.format("--%s=", oldOptionName))) {
+      addDeprecationWarning(oldOptionName, String.format("Use --%s instead", optionName));
+    }
+  }
+
   private void addDeprecationWarning(String optionName, String warning) {
     warnings.add(
         String.format(
@@ -476,6 +489,8 @@ class OptionsParserImpl {
     OptionDefinition optionDefinition = parsedOption.getOptionDefinition();
     // All options can be deprecated; check and warn before doing any option-type specific work.
     maybeAddDeprecationWarning(optionDefinition, parsedOption.getPriority().getPriorityCategory());
+    // Check if the old option name is used and add a warning
+    maybeAddOldNameWarning(parsedOption);
     // Track the value, before any remaining option-type specific work that is done outside of
     // the OptionValueDescription.
     OptionValueDescription entry =

--- a/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
@@ -1871,6 +1871,9 @@ public class OptionsParserTest {
     parser.parse("--old_name=foo");
     OldNameExample result = parser.getOptions(OldNameExample.class);
     assertThat(result.flag).isEqualTo("foo");
+    // Using old option name should cause a warning
+    assertThat(parser.getWarnings()).contains(
+            "Option 'old_name' is deprecated: Use --new_name instead");
 
     // Should also work by its new name.
     parser = OptionsParser.builder().optionsClasses(OldNameExample.class).build();


### PR DESCRIPTION
This PR modifies the option parser to print a warning when the old name of an option is used. The warning indicates that the old name is deprecated and the option new name should be used.

Fixes: #12565