### PR TITLE
Docs: Fix BES remote caching URL

### DIFF
--- a/site/docs/build-event-protocol.md
+++ b/site/docs/build-event-protocol.md
@@ -225,7 +225,7 @@ The BEP typically contains many references to log files (test.log, test.xml,
 etc. ) stored on the machine where Bazel is running. A remote BES server
 typically can't access these files as they are on different machines. A way to
 work around this issue is to use Bazel with [remote
-caching](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/remote/README.md).
+caching](remote-caching.html).
 Bazel will upload all output files to the remote cache (including files
 referenced in the BEP) and the BES server can then fetch the referenced files
 from the cache.


### PR DESCRIPTION
The original link https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/remote/README.md is a redirect