### PR TITLE
Export proguard specs from aar_import

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AarImport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AarImport.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.rules.android;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
@@ -45,6 +46,8 @@ import com.google.devtools.build.lib.rules.java.JavaSemantics;
 import com.google.devtools.build.lib.rules.java.JavaSourceInfoProvider;
 import com.google.devtools.build.lib.rules.java.JavaSourceJarsProvider;
 import com.google.devtools.build.lib.rules.java.JavaToolchainProvider;
+import com.google.devtools.build.lib.rules.java.ProguardLibrary;
+import com.google.devtools.build.lib.rules.java.ProguardSpecProvider;
 import com.google.devtools.build.lib.starlarkbuildapi.android.DataBindingV2ProviderApi;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import javax.annotation.Nullable;
@@ -61,6 +64,7 @@ import javax.annotation.Nullable;
 public class AarImport implements RuleConfiguredTargetFactory {
   private static final String ANDROID_MANIFEST = "AndroidManifest.xml";
   private static final String MERGED_JAR = "classes_and_libs_merged.jar";
+  private static final String PROGUARD_SPEC = "proguard.txt";
 
   private final JavaSemantics javaSemantics;
   private final AndroidSemantics androidSemantics;
@@ -242,6 +246,7 @@ public class AarImport implements RuleConfiguredTargetFactory {
         .setFilesToBuild(filesToBuild)
         .addProvider(RunfilesProvider.class, RunfilesProvider.EMPTY)
         .addNativeDeclaredProvider(dataBindingV2Provider)
+        .addNativeDeclaredProvider(new ProguardSpecProvider(extractProguardSpecs(ruleContext, aar)))
         .addNativeDeclaredProvider(
             new AndroidNativeLibsInfo(
                 AndroidCommon.collectTransitiveNativeLibs(ruleContext).add(nativeLibs).build()))
@@ -257,6 +262,47 @@ public class AarImport implements RuleConfiguredTargetFactory {
       ImmutableList<TransitiveInfoCollection> deps, boolean isDirect) {
     JavaCompilationArgsProvider provider = JavaCompilationArgsProvider.legacyFromTargets(deps);
     return isDirect ? provider.getDirectCompileTimeJars() : provider.getTransitiveCompileTimeJars();
+  }
+
+  /**
+   * Collect Proguard Specs from transitives and proguard.txt if it exists in the AAR file.
+   * In the case the proguard.txt file does exists, we need to extract it from the AAR file
+   */
+  private NestedSet<Artifact> extractProguardSpecs(RuleContext ruleContext, Artifact aar) {
+
+    NestedSet<Artifact> proguardSpecs = new ProguardLibrary(ruleContext)
+            .collectProguardSpecs(ImmutableSet.of("exports"));
+
+    Artifact proguardSpecArtifact = createAarArtifact(ruleContext, PROGUARD_SPEC);
+
+    ruleContext.registerAction(
+            createAarEmbeddedProguardExtractorActions(ruleContext, aar, proguardSpecArtifact));
+
+    NestedSetBuilder<Artifact> builder = NestedSetBuilder.naiveLinkOrder();
+    return builder.addTransitive(proguardSpecs).add(proguardSpecArtifact).build();
+  }
+
+  /**
+   * Create action to extract embedded Proguard.txt from an AAR. If the file is not found, an empty file will be created
+   */
+  private static Action[] createAarEmbeddedProguardExtractorActions(
+          RuleContext ruleContext,
+          Artifact aar,
+          Artifact proguardSpecArtifact) {
+    return new SpawnAction.Builder()
+            .useDefaultShellEnvironment()
+            .setExecutable(
+                    ruleContext.getExecutablePrerequisite(AarImportBaseRule.AAR_EMBEDDED_PROGUARD_EXTACTOR))
+            .setMnemonic("AarEmbeddedProguardExtractor")
+            .setProgressMessage("Extracting proguard.txt from %s", aar.getFilename())
+            .addInput(aar)
+            .addOutput(proguardSpecArtifact)
+            .addCommandLine(
+                    CustomCommandLine.builder()
+                            .addExecPath("--input_aar", aar)
+                            .addExecPath("--output_proguard_file", proguardSpecArtifact)
+                            .build())
+            .build(ruleContext);
   }
 
   private NestedSet<Artifact> getBootclasspath(RuleContext ruleContext) {

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AarImportBaseRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AarImportBaseRule.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.util.FileType;
 public class AarImportBaseRule implements RuleDefinition {
 
   static final String AAR_EMBEDDED_JARS_EXTACTOR = "$aar_embedded_jars_extractor";
+  static final String AAR_EMBEDDED_PROGUARD_EXTACTOR = "$aar_embedded_proguard_extractor";
   static final String AAR_NATIVE_LIBS_ZIP_CREATOR = "$aar_native_libs_zip_creator";
   static final String AAR_RESOURCES_EXTRACTOR = "$aar_resources_extractor";
   static final String ZIPPER = "$zipper";
@@ -66,6 +67,11 @@ public class AarImportBaseRule implements RuleDefinition {
                 .cfg(HostTransition.createFactory())
                 .exec()
                 .value(env.getToolsLabel("//tools/android:aar_embedded_jars_extractor")))
+        .add(
+              attr(AAR_EMBEDDED_PROGUARD_EXTACTOR, LABEL)
+                .cfg(HostTransition.createFactory())
+                .exec()
+                .value(env.getToolsLabel("//tools/android:aar_embedded_proguard_extractor")))
         .add(
             attr(AAR_NATIVE_LIBS_ZIP_CREATOR, LABEL)
                 .cfg(HostTransition.createFactory())

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -390,6 +390,7 @@ public final class BazelAnalysisMock extends AnalysisMock {
         .add("            jars = [ 'ZipFilterAction_deploy.jar' ])")
         .add("sh_binary(name = 'aar_resources_extractor', srcs = ['empty.sh'])")
         .add("sh_binary(name = 'aar_embedded_jars_extractor', srcs = ['empty.sh'])")
+        .add("sh_binary(name = 'aar_embedded_proguard_extractor', srcs = ['empty.sh'])")
         .add("java_import(name = 'idlclass_import',")
         .add("            jars = [ 'idlclass.jar' ])")
         .add("exports_files(['adb', 'adb_static'])")

--- a/src/test/java/com/google/devtools/build/lib/rules/android/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/BUILD
@@ -28,6 +28,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/rules/java:java-compilation",
         "//src/test/java/com/google/devtools/build/lib/actions/util",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
+        "//src/main/java/com/google/devtools/build/lib/rules/java:java-rules",
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:truth",

--- a/tools/android/BUILD
+++ b/tools/android/BUILD
@@ -119,6 +119,21 @@ py_test(
 )
 
 py_binary(
+    name = "aar_embedded_proguard_extractor",
+    srcs = ["aar_embedded_proguard_extractor.py"],
+    deps = [
+        ":junction_lib",
+        "//third_party/py/abseil",
+    ],
+)
+
+py_test(
+    name = "aar_embedded_proguard_extractor_test",
+    srcs = ["aar_embedded_proguard_extractor_test.py"],
+    deps = [":aar_embedded_proguard_extractor"],
+)
+
+py_binary(
     name = "aar_embedded_jars_extractor",
     srcs = ["aar_embedded_jars_extractor.py"],
     deps = [

--- a/tools/android/BUILD.tools
+++ b/tools/android/BUILD.tools
@@ -329,6 +329,16 @@ py_binary(
 )
 
 py_binary(
+    name = "aar_embedded_proguard_extractor",
+    srcs = ["aar_embedded_proguard_extractor.py"],
+    python_version = PY_BINARY_VERSION,
+    deps = [
+        ":junction_lib",
+        "//third_party/py/abseil",
+    ],
+)
+
+py_binary(
     name = "aar_embedded_jars_extractor",
     srcs = ["aar_embedded_jars_extractor.py"],
     python_version = "PY3",

--- a/tools/android/aar_embedded_proguard_extractor.py
+++ b/tools/android/aar_embedded_proguard_extractor.py
@@ -1,0 +1,78 @@
+# Lint as: python2, python3
+# pylint: disable=g-direct-third-party-import
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A tool for extracting all jar files from an AAR.
+
+An AAR may contain JARs at /classes.jar and /libs/*.jar. This tool extracts all
+of the jars and creates a param file for singlejar to merge them into one jar.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import re
+import sys
+import zipfile
+
+# Do not edit this line. Copybara replaces it with PY2 migration helper.
+from absl import app
+from absl import flags
+import six
+
+from tools.android import junction
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string("input_aar", None, "Input AAR")
+flags.mark_flag_as_required("input_aar")
+flags.DEFINE_string("output_proguard_file", None,
+                    "Output parameter file for proguard")
+flags.mark_flag_as_required("output_proguard_file")
+
+# Attempt to extract proguard spec from AAR. If the file doesn't exist, an empty proguard spec file will be created
+def ExtractEmbeddedProguard(aar, output):
+  proguard_spec = "proguard.txt"
+
+  if proguard_spec in aar.namelist():
+    output.write(aar.read(proguard_spec))
+
+def _Main(input_aar, output_proguard_file):
+  with zipfile.ZipFile(input_aar, "r") as aar:
+    with open(output_proguard_file, 'wb') as output:
+      ExtractEmbeddedProguard(aar, output)
+
+def main(unused_argv):
+  if os.name == "nt":
+    # Shorten paths unconditionally, because the extracted paths in
+    # ExtractEmbeddedJars (which we cannot yet predict, because they depend on
+    # the names of the Zip entries) may be longer than MAX_PATH.
+    aar_long = os.path.abspath(FLAGS.input_aar)
+    proguard_long = os.path.abspath(FLAGS.output_proguard_file)
+
+    with junction.TempJunction(os.path.dirname(aar_long)) as aar_junc:
+      with junction.TempJunction(os.path.dirname(proguard_long)) as proguard_junc:
+        _Main(
+          os.path.join(aar_junc, os.path.basename(aar_long)),
+          os.path.join(proguard_junc, os.path.basename(proguard_long)))
+  else:
+    _Main(FLAGS.input_aar, FLAGS.output_proguard_file)
+
+
+if __name__ == "__main__":
+  FLAGS(sys.argv)
+  app.run(main)

--- a/tools/android/aar_embedded_proguard_extractor_test.py
+++ b/tools/android/aar_embedded_proguard_extractor_test.py
@@ -1,0 +1,54 @@
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for aar_embedded_jars_extractor."""
+
+import io
+import os
+import shutil
+import unittest
+import zipfile
+
+from tools.android import aar_embedded_proguard_extractor
+
+
+class AarEmbeddedProguardExtractor(unittest.TestCase):
+  """Unit tests for aar_embedded_proguard_extractor.py."""
+
+  # Python 2 alias
+  if not hasattr(unittest.TestCase, "assertCountEqual"):
+
+    def assertCountEqual(self, *args):
+      return self.assertItemsEqual(*args)
+
+  def setUp(self):
+    os.chdir(os.environ["TEST_TMPDIR"])
+
+  def testNoProguardTxt(self):
+    aar = zipfile.ZipFile(io.BytesIO(), "w")
+    proguard_file = io.BytesIO()
+    aar_embedded_proguard_extractor.ExtractEmbeddedProguard(aar, proguard_file)
+    proguard_file.seek(0)
+    self.assertEqual(b"", proguard_file.read())
+
+  def testWithProguardTxt(self):
+    aar = zipfile.ZipFile(io.BytesIO(), "w")
+    aar.writestr("proguard.txt", "hello world")
+    proguard_file = io.BytesIO()
+    aar_embedded_proguard_extractor.ExtractEmbeddedProguard(aar, proguard_file)
+    proguard_file.seek(0)
+    self.assertEqual(b'hello world', proguard_file.read())
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
**Background**
https://github.com/bazelbuild/bazel/issues/3778

proguard specs from the `aar_import` rule do not get bubbled up to `android_binary`. In this PR, I wire up a `ProguardSpecProvider` from this rule that exports the `proguard.txt` within an AAR if it exists and any transitive proguard specs from the `exports` attribute.

**Changes**
* Add an `aar_embedded_proguard_extractor` script to extract `proguard.txt` from an AAR if it exists otherwise generate an empty proguard specs file
* In AarImport, wire up the proguard extractor action and export results through a `ProguardSpecProvider`.

Once this lands, the android rules would need to be bumped.

**Test Plan**
* Added tests for the extraction python script
* Added tests for the `aar_import` rule changes