### PR TITLE
Starlark: faster parameter type check for Object

### DIFF
--- a/src/main/java/net/starlark/java/eval/BuiltinFunction.java
+++ b/src/main/java/net/starlark/java/eval/BuiltinFunction.java
@@ -342,9 +342,14 @@ public final class BuiltinFunction implements StarlarkCallable {
   }
 
   private void checkParamValue(ParamDescriptor param, Object value) throws EvalException {
+    List<Class<?>> allowedClasses = param.getAllowedClasses();
+    if (allowedClasses == null) {
+      return;
+    }
+
     // Value must belong to one of the specified classes.
     boolean ok = false;
-    for (Class<?> cls : param.getAllowedClasses()) {
+    for (Class<?> cls : allowedClasses) {
       if (cls.isInstance(value)) {
         ok = true;
         break;

--- a/src/main/java/net/starlark/java/eval/ParamDescriptor.java
+++ b/src/main/java/net/starlark/java/eval/ParamDescriptor.java
@@ -33,7 +33,10 @@ final class ParamDescriptor {
   @Nullable private final Object defaultValue;
   private final boolean named;
   private final boolean positional;
-  private final List<Class<?>> allowedClasses; // non-empty
+  // Null means any class is allowed.
+  // Should be not empty otherwise.
+  @Nullable
+  private final List<Class<?>> allowedClasses;
   // The semantics flag responsible for disabling this parameter, or null if enabled.
   // It is an error for Starlark code to supply a value to a disabled parameter.
   @Nullable private final String disabledByFlag;
@@ -51,7 +54,11 @@ final class ParamDescriptor {
     this.defaultValue = defaultExpr.isEmpty() ? null : evalDefault(name, defaultExpr);
     this.named = named;
     this.positional = positional;
-    this.allowedClasses = allowedClasses;
+    if (allowedClasses.contains(Object.class)) {
+      this.allowedClasses = null;
+    } else {
+      this.allowedClasses = allowedClasses;
+    }
     this.disabledByFlag = disabledByFlag;
   }
 
@@ -120,6 +127,7 @@ final class ParamDescriptor {
     return buf.toString();
   }
 
+  @Nullable
   List<Class<?>> getAllowedClasses() {
     return allowedClasses;
   }


### PR DESCRIPTION
When `@StarlarkMethod` `@Param` does not specify `allowedTypes`,
allowed types is `{Object.class}`. This is the most common case,
optimize this case avoiding instanceof check in a loop.

For this benchmark:

```
def foo():
    for i in range(10):
        print(i)
        for j in range(1000):
            for k in range(5000):
                type(1)
foo()
```

Result is:

```
A: n=100 mean=5.425 std=0.322 se=0.032 min=5.022 med=5.363
B: n=100 mean=5.294 std=0.359 se=0.036 min=4.910 med=5.165
B/A: 0.976 0.958..0.994 (95% conf)
```