### PR TITLE
Add support for mips64el

### DIFF
--- a/src/conditions/BUILD
+++ b/src/conditions/BUILD
@@ -31,6 +31,15 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_mips64el",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:mips64el",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "linux_arm",
     constraint_values = [
         "@platforms//os:linux",

--- a/src/conditions/BUILD.tools
+++ b/src/conditions/BUILD.tools
@@ -62,6 +62,15 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_mips64el",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:mips64el",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "darwin_x86_64",
     constraint_values = [
         "@platforms//os:macos",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
@@ -59,6 +59,8 @@ public class AutoCpuConverter implements Converter<String> {
               return "arm";
             case AARCH64:
               return "aarch64";
+            case MIPS64EL:
+              return "mips64el";
             case S390X:
               return "s390x";
             default:

--- a/src/main/java/com/google/devtools/build/lib/util/CPU.java
+++ b/src/main/java/com/google/devtools/build/lib/util/CPU.java
@@ -26,6 +26,7 @@ public enum CPU {
   PPC("ppc", ImmutableSet.of("ppc", "ppc64", "ppc64le")),
   ARM("arm", ImmutableSet.of("arm", "armv7l")),
   AARCH64("aarch64", ImmutableSet.of("aarch64")),
+  MIPS64EL("mips64el", ImmutableSet.of("mips64el")),
   S390X("s390x", ImmutableSet.of("s390x", "s390")),
   UNKNOWN("unknown", ImmutableSet.<String>of());
 

--- a/tools/cpp/lib_cc_configure.bzl
+++ b/tools/cpp/lib_cc_configure.bzl
@@ -199,6 +199,8 @@ def get_cpu_value(repository_ctx):
         return "arm"
     if result.stdout.strip() in ["aarch64"]:
         return "aarch64"
+    if result.stdout.strip() in ["mips64el"]:
+        return "mips64el"
     return "k8" if result.stdout.strip() in ["amd64", "x86_64", "x64"] else "piii"
 
 def is_cc_configure_debug(repository_ctx):

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -98,6 +98,7 @@ cc_library(
     name = "jni",
     hdrs = [":jni_header"] + select({
         "//src/conditions:linux_aarch64": [":jni_md_header-linux"],
+        "//src/conditions:linux_mips64el": [":jni_md_header-linux"],
         "//src/conditions:linux_ppc64le": [":jni_md_header-linux"],
         "//src/conditions:linux_s390x": [":jni_md_header-linux"],
         "//src/conditions:linux_x86_64": [":jni_md_header-linux"],
@@ -109,6 +110,7 @@ cc_library(
     }),
     includes = ["include"] + select({
         "//src/conditions:linux_aarch64": ["include/linux"],
+        "//src/conditions:linux_mips64el": ["include/linux"],
         "//src/conditions:linux_ppc64le": ["include/linux"],
         "//src/conditions:linux_s390x": ["include/linux"],
         "//src/conditions:linux_x86_64": ["include/linux"],


### PR DESCRIPTION
my host is mips64el:
```
uname -m
mips64el
```
with these changes I was able to compile bazel in my host.