### PR TITLE
Enable junit4 use in Debian builds

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -624,8 +624,9 @@ java_import(
     jars = ["guava/guava-testlib-29.0-jre.jar"],
 )
 
-java_import(
+distrib_java_import(
     name = "junit4",
+    enable_distributions = ["debian"],
     jars = [
         "hamcrest/hamcrest-core-1.3.jar",
         "junit/junit-4.13.jar",

--- a/tools/distributions/debian/debian_java.BUILD
+++ b/tools/distributions/debian/debian_java.BUILD
@@ -449,3 +449,12 @@ filegroup(
         "grpc-stub.jar",
     ],
 )
+
+# junit4
+java_import(
+    name = "junit4",
+    jars = [
+        "hamcrest-core.jar",
+        "junit4.jar",
+    ],
+)


### PR DESCRIPTION
Using @meteorcloudy's method to enable use of native Debian libraries for junit4