### PR TITLE
Look for WORKSPACE.bazel as well in Bazel wrapper script

### DIFF
--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -24,7 +24,7 @@ set -eu
 # 1. Set $USE_BAZEL_VERSION to a version number
 #    (e.g. export USE_BAZEL_VERSION=1.0.0).
 # 2. Add a .bazelversion file that contains a version number next to your
-#    WORKSPACE file.
+#    WORKSPACE[.bazel] file.
 # 3. Otherwise, the latest Bazel version will be used.
 #
 # This wrapper only recognizes Bazel versions installed next to itself, thus
@@ -91,7 +91,7 @@ function get_realpath() {
 function get_workspace_root() {
   workspace_dir="${PWD}"
   while [[ "${workspace_dir}" != / ]]; do
-    if [[ -e "${workspace_dir}/WORKSPACE" ]]; then
+    if [[ -e "${workspace_dir}/WORKSPACE" || -e "${workspace_dir}/WORKSPACE.bazel"]]; then
       readonly workspace_dir
       return
     fi

--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -91,7 +91,7 @@ function get_realpath() {
 function get_workspace_root() {
   workspace_dir="${PWD}"
   while [[ "${workspace_dir}" != / ]]; do
-    if [[ -e "${workspace_dir}/WORKSPACE" || -e "${workspace_dir}/WORKSPACE.bazel"]]; then
+    if [[ -e "${workspace_dir}/WORKSPACE" || -e "${workspace_dir}/WORKSPACE.bazel" ]]; then
       readonly workspace_dir
       return
     fi

--- a/src/test/shell/bazel/bazel_wrapper_test.sh
+++ b/src/test/shell/bazel/bazel_wrapper_test.sh
@@ -103,6 +103,23 @@ test_bazelversion_file() {
   expect_log "My args: build //src:bazel"
 }
 
+test_workspace_with_extension() {
+  setup_mock
+  mv WORKSPACE WORKSPACE.bazel
+
+  echo "1.0.1" > .bazelversion
+
+  ../bin/bazel info &> "$TEST_log"
+  expect_log "Hello from bazel-1.0.1"
+  expect_log "My args: info"
+
+  cd subdir
+  ../../bin/bazel build //src:bazel &> "$TEST_log"
+  expect_log "Hello from bazel-1.0.1"
+  expect_log "My args: build //src:bazel"
+}
+
+
 test_empty_bazelversion_file() {
   setup_mock
 


### PR DESCRIPTION
WORKSPACE.bazel is a valid alternative name for this file
(https://docs.bazel.build/versions/master/build-ref.html#workspace)