### PR TITLE
Add sanitizer support to Apple platforms

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5477,6 +5477,29 @@ def _impl(ctx):
                         flag_group(
                             flags = [
                                 "-D_FORTIFY_SOURCE=1",
+                            ],
+                        ),
+                    ],
+                    with_features = [with_feature_set(not_features = ["asan"])],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.clif_match,
+                        ACTION_NAMES.objc_compile,
+                        ACTION_NAMES.objcpp_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
                                 "-fstack-protector",
                                 "-fcolor-diagnostics",
                                 "-Wall",
@@ -5525,7 +5548,6 @@ def _impl(ctx):
                             flags = [
                                 "-g0",
                                 "-O2",
-                                "-D_FORTIFY_SOURCE=1",
                                 "-DNDEBUG",
                                 "-DNS_BLOCK_ASSERTIONS=1",
                             ],
@@ -5597,6 +5619,29 @@ def _impl(ctx):
                         flag_group(
                             flags = [
                                 "-D_FORTIFY_SOURCE=1",
+                            ],
+                        ),
+                    ],
+                    with_features = [with_feature_set(not_features = ["asan"])],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.preprocess_assemble,
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.clif_match,
+                        ACTION_NAMES.objc_compile,
+                        ACTION_NAMES.objcpp_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
                                 "-fstack-protector",
                                 "-fcolor-diagnostics",
                                 "-Wall",
@@ -5645,7 +5690,6 @@ def _impl(ctx):
                             flags = [
                                 "-g0",
                                 "-O2",
-                                "-D_FORTIFY_SOURCE=1",
                                 "-DNDEBUG",
                                 "-DNS_BLOCK_ASSERTIONS=1",
                             ],
@@ -6082,6 +6126,141 @@ def _impl(ctx):
         ],
     )
 
+    asan_feature = feature(
+        name = "asan",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=address"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["asan"]),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=address"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["asan"]),
+                ],
+            ),
+        ],
+    )
+
+    tsan_feature = feature(
+        name = "tsan",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=thread"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["tsan"]),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=thread"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["tsan"]),
+                ],
+            ),
+        ],
+    )
+
+    ubsan_feature = feature(
+        name = "ubsan",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=undefined"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["ubsan"]),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=undefined"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["ubsan"]),
+                ],
+            ),
+        ],
+    )
+
+    default_sanitizer_flags_feature = feature(
+        name = "default_sanitizer_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-O1",
+                            "-gline-tables-only",
+                            "-fno-omit-frame-pointer",
+                            "-fno-sanitize-recover=all",
+                        ],
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(features = ["asan"]),
+                    with_feature_set(features = ["tsan"]),
+                    with_feature_set(features = ["ubsan"]),
+                ],
+            ),
+        ],
+    )
+
     if (ctx.attr.cpu == "ios_arm64" or
         ctx.attr.cpu == "ios_arm64e" or
         ctx.attr.cpu == "ios_armv7" or
@@ -6167,6 +6346,10 @@ def _impl(ctx):
             compiler_output_flags_feature,
             objcopy_embed_flags_feature,
             set_install_name,
+            asan_feature,
+            tsan_feature,
+            ubsan_feature,
+            default_sanitizer_flags_feature,
         ]
     elif (ctx.attr.cpu == "darwin_x86_64" or
           ctx.attr.cpu == "darwin_arm64" or
@@ -6247,6 +6430,10 @@ def _impl(ctx):
             objcopy_embed_flags_feature,
             dynamic_linking_mode_feature,
             set_install_name,
+            asan_feature,
+            tsan_feature,
+            ubsan_feature,
+            default_sanitizer_flags_feature,
         ]
     elif (ctx.attr.cpu == "armeabi-v7a"):
         features = [
@@ -6324,6 +6511,10 @@ def _impl(ctx):
             supports_pic_feature,
             objcopy_embed_flags_feature,
             set_install_name,
+            asan_feature,
+            tsan_feature,
+            ubsan_feature,
+            default_sanitizer_flags_feature,
         ]
     else:
         fail("Unreachable")


### PR DESCRIPTION
This adds support for asan, tsan, and ubsan on Apple platforms.

Fixes https://github.com/bazelbuild/bazel/issues/4984 and https://github.com/bazelbuild/bazel/issues/6932