### PR TITLE
Enable junit4 use in Debian builds

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -624,8 +624,9 @@ java_import(
     jars = ["guava/guava-testlib-29.0-jre.jar"],
 )
 
-java_import(
+distrib_java_import(
     name = "junit4",
+    enable_distributions = ["debian"],
     jars = [
         "hamcrest/hamcrest-core-1.3.jar",
         "junit/junit-4.13.jar",


### PR DESCRIPTION
Changes of https://github.com/bazelbuild/bazel/pull/12755 under third_party/