### PR TITLE
Add SHA-1 to subresource integrity format for download() checksums

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Checksum.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/Checksum.java
@@ -43,6 +43,11 @@ public class Checksum {
     byte[] hash = null;
     int expectedLength = 0;
 
+    if (integrity.startsWith("sha1-")) {
+      keyType = KeyType.SHA1;
+      expectedLength = 20;
+      hash = decoder.decode(integrity.substring(5));
+    }
     if (integrity.startsWith("sha256-")) {
       keyType = KeyType.SHA256;
       expectedLength = 32;
@@ -63,7 +68,7 @@ public class Checksum {
       throw new IllegalArgumentException(
           "Unsupported checksum algorithm: '"
               + integrity
-              + "' (expected SHA-256, SHA-384, or SHA-512)");
+              + "' (expected SHA-1, SHA-256, SHA-384, or SHA-512)");
     }
 
     if (hash.length != expectedLength) {


### PR DESCRIPTION
npm packages commonly still use SHA-1. While it may be discouraged for its poor security, Bazel cannot enforce what external ecosystems currently do.

I tested this locally against a feature we are working on in rules_nodejs.