### PR TITLE
Starlark: reuse positional array in native calls where possible

### DIFF
--- a/src/main/java/net/starlark/java/eval/BuiltinFunction.java
+++ b/src/main/java/net/starlark/java/eval/BuiltinFunction.java
@@ -155,6 +155,11 @@ public final class BuiltinFunction implements StarlarkCallable {
 
     ParamDescriptor[] parameters = desc.getParameters();
 
+    // fast track
+    if (desc.isCanReusePositionalWithoutChecks() && positional.length == parameters.length && named.length == 0) {
+      return positional;
+    }
+
     // Allocate argument vector.
     int n = parameters.length;
     if (desc.acceptsExtraArgs()) {


### PR DESCRIPTION
For certain calls like `type(x)` or `str(x)` or `l.append(x)` we
can reuse `positional` array argument of `fastcall` to pass it to
the `MethodDescriptor.call` and skip all runtime checks in
`BuiltinFunction`.

This optimization cannot be applied if
* a function has extra positional or named arguments
* has arguments guarded by flag
* accepts extra `StarlarkThread` parameter
* has unfilled arguments with default values

So this optimation won't be used for calls `list(x)` or `bool()`.

For `type(1)` called in loop, the result is 15% speedup:

```
A: n=30 mean=5.705 std=0.387 se=0.071 min=5.131 med=5.827
B: n=30 mean=4.860 std=0.345 se=0.064 min=4.396 med=4.946
B/A: 0.852 0.820..0.884 (95% conf)
```

For `bool()` (no argument) called in loop, it results in 1% slowdown:

```
A: n=29 mean=9.045 std=0.603 se=0.113 min=8.096 med=9.400
B: n=29 mean=9.134 std=0.520 se=0.098 min=8.248 med=9.448
B/A: 1.010 0.976..1.045 (95% conf)
```