### PR TITLE
Attach local JDK to JVM8_TOOLCHAIN_CONFIGURATION.

### DIFF
--- a/src/test/shell/bazel/bazel_java_test_defaults.sh
+++ b/src/test/shell/bazel/bazel_java_test_defaults.sh
@@ -209,7 +209,6 @@ load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolcha
 default_java_toolchain(
   name = "jvm8_toolchain",
   configuration = JVM8_TOOLCHAIN_CONFIGURATION,
-  java_runtime = "@local_jdk//:jdk",
 )
 EOF
   bazel query //:jvm8_toolchain || fail "default_java_toolchain target failed to build"

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -467,3 +467,10 @@ java_runtime_version_alias(
     ),
     visibility = ["//visibility:public"],
 )
+
+java_runtime_version_alias(
+    name = "jdk_8",
+    runtime_version = "8",
+    selected_java_runtime = ":legacy_current_java_runtime",
+    visibility = ["//visibility:public"],
+)

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -467,10 +467,3 @@ java_runtime_version_alias(
     ),
     visibility = ["//visibility:public"],
 )
-
-java_runtime_version_alias(
-    name = "jdk_8",
-    runtime_version = "8",
-    selected_java_runtime = ":legacy_current_java_runtime",
-    visibility = ["//visibility:public"],
-)

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -15,7 +15,7 @@
 """Bazel rules for creating Java toolchains."""
 
 JDK8_JVM_OPTS = [
-    "-Xbootclasspath/p:$(location @bazel_tools//tools/jdk:javac_jar)",
+    "-Xbootclasspath/p:$(location @remote_java_tools//:javac_jar)",
 ]
 
 # JVM options, without patching java.compiler and jdk.compiler modules.

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -74,7 +74,7 @@ _BASE_TOOLCHAIN_CONFIGURATION = dict(
 JVM8_TOOLCHAIN_CONFIGURATION = dict(
     tools = ["@remote_java_tools//:javac_jar"],
     jvm_opts = ["-Xbootclasspath/p:$(location @remote_java_tools//:javac_jar)"],
-    java_runtime = "@local_jdk//:jdk",
+    java_runtime = "@bazel_tools//tools/jdk:jdk_8",
 )
 
 DEFAULT_TOOLCHAIN_CONFIGURATION = dict(

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -74,7 +74,7 @@ _BASE_TOOLCHAIN_CONFIGURATION = dict(
 JVM8_TOOLCHAIN_CONFIGURATION = dict(
     tools = ["@remote_java_tools//:javac_jar"],
     jvm_opts = ["-Xbootclasspath/p:$(location @remote_java_tools//:javac_jar)"],
-    java_runtime = "@bazel_tools//tools/jdk:jdk_8",
+    java_runtime = "@local_jdk//:jdk",
 )
 
 DEFAULT_TOOLCHAIN_CONFIGURATION = dict(

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -74,6 +74,7 @@ _BASE_TOOLCHAIN_CONFIGURATION = dict(
 JVM8_TOOLCHAIN_CONFIGURATION = dict(
     tools = ["@remote_java_tools//:javac_jar"],
     jvm_opts = ["-Xbootclasspath/p:$(location @remote_java_tools//:javac_jar)"],
+    java_runtime = "@bazel_tools//tools/jdk:jdk_8",
 )
 
 DEFAULT_TOOLCHAIN_CONFIGURATION = dict(


### PR DESCRIPTION
This is a partial revert of ec29e28a7f729c6a899ad0a75c770c4d174d78af.
The commit support rules_appengine usecase, which needs to supply additional parameters to a toolchain compiling with JDK8.
Previously the whole commit broke repos that are using bazel-toolchains.

Caveat: the downstream still breaks rules_appengine on Java 11 only system (Ubuntu 18.04). I believe this is correct behaviour, because rules_appengine seem to support only Java 8.

Addresses issue: https://github.com/bazelbuild/rules_appengine/issues/119