### PR TITLE
Fix coverage support when using default_java_toolchain.

### DIFF
--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -99,6 +99,8 @@ function get_coverage_file_path_from_test_log() {
 
 function test_java_test_coverage() {
   cat <<EOF > BUILD
+load("//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
+
 java_test(
     name = "test",
     srcs = glob(["src/test/**/*.java"]),
@@ -109,6 +111,10 @@ java_test(
 java_library(
     name = "collatz-lib",
     srcs = glob(["src/main/**/*.java"]),
+)
+
+default_java_toolchain(
+    name = "custom_toolchain"
 )
 EOF
 
@@ -179,7 +185,10 @@ LH:5
 LF:6
 end_of_record"
 
-assert_coverage_result "$expected_result" "$coverage_file_path"
+  assert_coverage_result "$expected_result" "$coverage_file_path"
+
+  bazel coverage --test_output=all --java_toolchain=//:custom_toolchain //:test &>$TEST_log || fail "Coverage with default_java_toolchain for //:test failed"
+  assert_coverage_result "$expected_result" "$coverage_file_path"
 }
 
 function test_java_test_coverage_combined_report() {

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -189,9 +189,6 @@ end_of_record"
 
   bazel coverage --test_output=all --java_toolchain=//:custom_toolchain //:test &>$TEST_log || fail "Coverage with default_java_toolchain for //:test failed"
   assert_coverage_result "$expected_result" "$coverage_file_path"
-
-  bazel coverage --test_output=all --javabase=@bazel_tools//tools/jdk:remote_jdk11 --java_toolchain=@bazel_tools//tools/jdk:toolchain_java10 //:test &>$TEST_log || fail "Coverage with default_java_toolchain for //:test failed"
-  assert_coverage_result "$expected_result" "$coverage_file_path"
 }
 
 function test_java_test_coverage_combined_report() {

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -189,6 +189,9 @@ end_of_record"
 
   bazel coverage --test_output=all --java_toolchain=//:custom_toolchain //:test &>$TEST_log || fail "Coverage with default_java_toolchain for //:test failed"
   assert_coverage_result "$expected_result" "$coverage_file_path"
+
+  bazel coverage --test_output=all --javabase=@bazel_tools//tools/jdk:remote_jdk11 --java_toolchain=@bazel_tools//tools/jdk:toolchain_java10 //:test &>$TEST_log || fail "Coverage with default_java_toolchain for //:test failed"
+  assert_coverage_result "$expected_result" "$coverage_file_path"
 }
 
 function test_java_test_coverage_combined_report() {

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -271,7 +271,7 @@ remote_java_tools_java_import(
     target = ":java_tools/JacocoCoverage_jarjar_deploy.jar",
 )
 
-remote_java_tools_java_import(
+remote_java_tools_filegroup(
     name = "JacocoCoverage",
     target = ":java_tools/JacocoCoverage_jarjar_deploy.jar",
 )

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -56,6 +56,7 @@ DEFAULT_TOOLCHAIN_CONFIGURATION = {
     "header_compiler_direct": ["@bazel_tools//tools/jdk:turbine_direct"],
     "ijar": ["@bazel_tools//tools/jdk:ijar"],
     "javabuilder": ["@bazel_tools//tools/jdk:javabuilder"],
+    "jacocorunner": "@bazel_tools//tools/jdk:JacocoCoverage",
     "tools": [
         "@bazel_tools//tools/jdk:javac_jar",
         "@bazel_tools//tools/jdk:java_compiler_jar",


### PR DESCRIPTION
In such case jacoco runner was not set on the java_toolchain.

Issue https://github.com/bazelbuild/bazel/issues/12793