### PR TITLE
Release Java tools v11.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,7 @@
 workspace(name = "io_bazel")
 
 load("//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
-load("//:distdir.bzl", "distdir_tar", "dist_http_archive")
+load("//:distdir.bzl", "dist_http_archive", "distdir_tar")
 load("//:distdir_deps.bzl", "DIST_DEPS")
 
 # These can be used as values for the patch_cmds and patch_cmds_win attributes
@@ -662,9 +662,9 @@ http_archive(
     name = "remote_java_tools_test",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "09ecd438f1a10aa36bf0a6a2f24ead884ef7e8e8a46d086f8af6db33556b76a8",
+    sha256 = "12cffbb7c87622a6bd6e9231e81ecb9efdb118afbdd6e047ef06eeb3d72a7dc3",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.0/java_tools-v11.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.1/java_tools-v11.1.zip",
     ],
 )
 
@@ -673,9 +673,9 @@ http_archive(
     name = "remote_java_tools_test_linux",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "b66d5b97b90cb20787cfa61565672b0538912d230f120a03f38020052f25c4bc",
+    sha256 = "a0dea21d348c8be94d06fde5a6c18d7691aa659cd56c3f1f932f0a28ae943a23",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.0/java_tools_linux-v11.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.1/java_tools_linux-v11.1.zip",
     ],
 )
 
@@ -684,9 +684,9 @@ http_archive(
     name = "remote_java_tools_test_windows",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "8a683275b0f24e011b56e27eb4d7e35919d774ae57ec3353d48606cfc81e4116",
+    sha256 = "ac4d22ce9b10a1d5e46cbae0beb63221d96043d1f3543a729482005481e3e51a",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.0/java_tools_windows-v11.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.1/java_tools_windows-v11.1.zip",
     ],
 )
 
@@ -695,9 +695,9 @@ http_archive(
     name = "remote_java_tools_test_darwin",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "39e3bb7e554e817de76a9b2cc9354b0c2363108dfcd56b360d3c35eadc8cddbd",
+    sha256 = "72a2f34806e7f83b111601495c3bd401b96ea1794daa259608481fd4f6a60629",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.0/java_tools_darwin-v11.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.1/java_tools_darwin-v11.1.zip",
     ],
 )
 

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -213,11 +213,11 @@ DIST_DEPS = {
     },
     "remote_java_tools": {
         "aliases": ["remote_java_tools_test", "remote_java_tools_for_testing"],
-        "archive": "java_tools-v11.0.zip",
-        "sha256": "09ecd438f1a10aa36bf0a6a2f24ead884ef7e8e8a46d086f8af6db33556b76a8",
+        "archive": "java_tools-v11.1.zip",
+        "sha256": "12cffbb7c87622a6bd6e9231e81ecb9efdb118afbdd6e047ef06eeb3d72a7dc3",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.0/java_tools-v11.0.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v11.0/java_tools-v11.0.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.1/java_tools-v11.1.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v11.1/java_tools-v11.1.zip",
         ],
         "used_in": [
             "additional_distfiles",
@@ -227,10 +227,10 @@ DIST_DEPS = {
     "remote_java_tools_linux": {
         "aliases": ["remote_java_tools_test_linux", "remote_java_tools_linux_for_testing"],
         "archive": "java_tools_linux-v11.0.zip",
-        "sha256": "b66d5b97b90cb20787cfa61565672b0538912d230f120a03f38020052f25c4bc",
+        "sha256": "a0dea21d348c8be94d06fde5a6c18d7691aa659cd56c3f1f932f0a28ae943a23",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.0/java_tools_linux-v11.0.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v11.0/java_tools_linux-v11.0.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.1/java_tools_linux-v11.1.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v11.1/java_tools_linux-v11.1.zip",
         ],
         "used_in": [
             "additional_distfiles",
@@ -240,10 +240,10 @@ DIST_DEPS = {
     "remote_java_tools_windows": {
         "aliases": ["remote_java_tools_test_windows", "remote_java_tools_windows_for_testing"],
         "archive": "java_tools_windows-v11.0.zip",
-        "sha256": "8a683275b0f24e011b56e27eb4d7e35919d774ae57ec3353d48606cfc81e4116",
+        "sha256": "ac4d22ce9b10a1d5e46cbae0beb63221d96043d1f3543a729482005481e3e51a",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.0/java_tools_windows-v11.0.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v11.0/java_tools_windows-v11.0.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.1/java_tools_windows-v11.1.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v11.1/java_tools_windows-v11.1.zip",
         ],
         "used_in": [
             "additional_distfiles",
@@ -253,10 +253,10 @@ DIST_DEPS = {
     "remote_java_tools_darwin": {
         "aliases": ["remote_java_tools_test_darwin", "remote_java_tools_darwin_for_testing"],
         "archive": "java_tools_darwin-v11.0.zip",
-        "sha256": "39e3bb7e554e817de76a9b2cc9354b0c2363108dfcd56b360d3c35eadc8cddbd",
+        "sha256": "72a2f34806e7f83b111601495c3bd401b96ea1794daa259608481fd4f6a60629",
         "urls": [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.0/java_tools_darwin-v11.0.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v11.0/java_tools_darwin-v11.0.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.1/java_tools_darwin-v11.1.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v11.1/java_tools_darwin-v11.1.zip",
         ],
         "used_in": [
             "additional_distfiles",

--- a/src/test/shell/bazel/bazel_java14_test.sh
+++ b/src/test/shell/bazel/bazel_java14_test.sh
@@ -134,4 +134,104 @@ EOF
   expect_log "0"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/12605
+function test_java15_plugins() {
+  mkdir -p java/main
+  cat >java/main/BUILD <<EOF
+java_library(
+    name = "Anno",
+    srcs = ["Anno.java"],
+)
+
+java_plugin(
+    name = "Proc",
+    srcs = ["Proc.java"],
+    deps = [":Anno"],
+    processor_class = "ex.Proc",
+    generates_api = True,
+)
+
+java_library(
+    name = "C1",
+    srcs = ["C1.java"],
+    deps = [":Anno"],
+    plugins = [":Proc"],
+)
+
+java_library(
+    name = "C2",
+    srcs = ["C2.java"],
+    deps = [":C1"],
+)
+EOF
+
+  cat >java/main/C1.java <<EOF
+package ex;
+
+public class C1 {
+    @Anno
+    @Deprecated
+    public void m() {}
+}
+EOF
+
+
+  cat >java/main/C2.java <<EOF
+package ex;
+
+public class C2 {
+    public void m() {
+        new C1().m();
+    }
+}
+
+EOF
+
+  cat >java/main/Anno.java <<EOF
+package ex;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface Anno {}
+EOF
+
+  cat >java/main/Proc.java <<EOF
+package ex;
+
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic.Kind;
+
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedAnnotationTypes("ex.Anno")
+public class Proc extends AbstractProcessor {
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        Elements els = processingEnv.getElementUtils();
+        for (Element el : roundEnv.getElementsAnnotatedWith(Anno.class)) {
+            if (els.isDeprecated(el)) {
+                processingEnv.getMessager().printMessage(Kind.WARNING, "deprecated");
+            }
+        }
+        return true;
+    }
+}
+EOF
+
+  bazel build //java/main:C2 &>"${TEST_log}" || fail "Expected to build"
+}
+
 run_suite "Tests new Java 14 language features"

--- a/src/test/shell/bazel/bazel_java15_test.sh
+++ b/src/test/shell/bazel/bazel_java15_test.sh
@@ -135,4 +135,106 @@ EOF
   expect_log "^World\$"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/12605
+function test_java15_plugins() {
+  mkdir -p java/main
+  cat >java/main/BUILD <<EOF
+java_library(
+    name = "Anno",
+    srcs = ["Anno.java"],
+)
+
+java_plugin(
+    name = "Proc",
+    srcs = ["Proc.java"],
+    deps = [":Anno"],
+    processor_class = "ex.Proc",
+    generates_api = True,
+)
+
+java_library(
+    name = "C1",
+    srcs = ["C1.java"],
+    deps = [":Anno"],
+    plugins = [":Proc"],
+)
+
+java_library(
+    name = "C2",
+    srcs = ["C2.java"],
+    deps = [":C1"],
+)
+EOF
+
+  cat >java/main/C1.java <<EOF
+package ex;
+
+public class C1 {
+    @Anno
+    @Deprecated
+    public void m() {}
+}
+EOF
+
+
+  cat >java/main/C2.java <<EOF
+package ex;
+
+public class C2 {
+    public void m() {
+        new C1().m();
+    }
+}
+
+EOF
+
+  cat >java/main/Anno.java <<EOF
+package ex;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface Anno {}
+EOF
+
+  cat >java/main/Proc.java <<EOF
+package ex;
+
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic.Kind;
+
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedAnnotationTypes("ex.Anno")
+public class Proc extends AbstractProcessor {
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        Elements els = processingEnv.getElementUtils();
+        for (Element el : roundEnv.getElementsAnnotatedWith(Anno.class)) {
+            if (els.isDeprecated(el)) {
+                processingEnv.getMessager().printMessage(Kind.WARNING, "deprecated");
+            }
+        }
+        return true;
+    }
+}
+EOF
+
+  bazel build //java/main:C2 &>"${TEST_log}" || fail "Expected to build"
+}
+
+
+
 run_suite "Tests new Java 15 language features"

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1655,4 +1655,105 @@ EOF
   expect_log "hello 123"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/12605
+function test_java15_plugins() {
+  mkdir -p java/main
+  cat >java/main/BUILD <<EOF
+java_library(
+    name = "Anno",
+    srcs = ["Anno.java"],
+)
+
+java_plugin(
+    name = "Proc",
+    srcs = ["Proc.java"],
+    deps = [":Anno"],
+    processor_class = "ex.Proc",
+    generates_api = True,
+)
+
+java_library(
+    name = "C1",
+    srcs = ["C1.java"],
+    deps = [":Anno"],
+    plugins = [":Proc"],
+)
+
+java_library(
+    name = "C2",
+    srcs = ["C2.java"],
+    deps = [":C1"],
+)
+EOF
+
+  cat >java/main/C1.java <<EOF
+package ex;
+
+public class C1 {
+    @Anno
+    @Deprecated
+    public void m() {}
+}
+EOF
+
+
+  cat >java/main/C2.java <<EOF
+package ex;
+
+public class C2 {
+    public void m() {
+        new C1().m();
+    }
+}
+
+EOF
+
+  cat >java/main/Anno.java <<EOF
+package ex;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface Anno {}
+EOF
+
+  cat >java/main/Proc.java <<EOF
+package ex;
+
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic.Kind;
+
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedAnnotationTypes("ex.Anno")
+public class Proc extends AbstractProcessor {
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        Elements els = processingEnv.getElementUtils();
+        for (Element el : roundEnv.getElementsAnnotatedWith(Anno.class)) {
+            if (els.isDeprecated(el)) {
+                processingEnv.getMessager().printMessage(Kind.WARNING, "deprecated");
+            }
+        }
+        return true;
+    }
+}
+EOF
+
+  bazel build //java/main:C2 &>"${TEST_log}" || fail "Expected to build"
+}
+
+
 run_suite "Java integration tests"

--- a/src/test/shell/bazel/testdata/jdk_http_archives
+++ b/src/test/shell/bazel/testdata/jdk_http_archives
@@ -2,33 +2,33 @@
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "remote_java_tools_test",
-    sha256 = "09ecd438f1a10aa36bf0a6a2f24ead884ef7e8e8a46d086f8af6db33556b76a8",
+    sha256 = "12cffbb7c87622a6bd6e9231e81ecb9efdb118afbdd6e047ef06eeb3d72a7dc3",
     urls = [
-         "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.0/java_tools-v11.0.zip",
+         "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.1/java_tools-v11.1.zip",
     ],
 )
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "remote_java_tools_test_linux",
-    sha256 = "b66d5b97b90cb20787cfa61565672b0538912d230f120a03f38020052f25c4bc",
+    sha256 = "a0dea21d348c8be94d06fde5a6c18d7691aa659cd56c3f1f932f0a28ae943a23",
     urls = [
-         "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.0/java_tools_linux-v11.0.zip",
+         "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.1/java_tools_linux-v11.1.zip",
     ],
 )
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "remote_java_tools_test_windows",
-    sha256 = "8a683275b0f24e011b56e27eb4d7e35919d774ae57ec3353d48606cfc81e4116",
+    sha256 = "ac4d22ce9b10a1d5e46cbae0beb63221d96043d1f3543a729482005481e3e51a",
     urls = [
-        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.0/java_tools_windows-v11.0.zip",
+        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.1/java_tools_windows-v11.1.zip",
     ],
 )
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "remote_java_tools_test_darwin",
-    sha256 = "39e3bb7e554e817de76a9b2cc9354b0c2363108dfcd56b360d3c35eadc8cddbd",
+    sha256 = "72a2f34806e7f83b111601495c3bd401b96ea1794daa259608481fd4f6a60629",
     urls = [
-         "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.0/java_tools_darwin-v11.0.zip",
+         "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.1/java_tools_darwin-v11.1.zip",
     ],
 )
 


### PR DESCRIPTION
Changes:
```
8cc0e261a3 cushon Include <limits>
960b7a99af Googler Adds an api-android target to the sharding API.
7749cf7579 Googler Use getRunfilesPath when constructing runfiles input manifest maps.
1489f0f4ca Timothy Klim Support Scala3 .tasty files
d113d74541 Liam Miller-Cushon Update turbine
41b3ab66b7 larsrc Create TestUtils methods to generate unique temp dirs, deprecate the current ones that are decidedly non-unique.
```

Fixes https://github.com/bazelbuild/bazel/issues/12605, https://github.com/bazelbuild/java_tools/issues/41
