### PR TITLE
Revert JacocoCoverage target to remote_java_tools_java_import.

### DIFF
--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -271,8 +271,13 @@ remote_java_tools_java_import(
     target = ":java_tools/JacocoCoverage_jarjar_deploy.jar",
 )
 
-remote_java_tools_filegroup(
+remote_java_tools_java_import(
     name = "JacocoCoverage",
+    target = ":java_tools/JacocoCoverage_jarjar_deploy.jar",
+)
+
+remote_java_tools_filegroup(
+    name = "JacocoCoverageFilegroup",
     target = ":java_tools/JacocoCoverage_jarjar_deploy.jar",
 )
 

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -56,7 +56,7 @@ DEFAULT_TOOLCHAIN_CONFIGURATION = {
     "header_compiler_direct": ["@bazel_tools//tools/jdk:turbine_direct"],
     "ijar": ["@bazel_tools//tools/jdk:ijar"],
     "javabuilder": ["@bazel_tools//tools/jdk:javabuilder"],
-    "jacocorunner": "@bazel_tools//tools/jdk:JacocoCoverage",
+    "jacocorunner": "@bazel_tools//tools/jdk:JacocoCoverageFilegroup",
     "tools": [
         "@bazel_tools//tools/jdk:javac_jar",
         "@bazel_tools//tools/jdk:java_compiler_jar",


### PR DESCRIPTION
And add a new target for remore_java_tools_filegroup.

JacocoCoverage target is used in downstream projects.

Related issue: https://github.com/bazelbuild/bazel/issues/12793