### PR TITLE
Only download JDK repositories that are needed

### DIFF
--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -419,18 +419,45 @@ py_test(
     ],
 )
 
+# Aliases for JDKs, so that they are only downloaded when needed. Do not use,
+# the aliases are only temporary.
+_JDKS = [
+    "remotejdk11_macos",
+    "remotejdk11_win",
+    "remotejdk11_linux_aarch64",
+    "remotejdk11_win",
+    "remotejdk11_linux",
+    "remotejdk11_linux_ppc64le",
+    "remotejdk11_linux_s390x",
+    "remotejdk14_macos",
+    "remotejdk14_win",
+    "remotejdk14_linux",
+    "remotejdk15_macos",
+    "remotejdk15_win",
+    "remotejdk15_linux",
+]
+
+[
+    alias(
+        name = JDK,
+        actual = "@%s//:jdk" % JDK,
+        deprecation = "Only to support Java plaformization transition",
+    )
+    for JDK in _JDKS
+]
+
 # A JDK 11 for use as a --host_javabase.
 java_runtime_version_alias(
     name = "remote_jdk11",
     runtime_version = "remotejdk_11",
     selected_java_runtime = select(
         {
-            "//src/conditions:darwin": "@remotejdk11_macos//:jdk",
-            "//src/conditions:windows": "@remotejdk11_win//:jdk",
-            "//src/conditions:linux_aarch64": "@remotejdk11_linux_aarch64//:jdk",
-            "//src/conditions:linux_x86_64": "@remotejdk11_linux//:jdk",
-            "//src/conditions:linux_ppc64le": "@remotejdk11_linux_ppc64le//:jdk",
-            "//src/conditions:linux_s390x": "@remotejdk11_linux_s390x//:jdk",
+            "//src/conditions:darwin": ":remotejdk11_macos",
+            "//src/conditions:windows": ":remotejdk11_win",
+            "//src/conditions:linux_aarch64": ":remotejdk11_linux_aarch64",
+            "//src/conditions:linux_x86_64": ":remotejdk11_linux",
+            "//src/conditions:linux_ppc64le": ":remotejdk11_linux_ppc64le",
+            "//src/conditions:linux_s390x": ":remotejdk11_linux_s390x",
         },
         no_match_error = "Could not find a JDK for host execution environment, please explicitly" +
                          " provide one using `--host_javabase.`",
@@ -443,9 +470,9 @@ java_runtime_version_alias(
     runtime_version = "remotejdk_14",
     selected_java_runtime = select(
         {
-            "//src/conditions:darwin": "@remotejdk14_macos//:jdk",
-            "//src/conditions:windows": "@remotejdk14_win//:jdk",
-            "//src/conditions:linux_x86_64": "@remotejdk14_linux//:jdk",
+            "//src/conditions:darwin": ":remotejdk14_macos",
+            "//src/conditions:windows": ":remotejdk14_win",
+            "//src/conditions:linux_x86_64": ":remotejdk14_linux",
         },
         no_match_error = "Could not find a JDK for host execution environment, please explicitly" +
                          " provide one using `--host_javabase.`",
@@ -458,9 +485,9 @@ java_runtime_version_alias(
     runtime_version = "remotejdk_15",
     selected_java_runtime = select(
         {
-            "//src/conditions:darwin": "@remotejdk15_macos//:jdk",
-            "//src/conditions:windows": "@remotejdk15_win//:jdk",
-            "//src/conditions:linux_x86_64": "@remotejdk15_linux//:jdk",
+            "//src/conditions:darwin": ":remotejdk15_macos",
+            "//src/conditions:windows": ":remotejdk15_win",
+            "//src/conditions:linux_x86_64": ":remotejdk15_linux",
         },
         no_match_error = "Could not find a JDK for host execution environment, please explicitly" +
                          " provide one using `--host_javabase.`",

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -419,8 +419,7 @@ py_test(
     ],
 )
 
-# Aliases for JDKs, so that they are only downloaded when needed. Do not use,
-# the aliases are only temporary.
+# Aliases for JDKs, so that they are only downloaded when needed.
 _JDKS = [
     "remotejdk11_macos",
     "remotejdk11_win",
@@ -441,7 +440,7 @@ _JDKS = [
     alias(
         name = JDK,
         actual = "@%s//:jdk" % JDK,
-        deprecation = "Only to support Java plaformization transition",
+        visibility = ["//visibility:private"],
     )
     for JDK in _JDKS
 ]

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -145,6 +145,26 @@ config_setting(
     values = {"define": "EXECUTOR=remote"},
 )
 
+[
+    (
+        alias(
+            name = "ijar_prebuilt_binary_%s" % OS,
+            actual = "@remote_java_tools_%s//:ijar_prebuilt_binary" % OS,
+            visibility = ["//visibility:private"],
+        ),
+        alias(
+            name = "prebuilt_singlejar_%s" % OS,
+            actual = "@remote_java_tools_%s//:prebuilt_singlejar" % OS,
+            visibility = ["//visibility:private"],
+        ),
+    )
+    for OS in [
+        "linux",
+        "darwin",
+        "windows",
+    ]
+]
+
 # On Windows, executables end in ".exe", but the label we reach it through
 # must be platform-independent. Thus, we create a little filegroup that
 # contains the appropriate platform-dependent file.
@@ -159,9 +179,9 @@ alias(
 alias(
     name = "ijar_prebuilt_binary_or_cc_binary",
     actual = select({
-        "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:ijar_prebuilt_binary",
-        "//src/conditions:darwin": "@remote_java_tools_darwin//:ijar_prebuilt_binary",
-        "//src/conditions:windows": "@remote_java_tools_windows//:ijar_prebuilt_binary",
+        "//src/conditions:linux_x86_64": ":ijar_prebuilt_binary_linux",
+        "//src/conditions:darwin": ":ijar_prebuilt_binary_darwin",
+        "//src/conditions:windows": ":ijar_prebuilt_binary_windows",
         "//conditions:default": "@remote_java_tools//:ijar_cc_binary",
     }),
 )
@@ -169,9 +189,9 @@ alias(
 alias(
     name = "ijar_prebuilt_binary",
     actual = select({
-        "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:ijar_prebuilt_binary",
-        "//src/conditions:darwin": "@remote_java_tools_darwin//:ijar_prebuilt_binary",
-        "//src/conditions:windows": "@remote_java_tools_windows//:ijar_prebuilt_binary",
+        "//src/conditions:linux_x86_64": ":ijar_prebuilt_binary_linux",
+        "//src/conditions:darwin": ":ijar_prebuilt_binary_darwin",
+        "//src/conditions:windows": ":ijar_prebuilt_binary_windows",
     }),
 )
 
@@ -192,9 +212,9 @@ alias(
 alias(
     name = "singlejar_prebuilt_or_cc_binary",
     actual = select({
-        "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:prebuilt_singlejar",
-        "//src/conditions:darwin": "@remote_java_tools_darwin//:prebuilt_singlejar",
-        "//src/conditions:windows": "@remote_java_tools_windows//:prebuilt_singlejar",
+        "//src/conditions:linux_x86_64": ":prebuilt_singlejar_linux",
+        "//src/conditions:darwin": ":prebuilt_singlejar_darwin",
+        "//src/conditions:windows": ":prebuilt_singlejar_windows",
         "//conditions:default": "@remote_java_tools//:singlejar_cc_bin",
     }),
 )
@@ -202,9 +222,9 @@ alias(
 alias(
     name = "prebuilt_singlejar",
     actual = select({
-        "//src/conditions:linux_x86_64": "@remote_java_tools_linux//:prebuilt_singlejar",
-        "//src/conditions:darwin": "@remote_java_tools_darwin//:prebuilt_singlejar",
-        "//src/conditions:windows": "@remote_java_tools_windows//:prebuilt_singlejar",
+        "//src/conditions:linux_x86_64": ":prebuilt_singlejar_linux",
+        "//src/conditions:darwin": ":prebuilt_singlejar_darwin",
+        "//src/conditions:windows": ":prebuilt_singlejar_windows",
     }),
 )
 
@@ -424,7 +444,6 @@ _JDKS = [
     "remotejdk11_macos",
     "remotejdk11_win",
     "remotejdk11_linux_aarch64",
-    "remotejdk11_win",
     "remotejdk11_linux",
     "remotejdk11_linux_ppc64le",
     "remotejdk11_linux_s390x",


### PR DESCRIPTION
The problem were `select`s that pointed to remote repos, which causes all the remote repos to be downloaded. Inserting an alias in between prevents this download.

Fixes https://github.com/bazelbuild/bazel/issues/12778