### PR TITLE
Mention in profile that we are aquiring resources when doing so.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
@@ -200,7 +200,7 @@ public class ResourceManager {
     Preconditions.checkState(
         !threadHasResources(), "acquireResources with existing resource lock during %s", owner);
 
-    AutoProfiler p = profiled(owner.describe(), ProfilerTask.ACTION_LOCK);
+    AutoProfiler p = profiled("Aquiring resources for: " + owner.describe(), ProfilerTask.ACTION_LOCK);
     CountDownLatch latch = null;
     try {
       latch = acquire(resources);


### PR DESCRIPTION
Without this additional text it's quite confusing.

Before: 
![image](https://user-images.githubusercontent.com/418721/104927601-ef0ac800-59a1-11eb-983d-5269969cb187.png)

After:
![image](https://user-images.githubusercontent.com/418721/104927686-03e75b80-59a2-11eb-9c06-8039fdb98f06.png)

Found while looking at https://github.com/bazelbuild/bazel/issues/12725
