### PR TITLE
Update RBE configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,14 +9,13 @@ build:remote_shared --google_default_credentials
 build:remote_shared --jobs=100
 build:remote_shared --action_env=PATH=/bin:/usr/bin:/usr/local/bin
 build:remote_shared --disk_cache=
+build:remote_shared --java_runtime_version=rbe_jdk
+build:remote_shared --tool_java_runtime_version=rbe_jdk
 # Workaround for singlejar incompatibility with RBE
 build:remote_shared --noexperimental_check_desugar_deps
 
 # Configuration to build and test Bazel on RBE on Ubuntu 18.04 with Java 11
-build:ubuntu1804_java11 --host_javabase=@rbe_ubuntu1804_java11//java:jdk
-build:ubuntu1804_java11 --javabase=@rbe_ubuntu1804_java11//java:jdk
-build:ubuntu1804_java11 --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java9
-build:ubuntu1804_java11 --java_toolchain=@bazel_tools//tools/jdk:toolchain_java9
+build:ubuntu1804_java11 --extra_toolchains=@rbe_ubuntu1804_java11//java:all
 build:ubuntu1804_java11 --crosstool_top=@rbe_ubuntu1804_java11//cc:toolchain
 build:ubuntu1804_java11 --extra_toolchains=@rbe_ubuntu1804_java11//config:cc-toolchain
 build:ubuntu1804_java11 --extra_execution_platforms=//:rbe_ubuntu1804_java11_platform
@@ -26,10 +25,7 @@ build:ubuntu1804_java11 --platforms=//:rbe_ubuntu1804_java11_platform
 build:ubuntu1804_java11 --config=remote_shared
 
 # Configuration to build and test Bazel on RBE on Ubuntu 16.04 with Java 8
-build:ubuntu1604_java8 --host_javabase=@rbe_ubuntu1604_java8//java:jdk
-build:ubuntu1604_java8 --javabase=@rbe_ubuntu1604_java8//java:jdk
-build:ubuntu1604_java8 --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:ubuntu1604_java8 --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:ubuntu1604_java8 --extra_toolchains=@rbe_ubuntu1604_java8//java:all
 build:ubuntu1604_java8 --crosstool_top=@rbe_ubuntu1604_java8//cc:toolchain
 build:ubuntu1604_java8 --extra_toolchains=@rbe_ubuntu1604_java8//config:cc-toolchain
 build:ubuntu1604_java8 --extra_execution_platforms=//:rbe_ubuntu1604_java8_platform
@@ -37,6 +33,16 @@ build:ubuntu1604_java8 --extra_execution_platforms=//:rbe_ubuntu1604_java8_highc
 build:ubuntu1604_java8 --host_platform=//:rbe_ubuntu1604_java8_platform
 build:ubuntu1604_java8 --platforms=//:rbe_ubuntu1604_java8_platform
 build:ubuntu1604_java8 --config=remote_shared
+
+#TODO(ilist): remove once Bazel version on RBE is > 4.0.0
+build:ubuntu1804_java11 --host_javabase=@rbe_ubuntu1804_java11//java:jdk
+build:ubuntu1804_java11 --javabase=@rbe_ubuntu1804_java11//java:jdk
+build:ubuntu1804_java11 --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java9
+build:ubuntu1804_java11 --java_toolchain=@bazel_tools//tools/jdk:toolchain_java9
+build:ubuntu1604_java8 --host_javabase=@rbe_ubuntu1604_java8//java:jdk
+build:ubuntu1604_java8 --javabase=@rbe_ubuntu1604_java8//java:jdk
+build:ubuntu1604_java8 --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:ubuntu1604_java8 --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 
 # Alias
 build:remote --config=ubuntu1604_java8

--- a/BUILD
+++ b/BUILD
@@ -187,15 +187,6 @@ genrule(
     visibility = ["//:__subpackages__"],
 )
 
-# This is a workaround for fetching Bazel toolchains, for remote execution.
-# See https://github.com/bazelbuild/bazel/issues/3246.
-# Will be removed once toolchain fetching is supported.
-filegroup(
-    name = "dummy_toolchain_reference",
-    srcs = ["@bazel_toolchains//configs/debian8_clang/0.2.0/bazel_0.9.0:empty"],
-    visibility = ["//visibility:public"],
-)
-
 constraint_setting(name = "machine_size")
 
 # A machine with "high cpu count".

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -32,12 +32,12 @@ DIST_DEPS = {
         ],
     },
     "bazel_toolchains": {
-        "archive": "bazel-toolchains-3.1.0.tar.gz",
-        "sha256": "726b5423e1c7a3866a3a6d68e7123b4a955e9fcbe912a51e0f737e6dab1d0af2",
-        "strip_prefix": "bazel-toolchains-3.1.0",
+        "archive": "b9bc541aae7bd8e09c6954e2e9da3f7ffe4f77f0.tar.gz",
+        "sha256": "0fe656c3503ee318ba21e3147186b0959ddb8514e4826174e5c178cd1968bdb9",
+        "strip_prefix": "bazel-toolchains-b9bc541aae7bd8e09c6954e2e9da3f7ffe4f77f0",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.0/bazel-toolchains-3.1.0.tar.gz",
+            #TODO(ilist): mirror and update to 4.0.0 version once it is released
+            "https://github.com/bazelbuild/bazel-toolchains/archive/b9bc541aae7bd8e09c6954e2e9da3f7ffe4f77f0.tar.gz",
         ],
         "used_in": [
             "additional_distfiles",

--- a/src/BUILD
+++ b/src/BUILD
@@ -698,7 +698,6 @@ filegroup(
     srcs = [
         "@android_tools_for_testing//:WORKSPACE",
         "@bazel_skylib//:WORKSPACE",
-        "@bazel_toolchains//:WORKSPACE",
         "@com_google_protobuf//:WORKSPACE",
         "@openjdk11_darwin_archive//:WORKSPACE",
         "@openjdk11_linux_archive//:WORKSPACE",

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -140,20 +140,12 @@ alias(
     actual = "@local_jdk//:javadoc",
 )
 
-config_setting(
-    name = "remote",
-    values = {"define": "EXECUTOR=remote"},
-)
-
 # On Windows, executables end in ".exe", but the label we reach it through
 # must be platform-independent. Thus, we create a little filegroup that
 # contains the appropriate platform-dependent file.
 alias(
     name = "ijar",
-    actual = select({
-        ":remote": "@remote_java_tools//:ijar_cc_binary",
-        "//conditions:default": ":ijar_prebuilt_binary_or_cc_binary",
-    }),
+    actual = ":ijar_prebuilt_binary_or_cc_binary",
 )
 
 alias(
@@ -183,10 +175,7 @@ alias(
 # must be platform-independent.
 alias(
     name = "singlejar",
-    actual = select({
-        ":remote": "@remote_java_tools//:singlejar_cc_bin",
-        "//conditions:default": ":singlejar_prebuilt_or_cc_binary",
-    }),
+    actual = ":singlejar_prebuilt_or_cc_binary",
 )
 
 alias(


### PR DESCRIPTION
Added RBE parameters to bazelrc, that will be needed once this version of Bazel is released. (RBE via bazel-toolchains is running using latest release bazel, in this case 3.7.2).

I updated bazel-toolchains repo, because it contains modifications that will be needed - detection of java version and generation of toolchains that are compatible with toolchain resolution.

I removed dummy_toolchain_reference, because the bug has apparently been fixed, and all tests pass without the workaround.

I removed special casing using EXECUTOR=remote for ijar and singlejar. This works with older version of Bazel on RBE, because execution constraints (os:windows/linux, cpu) were already properly detected.

