### PR TITLE
Revert "Switch to -fdebug-compilation-dir"

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5366,7 +5366,7 @@ def _impl(ctx):
                     ACTION_NAMES.objc_compile,
                     ACTION_NAMES.objcpp_compile,
                 ],
-                flag_groups = [flag_group(flags = ["-fdebug-compilation-dir", "."])],
+                flag_groups = [flag_group(flags = ["DEBUG_PREFIX_MAP_PWD=."])],
             ),
         ],
     )

--- a/tools/osx/crosstool/wrapped_clang.cc
+++ b/tools/osx/crosstool/wrapped_clang.cc
@@ -318,6 +318,9 @@ void ProcessArgument(const std::string arg, const std::string developer_dir,
   }
 
   std::string dest_dir, bitcode_symbol_map;
+  if (SetArgIfFlagPresent(arg, "DEBUG_PREFIX_MAP_PWD", &dest_dir)) {
+    new_arg = "-fdebug-prefix-map=" + cwd + "=" + dest_dir;
+  }
   if (arg.compare("OSO_PREFIX_MAP_PWD") == 0) {
     new_arg = "-Wl,-oso_prefix," + cwd + "/";
   }


### PR DESCRIPTION
This reverts commit 0cb8757781e3ab9b4aee06483b74b46a2e4c6126.

This flag isn't supported by Xcode 11.2, which is the newest available
version for macOS 10.14

https://github.com/bazelbuild/bazel/pull/12354#issuecomment-765399006

Fixes https://github.com/bazelbuild/bazel/issues/12905