### PR TITLE
Add additional_outputs argument to cc_common.link

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcModule.java
@@ -158,6 +158,7 @@ public class BazelCcModule extends CcModule
       boolean linkDepsStatically,
       StarlarkInt stamp,
       Sequence<?> additionalInputs, // <Artifact> expected
+      Sequence<?> additionalOutputs, // <Artifact> expected
       Object grepIncludes,
       Object linkArtifactNameSuffix,
       Object neverLink,
@@ -183,6 +184,7 @@ public class BazelCcModule extends CcModule
         linkDepsStatically,
         stamp,
         additionalInputs,
+        additionalOutputs,
         /* grepIncludes= */ null,
         linkArtifactNameSuffix,
         neverLink,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -2107,6 +2107,7 @@ public abstract class CcModule
       boolean linkDepsStatically,
       StarlarkInt stamp,
       Sequence<?> additionalInputs,
+      Sequence<?> additionalOutputs,
       Object grepIncludes,
       Object linkedArtifactNameSuffixObject,
       Object neverLinkObject,
@@ -2185,6 +2186,8 @@ public abstract class CcModule
             .setIsStampingEnabled(isStampingEnabled)
             .addNonCodeLinkerInputs(
                 Sequence.cast(additionalInputs, Artifact.class, "additional_inputs"))
+            .addNonCodeLinkerOutputs(
+                Sequence.cast(additionalOutputs, Artifact.class, "additional_outputs"))
             .setDynamicLinkType(dynamicLinkTargetType)
             .addCcLinkingContexts(
                 Sequence.cast(linkingContexts, CcLinkingContext.class, "linking_contexts"))

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/BazelCcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/BazelCcModuleApi.java
@@ -417,6 +417,12 @@ public interface BazelCcModuleApi<
             named = true,
             defaultValue = "[]"),
         @Param(
+            name = "additional_outputs",
+            doc = "For additional outputs to the linking action, e.g.: map files.",
+            positional = false,
+            named = true,
+            defaultValue = "[]"),
+        @Param(
             name = "grep_includes",
             positional = false,
             named = true,
@@ -502,6 +508,7 @@ public interface BazelCcModuleApi<
       boolean linkDepsStatically,
       StarlarkInt stamp,
       Sequence<?> additionalInputs, // <FileT> expected
+      Sequence<?> additionalOutputs, // <FileT> expected
       Object grepIncludes,
       Object linkArtifactNameSuffix,
       Object neverLink,

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/cpp/FakeCcModule.java
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/cpp/FakeCcModule.java
@@ -335,6 +335,7 @@ public class FakeCcModule
       boolean linkDepsStatically,
       StarlarkInt stamp,
       Sequence<?> additionalInputs,
+      Sequence<?> additionalOutputs,
       Object grepIncludes,
       Object linkArtifactNameSuffix,
       Object neverLink,


### PR DESCRIPTION
This allows additional linker output files to be available to custom
build rules, for example to produce the map file as following:

    map_file = ctx.actions.declare_file(ctx.label.name + ".map")
    linking_outputs = cc_common.link(
        additional_outputs = [map_file],
        user_link_flags = ["-Xlinker", "-Map=%s" % map_file.path],
    ...