### PR TITLE
Prevent a crash when using --repo_env=VAR without a value

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -243,7 +243,14 @@ public class CommandEnvironment {
     CoreOptions configOpts = options.getOptions(CoreOptions.class);
     if (configOpts != null) {
       for (Map.Entry<String, String> entry : configOpts.repositoryEnvironment) {
-        repoEnv.put(entry.getKey(), entry.getValue());
+        String name = entry.getKey();
+        String value = entry.getValue();
+        if (value == null) {
+          value = System.getenv(name);
+        }
+        if (value != null) {
+          repoEnv.put(name, value);
+        }
       }
     }
   }


### PR DESCRIPTION
The --repo_env option is documented in the same way as --action_env. In
addition to allowing you to set explicit values, you can also use it to
explicitly pick values from the environment in which Bazel was invoked.
Unfortunately, this causes a null pointer exception in Starlark due to a
null string stored as a map value.

This change extends the logic of converting --repo_env to a map to take
null values into account. When null, the value is loaded from the
current environment. This behaviour is useful in case you want to do
something like this:

--incompatible_strict_action_env --action_env=PATH=... --repo_env=PATH

This allows you to run build actions with a strict value for $PATH (e.g.,
to get a decent action cache hit rate in case of remote execution),
while still allowing repository_ctx.which() to find tools on the host
system using $PATH.