### PR TITLE
Fix ijar failing on empty jars.

### DIFF
--- a/third_party/ijar/ijar.cc
+++ b/third_party/ijar/ijar.cc
@@ -371,8 +371,8 @@ static void OpenFilesAndProcessJar(const char *file_out, const char *file_in,
     abort();
   }
   u8 output_length = in->CalculateOutputLength();
-  if (output_length < 103ull + DUMMY_PATH_LENGTH) {
-    output_length = 103ull + DUMMY_PATH_LENGTH;
+  if (output_length < 98ull + 2 * DUMMY_PATH_LENGTH) {
+    output_length = 98ull + 2 * DUMMY_PATH_LENGTH;
   }
   output_length += EstimateManifestOutputSize(target_label, injecting_rule_kind);
 

--- a/third_party/ijar/ijar.cc
+++ b/third_party/ijar/ijar.cc
@@ -370,9 +370,12 @@ static void OpenFilesAndProcessJar(const char *file_out, const char *file_in,
             strerror(errno));
     abort();
   }
-  u8 output_length =
-      std::max(in->CalculateOutputLength(), 103ull + DUMMY_PATH_LENGTH) +
-      EstimateManifestOutputSize(target_label, injecting_rule_kind);
+  u8 output_length = in->CalculateOutputLength();
+  if (output_length < 103ull + DUMMY_PATH_LENGTH) {
+    output_length = 103ull + DUMMY_PATH_LENGTH;
+  }
+  output_length += EstimateManifestOutputSize(target_label, injecting_rule_kind);
+
   std::unique_ptr<ZipBuilder> out(ZipBuilder::Create(file_out, output_length));
   if (out == NULL) {
     fprintf(stderr, "Unable to open output file %s: %s\n", file_out,

--- a/third_party/ijar/ijar.cc
+++ b/third_party/ijar/ijar.cc
@@ -54,6 +54,8 @@ const char *TARGET_LABEL_KEY = "Target-Label: ";
 const size_t TARGET_LABEL_KEY_LENGTH = strlen(TARGET_LABEL_KEY);
 const char *INJECTING_RULE_KIND_KEY = "Injecting-Rule-Kind: ";
 const size_t INJECTING_RULE_KIND_KEY_LENGTH = strlen(INJECTING_RULE_KIND_KEY);
+const char *DUMMY_FILE = "dummy";
+const size_t DUMMY_PATH_LENGTH = strlen(DUMMY_FILE);
 
 class JarExtractorProcessor : public ZipExtractorProcessor {
  public:
@@ -369,7 +371,7 @@ static void OpenFilesAndProcessJar(const char *file_out, const char *file_in,
     abort();
   }
   u8 output_length =
-      in->CalculateOutputLength() +
+      std::max(in->CalculateOutputLength(), 103ull + DUMMY_PATH_LENGTH) +
       EstimateManifestOutputSize(target_label, injecting_rule_kind);
   std::unique_ptr<ZipBuilder> out(ZipBuilder::Create(file_out, output_length));
   if (out == NULL) {
@@ -388,7 +390,7 @@ static void OpenFilesAndProcessJar(const char *file_out, const char *file_in,
 
   // Add dummy file, since javac doesn't like truly empty jars.
   if (out->GetNumberFiles() == 0) {
-    out->WriteEmptyFile("dummy");
+    out->WriteEmptyFile(DUMMY_FILE);
   }
   // Finish writing the output file
   if (out->Finish() < 0) {

--- a/third_party/ijar/test/BUILD
+++ b/third_party/ijar/test/BUILD
@@ -160,6 +160,14 @@ genrule(
     tools = ["//third_party/ijar"],
 )
 
+genrule(
+    name = "empty_without_target_label",
+    srcs = [":empty_zip.jar"],
+    outs = ["empty_without_target_label.jar"],
+    cmd = "$(location //third_party/ijar) $< $@",
+    tools = ["//third_party/ijar"],
+)
+
 java_library(
     name = "typeannotations2",
     srcs = glob(["typeannotations2/**/*.java"]),
@@ -357,7 +365,7 @@ java_binary(
         ("largest_regular", 65535),
         ("smallest_zip64", 65536),
         ("definitely_zip64", 70000),
-        ("empty_zip", 1),
+        ("empty_zip", 0),
     ]
 ]
 


### PR DESCRIPTION
The problem happened when all the files are filtered out. In such case a dummy file is created, but it was not accounted for in the size estimation.
Fixes https://github.com/bazelbuild/bazel/issues/10162