### PR TITLE
Update platforms_test to not rely on filegroup not using toolchain

### DIFF
--- a/src/test/shell/bazel/platforms_test.sh
+++ b/src/test/shell/bazel/platforms_test.sh
@@ -78,7 +78,9 @@ EOF
   mkdir -p override || fail "couldn't create override directory"
   touch override/WORKSPACE || fail "couldn't touch override/WORKSPACE"
   cat > override/BUILD <<EOF
-filegroup(name = 'yolo')
+# Have to use a rule that doesn't require a target platform, or else there will
+# be a cycle.
+toolchain_type(name = 'yolo')
 EOF
 
   cd platforms_can_be_overridden || fail "couldn't cd into workspace"


### PR DESCRIPTION
resolution.

Part of work on #12899.