### PR TITLE
Support proguard 5.3.3 or 6.2.2 in the tests

### DIFF
--- a/src/test/shell/bazel/bazel_java_tools_dist_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_dist_test.sh
@@ -147,18 +147,14 @@ function test_java_tools_has_jacocoagent() {
   expect_path_in_java_tools "third_party/asm/asm-8.0-sources.jar"
 }
 
+# TODO(bencodes) These tests should assert against a 6.2.2 after proguard is switched over
 function test_java_tools_has_proguard() {
   expect_path_in_java_tools "third_party/java/proguard"
-  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3" \
-    || expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2"
-  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3/bin" \
-    || expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2/bin"
-  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3/buildscripts" \
-    || expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2/buildscripts"
-  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3/src" \
-    || expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2/src"
-  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3/src/proguard" \
-    || expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2/src/proguard"
+  expect_path_in_java_tools "third_party/java/proguard/proguard.*"
+  expect_path_in_java_tools "third_party/java/proguard/proguard.*/bin"
+  expect_path_in_java_tools "third_party/java/proguard/proguard.*/buildscripts"
+  expect_path_in_java_tools "third_party/java/proguard/proguard.*/src"
+  expect_path_in_java_tools "third_party/java/proguard/proguard.*/src/proguard"
 }
 
 run_suite "Java tools archive tests"

--- a/src/test/shell/bazel/bazel_java_tools_dist_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_dist_test.sh
@@ -149,11 +149,16 @@ function test_java_tools_has_jacocoagent() {
 
 function test_java_tools_has_proguard() {
   expect_path_in_java_tools "third_party/java/proguard"
-  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3"
-  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3/bin"
-  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3/buildscripts"
-  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3/src"
-  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3/src/proguard"
+  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3" \
+    || expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2"
+  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3/bin" \
+    || expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2/bin"
+  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3/buildscripts" \
+    || expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2/buildscripts"
+  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3/src" \
+    || expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2/src"
+  expect_path_in_java_tools "third_party/java/proguard/proguard5.3.3/src/proguard" \
+    || expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2/src/proguard"
 }
 
 run_suite "Java tools archive tests"

--- a/src/test/shell/bazel/bazel_java_tools_dist_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_dist_test.sh
@@ -147,7 +147,7 @@ function test_java_tools_has_jacocoagent() {
   expect_path_in_java_tools "third_party/asm/asm-8.0-sources.jar"
 }
 
-# TODO(bencodes) These tests should assert against a 6.2.2 after proguard is switched over
+# TODO(bencodes) This test should assert against a 6.2.2 after proguard is switched over
 function test_java_tools_has_proguard() {
   expect_path_in_java_tools "third_party/java/proguard"
   expect_path_in_java_tools "third_party/java/proguard/proguard.*"

--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -189,7 +189,8 @@ function test_java_tools_has_jacocoagent() {
 
 function test_java_tools_has_proguard() {
   expect_path_in_java_tools "java_tools/third_party/java/proguard/proguard.jar"
-  expect_path_in_java_tools "java_tools/third_party/java/proguard/GPL.html"
+  expect_path_in_java_tools "java_tools/third_party/java/proguard/GPL.html" \
+    || expect_path_in_java_tools "java_tools/third_party/java/proguard/GPL.md"
 }
 
 function test_java_tools_toolchain_builds() {

--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -189,8 +189,7 @@ function test_java_tools_has_jacocoagent() {
 
 function test_java_tools_has_proguard() {
   expect_path_in_java_tools "java_tools/third_party/java/proguard/proguard.jar"
-  expect_path_in_java_tools "java_tools/third_party/java/proguard/GPL.html" \
-    || expect_path_in_java_tools "java_tools/third_party/java/proguard/GPL.md"
+  expect_path_in_java_tools "java_tools/third_party/java/proguard/GPL.*"
 }
 
 function test_java_tools_toolchain_builds() {

--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -187,6 +187,7 @@ function test_java_tools_has_jacocoagent() {
   expect_path_in_java_tools "java_tools/third_party/java/jacoco/LICENSE"
 }
 
+# TODO(bencodes) This test should assert against a 6.2.2 after proguard is switched over
 function test_java_tools_has_proguard() {
   expect_path_in_java_tools "java_tools/third_party/java/proguard/proguard.jar"
   expect_path_in_java_tools "java_tools/third_party/java/proguard/GPL.*"


### PR DESCRIPTION
Pulling this out https://github.com/bazelbuild/bazel/pull/12509 so that it's easier to merge and sync