### PR TITLE
Revert default cpu value on x86 macOS to "darwin"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
@@ -31,12 +31,12 @@ public class AutoCpuConverter implements Converter<String> {
   public String convert(String input) throws OptionsParsingException {
     if (input.isEmpty()) {
       // TODO(philwo) - replace these deprecated names with more logical ones (e.g. k8 becomes
-      // linux-x86_64 ...).
+      // linux-x86_64, darwin includes the CPU architecture, ...).
       switch (OS.getCurrent()) {
         case DARWIN:
           switch (CPU.getCurrent()) {
             case X86_64:
-              return "darwin_x86_64";
+              return "darwin";
             case AARCH64:
               return "darwin_arm64";
             default:

--- a/tools/cpp/lib_cc_configure.bzl
+++ b/tools/cpp/lib_cc_configure.bzl
@@ -183,7 +183,7 @@ def get_cpu_value(repository_ctx):
     if os_name.startswith("mac os"):
         # Check if we are on x86_64 or arm64 and return the corresponding cpu value.
         result = repository_ctx.execute(["uname", "-m"])
-        return "darwin_" + result.stdout.strip()
+        return "darwin" + ("_arm64" if result.stdout.strip() == "arm64" else "")
     if os_name.find("freebsd") != -1:
         return "freebsd"
     if os_name.find("openbsd") != -1:


### PR DESCRIPTION
Many downstream projects are still depending on the default cpu value
on x86 macOS being "darwin" instead of "darwin_x86_64"

https://buildkite.com/bazel/bazel-auto-sheriff-face-with-cowboy-hat/builds/412

Related: #11628