### PR TITLE
Switch Bazel over to proguard 6.2.2 in the tests

### DIFF
--- a/src/test/shell/bazel/bazel_java_tools_dist_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_dist_test.sh
@@ -147,14 +147,13 @@ function test_java_tools_has_jacocoagent() {
   expect_path_in_java_tools "third_party/asm/asm-8.0-sources.jar"
 }
 
-# TODO(bencodes) This test should assert against a 6.2.2 after proguard is switched over
 function test_java_tools_has_proguard() {
   expect_path_in_java_tools "third_party/java/proguard"
-  expect_path_in_java_tools "third_party/java/proguard/proguard.*"
-  expect_path_in_java_tools "third_party/java/proguard/proguard.*/bin"
-  expect_path_in_java_tools "third_party/java/proguard/proguard.*/buildscripts"
-  expect_path_in_java_tools "third_party/java/proguard/proguard.*/src"
-  expect_path_in_java_tools "third_party/java/proguard/proguard.*/src/proguard"
+  expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2"
+  expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2/bin"
+  expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2/buildscripts"
+  expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2/src"
+  expect_path_in_java_tools "third_party/java/proguard/proguard6.2.2/src/proguard"
 }
 
 run_suite "Java tools archive tests"

--- a/src/test/shell/bazel/bazel_java_tools_test.sh
+++ b/src/test/shell/bazel/bazel_java_tools_test.sh
@@ -187,10 +187,9 @@ function test_java_tools_has_jacocoagent() {
   expect_path_in_java_tools "java_tools/third_party/java/jacoco/LICENSE"
 }
 
-# TODO(bencodes) This test should assert against a 6.2.2 after proguard is switched over
 function test_java_tools_has_proguard() {
   expect_path_in_java_tools "java_tools/third_party/java/proguard/proguard.jar"
-  expect_path_in_java_tools "java_tools/third_party/java/proguard/GPL.*"
+  expect_path_in_java_tools "java_tools/third_party/java/proguard/GPL.md"
 }
 
 function test_java_tools_toolchain_builds() {


### PR DESCRIPTION
Last little but of cleanup after switching Bazel over to Progard 6.2.2.