### PR TITLE
PlatformProviderUtils should ignore targets that don't have the needed

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/RuleContextConstraintSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/RuleContextConstraintSemantics.java
@@ -15,7 +15,6 @@
 package com.google.devtools.build.lib.analysis.constraints;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Streams.stream;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Joiner;
@@ -912,9 +911,9 @@ public class RuleContextConstraintSemantics implements ConstraintSemantics<RuleC
     if (ruleContext.getRule().getRuleClassObject().useToolchainResolution()
         && ruleContext.attributes().has("target_compatible_with")) {
       ImmutableList<ConstraintValueInfo> invalidConstraintValues =
-          stream(
-                  PlatformProviderUtils.constraintValues(
-                      ruleContext.getPrerequisites("target_compatible_with")))
+          PlatformProviderUtils.constraintValues(
+                  ruleContext.getPrerequisites("target_compatible_with"))
+              .stream()
               .filter(cv -> !ruleContext.targetPlatformHasConstraint(cv))
               .collect(toImmutableList());
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformProviderUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformProviderUtils.java
@@ -14,8 +14,12 @@
 
 package com.google.devtools.build.lib.analysis.platform;
 
-import com.google.common.collect.Iterables;
+import static com.google.common.base.Predicates.notNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.ProviderCollection;
+import java.util.List;
 import javax.annotation.Nullable;
 
 /** Utility methods to help locate platform-related providers. */
@@ -31,8 +35,11 @@ public class PlatformProviderUtils {
   }
 
   /** Retrieves and casts {@link PlatformInfo} providers from the given targets. */
-  public static Iterable<PlatformInfo> platforms(Iterable<? extends ProviderCollection> targets) {
-    return Iterables.transform(targets, PlatformProviderUtils::platform);
+  public static ImmutableList<PlatformInfo> platforms(List<? extends ProviderCollection> targets) {
+    return targets.stream()
+        .map(PlatformProviderUtils::platform)
+        .filter(notNull())
+        .collect(toImmutableList());
   }
 
   /** Retrieves and casts the {@link ConstraintSettingInfo} provider from the given target. */
@@ -45,9 +52,12 @@ public class PlatformProviderUtils {
   }
 
   /** Retrieves and casts {@link ConstraintSettingInfo} providers from the given targets. */
-  public static Iterable<ConstraintSettingInfo> constraintSettings(
-      Iterable<? extends ProviderCollection> targets) {
-    return Iterables.transform(targets, PlatformProviderUtils::constraintSetting);
+  public static List<ConstraintSettingInfo> constraintSettings(
+      List<? extends ProviderCollection> targets) {
+    return targets.stream()
+        .map(PlatformProviderUtils::constraintSetting)
+        .filter(notNull())
+        .collect(toImmutableList());
   }
 
   /** Retrieves and casts the {@link ConstraintValueInfo} provider from the given target. */
@@ -65,9 +75,12 @@ public class PlatformProviderUtils {
   }
 
   /** Retrieves and casts {@link ConstraintValueInfo} providers from the given targets. */
-  public static Iterable<ConstraintValueInfo> constraintValues(
-      Iterable<? extends ProviderCollection> targets) {
-    return Iterables.transform(targets, PlatformProviderUtils::constraintValue);
+  public static ImmutableList<ConstraintValueInfo> constraintValues(
+      List<? extends ProviderCollection> targets) {
+    return targets.stream()
+        .map(PlatformProviderUtils::constraintValue)
+        .filter(notNull())
+        .collect(toImmutableList());
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/Platform.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/Platform.java
@@ -14,9 +14,9 @@
 
 package com.google.devtools.build.lib.rules.platform;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.actions.MutableActionGraph.ActionConflictException;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.FileProvider;
@@ -35,7 +35,6 @@ import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.util.CPU;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.Pair;
-import java.util.List;
 import java.util.Map;
 
 /** Defines a platform for execution contexts. */
@@ -49,10 +48,9 @@ public class Platform implements RuleConfiguredTargetFactory {
 
     PlatformInfo.Builder platformBuilder = PlatformInfo.builder().setLabel(ruleContext.getLabel());
 
-    List<PlatformInfo> parentPlatforms =
-        Lists.newArrayList(
-            PlatformProviderUtils.platforms(
-                ruleContext.getPrerequisites(PlatformRule.PARENTS_PLATFORM_ATTR)));
+    ImmutableList<PlatformInfo> parentPlatforms =
+        PlatformProviderUtils.platforms(
+            ruleContext.getPrerequisites(PlatformRule.PARENTS_PLATFORM_ATTR));
 
     if (parentPlatforms.size() > 1) {
       throw ruleContext.throwWithAttributeError(
@@ -130,7 +128,7 @@ public class Platform implements RuleConfiguredTargetFactory {
 
     // Add the CPU.
     CPU cpu = cpuValues.getFirst();
-    Iterable<ConstraintValueInfo> cpuConstraintValues =
+    ImmutableList<ConstraintValueInfo> cpuConstraintValues =
         PlatformProviderUtils.constraintValues(
             ruleContext.getPrerequisites(PlatformRule.CPU_CONSTRAINTS_ATTR));
     for (ConstraintValueInfo constraint : cpuConstraintValues) {
@@ -142,7 +140,7 @@ public class Platform implements RuleConfiguredTargetFactory {
 
     // Add the OS.
     OS os = cpuValues.getSecond();
-    Iterable<ConstraintValueInfo> osConstraintValues =
+    ImmutableList<ConstraintValueInfo> osConstraintValues =
         PlatformProviderUtils.constraintValues(
             ruleContext.getPrerequisites(PlatformRule.OS_CONSTRAINTS_ATTR));
     for (ConstraintValueInfo constraint : osConstraintValues) {

--- a/src/main/java/com/google/devtools/build/lib/rules/platform/Toolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/platform/Toolchain.java
@@ -14,7 +14,9 @@
 
 package com.google.devtools.build.lib.rules.platform;
 
-import com.google.common.collect.Iterables;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.actions.MutableActionGraph.ActionConflictException;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.FileProvider;
@@ -41,16 +43,16 @@ public class Toolchain implements RuleConfiguredTargetFactory {
     ToolchainTypeInfo toolchainType =
         PlatformProviderUtils.toolchainType(
             ruleContext.getPrerequisite(ToolchainRule.TOOLCHAIN_TYPE_ATTR));
-    Iterable<ConstraintValueInfo> execConstraints =
+    ImmutableList<ConstraintValueInfo> execConstraints =
         PlatformProviderUtils.constraintValues(
             ruleContext.getPrerequisites(ToolchainRule.EXEC_COMPATIBLE_WITH_ATTR));
-    Iterable<ConstraintValueInfo> targetConstraints =
+    ImmutableList<ConstraintValueInfo> targetConstraints =
         PlatformProviderUtils.constraintValues(
             ruleContext.getPrerequisites(ToolchainRule.TARGET_COMPATIBLE_WITH_ATTR));
-    Iterable<ConfigMatchingProvider> targetSettings =
-        Iterables.transform(
-            ruleContext.getPrerequisites(ToolchainRule.TARGET_SETTING_ATTR),
-            target -> target.getProvider(ConfigMatchingProvider.class));
+    ImmutableList<ConfigMatchingProvider> targetSettings =
+        ruleContext.getPrerequisites(ToolchainRule.TARGET_SETTING_ATTR).stream()
+            .map(target -> target.getProvider(ConfigMatchingProvider.class))
+            .collect(toImmutableList());
     Label toolchainLabel =
         ruleContext.attributes().get(ToolchainRule.TOOLCHAIN_ATTR, BuildType.NODEP_LABEL);
 


### PR DESCRIPTION
provider.

Also update PlatformProviderUtils to work directly with Lists.

This prevents a few types of crash that can occur from having null
values in a List.

Fixes #12879.