### PR TITLE
Starlark: make universe indexed

### DIFF
--- a/src/main/java/net/starlark/java/eval/BUILD
+++ b/src/main/java/net/starlark/java/eval/BUILD
@@ -25,6 +25,7 @@ java_library(
         "FlagGuardedValue.java",
         "FormatParser.java",
         "HasBinary.java",
+        "ImportedScopeObjects.java",
         "JNI.java",
         "MethodDescriptor.java",
         "MethodLibrary.java",

--- a/src/main/java/net/starlark/java/eval/Eval.java
+++ b/src/main/java/net/starlark/java/eval/Eval.java
@@ -699,7 +699,7 @@ final class Eval {
         result = fn(fr).getModule().getPredeclared(id.getName());
         break;
       case UNIVERSAL:
-        result = Starlark.UNIVERSE.get(id.getName());
+        result = Starlark.UNIVERSE_OBJECTS.valueByIndex(bind.getIndex());
         break;
       default:
         throw new IllegalStateException(bind.toString());

--- a/src/main/java/net/starlark/java/eval/ImportedScopeObjects.java
+++ b/src/main/java/net/starlark/java/eval/ImportedScopeObjects.java
@@ -1,0 +1,43 @@
+package net.starlark.java.eval;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.stream.IntStream;
+
+/** Map from name to value with index by name. */
+class ImportedScopeObjects {
+
+  private final ImmutableMap<String, Object> byName;
+  private final ImmutableList<Object> byIndex;
+  private final ImmutableMap<String, Integer> indexByName;
+
+  private ImportedScopeObjects(ImmutableMap<String, Object> byName) {
+    this.byName = byName;
+
+    ImmutableList<String> names = byName.keySet().asList();
+    this.indexByName =
+        IntStream.range(0, names.size())
+            .boxed()
+            .collect(ImmutableMap.toImmutableMap(names::get, i -> i));
+
+    // This is consistent with `indexByName` because `ImmutableMap` is ordered.
+    this.byIndex = byName.values().asList();
+  }
+
+  /** Create a scope object from given value map by name. */
+  public static ImportedScopeObjects create(ImmutableMap<String, Object> valuesByName) {
+    return new ImportedScopeObjects(valuesByName);
+  }
+
+  /** Get value index by name or {@code -1} if name is undefined. */
+  public int indexByName(String name) {
+    Integer index = indexByName.get(name);
+    return index != null ? index : -1;
+  }
+
+  /** Get a value by index. */
+  public Object valueByIndex(int index) {
+    return byIndex.get(index);
+  }
+}

--- a/src/main/java/net/starlark/java/eval/Module.java
+++ b/src/main/java/net/starlark/java/eval/Module.java
@@ -171,10 +171,10 @@ public final class Module implements Resolver.Module {
 
   /** Implements the resolver's module interface. */
   @Override
-  public Resolver.Scope resolve(String name) throws Undefined {
+  public ResolvedName resolve(String name) throws Undefined {
     // global?
     if (globalIndex.containsKey(name)) {
-      return Resolver.Scope.GLOBAL;
+      return ResolvedName.GLOBAL;
     }
 
     // predeclared?
@@ -184,12 +184,13 @@ public final class Module implements Resolver.Module {
         // Name is correctly spelled, but access is disabled by a flag.
         throw new Undefined(((FlagGuardedValue) v).getErrorFromAttemptingAccess(name), null);
       }
-      return Resolver.Scope.PREDECLARED;
+      return ResolvedName.PREDECLARED;
     }
 
     // universal?
-    if (Starlark.UNIVERSE.containsKey(name)) {
-      return Resolver.Scope.UNIVERSAL;
+    int universeIndex = Starlark.UNIVERSE_OBJECTS.indexByName(name);
+    if (universeIndex >= 0) {
+      return ResolvedName.universal(universeIndex);
     }
 
     // undefined

--- a/src/main/java/net/starlark/java/eval/Starlark.java
+++ b/src/main/java/net/starlark/java/eval/Starlark.java
@@ -96,6 +96,11 @@ public final class Starlark {
   }
 
   /**
+   * Universal bindings index.
+   */
+  static final ImportedScopeObjects UNIVERSE_OBJECTS = ImportedScopeObjects.create(UNIVERSE);
+
+  /**
    * Reports whether the argument is a legal Starlark value: a string, boolean, or StarlarkValue.
    */
   public static boolean valid(Object x) {


### PR DESCRIPTION
About 5% win for `type(1)` called in loop.

Same optimization can be applied to predeclared scope, but the win
will be smaller, because predeclared objects are likely used less
often.

This commit does not change Starlark public API.