### PR TITLE
Starlark: cache semantics-independent method descriptors

### DIFF
--- a/src/main/java/net/starlark/java/eval/MethodDescriptor.java
+++ b/src/main/java/net/starlark/java/eval/MethodDescriptor.java
@@ -287,4 +287,14 @@ final class MethodDescriptor {
   boolean isSelfCall() {
     return selfCall;
   }
+
+  /** Descriptor behavior depends on semantics. */
+  boolean isSemanticsDependent() {
+    // Note `disableWithFlag` and `enableOnlyWithFlag` are not used anywhere
+    // in method descriptor itself, but these are used to determine
+    // whether include or exclude method in the list of object methods.
+    return !annotation.disableWithFlag().isEmpty()
+        || !annotation.enableOnlyWithFlag().isEmpty()
+        || Arrays.stream(parameters).anyMatch(ParamDescriptor::isSemanticsDependent);
+  }
 }


### PR DESCRIPTION
... in BuiltinFunction

If `MethodDescriptor` is created the same for given method regardless
of semantics, that method descriptor can be cached safely.

15% performance win for `type(1)` called in loop.

Note the existing moved comment says:

> thread's semantics determine the dynamic behavior of the method call; this includes a **run-time check for whether the method was disabled by the semantics**.

There's a bug in current implementation, reproduced by last commit in this branch: https://github.com/stepancheg/bazel/commits/npe-flag

I kept the comment because it is irrelevant to this PR.