### PR TITLE
Starlark: per-semantics caches

### DIFF
--- a/src/main/java/net/starlark/java/eval/BUILD
+++ b/src/main/java/net/starlark/java/eval/BUILD
@@ -15,7 +15,7 @@ java_library(
     name = "eval",
     srcs = [
         "BuiltinFunction.java",
-        "CallUtils.java",
+        "DescriptorCache.java",
         "CpuProfiler.java",
         "Debug.java",
         "Dict.java",

--- a/src/main/java/net/starlark/java/eval/BuiltinFunction.java
+++ b/src/main/java/net/starlark/java/eval/BuiltinFunction.java
@@ -81,7 +81,7 @@ public final class BuiltinFunction implements StarlarkCallable {
   private MethodDescriptor getMethodDescriptor(StarlarkSemantics semantics) {
     MethodDescriptor desc = this.desc;
     if (desc == null) {
-      desc = CallUtils.getAnnotatedMethods(semantics, obj.getClass()).get(methodName);
+      desc = DescriptorCache.getAnnotatedMethods(semantics, obj.getClass()).get(methodName);
       Preconditions.checkArgument(
           !desc.isStructField(),
           "BuiltinFunction constructed for MethodDescriptor(structField=True)");

--- a/src/main/java/net/starlark/java/eval/BuiltinFunction.java
+++ b/src/main/java/net/starlark/java/eval/BuiltinFunction.java
@@ -72,16 +72,16 @@ public final class BuiltinFunction implements StarlarkCallable {
   @Override
   public Object fastcall(StarlarkThread thread, Object[] positional, Object[] named)
       throws EvalException, InterruptedException {
-    MethodDescriptor desc = getMethodDescriptor(thread.getSemantics());
+    MethodDescriptor desc = getMethodDescriptor(thread.cache);
     Object[] vector = getArgumentVector(thread, desc, positional, named);
     return desc.call(
         obj instanceof String ? StringModule.INSTANCE : obj, vector, thread.mutability());
   }
 
-  private MethodDescriptor getMethodDescriptor(StarlarkSemantics semantics) {
+  private MethodDescriptor getMethodDescriptor(DescriptorCache caches) {
     MethodDescriptor desc = this.desc;
     if (desc == null) {
-      desc = DescriptorCache.getAnnotatedMethods(semantics, obj.getClass()).get(methodName);
+      desc = caches.getAnnotatedMethods(obj.getClass()).get(methodName);
       Preconditions.checkArgument(
           !desc.isStructField(),
           "BuiltinFunction constructed for MethodDescriptor(structField=True)");
@@ -93,7 +93,7 @@ public final class BuiltinFunction implements StarlarkCallable {
    * Returns the StarlarkMethod annotation of this Starlark-callable Java method.
    */
   public StarlarkMethod getAnnotation() {
-    return getMethodDescriptor(StarlarkSemantics.DEFAULT).getAnnotation();
+    return getMethodDescriptor(DescriptorCache.forSemantics(StarlarkSemantics.DEFAULT)).getAnnotation();
   }
 
   @Override

--- a/src/main/java/net/starlark/java/eval/DescriptorCache.java
+++ b/src/main/java/net/starlark/java/eval/DescriptorCache.java
@@ -27,9 +27,9 @@ import net.starlark.java.annot.StarlarkAnnotations;
 import net.starlark.java.annot.StarlarkMethod;
 
 /** Helper functions for StarlarkMethod-annotated fields and methods. */
-final class CallUtils {
+final class DescriptorCache {
 
-  private CallUtils() {} // uninstantiable
+  private DescriptorCache() {} // uninstantiable
 
   private static CacheValue getCacheValue(Class<?> cls, StarlarkSemantics semantics) {
     if (cls == String.class) {

--- a/src/main/java/net/starlark/java/eval/Eval.java
+++ b/src/main/java/net/starlark/java/eval/Eval.java
@@ -426,7 +426,7 @@ final class Eval {
         Object x =
             Starlark.getattr(
                 fr.thread.mutability(),
-                fr.thread.getSemantics(),
+                fr.thread.cache,
                 object,
                 field,
                 /*defaultValue=*/ null);
@@ -574,7 +574,7 @@ final class Eval {
     String name = dot.getField().getName();
     try {
       return Starlark.getattr(
-          fr.thread.mutability(), fr.thread.getSemantics(), object, name, /*defaultValue=*/ null);
+          fr.thread.mutability(), fr.thread.cache, object, name, /*defaultValue=*/ null);
     } catch (EvalException ex) {
       fr.setErrorLocation(dot.getDotLocation());
       throw ex;

--- a/src/main/java/net/starlark/java/eval/MethodLibrary.java
+++ b/src/main/java/net/starlark/java/eval/MethodLibrary.java
@@ -604,7 +604,7 @@ class MethodLibrary {
       },
       useStarlarkThread = true)
   public boolean hasattr(Object obj, String name, StarlarkThread thread) throws EvalException {
-    return Starlark.hasattr(thread.getSemantics(), obj, name);
+    return Starlark.hasattr(thread.cache, obj, name);
   }
 
   @StarlarkMethod(
@@ -630,7 +630,7 @@ class MethodLibrary {
       throws EvalException, InterruptedException {
     return Starlark.getattr(
         thread.mutability(),
-        thread.getSemantics(),
+        thread.cache,
         obj,
         name,
         defaultValue == Starlark.UNBOUND ? null : defaultValue);
@@ -644,7 +644,7 @@ class MethodLibrary {
       parameters = {@Param(name = "x", doc = "The object to check.")},
       useStarlarkThread = true)
   public StarlarkList<?> dir(Object object, StarlarkThread thread) throws EvalException {
-    return Starlark.dir(thread.mutability(), thread.getSemantics(), object);
+    return Starlark.dir(thread.mutability(), thread.cache, object);
   }
 
   @StarlarkMethod(

--- a/src/main/java/net/starlark/java/eval/Starlark.java
+++ b/src/main/java/net/starlark/java/eval/Starlark.java
@@ -605,7 +605,7 @@ public final class Starlark {
     } else {
       // @StarlarkMethod(selfCall)?
       MethodDescriptor desc =
-          CallUtils.getSelfCallMethodDescriptor(thread.getSemantics(), fn.getClass());
+          DescriptorCache.getSelfCallMethodDescriptor(thread.getSemantics(), fn.getClass());
       if (desc == null) {
         throw errorf("'%s' object is not callable", type(fn));
       }
@@ -672,7 +672,7 @@ public final class Starlark {
   public static boolean hasattr(StarlarkSemantics semantics, Object x, String name)
       throws EvalException {
     return (x instanceof Structure && ((Structure) x).getValue(name) != null)
-        || CallUtils.getAnnotatedMethods(semantics, x.getClass()).containsKey(name);
+        || DescriptorCache.getAnnotatedMethods(semantics, x.getClass()).containsKey(name);
   }
 
   /**
@@ -688,7 +688,7 @@ public final class Starlark {
       @Nullable Object defaultValue)
       throws EvalException, InterruptedException {
     // StarlarkMethod-annotated field or method?
-    MethodDescriptor method = CallUtils.getAnnotatedMethods(semantics, x.getClass()).get(name);
+    MethodDescriptor method = DescriptorCache.getAnnotatedMethods(semantics, x.getClass()).get(name);
     if (method != null) {
       if (method.isStructField()) {
         return method.callField(x, semantics, mu);
@@ -733,7 +733,7 @@ public final class Starlark {
     if (x instanceof Structure) {
       fields.addAll(((Structure) x).getFieldNames());
     }
-    fields.addAll(CallUtils.getAnnotatedMethods(semantics, x.getClass()).keySet());
+    fields.addAll(DescriptorCache.getAnnotatedMethods(semantics, x.getClass()).keySet());
     return StarlarkList.copyOf(mu, fields);
   }
 
@@ -747,7 +747,7 @@ public final class Starlark {
    */
   public static Object getAnnotatedField(StarlarkSemantics semantics, Object x, String name)
       throws EvalException, InterruptedException {
-    return CallUtils.getAnnotatedField(semantics, x, name);
+    return DescriptorCache.getAnnotatedField(semantics, x, name);
   }
 
   /**
@@ -757,7 +757,7 @@ public final class Starlark {
    * <p>Most callers should use {@link #dir} instead.
    */
   public static ImmutableSet<String> getAnnotatedFieldNames(StarlarkSemantics semantics, Object x) {
-    return CallUtils.getAnnotatedFieldNames(semantics, x);
+    return DescriptorCache.getAnnotatedFieldNames(semantics, x);
   }
 
   /**
@@ -772,7 +772,7 @@ public final class Starlark {
   public static ImmutableMap<Method, StarlarkMethod> getMethodAnnotations(Class<?> clazz) {
     ImmutableMap.Builder<Method, StarlarkMethod> result = ImmutableMap.builder();
     for (MethodDescriptor desc :
-        CallUtils.getAnnotatedMethods(StarlarkSemantics.DEFAULT, clazz).values()) {
+        DescriptorCache.getAnnotatedMethods(StarlarkSemantics.DEFAULT, clazz).values()) {
       result.put(desc.getMethod(), desc.getAnnotation());
     }
     return result.build();
@@ -785,7 +785,7 @@ public final class Starlark {
    */
   @Nullable
   public static Method getSelfCallMethod(StarlarkSemantics semantics, Class<?> clazz) {
-    return CallUtils.getSelfCallMethod(semantics, clazz);
+    return DescriptorCache.getSelfCallMethod(semantics, clazz);
   }
 
   /** Equivalent to {@code addMethods(env, v, StarlarkSemantics.DEFAULT)}. */
@@ -806,7 +806,7 @@ public final class Starlark {
     Class<?> cls = v.getClass();
     // TODO(adonovan): rather than silently skip the selfCall method, reject it.
     for (Map.Entry<String, MethodDescriptor> e :
-        CallUtils.getAnnotatedMethods(semantics, cls).entrySet()) {
+        DescriptorCache.getAnnotatedMethods(semantics, cls).entrySet()) {
       String name = e.getKey();
 
       // We cannot accept fields, as they are inherently problematic:

--- a/src/main/java/net/starlark/java/eval/StarlarkThread.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkThread.java
@@ -205,6 +205,9 @@ public final class StarlarkThread {
   /** The semantics options that affect how Starlark code is evaluated. */
   private final StarlarkSemantics semantics;
 
+  /** Caches for current thread semantics. */
+  final DescriptorCache cache;
+
   /** Whether recursive calls are allowed (cached from semantics). */
   private final boolean allowRecursion;
 
@@ -385,6 +388,7 @@ public final class StarlarkThread {
     this.mutability = mu;
     this.semantics = semantics;
     this.allowRecursion = semantics.getBool(StarlarkSemantics.ALLOW_RECURSION);
+    this.cache = DescriptorCache.forSemantics(semantics);
   }
 
   /**


### PR DESCRIPTION
Instead of caching `(semantics, class) -> descriptors`, do
two-level caches `semantics -> class -> descriptors`.

Now when a thread is created, it looks up caches object by semantics.

And then to lookup a descriptor, we perform lookup by class name,
instead of lookup by `(semantics, class)`.

Although, hashmap lookup is constant time, lookup by class is faster
than lookup by `(semantics, class)`.

This commit slightly improves performance of getattr operation for
about 5%.  Measured with this:

```
l = []
for i in range(...):
    l.append  # just getattr, no call
    ...
    l.append
```

First commit renames `CallUtils` to `DescriptorCaches`. Second commit implements this logic.