### PR TITLE
Add --experimental_remote_grpc_max_channels to allow users manually configure number of gRPC channels

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -321,6 +321,10 @@ public final class RemoteModule extends BlazeModule {
       // number of required channels is calculated as: ceil(jobs / 100).
       poolSize = (int) Math.ceil((double) buildRequestOptions.jobs / 100.0);
     }
+    if (remoteOptions.remoteGrpcMaxChannels > 0) {
+      poolSize = remoteOptions.remoteGrpcMaxChannels;
+    }
+
     if (enableRemoteExecution) {
       ImmutableList.Builder<ClientInterceptor> interceptors = ImmutableList.builder();
       interceptors.add(TracingMetadataUtils.newExecHeadersInterceptor(remoteOptions));

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -89,6 +89,16 @@ public final class RemoteOptions extends OptionsBase {
   public boolean remoteExecutionKeepalive;
 
   @Option(
+      name = "experimental_remote_grpc_max_channels",
+      defaultValue = "0",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
+      help =
+          "The number of gRPC channels to the remote cache/executor. By default Bazel chooses the"
+              + " number based on --jobs.")
+  public int remoteGrpcMaxChannels;
+
+  @Option(
       name = "remote_cache",
       oldName = "remote_http_cache",
       defaultValue = "null",


### PR DESCRIPTION
For remote RPCs, gRPC limits the number of in-flight requests per connection to MAX_CONCURRENT_STREAMS. Exceeding it will cause RPCs to be queued. The problem is described at #11801 and we added a channel pool in #11937 to overcome this limitation.

However, the assumption we made for calculating the size of channel pool is not accurate. Bazel uploads/downloads inputs/outputs concurrently, which could lead to substantially more than `2 * jobs` RPCs in flight at any given time. Number of inputs/outputs various across actions and Bazel doesn't know up front what the max number of inputs/outputs of an action in the build is, so there's really no way to choose the number of connections intelligently.

Failed opening enough connections for a build could reduce the throughput and lead to `GOAWAY/load_shed` error in some cases.

This PR is a short-term fix which adds an experimental flag `--experimental_remote_grpc_max_channels` allowing users manually configure the number of gRPC channels.

For a long-term fix, we probably need to build a client-side RPCs queue and increase the size of channel pool dynamically.

Related issues: #12920, #12363
Internal discussion: b/178710657