### PR TITLE
Add --experimental_repository_disable_download to allow users disable download for external repos

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -237,6 +237,8 @@ public class BazelRepositoryModule extends BlazeModule {
 
     RepositoryOptions repoOptions = env.getOptions().getOptions(RepositoryOptions.class);
     if (repoOptions != null) {
+      downloadManager.setDisableDownload(repoOptions.disableDownload);
+
       repositoryCache.setHardlink(repoOptions.useHardlinks);
       if (repoOptions.experimentalScaleTimeouts > 0.0) {
         starlarkRepositoryFunction.setTimeoutScaling(repoOptions.experimentalScaleTimeouts);

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -57,6 +57,15 @@ public class RepositoryOptions extends OptionsBase {
   public boolean useHardlinks;
 
   @Option(
+      name = "experimental_repository_disable_download",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+      help = "If set, downloading external repositories is not allowed.")
+  public boolean disableDownload;
+
+  @Option(
       name = "distdir",
       oldName = "experimental_distdir",
       defaultValue = "null",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -46,6 +46,7 @@ public class DownloadManager {
   private List<Path> distdir = ImmutableList.of();
   private UrlRewriter rewriter;
   private final Downloader downloader;
+  private boolean disableDownload = false;
 
   public DownloadManager(RepositoryCache repositoryCache, Downloader downloader) {
     this.repositoryCache = repositoryCache;
@@ -58,6 +59,10 @@ public class DownloadManager {
 
   public void setUrlRewriter(UrlRewriter rewriter) {
     this.rewriter = rewriter;
+  }
+
+  public void setDisableDownload(boolean disableDownload) {
+    this.disableDownload = disableDownload;
   }
 
   /**
@@ -192,6 +197,10 @@ public class DownloadManager {
           }
         }
       }
+    }
+
+    if (disableDownload) {
+      throw new IOException(String.format("Failed to download repo %s: download is disabled.", repo));
     }
 
     try {

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2099,7 +2099,6 @@ function test_disable_download_should_allow_distdir() {
   echo 'Hello World' > x/file.txt
   tar cvf x.tar x
   sha256=$(sha256sum x.tar | head -c 64)
-  serve_file x.tar
 
   mkdir main
   cp x.tar main
@@ -2108,7 +2107,7 @@ function test_disable_download_should_allow_distdir() {
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
   name="ext",
-  url = "http://127.0.0.1:$nc_port/x.tar",
+  url = "http://127.0.0.1/x.tar",
   sha256="$sha256",
 )
 EOF

--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2061,4 +2061,93 @@ EOF
       || fail "Expected success despite needing a file behind basic auth"
 }
 
+function test_disable_download_should_prevent_downloading() {
+  mkdir x
+  echo 'exports_files(["file.txt"])' > x/BUILD
+  echo 'Hello World' > x/file.txt
+  tar cvf x.tar x
+  sha256=$(sha256sum x.tar | head -c 64)
+  serve_file x.tar
+
+  mkdir main
+  cd main
+  cat > WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+  name="ext",
+  url = "http://127.0.0.1:$nc_port/x.tar",
+  sha256="$sha256",
+)
+EOF
+  cat > BUILD <<'EOF'
+genrule(
+  name = "it",
+  srcs = ["@ext//x:file.txt"],
+  outs = ["it.txt"],
+  cmd = "cp $< $@",
+)
+EOF
+
+  bazel build --experimental_repository_disable_download //:it > "${TEST_log}" 2>&1 \
+      && fail "Expected failure" || :
+  expect_log "Failed to download repo ext: download is disabled"
+}
+
+function test_disable_download_should_allow_distdir() {
+  mkdir x
+  echo 'exports_files(["file.txt"])' > x/BUILD
+  echo 'Hello World' > x/file.txt
+  tar cvf x.tar x
+  sha256=$(sha256sum x.tar | head -c 64)
+  serve_file x.tar
+
+  mkdir main
+  cp x.tar main
+  cd main
+  cat > WORKSPACE <<EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+  name="ext",
+  url = "http://127.0.0.1:$nc_port/x.tar",
+  sha256="$sha256",
+)
+EOF
+  cat > BUILD <<'EOF'
+genrule(
+  name = "it",
+  srcs = ["@ext//x:file.txt"],
+  outs = ["it.txt"],
+  cmd = "cp $< $@",
+)
+EOF
+
+  bazel build --distdir="." --experimental_repository_disable_download //:it || fail "Failed to build"
+}
+
+function test_disable_download_should_allow_local_repository() {
+  mkdir x
+  echo 'exports_files(["file.txt"])' > x/BUILD
+  echo 'Hello World' > x/file.txt
+  touch x/WORKSPACE
+
+  mkdir main
+  cd main
+  cat > WORKSPACE <<EOF
+local_repository(
+  name="ext",
+  path="../x",
+)
+EOF
+  cat > BUILD <<'EOF'
+genrule(
+  name = "it",
+  srcs = ["@ext//:file.txt"],
+  outs = ["it.txt"],
+  cmd = "cp $< $@",
+)
+EOF
+
+  bazel build --experimental_repository_disable_download //:it || fail "Failed to build"
+}
+
 run_suite "local repository tests"


### PR DESCRIPTION
This PR adds a flag `--experimental_repository_disable_download` which when set will prevent Bazel from downloading external repositories.  However, `local_repository`, `new_local_repository` and external repositories already downloaded in the repository cache  would still work.