### PR TITLE
Docs: update --experimental_worker_multiplex

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
@@ -175,7 +175,7 @@ public class WorkerOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
-          "Currently a no-op. Future: If enabled, workers that support the experimental"
-              + " multiplexing feature will use that feature.")
+          "If enabled, workers that support the experimental multiplexing feature will use that"
+              + " feature.")
   public boolean workerMultiplex;
 }


### PR DESCRIPTION
The flag is not a no-op anymore.
WorkerModule.registerSpawnStrategies passes its
value to the WorkerSpawnRunner ctor.