### PR TITLE
Fix jar Class-Path url encoding in java_stub_template

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -313,7 +313,7 @@ function create_and_run_classpath_jar() {
       path="file:${path}" # e.g. "file:/usr/local/foo.jar"
     fi
 
-    path=$(sed "s/ /%20/g" <<< "${path}")
+    path=$(sed "s/ /%20/g; s/%/%25/g" <<< "${path}")
     MANIFEST_CLASSPATH+=("${path}")
   done
   IFS="$OLDIFS"

--- a/src/test/shell/bazel/java_launcher_test.sh
+++ b/src/test/shell/bazel/java_launcher_test.sh
@@ -57,6 +57,16 @@ java_binary(
     deps = [":hellolib"],
     main_class = "hello.Hello",
 )
+java_library(
+    name = "hellolib%special%lib",
+    srcs = ["HelloLib.java"],
+)
+java_binary(
+    name = "hello_special",
+    srcs = ["Hello.java"],
+    deps = [":hellolib%special%lib"],
+    main_class = "hello.Hello",
+)
 EOF
   bazel build //$pkg/java/hello:hello || fail "expected success"
   ${PRODUCT_NAME}-bin/$pkg/java/hello/hello >& "$TEST_log" || \
@@ -64,6 +74,15 @@ EOF
   expect_log "Hello World!"
 
   ${PRODUCT_NAME}-bin/$pkg/java/hello/hello --classpath_limit=0 >& "$TEST_log" || \
+    fail "expected success"
+  expect_log "Hello World!"
+
+  bazel build //$pkg/java/hello:hello_special || fail "expected success"
+  ${PRODUCT_NAME}-bin/$pkg/java/hello/hello_special >& "$TEST_log" || \
+    fail "expected success"
+  expect_log "Hello World!"
+
+  ${PRODUCT_NAME}-bin/$pkg/java/hello/hello_special --classpath_limit=0 >& "$TEST_log" || \
     fail "expected success"
   expect_log "Hello World!"
 }


### PR DESCRIPTION
This recently got patched in the native launcher [here](https://github.com/bazelbuild/bazel/pull/12809) but it wasn't ported over to `java_stub_template.txt`. The original issue for this is https://github.com/bazelbuild/bazel/issues/10620