### PR TITLE
[WIP] Make the Starlark executable paths explicitly part of the CcToolchain…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProvider.java
@@ -42,7 +42,6 @@ import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkThread;
-import net.starlark.java.syntax.Location;
 
 /** Information about a C++ compiler used by the <code>cc_*</code> rules. */
 @Immutable
@@ -109,7 +108,16 @@ public final class CcToolchainProvider extends ToolchainInfo
           /* additionalMakeVariables= */ ImmutableMap.of(),
           /* legacyCcFlagsMakeVariable= */ "",
           /* allowlistForLayeringCheck= */ null,
-          /* allowListForLooseHeaderCheck= */ null);
+          /* allowListForLooseHeaderCheck= */ null,
+          /* objcopyExecutable= */ "",
+          /* compilerExecutable= */ "",
+          /* preprocessorExecutable= */ "",
+          /* nmExecutable= */ "",
+          /* objdumpExecutable= */ "",
+          /* arExecutable= */ "",
+          /* stripExecutable= */ "",
+          /* ldExecutable= */ "",
+          /* gcovExecutable= */ "");
 
   @Nullable private final CppConfiguration cppConfiguration;
   private final PathFragment crosstoolTopPathFragment;
@@ -174,6 +182,16 @@ public final class CcToolchainProvider extends ToolchainInfo
   private final PackageSpecificationProvider allowlistForLayeringCheck;
   private final PackageSpecificationProvider allowListForLooseHeaderCheck;
 
+  private final String objcopyExecutable;
+  private final String compilerExecutable;
+  private final String preprocessorExecutable;
+  private final String nmExecutable;
+  private final String objdumpExecutable;
+  private final String arExecutable;
+  private final String stripExecutable;
+  private final String ldExecutable;
+  private final String gcovExecutable;
+
   public CcToolchainProvider(
       ImmutableMap<String, Object> values,
       @Nullable CppConfiguration cppConfiguration,
@@ -229,8 +247,17 @@ public final class CcToolchainProvider extends ToolchainInfo
       ImmutableMap<String, String> additionalMakeVariables,
       String legacyCcFlagsMakeVariable,
       PackageSpecificationProvider allowlistForLayeringCheck,
-      PackageSpecificationProvider allowListForLooseHeaderCheck) {
-    super(values, Location.BUILTIN);
+      PackageSpecificationProvider allowListForLooseHeaderCheck,
+      String objcopyExecutable,
+      String compilerExecutable,
+      String preprocessorExecutable,
+      String nmExecutable,
+      String objdumpExecutable,
+      String arExecutable,
+      String stripExecutable,
+      String ldExecutable,
+      String gcovExecutable) {
+    super(values);
     this.cppConfiguration = cppConfiguration;
     this.crosstoolTopPathFragment = crosstoolTopPathFragment;
     this.allFiles = Preconditions.checkNotNull(allFiles);
@@ -288,6 +315,16 @@ public final class CcToolchainProvider extends ToolchainInfo
     this.legacyCcFlagsMakeVariable = legacyCcFlagsMakeVariable;
     this.allowlistForLayeringCheck = allowlistForLayeringCheck;
     this.allowListForLooseHeaderCheck = allowListForLooseHeaderCheck;
+
+    this.objcopyExecutable = objcopyExecutable;
+    this.compilerExecutable = compilerExecutable;
+    this.preprocessorExecutable = preprocessorExecutable;
+    this.nmExecutable = nmExecutable;
+    this.objdumpExecutable = objdumpExecutable;
+    this.arExecutable = arExecutable;
+    this.stripExecutable = stripExecutable;
+    this.ldExecutable = ldExecutable;
+    this.gcovExecutable = gcovExecutable;
   }
 
   /**
@@ -899,6 +936,51 @@ public final class CcToolchainProvider extends ToolchainInfo
   public FdoContext getFdoContextForStarlark(StarlarkThread thread) throws EvalException {
     CcModule.checkPrivateStarlarkificationAllowlist(thread);
     return fdoContext;
+  }
+
+  @Override
+  public String objcopyExecutable() {
+    return objcopyExecutable;
+  }
+
+  @Override
+  public String compilerExecutable() {
+    return compilerExecutable;
+  }
+
+  @Override
+  public String preprocessorExecutable() {
+    return preprocessorExecutable;
+  }
+
+  @Override
+  public String nmExecutable() {
+    return nmExecutable;
+  }
+
+  @Override
+  public String objdumpExecutable() {
+    return objdumpExecutable;
+  }
+
+  @Override
+  public String arExecutable() {
+    return arExecutable;
+  }
+
+  @Override
+  public String stripExecutable() {
+    return stripExecutable;
+  }
+
+  @Override
+  public String ldExecutable() {
+    return ldExecutable;
+  }
+
+  @Override
+  public String gcovExecutable() {
+    return gcovExecutable;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcToolchainProviderHelper.java
@@ -189,7 +189,7 @@ public class CcToolchainProviderHelper {
         attributes.getAllowlistForLooseHeaderCheck();
 
     return new CcToolchainProvider(
-        getToolchainForStarlark(toolPaths),
+        /* values= */ ImmutableMap.of(),
         cppConfiguration,
         toolchainFeatures,
         toolsDirectory,
@@ -251,7 +251,16 @@ public class CcToolchainProviderHelper {
         computeAdditionalMakeVariables(toolchainConfigInfo),
         computeLegacyCcFlagsMakeVariable(toolchainConfigInfo),
         allowlistForLayeringCheck,
-        allowlistForLooseHeaderCheck);
+        allowlistForLooseHeaderCheck,
+        getStarlarkValueForTool(Tool.OBJCOPY, toolPaths),
+        getStarlarkValueForTool(Tool.GCC, toolPaths),
+        getStarlarkValueForTool(Tool.CPP, toolPaths),
+        getStarlarkValueForTool(Tool.NM, toolPaths),
+        getStarlarkValueForTool(Tool.OBJDUMP, toolPaths),
+        getStarlarkValueForTool(Tool.AR, toolPaths),
+        getStarlarkValueForTool(Tool.STRIP, toolPaths),
+        getStarlarkValueForTool(Tool.LD, toolPaths),
+        getStarlarkValueForTool(Tool.GCOV, toolPaths));
   }
 
   @Nullable
@@ -381,21 +390,6 @@ public class CcToolchainProviderHelper {
       Tool tool, ImmutableMap<String, PathFragment> toolPaths) {
     PathFragment toolPath = getToolPathFragment(toolPaths, tool);
     return toolPath != null ? toolPath.getPathString() : "";
-  }
-
-  private static ImmutableMap<String, Object> getToolchainForStarlark(
-      ImmutableMap<String, PathFragment> toolPaths) {
-    return ImmutableMap.<String, Object>builder()
-        .put("objcopy_executable", getStarlarkValueForTool(Tool.OBJCOPY, toolPaths))
-        .put("compiler_executable", getStarlarkValueForTool(Tool.GCC, toolPaths))
-        .put("preprocessor_executable", getStarlarkValueForTool(Tool.CPP, toolPaths))
-        .put("nm_executable", getStarlarkValueForTool(Tool.NM, toolPaths))
-        .put("objdump_executable", getStarlarkValueForTool(Tool.OBJDUMP, toolPaths))
-        .put("ar_executable", getStarlarkValueForTool(Tool.AR, toolPaths))
-        .put("strip_executable", getStarlarkValueForTool(Tool.STRIP, toolPaths))
-        .put("ld_executable", getStarlarkValueForTool(Tool.LD, toolPaths))
-        .put("gcov_executable", getStarlarkValueForTool(Tool.GCOV, toolPaths))
-        .build();
   }
 
   private static PathFragment calculateSysroot(Label libcTopLabel, PathFragment defaultSysroot) {

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcToolchainProviderApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcToolchainProviderApi.java
@@ -180,4 +180,49 @@ public interface CcToolchainProviderApi<
 
   @StarlarkMethod(name = "fdo_context", documented = false, useStarlarkThread = true)
   FdoContextT getFdoContextForStarlark(StarlarkThread thread) throws EvalException;
+
+  @StarlarkMethod(
+      name = "objcopy_executable",
+      structField = true,
+      doc = "The path to the objcopy binary.")
+  String objcopyExecutable();
+
+  @StarlarkMethod(
+      name = "compiler_executable",
+      structField = true,
+      doc = "The path to the compiler binary.")
+  String compilerExecutable();
+
+  @StarlarkMethod(
+      name = "preprocessor_executable",
+      structField = true,
+      doc = "The path to the preprocessor binary.")
+  String preprocessorExecutable();
+
+  @StarlarkMethod(name = "nm_executable", structField = true, doc = "The path to the nm binary.")
+  String nmExecutable();
+
+  @StarlarkMethod(
+      name = "objdump_executable",
+      structField = true,
+      doc = "The path to the objdump binary.")
+  String objdumpExecutable();
+
+  @StarlarkMethod(name = "ar_executable", structField = true, doc = "The path to the ar binary.")
+  String arExecutable();
+
+  @StarlarkMethod(
+      name = "strip_executable",
+      structField = true,
+      doc = "The path to the strip binary.")
+  String stripExecutable();
+
+  @StarlarkMethod(name = "ld_executable", structField = true, doc = "The path to the ld binary.")
+  String ldExecutable();
+
+  @StarlarkMethod(
+      name = "gcov_executable",
+      structField = true,
+      doc = "The path to the gcov binary.")
+  String gcovExecutable();
 }


### PR DESCRIPTION
…Provider API.

They were previously added by the ToolchainInfo machinery, but that is being removed.

PiperOrigin-RevId: 355472723
Change-Id: Id4e3f5c195a4b37b55d0d3221a43e4525a080f2e