### PR TITLE
Starlark: faster stmt/expr switch in the interpreter

### DIFF
--- a/src/main/java/net/starlark/java/syntax/AssignmentStatement.java
+++ b/src/main/java/net/starlark/java/syntax/AssignmentStatement.java
@@ -35,7 +35,7 @@ public final class AssignmentStatement extends Statement {
    */
   AssignmentStatement(
       FileLocations locs, Expression lhs, @Nullable TokenKind op, int opOffset, Expression rhs) {
-    super(locs);
+    super(locs, Kind.ASSIGNMENT);
     this.lhs = lhs;
     this.op = op;
     this.opOffset = opOffset;
@@ -81,10 +81,5 @@ public final class AssignmentStatement extends Statement {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.ASSIGNMENT;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/BinaryOperatorExpression.java
+++ b/src/main/java/net/starlark/java/syntax/BinaryOperatorExpression.java
@@ -46,7 +46,7 @@ public final class BinaryOperatorExpression extends Expression {
 
   BinaryOperatorExpression(
       FileLocations locs, Expression x, TokenKind op, int opOffset, Expression y) {
-    super(locs);
+    super(locs, Kind.BINARY_OPERATOR);
     this.x = x;
     this.op = op;
     this.opOffset = opOffset;
@@ -92,10 +92,5 @@ public final class BinaryOperatorExpression extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.BINARY_OPERATOR;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/CallExpression.java
+++ b/src/main/java/net/starlark/java/syntax/CallExpression.java
@@ -33,7 +33,7 @@ public final class CallExpression extends Expression {
       Location lparenLocation,
       ImmutableList<Argument> arguments,
       int rparenOffset) {
-    super(locs);
+    super(locs, Kind.CALL);
     this.function = Preconditions.checkNotNull(function);
     this.lparenLocation = lparenLocation;
     this.arguments = arguments;
@@ -95,10 +95,5 @@ public final class CallExpression extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.CALL;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/Comprehension.java
+++ b/src/main/java/net/starlark/java/syntax/Comprehension.java
@@ -124,7 +124,7 @@ public final class Comprehension extends Expression {
       Node body,
       ImmutableList<Clause> clauses,
       int rbracketOffset) {
-    super(locs);
+    super(locs, Kind.COMPREHENSION);
     this.isDict = isDict;
     this.lbracketOffset = lbracketOffset;
     this.body = body;
@@ -162,10 +162,4 @@ public final class Comprehension extends Expression {
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
   }
-
-  @Override
-  public Kind kind() {
-    return Kind.COMPREHENSION;
-  }
-
 }

--- a/src/main/java/net/starlark/java/syntax/ConditionalExpression.java
+++ b/src/main/java/net/starlark/java/syntax/ConditionalExpression.java
@@ -34,7 +34,7 @@ public final class ConditionalExpression extends Expression {
 
   /** Constructor for a conditional expression */
   ConditionalExpression(FileLocations locs, Expression t, Expression cond, Expression f) {
-    super(locs);
+    super(locs, Kind.CONDITIONAL);
     this.t = t;
     this.cond = cond;
     this.f = f;
@@ -53,10 +53,5 @@ public final class ConditionalExpression extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.CONDITIONAL;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/DefStatement.java
+++ b/src/main/java/net/starlark/java/syntax/DefStatement.java
@@ -34,7 +34,7 @@ public final class DefStatement extends Statement {
       Identifier identifier,
       ImmutableList<Parameter> parameters,
       ImmutableList<Statement> body) {
-    super(locs);
+    super(locs, Kind.DEF);
     this.defOffset = defOffset;
     this.identifier = identifier;
     this.parameters = Preconditions.checkNotNull(parameters);
@@ -87,10 +87,5 @@ public final class DefStatement extends Statement {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.DEF;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/DictExpression.java
+++ b/src/main/java/net/starlark/java/syntax/DictExpression.java
@@ -66,7 +66,7 @@ public final class DictExpression extends Expression {
   private final int rbraceOffset;
 
   DictExpression(FileLocations locs, int lbraceOffset, List<Entry> entries, int rbraceOffset) {
-    super(locs);
+    super(locs, Kind.DICT_EXPR);
     this.lbraceOffset = lbraceOffset;
     this.entries = ImmutableList.copyOf(entries);
     this.rbraceOffset = rbraceOffset;
@@ -85,11 +85,6 @@ public final class DictExpression extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.DICT_EXPR;
   }
 
   public ImmutableList<Entry> getEntries() {

--- a/src/main/java/net/starlark/java/syntax/DotExpression.java
+++ b/src/main/java/net/starlark/java/syntax/DotExpression.java
@@ -21,7 +21,7 @@ public final class DotExpression extends Expression {
   private final Identifier field;
 
   DotExpression(FileLocations locs, Expression object, int dotOffset, Identifier field) {
-    super(locs);
+    super(locs, Kind.DOT);
     this.object = object;
     this.dotOffset = dotOffset;
     this.field = field;
@@ -52,10 +52,5 @@ public final class DotExpression extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.DOT;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/Expression.java
+++ b/src/main/java/net/starlark/java/syntax/Expression.java
@@ -46,15 +46,20 @@ public abstract class Expression extends Node {
     UNARY_OPERATOR,
   }
 
-  Expression(FileLocations locs) {
+  private final Kind kind;
+
+  Expression(FileLocations locs, Kind kind) {
     super(locs);
+    this.kind = kind;
   }
 
   /**
    * Kind of the expression. This is similar to using instanceof, except that it's more efficient
    * and can be used in a switch/case.
    */
-  public abstract Kind kind();
+  public final Kind kind() {
+    return kind;
+  }
 
   /** Parses an expression with the default options. */
   public static Expression parse(ParserInput input) throws SyntaxError.Exception {

--- a/src/main/java/net/starlark/java/syntax/ExpressionStatement.java
+++ b/src/main/java/net/starlark/java/syntax/ExpressionStatement.java
@@ -20,7 +20,7 @@ public final class ExpressionStatement extends Statement {
   private final Expression expression;
 
   ExpressionStatement(FileLocations locs, Expression expression) {
-    super(locs);
+    super(locs, Kind.EXPRESSION);
     this.expression = expression;
   }
 
@@ -41,10 +41,5 @@ public final class ExpressionStatement extends Statement {
   @Override
   public int getEndOffset() {
     return expression.getEndOffset();
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.EXPRESSION;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/FloatLiteral.java
+++ b/src/main/java/net/starlark/java/syntax/FloatLiteral.java
@@ -20,7 +20,7 @@ public final class FloatLiteral extends Expression {
   private final double value;
 
   FloatLiteral(FileLocations locs, String raw, int tokenOffset, double value) {
-    super(locs);
+    super(locs, Kind.FLOAT_LITERAL);
     this.raw = raw;
     this.tokenOffset = tokenOffset;
     this.value = value;
@@ -49,10 +49,5 @@ public final class FloatLiteral extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.FLOAT_LITERAL;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/FlowStatement.java
+++ b/src/main/java/net/starlark/java/syntax/FlowStatement.java
@@ -21,7 +21,7 @@ public final class FlowStatement extends Statement {
 
   /** @param kind The label of the statement (break, continue, or pass) */
   FlowStatement(FileLocations locs, TokenKind kind, int offset) {
-    super(locs);
+    super(locs, Kind.FLOW);
     this.kind = kind;
     this.offset = offset;
   }
@@ -48,10 +48,5 @@ public final class FlowStatement extends Statement {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Statement.Kind kind() {
-    return Statement.Kind.FLOW;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/ForStatement.java
+++ b/src/main/java/net/starlark/java/syntax/ForStatement.java
@@ -31,7 +31,7 @@ public final class ForStatement extends Statement {
       Expression vars,
       Expression iterable,
       ImmutableList<Statement> body) {
-    super(locs);
+    super(locs, Kind.FOR);
     this.forOffset = forOffset;
     this.vars = Preconditions.checkNotNull(vars);
     this.iterable = Preconditions.checkNotNull(iterable);
@@ -77,10 +77,5 @@ public final class ForStatement extends Statement {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.FOR;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/Identifier.java
+++ b/src/main/java/net/starlark/java/syntax/Identifier.java
@@ -28,7 +28,7 @@ public final class Identifier extends Expression {
   @Nullable private Resolver.Binding binding;
 
   Identifier(FileLocations locs, String name, int nameOffset) {
-    super(locs);
+    super(locs, Kind.IDENTIFIER);
     this.name = name;
     this.nameOffset = nameOffset;
   }
@@ -69,11 +69,6 @@ public final class Identifier extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.IDENTIFIER;
   }
 
   /** Reports whether the string is a valid identifier. */

--- a/src/main/java/net/starlark/java/syntax/IfStatement.java
+++ b/src/main/java/net/starlark/java/syntax/IfStatement.java
@@ -33,7 +33,7 @@ public final class IfStatement extends Statement {
       int ifOffset,
       Expression condition,
       List<Statement> thenBlock) {
-    super(locs);
+    super(locs, Kind.IF);
     this.token = token;
     this.ifOffset = ifOffset;
     this.condition = condition;
@@ -88,10 +88,5 @@ public final class IfStatement extends Statement {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.IF;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/IndexExpression.java
+++ b/src/main/java/net/starlark/java/syntax/IndexExpression.java
@@ -31,7 +31,7 @@ public final class IndexExpression extends Expression {
       int lbracketOffset,
       Expression key,
       int rbracketOffset) {
-    super(locs);
+    super(locs, Kind.INDEX);
     this.object = object;
     this.lbracketOffset = lbracketOffset;
     this.key = key;
@@ -63,10 +63,5 @@ public final class IndexExpression extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.INDEX;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/IntLiteral.java
+++ b/src/main/java/net/starlark/java/syntax/IntLiteral.java
@@ -22,7 +22,7 @@ public final class IntLiteral extends Expression {
   private final Number value; // = Integer | Long | BigInteger
 
   IntLiteral(FileLocations locs, String raw, int tokenOffset, Number value) {
-    super(locs);
+    super(locs, Kind.INT_LITERAL);
     this.raw = raw;
     this.tokenOffset = tokenOffset;
     this.value = value;
@@ -54,11 +54,6 @@ public final class IntLiteral extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.INT_LITERAL;
   }
 
   /**

--- a/src/main/java/net/starlark/java/syntax/LambdaExpression.java
+++ b/src/main/java/net/starlark/java/syntax/LambdaExpression.java
@@ -29,7 +29,7 @@ public final class LambdaExpression extends Expression {
 
   LambdaExpression(
       FileLocations locs, int lambdaOffset, ImmutableList<Parameter> parameters, Expression body) {
-    super(locs);
+    super(locs, Kind.LAMBDA);
     this.lambdaOffset = lambdaOffset;
     this.parameters = Preconditions.checkNotNull(parameters);
     this.body = Preconditions.checkNotNull(body);
@@ -66,10 +66,5 @@ public final class LambdaExpression extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.LAMBDA;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/ListExpression.java
+++ b/src/main/java/net/starlark/java/syntax/ListExpression.java
@@ -34,7 +34,7 @@ public final class ListExpression extends Expression {
       int lbracketOffset,
       List<Expression> elements,
       int rbracketOffset) {
-    super(locs);
+    super(locs, Kind.LIST_EXPR);
     // An unparenthesized tuple must be non-empty.
     Preconditions.checkArgument(
         !elements.isEmpty() || (lbracketOffset >= 0 && rbracketOffset >= 0));
@@ -102,10 +102,5 @@ public final class ListExpression extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Expression.Kind kind() {
-    return Expression.Kind.LIST_EXPR;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/LoadStatement.java
+++ b/src/main/java/net/starlark/java/syntax/LoadStatement.java
@@ -53,7 +53,7 @@ public final class LoadStatement extends Statement {
       StringLiteral module,
       ImmutableList<Binding> bindings,
       int rparenOffset) {
-    super(locs);
+    super(locs, Kind.LOAD);
     this.loadOffset = loadOffset;
     this.module = module;
     this.bindings = bindings;
@@ -81,10 +81,5 @@ public final class LoadStatement extends Statement {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.LOAD;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/ReturnStatement.java
+++ b/src/main/java/net/starlark/java/syntax/ReturnStatement.java
@@ -22,7 +22,7 @@ public final class ReturnStatement extends Statement {
   @Nullable private final Expression result;
 
   ReturnStatement(FileLocations locs, int returnOffset, @Nullable Expression result) {
-    super(locs);
+    super(locs, Kind.RETURN);
     this.returnOffset = returnOffset;
     this.result = result;
   }
@@ -53,10 +53,5 @@ public final class ReturnStatement extends Statement {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.RETURN;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/SliceExpression.java
+++ b/src/main/java/net/starlark/java/syntax/SliceExpression.java
@@ -33,7 +33,7 @@ public final class SliceExpression extends Expression {
       Expression stop,
       Expression step,
       int rbracketOffset) {
-    super(locs);
+    super(locs, Kind.SLICE);
     this.object = object;
     this.lbracketOffset = lbracketOffset;
     this.start = start;
@@ -78,10 +78,5 @@ public final class SliceExpression extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.SLICE;
   }
 }

--- a/src/main/java/net/starlark/java/syntax/Statement.java
+++ b/src/main/java/net/starlark/java/syntax/Statement.java
@@ -31,13 +31,18 @@ public abstract class Statement extends Node {
     RETURN,
   }
 
-  Statement(FileLocations locs) {
+  private final Kind kind;
+
+  Statement(FileLocations locs, Kind kind) {
     super(locs);
+    this.kind = kind;
   }
 
   /**
    * Kind of the statement. This is similar to using instanceof, except that it's more efficient and
    * can be used in a switch/case.
    */
-  public abstract Kind kind();
+  public final Kind kind() {
+    return kind;
+  }
 }

--- a/src/main/java/net/starlark/java/syntax/StringLiteral.java
+++ b/src/main/java/net/starlark/java/syntax/StringLiteral.java
@@ -25,7 +25,7 @@ public final class StringLiteral extends Expression {
   private final int endOffset;
 
   StringLiteral(FileLocations locs, int startOffset, String value, int endOffset) {
-    super(locs);
+    super(locs, Kind.STRING_LITERAL);
     this.startOffset = startOffset;
     this.value = value;
     this.endOffset = endOffset;
@@ -57,11 +57,6 @@ public final class StringLiteral extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.STRING_LITERAL;
   }
 
   // -- hooks to support Skyframe serialization without creating a dependency --

--- a/src/main/java/net/starlark/java/syntax/UnaryOperatorExpression.java
+++ b/src/main/java/net/starlark/java/syntax/UnaryOperatorExpression.java
@@ -21,7 +21,7 @@ public final class UnaryOperatorExpression extends Expression {
   private final Expression x;
 
   UnaryOperatorExpression(FileLocations locs, TokenKind op, int opOffset, Expression x) {
-    super(locs);
+    super(locs, Kind.UNARY_OPERATOR);
     this.op = op;
     this.opOffset = opOffset;
     this.x = x;
@@ -59,10 +59,5 @@ public final class UnaryOperatorExpression extends Expression {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
-  }
-
-  @Override
-  public Kind kind() {
-    return Kind.UNARY_OPERATOR;
   }
 }


### PR DESCRIPTION
Apparently, virtual calls `Statement.kind()` and `Expression.kind()`
are quite expensive. JVM/CPU are unable to predict/inline/optimize
it properly.

Make them non-virtual.

Speed up is 5-10% in statements/expression heavy code.

This is a very simple optimization. I don't know how far the bytecode
interpreter is. If it is not going to be committed soon, maybe it's
worth landing this.

```
A: n=47 mean=3.978 std=0.257 se=0.037 min=3.730 med=3.860
B: n=47 mean=3.660 std=0.268 se=0.039 min=3.395 med=3.490
B/A: 0.920 0.894..0.947 (95% conf)
```

```
def test():
  for i in range(10):
    print(i)
    for j in range(1000000):
      k = list()
      l = []
      m = k + l
      if j % 2 == 0:
        type(k)

test()
```