### PR TITLE
 Convert special characters in classpath to hexadecimal representation in java_stub_template

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt
@@ -300,7 +300,20 @@ function create_and_run_classpath_jar() {
   OLDIFS="$IFS"
   IFS="${CLASSPATH_SEPARATOR}" # Use a custom separator for the loop.
   for path in ${CLASSPATH}; do
-    # Convert spaces to %20
+    # Loop through the characters of the path and convert characters that are
+    # not alphanumeric nor -_.~/ to their 2-digit hexadecimal representation
+    local i c buff
+    local converted_path=""
+
+    for ((i=0; i<${#path}; i++)); do
+      c=${path:$i:1}
+      case ${c} in
+            [-_.~/a-zA-Z0-9] ) buff=${c} ;;
+            * )               printf -v buff '%%%02x' "'$c'"
+      esac
+      converted_path+="${buff}"
+    done
+    path=${converted_path}
 
     if is_windows; then
       path="file:/${path}" # e.g. "file:/C:/temp/foo.jar"
@@ -313,7 +326,6 @@ function create_and_run_classpath_jar() {
       path="file:${path}" # e.g. "file:/usr/local/foo.jar"
     fi
 
-    path=$(sed "s/ /%20/g" <<< "${path}")
     MANIFEST_CLASSPATH+=("${path}")
   done
   IFS="$OLDIFS"

--- a/src/test/shell/bazel/java_launcher_test.sh
+++ b/src/test/shell/bazel/java_launcher_test.sh
@@ -57,6 +57,16 @@ java_binary(
     deps = [":hellolib"],
     main_class = "hello.Hello",
 )
+java_library(
+    name = "hellolib%special%lib",
+    srcs = ["HelloLib.java"],
+)
+java_binary(
+    name = "hello_special",
+    srcs = ["Hello.java"],
+    deps = [":hellolib%special%lib"],
+    main_class = "hello.Hello",
+)
 EOF
   bazel build //$pkg/java/hello:hello || fail "expected success"
   ${PRODUCT_NAME}-bin/$pkg/java/hello/hello >& "$TEST_log" || \
@@ -64,6 +74,15 @@ EOF
   expect_log "Hello World!"
 
   ${PRODUCT_NAME}-bin/$pkg/java/hello/hello --classpath_limit=0 >& "$TEST_log" || \
+    fail "expected success"
+  expect_log "Hello World!"
+
+  bazel build //$pkg/java/hello:hello_special || fail "expected success"
+  ${PRODUCT_NAME}-bin/$pkg/java/hello/hello_special >& "$TEST_log" || \
+    fail "expected success"
+  expect_log "Hello World!"
+
+  ${PRODUCT_NAME}-bin/$pkg/java/hello/hello_special --classpath_limit=0 >& "$TEST_log" || \
     fail "expected success"
   expect_log "Hello World!"
 }


### PR DESCRIPTION
This PR fixes the url-encoding in `java_stub_template` to convert different special characters to their 2-digit hexadecimal representation.

Fixes: #10620 