### PR TITLE
Specify wrapped_clang_pp for c++ compile actions

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -1348,7 +1348,7 @@ def _impl(ctx):
             ],
             tools = [
                 tool(
-                    path = "wrapped_clang",
+                    path = "wrapped_clang_pp",
                     execution_requirements = xcode_execution_requirements,
                 ),
             ],
@@ -1383,7 +1383,7 @@ def _impl(ctx):
             ],
             tools = [
                 tool(
-                    path = "wrapped_clang",
+                    path = "wrapped_clang_pp",
                     execution_requirements = xcode_execution_requirements,
                 ),
             ],
@@ -1426,7 +1426,7 @@ def _impl(ctx):
             ],
             tools = [
                 tool(
-                    path = "wrapped_clang",
+                    path = "wrapped_clang_pp",
                     execution_requirements = xcode_execution_requirements,
                 ),
             ],
@@ -1466,7 +1466,7 @@ def _impl(ctx):
             ],
             tools = [
                 tool(
-                    path = "wrapped_clang",
+                    path = "wrapped_clang_pp",
                     execution_requirements = xcode_execution_requirements,
                 ),
             ],
@@ -1503,7 +1503,7 @@ def _impl(ctx):
             ],
             tools = [
                 tool(
-                    path = "wrapped_clang",
+                    path = "wrapped_clang_pp",
                     execution_requirements = xcode_execution_requirements,
                 ),
             ],
@@ -1539,7 +1539,7 @@ def _impl(ctx):
             ],
             tools = [
                 tool(
-                    path = "wrapped_clang",
+                    path = "wrapped_clang_pp",
                     execution_requirements = xcode_execution_requirements,
                 ),
             ],
@@ -1609,7 +1609,7 @@ def _impl(ctx):
             ],
             tools = [
                 tool(
-                    path = "wrapped_clang",
+                    path = "wrapped_clang_pp",
                     execution_requirements = xcode_execution_requirements,
                 ),
             ],
@@ -1646,7 +1646,7 @@ def _impl(ctx):
             ],
             tools = [
                 tool(
-                    path = "wrapped_clang",
+                    path = "wrapped_clang_pp",
                     execution_requirements = xcode_execution_requirements,
                 ),
             ],
@@ -1719,7 +1719,7 @@ def _impl(ctx):
             ],
             tools = [
                 tool(
-                    path = "wrapped_clang",
+                    path = "wrapped_clang_pp",
                     execution_requirements = xcode_execution_requirements,
                 ),
             ],


### PR DESCRIPTION
The OSX crosstool actions export the `wrapped_clang` path for all actions, even ones that are ostensibly c++, which results in clang getting called as `clang`, not `clang++` for c++ sources.  I assume this works because other features replicate the c++ specific parts of the compiler driver.  However, some downstream tools such as rules_foreign_cc don't preserve that behavior well enough for it to work, and as a result fail to compile c++ sources due to effectively using clang and not clang++ to compile.

As an example, rules_foreign_cc retrieves the c++ compiler with:
```
       cxx = cc_common.get_tool_for_action(
            feature_configuration = feature_configuration,
            action_name = CPP_COMPILE_ACTION_NAME,
        ),
``` 
As it exists now, this returns `wrapped_clang`, not `wrapped_clang_pp`.  With this patch, `wrapped_clang_pp` is correctly returned and c++ compilation succeeds.