### PR TITLE
Starlark: use single indexing for globals

### DIFF
--- a/src/main/java/net/starlark/java/eval/Eval.java
+++ b/src/main/java/net/starlark/java/eval/Eval.java
@@ -91,7 +91,7 @@ final class Eval {
         if (stmt instanceof AssignmentStatement) {
           AssignmentStatement assign = (AssignmentStatement) stmt;
           for (Identifier id : Identifier.boundIdentifiers(assign.getLHS())) {
-            Object value = fn(fr).getGlobal(id.getBinding().getIndex());
+            Object value = fn(fr).getModule().getGlobalByIndex(id.getBinding().getIndex());
             fr.thread.postAssignHook.assign(id.getName(), value);
           }
         }
@@ -196,7 +196,7 @@ final class Eval {
     // since both were compiled from the same Program.
     StarlarkFunction fn = fn(fr);
     return new StarlarkFunction(
-        rfn, fn.getModule(), fn.globalIndex, Tuple.wrap(defaults), Tuple.wrap(freevars));
+        rfn, fn.getModule(), Tuple.wrap(defaults), Tuple.wrap(freevars));
   }
 
   private static TokenKind execIf(StarlarkThread.Frame fr, IfStatement node)
@@ -340,7 +340,7 @@ final class Eval {
         ((StarlarkFunction.Cell) fr.locals[bind.getIndex()]).x = value;
         break;
       case GLOBAL:
-        fn(fr).setGlobal(bind.getIndex(), value);
+        fn(fr).getModule().setGlobalByIndex(bind.getIndex(), value);
         break;
       default:
         throw new IllegalStateException(bind.getScope().toString());
@@ -693,7 +693,7 @@ final class Eval {
         result = fn(fr).getFreeVar(bind.getIndex()).x;
         break;
       case GLOBAL:
-        result = fn(fr).getGlobal(bind.getIndex());
+        result = fn(fr).getModule().getGlobalByIndex(bind.getIndex());
         break;
       case PREDECLARED:
         result = fn(fr).getModule().getPredeclared(id.getName());

--- a/src/main/java/net/starlark/java/eval/Starlark.java
+++ b/src/main/java/net/starlark/java/eval/Starlark.java
@@ -871,22 +871,14 @@ public final class Starlark {
     Resolver.Function rfn = prog.getResolvedFunction();
 
     // A given Module may be passed to execFileProgram multiple times in sequence,
-    // for different compiled Programs. (This happens in the REPL, and in
-    // EvaluationTestCase scenarios. It is not true of the go.starlark.net
-    // implementation, and it complicates things significantly.
-    // It would be nice to stop doing that.)
-    //
-    // Therefore StarlarkFunctions from different Programs (files) but initializing
-    // the same Module need different mappings from the Program's numbering of
-    // globals to the Module's numbering of globals, and to access a global requires
-    // two array lookups.
-    int[] globalIndex = module.getIndicesOfGlobals(rfn.getGlobals());
+    // for different compiled Programs.
+
+    prog.assertResolvedInModuleModule(module);
 
     StarlarkFunction toplevel =
         new StarlarkFunction(
             rfn,
             module,
-            globalIndex,
             /*defaultValues=*/ Tuple.empty(),
             /*freevars=*/ Tuple.empty());
     return Starlark.fastcall(thread, toplevel, EMPTY, EMPTY);
@@ -933,9 +925,8 @@ public final class Starlark {
     Expression expr = Expression.parse(input, options);
     Program prog = Program.compileExpr(expr, module, options);
     Resolver.Function rfn = prog.getResolvedFunction();
-    int[] globalIndex = module.getIndicesOfGlobals(rfn.getGlobals()); // see execFileProgram
     return new StarlarkFunction(
-        rfn, module, globalIndex, /*defaultValues=*/ Tuple.empty(), /*freevars=*/ Tuple.empty());
+        rfn, module, /*defaultValues=*/ Tuple.empty(), /*freevars=*/ Tuple.empty());
   }
 
   /**

--- a/src/main/java/net/starlark/java/eval/StarlarkFunction.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkFunction.java
@@ -38,10 +38,6 @@ public final class StarlarkFunction implements StarlarkCallable {
   final Resolver.Function rfn;
   private final Module module; // a function closes over its defining module
 
-  // Index in Module.globals of ith Program global (Resolver.Binding(GLOBAL).index).
-  // See explanation at Starlark.execFileProgram.
-  final int[] globalIndex;
-
   // Default values of optional parameters.
   // Indices correspond to the subsequence of parameters after the initial
   // required parameters and before *args/**kwargs.
@@ -55,25 +51,12 @@ public final class StarlarkFunction implements StarlarkCallable {
   StarlarkFunction(
       Resolver.Function rfn,
       Module module,
-      int[] globalIndex,
       Tuple defaultValues,
       Tuple freevars) {
     this.rfn = rfn;
     this.module = module;
-    this.globalIndex = globalIndex;
     this.defaultValues = defaultValues;
     this.freevars = freevars;
-  }
-
-  // Sets a global variable, given its index in this function's compiled Program.
-  void setGlobal(int progIndex, Object value) {
-    module.setGlobalByIndex(globalIndex[progIndex], value);
-  }
-
-  // Gets the value of a global variable, given its index in this function's compiled Program.
-  @Nullable
-  Object getGlobal(int progIndex) {
-    return module.getGlobalByIndex(globalIndex[progIndex]);
   }
 
   boolean isToplevel() {

--- a/src/main/java/net/starlark/java/syntax/Program.java
+++ b/src/main/java/net/starlark/java/syntax/Program.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package net.starlark.java.syntax;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -25,13 +26,15 @@ public final class Program {
   private final Resolver.Function body;
   private final ImmutableList<String> loads;
   private final ImmutableList<Location> loadLocations;
+  private final Resolver.Module module;
 
   private Program(
-      Resolver.Function body, ImmutableList<String> loads, ImmutableList<Location> loadLocations) {
+      Resolver.Function body, ImmutableList<String> loads, ImmutableList<Location> loadLocations, Resolver.Module module) {
     // TODO(adonovan): compile here.
     this.body = body;
     this.loads = loads;
     this.loadLocations = loadLocations;
+    this.module = module;
   }
 
   // TODO(adonovan): eliminate once Eval no longer needs access to syntax.
@@ -52,6 +55,11 @@ public final class Program {
   /*** Returns the location of the ith load (see {@link #getLoads}). */
   public Location getLoadLocation(int i) {
     return loadLocations.get(i);
+  }
+
+  /** Check this program was resolved with given module. */
+  public void assertResolvedInModuleModule(Resolver.Module module) {
+    Preconditions.checkState(this.module == module, "Program must be resolved and executed with the same module");
   }
 
   /**
@@ -81,7 +89,7 @@ public final class Program {
       }
     }
 
-    return new Program(file.getResolvedFunction(), loads.build(), loadLocations.build());
+    return new Program(file.getResolvedFunction(), loads.build(), loadLocations.build(), env);
   }
 
   /**
@@ -94,6 +102,6 @@ public final class Program {
   public static Program compileExpr(Expression expr, Resolver.Module module, FileOptions options)
       throws SyntaxError.Exception {
     Resolver.Function body = Resolver.resolveExpr(expr, module, options);
-    return new Program(body, /*loads=*/ ImmutableList.of(), /*loadLocations=*/ ImmutableList.of());
+    return new Program(body, /*loads=*/ ImmutableList.of(), /*loadLocations=*/ ImmutableList.of(), module);
   }
 }


### PR DESCRIPTION
* functions no longer have index from resolved global index to module global index
* it is a runtime error now to execute a program with a different module
  than which was used to resolve

Interpreter becomes a littler simpler and a bit faster.

This commit modifies the `Resolver.Module` interface same way as
PR to make universe indexed [1].

[1]: https://github.com/bazelbuild/bazel/pull/12934