### PR TITLE
cc_shared_library: Don't fail when same shared lib is depended multiple times

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcBinary.java
@@ -1510,14 +1510,16 @@ public abstract class CcBinary implements RuleConfiguredTargetFactory {
       String owner = ccSharedLibraryInfo.getLinkerInput().getOwner().toString();
       for (String linkOnceStaticLib : ccSharedLibraryInfo.getLinkOnceStaticLibs()) {
         if (linkOnceStaticLibsMap.containsKey(linkOnceStaticLib)) {
-          ruleContext.attributeError(
-              "dynamic_deps",
-              "Two shared libraries in dependencies link the same library statically. Both "
-                  + linkOnceStaticLibsMap.get(linkOnceStaticLib)
-                  + " and "
-                  + owner
-                  + " link statically "
-                  + linkOnceStaticLib);
+          if (!linkOnceStaticLibsMap.get(linkOnceStaticLib).equals(owner)) {
+            ruleContext.attributeError(
+                "dynamic_deps",
+                "Two shared libraries in dependencies link the same library statically. Both "
+                    + linkOnceStaticLibsMap.get(linkOnceStaticLib)
+                    + " and "
+                    + owner
+                    + " link statically "
+                    + linkOnceStaticLib);
+          }
         }
         linkOnceStaticLibsMap.put(linkOnceStaticLib, owner);
       }


### PR DESCRIPTION
When using `--experimental-cc-shared-library`, the duplicate symbol check fails if a shared lib is linked multiple times.  For example:

```
cc_library(name="X_static")
cc_shared_library(name="X_shared", roots=[":X_static"])

cc_shared_library(name="A", dynamic_deps=[":X_shared"])
cc_shared_library(name="B", dynamic_deps=[":X_shared"])

cc_binary(name="test", dynamic_deps=[":A", ":B"])
```

Will yield an error like:

> in dynamic_deps attribute of cc_binary rule //:test: Two shared libraries in dependencies link the same library statically. Both //:X_shared and //:X_shared link statically //:X_static

This fix checks to ensure it is truly different shared libraries exporting the same static lib.