### PR TITLE
Report errors parsing rewriter config file

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
@@ -22,6 +22,8 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//src/main/java/net/starlark/java/syntax",
+        "//src/main/protobuf:failure_details_proto",
         "//third_party:flogger",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterConfig.java
@@ -16,6 +16,8 @@ package com.google.devtools.build.lib.bazel.repository.downloader;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import net.starlark.java.syntax.Location;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
@@ -72,15 +74,17 @@ class UrlRewriterConfig {
   /**
    * Constructor to use. The {@code config} will be read to completion.
    *
+   * @throws UrlRewriterParseException If the file contents was invalid.
    * @throws UncheckedIOException If any processing problems occur.
    */
-  public UrlRewriterConfig(Reader config) {
+  public UrlRewriterConfig(String filePathForErrorReporting, Reader config) throws UrlRewriterParseException {
     ImmutableSet.Builder<String> allowList = ImmutableSet.builder();
     ImmutableSet.Builder<String> blockList = ImmutableSet.builder();
     ImmutableMultimap.Builder<Pattern, String> rewrites = ImmutableMultimap.builder();
 
     try (BufferedReader reader = new BufferedReader(config)) {
-      for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+      int lineNumber = 1;
+      for (String line = reader.readLine(); line != null; line = reader.readLine(), lineNumber++) {
         // Find the first word
         List<String> parts = SPLITTER.splitToList(line);
         if (parts.isEmpty()) {
@@ -92,34 +96,41 @@ class UrlRewriterConfig {
           continue;
         }
 
+        Location location = Location.fromFileLineColumn(filePathForErrorReporting, lineNumber, 0);
+
         switch (parts.get(0)) {
           case "allow":
             if (parts.size() != 2) {
-              throw new IllegalStateException(
-                  "Only the host name is allowed after `allow`: " + line);
+              throw new UrlRewriterParseException(
+                  "Only the host name is allowed after `allow`: " + line,
+                  location);
             }
             allowList.add(parts.get(1));
             break;
 
           case "block":
             if (parts.size() != 2) {
-              throw new IllegalStateException(
-                  "Only the host name is allowed after `block`: " + line);
+              throw new UrlRewriterParseException(
+                  "Only the host name is allowed after `block`: " + line,
+                  location);
             }
             blockList.add(parts.get(1));
             break;
 
           case "rewrite":
             if (parts.size() != 3) {
-              throw new IllegalStateException(
+              throw new UrlRewriterParseException(
                   "Only the matching pattern and rewrite pattern is allowed after `rewrite`: "
-                      + line);
+                      + line,
+                  location);
             }
             rewrites.put(Pattern.compile(parts.get(1)), parts.get(2));
             break;
 
           default:
-            throw new IllegalStateException("Unable to parse: " + line);
+            throw new UrlRewriterParseException(
+                "Unable to parse: " + line,
+                location);
         }
       }
     } catch (IOException e) {

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterParseException.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterParseException.java
@@ -1,0 +1,16 @@
+package com.google.devtools.build.lib.bazel.repository.downloader;
+
+import net.starlark.java.syntax.Location;
+
+public class UrlRewriterParseException extends Exception {
+    private Location location;
+
+    public UrlRewriterParseException(String message, Location location) {
+        super(message);
+        this.location = location;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+}

--- a/src/main/protobuf/failure_details.proto
+++ b/src/main/protobuf/failure_details.proto
@@ -240,6 +240,7 @@ message ExternalRepository {
   enum Code {
     EXTERNAL_REPOSITORY_UNKNOWN = 0 [(metadata) = { exit_code: 37 }];
     OVERRIDE_DISALLOWED_MANAGED_DIRECTORIES = 1 [(metadata) = { exit_code: 2 }];
+    BAD_DOWNLOADER_CONFIG = 2 [(metadata) = { exit_code: 2 }];
   }
   Code code = 1;
   // Additional data could include external repository names.

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/BUILD
@@ -21,6 +21,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/net/starlark/java/syntax",
         "//src/test/java/com/google/devtools/build/lib/testutil",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriterTest.java
@@ -14,12 +14,15 @@
 package com.google.devtools.build.lib.bazel.repository.downloader;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+
+import net.starlark.java.syntax.Location;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,8 +32,8 @@ import org.junit.runners.JUnit4;
 public class UrlRewriterTest {
 
   @Test
-  public void byDefaultTheUrlRewriterDoesNothing() throws MalformedURLException {
-    UrlRewriter munger = new UrlRewriter(str -> {}, new StringReader(""));
+  public void byDefaultTheUrlRewriterDoesNothing() throws Exception {
+    UrlRewriter munger = new UrlRewriter(str -> {}, "/dev/null", new StringReader(""));
 
     List<URL> urls = ImmutableList.of(new URL("http://example.com"));
     List<URL> amended = munger.amend(urls);
@@ -39,9 +42,9 @@ public class UrlRewriterTest {
   }
 
   @Test
-  public void shouldBeAbleToBlockParticularHostsRegardlessOfScheme() throws MalformedURLException {
+  public void shouldBeAbleToBlockParticularHostsRegardlessOfScheme() throws Exception {
     String config = "block example.com";
-    UrlRewriter munger = new UrlRewriter(str -> {}, new StringReader(config));
+    UrlRewriter munger = new UrlRewriter(str -> {}, "/dev/null", new StringReader(config));
 
     List<URL> urls =
         ImmutableList.of(
@@ -54,9 +57,9 @@ public class UrlRewriterTest {
   }
 
   @Test
-  public void shouldAllowAUrlToBeRewritten() throws MalformedURLException {
+  public void shouldAllowAUrlToBeRewritten() throws Exception {
     String config = "rewrite example.com/foo/(.*) mycorp.com/$1/foo";
-    UrlRewriter munger = new UrlRewriter(str -> {}, new StringReader(config));
+    UrlRewriter munger = new UrlRewriter(str -> {}, "/dev/null", new StringReader(config));
 
     List<URL> urls = ImmutableList.of(new URL("https://example.com/foo/bar"));
     List<URL> amended = munger.amend(urls);
@@ -65,11 +68,11 @@ public class UrlRewriterTest {
   }
 
   @Test
-  public void rewritesCanExpandToMoreThanOneUrl() throws MalformedURLException {
+  public void rewritesCanExpandToMoreThanOneUrl() throws Exception {
     String config =
         "rewrite example.com/foo/(.*) mycorp.com/$1/somewhere\n"
             + "rewrite example.com/foo/(.*) mycorp.com/$1/elsewhere";
-    UrlRewriter munger = new UrlRewriter(str -> {}, new StringReader(config));
+    UrlRewriter munger = new UrlRewriter(str -> {}, "/dev/null", new StringReader(config));
 
     List<URL> urls = ImmutableList.of(new URL("https://example.com/foo/bar"));
     List<URL> amended = munger.amend(urls);
@@ -80,10 +83,10 @@ public class UrlRewriterTest {
   }
 
   @Test
-  public void shouldBlockAllUrlsOtherThanSpecificOnes() throws MalformedURLException {
+  public void shouldBlockAllUrlsOtherThanSpecificOnes() throws Exception {
     String config = "" + "block *\n" + "allow example.com";
 
-    UrlRewriter munger = new UrlRewriter(str -> {}, new StringReader(config));
+    UrlRewriter munger = new UrlRewriter(str -> {}, "/dev/null", new StringReader(config));
 
     List<URL> urls =
         ImmutableList.of(
@@ -98,7 +101,7 @@ public class UrlRewriterTest {
   }
 
   @Test
-  public void commentsArePrecededByTheHashCharacter() throws MalformedURLException {
+  public void commentsArePrecededByTheHashCharacter() throws Exception {
     String config =
         ""
             + "# Block everything\n"
@@ -106,7 +109,7 @@ public class UrlRewriterTest {
             + "# But allow example.com\n"
             + "allow example.com";
 
-    UrlRewriter munger = new UrlRewriter(str -> {}, new StringReader(config));
+    UrlRewriter munger = new UrlRewriter(str -> {}, "/dev/null", new StringReader(config));
 
     List<URL> urls = ImmutableList.of(new URL("https://foo.com"), new URL("https://example.com"));
     List<URL> amended = munger.amend(urls);
@@ -115,10 +118,10 @@ public class UrlRewriterTest {
   }
 
   @Test
-  public void allowListAppliesToSubdomainsToo() throws MalformedURLException {
+  public void allowListAppliesToSubdomainsToo() throws Exception {
     String config = "" + "block *\n" + "allow example.com";
 
-    UrlRewriter munger = new UrlRewriter(str -> {}, new StringReader(config));
+    UrlRewriter munger = new UrlRewriter(str -> {}, "/dev/null", new StringReader(config));
 
     List<URL> amended = munger.amend(ImmutableList.of(new URL("https://subdomain.example.com")));
 
@@ -126,10 +129,10 @@ public class UrlRewriterTest {
   }
 
   @Test
-  public void blockListAppliesToSubdomainsToo() throws MalformedURLException {
+  public void blockListAppliesToSubdomainsToo() throws Exception {
     String config = "block example.com";
 
-    UrlRewriter munger = new UrlRewriter(str -> {}, new StringReader(config));
+    UrlRewriter munger = new UrlRewriter(str -> {}, "/dev/null", new StringReader(config));
 
     List<URL> amended = munger.amend(ImmutableList.of(new URL("https://subdomain.example.com")));
 
@@ -137,10 +140,10 @@ public class UrlRewriterTest {
   }
 
   @Test
-  public void emptyLinesAreFine() throws MalformedURLException {
+  public void emptyLinesAreFine() throws Exception {
     String config = "" + "\n" + "   \n" + "block *\n" + "\t  \n" + "allow example.com";
 
-    UrlRewriter munger = new UrlRewriter(str -> {}, new StringReader(config));
+    UrlRewriter munger = new UrlRewriter(str -> {}, "/dev/null", new StringReader(config));
 
     List<URL> amended = munger.amend(ImmutableList.of(new URL("https://subdomain.example.com")));
 
@@ -148,10 +151,10 @@ public class UrlRewriterTest {
   }
 
   @Test
-  public void rewritingUrlsIsAppliedBeforeBlocking() throws MalformedURLException {
+  public void rewritingUrlsIsAppliedBeforeBlocking() throws Exception {
     String config = "" + "block bad.com\n" + "rewrite bad.com/foo/(.*) mycorp.com/$1";
 
-    UrlRewriter munger = new UrlRewriter(str -> {}, new StringReader(config));
+    UrlRewriter munger = new UrlRewriter(str -> {}, "/dev/null", new StringReader(config));
 
     List<URL> amended =
         munger.amend(
@@ -161,16 +164,27 @@ public class UrlRewriterTest {
   }
 
   @Test
-  public void rewritingUrlsIsAppliedBeforeAllowing() throws MalformedURLException {
+  public void rewritingUrlsIsAppliedBeforeAllowing() throws Exception {
     String config =
         "" + "block *\n" + "allow mycorp.com\n" + "rewrite bad.com/foo/(.*) mycorp.com/$1";
 
-    UrlRewriter munger = new UrlRewriter(str -> {}, new StringReader(config));
+    UrlRewriter munger = new UrlRewriter(str -> {}, "/dev/null", new StringReader(config));
 
     List<URL> amended =
         munger.amend(
             ImmutableList.of(new URL("https://www.bad.com"), new URL("https://bad.com/foo/bar")));
 
     assertThat(amended).containsExactly(new URL("https://mycorp.com/bar"));
+  }
+
+  @Test
+  public void parseError() throws Exception {
+    String config = "#comment\nhello";
+    try {
+      new UrlRewriterConfig("/some/file", new StringReader(config));
+      fail();
+    } catch (UrlRewriterParseException e) {
+      assertThat(e.getLocation()).isEqualTo(Location.fromFileLineColumn("/some/file", 2, 0));
+    }
   }
 }


### PR DESCRIPTION
Before this change, an invalid config file results in a silent server
crash.