### PR TITLE
Split the override_repository argument only at the first equals sign.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -163,7 +163,7 @@ public class RepositoryOptions extends OptionsBase {
 
     @Override
     public RepositoryOverride convert(String input) throws OptionsParsingException {
-      String[] pieces = input.split("=");
+      String[] pieces = input.split("=", 2);
       if (pieces.length != 2) {
         throw new OptionsParsingException(
             "Repository overrides must be of the form 'repository-name=path'", input);

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptionsTest.java
@@ -47,6 +47,14 @@ public class RepositoryOptionsTest {
   }
 
   @Test
+  public void testOverridePathWithEqualsSign() throws Exception {
+    RepositoryOverride actual = converter.convert("foo=/bar=/baz");
+    assertThat(actual.repositoryName())
+            .isEqualTo(RepositoryName.createFromValidStrippedName("foo"));
+    assertThat(actual.path()).isEqualTo(PathFragment.create("/bar=/baz"));
+  }
+
+  @Test
   public void testInvalidOverride() throws Exception {
     expectedException.expect(OptionsParsingException.class);
     expectedException.expectMessage(


### PR DESCRIPTION
Fixes #12987.