### PR TITLE
Expose java stub template through @bazel_tools

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BUILD
@@ -13,6 +13,11 @@ filegroup(
     visibility = ["//src:__subpackages__"],
 )
 
+exports_files(
+    ["java_stub_template.txt"],
+    visibility = ["//tools/java:__pkg__"]
+)
+
 java_library(
     name = "java",
     srcs = glob(

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -49,6 +49,7 @@ filegroup(
         "//tools/cpp:embedded_tools",
         "//tools/genrule:srcs",
         "//tools/java:embedded_tools",
+        "//tools/java:java_stub_template.txt",
         "//tools/j2objc:srcs",
         "//tools/jdk:package-srcs",
         "//tools/jdk:srcs",

--- a/tools/java/BUILD
+++ b/tools/java/BUILD
@@ -9,6 +9,16 @@ filegroup(
     visibility = ["//tools:__pkg__"],
 )
 
+genrule(
+    name = "copy_java_stub_template",
+    srcs = [
+        "//src/main/java/com/google/devtools/build/lib/bazel/rules/java:java_stub_template.txt",
+    ],
+    outs = ["java_stub_template.txt"],
+    cmd = "cp $< $@",
+    visibility = ["//tools:__pkg__"],
+)
+
 filegroup(
     name = "embedded_tools",
     srcs = ["//tools/java/runfiles:embedded_tools"],


### PR DESCRIPTION
Currently rules_kotlin downloads this via raw.githubusercontent.com:

https://github.com/bazelbuild/rules_kotlin/blob/96c70d1d3cc788b03406f7db6a659c78d311c3d8/kotlin/internal/repositories/release_repositories.bzl#L55-L62

https://github.com/bazelbuild/rules_kotlin/blob/96c70d1d3cc788b03406f7db6a659c78d311c3d8/kotlin/internal/jvm/jvm.bzl#L135-L138

This will allow rules_kotlin to point at a file from Bazel proper,
rather than downloading it via the internet.