### PR TITLE
Shade com.google.common.** in the Jacoco test runner.

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoCoverage.jarjar
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/JacocoCoverage.jarjar
@@ -1,2 +1,3 @@
+rule com.google.common.** com.google.testing.coverage.jarjar.@0
 rule org.apache.commons.** com.google.testing.coverage.jarjar.@0
 rule org.objectweb.asm.** com.google.testing.coverage.jarjar.@0


### PR DESCRIPTION
This isolates the Bazel coverage runner's version of Guava from the
user's.

Resolves #12998

Testing Done:
- Verified `bazel coverage` worked against a crufty internal target
  using this patch with java_tools javac11-10.5 and Bazel 4.0.0.
- `bazelisk build src:java_tools.zip`; manual inspection of
  `JacocoCoverage_jarjar_deploy.jar`.
