### PR TITLE
Add --host_macos_minimum_os flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
@@ -164,6 +164,17 @@ public class AppleCommandLineOptions extends FragmentOptions {
   public DottedVersion.Option macosMinimumOs;
 
   @Option(
+      name = "host_macos_minimum_os",
+      defaultValue = "null",
+      converter = DottedVersionConverter.class,
+      documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+      effectTags = {OptionEffectTag.LOSES_INCREMENTAL_STATE},
+      help =
+          "Minimum compatible macOS version for host targets. "
+              + "If unspecified, uses 'macos_sdk_version'.")
+  public DottedVersion.Option hostMacosMinimumOs;
+
+  @Option(
       name = "experimental_prefer_mutual_xcode",
       defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
@@ -488,6 +499,7 @@ public class AppleCommandLineOptions extends FragmentOptions {
     host.watchOsSdkVersion = watchOsSdkVersion;
     host.tvOsSdkVersion = tvOsSdkVersion;
     host.macOsSdkVersion = macOsSdkVersion;
+    host.macosMinimumOs = hostMacosMinimumOs;
     // The host apple platform type will always be MACOS, as no other apple platform type can
     // currently execute build actions. If that were the case, a host_apple_platform_type flag might
     // be needed.

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcBuildVariablesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcBuildVariablesTest.java
@@ -197,6 +197,45 @@ public class ObjcBuildVariablesTest extends LinkBuildVariablesTestCase {
   }
 
   @Test
+  public void testAppleBuildVariablesMacosHost() throws Exception {
+    MockObjcSupport.setup(mockToolsConfig);
+    String dummyMinimumOsValue = "13.579";
+    useConfiguration(
+        "--crosstool_top=//tools/osx/crosstool",
+        "--cpu=darwin_x86_64",
+        "--host_cpu=darwin_x86_64",
+        "--macos_minimum_os=10.11",
+        "--host_macos_minimum_os=" + dummyMinimumOsValue);
+    scratch.file(
+        "x/BUILD",
+        "apple_binary(",
+        "   name = 'bin',",
+        "   deps = [':a'],",
+        "   platform_type = 'macos',",
+        ")",
+        "cc_library(",
+        "   name = 'a',",
+        "   srcs = ['a.cc'],",
+        ")");
+    scratch.file("x/a.cc");
+
+    ConfiguredTarget target = getHostConfiguredTarget("//x:bin");
+    Artifact lipoBin =
+            getBinArtifact(
+                    Label.parseAbsolute("//x:bin", ImmutableMap.of()).getName() + "_lipobin", target);
+    Action lipoAction = getGeneratingAction(lipoBin);
+    Artifact bin = ActionsTestUtil.getFirstArtifactEndingWith(lipoAction.getInputs(), "_bin");
+    CommandAction appleBinLinkAction = (CommandAction) getGeneratingAction(bin);
+    Artifact archive =
+            ActionsTestUtil.getFirstArtifactEndingWith(appleBinLinkAction.getInputs(), "liba.a");
+    CppLinkAction ccArchiveAction = (CppLinkAction) getGeneratingAction(archive);
+
+    CcToolchainVariables variables = ccArchiveAction.getLinkCommandLine().getBuildVariables();
+    assertThat(getVariableValue(getRuleContext(), variables, AppleCcToolchain.VERSION_MIN_KEY))
+            .contains(dummyMinimumOsValue);
+  }
+
+  @Test
   public void testDefaultBuildVariablesIos() throws Exception {
      MockObjcSupport.setup(mockToolsConfig);
     useConfiguration(


### PR DESCRIPTION
This flag makes sure we set the minimum macOS version when compiling
host tools. Otherwise you can end up not sharing caches across
different OS versions.

Fixes https://github.com/bazelbuild/bazel/issues/12988