### PR TITLE
Fix NullPointerException in cquery --output=graph.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.query2.query.output.GraphOutputWriter.NodeR
 import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
 import java.io.OutputStream;
 import java.util.Comparator;
+import java.util.Objects;
 
 /** cquery output formatter that prints the result as factored graph in AT&amp;T GraphViz format. */
 class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
@@ -50,9 +51,20 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
               // Order graph output first by target label, then by configuration hash.
               Label label1 = ct1.getLabel();
               Label label2 = ct2.getLabel();
-              return label1.equals(label2)
-                  ? ct1.getConfigurationChecksum().compareTo(ct2.getConfigurationChecksum())
-                  : label1.compareTo(label2);
+              if (!label1.equals(label2)) {
+                return label1.compareTo(label2);
+              }
+              String checksum1 = ct1.getConfigurationChecksum();
+              String checksum2 = ct2.getConfigurationChecksum();
+              if (Objects.equals(checksum1, checksum2)) {
+                return 0;
+              } else if (checksum1 == null) {
+                return -1;
+              } else if (checksum2 == null) {
+                return 1;
+              } else {
+                return checksum1.compareTo(checksum2);
+              }
             };
 
         @Override

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/GraphOutputFormatterCallback.java
@@ -56,9 +56,7 @@ class GraphOutputFormatterCallback extends CqueryThreadsafeCallback {
               }
               String checksum1 = ct1.getConfigurationChecksum();
               String checksum2 = ct2.getConfigurationChecksum();
-              if (Objects.equals(checksum1, checksum2)) {
-                return 0;
-              } else if (checksum1 == null) {
+              if (checksum1 == null) {
                 return -1;
               } else if (checksum2 == null) {
                 return 1;


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/12915.

The repro from the bug crashes because these two deps are compared:


`Target: @remote_java_tools_linux//:java_tools/src/tools/singlejar/singlejar_local`
`Config: d8d0eb07eb92791668ac973282be1523379b0025b22f0ade56b13d519f2feb2a`

`Target: @remote_java_tools_linux//:java_tools/src/tools/singlejar/singlejar_local`
`Config: null`

This is a `cc_binary`: https://github.com/bazelbuild/bazel/blob/0c1257ed4e1b83f8d0f6c79d641f6bfcf4d1cfc4/src/tools/singlejar/BUILD#L92-L93

I have no idea why the graph visitor tags one of its instances with a null configuration. Nevertheless, this code is still safer.
