### PR TITLE
Starlark: speed-up StarlarkThread.push

### DIFF
--- a/src/main/java/net/starlark/java/eval/BUILD
+++ b/src/main/java/net/starlark/java/eval/BUILD
@@ -18,6 +18,7 @@ java_library(
         "CallUtils.java",
         "CpuProfiler.java",
         "Debug.java",
+        "DebugProfile.java",
         "Dict.java",
         "Eval.java",
         "EvalException.java",

--- a/src/main/java/net/starlark/java/eval/CpuProfiler.java
+++ b/src/main/java/net/starlark/java/eval/CpuProfiler.java
@@ -126,7 +126,7 @@ final class CpuProfiler {
   }
 
   /** Start the profiler. */
-  static void start(OutputStream out, Duration period) {
+  static synchronized void start(OutputStream out, Duration period) {
     if (!supported()) {
       throw new UnsupportedOperationException("this platform does not support Starlark profiling");
     }
@@ -140,16 +140,18 @@ final class CpuProfiler {
     }
 
     instance = new CpuProfiler(out, period);
+    DebugProfile.add(1);
   }
 
   /** Stop the profiler and wait for the log to be written. */
-  static void stop() throws IOException {
+  static synchronized void stop() throws IOException {
     if (instance == null) {
       throw new IllegalStateException("stop without start");
     }
 
     CpuProfiler profiler = instance;
     instance = null;
+    DebugProfile.add(-1);
 
     stopTimer();
 

--- a/src/main/java/net/starlark/java/eval/Debug.java
+++ b/src/main/java/net/starlark/java/eval/Debug.java
@@ -99,6 +99,7 @@ public final class Debug {
     if (prev != null) {
       prev.close();
     }
+    DebugProfile.add((dbg != null ? 1 : 0) - (prev != null ? 1 : 0));
   }
 
   /**
@@ -170,7 +171,9 @@ public final class Debug {
    * This interface is provided to support special tools; ordinary clients should have no need for
    * it.
    */
-  public static void setThreadHook(ThreadHook hook) {
+  public static synchronized void setThreadHook(ThreadHook hook) {
+    ThreadHook oldHook = threadHook;
     threadHook = hook;
+    DebugProfile.add((hook != null ? 1 : 0) - (oldHook != null ? 1 : 0));
   }
 }

--- a/src/main/java/net/starlark/java/eval/DebugProfile.java
+++ b/src/main/java/net/starlark/java/eval/DebugProfile.java
@@ -1,0 +1,22 @@
+package net.starlark.java.eval;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Hold the information about the number of debuggers or profilers
+ * attached to this process.
+ */
+class DebugProfile {
+
+  private static final AtomicInteger numberOfAgents = new AtomicInteger(0);
+
+  /** Add or subtract the number of agents (profilers or debuggers). */
+  static void add(int delta) {
+    numberOfAgents.addAndGet(delta);
+  }
+
+  /** True iff the number of agents (profilers or debuggers) is non-zero. */
+  static boolean hasAny() {
+    return numberOfAgents.get() != 0;
+  }
+}

--- a/src/main/java/net/starlark/java/eval/StarlarkThread.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkThread.java
@@ -60,6 +60,9 @@ public final class StarlarkThread {
   @Nullable private CpuProfiler profiler;
   StarlarkThread savedThread; // saved StarlarkThread, when profiling reentrant evaluation
 
+  // When true, current process has or had at least one profiler or debugger attached.
+  private boolean hasAnyProfileDebug = false;
+
   private final Map<Class<?>, Object> threadLocals = new HashMap<>();
 
   private boolean interruptible = true;
@@ -125,12 +128,13 @@ public final class StarlarkThread {
     final StarlarkCallable fn; // the called function
 
     @Nullable
-    final Debug.Debugger dbg = Debug.debugger.get(); // the debugger, if active for this frame
+    final Debug.Debugger dbg; // the debugger, if active for this frame
 
     Object result = Starlark.NONE; // the operand of a Starlark return statement
 
     // Current PC location. Initially fn.getLocation(); for Starlark functions,
     // it is updated at key points when it may be observed: calls, breakpoints, errors.
+    @Nullable
     private Location loc;
 
     // Indicates that setErrorLocation has been called already and the error
@@ -144,9 +148,10 @@ public final class StarlarkThread {
 
     @Nullable private Object profileSpan; // current span of walltime call profiler
 
-    private Frame(StarlarkThread thread, StarlarkCallable fn) {
+    private Frame(StarlarkThread thread, StarlarkCallable fn, boolean hasAnyProfileDebug) {
       this.thread = thread;
       this.fn = fn;
+      this.dbg = hasAnyProfileDebug ? Debug.debugger.get() : null;
     }
 
     // Updates the PC location in this frame.
@@ -175,7 +180,7 @@ public final class StarlarkThread {
 
     @Override
     public Location getLocation() {
-      return loc;
+      return loc != null ? loc : fn.getLocation();
     }
 
     @Override
@@ -198,7 +203,7 @@ public final class StarlarkThread {
 
     @Override
     public String toString() {
-      return fn.getName() + "@" + loc;
+      return fn.getName() + "@" + getLocation();
     }
   }
 
@@ -222,30 +227,32 @@ public final class StarlarkThread {
 
   /** Pushes a function onto the call stack. */
   void push(StarlarkCallable fn) {
-    Frame fr = new Frame(this, fn);
+    this.hasAnyProfileDebug |= DebugProfile.hasAny();
+
+    Frame fr = new Frame(this, fn, hasAnyProfileDebug);
     callstack.add(fr);
 
-    // Notify debug tools of the thread's first push.
-    if (callstack.size() == 1 && Debug.threadHook != null) {
-      Debug.threadHook.onPushFirst(this);
-    }
+    if (hasAnyProfileDebug) {
+      // Notify debug tools of the thread's first push.
+      if (callstack.size() == 1 && Debug.threadHook != null) {
+        Debug.threadHook.onPushFirst(this);
+      }
 
-    fr.loc = fn.getLocation();
+      // Start wall-time call profile span.
+      CallProfiler callProfiler = StarlarkThread.callProfiler;
+      if (callProfiler != null) {
+        fr.profileSpan = callProfiler.start(fn);
+      }
 
-    // Start wall-time call profile span.
-    CallProfiler callProfiler = StarlarkThread.callProfiler;
-    if (callProfiler != null) {
-      fr.profileSpan = callProfiler.start(fn);
-    }
-
-    // Poll for newly installed CPU profiler.
-    if (profiler == null) {
-      this.profiler = CpuProfiler.get();
-      if (profiler != null) {
-        cpuTicks.set(0);
-        // Associated current Java thread with this StarlarkThread.
-        // (Save the previous association so we can restore it later.)
-        this.savedThread = CpuProfiler.setStarlarkThread(this);
+      // Poll for newly installed CPU profiler.
+      if (profiler == null) {
+        this.profiler = CpuProfiler.get();
+        if (profiler != null) {
+          cpuTicks.set(0);
+          // Associated current Java thread with this StarlarkThread.
+          // (Save the previous association so we can restore it later.)
+          this.savedThread = CpuProfiler.setStarlarkThread(this);
+        }
       }
     }
   }
@@ -255,33 +262,37 @@ public final class StarlarkThread {
     int last = callstack.size() - 1;
     Frame fr = callstack.get(last);
 
-    if (profiler != null) {
-      int ticks = cpuTicks.getAndSet(0);
-      if (ticks > 0) {
-        profiler.addEvent(ticks, getDebugCallStack());
-      }
+    if (hasAnyProfileDebug) {
+      if (profiler != null) {
+        int ticks = cpuTicks.getAndSet(0);
+        if (ticks > 0) {
+          profiler.addEvent(ticks, getDebugCallStack());
+        }
 
-      // If this is the final pop in this thread,
-      // unregister it from the profiler.
-      if (last == 0) {
-        // Restore the previous association (in case of reentrant evaluation).
-        CpuProfiler.setStarlarkThread(this.savedThread);
-        this.savedThread = null;
-        this.profiler = null;
+        // If this is the final pop in this thread,
+        // unregister it from the profiler.
+        if (last == 0) {
+          // Restore the previous association (in case of reentrant evaluation).
+          CpuProfiler.setStarlarkThread(this.savedThread);
+          this.savedThread = null;
+          this.profiler = null;
+        }
       }
     }
 
     callstack.remove(last); // pop
 
-    // End wall-time profile span.
-    CallProfiler callProfiler = StarlarkThread.callProfiler;
-    if (callProfiler != null && fr.profileSpan != null) {
-      callProfiler.end(fr.profileSpan);
-    }
+    if (hasAnyProfileDebug) {
+      // End wall-time profile span.
+      CallProfiler callProfiler = StarlarkThread.callProfiler;
+      if (callProfiler != null && fr.profileSpan != null) {
+        callProfiler.end(fr.profileSpan);
+      }
 
-    // Notify debug tools of the thread's last pop.
-    if (last == 0 && Debug.threadHook != null) {
-      Debug.threadHook.onPopLast(this);
+      // Notify debug tools of the thread's last pop.
+      if (last == 0 && Debug.threadHook != null) {
+        Debug.threadHook.onPopLast(this);
+      }
     }
   }
 
@@ -354,7 +365,7 @@ public final class StarlarkThread {
    * returns BUILTIN if called with fewer than two frames (such as within a test).
    */
   public Location getCallerLocation() {
-    return toplevel() ? Location.BUILTIN : frame(1).loc;
+    return toplevel() ? Location.BUILTIN : frame(1).getLocation();
   }
 
   /**
@@ -453,7 +464,7 @@ public final class StarlarkThread {
   public ImmutableList<CallStackEntry> getCallStack() {
     ImmutableList.Builder<CallStackEntry> stack = ImmutableList.builder();
     for (Frame fr : callstack) {
-      stack.add(new CallStackEntry(fr.fn.getName(), fr.loc));
+      stack.add(new CallStackEntry(fr.fn.getName(), fr.getLocation()));
     }
     return stack.build();
   }
@@ -481,8 +492,10 @@ public final class StarlarkThread {
   }
 
   /** Installs a global hook that will be notified of function calls. */
-  public static void setCallProfiler(@Nullable CallProfiler p) {
+  public static synchronized void setCallProfiler(@Nullable CallProfiler p) {
+    CallProfiler oldProfiler = callProfiler;
     callProfiler = p;
+    DebugProfile.add((p != null ? 1 : 0) - (oldProfiler != null ? 1 : 0));
   }
 
   @Nullable private static CallProfiler callProfiler = null;


### PR DESCRIPTION
* Do not initialize `Frame.loc`
* Check for enabled debuggers and profilers only once

Most of the time Starlark is executed without any debuggers or
profilers attached. We don't need to enumerate all of them at each
invocation.

Instead, hold a single variable which provides information whether
any debugger or profiler is attached.

This slightly reduces function invocation cost.

5% for this test:

```
def qux():
  pass

def baz():
  qux()

def bar():
  baz()

def foo():
  bar()

def test():
  for i in range(10):
    print(i)
    for j in range(1000000):
      foo()

test()
```