### PR TITLE
Starlark: special case for String in checkHashable

### DIFF
--- a/src/main/java/net/starlark/java/eval/Starlark.java
+++ b/src/main/java/net/starlark/java/eval/Starlark.java
@@ -149,11 +149,15 @@ public final class Starlark {
    * @throws EvalException otherwise.
    */
   public static void checkHashable(Object x) throws EvalException {
-    if (x instanceof StarlarkValue) {
+    if (x instanceof String) {
+      // Strings are the most common dict keys.
+      // Check them first for that reason, but also because
+      // instanceof interface is slow.
+    } else if (x instanceof StarlarkValue) {
       ((StarlarkValue) x).checkHashable();
     } else {
       Starlark.checkValid(x);
-      // String and Boolean are hashable.
+      // Boolean are hashable.
     }
   }
 


### PR DESCRIPTION
* Strings are probably the most common dict keys
* instanceof interface invocation is very slow compared to
  instanceof class, especially instanceof final class

So make special case for `String` in `Starlark.checkHashable`.

Demonstrated on this test, which is 25% faster.

```
def test():
  for i in range(10):
    print(i)
    d = {}
    for _ in range(1000000):
      d.clear()
      d["aaa"] = 1
      d["bbb"] = 2
      d["ccc"] = 2
      d["ddd"] = 2
      d["aaa"] = 2
      d["aaa"] = 2
      d["bbb"] = 2
      d["ccc"] = 2
      d["ddd"] = 2
      d["aaa"] = 2

test()
```