### PR TITLE
Starlark: @StarlarkMethod.trustReturnsValid

### DIFF
--- a/src/main/java/net/starlark/java/annot/StarlarkMethod.java
+++ b/src/main/java/net/starlark/java/annot/StarlarkMethod.java
@@ -170,6 +170,12 @@ public @interface StarlarkMethod {
   boolean allowReturnNones() default false;
 
   /**
+   * If true, for a method which returns any type not known to be a valid Starlark value,
+   * the Starlark interpreter does not validate that the returned object is a legal Starlark value.
+   */
+  boolean trustReturnsValid() default false;
+
+  /**
    * If true, the StarlarkThread will be passed as an argument of the annotated function. (Thus, the
    * annotated method signature must contain StarlarkThread as a parameter. See the interface-level
    * javadoc for details.)

--- a/src/main/java/net/starlark/java/eval/Dict.java
+++ b/src/main/java/net/starlark/java/eval/Dict.java
@@ -214,6 +214,7 @@ public class Dict<K, V>
             named = true,
             doc = "The default value to use (instead of None) if the key is not found.")
       },
+      trustReturnsValid = true,
       useStarlarkThread = true)
   // TODO(adonovan): This method is named get2 as a temporary workaround for a bug in
   // StarlarkAnnotations.getStarlarkMethod. The two 'get' methods cause it to get
@@ -247,6 +248,7 @@ public class Dict<K, V>
             named = true,
             doc = "a default value if the key is absent."),
       },
+      trustReturnsValid = true,
       useStarlarkThread = true)
   public Object pop(Object key, Object defaultValue, StarlarkThread thread) throws EvalException {
     Starlark.checkMutable(this);
@@ -298,7 +300,8 @@ public class Dict<K, V>
             defaultValue = "None",
             named = true,
             doc = "a default value if the key is absent."),
-      })
+      },
+      trustReturnsValid = true)
   public V setdefault(K key, V defaultValue) throws EvalException {
     Starlark.checkMutable(this);
     Starlark.checkHashable(key);

--- a/src/main/java/net/starlark/java/eval/MethodDescriptor.java
+++ b/src/main/java/net/starlark/java/eval/MethodDescriptor.java
@@ -68,6 +68,7 @@ final class MethodDescriptor {
       boolean extraKeywords,
       boolean selfCall,
       boolean allowReturnNones,
+      boolean trustReturnsValid,
       boolean useStarlarkThread,
       boolean useStarlarkSemantics) {
     this.method = method;
@@ -92,7 +93,8 @@ final class MethodDescriptor {
       howToHandleReturn = HowToHandleReturn.NULL_TO_NONE;
     } else if (StarlarkValue.class.isAssignableFrom(ret)
         || String.class == ret
-        || Boolean.class == ret) {
+        || Boolean.class == ret
+        || trustReturnsValid) {
       howToHandleReturn =
           allowReturnNones ? HowToHandleReturn.NULL_TO_NONE : HowToHandleReturn.ERROR_ON_NULL;
     } else if (ret == int.class) {
@@ -131,6 +133,7 @@ final class MethodDescriptor {
         !annotation.extraKeywords().name().isEmpty(),
         annotation.selfCall(),
         annotation.allowReturnNones(),
+        annotation.trustReturnsValid(),
         annotation.useStarlarkThread(),
         annotation.useStarlarkSemantics());
   }

--- a/src/main/java/net/starlark/java/eval/MethodLibrary.java
+++ b/src/main/java/net/starlark/java/eval/MethodLibrary.java
@@ -40,7 +40,8 @@ class MethodLibrary {
               + "or if no arguments are given. "
               + "<pre class=\"language-python\">min(2, 5, 4) == 2\n"
               + "min([5, 6, 3]) == 3</pre>",
-      extraPositionals = @Param(name = "args", doc = "The elements to be checked."))
+      extraPositionals = @Param(name = "args", doc = "The elements to be checked."),
+      trustReturnsValid = true)
   public Object min(Sequence<?> args) throws EvalException {
     return findExtreme(args, Starlark.ORDERING.reverse());
   }
@@ -54,7 +55,8 @@ class MethodLibrary {
               + "or if no arguments are given. "
               + "<pre class=\"language-python\">max(2, 5, 4) == 5\n"
               + "max([5, 6, 3]) == 6</pre>",
-      extraPositionals = @Param(name = "args", doc = "The elements to be checked."))
+      extraPositionals = @Param(name = "args", doc = "The elements to be checked."),
+      trustReturnsValid = true)
   public Object max(Sequence<?> args) throws EvalException {
     return findExtreme(args, Starlark.ORDERING);
   }
@@ -625,6 +627,7 @@ class MethodLibrary {
                 "The default value to return in case the struct "
                     + "doesn't have an attribute of the given name.")
       },
+      trustReturnsValid = true,
       useStarlarkThread = true)
   public Object getattr(Object obj, String name, Object defaultValue, StarlarkThread thread)
       throws EvalException, InterruptedException {

--- a/src/main/java/net/starlark/java/eval/StarlarkList.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkList.java
@@ -538,7 +538,8 @@ public final class StarlarkList<E> extends AbstractList<E>
             },
             defaultValue = "-1",
             doc = "The index of the item.")
-      })
+      },
+      trustReturnsValid = true)
   public Object pop(Object i) throws EvalException {
     int arg = i == Starlark.NONE ? -1 : Starlark.toInt(i, "i");
     int index = EvalUtils.getSequenceIndex(arg, size);


### PR DESCRIPTION
When `@StarlarkMethod(trustReturnsValid = true)` is specified, the interpreter does not check the method returns a valid Starlark object (which is does by default unless return type is statically known to be valid).

Object validity check is quite expensive.

Speed up is 4% for this test:

```
def test():
  for i in range(10):
    print(i)
    d = {"a": range(10), "b": {}, "c": 4, "d": 5, "e": (), "f": True, "g": []}
    for _ in range(1000000):
      d.get("a")
      d.get("b")
      d.get("c")
      d.get("d")
      d.get("e")
      d.get("f")
      d.get("g")

test()
```

* First commit adds an annotation parameter and handling of this parameter
* Second commit annotates `net.starlark.java` builtins with this annotation