### PR TITLE
Fix link text

### DIFF
--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -148,8 +148,9 @@ src/my/app/tests/test.cc
   are from the <code>visibility</code> attribute of rules or from the
   <code>default_visibility</code> attribute of the <code>package</code>
   function; they do not generate or consume files. For more information, refer
-  to the appropriate section of the <a
-  href='be/functions.html#package_group'>Build Encyclopedia</a>.
+  to the <a
+  href='be/functions.html#package_group'><code>package_group</code> 
+  documentation</a>.
 </p>
 
 


### PR DESCRIPTION
I realize the link starts with be/ but from the user experience POV, that link doesn't refer into the build encyclopedia, at least not according to the TOC in the left-hand column.  If you don't want to accept this change, perhaps the TOC should be changed to reflect the file structure of the site?