### PR TITLE
Correct(?) package name

### DIFF
--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -178,7 +178,8 @@ src/my/app/tests/test.cc
 
 <p>
 
-  Each label has two parts, a package name (<code>my/app/main</code>)
+  Each label has two parts, a package name
+  (<code>@myrepo//my/app/main</code> or <code>//my/app/main</code>)
   and a target name (<code>app_binary</code>). Every label uniquely
   identifies a target. Labels sometimes appear in other forms; when
   the colon is omitted, the target name is assumed to be the same as


### PR DESCRIPTION
If  `@myrepo//` and `//` are not part of the package name, then the label has at least 3 parts, so I'm assuming my change is correct.  If not, please correct me.