### PR TITLE
Correct statement about command-line

### DIFF
--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -234,7 +234,7 @@ testdata/input.txt
 </pre>
 
 <p>
-  But from other packages, or from the command-line, these file
+  But from other packages, these file
   targets must always be referred to by their complete label, e.g.
   <code>//my/app:generate.cc</code>.
 </p>

--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -234,7 +234,7 @@ testdata/input.txt
 </pre>
 
 <p>
-  But from other packages, these file
+  From other packages, these file
   targets must always be referred to by their complete label, e.g.
   <code>//my/app:generate.cc</code>.
 </p>
@@ -994,4 +994,3 @@ data = glob(["testdata/**"])  # use this instead
       a directory as a label in an argument other than <code>data</code>, it
       will fail and you will get a (probably cryptic) error message.
    </p>
-


### PR DESCRIPTION
Since 

```
bazel build :hello-greet.cc
```
and
```
bazel build hello-greet.cc
```
both work for me, I assume the statement about what's allowed at the command line is wrong.