### PR TITLE
Clarify that a label names a target.

### DIFF
--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -349,8 +349,8 @@ testdata/input.txt
 
 <p>
   Although Bazel allows targets to be declared in the package at the build root
-  (e.g. <code>//:foo</code>), it is discouraged: it is better if every target
-  is associated with package having a descriptive name.
+  (e.g. <code>//:foo</code>), you are encouraged to leave that package empty:
+  it is better if every target is associated with package having a descriptive name.
 </p>
   
 <p>

--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -348,7 +348,8 @@ testdata/input.txt
 </p>
 
 <p>
-  Although Bazel allows a package at the build root (e.g. <code>//:foo</code>), this
+  Although Bazel allows a package at the build root (e.g.
+  one that defines a target <code>//:foo</code>), this
   is not advised and projects should attempt to use more descriptively named
   packages.
 </p>

--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -350,7 +350,7 @@ testdata/input.txt
 <p>
   Although Bazel allows targets to be declared in the package at the build root
   (e.g. <code>//:foo</code>), you are encouraged to leave that package empty:
-  it is better if every target is associated with package having a descriptive name.
+  it is better if every target is in a package having a descriptive name.
 </p>
   
 <p>

--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -348,11 +348,11 @@ testdata/input.txt
 </p>
 
 <p>
-  Although Bazel allows a package at the build root (e.g.
-  one that defines a target <code>//:foo</code>), this
-  is not advised and projects should attempt to use more descriptively named
-  packages.
+  Although Bazel allows targets to be declared in the package at the build root
+  (e.g. <code>//:foo</code>), it is discouraged: it is better if every target
+  is associated with package having a descriptive name.
 </p>
+  
 <p>
   Package names may not contain the substring <code>//</code>, nor
   end with a slash.

--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -348,9 +348,9 @@ testdata/input.txt
 </p>
 
 <p>
-  Although Bazel allows targets to be declared in the package at the build root
-  (e.g. <code>//:foo</code>), you are encouraged to leave that package empty:
-  it is better if every target is in a package having a descriptive name.
+  Although Bazel supports targets in the workspace's root package
+  (e.g. <code>//:foo</code>), it's best to leave that package empty 
+  so all meaningful packages have descriptive names.
 </p>
   
 <p>


### PR DESCRIPTION
The text as written implies `//:foo` names a package.