### PR TITLE
Be less aggressive in interpreting flags as response files

### DIFF
--- a/tools/cpp/osx_cc_wrapper.sh.tpl
+++ b/tools/cpp/osx_cc_wrapper.sh.tpl
@@ -51,14 +51,21 @@ function parse_option() {
 }
 
 # let parse the option list
+IGNORE_AT=false
 for i in "$@"; do
-    if [[ "$i" = @* ]]; then
-        while IFS= read -r opt
-        do
-            parse_option "$opt"
-        done < "${i:1}" || exit 1
-    else
+    if [[ "$i" = "-install_name" || "$i" = "-Xlinker" ]]; then
         parse_option "$i"
+        IGNORE_AT=true
+    else
+        if [[ ("$i" = @*) && ("$IGNORE_AT" = false) ]]; then
+            while IFS= read -r opt
+            do
+                parse_option "$opt"
+            done < "${i:1}" || exit 1
+        else
+            parse_option "$i"
+        fi
+        IGNORE_AT=false
     fi
 done
 


### PR DESCRIPTION
Both -Xlinker and -install_name will often receive flags starting with
`@`, specifically `@loader_path` or `@rpath`. Bazel 4.0 started
interpreting those as response files which broke our build.

This PR addresses this by hardcoding those flags. This is a pretty
ugly solution so I’m very open to better ideas. That said, there is
some precedence for doing that in
[rules-haskell](https://github.com/tweag/rules_haskell/blob/e8623a8c5ea502fbe6286d8ae5fb58f4915e92c5/haskell/private/cc_wrapper.py.tpl#L448).