### PR TITLE
Starlark: faster list iteration

### DIFF
--- a/src/main/java/net/starlark/java/eval/StarlarkList.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkList.java
@@ -20,7 +20,10 @@ import com.google.common.collect.Iterables;
 import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import javax.annotation.Nullable;
+
+import com.google.common.collect.Iterators;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;
@@ -312,6 +315,12 @@ public final class StarlarkList<E> extends AbstractList<E>
   @Override
   public int size() {
     return size;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Iterator<E> iterator() {
+    return (Iterator<E>) Iterators.forArray(elems, 0, size);
   }
 
   @Override

--- a/src/main/java/net/starlark/java/eval/Tuple.java
+++ b/src/main/java/net/starlark/java/eval/Tuple.java
@@ -16,6 +16,7 @@ package net.starlark.java.eval;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.ObjectArrays;
 import java.util.AbstractCollection;
 import java.util.AbstractList;
@@ -145,6 +146,11 @@ public final class Tuple extends AbstractList<Object>
   @Override
   public int size() {
     return elems.length;
+  }
+
+  @Override
+  public Iterator<Object> iterator() {
+    return Iterators.forArray(elems);
   }
 
   @Override


### PR DESCRIPTION
`AbstractList` iterator does unnecessary work like tracking `modCount`
which is never updated for `StarlarkList`.

About 10% for the benchmark:

```
def test():
    l = [1, 2, 3, 4, 5]
    for i in range(10):
        print(i)
        for j in range(5000000):
            for x in l:
                pass

test()
```