### PR TITLE
Implement getMessage for BulkTransferException

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BulkTransferException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/BulkTransferException.java
@@ -51,4 +51,13 @@ class BulkTransferException extends IOException {
     return e instanceof BulkTransferException
         && ((BulkTransferException) e).onlyCausedByCacheNotFoundException();
   }
+
+  @Override
+  public String getMessage() {
+    // If there is only one suppressed exception, displaying that in the message should be helpful.
+    if (super.getSuppressed().length == 1) {
+      return super.getSuppressed()[0].getMessage();
+    }
+    return String.format("%d errors during bulk transfer", super.getSuppressed().length);
+  }
 }


### PR DESCRIPTION
Before this change, BulkTransferExceptions would be reported like this:
```
  Executing genrule //:foo failed: Exec failed due to IOException: null
```
By implementing getMessage(), we get a more informative message, in the case
when there is only one suppressed exception:
```
  Executing genrule //:foo failed: Exec failed due to IOException:
    Output download failed: Expected digest '8a39d2abd3999ab73c34db2476849cddf303ce389b35826850f9a700589b4a90/262144'
    does not match received digest 'dae4d3dce1bb0a9414f61a65ee07622fa225ec01e6efe6df6e78f9ad5c58480d/327680'.
```
and in the case when there are multiple suppressed exceptions:
```
  Executing genrule //:foo failed: Exec failed due to IOException:
    2 errors during bulk transfer
```
This helps diagnosing issues like https://github.com/bazelbuild/bazel/issues/12927