### PR TITLE
remove signal unsafe code from signal handlers

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -355,7 +355,6 @@ static void EnterSandbox() {
 }
 
 static void ForwardSignal(int signum) {
-  PRINT_DEBUG("ForwardSignal(%d)", signum);
   kill(-global_child_pid, signum);
 }
 


### PR DESCRIPTION
Problem

Signal handlers must only call signal-safe code. In particular the
functions it calls must be reentrant or uninterruptible by a signal.

For more information see
https://www.freebsd.org/cgi/man.cgi?query=sigaction&sektion=2&apropos=0&manpath=FreeBSD+13.0
or
https://man7.org/linux/man-pages/man7/signal-safety.7.html

fprintf is not such a function but is called inside of ForwardSignal
(via PRINT_DEBUG)

Solution

Remove the call.