### PR TITLE
Change gceMachineType of highcpu platform from n1-highcpu-32 to e2-highcpu-32

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -238,7 +238,7 @@ REMOTE_PLATFORMS = ("rbe_ubuntu1604_java8", "rbe_ubuntu1804_java11")
             {PARENT_REMOTE_EXECUTION_PROPERTIES}
             properties: {
                 name: "gceMachineType"
-                value: "n1-highcpu-32"
+                value: "e2-highcpu-32"
             }
             """,
     )


### PR DESCRIPTION
Since the worker pools are migrated from n1 machines to e2.

Fixes `FAILED_PRECONDITION: there are no bots capable of executing the action, requested action properties: gceMachineType = n1-highcpu-32, OSFamily = Linux` errors in Bazel CI.