### PR TITLE
Add ZERO_AR_DATE to apple_env

### DIFF
--- a/tools/objc/libtool.sh
+++ b/tools/objc/libtool.sh
@@ -34,9 +34,6 @@ fi
 
 WRAPPER="${MY_LOCATION}/xcrunwrapper.sh"
 
-# Ensure 0 timestamping for hermetic results.
-export ZERO_AR_DATE=1
-
 if [ ! -f "${MY_LOCATION}"/libtool_check_unique ] ; then
     echo "libtool_check_unique not found. Please file an issue at github.com/bazelbuild/bazel"
 elif "${MY_LOCATION}"/libtool_check_unique "$@"; then

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -4559,6 +4559,10 @@ def _impl(ctx):
                         key = "APPLE_SDK_PLATFORM",
                         value = "%{apple_sdk_platform_value}",
                     ),
+                    env_entry(
+                        key = "ZERO_AR_DATE",
+                        value = "1",
+                    ),
                 ] + [env_entry(key = key, value = value) for key, value in ctx.attr.extra_env.items()],
             ),
         ],


### PR DESCRIPTION
This variable disables timestamps in archives and binary links in
Apple's toolchain. Previously this was set for archives but not the
links themselves.

Relevant logic in ld64: https://github.com/keith/ld64/blob/86955a06a7e8e0d18ab28e521aa1122bfecd05a9/src/ld/Options.cpp#L4420-L4422

Fixes the other half of https://github.com/bazelbuild/bazel/issues/10886