### PR TITLE
Add target label to spawn events log

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -127,6 +127,10 @@ public class SpawnLogContext implements ActionContext {
     }
     builder.setRemotable(Spawns.mayBeExecutedRemotely(spawn));
 
+    if (spawn.getResourceOwner().getOwner().getLabel() != null) {
+      builder.setOwnerLabel(spawn.getResourceOwner().getOwner().getLabel().getCanonicalForm());
+    }
+
     Platform execPlatform = PlatformUtils.getPlatformProto(spawn, remoteOptions);
     if (execPlatform != null) {
       builder.setPlatform(buildPlatform(execPlatform));

--- a/src/main/protobuf/spawn.proto
+++ b/src/main/protobuf/spawn.proto
@@ -123,4 +123,5 @@ message SpawnExec {
   // Its semantics varies greatly depending on the status field.
   // Dependable: if status is empty, exit_code is guaranteed to be zero.
   int32 exit_code = 15;
+  string owner_label = 16;
 }


### PR DESCRIPTION
Allows attribution of the action to a target for better metrics collection