### PR TITLE
Support contraint_values in select()s for alias rules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/Alias.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/Alias.java
@@ -89,10 +89,6 @@ public class Alias implements RuleConfiguredTargetFactory {
                   .allowedRuleClasses(ANY_RULE)
                   .mandatory())
           .canHaveAnyProvider()
-          // Aliases themselves do not need toolchains or an execution platform, so this is fine.
-          // The actual target will resolve platforms and toolchains with no issues regardless of
-          // this setting.
-          .useToolchainResolution(false)
           .build();
     }
 


### PR DESCRIPTION
Fixes #13047

Tested by running `bazel test //src/test/java/com/google/devtools/build/lib/...`