### PR TITLE
Add external_include_paths C++ feature

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariables.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CompileBuildVariables.java
@@ -65,6 +65,13 @@ public enum CompileBuildVariables {
    */
   SYSTEM_INCLUDE_PATHS("system_include_paths"),
   /**
+   * Variable for the collection of external include paths.
+   *
+   * @see CcCompilationContext#getExternalIncludeDirs().
+   */
+  EXTERNAL_INCLUDE_PATHS("external_include_paths"),
+
+  /**
    * Variable for the collection of framework include paths.
    *
    * @see CcCompilationContext#getFrameworkIncludeDirs().
@@ -313,6 +320,7 @@ public enum CompileBuildVariables {
         userCompileFlags,
         dotdFileExecPath,
         usePic,
+        ImmutableList.of(),
         ImmutableMap.of());
     return buildVariables.build();
   }
@@ -331,6 +339,7 @@ public enum CompileBuildVariables {
       Iterable<String> userCompileFlags,
       String dotdFileExecPath,
       boolean usePic,
+      ImmutableList<PathFragment> externalIncludeDirs,
       Map<String, String> additionalBuildVariables) {
     buildVariables.addStringSequenceVariable(
         USER_COMPILE_FLAGS.getVariableName(), userCompileFlags);
@@ -379,6 +388,10 @@ public enum CompileBuildVariables {
     if (usePic) {
       buildVariables.addStringVariable(PIC.getVariableName(), "");
     }
+
+    buildVariables.addStringSequenceVariable(
+        EXTERNAL_INCLUDE_PATHS.getVariableName(),
+        Iterables.transform(externalIncludeDirs, PathFragment::getSafePathString));
 
     buildVariables.addAllStringVariables(additionalBuildVariables);
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
@@ -245,6 +245,9 @@ public class CppRuleClasses {
   /** A string constant for the include_paths feature. */
   public static final String INCLUDE_PATHS = "include_paths";
 
+  /** A string constant for the external_include_paths feature. */
+  public static final String EXTERNAL_INCLUDE_PATHS = "external_include_paths";
+
   /** A string constant for the feature signalling static linking mode. */
   public static final String STATIC_LINKING_MODE = "static_linking_mode";
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/cc_toolchain_config.bzl
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/cc_toolchain_config.bzl
@@ -92,6 +92,7 @@ _FEATURE_NAMES = struct(
     fission_flags_for_lto_backend = "fission_flags_for_lto_backend",
     min_os_version_flag = "min_os_version_flag",
     include_directories = "include_directories",
+    external_include_paths = "external_include_paths",
     absolute_path_directories = "absolute_path_directories",
     from_package = "from_package",
     change_tool = "change_tool",
@@ -988,6 +989,22 @@ _include_directories_feature = feature(
     ],
 )
 
+_external_include_paths_feature = feature(
+    name = _FEATURE_NAMES.external_include_paths,
+    flag_sets = [
+        flag_set(
+            actions = [ACTION_NAMES.cpp_compile],
+            flag_groups = [
+                flag_group(
+                    flags = [
+                        "-isystem",
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
 _from_package_feature = feature(
     name = _FEATURE_NAMES.from_package,
     flag_sets = [
@@ -1260,6 +1277,7 @@ _feature_name_to_feature = {
     _FEATURE_NAMES.fission_flags_for_lto_backend: _fission_flags_for_lto_backend_feature,
     _FEATURE_NAMES.min_os_version_flag: _min_os_version_flag_feature,
     _FEATURE_NAMES.include_directories: _include_directories_feature,
+    _FEATURE_NAMES.external_include_paths: _external_include_paths_feature,
     _FEATURE_NAMES.from_package: _from_package_feature,
     _FEATURE_NAMES.absolute_path_directories: _absolute_path_directories_feature,
     _FEATURE_NAMES.change_tool: _change_tool_feature,

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -374,6 +374,8 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/rules/cpp",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
         "//src/test/java/com/google/devtools/build/lib/packages:testutil",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",
         "//third_party:junit4",
         "//third_party:truth",

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -669,6 +669,32 @@ def _impl(ctx):
         ],
     )
 
+    external_include_paths_feature = feature(
+        name = "external_include_paths",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-isystem", "%{external_include_paths}"],
+                        iterate_over = "external_include_paths",
+                        expand_if_available = "external_include_paths",
+                    ),
+                ],
+            ),
+        ],
+    )
+
     symbol_counts_feature = feature(
         name = "symbol_counts",
         flag_sets = [
@@ -1167,6 +1193,7 @@ def _impl(ctx):
             preprocessor_defines_feature,
             includes_feature,
             include_paths_feature,
+            external_include_paths_feature,
             fdo_instrument_feature,
             cs_fdo_instrument_feature,
             cs_fdo_optimize_feature,


### PR DESCRIPTION
Projects with strict warnings level experience issues when they depend on third party libraries with less-strict warnings: The compiler will emit warnings for external sources. See #12009 for more.

This change optionally silences those warnings, by changing -I flags to -isystem flags and by adding -isystem flags for each -iquote flag, in case of external dependencies, i.e: those targets that come from a non-main workspace.

The new behavior can be enabled by --features=external_include_paths, otherwise there's no functional change.

The default flag_group in unix_cc_toolchain_config will silence warnings coming from -I and -iquote dirs in case of GCC, and -I for Clang. Clang will still produce warnings for -iquote dirs, therefore the Clang specific --system-header-prefix is recommended instead.
