### PR TITLE
Also strip Swift symbols when --objc_enable_binary_stripping is passed

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
@@ -1567,7 +1567,7 @@ public class CompilationSupport {
         stripArgs = ImmutableList.of("-x");
         break;
       case DEFAULT:
-        stripArgs = ImmutableList.<String>of();
+        stripArgs = ImmutableList.of("-x", "-T");
         break;
       default:
         throw new IllegalArgumentException("Unsupported stripping type " + strippingType);


### PR DESCRIPTION
Resolves https://github.com/bazelbuild/bazel/issues/13122
