### PR TITLE
Set Platform on Action not just Command

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
@@ -117,7 +117,7 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
     MerkleTree merkleTree = MerkleTree.build(inputFiles, digestUtil);
     Action action =
         RemoteSpawnRunner.buildAction(
-            commandHash, merkleTree.getRootDigest(), timeout, acceptCached);
+            commandHash, merkleTree.getRootDigest(), platform, timeout, acceptCached);
     Digest actionDigest = digestUtil.compute(action);
     ActionKey actionKey = new ActionKey(actionDigest);
     ActionResult actionResult;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -148,7 +148,7 @@ final class RemoteSpawnCache implements SpawnCache {
     RemoteOutputsMode remoteOutputsMode = options.remoteOutputsMode;
     Action action =
         RemoteSpawnRunner.buildAction(
-            digestUtil.compute(command), merkleTreeRoot, context.getTimeout(), true);
+            digestUtil.compute(command), merkleTreeRoot, platform, context.getTimeout(), true);
     // Look up action cache, and reuse the action output if it is found.
     ActionKey actionKey = digestUtil.computeActionKey(action);
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -242,7 +242,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
     Digest commandHash = digestUtil.compute(command);
     Action action =
         buildAction(
-            commandHash, merkleTree.getRootDigest(), context.getTimeout(), spawnCacheableRemotely);
+            commandHash, merkleTree.getRootDigest(), platform, context.getTimeout(), spawnCacheableRemotely);
 
     spawnMetrics.setParseTime(totalTime.elapsed());
 
@@ -695,7 +695,7 @@ public class RemoteSpawnRunner implements SpawnRunner {
         .build();
   }
 
-  static Action buildAction(Digest command, Digest inputRoot, Duration timeout, boolean cacheable) {
+  static Action buildAction(Digest command, Digest inputRoot, @Nullable Platform platform, Duration timeout, boolean cacheable) {
 
     Action.Builder action = Action.newBuilder();
     action.setCommandDigest(command);
@@ -705,6 +705,9 @@ public class RemoteSpawnRunner implements SpawnRunner {
     }
     if (!cacheable) {
       action.setDoNotCache(true);
+    }
+    if (platform != null) {
+      action.setPlatform(platform);
     }
     return action.build();
   }


### PR DESCRIPTION
https://github.com/bazelbuild/remote-apis/pull/167 promoted the field,
but left the old one present for legacy fallback for remote execution
platforms which haven't updated yet.

This PR sets both.