### PR TITLE
osx_cc_wrapper: Only expand existing response files

### DIFF
--- a/tools/cpp/osx_cc_wrapper.sh
+++ b/tools/cpp/osx_cc_wrapper.sh
@@ -53,7 +53,7 @@ function parse_option() {
 
 # let parse the option list
 for i in "$@"; do
-    if [[ "$i" = @* && "${i:1}" ]]; then
+    if [[ "$i" = @* && -r "${i:1}" ]]; then
         while IFS= read -r opt
         do
             parse_option "$opt"

--- a/tools/cpp/osx_cc_wrapper.sh
+++ b/tools/cpp/osx_cc_wrapper.sh
@@ -53,7 +53,7 @@ function parse_option() {
 
 # let parse the option list
 for i in "$@"; do
-    if [[ "$i" = @* ]]; then
+    if [[ "$i" = @* && "${i:1}" ]]; then
         while IFS= read -r opt
         do
             parse_option "$opt"

--- a/tools/cpp/osx_cc_wrapper.sh.tpl
+++ b/tools/cpp/osx_cc_wrapper.sh.tpl
@@ -52,7 +52,7 @@ function parse_option() {
 
 # let parse the option list
 for i in "$@"; do
-    if [[ "$i" = @* ]]; then
+    if [[ "$i" = @* && -r "${i:1}" ]]; then
         while IFS= read -r opt
         do
             parse_option "$opt"


### PR DESCRIPTION
Closes #13044 
Applies the changes suggested in https://github.com/bazelbuild/bazel/pull/13044#issuecomment-783539568

Not all arguments starting with `@` represent response files, e.g. `-install_name @rpath/...` or `-Xlinker -rpath -Xlinker @loader_path/...` do not refer to response files and attempting to read them as such will fail the build.

Users don't always have control over these arguments, meaning transforming them to `-Wl,-install_name,@rpath/...` or `-Wl,-rpath,@loader_path/...` is not always an option. E.g. as described in https://github.com/bazelbuild/bazel/pull/13044#issuecomment-779380394 where these flags are emitted by the Haskell compiler GHC (see https://github.com/bazelbuild/bazel/pull/13044#issuecomment-782228172 for their reasoning).

With this change `osx_cc_wrapper` will only interpret arguments starting with `@` as response files if the corresponding file exists and is readable. This is analogous to the behavior defined in `wrapped_clang.cc`. See https://github.com/bazelbuild/bazel/pull/13044#issuecomment-783539568 for discussion.