### PR TITLE
Allow .S files in C++ Starlark cc_common.compile.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -1979,8 +1979,14 @@ public abstract class CcModule
     validateExtensions(
         "srcs",
         sources,
-        CppFileTypes.ALL_C_CLASS_SOURCE.including(CppFileTypes.ASSEMBLER),
-        FileTypeSet.of(CppFileTypes.CPP_SOURCE, CppFileTypes.C_SOURCE, CppFileTypes.ASSEMBLER));
+        CppFileTypes.ALL_C_CLASS_SOURCE.including(
+          CppFileTypes.ASSEMBLER_WITH_C_PREPROCESSOR,
+          CppFileTypes.ASSEMBLER),
+        FileTypeSet.of(
+          CppFileTypes.CPP_SOURCE,
+          CppFileTypes.C_SOURCE,
+          CppFileTypes.ASSEMBLER_WITH_C_PREPROCESSOR,
+          CppFileTypes.ASSEMBLER));
     validateExtensions(
         "public_hdrs",
         publicHeaders,


### PR DESCRIPTION
.S files are (typically handwritten) assembly files that require
preprocessing, compared to their lower-capital .s counterparts that can
be compiled directly into object files.

Native cc_library rules already allow .S files in srcs [1]. However, the
Starlark cc_common.compile srcs argument doesn't accept them. This
change adds .S files to the list of valid srcs for cc_common.compile.

This is required for building AOSP, as there are handwritten source files in
Android's libc with the .S extension [2] that will be compiled through
Starlark C++ rules, e.g. directly into .o files.

[1] https://cs.opensource.google/bazel/bazel/+/master:src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java;l=280;drc=35de1e352459729f95d552b6ae5af9ce7d00a943
[2] https://cs.android.com/search?q=f:%5C.S$&sq=