### PR TITLE
Use a dummy toolchain context for rules that don't have one.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
@@ -76,6 +76,7 @@ import com.google.devtools.build.lib.packages.semantics.BuildLanguageOptions;
 import com.google.devtools.build.lib.shell.ShellUtils;
 import com.google.devtools.build.lib.shell.ShellUtils.TokenizationException;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkRuleContextApi;
+import com.google.devtools.build.lib.starlarkbuildapi.platform.ToolchainContextApi;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -701,9 +702,24 @@ public final class StarlarkRuleContext implements StarlarkRuleContextApi<Constra
   }
 
   @Override
-  public ResolvedToolchainContext toolchains() throws EvalException {
+  public ToolchainContextApi toolchains() throws EvalException {
     checkMutable("toolchains");
-    return ruleContext.getToolchainContext();
+    ResolvedToolchainContext toolchainContext = ruleContext.getToolchainContext();
+    if (toolchainContext == null) {
+      // Starlark rules are easier if this cannot be null, so return a no-op value instead.
+      return new ToolchainContextApi() {
+        @Override
+        public Object getIndex(StarlarkSemantics semantics, Object key) throws EvalException {
+          return Starlark.NONE;
+        }
+
+        @Override
+        public boolean containsKey(StarlarkSemantics semantics, Object key) throws EvalException {
+          return false;
+        }
+      };
+    }
+    return toolchainContext;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java
@@ -709,12 +709,12 @@ public final class StarlarkRuleContext implements StarlarkRuleContextApi<Constra
       // Starlark rules are easier if this cannot be null, so return a no-op value instead.
       return new ToolchainContextApi() {
         @Override
-        public Object getIndex(StarlarkSemantics semantics, Object key) throws EvalException {
+        public Object getIndex(StarlarkSemantics semantics, Object key) {
           return Starlark.NONE;
         }
 
         @Override
-        public boolean containsKey(StarlarkSemantics semantics, Object key) throws EvalException {
+        public boolean containsKey(StarlarkSemantics semantics, Object key) {
           return false;
         }
       };

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
@@ -3123,4 +3123,28 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
     Object result = ev.eval("ruleContext.build_file_path");
     assertThat(result).isEqualTo("bar/BUILD");
   }
+
+  @Test
+  public void testNoToolchainContext() throws Exception {
+    scratch.file(
+        "test/BUILD",
+        "load(':rule.bzl', 'sample_setting')",
+        "toolchain_type(name = 'toolchain_type')",
+        "sample_setting(",
+        "    name = 'test',",
+        "    build_setting_default = True,",
+        ")");
+    scratch.file(
+        "test/rule.bzl",
+        "def _sample_impl(ctx):",
+        "    info = ctx.toolchains['//:toolchain_type']",
+        "    if info:",
+        "        fail('Toolchain should be empty')",
+        "sample_setting = rule(",
+        "    implementation = _sample_impl,",
+        "    build_setting = config.bool(flag = True),",
+        ")");
+    getConfiguredTarget("//test:test");
+    assertNoEvents();
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
@@ -3138,7 +3138,7 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
         "test/rule.bzl",
         "def _sample_impl(ctx):",
         "    info = ctx.toolchains['//:toolchain_type']",
-        "    if info:",
+        "    if info != None:",
         "        fail('Toolchain should be empty')",
         "sample_setting = rule(",
         "    implementation = _sample_impl,",

--- a/src/test/shell/bazel/toolchain_test.sh
+++ b/src/test/shell/bazel/toolchain_test.sh
@@ -2034,35 +2034,6 @@ EOF
   expect_not_log "does not provide ToolchainTypeInfo"
 }
 
-function test_toolchain_from_no_toolchain_rule() {
-  # Create a build_setting that tries to load a toolchain.
-  # build_settings cnanot actually have toolchains because they
-  # are part of the configuration.
-  mkdir -p demo
-  cat >> demo/BUILD <<EOF
-load(":rule.bzl", "sample_setting")
-
-toolchain_type(name = "toolchain_type")
-sample_setting(
-    name = "demo",
-    build_setting_default = True,
-)
-EOF
-  cat >> demo/rule.bzl <<EOF
-def _sample_impl(ctx):
-    info = ctx.toolchains["//:toolchain_type"]
-    if info:
-        fail("Toolchain should be empty")
-
-sample_setting = rule(
-    implementation = _sample_impl,
-    build_setting = config.bool(flag = True),
-)
-EOF
-
-  bazel build //demo &> $TEST_log || fail "Build should succeed"
-}
-
 # TODO(katre): Test using toolchain-provided make variables from a genrule.
 
 run_suite "toolchain tests"

--- a/src/test/shell/bazel/toolchain_test.sh
+++ b/src/test/shell/bazel/toolchain_test.sh
@@ -2034,6 +2034,35 @@ EOF
   expect_not_log "does not provide ToolchainTypeInfo"
 }
 
+function test_toolchain_from_no_toolchain_rule() {
+  # Create a build_setting that tries to load a toolchain.
+  # build_settings cnanot actually have toolchains because they
+  # are part of the configuration.
+  mkdir -p demo
+  cat >> demo/BUILD <<EOF
+load(":rule.bzl", "sample_setting")
+
+toolchain_type(name = "toolchain_type")
+sample_setting(
+    name = "demo",
+    build_setting_default = True,
+)
+EOF
+  cat >> demo/rule.bzl <<EOF
+def _sample_impl(ctx):
+    info = ctx.toolchains["//:toolchain_type"]
+    if info:
+        fail("Toolchain should be empty")
+
+sample_setting = rule(
+    implementation = _sample_impl,
+    build_setting = config.bool(flag = True),
+)
+EOF
+
+  bazel build //demo &> $TEST_log || fail "Build should succeed"
+}
+
 # TODO(katre): Test using toolchain-provided make variables from a genrule.
 
 run_suite "toolchain tests"


### PR DESCRIPTION
Fixes #12610.