### PR TITLE
Silence swiftmodule timestamp warnings

### DIFF
--- a/tools/osx/crosstool/wrapped_clang.cc
+++ b/tools/osx/crosstool/wrapped_clang.cc
@@ -419,7 +419,8 @@ int main(int argc, char *argv[]) {
   RunSubProcess(invocation_args);
 
   std::vector<std::string> dsymutil_args = {
-      "/usr/bin/xcrun", "dsymutil", linked_binary, "-o", dsym_path, "--flat"};
+      "/usr/bin/xcrun", "dsymutil", linked_binary, "-o", dsym_path, "--flat",
+      "--no-swiftmodule-timestamp"};
   ExecProcess(dsymutil_args);
   std::cerr << "ExecProcess should not return. Please fix!\n";
   abort();


### PR DESCRIPTION
As part of https://github.com/bazelbuild/bazel/pull/13091 dsymtuil started producing these warnings:

```
warning: Timestamp mismatch for bazel-out/ios-x86_64-min11.0-applebin_ios-ios_x86_64-fastbuild-ST-7786d55448f4/bin/Modules/DependencyInjection/DependencyInjection.swiftmodule: 2021-03-05 13:54:33.542331246 and 1969-12-31 16:00:00.000000000
```

In general we're happily ignoring this to get hermetic outputs instead (it's being compared against the file modification timestamp)

This change disables this warning.

It appears this feature has been around for at least 3 years https://github.com/apple/llvm-project/commit/2dd9848304c94b91399ad56189aa373fa9aebde6 so we should be good for all the versions of Xcode we support.

Relevant logic: https://github.com/apple/llvm-project/blob/902bb11a46eb82e81d7e8b34450481e143a208b2/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp#L407-L421