### PR TITLE
Cleanup: Replace NULL with nullptr

### DIFF
--- a/examples/windows/dll/hello_world-load-dll-at-runtime.cpp
+++ b/examples/windows/dll/hello_world-load-dll-at-runtime.cpp
@@ -12,11 +12,11 @@ int main() {
 
   hellolib = LoadLibrary(TEXT("hellolib.dll"));
 
-  if (hellolib != NULL) {
+  if (hellolib != nullptr) {
     get_time = (GET_TIME_PTR)GetProcAddress(hellolib, "get_time");
     say_hello = (SAY_HELLO_PTR)GetProcAddress(hellolib, "say_hello");
 
-    if (NULL != get_time && NULL != say_hello) {
+    if (nullptr != get_time && nullptr != say_hello) {
       success = TRUE;
       char *now = get_time();
       say_hello(now);

--- a/src/main/cpp/archive_utils.cc
+++ b/src/main/cpp/archive_utils.cc
@@ -37,7 +37,7 @@ struct PartialZipExtractor : public devtools_ijar::ZipExtractorProcessor {
 
   // Scan the zip file "archive_path" until a file named "stop_entry" is seen,
   // then stop.
-  // If entry_names is not null, it receives a list of all file members
+  // If entry_names is not nullptr, it receives a list of all file members
   // up to and including "stop_entry".
   // If a callback is given, it is run with the name and contents of
   // each such member.

--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -738,7 +738,7 @@ static void WriteFileToStderrOrDie(const blaze_util::Path &path) {
   FILE *fp = fopen(path.AsNativePath().c_str(), "r");
 #endif
 
-  if (fp == NULL) {
+  if (fp == nullptr) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "opening " << path.AsPrintablePath()
         << " failed: " << GetLastErrorString();
@@ -1385,7 +1385,7 @@ static map<string, EnvVarValue> PrepareEnvironmentForJvm() {
   // environment variables to modify the current process, we may actually use
   // such map to configure a process from scratch (via interfaces like execvpe
   // or posix_spawn), so we need to inherit any untouched variables.
-  for (char **entry = environ; *entry != NULL; entry++) {
+  for (char **entry = environ; *entry != nullptr; entry++) {
     const std::string var_value = *entry;
     std::string::size_type equals = var_value.find('=');
     if (equals == std::string::npos) {
@@ -2089,7 +2089,7 @@ unsigned int BlazeServer::Communicate(
 
     // Execute the requested program, but before doing so, flush everything
     // we still have to say.
-    fflush(NULL);
+    fflush(nullptr);
     ExecuteRunRequest(blaze_util::Path(request.argv(0)), argv);
   }
 

--- a/src/main/cpp/blaze_util.cc
+++ b/src/main/cpp/blaze_util.cc
@@ -48,12 +48,12 @@ const char* GetUnaryOption(const char *arg,
                            const char *next_arg,
                            const char *key) {
   const char *value = blaze_util::var_strprefix(arg, key);
-  if (value == NULL) {
-    return NULL;
+  if (value == nullptr) {
+    return nullptr;
   } else if (value[0] == '=') {
     return value + 1;
   } else if (value[0]) {
-    return NULL;  // trailing garbage in key name
+    return nullptr;  // trailing garbage in key name
   }
 
   return next_arg;
@@ -61,7 +61,7 @@ const char* GetUnaryOption(const char *arg,
 
 bool GetNullaryOption(const char *arg, const char *key) {
   const char *value = blaze_util::var_strprefix(arg, key);
-  if (value == NULL) {
+  if (value == nullptr) {
     return false;
   } else if (value[0] == '=') {
     BAZEL_DIE(blaze_exit_code::BAD_ARGV)
@@ -77,7 +77,7 @@ bool GetNullaryOption(const char *arg, const char *key) {
 const char* SearchUnaryOption(const vector<string>& args,
                               const char *key, bool warn_if_dupe) {
   if (args.empty()) {
-    return NULL;
+    return nullptr;
   }
 
   const char* value = nullptr;
@@ -101,7 +101,7 @@ const char* SearchUnaryOption(const vector<string>& args,
     const char* result = GetUnaryOption(args[i].c_str(),
                                         args[i + 1].c_str(),
                                         key);
-    if (result != NULL) {
+    if (result != nullptr) {
       // 'key' was found and 'result' has its value.
       if (value) {
         // 'key' was found once before, because 'value' is not empty.
@@ -121,7 +121,7 @@ const char* SearchUnaryOption(const vector<string>& args,
       if (!found_dupe) {
         // We did not find a duplicate in the first N-1 arguments. Examine the
         // last argument, it may be a duplicate.
-        found_dupe = (GetUnaryOption(args[i].c_str(), NULL, key) != nullptr);
+        found_dupe = (GetUnaryOption(args[i].c_str(), nullptr, key) != nullptr);
       }
       if (found_dupe) {
         BAZEL_LOG(WARNING) << key << " is given more than once, "
@@ -133,7 +133,7 @@ const char* SearchUnaryOption(const vector<string>& args,
     // 'value' is empty, so 'key' was not yet found in the first N-1 arguments.
     // If 'key' is in the last argument, we'll parse and return the value from
     // that, and if it isn't, we'll return NULL.
-    return GetUnaryOption(args[i].c_str(), NULL, key);
+    return GetUnaryOption(args[i].c_str(), nullptr, key);
   }
 }
 

--- a/src/main/cpp/blaze_util.h
+++ b/src/main/cpp/blaze_util.h
@@ -49,7 +49,7 @@ bool GetNullaryOption(const char *arg, const char *key);
 // When 'warn_if_dupe' is true, the method checks if 'key' is specified more
 // than once and prints a warning if so.
 // Returns the value of the 'key' flag iff it occurs in args.
-// Returns NULL otherwise.
+// Returns nullptr otherwise.
 const char* SearchUnaryOption(const std::vector<std::string>& args,
                               const char* key, bool warn_if_dupe);
 

--- a/src/main/cpp/blaze_util_bsd.cc
+++ b/src/main/cpp/blaze_util_bsd.cc
@@ -63,10 +63,10 @@ using std::string;
 string GetOutputRoot() {
   char buf[2048];
   struct passwd pwbuf;
-  struct passwd *pw = NULL;
+  struct passwd *pw = nullptr;
   int uid = getuid();
   int r = getpwuid_r(uid, &pwbuf, buf, 2048, &pw);
-  if (r != -1 && pw != NULL) {
+  if (r != -1 && pw != nullptr) {
     return blaze_util::JoinPath(pw->pw_dir, ".cache/bazel");
   } else {
     return "/tmp";

--- a/src/main/cpp/blaze_util_darwin.cc
+++ b/src/main/cpp/blaze_util_darwin.cc
@@ -49,7 +49,7 @@ using std::string;
 using std::vector;
 
 // A stack based class for RAII type handling of CF based types that need
-// CFRelease called on them. Checks for NULL before calling release.
+// CFRelease called on them. Checks for nullptr before calling release.
 template <typename T> class CFScopedReleaser {
  public:
   explicit CFScopedReleaser(T value) : value_(value) { }
@@ -60,7 +60,7 @@ template <typename T> class CFScopedReleaser {
   }
   T get() { return value_; }
   operator T() { return value_; }
-  bool isValid() { return value_ != NULL; }
+  bool isValid() { return value_ != nullptr; }
 
  private:
   T value_;
@@ -105,8 +105,8 @@ void WarnFilesystemType(const blaze_util::Path &output_base) {
       kCFAllocatorDefault,
       reinterpret_cast<const UInt8 *>(output_base.AsNativePath().c_str()),
       output_base.AsNativePath().length(), true));
-  CFBooleanRef cf_local = NULL;
-  CFErrorRef cf_error = NULL;
+  CFBooleanRef cf_local = nullptr;
+  CFErrorRef cf_error = nullptr;
   if (!cf_url.isValid() ||
       !CFURLCopyResourcePropertyForKey(cf_url, kCFURLVolumeIsLocalKey,
                                        &cf_local, &cf_error)) {
@@ -136,7 +136,7 @@ string GetSelfPath(const char* argv0) {
 
 uint64_t GetMillisecondsMonotonic() {
   struct timeval ts = {};
-  if (gettimeofday(&ts, NULL) < 0) {
+  if (gettimeofday(&ts, nullptr) < 0) {
     BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
         << "error calling gettimeofday: " << GetLastErrorString();
   }
@@ -178,14 +178,14 @@ string GetSystemJavabase() {
 
   // java_home will print a warning if no JDK could be found
   FILE *output = popen("/usr/libexec/java_home -v 1.8+ 2> /dev/null", "r");
-  if (output == NULL) {
+  if (output == nullptr) {
     return "";
   }
 
   char buf[512];
   char *result = fgets(buf, sizeof(buf), output);
   pclose(output);
-  if (result == NULL) {
+  if (result == nullptr) {
     return "";
   }
 
@@ -225,7 +225,7 @@ void ExcludePathFromBackup(const blaze_util::Path &path) {
                        << "' from backups";
     return;
   }
-  CFErrorRef cf_error = NULL;
+  CFErrorRef cf_error = nullptr;
   if (!CFURLSetResourcePropertyForKey(cf_url, kCFURLIsExcludedFromBackupKey,
                                       kCFBooleanTrue, &cf_error)) {
     CFScopedReleaser<CFErrorRef> cf_error_releaser(cf_error);

--- a/src/main/cpp/blaze_util_linux.cc
+++ b/src/main/cpp/blaze_util_linux.cc
@@ -51,10 +51,10 @@ string GetOutputRoot() {
   } else {
     char buf[2048];
     struct passwd pwbuf;
-    struct passwd *pw = NULL;
+    struct passwd *pw = nullptr;
     int uid = getuid();
     int r = getpwuid_r(uid, &pwbuf, buf, 2048, &pw);
-    if (r != -1 && pw != NULL) {
+    if (r != -1 && pw != nullptr) {
       base = pw->pw_dir;
     }
   }
@@ -152,7 +152,7 @@ string GetSystemJavabase() {
 
   // Resolve all symlinks.
   char resolved_path[PATH_MAX];
-  if (realpath(javac_dir.c_str(), resolved_path) == NULL) {
+  if (realpath(javac_dir.c_str(), resolved_path) == nullptr) {
     return "";
   }
   javac_dir = resolved_path;

--- a/src/main/cpp/blaze_util_posix.cc
+++ b/src/main/cpp/blaze_util_posix.cc
@@ -190,7 +190,7 @@ void SignalHandler::Install(const string& product_name,
   // Unblock all signals.
   sigset_t sigset;
   sigemptyset(&sigset);
-  sigprocmask(SIG_SETMASK, &sigset, NULL);
+  sigprocmask(SIG_SETMASK, &sigset, nullptr);
 
   signal(SIGINT, handler);
   signal(SIGTERM, handler);
@@ -255,7 +255,7 @@ class CharPP {
     for (; i < args.size(); i++) {
       charpp_[i] = strdup(args[i].c_str());
     }
-    charpp_[i] = NULL;
+    charpp_[i] = nullptr;
   }
 
   // Constructs a new CharPP from a list of environment variables.
@@ -279,12 +279,12 @@ class CharPP {
           assert(false);
       }
     }
-    charpp_[i] = NULL;
+    charpp_[i] = nullptr;
   }
 
   // Deletes all memory held by the CharPP.
   ~CharPP() {
-    for (char** ptr = charpp_; *ptr != NULL; ptr++) {
+    for (char** ptr = charpp_; *ptr != nullptr; ptr++) {
       free(*ptr);
     }
     free(charpp_);
@@ -532,13 +532,13 @@ void CreateSecureOutputRoot(const blaze_util::Path& path) {
 
 string GetEnv(const string& name) {
   char* result = getenv(name.c_str());
-  return result != NULL ? string(result) : "";
+  return result != nullptr ? string(result) : "";
 }
 
 string GetPathEnv(const string& name) { return GetEnv(name); }
 
 bool ExistsEnv(const string& name) {
-  return getenv(name.c_str()) != NULL;
+  return getenv(name.c_str()) != nullptr;
 }
 
 void SetEnv(const string& name, const string& value) {
@@ -558,8 +558,8 @@ void SetupStdStreams() {
   // output (when for example a query returns results as proto), in which case
   // we must not perform line buffering on the client side. So turn off
   // buffering here completely.
-  setvbuf(stdout, NULL, _IONBF, 0);
-  setvbuf(stderr, NULL, _IONBF, 0);
+  setvbuf(stdout, nullptr, _IONBF, 0);
+  setvbuf(stderr, nullptr, _IONBF, 0);
 
   // Ensure we have three open fds.  Otherwise we can end up with
   // bizarre things like stdout going to the lock file, etc.
@@ -736,7 +736,7 @@ void TrySleep(unsigned int milliseconds) {
   time_t seconds_part = (time_t)(milliseconds / 1000);
   long nanoseconds_part = ((long)(milliseconds % 1000)) * 1000 * 1000;
   struct timespec sleeptime = {seconds_part, nanoseconds_part};
-  nanosleep(&sleeptime, NULL);
+  nanosleep(&sleeptime, nullptr);
 }
 
 string GetUserName() {
@@ -746,7 +746,7 @@ string GetUserName() {
   }
   errno = 0;
   passwd *pwent = getpwuid(getuid());  // NOLINT (single-threaded)
-  if (pwent == NULL || pwent->pw_name == NULL) {
+  if (pwent == nullptr || pwent->pw_name == nullptr) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
         << "$USER is not set, and unable to look up name of current user: "
         << GetLastErrorString();

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -89,7 +89,7 @@ class WindowsDumper : public Dumper {
   bool Finish(string* error) override;
 
  private:
-  WindowsDumper() : threadpool_(NULL), cleanup_group_(NULL) {}
+  WindowsDumper() : threadpool_(nullptr), cleanup_group_(nullptr) {}
 
   PTP_POOL threadpool_;
   PTP_CLEANUP_GROUP cleanup_group_;
@@ -135,8 +135,8 @@ Dumper* Create(string* error) { return WindowsDumper::Create(error); }
 WindowsDumper* WindowsDumper::Create(string* error) {
   unique_ptr<WindowsDumper> result(new WindowsDumper());
 
-  result->threadpool_ = CreateThreadpool(NULL);
-  if (result->threadpool_ == NULL) {
+  result->threadpool_ = CreateThreadpool(nullptr);
+  if (result->threadpool_ == nullptr) {
     if (error) {
       string msg = GetLastErrorString();
       *error = "CreateThreadpool failed: " + msg;
@@ -145,7 +145,7 @@ WindowsDumper* WindowsDumper::Create(string* error) {
   }
 
   result->cleanup_group_ = CreateThreadpoolCleanupGroup();
-  if (result->cleanup_group_ == NULL) {
+  if (result->cleanup_group_ == nullptr) {
     string msg = GetLastErrorString();
     CloseThreadpool(result->threadpool_);
     if (error) {
@@ -164,7 +164,7 @@ WindowsDumper* WindowsDumper::Create(string* error) {
   InitializeThreadpoolEnvironment(&result->threadpool_env_);
   SetThreadpoolCallbackPool(&result->threadpool_env_, result->threadpool_);
   SetThreadpoolCallbackCleanupGroup(&result->threadpool_env_,
-                                    result->cleanup_group_, NULL);
+                                    result->cleanup_group_, nullptr);
 
   return result.release();  // release pointer ownership
 }
@@ -184,7 +184,7 @@ void WindowsDumper::Dump(const void* data, const size_t size,
                                               &dir_cache_lock_, &dir_cache_,
                                               &error_lock_, &error_msg_));
   PTP_WORK w = CreateThreadpoolWork(WorkCallback, ctx.get(), &threadpool_env_);
-  if (w == NULL) {
+  if (w == nullptr) {
     string err = GetLastErrorString();
     err = string("WindowsDumper::Dump() couldn't submit work: ") + err;
 
@@ -197,14 +197,14 @@ void WindowsDumper::Dump(const void* data, const size_t size,
 }
 
 bool WindowsDumper::Finish(string* error) {
-  if (threadpool_ == NULL) {
+  if (threadpool_ == nullptr) {
     return true;
   }
-  CloseThreadpoolCleanupGroupMembers(cleanup_group_, FALSE, NULL);
+  CloseThreadpoolCleanupGroupMembers(cleanup_group_, FALSE, nullptr);
   CloseThreadpoolCleanupGroup(cleanup_group_);
   CloseThreadpool(threadpool_);
-  threadpool_ = NULL;
-  cleanup_group_ = NULL;
+  threadpool_ = nullptr;
+  cleanup_group_ = nullptr;
 
   std::lock_guard<std::mutex> g(error_lock_);
   if (!error_msg_.empty() && error) {
@@ -429,7 +429,7 @@ string GetHomeDir() {
   // is the same as %USERPROFILE%, but it does not require the envvar to be set.
   // On Windows 2016 Server, Nano server: FOLDERID_Profile is unknown but
   // %USERPROFILE% is set. See https://github.com/bazelbuild/bazel/issues/6701
-  if (SUCCEEDED(::SHGetKnownFolderPath(FOLDERID_Profile, KF_FLAG_DEFAULT, NULL,
+  if (SUCCEEDED(::SHGetKnownFolderPath(FOLDERID_Profile, KF_FLAG_DEFAULT, nullptr,
                                        &wpath))) {
     string result = blaze_util::WstringToCstring(wpath);
     ::CoTaskMemFree(wpath);
@@ -580,10 +580,10 @@ static HANDLE CreateJvmOutputFile(const blaze_util::Path& path,
         /* dwCreationDisposition */
         daemon_out_append ? OPEN_ALWAYS : CREATE_ALWAYS,
         /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
-        /* hTemplateFile */ NULL);
+        /* hTemplateFile */ nullptr);
     if (handle != INVALID_HANDLE_VALUE) {
       if (daemon_out_append
-          && !SetFilePointerEx(handle, {0}, NULL, FILE_END)) {
+          && !SetFilePointerEx(handle, {0}, nullptr, FILE_END)) {
         fprintf(stderr, "Could not seek to end of file (%s)\n",
                 path.AsPrintablePath().c_str());
         return INVALID_HANDLE_VALUE;
@@ -633,11 +633,11 @@ int ExecuteDaemon(const blaze_util::Path& exe,
                   const StartupOptions& options,
                   BlazeServerStartup** server_startup) {
   SECURITY_ATTRIBUTES inheritable_handle_sa = {sizeof(SECURITY_ATTRIBUTES),
-                                               NULL, TRUE};
+                                               nullptr, TRUE};
 
   AutoHandle devnull(::CreateFileW(
       L"NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
-      &inheritable_handle_sa, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL));
+      &inheritable_handle_sa, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
   if (!devnull.IsValid()) {
     std::string error = GetLastErrorString();
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)
@@ -705,15 +705,15 @@ int ExecuteDaemon(const blaze_util::Path& exe,
     WithEnvVars env_obj(env);
 
     ok = CreateProcessW(
-        /* lpApplicationName */ NULL,
+        /* lpApplicationName */ nullptr,
         /* lpCommandLine */ cmdline.cmdline,
-        /* lpProcessAttributes */ NULL,
-        /* lpThreadAttributes */ NULL,
+        /* lpProcessAttributes */ nullptr,
+        /* lpThreadAttributes */ nullptr,
         /* bInheritHandles */ TRUE,
         /* dwCreationFlags */ DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP |
             EXTENDED_STARTUPINFO_PRESENT,
-        /* lpEnvironment */ NULL,
-        /* lpCurrentDirectory */ NULL,
+        /* lpEnvironment */ nullptr,
+        /* lpCurrentDirectory */ nullptr,
         /* lpStartupInfo */ &startupInfoEx.StartupInfo,
         /* lpProcessInformation */ &processInfo);
   }
@@ -937,7 +937,7 @@ void CreateSecureOutputRoot(const blaze_util::Path& path) {
 }
 
 string GetEnv(const string& name) {
-  DWORD size = ::GetEnvironmentVariableA(name.c_str(), NULL, 0);
+  DWORD size = ::GetEnvironmentVariableA(name.c_str(), nullptr, 0);
   if (size == 0) {
     return string();  // unset or empty envvar
   }
@@ -966,7 +966,7 @@ string GetPathEnv(const string& name) {
 }
 
 bool ExistsEnv(const string& name) {
-  return ::GetEnvironmentVariableA(name.c_str(), NULL, 0) != 0;
+  return ::GetEnvironmentVariableA(name.c_str(), nullptr, 0) != 0;
 }
 
 void SetEnv(const string& name, const string& value) {
@@ -991,7 +991,7 @@ bool WarnIfStartedFromDesktop() {
       "Try opening a console, such as the Windows Command Prompt (cmd.exe) "
       "or PowerShell, and running \"bazel help\".\n\n"
       "Press Enter to close this window...");
-  ReadFile(GetStdHandle(STD_INPUT_HANDLE), dummy, 1, dummy, NULL);
+  ReadFile(GetStdHandle(STD_INPUT_HANDLE), dummy, 1, dummy, nullptr);
   return true;
 }
 
@@ -1015,13 +1015,13 @@ void SetupStdStreams() {
                                      STD_ERROR_HANDLE};
   for (int i = 0; i <= 2; ++i) {
     HANDLE handle = ::GetStdHandle(stdhandles[i]);
-    if (handle == INVALID_HANDLE_VALUE || handle == NULL) {
+    if (handle == INVALID_HANDLE_VALUE || handle == nullptr) {
       // Ensure we have open fds to each std* stream. Otherwise we can end up
       // with bizarre things like stdout going to the lock file, etc.
       _open("NUL", (i == 0) ? _O_RDONLY : _O_WRONLY);
     }
     DWORD mode = 0;
-    if (i > 0 && handle != INVALID_HANDLE_VALUE && handle != NULL &&
+    if (i > 0 && handle != INVALID_HANDLE_VALUE && handle != nullptr &&
         ::GetConsoleMode(handle, &mode)) {
       DWORD newmode = mode | ENABLE_PROCESSED_OUTPUT |
                       ENABLE_WRAP_AT_EOL_OUTPUT |
@@ -1096,10 +1096,10 @@ uint64_t AcquireLock(const blaze_util::Path& output_base, bool batch_mode,
         /* lpFileName */ lockfile.AsNativePath().c_str(),
         /* dwDesiredAccess */ GENERIC_READ | GENERIC_WRITE,
         /* dwShareMode */ FILE_SHARE_READ,
-        /* lpSecurityAttributes */ NULL,
+        /* lpSecurityAttributes */ nullptr,
         /* dwCreationDisposition */ CREATE_ALWAYS,
         /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
-        /* hTemplateFile */ NULL);
+        /* hTemplateFile */ nullptr);
     if (blaze_lock->handle != INVALID_HANDLE_VALUE) {
       // We could open the file, so noone else holds a lock on it.
       break;

--- a/src/main/cpp/option_processor.cc
+++ b/src/main/cpp/option_processor.cc
@@ -625,7 +625,7 @@ static void PreprocessEnvString(const string* env_str) {
 
 static std::vector<std::string> GetProcessedEnv() {
   std::vector<std::string> processed_env;
-  for (char** env = environ; *env != NULL; env++) {
+  for (char** env = environ; *env != nullptr; env++) {
     string env_str(*env);
     if (IsValidEnvName(*env)) {
       PreprocessEnvString(&env_str);

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -224,8 +224,8 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
   // options begin with "--" or "-". Values are given together with the option
   // delimited by '=' or in the next option.
   const char* arg = argstr.c_str();
-  const char* next_arg = next_argstr.empty() ? NULL : next_argstr.c_str();
-  const char* value = NULL;
+  const char* next_arg = next_argstr.empty() ? nullptr : next_argstr.c_str();
+  const char* value = nullptr;
 
   bool is_nullary;
   if (!MaybeCheckValidNullary(argstr, &is_nullary, error)) {
@@ -267,42 +267,42 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
     return blaze_exit_code::SUCCESS;
   }
 
-  if ((value = GetUnaryOption(arg, next_arg, "--output_base")) != NULL) {
+  if ((value = GetUnaryOption(arg, next_arg, "--output_base")) != nullptr) {
     output_base = blaze_util::Path(blaze::AbsolutePathFromFlag(value));
     option_sources["output_base"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg,
-                                     "--install_base")) != NULL) {
+                                     "--install_base")) != nullptr) {
     install_base = blaze::AbsolutePathFromFlag(value);
     option_sources["install_base"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg,
-                                     "--output_user_root")) != NULL) {
+                                     "--output_user_root")) != nullptr) {
     output_user_root = blaze::AbsolutePathFromFlag(value);
     option_sources["output_user_root"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg,
-                                     "--server_jvm_out")) != NULL) {
+                                     "--server_jvm_out")) != nullptr) {
     server_jvm_out = blaze_util::Path(blaze::AbsolutePathFromFlag(value));
     option_sources["server_jvm_out"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--failure_detail_out")) !=
-             NULL) {
+             nullptr) {
     failure_detail_out = blaze_util::Path(blaze::AbsolutePathFromFlag(value));
     option_sources["failure_detail_out"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--host_jvm_profile")) !=
-             NULL) {
+             nullptr) {
     host_jvm_profile = value;
     option_sources["host_jvm_profile"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--server_javabase")) !=
-             NULL) {
+             nullptr) {
     // TODO(bazel-team): Consider examining the javabase and re-execing in case
     // of architecture mismatch.
     explicit_server_javabase_ =
         blaze_util::Path(blaze::AbsolutePathFromFlag(value));
     option_sources["server_javabase"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--host_jvm_args")) !=
-             NULL) {
+             nullptr) {
     host_jvm_args.push_back(value);
     option_sources["host_jvm_args"] = rcfile;  // NB: This is incorrect
   } else if ((value = GetUnaryOption(arg, next_arg, "--io_nice_level")) !=
-             NULL) {
+             nullptr) {
     if (!blaze_util::safe_strto32(value, &io_nice_level) ||
         io_nice_level > 7) {
       blaze_util::StringPrintf(error,
@@ -312,7 +312,7 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
     }
     option_sources["io_nice_level"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--max_idle_secs")) !=
-             NULL) {
+             nullptr) {
     if (!blaze_util::safe_strto32(value, &max_idle_secs) ||
         max_idle_secs < 0) {
       blaze_util::StringPrintf(error,
@@ -321,7 +321,7 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
     }
     option_sources["max_idle_secs"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--macos_qos_class")) !=
-             NULL) {
+             nullptr) {
     // We parse the value of this flag on all platforms even if it is
     // macOS-specific to ensure that rc files mentioning it are valid.
     if (strcmp(value, "user-interactive") == 0) {
@@ -351,7 +351,7 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
     }
     option_sources["macos_qos_class"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg,
-                                     "--connect_timeout_secs")) != NULL) {
+                                     "--connect_timeout_secs")) != nullptr) {
     if (!blaze_util::safe_strto32(value, &connect_timeout_secs) ||
         connect_timeout_secs < 1 || connect_timeout_secs > 3600) {
       blaze_util::StringPrintf(
@@ -363,7 +363,7 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
     }
     option_sources["connect_timeout_secs"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg,
-                                     "--local_startup_timeout_secs")) != NULL) {
+                                     "--local_startup_timeout_secs")) != nullptr) {
     if (!blaze_util::safe_strto32(value, &local_startup_timeout_secs) ||
         local_startup_timeout_secs < 1) {
       blaze_util::StringPrintf(
@@ -375,16 +375,16 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
     }
     option_sources["local_startup_timeout_secs"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--digest_function")) !=
-             NULL) {
+             nullptr) {
     digest_function = value;
     option_sources["digest_function"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg,
                                      "--unix_digest_hash_attribute_name")) !=
-             NULL) {
+             nullptr) {
     unix_digest_hash_attribute_name = value;
     option_sources["unix_digest_hash_attribute_name"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--command_port")) !=
-             NULL) {
+             nullptr) {
     if (!blaze_util::safe_strto32(value, &command_port) ||
         command_port < 0 || command_port > 65535) {
       blaze_util::StringPrintf(error,
@@ -395,7 +395,7 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
     }
     option_sources["command_port"] = rcfile;
   } else if ((value = GetUnaryOption(arg, next_arg, "--invocation_policy")) !=
-             NULL) {
+             nullptr) {
     if (!have_invocation_policy_) {
       have_invocation_policy_ = true;
       invocation_policy = value;
@@ -422,7 +422,7 @@ blaze_exit_code::ExitCode StartupOptions::ProcessArg(
     }
   }
 
-  *is_space_separated = ((value == next_arg) && (value != NULL));
+  *is_space_separated = ((value == next_arg) && (value != nullptr));
   return blaze_exit_code::SUCCESS;
 }
 

--- a/src/main/cpp/util/errors_windows.cc
+++ b/src/main/cpp/util/errors_windows.cc
@@ -37,8 +37,8 @@ string GetLastErrorString() {
   size_t size = FormatMessageA(
       FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
           FORMAT_MESSAGE_IGNORE_INSERTS,
-      NULL, last_error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-      (LPSTR)&message_buffer, 0, NULL);
+      nullptr, last_error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      (LPSTR)&message_buffer, 0, nullptr);
 
   stringstream result;
   result << "(error: " << last_error << "): " << message_buffer;

--- a/src/main/cpp/util/file_posix.cc
+++ b/src/main/cpp/util/file_posix.cc
@@ -153,12 +153,12 @@ string CreateTempDir(const std::string &prefix) {
 
 static bool RemoveDirRecursively(const std::string &path) {
   DIR *dir;
-  if ((dir = opendir(path.c_str())) == NULL) {
+  if ((dir = opendir(path.c_str())) == nullptr) {
     return false;
   }
 
   struct dirent *ent;
-  while ((ent = readdir(dir)) != NULL) {
+  while ((ent = readdir(dir)) != nullptr) {
     if (!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, "..")) {
       continue;
     }
@@ -354,8 +354,8 @@ bool PathExists(const string& path) {
 bool PathExists(const Path &path) { return PathExists(path.AsNativePath()); }
 
 string MakeCanonical(const char *path) {
-  char *resolved_path = realpath(path, NULL);
-  if (resolved_path == NULL) {
+  char *resolved_path = realpath(path, nullptr);
+  if (resolved_path == nullptr) {
     return "";
   } else {
     string ret = resolved_path;
@@ -476,10 +476,10 @@ bool PosixFileMtime::Set(const Path &path, const struct utimbuf &mtime) {
 }
 
 time_t PosixFileMtime::GetNow() {
-  time_t result = time(NULL);
+  time_t result = time(nullptr);
   if (result == -1) {
     BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
-        << "time(NULL) failed: " << GetLastErrorString();
+        << "time(nullptr) failed: " << GetLastErrorString();
   }
   return result;
 }
@@ -506,7 +506,7 @@ bool MakeDirectories(const Path &path, unsigned int mode) {
 
 string GetCwd() {
   char cwdbuf[PATH_MAX];
-  if (getcwd(cwdbuf, sizeof cwdbuf) == NULL) {
+  if (getcwd(cwdbuf, sizeof cwdbuf) == nullptr) {
     BAZEL_DIE(blaze_exit_code::INTERNAL_ERROR)
         << "getcwd() failed: " << GetLastErrorString();
   }
@@ -522,12 +522,12 @@ void ForEachDirectoryEntry(const string &path,
   DIR *dir;
   struct dirent *ent;
 
-  if ((dir = opendir(path.c_str())) == NULL) {
+  if ((dir = opendir(path.c_str())) == nullptr) {
     // This is not a directory or it cannot be opened.
     return;
   }
 
-  while ((ent = readdir(dir)) != NULL) {
+  while ((ent = readdir(dir)) != nullptr) {
     if (!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, "..")) {
       continue;
     }

--- a/src/main/cpp/util/file_windows.cc
+++ b/src/main/cpp/util/file_windows.cc
@@ -77,12 +77,12 @@ class WindowsPipe : public IPipe {
   bool Send(const void* buffer, int size) override {
     DWORD actually_written = 0;
     return ::WriteFile(_write_handle, buffer, size, &actually_written,
-                       NULL) == TRUE;
+                       nullptr) == TRUE;
   }
 
   int Receive(void* buffer, int size, int* error) override {
     DWORD actually_read = 0;
-    BOOL result = ::ReadFile(_read_handle, buffer, size, &actually_read, NULL);
+    BOOL result = ::ReadFile(_read_handle, buffer, size, &actually_read, nullptr);
     if (error != nullptr) {
       // TODO(laszlocsomor): handle the error mode that is errno=EINTR on Linux.
       *error = result ? IPipe::SUCCESS : IPipe::OTHER_ERROR;
@@ -97,7 +97,7 @@ class WindowsPipe : public IPipe {
 
 IPipe* CreatePipe() {
   // The pipe HANDLEs can be inherited.
-  SECURITY_ATTRIBUTES sa = {sizeof(SECURITY_ATTRIBUTES), NULL, TRUE};
+  SECURITY_ATTRIBUTES sa = {sizeof(SECURITY_ATTRIBUTES), nullptr, TRUE};
   HANDLE read_handle = INVALID_HANDLE_VALUE;
   HANDLE write_handle = INVALID_HANDLE_VALUE;
   if (!CreatePipe(&read_handle, &write_handle, &sa, 0)) {
@@ -144,13 +144,13 @@ bool WindowsFileMtime::IsUntampered(const Path& path) {
       /* lpFileName */ path.AsNativePath().c_str(),
       /* dwDesiredAccess */ GENERIC_READ,
       /* dwShareMode */ FILE_SHARE_READ,
-      /* lpSecurityAttributes */ NULL,
+      /* lpSecurityAttributes */ nullptr,
       /* dwCreationDisposition */ OPEN_EXISTING,
       /* dwFlagsAndAttributes */
       // Per CreateFile's documentation on MSDN, opening directories requires
       // the FILE_FLAG_BACKUP_SEMANTICS flag.
       is_directory ? FILE_FLAG_BACKUP_SEMANTICS : FILE_ATTRIBUTE_NORMAL,
-      /* hTemplateFile */ NULL));
+      /* hTemplateFile */ nullptr));
 
   if (!handle.IsValid()) {
     return false;
@@ -187,20 +187,20 @@ bool WindowsFileMtime::Set(const Path& path, FILETIME time) {
       /* lpFileName */ path.AsNativePath().c_str(),
       /* dwDesiredAccess */ FILE_WRITE_ATTRIBUTES,
       /* dwShareMode */ FILE_SHARE_READ,
-      /* lpSecurityAttributes */ NULL,
+      /* lpSecurityAttributes */ nullptr,
       /* dwCreationDisposition */ OPEN_EXISTING,
       /* dwFlagsAndAttributes */
       IsDirectoryW(path.AsNativePath())
           ? (FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS)
           : FILE_ATTRIBUTE_NORMAL,
-      /* hTemplateFile */ NULL));
+      /* hTemplateFile */ nullptr));
   if (!handle.IsValid()) {
     return false;
   }
   return ::SetFileTime(
              /* hFile */ handle,
-             /* lpCreationTime */ NULL,
-             /* lpLastAccessTime */ NULL,
+             /* lpCreationTime */ nullptr,
+             /* lpLastAccessTime */ nullptr,
              /* lpLastWriteTime */ &time) == TRUE;
 }
 
@@ -233,17 +233,17 @@ static bool OpenFileForReading(const Path& path, HANDLE* result) {
       /* lpFileName */ path.AsNativePath().c_str(),
       /* dwDesiredAccess */ GENERIC_READ,
       /* dwShareMode */ kAllShare,
-      /* lpSecurityAttributes */ NULL,
+      /* lpSecurityAttributes */ nullptr,
       /* dwCreationDisposition */ OPEN_EXISTING,
       /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
-      /* hTemplateFile */ NULL);
+      /* hTemplateFile */ nullptr);
   return true;
 }
 
 int ReadFromHandle(file_handle_type handle, void* data, size_t size,
                    int* error) {
   DWORD actually_read = 0;
-  bool success = ::ReadFile(handle, data, size, &actually_read, NULL);
+  bool success = ::ReadFile(handle, data, size, &actually_read, nullptr);
   if (error != nullptr) {
     // TODO(laszlocsomor): handle the error cases that are errno=EINTR and
     // errno=EAGAIN on Linux.
@@ -322,17 +322,17 @@ bool WriteFile(const void* data, size_t size, const Path& path,
       /* lpFileName */ path.AsNativePath().c_str(),
       /* dwDesiredAccess */ GENERIC_WRITE,
       /* dwShareMode */ FILE_SHARE_READ,
-      /* lpSecurityAttributes */ NULL,
+      /* lpSecurityAttributes */ nullptr,
       /* dwCreationDisposition */ CREATE_ALWAYS,
       /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
-      /* hTemplateFile */ NULL));
+      /* hTemplateFile */ nullptr));
   if (!handle.IsValid()) {
     return false;
   }
 
   // TODO(laszlocsomor): respect `perm` and set the file permissions accordingly
   DWORD actually_written = 0;
-  ::WriteFile(handle, data, size, &actually_written, NULL);
+  ::WriteFile(handle, data, size, &actually_written, nullptr);
   return actually_written == size;
 }
 
@@ -343,7 +343,7 @@ int WriteToStdOutErr(const void* data, size_t size, bool to_stdout) {
     return WriteResult::OTHER_ERROR;
   }
 
-  if (::WriteFile(h, data, size, &written, NULL)) {
+  if (::WriteFile(h, data, size, &written, nullptr)) {
     return (written == size) ? WriteResult::SUCCESS : WriteResult::OTHER_ERROR;
   } else {
     return (GetLastError() == ERROR_NO_DATA) ? WriteResult::BROKEN_PIPE
@@ -411,8 +411,8 @@ static bool RealPath(const WCHAR* path, unique_ptr<WCHAR[]>* result = nullptr) {
   // Attempt opening the path, which may be anything -- a file, a directory, a
   // symlink, even a dangling symlink is fine.
   // Follow reparse points, getting us that much closer to the real path.
-  AutoHandle h(CreateFileW(path, 0, kAllShare, NULL, OPEN_EXISTING,
-                           FILE_FLAG_BACKUP_SEMANTICS, NULL));
+  AutoHandle h(CreateFileW(path, 0, kAllShare, nullptr, OPEN_EXISTING,
+                           FILE_FLAG_BACKUP_SEMANTICS, nullptr));
   if (!h.IsValid()) {
     // Path does not exist or it's a dangling junction/symlink.
     return false;
@@ -495,8 +495,8 @@ string MakeCanonical(const char* path) {
 }
 
 static bool CanReadFileW(const wstring& path) {
-  AutoHandle handle(CreateFileW(path.c_str(), GENERIC_READ, kAllShare, NULL,
-                                OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL));
+  AutoHandle handle(CreateFileW(path.c_str(), GENERIC_READ, kAllShare, nullptr,
+                                OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
   return handle.IsValid();
 }
 
@@ -548,10 +548,10 @@ bool CanAccessDirectory(const Path& path) {
       /* lpFileName */ dummy_path.AsNativePath().c_str(),
       /* dwDesiredAccess */ GENERIC_WRITE | GENERIC_READ,
       /* dwShareMode */ kAllShare,
-      /* lpSecurityAttributes */ NULL,
+      /* lpSecurityAttributes */ nullptr,
       /* dwCreationDisposition */ OPEN_ALWAYS,
       /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
-      /* hTemplateFile */ NULL);
+      /* hTemplateFile */ nullptr);
   DWORD err = GetLastError();
   if (handle == INVALID_HANDLE_VALUE) {
     // We couldn't open the file, and not because the dummy file already exists.
@@ -573,8 +573,8 @@ bool IsDirectoryW(const wstring& path) {
   // Attempt opening the path, which may be anything -- a file, a directory, a
   // symlink, even a dangling symlink is fine.
   // Follow reparse points in order to return false for dangling ones.
-  AutoHandle h(CreateFileW(path.c_str(), 0, kAllShare, NULL, OPEN_EXISTING,
-                           FILE_FLAG_BACKUP_SEMANTICS, NULL));
+  AutoHandle h(CreateFileW(path.c_str(), 0, kAllShare, nullptr, OPEN_EXISTING,
+                           FILE_FLAG_BACKUP_SEMANTICS, nullptr));
   BY_HANDLE_FILE_INFORMATION info;
   return h.IsValid() && GetFileInformationByHandle(h, &info) &&
          info.dwFileAttributes != INVALID_FILE_ATTRIBUTES &&
@@ -620,7 +620,7 @@ bool MakeDirectoriesW(const wstring& path, unsigned int mode) {
         << ") could not find dirname: " << GetLastErrorString();
   }
   return MakeDirectoriesW(parent, mode) &&
-         ::CreateDirectoryW(abs_path.c_str(), NULL) == TRUE;
+         ::CreateDirectoryW(abs_path.c_str(), nullptr) == TRUE;
 }
 
 bool MakeDirectories(const string& path, unsigned int mode) {

--- a/src/main/cpp/util/path_posix.cc
+++ b/src/main/cpp/util/path_posix.cc
@@ -49,7 +49,7 @@ std::pair<std::string, std::string> SplitPath(const std::string &path) {
 }
 
 bool IsDevNull(const char *path) {
-  return path != NULL && *path != 0 && strncmp("/dev/null\0", path, 10) == 0;
+  return path != nullptr && *path != 0 && strncmp("/dev/null\0", path, 10) == 0;
 }
 
 bool IsRootDirectory(const std::string &path) {

--- a/src/main/cpp/util/path_windows.cc
+++ b/src/main/cpp/util/path_windows.cc
@@ -426,7 +426,7 @@ bool AsShortWindowsPath(const std::wstring& path, std::wstring* result,
 }
 
 bool IsDevNull(const char* path) {
-  return path != NULL && *path != 0 &&
+  return path != nullptr && *path != 0 &&
          (strncmp("/dev/null\0", path, 10) == 0 ||
           ((path[0] == 'N' || path[0] == 'n') &&
            (path[1] == 'U' || path[1] == 'u') &&
@@ -434,7 +434,7 @@ bool IsDevNull(const char* path) {
 }
 
 bool IsDevNull(const wchar_t* path) {
-  return path != NULL && *path != 0 &&
+  return path != nullptr && *path != 0 &&
          (wcsncmp(L"/dev/null\0", path, 10) == 0 ||
           ((path[0] == L'N' || path[0] == L'n') &&
            (path[1] == L'U' || path[1] == L'u') &&

--- a/src/main/cpp/util/strings.cc
+++ b/src/main/cpp/util/strings.cc
@@ -316,7 +316,7 @@ static bool UStrToVStr(const std::basic_string<U> &input,
   }
 
   // The output buffer was too small. Get required buffer size.
-  res = Convert(use_utf8, input, NULL, 0);
+  res = Convert(use_utf8, input, nullptr, 0);
   if (res > 0) {
     buf_size = res;
     buf.reset(new V[buf_size]);
@@ -335,7 +335,7 @@ static bool UStrToVStr(const std::basic_string<U> &input,
 static int ConvertWcsToMbs(const bool use_utf8, const std::wstring &input,
                            char *output, const size_t output_size) {
   return WideCharToMultiByte(use_utf8 ? CP_UTF8 : CP_ACP, 0, input.c_str(), -1,
-                             output, output_size, NULL, NULL);
+                             output, output_size, nullptr, nullptr);
 }
 
 static int ConvertMbsToWcs(const bool /* unused */, const std::string &input,

--- a/src/main/cpp/util/strings.h
+++ b/src/main/cpp/util/strings.h
@@ -55,7 +55,7 @@ bool ends_with(const std::string &haystack, const std::string &needle);
 bool ends_with(const std::wstring &haystack, const std::wstring &needle);
 
 // Matches a prefix (which must be a char* literal!) against the beginning of
-// str. Returns a pointer past the prefix, or NULL if the prefix wasn't matched.
+// str. Returns a pointer past the prefix, or nullptr if the prefix wasn't matched.
 // (Like the standard strcasecmp(), but for efficiency doesn't call strlen() on
 // prefix, and returns a pointer rather than an int.)
 //
@@ -64,21 +64,21 @@ bool ends_with(const std::wstring &haystack, const std::wstring &needle);
 #define strprefix(str, prefix)                         \
   (strncmp(str, prefix, sizeof("" prefix "") - 1) == 0 \
        ? str + sizeof(prefix) - 1                      \
-       : NULL)
+       : nullptr)
 #endif
 
-// Matches a prefix; returns a pointer past the prefix, or NULL if not found.
+// Matches a prefix; returns a pointer past the prefix, or nullptr if not found.
 // (Like strprefix() and strcaseprefix() but not restricted to searching for
 // char* literals). Templated so searching a const char* returns a const char*,
 // and searching a non-const char* returns a non-const char*.
-// Matches a prefix; returns a pointer past the prefix, or NULL if not found.
+// Matches a prefix; returns a pointer past the prefix, or nullptr if not found.
 // (Like strprefix() and strcaseprefix() but not restricted to searching for
 // char* literals). Templated so searching a const char* returns a const char*,
 // and searching a non-const char* returns a non-const char*.
 template <class CharStar>
 inline CharStar var_strprefix(CharStar str, const char *prefix) {
   const int len = strlen(prefix);
-  return strncmp(str, prefix, len) == 0 ? str + len : NULL;
+  return strncmp(str, prefix, len) == 0 ? str + len : nullptr;
 }
 
 // Join the elements of pieces separated by delimeter.  Returns the joined

--- a/src/main/java/net/starlark/java/eval/cpu_profiler_posix.cc
+++ b/src/main/java/net/starlark/java/eval/cpu_profiler_posix.cc
@@ -102,14 +102,14 @@ Java_net_starlark_java_eval_CpuProfiler_gettid(JNIEnv *env, jclass clazz) {
 // Java really does everything it can to make system programming hateful.
 static jobject makeFD(JNIEnv *env, int fd) {
   jclass fdclass = env->FindClass("java/io/FileDescriptor");
-  if (fdclass == NULL) return NULL;  // exception
+  if (fdclass == nullptr) return nullptr;  // exception
 
   jmethodID init = env->GetMethodID(fdclass, "<init>", "()V");
-  if (init == NULL) return NULL;  // exception
+  if (init == nullptr) return nullptr;  // exception
   jobject fdobj = env->NewObject(fdclass, init);
 
   jfieldID fd_field = env->GetFieldID(fdclass, "fd", "I");
-  if (fd_field == NULL) return NULL;  // exception
+  if (fd_field == nullptr) return nullptr;  // exception
   env->SetIntField(fdobj, fd_field, fd);
 
   return fdobj;

--- a/src/main/native/fsevents.cc
+++ b/src/main/native/fsevents.cc
@@ -94,25 +94,25 @@ Java_com_google_devtools_build_lib_skyframe_MacOSXFsEventsDiffAwareness_create(
   FSEventStreamContext context;
   context.version = 0;
   context.info = static_cast<void *>(info);
-  context.retain = NULL;
-  context.release = NULL;
-  context.copyDescription = NULL;
+  context.retain = nullptr;
+  context.release = nullptr;
+  context.copyDescription = nullptr;
 
   // Create an CFArrayRef of CFStringRef from the Java array of String
   jsize length = env->GetArrayLength(paths);
   CFStringRef *pathsArray = new CFStringRef[length];
   for (int i = 0; i < length; i++) {
     jstring path = (jstring)env->GetObjectArrayElement(paths, i);
-    const char *pathCStr = env->GetStringUTFChars(path, NULL);
+    const char *pathCStr = env->GetStringUTFChars(path, nullptr);
     pathsArray[i] =
-        CFStringCreateWithCString(NULL, pathCStr, kCFStringEncodingUTF8);
+        CFStringCreateWithCString(nullptr, pathCStr, kCFStringEncodingUTF8);
     env->ReleaseStringUTFChars(path, pathCStr);
   }
   CFArrayRef pathsToWatch =
-      CFArrayCreate(NULL, (const void **)pathsArray, 1, NULL);
+      CFArrayCreate(nullptr, (const void **)pathsArray, 1, nullptr);
   delete[] pathsArray;
   info->stream = FSEventStreamCreate(
-      NULL, &FsEventsDiffAwarenessCallback, &context, pathsToWatch,
+      nullptr, &FsEventsDiffAwarenessCallback, &context, pathsToWatch,
       kFSEventStreamEventIdSinceNow, static_cast<CFAbsoluteTime>(latency),
       kFSEventStreamCreateFlagNoDefer | kFSEventStreamCreateFlagFileEvents);
 
@@ -158,10 +158,10 @@ Java_com_google_devtools_build_lib_skyframe_MacOSXFsEventsDiffAwareness_poll(
 
   jobjectArray result;
   if (info->everything_changed) {
-    result = NULL;
+    result = nullptr;
   } else {
     jclass classString = env->FindClass("java/lang/String");
-    result = env->NewObjectArray(info->paths.size(), classString, NULL);
+    result = env->NewObjectArray(info->paths.size(), classString, nullptr);
     int i = 0;
     for (auto it = info->paths.begin(); it != info->paths.end(); it++, i++) {
       env->SetObjectArrayElement(result, i, env->NewStringUTF(it->c_str()));

--- a/src/main/native/latin1_jni_path.cc
+++ b/src/main/native/latin1_jni_path.cc
@@ -73,9 +73,9 @@ char *GetStringLatin1Chars(JNIEnv *env, jstring jstr) {
     return result;
   }
 
-  const jchar *str = env->GetStringCritical(jstr, NULL);
-  if (str == NULL) {
-    return NULL;
+  const jchar *str = env->GetStringCritical(jstr, nullptr);
+  if (str == nullptr) {
+    return nullptr;
   }
 
   char *result = new char[len + 1];

--- a/src/main/native/unix_jni.cc
+++ b/src/main/native/unix_jni.cc
@@ -109,7 +109,7 @@ void PostException(JNIEnv *env, int error_number, const std::string& message) {
       exception_classname = "java/io/IOException";
   }
   jclass exception_class = env->FindClass(exception_classname);
-  if (exception_class != NULL) {
+  if (exception_class != nullptr) {
     env->ThrowNew(exception_class,
                   (message + " (" + ErrorMessage(error_number) + ")").c_str());
   } else {
@@ -136,15 +136,15 @@ static bool PostRuntimeException(JNIEnv *env, int error_number,
       exception_classname = "java/lang/UnsupportedOperationException";
       break;
     default:
-      exception_classname = NULL;
+      exception_classname = nullptr;
   }
 
-  if (exception_classname == NULL) {
+  if (exception_classname == nullptr) {
     return false;
   }
 
   jclass exception_class = env->FindClass(exception_classname);
-  if (exception_class != NULL) {
+  if (exception_class != nullptr) {
      std::string message(file_path);
      message += " (";
      message += ErrorMessage(error_number);
@@ -166,7 +166,7 @@ Java_com_google_devtools_build_lib_unix_NativePosixFiles_readlink(JNIEnv *env,
                                                      jstring path) {
   const char *path_chars = GetStringLatin1Chars(env, path);
   char target[PATH_MAX] = "";
-  jstring r = NULL;
+  jstring r = nullptr;
   if (readlink(path_chars, target, arraysize(target)) == -1) {
     PostException(env, errno, path_chars);
   } else {
@@ -219,18 +219,18 @@ Java_com_google_devtools_build_lib_unix_NativePosixFiles_symlink(JNIEnv *env,
 
 static jobject NewFileStatus(JNIEnv *env,
                              const portable_stat_struct &stat_ref) {
-  static jclass file_status_class = NULL;
-  if (file_status_class == NULL) {  // note: harmless race condition
+  static jclass file_status_class = nullptr;
+  if (file_status_class == nullptr) {  // note: harmless race condition
     jclass local =
         env->FindClass("com/google/devtools/build/lib/unix/FileStatus");
-    CHECK(local != NULL);
+    CHECK(local != nullptr);
     file_status_class = static_cast<jclass>(env->NewGlobalRef(local));
   }
 
-  static jmethodID method = NULL;
-  if (method == NULL) {  // note: harmless race condition
+  static jmethodID method = nullptr;
+  if (method == nullptr) {  // note: harmless race condition
     method = env->GetMethodID(file_status_class, "<init>", "(IIIIIIIJIJ)V");
-    CHECK(method != NULL);
+    CHECK(method != nullptr);
   }
 
   return env->NewObject(
@@ -245,25 +245,25 @@ static jobject NewFileStatus(JNIEnv *env,
 static jobject NewErrnoFileStatus(JNIEnv *env,
                                   int saved_errno,
                                   const portable_stat_struct &stat_ref) {
-  static jclass errno_file_status_class = NULL;
-  if (errno_file_status_class == NULL) {  // note: harmless race condition
+  static jclass errno_file_status_class = nullptr;
+  if (errno_file_status_class == nullptr) {  // note: harmless race condition
     jclass local =
         env->FindClass("com/google/devtools/build/lib/unix/ErrnoFileStatus");
-    CHECK(local != NULL);
+    CHECK(local != nullptr);
     errno_file_status_class = static_cast<jclass>(env->NewGlobalRef(local));
   }
 
-  static jmethodID no_error_ctor = NULL;
-  if (no_error_ctor == NULL) {  // note: harmless race condition
+  static jmethodID no_error_ctor = nullptr;
+  if (no_error_ctor == nullptr) {  // note: harmless race condition
     no_error_ctor = env->GetMethodID(errno_file_status_class,
                                      "<init>", "(IIIIIIIJIJ)V");
-    CHECK(no_error_ctor != NULL);
+    CHECK(no_error_ctor != nullptr);
   }
 
-  static jmethodID errorno_ctor = NULL;
-  if (errorno_ctor == NULL) {  // note: harmless race condition
+  static jmethodID errorno_ctor = nullptr;
+  if (errorno_ctor == nullptr) {  // note: harmless race condition
     errorno_ctor = env->GetMethodID(errno_file_status_class, "<init>", "(I)V");
-    CHECK(errorno_ctor != NULL);
+    CHECK(errorno_ctor != nullptr);
   }
 
   if (saved_errno != 0) {
@@ -284,7 +284,7 @@ static void SetIntField(JNIEnv *env,
                         const char *name,
                         int val) {
   jfieldID fid = env->GetFieldID(clazz, name, "I");
-  CHECK(fid != NULL);
+  CHECK(fid != nullptr);
   env->SetIntField(object, fid, val);
 }
 
@@ -318,11 +318,11 @@ static jobject StatCommon(JNIEnv *env, jstring path,
 
     if (PostRuntimeException(env, saved_errno, path_chars)) {
       ReleaseStringLatin1Chars(path_chars);
-      return NULL;
+      return nullptr;
     } else if (should_throw) {
       PostException(env, saved_errno, path_chars);
       ReleaseStringLatin1Chars(path_chars);
-      return NULL;
+      return nullptr;
     }
   }
   ReleaseStringLatin1Chars(path_chars);
@@ -402,7 +402,7 @@ Java_com_google_devtools_build_lib_unix_NativePosixFiles_utime(JNIEnv *env,
   }
 #else
   struct utimbuf buf = { modtime, modtime };
-  struct utimbuf *bufptr = now ? NULL : &buf;
+  struct utimbuf *bufptr = now ? nullptr : &buf;
   if (::utime(path_chars, bufptr) == -1) {
     // EACCES ENOENT EMULTIHOP ELOOP EINTR
     // ENOTDIR ENOLINK EPERM EROFS   -> IOException
@@ -540,18 +540,18 @@ static jobject NewDirents(JNIEnv *env,
                           jobjectArray names,
                           jbyteArray types) {
   // See http://java.sun.com/docs/books/jni/html/fldmeth.html#26855
-  static jclass dirents_class = NULL;
-  if (dirents_class == NULL) {  // note: harmless race condition
+  static jclass dirents_class = nullptr;
+  if (dirents_class == nullptr) {  // note: harmless race condition
     jclass local = env->FindClass("com/google/devtools/build/lib/unix/NativePosixFiles$Dirents");
-    CHECK(local != NULL);
+    CHECK(local != nullptr);
     dirents_class = static_cast<jclass>(env->NewGlobalRef(local));
   }
 
-  static jmethodID ctor = NULL;
-  if (ctor == NULL) {  // note: harmless race condition
+  static jmethodID ctor = nullptr;
+  if (ctor == nullptr) {  // note: harmless race condition
     ctor =
         env->GetMethodID(dirents_class, "<init>", "([Ljava/lang/String;[B)V");
-    CHECK(ctor != NULL);
+    CHECK(ctor != nullptr);
   }
 
   return env->NewObject(dirents_class, ctor, names, types);
@@ -596,15 +596,15 @@ Java_com_google_devtools_build_lib_unix_NativePosixFiles_readdir(JNIEnv *env,
                                                     jchar read_types) {
   const char *path_chars = GetStringLatin1Chars(env, path);
   DIR *dirh;
-  while ((dirh = ::opendir(path_chars)) == NULL && errno == EINTR) { }
-  if (dirh == NULL) {
+  while ((dirh = ::opendir(path_chars)) == nullptr && errno == EINTR) { }
+  if (dirh == nullptr) {
     // EACCES EMFILE ENFILE ENOENT ENOTDIR -> IOException
     // ENOMEM                              -> OutOfMemoryError
     PostException(env, errno, path_chars);
   }
   ReleaseStringLatin1Chars(path_chars);
-  if (dirh == NULL) {
-    return NULL;
+  if (dirh == nullptr) {
+    return nullptr;
   }
   int fd = dirfd(dirh);
 
@@ -615,7 +615,7 @@ Java_com_google_devtools_build_lib_unix_NativePosixFiles_readdir(JNIEnv *env,
     // EOF, this is the only way to reliably distinguish EOF from error.
     errno = 0;
     struct dirent *entry = ::readdir(dirh);
-    if (entry == NULL) {
+    if (entry == nullptr) {
       if (errno == 0) break;  // EOF
       // It is unclear whether an error can also skip some records.
       // That does not appear to happen with glibc, at least.
@@ -624,7 +624,7 @@ Java_com_google_devtools_build_lib_unix_NativePosixFiles_readdir(JNIEnv *env,
       // Otherwise, this is a real error we should report.
       PostException(env, errno, path_chars);
       ::closedir(dirh);
-      return NULL;
+      return nullptr;
     }
     // Omit . and .. from results.
     if (entry->d_name[0] == '.') {
@@ -639,25 +639,25 @@ Java_com_google_devtools_build_lib_unix_NativePosixFiles_readdir(JNIEnv *env,
 
   if (::closedir(dirh) < 0 && errno != EINTR) {
     PostException(env, errno, path_chars);
-    return NULL;
+    return nullptr;
   }
 
   size_t len = entries.size();
   jclass jlStringClass = env->GetObjectClass(path);
-  jobjectArray names_obj = env->NewObjectArray(len, jlStringClass, NULL);
-  if (names_obj == NULL && env->ExceptionOccurred()) {
-    return NULL;  // async exception!
+  jobjectArray names_obj = env->NewObjectArray(len, jlStringClass, nullptr);
+  if (names_obj == nullptr && env->ExceptionOccurred()) {
+    return nullptr;  // async exception!
   }
 
   for (size_t ii = 0; ii < len; ++ii) {
     jstring s = NewStringLatin1(env, entries[ii].c_str());
-    if (s == NULL && env->ExceptionOccurred()) {
-      return NULL;  // async exception!
+    if (s == nullptr && env->ExceptionOccurred()) {
+      return nullptr;  // async exception!
     }
     env->SetObjectArrayElement(names_obj, ii, s);
   }
 
-  jbyteArray types_obj = NULL;
+  jbyteArray types_obj = nullptr;
   if (read_types != 'n') {
     CHECK(len == types.size());
     types_obj = env->NewByteArray(len);
@@ -707,7 +707,7 @@ Java_com_google_devtools_build_lib_unix_NativePosixFiles_remove(JNIEnv *env,
                                                    jclass clazz,
                                                    jstring path) {
   const char *path_chars = GetStringLatin1Chars(env, path);
-  if (path_chars == NULL) {
+  if (path_chars == nullptr) {
     return false;
   }
   bool ok = remove(path_chars) != -1;
@@ -760,7 +760,7 @@ static void PostDeleteTreesBelowException(
       path += "/";
       path += *iter;
     }
-    if (entry != NULL) {
+    if (entry != nullptr) {
       path += "/";
       path += entry;
     }
@@ -796,25 +796,25 @@ static DIR* ForceOpendir(JNIEnv* env, const std::vector<std::string>& dir_path,
     // recursion).
     if (errno == EACCES && dir_fd != AT_FDCWD) {
       if (fchmod(dir_fd, 0700) == -1) {
-        PostDeleteTreesBelowException(env, errno, "fchmod", dir_path, NULL);
-        return NULL;
+        PostDeleteTreesBelowException(env, errno, "fchmod", dir_path, nullptr);
+        return nullptr;
       }
     }
     if (fchmodat(dir_fd, entry, 0700, 0) == -1) {
       PostDeleteTreesBelowException(env, errno, "fchmodat", dir_path, entry);
-      return NULL;
+      return nullptr;
     }
     fd = openat(dir_fd, entry, flags);
     if (fd == -1) {
       PostDeleteTreesBelowException(env, errno, "opendir", dir_path, entry);
-      return NULL;
+      return nullptr;
     }
   }
   DIR* dir = fdopendir(fd);
-  if (dir == NULL) {
+  if (dir == nullptr) {
     PostDeleteTreesBelowException(env, errno, "fdopendir", dir_path, entry);
     close(fd);
-    return NULL;
+    return nullptr;
   }
   return dir;
 }
@@ -836,7 +836,7 @@ static int ForceDelete(JNIEnv* env, const std::vector<std::string>& dir_path,
   const int flags = is_dir ? AT_REMOVEDIR : 0;
   if (unlinkat(dir_fd, entry, flags) == -1) {
     if (fchmod(dir_fd, 0700) == -1) {
-      PostDeleteTreesBelowException(env, errno, "fchmod", dir_path, NULL);
+      PostDeleteTreesBelowException(env, errno, "fchmod", dir_path, nullptr);
       return -1;
     }
     if (unlinkat(dir_fd, entry, flags) == -1) {
@@ -901,8 +901,8 @@ static int IsSubdir(JNIEnv* env, const std::vector<std::string>& dir_path,
 static int DeleteTreesBelow(JNIEnv* env, std::vector<std::string>* dir_path,
                             const int dir_fd, const char* entry) {
   DIR *dir = ForceOpendir(env, *dir_path, dir_fd, entry);
-  if (dir == NULL) {
-    CHECK(env->ExceptionOccurred() != NULL);
+  if (dir == nullptr) {
+    CHECK(env->ExceptionOccurred() != nullptr);
     return -1;
   }
 
@@ -917,9 +917,9 @@ static int DeleteTreesBelow(JNIEnv* env, std::vector<std::string>* dir_path,
   for (;;) {
     errno = 0;
     struct dirent* de = readdir(dir);
-    if (de == NULL) {
+    if (de == nullptr) {
       if (errno != 0) {
-        PostDeleteTreesBelowException(env, errno, "readdir", *dir_path, NULL);
+        PostDeleteTreesBelowException(env, errno, "readdir", *dir_path, nullptr);
       }
       break;
     }
@@ -930,7 +930,7 @@ static int DeleteTreesBelow(JNIEnv* env, std::vector<std::string>* dir_path,
 
     bool is_dir;
     if (IsSubdir(env, *dir_path, dirfd(dir), de, &is_dir) == -1) {
-      CHECK(env->ExceptionOccurred() != NULL);
+      CHECK(env->ExceptionOccurred() != nullptr);
       break;
     }
     if (is_dir) {
@@ -939,24 +939,24 @@ static int DeleteTreesBelow(JNIEnv* env, std::vector<std::string>* dir_path,
       dir_files.push_back(de->d_name);
     }
   }
-  if (env->ExceptionOccurred() == NULL) {
+  if (env->ExceptionOccurred() == nullptr) {
     for (const auto &file : dir_files) {
       if (ForceDelete(env, *dir_path, dirfd(dir), file.c_str(), false) == -1) {
-        CHECK(env->ExceptionOccurred() != NULL);
+        CHECK(env->ExceptionOccurred() != nullptr);
         break;
       }
     }
     // DeleteTreesBelow is recursive; don't hold on to file names unnecessarily.
     dir_files.clear();
   }
-  if (env->ExceptionOccurred() == NULL) {
+  if (env->ExceptionOccurred() == nullptr) {
     for (const auto &subdir : dir_subdirs) {
       if (DeleteTreesBelow(env, dir_path, dirfd(dir), subdir.c_str()) == -1) {
-        CHECK(env->ExceptionOccurred() != NULL);
+        CHECK(env->ExceptionOccurred() != nullptr);
         break;
       }
       if (ForceDelete(env, *dir_path, dirfd(dir), subdir.c_str(), true) == -1) {
-        CHECK(env->ExceptionOccurred() != NULL);
+        CHECK(env->ExceptionOccurred() != nullptr);
         break;
       }
     }
@@ -964,12 +964,12 @@ static int DeleteTreesBelow(JNIEnv* env, std::vector<std::string>* dir_path,
   if (closedir(dir) == -1) {
     // Prefer reporting the error encountered while processing entries,
     // not the (unlikely) error on close.
-    if (env->ExceptionOccurred() == NULL) {
-      PostDeleteTreesBelowException(env, errno, "closedir", *dir_path, NULL);
+    if (env->ExceptionOccurred() == nullptr) {
+      PostDeleteTreesBelowException(env, errno, "closedir", *dir_path, nullptr);
     }
   }
   dir_path->pop_back();
-  return env->ExceptionOccurred() == NULL ? 0 : -1;
+  return env->ExceptionOccurred() == nullptr ? 0 : -1;
 }
 
 /*
@@ -984,7 +984,7 @@ Java_com_google_devtools_build_lib_unix_NativePosixFiles_deleteTreesBelow(
   const char *path_chars = GetStringLatin1Chars(env, path);
   std::vector<std::string> dir_path;
   if (DeleteTreesBelow(env, &dir_path, AT_FDCWD, path_chars) == -1) {
-    CHECK(env->ExceptionOccurred() != NULL);
+    CHECK(env->ExceptionOccurred() != nullptr);
   }
   CHECK(dir_path.empty());
   ReleaseStringLatin1Chars(path_chars);
@@ -1005,7 +1005,7 @@ static jbyteArray getxattr_common(JNIEnv *env,
 
   // TODO(bazel-team): on ERANGE, try again with larger buffer.
   jbyte value[4096];
-  jbyteArray result = NULL;
+  jbyteArray result = nullptr;
   bool attr_not_found = false;
   ssize_t size = getxattr(path_chars, name_chars, value, arraysize(value),
                           &attr_not_found);
@@ -1017,7 +1017,7 @@ static jbyteArray getxattr_common(JNIEnv *env,
     result = env->NewByteArray(size);
     // Result may be NULL if allocation failed. In that case, we'll return the
     // NULL and an OOME will be thrown when we are back in Java.
-    if (result != NULL) {
+    if (result != nullptr) {
       env->SetByteArrayRegion(result, 0, size, value);
     }
   }

--- a/src/main/native/unix_jni_bsd.cc
+++ b/src/main/native/unix_jni_bsd.cc
@@ -111,7 +111,7 @@ ssize_t portable_lgetxattr(const char *path, const char *name, void *value,
 
 int portable_sysctlbyname(const char *name_chars, long *mibp, size_t *sizep) {
 #if defined(HAVE_SYSCTLBYNAME)
-  return sysctlbyname(name_chars, mibp, sizep, NULL, 0);
+  return sysctlbyname(name_chars, mibp, sizep, nullptr, 0);
 #else
   errno = ENOSYS;
   return -1;

--- a/src/main/native/unix_jni_darwin.cc
+++ b/src/main/native/unix_jni_darwin.cc
@@ -77,8 +77,8 @@ int portable_fstatat(
     l++;
   }
   strncat(dirPath, name, PATH_MAX2-l-1);
-  char *newpath = realpath(dirPath, NULL);  // this resolve the relative path
-  if (newpath == NULL) {
+  char *newpath = realpath(dirPath, nullptr);  // this resolve the relative path
+  if (newpath == nullptr) {
     return -1;
   }
   int r = portable_stat(newpath, statbuf);
@@ -127,7 +127,7 @@ ssize_t portable_lgetxattr(const char *path, const char *name, void *value,
 }
 
 int portable_sysctlbyname(const char *name_chars, long *mibp, size_t *sizep) {
-  return sysctlbyname(name_chars, mibp, sizep, NULL, 0);
+  return sysctlbyname(name_chars, mibp, sizep, nullptr, 0);
 }
 
 // Queue used for all of our anomaly tracking.
@@ -149,11 +149,11 @@ static dispatch_queue_t JniDispatchQueue() {
 // macOS. Use `log_if_possible` to log when supported.
 static os_log_t JniOSLog() {
   static dispatch_once_t once_token;
-  static os_log_t log = NULL;
+  static os_log_t log = nullptr;
   // On macOS < 10.12, os_log_create is not available. Since we target 10.10,
   // this will be weakly linked and can be checked for availability at run
   // time.
-  if (&os_log_create != NULL) {
+  if (&os_log_create != nullptr) {
     dispatch_once(&once_token, ^{
       log = os_log_create("build.bazel", "jni");
       CHECK(log);
@@ -167,7 +167,7 @@ static os_log_t JniOSLog() {
 #define log_if_possible(msg)   \
   do {                         \
     os_log_t log = JniOSLog(); \
-    if (log != NULL) {         \
+    if (log != nullptr) {         \
       os_log_debug(log, msg);  \
     }                          \
   } while (0);
@@ -298,7 +298,7 @@ int portable_suspend_count() {
     CHECK(signal_val != SIG_ERR);
     dispatch_source_t signal_source =
         dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGCONT, 0, queue);
-    CHECK(signal_source != NULL);
+    CHECK(signal_source != nullptr);
     dispatch_source_set_event_handler(signal_source, ^{
       log_if_possible("suspend anomaly due to SIGCONT");
       ++suspend_state.suspend_count;
@@ -318,7 +318,7 @@ int portable_memory_pressure_warning_count() {
     dispatch_source_t source = dispatch_source_create(
         DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0, DISPATCH_MEMORYPRESSURE_WARN,
         JniDispatchQueue());
-    CHECK(source != NULL);
+    CHECK(source != nullptr);
     dispatch_source_set_event_handler(source, ^{
       dispatch_source_memorypressure_flags_t pressureLevel =
           dispatch_source_get_data(source);
@@ -342,7 +342,7 @@ int portable_memory_pressure_critical_count() {
     dispatch_source_t source = dispatch_source_create(
         DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0,
         DISPATCH_MEMORYPRESSURE_CRITICAL, JniDispatchQueue());
-    CHECK(source != NULL);
+    CHECK(source != nullptr);
     dispatch_source_set_event_handler(source, ^{
       dispatch_source_memorypressure_flags_t pressureLevel =
           dispatch_source_get_data(source);

--- a/src/main/native/windows/file.cc
+++ b/src/main/native/windows/file.cc
@@ -110,7 +110,7 @@ wstring GetLongPath(const WCHAR* path, unique_ptr<WCHAR[]>* result) {
   }
 
   std::wstring wpath(AddUncPrefixMaybe(path));
-  DWORD size = ::GetLongPathNameW(wpath.c_str(), NULL, 0);
+  DWORD size = ::GetLongPathNameW(wpath.c_str(), nullptr, 0);
   if (size == 0) {
     DWORD err_code = GetLastError();
     return MakeErrorMessage(WSTR(__FILE__), __LINE__, L"GetLongPathNameW", path,
@@ -214,14 +214,14 @@ int CreateJunction(const wstring& junction_name, const wstring& junction_target,
   // directory, or the path was invalid to begin with. Either way set `create`
   // to false, meaning we'll just attempt to open the path for metadata-reading
   // and check if it's a junction pointing to the desired target.
-  bool create = CreateDirectoryW(name.c_str(), NULL) != 0;
+  bool create = CreateDirectoryW(name.c_str(), nullptr) != 0;
 
   AutoHandle handle;
   if (create) {
     handle = CreateFileW(
-        name.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL,
+        name.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, nullptr,
         OPEN_EXISTING,
-        FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+        FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, nullptr);
   }
 
   if (!handle.IsValid()) {
@@ -234,8 +234,8 @@ int CreateJunction(const wstring& junction_name, const wstring& junction_target,
     create = false;
     handle = CreateFileW(
         name.c_str(), 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-        NULL, OPEN_EXISTING,
-        FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+        nullptr, OPEN_EXISTING,
+        FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, nullptr);
     if (!handle.IsValid()) {
       // We can't open the directory at all: either it disappeared, or it turned
       // into a file, or the path is invalid, or another process holds it open
@@ -375,7 +375,7 @@ int CreateJunction(const wstring& junction_name, const wstring& junction_target,
             handle, FSCTL_SET_REPARSE_POINT, reparse_buffer,
             reparse_buffer->ReparseDataLength +
                 offsetof(REPARSE_DATA_BUFFER, GenericReparseBuffer.DataBuffer),
-            NULL, 0, &bytes_returned, NULL)) {
+            nullptr, 0, &bytes_returned, nullptr)) {
       DWORD err = GetLastError();
       if (err == ERROR_DIR_NOT_EMPTY) {
         return CreateJunctionResult::kAlreadyExistsButNotJunction;
@@ -391,9 +391,9 @@ int CreateJunction(const wstring& junction_name, const wstring& junction_target,
     // The junction already exists. Check if it points to the right target.
 
     DWORD bytes_returned;
-    if (!::DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, NULL, 0,
+    if (!::DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, nullptr, 0,
                            reparse_buffer, MAXIMUM_REPARSE_DATA_BUFFER_SIZE,
-                           &bytes_returned, NULL)) {
+                           &bytes_returned, nullptr)) {
       DWORD err = GetLastError();
       // Some unknown error occurred.
       if (error) {
@@ -470,9 +470,9 @@ int ReadSymlinkOrJunction(const wstring& path, wstring* result,
 
   AutoHandle handle(CreateFileW(
       AddUncPrefixMaybe(path).c_str(), 0,
-      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL,
+      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
       OPEN_EXISTING, FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
-      NULL));
+      nullptr));
   if (!handle.IsValid()) {
     DWORD err = GetLastError();
     if (err == ERROR_SHARING_VIOLATION) {
@@ -495,9 +495,9 @@ int ReadSymlinkOrJunction(const wstring& path, wstring* result,
   uint8_t raw_buf[MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
   PREPARSE_DATA_BUFFER buf = reinterpret_cast<PREPARSE_DATA_BUFFER>(raw_buf);
   DWORD bytes_returned;
-  if (!::DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, NULL, 0, buf,
+  if (!::DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, nullptr, 0, buf,
                          MAXIMUM_REPARSE_DATA_BUFFER_SIZE, &bytes_returned,
-                         NULL)) {
+                         nullptr)) {
     DWORD err = GetLastError();
     if (err == ERROR_NOT_A_REPARSE_POINT) {
       return ReadSymlinkOrJunctionResult::kNotALink;

--- a/src/main/native/windows/processes-jni.cc
+++ b/src/main/native/windows/processes-jni.cc
@@ -52,7 +52,7 @@ class JavaByteArray {
       : env_(env),
         array_(java_array),
         size_(java_array != nullptr ? env->GetArrayLength(java_array) : 0),
-        ptr_(java_array != nullptr ? env->GetByteArrayElements(java_array, NULL)
+        ptr_(java_array != nullptr ? env->GetByteArrayElements(java_array, nullptr)
                                    : nullptr) {}
 
   ~JavaByteArray() {
@@ -90,7 +90,7 @@ class NativeOutputStream {
     //
     // Therefore if this process bequested `handle_` to a child process, we
     // cannot cancel I/O in the child process.
-    CancelIoEx(handle_, NULL);
+    CancelIoEx(handle_, nullptr);
     CloseHandle(handle_);
     handle_ = INVALID_HANDLE_VALUE;
   }
@@ -104,7 +104,7 @@ class NativeOutputStream {
     }
 
     DWORD avail = 0;
-    if (!::PeekNamedPipe(handle_, NULL, 0, NULL, &avail, NULL)) {
+    if (!::PeekNamedPipe(handle_, nullptr, 0, nullptr, &avail, nullptr)) {
       // Check if either the other end closed the pipe or we did it with
       // NativeOutputStream.Close() . In the latter case, we'll get a "system
       // call interrupted" error.
@@ -140,7 +140,7 @@ class NativeOutputStream {
     }
 
     DWORD bytes_read;
-    if (!::ReadFile(handle_, bytes.ptr() + offset, length, &bytes_read, NULL)) {
+    if (!::ReadFile(handle_, bytes.ptr() + offset, length, &bytes_read, nullptr)) {
       // Check if either the other end closed the pipe or we did it with
       // NativeOutputStream.Close() . In the latter case, we'll get a "system
       // call interrupted" error.
@@ -270,7 +270,7 @@ class NativeProcess {
           /* lpSecurityAttributes */ &sa,
           /* dwCreationDisposition */ OPEN_ALWAYS,
           /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
-          /* hTemplateFile */ NULL);
+          /* hTemplateFile */ nullptr);
 
       if (!stdout_process.IsValid()) {
         DWORD err_code = GetLastError();
@@ -279,7 +279,7 @@ class NativeProcess {
                                                   stdout_redirect, err_code);
         return false;
       }
-      if (!SetFilePointerEx(stdout_process, {0}, NULL, FILE_END)) {
+      if (!SetFilePointerEx(stdout_process, {0}, nullptr, FILE_END)) {
         DWORD err_code = GetLastError();
         error_ = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
                                                   L"nativeCreateProcess",
@@ -331,7 +331,7 @@ class NativeProcess {
           /* lpSecurityAttributes */ &sa,
           /* dwCreationDisposition */ OPEN_ALWAYS,
           /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
-          /* hTemplateFile */ NULL);
+          /* hTemplateFile */ nullptr);
 
       if (!stderr_process.IsValid()) {
         DWORD err_code = GetLastError();
@@ -340,7 +340,7 @@ class NativeProcess {
                                                   stderr_redirect, err_code);
         return false;
       }
-      if (!SetFilePointerEx(stderr_process, {0}, NULL, FILE_END)) {
+      if (!SetFilePointerEx(stderr_process, {0}, nullptr, FILE_END)) {
         DWORD err_code = GetLastError();
         error_ = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
                                                   L"nativeCreateProcess",
@@ -401,7 +401,7 @@ class NativeProcess {
     DWORD bytes_written;
 
     if (!::WriteFile(stdin_, bytes.ptr() + offset, length, &bytes_written,
-                     NULL)) {
+                     nullptr)) {
       DWORD err_code = GetLastError();
       error_ = bazel::windows::MakeErrorMessage(WSTR(__FILE__), __LINE__,
                                                 L"NativeProcess:WriteStdin",

--- a/src/main/native/windows/util.cc
+++ b/src/main/native/windows/util.cc
@@ -56,11 +56,11 @@ wstring GetLastErrorString(DWORD error_code) {
     return L"";
   }
 
-  LPWSTR message = NULL;
+  LPWSTR message = nullptr;
   DWORD size = FormatMessageW(
       FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS |
           FORMAT_MESSAGE_ALLOCATE_BUFFER,
-      NULL, error_code, LANG_USER_DEFAULT, (LPWSTR)&message, 0, NULL);
+      nullptr, error_code, LANG_USER_DEFAULT, (LPWSTR)&message, 0, nullptr);
 
   if (size == 0) {
     wstringstream err;
@@ -90,7 +90,7 @@ bool AutoAttributeList::Create(HANDLE stdin_h, HANDLE stdout_h, HANDLE stderr_h,
   SIZE_T size = 0;
   // According to MSDN, the first call to InitializeProcThreadAttributeList is
   // expected to fail.
-  InitializeProcThreadAttributeList(NULL, kAttributeCount, 0, &size);
+  InitializeProcThreadAttributeList(nullptr, kAttributeCount, 0, &size);
   SetLastError(ERROR_SUCCESS);
 
   std::unique_ptr<uint8_t[]> data(new uint8_t[size]);
@@ -111,8 +111,8 @@ bool AutoAttributeList::Create(HANDLE stdin_h, HANDLE stdout_h, HANDLE stderr_h,
   if (!UpdateProcThreadAttribute(
           attrs, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
           attr_list->handles_.ValidHandles(),
-          attr_list->handles_.ValidHandlesCount() * sizeof(HANDLE), NULL,
-          NULL)) {
+          attr_list->handles_.ValidHandlesCount() * sizeof(HANDLE), nullptr,
+          nullptr)) {
     if (error_msg) {
       DWORD err = GetLastError();
       *error_msg = MakeErrorMessage(WSTR(__FILE__), __LINE__,
@@ -245,7 +245,7 @@ wstring AsShortPath(wstring path, wstring* result) {
   static const size_t kMaxShortPath = MAX_PATH + 4;
 
   WCHAR wshort[kMaxShortPath];
-  DWORD wshort_size = ::GetShortPathNameW(wlong.c_str(), NULL, 0);
+  DWORD wshort_size = ::GetShortPathNameW(wlong.c_str(), nullptr, 0);
   if (wshort_size == 0) {
     DWORD err_code = GetLastError();
     wstring res = MakeErrorMessage(WSTR(__FILE__), __LINE__,

--- a/src/main/native/windows/util.h
+++ b/src/main/native/windows/util.h
@@ -51,7 +51,7 @@ class AutoHandle {
   }
 
   bool IsValid() const {
-    return handle_ != INVALID_HANDLE_VALUE && handle_ != NULL;
+    return handle_ != INVALID_HANDLE_VALUE && handle_ != nullptr;
   }
 
   AutoHandle& operator=(const HANDLE& rhs) {

--- a/src/main/tools/build-runfiles-windows.cc
+++ b/src/main/tools/build-runfiles-windows.cc
@@ -54,8 +54,8 @@ string GetLastErrorString() {
   size_t size = FormatMessageA(
       FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
           FORMAT_MESSAGE_IGNORE_INSERTS,
-      NULL, last_error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-      (LPSTR)&message_buffer, 0, NULL);
+      nullptr, last_error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      (LPSTR)&message_buffer, 0, nullptr);
 
   stringstream result;
   result << "(error: " << last_error << "): " << message_buffer;

--- a/src/main/tools/process-tools-darwin.cc
+++ b/src/main/tools/process-tools-darwin.cc
@@ -39,7 +39,7 @@ int WaitForProcessToTerminate(pid_t pid) {
   int nev;
   struct kevent ke;
 retry:
-  if ((nev = kevent(kq, &kc, 1, &ke, 1, NULL)) == -1) {
+  if ((nev = kevent(kq, &kc, 1, &ke, 1, nullptr)) == -1) {
     if (errno == EINTR) {
       goto retry;
     }
@@ -68,24 +68,24 @@ int WaitForProcessGroupToTerminate(pid_t pgid) {
     // have to first query the size of the output data and then account for
     // the fact that the size might change by the time we actually issue
     // the query.
-    struct kinfo_proc *procs = NULL;
+    struct kinfo_proc *procs = nullptr;
     size_t nprocs = 0;
     do {
       size_t len;
-      if (sysctl(name, 4, 0, &len, NULL, 0) == -1) {
+      if (sysctl(name, 4, 0, &len, nullptr, 0) == -1) {
         return -1;
       }
       procs = (struct kinfo_proc *)malloc(len);
-      if (sysctl(name, 4, procs, &len, NULL, 0) == -1) {
+      if (sysctl(name, 4, procs, &len, nullptr, 0) == -1) {
         if (errno != ENOMEM) {
           DIE("Unexpected error code %d", errno);
         }
         free(procs);
-        procs = NULL;
+        procs = nullptr;
       } else {
         nprocs = len / sizeof(struct kinfo_proc);
       }
-    } while (procs == NULL);
+    } while (procs == nullptr);
     if (nprocs < 1) {
       DIE("Must have found the group leader at least");
     }
@@ -110,7 +110,7 @@ int WaitForProcessGroupToTerminate(pid_t pgid) {
     struct timespec ts;
     ts.tv_sec = 0;
     ts.tv_nsec = 1000000;
-    if (nanosleep(&ts, NULL) == -1) {
+    if (nanosleep(&ts, nullptr) == -1) {
       return -1;
     }
   }

--- a/src/test/cpp/blaze_util_windows_test.cc
+++ b/src/test/cpp/blaze_util_windows_test.cc
@@ -39,20 +39,20 @@ using std::wstring;
 // are case-insensitive on Windows).
 //
 // This is a macro so the assertions will have the correct line number.
-#define ASSERT_ENVVAR_UNSET(/* const char* */ key)                            \
-  {                                                                           \
-    ASSERT_EQ(::GetEnvironmentVariableA(key, NULL, 0), (DWORD)0);             \
-    ASSERT_EQ(                                                                \
-        ::GetEnvironmentVariableA(blaze_util::AsLower(key).c_str(), NULL, 0), \
-        (DWORD)0);                                                            \
-    ASSERT_EQ(::GetEnvironmentVariableW(                                      \
-                  blaze_util::CstringToWstring(key).c_str(), NULL, 0),        \
-              (DWORD)0);                                                      \
-    ASSERT_EQ(                                                                \
-        ::GetEnvironmentVariableW(                                            \
-            blaze_util::CstringToWstring(blaze_util::AsLower(key)).c_str(),   \
-            NULL, 0),                                                         \
-        (DWORD)0);                                                            \
+#define ASSERT_ENVVAR_UNSET(/* const char* */ key)                               \
+  {                                                                              \
+    ASSERT_EQ(::GetEnvironmentVariableA(key, nullptr, 0), (DWORD)0);             \
+    ASSERT_EQ(                                                                   \
+        ::GetEnvironmentVariableA(blaze_util::AsLower(key).c_str(), nullptr, 0), \
+        (DWORD)0);                                                               \
+    ASSERT_EQ(::GetEnvironmentVariableW(                                         \
+                  blaze_util::CstringToWstring(key).c_str(), nullptr, 0),        \
+              (DWORD)0);                                                         \
+    ASSERT_EQ(                                                                   \
+        ::GetEnvironmentVariableW(                                               \
+            blaze_util::CstringToWstring(blaze_util::AsLower(key)).c_str(),      \
+            nullptr, 0),                                                         \
+        (DWORD)0);                                                               \
   }
 
 // Asserts that the envvar named `key` is set to the `expected` value.
@@ -66,7 +66,7 @@ using std::wstring;
   {                                                                       \
     string key(_key);                                                     \
     string expected(_expected);                                           \
-    DWORD size = ::GetEnvironmentVariableA(key.c_str(), NULL, 0);         \
+    DWORD size = ::GetEnvironmentVariableA(key.c_str(), nullptr, 0);      \
     ASSERT_GT(size, (DWORD)0);                                            \
     unique_ptr<char[]> buf(new char[size]);                               \
                                                                           \
@@ -84,7 +84,7 @@ using std::wstring;
     /* Assert that GetEnvironmentVariableW can retrieve the value. */     \
     wstring wkey(blaze_util::CstringToWstring(key));                      \
     wstring wexpected(blaze_util::CstringToWstring(expected));            \
-    size = ::GetEnvironmentVariableW(wkey.c_str(), NULL, 0);              \
+    size = ::GetEnvironmentVariableW(wkey.c_str(), nullptr, 0);           \
     ASSERT_GT(size, (DWORD)0);                                            \
     unique_ptr<WCHAR[]> wbuf(new WCHAR[size]);                            \
     ASSERT_EQ(::GetEnvironmentVariableW(wkey.c_str(), wbuf.get(), size),  \

--- a/src/test/cpp/util/file_posix_test.cc
+++ b/src/test/cpp/util/file_posix_test.cc
@@ -81,9 +81,9 @@ TEST(FilePosixTest, GetAllFilesUnder) {
 
 TEST(FilePosixTest, MakeDirectories) {
   const char* tmp_dir = getenv("TEST_TMPDIR");
-  ASSERT_STRNE(tmp_dir, NULL);
+  ASSERT_STRNE(tmp_dir, nullptr);
   const char* test_src_dir = getenv("TEST_SRCDIR");
-  ASSERT_STRNE(NULL, test_src_dir);
+  ASSERT_STRNE(nullptr, test_src_dir);
 
   string dir = JoinPath(tmp_dir, "x/y/z");
   bool ok = MakeDirectories(dir, 0755);
@@ -142,7 +142,7 @@ TEST(FilePosixTest, MakeDirectories) {
 
 TEST(FilePosixTest, HammerMakeDirectories) {
   const char* tmp_dir = getenv("TEST_TMPDIR");
-  ASSERT_STRNE(tmp_dir, NULL);
+  ASSERT_STRNE(tmp_dir, nullptr);
 
   string path = JoinPath(tmp_dir, "x/y/z");
   // TODO(ulfjack): Fix this!
@@ -237,7 +237,7 @@ class MockDirectoryEntryConsumer : public DirectoryEntryConsumer {
 TEST(FilePosixTest, ForEachDirectoryEntry) {
   // Get the test's temp dir.
   char* tmpdir_cstr = getenv("TEST_TMPDIR");
-  ASSERT_FALSE(tmpdir_cstr == NULL);
+  ASSERT_FALSE(tmpdir_cstr == nullptr);
   string tempdir(tmpdir_cstr);
   ASSERT_FALSE(tempdir.empty());
   if (tempdir.back() == '/') {

--- a/src/test/cpp/util/file_windows_test.cc
+++ b/src/test/cpp/util/file_windows_test.cc
@@ -79,8 +79,8 @@ static void AssertTearDown(const WCHAR* dir1, const WCHAR* dir2) {
   wstring dir1str(wtmpdir + L"\\" + dir1);
   wstring subdir(dir1str + L"\\subdir");
   wstring wfile(subdir + L"\\hello.txt");
-  EXPECT_TRUE(::CreateDirectoryW(dir1str.c_str(), NULL));
-  EXPECT_TRUE(::CreateDirectoryW(subdir.c_str(), NULL));
+  EXPECT_TRUE(::CreateDirectoryW(dir1str.c_str(), nullptr));
+  EXPECT_TRUE(::CreateDirectoryW(subdir.c_str(), nullptr));
   EXPECT_TRUE(CreateDummyFile(wfile));
   EXPECT_NE(::GetFileAttributesW(wfile.c_str()), INVALID_FILE_ATTRIBUTES);
   ASSERT_EQ(::GetFileAttributesW((wtmpdir + L"\\" + dir2).c_str()),
@@ -323,7 +323,7 @@ TEST_F(FileWindowsTest, TestMtimeHandling) {
   Path tempdir(tempdir_cstr);
 
   Path target = tempdir.GetRelative("target" TOSTRING(__LINE__));
-  EXPECT_TRUE(CreateDirectoryW(target.AsNativePath().c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(target.AsNativePath().c_str(), nullptr));
 
   std::unique_ptr<IFileMtime> mtime(CreateFileMtime());
   // Assert that a directory is always a good embedded binary. (We do not care

--- a/src/test/cpp/util/path_posix_test.cc
+++ b/src/test/cpp/util/path_posix_test.cc
@@ -145,7 +145,7 @@ TEST(PathPosixTest, IsDevNullTest) {
   ASSERT_FALSE(IsDevNull("dev/null"));
   ASSERT_FALSE(IsDevNull("/dev/nul"));
   ASSERT_FALSE(IsDevNull("/dev/nulll"));
-  ASSERT_FALSE(IsDevNull(NULL));
+  ASSERT_FALSE(IsDevNull(nullptr));
   ASSERT_FALSE(IsDevNull(""));
 }
 

--- a/src/test/cpp/util/windows_test_util.cc
+++ b/src/test/cpp/util/windows_test_util.cc
@@ -33,7 +33,7 @@ using std::unique_ptr;
 using std::wstring;
 
 wstring GetTestTmpDirW() {
-  DWORD size = ::GetEnvironmentVariableW(L"TEST_TMPDIR", NULL, 0);
+  DWORD size = ::GetEnvironmentVariableW(L"TEST_TMPDIR", nullptr, 0);
   unique_ptr<WCHAR[]> buf(new WCHAR[size]);
   ::GetEnvironmentVariableW(L"TEST_TMPDIR", buf.get(), size);
   wstring result(buf.get());
@@ -98,14 +98,14 @@ bool CreateDummyFile(const wstring& path, const std::string& content) {
 bool CreateDummyFile(const std::wstring& path, const void* content,
                      const DWORD size) {
   HANDLE handle =
-      ::CreateFileW(path.c_str(), GENERIC_WRITE, FILE_SHARE_READ, NULL,
-                    CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+      ::CreateFileW(path.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr,
+                    CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
   if (handle == INVALID_HANDLE_VALUE) {
     return false;
   }
   bool result = true;
   DWORD actually_written = 0;
-  if (!::WriteFile(handle, content, size, &actually_written, NULL) &&
+  if (!::WriteFile(handle, content, size, &actually_written, nullptr) &&
       actually_written != size) {
     result = false;
   }

--- a/src/test/cpp/util/windows_test_util_test.cc
+++ b/src/test/cpp/util/windows_test_util_test.cc
@@ -32,7 +32,7 @@ using std::wstring;
 
 class WindowsTestUtilTest : public ::testing::Test {
  public:
-  void SetUp() override { ::CreateDirectoryW(GetTestTmpDirW().c_str(), NULL); }
+  void SetUp() override { ::CreateDirectoryW(GetTestTmpDirW().c_str(), nullptr); }
   void TearDown() override { DeleteAllUnder(GetTestTmpDirW()); }
 };
 
@@ -55,10 +55,10 @@ TEST_F(WindowsTestUtilTest, TestDeleteAllUnder) {
   wstring wtemp = GetTestTmpDirW();
   EXPECT_FALSE(wtemp.empty());
   wstring dir1 = wstring(L"\\\\?\\") + wtemp + L"\\dir1";
-  EXPECT_TRUE(::CreateDirectoryW(dir1.c_str(), NULL));
+  EXPECT_TRUE(::CreateDirectoryW(dir1.c_str(), nullptr));
   EXPECT_TRUE(CreateDummyFile(dir1 + L"\\file1.txt"));
   wstring dir2 = dir1 + L"\\dir2";
-  EXPECT_TRUE(::CreateDirectoryW(dir2.c_str(), NULL));
+  EXPECT_TRUE(::CreateDirectoryW(dir2.c_str(), nullptr));
   EXPECT_TRUE(CreateDummyFile(dir2 + L"\\file2.txt"));
   ASSERT_TRUE(DeleteAllUnder(dir1));
 }

--- a/src/test/java/com/google/devtools/build/lib/shell/cat_file.cc
+++ b/src/test/java/com/google/devtools/build/lib/shell/cat_file.cc
@@ -22,7 +22,7 @@ int main(int argc, char** argv) {
     return 1;
   }
   FILE* f = fopen(argv[1], "rt");
-  if (f == NULL) {
+  if (f == nullptr) {
     fprintf(stderr, "ERROR(%s:%d): cannot open \"%s\"\n", __FILE__, __LINE__,
             argv[1]);
     return 1;

--- a/src/test/native/windows/file_test.cc
+++ b/src/test/native/windows/file_test.cc
@@ -83,7 +83,7 @@ TEST_F(WindowsFileOperationsTest, TestIsAbsoluteWindowsStylePath) {
 TEST_F(WindowsFileOperationsTest, TestCreateJunction) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring target(tmp + L"\\junc_target");
-  EXPECT_TRUE(::CreateDirectoryW(target.c_str(), NULL));
+  EXPECT_TRUE(::CreateDirectoryW(target.c_str(), nullptr));
   wstring file1(target + L"\\foo");
   EXPECT_TRUE(blaze_util::CreateDummyFile(file1));
 
@@ -165,7 +165,7 @@ TEST_F(WindowsFileOperationsTest, TestCanCreateNonDanglingJunction) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring name = tmp + L"\\junc" WLINE;
   wstring target = tmp + L"\\target" WLINE;
-  EXPECT_TRUE(CreateDirectoryW(target.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(target.c_str(), nullptr));
   ASSERT_EQ(CreateJunction(name, target, nullptr),
             CreateJunctionResult::kSuccess);
 }
@@ -195,7 +195,7 @@ TEST_F(WindowsFileOperationsTest, TestCannotCreateJunctionFromEmptyDirectory) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring name = tmp + L"\\junc" WLINE;
   wstring target = tmp + L"\\target" WLINE;
-  EXPECT_TRUE(CreateDirectoryW(name.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(name.c_str(), nullptr));
   ASSERT_EQ(CreateJunction(name, target, nullptr),
             CreateJunctionResult::kAlreadyExistsButNotJunction);
 }
@@ -205,7 +205,7 @@ TEST_F(WindowsFileOperationsTest,
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring name = tmp + L"\\junc" WLINE;
   wstring target = tmp + L"\\target" WLINE;
-  EXPECT_TRUE(CreateDirectoryW(name.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(name.c_str(), nullptr));
   EXPECT_TRUE(blaze_util::CreateDummyFile(name + L"\\hello.txt"));
   ASSERT_EQ(CreateJunction(name, target, nullptr),
             CreateJunctionResult::kAlreadyExistsButNotJunction);
@@ -224,10 +224,10 @@ TEST_F(WindowsFileOperationsTest, TestCannotCreateButCanCheckIfNameIsBusy) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring name = tmp + L"\\junc" WLINE;
   wstring target = tmp + L"\\target" WLINE;
-  EXPECT_TRUE(CreateDirectoryW(name.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(name.c_str(), nullptr));
   HANDLE h = CreateFileW(
-      name.c_str(), GENERIC_WRITE, 0, NULL, OPEN_EXISTING,
-      FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+      name.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING,
+      FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
   EXPECT_NE(h, INVALID_HANDLE_VALUE);
   int actual = CreateJunction(name, target, nullptr);
   CloseHandle(h);
@@ -238,9 +238,9 @@ TEST_F(WindowsFileOperationsTest, TestCanCreateJunctionIfTargetIsBusy) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring name = tmp + L"\\junc" WLINE;
   wstring target = tmp + L"\\target" WLINE;
-  EXPECT_TRUE(CreateDirectoryW(target.c_str(), NULL));
-  HANDLE h = CreateFileW(target.c_str(), GENERIC_WRITE, 0, NULL, OPEN_EXISTING,
-                         FILE_FLAG_BACKUP_SEMANTICS, NULL);
+  EXPECT_TRUE(CreateDirectoryW(target.c_str(), nullptr));
+  HANDLE h = CreateFileW(target.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING,
+                         FILE_FLAG_BACKUP_SEMANTICS, nullptr);
   EXPECT_NE(h, INVALID_HANDLE_VALUE);
   int actual = CreateJunction(name, target, nullptr);
   CloseHandle(h);
@@ -257,7 +257,7 @@ TEST_F(WindowsFileOperationsTest, TestCanDeleteExistingFile) {
 TEST_F(WindowsFileOperationsTest, TestCanDeleteExistingDirectory) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring path = tmp + L"\\dir" WLINE;
-  EXPECT_TRUE(CreateDirectoryW(path.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(path.c_str(), nullptr));
   ASSERT_EQ(DeletePath(path.c_str(), nullptr), DeletePathResult::kSuccess);
 }
 
@@ -265,7 +265,7 @@ TEST_F(WindowsFileOperationsTest, TestCanDeleteExistingJunction) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring name = tmp + L"\\junc" WLINE;
   wstring target = tmp + L"\\target" WLINE;
-  EXPECT_TRUE(CreateDirectoryW(target.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(target.c_str(), nullptr));
   EXPECT_EQ(CreateJunction(name, target, nullptr),
             CreateJunctionResult::kSuccess);
   ASSERT_EQ(DeletePath(name.c_str(), nullptr), DeletePathResult::kSuccess);
@@ -275,7 +275,7 @@ TEST_F(WindowsFileOperationsTest, TestCanDeleteExistingJunctionWithoutTarget) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring name = tmp + L"\\junc" WLINE;
   wstring target = tmp + L"\\target" WLINE;
-  EXPECT_TRUE(CreateDirectoryW(target.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(target.c_str(), nullptr));
   EXPECT_EQ(CreateJunction(name, target, nullptr),
             CreateJunctionResult::kSuccess);
   EXPECT_TRUE(RemoveDirectoryW(target.c_str()));
@@ -306,7 +306,7 @@ TEST_F(WindowsFileOperationsTest, TestCannotDeleteNonEmptyDirectory) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring parent = tmp + L"\\dir" WLINE;
   wstring child = parent + L"\\file" WLINE;
-  EXPECT_TRUE(CreateDirectoryW(parent.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(parent.c_str(), nullptr));
   EXPECT_TRUE(blaze_util::CreateDummyFile(child));
   ASSERT_EQ(DeletePath(parent.c_str(), nullptr),
             DeletePathResult::kDirectoryNotEmpty);
@@ -316,8 +316,8 @@ TEST_F(WindowsFileOperationsTest, TestCannotDeleteBusyFile) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring path = tmp + L"\\file" WLINE;
   EXPECT_TRUE(blaze_util::CreateDummyFile(path));
-  HANDLE h = CreateFileW(path.c_str(), GENERIC_WRITE, 0, NULL, OPEN_EXISTING,
-                         FILE_ATTRIBUTE_NORMAL, NULL);
+  HANDLE h = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING,
+                         FILE_ATTRIBUTE_NORMAL, nullptr);
   EXPECT_NE(h, INVALID_HANDLE_VALUE);
   int actual = DeletePath(path.c_str(), nullptr);
   CloseHandle(h);
@@ -327,9 +327,9 @@ TEST_F(WindowsFileOperationsTest, TestCannotDeleteBusyFile) {
 TEST_F(WindowsFileOperationsTest, TestCannotDeleteBusyDirectory) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring path = tmp + L"\\dir" WLINE;
-  EXPECT_TRUE(CreateDirectoryW(path.c_str(), NULL));
-  HANDLE h = CreateFileW(path.c_str(), GENERIC_WRITE, 0, NULL, OPEN_EXISTING,
-                         FILE_FLAG_BACKUP_SEMANTICS, NULL);
+  EXPECT_TRUE(CreateDirectoryW(path.c_str(), nullptr));
+  HANDLE h = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING,
+                         FILE_FLAG_BACKUP_SEMANTICS, nullptr);
   EXPECT_NE(h, INVALID_HANDLE_VALUE);
   int actual = DeletePath(path.c_str(), nullptr);
   CloseHandle(h);
@@ -340,13 +340,13 @@ TEST_F(WindowsFileOperationsTest, TestCannotDeleteBusyJunction) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring name = tmp + L"\\junc" WLINE;
   wstring target = tmp + L"\\target" WLINE;
-  EXPECT_TRUE(CreateDirectoryW(target.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(target.c_str(), nullptr));
   EXPECT_EQ(CreateJunction(name, target, nullptr),
             CreateJunctionResult::kSuccess);
   // Open the junction itself (do not follow symlinks).
   HANDLE h = CreateFileW(
-      name.c_str(), GENERIC_WRITE, 0, NULL, OPEN_EXISTING,
-      FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+      name.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING,
+      FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
   EXPECT_NE(h, INVALID_HANDLE_VALUE);
   int actual = DeletePath(name.c_str(), nullptr);
   CloseHandle(h);
@@ -357,12 +357,12 @@ TEST_F(WindowsFileOperationsTest, TestCanDeleteJunctionWhoseTargetIsBusy) {
   wstring tmp(kUncPrefix + GetTestTmpDirW());
   wstring name = tmp + L"\\junc" WLINE;
   wstring target = tmp + L"\\target" WLINE;
-  EXPECT_TRUE(CreateDirectoryW(target.c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(target.c_str(), nullptr));
   EXPECT_EQ(CreateJunction(name, target, nullptr),
             CreateJunctionResult::kSuccess);
   // Open the junction's target (follow symlinks).
-  HANDLE h = CreateFileW(target.c_str(), GENERIC_WRITE, 0, NULL, OPEN_EXISTING,
-                         FILE_FLAG_BACKUP_SEMANTICS, NULL);
+  HANDLE h = CreateFileW(target.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING,
+                         FILE_FLAG_BACKUP_SEMANTICS, nullptr);
   EXPECT_NE(h, INVALID_HANDLE_VALUE);
   int actual = DeletePath(name.c_str(), nullptr);
   CloseHandle(h);

--- a/src/test/native/windows/process_test.cc
+++ b/src/test/native/windows/process_test.cc
@@ -67,14 +67,14 @@ void AssertSubprocessReceivesArgsAsIntended(
   // SECURITY_ATTRIBUTES for inheritable HANDLEs.
   SECURITY_ATTRIBUTES sa;
   sa.nLength = sizeof(sa);
-  sa.lpSecurityDescriptor = NULL;
+  sa.lpSecurityDescriptor = nullptr;
   sa.bInheritHandle = TRUE;
 
   // Open /dev/null that will be redirected into the subprocess' stdin.
   bazel::windows::AutoHandle devnull(
       CreateFileW(L"NUL", GENERIC_READ,
                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, &sa,
-                  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL));
+                  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
   ASSERT_TRUE(devnull.IsValid());
 
   // Create a pipe that the subprocess' stdout will be redirected to.
@@ -128,8 +128,8 @@ void AssertSubprocessReceivesArgsAsIntended(
     // Run the subprocess.
     PROCESS_INFORMATION processInfo;
     BOOL ok = CreateProcessW(
-        NULL, cmdline, NULL, NULL, TRUE,
-        CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT, NULL, NULL,
+        nullptr, cmdline, nullptr, nullptr, TRUE,
+        CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT, nullptr, nullptr,
         &startupInfo.StartupInfo, &processInfo);
     if (!ok) {
       DWORD err = GetLastError();
@@ -149,7 +149,7 @@ void AssertSubprocessReceivesArgsAsIntended(
     // null-terminated strings in the pipe, making it easy to read them out
     // later.
     DWORD dummy;
-    ASSERT_TRUE(WriteFile(pipe_write, "\0", 1, &dummy, NULL));
+    ASSERT_TRUE(WriteFile(pipe_write, "\0", 1, &dummy, nullptr));
   }
 
   // Read the output of the subprocesses from the pipe. They are divided by
@@ -159,7 +159,7 @@ void AssertSubprocessReceivesArgsAsIntended(
   DWORD total_output_len;
   char buf[0x10000];
   pipe_write = INVALID_HANDLE_VALUE;
-  if (!ReadFile(pipe_read, buf, 0x10000, &total_output_len, NULL)) {
+  if (!ReadFile(pipe_read, buf, 0x10000, &total_output_len, nullptr)) {
     DWORD err = GetLastError();
     ASSERT_EQ(err, 0);
   }

--- a/src/test/native/windows/util_test.cc
+++ b/src/test/native/windows/util_test.cc
@@ -43,7 +43,7 @@ static const wstring kUncPrefix = wstring(L"\\\\?\\");
 // Retrieves TEST_TMPDIR as a shortened path. Result won't have a "\\?\" prefix.
 static void GetShortTempDir(wstring* result) {
   unique_ptr<WCHAR[]> buf;
-  DWORD size = ::GetEnvironmentVariableW(L"TEST_TMPDIR", NULL, 0);
+  DWORD size = ::GetEnvironmentVariableW(L"TEST_TMPDIR", nullptr, 0);
   ASSERT_GT(size, (DWORD)0);
   // `size` accounts for the null-terminator
   buf.reset(new WCHAR[size]);
@@ -59,7 +59,7 @@ static void GetShortTempDir(wstring* result) {
   std::replace(tmpdir.begin(), tmpdir.end(), '/', '\\');
 
   // Convert to 8dot3 style short path.
-  size = ::GetShortPathNameW(tmpdir.c_str(), NULL, 0);
+  size = ::GetShortPathNameW(tmpdir.c_str(), nullptr, 0);
   ASSERT_GT(size, (DWORD)0);
   // `size` accounts for the null-terminator
   buf.reset(new WCHAR[size]);
@@ -88,15 +88,15 @@ static wstring CreateDummyFile(wstring path) {
       /* lpFileName */ path.c_str(),
       /* dwDesiredAccess */ GENERIC_WRITE,
       /* dwShareMode */ FILE_SHARE_READ,
-      /* lpSecurityAttributes */ NULL,
+      /* lpSecurityAttributes */ nullptr,
       /* dwCreationDisposition */ CREATE_ALWAYS,
       /* dwFlagsAndAttributes */ FILE_ATTRIBUTE_NORMAL,
-      /* hTemplateFile */ NULL);
+      /* hTemplateFile */ nullptr);
   if (handle == INVALID_HANDLE_VALUE) {
     return ReturnEmptyOrError(false, L"CreateFileW", path);
   }
   DWORD actually_written = 0;
-  WriteFile(handle, "hello", 5, &actually_written, NULL);
+  WriteFile(handle, "hello", 5, &actually_written, nullptr);
   if (actually_written == 0) {
     return ReturnEmptyOrError(false, L"WriteFile", path);
   }
@@ -123,7 +123,7 @@ static wstring DeleteDummyFile(wstring path) {
 // Creates a directory under `path`. `path` should NOT have a "\\?\" prefix.
 static wstring CreateDir(wstring path) {
   path = kUncPrefix + path;
-  return ReturnEmptyOrError(::CreateDirectoryW(path.c_str(), NULL),
+  return ReturnEmptyOrError(::CreateDirectoryW(path.c_str(), nullptr),
                             L"CreateDirectoryW", path);
 }
 

--- a/src/test/py/bazel/testdata/runfiles_test/foo/foo.cc
+++ b/src/test/py/bazel/testdata/runfiles_test/foo/foo.cc
@@ -144,8 +144,8 @@ int _main(int argc, char** argv) {
 #ifdef IS_WINDOWS
     PROCESS_INFORMATION processInfo;
     STARTUPINFOA startupInfo = {0};
-    BOOL ok = CreateProcessA(NULL, argv0.get(), NULL, NULL, FALSE, 0,
-                             envvars.get(), NULL, &startupInfo, &processInfo);
+    BOOL ok = CreateProcessA(nullptr, argv0.get(), nullptr, nullptr, FALSE, 0,
+                             envvars.get(), nullptr, &startupInfo, &processInfo);
     if (!ok) {
       DWORD err = GetLastError();
       fprintf(stderr, "ERROR: CreateProcessA error: %d\n", err);
@@ -155,7 +155,7 @@ int _main(int argc, char** argv) {
     CloseHandle(processInfo.hProcess);
     CloseHandle(processInfo.hThread);
 #else
-    char* args[2] = {argv0.get(), NULL};
+    char* args[2] = {argv0.get(), nullptr};
     pid_t child = fork();
     if (child) {
       int status;

--- a/src/test/res/app.cc
+++ b/src/test/res/app.cc
@@ -25,7 +25,7 @@ int main() {
 #ifdef _WIN32
   WCHAR p[100];
   memset(p, 0, sizeof(p));
-  int l = LoadStringW(GetModuleHandle(NULL), IDS_STRING, p, 100);
+  int l = LoadStringW(GetModuleHandle(nullptr), IDS_STRING, p, 100);
   wprintf(L"l=%d, p=(%s)", l, p);
 #else   // not _WIN32
   printf("not supported");

--- a/src/test/shell/integration/spend_cpu_time.cc
+++ b/src/test/shell/integration/spend_cpu_time.cc
@@ -36,7 +36,7 @@ static uint64_t ElapsedCpuMillisSince(const clock_t before) {
 // Computes the time that passed, in millis, since the previous timestamp.
 static uint64_t ElapsedWallTimeMillisSince(const struct timeval* before) {
   struct timeval now;
-  gettimeofday(&now, NULL);
+  gettimeofday(&now, nullptr);
   return (now.tv_sec * 1000 + now.tv_usec / 1000) -
       (before->tv_sec * 1000 + before->tv_usec / 1000);
 }
@@ -72,12 +72,12 @@ static void WasteUserTime(const uint64_t millis) {
 // function again with the remainder.
 static void WasteSystemTime(const uint64_t millis) {
   char current_dir_path[MAXPATHLEN];
-  if (getcwd(current_dir_path, sizeof(current_dir_path)) == NULL) {
+  if (getcwd(current_dir_path, sizeof(current_dir_path)) == nullptr) {
     err(EXIT_FAILURE, "getcwd() failed");
   }
 
   struct timeval before;
-  gettimeofday(&before, NULL);
+  gettimeofday(&before, nullptr);
   while (ElapsedWallTimeMillisSince(&before) < millis) {
     // Arbitrary syscall to waste system time.
     if (chdir(current_dir_path) != 0) {

--- a/src/tools/launcher/launcher.cc
+++ b/src/tools/launcher/launcher.cc
@@ -244,16 +244,16 @@ ExitCode BinaryLauncherBase::LaunchProcess(const wstring& executable,
   STARTUPINFOW startupInfo = {0};
   startupInfo.cb = sizeof(startupInfo);
   BOOL ok = CreateProcessW(
-      /* lpApplicationName */ NULL,
+      /* lpApplicationName */ nullptr,
       /* lpCommandLine */ cmdline.cmdline,
-      /* lpProcessAttributes */ NULL,
-      /* lpThreadAttributes */ NULL,
+      /* lpProcessAttributes */ nullptr,
+      /* lpThreadAttributes */ nullptr,
       /* bInheritHandles */ FALSE,
       /* dwCreationFlags */
       suppressOutput ? CREATE_NO_WINDOW  // no console window => no output
                      : 0,
-      /* lpEnvironment */ NULL,
-      /* lpCurrentDirectory */ NULL,
+      /* lpEnvironment */ nullptr,
+      /* lpCurrentDirectory */ nullptr,
       /* lpStartupInfo */ &startupInfo,
       /* lpProcessInformation */ &processInfo);
   if (!ok) {

--- a/src/tools/launcher/util/data_parser_test.cc
+++ b/src/tools/launcher/util/data_parser_test.cc
@@ -43,11 +43,11 @@ class LaunchDataParserTest : public ::testing::Test {
 
   void SetUp() override {
     char* tmpdir = getenv("TEST_TMPDIR");
-    if (tmpdir != NULL) {
+    if (tmpdir != nullptr) {
       test_tmpdir = string(tmpdir);
     } else {
       tmpdir = getenv("TEMP");
-      ASSERT_FALSE(tmpdir == NULL);
+      ASSERT_FALSE(tmpdir == nullptr);
       test_tmpdir = string(tmpdir);
     }
   }

--- a/src/tools/launcher/util/launcher_util.cc
+++ b/src/tools/launcher/util/launcher_util.cc
@@ -52,8 +52,8 @@ string GetLastErrorString() {
   size_t size = FormatMessageA(
       FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
           FORMAT_MESSAGE_IGNORE_INSERTS,
-      NULL, last_error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-      (LPSTR)&message_buffer, 0, NULL);
+      nullptr, last_error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      (LPSTR)&message_buffer, 0, nullptr);
 
   stringstream result;
   result << "(error: " << last_error << "): " << message_buffer;

--- a/src/tools/launcher/util/launcher_util_test.cc
+++ b/src/tools/launcher/util/launcher_util_test.cc
@@ -50,11 +50,11 @@ class LaunchUtilTest : public ::testing::Test {
 
   void SetUp() override {
     char* tmpdir = getenv("TEST_TMPDIR");
-    if (tmpdir != NULL) {
+    if (tmpdir != nullptr) {
       test_tmpdir = blaze_util::CstringToWstring(string(tmpdir));
     } else {
       tmpdir = getenv("TEMP");
-      ASSERT_FALSE(tmpdir == NULL);
+      ASSERT_FALSE(tmpdir == nullptr);
       test_tmpdir = blaze_util::CstringToWstring(string(tmpdir));
     }
   }
@@ -113,7 +113,7 @@ TEST_F(LaunchUtilTest, DoesFilePathExistTest) {
 TEST_F(LaunchUtilTest, DoesDirectoryPathExistTest) {
   wstring dir1 = GetTmpDir() + L"/dir1";
   wstring dir2 = GetTmpDir() + L"/dir2";
-  CreateDirectoryW(dir1.c_str(), NULL);
+  CreateDirectoryW(dir1.c_str(), nullptr);
   ASSERT_TRUE(DoesDirectoryPathExist(dir1.c_str()));
   ASSERT_FALSE(DoesDirectoryPathExist(dir2.c_str()));
 }

--- a/src/tools/singlejar/input_jar.h
+++ b/src/tools/singlejar/input_jar.h
@@ -53,7 +53,7 @@ class InputJar {
   // Opens the file, memory maps it and locates Central Directory.
   bool Open(const std::string& path);
 
-  // Returns the next Central Directory Header or NULL.
+  // Returns the next Central Directory Header or nullptr.
   const CDH *NextEntry(const LH **local_header_ptr) {
     if (path_.empty()) {
       diag_errx(1, "%s:%d: call Open() first!", __FILE__, __LINE__);

--- a/src/tools/singlejar/output_jar.cc
+++ b/src/tools/singlejar/output_jar.cc
@@ -282,7 +282,7 @@ bool OutputJar::Open() {
                              // Must share for reading, otherwise
                              // symlink-following file existence checks (e.g.
                              // java.nio.file.Files.exists()) fail.
-                             FILE_SHARE_READ, NULL, CREATE_ALWAYS, 0, NULL);
+                             FILE_SHARE_READ, nullptr, CREATE_ALWAYS, 0, nullptr);
   if (hFile == INVALID_HANDLE_VALUE) {
     diag_warn("%s:%d: CreateFileW failed for %S", __FILE__, __LINE__,
               wpath.c_str());
@@ -958,7 +958,7 @@ ssize_t OutputJar::CopyAppendData(int in_fd, off64_t offset, size_t count) {
   while (static_cast<size_t>(total_written) < count) {
     ssize_t len = std::min(kBufferSize, count - total_written);
     DWORD n_read;
-    if (!::ReadFile(hFile, buffer.get(), len, &n_read, NULL)) {
+    if (!::ReadFile(hFile, buffer.get(), len, &n_read, nullptr)) {
       return -1;
     }
     if (n_read == 0) {

--- a/tools/cpp/runfiles/runfiles_src.cc
+++ b/tools/cpp/runfiles/runfiles_src.cc
@@ -176,7 +176,7 @@ bool IsAbsolute(const string& path) {
 
 string GetEnv(const string& key) {
 #ifdef _WIN32
-  DWORD size = ::GetEnvironmentVariableA(key.c_str(), NULL, 0);
+  DWORD size = ::GetEnvironmentVariableA(key.c_str(), nullptr, 0);
   if (size == 0) {
     return string();  // unset or empty envvar
   }
@@ -185,7 +185,7 @@ string GetEnv(const string& key) {
   return value.get();
 #else
   char* result = getenv(key.c_str());
-  return (result == NULL) ? string() : string(result);
+  return (result == nullptr) ? string() : string(result);
 #endif
 }
 

--- a/tools/cpp/runfiles/runfiles_test.cc
+++ b/tools/cpp/runfiles/runfiles_test.cc
@@ -95,7 +95,7 @@ void RunfilesTest::AssertEnvvars(const Runfiles& runfiles,
 
 string RunfilesTest::GetTemp() {
 #ifdef _WIN32
-  DWORD size = ::GetEnvironmentVariableA("TEST_TMPDIR", NULL, 0);
+  DWORD size = ::GetEnvironmentVariableA("TEST_TMPDIR", nullptr, 0);
   if (size == 0) {
     return string();  // unset or empty envvar
   }
@@ -104,7 +104,7 @@ string RunfilesTest::GetTemp() {
   return value.get();
 #else
   char* result = getenv("TEST_TMPDIR");
-  return result != NULL ? string(result) : string();
+  return result != nullptr ? string(result) : string();
 #endif
 }
 
@@ -132,7 +132,7 @@ RunfilesTest::MockFile* RunfilesTest::MockFile::Create(
 #ifdef _WIN32
   while ((i = name.find_first_of("/\\", i + 1)) != string::npos) {
     string d = tmp + "\\" + name.substr(0, i);
-    if (!CreateDirectoryA(d.c_str(), NULL)) {
+    if (!CreateDirectoryA(d.c_str(), nullptr)) {
       cerr << "ERROR: " << __FILE__ << "(" << __LINE__
            << "): failed to create directory \"" << d << "\"" << endl;
       return nullptr;

--- a/tools/osx/crosstool/wrapped_clang.cc
+++ b/tools/osx/crosstool/wrapped_clang.cc
@@ -123,7 +123,7 @@ void ExecProcess(const std::vector<std::string> &args) {
 void RunSubProcess(const std::vector<std::string> &args) {
   std::vector<const char *> exec_argv = ConvertToCArgs(args);
   pid_t pid;
-  int status = posix_spawn(&pid, args[0].c_str(), NULL, NULL,
+  int status = posix_spawn(&pid, args[0].c_str(), nullptr, nullptr,
                            const_cast<char **>(exec_argv.data()), environ);
   if (status == 0) {
     int wait_status;

--- a/tools/test/windows/tw.cc
+++ b/tools/test/windows/tw.cc
@@ -195,7 +195,7 @@ enum class DeleteAfterwards { kEnabled, kDisabled };
 void WriteStdout(const std::string& s) {
   DWORD written;
   WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), s.c_str(), s.size(), &written,
-            NULL);
+            nullptr);
 }
 
 void LogError(const int line) {
@@ -324,7 +324,7 @@ std::wstring AsMixedPath(const std::wstring& path) {
 bool IsReadableFile(const Path& p) {
   HANDLE h = CreateFileW(AddUncPrefixMaybe(p).c_str(), GENERIC_READ,
                          FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                         NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                         nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
   if (h == INVALID_HANDLE_VALUE) {
     return false;
   }
@@ -403,7 +403,7 @@ bool SetPathEnv(const wchar_t* name, const Path& path) {
 }
 
 bool UnsetEnv(const wchar_t* name) {
-  if (SetEnvironmentVariableW(name, NULL) != 0) {
+  if (SetEnvironmentVariableW(name, nullptr) != 0) {
     return true;
   } else {
     DWORD err = GetLastError();
@@ -784,8 +784,8 @@ bool CreateZipBuilder(const Path& zip, const ZipEntryPaths& entry_paths,
 
 bool OpenFileForWriting(const Path& path, bazel::windows::AutoHandle* result) {
   HANDLE h = CreateFileW(AddUncPrefixMaybe(path).c_str(), GENERIC_WRITE,
-                         FILE_SHARE_READ | FILE_SHARE_DELETE, NULL,
-                         CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+                         FILE_SHARE_READ | FILE_SHARE_DELETE, nullptr,
+                         CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
   if (h == INVALID_HANDLE_VALUE) {
     DWORD err = GetLastError();
     LogErrorWithArgAndValue(__LINE__, "Failed to open file", path.Get(), err);
@@ -799,7 +799,7 @@ bool OpenExistingFileForRead(const Path& abs_path,
                              bazel::windows::AutoHandle* result) {
   HANDLE h = CreateFileW(AddUncPrefixMaybe(abs_path).c_str(), GENERIC_READ,
                          FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                         NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                         nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
   if (h == INVALID_HANDLE_VALUE) {
     DWORD err = GetLastError();
     LogErrorWithArgAndValue(__LINE__, "Failed to open file", abs_path.Get(),
@@ -824,7 +824,7 @@ bool ReadFromFile(HANDLE handle, uint8_t* dest, DWORD max_read) {
   DWORD read = 0;
   do {
     if (!ReadFile(handle, dest + total_read, max_read - total_read, &read,
-                  NULL)) {
+                  nullptr)) {
       DWORD err = GetLastError();
       LogErrorWithValue(__LINE__, "Failed to read file", err);
       return false;
@@ -840,7 +840,7 @@ bool WriteToFile(HANDLE output, const void* buffer, const size_t size) {
   while (total_written < size) {
     DWORD written;
     if (!WriteFile(output, static_cast<const uint8_t*>(buffer) + total_written,
-                   size - total_written, &written, NULL)) {
+                   size - total_written, &written, nullptr)) {
       DWORD err = GetLastError();
       LogErrorWithValue(__LINE__, "Failed to write file", err);
       return false;
@@ -863,7 +863,7 @@ bool AppendFileTo(const Path& file, const size_t total_size, HANDLE output) {
   while (true) {
     // Read at most `buf_size` many bytes from the input file.
     DWORD read = 0;
-    if (!ReadFile(input, buffer.get(), buf_size, &read, NULL)) {
+    if (!ReadFile(input, buffer.get(), buf_size, &read, nullptr)) {
       DWORD err = GetLastError();
       LogErrorWithArgAndValue(__LINE__, "Failed to read file", file.Get(), err);
       return false;
@@ -893,7 +893,7 @@ std::string GetMimeType(const std::string& filename) {
   char data[1000];
   DWORD data_size = 1000 * sizeof(char);
   if (RegGetValueA(HKEY_CLASSES_ROOT, filename.c_str() + pos, "Content Type",
-                   RRF_RT_REG_SZ, NULL, data, &data_size) == ERROR_SUCCESS) {
+                   RRF_RT_REG_SZ, nullptr, data, &data_size) == ERROR_SUCCESS) {
     return data;
   }
   // The file extension is unknown, or it does not have a "Content Type" value,
@@ -1220,7 +1220,7 @@ bool StartSubprocess(const Path& path, const std::wstring& args,
                      LARGE_INTEGER* start_time,
                      bazel::windows::WaitableProcess* process) {
   SECURITY_ATTRIBUTES inheritable_handle_sa = {sizeof(SECURITY_ATTRIBUTES),
-                                               NULL, TRUE};
+                                               nullptr, TRUE};
 
   // Create a pipe to stream the output of the subprocess to this process.
   // The subprocess inherits two copies of the writing end (one for stdout, one
@@ -1252,7 +1252,7 @@ bool StartSubprocess(const Path& path, const std::wstring& args,
   bazel::windows::AutoHandle devnull_read(CreateFileW(
       L"NUL", GENERIC_READ,
       FILE_SHARE_WRITE | FILE_SHARE_READ | FILE_SHARE_DELETE,
-      &inheritable_handle_sa, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL));
+      &inheritable_handle_sa, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
   if (devnull_read == INVALID_HANDLE_VALUE) {
     DWORD err = GetLastError();
     LogErrorWithValue(__LINE__, "CreateFileW", err);
@@ -1414,7 +1414,7 @@ bool TeeImpl::Create(bazel::windows::AutoHandle* input,
                      std::unique_ptr<Tee>* result) {
   std::unique_ptr<TeeImpl> tee(new TeeImpl(input, output1, output2));
   bazel::windows::AutoHandle thread(
-      CreateThread(NULL, 0, ThreadFunc, tee.get(), 0, NULL));
+      CreateThread(nullptr, 0, ThreadFunc, tee.get(), 0, nullptr));
   if (!thread.IsValid()) {
     return false;
   }
@@ -1430,10 +1430,10 @@ bool TeeImpl::MainFunc() const {
   static constexpr size_t kBufferSize = 0x10000;
   DWORD read;
   uint8_t content[kBufferSize];
-  while (ReadFile(input_, content, kBufferSize, &read, NULL)) {
+  while (ReadFile(input_, content, kBufferSize, &read, nullptr)) {
     DWORD written;
-    if (read > 0 && (!WriteFile(output1_, content, read, &written, NULL) ||
-                     !WriteFile(output2_, content, read, &written, NULL))) {
+    if (read > 0 && (!WriteFile(output1_, content, read, &written, nullptr) ||
+                     !WriteFile(output2_, content, read, &written, nullptr))) {
       return false;
     }
   }
@@ -1773,7 +1773,7 @@ Path Path::Dirname() const {
 IFStream* IFStreamImpl::Create(HANDLE handle, DWORD page_size) {
   std::unique_ptr<uint8_t[]> data(new uint8_t[page_size * 2]);
   DWORD read;
-  if (!ReadFile(handle, data.get(), page_size * 2, &read, NULL)) {
+  if (!ReadFile(handle, data.get(), page_size * 2, &read, nullptr)) {
     DWORD err = GetLastError();
     if (err == ERROR_BROKEN_PIPE) {
       read = 0;
@@ -1799,7 +1799,7 @@ int IFStreamImpl::Get() {
   // Overwrite the *active* page: we are about to move off of it.
   DWORD offs = (pos_ < page_size_) ? 0 : page_size_;
   DWORD read;
-  if (!ReadFile(handle_, pages_.get() + offs, page_size_, &read, NULL)) {
+  if (!ReadFile(handle_, pages_.get() + offs, page_size_, &read, nullptr)) {
     DWORD err = GetLastError();
     if (err == ERROR_BROKEN_PIPE) {
       // The stream is reading from a pipe, and there's no more data.

--- a/tools/test/windows/tw_test.cc
+++ b/tools/test/windows/tw_test.cc
@@ -138,8 +138,8 @@ void CompareZipEntryPaths(char const* const* actual,
 
 HANDLE FopenRead(const std::wstring& unc_path) {
   return CreateFileW(unc_path.c_str(), GENERIC_READ,
-                     FILE_SHARE_READ | FILE_SHARE_DELETE, NULL, OPEN_EXISTING,
-                     FILE_ATTRIBUTE_NORMAL, NULL);
+                     FILE_SHARE_READ | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING,
+                     FILE_ATTRIBUTE_NORMAL, nullptr);
 }
 
 HANDLE FopenContents(const wchar_t* wline, const char* contents, DWORD size) {
@@ -160,9 +160,9 @@ TEST_F(TestWrapperWindowsTest, TestGetFileListRelativeTo) {
 
   // Create a directory structure to parse.
   std::wstring root = tmpdir + L"\\tmp" + WLINE;
-  EXPECT_TRUE(CreateDirectoryW(root.c_str(), NULL));
-  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo").c_str(), NULL));
-  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo\\sub").c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(root.c_str(), nullptr));
+  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo").c_str(), nullptr));
+  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo\\sub").c_str(), nullptr));
   EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\foo\\sub\\file1", ""));
   EXPECT_TRUE(
       blaze_util::CreateDummyFile(root + L"\\foo\\sub\\file2", "hello"));
@@ -317,9 +317,9 @@ TEST_F(TestWrapperWindowsTest, TestCreateZip) {
 
   // Create a directory structure to archive.
   std::wstring root = tmpdir + L"\\tmp" + WLINE;
-  EXPECT_TRUE(CreateDirectoryW(root.c_str(), NULL));
-  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo").c_str(), NULL));
-  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo\\sub").c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(root.c_str(), nullptr));
+  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo").c_str(), nullptr));
+  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo\\sub").c_str(), nullptr));
   EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\foo\\sub\\file1", ""));
   EXPECT_TRUE(
       blaze_util::CreateDummyFile(root + L"\\foo\\sub\\file2", "hello"));
@@ -414,9 +414,9 @@ TEST_F(TestWrapperWindowsTest, TestCreateUndeclaredOutputsAnnotations) {
 
   // Create a directory structure to parse.
   std::wstring root = tmpdir + L"\\tmp" + WLINE;
-  EXPECT_TRUE(CreateDirectoryW(root.c_str(), NULL));
-  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo").c_str(), NULL));
-  EXPECT_TRUE(CreateDirectoryW((root + L"\\bar.part").c_str(), NULL));
+  EXPECT_TRUE(CreateDirectoryW(root.c_str(), nullptr));
+  EXPECT_TRUE(CreateDirectoryW((root + L"\\foo").c_str(), nullptr));
+  EXPECT_TRUE(CreateDirectoryW((root + L"\\bar.part").c_str(), nullptr));
   EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\a.part", "Hello a"));
   EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\b.txt", "Hello b"));
   EXPECT_TRUE(blaze_util::CreateDummyFile(root + L"\\c.part", "Hello c"));
@@ -431,7 +431,7 @@ TEST_F(TestWrapperWindowsTest, TestCreateUndeclaredOutputsAnnotations) {
   ASSERT_NE(h, INVALID_HANDLE_VALUE);
   char content[100];
   DWORD read;
-  bool success = ReadFile(h, content, 100, &read, NULL) != FALSE;
+  bool success = ReadFile(h, content, 100, &read, nullptr) != FALSE;
   CloseHandle(h);
   EXPECT_TRUE(success);
   ASSERT_EQ(std::string(content, read), std::string("Hello aHello c"));
@@ -439,13 +439,13 @@ TEST_F(TestWrapperWindowsTest, TestCreateUndeclaredOutputsAnnotations) {
 
 TEST_F(TestWrapperWindowsTest, TestTee) {
   HANDLE read1_h, write1_h;
-  EXPECT_TRUE(CreatePipe(&read1_h, &write1_h, NULL, 0));
+  EXPECT_TRUE(CreatePipe(&read1_h, &write1_h, nullptr, 0));
   bazel::windows::AutoHandle read1(read1_h), write1(write1_h);
   HANDLE read2_h, write2_h;
-  EXPECT_TRUE(CreatePipe(&read2_h, &write2_h, NULL, 0));
+  EXPECT_TRUE(CreatePipe(&read2_h, &write2_h, nullptr, 0));
   bazel::windows::AutoHandle read2(read2_h), write2(write2_h);
   HANDLE read3_h, write3_h;
-  EXPECT_TRUE(CreatePipe(&read3_h, &write3_h, NULL, 0));
+  EXPECT_TRUE(CreatePipe(&read3_h, &write3_h, nullptr, 0));
   bazel::windows::AutoHandle read3(read3_h), write3(write3_h);
 
   std::unique_ptr<bazel::tools::test_wrapper::Tee> tee;
@@ -454,21 +454,21 @@ TEST_F(TestWrapperWindowsTest, TestTee) {
   DWORD written, read;
   char content[100];
 
-  EXPECT_TRUE(WriteFile(write1, "hello", 5, &written, NULL));
+  EXPECT_TRUE(WriteFile(write1, "hello", 5, &written, nullptr));
   EXPECT_EQ(written, 5);
-  EXPECT_TRUE(ReadFile(read2, content, 100, &read, NULL));
+  EXPECT_TRUE(ReadFile(read2, content, 100, &read, nullptr));
   EXPECT_EQ(read, 5);
   EXPECT_EQ(std::string(content, read), "hello");
-  EXPECT_TRUE(ReadFile(read3, content, 100, &read, NULL));
+  EXPECT_TRUE(ReadFile(read3, content, 100, &read, nullptr));
   EXPECT_EQ(read, 5);
   EXPECT_EQ(std::string(content, read), "hello");
 
-  EXPECT_TRUE(WriteFile(write1, "foo", 3, &written, NULL));
+  EXPECT_TRUE(WriteFile(write1, "foo", 3, &written, nullptr));
   EXPECT_EQ(written, 3);
-  EXPECT_TRUE(ReadFile(read2, content, 100, &read, NULL));
+  EXPECT_TRUE(ReadFile(read2, content, 100, &read, nullptr));
   EXPECT_EQ(read, 3);
   EXPECT_EQ(std::string(content, read), "foo");
-  EXPECT_TRUE(ReadFile(read3, content, 100, &read, NULL));
+  EXPECT_TRUE(ReadFile(read3, content, 100, &read, nullptr));
   EXPECT_EQ(read, 3);
   EXPECT_EQ(std::string(content, read), "foo");
 


### PR DESCRIPTION
At several places, NULL and nullptr were mixed. This commit cleans this up and switches NULL to nullptr where appropriate.