### PR TITLE
Expand target_compatible_with to all non-workspace rules

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/target_compatible_with.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/target_compatible_with.html
@@ -10,9 +10,9 @@ that must be present in the target platform for this target to be considered
 rule type. If the target platform does not satisfy all listed constraints then
 the target is considered <em>incompatible</em>. Incompatible targets are
 skipped for building and testing when the target pattern is expanded
-(e.g. `//...`, `:all`). When explicitly specified on the command line,
-incompatible targets cause Bazel to print an error and cause a build or test
-failure.
+(e.g. <code>//...</code>, <code>:all</code>). When explicitly specified on the
+command line, incompatible targets cause Bazel to print an error and cause a
+build or test failure.
 </p>
 
 <p>
@@ -23,6 +23,13 @@ considered incompatible. They are also skipped for building and testing.
 <p>
 An empty list (which is the default) signifies that the target is compatible
 with all platforms.
+<p>
+
+<p>
+All rules other than [Workspace Rules](workspace.html) support this attribute.
+For some rules this attribute has no effect. For example, specifying
+<code>target_compatible_with</code> for a
+<code><a href="c-cpp.html#cc_toolchain">cc_toolchain</a></code> is not useful.
 <p>
 
 <p>

--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -381,6 +381,13 @@ public class BaseRuleClasses {
           .add(
               attr("distribs", DISTRIBUTIONS)
                   .nonconfigurable("Used in core loading phase logic with no access to configs"))
+          // Any rule that has provides its own meaning for the "target_compatible_with" attribute
+          // has to be excluded in `RuleContextConstraintSemantics.incompatibleConfiguredTarget()`.
+          .add(
+              attr(RuleClass.TARGET_RESTRICTED_TO_ATTR, LABEL_LIST)
+                  .mandatoryProviders(ConstraintValueInfo.PROVIDER.id())
+                  // This should be configurable to allow for complex types of restrictions.
+                  .allowedFileTypes(FileTypeSet.NO_FILE))
           .build();
     }
 
@@ -441,11 +448,6 @@ public class BaseRuleClasses {
                   .allowedFileTypes()
                   .nonconfigurable("Used in toolchain resolution")
                   .value(ImmutableList.of()))
-          .add(
-              attr(RuleClass.TARGET_RESTRICTED_TO_ATTR, LABEL_LIST)
-                  .mandatoryProviders(ConstraintValueInfo.PROVIDER.id())
-                  // This should be configurable to allow for complex types of restrictions.
-                  .allowedFileTypes(FileTypeSet.NO_FILE))
           .build();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/constraints/RuleContextConstraintSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/constraints/RuleContextConstraintSemantics.java
@@ -907,8 +907,11 @@ public class RuleContextConstraintSemantics implements ConstraintSemantics<RuleC
       RuleContext ruleContext,
       OrderedSetMultimap<DependencyKind, ConfiguredTargetAndData> prerequisiteMap)
       throws ActionConflictException, InterruptedException {
-    // The target (ruleContext) is incompatible if explicitly specified to be.
-    if (ruleContext.getRule().getRuleClassObject().useToolchainResolution()
+    // The target (ruleContext) is incompatible if explicitly specified to be. Any rule that has
+    // provides its own meaning for the "target_compatible_with" attribute has to be excluded here.
+    // For example, the "toolchain" rule uses "target_compatible_with" for bazel's toolchain
+    // resolution.
+    if (!ruleContext.getRule().getRuleClass().equals("toolchain")
         && ruleContext.attributes().has("target_compatible_with")) {
       ImmutableList<ConstraintValueInfo> invalidConstraintValues =
           PlatformProviderUtils.constraintValues(


### PR DESCRIPTION
This patch makes it so the `target_compatible_with` attribute can be
used with all non-workspace rules. The motivation here is to allow
rules like `filegroup` and `cc_import` to also make use of
incompatible target skipping. Even though these rules don't
inherently generate files that are incompatible with the target
platform, they can be used to provide incompatible files to other
targets. Before this patch the user had to do something like this to
create an incompatible pre-compiled library:

    cc_import(
        name = "foo_import",
        shared_library = "foo.so",
    )

    cc_library(
        name = "foo",
        deps = [":foo_import"],
        target_compatible_with = ["//:foo_platform"],
    )

Now users can directly declare compatibility on the `cc_import` rule.

    cc_import(
        name = "foo_import",
        shared_library = "foo.so",
        target_compatible_with = ["//:foo_platform"],
    )

Unfortunately, This does mean that some rules like `cc_toolchain` now
have a `target_compatible_with` that doesn't serve any purpose.

Before the changes in `BaseRulesClasses.java` the test would error out
with meesages like this:

    //target_skipping:some_precompiled_library: no such attribute 'target_compatible_with' in 'cc_import' rule
    //target_skipping:filegroup: no such attribute 'target_compatible_with' in 'filegroup' rule

I also took this opportunity to update the documentation a bit.

Fixes #12745