### PR TITLE
Update documentation on //... and //:all

### DIFF
--- a/site/docs/build-ref.html
+++ b/site/docs/build-ref.html
@@ -293,7 +293,7 @@ app_binary
   The precise details of allowed target names are below.
 </p>
 
-<h4 id="name">Target names, <code>//...:<b>target-name</b></code></h4>
+<h4 id="name">Target names, <code>//&lt;package name&gt;:<b>target-name</b></code></h4>
 
 <p><code>target-name</code> is the name of the target within the package.
   The name of a rule is the value of the <code>name</code>
@@ -331,7 +331,7 @@ app_binary
   certain rules must match their principal source file, which may
   reside in a subdirectory of the package.</p>
 
-<h4>Package names, <code>//<b>package-name</b>:...</code></h4>
+<h4>Package names, <code>//<b>package-name</b>:&lt;target name&gt;</code></h4>
 <p>
   The name of a package is the name of the directory containing its
 

--- a/site/docs/guide.md
+++ b/site/docs/guide.md
@@ -139,15 +139,15 @@ workspace.
 </tr>
 <tr>
   <td><code>//foo/bar:all</code></td>
-  <td>All rules in the package <code>foo/bar</code>.</td>
+  <td>All rule targets in the package <code>foo/bar</code>.</td>
 </tr>
 <tr>
   <td><code>//foo/...</code></td>
-  <td>All rules in all packages beneath the directory <code>foo</code>.</td>
+  <td>All rule targets in all packages beneath the directory <code>foo</code>.</td>
 </tr>
 <tr>
   <td><code>//foo/...:all</code></td>
-  <td>All rules in all packages beneath the directory <code>foo</code>.</td>
+  <td>All rule targets in all packages beneath the directory <code>foo</code>.</td>
 </tr>
 <tr>
   <td><code>//foo/...:*</code></td>
@@ -156,6 +156,16 @@ workspace.
 <tr>
   <td><code>//foo/...:all-targets</code></td>
   <td>All targets (rules and files) in all packages beneath the directory <code>foo</code>.</td>
+</tr>
+<tr>
+  <td><code>//...</code></td>
+  <td>All targets in packages in the workspace. This does not include targets 
+  from a href="external.html">external repositories</a>.</td>
+</tr>
+<tr>
+  <td><code>//:all</code></td>
+  <td>All targets in the top-level package, if there is a BUILD file at the 
+  root of the workspace.</td>
 </tr>
 </table>
 


### PR DESCRIPTION
The intent of this patch is to be a little more explicit about these
two patterns. It appears that there currently isn't a spot that
explicitly documents these patterns.

I also decided to update the examples for "Target names" and "Package
names" because the `...` syntax does have a special meaning. I thought
it best to avoid confusion for those cases.