### PR TITLE
Starlark: override contains for Tuple and StarlarkList

### DIFF
--- a/src/main/java/net/starlark/java/eval/StarlarkList.java
+++ b/src/main/java/net/starlark/java/eval/StarlarkList.java
@@ -315,6 +315,21 @@ public final class StarlarkList<E> extends AbstractList<E>
   }
 
   @Override
+  public boolean contains(Object o) {
+    // StarlarkList contains only valid Starlark objects (which are non-null)
+    if (o == null) {
+      return false;
+    }
+    for (int i = 0; i < size; i++) {
+      Object elem = elems[i];
+      if (o.equals(elem)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
   public StarlarkList<E> getSlice(Mutability mu, int start, int stop, int step)
       throws EvalException {
     RangeList indices = new RangeList(start, stop, step);

--- a/src/main/java/net/starlark/java/eval/Tuple.java
+++ b/src/main/java/net/starlark/java/eval/Tuple.java
@@ -148,6 +148,20 @@ public final class Tuple extends AbstractList<Object>
   }
 
   @Override
+  public boolean contains(Object o) {
+    // Tuple contains only valid Starlark objects (which are non-null)
+    if (o == null) {
+      return false;
+    }
+    for (Object elem : elems) {
+      if (o.equals(elem)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
   public Tuple subList(int from, int to) {
     return wrap(Arrays.copyOfRange(elems, from, to));
   }


### PR DESCRIPTION
Makes `x in [...]` operations a bit faster.