### PR TITLE
SpawnAction.Builder: use callable PathFragment

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/CustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/CustomCommandLine.java
@@ -797,6 +797,16 @@ public final class CustomCommandLine extends CommandLine {
     }
 
     /**
+     * Adds an artifact by calling {@link PathFragment#getCallablePathString}.
+     *
+     * <p>Prefer this over manually calling {@link PathFragment#getCallablePathString}, as it avoids
+     * storing a copy of the path string.
+     */
+    public Builder addCallablePath(@Nullable PathFragment value) {
+      return addObjectInternal(new CallablePathFragment(value));
+    }
+
+    /**
      * Adds an artifact by calling {@link PathFragment#getPathString}.
      *
      * <p>Prefer this over manually calling {@link PathFragment#getPathString}, as it avoids storing
@@ -1318,6 +1328,20 @@ public final class CustomCommandLine extends CommandLine {
       } else {
         fingerprint.addString(CommandLineItem.expandToCommandLine(substitutedArg));
       }
+    }
+  }
+
+  /** A {@link PathFragment} that is expanded with {@link PathFragment#getCallablePathString()}. */
+  private static final class CallablePathFragment {
+    public final PathFragment fragment;
+
+    CallablePathFragment(PathFragment fragment) {
+      this.fragment = fragment;
+    }
+
+    @Override
+    public String toString() {
+      return fragment.getCallablePathString();
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -76,6 +76,7 @@ import com.google.devtools.build.lib.util.Fingerprint;
 import com.google.devtools.build.lib.util.LazyString;
 import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.util.ShellEscaper;
+import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.google.errorprone.annotations.DoNotCall;
@@ -962,7 +963,12 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     }
 
     /**
-     * Sets the executable path; the path is interpreted relative to the execution root.
+     * Sets the executable path; the path is interpreted relative to the execution root, unless it's
+     * a bare file name.
+     *
+     * <p><b>Caution</b>: if the executable is a bare file name ("foo"), it will be interpreted
+     * relative to PATH. See https://github.com/bazelbuild/bazel/issues/13189 for details. To avoid
+     * that, use {@link #setExecutable(Artifact)} instead.
      *
      * <p>Calling this method overrides any previous values set via calls to {@link #setExecutable},
      * {@link #setJavaExecutable}, or {@link #setShellCommand}.
@@ -981,7 +987,9 @@ public class SpawnAction extends AbstractAction implements CommandAction {
      */
     public Builder setExecutable(Artifact executable) {
       addTool(executable);
-      return setExecutable(executable.getExecPath());
+      this.executableArgs = CustomCommandLine.builder().addCallablePath(executable.getExecPath());
+      this.isShellCommand = false;
+      return this;
     }
 
     /**
@@ -1007,7 +1015,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     public Builder setExecutable(FilesToRunProvider executableProvider) {
       Preconditions.checkArgument(executableProvider.getExecutable() != null,
           "The target does not have an executable");
-      setExecutable(executableProvider.getExecutable().getExecPath());
+      setExecutable(executableProvider.getExecutable());
       return addTool(executableProvider);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTemplate.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTemplate.java
@@ -361,7 +361,11 @@ public final class SpawnActionTemplate extends ActionKeyCacher
 
     /**
      * Sets the executable path used by expanded actions. The path is interpreted relative to the
-     * execution root.
+     * execution root, unless it's a bare file name.
+     *
+     * <p><b>Caution</b>: if the executable is a bare file name ("foo"), it will be interpreted
+     * relative to PATH. See https://github.com/bazelbuild/bazel/issues/13189 for details. To avoid
+     * that, use {@link #setExecutable(Artifact)} instead.
      *
      * <p>Calling this method overrides any previous values set via calls to
      * {@link #setExecutable(Artifact)} and {@link #setExecutable(FilesToRunProvider)}.

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ProtobufSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ProtobufSupport.java
@@ -259,7 +259,7 @@ final class ProtobufSupport {
             .addTransitiveInputs(getAllProtos())
             .addOutputs(getGeneratedProtoOutputs(getAllProtos(), HEADER_SUFFIX))
             .addOutputs(getGeneratedProtoOutputs(getOutputProtos(), SOURCE_SUFFIX))
-            .setExecutable(attributes.getProtoCompiler().getExecPath())
+            .setExecutable(attributes.getProtoCompiler())
             .addCommandLine(getGenerationCommandLine(outputGroupFile, skipGroupFile))
             .build(ruleContext));
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
@@ -158,6 +158,19 @@ public class SpawnActionTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testBuilderWithExecutableInRootPcakage() throws Exception {
+    Artifact tool = getSourceArtifact("tool.bin");
+    Action[] actions = builder()
+      .setExecutable(tool)
+      .addOutput(destinationArtifact)
+      .build(ActionsTestUtil.NULL_ACTION_OWNER, targetConfig);
+    collectingAnalysisEnvironment.registerAction(actions);
+    SpawnAction action = (SpawnAction) actions[0];
+    assertThat(action.getArguments()).hasSize(1);
+    assertThat(action.getArguments().get(0)).matches("\\.[/\\\\]tool.bin");
+  }
+
+  @Test
   public void testBuilderWithJavaExecutable() throws Exception {
     Action[] actions = builder()
         .addOutput(destinationArtifact)


### PR DESCRIPTION
If you pass an Artifact or FilesToRunProvider to
Builder.setExecutable, it will now use the
callable path, not just the execpath.

Fixes https://github.com/bazelbuild/bazel/issues/13189

Unfortunately, call sites that pass PathFragment
are susceptible to the bug, because PathFragment
is inherently ambiguous: if it's a bare file name,
the shell resolves it against PATH, otherwise
against the current directory.

RELNOTES: none