### PR TITLE
Implement filtering on JUnit @Category annotations

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/junit/junit4/runner/CategoryFilter.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/junit4/runner/CategoryFilter.java
@@ -1,0 +1,102 @@
+package com.google.testing.junit.junit4.runner;
+
+import org.junit.experimental.categories.Category;
+import org.junit.runner.Description;
+import org.junit.runner.manipulation.Filter;
+
+import java.util.Set;
+import java.util.StringJoiner;
+
+/**
+ * A filter that can be used to select tests and suites based on {@link Category} annotations. It will match any tests
+ * that have at least one included category and no excluded categories. If the user has not specified categories to
+ * include, it will allow any tests that are not explicitly excluded.
+ */
+public class CategoryFilter extends Filter {
+
+    private final Set<Class<?>> included, excluded;
+
+    public CategoryFilter(Set<Class<?>> included, Set<Class<?>> excluded) {
+        this.included = included;
+        this.excluded = excluded;
+    }
+
+    @Override
+    public boolean shouldRun(Description description) {
+        Category annotation = description.getAnnotation(Category.class);
+        // Is the object explicitly excluded?
+        if (isExcluded(annotation)) {
+            return false;
+        }
+        // Is the object a test whose parent class is explicitly included or excluded?
+        if (description.isTest()) {
+            Class<?> testClass = description.getTestClass();
+            if (testClass != null) {
+                Category parentAnnotation = testClass.getAnnotation(Category.class);
+                if (isExcluded(parentAnnotation)) {
+                    return false;
+                }
+                if (isIncluded(parentAnnotation)) {
+                    return true;
+                }
+            }
+        } else {
+            // Is the object a test suite that contains any explicitly included tests?
+            for (Description child : description.getChildren()) {
+                Category childAnnotation = child.getAnnotation(Category.class);
+                if (isIncluded(childAnnotation) && !isExcluded(childAnnotation)) {
+                    return true;
+                }
+            }
+        }
+        // Check this last, as tests may be excluded by their parent classes.
+        return isIncluded(annotation);
+    }
+
+    private boolean isIncluded(Category annotation) {
+        if (included.isEmpty()) {
+            // If the user has not specified any included categories, we should default to a permissive mode
+            // where any tests that have not explicitly been excluded are run. Otherwise, no tests would run.
+            return true;
+        }
+        return contains(included, annotation);
+    }
+
+    private boolean isExcluded(Category annotation) {
+        if (excluded.isEmpty()) {
+            return false;
+        }
+        return contains(excluded, annotation);
+    }
+
+    private boolean contains(Set<Class<?>> set, Category annotation) {
+        if (annotation == null) {
+            return false;
+        }
+        for (Class<?> clazz : annotation.value()) {
+            if (set.contains(clazz)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String describe() {
+        return toString();
+    }
+
+    private String listClasses(String prefix, Iterable<Class<?>> classes) {
+        StringJoiner j = new StringJoiner(", ", prefix + " [", "]");
+        for (Class<?> c : classes) {
+            j.add(c.getSimpleName());
+        }
+        return j.toString();
+    }
+
+    @Override
+    public String toString() {
+        return (included.isEmpty() ? "all tests" : listClasses("categories", included))
+             + (excluded.isEmpty() ? "" : listClasses(" excluding categories", excluded));
+    }
+}

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4InstanceModules.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4InstanceModules.java
@@ -14,9 +14,9 @@
 
 package com.google.testing.junit.runner.junit4;
 
+import javax.inject.Singleton;
 import java.util.Arrays;
 import java.util.List;
-import javax.inject.Singleton;
 
 /**
  * Utility classes which hold state or are, for testing purposes, implemented with non-static
@@ -68,10 +68,13 @@ public final class JUnit4InstanceModules {
 
     @Singleton
     static JUnit4Config config(JUnit4Options options) {
+
       return new JUnit4Config(
           options.getTestRunnerFailFast(),
           options.getTestIncludeFilter(),
-          options.getTestExcludeFilter());
+          options.getTestExcludeFilter(),
+          options.getTestIncludeCategories(),
+          options.getTestExcludeCategories());
     }
   }
 

--- a/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4Options.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4/JUnit4Options.java
@@ -14,12 +14,12 @@
 
 package com.google.testing.junit.runner.junit4;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * Simple options parser for JUnit 4.
@@ -32,6 +32,8 @@ class JUnit4Options {
 
   public static final String TEST_INCLUDE_FILTER_OPTION = "--test_filter";
   public static final String TEST_EXCLUDE_FILTER_OPTION = "--test_exclude_filter";
+  public static final String TEST_INCLUDE_CATEGORIES_FILTER_OPTION = "--test_categories";
+  public static final String TEST_EXCLUDE_CATEGORIES_FILTER_OPTION = "--test_exclude_categories";
 
   // This gets passed in by the build system.
   private static final String TESTBRIDGE_TEST_ONLY = "TESTBRIDGE_TEST_ONLY";
@@ -49,6 +51,8 @@ class JUnit4Options {
 
     optionsMap.put(TEST_INCLUDE_FILTER_OPTION, null);
     optionsMap.put(TEST_EXCLUDE_FILTER_OPTION, null);
+    optionsMap.put(TEST_INCLUDE_CATEGORIES_FILTER_OPTION, null);
+    optionsMap.put(TEST_EXCLUDE_CATEGORIES_FILTER_OPTION, null);
 
     for (Iterator<String> it = args.iterator(); it.hasNext();) {
       String arg = it.next();
@@ -63,7 +67,7 @@ class JUnit4Options {
       } else if (optionsMap.containsKey(arg)) {
         // next argument is the regexp
         if (!it.hasNext()) {
-          throw new RuntimeException("No filter expression specified after " + arg);
+          throw new RuntimeException("No argument given after " + arg);
         }
         optionsMap.put(arg, it.next());
         continue;
@@ -77,16 +81,22 @@ class JUnit4Options {
       optionsMap.put(TEST_INCLUDE_FILTER_OPTION, testFilter);
     }
     boolean testRunnerFailFast = "1".equals(envVars.get(TESTBRIDGE_TEST_RUNNER_FAIL_FAST));
+
     return new JUnit4Options(
         testRunnerFailFast,
         optionsMap.get(TEST_INCLUDE_FILTER_OPTION),
         optionsMap.get(TEST_EXCLUDE_FILTER_OPTION),
+        optionsMap.get(TEST_INCLUDE_CATEGORIES_FILTER_OPTION),
+        optionsMap.get(TEST_EXCLUDE_CATEGORIES_FILTER_OPTION),
         unparsedArgs.toArray(new String[0]));
   }
+
 
   private final boolean testRunnerFailFast;
   private final String testIncludeFilter;
   private final String testExcludeFilter;
+  private final String testIncludeCategories;
+  private final String testExcludeCategories;
   private final String[] unparsedArgs;
 
   // VisibleForTesting
@@ -94,10 +104,14 @@ class JUnit4Options {
       boolean testRunnerFailFast,
       @Nullable String testIncludeFilter,
       @Nullable String testExcludeFilter,
+      @Nullable String testIncludeCategories,
+      @Nullable String testExcludeCategories,
       String[] unparsedArgs) {
     this.testRunnerFailFast = testRunnerFailFast;
     this.testIncludeFilter = testIncludeFilter;
     this.testExcludeFilter = testExcludeFilter;
+    this.testIncludeCategories = testIncludeCategories;
+    this.testExcludeCategories = testExcludeCategories;
     this.unparsedArgs = unparsedArgs;
   }
 
@@ -115,6 +129,22 @@ class JUnit4Options {
    */
   String getTestIncludeFilter() {
     return testIncludeFilter;
+  }
+
+  /**
+   * Returns the value of the test_categories option, or <code>null</code> if
+   * it was not specified.
+   */
+  String getTestIncludeCategories() {
+    return testIncludeCategories;
+  }
+
+  /**
+   * Returns the value of the test_exclude_categories option, or <code>null</code> if
+   * it was not specified.
+   */
+  String getTestExcludeCategories() {
+    return testExcludeCategories;
   }
 
   /**

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/BUILD
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/BUILD
@@ -16,6 +16,7 @@ java_library(
     deps = [
         "//src/java_tools/junitrunner/java/com/google/testing/junit/runner/internal",
         "//src/java_tools/junitrunner/java/com/google/testing/junit/runner/internal:junit4",
+        "//src/java_tools/junitrunner/java/com/google/testing/junit/junit4:runner",
         "//src/java_tools/junitrunner/java/com/google/testing/junit/runner/junit4",
         "//src/java_tools/junitrunner/java/com/google/testing/junit/runner/model",
         "//src/java_tools/junitrunner/java/com/google/testing/junit/runner/sharding",

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/junit4/JUnit4ConfigTest.java
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/junit4/JUnit4ConfigTest.java
@@ -14,16 +14,19 @@
 
 package com.google.testing.junit.runner.junit4;
 
+import com.google.testing.junit.junit4.runner.CategoryFilter;
+import com.google.testing.junit.runner.util.GoogleTestSecurityManager;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Properties;
+
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.testing.junit.runner.junit4.JUnit4Config.JUNIT_API_VERSION_PROPERTY;
 import static com.google.testing.junit.runner.junit4.JUnit4Config.SHOULD_INSTALL_SECURITY_MANAGER_PROPERTY;
 import static org.junit.Assert.assertThrows;
-
-import com.google.testing.junit.runner.util.GoogleTestSecurityManager;
-import java.util.Properties;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link JUnit4Config}.
@@ -38,7 +41,7 @@ public class JUnit4ConfigTest {
   }
 
   private JUnit4Config createConfigWithProperties(Properties properties) {
-    return new JUnit4Config("", null, null, properties);
+    return new JUnit4Config("", null, null, null, null, properties);
   }
 
   @Test
@@ -104,4 +107,21 @@ public class JUnit4ConfigTest {
     JUnit4Config config = createConfigWithProperties(properties);
     assertThat(config.shouldInstallSecurityManager()).isFalse();
   }
+
+  @Test
+  public void testThrowsOnBadCategoryClasses() {
+    Assert.assertThrows(
+            RuntimeException.class,
+            () -> new JUnit4Config(null, null, "not.a.real.Class", null, null));
+    Assert.assertThrows(
+            RuntimeException.class,
+            () -> new JUnit4Config(null, null, null, "not.a.real.Class", null));
+  }
+
+  @Test
+  public void testCreatesCategoryFilter() {
+    JUnit4Config config = new JUnit4Config(null, null, Object.class.getName(), Boolean.class.getName(), null);
+    assertThat(config.getCategoriesFilter()).isInstanceOf(CategoryFilter.class);
+  }
+
 }

--- a/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/junit4/JUnit4OptionsTest.java
+++ b/src/java_tools/junitrunner/javatests/com/google/testing/junit/runner/junit4/JUnit4OptionsTest.java
@@ -14,16 +14,17 @@
 
 package com.google.testing.junit.runner.junit4;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
-
 import com.google.common.collect.ImmutableList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Tests for {@link JUnit4Options}
@@ -36,6 +37,8 @@ public class JUnit4OptionsTest {
   @Test
   public void testParse_noArgs() throws Exception {
     JUnit4Options options = JUnit4Options.parse(EMPTY_ENV, ImmutableList.<String>of());
+    assertThat(options.getTestIncludeCategories()).isNull();
+    assertThat(options.getTestExcludeCategories()).isNull();
     assertThat(options.getTestIncludeFilter()).isNull();
     assertThat(options.getUnparsedArgs()).isEmpty();
   }
@@ -45,6 +48,18 @@ public class JUnit4OptionsTest {
     JUnit4Options options = JUnit4Options.parse(EMPTY_ENV, ImmutableList.of("--bar", "baz"));
     assertThat(options.getTestIncludeFilter()).isNull();
     assertThat(options.getUnparsedArgs()).isEqualTo(new String[] {"--bar", "baz"});
+  }
+
+  @Test
+  public void testParse_includeCategories() {
+    JUnit4Options options = JUnit4Options.parse(EMPTY_ENV, ImmutableList.of("--test_categories", "java.lang.Object"));
+    assertThat(options.getTestIncludeCategories()).isNotNull();
+  }
+
+  @Test
+  public void testParse_excludeCategories() {
+    JUnit4Options options = JUnit4Options.parse(EMPTY_ENV, ImmutableList.of("--test_exclude_categories", "java.lang.Object"));
+    assertThat(options.getTestExcludeCategories()).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
This PR adds support for filtering on `@Category` in JUnit tests, configurable by two new command-line flags `--test_categories` and `--test_exclude_categories` in `BazelTestRunner`.

Fixes #13197