### PR TITLE
Convert --toolchain_resolution_debug to take a regex of toolchain typ…

### DIFF
--- a/site/docs/toolchains.md
+++ b/site/docs/toolchains.md
@@ -432,6 +432,7 @@ independently to each version of the target.
 ## Debugging toolchains
 
 When adding toolchain support to an existing rule, use the
-`--toolchain_resolution_debug` flag to make toolchain resolution verbose. Bazel
-will output names of toolchains it is checking and skipping during the
-resolution process.
+`--toolchain_resolution_debug=regex` flag to output debug information from
+toolchain resolution for toolchain types that match the regex. You can use `.*`
+to output all information. Bazel will output names of toolchains it is checking
+and skipping during the resolution process.

--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -1649,11 +1649,12 @@ echo "STABLE_USER_NAME $USER"
   register_toolchains()</a>.
 </p>
 
-<h4 id="flag--toolchain_resolution_debug"><code class='flag'>--toolchain_resolution_debug=false</code></h4>
+<h4 id="flag--toolchain_resolution_debug"><code class='flag'>--toolchain_resolution_debug=<var>regex</var></code></h4>
 <p>
-  Print debug information while finding toolchains for a rule. This might help
-  developers of Bazel or Starlark rules with debugging failures due to missing
-  toolchains.
+  Print debug information while finding toolchains if the toolchain type matches
+  the regex. Multiple regexes can be separated by commas. The regex can be
+  negated by using a <code>-</code> at the beginning. This might help developers
+  of Bazel or Starlark rules with debugging failures due to missing toolchains.
 </p>
 
 <h3 id='misc_build_options'>Miscellaneous</h3>

--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformConfiguration.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.EventHandler;
 import com.google.devtools.build.lib.starlarkbuildapi.platform.PlatformConfigurationApi;
 import com.google.devtools.build.lib.util.RegexFilter;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +37,7 @@ public class PlatformConfiguration extends Fragment implements PlatformConfigura
   private final Label targetPlatform;
   private final ImmutableList<String> extraToolchains;
   private final List<Map.Entry<RegexFilter, List<Label>>> targetFilterToAdditionalExecConstraints;
+  private final RegexFilter toolchainResolutionDebugRegexFilter;
 
   public PlatformConfiguration(BuildOptions buildOptions) {
     PlatformOptions platformOptions = buildOptions.get(PlatformOptions.class);
@@ -46,6 +48,7 @@ public class PlatformConfiguration extends Fragment implements PlatformConfigura
     this.extraToolchains = ImmutableList.copyOf(platformOptions.extraToolchains);
     this.targetFilterToAdditionalExecConstraints =
         platformOptions.targetFilterToAdditionalExecConstraints;
+    this.toolchainResolutionDebugRegexFilter = platformOptions.toolchainResolutionDebug;
   }
 
   @Override
@@ -110,5 +113,24 @@ public class PlatformConfiguration extends Fragment implements PlatformConfigura
       }
     }
     return constraints.build();
+  }
+
+  /** Returns true if toolchain resolution debug info should be printed for this toolchain type. */
+  public boolean debugToolchainResolution(Label toolchainType) {
+    return debugToolchainResolution(ImmutableList.of(toolchainType));
+  }
+
+  /**
+   * Returns true if toolchain resolution debug info should be printed for any of these toolchain
+   * types.
+   */
+  public boolean debugToolchainResolution(Collection<Label> toolchainTypes) {
+    if (toolchainTypes.isEmpty()) {
+      // Check an empty string, in case the filter is .*
+      return this.toolchainResolutionDebugRegexFilter.test("");
+    }
+    return toolchainTypes.stream()
+        .map(Label::getCanonicalForm)
+        .anyMatch(toolchainType -> this.toolchainResolutionDebugRegexFilter.test(toolchainType));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
@@ -148,13 +148,15 @@ public class PlatformOptions extends FragmentOptions {
 
   @Option(
       name = "toolchain_resolution_debug",
-      defaultValue = "false",
+      defaultValue = "-.*",
+      converter = RegexFilter.RegexFilterConverter.class,
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
       help =
-          "Print debug information while finding toolchains for a rule. This might help developers "
-              + "of Bazel or Starlark rules with debugging failures due to missing toolchains.")
-  public boolean toolchainResolutionDebug;
+          "Print debug information during toolchain resolution. The flag takes a regex, which is"
+              + " checked against toolchain types to see which to debug. Multiple regexes may be"
+              + " separated by commas, and then each regex is checked separately.")
+  public RegexFilter toolchainResolutionDebug;
 
   @Option(
       name = "incompatible_auto_configure_host_platform",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionFunction.java
@@ -19,7 +19,7 @@ import static java.util.stream.Collectors.joining;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.devtools.build.lib.analysis.PlatformOptions;
+import com.google.devtools.build.lib.analysis.PlatformConfiguration;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
 import com.google.devtools.build.lib.analysis.platform.ConstraintCollection;
@@ -79,7 +79,10 @@ public class SingleToolchainResolutionFunction implements SkyFunction {
     }
 
     // Find the right one.
-    boolean debug = configuration.getOptions().get(PlatformOptions.class).toolchainResolutionDebug;
+    boolean debug =
+        configuration
+            .getFragment(PlatformConfiguration.class)
+            .debugToolchainResolution(key.toolchainTypeLabel());
     return resolveConstraints(
         key.toolchainTypeLabel(),
         key.availableExecutionPlatformKeys(),

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunction.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Table;
 import com.google.devtools.build.lib.analysis.PlatformConfiguration;
-import com.google.devtools.build.lib.analysis.PlatformOptions;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
@@ -81,7 +80,9 @@ public class ToolchainResolutionFunction implements SkyFunction {
 
       // Check if debug output should be generated.
       boolean debug =
-          configuration.getOptions().get(PlatformOptions.class).toolchainResolutionDebug;
+          configuration
+              .getFragment(PlatformConfiguration.class)
+              .debugToolchainResolution(key.requiredToolchainTypeLabels());
 
       // Load the configured target for the toolchain types to ensure that they are valid and
       // resolve aliases.

--- a/src/test/java/com/google/devtools/build/lib/rules/android/AndroidBuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/AndroidBuildViewTestCase.java
@@ -79,7 +79,7 @@ public abstract class AndroidBuildViewTestCase extends BuildViewTestCase {
     ImmutableList.Builder<String> fullArgs = ImmutableList.builder();
     fullArgs.add("--incompatible_enable_android_toolchain_resolution");
     // Uncomment the below to get more info when tests fail because of toolchain resolution.
-    //  fullArgs.add("--toolchain_resolution_debug");
+    //  fullArgs.add("--toolchain_resolution_debug=tools/android:.*toolchain_type");
     boolean hasPlatform = false;
     for (String arg : args) {
       if (arg.startsWith("--android_sdk=")) {

--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1552,7 +1552,11 @@ platform(
         }
 )
 EOF
-  bazel build --extra_execution_platforms=":my_platform" --toolchain_resolution_debug :a --execution_log_json_file out.txt &> $TEST_log || fail "Build failed"
+  bazel build \
+      --extra_execution_platforms=":my_platform" \
+      --toolchain_resolution_debug=.* \
+      --execution_log_json_file out.txt \
+      :a &> $TEST_log || fail "Build failed"
   grep "key3" out.txt || fail "Did not find the target attribute key"
   grep "child_value" out.txt || fail "Did not find the overriding value"
   grep "key2" out.txt || fail "Did not find the platform key"

--- a/src/test/shell/bazel/bazel_with_jdk_test.sh
+++ b/src/test/shell/bazel/bazel_with_jdk_test.sh
@@ -168,16 +168,22 @@ EOF
   export JAVA_HOME="$PWD/jdk"
   export PATH="$PWD/jdk/bin:$PATH"
 
-  bazel cquery --toolchain_resolution_debug --java_runtime_version=8 '//java/main:JavaExample' \
-      &>"${TEST_log}" || fail "Autodetecting a fake JDK version 8 and selecting it failed"
+  bazel cquery \
+      --toolchain_resolution_debug=tools/jdk:runtime_toolchain_type \
+      --java_runtime_version=8 \
+      //java/main:JavaExample &>"${TEST_log}" || fail "Autodetecting a fake JDK version 8 and selecting it failed"
   expect_log "@bazel_tools//tools/jdk:runtime_toolchain_type -> toolchain @local_jdk//:jdk"
 
-  bazel cquery --toolchain_resolution_debug --java_runtime_version=local_jdk_8 '//java/main:JavaExample' \
-      &>"${TEST_log}" || fail "Autodetecting a fake JDK version 8 and selecting it failed"
+  bazel cquery \
+      --toolchain_resolution_debug=tools/jdk:runtime_toolchain_type \
+      --java_runtime_version=local_jdk_8 \
+      //java/main:JavaExample &>"${TEST_log}" || fail "Autodetecting a fake JDK version 8 and selecting it failed"
   expect_log "@bazel_tools//tools/jdk:runtime_toolchain_type -> toolchain @local_jdk//:jdk"
 
-  bazel cquery --toolchain_resolution_debug --java_runtime_version=11 '//java/main:JavaExample' \
-      &>"${TEST_log}" || fail "Selecting prepackaged JDK version 11 failed"
+  bazel cquery \
+      --toolchain_resolution_debug=tools/jdk:runtime_toolchain_type \
+      --java_runtime_version=11 \
+      //java/main:JavaExample &>"${TEST_log}" || fail "Autodetecting a fake JDK version 8 and selecting it failed"
   expect_not_log "@bazel_tools//tools/jdk:runtime_toolchain_type -> toolchain @local_jdk//:jdk"
 }
 
@@ -197,16 +203,22 @@ EOF
   export JAVA_HOME="$PWD/jdk"
   export PATH="$PWD/jdk/bin:$PATH"
 
-  bazel cquery --toolchain_resolution_debug --java_runtime_version=11 '//java/main:JavaExample' \
-      &>"${TEST_log}" || fail "Autodetecting a fake JDK version 11 and selecting it failed"
+  bazel cquery \
+      --toolchain_resolution_debug=tools/jdk:runtime_toolchain_type \
+      --java_runtime_version=11 \
+      //java/main:JavaExample &>"${TEST_log}" || fail "Autodetecting a fake JDK version 11 and selecting it failed"
   expect_log "@bazel_tools//tools/jdk:runtime_toolchain_type -> toolchain @local_jdk//:jdk"
 
-  bazel cquery --toolchain_resolution_debug --java_runtime_version=local_jdk_11 '//java/main:JavaExample' \
-      &>"${TEST_log}" || fail "Autodetecting a fake JDK version 8 and selecting it failed"
+  bazel cquery \
+      --toolchain_resolution_debug=tools/jdk:runtime_toolchain_type \
+      --java_runtime_version=local_jdk_11 \
+      //java/main:JavaExample &>"${TEST_log}" || fail "Autodetecting a fake JDK version 11 and selecting it failed"
   expect_log "@bazel_tools//tools/jdk:runtime_toolchain_type -> toolchain @local_jdk//:jdk"
 
-  bazel cquery --toolchain_resolution_debug --java_runtime_version=15 '//java/main:JavaExample' \
-      &>"${TEST_log}"  || fail "Selecting prepackaged JDK version 15 failed"
+  bazel cquery \
+      --toolchain_resolution_debug=tools/jdk:runtime_toolchain_type \
+      --java_runtime_version=15 \
+      //java/main:JavaExample &>"${TEST_log}" || fail "Autodetecting a fake JDK version 11 and selecting it failed"
   expect_not_log "@bazel_tools//tools/jdk:runtime_toolchain_type -> toolchain @local_jdk//:jdk"
 }
 
@@ -226,7 +238,9 @@ EOF
   export JAVA_HOME="$PWD/jdk"
   export PATH="$PWD/jdk/bin:$PATH"
 
-  bazel cquery --toolchain_resolution_debug '//java/main:JavaExample' &>"${TEST_log}" \
+  bazel cquery \
+      --toolchain_resolution_debug=tools/jdk:runtime_toolchain_type \
+      //java/main:JavaExample &>"${TEST_log}" \
       || fail "Failed to resolve Java toolchain when version cannot be detected"
   expect_log "@bazel_tools//tools/jdk:runtime_toolchain_type -> toolchain @local_jdk//:jdk"
 }

--- a/src/test/shell/bazel/platforms_test.sh
+++ b/src/test/shell/bazel/platforms_test.sh
@@ -235,7 +235,11 @@ platform(
         }
 )
 EOF
-  bazel build --extra_execution_platforms=":my_platform" --toolchain_resolution_debug :a --execution_log_json_file out.txt &> $TEST_log || fail "Build failed"
+  bazel build \
+      --extra_execution_platforms=":my_platform" \
+      --toolchain_resolution_debug=.* \
+       --execution_log_json_file out.txt \
+      :a &> $TEST_log || fail "Build failed"
   grep "key3" out.txt || fail "Did not find the target attribute key"
   grep "child_value" out.txt || fail "Did not find the overriding value"
   grep "key2" out.txt || fail "Did not find the platform key"

--- a/src/test/shell/bazel/toolchain_test.sh
+++ b/src/test/shell/bazel/toolchain_test.sh
@@ -530,7 +530,7 @@ use_toolchain(
 EOF
 
   bazel build \
-    --toolchain_resolution_debug \
+    --toolchain_resolution_debug=toolchain:test_toolchain \
     --incompatible_auto_configure_host_platform \
     //demo:use &> $TEST_log || fail "Build failed"
   expect_log 'ToolchainResolution:   Type //toolchain:test_toolchain: target platform @local_config_platform//.*: execution @local_config_platform//:host: Selected toolchain //:test_toolchain_impl_1'
@@ -904,14 +904,14 @@ EOF
 
   # When no platform has the constraint, an error
   bazel build \
-    --toolchain_resolution_debug \
+    --toolchain_resolution_debug=.* \
     //demo:target &> $TEST_log && fail "Build failure expected"
   expect_log "While resolving toolchains for target //demo:target: .* from available execution platforms \[\]"
 
   # When the platform exists, it is used.
   bazel build \
     --extra_execution_platforms=//platform:test_platform \
-    --toolchain_resolution_debug \
+    --toolchain_resolution_debug=.* \
     //demo:target &> $TEST_log || fail "Build failed"
   expect_log "Selected execution platform //platform:test_platform"
 }
@@ -964,7 +964,7 @@ EOF
   # Build the target, using debug messages to verify the correct platform was selected.
   bazel build \
     --extra_execution_platforms=//platforms:all \
-    --toolchain_resolution_debug \
+    --toolchain_resolution_debug=toolchain:test_toolchain \
     //demo:use &> $TEST_log || fail "Build failed"
   expect_log "Selected execution platform //platforms:platform2"
 }
@@ -1020,7 +1020,7 @@ EOF
   # Build the target, using debug messages to verify the correct platform was selected.
   bazel build \
     --extra_execution_platforms=//platforms:all \
-    --toolchain_resolution_debug \
+    --toolchain_resolution_debug=toolchain:test_toolchain \
     //demo:use &> $TEST_log || fail "Build failed"
   expect_log "Selected execution platform //platforms:platform2"
 }
@@ -1090,7 +1090,7 @@ EOF
   # Build the target, using debug messages to verify the correct platform was selected.
   bazel build \
     --extra_execution_platforms=//platforms:all \
-    --toolchain_resolution_debug \
+    --toolchain_resolution_debug=toolchain:test_toolchain \
     //demo:use &> $TEST_log || fail "Build failed"
   expect_log "Selected execution platform //platforms:platform2_4"
 }


### PR DESCRIPTION
…es to debug

Work towards #12110.
Fixes #7713.

RELNOTES: The flag `--toolchain_resolution_debug` now takes a regex argument, which is used to check which toolchain types should have debug info printed. You may use `.*` as an argument to keep the current behavior of debugging every toolchain type.