### PR TITLE
[WIP] Update Java-related toolchains to enable the toolchain transition.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
@@ -219,8 +219,7 @@ public class JavaStarlarkApiTest extends BuildViewTestCase {
         "jrule = rule(_impl, attrs = { '_java_runtime': attr.label(default=Label('//a:alias'))})");
 
     useConfiguration("--extra_toolchains=//a:all", "--platforms=//a:platform");
-    // TODO(b/129637690): the runtime shouldn't be resolved in the host config
-    ConfiguredTarget genrule = getHostConfiguredTarget("//a:gen");
+    ConfiguredTarget genrule = getConfiguredTarget("//a:gen");
     ConfiguredTarget ct = getConfiguredTarget("//a:r");
     StructImpl myInfo = getMyInfoFromTarget(ct);
     String javaHomeExecPath = (String) myInfo.getValue("java_home_exec_path");

--- a/tools/jdk/java_toolchain_alias.bzl
+++ b/tools/jdk/java_toolchain_alias.bzl
@@ -36,6 +36,7 @@ def _java_runtime_alias(ctx):
 java_runtime_alias = rule(
     implementation = _java_runtime_alias,
     toolchains = ["@bazel_tools//tools/jdk:runtime_toolchain_type"],
+    incompatible_use_toolchain_transition = True,
     attrs = {
         "_java_runtime": attr.label(
             default = Label("@bazel_tools//tools/jdk:legacy_current_java_runtime"),
@@ -103,6 +104,7 @@ _java_runtime_transition = transition(
 java_runtime_version_alias = rule(
     implementation = _java_runtime_version_alias,
     toolchains = ["@bazel_tools//tools/jdk:runtime_toolchain_type"],
+    incompatible_use_toolchain_transition = True,
     attrs = {
         "runtime_version": attr.string(mandatory = True),
         # TODO(ilist): remove after java toolchain resolution flag is flipped


### PR DESCRIPTION
This means that Java toolchains will no longer always be in the host configuration, but can use target and exec transitions.

See https://github.com/bazelbuild/proposals/blob/master/designs/2019-02-12-toolchain-transitions.md for details about the new capabilities, and https://github.com/bazelbuild/proposals/blob/master/designs/2020-02-07-toolchain-transition-migration.md for details about the migration.

Note that the `incompatible_use_toolchain_transition` is intended to be removed once the migration has completed. A similar change will be sent at that point to remove it.

PiperOrigin-RevId: 362295344
Change-Id: I8d163e0e3c7550e88ca2c023be8ca4405b6317b4