### PR TITLE
[WIP] JavaToolchainProvider no longer extends ToolchainInfo.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaRuntimeInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaRuntimeInfo.java
@@ -69,7 +69,7 @@ public final class JavaRuntimeInfo extends ToolchainInfo implements JavaRuntimeI
   }
 
   @Nullable
-  private static JavaRuntimeInfo from(RuleContext ruleContext, String attributeName) {
+  static JavaRuntimeInfo from(RuleContext ruleContext, String attributeName) {
     if (!ruleContext.attributes().has(attributeName, BuildType.LABEL)) {
       return null;
     }

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -182,7 +182,7 @@ public class JavaStarlarkCommon
 
   @Override
   public Provider getJavaToolchainProvider() {
-    return ToolchainInfo.PROVIDER;
+    return JavaToolchainProvider.PROVIDER;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchain.java
@@ -104,8 +104,7 @@ public class JavaToolchain implements RuleConfiguredTargetFactory {
 
     FilesToRunProvider jacocoRunner = ruleContext.getExecutablePrerequisite("jacocorunner");
 
-    JavaRuntimeInfo javaRuntime =
-        (JavaRuntimeInfo) ruleContext.getPrerequisite("java_runtime").get(ToolchainInfo.PROVIDER);
+    JavaRuntimeInfo javaRuntime = JavaRuntimeInfo.from(ruleContext, "java_runtime");
 
     JavaToolchainProvider provider =
         JavaToolchainProvider.create(
@@ -136,10 +135,13 @@ public class JavaToolchain implements RuleConfiguredTargetFactory {
             proguardAllowlister,
             semantics,
             javaRuntime);
+    ToolchainInfo toolchainInfo =
+        new ToolchainInfo(ImmutableMap.<String, Object>builder().put("java", provider).build());
     RuleConfiguredTargetBuilder builder =
         new RuleConfiguredTargetBuilder(ruleContext)
             .addStarlarkTransitiveInfo(JavaToolchainProvider.LEGACY_NAME, provider)
             .addNativeDeclaredProvider(provider)
+            .addNativeDeclaredProvider(toolchainInfo)
             .addProvider(RunfilesProvider.class, RunfilesProvider.simple(Runfiles.EMPTY))
             .setFilesToBuild(new NestedSetBuilder<Artifact>(Order.STABLE_ORDER).build());
 

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaToolchainStarlarkApiProviderApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaToolchainStarlarkApiProviderApi.java
@@ -18,7 +18,7 @@ import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.starlarkbuildapi.FileApi;
 import com.google.devtools.build.lib.starlarkbuildapi.FilesToRunProviderApi;
-import com.google.devtools.build.lib.starlarkbuildapi.platform.ToolchainInfoApi;
+import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
@@ -34,7 +34,7 @@ import net.starlark.java.eval.Sequence;
     doc =
         "Provides access to information about the Java toolchain rule. "
             + "Accessible as a 'java_toolchain' field on a Target struct.")
-public interface JavaToolchainStarlarkApiProviderApi extends ToolchainInfoApi {
+public interface JavaToolchainStarlarkApiProviderApi extends StructApi {
 
   String LEGACY_NAME = "java_toolchain";
 

--- a/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/java/FakeJavaToolchainStarlarkApiProviderApi.java
+++ b/src/main/java/com/google/devtools/build/skydoc/fakebuildapi/java/FakeJavaToolchainStarlarkApiProviderApi.java
@@ -18,7 +18,6 @@ import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.starlarkbuildapi.FileApi;
 import com.google.devtools.build.lib.starlarkbuildapi.FilesToRunProviderApi;
 import com.google.devtools.build.lib.starlarkbuildapi.java.JavaToolchainStarlarkApiProviderApi;
-import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Sequence;
 
@@ -60,17 +59,17 @@ final class FakeJavaToolchainStarlarkApiProviderApi implements JavaToolchainStar
   }
 
   @Override
-  public String toProto() throws EvalException {
-    return "";
-  }
-
-  @Override
-  public String toJson() throws EvalException {
-    return "";
-  }
-
-  @Override
   public void repr(Printer printer) {}
 
   private FakeJavaToolchainStarlarkApiProviderApi() {}
+
+  @Override
+  public String toProto() {
+    return null;
+  }
+
+  @Override
+  public String toJson() {
+    return null;
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/java/JavaStarlarkApiTest.java
@@ -23,7 +23,6 @@ import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
-import com.google.devtools.build.lib.analysis.platform.ToolchainInfo;
 import com.google.devtools.build.lib.analysis.test.InstrumentedFilesInfo;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -1853,11 +1852,9 @@ public class JavaStarlarkApiTest extends BuildViewTestCase {
             configuredTarget.get(
                 new StarlarkProvider.Key(
                     Label.parseAbsolute("//foo:rule.bzl", ImmutableMap.of()), "result"));
-    Label javaToolchainLabel =
-        ((JavaToolchainProvider)
-                ((ConfiguredTarget) info.getValue("java_toolchain_label"))
-                    .get(ToolchainInfo.PROVIDER))
-            .getToolchainLabel();
+    JavaToolchainProvider javaToolchainProvider =
+        JavaToolchainProvider.from((ConfiguredTarget) info.getValue("java_toolchain_label"));
+    Label javaToolchainLabel = javaToolchainProvider.getToolchainLabel();
     assertWithMessage(javaToolchainLabel.toString())
         .that(
             javaToolchainLabel.toString().endsWith("jdk:remote_toolchain")
@@ -1896,11 +1893,9 @@ public class JavaStarlarkApiTest extends BuildViewTestCase {
             configuredTarget.get(
                 new StarlarkProvider.Key(
                     Label.parseAbsolute("//foo:rule.bzl", ImmutableMap.of()), "result"));
-    Label javaToolchainLabel =
-        ((JavaToolchainProvider)
-                ((ConfiguredTarget) info.getValue("java_toolchain_label"))
-                    .get(ToolchainInfo.PROVIDER))
-            .getToolchainLabel();
+    JavaToolchainProvider javaToolchainProvider =
+        JavaToolchainProvider.from((ConfiguredTarget) info.getValue("java_toolchain_label"));
+    Label javaToolchainLabel = javaToolchainProvider.getToolchainLabel();
     assertThat(javaToolchainLabel.toString()).isEqualTo("//java/com/google/test:toolchain");
   }
 

--- a/tools/jdk/java_toolchain_alias.bzl
+++ b/tools/jdk/java_toolchain_alias.bzl
@@ -118,12 +118,20 @@ java_runtime_version_alias = rule(
 
 def _java_toolchain_alias(ctx):
     """An experimental implementation of java_toolchain_alias using toolchain resolution."""
+    toolchain_info = None
     if java_common.is_java_toolchain_resolution_enabled_do_not_use(ctx = ctx):
-        toolchain = ctx.toolchains["@bazel_tools//tools/jdk:toolchain_type"]
+        toolchain_info = ctx.toolchains["@bazel_tools//tools/jdk:toolchain_type"]
+        if hasattr(toolchain_info, "java"):
+            toolchain = toolchain_info.java
+        else:
+            toolchain = toolchain_info
     else:
         toolchain = ctx.attr._java_toolchain[java_common.JavaToolchainInfo]
+    providers = [toolchain]
+    if toolchain_info != None and toolchain_info != toolchain:
+        providers.append(toolchain_info)
     return struct(
-        providers = [toolchain],
+        providers = providers,
         # Use the legacy provider syntax for compatibility with the native rules.
         java_toolchain = toolchain,
     )


### PR DESCRIPTION
Instead, the toolchain is provided in a field on ToolchainInfo, called "java".

PiperOrigin-RevId: 362515978
Change-Id: I23ccb8b53234acd81edea60c5d67eb15dc0d4cf5