### PR TITLE
Add an alias for `TestParameterInjector` to `third_party`.

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -657,6 +657,12 @@ java_import(
     jars = ["objenesis/objenesis-1_3.jar"],
 )
 
+java_library(
+    name = "testparameterinjector",
+    testonly = True,
+    exports= ["@com_google_testparameterinjector//:testparameterinjector"],
+)
+
 filegroup(
     name = "turbine_direct",
     srcs = ["turbine/turbine_direct.jar"],


### PR DESCRIPTION
Add a `//third_party/testparameterinjector` alias for `TestParameterInjector`.