### PR TITLE
Add docs for host_conlyopt and host_linkopt

### DIFF
--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -187,12 +187,28 @@ Package path elements may be specified in three formats:
   host configuration.
 </p>
 
+<h4 id='flag--host_conlyopt'><code class='flag'>--host_conlyopt=<var>cc-option</var></code></h4>
+<p>
+  This option takes an argument which is to be passed to the compiler for C source files
+  that are compiled in the host configuration. This is analogous to
+  the <a href='#flag--conlyopt'><code class='flag'>--conlyopt</code></a> option, but applies only
+  to the host configuration.
+</p>
+
 <h4 id='flag--host_cxxopt'><code class='flag'>--host_cxxopt=<var>cc-option</var></code></h4>
 <p>
   This option takes an argument which is to be passed to the compiler for C++ source files
   that are compiled in the host configuration. This is analogous to
   the <a href='#flag--cxxopt'><code class='flag'>--cxxopt</code></a> option, but applies only to the
   host configuration.
+</p>
+
+<h4 id='flag--host_linkopt'><code class='flag'>--host_linkopt=<var>linker-option</var></code></h4>
+<p>
+  This option takes an argument which is to be passed to the linker for source files
+  that are compiled in the host configuration. This is analogous to
+  the <a href='#flag--linkopt'><code class='flag'>--linkopt</code></a> option, but applies only to
+  the host configuration.
 </p>
 
 <h4 id='flag--conlyopt'><code class='flag'>--conlyopt=<var>cc-option</var></code></h4>


### PR DESCRIPTION
Options were added in c026569 but seem to have never made it into the user manual