### PR TITLE
Fix order of build request id and command id

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -177,7 +177,7 @@ public final class RemoteModule extends BlazeModule {
             retrier);
     ServerCapabilities capabilities = null;
     try {
-      capabilities = rsc.get(env.getCommandId().toString(), env.getBuildRequestId());
+      capabilities = rsc.get(env.getBuildRequestId(), env.getCommandId().toString());
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       return;


### PR DESCRIPTION
They should be in this order rather than the other way round.

See `RemoteServerCapabilities.get`.

Change-Id: I4be952cc2ad43ae35c7052bd26b153b1e887e562