### PR TITLE
[WIP] Use a LabelConversionContext in rule.toolchains to improve parsing

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -188,7 +188,6 @@ java_library(
         "DependencyResolver.java",
         "EmptyConfiguredTarget.java",
         "EventHandlingErrorReporter.java",
-        "ExecGroupCollection.java",
         "Expander.java",
         "ExtraActionUtils.java",
         "ExtraActionsVisitor.java",
@@ -349,7 +348,9 @@ java_library(
         ":starlark/function_transition_util",
         ":starlark/starlark_api_provider",
         ":starlark/starlark_command_line",
+        ":starlark/starlark_exec_group_collection",
         ":starlark/starlark_late_bound_default",
+        ":starlark/starlark_toolchain_context",
         ":template_variable_info",
         ":test/analysis_failure",
         ":test/analysis_failure_info",
@@ -2219,6 +2220,38 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi",
         "//src/main/java/net/starlark/java/eval",
+    ],
+)
+
+java_library(
+    name = "starlark/starlark_exec_group_collection",
+    srcs = ["starlark/StarlarkExecGroupCollection.java"],
+    deps = [
+        ":resolved_toolchain_context",
+        ":starlark/starlark_toolchain_context",
+        ":toolchain_collection",
+        "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform",
+        "//src/main/java/net/starlark/java/eval",
+        "//src/main/java/net/starlark/java/syntax",
+        "//third_party:auto_value",
+        "//third_party:guava",
+    ],
+)
+
+java_library(
+    name = "starlark/starlark_toolchain_context",
+    srcs = ["starlark/StarlarkToolchainContext.java"],
+    deps = [
+        ":resolved_toolchain_context",
+        "//src/main/java/com/google/devtools/build/lib/analysis/platform",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/cmdline:cmdline-primitives",
+        "//src/main/java/com/google/devtools/build/lib/packages",
+        "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform",
+        "//src/main/java/net/starlark/java/eval",
+        "//third_party:auto_value",
+        "//third_party:guava_checked_in",
+        "//third_party:jsr305_checked_in",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java
@@ -30,7 +30,6 @@ import com.google.devtools.build.lib.actions.extra.ExtraActionInfo;
 import com.google.devtools.build.lib.actions.extra.SpawnInfo;
 import com.google.devtools.build.lib.analysis.BashCommandConstructor;
 import com.google.devtools.build.lib.analysis.CommandHelper;
-import com.google.devtools.build.lib.analysis.ExecGroupCollection;
 import com.google.devtools.build.lib.analysis.FilesToRunProvider;
 import com.google.devtools.build.lib.analysis.PseudoAction;
 import com.google.devtools.build.lib.analysis.RuleContext;
@@ -630,7 +629,7 @@ public class StarlarkActionFactory implements StarlarkActionFactoryApi {
 
     if (execGroupUnchecked != Starlark.NONE) {
       String execGroup = (String) execGroupUnchecked;
-      if (!ExecGroupCollection.isValidGroupName(execGroup)
+      if (!StarlarkExecGroupCollection.isValidGroupName(execGroup)
           || !ruleContext.hasToolchainContext(execGroup)) {
         throw Starlark.errorf("Action declared for non-existent exec group '%s'.", execGroup);
       }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkToolchainContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkToolchainContext.java
@@ -1,0 +1,135 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.analysis.starlark;
+
+import static java.util.stream.Collectors.joining;
+
+import com.google.auto.value.AutoValue;
+import com.google.devtools.build.lib.analysis.ResolvedToolchainContext;
+import com.google.devtools.build.lib.analysis.platform.ToolchainInfo;
+import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
+import com.google.devtools.build.lib.packages.BazelModuleContext;
+import com.google.devtools.build.lib.packages.BazelStarlarkContext;
+import com.google.devtools.build.lib.packages.BuildType.LabelConversionContext;
+import com.google.devtools.build.lib.starlarkbuildapi.platform.ToolchainContextApi;
+import javax.annotation.Nullable;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Module;
+import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkSemantics;
+import net.starlark.java.eval.StarlarkThread;
+
+/**
+ * An implementation of StarlarkContextApi that can better handle converting strings into Labels.
+ */
+@AutoValue
+public abstract class StarlarkToolchainContext implements ToolchainContextApi {
+
+  private static final ToolchainContextApi NO_OP =
+      new ToolchainContextApi() {
+        @Override
+        public Object getIndex(StarlarkSemantics semantics, Object key) {
+          return Starlark.NONE;
+        }
+
+        @Override
+        public boolean containsKey(StarlarkSemantics semantics, Object key) {
+          return false;
+        }
+      };
+
+  public static ToolchainContextApi create(
+      StarlarkThread thread, @Nullable ResolvedToolchainContext toolchainContext) {
+    if (toolchainContext == null) {
+      return NO_OP;
+    }
+
+    return new AutoValue_StarlarkToolchainContext(thread, toolchainContext);
+  }
+
+  protected abstract StarlarkThread starlarkThread();
+
+  protected abstract ResolvedToolchainContext toolchainContext();
+
+  @Override
+  public boolean isImmutable() {
+    return true;
+  }
+
+  @Override
+  public void repr(Printer printer) {
+    printer.append("<toolchain_context.resolved_labels: ");
+    printer.append(
+        toolchainContext().toolchains().keySet().stream()
+            .map(ToolchainTypeInfo::typeLabel)
+            .map(Label::toString)
+            .collect(joining(", ")));
+    printer.append(">");
+  }
+
+  private Label transformKey(Object key) throws EvalException {
+    if (key instanceof Label) {
+      return (Label) key;
+    } else if (key instanceof ToolchainTypeInfo) {
+      return ((ToolchainTypeInfo) key).typeLabel();
+    } else if (key instanceof String) {
+      try {
+        BazelStarlarkContext bazelStarlarkContext = BazelStarlarkContext.from(starlarkThread());
+        LabelConversionContext context =
+            new LabelConversionContext(
+                BazelModuleContext.of(Module.ofInnermostEnclosingStarlarkFunction(starlarkThread()))
+                    .label(),
+                bazelStarlarkContext.getRepoMapping(),
+                bazelStarlarkContext.getConvertedLabelsInPackage());
+
+        return context.convert((String) key);
+      } catch (LabelSyntaxException e) {
+        throw Starlark.errorf("Unable to parse toolchain label '%s': %s", key, e.getMessage());
+      }
+    } else {
+      throw Starlark.errorf(
+          "Toolchains only supports indexing by toolchain type, got %s instead",
+          Starlark.type(key));
+    }
+  }
+
+  @Override
+  public ToolchainInfo getIndex(StarlarkSemantics semantics, Object key) throws EvalException {
+    Label toolchainTypeLabel = transformKey(key);
+
+    if (!containsKey(semantics, key)) {
+      // TODO(bazel-configurability): The list of available toolchain types is confusing in the
+      // presence of aliases, since it only contains the actual label, not the alias passed to the
+      // rule definition.
+      throw Starlark.errorf(
+          "In %s, toolchain type %s was requested but only types [%s] are configured",
+          toolchainContext().targetDescription(),
+          toolchainTypeLabel,
+          toolchainContext().requiredToolchainTypes().stream()
+              .map(ToolchainTypeInfo::typeLabel)
+              .map(Label::toString)
+              .collect(joining(", ")));
+    }
+    return toolchainContext().forToolchainType(toolchainTypeLabel);
+  }
+
+  @Override
+  public boolean containsKey(StarlarkSemantics semantics, Object key) throws EvalException {
+    Label toolchainTypeLabel = transformKey(key);
+    return toolchainContext().requestedToolchainTypeLabels().containsKey(toolchainTypeLabel);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/ConstraintSettingInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/ConstraintSettingInfoTest.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.analysis.platform;
 
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.cmdline.Label;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,9 +30,10 @@ public class ConstraintSettingInfoTest extends BuildViewTestCase {
   public void constraintSetting_equalsTester() {
     new EqualsTester()
         .addEqualityGroup(
-            ConstraintSettingInfo.create(makeLabel("//constraint:basic")),
-            ConstraintSettingInfo.create(makeLabel("//constraint:basic")))
-        .addEqualityGroup(ConstraintSettingInfo.create(makeLabel("//constraint:other")))
+            ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//constraint:basic")),
+            ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//constraint:basic")))
+        .addEqualityGroup(ConstraintSettingInfo.create(
+            Label.parseAbsoluteUnchecked("//constraint:other")))
         .testEquals();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/ConstraintValueInfoTest.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.analysis.platform;
 
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.cmdline.Label;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,19 +28,23 @@ public class ConstraintValueInfoTest extends BuildViewTestCase {
 
   @Test
   public void constraintValue_equalsTester() {
-    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(makeLabel("//constraint:basic"));
-    ConstraintSettingInfo setting2 = ConstraintSettingInfo.create(makeLabel("//constraint:other"));
+    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:basic"));
+    ConstraintSettingInfo setting2 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:other"));
     new EqualsTester()
         .addEqualityGroup(
             // Base case.
-            ConstraintValueInfo.create(setting1, makeLabel("//constraint:value")),
-            ConstraintValueInfo.create(setting1, makeLabel("//constraint:value")))
+            ConstraintValueInfo.create(setting1, Label.parseAbsoluteUnchecked("//constraint:value")),
+            ConstraintValueInfo.create(setting1, Label.parseAbsoluteUnchecked("//constraint:value")))
         .addEqualityGroup(
             // Different label.
-            ConstraintValueInfo.create(setting1, makeLabel("//constraint:otherValue")))
+            ConstraintValueInfo.create(setting1,
+                Label.parseAbsoluteUnchecked("//constraint:otherValue")))
         .addEqualityGroup(
             // Different setting.
-            ConstraintValueInfo.create(setting2, makeLabel("//constraint:otherValue")))
+            ConstraintValueInfo.create(setting2,
+                Label.parseAbsoluteUnchecked("//constraint:otherValue")))
         .testEquals();
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/DeclaredToolchainInfoTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.cmdline.Label;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,23 +31,24 @@ public class DeclaredToolchainInfoTest extends BuildViewTestCase {
 
   @Test
   public void toolchainInfo_overlappingConstraintsError() throws Exception {
-    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(makeLabel("//constraint:basic"));
+    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:basic"));
     ConstraintSettingInfo setting2 =
-        ConstraintSettingInfo.create(makeLabel("//constraint:complex"));
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//constraint:complex"));
 
     DeclaredToolchainInfo.Builder builder = DeclaredToolchainInfo.builder();
 
     builder.addExecConstraints(
-        ConstraintValueInfo.create(setting1, makeLabel("//constraint:value1")));
+        ConstraintValueInfo.create(setting1, Label.parseAbsoluteUnchecked("//constraint:value1")));
     builder.addExecConstraints(
-        ConstraintValueInfo.create(setting1, makeLabel("//constraint:value2")));
+        ConstraintValueInfo.create(setting1, Label.parseAbsoluteUnchecked("//constraint:value2")));
 
     builder.addTargetConstraints(
-        ConstraintValueInfo.create(setting2, makeLabel("//constraint:value3")));
+        ConstraintValueInfo.create(setting2, Label.parseAbsoluteUnchecked("//constraint:value3")));
     builder.addTargetConstraints(
-        ConstraintValueInfo.create(setting2, makeLabel("//constraint:value4")));
+        ConstraintValueInfo.create(setting2, Label.parseAbsoluteUnchecked("//constraint:value4")));
     builder.addTargetConstraints(
-        ConstraintValueInfo.create(setting2, makeLabel("//constraint:value5")));
+        ConstraintValueInfo.create(setting2, Label.parseAbsoluteUnchecked("//constraint:value5")));
 
     DeclaredToolchainInfo.DuplicateConstraintException exception =
         assertThrows(
@@ -70,50 +72,55 @@ public class DeclaredToolchainInfoTest extends BuildViewTestCase {
   @Test
   public void toolchainInfo_equalsTester() throws Exception {
     ConstraintSettingInfo setting1 =
-        ConstraintSettingInfo.create(makeLabel("//constraint:setting1"));
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//constraint:setting1"));
     ConstraintValueInfo constraint1 =
-        ConstraintValueInfo.create(setting1, makeLabel("//constraint:foo"));
+        ConstraintValueInfo.create(setting1, Label.parseAbsoluteUnchecked("//constraint:foo"));
     ConstraintValueInfo constraint2 =
-        ConstraintValueInfo.create(setting1, makeLabel("//constraint:bar"));
+        ConstraintValueInfo.create(setting1, Label.parseAbsoluteUnchecked("//constraint:bar"));
 
     new EqualsTester()
         .addEqualityGroup(
             // Base case.
             DeclaredToolchainInfo.builder()
-                .toolchainType(ToolchainTypeInfo.create(makeLabel("//toolchain:tc1")))
+                .toolchainType(ToolchainTypeInfo.create(
+                    Label.parseAbsoluteUnchecked("//toolchain:tc1")))
                 .addExecConstraints(ImmutableList.of(constraint1))
                 .addTargetConstraints(ImmutableList.of(constraint2))
-                .toolchainLabel(makeLabel("//toolchain:toolchain1"))
+                .toolchainLabel(Label.parseAbsoluteUnchecked("//toolchain:toolchain1"))
                 .build(),
             DeclaredToolchainInfo.builder()
-                .toolchainType(ToolchainTypeInfo.create(makeLabel("//toolchain:tc1")))
+                .toolchainType(ToolchainTypeInfo.create(
+                    Label.parseAbsoluteUnchecked("//toolchain:tc1")))
                 .addExecConstraints(ImmutableList.of(constraint1))
                 .addTargetConstraints(ImmutableList.of(constraint2))
-                .toolchainLabel(makeLabel("//toolchain:toolchain1"))
+                .toolchainLabel(Label.parseAbsoluteUnchecked("//toolchain:toolchain1"))
                 .build())
         .addEqualityGroup(
             // Different type.
             DeclaredToolchainInfo.builder()
-                .toolchainType(ToolchainTypeInfo.create(makeLabel("//toolchain:tc2")))
+                .toolchainType(ToolchainTypeInfo.create(
+                    Label.parseAbsoluteUnchecked("//toolchain:tc2")))
                 .addExecConstraints(ImmutableList.of(constraint1))
                 .addTargetConstraints(ImmutableList.of(constraint2))
-                .toolchainLabel(makeLabel("//toolchain:toolchain1"))
+                .toolchainLabel(Label.parseAbsoluteUnchecked("//toolchain:toolchain1"))
                 .build())
         .addEqualityGroup(
             // Different constraints.
             DeclaredToolchainInfo.builder()
-                .toolchainType(ToolchainTypeInfo.create(makeLabel("//toolchain:tc1")))
+                .toolchainType(ToolchainTypeInfo.create(
+                    Label.parseAbsoluteUnchecked("//toolchain:tc1")))
                 .addExecConstraints(ImmutableList.of(constraint2))
                 .addTargetConstraints(ImmutableList.of(constraint1))
-                .toolchainLabel(makeLabel("//toolchain:toolchain1"))
+                .toolchainLabel(Label.parseAbsoluteUnchecked("//toolchain:toolchain1"))
                 .build())
         .addEqualityGroup(
             // Different toolchain label.
             DeclaredToolchainInfo.builder()
-                .toolchainType(ToolchainTypeInfo.create(makeLabel("//toolchain:tc1")))
+                .toolchainType(ToolchainTypeInfo.create(
+                    Label.parseAbsoluteUnchecked("//toolchain:tc1")))
                 .addExecConstraints(ImmutableList.of(constraint1))
                 .addTargetConstraints(ImmutableList.of(constraint2))
-                .toolchainLabel(makeLabel("//toolchain:toolchain2"))
+                .toolchainLabel(Label.parseAbsoluteUnchecked("//toolchain:toolchain2"))
                 .build())
         .testEquals();
   }

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformInfoTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.cmdline.Label;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,21 +32,25 @@ public class PlatformInfoTest extends BuildViewTestCase {
 
   @Test
   public void platformInfo() throws Exception {
-    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(makeLabel("//constraint:s1"));
-    ConstraintSettingInfo setting2 = ConstraintSettingInfo.create(makeLabel("//constraint:s2"));
+    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:s1"));
+    ConstraintSettingInfo setting2 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:s2"));
 
     PlatformInfo.Builder builder = PlatformInfo.builder();
-    builder.addConstraint(ConstraintValueInfo.create(setting1, makeLabel("//constraint:v1")));
-    builder.addConstraint(ConstraintValueInfo.create(setting2, makeLabel("//constraint:v2")));
+    builder.addConstraint(ConstraintValueInfo.create(setting1,
+        Label.parseAbsoluteUnchecked("//constraint:v1")));
+    builder.addConstraint(ConstraintValueInfo.create(setting2,
+        Label.parseAbsoluteUnchecked("//constraint:v2")));
     PlatformInfo platformInfo = builder.build();
 
     assertThat(platformInfo).isNotNull();
     assertThat(platformInfo.constraints().has(setting1)).isTrue();
     assertThat(platformInfo.constraints().get(setting1).label())
-        .isEqualTo(makeLabel("//constraint:v1"));
+        .isEqualTo(Label.parseAbsoluteUnchecked("//constraint:v1"));
     assertThat(platformInfo.constraints().has(setting2)).isTrue();
     assertThat(platformInfo.constraints().get(setting2).label())
-        .isEqualTo(makeLabel("//constraint:v2"));
+        .isEqualTo(Label.parseAbsoluteUnchecked("//constraint:v2"));
   }
 
   @Test
@@ -60,58 +65,71 @@ public class PlatformInfoTest extends BuildViewTestCase {
 
   @Test
   public void platformInfo_parentPlatform_noOverlaps() throws Exception {
-    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(makeLabel("//constraint:s1"));
-    ConstraintSettingInfo setting2 = ConstraintSettingInfo.create(makeLabel("//constraint:s2"));
-    ConstraintSettingInfo setting3 = ConstraintSettingInfo.create(makeLabel("//constraint:s3"));
+    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:s1"));
+    ConstraintSettingInfo setting2 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:s2"));
+    ConstraintSettingInfo setting3 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:s3"));
 
     PlatformInfo parent =
         PlatformInfo.builder()
-            .addConstraint(ConstraintValueInfo.create(setting1, makeLabel("//constraint:v1")))
+            .addConstraint(ConstraintValueInfo.create(setting1,
+                Label.parseAbsoluteUnchecked("//constraint:v1")))
             .build();
 
     PlatformInfo.Builder builder = PlatformInfo.builder();
     builder.setParent(parent);
-    builder.addConstraint(ConstraintValueInfo.create(setting2, makeLabel("//constraint:v2")));
-    builder.addConstraint(ConstraintValueInfo.create(setting3, makeLabel("//constraint:v3")));
+    builder.addConstraint(ConstraintValueInfo.create(setting2,
+        Label.parseAbsoluteUnchecked("//constraint:v2")));
+    builder.addConstraint(ConstraintValueInfo.create(setting3,
+        Label.parseAbsoluteUnchecked("//constraint:v3")));
     PlatformInfo platformInfo = builder.build();
 
     assertThat(platformInfo).isNotNull();
     assertThat(platformInfo.constraints().has(setting1)).isTrue();
     assertThat(platformInfo.constraints().get(setting1).label())
-        .isEqualTo(makeLabel("//constraint:v1"));
+        .isEqualTo(Label.parseAbsoluteUnchecked("//constraint:v1"));
     assertThat(platformInfo.constraints().has(setting2)).isTrue();
     assertThat(platformInfo.constraints().get(setting2).label())
-        .isEqualTo(makeLabel("//constraint:v2"));
+        .isEqualTo(Label.parseAbsoluteUnchecked("//constraint:v2"));
     assertThat(platformInfo.constraints().has(setting3)).isTrue();
     assertThat(platformInfo.constraints().get(setting3).label())
-        .isEqualTo(makeLabel("//constraint:v3"));
+        .isEqualTo(Label.parseAbsoluteUnchecked("//constraint:v3"));
   }
 
   @Test
   public void platformInfo_parentPlatform_overlaps() throws Exception {
-    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(makeLabel("//constraint:s1"));
-    ConstraintSettingInfo setting2 = ConstraintSettingInfo.create(makeLabel("//constraint:s2"));
-    ConstraintSettingInfo setting3 = ConstraintSettingInfo.create(makeLabel("//constraint:s3"));
+    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:s1"));
+    ConstraintSettingInfo setting2 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:s2"));
+    ConstraintSettingInfo setting3 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:s3"));
 
     PlatformInfo parent =
         PlatformInfo.builder()
-            .addConstraint(ConstraintValueInfo.create(setting1, makeLabel("//constraint:v1")))
+            .addConstraint(ConstraintValueInfo.create(setting1,
+                Label.parseAbsoluteUnchecked("//constraint:v1")))
             .build();
 
     PlatformInfo.Builder builder = PlatformInfo.builder();
     builder.setParent(parent);
-    builder.addConstraint(ConstraintValueInfo.create(setting1, makeLabel("//constraint:v1a")));
-    builder.addConstraint(ConstraintValueInfo.create(setting2, makeLabel("//constraint:v2")));
-    builder.addConstraint(ConstraintValueInfo.create(setting3, makeLabel("//constraint:v3")));
+    builder.addConstraint(ConstraintValueInfo.create(setting1,
+        Label.parseAbsoluteUnchecked("//constraint:v1a")));
+    builder.addConstraint(ConstraintValueInfo.create(setting2,
+        Label.parseAbsoluteUnchecked("//constraint:v2")));
+    builder.addConstraint(ConstraintValueInfo.create(setting3,
+        Label.parseAbsoluteUnchecked("//constraint:v3")));
     PlatformInfo platformInfo = builder.build();
 
     assertThat(platformInfo).isNotNull();
     assertThat(platformInfo.constraints().get(setting1).label())
-        .isEqualTo(makeLabel("//constraint:v1a"));
+        .isEqualTo(Label.parseAbsoluteUnchecked("//constraint:v1a"));
     assertThat(platformInfo.constraints().get(setting2).label())
-        .isEqualTo(makeLabel("//constraint:v2"));
+        .isEqualTo(Label.parseAbsoluteUnchecked("//constraint:v2"));
     assertThat(platformInfo.constraints().get(setting3).label())
-        .isEqualTo(makeLabel("//constraint:v3"));
+        .isEqualTo(Label.parseAbsoluteUnchecked("//constraint:v3"));
   }
 
   @Test
@@ -184,21 +202,29 @@ public class PlatformInfoTest extends BuildViewTestCase {
 
   @Test
   public void platformInfo_overlappingConstraintsError() throws Exception {
-    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(makeLabel("//constraint:basic"));
+    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:basic"));
     ConstraintSettingInfo setting2 =
-        ConstraintSettingInfo.create(makeLabel("//constraint:complex"));
-    ConstraintSettingInfo setting3 = ConstraintSettingInfo.create(makeLabel("//constraint:single"));
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//constraint:complex"));
+    ConstraintSettingInfo setting3 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:single"));
 
     PlatformInfo.Builder builder = PlatformInfo.builder();
 
-    builder.addConstraint(ConstraintValueInfo.create(setting1, makeLabel("//constraint:value1")));
-    builder.addConstraint(ConstraintValueInfo.create(setting1, makeLabel("//constraint:value2")));
+    builder.addConstraint(ConstraintValueInfo.create(setting1,
+        Label.parseAbsoluteUnchecked("//constraint:value1")));
+    builder.addConstraint(ConstraintValueInfo.create(setting1,
+        Label.parseAbsoluteUnchecked("//constraint:value2")));
 
-    builder.addConstraint(ConstraintValueInfo.create(setting2, makeLabel("//constraint:value3")));
-    builder.addConstraint(ConstraintValueInfo.create(setting2, makeLabel("//constraint:value4")));
-    builder.addConstraint(ConstraintValueInfo.create(setting2, makeLabel("//constraint:value5")));
+    builder.addConstraint(ConstraintValueInfo.create(setting2,
+        Label.parseAbsoluteUnchecked("//constraint:value3")));
+    builder.addConstraint(ConstraintValueInfo.create(setting2,
+        Label.parseAbsoluteUnchecked("//constraint:value4")));
+    builder.addConstraint(ConstraintValueInfo.create(setting2,
+        Label.parseAbsoluteUnchecked("//constraint:value5")));
 
-    builder.addConstraint(ConstraintValueInfo.create(setting3, makeLabel("//constraint:value6")));
+    builder.addConstraint(ConstraintValueInfo.create(setting3,
+        Label.parseAbsoluteUnchecked("//constraint:value6")));
 
     ConstraintCollection.DuplicateConstraintException exception =
         assertThrows(
@@ -215,53 +241,55 @@ public class PlatformInfoTest extends BuildViewTestCase {
 
   @Test
   public void platformInfo_equalsTester() throws Exception {
-    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(makeLabel("//constraint:basic"));
-    ConstraintSettingInfo setting2 = ConstraintSettingInfo.create(makeLabel("//constraint:other"));
+    ConstraintSettingInfo setting1 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:basic"));
+    ConstraintSettingInfo setting2 = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//constraint:other"));
 
     ConstraintValueInfo value1 =
-        ConstraintValueInfo.create(setting1, makeLabel("//constraint:value1"));
+        ConstraintValueInfo.create(setting1, Label.parseAbsoluteUnchecked("//constraint:value1"));
     ConstraintValueInfo value2 =
-        ConstraintValueInfo.create(setting2, makeLabel("//constraint:value2"));
+        ConstraintValueInfo.create(setting2, Label.parseAbsoluteUnchecked("//constraint:value2"));
     ConstraintValueInfo value3 =
-        ConstraintValueInfo.create(setting2, makeLabel("//constraint:value3"));
+        ConstraintValueInfo.create(setting2, Label.parseAbsoluteUnchecked("//constraint:value3"));
 
     new EqualsTester()
         .addEqualityGroup(
             // Base case.
             PlatformInfo.builder()
-                .setLabel(makeLabel("//platform/plat1"))
+                .setLabel(Label.parseAbsoluteUnchecked("//platform/plat1"))
                 .addConstraint(value1)
                 .addConstraint(value2)
                 .build(),
             PlatformInfo.builder()
-                .setLabel(makeLabel("//platform/plat1"))
+                .setLabel(Label.parseAbsoluteUnchecked("//platform/plat1"))
                 .addConstraint(value1)
                 .addConstraint(value2)
                 .build())
         .addEqualityGroup(
             // Different label.
             PlatformInfo.builder()
-                .setLabel(makeLabel("//platform/plat2"))
+                .setLabel(Label.parseAbsoluteUnchecked("//platform/plat2"))
                 .addConstraint(value1)
                 .addConstraint(value2)
                 .build())
         .addEqualityGroup(
             // Extra constraint.
             PlatformInfo.builder()
-                .setLabel(makeLabel("//platform/plat1"))
+                .setLabel(Label.parseAbsoluteUnchecked("//platform/plat1"))
                 .addConstraint(value1)
                 .addConstraint(value3)
                 .build())
         .addEqualityGroup(
             // Missing constraint.
             PlatformInfo.builder()
-                .setLabel(makeLabel("//platform/plat1"))
+                .setLabel(Label.parseAbsoluteUnchecked("//platform/plat1"))
                 .addConstraint(value1)
                 .build())
         .addEqualityGroup(
             // Different remote exec properties.
             PlatformInfo.builder()
-                .setLabel(makeLabel("//platform/plat1"))
+                .setLabel(Label.parseAbsoluteUnchecked("//platform/plat1"))
                 .addConstraint(value1)
                 .addConstraint(value2)
                 .setRemoteExecutionProperties("foo")
@@ -358,11 +386,12 @@ public class PlatformInfoTest extends BuildViewTestCase {
 
     PlatformInfo provider = PlatformProviderUtils.platform(platform);
     assertThat(provider).isNotNull();
-    assertThat(provider.label()).isEqualTo(makeLabel("//test/platform:custom"));
+    assertThat(provider.label()).isEqualTo(Label.parseAbsoluteUnchecked("//test/platform:custom"));
     ConstraintSettingInfo constraintSetting =
-        ConstraintSettingInfo.create(makeLabel("//test/constraint:basic"));
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//test/constraint:basic"));
     ConstraintValueInfo constraintValue =
-        ConstraintValueInfo.create(constraintSetting, makeLabel("//test/constraint:foo"));
+        ConstraintValueInfo.create(constraintSetting,
+            Label.parseAbsoluteUnchecked("//test/constraint:foo"));
     assertThat(provider.constraints().get(constraintSetting)).isEqualTo(constraintValue);
   }
 
@@ -417,20 +446,22 @@ public class PlatformInfoTest extends BuildViewTestCase {
 
     PlatformInfo provider = PlatformProviderUtils.platform(platform);
     assertThat(provider).isNotNull();
-    assertThat(provider.label()).isEqualTo(makeLabel("//test/platform:custom"));
+    assertThat(provider.label()).isEqualTo(Label.parseAbsoluteUnchecked("//test/platform:custom"));
 
     // Check that overrides work.
     ConstraintSettingInfo constraintSetting =
-        ConstraintSettingInfo.create(makeLabel("//test/constraint:basic"));
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//test/constraint:basic"));
     ConstraintValueInfo constraintValue =
-        ConstraintValueInfo.create(constraintSetting, makeLabel("//test/constraint:bar"));
+        ConstraintValueInfo.create(constraintSetting,
+            Label.parseAbsoluteUnchecked("//test/constraint:bar"));
     assertThat(provider.constraints().get(constraintSetting)).isEqualTo(constraintValue);
 
     // Check that inheritance works.
     ConstraintSettingInfo constraintSetting2 =
-        ConstraintSettingInfo.create(makeLabel("//test/constraint:complex"));
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//test/constraint:complex"));
     ConstraintValueInfo constraintValue2 =
-        ConstraintValueInfo.create(constraintSetting2, makeLabel("//test/constraint:baz"));
+        ConstraintValueInfo.create(constraintSetting2,
+            Label.parseAbsoluteUnchecked("//test/constraint:baz"));
     assertThat(provider.constraints().get(constraintSetting2)).isEqualTo(constraintValue2);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/ToolchainInfoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/ToolchainInfoTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.cmdline.Label;
 import net.starlark.java.syntax.Location;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,7 +63,8 @@ public class ToolchainInfoTest extends BuildViewTestCase {
 
     ConfiguredTarget extraLabel = (ConfiguredTarget) provider.getValue("extra_label");
     assertThat(extraLabel).isNotNull();
-    assertThat(extraLabel.getLabel()).isEqualTo(makeLabel("//test/toolchain:dep"));
+    assertThat(extraLabel.getLabel()).isEqualTo(
+        Label.parseAbsoluteUnchecked("//test/toolchain:dep"));
     assertThat(provider.getValue("extra_str")).isEqualTo("foo");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewTestCase.java
@@ -1481,7 +1481,7 @@ public abstract class BuildViewTestCase extends FoundationTestCase {
     BuildConfiguration config = getConfiguration(owner);
     return getGenfilesArtifact(
         packageRelativePath,
-        ConfiguredTargetKey.builder().setLabel(makeLabel(owner)).setConfiguration(config).build(),
+        ConfiguredTargetKey.builder().setLabel(Label.parseAbsoluteUnchecked(owner)).setConfiguration(config).build(),
         config);
   }
 
@@ -1692,17 +1692,9 @@ public abstract class BuildViewTestCase extends FoundationTestCase {
         (Rule) ctad.getTarget(), ctad.getConfiguredTarget().getConfigConditions());
   }
 
-  public static Label makeLabel(String label) {
-    try {
-      return Label.parseAbsolute(label, ImmutableMap.of());
-    } catch (LabelSyntaxException e) {
-      throw new IllegalStateException(e);
-    }
-  }
-
   private ConfiguredTargetKey makeConfiguredTargetKey(String label) {
     return ConfiguredTargetKey.builder()
-        .setLabel(makeLabel(label))
+        .setLabel(Label.parseAbsoluteUnchecked(label))
         .setConfiguration(getConfiguration(label))
         .build();
   }

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/ConstraintCollectionApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/ConstraintCollectionApiTest.java
@@ -207,7 +207,7 @@ public class ConstraintCollectionApiTest extends PlatformTestCase {
     assertThat(constraintCollectionWithDefault.has(basicConstraintSetting)).isTrue();
     assertThat(constraintCollectionWithDefault.get(basicConstraintSetting)).isNotNull();
     assertThat(constraintCollectionWithDefault.get(basicConstraintSetting).label())
-        .isEqualTo(makeLabel("//constraint/default:foo"));
+        .isEqualTo(Label.parseAbsoluteUnchecked("//constraint/default:foo"));
     assertThat(constraintCollectionWithDefault.has(otherConstraintSetting)).isFalse();
     assertThat(constraintCollectionWithDefault.get(otherConstraintSetting)).isNull();
 
@@ -217,7 +217,7 @@ public class ConstraintCollectionApiTest extends PlatformTestCase {
     assertThat(constraintCollectionWithDefault.has(basicConstraintSetting)).isTrue();
     assertThat(constraintCollectionWithoutDefault.get(basicConstraintSetting)).isNotNull();
     assertThat(constraintCollectionWithoutDefault.get(basicConstraintSetting).label())
-        .isEqualTo(makeLabel("//constraint/default:bar"));
+        .isEqualTo(Label.parseAbsoluteUnchecked("//constraint/default:bar"));
   }
 
   private Set<Label> collectLabels(Collection<? extends ConstraintSettingInfo> settings) {

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/PlatformInfoApiTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/PlatformInfoApiTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.platform.ConstraintSettingInfo;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
+import com.google.devtools.build.lib.cmdline.Label;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,9 +40,9 @@ public class PlatformInfoApiTest extends PlatformTestCase {
     PlatformInfo platformInfo = fetchPlatformInfo("//foo:my_platform");
     assertThat(platformInfo).isNotNull();
     ConstraintSettingInfo constraintSetting =
-        ConstraintSettingInfo.create(makeLabel("//foo:basic"));
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//foo:basic"));
     ConstraintValueInfo constraintValue =
-        ConstraintValueInfo.create(constraintSetting, makeLabel("//foo:value1"));
+        ConstraintValueInfo.create(constraintSetting, Label.parseAbsoluteUnchecked("//foo:value1"));
     assertThat(platformInfo.constraints().get(constraintSetting)).isEqualTo(constraintValue);
     assertThat(platformInfo.remoteExecutionProperties()).isEmpty();
   }
@@ -94,14 +95,14 @@ public class PlatformInfoApiTest extends PlatformTestCase {
     PlatformInfo platformInfo = fetchPlatformInfo("//foo:my_platform");
     assertThat(platformInfo).isNotNull();
     ConstraintSettingInfo constraintSetting1 =
-        ConstraintSettingInfo.create(makeLabel("//foo:setting1"));
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//foo:setting1"));
     ConstraintValueInfo constraintValue1 =
-        ConstraintValueInfo.create(constraintSetting1, makeLabel("//foo:value1"));
+        ConstraintValueInfo.create(constraintSetting1, Label.parseAbsoluteUnchecked("//foo:value1"));
     assertThat(platformInfo.constraints().get(constraintSetting1)).isEqualTo(constraintValue1);
     ConstraintSettingInfo constraintSetting2 =
-        ConstraintSettingInfo.create(makeLabel("//foo:setting2"));
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//foo:setting2"));
     ConstraintValueInfo constraintValue2 =
-        ConstraintValueInfo.create(constraintSetting2, makeLabel("//foo:value2"));
+        ConstraintValueInfo.create(constraintSetting2, Label.parseAbsoluteUnchecked("//foo:value2"));
     assertThat(platformInfo.constraints().get(constraintSetting2)).isEqualTo(constraintValue2);
   }
 
@@ -118,9 +119,10 @@ public class PlatformInfoApiTest extends PlatformTestCase {
     PlatformInfo platformInfo = fetchPlatformInfo("//foo:my_platform");
     assertThat(platformInfo).isNotNull();
     ConstraintSettingInfo constraintSetting1 =
-        ConstraintSettingInfo.create(makeLabel("//foo:setting1"));
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//foo:setting1"));
     ConstraintValueInfo constraintValue1 =
-        ConstraintValueInfo.create(constraintSetting1, makeLabel("//foo:value1b"));
+        ConstraintValueInfo.create(constraintSetting1,
+            Label.parseAbsoluteUnchecked("//foo:value1b"));
     assertThat(platformInfo.constraints().get(constraintSetting1)).isEqualTo(constraintValue1);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/PlatformTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/PlatformTest.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformProviderUtils;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.cmdline.Label;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -70,12 +71,15 @@ public class PlatformTest extends BuildViewTestCase {
 
     // Check the CPU and OS.
     ConstraintSettingInfo cpuConstraint =
-        ConstraintSettingInfo.create(makeLabel("//autoconfig:cpu"));
-    ConstraintSettingInfo osConstraint = ConstraintSettingInfo.create(makeLabel("//autoconfig:os"));
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//autoconfig:cpu"));
+    ConstraintSettingInfo osConstraint = ConstraintSettingInfo.create(
+        Label.parseAbsoluteUnchecked("//autoconfig:os"));
     assertThat(hostPlatformProvider.constraints().get(cpuConstraint))
-        .isEqualTo(ConstraintValueInfo.create(cpuConstraint, makeLabel("//autoconfig:x86_32")));
+        .isEqualTo(ConstraintValueInfo.create(cpuConstraint,
+            Label.parseAbsoluteUnchecked("//autoconfig:x86_32")));
     assertThat(hostPlatformProvider.constraints().get(osConstraint))
-        .isEqualTo(ConstraintValueInfo.create(osConstraint, makeLabel("//autoconfig:linux")));
+        .isEqualTo(ConstraintValueInfo.create(osConstraint,
+            Label.parseAbsoluteUnchecked("//autoconfig:linux")));
 
     // Check the target platform.
     ConfiguredTarget targetPlatform = getConfiguredTarget("//autoconfig:target");
@@ -86,8 +90,10 @@ public class PlatformTest extends BuildViewTestCase {
 
     // Check the CPU and OS.
     assertThat(targetPlatformProvider.constraints().get(cpuConstraint))
-        .isEqualTo(ConstraintValueInfo.create(cpuConstraint, makeLabel("//autoconfig:x86_64")));
+        .isEqualTo(ConstraintValueInfo.create(cpuConstraint,
+            Label.parseAbsoluteUnchecked("//autoconfig:x86_64")));
     assertThat(targetPlatformProvider.constraints().get(osConstraint))
-        .isEqualTo(ConstraintValueInfo.create(osConstraint, makeLabel("//autoconfig:linux")));
+        .isEqualTo(ConstraintValueInfo.create(osConstraint,
+            Label.parseAbsoluteUnchecked("//autoconfig:linux")));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/ToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/ToolchainTest.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.analysis.platform.DeclaredToolchainInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformProviderUtils;
 import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.cmdline.Label;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,18 +79,22 @@ public class ToolchainTest extends BuildViewTestCase {
     DeclaredToolchainInfo provider = PlatformProviderUtils.declaredToolchainInfo(target);
     assertThat(provider).isNotNull();
     assertThat(provider.toolchainType())
-        .isEqualTo(ToolchainTypeInfo.create(makeLabel("//toolchain:demo_toolchain")));
+        .isEqualTo(ToolchainTypeInfo.create(
+            Label.parseAbsoluteUnchecked("//toolchain:demo_toolchain")));
 
     ConstraintSettingInfo basicConstraintSetting =
-        ConstraintSettingInfo.create(makeLabel("//constraint:basic"));
+        ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//constraint:basic"));
     assertThat(provider.execConstraints().get(basicConstraintSetting))
         .isEqualTo(
-            ConstraintValueInfo.create(basicConstraintSetting, makeLabel("//constraint:foo")));
+            ConstraintValueInfo.create(basicConstraintSetting,
+                Label.parseAbsoluteUnchecked("//constraint:foo")));
     assertThat(provider.targetConstraints().get(basicConstraintSetting))
         .isEqualTo(
-            ConstraintValueInfo.create(basicConstraintSetting, makeLabel("//constraint:bar")));
+            ConstraintValueInfo.create(basicConstraintSetting,
+                Label.parseAbsoluteUnchecked("//constraint:bar")));
 
-    assertThat(provider.toolchainLabel()).isEqualTo(makeLabel("//toolchain:toolchain_def1"));
+    assertThat(provider.toolchainLabel()).isEqualTo(
+        Label.parseAbsoluteUnchecked("//toolchain:toolchain_def1"));
   }
 
   @Test
@@ -127,10 +132,12 @@ public class ToolchainTest extends BuildViewTestCase {
     assertThat(target).isNotNull();
     assertThat(provider).isNotNull();
     assertThat(provider.toolchainType())
-        .isEqualTo(ToolchainTypeInfo.create(makeLabel("//toolchain:demo_toolchain")));
+        .isEqualTo(ToolchainTypeInfo.create(
+            Label.parseAbsoluteUnchecked("//toolchain:demo_toolchain")));
     assertThat(provider.targetSettings().stream().anyMatch(ConfigMatchingProvider::matches))
         .isTrue();
-    assertThat(provider.toolchainLabel()).isEqualTo(makeLabel("//toolchain:toolchain_def1"));
+    assertThat(provider.toolchainLabel()).isEqualTo(
+        Label.parseAbsoluteUnchecked("//toolchain:toolchain_def1"));
   }
 
   @Test
@@ -168,10 +175,12 @@ public class ToolchainTest extends BuildViewTestCase {
     assertThat(target).isNotNull();
     assertThat(provider).isNotNull();
     assertThat(provider.toolchainType())
-        .isEqualTo(ToolchainTypeInfo.create(makeLabel("//toolchain:demo_toolchain")));
+        .isEqualTo(ToolchainTypeInfo.create(
+            Label.parseAbsoluteUnchecked("//toolchain:demo_toolchain")));
     assertThat(provider.targetSettings().stream().anyMatch(ConfigMatchingProvider::matches))
         .isFalse();
-    assertThat(provider.toolchainLabel()).isEqualTo(makeLabel("//toolchain:toolchain_def1"));
+    assertThat(provider.toolchainLabel()).isEqualTo(
+        Label.parseAbsoluteUnchecked("//toolchain:toolchain_def1"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/platform/ToolchainTestCase.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/platform/ToolchainTestCase.java
@@ -118,23 +118,27 @@ public abstract class ToolchainTestCase extends BuildViewTestCase {
         "platform(name = 'mac',",
         "    constraint_values = ['//constraints:mac', '//constraints:non_default_value'])");
 
-    setting = ConstraintSettingInfo.create(makeLabel("//constraints:os"));
-    linuxConstraint = ConstraintValueInfo.create(setting, makeLabel("//constraints:linux"));
-    macConstraint = ConstraintValueInfo.create(setting, makeLabel("//constraints:mac"));
+    setting = ConstraintSettingInfo.create(Label.parseAbsoluteUnchecked("//constraints:os"));
+    linuxConstraint = ConstraintValueInfo.create(setting,
+        Label.parseAbsoluteUnchecked("//constraints:linux"));
+    macConstraint = ConstraintValueInfo.create(setting,
+        Label.parseAbsoluteUnchecked("//constraints:mac"));
     defaultedSetting =
-        ConstraintSettingInfo.create(makeLabel("//constraints:setting_with_default"));
+        ConstraintSettingInfo.create(
+            Label.parseAbsoluteUnchecked("//constraints:setting_with_default"));
     defaultedConstraint =
-        ConstraintValueInfo.create(defaultedSetting, makeLabel("//constraints:non_default_value"));
+        ConstraintValueInfo.create(defaultedSetting,
+            Label.parseAbsoluteUnchecked("//constraints:non_default_value"));
 
     linuxPlatform =
         PlatformInfo.builder()
-            .setLabel(makeLabel("//platforms:linux"))
+            .setLabel(Label.parseAbsoluteUnchecked("//platforms:linux"))
             .addConstraint(linuxConstraint)
             .addConstraint(defaultedConstraint)
             .build();
     macPlatform =
         PlatformInfo.builder()
-            .setLabel(makeLabel("//platforms:mac"))
+            .setLabel(Label.parseAbsoluteUnchecked("//platforms:mac"))
             .addConstraint(macConstraint)
             .addConstraint(defaultedConstraint)
             .build();
@@ -190,7 +194,7 @@ public abstract class ToolchainTestCase extends BuildViewTestCase {
         ImmutableList.of("//constraints:linux"),
         "bar");
 
-    testToolchainTypeLabel = makeLabel("//toolchain:test_toolchain");
+    testToolchainTypeLabel = Label.parseAbsoluteUnchecked("//toolchain:test_toolchain");
     testToolchainType = ToolchainTypeInfo.create(testToolchainTypeLabel);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ConstraintValueLookupUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ConstraintValueLookupUtilTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.rules.platform.ToolchainTestCase;
 import com.google.devtools.build.lib.skyframe.ConstraintValueLookupUtil.InvalidConstraintValueException;
 import com.google.devtools.build.lib.skyframe.util.SkyframeExecutorTestUtils;
@@ -70,12 +71,12 @@ public class ConstraintValueLookupUtilTest extends ToolchainTestCase {
   public void testConstraintValueLookup() throws Exception {
     ConfiguredTargetKey linuxKey =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//constraints:linux"))
+            .setLabel(Label.parseAbsoluteUnchecked("//constraints:linux"))
             .setConfigurationKey(targetConfigKey)
             .build();
     ConfiguredTargetKey macKey =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//constraints:mac"))
+            .setLabel(Label.parseAbsoluteUnchecked("//constraints:mac"))
             .setConfigurationKey(targetConfigKey)
             .build();
     GetConstraintValueInfoKey key =
@@ -98,7 +99,7 @@ public class ConstraintValueLookupUtilTest extends ToolchainTestCase {
 
     ConfiguredTargetKey targetKey =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//invalid:not_a_constraint"))
+            .setLabel(Label.parseAbsoluteUnchecked("//invalid:not_a_constraint"))
             .setConfigurationKey(targetConfigKey)
             .build();
     GetConstraintValueInfoKey key = GetConstraintValueInfoKey.create(ImmutableList.of(targetKey));
@@ -121,7 +122,7 @@ public class ConstraintValueLookupUtilTest extends ToolchainTestCase {
   public void testConstraintValueLookup_targetDoesNotExist() throws Exception {
     ConfiguredTargetKey targetKey =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//fake:missing"))
+            .setLabel(Label.parseAbsoluteUnchecked("//fake:missing"))
             .setConfigurationKey(targetConfigKey)
             .build();
     GetConstraintValueInfoKey key = GetConstraintValueInfoKey.create(ImmutableList.of(targetKey));

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PlatformLookupUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PlatformLookupUtilTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.analysis.util.AnalysisMock;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.rules.platform.ToolchainTestCase;
 import com.google.devtools.build.lib.skyframe.PlatformLookupUtil.InvalidPlatformException;
 import com.google.devtools.build.lib.skyframe.util.SkyframeExecutorTestUtils;
@@ -70,12 +71,12 @@ public class PlatformLookupUtilTest extends ToolchainTestCase {
   public void testPlatformLookup() throws Exception {
     ConfiguredTargetKey linuxKey =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//platforms:linux"))
+            .setLabel(Label.parseAbsoluteUnchecked("//platforms:linux"))
             .setConfigurationKey(targetConfigKey)
             .build();
     ConfiguredTargetKey macKey =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//platforms:mac"))
+            .setLabel(Label.parseAbsoluteUnchecked("//platforms:mac"))
             .setConfigurationKey(targetConfigKey)
             .build();
     GetPlatformInfoKey key = GetPlatformInfoKey.create(ImmutableList.of(linuxKey, macKey));
@@ -97,7 +98,7 @@ public class PlatformLookupUtilTest extends ToolchainTestCase {
 
     ConfiguredTargetKey targetKey =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//invalid:not_a_platform"))
+            .setLabel(Label.parseAbsoluteUnchecked("//invalid:not_a_platform"))
             .setConfigurationKey(targetConfigKey)
             .build();
     GetPlatformInfoKey key = GetPlatformInfoKey.create(ImmutableList.of(targetKey));
@@ -120,7 +121,7 @@ public class PlatformLookupUtilTest extends ToolchainTestCase {
   public void testPlatformLookup_targetDoesNotExist() throws Exception {
     ConfiguredTargetKey targetKey =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//fake:missing"))
+            .setLabel(Label.parseAbsoluteUnchecked("//fake:missing"))
             .setConfigurationKey(targetConfigKey)
             .build();
     GetPlatformInfoKey key = GetPlatformInfoKey.create(ImmutableList.of(targetKey));

--- a/src/test/java/com/google/devtools/build/lib/skyframe/RegisteredExecutionPlatformsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/RegisteredExecutionPlatformsFunctionTest.java
@@ -113,7 +113,8 @@ public class RegisteredExecutionPlatformsFunctionTest extends ToolchainTestCase 
     // list.
     assertExecutionPlatformLabels(result.get(executionPlatformsKey))
         .containsAtLeast(
-            makeLabel("//extra:execution_platform_1"), makeLabel("//extra:execution_platform_2"))
+            Label.parseAbsoluteUnchecked("//extra:execution_platform_1"),
+            Label.parseAbsoluteUnchecked("//extra:execution_platform_2"))
         .inOrder();
   }
 
@@ -139,7 +140,8 @@ public class RegisteredExecutionPlatformsFunctionTest extends ToolchainTestCase 
     // list.
     assertExecutionPlatformLabels(result.get(executionPlatformsKey))
         .containsAtLeast(
-            makeLabel("//extra:execution_platform_1"), makeLabel("//extra:execution_platform_2"))
+            Label.parseAbsoluteUnchecked("//extra:execution_platform_1"),
+            Label.parseAbsoluteUnchecked("//extra:execution_platform_2"))
         .inOrder();
   }
 
@@ -163,7 +165,8 @@ public class RegisteredExecutionPlatformsFunctionTest extends ToolchainTestCase 
     // list.
     assertExecutionPlatformLabels(result.get(executionPlatformsKey))
         .containsAtLeast(
-            makeLabel("//extra:execution_platform_1"), makeLabel("//extra:execution_platform_2"))
+            Label.parseAbsoluteUnchecked("//extra:execution_platform_1"),
+            Label.parseAbsoluteUnchecked("//extra:execution_platform_2"))
         .inOrder();
   }
 
@@ -190,7 +193,8 @@ public class RegisteredExecutionPlatformsFunctionTest extends ToolchainTestCase 
     assertExecutionPlatformLabels(
             result.get(executionPlatformsKey), PackageIdentifier.createInMainRepo("extra"))
         .containsExactly(
-            makeLabel("//extra:execution_platform_1"), makeLabel("//extra:execution_platform_2"))
+            Label.parseAbsoluteUnchecked("//extra:execution_platform_1"),
+            Label.parseAbsoluteUnchecked("//extra:execution_platform_2"))
         .inOrder();
   }
 
@@ -214,7 +218,8 @@ public class RegisteredExecutionPlatformsFunctionTest extends ToolchainTestCase 
     // list.
     assertExecutionPlatformLabels(result.get(executionPlatformsKey))
         .containsAtLeast(
-            makeLabel("//extra:execution_platform_1"), makeLabel("//extra:execution_platform_2"))
+            Label.parseAbsoluteUnchecked("//extra:execution_platform_1"),
+            Label.parseAbsoluteUnchecked("//extra:execution_platform_2"))
         .inOrder();
   }
 
@@ -254,7 +259,7 @@ public class RegisteredExecutionPlatformsFunctionTest extends ToolchainTestCase 
         requestExecutionPlatformsFromSkyframe(executionPlatformsKey);
     assertThatEvaluationResult(result).hasNoError();
     assertExecutionPlatformLabels(result.get(executionPlatformsKey))
-        .contains(makeLabel("//platform:execution_platform_1"));
+        .contains(Label.parseAbsoluteUnchecked("//platform:execution_platform_1"));
 
     // Re-write the WORKSPACE.
     rewriteWorkspace("register_execution_platforms('//platform:execution_platform_2')");
@@ -263,7 +268,7 @@ public class RegisteredExecutionPlatformsFunctionTest extends ToolchainTestCase 
     result = requestExecutionPlatformsFromSkyframe(executionPlatformsKey);
     assertThatEvaluationResult(result).hasNoError();
     assertExecutionPlatformLabels(result.get(executionPlatformsKey))
-        .contains(makeLabel("//platform:execution_platform_2"));
+        .contains(Label.parseAbsoluteUnchecked("//platform:execution_platform_2"));
   }
 
   @Test
@@ -271,12 +276,12 @@ public class RegisteredExecutionPlatformsFunctionTest extends ToolchainTestCase 
       throws ConstraintCollection.DuplicateConstraintException {
     ConfiguredTargetKey executionPlatformKey1 =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//test:executionPlatform1"))
+            .setLabel(Label.parseAbsoluteUnchecked("//test:executionPlatform1"))
             .setConfigurationKey(null)
             .build();
     ConfiguredTargetKey executionPlatformKey2 =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//test:executionPlatform2"))
+            .setLabel(Label.parseAbsoluteUnchecked("//test:executionPlatform2"))
             .setConfigurationKey(null)
             .build();
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/RegisteredToolchainsFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/RegisteredToolchainsFunctionTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import com.google.devtools.build.lib.analysis.platform.DeclaredToolchainInfo;
 import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.rules.platform.ToolchainTestCase;
 import com.google.devtools.build.skyframe.EvaluationResult;
@@ -55,25 +56,23 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
     assertThat(
             value.registeredToolchains().stream()
                 .anyMatch(
-                    toolchain ->
-                        toolchain.toolchainType().equals(testToolchainType)
-                            && toolchain.execConstraints().get(setting).equals(linuxConstraint)
-                            && toolchain.targetConstraints().get(setting).equals(macConstraint)
-                            && toolchain
-                                .toolchainLabel()
-                                .equals(makeLabel("//toolchain:toolchain_1_impl"))))
+                    toolchain -> toolchain.toolchainType().equals(testToolchainType)
+                        && toolchain.execConstraints().get(setting).equals(linuxConstraint)
+                        && toolchain.targetConstraints().get(setting).equals(macConstraint)
+                        && toolchain
+                            .toolchainLabel()
+                            .equals(Label.parseAbsoluteUnchecked("//toolchain:toolchain_1_impl"))))
         .isTrue();
 
     assertThat(
             value.registeredToolchains().stream()
                 .anyMatch(
-                    toolchain ->
-                        toolchain.toolchainType().equals(testToolchainType)
-                            && toolchain.execConstraints().get(setting).equals(macConstraint)
-                            && toolchain.targetConstraints().get(setting).equals(linuxConstraint)
-                            && toolchain
-                                .toolchainLabel()
-                                .equals(makeLabel("//toolchain:toolchain_2_impl"))))
+                    toolchain -> toolchain.toolchainType().equals(testToolchainType)
+                        && toolchain.execConstraints().get(setting).equals(macConstraint)
+                        && toolchain.targetConstraints().get(setting).equals(linuxConstraint)
+                        && toolchain
+                            .toolchainLabel()
+                            .equals(Label.parseAbsoluteUnchecked("//toolchain:toolchain_2_impl"))))
         .isTrue();
   }
 
@@ -105,7 +104,8 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
     // Verify that the target registered with the extra_toolchains flag is first in the list.
     assertToolchainLabels(result.get(toolchainsKey))
         .containsAtLeast(
-            makeLabel("//extra:extra_toolchain_impl"), makeLabel("//toolchain:toolchain_1_impl"))
+            Label.parseAbsoluteUnchecked("//extra:extra_toolchain_impl"),
+            Label.parseAbsoluteUnchecked("//toolchain:toolchain_1_impl"))
         .inOrder();
   }
 
@@ -147,9 +147,9 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
     // Verify that the target registered with the extra_toolchains flag is first in the list.
     assertToolchainLabels(result.get(toolchainsKey))
         .containsAtLeast(
-            makeLabel("//extra:extra_toolchain_impl_1"),
-            makeLabel("//extra:extra_toolchain_impl_2"),
-            makeLabel("//toolchain:toolchain_1_impl"))
+            Label.parseAbsoluteUnchecked("//extra:extra_toolchain_impl_1"),
+            Label.parseAbsoluteUnchecked("//extra:extra_toolchain_impl_2"),
+            Label.parseAbsoluteUnchecked("//toolchain:toolchain_1_impl"))
         .inOrder();
   }
 
@@ -217,9 +217,9 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
     assertThatEvaluationResult(result).hasNoError();
     assertToolchainLabels(result.get(toolchainsKey), PackageIdentifier.createInMainRepo("extra"))
         .containsExactly(
-            makeLabel("//extra:extra_toolchain1_impl"),
-            makeLabel("//extra:extra_toolchain2_impl"),
-            makeLabel("//extra/more:more_toolchain_impl"));
+            Label.parseAbsoluteUnchecked("//extra:extra_toolchain1_impl"),
+            Label.parseAbsoluteUnchecked("//extra:extra_toolchain2_impl"),
+            Label.parseAbsoluteUnchecked("//extra/more:more_toolchain_impl"));
   }
 
   @Test
@@ -251,9 +251,9 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
     assertThatEvaluationResult(result).hasNoError();
     assertToolchainLabels(result.get(toolchainsKey))
         .containsAtLeast(
-            makeLabel("//extra:extra_toolchain1_impl"),
-            makeLabel("//extra:extra_toolchain2_impl"),
-            makeLabel("//extra/more:more_toolchain_impl"));
+            Label.parseAbsoluteUnchecked("//extra:extra_toolchain1_impl"),
+            Label.parseAbsoluteUnchecked("//extra:extra_toolchain2_impl"),
+            Label.parseAbsoluteUnchecked("//extra/more:more_toolchain_impl"));
   }
 
   @Test
@@ -265,7 +265,7 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
         requestToolchainsFromSkyframe(toolchainsKey);
     assertThatEvaluationResult(result).hasNoError();
     assertToolchainLabels(result.get(toolchainsKey))
-        .contains(makeLabel("//toolchain:toolchain_1_impl"));
+        .contains(Label.parseAbsoluteUnchecked("//toolchain:toolchain_1_impl"));
 
     // Re-write the WORKSPACE.
     rewriteWorkspace("register_toolchains('//toolchain:toolchain_2')");
@@ -274,24 +274,26 @@ public class RegisteredToolchainsFunctionTest extends ToolchainTestCase {
     result = requestToolchainsFromSkyframe(toolchainsKey);
     assertThatEvaluationResult(result).hasNoError();
     assertToolchainLabels(result.get(toolchainsKey))
-        .contains(makeLabel("//toolchain:toolchain_2_impl"));
+        .contains(Label.parseAbsoluteUnchecked("//toolchain:toolchain_2_impl"));
   }
 
   @Test
   public void testRegisteredToolchainsValue_equalsAndHashCode() throws Exception {
     DeclaredToolchainInfo toolchain1 =
         DeclaredToolchainInfo.builder()
-            .toolchainType(ToolchainTypeInfo.create(makeLabel("//test:toolchain")))
+            .toolchainType(ToolchainTypeInfo.create(
+                Label.parseAbsoluteUnchecked("//test:toolchain")))
             .addExecConstraints(ImmutableList.of())
             .addTargetConstraints(ImmutableList.of())
-            .toolchainLabel(makeLabel("//test/toolchain_impl_1"))
+            .toolchainLabel(Label.parseAbsoluteUnchecked("//test/toolchain_impl_1"))
             .build();
     DeclaredToolchainInfo toolchain2 =
         DeclaredToolchainInfo.builder()
-            .toolchainType(ToolchainTypeInfo.create(makeLabel("//test:toolchain")))
+            .toolchainType(ToolchainTypeInfo.create(
+                Label.parseAbsoluteUnchecked("//test:toolchain")))
             .addExecConstraints(ImmutableList.of())
             .addTargetConstraints(ImmutableList.of())
-            .toolchainLabel(makeLabel("//test/toolchain_impl_2"))
+            .toolchainLabel(Label.parseAbsoluteUnchecked("//test/toolchain_impl_2"))
             .build();
 
     new EqualsTester()

--- a/src/test/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionFunctionTest.java
@@ -85,7 +85,7 @@ public class SingleToolchainResolutionFunctionTest extends ToolchainTestCase {
 
     SingleToolchainResolutionValue singleToolchainResolutionValue = result.get(key);
     assertThat(singleToolchainResolutionValue.availableToolchainLabels())
-        .containsExactly(macCtkey, makeLabel("//toolchain:toolchain_2_impl"));
+        .containsExactly(macCtkey, Label.parseAbsoluteUnchecked("//toolchain:toolchain_2_impl"));
   }
 
   @Test
@@ -116,9 +116,9 @@ public class SingleToolchainResolutionFunctionTest extends ToolchainTestCase {
     assertThat(singleToolchainResolutionValue.availableToolchainLabels())
         .containsExactly(
             linuxCtkey,
-            makeLabel("//extra:extra_toolchain_impl"),
+            Label.parseAbsoluteUnchecked("//extra:extra_toolchain_impl"),
             macCtkey,
-            makeLabel("//toolchain:toolchain_2_impl"));
+            Label.parseAbsoluteUnchecked("//toolchain:toolchain_2_impl"));
   }
 
   @Test
@@ -144,30 +144,32 @@ public class SingleToolchainResolutionFunctionTest extends ToolchainTestCase {
         .addEqualityGroup(
             SingleToolchainResolutionValue.create(
                 testToolchainType,
-                ImmutableMap.of(linuxCtkey, makeLabel("//test:toolchain_impl_1"))),
+                ImmutableMap.of(linuxCtkey, Label.parseAbsoluteUnchecked("//test:toolchain_impl_1"))),
             SingleToolchainResolutionValue.create(
                 testToolchainType,
-                ImmutableMap.of(linuxCtkey, makeLabel("//test:toolchain_impl_1"))))
+                ImmutableMap.of(linuxCtkey, Label.parseAbsoluteUnchecked("//test:toolchain_impl_1"))))
         // Different execution platform, same label.
         .addEqualityGroup(
             SingleToolchainResolutionValue.create(
-                testToolchainType, ImmutableMap.of(macCtkey, makeLabel("//test:toolchain_impl_1"))))
+                testToolchainType, ImmutableMap.of(macCtkey,
+                    Label.parseAbsoluteUnchecked("//test:toolchain_impl_1"))))
         // Same execution platform, different label.
         .addEqualityGroup(
             SingleToolchainResolutionValue.create(
                 testToolchainType,
-                ImmutableMap.of(linuxCtkey, makeLabel("//test:toolchain_impl_2"))))
+                ImmutableMap.of(linuxCtkey, Label.parseAbsoluteUnchecked("//test:toolchain_impl_2"))))
         // Different execution platform, different label.
         .addEqualityGroup(
             SingleToolchainResolutionValue.create(
-                testToolchainType, ImmutableMap.of(macCtkey, makeLabel("//test:toolchain_impl_2"))))
+                testToolchainType, ImmutableMap.of(macCtkey,
+                    Label.parseAbsoluteUnchecked("//test:toolchain_impl_2"))))
         // Multiple execution platforms.
         .addEqualityGroup(
             SingleToolchainResolutionValue.create(
                 testToolchainType,
                 ImmutableMap.<ConfiguredTargetKey, Label>builder()
-                    .put(linuxCtkey, makeLabel("//test:toolchain_impl_1"))
-                    .put(macCtkey, makeLabel("//test:toolchain_impl_1"))
+                    .put(linuxCtkey, Label.parseAbsoluteUnchecked("//test:toolchain_impl_1"))
+                    .put(macCtkey, Label.parseAbsoluteUnchecked("//test:toolchain_impl_1"))
                     .build()))
         .testEquals();
   }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/TargetCycleReporterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/TargetCycleReporterTest.java
@@ -17,6 +17,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.skyframe.CycleInfo;
 import com.google.devtools.build.skyframe.SkyKey;
 import org.junit.Test;
@@ -47,12 +48,12 @@ public class TargetCycleReporterTest extends BuildViewTestCase {
     CycleInfo cycle =
         new CycleInfo(
             ImmutableList.of(
-                TransitiveTargetKey.of(makeLabel("//foo:b")),
-                TransitiveTargetKey.of(makeLabel("//foo:c"))));
+                TransitiveTargetKey.of(Label.parseAbsoluteUnchecked("//foo:b")),
+                TransitiveTargetKey.of(Label.parseAbsoluteUnchecked("//foo:c"))));
 
     ConfiguredTargetKey ctKey =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//foo:a"))
+            .setLabel(Label.parseAbsoluteUnchecked("//foo:a"))
             .setConfiguration(targetConfig)
             .build();
     assertThat(cycleReporter.getAdditionalMessageAboutCycle(reporter, ctKey, cycle))
@@ -70,10 +71,10 @@ public class TargetCycleReporterTest extends BuildViewTestCase {
 
     SkyKey starlarkAspectKey =
         AspectValueKey.createStarlarkAspectKey(
-            makeLabel("//foo:a"),
+            Label.parseAbsoluteUnchecked("//foo:a"),
             targetConfig,
             targetConfig,
-            makeLabel("//foo:b"),
+            Label.parseAbsoluteUnchecked("//foo:b"),
             "my Starlark key");
     assertThat(cycleReporter.getAdditionalMessageAboutCycle(reporter, starlarkAspectKey, cycle))
         .contains(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunctionTest.java
@@ -98,7 +98,7 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
         "register_execution_platforms('//platforms:linux')");
 
     // Set up an alias for the toolchain type.
-    Label aliasedToolchainTypeLabel = makeLabel("//alias:toolchain_type");
+    Label aliasedToolchainTypeLabel = Label.parseAbsoluteUnchecked("//alias:toolchain_type");
     scratch.file(
         "alias/BUILD", "alias(name = 'toolchain_type', actual = '//toolchain:test_toolchain')");
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainTypeLookupUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainTypeLookupUtilTest.java
@@ -92,7 +92,7 @@ public class ToolchainTypeLookupUtilTest extends ToolchainTestCase {
   public void testToolchainTypeLookup_toolchainAlias() throws Exception {
     scratch.file(
         "alias/BUILD", "alias(name = 'toolchain_type', actual = '" + testToolchainTypeLabel + "')");
-    Label aliasToolchainTypeLabel = makeLabel("//alias:toolchain_type");
+    Label aliasToolchainTypeLabel = Label.parseAbsoluteUnchecked("//alias:toolchain_type");
     ConfiguredTargetKey testToolchainTypeKey =
         ConfiguredTargetKey.builder()
             .setLabel(aliasToolchainTypeLabel)
@@ -122,7 +122,7 @@ public class ToolchainTypeLookupUtilTest extends ToolchainTestCase {
 
     ConfiguredTargetKey targetKey =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//invalid:not_a_toolchain_type"))
+            .setLabel(Label.parseAbsoluteUnchecked("//invalid:not_a_toolchain_type"))
             .setConfigurationKey(targetConfigKey)
             .build();
     GetToolchainTypeInfoKey key = GetToolchainTypeInfoKey.create(ImmutableList.of(targetKey));
@@ -145,7 +145,7 @@ public class ToolchainTypeLookupUtilTest extends ToolchainTestCase {
   public void testToolchainTypeLookup_targetDoesNotExist() throws Exception {
     ConfiguredTargetKey targetKey =
         ConfiguredTargetKey.builder()
-            .setLabel(makeLabel("//fake:missing"))
+            .setLabel(Label.parseAbsoluteUnchecked("//fake:missing"))
             .setConfigurationKey(targetConfigKey)
             .build();
     GetToolchainTypeInfoKey key = GetToolchainTypeInfoKey.create(ImmutableList.of(targetKey));

--- a/src/test/java/com/google/devtools/build/lib/starlark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/starlark/BUILD
@@ -41,6 +41,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis:file_provider",
         "//src/main/java/com/google/devtools/build/lib/analysis:resolved_toolchain_context",
         "//src/main/java/com/google/devtools/build/lib/analysis:starlark/args",
+        "//src/main/java/com/google/devtools/build/lib/analysis:starlark/starlark_exec_group_collection",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/analysis_failure",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/analysis_failure_info",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/analysis_test_result_info",

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -497,7 +497,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         ev, "def _impl(ctx): pass", "a1 = aspect(_impl, toolchains=['//test:my_toolchain_type'])");
     StarlarkDefinedAspect a = (StarlarkDefinedAspect) ev.lookup("a1");
     assertThat(a.getRequiredToolchains()).containsExactly(
-        Label.parseAbsoluteUnchecked("//test:my_toolchain_type"));
+        Label.parseAbsoluteUnchecked("//test:my_toolchain_type", false));
   }
 
   @Test
@@ -1859,7 +1859,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         "r1 = rule(impl, toolchains=['//test:my_toolchain_type'])");
     RuleClass c = ((StarlarkRuleFunction) ev.lookup("r1")).getRuleClass();
     assertThat(c.getRequiredToolchains()).containsExactly(
-        Label.parseAbsoluteUnchecked("//test:my_toolchain_type"));
+        Label.parseAbsoluteUnchecked("//test:my_toolchain_type", false));
   }
 
   @Test
@@ -1875,8 +1875,8 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         ")");
     RuleClass c = ((StarlarkRuleFunction) ev.lookup("r1")).getRuleClass();
     assertThat(c.getExecutionPlatformConstraints())
-        .containsExactly(Label.parseAbsoluteUnchecked("//constraint:cv1"),
-            Label.parseAbsoluteUnchecked("//constraint:cv2"));
+        .containsExactly(Label.parseAbsoluteUnchecked("//constraint:cv1", false),
+            Label.parseAbsoluteUnchecked("//constraint:cv2", false));
   }
 
   @Test
@@ -1899,11 +1899,11 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
     RuleClass plum = ((StarlarkRuleFunction) ev.lookup("plum")).getRuleClass();
     assertThat(plum.getRequiredToolchains()).isEmpty();
     assertThat(plum.getExecGroups().get("group").requiredToolchains())
-        .containsExactly(Label.parseAbsoluteUnchecked("//test:my_toolchain_type"));
+        .containsExactly(Label.parseAbsoluteUnchecked("//test:my_toolchain_type", false));
     assertThat(plum.getExecutionPlatformConstraints()).isEmpty();
     assertThat(plum.getExecGroups().get("group").execCompatibleWith())
-        .containsExactly(Label.parseAbsoluteUnchecked("//constraint:cv1"),
-            Label.parseAbsoluteUnchecked("//constraint:cv2"));
+        .containsExactly(Label.parseAbsoluteUnchecked("//constraint:cv1", false),
+            Label.parseAbsoluteUnchecked("//constraint:cv2", false));
   }
 
   @Test
@@ -1953,10 +1953,10 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         ")");
     ExecGroup group = ((ExecGroup) ev.lookup("group"));
     assertThat(group.requiredToolchains()).containsExactly(
-        Label.parseAbsoluteUnchecked("//test:my_toolchain_type"));
+        Label.parseAbsoluteUnchecked("//test:my_toolchain_type", false));
     assertThat(group.execCompatibleWith())
-        .containsExactly(Label.parseAbsoluteUnchecked("//constraint:cv1"),
-            Label.parseAbsoluteUnchecked("//constraint:cv2"));
+        .containsExactly(Label.parseAbsoluteUnchecked("//constraint:cv1", false),
+            Label.parseAbsoluteUnchecked("//constraint:cv2", false));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -496,7 +496,8 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
     evalAndExport(
         ev, "def _impl(ctx): pass", "a1 = aspect(_impl, toolchains=['//test:my_toolchain_type'])");
     StarlarkDefinedAspect a = (StarlarkDefinedAspect) ev.lookup("a1");
-    assertThat(a.getRequiredToolchains()).containsExactly(makeLabel("//test:my_toolchain_type"));
+    assertThat(a.getRequiredToolchains()).containsExactly(
+        Label.parseAbsoluteUnchecked("//test:my_toolchain_type"));
   }
 
   @Test
@@ -1857,7 +1858,8 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         "def impl(ctx): return None",
         "r1 = rule(impl, toolchains=['//test:my_toolchain_type'])");
     RuleClass c = ((StarlarkRuleFunction) ev.lookup("r1")).getRuleClass();
-    assertThat(c.getRequiredToolchains()).containsExactly(makeLabel("//test:my_toolchain_type"));
+    assertThat(c.getRequiredToolchains()).containsExactly(
+        Label.parseAbsoluteUnchecked("//test:my_toolchain_type"));
   }
 
   @Test
@@ -1873,7 +1875,8 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         ")");
     RuleClass c = ((StarlarkRuleFunction) ev.lookup("r1")).getRuleClass();
     assertThat(c.getExecutionPlatformConstraints())
-        .containsExactly(makeLabel("//constraint:cv1"), makeLabel("//constraint:cv2"));
+        .containsExactly(Label.parseAbsoluteUnchecked("//constraint:cv1"),
+            Label.parseAbsoluteUnchecked("//constraint:cv2"));
   }
 
   @Test
@@ -1896,10 +1899,11 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
     RuleClass plum = ((StarlarkRuleFunction) ev.lookup("plum")).getRuleClass();
     assertThat(plum.getRequiredToolchains()).isEmpty();
     assertThat(plum.getExecGroups().get("group").requiredToolchains())
-        .containsExactly(makeLabel("//test:my_toolchain_type"));
+        .containsExactly(Label.parseAbsoluteUnchecked("//test:my_toolchain_type"));
     assertThat(plum.getExecutionPlatformConstraints()).isEmpty();
     assertThat(plum.getExecGroups().get("group").execCompatibleWith())
-        .containsExactly(makeLabel("//constraint:cv1"), makeLabel("//constraint:cv2"));
+        .containsExactly(Label.parseAbsoluteUnchecked("//constraint:cv1"),
+            Label.parseAbsoluteUnchecked("//constraint:cv2"));
   }
 
   @Test
@@ -1948,9 +1952,11 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         "  exec_compatible_with=['//constraint:cv1', '//constraint:cv2'],",
         ")");
     ExecGroup group = ((ExecGroup) ev.lookup("group"));
-    assertThat(group.requiredToolchains()).containsExactly(makeLabel("//test:my_toolchain_type"));
+    assertThat(group.requiredToolchains()).containsExactly(
+        Label.parseAbsoluteUnchecked("//test:my_toolchain_type"));
     assertThat(group.execCompatibleWith())
-        .containsExactly(makeLabel("//constraint:cv1"), makeLabel("//constraint:cv2"));
+        .containsExactly(Label.parseAbsoluteUnchecked("//constraint:cv1"),
+            Label.parseAbsoluteUnchecked("//constraint:cv2"));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleContextTest.java
@@ -32,12 +32,12 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.ActionsProvider;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
-import com.google.devtools.build.lib.analysis.ExecGroupCollection;
 import com.google.devtools.build.lib.analysis.ResolvedToolchainContext;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.actions.FileWriteAction;
 import com.google.devtools.build.lib.analysis.actions.StarlarkAction;
 import com.google.devtools.build.lib.analysis.configuredtargets.FileConfiguredTarget;
+import com.google.devtools.build.lib.analysis.starlark.StarlarkExecGroupCollection;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkRuleContext;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
 import com.google.devtools.build.lib.analysis.util.MockRule;
@@ -2966,9 +2966,10 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
                     Label.parseAbsoluteUnchecked("//something:defs.bzl"), "result"));
     assertThat(info).isNotNull();
     assertThat(info.getValue("toolchain_value")).isEqualTo("foo");
-    assertThat(info.getValue("exec_groups")).isInstanceOf(ExecGroupCollection.class);
+    assertThat(info.getValue("exec_groups")).isInstanceOf(StarlarkExecGroupCollection.class);
     ImmutableMap<String, ResolvedToolchainContext> toolchainContexts =
-        ((ExecGroupCollection) info.getValue("exec_groups")).getToolchainCollectionForTesting();
+        ((StarlarkExecGroupCollection) info.getValue("exec_groups"))
+            .getToolchainCollectionForTesting();
     assertThat(toolchainContexts.keySet()).containsExactly(DEFAULT_EXEC_GROUP_NAME, "dragonfruit");
     assertThat(toolchainContexts.get(DEFAULT_EXEC_GROUP_NAME).requiredToolchainTypes()).isEmpty();
     assertThat(toolchainContexts.get("dragonfruit").resolvedToolchainLabels())
@@ -3022,9 +3023,10 @@ public final class StarlarkRuleContextTest extends BuildViewTestCase {
                     Label.parseAbsoluteUnchecked("//something:defs.bzl"), "result"));
     assertThat(info).isNotNull();
     assertThat(info.getValue("toolchain_value")).isEqualTo("foo");
-    assertThat(info.getValue("exec_groups")).isInstanceOf(ExecGroupCollection.class);
+    assertThat(info.getValue("exec_groups")).isInstanceOf(StarlarkExecGroupCollection.class);
     ImmutableMap<String, ResolvedToolchainContext> toolchainContexts =
-        ((ExecGroupCollection) info.getValue("exec_groups")).getToolchainCollectionForTesting();
+        ((StarlarkExecGroupCollection) info.getValue("exec_groups"))
+            .getToolchainCollectionForTesting();
     assertThat(toolchainContexts.keySet())
         .containsExactly(DEFAULT_EXEC_GROUP_NAME, "dragonfruit", "passionfruit");
     assertThat(toolchainContexts.get(DEFAULT_EXEC_GROUP_NAME).requiredToolchainTypes()).isEmpty();


### PR DESCRIPTION
Also move label conversion into the LabelConversionContext so it can be shared more widely.