### PR TITLE
Add the requirement of /showIncludes for MSVC

### DIFF
--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -137,6 +137,8 @@ To build C++ targets with MSVC, you need:
 
 *   [The Visual C++ compiler](install-windows.html#install-vc).
 
+*   The compiler flag `/showIncludes` in case that you define your custom toolchain.
+
 *   (Optional) The `BAZEL_VC` and `BAZEL_VC_FULL_VERSION` environment variable.
 
     Bazel automatically detects the Visual C++ compiler on your system.


### PR DESCRIPTION
MSVC is not working in Bazel if showIncludes is not declared https://github.com/bazelbuild/bazel/issues/13220