### PR TITLE
Change `set -x` in coverage to be set by var

### DIFF
--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
  # Copyright 2016 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,10 +31,15 @@
 # - COVERAGE_GCOV_OPTIONS   Additional options to pass to gcov.
 # - ROOT                    Location from where the code coverage collection
 #                           was invoked.
+# - VERBOSE_COVERAGE        Print debug info from the coverage scripts
 #
 # The script looks in $COVERAGE_DIR for the C++ metadata coverage files (either
 # gcda or profraw) and uses either lcov or gcov to get the coverage data.
 # The coverage data is placed in $COVERAGE_OUTPUT_FILE.
+
+if [[ -n "$VERBOSE_COVERAGE" ]]; then
+  set -x
+fi
 
 # Checks if clang llvm coverage should be used instead of lcov.
 function uses_llvm() {

--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #
@@ -21,9 +21,14 @@
 #   LCOV_MERGER - mandatory, location of the LcovMerger
 #   COVERAGE_DIR - optional, location of the coverage temp directory
 #   COVERAGE_OUTPUT_FILE - optional, location of the final lcov file
+#   VERBOSE_COVERAGE - optional, print debug info from the coverage scripts
 #
 # Script expects that it will be started in the execution root directory and
 # not in the test's runfiles directory.
+
+if [[ -n "$VERBOSE_COVERAGE" ]]; then
+  set -x
+fi
 
 function resolve_links() {
   local name="$1"


### PR DESCRIPTION
Using `set -x` in the coverage scripts causes a lot of noise, this changes it to be off by default, but something you can enable by passing `--test_env=VERBOSE_COVERAGE=1` for debugging.