### PR TITLE
Update Fedora installation instructions in docs

### DIFF
--- a/site/docs/install-redhat.md
+++ b/site/docs/install-redhat.md
@@ -35,7 +35,7 @@ version of the Bazel package.
 
     ```bash
     dnf copr enable vbatts/bazel
-    dnf install bazel3
+    dnf install bazel4
     ```
 
 ## Installing on CentOS 7
@@ -47,5 +47,5 @@ version of the Bazel package.
 2. Run the following command:
 
     ```bash
-    yum install bazel3
+    yum install bazel4
     ```


### PR DESCRIPTION
For [the Fedora installation instructions for Bazel 4](https://docs.bazel.build/versions/4.0.0/install-redhat.html), it says to do `dnf install bazel3`, but since the docs are for v4 I think it should be `dnf install bazel4`