### PR TITLE
Update ConfiguredTargetFunction.computeUnloadedToolchainContexts to

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainContextKey.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainContextKey.java
@@ -14,10 +14,12 @@
 package com.google.devtools.build.lib.skyframe;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
+import java.util.Optional;
 
 /**
  * {@link SkyKey} implementation used for {@link ToolchainResolutionFunction} to produce {@link
@@ -31,7 +33,8 @@ public abstract class ToolchainContextKey implements SkyKey {
     return new AutoValue_ToolchainContextKey.Builder()
         .requiredToolchainTypeLabels(ImmutableSet.of())
         .execConstraintLabels(ImmutableSet.of())
-        .shouldSanityCheckConfiguration(false);
+        .shouldSanityCheckConfiguration(false)
+        .forceExecutionPlatform(Optional.empty());
   }
 
   @Override
@@ -46,6 +49,8 @@ public abstract class ToolchainContextKey implements SkyKey {
   abstract ImmutableSet<Label> execConstraintLabels();
 
   abstract boolean shouldSanityCheckConfiguration();
+
+  abstract Optional<Label> forceExecutionPlatform();
 
   /** Builder for {@link ToolchainContextKey}. */
   @AutoValue.Builder
@@ -63,5 +68,12 @@ public abstract class ToolchainContextKey implements SkyKey {
     Builder shouldSanityCheckConfiguration(boolean shouldSanityCheckConfiguration);
 
     ToolchainContextKey build();
+
+    Builder forceExecutionPlatform(Optional<Label> execPlatform);
+
+    default Builder forceExecutionPlatform(Label execPlatform) {
+      Preconditions.checkNotNull(execPlatform);
+      return forceExecutionPlatform(Optional.of(execPlatform));
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunction.java
@@ -435,20 +435,12 @@ public class ToolchainResolutionFunction implements SkyFunction {
     ImmutableSet<ToolchainTypeInfo> requiredToolchainTypes = requiredToolchainTypesBuilder.build();
 
     // Find and return the first execution platform which has all required toolchains.
-    Optional<ConfiguredTargetKey> selectedExecutionPlatformKey;
-    if (!requiredToolchainTypeLabels.isEmpty()) {
-      selectedExecutionPlatformKey =
-          findExecutionPlatformForToolchains(
-              requiredToolchainTypes,
-              forcedExecutionPlatform,
-              platformKeys.executionPlatformKeys(),
-              resolvedToolchains);
-    } else if (!platformKeys.executionPlatformKeys().isEmpty()) {
-      // Just use the first execution platform.
-      selectedExecutionPlatformKey = Optional.of(platformKeys.executionPlatformKeys().get(0));
-    } else {
-      selectedExecutionPlatformKey = Optional.empty();
-    }
+    Optional<ConfiguredTargetKey> selectedExecutionPlatformKey =
+        findExecutionPlatformForToolchains(
+            requiredToolchainTypes,
+            forcedExecutionPlatform,
+            platformKeys.executionPlatformKeys(),
+            resolvedToolchains);
 
     if (!selectedExecutionPlatformKey.isPresent()) {
       throw new NoMatchingPlatformException(
@@ -519,6 +511,12 @@ public class ToolchainResolutionFunction implements SkyFunction {
       ConfiguredTargetKey executionPlatformKey,
       ImmutableSet<ToolchainTypeInfo> requiredToolchainTypes,
       Table<ConfiguredTargetKey, ToolchainTypeInfo, Label> resolvedToolchains) {
+    if (requiredToolchainTypes.isEmpty()) {
+      // Since there aren't any toolchains, we should be able to use any execution platform that
+      // has made it this far.
+      return true;
+    }
+
     if (!resolvedToolchains.containsRow(executionPlatformKey)) {
       return false;
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/UnloadedToolchainContext.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/UnloadedToolchainContext.java
@@ -41,7 +41,4 @@ public interface UnloadedToolchainContext extends ToolchainContext, SkyValue {
 
   @Override
   ImmutableSet<Label> resolvedToolchainLabels();
-
-  /** Returns a copy of this context, without the resolved toolchain data. */
-  UnloadedToolchainContext withoutResolvedToolchains();
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/UnloadedToolchainContextImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/UnloadedToolchainContextImpl.java
@@ -74,9 +74,4 @@ public abstract class UnloadedToolchainContextImpl implements SkyValue, Unloaded
   }
 
   protected abstract Builder toBuilder();
-
-  @Override
-  public UnloadedToolchainContext withoutResolvedToolchains() {
-    return this.toBuilder().setToolchainTypeToResolved(ImmutableSetMultimap.of()).build();
-  }
 }

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunctionTest.java
@@ -434,9 +434,8 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
 
   @Test
   public void resolve_forceExecutionPlatform() throws Exception {
-    // This should select platform linux, toolchain extra_toolchain_linux, due to the forced
-    // platform,
-    // even though platform mac is registered first.
+    // This should select execution platform linux, toolchain extra_toolchain_linux, due to the
+    // forced executin platform, even though execution platform mac is registered first.
     addToolchain(
         /* packageName= */ "extra",
         /* toolchainName= */ "extra_toolchain_linux",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunctionTest.java
@@ -435,7 +435,7 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
   @Test
   public void resolve_forceExecutionPlatform() throws Exception {
     // This should select execution platform linux, toolchain extra_toolchain_linux, due to the
-    // forced executin platform, even though execution platform mac is registered first.
+    // forced execution platform, even though execution platform mac is registered first.
     addToolchain(
         /* packageName= */ "extra",
         /* toolchainName= */ "extra_toolchain_linux",
@@ -468,6 +468,29 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
 
     assertThat(unloadedToolchainContext).hasToolchainType(testToolchainTypeLabel);
     assertThat(unloadedToolchainContext).hasResolvedToolchain("//extra:extra_toolchain_linux_impl");
+    assertThat(unloadedToolchainContext).hasExecutionPlatform("//platforms:linux");
+    assertThat(unloadedToolchainContext).hasTargetPlatform("//platforms:linux");
+  }
+
+  @Test
+  public void resolve_forceExecutionPlatform_noRequiredToolchains() throws Exception {
+    // This should select execution platform linux, due to the forced execution platform, even
+    // though execution platform mac is registered first.
+    rewriteWorkspace("register_execution_platforms('//platforms:mac', '//platforms:linux')");
+
+    useConfiguration("--platforms=//platforms:linux");
+    ToolchainContextKey key =
+        ToolchainContextKey.key()
+            .configurationKey(targetConfigKey)
+            .forceExecutionPlatform(Label.parseAbsoluteUnchecked("//platforms:linux"))
+            .build();
+
+    EvaluationResult<UnloadedToolchainContext> result = invokeToolchainResolution(key);
+
+    assertThatEvaluationResult(result).hasNoError();
+    UnloadedToolchainContext unloadedToolchainContext = result.get(key);
+    assertThat(unloadedToolchainContext).isNotNull();
+
     assertThat(unloadedToolchainContext).hasExecutionPlatform("//platforms:linux");
     assertThat(unloadedToolchainContext).hasTargetPlatform("//platforms:linux");
   }


### PR DESCRIPTION
directly require the correct execution platform.

This fixes several issues around toolchains that depend on toolchains.

Fixes #13243.