### PR TITLE
[WIP] JavaRuntimeInfo no longer extends ToolchainInfo.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaRuntime.java
@@ -30,6 +30,7 @@ import com.google.devtools.build.lib.analysis.Runfiles;
 import com.google.devtools.build.lib.analysis.RunfilesProvider;
 import com.google.devtools.build.lib.analysis.TemplateVariableInfo;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
+import com.google.devtools.build.lib.analysis.platform.ToolchainInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -116,11 +117,15 @@ public class JavaRuntime implements RuleConfiguredTargetFactory {
                 "JAVABASE", javaHome.getPathString()),
             ruleContext.getRule().getLocation());
 
+    ToolchainInfo toolchainInfo =
+        new ToolchainInfo(
+            ImmutableMap.<String, Object>builder().put("java_runtime", javaRuntime).build());
     return new RuleConfiguredTargetBuilder(ruleContext)
         .addProvider(RunfilesProvider.class, RunfilesProvider.simple(runfiles))
         .setFilesToBuild(filesToBuild)
         .addNativeDeclaredProvider(javaRuntime)
         .addNativeDeclaredProvider(templateVariableInfo)
+        .addNativeDeclaredProvider(toolchainInfo)
         .build();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaRuntimeInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaRuntimeInfo.java
@@ -16,7 +16,6 @@ package com.google.devtools.build.lib.rules.java;
 
 import static com.google.devtools.build.lib.rules.java.JavaRuleClasses.JAVA_RUNTIME_ATTRIBUTE_NAME;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
@@ -25,17 +24,22 @@ import com.google.devtools.build.lib.collect.nestedset.Depset;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.BuildType;
+import com.google.devtools.build.lib.packages.BuiltinProvider;
+import com.google.devtools.build.lib.packages.NativeInfo;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec.VisibleForSerialization;
 import com.google.devtools.build.lib.starlarkbuildapi.java.JavaRuntimeInfoApi;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import javax.annotation.Nullable;
-import net.starlark.java.syntax.Location;
+import net.starlark.java.eval.EvalException;
 
 /** Information about the Java runtime used by the <code>java_*</code> rules. */
 @Immutable
 @AutoCodec
-public final class JavaRuntimeInfo extends ToolchainInfo implements JavaRuntimeInfoApi {
+public final class JavaRuntimeInfo extends NativeInfo implements JavaRuntimeInfoApi {
+
+  public static final BuiltinProvider<JavaRuntimeInfo> PROVIDER =
+      new BuiltinProvider<JavaRuntimeInfo>("JavaRuntimeInfo", JavaRuntimeInfo.class) {};
 
   public static JavaRuntimeInfo create(
       NestedSet<Artifact> javaBaseInputs,
@@ -69,7 +73,7 @@ public final class JavaRuntimeInfo extends ToolchainInfo implements JavaRuntimeI
   }
 
   @Nullable
-  static JavaRuntimeInfo from(RuleContext ruleContext, String attributeName) {
+  public static JavaRuntimeInfo from(RuleContext ruleContext, String attributeName) {
     if (!ruleContext.attributes().has(attributeName, BuildType.LABEL)) {
       return null;
     }
@@ -78,7 +82,19 @@ public final class JavaRuntimeInfo extends ToolchainInfo implements JavaRuntimeI
       return null;
     }
 
-    return (JavaRuntimeInfo) prerequisite.get(ToolchainInfo.PROVIDER);
+    ToolchainInfo toolchainInfo = prerequisite.get(ToolchainInfo.PROVIDER);
+    if (toolchainInfo != null) {
+      try {
+        JavaRuntimeInfo result = (JavaRuntimeInfo) toolchainInfo.getValue("java_runtime");
+        if (result != null) {
+          return result;
+        }
+      } catch (EvalException e) {
+        ruleContext.ruleError(String.format("There was an error reading the Java runtime: %s", e));
+      }
+    }
+    ruleContext.ruleError("The selected Java runtime is not a JavaRuntimeInfo");
+    return null;
   }
 
   private final NestedSet<Artifact> javaBaseInputs;
@@ -97,7 +113,7 @@ public final class JavaRuntimeInfo extends ToolchainInfo implements JavaRuntimeI
       PathFragment javaBinaryExecPath,
       PathFragment javaHomeRunfilesPath,
       PathFragment javaBinaryRunfilesPath) {
-    super(ImmutableMap.of(), Location.BUILTIN);
+    super();
     this.javaBaseInputs = javaBaseInputs;
     this.javaBaseInputsMiddleman = javaBaseInputsMiddleman;
     this.javaHome = javaHome;
@@ -155,6 +171,11 @@ public final class JavaRuntimeInfo extends ToolchainInfo implements JavaRuntimeI
   @Override
   public Depset starlarkJavaBaseInputs() {
     return Depset.of(Artifact.TYPE, javaBaseInputs());
+  }
+
+  @Override
+  public com.google.devtools.build.lib.packages.Provider getProvider() {
+    return PROVIDER;
   }
 
   // Not all of JavaRuntimeInfo is exposed to Starlark, which makes implementing deep equality

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaStarlarkCommon.java
@@ -21,7 +21,6 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.analysis.PlatformOptions;
 import com.google.devtools.build.lib.analysis.TransitiveInfoCollection;
 import com.google.devtools.build.lib.analysis.platform.ConstraintValueInfo;
-import com.google.devtools.build.lib.analysis.platform.ToolchainInfo;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkActionFactory;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkRuleContext;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -221,7 +220,7 @@ public class JavaStarlarkCommon
 
   @Override
   public Provider getJavaRuntimeProvider() {
-    return ToolchainInfo.PROVIDER;
+    return JavaRuntimeInfo.PROVIDER;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaRuntimeInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaRuntimeInfoApi.java
@@ -16,7 +16,7 @@ package com.google.devtools.build.lib.starlarkbuildapi.java;
 
 import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.lib.collect.nestedset.Depset;
-import com.google.devtools.build.lib.starlarkbuildapi.platform.ToolchainInfoApi;
+import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 
@@ -25,7 +25,7 @@ import net.starlark.java.annot.StarlarkMethod;
     name = "JavaRuntimeInfo",
     category = DocCategory.PROVIDER,
     doc = "Information about the Java runtime being used.")
-public interface JavaRuntimeInfoApi extends ToolchainInfoApi {
+public interface JavaRuntimeInfoApi extends StructApi {
 
   @StarlarkMethod(
       name = "java_home",

--- a/tools/jdk/java_toolchain_alias.bzl
+++ b/tools/jdk/java_toolchain_alias.bzl
@@ -16,11 +16,16 @@
 
 def _java_runtime_alias(ctx):
     """An experimental implementation of java_runtime_alias using toolchain resolution."""
+    toolchain_info = None
     if java_common.is_java_toolchain_resolution_enabled_do_not_use(ctx = ctx):
-        toolchain = ctx.toolchains["@bazel_tools//tools/jdk:runtime_toolchain_type"]
+        toolchain_info = ctx.toolchains["@bazel_tools//tools/jdk:runtime_toolchain_type"]
+        if hasattr(toolchain_info, "java_runtime"):
+            toolchain = toolchain_info.java_runtime
+        else:
+            toolchain = toolchain_info
     else:
         toolchain = ctx.attr._java_runtime[java_common.JavaRuntimeInfo]
-    return [
+    providers = [
         toolchain,
         platform_common.TemplateVariableInfo({
             "JAVA": str(toolchain.java_executable_exec_path),
@@ -32,6 +37,9 @@ def _java_runtime_alias(ctx):
             files = toolchain.files,
         ),
     ]
+    if toolchain_info != None and toolchain_info != toolchain:
+        providers.append(toolchain_info)
+    return providers
 
 java_runtime_alias = rule(
     implementation = _java_runtime_alias,
@@ -47,9 +55,13 @@ java_runtime_alias = rule(
 def _java_host_runtime_alias(ctx):
     """An experimental implementation of java_host_runtime_alias using toolchain resolution."""
     runtime = ctx.attr._runtime
+    java_runtime = runtime[java_common.JavaRuntimeInfo]
+    template_variable_info = runtime[platform_common.TemplateVariableInfo]
+    toolchain_info = platform_common.ToolchainInfo(java_runtime = java_runtime)
     return [
-        runtime[java_common.JavaRuntimeInfo],
-        runtime[platform_common.TemplateVariableInfo],
+        java_runtime,
+        template_variable_info,
+        toolchain_info,
         # Create a new DefaultInfo instead of propagating runtime[DefaultInfo]
         # directly.
         DefaultInfo(
@@ -71,15 +83,25 @@ java_host_runtime_alias = rule(
             cfg = "host",
         ),
     },
+    provides = [
+        java_common.JavaRuntimeInfo,
+        platform_common.TemplateVariableInfo,
+        platform_common.ToolchainInfo,
+    ],
 )
 
 def _java_runtime_version_alias(ctx):
     """An alias fixing a specific version of java_runtime."""
+    toolchain_info = None
     if java_common.is_java_toolchain_resolution_enabled_do_not_use(ctx = ctx):
-        toolchain = ctx.toolchains["@bazel_tools//tools/jdk:runtime_toolchain_type"]
+        toolchain_info = ctx.toolchains["@bazel_tools//tools/jdk:runtime_toolchain_type"]
+        if hasattr(toolchain_info, "java_runtime"):
+            toolchain = toolchain_info.java_runtime
+        else:
+            toolchain = toolchain_info
     else:
         toolchain = ctx.attr.selected_java_runtime[java_common.JavaRuntimeInfo]
-    return [
+    providers = [
         toolchain,
         platform_common.TemplateVariableInfo({
             "JAVA": str(toolchain.java_executable_exec_path),
@@ -91,6 +113,9 @@ def _java_runtime_version_alias(ctx):
             files = toolchain.files,
         ),
     ]
+    if toolchain_info != None and toolchain_info != toolchain:
+        providers.append(toolchain_info)
+    return providers
 
 def _java_runtime_transition_impl(settings, attr):
     return {"//command_line_option:java_runtime_version": attr.runtime_version}


### PR DESCRIPTION
Instead, the toolchain is provided in a field on ToolchainInfo, called "java_runtime".

PiperOrigin-RevId: 362539409
Change-Id: Iac18f3705d83059ac6de1f8d7296bc081c5b0454