### PR TITLE
Workaround strongly encapsulate JDK internals by default

### DIFF
--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -26,6 +26,8 @@ BASE_JDK9_JVM_OPTS = [
     "--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
     "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
     "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
     "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
     "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
     "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
@@ -234,7 +236,9 @@ def _bootclasspath_impl(ctx):
 
     args = ctx.actions.args()
     args.add("-XX:+IgnoreUnrecognizedVMOptions")
+    args.add("--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED")
     args.add("--add-exports=jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED")
+    args.add("--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED")
     args.add_joined(
         "-cp",
         [class_outputs[0].dirname, "%s/lib/tools.jar" % host_javabase.java_home],


### PR DESCRIPTION
Closes #13138. See: [1] for more details.

[1] https://openjdk.java.net/jeps/396

Change-Id: I9270602cd9157545a2f95b271592bd953f17264f