### PR TITLE
Create blank coverage reports before running tests

### DIFF
--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -146,14 +146,14 @@ if [[ "$IS_COVERAGE_SPAWN" == "0" ]]; then
   # TODO(bazel-team): cd should be avoided.
   cd "$TEST_SRCDIR/$TEST_WORKSPACE"
 
-  # Execute the test.
-  "$@"
-  TEST_STATUS=$?
-
   # Always create the coverage report.
   if [[ "$SPLIT_COVERAGE_POST_PROCESSING" == "0" ]]; then
     touch $COVERAGE_OUTPUT_FILE
   fi
+
+  # Execute the test.
+  "$@"
+  TEST_STATUS=$?
 
   if [[ $TEST_STATUS -ne 0 ]]; then
     echo --


### PR DESCRIPTION
This ensures that the output file bazel expects exists even if the
coverage test task times out.  If it does not exist then the final
coverage-aggregation action will not run because it is missing an
input file.