### PR TITLE
Throw exception if 'None' value given to List-type command line options in Bazel transitions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
@@ -333,7 +333,7 @@ public class FunctionTransitionUtil {
                           optionValueAsList.stream().map(Object::toString).collect(joining(",")));
             }
           } else if (def.getType() == List.class && optionValue == null) {
-            convertedValue = def.getDefaultValue();
+            throw ValidationException.format("'None' value not allowed for List-type option '%s'. Please use '[]' instead if trying to set option to empty value.", optionName);
           } else if (optionValue == null || def.getType().isInstance(optionValue)) {
             convertedValue = optionValue;
           } else if (def.getType().equals(boolean.class) && optionValue instanceof Boolean) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
@@ -332,6 +332,8 @@ public class FunctionTransitionUtil {
                       .convert(
                           optionValueAsList.stream().map(Object::toString).collect(joining(",")));
             }
+          } else if (def.getType() == List.class && optionValue == null) {
+            convertedValue = def.getDefaultValue();
           } else if (optionValue == null || def.getType().isInstance(optionValue)) {
             convertedValue = optionValue;
           } else if (def.getType().equals(boolean.class) && optionValue instanceof Boolean) {

--- a/src/test/java/com/google/devtools/build/lib/analysis/StarlarkRuleTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/StarlarkRuleTransitionProviderTest.java
@@ -1329,7 +1329,7 @@ public class StarlarkRuleTransitionProviderTest extends BuildViewTestCase {
   }
 
   @Test
-  public void successfulTypeConversionOfNativeListOptionNone() throws Exception {
+  public void failedTypeConversionOfNativeListOptionNone() throws Exception {
     writeAllowlistFile();
     scratch.file(
         "test/transitions.bzl",
@@ -1355,9 +1355,9 @@ public class StarlarkRuleTransitionProviderTest extends BuildViewTestCase {
         "load('//test:rules.bzl', 'my_rule')",
         "my_rule(name = 'test')");
 
-    ConfiguredTarget ct = getConfiguredTarget("//test");
-    assertNoEvents();
-    assertThat(getConfiguration(ct).getOptions().get(CppOptions.class).coptList).isEmpty();
+    reporter.removeHandler(failFastHandler);
+    getConfiguredTarget("//test");
+    assertContainsEvent("'None' value not allowed for List-type option 'copt'. Please use '[]' instead if trying to set option to empty value.");
   }
 
   @Test


### PR DESCRIPTION
* Proposed fix for #12559 
* Command line options specified as Java List types should default to empty when given 'None' Starlark value for Bazel transitions