### PR TITLE
Allow oso_prefix_is_pwd to be used with all osx cpp link actions

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5799,7 +5799,8 @@ def _impl(ctx):
         name = "oso_prefix_is_pwd",
         flag_sets = [
             flag_set(
-                actions = ["objc-executable", "objc++-executable"],
+                actions = all_link_actions +
+                          ["objc-executable", "objc++-executable"],
                 flag_groups = [flag_group(flags = ["OSO_PREFIX_MAP_PWD"])],
             ),
         ],


### PR DESCRIPTION
Expands the targeted actions to allow stripping the absolute build path for debug symbols from all libraries.  The support in wrapped_clang is indifferent to whether we are linking a true objc or regular cpp library.

When used in concert with `--features=oso_prefix_is_pwd --remote_download_outputs=all`, allows successful local debugging of executables/libraries built remotely.  Probably also helps with sandboxed actions.

Helps mitigate #6327 and kinda sorta #2537?