### PR TITLE
In example code for ctx.actions.run, put args in a list

### DIFF
--- a/site/docs/skylark/rules.md
+++ b/site/docs/skylark/rules.md
@@ -390,7 +390,7 @@ def _example_library_impl(ctx):
     ctx.actions.run(
         mnemonic="ExampleCompile",
         executable = ctx.executable._compiler,
-        arguments=args,
+        arguments = [args],
         inputs = inputs,
         outputs = [output_file],
     )


### PR DESCRIPTION
Per the documentation for `ctx.actions.run`, the `arguments` parameter should be a list of strings or `actions.args()` objects:

https://docs.bazel.build/versions/master/skylark/lib/actions.html#run

When I try to pass a single `actions.args()` object in my own code, I get an error, so I believe the code sample is wrong.