### PR TITLE
Don't rely on dirname when invoking wrapped_clang

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -123,7 +123,7 @@ def configure_osx_toolchain(repository_ctx, overriden_tools):
         # the C++ actions behave consistently.
         cc = repository_ctx.path("wrapped_clang")
 
-        cc_path = '"$(/usr/bin/dirname "$0")"/wrapped_clang'
+        cc_path = "external/%s/wrapped_clang" % repository_ctx.name
         repository_ctx.template(
             "cc_wrapper.sh",
             paths["@bazel_tools//tools/cpp:osx_cc_wrapper.sh.tpl"],


### PR DESCRIPTION
Its path can already be resolved from the repo name.
