### PR TITLE
Use user-defined `DEVELOPER_DIR` environment variable if it's set

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/local/XcodeLocalEnvProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/XcodeLocalEnvProvider.java
@@ -68,6 +68,7 @@ public final class XcodeLocalEnvProvider implements LocalEnvProvider {
   public ImmutableMap<String, String> rewriteLocalEnv(
       Map<String, String> env, BinTools binTools, String fallbackTmpDir)
       throws IOException, InterruptedException {
+    boolean containsDeveloperDir = env.containsKey(AppleConfiguration.DEVELOPER_DIR_ENV_NAME);
     boolean containsXcodeVersion = env.containsKey(AppleConfiguration.XCODE_VERSION_ENV_NAME);
     boolean containsAppleSdkVersion =
         env.containsKey(AppleConfiguration.APPLE_SDK_VERSION_ENV_NAME);
@@ -92,7 +93,7 @@ public final class XcodeLocalEnvProvider implements LocalEnvProvider {
     // TODO(bazel-team): Bazel's view of the xcode version and developer dir should be explicitly
     // set for build hermeticity.
     String developerDir = "";
-    if (containsXcodeVersion) {
+    if (containsXcodeVersion && !containsDeveloperDir) {
       String version = env.get(AppleConfiguration.XCODE_VERSION_ENV_NAME);
       developerDir = getDeveloperDir(binTools, DottedVersion.fromStringUnchecked(version));
       newEnvBuilder.put("DEVELOPER_DIR", developerDir);

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleConfiguration.java
@@ -42,6 +42,10 @@ import javax.annotation.Nullable;
 @RequiresOptions(options = {AppleCommandLineOptions.class})
 public class AppleConfiguration extends Fragment implements AppleConfigurationApi<PlatformType> {
   /**
+   * Environment variable name for the developer dir of the selected Xcode.
+   **/
+  public static final String DEVELOPER_DIR_ENV_NAME = "DEVELOPER_DIR";
+  /**
    * Environment variable name for the xcode version. The value of this environment variable should
    * be set to the version (for example, "7.2") of xcode to use when invoking part of the apple
    * toolkit in action execution.


### PR DESCRIPTION
This fixes a Bazel crash if the user defines their own `DEVELOPER_DIR`
environment variable via a custom Xcode toolchain.

Fixes https://github.com/bazelbuild/bazel/issues/13330.
