### PR TITLE
Fix broken tag to external.html

### DIFF
--- a/site/docs/guide.md
+++ b/site/docs/guide.md
@@ -160,7 +160,7 @@ workspace.
 <tr>
   <td><code>//...</code></td>
   <td>All targets in packages in the workspace. This does not include targets
-  from a href="external.html">external repositories</a>.</td>
+  from <a href="external.html">external repositories</a>.</td>
 </tr>
 <tr>
   <td><code>//:all</code></td>


### PR DESCRIPTION
The link to the [Working with External Dependencies](https://docs.bazel.build/versions/master/external.html) page in the `#specifying-targets-to-build` section  is broken due to missing `<` opening the `a` tag.