### PR TITLE
docs: don't indicate that genrule is for minifying JavaScript

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRuleRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/genrule/BazelGenRuleRule.java
@@ -65,8 +65,8 @@ public final class BazelGenRuleRule implements RuleDefinition {
 <p>A <code>genrule</code> generates one or more files using a user-defined Bash command.</p>
 
 <p>
-  Genrules are generic build rules that you can use if there's no specific rule for the task. If for
-  example you want to minify JavaScript files then you can use a genrule to do so. If however you
+  Genrules are generic build rules that you can use if there's no specific rule for the task.
+  For example, you could run a Bash one-liner. If however you
   need to compile C++ files, stick to the existing <code>cc_*</code> rules, because all the heavy
   lifting has already been done for you.
 </p>


### PR DESCRIPTION
We have purpose-built rules for that in rules_nodejs, and also, using genrule doesn't work well for nodejs tools since we have
a dedicated rule npm_package_bin that understands how to run these as actions.