### PR TITLE
Allow excluding --config flag sets, instead of just accumulating them.

### DIFF
--- a/site/docs/guide.md
+++ b/site/docs/guide.md
@@ -927,6 +927,22 @@ This syntax does not extend to the use of `startup` to set
 [startup options](#option-defaults), e.g. setting
 `startup:config-name --some_startup_option` in the .bazelrc will be ignored.
 
+#### `--noconfig`
+
+Some Bazel flags accumulate values and cannot be completely overridden, yet it
+may be useful to set defaults for them in a `.bazelrc` file. To override these
+values, use `--noconfig`. `--noconfig=foo` prevents the expansion of the `foo`
+config, allowing certain config groups to exclude others.
+
+`--noconfig` options are processed before configs are actually applied, so
+setting `--noconfig=foo` as a default (even through some config group that is
+applied by default) would prevent `--config=foo` from ever being applied. In
+particular, whereas alternative configs might exclude the default, the default
+shouldn't exclude the alternatives.
+
+For clarity, it is best to keep any usage of `--noconfig` close to toplevel
+configs.
+
 #### Example
 
 Here's an example `~/.bazelrc` file:

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -83,6 +83,19 @@ public class CommonCommandOptions extends OptionsBase {
   public List<String> configs;
 
   @Option(
+      name = "noconfig",
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      allowMultiple = true,
+      help =
+          "Config sections to avoid selecting from the rc files. Values are collected from config "
+              + "sections before they are actually applied, so noconfig takes precedence. In "
+              + "particular, setting --noconfig=<config> as a default prevents --config=<config> "
+              + "from ever being applied, so use this carefully.")
+  public List<String> noconfigs;
+
+  @Option(
       name = "logging",
       defaultValue = "3", // Level.INFO
       documentationCategory = OptionDocumentationCategory.LOGGING,


### PR DESCRIPTION
Some Bazel flags accumulate values and cannot be completely overridden, yet it may be useful to set defaults for them in a `.bazelrc` file. To override these values, use `--noconfig`. `--noconfig=foo` prevents the expansion of the `foo` config, allowing certain config groups to exclude others.

`--noconfig` options are processed before configs are actually applied, so setting `--noconfig=foo` as a default (even through some config group that is applied by default) would prevent `--config=foo` from ever being applied. In particular, whereas alternative configs might exclude the default, the default shouldn't exclude the alternatives. For example,

```
build:rbe-default-platform    # ...
build:rbe-other-platform      # ...
build:rbe-other-platform      --noconfig=rbe-default-platform
build                         --config=rbe-default-platform
```

(Without `--noconfig`, this wouldn't work because of `--extra_execution_platforms`.)

To keep things simpler, we don't support `--noconfig` settings from platform-dependent configuration; it should probably be easy enough to work around any need for `--noconfig` there.

For clarity, it is best to keep any usage of `--noconfig` close to toplevel configs.

Closes #13284.