### PR TITLE
Define version-specific shebangs for the default python runtimes

### DIFF
--- a/tools/python/toolchain.bzl
+++ b/tools/python/toolchain.bzl
@@ -174,6 +174,7 @@ def define_autodetecting_toolchain(
         name = "_autodetecting_py2_runtime",
         interpreter = ":py2wrapper.sh",
         python_version = "PY2",
+        stub_shebang = "#!/usr/bin/env python2",
         visibility = ["//visibility:private"],
     )
 
@@ -181,6 +182,7 @@ def define_autodetecting_toolchain(
         name = "_autodetecting_py3_runtime",
         interpreter = ":py3wrapper.sh",
         python_version = "PY3",
+        stub_shebang = "#!/usr/bin/env python3",
         visibility = ["//visibility:private"],
     )
 
@@ -188,6 +190,7 @@ def define_autodetecting_toolchain(
         name = "_autodetecting_py2_runtime_nonstrict",
         interpreter = ":py2wrapper_nonstrict.sh",
         python_version = "PY2",
+        stub_shebang = "#!/usr/bin/env python2",
         visibility = ["//visibility:private"],
     )
 
@@ -195,6 +198,7 @@ def define_autodetecting_toolchain(
         name = "_autodetecting_py3_runtime_nonstrict",
         interpreter = ":py3wrapper_nonstrict.sh",
         python_version = "PY3",
+        stub_shebang = "#!/usr/bin/env python3",
         visibility = ["//visibility:private"],
     )
 


### PR DESCRIPTION
Prior to this commit, the python stub generated with the autodetected runtimes will use `#!/usr/bin/env python` as the shebang line. For modern python3 systems, this may not exist. It's more reliable to have each specific python runtime version specify a shebang of that particular python version.