### PR TITLE
Add build_workspace_root to repository_ctx

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -102,6 +102,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
 
   private final Rule rule;
   private final PathPackageLocator packageLocator;
+  private final Path workspaceRoot;
   private final StructImpl attrObject;
   private final ImmutableSet<PathFragment> ignoredPatterns;
   private final SyscallCache syscallCache;
@@ -122,7 +123,8 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       @Nullable ProcessWrapper processWrapper,
       StarlarkSemantics starlarkSemantics,
       @Nullable RepositoryRemoteExecutor remoteExecutor,
-      SyscallCache syscallCache)
+      SyscallCache syscallCache,
+      Path workspaceRoot)
       throws EvalException {
     super(
         outputDirectory,
@@ -137,6 +139,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
     this.packageLocator = packageLocator;
     this.ignoredPatterns = ignoredPatterns;
     this.syscallCache = syscallCache;
+    this.workspaceRoot = workspaceRoot;
     WorkspaceAttributeMapper attrs = WorkspaceAttributeMapper.of(rule);
     ImmutableMap.Builder<String, Object> attrBuilder = new ImmutableMap.Builder<>();
     for (String name : attrs.getAttributeNames()) {
@@ -160,6 +163,14 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       doc = "The name of the external repository created by this rule.")
   public String getName() {
     return rule.getName();
+  }
+
+  @StarlarkMethod(
+      name = "workspace_root",
+      structField = true,
+      doc = "The path to the root workspace of the bazel invocation.")
+  public StarlarkPath getWorkspaceRoot() {
+    return new StarlarkPath(workspaceRoot);
   }
 
   @StarlarkMethod(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -182,7 +182,8 @@ public class StarlarkRepositoryFunction extends RepositoryFunction {
               processWrapper,
               starlarkSemantics,
               repositoryRemoteExecutor,
-              syscallCache);
+              syscallCache,
+              directories.getWorkspace());
 
       if (starlarkRepositoryContext.isRemotable()) {
         // If a rule is declared remotable then invalidate it if remote execution gets

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -170,7 +170,8 @@ public final class StarlarkRepositoryContextTest {
             /*processWrapper=*/ null,
             starlarkSemantics,
             repoRemoteExecutor,
-            SyscallCache.NO_CACHE);
+            SyscallCache.NO_CACHE,
+            root.asPath());
   }
 
   protected void setUpContextForRule(String name) throws Exception {
@@ -474,5 +475,11 @@ public final class StarlarkRepositoryContextTest {
     scratch.file("/my/folder/c");
     assertThat(context.path("/my/folder").readdir()).containsExactly(
         context.path("/my/folder/a"), context.path("/my/folder/b"), context.path("/my/folder/c"));
+  }
+
+  @Test
+  public void testWorkspaceRoot() throws Exception {
+    setUpContextForRule("test");
+    assertThat(context.getWorkspaceRoot().getPath()).isEqualTo(root.asPath());
   }
 }


### PR DESCRIPTION
There are a number of use-cases for this, and I've seen it come up in
`bazel-discuss` and similar. It is possible to abuse this information,
but this information is currently available by looking up something like:

```python
repository_ctx.path(Label("@//:WORKSPACE")).dirname
```

But this is unreliable as `WORKSPACE.bazel` was added as an alternative
to `WORKSPACE`, and trying to look up a label which doesn't exist is a
fatal error.

We're currently using this to work around the fact that labels can't
exist if the file they point at doesn't already exist.
In repository rules we want users to be able to set an attribute to
point at a lockfile, which may not yet exist, and which our rule may
create as a side-effect of running. The nicest way we've worked out how
to do this is to use a `attr.string`, and use `repository_ctx.execute`
to test for the existence of a file, but that relies on being able to
find the path to the root repository.

It may be interesting to try to introduce some kind of fallible
label/path lookup, but that feels like a much bigger change for the
future.