### PR TITLE
Support `--no@//:bool_flag` on the command line.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
@@ -259,7 +259,10 @@ public class StarlarkOptionsParser {
           buildSettingTarget.getAssociatedRule().getRuleClassObject().getBuildSetting();
       if (current.getType().equals(BOOLEAN)) {
         // --boolean_flag or --noboolean_flag
-        unparsedOptions.put(name, new Pair<>(String.valueOf(booleanValue), buildSettingTarget));
+        // Ditto w/r/t canonical form.
+        unparsedOptions.put(
+            buildSettingTarget.getLabel().getCanonicalForm(),
+            new Pair<>(String.valueOf(booleanValue), buildSettingTarget));
       } else {
         if (!booleanValue) {
           // --no(non_boolean_flag)

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkOptionsParsingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkOptionsParsingTest.java
@@ -214,6 +214,18 @@ public class StarlarkOptionsParsingTest extends StarlarkOptionsTestCase {
     assertThat(result.getResidue()).isEmpty();
   }
 
+  // test --no@main_workspace//:bool_flag
+  @Test
+  public void testNoPrefixedBooleanFlag_withWorkspace() throws Exception {
+    writeBasicBoolFlag();
+
+    OptionsParsingResult result = parseStarlarkOptions("--no@//test:my_bool_setting");
+
+    assertThat(result.getStarlarkOptions()).hasSize(1);
+    assertThat(result.getStarlarkOptions().get("//test:my_bool_setting")).isEqualTo(false);
+    assertThat(result.getResidue()).isEmpty();
+  }
+
   // test --noint_flag
   @Test
   public void testNoPrefixedNonBooleanFlag() throws Exception {


### PR DESCRIPTION
This applies label canonicalization to starlark flags having a `--no`
prefix.

Relates to #11128.