### PR TITLE
Delete macOS link_cocoa feature

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
@@ -6855,29 +6855,6 @@ def _impl(ctx):
         provides = ["profile"],
     )
 
-    if (ctx.attr.cpu == "darwin_x86_64"):
-        link_cocoa_feature = feature(
-            name = "link_cocoa",
-            flag_sets = [
-                flag_set(
-                    actions = _OBJC_LINK_ACTIONS,
-                    flag_groups = [flag_group(flags = ["-framework Cocoa"])],
-                ),
-            ],
-        )
-    elif (ctx.attr.cpu == "ios_arm64" or
-          ctx.attr.cpu == "ios_armv7" or
-          ctx.attr.cpu == "ios_i386" or
-          ctx.attr.cpu == "ios_x86_64" or
-          ctx.attr.cpu == "tvos_arm64" or
-          ctx.attr.cpu == "tvos_x86_64" or
-          ctx.attr.cpu == "watchos_armv7k" or
-          ctx.attr.cpu == "watchos_i386" or
-          ctx.attr.cpu == "x64_windows"):
-        link_cocoa_feature = feature(name = "link_cocoa")
-    else:
-        link_cocoa_feature = None
-
     objc_actions_feature = feature(
         name = "objc_actions",
         implies = [
@@ -7907,7 +7884,6 @@ def _impl(ctx):
         gcc_coverage_map_format_feature,
         cpp_linker_flags_feature,
         apply_implicit_frameworks_feature,
-        link_cocoa_feature,
         apply_simulator_compiler_flags_feature,
         unfiltered_cxx_flags_feature,
         bitcode_embedded_markers_feature,

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/AppleBinaryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/AppleBinaryTest.java
@@ -685,24 +685,6 @@ public class AppleBinaryTest extends ObjcRuleTestCase {
   }
 
   @Test
-  public void testLinkCocoaFeatureWithCrosstoolMacos() throws Exception {
-    useConfiguration(
-        "--macos_cpus=x86_64",
-        "--macos_sdk_version=10.11",
-        "--macos_minimum_os=10.11");
-    getRuleType().scratchTarget(
-        scratch, "platform_type", "'macos'", "features", "['link_cocoa']");
-
-    Action lipoAction = actionProducingArtifact("//x:x", "_lipobin");
-    Artifact binArtifact = getFirstArtifactEndingWith(lipoAction.getInputs(), "x/x_bin");
-    CommandAction linkAction = (CommandAction) getGeneratingAction(binArtifact);
-
-    assertThat(linkAction.getArguments()).containsAtLeastElementsIn(IMPLICIT_MAC_FRAMEWORK_FLAGS);
-    assertThat(linkAction.getArguments()).containsAtLeastElementsIn(COCOA_FEATURE_FLAGS);
-    assertThat(linkAction.getArguments()).doesNotContain(UIKIT_FRAMEWORK_FLAG);
-  }
-
-  @Test
   public void testAliasedLinkoptsThroughObjcLibrary() throws Exception {
     checkAliasedLinkoptsThroughObjcLibrary(getRuleType());
   }

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -5955,34 +5955,6 @@ def _impl(ctx):
         provides = ["profile"],
     )
 
-    if (ctx.attr.cpu == "darwin_x86_64" or
-        ctx.attr.cpu == "darwin_arm64" or
-        ctx.attr.cpu == "darwin_arm64e"):
-        link_cocoa_feature = feature(
-            name = "link_cocoa",
-            flag_sets = [
-                flag_set(
-                    actions = ["objc-executable", "objc++-executable"],
-                    flag_groups = [flag_group(flags = ["-framework", "Cocoa"])],
-                ),
-            ],
-        )
-    elif (ctx.attr.cpu == "armeabi-v7a" or
-          ctx.attr.cpu == "ios_arm64" or
-          ctx.attr.cpu == "ios_arm64e" or
-          ctx.attr.cpu == "ios_armv7" or
-          ctx.attr.cpu == "ios_i386" or
-          ctx.attr.cpu == "ios_x86_64" or
-          ctx.attr.cpu == "tvos_arm64" or
-          ctx.attr.cpu == "tvos_x86_64" or
-          ctx.attr.cpu == "watchos_arm64_32" or
-          ctx.attr.cpu == "watchos_armv7k" or
-          ctx.attr.cpu == "watchos_i386" or
-          ctx.attr.cpu == "watchos_x86_64"):
-        link_cocoa_feature = feature(name = "link_cocoa")
-    else:
-        link_cocoa_feature = None
-
     user_compile_flags_feature = feature(
         name = "user_compile_flags",
         flag_sets = [
@@ -6349,7 +6321,6 @@ def _impl(ctx):
             dead_strip_feature,
             cpp_linker_flags_feature,
             apply_implicit_frameworks_feature,
-            link_cocoa_feature,
             apply_simulator_compiler_flags_feature,
             unfiltered_cxx_flags_feature,
             user_compile_flags_feature,
@@ -6429,7 +6400,6 @@ def _impl(ctx):
             dead_strip_feature,
             cpp_linker_flags_feature,
             apply_implicit_frameworks_feature,
-            link_cocoa_feature,
             apply_simulator_compiler_flags_feature,
             unfiltered_cxx_flags_feature,
             user_compile_flags_feature,
@@ -6508,7 +6478,6 @@ def _impl(ctx):
             dead_strip_feature,
             cpp_linker_flags_feature,
             apply_implicit_frameworks_feature,
-            link_cocoa_feature,
             apply_simulator_compiler_flags_feature,
             unfiltered_cxx_flags_feature,
             user_compile_flags_feature,


### PR DESCRIPTION
This feature doesn't appear to be necessary at this point, importing
this framework will link it successfully.