### PR TITLE
Update DEFAULT_MACOS_CPU to match host

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.skyframe.serialization.DeserializationConte
 import com.google.devtools.build.lib.skyframe.serialization.SerializationContext;
 import com.google.devtools.build.lib.skyframe.serialization.SerializationException;
 import com.google.devtools.build.lib.starlarkbuildapi.apple.AppleBitcodeModeApi;
+import com.google.devtools.build.lib.util.CPU;
 import com.google.devtools.common.options.Converters.CommaSeparatedOptionListConverter;
 import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
@@ -186,7 +187,7 @@ public class AppleCommandLineOptions extends FragmentOptions {
   public static final String DEFAULT_TVOS_CPU = "x86_64";
 
   /** The default macOS CPU value. */
-  public static final String DEFAULT_MACOS_CPU = "x86_64";
+  public static final String DEFAULT_MACOS_CPU = CPU.getCurrent() == CPU.AARCH64 ? "arm64" : "x86_64";
 
   /** The default Catalyst CPU value. */
   public static final String DEFAULT_CATALYST_CPU = "x86_64";

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/BUILD
@@ -39,6 +39,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/apple",
+        "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/java/net/starlark/java/eval",
         "//src/main/java/net/starlark/java/syntax",


### PR DESCRIPTION
With Apple Silicon machines host tools that use the apple_binary, or
apple fragment to fetch the CPU would be built for the wrong
architecture, even though the C++ logic would correctly identify the
host CPU. This changes this hardcoded value to correctly determine Apple
Silicon as arm64, and otherwise fallback to x86_64.

Fixes https://github.com/bazelbuild/bazel/issues/12671