### PR TITLE
Make try-import ignore unsupported paths

### DIFF
--- a/src/test/cpp/rc_file_test.cc
+++ b/src/test/cpp/rc_file_test.cc
@@ -857,6 +857,16 @@ TEST_F(BlazercImportTest, BazelRcTryImportDoesNotFailForUnreadableFile) {
   ParseOptionsAndCheckOutput(args, blaze_exit_code::SUCCESS, "", "");
 }
 
+// try-import ignores files that do not exist, even if the given path type is unsupported
+TEST_F(BlazercImportTest, BazelRcTryImportDoesNotFailForInvalidPath) {
+  const std::string invalid_rc_path = "/no/such/file.bazelrc";
+  std::string workspace_rc;
+  ASSERT_TRUE(
+      SetUpWorkspaceRcFile("try-import " + invalid_rc_path, &workspace_rc));
+
+  const std::vector<std::string> args = {"bazel", "build"};
+  ParseOptionsAndCheckOutput(args, blaze_exit_code::SUCCESS, "", "");
+}
 
 TEST_F(BlazercImportTest, BazelRcImportsMaintainsFlagOrdering) {
   TestBazelRcImportsMaintainsFlagOrdering("import");


### PR DESCRIPTION
Previously on windows, `try-import /foo/bar` invoked BAZEL_DIE.
Fixes https://github.com/bazelbuild/bazel/issues/13443
