### PR TITLE
Add `--host_macos_cpus` flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
@@ -322,6 +322,16 @@ public class AppleCommandLineOptions extends FragmentOptions {
   public List<String> macosCpus;
 
   @Option(
+          name = "host_macos_cpus",
+          allowMultiple = true,
+          converter = CommaSeparatedOptionListConverter.class,
+          defaultValue = "null",
+          documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
+          effectTags = {OptionEffectTag.LOSES_INCREMENTAL_STATE, OptionEffectTag.LOADING_AND_ANALYSIS, OptionEffectTag.AFFECTS_OUTPUTS},
+          help = "Comma-separated list of architectures for which to build host Apple macOS binaries.")
+  public List<String> hostMacosCpus;
+
+  @Option(
       name = "catalyst_cpus",
       allowMultiple = true,
       converter = CommaSeparatedOptionListConverter.class,
@@ -483,6 +493,7 @@ public class AppleCommandLineOptions extends FragmentOptions {
     // Preseve Xcode selection preferences so that the same Xcode version is used throughout the
     // build.
     host.preferMutualXcode = preferMutualXcode;
+    host.macosCpus = hostMacosCpus;
 
     return host;
   }


### PR DESCRIPTION
When your macOS build has tools that build with the Apple rules, such as
`macos_command_line_application`, you likely want to share caches
between Apple Silicon and Intel machines. Today your tool would build
for the host architecture (ideally, see https://github.com/bazelbuild/bazel/pull/13440)
which means the tools would differ between the different architectures,
leading to split caches. This flag allows you to pass
`--host_macos_cpus=arm64,x86_64` in order to produce a fat binary for
host tools. This has the downside of increasing binary size for your
tools, but likely that trade-off is worth it for almost everyone versus
having split caches.