### PR TITLE
Use `xcrun` to invoke `install_name_tool`

### DIFF
--- a/tools/cpp/osx_cc_wrapper.sh.tpl
+++ b/tools/cpp/osx_cc_wrapper.sh.tpl
@@ -27,7 +27,7 @@
 #
 set -eu
 
-INSTALL_NAME_TOOL="/usr/bin/install_name_tool"
+INSTALL_NAME_TOOL=/usr/bin/xcrun install_name_tool
 
 LIBS=
 LIB_DIRS=


### PR DESCRIPTION
`/usr/bin/install_name_tool` is a shim; it invokes `install_name_tool`
in the current active Xcode.

This allows using this template file to configure toolchain on
non-macOS. This doesn't change the behavior as both will end up invoking
the same tool.
