### PR TITLE
Update remote worker to use read offset of a byte stream read request

### DIFF
--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ByteStreamServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ByteStreamServer.java
@@ -85,6 +85,9 @@ final class ByteStreamServer extends ByteStreamImplBase {
       // TODO(olaola): refactor to fix this if the need arises.
       Chunker c =
           Chunker.builder().setInput(getFromFuture(cache.downloadBlob(context, digest))).build();
+      if (request.getReadOffset() != 0) {
+        c.seek(request.getReadOffset());
+      }
       while (c.hasNext()) {
         responseObserver.onNext(
             ReadResponse.newBuilder().setData(c.next().getData()).build());


### PR DESCRIPTION
This fixes digest mismatch issues when downloading outputs from remote worker.