### PR TITLE
Remove reference to archived project in docs.

### DIFF
--- a/site/docs/build-event-protocol.md
+++ b/site/docs/build-event-protocol.md
@@ -106,10 +106,6 @@ events to using the `--bes_backend=HOST:PORT` flag. If your backend uses gRPC,
 you must prefix the address with the appropriate scheme: `grpc://` for plaintext
 gRPC and `grpcs://` for gRPC with TLS enabled.
 
-There is currently an experimental open source implementation of the [Build
-Event Service](https://github.com/buildbarn/bb-event-service/) in Go as part of
-the Buildbarn suite of Remote Execution tools and services.
-
 ### Build Event Service flags
 
 Bazel has several flags related to the Build Event Service protocol, including:


### PR DESCRIPTION
The buildbarn project at https://github.com/buildbarn/bb-event-service/ was archived over a year ago, as discussed in https://github.com/buildbarn/bb-browser/issues/21, so it's not a good example reference anymore.