### PR TITLE
Make `-c opt` dead strip code for Apple builds by default.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
@@ -552,10 +552,11 @@ public class CompilationSupport implements StarlarkValue {
             .addAll(OBJC_ACTIONS)
             .add(CppRuleClasses.LANG_OBJC);
 
-    if (configuration.getFragment(ObjcConfiguration.class).shouldStripBinary()) {
+    ObjcConfiguration objcConfiguration = configuration.getFragment(ObjcConfiguration.class);
+    if (objcConfiguration.shouldDeadCodeStripBinary()) {
       activatedCrosstoolSelectables.add(DEAD_STRIP_FEATURE_NAME);
     }
-    if (configuration.getFragment(ObjcConfiguration.class).generateLinkmap()) {
+    if (objcConfiguration.generateLinkmap()) {
       activatedCrosstoolSelectables.add(GENERATE_LINKMAP_FEATURE_NAME);
     }
     // Add a feature identifying the Xcode version so CROSSTOOL authors can enable flags for
@@ -1148,9 +1149,9 @@ public class CompilationSupport implements StarlarkValue {
    * <p>Dsym bundle is generated if {@link ObjcConfiguration#generateDsym()} is set.
    *
    * <p>When Bazel flags {@code --compilation_mode=opt} and {@code --objc_enable_binary_stripping}
-   * are specified, additional optimizations will be performed on the linked binary: all-symbol
-   * stripping (using {@code /usr/bin/strip}) and dead-code stripping (using linker flags: {@code
-   * -dead_strip}).
+   * are specified, symbol stripping (using {@code /usr/bin/strip}) occurs. When Bazel {@code
+   * --compilation_mode=opt} is specified dead-code stripping (using linker flags: {@code
+   * -dead_strip}) occurs.
    *
    * @param objcProvider common information about this rule's attributes and its dependencies
    * @param ccLinkingContexts the linking contexts from this rule's dependencies

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
@@ -145,9 +145,8 @@ public class ObjcCommandLineOptions extends FragmentOptions {
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
       effectTags = {OptionEffectTag.ACTION_COMMAND_LINES},
       help =
-          "Whether to perform symbol and dead-code strippings on linked binaries. Binary "
-              + "strippings will be performed if both this flag and --compilation_mode=opt are "
-              + "specified.")
+          "Whether to perform symbol stripping on linked binaries. Stripping will be performed if"
+              + " both this flag and --compilation_mode=opt are specified.")
   public boolean enableBinaryStripping;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcConfiguration.java
@@ -188,12 +188,21 @@ public class ObjcConfiguration extends Fragment implements ObjcConfigurationApi<
   }
 
   /**
-   * Returns whether to perform symbol and dead-code strippings on linked binaries. The strippings
-   * are performed iff --compilation_mode=opt and --objc_enable_binary_stripping are specified.
+   * Returns whether to perform symbol stripping on linked binaries. The stripping is performed iff
+   * --compilation_mode=opt and --objc_enable_binary_stripping are specified.
    */
   @Override
   public boolean shouldStripBinary() {
     return this.enableBinaryStripping && getCompilationMode() == CompilationMode.OPT;
+  }
+
+  /**
+   * Returns whether to perform dead code elimination on linked binaries. The elimination is
+   * performed iff --compilation_mode=opt.
+   */
+  @Override
+  public boolean shouldDeadCodeStripBinary() {
+    return getCompilationMode() == CompilationMode.OPT;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/apple/ObjcConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/apple/ObjcConfigurationApi.java
@@ -106,8 +106,14 @@ public interface ObjcConfigurationApi<ApplePlatformTypeApiT extends ApplePlatfor
   @StarlarkMethod(
       name = "should_strip_binary",
       structField = true,
-      doc = "Returns whether to perform symbol and dead-code strippings on linked binaries.")
+      doc = "Returns whether to perform symbol stripping on linked binaries.")
   boolean shouldStripBinary();
+
+  @StarlarkMethod(
+      name = "should_dead_code_strip_binary",
+      structField = true,
+      doc = "Returns whether to perform dead code elimination on linked binaries.")
+  boolean shouldDeadCodeStripBinary();
 
   @StarlarkMethod(
       name = "signing_certificate_name",


### PR DESCRIPTION
Previously `objc_enable_binary_stripping` and `-c opt` were required to both
symbol strip and dead strip code. Symbol stripping and dead code stripping are very
different things. Dead code stripping is the elimination of dead code and should be done
in an optimized build. Unused code can be marked as "not dead" by using `exported symbols`
in the Apple build rules. Symbol stripping is the removal of symbol tables from an
executable.

`objc_enable_binary_stripping` now only controls symbol stripping.

Eventually I hope we deprecate `objc_enable_binary_stripping` and just use `strip=`.