### PR TITLE
cquery inherits from `test` not `build`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java
@@ -48,7 +48,12 @@ import java.util.Set;
 @Command(
   name = "cquery",
   builds = true,
-  inherits = {BuildCommand.class},
+  // We inherit from TestCommand so that we pick up changes like `test --test_arg=foo` in .bazelrc
+  // files.
+  // Without doing this, there is no easy way to use the output of cquery to determine whether a
+  // test has changed between two invocations, because the testrunner action is not easily
+  // introspectable.
+  inherits = {TestCommand.class},
   options = {CqueryOptions.class},
   usesConfigurationOptions = true,
   shortDescription = "Loads, analyzes, and queries the specified targets w/ configurations.",

--- a/src/test/shell/integration/configured_query_test.sh
+++ b/src/test/shell/integration/configured_query_test.sh
@@ -1289,4 +1289,27 @@ EOF
   expect_log "@repo//:japanese"
 }
 
+function test_test_arg_in_bazelrc() {
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg
+
+  cat >$pkg/BUILD <<EOF
+sh_test(
+    name = "test",
+    srcs = ["test.sh"],
+)
+EOF
+
+  touch $pkg/test.sh
+  chmod +x $pkg/test.sh
+
+  output_before="$(bazel cquery "//$pkg:test")"
+
+  add_to_bazelrc "test --test_arg=foo"
+
+  output_after="$(bazel cquery "//$pkg:test")"
+
+  assert_not_equals "${output_before}" "${output_after}"
+}
+
 run_suite "${PRODUCT_NAME} configured query tests"


### PR DESCRIPTION
This makes directives like `test --test_arg=foo` present in `.bazelrc` files be
factored into the configuration hash for test targets.

See https://github.com/bazelbuild/bazel/issues/13428 for extensive
context.