### PR TITLE
Add /d to describeCommandCwd

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/util/CommandFailureUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/util/CommandFailureUtils.java
@@ -111,7 +111,7 @@ public class CommandFailureUtils {
 
     @Override
     public void describeCommandCwd(String cwd, StringBuilder message) {
-      message.append("cd ").append(cwd).append("\n");
+      message.append("cd ").append("/d ").append(cwd).append("\n");
     }
 
     @Override


### PR DESCRIPTION
If the concrete output-base this command changes to is on a different drive (under windows), the `cd` does not work as expected.
According to the [docs](https://docs.microsoft.com/de-de/windows-server/administration/windows-commands/cd#parameters) adding this should actually result in the intended behaviour in all cases.

Fixes: #13496 