### PR TITLE
Add --no-log-init flag to docker sandbox.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DockerSandboxedSpawnRunner.java
@@ -344,7 +344,7 @@ final class DockerSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
               if (uid > 0) {
                 dockerfile.append(
                     String.format(
-                        "RUN [\"useradd\", \"-m\", \"-g\", \"%d\", \"-d\", \"%s\", \"-N\", \"-u\", "
+                        "RUN [\"useradd\", \"-l\", \"-m\", \"-g\", \"%d\", \"-d\", \"%s\", \"-N\", \"-u\", "
                             + "\"%d\", \"bazelbuild\"]\n",
                         gid, workDir, uid));
               }


### PR DESCRIPTION
This adds the `--no-log-init` flag (`-l`) to the internal `useradd` command used to initial the docker sandbox environment.

Without this flag, AD/LDAP/SSSD users that have large UID/GID values will be added to `lastlog`/`faillog`, but since docker does not support sparse files, this will cause the docker daemon to attempt to create a `/var/lib/docker/overlay2` entry that may consume all available disk space.

https://github.com/moby/moby/issues/5419#issuecomment-332785867

For one example, my SSSD-assigned uid is `1553201121`, which makes the _sparse_ size of my `lastlog` file 423GB.  If this uid is used by bazel's docker-sandbox, the resulting container attempts to create the full 423GB file, which I confirmed the hard way.