### PR TITLE
Fix unix toolchain for macos arm64 platform

### DIFF
--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -122,7 +122,7 @@ def cc_autoconf_impl(repository_ctx, overriden_tools = dict()):
         configure_windows_toolchain(repository_ctx)
     elif (cpu_value.startswith("darwin") and
           ("BAZEL_USE_CPP_ONLY_TOOLCHAIN" not in env or env["BAZEL_USE_CPP_ONLY_TOOLCHAIN"] != "1")):
-        configure_osx_toolchain(repository_ctx, overriden_tools)
+        configure_osx_toolchain(repository_ctx, cpu_value, overriden_tools)
     else:
         configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools)
 

--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -83,7 +83,7 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
              "https://github.com/bazelbuild/bazel/issues with the following:\n" +
              error_msg)
 
-def configure_osx_toolchain(repository_ctx, overriden_tools):
+def configure_osx_toolchain(repository_ctx, cpu_value, overriden_tools):
     """Configure C++ toolchain on macOS.
 
     Args:
@@ -187,4 +187,4 @@ def configure_osx_toolchain(repository_ctx, overriden_tools):
             },
         )
     else:
-        configure_unix_toolchain(repository_ctx, cpu_value = "darwin", overriden_tools = overriden_tools)
+        configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools = overriden_tools)

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -331,7 +331,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
     )
 
     repository_ctx.file("tools/cpp/empty.cc", "int main() {}")
-    darwin = cpu_value == "darwin"
+    darwin = cpu_value.startswith("darwin")
 
     cc = _find_generic(repository_ctx, "gcc", "CC", overriden_tools)
     is_clang = _is_clang(repository_ctx, cc)


### PR DESCRIPTION
This allow the basic unix toolchain to work on Apple silicon without
Xcode installed.

Fixes https://github.com/bazelbuild/bazel/issues/13514