### PR TITLE
Serve docs@head under /versions/main/

### DIFF
--- a/site/BUILD
+++ b/site/BUILD
@@ -167,15 +167,15 @@ jekyll_build(
     srcs = [
         "@jekyll_tree_%s//file" % DOC_VERSION["version"].split("-")[0].replace(".", "_")
         for DOC_VERSION in DOC_VERSIONS
-    ] + [":jekyll-tree"],  # jekyll-tree *must* come last to use layouts and includes from master
+    ] + [":jekyll-tree"],  # jekyll-tree *must* come last to use layouts and includes at head
     bucket = "docs.bazel.build",
 )
 
-# A smaller site build target. Contains just the docs for latest released version and master.
+# A smaller site build target. Contains just the docs for latest released version and head.
 jekyll_build(
     name = "site_latest",
     srcs = [
         "@jekyll_tree_%s//file" % DOC_VERSIONS[0]["version"].split("-")[0].replace(".", "_"),
-        ":jekyll-tree",  # jekyll-tree *must* come last to use layouts and includes from master
+        ":jekyll-tree",  # jekyll-tree *must* come last to use layouts and includes at head
     ],
 )

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -20,7 +20,7 @@ version: "4.1.0"
 
 # This must be kept in sync with //scripts/docs:doc_versions.bzl
 doc_versions:
-  - master
+  - main
   - 4.1.0
   - 4.0.0
   - 3.7.0

--- a/site/jekyll-tree.sh
+++ b/site/jekyll-tree.sh
@@ -45,7 +45,7 @@ readonly TMP=$(mktemp -d "${TMPDIR:-/tmp}/tmp.XXXXXXXX")
 readonly OUT_DIR="$TMP/out"
 trap "rm -rf ${TMP}" EXIT
 
-readonly VERSION="${DOC_VERSION:-master}"
+readonly VERSION="${DOC_VERSION:-main}"
 readonly VERSION_DIR="$OUT_DIR/versions/$VERSION"
 
 # Unpacks the base Jekyll tree, Build Encyclopedia, etc.
@@ -162,13 +162,13 @@ EOF
 # During setup, all documentation under docs are moved to the /versions/$VERSION
 # directory. This leaves nothing in the root directory.
 #
-# As a fix, when generating the master tarball, this function generates a
+# As a fix, when generating the head tarball, this function generates a
 # redirect from the root of the site for the given doc page under
 # /versions/$LATEST_RELEASE_VERSION so that
 # https://docs.bazel.build/foo.html will be redirected to
 # https://docs.bazel.build/versions/$LATEST_RELEASE_VERSION/foo.html
 function gen_redirects {
-  if [[ "$VERSION" == "master" ]]; then
+  if [[ "$VERSION" == "main" ]]; then
     pushd "$VERSION_DIR" > /dev/null
     for f in $(find . -name "*.html" -type f); do
       gen_redirect $f
@@ -177,6 +177,41 @@ function gen_redirects {
       gen_redirect $f
     done
     popd > /dev/null
+  fi
+}
+
+# TODO(https://github.com/bazelbuild/bazel/issues/12200):
+# Temporarily redirect /versions/master to main. Remove when we decide to stop
+# serving under the old name.
+
+# Generates a redirect for a documentation page under
+# /versions/$LATEST_RELEASE_VERSION.
+function gen_master_redirect {
+  f="$1"
+  local output_dir=$OUT_DIR/versions/master/$(dirname $f)
+  if [[ ! -d "$output_dir" ]]; then
+    mkdir -p "$output_dir"
+  fi
+
+  local src_basename=$(basename $f)
+  local md_basename="${src_basename%.*}.md"
+  local html_file="${f%.*}.html"
+  local redirect_file="$output_dir/$md_basename"
+  cat > "$redirect_file" <<EOF
+---
+layout: redirect
+redirect: /versions/main/$html_file
+---
+EOF
+}
+
+function gen_master_redirects {
+  if [[ "$VERSION" == "main" ]]; then
+    MASTER_DIR="$OUT_DIR/versions/master"
+    mkdir -p "$MASTER_DIR"
+    for f in $(cd "$OUT_DIR/versions/main" ; find . -name '*.html' -o -name '*.md' -type f) ; do
+      gen_master_redirect $f
+    done
   fi
 }
 
@@ -191,6 +226,7 @@ function main {
   unpack_skylark_rule_docs
   process_docs
   gen_redirects
+  gen_master_redirects
   package_output
 }
 main


### PR DESCRIPTION
See  #12200

Another good choice would be to use 'head' instead of main.
References to /master/ are redirected to /main/

Next step:
- wait for deploy and stability
- Change /master/ => /main/ in all the checked in docs.
- gradually do the same in other repositories
- remove the temporary redirection or move hosting to a site that handles regex redirects
