### PR TITLE
Suppress interrupted status during pool closure

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/grpc/ChannelConnectionFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/grpc/ChannelConnectionFactory.java
@@ -46,14 +46,20 @@ public interface ChannelConnectionFactory extends ConnectionFactory {
 
     @Override
     public void close() throws IOException {
+      // Clear interrupted status to prevent failure to await, indicated with #13512
+      boolean wasInterrupted = Thread.interrupted();
       // There is a bug (b/183340374) in gRPC that client doesn't try to close connections with
       // shutdown() if the channel received GO_AWAY frames. Using shutdownNow() here as a
       // workaround.
-      channel.shutdownNow();
       try {
+        channel.shutdownNow();
         channel.awaitTermination(Integer.MAX_VALUE, SECONDS);
       } catch (InterruptedException e) {
         throw new IOException(e.getMessage(), e);
+      } finally {
+        if (wasInterrupted) {
+          Thread.currentThread().interrupt();
+        }
       }
     }
 


### PR DESCRIPTION
awaitTermination will throw InterruptedException if the interrupted
status is set initially when it is called, even if no wait is required.
Pool closure should not respect active interrupted status when shutting
down and awaiting termination as a result of its call from
executionPhaseEnding, which will occur during abnormal exits from
ExecutionTool. Ignore this status initially and restore the flag upon
exit of the factory close. An external interrupt which occurs during the
awaitTermination will still trigger an InterruptedException, as
expected.

Fixes #13512