### PR TITLE
Explicitly export osx_archs.bzl

### DIFF
--- a/tools/osx/crosstool/BUILD.toolchains
+++ b/tools/osx/crosstool/BUILD.toolchains
@@ -2,6 +2,8 @@ load(":osx_archs.bzl", "OSX_TOOLS_ARCHS")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["osx_archs.bzl"])
+
 # Target constraints for each arch.
 # TODO(apple-rules): Rename osx constraint to macOS.
 OSX_TOOLS_CONSTRAINTS = {


### PR DESCRIPTION
Without this building `@local_config_cc//...` doesn't work:

```
bazel build --config=ors @local_config_cc//...

ERROR: /private/var/tmp/_bazel_ksmiley/e4a25840a6ead8553041b8c94f85a36e/external/local_config_cc/BUILD:12:6: no such target '@local_config_cc_toolchains//:osx_archs.bzl': target 'osx_archs.bzl' not declared in package ''; however, a source file of this name exists.  (Perhaps add 'exports_files(["osx_archs.bzl"])' to /BUILD?) defined by /private/var/tmp/_bazel_ksmiley/e4a25840a6ead8553041b8c94f85a36e/external/local_config_cc_toolchains/BUILD and referenced by '@local_config_cc//:osx_archs.bzl'
```

This target is used by rbe_configs_gen https://github.com/bazelbuild/bazel-toolchains#rbe_configs_gen---cli-tool-to-generate-configs