### PR TITLE
Reference osx_archs.bzl from bazel_tools

### DIFF
--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -39,7 +39,6 @@ def cc_autoconf_toolchains_impl(repository_ctx):
     paths = resolve_labels(repository_ctx, [
         "@bazel_tools//tools/cpp:BUILD.toolchains.tpl",
         "@bazel_tools//tools/osx/crosstool:BUILD.toolchains",
-        "@bazel_tools//tools/osx/crosstool:osx_archs.bzl",
         "@bazel_tools//tools/osx:xcode_locator.m",
     ])
     env = repository_ctx.os.environ
@@ -70,7 +69,6 @@ def cc_autoconf_toolchains_impl(repository_ctx):
 
         if should_use_xcode or xcode_toolchains:
             repository_ctx.symlink(paths["@bazel_tools//tools/osx/crosstool:BUILD.toolchains"], "BUILD")
-            repository_ctx.symlink(paths["@bazel_tools//tools/osx/crosstool:osx_archs.bzl"], "osx_archs.bzl")
         else:
             _generate_cpp_only_build_file(repository_ctx, cpu_value, paths)
     else:

--- a/tools/osx/crosstool/BUILD.toolchains
+++ b/tools/osx/crosstool/BUILD.toolchains
@@ -1,4 +1,4 @@
-load(":osx_archs.bzl", "OSX_TOOLS_ARCHS")
+load("@bazel_tools//tools/osx/crosstool:osx_archs.bzl", "OSX_TOOLS_ARCHS")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/osx/crosstool/BUILD.tpl
+++ b/tools/osx/crosstool/BUILD.tpl
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@local_config_cc_toolchains//:osx_archs.bzl", "OSX_TOOLS_ARCHS")
+load("@bazel_tools//tools/osx/crosstool:osx_archs.bzl", "OSX_TOOLS_ARCHS")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain_suite", "cc_library")
 load(":armeabi_cc_toolchain_config.bzl", "armeabi_cc_toolchain_config")
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
@@ -10,7 +10,7 @@ load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 # https://github.com/bazelbuild/bazel/pull/8459 we had to move the file to
 # @local_config_cc_toolchains. This alias is there to keep the code backwards
 # compatible (and serves no other purpose).
-alias(name = "osx_archs.bzl", actual = "@local_config_cc_toolchains//:osx_archs.bzl")
+alias(name = "osx_archs.bzl", actual = "@bazel_tools//tools/osx/crosstool:osx_archs.bzl")
 
 CC_TOOLCHAINS = [(
     cpu + "|compiler",


### PR DESCRIPTION
There doesn't seem to be a reason to symlink before referencing it. It
was brought up that referencing a local label in this toolchain
configuration is a bit strange when using remote execution.

https://bazelbuild.slack.com/archives/CA31HN1T3/p1622142347351500