### PR TITLE
Remove unneeded features from @tools/build_defs/pkg:pkg_tar.

### DIFF
--- a/tools/build_defs/pkg/BUILD
+++ b/tools/build_defs/pkg/BUILD
@@ -25,7 +25,7 @@ exports_files(
 py_library(
     name = "archive",
     srcs = ["archive.py"],
-    srcs_version = "PY2AND3",
+    srcs_version = "PY3",
     visibility = ["//visibility:public"],
 )
 
@@ -62,7 +62,7 @@ py_binary(
     name = "build_tar",
     srcs = ["build_tar.py"],
     python_version = "PY3",
-    srcs_version = "PY2AND3",
+    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":archive",
@@ -158,26 +158,6 @@ pkg_tar(
 )
 
 pkg_tar(
-    name = "test-tar-empty_files",
-    build_tar = ":build_tar",
-    empty_files = [
-        "/a",
-        "/b",
-    ],
-    mode = "0o777",
-)
-
-pkg_tar(
-    name = "test-tar-empty_dirs",
-    build_tar = ":build_tar",
-    empty_dirs = [
-        "/tmp",
-        "/pmt",
-    ],
-    mode = "0o777",
-)
-
-pkg_tar(
     name = "test-tar-mtime",
     srcs = [
         ":etc/nsswitch.conf",
@@ -197,8 +177,6 @@ sh_test(
         "testenv.sh",
         ":test-tar-.tar",
         ":test-tar-bz2.tar.bz2",
-        ":test-tar-empty_dirs.tar",
-        ":test-tar-empty_files.tar",
         ":test-tar-files_dict.tar",
         ":test-tar-gz.tar.gz",
         ":test-tar-inclusion-.tar",

--- a/tools/build_defs/pkg/BUILD
+++ b/tools/build_defs/pkg/BUILD
@@ -25,7 +25,7 @@ exports_files(
 py_library(
     name = "archive",
     srcs = ["archive.py"],
-    srcs_version = "PY3",
+    srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )
 
@@ -62,7 +62,7 @@ py_binary(
     name = "build_tar",
     srcs = ["build_tar.py"],
     python_version = "PY3",
-    srcs_version = "PY3",
+    srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
         ":archive",

--- a/tools/build_defs/pkg/build_test.sh
+++ b/tools/build_defs/pkg/build_test.sh
@@ -106,14 +106,6 @@ function test_tar() {
   check_eq "./
 ./not-etc/
 ./not-etc/mapped-filename.conf" "$(get_tar_listing test-tar-files_dict.tar)"
-  check_eq "drwxr-xr-x 0/0               0 2000-01-01 00:00 ./
--rwxrwxrwx 0/0               0 2000-01-01 00:00 ./a
--rwxrwxrwx 0/0               0 2000-01-01 00:00 ./b" \
-      "$(get_tar_verbose_listing test-tar-empty_files.tar)"
-  check_eq "drwxr-xr-x 0/0               0 2000-01-01 00:00 ./
-drwxrwxrwx 0/0               0 2000-01-01 00:00 ./tmp/
-drwxrwxrwx 0/0               0 2000-01-01 00:00 ./pmt/" \
-      "$(get_tar_verbose_listing test-tar-empty_dirs.tar)"
   check_eq \
     "drwxr-xr-x 0/0               0 1999-12-31 23:59 ./
 -r-xr-xr-x 0/0               2 1999-12-31 23:59 ./nsswitch.conf" \

--- a/tools/build_defs/pkg/pkg.bzl
+++ b/tools/build_defs/pkg/pkg.bzl
@@ -97,10 +97,6 @@ def _pkg_tar_impl(ctx):
             "--owner_names=%s=%s" % (_quote(key), ctx.attr.ownernames[key])
             for key in ctx.attr.ownernames
         ]
-    if ctx.attr.empty_files:
-        args += ["--empty_file=%s" % empty_file for empty_file in ctx.attr.empty_files]
-    if ctx.attr.empty_dirs:
-        args += ["--empty_dir=%s" % empty_dir for empty_dir in ctx.attr.empty_dirs]
     if ctx.attr.extension:
         dotPos = ctx.attr.extension.find(".")
         if dotPos > 0:
@@ -145,9 +141,7 @@ _real_pkg_tar = rule(
         "ownernames": attr.string_dict(),
         "extension": attr.string(default = "tar"),
         "symlinks": attr.string_dict(),
-        "empty_files": attr.string_list(),
         "include_runfiles": attr.bool(),
-        "empty_dirs": attr.string_list(),
         "remap_paths": attr.string_dict(),
         # Implicit dependencies.
         "build_tar": attr.label(


### PR DESCRIPTION
@tools/build_defs/pkg:pkg_tar is deprecated and replaced by @rules_pkg.
This PR pushes that concept forward by elminating features that are not used by Bazel.
By the next LTS track (5.x) I think we can reduce this pkg_tar into something
that serves as the tiny tar utility.

cc/ @nacl 