### PR TITLE
Remote: Display download progress when actions are downloading outputs from remote cache.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionProgressEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionProgressEvent.java
@@ -1,0 +1,42 @@
+package com.google.devtools.build.lib.actions;
+
+import com.google.devtools.build.lib.events.ExtendedEventHandler.ProgressLike;
+
+/**
+ * Notifies that an in-flight action is making progress..
+ */
+public class ActionProgressEvent implements ProgressLike {
+  private final ActionExecutionMetadata action;
+  private final String progressId;
+  private final String progress;
+  private final boolean isFinished;
+
+  public ActionProgressEvent(ActionExecutionMetadata action, String progressId, String progress, boolean isFinished) {
+    this.action = action;
+    this.progressId = progressId;
+    this.progress = progress;
+    this.isFinished = isFinished;
+  }
+
+  /** Gets the metadata associated with the action being scheduled. */
+  public ActionExecutionMetadata getActionMetadata() {
+    return action;
+  }
+
+  /**
+   * The id that uniquely determines the progress among all progress events within an action.
+   */
+  public String getProgressId() {
+    return progressId;
+  }
+
+  /** Human readable description of the progress */
+  public String getProgress() {
+    return progress;
+  }
+
+  /** Whether the download progress reported about is finished already */
+  public boolean isFinished() {
+    return isFinished;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionProgressEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionProgressEvent.java
@@ -3,7 +3,7 @@ package com.google.devtools.build.lib.actions;
 import com.google.devtools.build.lib.events.ExtendedEventHandler.ProgressLike;
 
 /**
- * Notifies that an in-flight action is making progress..
+ * Notifies that an in-flight action is making progress.
  */
 public class ActionProgressEvent implements ProgressLike {
   private final ActionExecutionMetadata action;

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionProgressEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionProgressEvent.java
@@ -1,42 +1,26 @@
 package com.google.devtools.build.lib.actions;
 
+import com.google.auto.value.AutoValue;
 import com.google.devtools.build.lib.events.ExtendedEventHandler.ProgressLike;
 
-/**
- * Notifies that an in-flight action is making progress.
- */
-public class ActionProgressEvent implements ProgressLike {
-  private final ActionExecutionMetadata action;
-  private final String progressId;
-  private final String progress;
-  private final boolean isFinished;
+/** Notifies that an in-flight action is making progress. */
+@AutoValue
+public abstract class ActionProgressEvent implements ProgressLike {
 
-  public ActionProgressEvent(ActionExecutionMetadata action, String progressId, String progress, boolean isFinished) {
-    this.action = action;
-    this.progressId = progressId;
-    this.progress = progress;
-    this.isFinished = isFinished;
+  public static ActionProgressEvent create(
+      ActionExecutionMetadata action, String progressId, String progress, boolean finished) {
+    return new AutoValue_ActionProgressEvent(action, progressId, progress, finished);
   }
 
   /** Gets the metadata associated with the action being scheduled. */
-  public ActionExecutionMetadata getActionMetadata() {
-    return action;
-  }
+  public abstract ActionExecutionMetadata action();
 
-  /**
-   * The id that uniquely determines the progress among all progress events within an action.
-   */
-  public String getProgressId() {
-    return progressId;
-  }
+  /** The id that uniquely determines the progress among all progress events within an action. */
+  public abstract String progressId();
 
   /** Human readable description of the progress */
-  public String getProgress() {
-    return progress;
-  }
+  public abstract String progress();
 
   /** Whether the download progress reported about is finished already */
-  public boolean isFinished() {
-    return isFinished;
-  }
+  public abstract boolean finished();
 }

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -328,7 +328,6 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
         return;
       }
 
-      // TODO(ulfjack): We should report more details to the UI.
       ExtendedEventHandler eventHandler = actionExecutionContext.getEventHandler();
       progress.postTo(eventHandler, action);
     }

--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -267,6 +267,7 @@ java_library(
     srcs = [
         "SpawnCheckingCacheEvent.java",
         "SpawnExecutingEvent.java",
+        "SpawnProgressEvent.java",
         "SpawnRunner.java",
         "SpawnSchedulingEvent.java",
     ],

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnProgressEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnProgressEvent.java
@@ -19,6 +19,8 @@ import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.exec.SpawnRunner.ProgressStatus;
 
+
+/** The {@link SpawnRunner} is making some progress. */
 @AutoValue
 public abstract class SpawnProgressEvent implements ProgressStatus {
 
@@ -26,8 +28,15 @@ public abstract class SpawnProgressEvent implements ProgressStatus {
     return new AutoValue_SpawnProgressEvent(resourceId, progress, finished);
   }
 
+  /**
+   * The id that uniquely determines the progress among all progress events for this spawn.
+   */
   abstract String progressId();
+
+  /** Human readable description of the progress */
   abstract String progress();
+
+  /** Whether the progress reported about is finished already */
   abstract boolean finished();
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnProgressEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnProgressEvent.java
@@ -1,0 +1,37 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.exec;
+
+import com.google.auto.value.AutoValue;
+import com.google.devtools.build.lib.actions.ActionProgressEvent;
+import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.exec.SpawnRunner.ProgressStatus;
+
+@AutoValue
+public abstract class SpawnProgressEvent implements ProgressStatus {
+
+  public static SpawnProgressEvent create(String resourceId, String progress, boolean finished) {
+    return new AutoValue_SpawnProgressEvent(resourceId, progress, finished);
+  }
+
+  abstract String progressId();
+  abstract String progress();
+  abstract boolean finished();
+
+  @Override
+  public void postTo(ExtendedEventHandler eventHandler, ActionExecutionMetadata action) {
+    eventHandler.post(new ActionProgressEvent(action, progressId(), progress(), finished()));
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnProgressEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnProgressEvent.java
@@ -41,6 +41,6 @@ public abstract class SpawnProgressEvent implements ProgressStatus {
 
   @Override
   public void postTo(ExtendedEventHandler eventHandler, ActionExecutionMetadata action) {
-    eventHandler.post(new ActionProgressEvent(action, progressId(), progress(), finished()));
+    eventHandler.post(ActionProgressEvent.create(action, progressId(), progress(), finished()));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -381,7 +381,8 @@ public class RemoteExecutionService {
           remotePathResolver,
           result.actionResult,
           action.spawnExecutionContext.getFileOutErr(),
-          action.spawnExecutionContext::lockOutputFiles);
+          action.spawnExecutionContext::lockOutputFiles,
+          action.spawnExecutionContext::report);
     } else {
       PathFragment inMemoryOutputPath = getInMemoryOutputPath(action.spawn);
       inMemoryOutput =

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -61,6 +61,7 @@ import com.google.rpc.Status;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -502,5 +503,24 @@ public final class Utils {
       Throwables.throwIfUnchecked(e);
       throw new AssertionError(e);
     }
+  }
+
+  public static String bytesCountToDisplayString(long bytes) {
+    Preconditions.checkArgument(bytes >= 0);
+
+    if (bytes < 1024) {
+      return bytes + " B";
+    }
+
+    String units = "KMGT";
+    int unitIndex = 0;
+
+    long value = bytes;
+    while ((unitIndex + 1) < units.length() && value >= (1 << 20)) {
+      value >>= 10;
+      unitIndex++;
+    }
+    DecimalFormat fmt = new DecimalFormat("0.#");
+    return String.format("%s %ciB", fmt.format(value / 1024.0), units.charAt(unitIndex));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.actions.ActionCompletionEvent;
 import com.google.devtools.build.lib.actions.ActionScanningCompletedEvent;
 import com.google.devtools.build.lib.actions.ActionStartedEvent;
 import com.google.devtools.build.lib.actions.CachingActionEvent;
+import com.google.devtools.build.lib.actions.ActionProgressEvent;
 import com.google.devtools.build.lib.actions.RunningActionEvent;
 import com.google.devtools.build.lib.actions.ScanningActionEvent;
 import com.google.devtools.build.lib.actions.SchedulingActionEvent;
@@ -690,6 +691,13 @@ public final class UiEventHandler implements EventHandler {
   @AllowConcurrentEvents
   public void runningAction(RunningActionEvent event) {
     stateTracker.runningAction(event);
+    refresh();
+  }
+
+  @Subscribe
+  @AllowConcurrentEvents
+  public void actionProgress(ActionProgressEvent event) {
+    stateTracker.actionProgress(event);
     refresh();
   }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -313,8 +313,8 @@ final class UiStateTracker {
      * Handle the progress event for the action.
      */
     synchronized void onProgressEvent(ActionProgressEvent event, long nanoChangeTime) {
-      String id = event.getProgressId();
-      if (event.isFinished()) {
+      String id = event.progressId();
+      if (event.finished()) {
         // a download is finished, clean it up
         runningProgress.remove(id);
         progressNanoStartTimes.remove(id);
@@ -566,8 +566,8 @@ final class UiStateTracker {
   }
 
   void actionProgress(ActionProgressEvent event) {
-    ActionExecutionMetadata action = event.getActionMetadata();
-    Artifact actionId = event.getActionMetadata().getPrimaryOutput();
+    ActionExecutionMetadata action = event.action();
+    Artifact actionId = event.action().getPrimaryOutput();
     long now = clock.nanoTime();
     getActionState(action, actionId, now).onProgressEvent(event, now);
   }
@@ -1136,7 +1136,7 @@ final class UiStateTracker {
     long nanoDownloadTime = nanoTime - actionState.progressNanoStartTimes.get(id);
     long downloadSeconds = nanoDownloadTime / NANOS_PER_SECOND;
 
-    String progress = download.getProgress();
+    String progress = download.progress();
     if (progress.isEmpty()) {
       progress = id;
     }

--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -1163,6 +1163,7 @@ final class UiStateTracker {
     int count = 0;
     int progressCount = actionState.runningProgress.size();
     String suffix = AND_MORE + " (" + progressCount + " progresses)";
+    int sampleSize = 1;
     for (String id : actionState.runningProgress) {
       if (count >= sampleSize) {
         break;
@@ -1176,9 +1177,6 @@ final class UiStateTracker {
           width,
           id,
           (count >= sampleSize && count < progressCount) ? suffix : "");
-    }
-    if (count < progressCount) {
-      terminalWriter.newline().append(leftMargin + suffix);
     }
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -391,7 +391,7 @@ public class GrpcCacheClientTest {
     result.addOutputFilesBuilder().setPath("b/empty").setDigest(emptyDigest);
     result.addOutputFilesBuilder().setPath("a/bar").setDigest(barDigest).setIsExecutable(true);
     remoteCache.download(
-        context, remotePathResolver, result.build(), null, /* outputFilesLocker= */ () -> {});
+        context, remotePathResolver, result.build(), null, /* outputFilesLocker= */ () -> {}, (progress) -> {});
     assertThat(DIGEST_UTIL.compute(execRoot.getRelative("a/foo"))).isEqualTo(fooDigest);
     assertThat(DIGEST_UTIL.compute(execRoot.getRelative("b/empty"))).isEqualTo(emptyDigest);
     assertThat(DIGEST_UTIL.compute(execRoot.getRelative("a/bar"))).isEqualTo(barDigest);
@@ -416,7 +416,7 @@ public class GrpcCacheClientTest {
     result.addOutputFilesBuilder().setPath("main/b/empty").setDigest(emptyDigest);
     result.addOutputFilesBuilder().setPath("main/a/bar").setDigest(barDigest).setIsExecutable(true);
     remoteCache.download(
-        context, remotePathResolver, result.build(), null, /* outputFilesLocker= */ () -> {});
+        context, remotePathResolver, result.build(), null, /* outputFilesLocker= */ () -> {}, (progress) -> {});
     assertThat(DIGEST_UTIL.compute(execRoot.getRelative("a/foo"))).isEqualTo(fooDigest);
     assertThat(DIGEST_UTIL.compute(execRoot.getRelative("b/empty"))).isEqualTo(emptyDigest);
     assertThat(DIGEST_UTIL.compute(execRoot.getRelative("a/bar"))).isEqualTo(barDigest);
@@ -453,7 +453,7 @@ public class GrpcCacheClientTest {
     result.addOutputFilesBuilder().setPath("a/foo").setDigest(fooDigest);
     result.addOutputDirectoriesBuilder().setPath("a/bar").setTreeDigest(barTreeDigest);
     remoteCache.download(
-        context, remotePathResolver, result.build(), null, /* outputFilesLocker= */ () -> {});
+        context, remotePathResolver, result.build(), null, /* outputFilesLocker= */ () -> {}, (progress) -> {});
 
     assertThat(DIGEST_UTIL.compute(execRoot.getRelative("a/foo"))).isEqualTo(fooDigest);
     assertThat(DIGEST_UTIL.compute(execRoot.getRelative("a/bar/qux"))).isEqualTo(quxDigest);
@@ -475,7 +475,7 @@ public class GrpcCacheClientTest {
     ActionResult.Builder result = ActionResult.newBuilder();
     result.addOutputDirectoriesBuilder().setPath("a/bar").setTreeDigest(barTreeDigest);
     remoteCache.download(
-        context, remotePathResolver, result.build(), null, /* outputFilesLocker= */ () -> {});
+        context, remotePathResolver, result.build(), null, /* outputFilesLocker= */ () -> {}, (progress) -> {});
 
     assertThat(execRoot.getRelative("a/bar").isDirectory()).isTrue();
   }
@@ -518,7 +518,7 @@ public class GrpcCacheClientTest {
     result.addOutputFilesBuilder().setPath("a/foo").setDigest(fooDigest);
     result.addOutputDirectoriesBuilder().setPath("a/bar").setTreeDigest(barTreeDigest);
     remoteCache.download(
-        context, remotePathResolver, result.build(), null, /* outputFilesLocker= */ () -> {});
+        context, remotePathResolver, result.build(), null, /* outputFilesLocker= */ () -> {}, (progress) -> {});
 
     assertThat(DIGEST_UTIL.compute(execRoot.getRelative("a/foo"))).isEqualTo(fooDigest);
     assertThat(DIGEST_UTIL.compute(execRoot.getRelative("a/bar/wobble/qux"))).isEqualTo(quxDigest);

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -274,13 +274,13 @@ public class RemoteSpawnCacheTest {
               }
             })
         .when(remoteCache)
-        .download(any(), any(), eq(actionResult), eq(outErr), any());
+        .download(any(), any(), eq(actionResult), eq(outErr), any(), any());
 
     CacheHandle entry = cache.lookup(simpleSpawn, simplePolicy);
     assertThat(entry.hasResult()).isTrue();
     SpawnResult result = entry.getResult();
     // All other methods on RemoteActionCache have side effects, so we verify all of them.
-    verify(remoteCache).download(any(), any(), eq(actionResult), eq(outErr), any());
+    verify(remoteCache).download(any(), any(), eq(actionResult), eq(outErr), any(), any());
     verify(remoteCache, never())
         .upload(
             any(RemoteActionExecutionContext.class),
@@ -644,7 +644,7 @@ public class RemoteSpawnCacheTest {
             });
     doThrow(new CacheNotFoundException(digest))
         .when(remoteCache)
-        .download(any(), any(), eq(actionResult), eq(outErr), any());
+        .download(any(), any(), eq(actionResult), eq(outErr), any(), any());
 
     CacheHandle entry = cache.lookup(simpleSpawn, simplePolicy);
     assertThat(entry.hasResult()).isFalse();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -380,6 +380,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             any(ActionResult.class),
             eq(outErr),
+            any(),
             any());
   }
 
@@ -710,6 +711,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             eq(result),
             any(FileOutErr.class),
+            any(),
             any());
     verify(cache, never())
         .downloadFile(any(RemoteActionExecutionContext.class), any(Path.class), any(Digest.class));
@@ -750,6 +752,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             eq(result),
             any(FileOutErr.class),
+            any(),
             any());
     verify(cache, never())
         .downloadFile(any(RemoteActionExecutionContext.class), any(Path.class), any(Digest.class));
@@ -776,6 +779,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             eq(cachedResult),
             any(FileOutErr.class),
+            any(),
             any());
     ActionResult execResult = ActionResult.newBuilder().setExitCode(31).build();
     ExecuteResponse succeeded = ExecuteResponse.newBuilder().setResult(execResult).build();
@@ -791,6 +795,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             eq(execResult),
             any(FileOutErr.class),
+            any(),
             any());
 
     Spawn spawn = newSimpleSpawn();
@@ -840,6 +845,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             eq(cachedResult),
             any(FileOutErr.class),
+            any(),
             any());
     doNothing()
         .when(cache)
@@ -848,6 +854,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             eq(execResult),
             any(FileOutErr.class),
+            any(),
             any());
 
     Spawn spawn = newSimpleSpawn();
@@ -917,6 +924,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             eq(cachedResult),
             any(FileOutErr.class),
+            any(),
             any());
   }
 
@@ -967,6 +975,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             eq(cachedResult),
             any(FileOutErr.class),
+            any(),
             any());
     verify(localRunner, never()).exec(eq(spawn), eq(policy));
   }
@@ -1012,6 +1021,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             eq(cachedResult),
             any(FileOutErr.class),
+            any(),
             any());
     verify(localRunner, never()).exec(eq(spawn), eq(policy));
   }
@@ -1178,6 +1188,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             any(ActionResult.class),
             eq(outErr),
+            any(),
             any());
   }
 
@@ -1224,6 +1235,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             any(ActionResult.class),
             eq(outErr),
+            any(),
             any());
   }
 
@@ -1276,6 +1288,7 @@ public class RemoteSpawnRunnerTest {
             any(RemotePathResolver.class),
             any(ActionResult.class),
             eq(outErr),
+            any(),
             any());
   }
 
@@ -1307,7 +1320,7 @@ public class RemoteSpawnRunnerTest {
     assertThat(result.status()).isEqualTo(Status.SUCCESS);
 
     // assert
-    verify(cache).download(any(), any(), eq(succeededAction), eq(outErr), any());
+    verify(cache).download(any(), any(), eq(succeededAction), eq(outErr), any(), any());
     verify(cache, never())
         .downloadMinimal(
             any(), any(), eq(succeededAction), anyCollection(), any(), any(), any(), any());


### PR DESCRIPTION
Normally, when executing action with remote cache/execution, the UI only display the "remote"/"remote-cache" strategy:
```
[500 / 1000] 500 actions, 3 running
    [Sched] Executing genrule //:test-1;
    Executing genrule //:test-2; 2s remote
    Executing genrule //:test-3; 3s remote ...
```

However, it doesn't tell users what is happening under the hood. #13555 fixed the confusion which the UI display the action is scheduling while it is actually downloading the outputs.

With this change, Bazel will display the downloads if action is downloading outputs. e.g.
```
[500 / 1000] 500 actions, 3 running
    [Sched] Executing genrule //:test-1; 1s remote
    Executing genrule //:test-2; Downloading 2.out, 20.1 KiB / 100 KiB; 2s remote        
    Executing genrule //:test-3; 3s remote ...
``` 

Add a generic `ActionProgressEvent` which can be reported within action execution to display detailed execution progress for that action.
