### PR TITLE
Use True instead of 1 to be more expressive

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLibrary.java
@@ -254,7 +254,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
 
     if (common.getLinkopts().contains("-static")) {
       ruleContext.attributeWarning("linkopts", "Using '-static' here won't work. "
-                                   + "Did you mean to use 'linkstatic=1' instead?");
+                                   + "Did you mean to use 'linkstatic=True' instead?");
     }
 
     linkingHelper.setShouldCreateDynamicLibrary(createDynamicLibrary);
@@ -526,7 +526,7 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
         && ccCompilationOutputs.getObjectFiles(true).isEmpty()) {
       if (!linkstaticAttribute && appearsToHaveObjectFiles(ruleContext.attributes())) {
         ruleContext.attributeWarning("linkstatic",
-            "setting 'linkstatic=1' is recommended if there are no object files");
+            "setting 'linkstatic=True' is recommended if there are no object files");
       }
     } else {
       if (!linkstaticAttribute && !appearsToHaveObjectFiles(ruleContext.attributes())) {
@@ -539,9 +539,9 @@ public abstract class CcLibrary implements RuleConfiguredTargetFactory {
              + element.prettyPrint() + ". "
              + "(You may have used some very confusing rule names in srcs? "
              + "Or the library consists entirely of a linker script?) "
-             + "Bazel assumed linkstatic=1, but this may be inappropriate. "
+             + "Bazel assumed linkstatic=True, but this may be inappropriate. "
              + "You may need to add an explicit '.cc' file to 'srcs'. "
-             + "Alternatively, add 'linkstatic=1' to suppress this warning");
+             + "Alternatively, add 'linkstatic=True' to suppress this warning");
       }
     }
   }

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcCommonTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcCommonTest.java
@@ -703,7 +703,7 @@ public class CcCommonTest extends BuildViewTestCase {
         "lib_with_dash_static",
         // message:
         "in linkopts attribute of cc_library rule //badlib:lib_with_dash_static: "
-            + "Using '-static' here won't work. Did you mean to use 'linkstatic=1' instead?",
+            + "Using '-static' here won't work. Did you mean to use 'linkstatic=True' instead?",
         // build file:
         "cc_library(name = 'lib_with_dash_static',",
         "   srcs = [ 'ok.cc' ],",


### PR DESCRIPTION
linkstatic conceptually can be True or False, using 1 can give the impression that any arbitrary value is allowed.