### PR TITLE
CppCompileAction: do not make declaredIncludeSrcs() part of the action key

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -1368,8 +1368,6 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
     fp.addBytes(commandLineKey);
     fp.addBoolean(validateTopLevelHeaderInclusions);
 
-    actionKeyContext.addNestedSetToFingerprint(fp, declaredIncludeSrcs);
-    fp.addInt(0); // mark the boundary between input types
     actionKeyContext.addNestedSetToFingerprint(fp, mandatoryInputs);
     fp.addInt(0);
     actionKeyContext.addNestedSetToFingerprint(fp, prunableHeaders);


### PR DESCRIPTION
There are two types of input discovery in Bazel:

  * include scanning is hard-disabled [1]
  * depfile parsing is active and the action key is updated accordingly

However, due to declaredIncludeSrcs() being part of the action key, a
change of the declared include srcs, either explicitly or via a glob(),
causes a CppCompileAction to be re-executed even though none of its
inputs (as reported by the compiler) had changed.

When an action does not discover inputs, there is no need to distinguish
between inputs and declared inputs since the inputs already go into the
cache key.
When an action does discover inputs, the action key gets updated after
parsing the depfile.

With this change, Bazel behaves much like Ninja in terms of avoiding
unnecessary recompiles of C++ translation units.

There should probably be an entry in the release notes because this
change makes existing cache entries non-candidates.

[1] https://github.com/bazelbuild/bazel/commit/1df4c71a9cf52f2dd24c4a10da75bb88631e7fde

Fixes: #8319
Hint-by: Lukacs T. Berki <lberki@google.com>