### PR TITLE
Remote: Do not upload empty output to remote cache.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTests.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTests.java
@@ -1305,6 +1305,27 @@ public class RemoteCacheTests {
   }
 
   @Test
+  public void testDownloadEmptyOutErr() throws Exception {
+    // Test that downloading empty stdout/stderr does not try to perform a download.
+
+    InMemoryRemoteCache remoteCache = newRemoteCache();
+    Digest emptyDigest = digestUtil.compute(new byte[0]);
+    ActionResult.Builder result = ActionResult.newBuilder();
+    result.setStdoutDigest(emptyDigest);
+    result.setStderrDigest(emptyDigest);
+
+    RemoteCache.waitForBulkTransfer(
+        remoteCache.downloadOutErr(
+            context,
+            result.build(),
+            new FileOutErr(execRoot.getRelative("stdout"), execRoot.getRelative("stderr"))),
+        true);
+
+    assertThat(remoteCache.getNumSuccessfulDownloads()).isEqualTo(0);
+    assertThat(remoteCache.getNumFailedDownloads()).isEqualTo(0);
+  }
+
+  @Test
   public void testDownloadFileWithSymlinkTemplate() throws Exception {
     // Test that when a symlink template is provided, we don't actually download files to disk.
     // Instead, a symbolic link should be created that points to a location where the file may


### PR DESCRIPTION
An unintended side-effect of change cc2b3ecb9283ebdb297fc3fb6407f4697c850ac2 is that zero-sized blob won't be uploaded to gRPC cache. However, the behavior is existed for a long time and the REAPI spec is also updated accordingly. This change makes the behavior explicit and brings it to other remote cache backends.

Context https://github.com/bazelbuild/bazel/issues/11063.

Fixes https://github.com/bazelbuild/bazel/issues/13349.