### PR TITLE
Support Action-Generated FDO Profiles 

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -395,12 +395,13 @@ public class CppOptions extends FragmentOptions {
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
       help =
           "Use FDO profile information to optimize compilation. Specify the name "
-              + "of the zip file containing the .gcda file tree, or an afdo file containing "
-              + "an auto profile. This flag also accepts files specified as labels, for "
-              + "example //foo/bar:file.afdo. Such labels must refer to input files; you may "
-              + "need to add an exports_files directive to the corresponding package to make "
-              + "the file visible to Bazel. It also accepts a raw or an indexed LLVM profile file. "
-              + "This flag will be superseded by fdo_profile rule.")
+              + "of a zip file containing a .gcda file tree, an afdo file containing "
+              + "an auto profile, or an LLVM profile file. This flag also accepts files "
+              + "specified as labels (e.g. `//foo/bar:file.afdo` - you may need to add "
+              + "an `exports_files` directive to the corresponding package) and labels "
+              + "pointing to `fdo_profile` targets. This flag will be superseded by the "
+              + "`fdo_profile` rule."
+              )
   public String fdoOptimizeForBuild;
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/FdoHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/FdoHelper.java
@@ -483,18 +483,13 @@ public class FdoHelper {
     }
 
     Artifact fdoArtifact = fdoArtifacts.get(0);
-    if (!fdoArtifact.isSourceArtifact()) {
-      ruleContext.ruleError("--fdo_optimize points to a target that is not an input file");
-      return null;
-    }
-
     Label fdoLabel = attributes.getFdoOptimize().getLabel();
     if (!fdoLabel
         .getPackageIdentifier()
         .getExecPath(ruleContext.getConfiguration().isSiblingRepositoryLayout())
         .getRelative(fdoLabel.getName())
         .equals(fdoArtifact.getExecPath())) {
-      ruleContext.ruleError("--fdo_optimize points to a target that is not an input file");
+      ruleContext.ruleError("--fdo_optimize points to a target that is not an input file or an fdo_profile rule");
       return null;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/FdoInputFile.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/FdoInputFile.java
@@ -88,9 +88,6 @@ public final class FdoInputFile implements HasFileType {
 
     if (isLabel) {
       Artifact artifact = ruleContext.getPrerequisiteArtifact("profile");
-      if (!artifact.isSourceArtifact()) {
-        ruleContext.attributeError("profile", " the target is not an input file");
-      }
       return new FdoInputFile(artifact, null);
     } else {
       if (!ruleContext.getFragment(CppConfiguration.class).isFdoAbsolutePathEnabled()) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/FdoProfileRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/FdoProfileRule.java
@@ -30,10 +30,10 @@ public final class FdoProfileRule implements RuleDefinition {
     return builder
         .requiresConfigurationFragments(CppConfiguration.class)
         /* <!-- #BLAZE_RULE(fdo_profile).ATTRIBUTE(profile) -->
-        Label of the FDO profile. The FDO file can have one of the following extensions:
-        .profraw for unindexed LLVM profile, .profdata for indexed LLVM profile, .zip that holds an
-        LLVM profraw profile, .afdo for AutoFDO profile, .xfdo for XBinary profile.
-        The label can also point to an fdo_absolute_path_profile rule.
+        Label of the FDO profile or a rule which generates it. The FDO file can have one of the
+        following extensions: .profraw for unindexed LLVM profile, .profdata for indexed LLVM
+        profile, .zip that holds an LLVM profraw profile, .afdo for AutoFDO profile, .xfdo for
+        XBinary profile. The label can also point to an fdo_absolute_path_profile rule.
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(
             attr("profile", LABEL)

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/BUILD
@@ -194,6 +194,25 @@ java_test(
 )
 
 java_test(
+    name = "CcBinaryFdoTest",
+    srcs = ["CcBinaryFdoTest.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/analysis:actions/symlink_action",
+        "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/rules/cpp",
+        "//src/main/java/com/google/devtools/build/lib/rules/genrule",
+        "//src/test/java/com/google/devtools/build/lib/actions/util",
+        "//src/test/java/com/google/devtools/build/lib/analysis/util",
+        "//src/test/java/com/google/devtools/build/lib/packages:testutil",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
+java_test(
     name = "CcHostToolchainAliasTest",
     srcs = ["CcHostToolchainAliasTest.java"],
     deps = [

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryFdoTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcBinaryFdoTest.java
@@ -1,0 +1,89 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.rules.cpp;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
+import com.google.devtools.build.lib.analysis.actions.SpawnAction;
+import com.google.devtools.build.lib.analysis.actions.SymlinkAction;
+import com.google.devtools.build.lib.analysis.util.AnalysisMock;
+import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.packages.util.Crosstool.CcToolchainConfig;
+import com.google.devtools.build.lib.rules.genrule.GenRuleAction;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for cc_binary with FDO. */
+@RunWith(JUnit4.class)
+public class CcBinaryFdoTest extends BuildViewTestCase {
+  @Test
+  public void testActionGraph() throws Exception {
+    AnalysisMock.get()
+        .ccSupport()
+        .setupCcToolchainConfig(mockToolsConfig, CcToolchainConfig.builder());
+    useConfiguration("--fdo_profile=//:mock_profile", "--compilation_mode=opt");
+
+    scratch.file("binary.cc", "int main() { return 0; }");
+    scratch.file(
+        "BUILD",
+        "genrule(name = 'generate-mock-profraw',",
+        "    outs = ['mock.profraw'],",
+        "    cmd = 'touch $@',",
+        ")",
+        "",
+        "fdo_profile(name = 'mock_profile',",
+        "     profile = 'mock.profraw',",
+        ")",
+        "",
+        "cc_binary(name = 'binary',",
+        "    srcs = ['binary.cc'],",
+        ")");
+
+    // Check the compile action uses a profdata file
+    CppCompileAction compileAction =
+        (CppCompileAction)
+            getGeneratingAction(
+                getBinArtifact("_objs/binary/binary.o", getConfiguredTarget("//:binary")));
+    assertThat(compileAction).isNotNull();
+    assertThat(compileAction.getArguments())
+        .contains(
+            "-fprofile-use=bazel-out/k8-opt/bin/external/bazel_tools/tools/cpp/fdo/everything/mock.profdata");
+    Artifact profData =
+        ActionsTestUtil.getFirstArtifactEndingWith(compileAction.getInputs(), ".profdata");
+    assertThat(profData).isNotNull();
+
+    // Get the action which generates the profdata file from the profraw file
+    SpawnAction profDataAction = (SpawnAction) getGeneratingAction(profData);
+    assertThat(profDataAction).isNotNull();
+    Artifact profRawSymlink =
+        ActionsTestUtil.getFirstArtifactEndingWith(profDataAction.getInputs(), ".profraw");
+    assertThat(profRawSymlink).isNotNull();
+
+    // Make sure the profData action is from the genrule
+    SymlinkAction profRawSymlinkAction = (SymlinkAction) getGeneratingAction(profRawSymlink);
+    assertThat(profRawSymlinkAction).isNotNull();
+    Artifact profRaw =
+        ActionsTestUtil.getFirstArtifactEndingWith(profRawSymlinkAction.getInputs(), ".profraw");
+    assertThat(profRaw).isNotNull();
+
+    // Make sure the symlink input is the genrule defined in the BUILD file
+    GenRuleAction profRawAction = (GenRuleAction) getGeneratingAction(profRaw);
+    assertThat(profRawAction).isNotNull();
+    assertThat(profRawAction.getOwner().getLabel().getCanonicalForm())
+        .isEqualTo("//:generate-mock-profraw");
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcToolchainTest.java
@@ -409,7 +409,7 @@ public class CcToolchainTest extends BuildViewTestCase {
         "    cmd='touch $@')");
     useConfiguration("-c", "opt", "--fdo_optimize=//a:gen_artifact");
     assertThat(getConfiguredTarget("//a:b")).isNull();
-    assertContainsEvent("--fdo_optimize points to a target that is not an input file");
+    assertContainsEvent("--fdo_optimize points to a target that is not an input file or an fdo_profile rule");
   }
 
   @Test
@@ -435,7 +435,7 @@ public class CcToolchainTest extends BuildViewTestCase {
     scratch.file("my_profile.afdo", "");
     useConfiguration("-c", "opt", "--fdo_optimize=//a:profile");
     assertThat(getConfiguredTarget("//a:b")).isNull();
-    assertContainsEvent("--fdo_optimize points to a target that is not an input file");
+    assertContainsEvent("--fdo_optimize points to a target that is not an input file or an fdo_profile rule");
   }
 
   @Test

--- a/tools/cpp/armeabi_cc_toolchain_config.bzl
+++ b/tools/cpp/armeabi_cc_toolchain_config.bzl
@@ -48,6 +48,7 @@ def _impl(ctx):
         tool_path(name = "gcc", path = "/bin/false"),
         tool_path(name = "gcov", path = "/bin/false"),
         tool_path(name = "ld", path = "/bin/false"),
+        tool_path(name = "llvm-profdata", path = "/bin/false"),
         tool_path(name = "nm", path = "/bin/false"),
         tool_path(name = "objcopy", path = "/bin/false"),
         tool_path(name = "objdump", path = "/bin/false"),

--- a/tools/cpp/cc_configure.bzl
+++ b/tools/cpp/cc_configure.bzl
@@ -150,6 +150,7 @@ cc_autoconf = repository_rule(
         "BAZEL_LINKOPTS",
         "BAZEL_LINKLIBS",
         "BAZEL_LLVM_COV",
+        "BAZEL_LLVM_PROFDATA",
         "BAZEL_PYTHON",
         "BAZEL_SH",
         "BAZEL_TARGET_CPU",

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -82,6 +82,7 @@ def _get_tool_paths(repository_ctx, overriden_tools):
             "ar",
             "ld",
             "llvm-cov",
+            "llvm-profdata",
             "cpp",
             "gcc",
             "dwp",
@@ -358,6 +359,14 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
         repository_ctx,
         "llvm-cov",
         "BAZEL_LLVM_COV",
+        overriden_tools,
+        warn = True,
+        silent = True,
+    )
+    overriden_tools["llvm-profdata"] = _find_generic(
+        repository_ctx,
+        "llvm-profdata",
+        "BAZEL_LLVM_PROFDATA",
         overriden_tools,
         warn = True,
         silent = True,

--- a/tools/zip/BUILD.tools
+++ b/tools/zip/BUILD.tools
@@ -7,3 +7,8 @@ filegroup(
         "//conditions:default": glob(["zipper/*"]),
     }),
 )
+
+alias(
+    name = "unzip_fdo",
+    actual = "zipper",
+)


### PR DESCRIPTION
Support using FDO files generated by actions. This is useful for workflows where you want to generate FDO data on remote executors without having to do two separate build steps.

To make FDO work (at least in my configuration) I had to make two additional changes:
* Add an `unzip_fdo` alias to the `tools/zip/BUILD.tools` because it's an implicit dependency of the FDO build action (Fixes #13619).
* Add `llvm-profdata` tool entries to the default toolchains (even though I use a custom toolchain that already has this - it seems every toolchain gets analyzed).

## Example
<details><summary>Click to expand examples</summary>

#### `BUILD`

```starlark
load("@rules_cc//cc:defs.bzl", "cc_binary", "fdo_profile")
load("//rules:fdo.bzl", "fdo_optimized_cc_binary", "generate_fdo_profile")

cc_binary(
    name = "unoptimized_binary",
    srcs = ["fdo.cc"],
)

# Create an FDO profile
generate_fdo_profile(
    name = "fdo.profraw",
    binary = "unoptimized_binary",
)

fdo_profile(
    name = "fdo_profile",
    profile = ":fdo.profraw",
)

# Create an FDO optimized binary
fdo_optimized_cc_binary(
    name = "optimized_binary",
    cc_binary = ":unoptimized_binary",
    fdo_profile = ":fdo_profile",
)
```

#### `fdo.bzl`
```starlark
_FEATURES_LABEL = "//command_line_option:features"
_FDO_OPTIMIZE = "//command_line_option:fdo_optimize"
_FDO_INSTRUMENT_FEATURE = "custom_fdo_instrument"  # Hack to workaround Bazel's builtin output location variable
_FDO_OPTIMIZE_FEATURE = "fdo_optimize"

def _instrument_fdo_impl(settings, attr):
    """Turn on FDO instrumentation."""
    features = list(settings.get(_FEATURES_LABEL, []))

    if _FDO_OPTIMIZE_FEATURE in features:
        features.remove(_FDO_OPTIMIZE_FEATURE)
    if _FDO_INSTRUMENT_FEATURE not in features:
        features.append(_FDO_INSTRUMENT_FEATURE)

    return {
        _FDO_OPTIMIZE: None,
        _FEATURES_LABEL: features,
    }

_instrument_fdo = transition(
    implementation = _instrument_fdo_impl,
    inputs = [_FEATURES_LABEL, _FDO_OPTIMIZE],
    outputs = [_FEATURES_LABEL, _FDO_OPTIMIZE],
)

def _enable_fdo_profile_impl(settings, attr):
    """Use an FDO profile for optimization."""
    features = list(settings.get(_FEATURES_LABEL, []))

    if _FDO_INSTRUMENT_FEATURE in features:
        features.remove(_FDO_INSTRUMENT_FEATURE)
    if _FDO_OPTIMIZE_FEATURE not in features:
        features.append(_FDO_OPTIMIZE_FEATURE)
    return {
        _FEATURES_LABEL: features,
        _FDO_OPTIMIZE: str(attr.fdo_profile),
    }

_enable_fdo_profile = transition(
    implementation = _enable_fdo_profile_impl,
    inputs = [_FEATURES_LABEL],
    outputs = [_FEATURES_LABEL, _FDO_OPTIMIZE],
)

_PROFRAW = ".profraw"

def _generate_fdo_profile_impl(ctx):
    binary = ctx.attr.binary[0]
    profile_name = ctx.attr.name
    if not profile_name.endswith(_PROFRAW):
        profile_name = profile_name + _PROFRAW
    profile = ctx.attr.profile or ctx.actions.declare_file(profile_name)
    ctx.actions.run(
        executable = binary.files_to_run,
        outputs = [profile],
        tools = binary.default_runfiles.files,
        arguments = ctx.attr.arguments or [],
        env = {
            "LLVM_PROFILE_FILE": profile.path,
        },
        input_manifests = None,
    )
    return DefaultInfo(files = depset([profile]), runfiles = ctx.runfiles(files = [profile]))

generate_fdo_profile = rule(
    doc = """Run a binary to get an FDO profile.""",
    implementation = _generate_fdo_profile_impl,
    attrs = {
        "profile": attr.output(),
        "binary": attr.label(executable = True, cfg = _instrument_fdo),
        "arguments": attr.string_list(mandatory = False),
        "_allowlist_function_transition": attr.label(default = "@bazel_tools//tools/allowlists/function_transition_allowlist"),
    },
)

def _optimized_cc_binary_impl(ctx):
    default_info = ctx.attr.cc_binary[0][DefaultInfo]
    executable = ctx.actions.declare_file(ctx.attr.name)
    ctx.actions.symlink(
        output = executable,
        target_file = default_info.files_to_run.executable,
    )
    return DefaultInfo(files = default_info.files, runfiles = default_info.default_runfiles, executable = executable)

fdo_optimized_cc_binary = rule(
    doc = """"Create an FDO optimized `cc_binary`.""",
    implementation = _optimized_cc_binary_impl,
    attrs = {
        "cc_binary": attr.label(executable = True, cfg = _enable_fdo_profile),
        "fdo_profile": attr.label(),
        "_allowlist_function_transition": attr.label(default = "@bazel_tools//tools/allowlists/function_transition_allowlist"),
    },
    executable = True,
)
```
</details>