### PR TITLE
Support .def file on cc_common.link

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcModule.java
@@ -174,6 +174,7 @@ public class BazelCcModule extends CcModule
       Object additionalLinkstampDefines,
       Object onlyForDynamicLibs,
       Object linkerOutputs,
+      Object defFile,
       StarlarkThread thread)
       throws InterruptedException, EvalException {
     return super.link(
@@ -200,6 +201,7 @@ public class BazelCcModule extends CcModule
         additionalLinkstampDefines,
         onlyForDynamicLibs,
         linkerOutputs,
+        defFile,
         thread);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -2156,6 +2156,7 @@ public abstract class CcModule
       Object additionalLinkstampDefines,
       Object onlyForDynamicLibsObject,
       Object linkerOutputsObject,
+      Object defFile,
       StarlarkThread thread)
       throws InterruptedException, EvalException {
     if (checkObjectsBound(
@@ -2243,6 +2244,7 @@ public abstract class CcModule
             .addAdditionalLinkstampDefines(asStringImmutableList(additionalLinkstampDefines))
             .setWillOnlyBeLinkedIntoDynamicLibraries(
                 convertFromNoneable(onlyForDynamicLibsObject, false))
+            .setDefFile(convertFromNoneable(defFile, /* defaultValue= */ null))
             .emitInterfaceSharedLibraries(
                 dynamicLinkTargetType == LinkTargetType.DYNAMIC_LIBRARY
                     && actualFeatureConfiguration.isEnabled(CppRuleClasses.TARGETS_WINDOWS)

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/BazelCcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/BazelCcModuleApi.java
@@ -509,7 +509,17 @@ public interface BazelCcModuleApi<
             positional = false,
             named = true,
             allowedTypes = {@ParamType(type = Sequence.class)},
-            defaultValue = "unbound")
+            defaultValue = "unbound"),
+        @Param(
+            name = "def_file",
+            doc = "Optional .def file path.",
+            positional = false,
+            named = true,
+            defaultValue = "None",
+            allowedTypes = {
+              @ParamType(type = FileApi.class),
+              @ParamType(type = NoneType.class),
+            })
       })
   LinkingOutputsT link(
       StarlarkActionFactoryT starlarkActionFactoryApi,
@@ -535,6 +545,7 @@ public interface BazelCcModuleApi<
       Object additionalLinkstampDefines,
       Object onlyForDynamicLibs,
       Object linkerOutputs,
+      Object defFile,
       StarlarkThread thread)
       throws InterruptedException, EvalException;
 


### PR DESCRIPTION
This allows rules to use the same api and crosstool support as the cc_binary windows_def_file