### PR TITLE
Allow multiple outputs in SpawnLog

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/bazel/execlog/StableSortTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/execlog/StableSortTest.java
@@ -363,4 +363,14 @@ public final class StableSortTest {
     List<SpawnExec> l = testStableSort(ImmutableList.of(f, e, d, c, b, a));
     assertThat(l).containsExactly(d, a, c, b, e, f).inOrder();
   }
+
+  @Test
+  public void stableSort_execsWithDuplicateOutputs() throws Exception {
+    SpawnExec a = createSpawnExec(ImmutableList.of("a"), ImmutableList.of("c"));
+    SpawnExec b = createSpawnExec(ImmutableList.of("b"), ImmutableList.of("c"));
+    SpawnExec c = createSpawnExec(ImmutableList.of("c"), ImmutableList.of("d"));
+
+    List<SpawnExec> l = testStableSort(ImmutableList.of(a, b, c));
+    assertThat(l).containsExactly(a, b, c).inOrder();
+  }
 }


### PR DESCRIPTION
As reported in https://github.com/bazelbuild/bazel/issues/12510 there might be multiple spawns with the same output when flaky tests are executed multiple times.

The fix is to remove the check for presence of duplicate outputs and to extend the sorting algorithm to accept multiple outputs with the same name.