### PR TITLE
Cherrypick request for 4.2.0: cquery inherits from `test` not `build`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java
@@ -46,16 +46,20 @@ import java.util.Set;
 
 /** Handles the 'cquery' command on the Blaze command line. */
 @Command(
-  name = "cquery",
-  builds = true,
-  inherits = {BuildCommand.class},
-  options = {CqueryOptions.class},
-  usesConfigurationOptions = true,
-  shortDescription = "Loads, analyzes, and queries the specified targets w/ configurations.",
-  allowResidue = true,
-  completion = "label",
-  help = "resource:cquery.txt"
-)
+    name = "cquery",
+    builds = true,
+    // We inherit from TestCommand so that we pick up changes like `test --test_arg=foo` in .bazelrc
+    // files.
+    // Without doing this, there is no easy way to use the output of cquery to determine whether a
+    // test has changed between two invocations, because the testrunner action is not easily
+    // introspectable.
+    inherits = {TestCommand.class},
+    options = {CqueryOptions.class},
+    usesConfigurationOptions = true,
+    shortDescription = "Loads, analyzes, and queries the specified targets w/ configurations.",
+    allowResidue = true,
+    completion = "label",
+    help = "resource:cquery.txt")
 public final class CqueryCommand implements BlazeCommand {
 
   @Override

--- a/src/test/shell/integration/configured_query_test.sh
+++ b/src/test/shell/integration/configured_query_test.sh
@@ -1232,4 +1232,27 @@ EOF
   assert_equals $? 1
 }
 
+function test_test_arg_in_bazelrc() {
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg
+
+  cat >$pkg/BUILD <<EOF
+sh_test(
+    name = "test",
+    srcs = ["test.sh"],
+)
+EOF
+
+  touch $pkg/test.sh
+  chmod +x $pkg/test.sh
+
+  output_before="$(bazel cquery "//$pkg:test")"
+
+  add_to_bazelrc "test --test_arg=foo"
+
+  output_after="$(bazel cquery "//$pkg:test")"
+
+  assert_not_equals "${output_before}" "${output_after}"
+}
+
 run_suite "${PRODUCT_NAME} configured query tests"


### PR DESCRIPTION
Cherrypick request for 4.2.0 (#13558).

This makes directives like `test --test_arg=foo` present in `.bazelrc` files be
factored into the configuration hash for test targets.

See https://github.com/bazelbuild/bazel/issues/13428 for extensive
context.

Closes #13491.

PiperOrigin-RevId: 382143334


## Justification
Currently some systems using `cquery` to perform test selection for CI under-triggers, this commit fixes that.

## Original commits
20aff82091125f1d8dced5aa36069ef5ae730878