### PR TITLE
avoid "too many open files" when copying from remote cache to local cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
@@ -55,6 +55,7 @@ import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.remote.RemoteCache.ActionResultMetadata.DirectoryMetadata;
 import com.google.devtools.build.lib.remote.RemoteCache.ActionResultMetadata.FileMetadata;
 import com.google.devtools.build.lib.remote.RemoteCache.ActionResultMetadata.SymlinkMetadata;
+import com.google.devtools.build.lib.remote.common.LazyFileOutputStream;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteActionFileArtifactValue;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
@@ -1026,57 +1027,6 @@ public class RemoteCache implements AutoCloseable {
         .setMessage(message)
         .setRemoteExecution(RemoteExecution.newBuilder().setCode(detailedCode))
         .build();
-  }
-
-  /**
-   * Creates an {@link OutputStream} that isn't actually opened until the first data is written.
-   * This is useful to only have as many open file descriptors as necessary at a time to avoid
-   * running into system limits.
-   */
-  private static class LazyFileOutputStream extends OutputStream {
-
-    private final Path path;
-    private OutputStream out;
-
-    public LazyFileOutputStream(Path path) {
-      this.path = path;
-    }
-
-    @Override
-    public void write(byte[] b) throws IOException {
-      ensureOpen();
-      out.write(b);
-    }
-
-    @Override
-    public void write(byte[] b, int off, int len) throws IOException {
-      ensureOpen();
-      out.write(b, off, len);
-    }
-
-    @Override
-    public void write(int b) throws IOException {
-      ensureOpen();
-      out.write(b);
-    }
-
-    @Override
-    public void flush() throws IOException {
-      ensureOpen();
-      out.flush();
-    }
-
-    @Override
-    public void close() throws IOException {
-      ensureOpen();
-      out.close();
-    }
-
-    private void ensureOpen() throws IOException {
-      if (out == null) {
-        out = path.getOutputStream();
-      }
-    }
   }
 
   /** In-memory representation of action result metadata. */

--- a/src/main/java/com/google/devtools/build/lib/remote/common/LazyFileOutputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/LazyFileOutputStream.java
@@ -1,0 +1,69 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.common;
+
+import com.google.devtools.build.lib.vfs.Path;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Creates an {@link OutputStream} that isn't actually opened until the first data is written.
+ * This is useful to only have as many open file descriptors as necessary at a time to avoid
+ * running into system limits.
+ */
+public class LazyFileOutputStream extends OutputStream {
+
+  private final Path path;
+  private OutputStream out;
+
+  public LazyFileOutputStream(Path path) {
+    this.path = path;
+  }
+
+  @Override
+  public void write(byte[] b) throws IOException {
+    ensureOpen();
+    out.write(b);
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    ensureOpen();
+    out.write(b, off, len);
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    ensureOpen();
+    out.write(b);
+  }
+
+  @Override
+  public void flush() throws IOException {
+    ensureOpen();
+    out.flush();
+  }
+
+  @Override
+  public void close() throws IOException {
+    ensureOpen();
+    out.close();
+  }
+
+  private void ensureOpen() throws IOException {
+    if (out == null) {
+      out = path.getOutputStream();
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.devtools.build.lib.remote.common.LazyFileOutputStream;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -142,11 +143,7 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
 
     Path tempPath = newTempPath();
     final OutputStream tempOut;
-    try {
-      tempOut = tempPath.getOutputStream();
-    } catch (IOException e) {
-      return Futures.immediateFailedFuture(e);
-    }
+    tempOut = new LazyFileOutputStream(tempPath);
 
     if (!options.incompatibleRemoteResultsIgnoreDisk || options.remoteAcceptCached) {
       ListenableFuture<Void> download =


### PR DESCRIPTION
If you fetch a build result from the remote cache and use a local disk cache at the same time, Bazel copies the remote cache entry to the local disk cache. Some strange work loads (probably triggered by build steps with > 1k output files) trigger
the error "too many open files".

This is a cherry-pick of the original commit 5d7df56b88.

##### Fix
Re-use the existing class `LazyFileOutputStream` in `DiskAndRemoteCacheClient.java`

##### Work-Around on Linux
 increase `DefaultLimitNOFILE` in `/etc/systemd/system.conf` and reboot

Resolves https://github.com/bazelbuild/bazel/issues/13435