### PR TITLE
Remove superfluous exception declarations from Java runfiles library

### DIFF
--- a/tools/java/runfiles/Runfiles.java
+++ b/tools/java/runfiles/Runfiles.java
@@ -247,7 +247,7 @@ public abstract class Runfiles {
   private static final class DirectoryBased extends Runfiles {
     private final String runfilesRoot;
 
-    DirectoryBased(String runfilesDir) throws IOException {
+    DirectoryBased(String runfilesDir) {
       Util.checkArgument(!Util.isNullOrEmpty(runfilesDir));
       Util.checkArgument(new File(runfilesDir).isDirectory());
       this.runfilesRoot = runfilesDir;
@@ -272,7 +272,7 @@ public abstract class Runfiles {
     return new ManifestBased(manifestPath);
   }
 
-  static Runfiles createDirectoryBasedForTesting(String runfilesDir) throws IOException {
+  static Runfiles createDirectoryBasedForTesting(String runfilesDir) {
     return new DirectoryBased(runfilesDir);
   }
 }

--- a/tools/java/runfiles/testing/RunfilesTest.java
+++ b/tools/java/runfiles/testing/RunfilesTest.java
@@ -40,8 +40,7 @@ public final class RunfilesTest {
     return File.separatorChar == '\\';
   }
 
-  private void assertRlocationArg(Runfiles runfiles, String path, @Nullable String error)
-      throws Exception {
+  private void assertRlocationArg(Runfiles runfiles, String path, @Nullable String error) {
     IllegalArgumentException e =
         assertThrows(IllegalArgumentException.class, () -> runfiles.rlocation(path));
     if (error != null) {
@@ -153,7 +152,7 @@ public final class RunfilesTest {
   }
 
   @Test
-  public void testFailsToCreateManifestBasedBecauseManifestDoesNotExist() throws Exception {
+  public void testFailsToCreateManifestBasedBecauseManifestDoesNotExist() {
     IOException e =
         assertThrows(
             IOException.class,
@@ -233,7 +232,7 @@ public final class RunfilesTest {
   }
 
   @Test
-  public void testDirectoryBasedRlocation() throws Exception {
+  public void testDirectoryBasedRlocation() {
     // The DirectoryBased implementation simply joins the runfiles directory and the runfile's path
     // on a "/". DirectoryBased does not perform any normalization, nor does it check that the path
     // exists.
@@ -259,7 +258,7 @@ public final class RunfilesTest {
   }
 
   @Test
-  public void testDirectoryBasedCtorArgumentValidation() throws Exception {
+  public void testDirectoryBasedCtorArgumentValidation() {
     assertThrows(
         IllegalArgumentException.class, () -> Runfiles.createDirectoryBasedForTesting(null));
 

--- a/tools/java/runfiles/testing/UtilTest.java
+++ b/tools/java/runfiles/testing/UtilTest.java
@@ -26,7 +26,7 @@ import org.junit.runners.JUnit4;
 public final class UtilTest {
 
   @Test
-  public void testIsNullOrEmpty() throws Exception {
+  public void testIsNullOrEmpty() {
     assertThat(Util.isNullOrEmpty(null)).isTrue();
     assertThat(Util.isNullOrEmpty("")).isTrue();
     assertThat(Util.isNullOrEmpty("\0")).isFalse();
@@ -34,7 +34,7 @@ public final class UtilTest {
   }
 
   @Test
-  public void testCheckArgument() throws Exception {
+  public void testCheckArgument() {
     Util.checkArgument(true, null, null);
 
     IllegalArgumentException e =


### PR DESCRIPTION
These were found using error-prones's [CheckedExceptionNotThrown](
https://errorprone.info/bugpattern/CheckedExceptionNotThrown).