### PR TITLE
Cherrypick for 4.2.0 Add the TEMP_FAILURE_RETRY macro to linux-sandbox-pid1.cc.

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -49,6 +49,19 @@
 #include <linux/fs.h>
 #endif
 
+#ifndef TEMP_FAILURE_RETRY
+// Some C standard libraries like musl do not define this macro, so we'll
+// include our own version for compatibility.
+#define TEMP_FAILURE_RETRY(exp)            \
+  ({                                       \
+    decltype(exp) _rc;                     \
+    do {                                   \
+      _rc = (exp);                         \
+    } while (_rc == -1 && errno == EINTR); \
+    _rc;                                   \
+  })
+#endif  // TEMP_FAILURE_RETRY
+
 #include "src/main/tools/linux-sandbox-options.h"
 #include "src/main/tools/linux-sandbox.h"
 #include "src/main/tools/logging.h"


### PR DESCRIPTION
Cherrypick request for 4.2.0 (#13558).

This allows us to build Bazel on Linux systems which use a C standard library that does not include this macro, like Alpine Linux (which uses musl).

Fixes #12460.

PiperOrigin-RevId: 374873483

**Original Commit:**

https://github.com/bazelbuild/bazel/commit/bcce6dd026e90336e80616a8c1004a79a2f8640c