### PR TITLE
[Cherrypick 4.2.0] Change MIN_BUILD_TOOLS_REVISION to 30.0.0

### DIFF
--- a/site/docs/tutorial/android-app.md
+++ b/site/docs/tutorial/android-app.md
@@ -155,7 +155,7 @@ android_sdk_repository(
     name = "androidsdk",
     path = "/path/to/Android/sdk",
     api_level = 25,
-    build_tools_version = "26.0.1"
+    build_tools_version = "30.0.3"
 )
 ```
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
@@ -158,7 +158,7 @@ public class AndroidSdkRepositoryFunction extends AndroidRepositoryFunction {
   private static final PathFragment BUILD_TOOLS_DIR = PathFragment.create("build-tools");
   private static final PathFragment PLATFORMS_DIR = PathFragment.create("platforms");
   private static final PathFragment SYSTEM_IMAGES_DIR = PathFragment.create("system-images");
-  private static final AndroidRevision MIN_BUILD_TOOLS_REVISION = AndroidRevision.parse("26.0.1");
+  private static final AndroidRevision MIN_BUILD_TOOLS_REVISION = AndroidRevision.parse("30.0.0");
   private static final String PATH_ENV_VAR = "ANDROID_HOME";
   private static final ImmutableList<String> PATH_ENV_VAR_AS_LIST = ImmutableList.of(PATH_ENV_VAR);
   private static final ImmutableList<String> LOCAL_MAVEN_REPOSITORIES =

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryRule.java
@@ -72,7 +72,7 @@ public class AndroidSdkRepositoryRule implements RuleDefinition {
         The version of the Android build tools to use from within the Android SDK. If not specified,
         the latest build tools version installed will be used.
 
-        <p>Bazel requires build tools version 26.0.1 or later.
+        <p>Bazel requires build tools version 30.0.0 or later.
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("build_tools_version", STRING).nonconfigurable("WORKSPACE rule"))
         /* <!-- #BLAZE_RULE(android_sdk_repository).ATTRIBUTE(api_level) -->


### PR DESCRIPTION
Cherrypick request for 4.2.0 (#13558).

This was originally https://github.com/bazelbuild/bazel/commit/0e652737988e3c115e98e1552f6fada52bc2b9a2
This is a complement to https://github.com/bazelbuild/bazel/pull/13702 ensuring we give a useful error if the project is using a version of the android sdk tools that's not up-to-date enough.

Bazel's Android tools requires Android Build Tools 30.0.0 or newer.

See https://github.com/bazelbuild/bazel/issues/13409

RELNOTES: The minimum Android build tools version for the Android rules is now 30.0.0
PiperOrigin-RevId: 378014192