### PR TITLE
Cherrypick for 4.2.0: Fix stripping of macOS loadable bundles

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
@@ -1074,6 +1074,9 @@ public class CompilationSupport {
     if (Iterables.contains(extraLinkArgs, "-dynamiclib")) {
       return StrippingType.DYNAMIC_LIB;
     }
+    if (Iterables.contains(extraLinkArgs, "-bundle")) {
+      return StrippingType.LOADABLE_BUNDLE;
+    }
     if (Iterables.contains(extraLinkArgs, "-kext")) {
       return StrippingType.KERNEL_EXTENSION;
     }
@@ -1544,6 +1547,7 @@ public class CompilationSupport {
   private enum StrippingType {
     DEFAULT,
     DYNAMIC_LIB,
+    LOADABLE_BUNDLE,
     KERNEL_EXTENSION
   }
 
@@ -1555,8 +1559,9 @@ public class CompilationSupport {
     final ImmutableList<String> stripArgs;
     switch (strippingType) {
       case DYNAMIC_LIB:
+      case LOADABLE_BUNDLE:
       case KERNEL_EXTENSION:
-        // For dylibs and kexts, must strip only local symbols.
+        // For dylibs, loadable bundles, and kexts, must strip only local symbols.
         stripArgs = ImmutableList.of("-x");
         break;
       case DEFAULT:


### PR DESCRIPTION
Cherrypick of https://github.com/bazelbuild/bazel/commit/1a0285c3b64b121268ced3eb9ad9d5ba396b4905 for 4.2.0 (#13558).

Without this bug fix, building stripped macOS loadable bundles fails--simply fixing a case that had been neglected.

Original commit message below:
----

Adds `-x` flag to stripping of macOS loadable bundles.

Loadable bundles--i.e. truly dynamically loadable libraries on macOS--cannot be stripped without this flag, since you'd be trying to strip away the all symbols, including those used for dynamic loading. Doing so results in `error: symbols referenced by indirect symbol table entries that can't be stripped`.

`-x` instead leads to the removal of the unneeded local symbols. As Apple notes in their man page: "For dynamic shared libraries, the maximum level of stripping is usually -x (to remove all non-global symbols)."

This should fix #11869

Closes #13314.

PiperOrigin-RevId: 368841977