### PR TITLE
[cherrypick request for 4.2.0] fix crash on empty virtual actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -91,6 +91,9 @@ public class SpawnLogContext implements ActionContext {
     try {
       for (Map.Entry<PathFragment, ActionInput> e : inputMap.entrySet()) {
         ActionInput input = e.getValue();
+        if (input instanceof VirtualActionInput.EmptyActionInput) {
+          continue;
+        }
         Path inputPath = execRoot.getRelative(input.getExecPathString());
         if (inputPath.isDirectory()) {
           listDirectoryContents(inputPath, builder::addInputs, metadataProvider);

--- a/src/test/shell/bazel/bazel_execlog_test.sh
+++ b/src/test/shell/bazel/bazel_execlog_test.sh
@@ -119,6 +119,26 @@ EOF
   wc output || fail "no output produced"
 }
 
+function test_empty_file_in_runfiles() {
+  mkdir d
+  touch d/main.py
+  cat > BUILD <<'EOF'
+py_binary(
+    name = "py_tool",
+    main = "d/main.py",
+    srcs = ["d/main.py"],
+)
+genrule(
+    name = "rule",
+    outs = ["out.txt"],
+    tools = [":py_tool"],
+    cmd = "echo hello > $(location out.txt)"
+)
+EOF
+  bazel build //:rule --experimental_execution_log_file output 2>&1 >> $TEST_log || fail "could not build"
+  [[ -e output ]] || fail "no output produced"
+}
+
 function test_negating_flags() {
   cat > BUILD <<'EOF'
 genrule(


### PR DESCRIPTION
Cherrypick request for 4.2.0 (#13558).

Fixes #13711 (which is a dupe of #12816).

Original commit:
- 7c92cfcf9a88933c29334f6271ad3f086f7f36f4

------

Fixes https://github.com/bazelbuild/bazel/issues/12816.

Closes #12819.

PiperOrigin-RevId: 355800567
(cherry picked from commit 7c92cfcf9a88933c29334f6271ad3f086f7f36f4)