### PR TITLE
Link referenced Dockerfile in the /scripts/README.md

### DIFF
--- a/scripts/docs/README.md
+++ b/scripts/docs/README.md
@@ -1,4 +1,4 @@
 This directory contains files required to build Bazel's website.
 
 The website is built using Jekyll running inside a Docker container.
-See the `Dockerfile` for instructions how to test this on your local machine.
+See the [`Dockerfile`](https://github.com/bazelbuild/bazel/blob/master/scripts/docs/Dockerfile) for instructions how to test this on your local machine.


### PR DESCRIPTION
I linked the Dockerfile that the README.md in /scripts/ was referencing.