### PR TITLE
Export Android tools in android sdk rule

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
@@ -80,4 +80,7 @@ create_system_images_filegroups(
 )
 
 exports_files([
+    'tools/bin/apkanalyzer',
+    'tools/bin/avdmanager',
+    'tools/emulator',
 %exported_files%] + glob(["system-images/**"], allow_empty = True))


### PR DESCRIPTION
We saw an issue similar to https://github.com/bazelbuild/bazel/issues/10077 and we need to export some android tools from sdk rules to be able to access them in our bazel rule