### PR TITLE
Allow sandboxed macOS actions to run /bin/ps

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
@@ -340,6 +340,7 @@ final class DarwinSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
       out.println("(version 1)");
       out.println("(debug deny)");
       out.println("(allow default)");
+      out.println("(allow process-exec (with no-sandbox) (literal \"/bin/ps\"))");
 
       if (!allowNetwork) {
         out.println("(deny network*)");


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/7448

On Apple Silicon (maybe not exclusively) using rules_foreign_cc without
this you end up seeing many `/bin/ps` failures when configure scripts
are running.