### PR TITLE
 [Cherrypick request 4.2.0] Cherrypicks for Android rules for Bazel 4.2.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -156,7 +156,7 @@ distdir_tar(
         "1.25.0.zip",
         # rules_nodejs
         "rules_nodejs-2.2.2.tar.gz",
-        "android_tools_pkg-0.21.0.tar.gz",
+        "android_tools_pkg-0.23.0.tar.gz",
         # bazelbuild/bazel-skylib
         "bazel-skylib-1.0.3.tar.gz",
         # bazelbuild/platforms
@@ -197,7 +197,7 @@ distdir_tar(
         "1.25.0.zip": "c78be58f5e0a29a04686b628cf54faaee0094322ae0ac99da5a8a8afca59a647",
         # rules_nodejs
         "rules_nodejs-2.2.2.tar.gz": "f2194102720e662dbf193546585d705e645314319554c6ce7e47d8b59f459e9c",
-        "android_tools_pkg-0.21.0.tar.gz": "a4a17c811de5ca0df81b93ccc34e4b8494da9176bda4c85512083c2172494190",
+        "android_tools_pkg-0.23.0.tar.gz": "ed5290594244c2eeab41f0104519bcef51e27c699ff4b379fcbd25215270513e",
         # bazelbuild/bazel-skylib
         "bazel-skylib-1.0.3.tar.gz": "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
         # bazelbuild/platforms
@@ -254,8 +254,8 @@ distdir_tar(
             "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/releases/download/2.2.2/rules_nodejs-2.2.2.tar.gz",
             "https://github.com/bazelbuild/rules_nodejs/releases/download/2.2.2/rules_nodejs-2.2.2.tar.gz",
         ],
-        "android_tools_pkg-0.21.0.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.21.0.tar.gz",
+        "android_tools_pkg-0.23.0.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.23.0.tar.gz",
         ],
         # bazelbuild/bazel-skylib
         "bazel-skylib-1.0.3.tar.gz": [
@@ -578,7 +578,7 @@ distdir_tar(
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz",
         "zulu11.45.27-ca-jdk11.0.10-macosx_aarch64.tar.gz",
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip",
-        "android_tools_pkg-0.21.0.tar.gz",
+        "android_tools_pkg-0.23.0.tar.gz",
         # bazelbuild/bazel-skylib
         "bazel-skylib-1.0.3.tar.gz",
         # bazelbuild/platforms
@@ -613,7 +613,7 @@ distdir_tar(
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz": "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",
         "zulu11.45.27-ca-jdk11.0.10-macosx_aarch64.tar.gz": "3dcc636e64ae58b922269c2dc9f20f6f967bee90e3f6847d643c4a566f1e8d8a",
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip": "a9695617b8374bfa171f166951214965b1d1d08f43218db9a2a780b71c665c18",
-        "android_tools_pkg-0.21.0.tar.gz": "a4a17c811de5ca0df81b93ccc34e4b8494da9176bda4c85512083c2172494190",
+        "android_tools_pkg-0.23.0.tar.gz": "ed5290594244c2eeab41f0104519bcef51e27c699ff4b379fcbd25215270513e",
         # bazelbuild/bazel-skylib
         "bazel-skylib-1.0.3.tar.gz": "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
         # bazelbuild/platforms
@@ -647,8 +647,8 @@ distdir_tar(
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz"],
         "zulu11.45.27-ca-jdk11.0.10-macosx_aarch64.tar.gz": ["https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.45.27-ca-jdk11.0.10-macosx_aarch64.tar.gz"],
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64.zip"],
-        "android_tools_pkg-0.21.0.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.21.0.tar.gz",
+        "android_tools_pkg-0.23.0.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.23.0.tar.gz",
         ],
         # bazelbuild/bazel-skylib
         "bazel-skylib-1.0.3.tar.gz": [
@@ -778,8 +778,8 @@ http_archive(
     name = "android_tools_for_testing",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "a4a17c811de5ca0df81b93ccc34e4b8494da9176bda4c85512083c2172494190",  # DO_NOT_REMOVE_THIS_ANDROID_TOOLS_UPDATE_MARKER
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.21.0.tar.gz",
+    sha256 = "ed5290594244c2eeab41f0104519bcef51e27c699ff4b379fcbd25215270513e",  # DO_NOT_REMOVE_THIS_ANDROID_TOOLS_UPDATE_MARKER
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.23.0.tar.gz",
 )
 
 # This must be kept in sync with src/main/java/com/google/devtools/build/lib/bazel/rules/coverage.WORKSPACE.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -156,7 +156,7 @@ distdir_tar(
         "1.25.0.zip",
         # rules_nodejs
         "rules_nodejs-2.2.2.tar.gz",
-        "android_tools_pkg-0.19.0rc3.tar.gz",
+        "android_tools_pkg-0.21.0.tar.gz",
         # bazelbuild/bazel-skylib
         "bazel-skylib-1.0.3.tar.gz",
         # bazelbuild/platforms
@@ -197,7 +197,7 @@ distdir_tar(
         "1.25.0.zip": "c78be58f5e0a29a04686b628cf54faaee0094322ae0ac99da5a8a8afca59a647",
         # rules_nodejs
         "rules_nodejs-2.2.2.tar.gz": "f2194102720e662dbf193546585d705e645314319554c6ce7e47d8b59f459e9c",
-        "android_tools_pkg-0.19.0rc3.tar.gz": "ea5c0589a01e2a9f43c20e5c145d3530e3b3bdbe7322789bc5da38d0ca49b837",
+        "android_tools_pkg-0.21.0.tar.gz": "a4a17c811de5ca0df81b93ccc34e4b8494da9176bda4c85512083c2172494190",
         # bazelbuild/bazel-skylib
         "bazel-skylib-1.0.3.tar.gz": "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
         # bazelbuild/platforms
@@ -254,8 +254,8 @@ distdir_tar(
             "https://mirror.bazel.build/github.com/bazelbuild/rules_nodejs/releases/download/2.2.2/rules_nodejs-2.2.2.tar.gz",
             "https://github.com/bazelbuild/rules_nodejs/releases/download/2.2.2/rules_nodejs-2.2.2.tar.gz",
         ],
-        "android_tools_pkg-0.19.0rc3.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc3.tar.gz",
+        "android_tools_pkg-0.21.0.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.21.0.tar.gz",
         ],
         # bazelbuild/bazel-skylib
         "bazel-skylib-1.0.3.tar.gz": [
@@ -578,7 +578,7 @@ distdir_tar(
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz",
         "zulu11.45.27-ca-jdk11.0.10-macosx_aarch64.tar.gz",
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip",
-        "android_tools_pkg-0.19.0rc3.tar.gz",
+        "android_tools_pkg-0.21.0.tar.gz",
         # bazelbuild/bazel-skylib
         "bazel-skylib-1.0.3.tar.gz",
         # bazelbuild/platforms
@@ -613,7 +613,7 @@ distdir_tar(
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz": "e1fe56769f32e2aaac95e0a8f86b5a323da5af3a3b4bba73f3086391a6cc056f",
         "zulu11.45.27-ca-jdk11.0.10-macosx_aarch64.tar.gz": "3dcc636e64ae58b922269c2dc9f20f6f967bee90e3f6847d643c4a566f1e8d8a",
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip": "a9695617b8374bfa171f166951214965b1d1d08f43218db9a2a780b71c665c18",
-        "android_tools_pkg-0.19.0rc3.tar.gz": "ea5c0589a01e2a9f43c20e5c145d3530e3b3bdbe7322789bc5da38d0ca49b837",
+        "android_tools_pkg-0.21.0.tar.gz": "a4a17c811de5ca0df81b93ccc34e4b8494da9176bda4c85512083c2172494190",
         # bazelbuild/bazel-skylib
         "bazel-skylib-1.0.3.tar.gz": "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
         # bazelbuild/platforms
@@ -647,8 +647,8 @@ distdir_tar(
         "zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-macosx_x64.tar.gz"],
         "zulu11.45.27-ca-jdk11.0.10-macosx_aarch64.tar.gz": ["https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.45.27-ca-jdk11.0.10-macosx_aarch64.tar.gz"],
         "zulu11.37.17-ca-jdk11.0.6-win_x64.zip": ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64.zip"],
-        "android_tools_pkg-0.19.0rc3.tar.gz": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc3.tar.gz",
+        "android_tools_pkg-0.21.0.tar.gz": [
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.21.0.tar.gz",
         ],
         # bazelbuild/bazel-skylib
         "bazel-skylib-1.0.3.tar.gz": [
@@ -778,8 +778,8 @@ http_archive(
     name = "android_tools_for_testing",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
-    sha256 = "ea5c0589a01e2a9f43c20e5c145d3530e3b3bdbe7322789bc5da38d0ca49b837",  # DO_NOT_REMOVE_THIS_ANDROID_TOOLS_UPDATE_MARKER
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc3.tar.gz",
+    sha256 = "a4a17c811de5ca0df81b93ccc34e4b8494da9176bda4c85512083c2172494190",  # DO_NOT_REMOVE_THIS_ANDROID_TOOLS_UPDATE_MARKER
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.21.0.tar.gz",
 )
 
 # This must be kept in sync with src/main/java/com/google/devtools/build/lib/bazel/rules/coverage.WORKSPACE.

--- a/site/docs/tutorial/android-app.md
+++ b/site/docs/tutorial/android-app.md
@@ -155,7 +155,7 @@ android_sdk_repository(
     name = "androidsdk",
     path = "/path/to/Android/sdk",
     api_level = 25,
-    build_tools_version = "26.0.1"
+    build_tools_version = "30.0.3"
 )
 ```
 

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryFunction.java
@@ -158,7 +158,7 @@ public class AndroidSdkRepositoryFunction extends AndroidRepositoryFunction {
   private static final PathFragment BUILD_TOOLS_DIR = PathFragment.create("build-tools");
   private static final PathFragment PLATFORMS_DIR = PathFragment.create("platforms");
   private static final PathFragment SYSTEM_IMAGES_DIR = PathFragment.create("system-images");
-  private static final AndroidRevision MIN_BUILD_TOOLS_REVISION = AndroidRevision.parse("26.0.1");
+  private static final AndroidRevision MIN_BUILD_TOOLS_REVISION = AndroidRevision.parse("30.0.0");
   private static final String PATH_ENV_VAR = "ANDROID_HOME";
   private static final ImmutableList<String> PATH_ENV_VAR_AS_LIST = ImmutableList.of(PATH_ENV_VAR);
   private static final ImmutableList<String> LOCAL_MAVEN_REPOSITORIES =

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidSdkRepositoryRule.java
@@ -72,7 +72,7 @@ public class AndroidSdkRepositoryRule implements RuleDefinition {
         The version of the Android build tools to use from within the Android SDK. If not specified,
         the latest build tools version installed will be used.
 
-        <p>Bazel requires build tools version 26.0.1 or later.
+        <p>Bazel requires build tools version 30.0.0 or later.
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("build_tools_version", STRING).nonconfigurable("WORKSPACE rule"))
         /* <!-- #BLAZE_RULE(android_sdk_repository).ATTRIBUTE(api_level) -->

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -3,6 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "android_tools",
-    sha256 = "ea5c0589a01e2a9f43c20e5c145d3530e3b3bdbe7322789bc5da38d0ca49b837",
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.19.0rc3.tar.gz",
+    sha256 = "a4a17c811de5ca0df81b93ccc34e4b8494da9176bda4c85512083c2172494190",
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.21.0.tar.gz",
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_remote_tools.WORKSPACE
@@ -3,6 +3,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # This must be kept in sync with the top-level WORKSPACE file.
 http_archive(
     name = "android_tools",
-    sha256 = "a4a17c811de5ca0df81b93ccc34e4b8494da9176bda4c85512083c2172494190",
-    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.21.0.tar.gz",
+    sha256 = "ed5290594244c2eeab41f0104519bcef51e27c699ff4b379fcbd25215270513e",
+    url = "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.23.0.tar.gz",
 )

--- a/tools/android/BUILD.tools
+++ b/tools/android/BUILD.tools
@@ -208,14 +208,15 @@ genrule(
         --noemit_dependency_metadata_as_needed \
         --nodesugar_try_with_resources_if_needed \
         --desugar_supported_core_libs \
+        --rewrite_core_library_prefix java/time/ \
         --rewrite_core_library_prefix java/lang/Double8 \
         --rewrite_core_library_prefix java/lang/Integer8 \
         --rewrite_core_library_prefix java/lang/Long8 \
         --rewrite_core_library_prefix java/lang/Math8 \
-        --rewrite_core_library_prefix java/time/ \
+        --rewrite_core_library_prefix java/io/Desugar \
+        --rewrite_core_library_prefix java/io/UncheckedIOException \
         --rewrite_core_library_prefix java/util/stream/ \
         --rewrite_core_library_prefix java/util/function/ \
-        --rewrite_core_library_prefix java/util/Comparators \
         --rewrite_core_library_prefix java/util/Desugar \
         --rewrite_core_library_prefix java/util/DoubleSummaryStatistics \
         --rewrite_core_library_prefix java/util/IntSummaryStatistics \
@@ -223,15 +224,13 @@ genrule(
         --rewrite_core_library_prefix java/util/Objects \
         --rewrite_core_library_prefix java/util/Optional \
         --rewrite_core_library_prefix java/util/PrimitiveIterator \
-        --rewrite_core_library_prefix java/util/SortedSet\\$$1 \
         --rewrite_core_library_prefix java/util/Spliterator \
         --rewrite_core_library_prefix java/util/StringJoiner \
-        --rewrite_core_library_prefix java/util/Tripwire \
+        --rewrite_core_library_prefix javadesugar/testing/ \
         --rewrite_core_library_prefix java/util/concurrent/ConcurrentHashMap \
-        --rewrite_core_library_prefix java/util/concurrent/DesugarUnsafe \
         --rewrite_core_library_prefix java/util/concurrent/ThreadLocalRandom \
         --rewrite_core_library_prefix java/util/concurrent/atomic/DesugarAtomic \
-        --retarget_core_library_member "java/util/LinkedHashSet#spliterator->java/util/DesugarLinkedHashSet" \
+        --auto_desugar_shadowed_api_use \
         --emulate_core_library_interface java/util/Collection \
         --emulate_core_library_interface java/util/Map \
         --emulate_core_library_interface java/util/Map\\$$Entry \

--- a/tools/android/desugar.sh
+++ b/tools/android/desugar.sh
@@ -59,6 +59,8 @@ readonly DESUGAR_JAVA8_LIBS_CONFIG=(--rewrite_core_library_prefix java/time/ \
     --rewrite_core_library_prefix java/lang/Integer8 \
     --rewrite_core_library_prefix java/lang/Long8 \
     --rewrite_core_library_prefix java/lang/Math8 \
+    --rewrite_core_library_prefix java/io/Desugar \
+    --rewrite_core_library_prefix java/io/UncheckedIOException \
     --rewrite_core_library_prefix java/util/stream/ \
     --rewrite_core_library_prefix java/util/function/ \
     --rewrite_core_library_prefix java/util/Desugar \
@@ -70,45 +72,17 @@ readonly DESUGAR_JAVA8_LIBS_CONFIG=(--rewrite_core_library_prefix java/time/ \
     --rewrite_core_library_prefix java/util/PrimitiveIterator \
     --rewrite_core_library_prefix java/util/Spliterator \
     --rewrite_core_library_prefix java/util/StringJoiner \
+    --rewrite_core_library_prefix javadesugar/testing/ \
     --rewrite_core_library_prefix java/util/concurrent/ConcurrentHashMap \
     --rewrite_core_library_prefix java/util/concurrent/ThreadLocalRandom \
     --rewrite_core_library_prefix java/util/concurrent/atomic/DesugarAtomic \
-    --retarget_core_library_member "java/lang/Double#max->java/lang/Double8" \
-    --retarget_core_library_member "java/lang/Double#min->java/lang/Double8" \
-    --retarget_core_library_member "java/lang/Double#sum->java/lang/Double8" \
-    --retarget_core_library_member "java/lang/Integer#max->java/lang/Integer8" \
-    --retarget_core_library_member "java/lang/Integer#min->java/lang/Integer8" \
-    --retarget_core_library_member "java/lang/Integer#sum->java/lang/Integer8" \
-    --retarget_core_library_member "java/lang/Long#max->java/lang/Long8" \
-    --retarget_core_library_member "java/lang/Long#min->java/lang/Long8" \
-    --retarget_core_library_member "java/lang/Long#sum->java/lang/Long8" \
-    --retarget_core_library_member "java/lang/Math#toIntExact->java/lang/Math8" \
-    --retarget_core_library_member "java/util/Arrays#stream->java/util/DesugarArrays" \
-    --retarget_core_library_member "java/util/Arrays#spliterator->java/util/DesugarArrays" \
-    --retarget_core_library_member "java/util/Calendar#toInstant->java/util/DesugarCalendar" \
-    --retarget_core_library_member "java/util/Date#from->java/util/DesugarDate" \
-    --retarget_core_library_member "java/util/Date#toInstant->java/util/DesugarDate" \
-    --retarget_core_library_member "java/util/GregorianCalendar#from->java/util/DesugarGregorianCalendar" \
-    --retarget_core_library_member "java/util/GregorianCalendar#toZonedDateTime->java/util/DesugarGregorianCalendar" \
-    --retarget_core_library_member "java/util/LinkedHashSet#spliterator->java/util/DesugarLinkedHashSet" \
-    --retarget_core_library_member "java/util/concurrent/atomic/AtomicInteger#getAndUpdate->java/util/concurrent/atomic/DesugarAtomicInteger" \
-    --retarget_core_library_member "java/util/concurrent/atomic/AtomicInteger#updateAndGet->java/util/concurrent/atomic/DesugarAtomicInteger" \
-    --retarget_core_library_member "java/util/concurrent/atomic/AtomicInteger#getAndAccumulate->java/util/concurrent/atomic/DesugarAtomicInteger" \
-    --retarget_core_library_member "java/util/concurrent/atomic/AtomicInteger#accumulateAndGet->java/util/concurrent/atomic/DesugarAtomicInteger" \
-    --retarget_core_library_member "java/util/concurrent/atomic/AtomicLong#getAndUpdate->java/util/concurrent/atomic/DesugarAtomicLong" \
-    --retarget_core_library_member "java/util/concurrent/atomic/AtomicLong#updateAndGet->java/util/concurrent/atomic/DesugarAtomicLong" \
-    --retarget_core_library_member "java/util/concurrent/atomic/AtomicLong#getAndAccumulate->java/util/concurrent/atomic/DesugarAtomicLong" \
-    --retarget_core_library_member "java/util/concurrent/atomic/AtomicLong#accumulateAndGet->java/util/concurrent/atomic/DesugarAtomicLong" \
-    --retarget_core_library_member "java/util/concurrent/atomic/AtomicReference#getAndUpdate->java/util/concurrent/atomic/DesugarAtomicReference" \
-    --retarget_core_library_member "java/util/concurrent/atomic/AtomicReference#updateAndGet->java/util/concurrent/atomic/DesugarAtomicReference" \
-    --retarget_core_library_member "java/util/concurrent/atomic/AtomicReference#getAndAccumulate->java/util/concurrent/atomic/DesugarAtomicReference" \
-    --retarget_core_library_member "java/util/concurrent/atomic/AtomicReference#accumulateAndGet->java/util/concurrent/atomic/DesugarAtomicReference" \
+    --auto_desugar_shadowed_api_use \
     --emulate_core_library_interface java/util/Collection \
     --emulate_core_library_interface java/util/Map \
     --emulate_core_library_interface java/util/Map\$Entry \
     --emulate_core_library_interface java/util/Iterator \
     --emulate_core_library_interface java/util/Comparator \
-    --dont_rewrite_core_library_invocation "java/util/Iterator#remove")
+    --dont_rewrite_core_library_invocation "java/util/Iterator#remove" )
 
 # Check for params file.  Desugar doesn't accept a mix of params files and flags
 # directly on the command line, so we need to build a new params file that adds

--- a/tools/android/runtime_deps/upload_android_tools.sh
+++ b/tools/android/runtime_deps/upload_android_tools.sh
@@ -31,7 +31,7 @@
 set -euo pipefail
 
 # The version of android_tools.tar.gz
-VERSION="0.19.0rc3"
+VERSION="0.21.0"
 VERSIONED_FILENAME="android_tools_pkg-$VERSION.tar.gz"
 
 # Create a temp directory to hold the versioned tarball, and clean it up when the script exits.


### PR DESCRIPTION
Cherrypick request for 4.2.0 (#13358)

This pull request combines 3 commits for Bazel 4.2.0:

https://github.com/bazelbuild/bazel/commit/586de95cbd4ac0375eba539d295edcb5bb2819c6
https://github.com/bazelbuild/bazel/commit/80feea06cbf06486280dac065e3caec5facbedb9
https://github.com/bazelbuild/bazel/commit/0e652737988e3c115e98e1552f6fada52bc2b9a2

Together, these update the version of the Bazel Android tools that the Android rules use to version 0.23.0, and updates the minimum version of the Android SDK build tools to 30.0.0.