### PR TITLE
local_java_runtime should create a public native#java_runtime

### DIFF
--- a/tools/jdk/local_java_repository.bzl
+++ b/tools/jdk/local_java_repository.bzl
@@ -16,7 +16,7 @@
 
 load(":default_java_toolchain.bzl", "JVM8_TOOLCHAIN_CONFIGURATION", "default_java_toolchain")
 
-def _detect_java_version(repository_ctx, java_bin, visibility = ["//visibility:public"]):
+def _detect_java_version(repository_ctx, java_bin):
     properties_out = repository_ctx.execute([java_bin, "-XshowSettings:properties"]).stderr
     # This returns an indented list of properties separated with newlines:
     # "  java.vendor.url.bug = ... \n"
@@ -38,7 +38,7 @@ def _detect_java_version(repository_ctx, java_bin, visibility = ["//visibility:p
         return minor
     return major
 
-def local_java_runtime(name, java_home, version, runtime_name = None):
+def local_java_runtime(name, java_home, version, runtime_name = None, visibility = ["//visibility:public"]):
     """Defines a java_runtime target together with Java runtime and compile toolchain definitions.
 
     Java runtime toolchain is constrained by flag --java_runtime_version having

--- a/tools/jdk/local_java_repository.bzl
+++ b/tools/jdk/local_java_repository.bzl
@@ -60,6 +60,7 @@ def local_java_runtime(name, java_home, version, runtime_name = None):
         native.java_runtime(
             name = runtime_name,
             java_home = java_home,
+            visibility = ["//visibility:public"],
         )
 
     native.config_setting(

--- a/tools/jdk/local_java_repository.bzl
+++ b/tools/jdk/local_java_repository.bzl
@@ -16,7 +16,7 @@
 
 load(":default_java_toolchain.bzl", "JVM8_TOOLCHAIN_CONFIGURATION", "default_java_toolchain")
 
-def _detect_java_version(repository_ctx, java_bin):
+def _detect_java_version(repository_ctx, java_bin, visibility = ["//visibility:public"]):
     properties_out = repository_ctx.execute([java_bin, "-XshowSettings:properties"]).stderr
     # This returns an indented list of properties separated with newlines:
     # "  java.vendor.url.bug = ... \n"
@@ -54,13 +54,14 @@ def local_java_runtime(name, java_home, version, runtime_name = None):
       java_home: Path to the JDK.
       version: Version of the JDK.
       runtime_name: name of java_runtime target if it already exists.
+      visibility: Visibility that will be applied to the java runtime target
     """
     if runtime_name == None:
         runtime_name = name
         native.java_runtime(
             name = runtime_name,
             java_home = java_home,
-            visibility = ["//visibility:public"],
+            visibility = visibility,
         )
 
     native.config_setting(


### PR DESCRIPTION
`local_java_repository` should expose the underlying `java_runtime` as public so that it can be used when creating custom java toolchains.

I'm able to reproduce this using `5.0.0-pre.20210708.4`

WORKSPACE
```
load("@bazel_tools//tools/jdk:local_java_repository.bzl", "local_java_repository")

local_java_repository(
    name = "jdk11",
    java_home = "/tmp/jdk11/11.0.11_9/jdk-unarchived/",
)
```

BUILD.bazel
```
load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")

default_java_toolchain(
    name = "java11",
    java_runtime = "@jdk11//:jdk11",
    # ...
    visibility = ["//visibility:public"],
)
```

Error message
```
(00:44:56) ERROR: .../BUILD.bazel:64:23: in java_toolchain rule //:jdk11_java_toolchain: target '@jdk11//:jdk11' is not visible from target '//:jdk11_java_toolchain'. Check the visibility declaration of the former target if you think the dependency is legitimate
```
