### PR TITLE
Flip --experimental_worker_allow_json_protocol

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
@@ -48,7 +48,7 @@ public class WorkerOptions extends OptionsBase {
 
   @Option(
       name = "experimental_worker_allow_json_protocol",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
       help =


### PR DESCRIPTION
Based on the discussion here
https://github.com/bazelbuild/bazel/pull/13607 we want to flip this and
leave it around temporarily, but there are also some refactorings coming
around how to do that. This flips the value now so it can be used
without the flag sooner in rolling releases.