### PR TITLE
Allow relative log paths

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -331,7 +331,7 @@ public class CommonCommandOptions extends OptionsBase {
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS, OptionEffectTag.BAZEL_MONITORING},
-      converter = OptionsUtils.AbsolutePathFragmentConverter.class,
+      converter = OptionsUtils.PathFragmentConverter.class,
       help =
           "If set, write memory usage data to the specified file at phase ends and stable heap to"
               + " master log at end of build.")

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -300,7 +300,7 @@ public class CommonCommandOptions extends OptionsBase {
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS, OptionEffectTag.BAZEL_MONITORING},
-      converter = OptionsUtils.AbsolutePathFragmentConverter.class,
+      converter = OptionsUtils.PathFragmentConverter.class,
       help =
           "If set, profile Bazel and write data to the specified "
               + "file. Use bazel analyze-profile to analyze the profile.")

--- a/src/test/shell/bazel/remote/remote_execution_with_xattr_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_with_xattr_test.sh
@@ -87,12 +87,12 @@ EOF
       --unix_digest_hash_attribute_name=user.checksum.sha256 \
       build \
       --remote_cache=grpc://localhost:${worker_port} \
-      --profile=/tmp/profile_log \
+      --profile=profile_log \
       --record_full_profiler_data \
       //:nothing || fail "Build failed"
-  grep -q "VFS md5.*file1" /tmp/profile_log && \
+  grep -q "VFS md5.*file1" profile_log && \
       fail "Bazel should not have computed a digest for file1"
-  grep -q "VFS md5.*file2" /tmp/profile_log || \
+  grep -q "VFS md5.*file2" profile_log || \
       fail "Bazel should have computed a digest for file2"
 }
 

--- a/src/test/shell/bazel/unix_digest_hash_attribute_name_test.sh
+++ b/src/test/shell/bazel/unix_digest_hash_attribute_name_test.sh
@@ -62,10 +62,10 @@ EOF
   bazel \
       --unix_digest_hash_attribute_name=user.checksum.sha256 \
       build \
-      --profile=/tmp/profile_log \
+      --profile=profile_log \
       --record_full_profiler_data \
       //:foo || fail "Build failed"
-  grep -q "VFS xattr.*BUILD" /tmp/profile_log || \
+  grep -q "VFS xattr.*BUILD" profile_log || \
       fail "Bazel did not perform getxattr() calls"
 }
 


### PR DESCRIPTION
This reverts commit bec1ea84caa75c8c3850b96d105627d1a36e322a and ed7f81a5bd0af39c1f94951aaa272e296baa9962

These changes required that users pass absolute paths to `--profile` and `--memory_profile` with the goal of disallowing users to alter the source tree through bazel invocations. Practically speaking it's very useful for users to quickly dump a log like `--profile=foo.log` for testing, where that won't be picked up by any bazel rules, and therefore shouldn't affect anything, or to write their logs to a `.gitignore`d / `.bazelignore`d directory such as `--profile=./tmp/logs/foo.log`. This has the advantage of making sure logs don't conflict between multiple source trees using bazel. Regardless This wouldn't restrict users from adding an absolute path in their bazel wrappers to the source root such as `--profile=$PWD/tmp/logs/foo.log`, so I think we should allow users to self regulate these issues.

More discussion: https://github.com/bazelbuild/bazel/commit/bec1ea84caa75c8c3850b96d105627d1a36e322a#commitcomment-53595211