### PR TITLE
Cherrypick for 4.2.0: Support extracting aar files.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorValue.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/DecompressorValue.java
@@ -98,7 +98,10 @@ public class DecompressorValue implements SkyValue {
   static Decompressor getDecompressor(Path archivePath)
       throws RepositoryFunctionException {
     String baseName = archivePath.getBaseName();
-    if (baseName.endsWith(".zip") || baseName.endsWith(".jar") || baseName.endsWith(".war")) {
+    if (baseName.endsWith(".zip")
+        || baseName.endsWith(".jar")
+        || baseName.endsWith(".war")
+        || baseName.endsWith(".aar")) {
       return ZipDecompressor.INSTANCE;
     } else if (baseName.endsWith(".tar")) {
       return TarFunction.INSTANCE;
@@ -111,8 +114,8 @@ public class DecompressorValue implements SkyValue {
     } else {
       throw new RepositoryFunctionException(
           Starlark.errorf(
-              "Expected a file with a .zip, .jar, .war, .tar, .tar.gz, .tgz, .tar.xz, .txz, or "
-                  + ".tar.bz2 suffix (got %s)",
+              "Expected a file with a .zip, .jar, .war, .aar, .tar, .tar.gz, .tgz, .tar.xz, .txz, "
+                  + "or .tar.bz2 suffix (got %s)",
               archivePath),
           Transience.PERSISTENT);
     }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/StarlarkRepositoryContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/repository/StarlarkRepositoryContextApi.java
@@ -502,7 +502,8 @@ public interface StarlarkRepositoryContextApi<RepositoryFunctionExceptionT exten
                     + " By default, the archive type is determined from the file extension of"
                     + " the URL."
                     + " If the file has no extension, you can explicitly specify either \"zip\","
-                    + " \"jar\", \"war\", \"tar.gz\", \"tgz\", \"tar.bz2\", or \"tar.xz\" here."),
+                    + " \"jar\", \"war\", \"aar\", \"tar.gz\", \"tgz\", \"tar.bz2\", or \"tar.xz\""
+                    + " here."),
         @Param(
             name = "stripPrefix",
             defaultValue = "''",

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -264,7 +264,7 @@ match a directory in the archive, Bazel will return an error.""",
 
 By default, the archive type is determined from the file extension of the
 URL. If the file has no extension, you can explicitly specify one of the
-following: `"zip"`, `"jar"`, `"war"`, `"tar"`, `"tar.gz"`, `"tgz"`,
+following: `"zip"`, `"jar"`, `"war"`, `"aar"`, `"tar"`, `"tar.gz"`, `"tgz"`,
 `"tar.xz"`, or `tar.bz2`.""",
     ),
     "patches": attr.label_list(
@@ -340,8 +340,8 @@ http_archive = repository_rule(
         """Downloads a Bazel repository as a compressed archive file, decompresses it,
 and makes its targets available for binding.
 
-It supports the following file extensions: `"zip"`, `"jar"`, `"war"`, `"tar"`,
-`"tar.gz"`, `"tgz"`, `"tar.xz"`, and `tar.bz2`.
+It supports the following file extensions: `"zip"`, `"jar"`, `"war"`, `"aar"`,
+`"tar"`, `"tar.gz"`, `"tgz"`, `"tar.xz"`, and `tar.bz2`.
 
 Examples:
   Suppose the current repository contains the source code for a chat program,


### PR DESCRIPTION
@katre, any chance this one could still go into 4.2.0 (#13558)?

It's a cherrypick of https://github.com/bazelbuild/bazel/commit/9055c67b17abf5fed487ae44d0e22f1c6ea1e50c.

This is handy, though not essential, for manipulating Android aars in repository rules. It only slightly generalizes an existing interface, without changing or removing any existing functionality.

Original commit message below:
----

Hey awesome Bazel team,

Would you consider allowing extract, download_and_extract, and http_archive to decompress .aar android archives? Figured I'd just toss up a PR to ask because it was such an easy addition; aars are just zip files under the hood, totally parallel to the jar/war cases already in the codebase.

The motivation is that you'll need this basic functionality to be able to depend on the native interface of an aar, which Android Studio & co are working on in [prefabs](https://developer.android.com/studio/build/native-dependencies). I ran into the lack of support while trying to hack myself support for https://github.com/bazelbuild/bazel/issues/13092.

Thanks for your consideration!
Chris

Closes #13098.

PiperOrigin-RevId: 387384152