### PR TITLE
Remote: Cleanup the code that determines whether the spawn should accept/upload results from/to remote cache.

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
+++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
@@ -34,7 +34,8 @@
     Note: for the purposes of this tag, the disk-cache is considered a local cache, whereas
     the http and gRPC caches are considered remote.
     If a combined cache is specified (i.e. a cache with local and remote components),
-    it's treated as a remote cache and disabled entirely.
+    it's treated as a remote cache and disabled entirely unless --incompatible_remote_results_ignore_disk
+    is set in which case the local components will be used.
   </li>
 
   <li><code>no-remote-exec</code> keyword results in the action or test never being

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
@@ -158,7 +158,7 @@ public class RemoteCache implements AutoCloseable {
         context, remotePathResolver, actionKey, action, command, outputs, outErr, resultBuilder);
     resultBuilder.setExitCode(exitCode);
     ActionResult result = resultBuilder.build();
-    if (exitCode == 0 && !action.getDoNotCache()) {
+    if (exitCode == 0) {
       cacheProtocol.uploadActionResult(context, actionKey, result);
     }
     return result;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -288,7 +288,7 @@ public class RemoteExecutionService {
         if (remoteOptions.incompatibleRemoteResultsIgnoreDisk) {
           return Spawns.mayBeCachedRemotely(spawn);
         } else {
-          return remoteOptions.remoteAcceptCached && Spawns.mayBeExecutedRemotely(spawn);
+          return remoteOptions.remoteAcceptCached && Spawns.mayBeCachedRemotely(spawn);
         }
       } else {
         // Remote cache

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.devtools.build.lib.profiler.ProfilerTask.REMOTE_DOWNLOAD;
 import static com.google.devtools.build.lib.remote.util.Utils.createSpawnResult;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -79,6 +80,11 @@ final class RemoteSpawnCache implements SpawnCache {
     this.verboseFailures = verboseFailures;
     this.cmdlineReporter = cmdlineReporter;
     this.remoteExecutionService = remoteExecutionService;
+  }
+
+  @VisibleForTesting
+  RemoteExecutionService getRemoteExecutionService() {
+    return remoteExecutionService;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -37,7 +37,6 @@ import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.SpawnResult.Status;
-import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.events.Event;
@@ -170,12 +169,12 @@ public class RemoteSpawnRunner implements SpawnRunner {
   public SpawnResult exec(Spawn spawn, SpawnExecutionContext context)
       throws ExecException, InterruptedException, IOException, ForbiddenActionInputException {
     Preconditions.checkArgument(
-        Spawns.mayBeExecutedRemotely(spawn), "Spawn can't be executed remotely. This is a bug.");
+        remoteExecutionService.mayBeExecutedRemotely(spawn),
+        "Spawn can't be executed remotely. This is a bug.");
 
     Stopwatch totalTime = Stopwatch.createStarted();
-    boolean spawnCacheableRemotely = Spawns.mayBeCachedRemotely(spawn);
-    boolean uploadLocalResults = remoteOptions.remoteUploadLocalResults && spawnCacheableRemotely;
-    boolean acceptCachedResult = remoteOptions.remoteAcceptCached && spawnCacheableRemotely;
+    boolean uploadLocalResults = remoteExecutionService.shouldUploadLocalResults(spawn);
+    boolean acceptCachedResult = remoteExecutionService.shouldAcceptCachedResult(spawn);
 
     RemoteAction action = remoteExecutionService.buildRemoteAction(spawn, context);
     SpawnMetrics.Builder spawnMetrics =

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteActionExecutionContext.java
@@ -14,9 +14,15 @@
 package com.google.devtools.build.lib.remote.common;
 
 import build.bazel.remote.execution.v2.RequestMetadata;
+import com.google.devtools.build.lib.actions.Spawn;
+import javax.annotation.Nullable;
 
 /** A context that provide remote execution related information for executing an action remotely. */
 public interface RemoteActionExecutionContext {
+
+  /** Returns the {@link Spawn} of the action being executed or {@code null}. */
+  @Nullable
+  Spawn getSpawn();
 
   /** Returns the {@link RequestMetadata} for the action being executed. */
   RequestMetadata getRequestMetadata();
@@ -29,6 +35,11 @@ public interface RemoteActionExecutionContext {
 
   /** Creates a {@link SimpleRemoteActionExecutionContext} with given {@link RequestMetadata}. */
   static RemoteActionExecutionContext create(RequestMetadata metadata) {
-    return new SimpleRemoteActionExecutionContext(metadata, new NetworkTime());
+    return new SimpleRemoteActionExecutionContext(/*spawn=*/ null, metadata, new NetworkTime());
+  }
+
+  /** Creates a {@link SimpleRemoteActionExecutionContext} with given {@link Spawn} and {@link RequestMetadata}. */
+  static RemoteActionExecutionContext createForSpawn(Spawn spawn, RequestMetadata metadata) {
+    return new SimpleRemoteActionExecutionContext(spawn, metadata, new NetworkTime());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteActionExecutionContext.java
@@ -14,14 +14,9 @@
 package com.google.devtools.build.lib.remote.common;
 
 import build.bazel.remote.execution.v2.RequestMetadata;
-import com.google.devtools.build.lib.actions.Spawn;
-import javax.annotation.Nullable;
 
 /** A context that provide remote execution related information for executing an action remotely. */
 public interface RemoteActionExecutionContext {
-
-  /** Returns the {@link Spawn} the context associated with if any. */
-  @Nullable Spawn getSpawn();
 
   /** Returns the {@link RequestMetadata} for the action being executed. */
   RequestMetadata getRequestMetadata();
@@ -34,14 +29,6 @@ public interface RemoteActionExecutionContext {
 
   /** Creates a {@link SimpleRemoteActionExecutionContext} with given {@link RequestMetadata}. */
   static RemoteActionExecutionContext create(RequestMetadata metadata) {
-    return new SimpleRemoteActionExecutionContext(/*spawn=*/ null, metadata, new NetworkTime());
-  }
-
-  /**
-   * Creates a {@link SimpleRemoteActionExecutionContext} with given {@link Spawn} and {@link
-   * RequestMetadata}.
-   */
-  static RemoteActionExecutionContext createForSpawn(Spawn spawn, RequestMetadata metadata) {
-    return new SimpleRemoteActionExecutionContext(spawn, metadata, new NetworkTime());
+    return new SimpleRemoteActionExecutionContext(metadata, new NetworkTime());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteActionExecutionContext.java
@@ -14,21 +14,34 @@
 package com.google.devtools.build.lib.remote.common;
 
 import build.bazel.remote.execution.v2.RequestMetadata;
+import com.google.devtools.build.lib.actions.Spawn;
+import javax.annotation.Nullable;
 
 /** A context that provide remote execution related information for executing an action remotely. */
 public interface RemoteActionExecutionContext {
 
-  /** Get the {@link RequestMetadata} for the action being executed. */
+  /** Returns the {@link Spawn} the context associated with if any. */
+  @Nullable Spawn getSpawn();
+
+  /** Returns the {@link RequestMetadata} for the action being executed. */
   RequestMetadata getRequestMetadata();
 
   /**
-   * Get the {@link NetworkTime} instance used to measure the network time during the action
+   * Returns the {@link NetworkTime} instance used to measure the network time during the action
    * execution.
    */
   NetworkTime getNetworkTime();
 
   /** Creates a {@link SimpleRemoteActionExecutionContext} with given {@link RequestMetadata}. */
   static RemoteActionExecutionContext create(RequestMetadata metadata) {
-    return new SimpleRemoteActionExecutionContext(metadata, new NetworkTime());
+    return new SimpleRemoteActionExecutionContext(/*spawn=*/ null, metadata, new NetworkTime());
+  }
+
+  /**
+   * Creates a {@link SimpleRemoteActionExecutionContext} with given {@link Spawn} and {@link
+   * RequestMetadata}.
+   */
+  static RemoteActionExecutionContext createForSpawn(Spawn spawn, RequestMetadata metadata) {
+    return new SimpleRemoteActionExecutionContext(spawn, metadata, new NetworkTime());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/SimpleRemoteActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/SimpleRemoteActionExecutionContext.java
@@ -14,17 +14,27 @@
 package com.google.devtools.build.lib.remote.common;
 
 import build.bazel.remote.execution.v2.RequestMetadata;
+import com.google.devtools.build.lib.actions.Spawn;
+import javax.annotation.Nullable;
 
 /** A {@link RemoteActionExecutionContext} implementation */
 public class SimpleRemoteActionExecutionContext implements RemoteActionExecutionContext {
 
+  private final Spawn spawn;
   private final RequestMetadata requestMetadata;
   private final NetworkTime networkTime;
 
   public SimpleRemoteActionExecutionContext(
-      RequestMetadata requestMetadata, NetworkTime networkTime) {
+      Spawn spawn, RequestMetadata requestMetadata, NetworkTime networkTime) {
+    this.spawn = spawn;
     this.requestMetadata = requestMetadata;
     this.networkTime = networkTime;
+  }
+
+  @Nullable
+  @Override
+  public Spawn getSpawn() {
+    return spawn;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/common/SimpleRemoteActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/SimpleRemoteActionExecutionContext.java
@@ -14,27 +14,17 @@
 package com.google.devtools.build.lib.remote.common;
 
 import build.bazel.remote.execution.v2.RequestMetadata;
-import com.google.devtools.build.lib.actions.Spawn;
-import javax.annotation.Nullable;
 
 /** A {@link RemoteActionExecutionContext} implementation */
 public class SimpleRemoteActionExecutionContext implements RemoteActionExecutionContext {
 
-  private final Spawn spawn;
   private final RequestMetadata requestMetadata;
   private final NetworkTime networkTime;
 
   public SimpleRemoteActionExecutionContext(
-      Spawn spawn, RequestMetadata requestMetadata, NetworkTime networkTime) {
-    this.spawn = spawn;
+      RequestMetadata requestMetadata, NetworkTime networkTime) {
     this.requestMetadata = requestMetadata;
     this.networkTime = networkTime;
-  }
-
-  @Nullable
-  @Override
-  public Spawn getSpawn() {
-    return spawn;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
@@ -14,7 +14,6 @@ java_library(
     name = "disk",
     srcs = glob(["*.java"]),
     deps = [
-        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/util",

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/BUILD
@@ -14,6 +14,7 @@ java_library(
     name = "disk",
     srcs = glob(["*.java"]),
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/util",

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -272,6 +272,7 @@ public final class RemoteOptions extends OptionsBase {
               + " cache, but not uploaded to the remote cache.\n"
               + "\t--noremote_accept_cached will result in Bazel checking for results in the disk"
               + " cache, but not in the remote cache.\n"
+              + "\tno-remote-exec actions can hit the disk cache.\n"
               + "See #8216 for details.")
   public boolean incompatibleRemoteResultsIgnoreDisk;
 

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -34,11 +34,13 @@ import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
 import com.google.devtools.build.lib.actions.SpawnResult;
+import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.remote.ExecutionStatusException;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
@@ -536,5 +538,33 @@ public final class Utils {
     // Format as single digit decimal number, but skipping the trailing .0.
     DecimalFormat fmt = new DecimalFormat("0.#");
     return String.format("%s %s", fmt.format(value / 1024.0), UNITS.get(unitIndex));
+  }
+
+  /** Returns {@code true} if the {@link Spawn} should accept cached result from remote cache. */
+  public static boolean shouldAcceptCachedResultFromRemoteCache(RemoteOptions options, Spawn spawn) {
+    return options.remoteAcceptCached && Spawns.mayBeCachedRemotely(spawn);
+  }
+
+  /** Returns {@code true} if the {@link Spawn} should accept cached result from disk cache. */
+  public static boolean shouldAcceptCachedResultFromDiskCache(RemoteOptions options, Spawn spawn) {
+    if (options.incompatibleRemoteResultsIgnoreDisk) {
+      return Spawns.mayBeCached(spawn);
+    } else {
+      return options.remoteAcceptCached && Spawns.mayBeCached(spawn);
+    }
+  }
+
+  /** Returns {@code true} if the {@link Spawn} should upload local results to remote cache. */
+  public static boolean shouldUploadLocalResultsToRemoteCache(RemoteOptions options, Spawn spawn) {
+    return options.remoteUploadLocalResults && Spawns.mayBeCachedRemotely(spawn);
+  }
+
+  /** Returns {@code true} if the {@link Spawn} should upload local results to disk cache. */
+  public static boolean shouldUploadLocalResultsToDiskCache(RemoteOptions options, Spawn spawn) {
+    if (options.incompatibleRemoteResultsIgnoreDisk) {
+      return Spawns.mayBeCached(spawn);
+    } else {
+      return options.remoteUploadLocalResults && Spawns.mayBeCached(spawn);
+    }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -34,13 +34,11 @@ import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
 import com.google.devtools.build.lib.actions.SpawnResult;
-import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.remote.ExecutionStatusException;
 import com.google.devtools.build.lib.remote.common.CacheNotFoundException;
 import com.google.devtools.build.lib.remote.common.OutputDigestMismatchException;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.ActionKey;
-import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.options.RemoteOutputsMode;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
@@ -538,33 +536,5 @@ public final class Utils {
     // Format as single digit decimal number, but skipping the trailing .0.
     DecimalFormat fmt = new DecimalFormat("0.#");
     return String.format("%s %s", fmt.format(value / 1024.0), UNITS.get(unitIndex));
-  }
-
-  /** Returns {@code true} if the {@link Spawn} should accept cached result from remote cache. */
-  public static boolean shouldAcceptCachedResultFromRemoteCache(RemoteOptions options, Spawn spawn) {
-    return options.remoteAcceptCached && Spawns.mayBeCachedRemotely(spawn);
-  }
-
-  /** Returns {@code true} if the {@link Spawn} should accept cached result from disk cache. */
-  public static boolean shouldAcceptCachedResultFromDiskCache(RemoteOptions options, Spawn spawn) {
-    if (options.incompatibleRemoteResultsIgnoreDisk) {
-      return Spawns.mayBeCached(spawn);
-    } else {
-      return options.remoteAcceptCached && Spawns.mayBeCached(spawn);
-    }
-  }
-
-  /** Returns {@code true} if the {@link Spawn} should upload local results to remote cache. */
-  public static boolean shouldUploadLocalResultsToRemoteCache(RemoteOptions options, Spawn spawn) {
-    return options.remoteUploadLocalResults && Spawns.mayBeCachedRemotely(spawn);
-  }
-
-  /** Returns {@code true} if the {@link Spawn} should upload local results to disk cache. */
-  public static boolean shouldUploadLocalResultsToDiskCache(RemoteOptions options, Spawn spawn) {
-    if (options.incompatibleRemoteResultsIgnoreDisk) {
-      return Spawns.mayBeCached(spawn);
-    } else {
-      return options.remoteUploadLocalResults && Spawns.mayBeCached(spawn);
-    }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -110,14 +110,13 @@ public class RemoteSpawnCacheTest {
   private SimpleSpawn simpleSpawn;
   private FakeActionInputFileCache fakeFileCache;
   @Mock private RemoteCache remoteCache;
-  private RemoteSpawnCache cache;
   private FileOutErr outErr;
   private final List<ProgressStatus> progressUpdates = new ArrayList<>();
 
   private StoredEventHandler eventHandler = new StoredEventHandler();
 
   private Reporter reporter;
-  private RemoteExecutionService service;
+  private RemotePathResolver remotePathResolver;
 
   private final SpawnExecutionContext simplePolicy =
       new SpawnExecutionContext() {
@@ -202,7 +201,23 @@ public class RemoteSpawnCacheTest {
         ResourceSet.ZERO);
   }
 
+  private RemoteSpawnCache createRemoteSpawnCache() {
+    return remoteSpawnCacheWithOptions(Options.getDefaults(RemoteOptions.class));
+  }
+
   private RemoteSpawnCache remoteSpawnCacheWithOptions(RemoteOptions options) {
+    RemoteExecutionService service = spy(
+        new RemoteExecutionService(
+            execRoot,
+            remotePathResolver,
+            BUILD_REQUEST_ID,
+            COMMAND_ID,
+            digestUtil,
+            options,
+            remoteCache,
+            null,
+            ImmutableSet.of(),
+            /* captureCorruptedOutputsDir= */ null));
     return new RemoteSpawnCache(execRoot, options, /* verboseFailures=*/ true, reporter, service);
   }
 
@@ -221,26 +236,11 @@ public class RemoteSpawnCacheTest {
     stdout.getParentDirectory().createDirectoryAndParents();
     stderr.getParentDirectory().createDirectoryAndParents();
     outErr = new FileOutErr(stdout, stderr);
-    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
     reporter = new Reporter(new EventBus());
     eventHandler = new StoredEventHandler();
     reporter.addHandler(eventHandler);
 
-    RemotePathResolver remotePathResolver = RemotePathResolver.createDefault(execRoot);
-    service =
-        spy(
-            new RemoteExecutionService(
-                execRoot,
-                remotePathResolver,
-                BUILD_REQUEST_ID,
-                COMMAND_ID,
-                digestUtil,
-                options,
-                remoteCache,
-                null,
-                ImmutableSet.of(),
-                /* captureCorruptedOutputsDir= */ null));
-    cache = remoteSpawnCacheWithOptions(options);
+    remotePathResolver = RemotePathResolver.createDefault(execRoot);
 
     fakeFileCache.createScratchInput(simpleSpawn.getInputFiles().getSingleton(), "xyz");
   }
@@ -249,6 +249,8 @@ public class RemoteSpawnCacheTest {
   @Test
   public void cacheHit() throws Exception {
     // arrange
+    RemoteSpawnCache cache = createRemoteSpawnCache();
+    RemoteExecutionService service = cache.getRemoteExecutionService();
     ActionResult actionResult = ActionResult.getDefaultInstance();
     when(remoteCache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
@@ -306,6 +308,7 @@ public class RemoteSpawnCacheTest {
 
   @Test
   public void cacheMiss() throws Exception {
+    RemoteSpawnCache cache = createRemoteSpawnCache();
     CacheHandle entry = cache.lookup(simpleSpawn, simplePolicy);
     assertThat(entry.hasResult()).isFalse();
     SpawnResult result =
@@ -359,13 +362,13 @@ public class RemoteSpawnCacheTest {
     RemoteOptions withLocalCache = Options.getDefaults(RemoteOptions.class);
     withLocalCache.diskCache = PathFragment.create("/etc/something/cache/here");
     for (RemoteSpawnCache remoteSpawnCache :
-        ImmutableList.of(cache, remoteSpawnCacheWithOptions(withLocalCache))) {
+        ImmutableList.of(createRemoteSpawnCache(), remoteSpawnCacheWithOptions(withLocalCache))) {
       for (String requirement :
           ImmutableList.of(ExecutionRequirements.NO_CACHE, ExecutionRequirements.LOCAL)) {
         SimpleSpawn uncacheableSpawn =
             simpleSpawnWithExecutionInfo(ImmutableMap.of(requirement, ""));
         CacheHandle entry = remoteSpawnCache.lookup(uncacheableSpawn, simplePolicy);
-        verify(service, never()).lookupCache(any());
+        verify(remoteSpawnCache.getRemoteExecutionService(), never()).lookupCache(any());
         assertThat(entry.hasResult()).isFalse();
         SpawnResult result =
             new SpawnResult.Builder()
@@ -456,7 +459,7 @@ public class RemoteSpawnCacheTest {
   public void noRemoteCacheStillUsesLocalCache() throws Exception {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     remoteOptions.diskCache = PathFragment.create("/etc/something/cache/here");
-    cache = remoteSpawnCacheWithOptions(remoteOptions);
+    RemoteSpawnCache cache = remoteSpawnCacheWithOptions(remoteOptions);
 
     SimpleSpawn cacheableSpawn =
         simpleSpawnWithExecutionInfo(ImmutableMap.of(ExecutionRequirements.NO_REMOTE_CACHE, ""));
@@ -470,6 +473,7 @@ public class RemoteSpawnCacheTest {
 
   @Test
   public void noRemoteExecStillUsesCache() throws Exception {
+    RemoteSpawnCache cache = createRemoteSpawnCache();
     SimpleSpawn cacheableSpawn =
         simpleSpawnWithExecutionInfo(ImmutableMap.of(ExecutionRequirements.NO_REMOTE_EXEC, ""));
     cache.lookup(cacheableSpawn, simplePolicy);
@@ -483,6 +487,7 @@ public class RemoteSpawnCacheTest {
   @Test
   public void failedActionsAreNotUploaded() throws Exception {
     // Only successful action results are uploaded to the remote cache.
+    RemoteSpawnCache cache = createRemoteSpawnCache();
     CacheHandle entry = cache.lookup(simpleSpawn, simplePolicy);
     verify(remoteCache)
         .downloadActionResult(
@@ -519,6 +524,7 @@ public class RemoteSpawnCacheTest {
 
   @Test
   public void printWarningIfUploadFails() throws Exception {
+    RemoteSpawnCache cache = createRemoteSpawnCache();
     CacheHandle entry = cache.lookup(simpleSpawn, simplePolicy);
     assertThat(entry.hasResult()).isFalse();
     SpawnResult result =
@@ -563,6 +569,7 @@ public class RemoteSpawnCacheTest {
 
   @Test
   public void printWarningIfDownloadFails() throws Exception {
+    RemoteSpawnCache cache = createRemoteSpawnCache();
     doThrow(new IOException(io.grpc.Status.UNAVAILABLE.asRuntimeException()))
         .when(remoteCache)
         .downloadActionResult(
@@ -623,6 +630,7 @@ public class RemoteSpawnCacheTest {
 
   @Test
   public void orphanedCachedResultIgnored() throws Exception {
+    RemoteSpawnCache cache = createRemoteSpawnCache();
     Digest digest = digestUtil.computeAsUtf8("bla");
     ActionResult actionResult =
         ActionResult.newBuilder()
@@ -644,7 +652,7 @@ public class RemoteSpawnCacheTest {
               }
             });
     doThrow(new CacheNotFoundException(digest))
-        .when(service)
+        .when(cache.getRemoteExecutionService())
         .downloadOutputs(any(), eq(RemoteActionResult.createFromCache(actionResult)));
 
     CacheHandle entry = cache.lookup(simpleSpawn, simplePolicy);
@@ -696,6 +704,7 @@ public class RemoteSpawnCacheTest {
 
   @Test
   public void failedCacheActionAsCacheMiss() throws Exception {
+    RemoteSpawnCache cache = createRemoteSpawnCache();
     ActionResult actionResult = ActionResult.newBuilder().setExitCode(1).build();
     when(remoteCache.downloadActionResult(
             any(RemoteActionExecutionContext.class),
@@ -713,7 +722,7 @@ public class RemoteSpawnCacheTest {
     // arrange
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     remoteOptions.remoteOutputsMode = RemoteOutputsMode.MINIMAL;
-    cache = remoteSpawnCacheWithOptions(remoteOptions);
+    RemoteSpawnCache cache = remoteSpawnCacheWithOptions(remoteOptions);
 
     ActionResult success = ActionResult.newBuilder().setExitCode(0).build();
     when(remoteCache.downloadActionResult(
@@ -726,7 +735,7 @@ public class RemoteSpawnCacheTest {
     // assert
     assertThat(cacheHandle.hasResult()).isTrue();
     assertThat(cacheHandle.getResult().exitCode()).isEqualTo(0);
-    verify(service).downloadOutputs(any(), eq(RemoteActionResult.createFromCache(success)));
+    verify(cache.getRemoteExecutionService()).downloadOutputs(any(), eq(RemoteActionResult.createFromCache(success)));
   }
 
   @Test
@@ -734,7 +743,7 @@ public class RemoteSpawnCacheTest {
     // arrange
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
     remoteOptions.remoteOutputsMode = RemoteOutputsMode.MINIMAL;
-    cache = remoteSpawnCacheWithOptions(remoteOptions);
+    RemoteSpawnCache cache = remoteSpawnCacheWithOptions(remoteOptions);
 
     IOException downloadFailure = new IOException("downloadMinimal failed");
 
@@ -743,7 +752,7 @@ public class RemoteSpawnCacheTest {
             any(RemoteActionExecutionContext.class), any(), /* inlineOutErr= */ eq(false)))
         .thenReturn(success);
     doThrow(downloadFailure)
-        .when(service)
+        .when(cache.getRemoteExecutionService())
         .downloadOutputs(any(), eq(RemoteActionResult.createFromCache(success)));
 
     // act
@@ -751,7 +760,7 @@ public class RemoteSpawnCacheTest {
 
     // assert
     assertThat(cacheHandle.hasResult()).isFalse();
-    verify(service).downloadOutputs(any(), eq(RemoteActionResult.createFromCache(success)));
+    verify(cache.getRemoteExecutionService()).downloadOutputs(any(), eq(RemoteActionResult.createFromCache(success)));
     assertThat(eventHandler.getEvents().size()).isEqualTo(1);
     Event evt = eventHandler.getEvents().get(0);
     assertThat(evt.getKind()).isEqualTo(EventKind.WARNING);


### PR DESCRIPTION
Remote cache (and execution) for an action can be controlled with following tags:
  - `no-remote-cache`: prevent remote caching, but allow local caching
  - `no-remote-exec`: prevent remote execution, but allow remote caching
  - `no-remote`: combine no-remote-cache and no-remote-exec
  - `no-cache`: extend no-remote-cache to also prevent local caching

A combined cache is treated as remote cache, hence is disabled for actions that are tagged with `no-remote-cache` unless `--incompatible_remote_results_ignore_disk` is set in which case local component is enabled.

Fixes #13621.