### PR TITLE
Refactor persistent worker key computation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -21,6 +21,11 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.regex.Pattern;
 
+/**
+ * A helper class to process a {@link Spawn} into a {@link WorkerKey}, which is used to select a
+ * persistent worker process (actions with equal keys are allowed to use the same worker process),
+ * and a separate list of flag files. The result is encapsulated as a {@link WorkerConfig}.
+ */
 class WorkerParser {
   public static final String ERROR_MESSAGE_PREFIX =
       "Worker strategy cannot execute this %s action, ";
@@ -124,6 +129,7 @@ class WorkerParser {
             .build());
   }
 
+  /** A pair of the {@link WorkerKey} and the list of flag files. */
   public static class WorkerConfig {
     private final WorkerKey workerKey;
     private final List<String> flagFiles;

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -103,9 +103,11 @@ class WorkerParser {
     }
 
     if (flagFiles.isEmpty()) {
-      throw createUserExecException(
-          String.format(ERROR_MESSAGE_PREFIX + REASON_NO_FLAGFILE, spawn.getMnemonic()),
-          FailureDetails.Worker.Code.NO_FLAGFILE);
+      throw new UserExecException(
+          FailureDetails.FailureDetail.newBuilder()
+              .setMessage(String.format(ERROR_MESSAGE_PREFIX + REASON_NO_FLAGFILE, spawn.getMnemonic()))
+              .setWorker(FailureDetails.Worker.newBuilder().setCode(FailureDetails.Worker.Code.NO_FLAGFILE))
+              .build());
     }
 
     ImmutableList.Builder<String> mnemonicFlags = ImmutableList.builder();
@@ -118,15 +120,6 @@ class WorkerParser {
         .add("--persistent_worker")
         .addAll(MoreObjects.firstNonNull(mnemonicFlags.build(), ImmutableList.of()))
         .build();
-  }
-
-  private static UserExecException createUserExecException(
-      String message, FailureDetails.Worker.Code detailedCode) {
-    return new UserExecException(
-        FailureDetails.FailureDetail.newBuilder()
-            .setMessage(message)
-            .setWorker(FailureDetails.Worker.newBuilder().setCode(detailedCode))
-            .build());
   }
 
   /** A pair of the {@link WorkerKey} and the list of flag files. */

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -9,12 +9,11 @@ import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.exec.BinTools;
-import com.google.devtools.build.lib.exec.SpawnRunner;
+import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.exec.local.LocalEnvProvider;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +53,12 @@ class WorkerParser {
     this.binTools = binTools;
   }
 
-  public WorkerConfig compute(Spawn spawn, SpawnRunner.SpawnExecutionContext context)
+  /**
+   * Processes the given {@link Spawn} and {@link SpawnExecutionContext} to compute the worker key.
+   * This involves splitting the command line into the worker startup command and the separate list
+   * of flag files. Returns a pair of the {@link WorkerKey} and list of flag files.
+   */
+  public WorkerConfig compute(Spawn spawn, SpawnExecutionContext context)
       throws ExecException, IOException, InterruptedException {
     // We assume that the spawn to be executed always gets at least one @flagfile.txt or
     // --flagfile=flagfile.txt argument, which contains the flags related to the work itself (as

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -1,0 +1,144 @@
+package com.google.devtools.build.lib.worker;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.HashCode;
+import com.google.devtools.build.lib.actions.ExecException;
+import com.google.devtools.build.lib.actions.Spawn;
+import com.google.devtools.build.lib.actions.Spawns;
+import com.google.devtools.build.lib.actions.UserExecException;
+import com.google.devtools.build.lib.exec.BinTools;
+import com.google.devtools.build.lib.exec.SpawnRunner;
+import com.google.devtools.build.lib.exec.local.LocalEnvProvider;
+import com.google.devtools.build.lib.server.FailureDetails;
+import com.google.devtools.build.lib.vfs.Path;
+import com.google.devtools.build.lib.vfs.PathFragment;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.regex.Pattern;
+
+class WorkerParser {
+  public static final String ERROR_MESSAGE_PREFIX =
+      "Worker strategy cannot execute this %s action, ";
+  public static final String REASON_NO_FLAGFILE =
+      "because the command-line arguments do not contain at least one @flagfile or --flagfile=";
+
+  /** Pattern for @flagfile.txt and --flagfile=flagfile.txt */
+  private static final Pattern FLAG_FILE_PATTERN = Pattern.compile("(?:@|--?flagfile=)(.+)");
+
+  private final Path execRoot;
+  private final boolean multiplex;
+  private final WorkerOptions workerOptions;
+  private final LocalEnvProvider localEnvProvider;
+  private final BinTools binTools;
+
+  public WorkerParser(
+      Path execRoot,
+      boolean multiplex,
+      WorkerOptions workerOptions,
+      LocalEnvProvider localEnvProvider,
+      BinTools binTools) {
+    this.execRoot = execRoot;
+    this.multiplex = multiplex;
+    this.workerOptions = workerOptions;
+    this.localEnvProvider = localEnvProvider;
+    this.binTools = binTools;
+  }
+
+  public WorkerConfig compute(Spawn spawn, SpawnRunner.SpawnExecutionContext context)
+      throws ExecException, IOException, InterruptedException {
+    // We assume that the spawn to be executed always gets at least one @flagfile.txt or
+    // --flagfile=flagfile.txt argument, which contains the flags related to the work itself (as
+    // opposed to start-up options for the executed tool). Thus, we can extract those elements from
+    // its args and put them into the WorkRequest instead.
+    List<String> flagFiles = new ArrayList<>();
+    ImmutableList<String> workerArgs = splitSpawnArgsIntoWorkerArgsAndFlagFiles(spawn, flagFiles);
+    ImmutableMap<String, String> env =
+        localEnvProvider.rewriteLocalEnv(spawn.getEnvironment(), binTools, "/tmp");
+
+    SortedMap<PathFragment, HashCode> workerFiles =
+        WorkerFilesHash.getWorkerFilesWithHashes(
+            spawn, context.getArtifactExpander(), context.getMetadataProvider());
+
+    HashCode workerFilesCombinedHash = WorkerFilesHash.getCombinedHash(workerFiles);
+
+    WorkerKey key =
+        new WorkerKey(
+            workerArgs,
+            env,
+            execRoot,
+            Spawns.getWorkerKeyMnemonic(spawn),
+            workerFilesCombinedHash,
+            workerFiles,
+            context.speculating(),
+            multiplex && Spawns.supportsMultiplexWorkers(spawn),
+            Spawns.supportsWorkerCancellation(spawn),
+            Spawns.getWorkerProtocolFormat(spawn));
+    return new WorkerConfig(key, flagFiles);
+  }
+
+  /**
+   * Splits the command-line arguments of the {@code Spawn} into the part that is used to start the
+   * persistent worker ({@code workerArgs}) and the part that goes into the {@code WorkRequest}
+   * protobuf ({@code flagFiles}).
+   */
+  private ImmutableList<String> splitSpawnArgsIntoWorkerArgsAndFlagFiles(
+      Spawn spawn, List<String> flagFiles) throws UserExecException {
+    ImmutableList.Builder<String> workerArgs = ImmutableList.builder();
+    for (String arg : spawn.getArguments()) {
+      if (FLAG_FILE_PATTERN.matcher(arg).matches()) {
+        flagFiles.add(arg);
+      } else {
+        workerArgs.add(arg);
+      }
+    }
+
+    if (flagFiles.isEmpty()) {
+      throw createUserExecException(
+          String.format(ERROR_MESSAGE_PREFIX + REASON_NO_FLAGFILE, spawn.getMnemonic()),
+          FailureDetails.Worker.Code.NO_FLAGFILE);
+    }
+
+    ImmutableList.Builder<String> mnemonicFlags = ImmutableList.builder();
+
+    workerOptions.workerExtraFlags.stream()
+        .filter(entry -> entry.getKey().equals(spawn.getMnemonic()))
+        .forEach(entry -> mnemonicFlags.add(entry.getValue()));
+
+    return workerArgs
+        .add("--persistent_worker")
+        .addAll(MoreObjects.firstNonNull(mnemonicFlags.build(), ImmutableList.of()))
+        .build();
+  }
+
+  private static UserExecException createUserExecException(
+      String message, FailureDetails.Worker.Code detailedCode) {
+    return new UserExecException(
+        FailureDetails.FailureDetail.newBuilder()
+            .setMessage(message)
+            .setWorker(FailureDetails.Worker.newBuilder().setCode(detailedCode))
+            .build());
+  }
+
+  public static class WorkerConfig {
+    private final WorkerKey workerKey;
+    private final List<String> flagFiles;
+
+    public WorkerConfig(WorkerKey workerKey, List<String> flagFiles) {
+      this.workerKey = workerKey;
+      this.flagFiles = ImmutableList.copyOf(flagFiles);
+    }
+
+    public WorkerKey getWorkerKey() {
+      return workerKey;
+    }
+
+    public List<String> getFlagFiles() {
+      return flagFiles;
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -81,8 +81,6 @@ import java.util.regex.Pattern;
 final class WorkerSpawnRunner implements SpawnRunner {
   public static final String ERROR_MESSAGE_PREFIX =
       "Worker strategy cannot execute this %s action, ";
-  public static final String REASON_NO_FLAGFILE =
-      "because the command-line arguments do not contain at least one @flagfile or --flagfile=";
   public static final String REASON_NO_TOOLS = "because the action has no tools";
   /**
    * The verbosity level implied by `--worker_verbose`. This value allows for manually setting some
@@ -90,14 +88,10 @@ final class WorkerSpawnRunner implements SpawnRunner {
    */
   private static final int VERBOSE_LEVEL = 10;
 
-  /** Pattern for @flagfile.txt and --flagfile=flagfile.txt */
-  private static final Pattern FLAG_FILE_PATTERN = Pattern.compile("(?:@|--?flagfile=)(.+)");
-
   private final SandboxHelpers helpers;
   private final Path execRoot;
   private final WorkerPool workers;
   private final ExtendedEventHandler reporter;
-  private final LocalEnvProvider localEnvProvider;
   private final BinTools binTools;
   private final ResourceManager resourceManager;
   private final RunfilesTreeUpdater runfilesTreeUpdater;
@@ -120,7 +114,6 @@ final class WorkerSpawnRunner implements SpawnRunner {
     this.execRoot = execRoot;
     this.workers = Preconditions.checkNotNull(workers);
     this.reporter = reporter;
-    this.localEnvProvider = localEnvProvider;
     this.binTools = binTools;
     this.resourceManager = resourceManager;
     this.runfilesTreeUpdater = runfilesTreeUpdater;

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.actions.ActionExecutionMetadata;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ExecException;
+import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.ExecutionRequirements.WorkerProtocolFormat;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
 import com.google.devtools.build.lib.actions.MetadataProvider;
@@ -95,13 +96,13 @@ final class WorkerSpawnRunner implements SpawnRunner {
   private final SandboxHelpers helpers;
   private final Path execRoot;
   private final WorkerPool workers;
-  private final boolean multiplex;
   private final ExtendedEventHandler reporter;
   private final LocalEnvProvider localEnvProvider;
   private final BinTools binTools;
   private final ResourceManager resourceManager;
   private final RunfilesTreeUpdater runfilesTreeUpdater;
   private final WorkerOptions workerOptions;
+  private final WorkerParser workerParser;
   private final AtomicInteger requestIdCounter = new AtomicInteger(1);
 
   public WorkerSpawnRunner(
@@ -118,12 +119,12 @@ final class WorkerSpawnRunner implements SpawnRunner {
     this.helpers = helpers;
     this.execRoot = execRoot;
     this.workers = Preconditions.checkNotNull(workers);
-    this.multiplex = multiplex;
     this.reporter = reporter;
     this.localEnvProvider = localEnvProvider;
     this.binTools = binTools;
     this.resourceManager = resourceManager;
     this.runfilesTreeUpdater = runfilesTreeUpdater;
+    this.workerParser = new WorkerParser(execRoot, multiplex, workerOptions, localEnvProvider, binTools);
     this.workerOptions = workerOptions;
   }
 
@@ -178,16 +179,6 @@ final class WorkerSpawnRunner implements SpawnRunner {
           spawn.getEnvironment(),
           context.getFileOutErr());
 
-      // We assume that the spawn to be executed always gets at least one @flagfile.txt or
-      // --flagfile=flagfile.txt argument, which contains the flags related to the work itself (as
-      // opposed to start-up options for the executed tool). Thus, we can extract those elements
-      // from
-      // its args and put them into the WorkRequest instead.
-      List<String> flagFiles = new ArrayList<>();
-      ImmutableList<String> workerArgs = splitSpawnArgsIntoWorkerArgsAndFlagFiles(spawn, flagFiles);
-      ImmutableMap<String, String> env =
-          localEnvProvider.rewriteLocalEnv(spawn.getEnvironment(), binTools, "/tmp");
-
       MetadataProvider inputFileCache = context.getMetadataProvider();
 
       SortedMap<PathFragment, HashCode> workerFiles =
@@ -208,6 +199,10 @@ final class WorkerSpawnRunner implements SpawnRunner {
       }
       SandboxOutputs outputs = helpers.getOutputs(spawn);
 
+      WorkerParser.WorkerConfig workerConfig = workerParser.compute(spawn, context);
+      WorkerKey key = workerConfig.getWorkerKey();
+      List<String> flagFiles = workerConfig.getFlagFiles();
+
       WorkerProtocolFormat protocolFormat = Spawns.getWorkerProtocolFormat(spawn);
       if (!workerOptions.experimentalJsonWorkerProtocol) {
         if (protocolFormat == WorkerProtocolFormat.JSON) {
@@ -216,19 +211,6 @@ final class WorkerSpawnRunner implements SpawnRunner {
                   + " --experimental_worker_allow_json_protocol is used");
         }
       }
-
-      WorkerKey key =
-          new WorkerKey(
-              workerArgs,
-              env,
-              execRoot,
-              Spawns.getWorkerKeyMnemonic(spawn),
-              workerFilesCombinedHash,
-              workerFiles,
-              context.speculating(),
-              multiplex && Spawns.supportsMultiplexWorkers(spawn),
-              Spawns.supportsWorkerCancellation(spawn),
-              protocolFormat);
 
       spawnMetrics =
           SpawnMetrics.Builder.forWorkerExec()


### PR DESCRIPTION
Extract the computation of the persistent worker key into a helper
class. This makes it easier to test and reuse (e.g., for remote
persistent workers).

Change-Id: Ia9aa073423281b67c16b4a351b13a812d9849e1c