### PR TITLE
[Cherrypicks for 4.2.0] Cherrypick two fixes

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -606,14 +606,17 @@ public final class SandboxModule extends BlazeModule {
 
     SandboxOptions options = env.getOptions().getOptions(SandboxOptions.class);
     int asyncTreeDeleteThreads = options != null ? options.asyncTreeDeleteIdleThreads : 0;
-    if (treeDeleter != null && asyncTreeDeleteThreads > 0) {
-      // If asynchronous deletions were requested, they may still be ongoing so let them be: trying
-      // to delete the base tree synchronously could fail as we can race with those other deletions,
-      // and scheduling an asynchronous deletion could race with future builds.
-      AsynchronousTreeDeleter treeDeleter =
-          (AsynchronousTreeDeleter) checkNotNull(this.treeDeleter);
+
+    // If asynchronous deletions were requested, they may still be ongoing so let them be: trying
+    // to delete the base tree synchronously could fail as we can race with those other deletions,
+    // and scheduling an asynchronous deletion could race with future builds.
+    if (asyncTreeDeleteThreads > 0 && treeDeleter instanceof AsynchronousTreeDeleter) {
+      AsynchronousTreeDeleter treeDeleter = (AsynchronousTreeDeleter) this.treeDeleter;
       treeDeleter.setThreads(asyncTreeDeleteThreads);
     }
+    // `treeDeleter` might not be an AsynchronousTreeDeleter if the user changed the option but
+    // then interrupted the build before the start of the execution phase. But that's OK, there
+    // will be nothing new to delete. See #13240.
 
     if (shouldCleanupSandboxBase) {
       try {

--- a/src/main/java/com/google/devtools/build/lib/worker/JsonWorkerMessageProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/JsonWorkerMessageProcessor.java
@@ -79,7 +79,10 @@ public final class JsonWorkerMessageProcessor implements WorkRequestHandler.Work
             path = reader.nextString();
             break;
           default:
-            continue;
+            // As per https://docs.bazel.build/versions/main/creating-workers.html#work-responses,
+            // unknown fields are ignored.
+            reader.skipValue();
+            break;
         }
       }
       reader.endObject();
@@ -125,6 +128,9 @@ public final class JsonWorkerMessageProcessor implements WorkRequestHandler.Work
             requestId = reader.nextInt();
             break;
           default:
+            // As per https://docs.bazel.build/versions/main/creating-workers.html#work-responses,
+            // unknown fields are ignored.
+            reader.skipValue();
             break;
         }
       }


### PR DESCRIPTION
Cherrypick request for 4.2.0 (#13558).

Fixes the default worker JSON protocol handler not allowing unknown fields, and a crash bug (#13240)