### PR TITLE
Report message from remote on status failure

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -27,6 +27,7 @@ import build.bazel.remote.execution.v2.ExecutionStage.Value;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.devtools.build.lib.actions.ActionInput;
@@ -494,6 +495,15 @@ public class RemoteSpawnRunner implements SpawnRunner {
     if (verboseFailures) {
       // On --verbose_failures print the whole stack trace
       errorMessage += "\n" + Throwables.getStackTraceAsString(exception);
+    }
+
+    if (exception.getCause() instanceof ExecutionStatusException) {
+      ExecutionStatusException e = (ExecutionStatusException) exception.getCause();
+      if (e.getResponse() != null) {
+        if (!Strings.isNullOrEmpty(e.getResponse().getMessage())) {
+          errorMessage += "\n" + e.getResponse().getMessage();
+        }
+      }
     }
 
     return new SpawnResult.Builder()

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -1078,6 +1078,35 @@ public class RemoteSpawnRunnerTest {
   }
 
   @Test
+  public void testExitCode_remoteMessage() throws Exception {
+    remoteOptions.remoteLocalFallback = false;
+
+    RemoteSpawnRunner runner = newSpawnRunner();
+
+    ExecutionStatusException cause = new ExecutionStatusException(
+        com.google.rpc.Status.getDefaultInstance(),
+        ExecuteResponse.newBuilder().setMessage("beep and indeed boop").build());
+
+    when(cache.downloadActionResult(
+        any(RemoteActionExecutionContext.class),
+        any(ActionKey.class),
+        /* inlineOutErr= */ eq(false)))
+        .thenReturn(null);
+    when(executor.executeRemotely(
+        any(RemoteActionExecutionContext.class),
+        any(ExecuteRequest.class),
+        any(OperationObserver.class)))
+        .thenThrow(new IOException("reasons", cause));
+
+    Spawn spawn = newSimpleSpawn();
+    SpawnExecutionContext policy = getSpawnContext(spawn);
+
+    SpawnResult result = runner.exec(spawn, policy);
+    assertThat(result.exitCode()).isEqualTo(ExitCode.REMOTE_ERROR.getNumericExitCode());
+    assertThat(result.getFailureMessage()).contains("beep and indeed boop");
+  }
+
+  @Test
   public void testMaterializeParamFiles() throws Exception {
     testParamFilesAreMaterializedForFlag("--materialize_param_files");
   }


### PR DESCRIPTION
If the remote has useful debugging information, it's more useful to show
it than discard it.