### PR TITLE
Remote: Propagate errors to call site when creating gRPC connections.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -133,6 +133,7 @@ java_library(
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/remote/grpc",
+        "//third_party:guava",
         "//third_party:netty",
         "//third_party/grpc:grpc-jar",
     ],


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/13724.