### PR TITLE
Support overriding debuggable in AndroidManifest

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/ProcessedAndroidData.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/ProcessedAndroidData.java
@@ -241,7 +241,7 @@ public class ProcessedAndroidData {
       Map<String, String> manifestValues) {
     return new AndroidResourcesProcessorBuilder()
         // Settings
-        .setDebug(dataContext.useDebug())
+        .setDebug(dataContext.useDebug() && !manifestValues.getOrDefault("debuggable", "true").equals("false"))
         .setJavaPackage(manifest.getPackage())
         .setApplicationId(manifestValues.get("applicationId"))
         .setVersionCode(manifestValues.get("versionCode"))


### PR DESCRIPTION
**Background**
I would like to add `debuggable="false"` into the `AndroidManifest.xml`, but specifying this directly in the `AndroidManifest.xml` does not take affect as `--debug-mode` is passed into `aapt2` which overrides what developers set. [ref](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/tools/aapt2/cmd/Link.h;l=292-294?q=debuggable&ss=android%2Fplatform%2Fsuperproject:frameworks%2Fbase%2Ftools%2Faapt2%2F)

The only way to get a debuggable apk is to require `--compilation-mode opt` which will invalidate the entire dep graph which is not feasible for large apps.
https://github.com/bazelbuild/bazel/issues/2575

**Changes**
* Add if `debuggable: "false"` is specified in `manifestValues` of the `android_binary` target do not set `--debug-mode true` during resource processor step

**Usage**
```
android_binary(
    name = "app",
    dex_shards = 10,
    manifest = "src/bazel/AndroidManifest.xml",
    manifest_values = {
        "minSdkVersion": "19",
        "appName": "...",
        "applicationId": "...",
        "debuggable": "false",
    },
    multidex = "native",
    visibility = ["//visibility:public"],
    deps = ["..."],
)
```

