### PR TITLE
Remove noisy logs from UrlRewriter.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/UrlRewriter.java
@@ -102,10 +102,6 @@ public class UrlRewriter {
     ImmutableList<URL> rewritten =
         urls.stream().map(rewriter).flatMap(Collection::stream).collect(toImmutableList());
 
-    if (!urls.equals(rewritten)) {
-      log.accept(String.format("Rewritten %s as %s", urls, rewritten));
-    }
-
     return rewritten;
   }
 


### PR DESCRIPTION
UrlRewriter prints log for each URL that is rewritten, in form of
`Rewritten %s as %s`. This causes tens of long logs to be printed,
making logs very noisy.

See also https://github.com/bazelbuild/bazel/issues/13764.