### PR TITLE
Add authentication support to the downloader rewriter

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -18,6 +18,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache;
 import com.google.devtools.build.lib.bazel.repository.cache.RepositoryCache.KeyType;
@@ -101,8 +102,11 @@ public class DownloadManager {
     }
 
     List<URL> rewrittenUrls = originalUrls;
+    Map<URI, Map<String, String>> rewrittenAuthHeaders = ImmutableMap.copyOf(authHeaders);
+
     if (rewriter != null) {
       rewrittenUrls = rewriter.amend(originalUrls);
+      rewrittenAuthHeaders = rewriter.updateAuthHeaders(rewrittenUrls, authHeaders);
     }
 
     URL mainUrl; // The "main" URL for this request
@@ -218,7 +222,7 @@ public class DownloadManager {
     try {
       downloader.download(
           rewrittenUrls,
-          authHeaders,
+          rewrittenAuthHeaders,
           checksum,
           canonicalId,
           destination,


### PR DESCRIPTION
The external repository downloader rewriter currently allows configuring
bazel to pull external dependencies from alternative locations. However,
it doesn't take credentials in the url into account.

This change fixes that by reading the user information from the URL
object and updating the authHeaders accordingly.