### PR TITLE
[Cherry-pick request 4.2.0] Refactors CompilationSupport for objc to use existing API

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingContext.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingContext.java
@@ -526,7 +526,7 @@ public class CcLinkingContext implements CcLinkingContextApi<Artifact> {
       return this;
     }
 
-    Builder addLinkstamps(List<Linkstamp> linkstamps) {
+    public Builder addLinkstamps(List<Linkstamp> linkstamps) {
       hasDirectLinkerInput = true;
       linkerInputBuilder.addLinkstamps(linkstamps);
       return this;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.ActionRegistry;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.analysis.FileProvider;
 import com.google.devtools.build.lib.analysis.RuleContext;
@@ -87,7 +88,9 @@ public final class CcLinkingHelper {
   private final BuildConfiguration configuration;
   private final CppConfiguration cppConfiguration;
 
-  private final List<Artifact> nonCodeLinkerInputs = new ArrayList<>();
+  private final NestedSetBuilder<Artifact> additionalLinkerInputsBuilder =
+      NestedSetBuilder.stableOrder();
+  private final List<Artifact> linkerOutputs = new ArrayList<>();
   private final List<String> linkopts = new ArrayList<>();
   private final List<CcLinkingContext> ccLinkingContexts = new ArrayList<>();
   private final NestedSetBuilder<Artifact> linkstamps = NestedSetBuilder.stableOrder();
@@ -96,6 +99,7 @@ public final class CcLinkingHelper {
   @Nullable private Artifact linkerOutputArtifact;
   private LinkTargetType staticLinkType = LinkTargetType.STATIC_LIBRARY;
   private LinkTargetType dynamicLinkType = LinkTargetType.NODEPS_DYNAMIC_LIBRARY;
+  private NestedSet<Artifact> additionalLinkerInputs;
   private boolean neverlink;
 
   private boolean emitInterfaceSharedLibraries;
@@ -194,19 +198,27 @@ public final class CcLinkingHelper {
     return this;
   }
 
-  /** Adds the corresponding non-code files as linker inputs. */
+  /**
+   * Adds the corresponding non-code files as linker inputs.
+   *
+   * <p>TODO(bazel-team): There is no practical difference in non-code inputs and additional linker
+   * inputs in CppLinkActionBuilder. So these should be merged. Even before that happens, it's
+   * totally fine for nonCodeLinkerInputs to contains precompiled libraries.
+   */
   public CcLinkingHelper addNonCodeLinkerInputs(List<Artifact> nonCodeLinkerInputs) {
-    for (Artifact nonCodeLinkerInput : nonCodeLinkerInputs) {
-      String basename = nonCodeLinkerInput.getFilename();
-      Preconditions.checkArgument(!Link.OBJECT_FILETYPES.matches(basename));
-      Preconditions.checkArgument(!Link.ARCHIVE_LIBRARY_FILETYPES.matches(basename));
-      Preconditions.checkArgument(!Link.SHARED_LIBRARY_FILETYPES.matches(basename));
-      this.nonCodeLinkerInputs.add(nonCodeLinkerInput);
-    }
-    if (fdoContext.getPropellerOptimizeInputFile() != null
-        && fdoContext.getPropellerOptimizeInputFile().getLdArtifact() != null) {
-      this.nonCodeLinkerInputs.add(fdoContext.getPropellerOptimizeInputFile().getLdArtifact());
-    }
+    this.additionalLinkerInputsBuilder.addAll(nonCodeLinkerInputs);
+    return this;
+  }
+
+  public CcLinkingHelper addTransitiveAdditionalLinkerInputs(
+      NestedSet<Artifact> additionalLinkerInputs) {
+    this.additionalLinkerInputsBuilder.addTransitive(additionalLinkerInputs);
+    return this;
+  }
+
+  /** TODO(bazel-team): Add to Starlark API */
+  public CcLinkingHelper addLinkerOutputs(List<Artifact> linkerOutputs) {
+    this.linkerOutputs.addAll(linkerOutputs);
     return this;
   }
 
@@ -361,6 +373,9 @@ public final class CcLinkingHelper {
       throws RuleErrorException, InterruptedException {
     Preconditions.checkNotNull(ccOutputs);
 
+    Preconditions.checkState(additionalLinkerInputs == null);
+    additionalLinkerInputs = additionalLinkerInputsBuilder.build();
+
     // Create link actions (only if there are object files or if explicitly requested).
     //
     // On some systems, the linker gives an error message if there are no input files. Even with
@@ -401,7 +416,8 @@ public final class CcLinkingHelper {
                           CcLinkingContext.LinkOptions.of(
                               ImmutableList.copyOf(linkopts), symbolGenerator)))
               .addLibraries(librariesToLink)
-              .addNonCodeInputs(nonCodeLinkerInputs)
+              // additionalLinkerInputsBuilder not expected to be a big list for now.
+              .addNonCodeInputs(additionalLinkerInputsBuilder.build().toList())
               .addLinkstamps(linkstampBuilder.build())
               .build();
     }
@@ -629,7 +645,6 @@ public final class CcLinkingHelper {
     CppLinkAction action =
         newLinkActionBuilder(linkedArtifact, linkTargetTypeUsedForNaming)
             .addObjectFiles(ccOutputs.getObjectFiles(usePic))
-            .addNonCodeInputs(nonCodeLinkerInputs)
             .addLtoCompilationContext(ccOutputs.getLtoCompilationContext())
             .setUsePicForLtoBackendActions(usePic)
             .setLinkingMode(LinkingMode.STATIC)
@@ -694,7 +709,6 @@ public final class CcLinkingHelper {
             .addActionInputs(linkActionInputs)
             .addLinkopts(linkopts)
             .addLinkopts(sonameLinkopts)
-            .addNonCodeInputs(nonCodeLinkerInputs)
             .addVariablesExtensions(variablesExtensions);
 
     dynamicLinkActionBuilder.addObjectFiles(ccOutputs.getObjectFiles(usePic));
@@ -829,28 +843,43 @@ public final class CcLinkingHelper {
 
   private CppLinkActionBuilder newLinkActionBuilder(
       Artifact outputArtifact, LinkTargetType linkType) {
-    return new CppLinkActionBuilder(
-            ruleErrorConsumer,
-            actionConstructionContext,
-            label,
-            outputArtifact,
-            configuration,
-            ccToolchain,
-            fdoContext,
-            featureConfiguration,
-            semantics)
-        .setGrepIncludes(grepIncludes)
-        .setIsStampingEnabled(isStampingEnabled)
-        .setTestOrTestOnlyTarget(isTestOrTestOnlyTarget)
-        .setLinkType(linkType)
-        .setLinkerFiles(
-            (cppConfiguration.useSpecificToolFiles()
-                    && linkType.linkerOrArchiver() == LinkerOrArchiver.ARCHIVER)
-                ? ccToolchain.getArFiles()
-                : ccToolchain.getLinkerFiles())
-        .setLinkArtifactFactory(linkArtifactFactory)
-        .setUseTestOnlyFlags(useTestOnlyFlags)
-        .addExecutionInfo(executionInfo);
+    if (!additionalLinkerInputsBuilder.isEmpty()) {
+      if (fdoContext.getPropellerOptimizeInputFile() != null
+          && fdoContext.getPropellerOptimizeInputFile().getLdArtifact() != null) {
+        this.additionalLinkerInputsBuilder.add(
+            fdoContext.getPropellerOptimizeInputFile().getLdArtifact());
+      }
+    }
+    CppLinkActionBuilder builder =
+        new CppLinkActionBuilder(
+                ruleErrorConsumer,
+                actionConstructionContext,
+                label,
+                outputArtifact,
+                configuration,
+                ccToolchain,
+                fdoContext,
+                featureConfiguration,
+                semantics)
+            .setGrepIncludes(grepIncludes)
+            .setMnemonic(
+                featureConfiguration.isEnabled(CppRuleClasses.LANG_OBJC) ? "ObjcLink" : null)
+            .setIsStampingEnabled(isStampingEnabled)
+            .setTestOrTestOnlyTarget(isTestOrTestOnlyTarget)
+            .setLinkType(linkType)
+            .setLinkerFiles(
+                (cppConfiguration.useSpecificToolFiles()
+                        && linkType.linkerOrArchiver() == LinkerOrArchiver.ARCHIVER)
+                    ? ccToolchain.getArFiles()
+                    : ccToolchain.getLinkerFiles())
+            .setLinkArtifactFactory(linkArtifactFactory)
+            .setUseTestOnlyFlags(useTestOnlyFlags)
+            .addTransitiveActionInputs(additionalLinkerInputs)
+            .addExecutionInfo(executionInfo);
+    for (Artifact output : linkerOutputs) {
+      builder.addActionOutput(output);
+    }
+    return builder;
   }
 
   /**
@@ -876,12 +905,28 @@ public final class CcLinkingHelper {
     linkedName =
         CppHelper.getArtifactNameForCategory(
             ruleErrorConsumer, ccToolchain, linkTargetType.getLinkerOutput(), linkedName);
+
+    ArtifactRoot artifactRoot = configuration.getBinDirectory(label.getRepository());
+    if (linkTargetType.equals(LinkTargetType.OBJC_FULLY_LINKED_ARCHIVE)) {
+      // TODO(blaze-team): This unfortunate editing of the name is here bedcause Objective-C rules
+      // were creating this type of archive without the lib prefix, unlike what the objective-c
+      // toolchain says with getArtifactNameForCategory.
+      // This can be fixed either when implicit outputs are removed from objc_library by keeping the
+      // lib prefix, or by editing the toolchain not to add it.
+      Preconditions.checkState(linkedName.startsWith("lib"));
+      linkedName = linkedName.substring(3);
+      artifactRoot =
+          ((RuleContext) actionConstructionContext).getRule().hasBinaryOutput()
+              ? configuration.getBinDir()
+              : configuration.getGenfilesDir();
+    }
       PathFragment artifactFragment =
           PathFragment.create(label.getName()).getParentDirectory().getRelative(linkedName);
 
     return CppHelper.getLinkedArtifact(
         label,
         actionConstructionContext,
+        artifactRoot,
         configuration,
         linkTargetType,
         linkedArtifactNameSuffix,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppHelper.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.actions.Action;
 import com.google.devtools.build.lib.actions.ActionOwner;
 import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.SpecialArtifact;
+import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.FailAction;
 import com.google.devtools.build.lib.actions.MiddlemanFactory;
 import com.google.devtools.build.lib.actions.ParamFileInfo;
@@ -473,19 +474,24 @@ public class CppHelper {
     }
 
     return getLinkedArtifact(
-        ruleContext.getLabel(), ruleContext, config, linkType, linkedArtifactNameSuffix, name);
+        ruleContext.getLabel(),
+        ruleContext,
+        ruleContext.getBinDirectory(),
+        config,
+        linkType,
+        linkedArtifactNameSuffix,
+        name);
   }
 
   public static Artifact getLinkedArtifact(
       Label label,
       ActionConstructionContext actionConstructionContext,
+      ArtifactRoot artifactRoot,
       BuildConfiguration config,
       LinkTargetType linkType,
       String linkedArtifactNameSuffix,
       PathFragment name) {
-    Artifact result =
-        actionConstructionContext.getPackageRelativeArtifact(
-            name, config.getBinDirectory(label.getRepository()));
+    Artifact result = actionConstructionContext.getPackageRelativeArtifact(name, artifactRoot);
 
     // If the linked artifact is not the linux default, then a FailAction is generated for said
     // linux default to satisfy the requirements of any implicit outputs.
@@ -507,7 +513,7 @@ public class CppHelper {
     return result;
   }
 
-  public static Artifact getLinuxLinkedArtifact(
+  private static Artifact getLinuxLinkedArtifact(
       Label label,
       ActionConstructionContext actionConstructionContext,
       BuildConfiguration config,

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java
@@ -1315,6 +1315,7 @@ public class CppLinkActionBuilder {
    * Adds non-code files to the set of inputs. They will not be passed to the linker command line
    * unless that is explicitly modified, too.
    */
+  // TOOD: Remove and just use method for addLinkerInputs
   public CppLinkActionBuilder addNonCodeInputs(Iterable<Artifact> inputs) {
     for (Artifact input : inputs) {
       addNonCodeInput(input);
@@ -1328,11 +1329,6 @@ public class CppLinkActionBuilder {
    * line unless that is explicitly modified, too.
    */
   public CppLinkActionBuilder addNonCodeInput(Artifact input) {
-    String basename = input.getFilename();
-    Preconditions.checkArgument(!Link.ARCHIVE_LIBRARY_FILETYPES.matches(basename), basename);
-    Preconditions.checkArgument(!Link.SHARED_LIBRARY_FILETYPES.matches(basename), basename);
-    Preconditions.checkArgument(!Link.OBJECT_FILETYPES.matches(basename), basename);
-
     this.nonCodeInputs.add(input);
     return this;
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/CompilationSupport.java
@@ -42,6 +42,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -66,6 +67,8 @@ import com.google.devtools.build.lib.analysis.test.InstrumentedFilesCollector;
 import com.google.devtools.build.lib.analysis.test.InstrumentedFilesCollector.InstrumentationSpec;
 import com.google.devtools.build.lib.analysis.test.InstrumentedFilesCollector.LocalMetadataCollector;
 import com.google.devtools.build.lib.analysis.test.InstrumentedFilesInfo;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
@@ -97,6 +100,7 @@ import com.google.devtools.build.lib.rules.cpp.CppLinkActionBuilder;
 import com.google.devtools.build.lib.rules.cpp.CppModuleMap;
 import com.google.devtools.build.lib.rules.cpp.CppModuleMapAction;
 import com.google.devtools.build.lib.rules.cpp.CppRuleClasses;
+import com.google.devtools.build.lib.rules.cpp.CppSemantics;
 import com.google.devtools.build.lib.rules.cpp.FdoContext;
 import com.google.devtools.build.lib.rules.cpp.IncludeProcessing;
 import com.google.devtools.build.lib.rules.cpp.IncludeScanning;
@@ -109,6 +113,7 @@ import com.google.devtools.build.lib.rules.objc.ObjcProvider.Flag;
 import com.google.devtools.build.lib.rules.objc.ObjcVariablesExtension.VariableCategory;
 import com.google.devtools.build.lib.util.FileTypeSet;
 import com.google.devtools.build.lib.util.Pair;
+import com.google.devtools.build.lib.vfs.FileSystemUtils;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1156,34 +1161,51 @@ public class CompilationSupport {
             .addVariableCategory(VariableCategory.EXECUTABLE_LINKING_VARIABLES);
 
     Artifact binaryToLink = getBinaryToLink();
-    CppLinkActionBuilder executableLinkActionBuilder =
-        new CppLinkActionBuilder(
+    CppSemantics cppSemantics = createObjcCppSemantics();
+    FeatureConfiguration featureConfiguration =
+        getFeatureConfiguration(ruleContext, toolchain, buildConfiguration);
+
+    Label binaryLabel = null;
+    try {
+      binaryLabel =
+          Label.create(ruleContext.getLabel().getPackageIdentifier(), binaryToLink.getFilename());
+    } catch (LabelSyntaxException e) {
+      // Formed from existing label, just replacing name with artifact name.
+    }
+
+    CcLinkingHelper executableLinkingHelper =
+        new CcLinkingHelper(
+                ruleContext,
+                binaryLabel,
                 ruleContext,
                 ruleContext,
-                ruleContext.getLabel(),
-                binaryToLink,
-                buildConfiguration,
+                cppSemantics,
+                featureConfiguration,
                 toolchain,
                 toolchain.getFdoContext(),
-                getFeatureConfiguration(ruleContext, toolchain, buildConfiguration),
-                createObjcCppSemantics())
+                buildConfiguration,
+                ruleContext.getFragment(CppConfiguration.class),
+                ruleContext.getSymbolGenerator(),
+                TargetUtils.getExecutionInfo(
+                    ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
             .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
             .setIsStampingEnabled(isStampingEnabled)
             .setTestOrTestOnlyTarget(ruleContext.isTestOnlyTarget() || ruleContext.isTestTarget())
-            .setMnemonic("ObjcLink")
-            .addActionInputs(bazelBuiltLibraries)
-            .addActionInputs(objcProvider.getCcLibraries())
-            .addTransitiveActionInputs(objcProvider.get(IMPORTED_LIBRARY))
-            .addTransitiveActionInputs(objcProvider.get(STATIC_FRAMEWORK_FILE))
-            .addTransitiveActionInputs(objcProvider.get(DYNAMIC_FRAMEWORK_FILE))
-            .addTransitiveActionInputs(objcProvider.get(LINK_INPUTS))
-            .setLinkerFiles(toolchain.getLinkerFiles())
-            .addActionInputs(prunedJ2ObjcArchives)
-            .addActionInputs(extraLinkInputs)
-            .addActionInput(inputFileList)
-            .setLinkType(linkType)
+            .addNonCodeLinkerInputs(bazelBuiltLibraries)
+            .addNonCodeLinkerInputs(objcProvider.getCcLibraries())
+            .addNonCodeLinkerInputs(ImmutableList.copyOf(prunedJ2ObjcArchives))
+            .addNonCodeLinkerInputs(ImmutableList.copyOf(extraLinkInputs))
+            .addNonCodeLinkerInputs(ImmutableList.of(inputFileList))
+            .addTransitiveAdditionalLinkerInputs(objcProvider.get(IMPORTED_LIBRARY))
+            .addTransitiveAdditionalLinkerInputs(objcProvider.get(STATIC_FRAMEWORK_FILE))
+            .addTransitiveAdditionalLinkerInputs(objcProvider.get(DYNAMIC_FRAMEWORK_FILE))
+            .addTransitiveAdditionalLinkerInputs(objcProvider.get(LINK_INPUTS))
+            .setShouldCreateStaticLibraries(false)
+            .setDynamicLinkType(linkType)
             .setLinkingMode(LinkingMode.STATIC)
             .addLinkopts(ImmutableList.copyOf(extraLinkArgs));
+
+    ImmutableList.Builder<Artifact> linkerOutputs = ImmutableList.builder();
 
     if (objcConfiguration.generateDsym()) {
       Artifact dsymSymbol =
@@ -1193,13 +1215,13 @@ public class CompilationSupport {
       extensionBuilder
           .setDsymSymbol(dsymSymbol)
           .addVariableCategory(VariableCategory.DSYM_VARIABLES);
-      executableLinkActionBuilder.addActionOutput(dsymSymbol);
+      linkerOutputs.add(dsymSymbol);
     }
 
     if (objcConfiguration.generateLinkmap()) {
       Artifact linkmap = intermediateArtifacts.linkmap();
       extensionBuilder.setLinkmap(linkmap).addVariableCategory(VariableCategory.LINKMAP_VARIABLES);
-      executableLinkActionBuilder.addActionOutput(linkmap);
+      linkerOutputs.add(linkmap);
     }
 
     if (appleConfiguration.getBitcodeMode() == AppleBitcodeMode.EMBEDDED) {
@@ -1207,29 +1229,39 @@ public class CompilationSupport {
       extensionBuilder
           .setBitcodeSymbolMap(bitcodeSymbolMap)
           .addVariableCategory(VariableCategory.BITCODE_VARIABLES);
-      executableLinkActionBuilder.addActionOutput(bitcodeSymbolMap);
+      linkerOutputs.add(bitcodeSymbolMap);
     }
 
-    executableLinkActionBuilder.addVariablesExtension(extensionBuilder.build());
+    executableLinkingHelper.addVariableExtension(extensionBuilder.build());
 
+    executableLinkingHelper.addLinkerOutputs(linkerOutputs.build());
+
+    CcLinkingContext.Builder linkstampsBuilder = CcLinkingContext.builder();
     for (CcLinkingContext context :
         CppHelper.getLinkingContextsFromDeps(
             ImmutableList.copyOf(ruleContext.getPrerequisites("deps")))) {
-      executableLinkActionBuilder.addLinkstamps(context.getLinkstamps().toList());
+      linkstampsBuilder.addLinkstamps(context.getLinkstamps().toList());
     }
+    CcLinkingContext linkstamps = linkstampsBuilder.build();
+    executableLinkingHelper.addCcLinkingContexts(ImmutableList.of(linkstamps));
 
-    CppLinkAction executableLinkAction = executableLinkActionBuilder.build();
+    executableLinkingHelper.link(CcCompilationOutputs.EMPTY);
+
+    ImmutableCollection<Artifact> linkstampValues =
+        CppLinkActionBuilder.mapLinkstampsToOutputs(
+                linkstamps.getLinkstamps().toSet(),
+                ruleContext,
+                ruleContext.getRepository(),
+                buildConfiguration,
+                binaryToLink,
+                CppLinkAction.DEFAULT_ARTIFACT_FACTORY)
+            .values();
 
     // Populate the input file list with both the compiled object files and any linkstamp object
     // files.
     registerObjFilelistAction(
-        ImmutableSet.<Artifact>builder()
-            .addAll(objFiles)
-            .addAll(executableLinkAction.getLinkstampObjectFileInputs())
-            .build(),
+        ImmutableSet.<Artifact>builder().addAll(objFiles).addAll(linkstampValues).build(),
         inputFileList);
-
-    ruleContext.registerAction(executableLinkAction);
 
     if (objcConfiguration.shouldStripBinary()) {
       registerBinaryStripAction(binaryToLink, getStrippingType(extraLinkArgs));
@@ -1316,12 +1348,7 @@ public class CompilationSupport {
       throws InterruptedException, RuleErrorException {
     checkNotNull(toolchain);
     checkNotNull(toolchain.getFdoContext());
-    PathFragment labelName = PathFragment.create(ruleContext.getLabel().getName());
-    String libraryIdentifier =
-        ruleContext
-            .getPackageDirectory()
-            .getRelative(labelName.replaceName("lib" + labelName.getBaseName()))
-            .getPathString();
+
     ObjcVariablesExtension extension =
         new ObjcVariablesExtension.Builder()
             .setRuleContext(ruleContext)
@@ -1331,30 +1358,42 @@ public class CompilationSupport {
             .setFullyLinkArchive(outputArchive)
             .addVariableCategory(VariableCategory.FULLY_LINK_VARIABLES)
             .build();
-    CppLinkAction fullyLinkAction =
-        new CppLinkActionBuilder(
-                ruleContext,
-                ruleContext,
-                ruleContext.getLabel(),
-                outputArchive,
-                buildConfiguration,
-                toolchain,
-                toolchain.getFdoContext(),
-                getFeatureConfiguration(ruleContext, toolchain, buildConfiguration),
-                createObjcCppSemantics())
-            .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
-            .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
-            .setTestOrTestOnlyTarget(ruleContext.isTestOnlyTarget() || ruleContext.isTestTarget())
-            .addActionInputs(objcProvider.getObjcLibraries())
-            .addActionInputs(objcProvider.getCcLibraries())
-            .addActionInputs(objcProvider.get(IMPORTED_LIBRARY).toSet())
-            .setLinkerFiles(toolchain.getLinkerFiles())
-            .setLinkType(LinkTargetType.OBJC_FULLY_LINKED_ARCHIVE)
-            .setLinkingMode(LinkingMode.STATIC)
-            .setLibraryIdentifier(libraryIdentifier)
-            .addVariablesExtension(extension)
-            .build();
-    ruleContext.registerAction(fullyLinkAction);
+
+    Label archiveLabel = null;
+    try {
+      archiveLabel =
+          Label.create(
+              ruleContext.getLabel().getPackageIdentifier(),
+              FileSystemUtils.removeExtension(outputArchive.getFilename()));
+    } catch (LabelSyntaxException e) {
+      // Formed from existing label, just replacing name with artifact name.
+    }
+
+    new CcLinkingHelper(
+            ruleContext,
+            archiveLabel,
+            ruleContext,
+            ruleContext,
+            createObjcCppSemantics(),
+            getFeatureConfiguration(ruleContext, toolchain, buildConfiguration),
+            toolchain,
+            toolchain.getFdoContext(),
+            buildConfiguration,
+            ruleContext.getFragment(CppConfiguration.class),
+            ruleContext.getSymbolGenerator(),
+            TargetUtils.getExecutionInfo(
+                ruleContext.getRule(), ruleContext.isAllowTagsPropagation()))
+        .setGrepIncludes(CppHelper.getGrepIncludes(ruleContext))
+        .setIsStampingEnabled(AnalysisUtils.isStampingEnabled(ruleContext))
+        .setTestOrTestOnlyTarget(ruleContext.isTestOnlyTarget() || ruleContext.isTestTarget())
+        .addNonCodeLinkerInputs(objcProvider.getObjcLibraries())
+        .addNonCodeLinkerInputs(objcProvider.getCcLibraries())
+        .addTransitiveAdditionalLinkerInputs(objcProvider.get(IMPORTED_LIBRARY))
+        .setLinkingMode(LinkingMode.STATIC)
+        .setStaticLinkType(LinkTargetType.OBJC_FULLY_LINKED_ARCHIVE)
+        .setShouldCreateDynamicLibrary(false)
+        .addVariableExtension(extension)
+        .link(CcCompilationOutputs.EMPTY);
 
     return this;
   }


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/13834

Original commit: 31b689ba7238abe5629a0de87fb6e245910526bb

---

This CL makes CompilationSupport use CcLinkingHelper instead of CppLinkActionBuilder. The former is the Java class used by the existing Starlark linking API.

This is in preparation for a future (unknown when) re-write of objc rules to
Starlark.

This is a rollforward after fixing an issue with implicit outputs of proto_libraries which had the j2objc_aspect applied on it. These artifacts were created with the genfiles dir while the C++ sandwich was always creating them in the bin dir.

RELNOTES:none
PiperOrigin-RevId: 353879792
(cherry picked from commit 31b689ba7238abe5629a0de87fb6e245910526bb)