### PR TITLE
[Cherrypick 4.2.0] Fix Windows tests for 4.2.0rc3 after Windows image update

### DIFF
--- a/src/test/shell/bazel/python_version_test.sh
+++ b/src/test/shell/bazel/python_version_test.sh
@@ -531,13 +531,13 @@ py_library(
     # (i.e., those implemented in C) use a different loader than
     # Python-implemented ones, even though they're both part of the standard
     # distribution of the interpreter.
-    srcs = ["re.py"],
+    srcs = ["mailbox.py"],
 )
 EOF
   cat > test/main.py << EOF
-import re
+import mailbox
 EOF
-  cat > test/re.py << EOF
+  cat > test/mailbox.py << EOF
 print("I am lib!")
 EOF
 

--- a/src/test/shell/bazel/resource_compiler_toolchain_test.sh
+++ b/src/test/shell/bazel/resource_compiler_toolchain_test.sh
@@ -181,14 +181,14 @@ function _assert_outputs() {
   [[ -e bazel-bin/foo.res ]] || fail "missing output"
   grep -q "src=foo.rc" "bazel-bin/foo.res" || fail "bad output"
   grep -q "out=.*\bfoo.res" "bazel-bin/foo.res" || fail "bad output"
-  grep -q ".*\bres1.dat$" "bazel-bin/foo.res" || fail "bad output"
-  grep -q ".*\bres2.dat$" "bazel-bin/foo.res" || fail "bad output"
+  grep -q ".*\bres1.dat" "bazel-bin/foo.res" || fail "bad output"
+  grep -q ".*\bres2.dat" "bazel-bin/foo.res" || fail "bad output"
 
   [[ -e bazel-bin/bar.res ]] || fail "missing output"
   grep -q "src=bar.rc" "bazel-bin/bar.res" || fail "bad output"
   grep -q "out=.*\bbar.res" "bazel-bin/bar.res" || fail "bad output"
-  grep -q ".*\bres1.dat$" "bazel-bin/bar.res" || fail "bad output"
-  grep -q ".*\bres2.dat$" "bazel-bin/bar.res" || fail "bad output"
+  grep -q ".*\bres1.dat" "bazel-bin/bar.res" || fail "bad output"
+  grep -q ".*\bres2.dat" "bazel-bin/bar.res" || fail "bad output"
 }
 
 function _assert_no_outputs() {

--- a/src/test/shell/integration/loading_phase_test.sh
+++ b/src/test/shell/integration/loading_phase_test.sh
@@ -598,8 +598,8 @@ function test_path_from_subdir() {
   cd "$pkg/subdir"
   bazel query '../BUILD + ../foo' >output 2> "$TEST_log" \
       || fail "Expected success"
-  assert_contains "^//$pkg:BUILD\$" output
-  assert_contains "^//$pkg:foo\$" output
+  assert_contains "^//$pkg:BUILD" output
+  assert_contains "^//$pkg:foo" output
 }
 
 function test_target_with_BUILD() {
@@ -607,7 +607,7 @@ function test_target_with_BUILD() {
   mkdir -p "$pkg" || fail "could not create \"$pkg\""
   echo 'filegroup(name = "foo/BUILD", srcs = [])' > "$pkg/BUILD" || fail "echo"
   bazel query "$pkg/foo/BUILD" >output 2> "$TEST_log" || fail "Expected success"
-  assert_contains "^//$pkg:foo/BUILD\$" output
+  assert_contains "^//$pkg:foo/BUILD" output
 }
 
 function test_directory_with_BUILD() {
@@ -615,7 +615,7 @@ function test_directory_with_BUILD() {
   mkdir -p "$pkg/BUILD" || fail "could not create \"$pkg/BUILD\""
   touch "$pkg/BUILD/BUILD" || fail "Couldn't touch"
   bazel query "$pkg/BUILD" >output 2> "$TEST_log" || fail "Expected success"
-  assert_contains "^//$pkg/BUILD:BUILD\$" output
+  assert_contains "^//$pkg/BUILD:BUILD" output
 }
 
 function test_missing_BUILD() {

--- a/src/test/shell/integration/target_compatible_with_test.sh
+++ b/src/test/shell/integration/target_compatible_with_test.sh
@@ -629,7 +629,7 @@ EOF
   # Validate that we get the dependency chain printed out.
   expect_log '^Dependency chain:$'
   expect_log '^    //target_skipping:generate_with_tool$'
-  expect_log "^    //target_skipping:generator_tool   <-- target platform didn't satisfy constraint //target_skipping:foo1$"
+  expect_log "^    //target_skipping:generator_tool   <-- target platform didn't satisfy constraint //target_skipping:foo1"
   expect_log 'FAILED: Build did NOT complete successfully'
 
   # Validate the test.
@@ -644,7 +644,7 @@ EOF
   expect_log '^Dependency chain:$'
   expect_log '^    //target_skipping:generated_test$'
   expect_log '^    //target_skipping:generate_with_tool$'
-  expect_log "^    //target_skipping:generator_tool   <-- target platform didn't satisfy constraint //target_skipping:foo1$"
+  expect_log "^    //target_skipping:generator_tool   <-- target platform didn't satisfy constraint //target_skipping:foo1"
   expect_log 'FAILED: Build did NOT complete successfully'
 }
 
@@ -692,7 +692,7 @@ EOF
   expect_log '^Dependency chain:$'
   expect_log '^    //target_skipping:generated_test$'
   expect_log '^    //target_skipping:generate_with_tool$'
-  expect_log "^    //target_skipping:generator_tool   <-- target platform didn't satisfy constraints \[//target_skipping:foo1, //target_skipping:bar2\]$"
+  expect_log "^    //target_skipping:generator_tool   <-- target platform didn't satisfy constraints \[//target_skipping:foo1, //target_skipping:bar2\]"
   expect_log 'FAILED: Build did NOT complete successfully'
 }
 
@@ -848,7 +848,7 @@ EOF
 
   # Make sure that the contents of the file are what we expect.
   cp ../${PRODUCT_NAME}-bin/target_skipping/host_tool_message.txt "${TEST_log}"
-  expect_log '^Hello World$'
+  expect_log 'Hello World'
 }
 
 # Validates that we successfully skip analysistest rule targets when they
@@ -916,8 +916,8 @@ function test_query() {
   bazel query \
     'deps(//target_skipping:sh_foo1)' &> "${TEST_log}" \
     || fail "Bazel query failed unexpectedly."
-  expect_log '^//target_skipping:sh_foo1$'
-  expect_log '^//target_skipping:genrule_foo1$'
+  expect_log '^//target_skipping:sh_foo1'
+  expect_log '^//target_skipping:genrule_foo1'
 }
 
 # Run a cquery on a target that is compatible. This should pass.


### PR DESCRIPTION
Cherrypick request for 4.2.0 (#13558).

Context: https://github.com/bazelbuild/bazel/issues/13816