### PR TITLE
Support `|` delimiter in ijar zipper to support `py_binary` zipping files with `=` in file name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/BazelPythonSemantics.java
@@ -356,15 +356,15 @@ public class BazelPythonSemantics implements PythonSemantics {
     PathFragment workspaceName = runfilesSupport.getWorkspaceName();
     CustomCommandLine.Builder argv = new CustomCommandLine.Builder();
     inputsBuilder.add(stubFile);
-    argv.addPrefixedExecPath("__main__.py=", stubFile);
+    argv.addPrefixedExecPath("__main__.py|", stubFile);
     boolean legacyExternalRunfiles = ruleContext.getConfiguration().legacyExternalRunfiles();
 
     // Creating __init__.py files under each directory
-    argv.add("__init__.py=");
+    argv.add("__init__.py|");
     argv.addDynamicString(
-        getZipRunfilesPath("__init__.py", workspaceName, legacyExternalRunfiles) + "=");
+        getZipRunfilesPath("__init__.py", workspaceName, legacyExternalRunfiles) + "|");
     for (String path : runfilesSupport.getRunfiles().getEmptyFilenames().toList()) {
-      argv.addDynamicString(getZipRunfilesPath(path, workspaceName, legacyExternalRunfiles) + "=");
+      argv.addDynamicString(getZipRunfilesPath(path, workspaceName, legacyExternalRunfiles) + "|");
     }
 
     // Read each runfile from execute path, add them into zip file at the right runfiles path.
@@ -373,7 +373,7 @@ public class BazelPythonSemantics implements PythonSemantics {
       if (!artifact.equals(executable) && !artifact.equals(zipFile)) {
         argv.addDynamicString(
             getZipRunfilesPath(artifact.getRunfilesPath(), workspaceName, legacyExternalRunfiles)
-                + "="
+                + "|"
                 + artifact.getExecPathString());
         inputsBuilder.add(artifact);
       }
@@ -385,7 +385,7 @@ public class BazelPythonSemantics implements PythonSemantics {
             .addOutput(zipFile)
             .setExecutable(zipper)
             .useDefaultShellEnvironment()
-            .addCommandLine(CustomCommandLine.builder().add("cC").addExecPath(zipFile).build())
+            .addCommandLine(CustomCommandLine.builder().add("cCP").addExecPath(zipFile).build())
             // zipper can only consume file list options from param file not other options,
             // so write file list in the param file.
             .addCommandLine(

--- a/third_party/ijar/test/zip_test.sh
+++ b/third_party/ijar/test/zip_test.sh
@@ -172,7 +172,7 @@ function test_zipper_specify_path() {
   mkdir -p ${TEST_TMPDIR}/files
   echo "toto" > ${TEST_TMPDIR}/files/a.txt
   echo "titi" > ${TEST_TMPDIR}/files/b.txt
-  rm -fr ${TEST_TMPDIR}/expect/foo/bar
+  rm -fr ${TEST_TMPDIR}/expect/foo
   mkdir -p ${TEST_TMPDIR}/expect/foo/bar
   touch ${TEST_TMPDIR}/expect/empty.txt
   echo "toto" > ${TEST_TMPDIR}/expect/foo/a.txt
@@ -183,6 +183,26 @@ function test_zipper_specify_path() {
   ${ZIPPER} cC ${TEST_TMPDIR}/output.zip empty.txt= \
       foo/a.txt=${TEST_TMPDIR}/files/a.txt \
       foo/bar/b.txt=${TEST_TMPDIR}/files/b.txt
+  (cd ${TEST_TMPDIR}/out && $UNZIP -q ${TEST_TMPDIR}/output.zip)
+  diff -r ${TEST_TMPDIR}/expect ${TEST_TMPDIR}/out &> $TEST_log \
+      || fail "Unzip after zipper output is not expected"
+}
+
+function test_zipper_specify_path_with_pipe_delimiter() {
+  mkdir -p ${TEST_TMPDIR}/files
+  echo "toto" > ${TEST_TMPDIR}/files/a=.txt
+  echo "titi" > ${TEST_TMPDIR}/files/b.txt
+  rm -fr ${TEST_TMPDIR}/expect/foo
+  mkdir -p ${TEST_TMPDIR}/expect/foo/bar
+  touch ${TEST_TMPDIR}/expect/empty.txt
+  echo "toto" > ${TEST_TMPDIR}/expect/foo/a=.txt
+  echo "titi" > ${TEST_TMPDIR}/expect/foo/bar/b.txt
+  rm -fr ${TEST_TMPDIR}/out
+  mkdir -p ${TEST_TMPDIR}/out
+
+  ${ZIPPER} cCP ${TEST_TMPDIR}/output.zip "empty.txt|" \
+      "foo/a=.txt|${TEST_TMPDIR}/files/a.txt" \
+      "foo/bar/b.txt|${TEST_TMPDIR}/files/b.txt"
   (cd ${TEST_TMPDIR}/out && $UNZIP -q ${TEST_TMPDIR}/output.zip)
   diff -r ${TEST_TMPDIR}/expect ${TEST_TMPDIR}/out &> $TEST_log \
       || fail "Unzip after zipper output is not expected"


### PR DESCRIPTION
**Background**
https://github.com/bazelbuild/bazel/issues/12841

`py_binary` build zip fails when a file contains `=` since that character is used as a delimiter. I added support for another mode in the ijar zipper to support `|` character as a delimiter which should be less likely to occur as it is a restricted character on windows systems. However, it does not fully mitigate the issue. A more stable solution is multi-char delimiter but requires larger structural changes.

**Changes**
* Add support for `|` delimiter to ijar zipper

**Test Plan**
* Tests pass. E2E tested on pybinary repo