### PR TITLE
Allow disk cache with remote exec

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -274,9 +274,9 @@ public final class RemoteModule extends BlazeModule {
       return;
     }
 
-    if ((enableHttpCache || enableDiskCache) && enableRemoteExecution) {
+    if (enableHttpCache && enableRemoteExecution) {
       throw createOptionsExitException(
-          "Cannot combine gRPC based remote execution with disk caching or HTTP-based caching",
+          "Cannot combine gRPC based remote execution with HTTP-based caching",
           FailureDetails.RemoteOptions.Code.EXECUTION_WITH_INVALID_CACHE);
     }
 
@@ -504,6 +504,22 @@ public final class RemoteModule extends BlazeModule {
             uploader, cacheClient, remoteBytestreamUriPrefix, buildRequestId, invocationId));
 
     if (enableRemoteExecution) {
+
+      if(enableDiskCache) {
+        try {
+        cacheClient = RemoteCacheClientFactory.createDiskAndRemoteClient(
+            env.getWorkingDirectory(),
+            remoteOptions.diskCache,
+            remoteOptions.remoteVerifyDownloads,
+            digestUtil,
+            cacheClient,
+            remoteOptions);
+        } catch (IOException e) {
+          handleInitFailure(env, e, Code.CACHE_INIT_FAILURE);
+          return;
+        }
+      }
+
       RemoteExecutionClient remoteExecutor;
       if (remoteOptions.remoteExecutionKeepalive) {
         RemoteRetrier execRetrier =

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -269,6 +269,8 @@ public class RemoteSpawnRunner implements SpawnRunner {
             }
 
             try {
+              // Don't want to reupload remote execution cache, just to disk cache
+              // remoteExecutionService.uploadOutputs(action);
               return downloadAndFinalizeSpawnResult(
                   action,
                   result,

--- a/src/test/shell/bazel/remote/remote_utils.sh
+++ b/src/test/shell/bazel/remote/remote_utils.sh
@@ -60,3 +60,21 @@ function stop_worker() {
     rm -rf "${cas_path}"
   fi
 }
+
+# Pass in the root of the disk cache and count number of files under /ac directory
+# output int to stdout
+function count_disk_ac_files() {
+  if [ -d "$1/ac" ]; then
+    expr $(find "$1/ac" -type f | wc -l)
+  else
+    echo 0
+  fi
+}
+
+function count_remote_ac_files() {
+  if [ -d "$cas_path/ac" ]; then
+    expr $(find "$cas_path/ac" -type f | wc -l)
+  else
+    echo 0
+  fi
+}


### PR DESCRIPTION
[the PR needs to have the tests cleaned up / amended, but
 I wanted to start the discussion before investing more time]

This allows usage of remote execution and a local disk cache.

The initial PR creating a combined disk and grpc cache mentioned issues with
findMissingDigests for DiskAndRemoteCacheClient,
but I noticed a couple oddities and I'm not sure if I'm missing something.
[https://cs.opensource.google/bazel/bazel/+/5f4d6995db1eb6a9d35dc163c0150283e830aa3d]

The original concern was that we should ignore the disk cache and only pay attention
to the remote cache when using DiskAndRemoteCacheClient with remote exec.  This makes
sense as bazel has to ensure the blobs are available remotely.

However, the code in findMissingDigests returns the union of all missing digests (both
disk and remote).  If it short-circuited the check by only checking  the disk cache
and only returned the disk-cache result if non-empty, I would understand the concern.
But the current code returns the union of the disk-cache result and the remote-cache result.

Additionally the current code for DiskCacheClient#findMissingBlobs unconditionally returns _all_ digests
as missing.  So in essence, the current code is always returning _all_ digests as missing.
This seems like a bug due to optimizations.
[I'm fixing this in the DiskAndRemoteCacheClient by only calling the remote for find Missing when doing remoteExec]

A test to resolve the concern would be to run remote action (which would populate both disk and remote cache).
  * verify it is in the disk cache.
  * clear the remote cache of both action cache and blobs
  * clear disk cache of blobs, but not action cache
  + run the action again.

Another concern is the current code won't upload to the remote caches (specifically the disk cache)
when the remote_exec happens.

I believe the general assumption is that most remote_exec engines will populate the remote cache themselves
so currently there isn't a call to `remoteExecutionService.uploadOutputs` when doing remote exec.
It is only there for local spawns.
Since the remote disk cache with remote exec is currently disabled, this hasn't come up.
The next time the action is attempted, it will be found in the remote_cache and pulled down.
With the current PR, the disk_cache will get populated when the ActionResult is pulled from the remote_cache
on a future run. I think that is good enough for now.

I left a note in RemoteSpawnRunner where we can update the disk cache at the
time of the RemoteExec, but that is more work to ensure we aren't doing double pushes the remote cache
so leaving out for now.

I spent some time trying to indicate in the executor log which "remote" cache client was hit:
   * disk or grpc.
Currently it is impossible to tell, but I think it would be helpful when looking a profiles, execution logs, etc.
Instead, the tests peek at the disk and remote cache (in the test tmp dir) to figure out
where actions and blobs are really stored.
If there is a way to agument DiskAndRemoteCache with more profile metrics via Profiler#profile or spawnMetricAccounting,
or ??? it would be great to add in a future PR and update the tests to use it.
Conceivably, we could use the grpc log to see which requests go to the remote cache and some fs stats to see what
goes to the disk cache :(

testing:
                                                            TEST1 disk  remote  TEST2 disk remote
  test1 -> remote_exec  [ remote_cache, disk_cache ]                 x      x
      (clear remote cache by restarting worker)                      x      -
    * verify still cached (assume remote cache)  [remote, disk]
    RESTART worker (clear cache)
    * verify still cached (assume disk cache)    [disk]              x      -

  test2 -> remote_exec  [remote_cache, disk_cache]                   x      -            x    x
     * verify
              CLEAR disk cache                                       -      -            -    x

I was hoping to post to the BuildSummaryStatsModule or ModuleCollector but can't figure out a good way.
 (any of these?)
      https://cs.opensource.google/bazel/bazel/+/master:src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java;l=1144?q=actionResultReceived&ss=bazel%2Fbazel
        countActionResult in BuildSummaryStatsModule and MetricsCollector