### PR TITLE
Add ios_sim_arm64 crosstool support

### DIFF
--- a/tools/osx/crosstool/BUILD.toolchains
+++ b/tools/osx/crosstool/BUILD.toolchains
@@ -40,6 +40,10 @@ OSX_TOOLS_CONSTRAINTS = {
         "@platforms//os:ios",
         "@platforms//cpu:x86_64",
     ],
+    "ios_sim_arm64": [
+        "@platforms//os:ios",
+        "@platforms//cpu:aarch64",
+    ],
     "tvos_arm64": [
         "@platforms//os:ios",
         "@platforms//cpu:aarch64",

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -73,6 +73,8 @@ def _impl(ctx):
         target_system_name = "i386-apple-watchos"
     elif (ctx.attr.cpu == "ios_x86_64"):
         target_system_name = "x86_64-apple-ios"
+    elif (ctx.attr.cpu == "ios_sim_arm64"):
+        target_system_name = "arm64-apple-ios-simulator"
     elif (ctx.attr.cpu == "darwin_x86_64"):
         target_system_name = "x86_64-apple-macosx"
     elif (ctx.attr.cpu == "darwin_arm64"):
@@ -100,6 +102,8 @@ def _impl(ctx):
 
     host_system_name = "x86_64-apple-macosx"
     arch = ctx.attr.cpu.split("_", 1)[-1]
+    if ctx.attr.cpu == "ios_sim_arm64":
+        arch = "arm64"
 
     all_compile_actions = [
         ACTION_NAMES.c_compile,
@@ -735,6 +739,7 @@ def _impl(ctx):
         ctx.attr.cpu == "ios_armv7" or
         ctx.attr.cpu == "ios_i386" or
         ctx.attr.cpu == "ios_x86_64" or
+        ctx.attr.cpu == "ios_sim_arm64" or
         ctx.attr.cpu == "watchos_arm64_32" or
         ctx.attr.cpu == "watchos_armv7k" or
         ctx.attr.cpu == "watchos_i386" or
@@ -919,6 +924,7 @@ def _impl(ctx):
 
     if (ctx.attr.cpu == "ios_i386" or
         ctx.attr.cpu == "ios_x86_64" or
+        ctx.attr.cpu == "ios_sim_arm64" or
         ctx.attr.cpu == "tvos_x86_64" or
         ctx.attr.cpu == "watchos_i386" or
         ctx.attr.cpu == "watchos_x86_64"):
@@ -987,6 +993,7 @@ def _impl(ctx):
         ctx.attr.cpu == "ios_armv7" or
         ctx.attr.cpu == "ios_i386" or
         ctx.attr.cpu == "ios_x86_64" or
+        ctx.attr.cpu == "ios_sim_arm64" or
         ctx.attr.cpu == "tvos_arm64" or
         ctx.attr.cpu == "tvos_x86_64" or
         ctx.attr.cpu == "watchos_arm64_32" or
@@ -1220,7 +1227,8 @@ def _impl(ctx):
     )
 
     if (ctx.attr.cpu == "ios_i386" or
-        ctx.attr.cpu == "ios_x86_64"):
+        ctx.attr.cpu == "ios_x86_64" or
+        ctx.attr.cpu == "ios_sim_arm64"):
         version_min_feature = feature(
             name = "version_min",
             flag_sets = [
@@ -1747,6 +1755,7 @@ def _impl(ctx):
         ctx.attr.cpu == "ios_armv7" or
         ctx.attr.cpu == "ios_i386" or
         ctx.attr.cpu == "ios_x86_64" or
+        ctx.attr.cpu == "ios_sim_arm64" or
         ctx.attr.cpu == "tvos_arm64" or
         ctx.attr.cpu == "tvos_x86_64" or
         ctx.attr.cpu == "watchos_arm64_32" or
@@ -2829,6 +2838,7 @@ def _impl(ctx):
         ctx.attr.cpu == "ios_armv7" or
         ctx.attr.cpu == "ios_i386" or
         ctx.attr.cpu == "ios_x86_64" or
+        ctx.attr.cpu == "ios_sim_arm64" or
         ctx.attr.cpu == "tvos_arm64" or
         ctx.attr.cpu == "tvos_x86_64" or
         ctx.attr.cpu == "watchos_arm64_32" or

--- a/tools/osx/crosstool/osx_archs.bzl
+++ b/tools/osx/crosstool/osx_archs.bzl
@@ -20,6 +20,7 @@ OSX_TOOLS_NON_DEVICE_ARCHS = [
     "darwin_arm64e",
     "ios_i386",
     "ios_x86_64",
+    "ios_sim_arm64",
     "watchos_i386",
     "watchos_x86_64",
     "tvos_x86_64",


### PR DESCRIPTION
Now that c1ea2d4b9cb6afa33eabba285f7c962c2f954e23 has landed this updates the crosstool to make use of the new arch.