### PR TITLE
Wire up include scanning.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BUILD
@@ -139,6 +139,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/rules/ninja/actions",
         "//src/main/java/com/google/devtools/build/lib/buildeventservice",
         "//src/main/java/com/google/devtools/build/lib/dynamic",
+        "//src/main/java/com/google/devtools/build/lib/includescanning",
         "//src/main/java/com/google/devtools/build/lib/metrics:memory-use-recorder",
         "//src/main/java/com/google/devtools/build/lib/metrics:metrics_module",
         "//src/main/java/com/google/devtools/build/lib/network:noop_connectivity",

--- a/src/main/java/com/google/devtools/build/lib/bazel/Bazel.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/Bazel.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.analysis.BlazeVersionInfo;
 import com.google.devtools.build.lib.bazel.repository.starlark.StarlarkRepositoryDebugModule;
+import com.google.devtools.build.lib.includescanning.IncludeScanningModule;
 import com.google.devtools.build.lib.runtime.BlazeModule;
 import com.google.devtools.build.lib.runtime.BlazeRuntime;
 import java.io.IOException;
@@ -77,7 +78,8 @@ public final class Bazel {
           com.google.devtools.build.lib.metrics.PostGCMemoryUseRecorder.GcAfterBuildModule.class,
           com.google.devtools.build.lib.packages.metrics.PackageMetricsModule.class,
           com.google.devtools.build.lib.metrics.MetricsModule.class,
-          BazelBuiltinCommandModule.class);
+          BazelBuiltinCommandModule.class,
+          IncludeScanningModule.class);
 
   public static void main(String[] args) {
     BlazeVersionInfo.setBuildInfo(tryGetBuildInfo());

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/CcRules.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/CcRules.java
@@ -80,7 +80,7 @@ public class CcRules implements RuleSet {
     builder.addRuleDefinition(new BazelCppRuleClasses.CcLibraryBaseRule());
     builder.addRuleDefinition(new BazelCcLibraryRule());
     builder.addRuleDefinition(new BazelCcImportRule());
-    builder.addRuleDefinition(new CcIncludeScanningRule());
+    builder.addRuleDefinition(new CcIncludeScanningRule(/* addGrepIncludes= */ false));
     builder.addRuleDefinition(new FdoProfileRule());
     builder.addRuleDefinition(new FdoPrefetchHintsRule());
     builder.addRuleDefinition(new CcLinkingRule());

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BUILD
@@ -42,6 +42,7 @@ java_library(
     name = "bazel_cpp_semantics",
     srcs = ["BazelCppSemantics.java"],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/build_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis:transitive_info_collection",

--- a/src/main/java/com/google/devtools/build/lib/includescanning/IncludeParser.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/IncludeParser.java
@@ -138,7 +138,8 @@ class IncludeParser {
   }
 
   /** {@link SkyValue} encapsulating the source-state-dependent part of {@link Hints}. */
-  public static class HintsRules implements SkyValue {
+  public static final class HintsRules implements SkyValue {
+    static final HintsRules EMPTY = new HintsRules(ImmutableList.of());
     private final ImmutableList<Rule> rules;
 
     private HintsRules(ImmutableList<Rule> rules) {

--- a/src/main/java/com/google/devtools/build/lib/includescanning/IncludeScanningModule.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/IncludeScanningModule.java
@@ -33,12 +33,14 @@ import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.buildtool.BuildRequest;
 import com.google.devtools.build.lib.concurrent.ExecutorUtil;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadHostile;
+import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.exec.ExecutorBuilder;
 import com.google.devtools.build.lib.exec.ExecutorLifecycleListener;
 import com.google.devtools.build.lib.exec.ModuleActionContextRegistry;
 import com.google.devtools.build.lib.includescanning.IncludeParser.Inclusion;
 import com.google.devtools.build.lib.rules.cpp.CppIncludeExtractionContext;
 import com.google.devtools.build.lib.rules.cpp.CppIncludeScanningContext;
+import com.google.devtools.build.lib.rules.cpp.CppOptions;
 import com.google.devtools.build.lib.rules.cpp.IncludeScanner.IncludeScanningHeaderData;
 import com.google.devtools.build.lib.rules.cpp.SwigIncludeScanningContext;
 import com.google.devtools.build.lib.runtime.BlazeModule;
@@ -66,6 +68,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /**
  * Module that provides implementations of {@link CppIncludeExtractionContext},
@@ -74,16 +77,14 @@ import java.util.function.Supplier;
 public class IncludeScanningModule extends BlazeModule {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
-  private static final PathFragment INCLUDE_HINTS_FILENAME =
-      PathFragment.create("tools/cpp/INCLUDE_HINTS");
-
   private final MutableSupplier<SpawnIncludeScanner> spawnIncludeScannerSupplier =
       new MutableSupplier<>();
   private final MutableSupplier<ArtifactFactory> artifactFactory = new MutableSupplier<>();
   private IncludeScannerLifecycleManager lifecycleManager;
 
+  @Nullable
   protected PathFragment getIncludeHintsFilename() {
-    return INCLUDE_HINTS_FILENAME;
+    return null;
   }
 
   @Override
@@ -106,7 +107,8 @@ public class IncludeScanningModule extends BlazeModule {
   @ThreadHostile
   public void executorInit(CommandEnvironment env, BuildRequest request, ExecutorBuilder builder) {
     lifecycleManager =
-        new IncludeScannerLifecycleManager(env, request, spawnIncludeScannerSupplier);
+        new IncludeScannerLifecycleManager(
+            env, request, spawnIncludeScannerSupplier, getIncludeHintsFilename() != null);
     builder.addExecutorLifecycleListener(lifecycleManager);
   }
 
@@ -119,6 +121,11 @@ public class IncludeScanningModule extends BlazeModule {
 
   @Override
   public void beforeCommand(CommandEnvironment env) {
+    CppOptions cppOptions = env.getOptions().getOptions(CppOptions.class);
+    if (cppOptions != null && cppOptions.experimentalIncludeScanning) {
+      env.getReporter()
+          .handle(Event.warn("Include scanning enabled. This feature is unsupported."));
+    }
     artifactFactory.set(env.getSkyframeBuildView().getArtifactFactory());
   }
 
@@ -137,10 +144,13 @@ public class IncludeScanningModule extends BlazeModule {
 
   @VisibleForTesting
   public static ImmutableMap<SkyFunctionName, SkyFunction> getSkyFunctions(
-      PathFragment includeHintsFile) {
-    return ImmutableMap.of(
-        IncludeScanningSkyFunctions.INCLUDE_HINTS,
-        new IncludeHintsFunction(includeHintsFile));
+      @Nullable PathFragment includeHintsFile) {
+    ImmutableMap.Builder<SkyFunctionName, SkyFunction> skyFunctions = ImmutableMap.builder();
+    if (includeHintsFile != null) {
+      skyFunctions.put(
+          IncludeScanningSkyFunctions.INCLUDE_HINTS, new IncludeHintsFunction(includeHintsFile));
+    }
+    return skyFunctions.build();
   }
 
   /**
@@ -225,6 +235,7 @@ public class IncludeScanningModule extends BlazeModule {
   private static final class IncludeScannerLifecycleManager implements ExecutorLifecycleListener {
     private final CommandEnvironment env;
     private final IncludeScanningOptions options;
+    private final boolean useIncludeHints;
 
     private final Supplier<SpawnIncludeScanner> spawnScannerSupplier;
     private IncludeScannerSupplier includeScannerSupplier;
@@ -233,9 +244,11 @@ public class IncludeScanningModule extends BlazeModule {
     IncludeScannerLifecycleManager(
         CommandEnvironment env,
         BuildRequest buildRequest,
-        MutableSupplier<SpawnIncludeScanner> spawnScannerSupplier) {
+        MutableSupplier<SpawnIncludeScanner> spawnScannerSupplier,
+        boolean useIncludeHints) {
       this.env = env;
       this.options = buildRequest.getOptions(IncludeScanningOptions.class);
+      this.useIncludeHints = useIncludeHints;
 
       spawnScannerSupplier.set(
           new SpawnIncludeScanner(
@@ -258,26 +271,32 @@ public class IncludeScanningModule extends BlazeModule {
     public void executionPhaseStarting(
         ActionGraph actionGraph, Supplier<ImmutableSet<Artifact>> topLevelArtifacts)
         throws AbruptExitException, InterruptedException {
-      try {
-        includeScannerSupplier.init(
-            new IncludeParser(
-                new IncludeParser.Hints(
-                    (IncludeParser.HintsRules)
-                        env.getSkyframeExecutor()
-                            .evaluateSkyKeyForExecutionSetup(
-                                env.getReporter(), IncludeHintsFunction.INCLUDE_HINTS_KEY),
-                    env.getSkyframeBuildView().getArtifactFactory())));
-      } catch (ExecException e) {
-        throw new AbruptExitException(
-            DetailedExitCode.of(
-                FailureDetail.newBuilder()
-                    .setMessage("could not initialize include hints: " + e.getMessage())
-                    .setIncludeScanning(
-                        IncludeScanning.newBuilder()
-                            .setCode(IncludeScanning.Code.INITIALIZE_INCLUDE_HINTS_ERROR))
-                    .build()),
-            e);
+      IncludeParser.HintsRules hintsRules;
+      if (useIncludeHints) {
+        try {
+          hintsRules =
+              (IncludeParser.HintsRules)
+                  env.getSkyframeExecutor()
+                      .evaluateSkyKeyForExecutionSetup(
+                          env.getReporter(), IncludeHintsFunction.INCLUDE_HINTS_KEY);
+        } catch (ExecException e) {
+          throw new AbruptExitException(
+              DetailedExitCode.of(
+                  FailureDetail.newBuilder()
+                      .setMessage("could not initialize include hints: " + e.getMessage())
+                      .setIncludeScanning(
+                          IncludeScanning.newBuilder()
+                              .setCode(IncludeScanning.Code.INITIALIZE_INCLUDE_HINTS_ERROR))
+                      .build()),
+              e);
+        }
+      } else {
+        hintsRules = IncludeParser.HintsRules.EMPTY;
       }
+      includeScannerSupplier.init(
+          new IncludeParser(
+              new IncludeParser.Hints(
+                  hintsRules, env.getSkyframeBuildView().getArtifactFactory())));
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/includescanning/LegacyIncludeScanner.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/LegacyIncludeScanner.java
@@ -537,19 +537,13 @@ public class LegacyIncludeScanner implements IncludeScanner {
     }
     ArtifactRoot root = includer.getRoot();
     Artifact sourceArtifact =
-        artifactFactory.resolveSourceArtifactWithAncestor(
-            name, parentDirectory, root, RepositoryName.MAIN);
+        artifactFactory.resolveSourceArtifactWithAncestor(name, parent, root, RepositoryName.MAIN);
     if (sourceArtifact == null) {
       // If the name had up-level references, this path may not be under any package. Otherwise,
       // we must have gotten an artifact, since it should be under the same package as the
       // including artifact.
       Preconditions.checkState(
-          name.containsUplevelReferences(),
-          "%s %s %s %s",
-          name,
-          parentDirectory,
-          rootRelativePath,
-          root);
+          name.containsUplevelReferences(), "%s %s %s %s", name, parent, rootRelativePath, root);
     }
     return sourceArtifact;
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppConfiguration.java
@@ -836,6 +836,10 @@ public final class CppConfiguration extends Fragment
     return cppOptions.generateLlvmLcov;
   }
 
+  public boolean experimentalIncludeScanning() {
+    return cppOptions.experimentalIncludeScanning;
+  }
+
   public boolean objcShouldScanIncludes() {
     return cppOptions.objcScanIncludes;
   }

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -1006,6 +1006,25 @@ public class CppOptions extends FragmentOptions {
   public boolean useArgsParamsFile;
 
   @Option(
+      name = "experimental_unsupported_and_brittle_include_scanning",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
+      effectTags = {
+        OptionEffectTag.LOADING_AND_ANALYSIS,
+        OptionEffectTag.EXECUTION,
+        OptionEffectTag.CHANGES_INPUTS
+      },
+      help =
+          "Whether to narrow inputs to C/C++ compilation by parsing #include lines from input"
+              + " files. This can improve performance and incrementality by decreasing the size of"
+              + " compilation input trees. However, it can also break builds because the include"
+              + " scanner does not fully implement C preprocessor semantics. In particular, it does"
+              + " not understand dynamic #include directives and ignores preprocessor conditional"
+              + " logic. Use at your own risk. Any issues relating to this flag that are filed will"
+              + " be closed.")
+  public boolean experimentalIncludeScanning;
+
+  @Option(
       name = "experimental_objc_include_scanning",
       defaultValue = "false",
       documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
@@ -1175,6 +1194,7 @@ public class CppOptions extends FragmentOptions {
     host.parseHeadersSkippedIfCorrespondingSrcsFound = parseHeadersSkippedIfCorrespondingSrcsFound;
     host.strictSystemIncludes = strictSystemIncludes;
     host.useArgsParamsFile = useArgsParamsFile;
+    host.experimentalIncludeScanning = experimentalIncludeScanning;
 
     // Save host options for further use.
     host.hostCoptList = hostCoptList;

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppRuleClasses.java
@@ -459,14 +459,25 @@ public class CppRuleClasses {
 
   /** Ancestor for all rules that do include scanning. */
   public static final class CcIncludeScanningRule implements RuleDefinition {
+    private final boolean addGrepIncludes;
+
+    public CcIncludeScanningRule(boolean addGrepIncludes) {
+      this.addGrepIncludes = addGrepIncludes;
+    }
+
+    public CcIncludeScanningRule() {
+      this(true);
+    }
+
     @Override
     public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
-      return builder
-          .add(
-              attr("$grep_includes", LABEL)
-                  .cfg(ExecutionTransitionFactory.create())
-                  .value(env.getToolsLabel("//tools/cpp:grep-includes")))
-          .build();
+      if (addGrepIncludes) {
+        builder.add(
+            attr("$grep_includes", LABEL)
+                .cfg(ExecutionTransitionFactory.create())
+                .value(env.getToolsLabel("//tools/cpp:grep-includes")));
+      }
+      return builder.build();
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/actions/util/TestAction.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/util/TestAction.java
@@ -94,6 +94,11 @@ public class TestAction extends AbstractAction {
   }
 
   @Override
+  public NestedSet<Artifact> getAllowedDerivedInputs() {
+    return NestedSetBuilder.<Artifact>wrap(Order.STABLE_ORDER, optionalInputs);
+  }
+
+  @Override
   public NestedSet<Artifact> discoverInputs(ActionExecutionContext actionExecutionContext) {
     Preconditions.checkState(discoversInputs(), this);
     NestedSet<Artifact> discoveredInputs =

--- a/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/testutil/AbstractQueryTest.java
@@ -621,13 +621,7 @@ public abstract class AbstractQueryTest<T> {
     if (testConfigurableAttributes()) {
       String implicitDeps = "";
       if (analysisMock.isThisBazel()) {
-        implicitDeps =
-            " + "
-                + helper.getToolsRepository()
-                + "//tools/def_parser:def_parser"
-                + " + "
-                + helper.getToolsRepository()
-                + "//tools/cpp:grep-includes";
+        implicitDeps = " + " + helper.getToolsRepository() + "//tools/def_parser:def_parser";
       }
       assertThat(eval("deps(//configurable:main, 1)" + TestConstants.CC_DEPENDENCY_CORRECTION))
           .containsExactlyElementsIn(
@@ -967,10 +961,7 @@ public abstract class AbstractQueryTest<T> {
               + "//tools/def_parser:def_parser"
               + " + "
               + helper.getToolsRepository()
-              + "//tools/def_parser:def_parser.exe"
-              + " + "
-              + helper.getToolsRepository()
-              + "//tools/cpp:grep-includes";
+              + "//tools/def_parser:def_parser.exe";
     }
 
     String targetDepsExpr = "//x:x + //x:x.cc";

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1382,4 +1382,35 @@ EOF
       fail "bazel build should've succeeded with --features=compiler_param_file"
 }
 
+function test_include_scanning_smoketest() {
+  # Make sure there are no packages containing tools/cpp/INCLUDE_HINTS to exercise that case in
+  # IncludeHintsFunction.
+  rm -rf BUILD tools
+  mkdir pkg
+  cat > pkg/BUILD <<EOF
+cc_binary(
+  name = 'bin',
+  srcs = ['bin.cc'],
+  deps = [':spurious_dep'],
+)
+
+cc_library(
+  name = 'spurious_dep',
+  hdrs = ['dep.h'],
+)
+EOF
+
+  cat > pkg/bin.cc <<EOF
+#define NASTY "dep.h"
+#include NASTY
+int main() { return 0; }
+EOF
+
+  touch pkg/dep.h
+
+  bazel build --experimental_unsupported_and_brittle_include_scanning --features=cc_include_scanning //pkg:bin &>"$TEST_log" && fail 'include scanning did not (wrongly) remove dependency' || true
+  expect_log "Include scanning enabled. This feature is unsupported."
+  expect_log "fatal error: '\?dep.h'\?"
+}
+
 run_suite "cc_integration_test"

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -357,6 +357,39 @@ EOF
   # TODO(ulfjack): Check that the test failure gets reported correctly.
 }
 
+function test_cc_include_scanning_and_minimal_downloads() {
+  cat > BUILD <<'EOF'
+cc_binary(
+name = 'bin',
+srcs = ['bin.cc', ':header.h'],
+)
+
+genrule(
+name = 'gen',
+outs = ['header.h'],
+cmd = 'touch $@',
+)
+EOF
+  cat > bin.cc <<EOF
+#include "header.h"
+int main() { return 0; }
+EOF
+  bazel build //:bin --remote_cache=grpc://localhost:${worker_port} >& $TEST_log \
+    || fail "Failed to populate remote cache"
+  bazel clean >& $TEST_log || fail "Failed to clean"
+  cat > bin.cc <<EOF
+#include "header.h"
+int main() { return 1; }
+EOF
+  bazel build \
+        --experimental_unsupported_and_brittle_include_scanning \
+        --features=cc_include_scanning \
+        --remote_cache=grpc://localhost:${worker_port} \
+        --remote_download_minimal \
+      //:bin >& $TEST_log \
+      || fail "Failed to build with --remote_download_minimal"
+}
+
 function test_local_fallback_works_with_local_strategy() {
   mkdir -p gen1
   cat > gen1/BUILD <<'EOF'
@@ -2060,6 +2093,7 @@ EOF
 
 
 function test_combined_disk_remote_exec_with_flag_combinations() {
+  rm -f ${TEST_TMPDIR}/test_expected
   declare -a testcases=(
      # ensure CAS entries get uploaded even when action entries don't.
      "--noremote_upload_local_results"


### PR DESCRIPTION
Enable Bazel to use C/C++ include scanning if the --experimental_include_scanning flag is given. Include scanning can improve performance and incrementality by decreasing the size of compilation input trees. This change gives the community an opportunity to try it out. Include scanning must not be enabled by default because limitations of the builtin include parser can break builds.