### PR TITLE
Remove --ios_cpu flag

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
@@ -190,7 +190,6 @@ public class AppleCommandLineOptions extends FragmentOptions {
   @VisibleForTesting public static final String DEFAULT_WATCHOS_SDK_VERSION = "2.0";
   @VisibleForTesting public static final String DEFAULT_MACOS_SDK_VERSION = "10.10";
   @VisibleForTesting public static final String DEFAULT_TVOS_SDK_VERSION = "9.0";
-  @VisibleForTesting static final String DEFAULT_IOS_CPU = "x86_64";
 
   /** The default watchos CPU value. */
   public static final String DEFAULT_WATCHOS_CPU = "i386";
@@ -204,16 +203,6 @@ public class AppleCommandLineOptions extends FragmentOptions {
 
   /** The default Catalyst CPU value. */
   public static final String DEFAULT_CATALYST_CPU = "x86_64";
-
-  @Option(
-    name = "ios_cpu",
-    defaultValue = DEFAULT_IOS_CPU,
-    documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
-    effectTags = {OptionEffectTag.NO_OP},
-    metadataTags = {OptionMetadataTag.DEPRECATED},
-    help = "Specifies to target CPU of iOS compilation."
-  )
-  public String iosCpu;
 
   @Option(
     name = "apple_compiler",

--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleConfiguration.java
@@ -215,7 +215,6 @@ public class AppleConfiguration extends Fragment implements AppleConfigurationAp
    *     the effective architecture.
    * <li>If the multi cpus flag (e.g. {@code --ios_multi_cpus}) is set and non-empty, then the first
    *     such architecture is returned.
-   * <li>In the case of iOS, use {@code --ios_cpu} for backwards compatibility.
    * <li>Use the default.
    * </ol>
    */
@@ -272,7 +271,6 @@ public class AppleConfiguration extends Fragment implements AppleConfigurationAp
    * that is the effective architecture.</li>
    * <li>If the multi-cpu flag (for example, {@code --ios_multi_cpus}) is non-empty, then, return
    * all architectures from that flag.</li>
-   * <li>In the case of iOS, use {@code --ios_cpu} for backwards compatibility.</li>
    * <li>Use the default.</li></ol>
    *
    * @throws IllegalArgumentException if {@code --apple_platform_type} is set (via prior

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/MultiArchBinarySupport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/MultiArchBinarySupport.java
@@ -461,10 +461,6 @@ public class MultiArchBinarySupport {
           splitOptions.get(AppleCommandLineOptions.class);
 
       appleCommandLineOptions.appleSplitCpu = cpu;
-      // If the new configuration does not use the apple crosstool, then it needs ios_cpu to be
-      // to decide architecture.
-      // TODO(b/29355778, b/28403953): Use a crosstool for any apple rule. Deprecate ios_cpu.
-      appleCommandLineOptions.iosCpu = cpu;
 
       String platformCpu = ApplePlatform.cpuStringForTarget(platformType, cpu);
       if (splitOptions.get(ObjcCommandLineOptions.class).enableCcDeps) {

--- a/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcCommandLineOptions.java
@@ -105,7 +105,7 @@ public class ObjcCommandLineOptions extends FragmentOptions {
     effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
     help =
         "Allows objc_* rules to depend on cc_library and causes any objc dependencies to be "
-            + "built with --cpu set to \"ios_<--ios_cpu>\" for any values in --ios_multi_cpu."
+            + "built with --cpu set values in --ios_multi_cpu."
   )
   public boolean enableCcDeps;
 

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/AppleStaticLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/AppleStaticLibraryTest.java
@@ -430,8 +430,8 @@ public class AppleStaticLibraryTest extends ObjcRuleTestCase {
         ")",
         "objc_library(name = 'objcLib', srcs = [ 'b.m' ])");
 
-    // Tests that ios_multi_cpus and ios_cpu are completely ignored.
-    useConfiguration("--ios_multi_cpus=x86_64", "--ios_cpu=x86_64", "--watchos_cpus=i386");
+    // Tests that ios_multi_cpus is completely ignored.
+    useConfiguration("--ios_multi_cpus=x86_64", "--watchos_cpus=i386");
 
     Action lipoAction = lipoLibAction("//package:test");
 

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/BazelJ2ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/BazelJ2ObjcLibraryTest.java
@@ -447,7 +447,7 @@ public class BazelJ2ObjcLibraryTest extends J2ObjcLibraryTest {
 
   @Test
   public void testTranspilationActionTreeArtifactOutputsFromSourceJar() throws Exception {
-    useConfiguration("--ios_cpu=i386", "--ios_minimum_os=1.0");
+    useConfiguration("--ios_multi_cpus=i386", "--ios_minimum_os=1.0");
     scratch.file("java/com/google/transpile/dummy.java");
     scratch.file("java/com/google/transpile/dummyjar.srcjar");
     scratch.file(
@@ -475,7 +475,7 @@ public class BazelJ2ObjcLibraryTest extends J2ObjcLibraryTest {
 
   @Test
   public void testGeneratedTreeArtifactFromGenJar() throws Exception {
-    useConfiguration("--ios_cpu=i386", "--ios_minimum_os=1.0");
+    useConfiguration("--ios_multi_cpus=i386", "--ios_minimum_os=1.0");
     addSimpleJ2ObjcLibraryWithJavaPlugin();
     ConfiguredTarget j2objcLibraryTarget =
         getConfiguredTarget("//java/com/google/app/test:transpile");
@@ -751,7 +751,7 @@ public class BazelJ2ObjcLibraryTest extends J2ObjcLibraryTest {
 
   @Test
   public void testArchiveLinkActionWithTreeArtifactFromGenJar() throws Exception {
-    useConfiguration("--ios_cpu=i386", "--ios_minimum_os=1.0");
+    useConfiguration("--ios_multi_cpus=i386", "--ios_minimum_os=1.0");
     addSimpleJ2ObjcLibraryWithJavaPlugin();
     Artifact archive = j2objcArchive("//java/com/google/app/test:transpile", "test");
     CommandAction archiveAction = (CommandAction) getGeneratingAction(archive);
@@ -829,7 +829,7 @@ public class BazelJ2ObjcLibraryTest extends J2ObjcLibraryTest {
 
   @Test
   public void testModuleMapFromGenJarTreeArtifact() throws Exception {
-    useConfiguration("--ios_cpu=i386", "--ios_minimum_os=1.0");
+    useConfiguration("--ios_multi_cpus=i386", "--ios_minimum_os=1.0");
     addSimpleJ2ObjcLibraryWithJavaPlugin();
     ConfiguredTarget j2objcLibraryTarget =
         getConfiguredTarget("//java/com/google/app/test:transpile");

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -206,7 +206,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
     useConfiguration(
         "--apple_platform_type=ios",
         "--cpu=ios_i386",
-        "--ios_cpu=i386",
+        "--ios_multi_cpus=i386",
         "--ios_minimum_os=9.10.11");
     createLibraryTargetWriter("//objc:lib")
         .setList("srcs", "a.mm")
@@ -304,7 +304,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   public void testCompilationModeDbg() throws Exception {
     useConfiguration(
         "--cpu=ios_i386",
-        "--ios_cpu=i386",
+        "--ios_multi_cpus=i386",
         "--compilation_mode=dbg");
     scratch.file("objc/a.m");
     scratch.file(
@@ -327,7 +327,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   public void testCompilationModeFastbuild() throws Exception {
     useConfiguration(
         "--cpu=ios_i386",
-        "--ios_cpu=i386",
+        "--ios_multi_cpus=i386",
         "--compilation_mode=fastbuild");
     scratch.file("objc/a.m");
     scratch.file(
@@ -350,7 +350,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   public void testCompilationModeOpt() throws Exception {
     useConfiguration(
         "--cpu=ios_i386",
-        "--ios_cpu=i386",
+        "--ios_multi_cpus=i386",
         "--compilation_mode=opt");
     scratch.file("objc/a.m");
     scratch.file(
@@ -479,7 +479,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testMultiPlatformLibrary() throws Exception {
-    useConfiguration("--ios_multi_cpus=i386,x86_64,armv7,arm64", "--ios_cpu=armv7");
+    useConfiguration("--ios_multi_cpus=i386,x86_64,armv7,arm64", "--ios_multi_cpus=armv7");
 
     createLibraryTargetWriter("//objc:lib")
         .setAndCreateFiles("srcs", "a.m", "b.m", "private.h")
@@ -491,7 +491,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testCompilationActions_simulator() throws Exception {
-    useConfiguration("--apple_platform_type=ios", "--cpu=ios_i386", "--ios_cpu=i386");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_i386", "--ios_multi_cpus=i386");
 
     scratch.file("objc/a.m");
     scratch.file("objc/non_arc.m");
@@ -536,7 +536,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testCompilationActions_device() throws Exception {
-    useConfiguration("--apple_platform_type=ios", "--cpu=ios_armv7", "--ios_cpu=armv7");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_armv7", "--ios_multi_cpus=armv7");
 
     scratch.file("objc/a.m");
     scratch.file("objc/non_arc.m");
@@ -616,7 +616,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testCompilationActionsWithCopts() throws Exception {
-    useConfiguration("--apple_platform_type=ios", "--cpu=ios_i386", "--ios_cpu=i386");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_i386", "--ios_multi_cpus=i386");
 
     scratch.file(
         "objc/defs.bzl",
@@ -893,7 +893,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testArchiveAction_simulator() throws Exception {
-    useConfiguration("--apple_platform_type=ios", "--cpu=ios_i386", "--ios_cpu=i386");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_i386", "--ios_multi_cpus=i386");
     createLibraryTargetWriter("//objc:lib")
         .setAndCreateFiles("srcs", "a.m", "b.m", "private.h")
         .setAndCreateFiles("hdrs", "c.h")
@@ -922,7 +922,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testArchiveAction_device() throws Exception {
-    useConfiguration("--apple_platform_type=ios", "--cpu=ios_armv7", "--ios_cpu=armv7");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_armv7", "--ios_multi_cpus=armv7");
     createLibraryTargetWriter("//objc:lib")
         .setAndCreateFiles("srcs", "a.m", "b.m", "private.h")
         .setAndCreateFiles("hdrs", "c.h")
@@ -982,7 +982,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
 
   @Test
   public void testPropagatesDefinesToDependersTransitively() throws Exception {
-    useConfiguration("--apple_platform_type=ios", "--cpu=ios_x86_64", "--ios_cpu=x86_64");
+    useConfiguration("--apple_platform_type=ios", "--cpu=ios_x86_64", "--ios_multi_cpus=x86_64");
     createLibraryTargetWriter("//lib1:lib1")
         .setAndCreateFiles("srcs", "a.m")
         .setAndCreateFiles("non_arc_srcs", "b.m")
@@ -1813,7 +1813,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
   public void testCompilationActionsWithIQuotesInCopts() throws Exception {
     useConfiguration(
         "--cpu=ios_i386",
-        "--ios_cpu=i386");
+        "--ios_multi_cpus=i386");
     createLibraryTargetWriter("//objc:lib")
         .setAndCreateFiles("srcs", "a.m", "b.m", "private.h")
         .setAndCreateFiles("hdrs", "c.h")
@@ -1876,7 +1876,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
     MockObjcSupport.setup(mockToolsConfig);
     useConfiguration(
         "--cpu=ios_x86_64",
-        "--ios_cpu=x86_64",
+        "--ios_multi_cpus=x86_64",
         "--apple_grte_top=//x");
     scratch.file(
         "x/BUILD",
@@ -1900,7 +1900,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
         mockToolsConfig, MockObjcSupport.darwinX86_64().withFeatures("default_feature"));
     useConfiguration(
         "--cpu=ios_x86_64",
-        "--ios_cpu=x86_64");
+        "--ios_multi_cpus=x86_64");
     scratch.file(
         "x/BUILD",
         "objc_library(",


### PR DESCRIPTION
This flag appears to be unused, it was set once but never read. Instead
users should prefer `--ios_multi_cpus` or `--cpu=ios_XXX`