### PR TITLE
Propagate the full workspace status info to cc_library linkstamp.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppBuildInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppBuildInfo.java
@@ -56,7 +56,7 @@ public final class CppBuildInfo implements BuildInfoFactory {
             buildInfoContext,
             config,
             BUILD_INFO_REDACTED_HEADER_NAME,
-            NestedSetBuilder.emptySet(Order.STABLE_ORDER),
+            NestedSetBuilder.create(Order.STABLE_ORDER, buildInfo, buildChangelist),
             true,
             true);
     WriteBuildInfoHeaderAction nonvolatileInfo =
@@ -96,7 +96,7 @@ public final class CppBuildInfo implements BuildInfoFactory {
         buildInfoContext.getBuildInfoArtifact(
             headerName,
             outputPath,
-            writeVolatileInfo && !inputs.isEmpty()
+            writeVolatileInfo && !writeNonVolatileInfo
                 ? BuildInfoType.NO_REBUILD
                 : BuildInfoType.FORCE_REBUILD_IF_CHANGED);
     return new WriteBuildInfoHeaderAction(


### PR DESCRIPTION
Minimal patch to fix #1992 and #4863.

Includes both predefined and custom keys as build information
for C++ stamping, treating all unknown keys as strings.

Makes it so that the build-info will be redacted iif both
volatile and non-volatile info is requested in a single header,
since the inputs are now always passed in to figure out the
available keys.