### PR TITLE
Enable llvm_coverage_map_format for darwin by default

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -1809,6 +1809,7 @@ def _impl(ctx):
 
     llvm_coverage_map_format_feature = feature(
         name = "llvm_coverage_map_format",
+        enabled = True,
         flag_sets = [
             flag_set(
                 actions = [


### PR DESCRIPTION
Coverage with clang and the default toolchain on darwin requires this
for coverage, previous you had to pass `--experimental_use_llvm_covmap`
always, but this removes that requirement. If folks have a reason to
this could still be disabled with `--features=-llvm_coverage_map_format`