### PR TITLE
LLVM BC support

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -34,6 +34,7 @@ public final class CppFileTypes {
   public static final FileType OBJCPP_SOURCE = FileType.of(".mm");
   public static final FileType CLIF_INPUT_PROTO = FileType.of(".ipb");
   public static final FileType CLIF_OUTPUT_PROTO = FileType.of(".opb");
+  public static final FileType BC_SOURCE = FileType.of(".bc");
 
   public static final FileTypeSet ALL_C_CLASS_SOURCE =
       FileTypeSet.of(

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/Link.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/Link.java
@@ -64,7 +64,10 @@ public abstract class Link {
   /** The set of object files */
   public static final FileTypeSet OBJECT_FILETYPES =
       FileTypeSet.of(
-          CppFileTypes.OBJECT_FILE, CppFileTypes.PIC_OBJECT_FILE, CppFileTypes.CLIF_OUTPUT_PROTO);
+          CppFileTypes.OBJECT_FILE,
+          CppFileTypes.PIC_OBJECT_FILE,
+          CppFileTypes.CLIF_OUTPUT_PROTO,
+          CppFileTypes.BC_SOURCE);
 
   /**
    * Whether a particular link target requires PIC code.


### PR DESCRIPTION
Using [rules_swift](https://github.com/bazelbuild/rules_swift) it is possible to generate LLVM IR BC files using `swift.emit_bc` feature, some days ago a [refactor](https://github.com/bazelbuild/rules_swift/commit/8cf36354655e6baa276fd7a5bae29b00ee5757c3#diff-535d0dbea9614c6905a30dfdb0e708df3b16fc68f8930d6aba519342509dc657R1948) to use `create_compilation_outputs` from `cc_common` was merged, it is giving us the following error since the bc extension is missing, this pr fixes it

```
Error in create_compilation_outputs: 'Somefile.swift.bc' has wrong extension. The list of possible extensions for 'objects' is: .o,.obj,.pic.o,.opb
```
