### PR TITLE
Flip incompatible_disallow_resource_jars flag.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaOptions.java
@@ -477,7 +477,7 @@ public class JavaOptions extends FragmentOptions {
 
   @Option(
       name = "incompatible_disallow_resource_jars",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.UNKNOWN},
       metadataTags = {


### PR DESCRIPTION
The resource_jars is not supported by java_common.compile function. In
order to rewrite java_library to Starlark the call needs to be extended or the
feature disabled. Because the migration is relatively simple I'm opting
to flip the flag and remove it.

RELNOTES[INC]: Flipped --incompatible_disallow_resource_jars (see https://github.com/bazelbuild/bazel/issues/13221).