### PR TITLE
[Cherrypick 4.2.1] Revert 80c59de in 4.2 branch

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
@@ -109,8 +109,6 @@ public class StarlarkOptionsParser {
     ImmutableMap.Builder<String, Object> parsedOptions = new ImmutableMap.Builder<>();
     for (Map.Entry<String, Pair<String, Target>> option : unparsedOptions.entrySet()) {
       String loadedFlag = option.getKey();
-      // String loadedFlag =
-      // Label.parseAbsoluteUnchecked(option.getKey()).getDefaultCanonicalForm();
       String unparsedValue = option.getValue().first;
       Target buildSettingTarget = option.getValue().second;
       BuildSetting buildSetting =
@@ -157,11 +155,7 @@ public class StarlarkOptionsParser {
     if (value != null) {
       // --flag=value or -flag=value form
       Target buildSettingTarget = loadBuildSetting(name, nativeOptionsParser, eventHandler);
-      // Use the unambiguous canonical form to ensure we don't have
-      // duplicate options getting into the starlark options map.
-      unparsedOptions.put(
-          buildSettingTarget.getLabel().getDefaultCanonicalForm(),
-          new Pair<>(value, buildSettingTarget));
+      unparsedOptions.put(name, new Pair<>(value, buildSettingTarget));
     } else {
       boolean booleanValue = true;
       // check --noflag form

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkOptionsParsingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkOptionsParsingTest.java
@@ -45,40 +45,18 @@ public class StarlarkOptionsParsingTest extends StarlarkOptionsTestCase {
     assertThat(result.getResidue()).isEmpty();
   }
 
-  // test --@main_workspace//flag=value parses out to //flag=value
-  // test --@other_workspace//flag=value parses out to @other_workspace//flag=value
+  // test --@workspace//flag=value
   @Test
   public void testFlagNameWithWorkspace() throws Exception {
     writeBasicIntFlag();
-    scratch.file("test/repo2/WORKSPACE");
-    scratch.file(
-        "test/repo2/defs.bzl",
-        "def _impl(ctx):",
-        "  pass",
-        "my_flag = rule(",
-        "  implementation = _impl,",
-        "  build_setting = config.int(flag = True),",
-        ")");
-    scratch.file(
-        "test/repo2/BUILD",
-        "load(':defs.bzl', 'my_flag')",
-        "my_flag(name = 'flag2', build_setting_default=2)");
-
-    rewriteWorkspace(
-        "workspace(name = 'starlark_options_test')",
-        "local_repository(",
-        "  name = 'repo2',",
-        "  path = 'test/repo2',",
-        ")");
+    rewriteWorkspace("workspace(name = 'starlark_options_test')");
 
     OptionsParsingResult result =
-        parseStarlarkOptions(
-            "--@starlark_options_test//test:my_int_setting=666 --@repo2//:flag2=222");
+        parseStarlarkOptions("--@starlark_options_test//test:my_int_setting=666");
 
-    assertThat(result.getStarlarkOptions()).hasSize(2);
-    assertThat(result.getStarlarkOptions().get("//test:my_int_setting"))
+    assertThat(result.getStarlarkOptions()).hasSize(1);
+    assertThat(result.getStarlarkOptions().get("@starlark_options_test//test:my_int_setting"))
         .isEqualTo(StarlarkInt.of(666));
-    assertThat(result.getStarlarkOptions().get("@repo2//:flag2")).isEqualTo(StarlarkInt.of(222));
     assertThat(result.getResidue()).isEmpty();
   }
 


### PR DESCRIPTION
This fixes #13890 by reverting 80c59dea59d4dce39d4b5d21665c3d7313197358 in the 4.2 series.