### PR TITLE
Apply Jacoco's instruction filtering to Java branch coverage

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/BranchDetailAnalyzer.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/BranchDetailAnalyzer.java
@@ -114,7 +114,7 @@ public class BranchDetailAnalyzer extends Analyzer {
 
   // Generate the line to probeExp map so that we can evaluate the coverage.
   private Map<Integer, BranchExp> mapProbes(final ClassReader reader) {
-    final ClassProbesMapper mapper = new ClassProbesMapper();
+    final ClassProbesMapper mapper = new ClassProbesMapper(reader.getClassName());
     final ClassProbesAdapter adapter = new ClassProbesAdapter(mapper, false);
     reader.accept(adapter, 0);
 

--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/ClassProbesMapper.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/ClassProbesMapper.java
@@ -14,30 +14,72 @@
 
 package com.google.testing.coverage;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import org.jacoco.core.internal.analysis.StringPool;
+import org.jacoco.core.internal.analysis.filter.Filters;
+import org.jacoco.core.internal.analysis.filter.IFilter;
+import org.jacoco.core.internal.analysis.filter.IFilterContext;
 import org.jacoco.core.internal.flow.ClassProbesVisitor;
 import org.jacoco.core.internal.flow.MethodProbesVisitor;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.Attribute;
 import org.objectweb.asm.FieldVisitor;
 
 /** A visitor that maps each source code line to the probes corresponding to the lines. */
 public class ClassProbesMapper extends ClassProbesVisitor {
   private Map<Integer, BranchExp> classLineToBranchExp;
 
+  private IFilter filter;
+
+  private SimpleFilterContext filterContext;
+
+  private StringPool stringPool;
+
   public Map<Integer, BranchExp> result() {
     return classLineToBranchExp;
   }
 
   /** Create a new probe mapper object. */
-  public ClassProbesMapper() {
+  public ClassProbesMapper(String className) {
     classLineToBranchExp = new TreeMap<Integer, BranchExp>();
+    filter = Filters.all();
+    filterContext = new SimpleFilterContext();
+    stringPool = new StringPool();
+    filterContext.setClassName(stringPool.get(className));
+  }
+
+  @Override
+  public AnnotationVisitor visitAnnotation(final String desc, final boolean visible) {
+    filterContext.addClassAnnotations(desc);
+    return super.visitAnnotation(desc, visible);
+  }
+
+  @Override
+  public void visitAttribute(final Attribute attribute) {
+    filterContext.addClassAttribute(attribute.type);
+  }
+
+  @Override
+  public void visitSource(final String source, final String debug) {
+    filterContext.setSourceFileName(stringPool.get(source));
+    filterContext.setSourceDebugExtension(debug);
+  }
+
+  @Override
+  public void visit(int version, int access, String name, String signature, String superName,
+      String[] interfaces) {
+    filterContext.setSuperClassName(stringPool.get(name));
   }
 
   /** Returns a visitor for mapping method code. */
   @Override
   public MethodProbesVisitor visitMethod(
       int access, String name, String desc, String signature, String[] exceptions) {
-    return new MethodProbesMapper() {
+    return new MethodProbesMapper(filterContext, filter) {
+
       @Override
       public void visitEnd() {
         super.visitEnd();
@@ -55,5 +97,69 @@ public class ClassProbesMapper extends ClassProbesVisitor {
   @Override
   public void visitTotalProbeCount(int count) {
     // Nothing to do. Maybe perform some checks here.
+  }
+  private class SimpleFilterContext implements IFilterContext {
+
+    String sourceFileName;
+    String sourceDebugExtension;
+    String className;
+    String superClassName;
+    Set<String> classAnnotations = new HashSet<>();
+    Set<String> classAttributes = new HashSet<>();
+
+    public void setClassName(String className) {
+      this.className = className;
+    }
+
+    @Override
+    public String getClassName() {
+      return className;
+    }
+
+    public void setSuperClassName(String superClassName) {
+      this.superClassName = superClassName;
+    }
+
+    @Override
+    public String getSuperClassName() {
+      return superClassName;
+    }
+
+    public void addClassAnnotations(String annotation) {
+      classAnnotations.add(annotation);
+    }
+
+    @Override
+    public Set<String> getClassAnnotations() {
+      return classAnnotations;
+    }
+
+    public void addClassAttribute(String attribute) {
+      classAttributes.add(attribute);
+    }
+
+    @Override
+    public Set<String> getClassAttributes() {
+      return classAttributes;
+    }
+
+
+    public void setSourceFileName(String sourceFileName) {
+      this.sourceFileName = sourceFileName;
+    }
+
+    @Override
+    public String getSourceFileName() {
+      return sourceFileName;
+    }
+
+    public void setSourceDebugExtension(String sourceDebugExtension) {
+      this.sourceDebugExtension = sourceDebugExtension;
+    }
+
+    @Override
+    public String getSourceDebugExtension() {
+      return sourceDebugExtension;
+    }
   }
 }

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -479,6 +479,7 @@ sh_test(
         "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
     ],
     tags = [
+        "manual",
         "no_windows",
     ],
 )
@@ -502,6 +503,7 @@ sh_test(
             "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
         ],
         tags = [
+            "manual",
             "no_windows",
         ],
     )


### PR DESCRIPTION
Jacoco applies a set of filters during its coverage analysis to remove
various compiler constructs that could lead to surprising outputs in
coverage results, leaving behind coverage data that closer fits the
code given to the compiler.

A simple java example is the function:

```
public int foo(String input) {
  switch (input) {
    case "A":
      return 1;
    case "B":
      return 2;
    case "C":
      return 3;
    default:
      return -1
  }
}
```

This would generate at least double the number of expected branches as
the compiler generates a second set of branches to operate on hashCode.
Jacoco would normally ignore the first set of branches, reducing the
number to the expected 4.

Because Bazel applies its own branch analysis step, Bazel's branch
coverage output does not benefit from this filtering.

This change adapts the custom analyzer to record the necessary
information during the ASM Tree walk in the same manner as Jacoco's
regular analyzer in order to apply the filters.

The filters have three output operations:

 * ignore - ignore a range of instructions
 * merge - merges the coverage information of two instructions
 * replaceBranches - retarget the output branches of an instruction

The first of these, ignore, is by far the simplest to implement and
covers the vast majority of use cases in Java.

By mapping the AbstractInsnNode objects recorded during the ASM Tree
walk to the Instruction objects used during branch analysis, we can
simply skip over Instruction objects that have had their associated
AbstractInsnNode object ignored by a filter.

The remaining operations, merge and replaceBranches, are left
unimplemeted for now; these require more care to handle, are harder
to test, and affect only a minority of cases, specifically:

 * merge is only used to handle duplication of finally blocks
 * replaceBranches is used by Kotlin and Eclipse compiler filters

Part of #12696