### PR TITLE
[Cherrypick 4.2.1] Fix cquery with --built_test_only

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java
@@ -81,7 +81,7 @@ public final class CqueryCommand implements BlazeCommand {
           "cquery should include 'tags = [\"manual\"]' targets by default",
           ImmutableList.of("--build_manual_tests"));
       optionsParser.parse(
-          PriorityCategory.COMPUTED_DEFAULT,
+          PriorityCategory.SOFTWARE_REQUIREMENT,
           // https://github.com/bazelbuild/bazel/issues/11078
           "cquery should not exclude test_suite rules",
           ImmutableList.of("--noexpand_test_suites"));
@@ -93,6 +93,10 @@ public final class CqueryCommand implements BlazeCommand {
                 "--include_config_fragments_provider="
                     + cqueryOptions.showRequiredConfigFragments));
       }
+      optionsParser.parse(
+          PriorityCategory.SOFTWARE_REQUIREMENT,
+          "cquery should not exclude tests",
+          ImmutableList.of("--nobuild_tests_only"));
     } catch (OptionsParsingException e) {
       throw new IllegalStateException("Cquery's known options failed to parse", e);
     }

--- a/src/test/shell/integration/configured_query_test.sh
+++ b/src/test/shell/integration/configured_query_test.sh
@@ -793,6 +793,20 @@ EOF
   assert_contains "//$pkg:my_test" output
 }
 
+function test_build_tests_only_override() {
+  local -r pkg=$FUNCNAME
+  mkdir -p $pkg
+  cat > $pkg/BUILD <<'EOF'
+cc_binary(
+  name = "not_a_test",
+  srcs = ["not_a_test.cc"])
+EOF
+
+  bazel cquery --build_tests_only "//$pkg:all" > output 2>"$TEST_log" || \
+    fail "Expected success"
+  assert_contains "//$pkg:not_a_test" output
+}
+
 function test_label_output_shows_alias_labels() {
   local -r pkg=$FUNCNAME
   mkdir -p $pkg


### PR DESCRIPTION
Cherrypick request for 4.2.1 (#13558). 

cquery: disable `--build_tests_only`.

PriorityCategory.SOFTWARE_REQUIREMENT cannot be overridden by the user, unlike
PriorityCategory.COMPUTED_DEFAULT. Also another existing flag that I think
deserves the same enforcement.

Re: concerns about aquery: none of this affects aquery because aquery doesn't
inherit from TestCommand:

https://github.com/bazelbuild/bazel/blob/a03442dd7408cdc6ef936f96cd3146ff6b3d09dd/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java#L56
https://github.com/bazelbuild/bazel/blob/a03442dd7408cdc6ef936f96cd3146ff6b3d09dd/src/main/java/com/google/devtools/build/lib/runtime/commands/AqueryCommand.java#L48

PiperOrigin-RevId: 388330077
(cherry picked from commit 9f67cdf3d51c05bc2209786aa24b72658b61362c)