### PR TITLE
Update sh_binary docs to mention shebang support

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/BazelShBinaryRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/sh/BazelShBinaryRule.java
@@ -50,11 +50,13 @@ public final class BazelShBinaryRule implements RuleDefinition {
 /*<!-- #BLAZE_RULE (NAME = sh_binary, TYPE = BINARY, FAMILY = Shell) -->
 
 <p>
-  The <code>sh_binary</code> rule is used to declare executable Bourne shell scripts.
+  The <code>sh_binary</code> rule is used to declare executable shell scripts.
   (<code>sh_binary</code> is a misnomer: its outputs aren't necessarily binaries.) This rule ensures
   that all dependencies are built, and appear in the <code>runfiles</code> area at execution time.
   We recommend that you name your <code>sh_binary()</code> rules after the name of the script minus
   the extension (e.g. <code>.sh</code>); the rule name and the file name must be distinct.
+  <code>sh_binary</code> respects shebangs, so any available interpreter may be used (eg.
+  <code>#!/bin/zsh</code>)
 </p>
 
 <h4 id="sh_binary_examples">Example</h4>


### PR DESCRIPTION
* sh_binary supports more than bourne shell scripts



For reference: 
https://github.com/bazelbuild/bazel/commit/0c0bfe6297bdc6c061a88c91c4eaff1776f6ef23
and 
#1468