### PR TITLE
Correctly report error when HTTP connection was closed before Content-Length was fulfilled.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/CheckContentLengthInputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/CheckContentLengthInputStream.java
@@ -54,10 +54,16 @@ public class CheckContentLengthInputStream extends InputStream {
   }
 
   private void check() throws IOException {
-    if (expectedSize != actualSize) {
+    if (actualSize < expectedSize) {
       throw new UnrecoverableHttpException(
           String.format(
-              "Connection was closed before Content-Length was fulfilled. Bytes read %s but wanted %s",
+              "Connection was closed before Content-Length was fulfilled. Bytes read %s but wanted"
+                  + " %s",
+              actualSize, expectedSize));
+    } else if (actualSize > expectedSize) {
+      throw new UnrecoverableHttpException(
+          String.format(
+              "Received more bytes than Content-Length. Bytes read %s but wanted %s",
               actualSize, expectedSize));
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/CheckContentLengthInputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/CheckContentLengthInputStream.java
@@ -1,0 +1,64 @@
+package com.google.devtools.build.lib.bazel.repository.downloader;
+
+import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadCompatible;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Input stream that guarantees its contents matches a size.
+ *
+ * <p>This class is not thread safe, but it is safe to message pass this object between threads.
+ */
+@ThreadCompatible
+public class CheckContentLengthInputStream extends InputStream {
+  private final InputStream delegate;
+  private final long expectedSize;
+  private long actualSize;
+
+  public CheckContentLengthInputStream(InputStream delegate, long expectedSize) {
+    this.delegate = delegate;
+    this.expectedSize = expectedSize;
+  }
+
+  @Override
+  public int read() throws IOException {
+    int result = delegate.read();
+    if (result == -1) {
+      check();
+    } else {
+      actualSize += result;
+    }
+    return result;
+  }
+
+  @Override
+  public int read(byte[] buffer, int offset, int length) throws IOException {
+    int amount = delegate.read(buffer, offset, length);
+    if (amount == -1) {
+      check();
+    } else {
+      actualSize += amount;
+    }
+    return amount;
+  }
+
+  @Override
+  public int available() throws IOException {
+    return delegate.available();
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+    check();
+  }
+
+  private void check() throws IOException {
+    if (expectedSize != actualSize) {
+      throw new UnrecoverableHttpException(
+          String.format(
+              "Connection was closed before Content-Length was fulfilled. Bytes read %s but wanted %s",
+              actualSize, expectedSize));
+    }
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStream.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStream.java
@@ -87,6 +87,16 @@ final class HttpStream extends FilterInputStream {
           stream = retrier;
         }
 
+        try {
+          String contentLength = connection.getHeaderField("Content-Length");
+          if (contentLength != null) {
+            long expectedSize = Long.parseLong(contentLength);
+            stream = new CheckContentLengthInputStream(stream, expectedSize);
+          }
+        } catch (NumberFormatException ignored) {
+            // ignored
+        }
+
         stream = progressInputStreamFactory.create(stream, connection.getURL(), originalUrl);
 
         // Determine if we need to transparently gunzip. See RFC2616 § 3.5 and § 14.11. Please note

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpStreamTest.java
@@ -39,7 +39,6 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPOutputStream;
@@ -210,9 +209,27 @@ public class HttpStreamTest {
   public void bigDataTruncated_throwsExpectedError() throws Exception {
     byte[] bigData = new byte[HttpStream.PRECHECK_BYTES + 70001];
     randoCalrissian.nextBytes(bigData);
-    byte[] truncated = Arrays.copyOfRange(bigData, 0, bigData.length - 1);
-    when(connection.getHeaderField("Content-Length")).thenReturn(String.valueOf(bigData.length));
-    when(connection.getInputStream()).thenReturn(new ByteArrayInputStream(truncated));
+    when(connection.getHeaderField("Content-Length")).thenReturn(String.valueOf(bigData.length + 1));
+    when(connection.getInputStream()).thenReturn(new ByteArrayInputStream(bigData));
+    try (HttpStream stream =
+                 streamFactory.create(
+                         connection,
+                         AURL,
+                         makeChecksum(Hashing.sha256().hashBytes(bigData).toString()),
+                         reconnector)) {
+      thrown.expect(IOException.class);
+      thrown.expectMessage("Content-Length");
+      ByteStreams.exhaust(stream);
+      fail("Should have thrown error before close()");
+    }
+  }
+
+  @Test
+  public void bigDataOverflowed_throwsExpectedError() throws Exception {
+    byte[] bigData = new byte[HttpStream.PRECHECK_BYTES + 70001];
+    randoCalrissian.nextBytes(bigData);
+    when(connection.getHeaderField("Content-Length")).thenReturn(String.valueOf(bigData.length - 1));
+    when(connection.getInputStream()).thenReturn(new ByteArrayInputStream(bigData));
     try (HttpStream stream =
                  streamFactory.create(
                          connection,


### PR DESCRIPTION
Instead of reporting checksum mismatch, the downloader will now report 

```
Connection was closed before Content-Length was fulfilled. Bytes read %s but wanted %s
```

when HTTP connection is closed before Content-Length is fulfilled.

Fixes https://github.com/bazelbuild/bazel/issues/12010.