### PR TITLE
Delete remaining code on src/objc_tools

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,8 +29,6 @@ android/ @ahumesky
 
 # Apple
 
-/src/objc_tools/ @allevato @davidgoldman @dmaclach @kelvinchan-google @reinhillman @thomasvl
-
 /src/test/shell/bazel/apple/ @allevato @davidgoldman @dmaclach @kelvinchan-google @reinhillman @thomasvl
 
 # Documentation

--- a/src/create_embedded_tools.py
+++ b/src/create_embedded_tools.py
@@ -41,8 +41,6 @@ output_paths = [
     ('*def_parser.exe', lambda x: 'tools/def_parser/def_parser.exe'),
     ('*zipper.exe', lambda x: 'tools/zip/zipper/zipper.exe'),
     ('*zipper', lambda x: 'tools/zip/zipper/zipper'),
-    ('*src/objc_tools/*',
-     lambda x: 'tools/objc/precomp_' + os.path.basename(x)),
     ('*xcode*make_hashed_objlist.py',
      lambda x: 'tools/objc/make_hashed_objlist.py'),
     ('*xcode*xcode-locator', lambda x: 'tools/objc/xcode-locator'),


### PR DESCRIPTION
The targets, `//src/objc_tools` and the directory were removed in 32246b2b60, but there are files to mention them.
This PR is a follow-up fix of 32246b2b60 to remove the remaining.