### PR TITLE
Fix darwin libtool with params files

### DIFF
--- a/tools/objc/libtool.sh
+++ b/tools/objc/libtool.sh
@@ -35,7 +35,8 @@ fi
 WRAPPER="${MY_LOCATION}/xcrunwrapper.sh"
 
 if [ ! -f "${MY_LOCATION}"/libtool_check_unique ] ; then
-    echo "libtool_check_unique not found. Please file an issue at github.com/bazelbuild/bazel"
+  echo "libtool_check_unique not found. Please file an issue at github.com/bazelbuild/bazel"
+  exit 1
 elif "${MY_LOCATION}"/libtool_check_unique "$@"; then
   # If there are no duplicate .o basenames,
   # libtool can be invoked with the original arguments.
@@ -44,7 +45,7 @@ elif "${MY_LOCATION}"/libtool_check_unique "$@"; then
 fi
 
 TEMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/libtool.XXXXXXXX")"
-trap "rm -rf \"${TEMPDIR}\"" EXIT
+trap 'rm -rf "$TEMPDIR"' EXIT
 
 # Creates a symbolic link to the input argument file and returns the symlink
 # file path.
@@ -67,62 +68,67 @@ if [[ ! -x "$python_executable" ]]; then
 fi
 
 ARGS=()
+handle_filelist=0
+keep_next=0
 
-while [[ $# -gt 0 ]]; do
-  ARG="$1"
-  shift
+function parse_option() {
+  local -r ARG="$1"
+  if [[ "$handle_filelist" == "1" ]]; then
+    handle_filelist=0
+    HASHED_FILELIST="${ARG%.objlist}_hashes.objlist"
+    rm -f "${HASHED_FILELIST}"
+    # Use python helper script for fast md5 calculation of many strings.
+    "$python_executable" "${MY_LOCATION}/make_hashed_objlist.py" \
+      "${ARG}" "${HASHED_FILELIST}" "${TEMPDIR}"
+    ARGS+=("${HASHED_FILELIST}")
+  elif [[ "$keep_next" == "1" ]]; then
+    keep_next=0
+    ARGS+=("$ARG")
+  else
+    case "${ARG}" in
+      # Filelist flag, need to symlink each input in the contents of file and
+      # pass a new filelist which contains the symlinks.
+      -filelist)
+        handle_filelist=1
+        ARGS+=("${ARG}")
+        ;;
+      @*)
+        path="${ARG:1}"
+        while IFS= read -r opt
+        do
+          parse_option "$opt"
+        done < "$path" || exit 1
+        ;;
+      # Flags with no args
+      -static|-s|-a|-c|-L|-T|-D|-no_warning_for_no_symbols)
+        ARGS+=("${ARG}")
+        ;;
+      # Single-arg flags
+      -arch_only|-syslibroot|-o)
+        keep_next=1
+        ARGS+=("${ARG}")
+        ;;
+      # Any remaining flags are unexpected and may ruin flag parsing.
+      # Add any flags here to libtool_check_unique.cc as well
+      -*)
+        echo "Unrecognized libtool flag ${ARG}"
+        exit 1
+        ;;
+      # Archive inputs can remain untouched, as they come from other targets.
+      *.a)
+        ARGS+=("${ARG}")
+        ;;
+      # Remaining args are input objects
+      *)
+        ARGS+=("$(hash_objfile "${ARG}")")
+        ;;
+    esac
+  fi
+}
 
-  # Libtool artifact symlinking. Apple's libtool has a bug when there are two
-  # input files with the same basename. We thus create symlinks that are named
-  # with a hash suffix for each input, and pass them to libtool.
-  # See b/28186497.
-  case "${ARG}" in
-    # Filelist flag, need to symlink each input in the contents of file and
-    # pass a new filelist which contains the symlinks.
-    -filelist)
-      ARGS+=("${ARG}")
-      ARG="$1"
-      shift
-      HASHED_FILELIST="${ARG%.objlist}_hashes.objlist"
-      rm -f "${HASHED_FILELIST}"
-      # Use python helper script for fast md5 calculation of many strings.
-      "$python_executable" "${MY_LOCATION}/make_hashed_objlist.py" \
-        "${ARG}" "${HASHED_FILELIST}" "${TEMPDIR}"
-      ARGS+=("${HASHED_FILELIST}")
-      ;;
-   # Output flag
-    -o)
-     ARGS+=("${ARG}")
-     ARG="$1"
-     shift
-     ARGS+=("${ARG}")
-     OUTPUTFILE="${ARG}"
-     ;;
-   # Flags with no args
-    -static|-s|-a|-c|-L|-T|-D|-no_warning_for_no_symbols)
-      ARGS+=("${ARG}")
-      ;;
-   # Single-arg flags
-   -arch_only|-syslibroot)
-     ARGS+=("${ARG}")
-     ARG="$1"
-     shift
-     ARGS+=("${ARG}")
-     ;;
-   # Any remaining flags are unexpected and may ruin flag parsing.
-   -*)
-     echo "Unrecognized libtool flag ${ARG}"
-     exit 1
-     ;;
-   # Archive inputs can remain untouched, as they come from other targets.
-   *.a)
-     ARGS+=("${ARG}")
-     ;;
-   # Remaining args are input objects
-   *)
-     ARGS+=("$(echo "$(hash_objfile "${ARG}")")")
-     ;;
-   esac
+for arg in "$@"; do
+  parse_option "$arg"
 done
 
-"${WRAPPER}" libtool "${ARGS[@]}"
+printf '%s\n' "${ARGS[@]}" > "$TEMPDIR/processed.params"
+"${WRAPPER}" libtool "@$TEMPDIR/processed.params"


### PR DESCRIPTION
This shim only exists to avoid the warning about linking object files
with the same basenames into a single library. Since we moved to params
files this hasn't worked because that file wasn't opened by
libtool_check_unique.cc, and therefore duplicate basenames were never
discovered.