### PR TITLE
Fixes #13887: Add downloaded_file_path param to http_jar

### DIFF
--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -311,7 +311,7 @@ function test_jar_download() {
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
 http_jar(name = 'endangered', url = 'http://127.0.0.1:$nc_port/lib.jar',
-         sha256='$sha256', file_name="foo.jar")
+         sha256='$sha256', downloaded_file_name="foo.jar")
 EOF
 
   mkdir -p zoo

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -338,7 +338,7 @@ EOF
   kill_nc
   expect_log "Tra-la!"
   output_base=$(bazel info output_base)
-  jar_dir=$output_base/external/endangered/file
+  jar_dir=$output_base/external/endangered/jar
   [[ -f ${jar_dir}/foo.jar ]] || fail "${jar_dir}/foo.jar not found"
 }
 

--- a/src/test/shell/bazel/external_integration_test.sh
+++ b/src/test/shell/bazel/external_integration_test.sh
@@ -311,7 +311,7 @@ function test_jar_download() {
   cat >> $(create_workspace_with_default_repos WORKSPACE) <<EOF
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
 http_jar(name = 'endangered', url = 'http://127.0.0.1:$nc_port/lib.jar',
-         sha256='$sha256')
+         sha256='$sha256', file_name="foo.jar")
 EOF
 
   mkdir -p zoo
@@ -337,6 +337,9 @@ EOF
   bazel run //zoo:ball-pit >& $TEST_log || echo "Expected run to succeed"
   kill_nc
   expect_log "Tra-la!"
+  output_base=$(bazel info output_base)
+  jar_dir=$output_base/external/endangered/file
+  [[ -f ${jar_dir}/foo.jar ]] || fail "${jar_dir}/foo.jar not found"
 }
 
 function test_http_to_https_redirect() {

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -190,10 +190,10 @@ def _http_jar_impl(ctx):
     if ctx.attr.url:
         all_urls = [ctx.attr.url] + all_urls
     auth = _get_auth(ctx, all_urls)
-    downloaded_file_path = ctx.attr.downloaded_file_path
+    downloaded_file_path = "jar/" + ctx.attr.downloaded_file_name
     download_info = ctx.download(
         all_urls,
-        "jar/" + downloaded_file_path,
+        downloaded_file_path,
         ctx.attr.sha256,
         canonical_id = ctx.attr.canonical_id,
         auth = auth,
@@ -503,9 +503,9 @@ unless it was added to the cache by a request with the same canonical id.
     "auth_patterns": attr.string_dict(
         doc = _AUTH_PATTERN_DOC,
     ),
-    "downloaded_file_path": attr.string(
+    "downloaded_file_name": attr.string(
         default = "downloaded.jar",
-        doc = "Path assigned to the jar downloaded",
+        doc = "Filename assigned to the jar downloaded",
     ),
 }
 

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -170,13 +170,13 @@ package(default_visibility = ["//visibility:public"])
 
 java_import(
   name = 'jar',
-  jars = ["{file_path}"],
+  jars = ["{file_name}"],
   visibility = ['//visibility:public'],
 )
 
 filegroup(
   name = 'file',
-  srcs = ["{file_path}"],
+  srcs = ["{file_name}"],
   visibility = ['//visibility:public'],
 )
 
@@ -190,16 +190,16 @@ def _http_jar_impl(ctx):
     if ctx.attr.url:
         all_urls = [ctx.attr.url] + all_urls
     auth = _get_auth(ctx, all_urls)
-    downloaded_file_path = "jar/" + ctx.attr.downloaded_file_name
+    downloaded_file_name = ctx.attr.downloaded_file_name
     download_info = ctx.download(
         all_urls,
-        downloaded_file_path,
+        "jar/" + downloaded_file_name,
         ctx.attr.sha256,
         canonical_id = ctx.attr.canonical_id,
         auth = auth,
     )
     ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))
-    ctx.file("jar/BUILD", _HTTP_JAR_BUILD.format(file_path = downloaded_file_path))
+    ctx.file("jar/BUILD", _HTTP_JAR_BUILD.format(file_name = downloaded_file_name))
     return update_attrs(ctx.attr, _http_jar_attrs.keys(), {"sha256": download_info.sha256})
 
 _http_archive_attrs = {

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -170,13 +170,13 @@ package(default_visibility = ["//visibility:public"])
 
 java_import(
   name = 'jar',
-  jars = ['downloaded.jar'],
+  jars = ["{file_path}"],
   visibility = ['//visibility:public'],
 )
 
 filegroup(
   name = 'file',
-  srcs = ['downloaded.jar'],
+  srcs = ["{file_path}"],
   visibility = ['//visibility:public'],
 )
 
@@ -190,15 +190,16 @@ def _http_jar_impl(ctx):
     if ctx.attr.url:
         all_urls = [ctx.attr.url] + all_urls
     auth = _get_auth(ctx, all_urls)
+    downloaded_file_path = ctx.attr.downloaded_file_path
     download_info = ctx.download(
         all_urls,
-        "jar/downloaded.jar",
+        "jar/" + downloaded_file_path,
         ctx.attr.sha256,
         canonical_id = ctx.attr.canonical_id,
         auth = auth,
     )
     ctx.file("WORKSPACE", "workspace(name = \"{name}\")".format(name = ctx.name))
-    ctx.file("jar/BUILD", _HTTP_JAR_BUILD)
+    ctx.file("jar/BUILD", _HTTP_JAR_BUILD.format(file_path = downloaded_file_path))
     return update_attrs(ctx.attr, _http_jar_attrs.keys(), {"sha256": download_info.sha256})
 
 _http_archive_attrs = {
@@ -501,6 +502,10 @@ unless it was added to the cache by a request with the same canonical id.
     ),
     "auth_patterns": attr.string_dict(
         doc = _AUTH_PATTERN_DOC,
+    ),
+    "downloaded_file_path": attr.string(
+        default = "downloaded.jar",
+        doc = "Path assigned to the jar downloaded",
     ),
 }
 


### PR DESCRIPTION
If multiple http_jar rules are used the downloaded jar is always named `downloaded.jar`. This is a problem when the jar
file is being copied, for example in the case of docker rules, since one jar overrides the other which is not the desired
behaviour in most cases.