### PR TITLE
Do not merge BranchExp objects in place

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/BranchExp.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/BranchExp.java
@@ -58,8 +58,10 @@ public class BranchExp implements CovExp {
   }
 
   /** Make a union of the branches of two BranchExp. */
-  public void merge(BranchExp other) {
-    branches.addAll(other.branches);
+  public BranchExp merge(BranchExp other) {
+    List<CovExp> mergedBranches = new ArrayList<>(branches);
+    mergedBranches.addAll(other.branches);
+    return new BranchExp(mergedBranches);
   }
 
   @Override

--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/MethodProbesMapper.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/MethodProbesMapper.java
@@ -424,7 +424,7 @@ public class MethodProbesMapper extends MethodProbesVisitor implements IFilterOu
           if (lineExp == null) {
             lineToBranchExp.put(insn.getLine(), exp);
           } else {
-            lineExp.merge(exp);
+            lineToBranchExp.put(insn.getLine(), lineExp.merge(exp));
           }
         } else {
           // If we reach here, the internal data of the mapping is inconsistent, either


### PR DESCRIPTION
BranchExp objects form a tree structure that is used in report branch
evaluations for a source line. Merging of these objects in place when
associating them to line numbers will alter the structures rooted at
other line numbers, potentially resulting in false positives in the
branch coverage report.

Fixes #13962