### PR TITLE
java_lite_proto_library: respect ProtoLangToolchainProvider.forbiddenProtos()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/proto/JavaLiteProtoAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/proto/JavaLiteProtoAspect.java
@@ -170,7 +170,7 @@ public class JavaLiteProtoAspect extends NativeAspectClass implements Configured
         transitiveOutputJars.addTransitive(provider.getJars());
       }
 
-      if (!protoInfo.getDirectProtoSources().isEmpty()) {
+      if (aspectCommon.shouldGenerateCode(protoInfo, "java_lite_proto_library")) {
         Artifact sourceJar = aspectCommon.getSourceJarArtifact();
         createProtoCompileAction(sourceJar);
         Artifact outputJar = aspectCommon.getOutputJarArtifact();

--- a/src/main/java/com/google/devtools/build/lib/rules/java/proto/JavaProtoAspectCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/proto/JavaProtoAspectCommon.java
@@ -207,7 +207,9 @@ public class JavaProtoAspectCommon {
 
     NestedSetBuilder<Artifact> forbiddenProtos = NestedSetBuilder.stableOrder();
     forbiddenProtos.addTransitive(getProtoToolchainProvider().forbiddenProtos());
-    forbiddenProtos.addTransitive(rpcSupport.getForbiddenProtos(ruleContext));
+    if (rpcSupport != null) {
+      forbiddenProtos.addTransitive(rpcSupport.getForbiddenProtos(ruleContext));
+    }
 
     final ProtoSourceFileExcludeList protoExcludeList =
         new ProtoSourceFileExcludeList(ruleContext, forbiddenProtos.build());


### PR DESCRIPTION
Fixes #13928