### PR TITLE
Support the Jacoco filter merge operation in Java branch coverage.

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/BranchExp.java
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/BranchExp.java
@@ -15,6 +15,7 @@
 package com.google.testing.coverage;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /** A branch coverage that must be evaluated as a combination of probes. */
@@ -57,11 +58,33 @@ public class BranchExp implements CovExp {
     branches.set(idx, exp);
   }
 
-  /** Make a union of the branches of two BranchExp. */
-  public BranchExp merge(BranchExp other) {
-    List<CovExp> mergedBranches = new ArrayList<>(branches);
-    mergedBranches.addAll(other.branches);
-    return new BranchExp(mergedBranches);
+  /** Make a new BranchExp representing the concatenation of branches in inputs. */
+  public static BranchExp concatenate(BranchExp first, BranchExp second) {
+    List<CovExp> branches = new ArrayList<>(first.branches);
+    branches.addAll(second.branches);
+    return new BranchExp(branches);
+  }
+
+  /** Make a new BranchExp representing the pairwise union of branches in inputs */
+  public static BranchExp union(BranchExp left, BranchExp right) {
+    List<CovExp> unionedBranches = new ArrayList<>();
+    int leftSize = left.branches.size();
+    int rightSize = right.branches.size();
+    int i;
+    for (i = 0; i < leftSize && i < rightSize; i++) {
+      List<CovExp> branches = Arrays.asList(left.branches.get(i), right.branches.get(i));
+      unionedBranches.add(new BranchExp(branches));
+    }
+    List<CovExp> remainder = leftSize < rightSize ? right.branches : left.branches;
+    for(; i < remainder.size(); i++) {
+      unionedBranches.add(new BranchExp(remainder.get(i)));
+    }
+    return new BranchExp(unionedBranches);
+  }
+
+  /** Wraps a CovExp in a BranchExp if it isn't one already. */
+  public static BranchExp ensureIsBranchExp(CovExp exp) {
+    return exp instanceof BranchExp ? (BranchExp) exp : new BranchExp(exp);
   }
 
   @Override

--- a/src/test/shell/bazel/bazel_coverage_java_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_java_test.sh
@@ -889,12 +889,8 @@ BRDA:9,0,3,0
 BRDA:12,0,0,-
 BRDA:12,0,1,-
 BRDA:18,0,0,0
-BRDA:18,0,1,0
-BRDA:18,0,2,0
-BRDA:18,0,3,0
-BRDA:18,0,4,0
-BRDA:18,0,5,1
-BRF:12
+BRDA:18,0,1,1
+BRF:8
 BRH:3"
   assert_coverage_result "$expected_result" "$coverage_file_path"
 
@@ -911,13 +907,9 @@ BRDA:9,0,2,0
 BRDA:9,0,3,1
 BRDA:12,0,0,1
 BRDA:12,0,1,0
-BRDA:18,0,0,0
-BRDA:18,0,1,0
-BRDA:18,0,2,1
-BRDA:18,0,3,1
-BRDA:18,0,4,0
-BRDA:18,0,5,0
-BRF:12
+BRDA:18,0,0,1
+BRDA:18,0,1,1
+BRF:8
 BRH:5"
   assert_coverage_result "$expected_result" "$coverage_file_path"
 
@@ -935,12 +927,8 @@ BRDA:9,0,3,1
 BRDA:12,0,0,1
 BRDA:12,0,1,1
 BRDA:18,0,0,1
-BRDA:18,0,1,0
-BRDA:18,0,2,0
-BRDA:18,0,3,1
-BRDA:18,0,4,0
-BRDA:18,0,5,0
-BRF:12
+BRDA:18,0,1,1
+BRF:8
 BRH:6"
   assert_coverage_result "$expected_result" "$coverage_file_path"
 
@@ -957,13 +945,9 @@ BRDA:9,0,2,0
 BRDA:9,0,3,1
 BRDA:12,0,0,0
 BRDA:12,0,1,1
-BRDA:18,0,0,0
+BRDA:18,0,0,1
 BRDA:18,0,1,1
-BRDA:18,0,2,0
-BRDA:18,0,3,0
-BRDA:18,0,4,1
-BRDA:18,0,5,0
-BRF:12
+BRF:8
 BRH:6"
   assert_coverage_result "$expected_result" "$coverage_file_path"
 
@@ -982,12 +966,27 @@ BRDA:12,0,0,1
 BRDA:12,0,1,1
 BRDA:18,0,0,0
 BRDA:18,0,1,1
-BRDA:18,0,2,0
-BRDA:18,0,3,1
-BRDA:18,0,4,0
-BRDA:18,0,5,0
-BRF:12
-BRH:6"
+BRF:8
+BRH:5"
+  assert_coverage_result "$expected_result" "$coverage_file_path"
+
+  bazel coverage --test_output=all //:test \
+    --coverage_report_generator=@bazel_tools//tools/test:coverage_report_generator \
+    --combined_report=lcov &>$TEST_log \
+    --test_filter=".*(testOdd|testException)" \
+   || echo "Coverage for //:test failed"
+
+  local coverage_file_path="$( get_coverage_file_path_from_test_log )"
+  local expected_result="BRDA:9,0,0,1
+BRDA:9,0,1,1
+BRDA:9,0,2,0
+BRDA:9,0,3,1
+BRDA:12,0,0,1
+BRDA:12,0,1,0
+BRDA:18,0,0,1
+BRDA:18,0,1,0
+BRF:8
+BRH:5"
   assert_coverage_result "$expected_result" "$coverage_file_path"
 }
 


### PR DESCRIPTION
Instructions that are indicated to be merged must have their corresponding
coverage expressions (`CovExp`) combined in a pairwise fashion.

e.g. A pair of branch expressions that should be merged:
`BranchExp(a, b)`, `BranchExp(c, d)`

Becomes:

`BranchExp(a | c, b | d)`

This is distinct from the previous merge operation on BranchExp which
simply joined the branches of the two objects (this has been renamed to
concatenate).

Part of #12696. 