### PR TITLE
Remote: Make `chmod 0555` behavior consistent

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -173,9 +173,11 @@ class RemoteActionInputFetcher implements ActionInputPrefetcher {
 
   private void finalizeDownload(Path path) {
     try {
-      path.chmod(0755);
+      // The permission of output file is changed to 0555 after action execution. We manually change the permission here
+      // for the downloaded file to keep this behaviour consistent.
+      path.chmod(0555);
     } catch (IOException e) {
-      logger.atWarning().withCause(e).log("Failed to chmod 755 on %s", path);
+      logger.atWarning().withCause(e).log("Failed to chmod 555 on %s", path);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -649,10 +649,10 @@ public class RemoteExecutionService {
      */
     Collections.sort(finishedDownloads, Comparator.comparing(f -> toTmpDownloadPath(f.path())));
 
-    // Move the output files from their temporary name to the actual output file name.
+    // Move the output files from their temporary name to the actual output file name. Executable bit
+    // is ignored since the file permission will be changed to 0555 after execution.
     for (FileMetadata outputFile : finishedDownloads) {
       FileSystemUtils.moveFile(toTmpDownloadPath(outputFile.path()), outputFile.path());
-      outputFile.path().setExecutable(outputFile.isExecutable());
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/UploadManifest.java
@@ -244,7 +244,8 @@ public class UploadManifest {
         .addOutputFilesBuilder()
         .setPath(remotePathResolver.localPathToOutputPath(file))
         .setDigest(digest)
-        .setIsExecutable(file.isExecutable());
+        // The permission of output file is changed to 0555 after action execution
+        .setIsExecutable(true);
 
     digestToFile.put(digest, file);
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -453,7 +453,8 @@ public class GrpcCacheClientTest {
 
     ActionResult result = uploadDirectory(remoteCache, ImmutableList.<Path>of(fooFile, barDir));
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
-    expectedResult.addOutputFilesBuilder().setPath("a/foo").setDigest(fooDigest);
+    // output files will have permission 0555 after action execution regardless the current permission
+    expectedResult.addOutputFilesBuilder().setPath("a/foo").setDigest(fooDigest).setIsExecutable(true);
     expectedResult.addOutputDirectoriesBuilder().setPath("bar").setTreeDigest(barDigest);
     assertThat(result).isEqualTo(expectedResult.build());
   }
@@ -719,7 +720,8 @@ public class GrpcCacheClientTest {
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
     expectedResult.setStdoutDigest(stdoutDigest);
     expectedResult.setStderrDigest(stderrDigest);
-    expectedResult.addOutputFilesBuilder().setPath("a/foo").setDigest(fooDigest);
+    // output files will have permission 0555 after action execution regardless the current permission
+    expectedResult.addOutputFilesBuilder().setPath("a/foo").setDigest(fooDigest).setIsExecutable(true);
     expectedResult
         .addOutputFilesBuilder()
         .setPath("bar")
@@ -778,7 +780,8 @@ public class GrpcCacheClientTest {
             command,
             ImmutableList.of(fooFile, barFile));
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
-    expectedResult.addOutputFilesBuilder().setPath("a/foo").setDigest(fooDigest);
+    // output files will have permission 0555 after action execution regardless the current permission
+    expectedResult.addOutputFilesBuilder().setPath("a/foo").setDigest(fooDigest).setIsExecutable(true);
     expectedResult
         .addOutputFilesBuilder()
         .setPath("bar")
@@ -828,9 +831,10 @@ public class GrpcCacheClientTest {
           }
         });
     ActionResult.Builder rb = ActionResult.newBuilder();
-    rb.addOutputFilesBuilder().setPath("a/foo").setDigest(fooDigest);
+    // output files will have permission 0555 after action execution regardless the current permission
+    rb.addOutputFilesBuilder().setPath("a/foo").setDigest(fooDigest).setIsExecutable(true);
     rb.addOutputFilesBuilder().setPath("bar").setDigest(barDigest).setIsExecutable(true);
-    rb.addOutputFilesBuilder().setPath("baz").setDigest(bazDigest);
+    rb.addOutputFilesBuilder().setPath("baz").setDigest(bazDigest).setIsExecutable(true);
     ActionResult result = rb.build();
     serviceRegistry.addService(
         new ActionCacheImplBase() {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcherTest.java
@@ -214,7 +214,7 @@ public class RemoteActionInputFetcherTest {
         .isEqualTo("hello world");
     assertThat(a1.getPath().isExecutable()).isTrue();
     assertThat(a1.getPath().isReadable()).isTrue();
-    assertThat(a1.getPath().isWritable()).isTrue();
+    assertThat(a1.getPath().isWritable()).isFalse();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteExecutionServiceTest.java
@@ -163,8 +163,9 @@ public class RemoteExecutionServiceTest {
   }
 
   @Test
-  public void downloadOutputs_outputFiles_maintainsExecutableBit() throws Exception {
-    // Test that downloading output files maintains executable bit works.
+  public void downloadOutputs_outputFiles_executableBitIgnored() throws Exception {
+    // Test that executable bit of downloaded output files are ignored since it will be chmod 555 after action
+    // execution.
 
     // arrange
     Digest fooDigest = cache.addContents(remoteActionExecutionContext, "foo-contents");
@@ -190,7 +191,7 @@ public class RemoteExecutionServiceTest {
     assertThat(digestUtil.compute(execRoot.getRelative("outputs/foo"))).isEqualTo(fooDigest);
     assertThat(digestUtil.compute(execRoot.getRelative("outputs/bar"))).isEqualTo(barDigest);
     assertThat(execRoot.getRelative("outputs/foo").isExecutable()).isFalse();
-    assertThat(execRoot.getRelative("outputs/bar").isExecutable()).isTrue();
+    assertThat(execRoot.getRelative("outputs/bar").isExecutable()).isFalse();
     assertThat(context.isLockOutputFilesCalled()).isTrue();
   }
 
@@ -255,7 +256,7 @@ public class RemoteExecutionServiceTest {
     // assert
     assertThat(digestUtil.compute(execRoot.getRelative("outputs/a/foo"))).isEqualTo(fooDigest);
     assertThat(digestUtil.compute(execRoot.getRelative("outputs/a/bar/qux"))).isEqualTo(quxDigest);
-    assertThat(execRoot.getRelative("outputs/a/bar/qux").isExecutable()).isTrue();
+    assertThat(execRoot.getRelative("outputs/a/bar/qux").isExecutable()).isFalse();
     assertThat(context.isLockOutputFilesCalled()).isTrue();
   }
 
@@ -1141,7 +1142,7 @@ public class RemoteExecutionServiceTest {
 
     // assert
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
-    expectedResult.addOutputFilesBuilder().setPath("outputs/a/foo").setDigest(fooDigest);
+    expectedResult.addOutputFilesBuilder().setPath("outputs/a/foo").setDigest(fooDigest).setIsExecutable(true);
     expectedResult.addOutputDirectoriesBuilder().setPath("outputs/bar").setTreeDigest(barDigest);
     assertThat(manifest.getActionResult()).isEqualTo(expectedResult.build());
 

--- a/src/test/java/com/google/devtools/build/lib/remote/UploadManifestTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/UploadManifestTest.java
@@ -77,7 +77,7 @@ public class UploadManifestTest {
     assertThat(um.getDigestToFile()).containsExactly(digest, link);
 
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
-    expectedResult.addOutputFilesBuilder().setPath("link").setDigest(digest);
+    expectedResult.addOutputFilesBuilder().setPath("link").setDigest(digest).setIsExecutable(true);
     assertThat(result.build()).isEqualTo(expectedResult.build());
   }
 
@@ -135,7 +135,7 @@ public class UploadManifestTest {
     assertThat(um.getDigestToFile()).containsExactly(digest, link);
 
     ActionResult.Builder expectedResult = ActionResult.newBuilder();
-    expectedResult.addOutputFilesBuilder().setPath("link").setDigest(digest);
+    expectedResult.addOutputFilesBuilder().setPath("link").setDigest(digest).setIsExecutable(true);
     assertThat(result.build()).isEqualTo(expectedResult.build());
   }
 


### PR DESCRIPTION
After action execution, permission of output files is changed to [`0555`](https://github.com/bazelbuild/bazel/issues/5588). This PR updates remote module in following ways to make the behavior consistent:

  1. Ignores `isExecutable` field of downloaded outputs from remote cache since the permission will be set to `0555` after action execution.
  2. Always set `isExecutable` to `true` instead of reading the real permission bits from file system when uploading local outputs.
  3. Do `chmod 0555` instead of `chmod 0755` when fetching inputs files for local actions which are outputs of previous remote actions. This should improve cache hit rate for builds that use dynamic execution and build without bytes.

Caveat: actions that depend on permission bits of input files (e.g. zip actions) shouldn't be executed dynamically since we have no control of input file permissions when running remotely. They should be always executed either locally or remotely.

b/198297058