### PR TITLE
Use rbe_preconfig for RBE toolchain configs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -208,17 +208,10 @@ REMOTE_PLATFORMS = ("rbe_ubuntu1604_java8", "rbe_ubuntu1804_java11")
     platform(
         name = platform_name + "_platform",
         parents = ["@" + platform_name + "//config:platform"],
-        remote_execution_properties = """
-            {PARENT_REMOTE_EXECUTION_PROPERTIES}
-            properties: {
-                name: "dockerNetwork"
-                value: "standard"
-            }
-            properties: {
-                name: "dockerPrivileged"
-                value: "true"
-            }
-            """,
+        exec_properties = {
+            "dockerNetwork": "standard",
+            "dockerPrivileged": "true",
+        },
     )
     for platform_name in REMOTE_PLATFORMS
 ]
@@ -232,13 +225,9 @@ REMOTE_PLATFORMS = ("rbe_ubuntu1604_java8", "rbe_ubuntu1804_java11")
             "//:highcpu_machine",
         ],
         parents = ["//:" + platform_name + "_platform"],
-        remote_execution_properties = """
-            {PARENT_REMOTE_EXECUTION_PROPERTIES}
-            properties: {
-                name: "gceMachineType"
-                value: "e2-highcpu-32"
-            }
-            """,
+        exec_properties = {
+            "gceMachineType": "e2-highcpu-32",
+        },
     )
     for platform_name in REMOTE_PLATFORMS
 ]

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -272,12 +272,10 @@ http_file(
     urls = ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64-minimal-b23d4e05466f2aa1fdcd72d3d3a8e962206b64bf-1581689080.zip"],
 )
 
-http_archive(
+dist_http_archive(
     name = "bazel_ci_rules",
-    sha256 = "092772e52fd573ee39282d88880ff2a49a2482affeabc1a30e295e0a2891624c",
-    urls = [
-        "https://github.com/bazelbuild/continuous-integration/releases/download/rules_1.0.0/bazel_ci_rules.tar.gz"
-    ]
+    patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
+    patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
 )
 
 load("@bazel_ci_rules//:rbe_repo.bzl", "rbe_preconfig")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -272,35 +272,25 @@ http_file(
     urls = ["https://mirror.bazel.build/openjdk/azul-zulu11.37.17-ca-jdk11.0.6/zulu11.37.17-ca-jdk11.0.6-win_x64-minimal-b23d4e05466f2aa1fdcd72d3d3a8e962206b64bf-1581689080.zip"],
 )
 
-dist_http_archive(
-    name = "bazel_toolchains",
-    patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
-    patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
+http_archive(
+    name = "bazel_ci_rules",
+    sha256 = "092772e52fd573ee39282d88880ff2a49a2482affeabc1a30e295e0a2891624c",
+    urls = [
+        "https://github.com/bazelbuild/continuous-integration/releases/download/rules_1.0.0/bazel_ci_rules.tar.gz"
+    ]
 )
 
-load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+load("@bazel_ci_rules//:rbe_repo.bzl", "rbe_preconfig")
 
-rbe_autoconfig(
-    name = "rbe_ubuntu1804_java11",
-    detect_java_home = True,
-    registry = "gcr.io",
-    repository = "bazel-public/ubuntu1804-bazel-java11",
-    tag = "latest",
-)
-
-rbe_autoconfig(
+rbe_preconfig(
     name = "rbe_ubuntu1604_java8",
-    detect_java_home = True,
-    registry = "gcr.io",
-    repository = "bazel-public/ubuntu1604-bazel-java8",
-    tag = "latest",
+    toolchain = "ubuntu1604-bazel-java8",
 )
 
-# Creates toolchain configuration for remote execution with BuildKite CI
-# for rbe_ubuntu1604.
-# To run the tests with RBE on BuildKite CI uncomment the two lines below
-# load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
-# rbe_autoconfig(name = "buildkite_config")
+rbe_preconfig(
+    name = "rbe_ubuntu1804_java11",
+    toolchain = "ubuntu1804-bazel-java11",
+)
 
 http_archive(
     name = "com_google_googletest",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -273,12 +273,12 @@ http_file(
 )
 
 dist_http_archive(
-    name = "bazel_ci_rules",
+    name = "bazelci_rules",
     patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
 )
 
-load("@bazel_ci_rules//:rbe_repo.bzl", "rbe_preconfig")
+load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
 
 rbe_preconfig(
     name = "rbe_ubuntu1604_java8",

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -31,13 +31,11 @@ DIST_DEPS = {
             "test_WORKSPACE_files",
         ],
     },
-    "bazel_toolchains": {
-        "archive": "bazel-toolchains-4.1.0.tar.gz",
-        "sha256": "179ec02f809e86abf56356d8898c8bd74069f1bd7c56044050c2cd3d79d0e024",
-        "strip_prefix": "bazel-toolchains-4.1.0",
+    "bazel_ci_rules": {
+        "archive": "bazel_ci_rules-1.0.0.tar.gz",
+        "sha256": "092772e52fd573ee39282d88880ff2a49a2482affeabc1a30e295e0a2891624c",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
+            "https://github.com/bazelbuild/continuous-integration/releases/download/rules_1.0.0/bazel_ci_rules.tar.gz",
         ],
         "used_in": [
             "additional_distfiles",

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -33,9 +33,10 @@ DIST_DEPS = {
     },
     "bazelci_rules": {
         "archive": "bazelci_rules-1.0.0.tar.gz",
-        "sha256": "092772e52fd573ee39282d88880ff2a49a2482affeabc1a30e295e0a2891624c",
+        "sha256": "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
+        "strip_prefix": "bazelci_rules-1.0.0",
         "urls": [
-            "https://github.com/bazelbuild/continuous-integration/releases/download/rules_1.0.0/bazelci_rules.tar.gz",
+            "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
         ],
         "used_in": [
             "additional_distfiles",

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -31,11 +31,11 @@ DIST_DEPS = {
             "test_WORKSPACE_files",
         ],
     },
-    "bazel_ci_rules": {
-        "archive": "bazel_ci_rules-1.0.0.tar.gz",
+    "bazelci_rules": {
+        "archive": "bazelci_rules-1.0.0.tar.gz",
         "sha256": "092772e52fd573ee39282d88880ff2a49a2482affeabc1a30e295e0a2891624c",
         "urls": [
-            "https://github.com/bazelbuild/continuous-integration/releases/download/rules_1.0.0/bazel_ci_rules.tar.gz",
+            "https://github.com/bazelbuild/continuous-integration/releases/download/rules_1.0.0/bazelci_rules.tar.gz",
         ],
         "used_in": [
             "additional_distfiles",


### PR DESCRIPTION
[`rbe_preconfig`](https://github.com/bazelbuild/continuous-integration/tree/master/rules) is a repo rule that downloads pre-generated, Bazel CI hosted RBE toolchain configs. The list of available toolchains can be checked with [`manifest.json`](https://storage.googleapis.com/bazel-ci/rbe-configs/manifest.json).

This PR replaces `rbe_autoconfig` with `rbe_preconfig` and removes the `bazel_toolchains` dependency.