### PR TITLE
Skylark create compilation outputs based on another object

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCcModule.java
@@ -227,10 +227,15 @@ public class BazelCcModule extends CcModule
       Object objectsObject,
       Object picObjectsObject,
       Object ltoCopmilationContextObject,
+      Object compilationOutputs,
       StarlarkThread thread)
       throws EvalException {
     return super.createCompilationOutputsFromStarlark(
-        objectsObject, picObjectsObject, ltoCopmilationContextObject, thread);
+        objectsObject,
+        picObjectsObject,
+        ltoCopmilationContextObject,
+        convertFromNoneable(compilationOutputs, /* defaultValue= */ null),
+        thread);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationOutputs.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationOutputs.java
@@ -254,6 +254,11 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
       return this;
     }
 
+    public Builder setObjectFiles(Iterable<Artifact> artifacts) {
+      objectFiles.clear();
+      return addObjectFiles(artifacts);
+    }
+
     /** Adds a pic object file. */
     public Builder addPicObjectFile(Artifact artifact) {
       picObjectFiles.add(artifact);
@@ -279,6 +284,11 @@ public class CcCompilationOutputs implements CcCompilationOutputsApi<Artifact> {
 
       Iterables.addAll(picObjectFiles, artifacts);
       return this;
+    }
+
+    public Builder setPicObjectFiles(Iterable<Artifact> artifacts) {
+      picObjectFiles.clear();
+      return addPicObjectFiles(artifacts);
     }
 
     public Builder addDwoFile(Artifact artifact) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java
@@ -2454,12 +2454,16 @@ public abstract class CcModule
       Object objectsObject,
       Object picObjectsObject,
       Object ltoCompilationContextObject,
+      CcCompilationOutputs compilationOutputs,
       StarlarkThread thread)
       throws EvalException {
     if (checkObjectsBound(ltoCompilationContextObject)) {
       CcModule.checkPrivateStarlarkificationAllowlist(thread);
     }
     CcCompilationOutputs.Builder ccCompilationOutputsBuilder = CcCompilationOutputs.builder();
+    if (compilationOutputs != null) {
+      ccCompilationOutputsBuilder.merge(compilationOutputs);
+    }
     NestedSet<Artifact> objects = convertToNestedSet(objectsObject, Artifact.class, "objects");
     validateExtensions(
         "objects",
@@ -2477,8 +2481,8 @@ public abstract class CcModule
         Link.OBJECT_FILETYPES,
         Link.OBJECT_FILETYPES,
         /* allowAnyTreeArtifacts= */ false);
-    ccCompilationOutputsBuilder.addObjectFiles(objects.toList());
-    ccCompilationOutputsBuilder.addPicObjectFiles(picObjects.toList());
+    ccCompilationOutputsBuilder.setObjectFiles(objects.toList());
+    ccCompilationOutputsBuilder.setPicObjectFiles(picObjects.toList());
     if (ltoCompilationContext != null) {
       ccCompilationOutputsBuilder.addLtoCompilationContext(ltoCompilationContext);
     }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/BazelCcModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/BazelCcModuleApi.java
@@ -649,11 +649,22 @@ public interface BazelCcModuleApi<
             positional = false,
             named = true,
             defaultValue = "unbound"),
+        @Param(
+            name = "compilation_outputs",
+            doc = "Compilation outputs object to base new object on.",
+            positional = false,
+            named = true,
+            defaultValue = "None",
+            allowedTypes = {
+              @ParamType(type = CcCompilationOutputsApi.class),
+              @ParamType(type = NoneType.class)
+            }),
       })
   CompilationOutputsT createCompilationOutputsFromStarlark(
       Object objectsObject,
       Object picObjectsObject,
       Object ltoCopmilationContextObject,
+      Object compilationOutputs,
       StarlarkThread thread)
       throws EvalException;
 


### PR DESCRIPTION
This patch adds a "compilation_outputs" argument to cc_common.create_compilation_outputs. All files in this object will be merged into the new object. This enables starlark code to modify object files from compilation phase while keeping all other files (coverage, debug, ...) intact.