### PR TITLE
Implement extra resources for test actions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/actions/BUILD
@@ -124,6 +124,7 @@ java_library(
         "//third_party:flogger",
         "//third_party:guava",
         "//third_party:jsr305",
+        "//third_party:rxjava3",
         "//third_party/protobuf:protobuf_java",
     ],
 )
@@ -305,6 +306,7 @@ java_library(
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:flogger",
         "//third_party:guava",
+        "//third_party:rxjava3",
     ],
 )
 

--- a/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
@@ -152,6 +152,35 @@ public class ExecutionRequirements {
             return null;
           });
 
+  /** How many extra resources an action requires for execution. */
+  public static final ParseableRequirement RESOURCES =
+      ParseableRequirement.create(
+          "resources:<str>:<int>",
+          Pattern.compile("resources:(.+:.+)"),
+          s -> {
+            Preconditions.checkNotNull(s);
+
+            int splitIndex = s.indexOf(":");
+            String resourceCount = s.substring(splitIndex+1);
+            int value;
+            try {
+              value = Integer.parseInt(resourceCount);
+            } catch (NumberFormatException e) {
+              return "can't be parsed as an integer";
+            }
+
+            // De-and-reserialize & compare to only allow canonical integer formats.
+            if (!Integer.toString(value).equals(resourceCount)) {
+              return "must be in canonical format (e.g. '4' instead of '+04')";
+            }
+
+            if (value < 1) {
+              return "can't be zero or negative";
+            }
+
+            return null;
+          });
+
   /** If an action supports running in persistent worker mode. */
   public static final String SUPPORTS_WORKERS = "supports-workers";
 

--- a/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ResourceManager.java
@@ -25,9 +25,13 @@ import com.google.devtools.build.lib.unix.ProcMeminfoParser;
 import com.google.devtools.build.lib.util.OS;
 import com.google.devtools.build.lib.util.Pair;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
 /**
@@ -137,6 +141,10 @@ public class ResourceManager {
   // definition in the ResourceSet class.
   private double usedRam;
 
+  // Used amount of extra resources. Corresponds to the extra resource
+  // definition in the ResourceSet class.
+  private Map<String, Float> usedExtraResources;
+
   // Used local test count. Corresponds to the local test count definition in the ResourceSet class.
   private int usedLocalTestCount;
 
@@ -145,6 +153,7 @@ public class ResourceManager {
 
   private ResourceManager() {
     requestList = new LinkedList<>();
+    usedExtraResources = new HashMap<>();
   }
 
   @VisibleForTesting public static ResourceManager instanceForTestingOnly() {
@@ -158,6 +167,7 @@ public class ResourceManager {
   public synchronized void resetResourceUsage() {
     usedCpu = 0;
     usedRam = 0;
+    usedExtraResources = new HashMap<>();
     usedLocalTestCount = 0;
     for (Pair<ResourceSet, CountDownLatch> request : requestList) {
       // CountDownLatch can be set only to 0 or 1.
@@ -177,6 +187,7 @@ public class ResourceManager {
         ResourceSet.create(
             staticResources.getMemoryMb(),
             staticResources.getCpuUsage(),
+            staticResources.getExtraResourceUsage(),
             staticResources.getLocalTestCount());
     processWaitingThreads();
   }
@@ -265,6 +276,17 @@ public class ResourceManager {
   private void incrementResources(ResourceSet resources) {
     usedCpu += resources.getCpuUsage();
     usedRam += resources.getMemoryMb();
+
+    resources.getExtraResourceUsage().entrySet().forEach(
+      resource -> {
+        String key = (String)resource.getKey();
+        float value = resource.getValue();
+        if (usedExtraResources.containsKey(key)) {
+          value += (float)usedExtraResources.get(key);
+        }
+        usedExtraResources.put(key, value);
+      });
+
     usedLocalTestCount += resources.getLocalTestCount();
   }
 
@@ -272,7 +294,7 @@ public class ResourceManager {
    * Return true if any resources have been claimed through this manager.
    */
   public synchronized boolean inUse() {
-    return usedCpu != 0.0 || usedRam != 0.0 || usedLocalTestCount != 0 || !requestList.isEmpty();
+    return usedCpu != 0.0 || usedRam != 0.0 || !usedExtraResources.isEmpty() || usedLocalTestCount != 0 || !requestList.isEmpty();
   }
 
 
@@ -323,6 +345,13 @@ public class ResourceManager {
   private synchronized boolean release(ResourceSet resources) {
     usedCpu -= resources.getCpuUsage();
     usedRam -= resources.getMemoryMb();
+
+    for (Map.Entry<String, Float> resource : resources.getExtraResourceUsage().entrySet()) {
+      String key = (String)resource.getKey();
+      float value = (float)usedExtraResources.get(key) - resource.getValue();
+      usedExtraResources.put(key, value);
+    }
+
     usedLocalTestCount -= resources.getLocalTestCount();
 
     // TODO(bazel-team): (2010) rounding error can accumulate and value below can end up being
@@ -334,6 +363,20 @@ public class ResourceManager {
     if (usedRam < epsilon) {
       usedRam = 0;
     }
+
+    Set<String> toRemove = new HashSet<>();
+    usedExtraResources.entrySet().forEach(
+      resource -> {
+        String key = (String)resource.getKey();
+        float value = (float)usedExtraResources.get(key);
+        if (value < epsilon) {
+          toRemove.add(key);
+        }
+      });
+    for (String key : toRemove) {
+      usedExtraResources.remove(key);
+    }
+
     if (!requestList.isEmpty()) {
       processWaitingThreads();
       return true;
@@ -361,12 +404,29 @@ public class ResourceManager {
     }
   }
 
+  /**
+   * Return true iff all requested extra resources are considered to be available.
+   */
+  private boolean areExtraResourcesAvailable(ResourceSet resources) {
+    for (Map.Entry<String, Float> resource : resources.getExtraResourceUsage().entrySet()) {
+      String key = (String)resource.getKey();
+      float used = (float)usedExtraResources.getOrDefault(key, 0f);
+      float requested = resource.getValue();
+      float available = (float)availableResources.getExtraResourceUsage().getOrDefault(key, 0f);
+      float epsilon = 0.0001f;  // Account for possible rounding errors.
+      if (requested != 0.0 && used != 0.0 && requested + used > available + epsilon) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   // Method will return true if all requested resources are considered to be available.
   private boolean areResourcesAvailable(ResourceSet resources) {
     Preconditions.checkNotNull(availableResources);
     // Comparison below is robust, since any calculation errors will be fixed
     // by the release() method.
-    if (usedCpu == 0.0 && usedRam == 0.0 && usedLocalTestCount == 0) {
+    if (usedCpu == 0.0 && usedRam == 0.0 && usedExtraResources.isEmpty() && usedLocalTestCount == 0) {
       return true;
     }
     // Use only MIN_NECESSARY_???_RATIO of the resource value to check for
@@ -410,9 +470,10 @@ public class ResourceManager {
     // 3) If used resource amount is less than total available resource amount.
     boolean cpuIsAvailable = cpu == 0.0 || usedCpu == 0.0 || usedCpu + cpu <= availableCpu;
     boolean ramIsAvailable = ram == 0.0 || usedRam == 0.0 || ram <= remainingRam;
+    boolean extraResourcesIsAvailable = areExtraResourcesAvailable(resources);
     boolean localTestCountIsAvailable = localTestCount == 0 || usedLocalTestCount == 0
         || usedLocalTestCount + localTestCount <= availableLocalTestCount;
-    return cpuIsAvailable && ramIsAvailable && localTestCountIsAvailable;
+    return cpuIsAvailable && ramIsAvailable && extraResourcesIsAvailable && localTestCountIsAvailable;
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;
 import com.google.devtools.build.lib.server.FailureDetails.TestAction;
 import com.google.devtools.build.lib.server.FailureDetails.TestAction.Code;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -162,32 +163,22 @@ public class TestTargetProperties {
     return isPersistentTestRunner;
   }
 
-  public ResourceSet getLocalResourceUsage(Label label, boolean usingLocalTestJobs)
-      throws UserExecException {
-    if (usingLocalTestJobs) {
-      return LOCAL_TEST_JOBS_BASED_RESOURCES;
-    }
-
+  private double getLocalCpuResourceUsage(Label label) throws UserExecException {
     ResourceSet testResourcesFromSize = TestTargetProperties.getResourceSetFromSize(size);
-
     // Tests can override their CPU reservation with a "cpu:<n>" tag.
-    ResourceSet testResourcesFromTag = null;
+    double cpuCount = -1.0;
     for (String tag : executionInfo.keySet()) {
       try {
         String cpus = ExecutionRequirements.CPU.parseIfMatches(tag);
         if (cpus != null) {
-          if (testResourcesFromTag != null) {
+          if (cpuCount != -1.0) {
             String message =
                 String.format(
                     "%s has more than one '%s' tag, but duplicate tags aren't allowed",
                     label, ExecutionRequirements.CPU.userFriendlyName());
             throw new UserExecException(createFailureDetail(message, Code.DUPLICATE_CPU_TAGS));
           }
-          testResourcesFromTag =
-              ResourceSet.create(
-                  testResourcesFromSize.getMemoryMb(),
-                  Float.parseFloat(cpus),
-                  testResourcesFromSize.getLocalTestCount());
+          cpuCount = Float.parseFloat(cpus);
         }
       } catch (ValidationException e) {
         String message =
@@ -200,8 +191,54 @@ public class TestTargetProperties {
         throw new UserExecException(createFailureDetail(message, Code.INVALID_CPU_TAG));
       }
     }
+    return cpuCount != -1.0 ? cpuCount : testResourcesFromSize.getCpuUsage();
+  }
 
-    return testResourcesFromTag != null ? testResourcesFromTag : testResourcesFromSize;
+  private ImmutableMap<String, Float> getLocalExtraResourceUsage(Label label) throws UserExecException {
+    // Tests can specify requirements for extra resources using "resources:<resourcename>:<amount>" tag.
+    Map<String, Float> extraResources = new HashMap<>();
+    for (String tag : executionInfo.keySet()) {
+      try {
+        String extras = ExecutionRequirements.RESOURCES.parseIfMatches(tag);
+        if (extras != null) {
+          int splitIndex = extras.indexOf(":");
+          String resourceName = extras.substring(0, splitIndex);
+          String resourceCount = extras.substring(splitIndex+1);
+          if (extraResources.get(resourceName) != null) {
+            String message =
+                String.format(
+                    "%s has more than one '%s' tag, but duplicate tags aren't allowed",
+                    label, ExecutionRequirements.RESOURCES.userFriendlyName());
+            throw new UserExecException(createFailureDetail(message, Code.DUPLICATE_CPU_TAGS));
+          }
+          extraResources.put(resourceName, Float.parseFloat(resourceCount));
+        }
+      } catch (ValidationException e) {
+        String message =
+            String.format(
+                "%s has a '%s' tag, but its value '%s' didn't pass validation: %s",
+                label,
+                ExecutionRequirements.RESOURCES.userFriendlyName(),
+                e.getTagValue(),
+                e.getMessage());
+        throw new UserExecException(createFailureDetail(message, Code.INVALID_CPU_TAG));
+      }
+    }
+    return ImmutableMap.copyOf(extraResources);
+  }
+
+  public ResourceSet getLocalResourceUsage(Label label, boolean usingLocalTestJobs)
+      throws UserExecException {
+    if (usingLocalTestJobs) {
+      return LOCAL_TEST_JOBS_BASED_RESOURCES;
+    }
+
+    ResourceSet testResourcesFromSize = TestTargetProperties.getResourceSetFromSize(size);
+    return ResourceSet.create(
+            testResourcesFromSize.getMemoryMb(),
+            getLocalCpuResourceUsage(label),
+            getLocalExtraResourceUsage(label),
+            testResourcesFromSize.getLocalTestCount());
   }
 
   private static FailureDetail createFailureDetail(String message, Code detailedCode) {

--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -107,6 +107,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -883,10 +884,14 @@ public class ExecutionTool {
     resources = ResourceSet.createWithRamCpu(options.localRamResources, options.localCpuResources);
     resourceMgr.setUseLocalMemoryEstimate(options.localMemoryEstimate);
 
+    ImmutableMap<String, Float> extraResources = options.localExtraResources.stream().collect(
+      ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue, (v1,v2) -> v1));
+
     resourceMgr.setAvailableResources(
         ResourceSet.create(
             resources.getMemoryMb(),
             resources.getCpuUsage(),
+            extraResources,
             request.getExecutionOptions().usingLocalTestJobs()
                 ? request.getExecutionOptions().localTestJobs
                 : Integer.MAX_VALUE));

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -302,8 +302,7 @@ public class ExecutionOptions extends OptionsBase {
               + "an integer, or \"HOST_CPUS\", optionally followed by [-|*]<float> "
               + "(eg. HOST_CPUS*.5 to use half the available CPU cores)."
               + "By default, (\"HOST_CPUS\"), Bazel will query system configuration to estimate "
-              + "number of CPU cores available for the locally executed build actions. "
-              + "Note: This is a no-op if --local_resources is set.",
+              + "number of CPU cores available for the locally executed build actions.",
       converter = CpuResourceConverter.class)
   public float localCpuResources;
 
@@ -318,10 +317,26 @@ public class ExecutionOptions extends OptionsBase {
               + "(eg. HOST_RAM*.5 to use half the available RAM)."
               + "By default, (\"HOST_RAM*.67\"), Bazel will query system configuration to estimate "
               + "amount of RAM available for the locally executed build actions and will use 67% "
-              + "of available RAM. "
-              + "Note: This is a no-op if --local_resources is set.",
+              + "of available RAM.",
       converter = RamResourceConverter.class)
   public float localRamResources;
+
+  @Option(
+      name = "local_extra_resources",
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      allowMultiple = true,
+      help =
+          "Set the number of extra resources available to Bazel. "
+            + "Takes in a string-float pair. Can be used multiple times to specify multiple "
+            + "types of extra resources. Bazel will limit concurrently running test actions "
+            + "based on the available extra resources and the extra resources required "
+            + "by the test actions.  Tests can declare the amount of extra resources they need "
+            + "by using a tag of the \"resources:<resoucename>:<amount>\" format. "
+            + "Available CPU, RAM and test job resources cannot be set with this flag.",
+      converter = Converters.StringToFloatAssignmentConverter.class)
+  public List<Map.Entry<String, Float>> localExtraResources;
 
   @Option(
     name = "experimental_local_memory_estimate",

--- a/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/TargetUtils.java
@@ -56,7 +56,8 @@ public final class TargetUtils {
         || tag.startsWith("disable-")
         || tag.startsWith("cpu:")
         || tag.equals(ExecutionRequirements.LOCAL)
-        || tag.equals(ExecutionRequirements.WORKER_KEY_MNEMONIC);
+        || tag.equals(ExecutionRequirements.WORKER_KEY_MNEMONIC)
+        || tag.startsWith("resources:");
   }
 
   private TargetUtils() {} // Uninstantiable.

--- a/src/main/java/com/google/devtools/common/options/Converters.java
+++ b/src/main/java/com/google/devtools/common/options/Converters.java
@@ -470,6 +470,24 @@ public final class Converters {
   }
 
   /**
+   * A converter for for assignments from a string value to a float value.
+   */
+  public static class StringToFloatAssignmentConverter implements Converter<Map.Entry<String, Float>> {
+    private static final AssignmentConverter baseConverter = new AssignmentConverter();
+
+    @Override
+    public Map.Entry<String, Float> convert(String input) throws OptionsParsingException, NumberFormatException {
+      Map.Entry<String, String> stringEntry = baseConverter.convert(input);
+      return Maps.immutableEntry(stringEntry.getKey(), Float.parseFloat(stringEntry.getValue()));
+    }
+
+    @Override
+    public String getTypeDescription() {
+      return "a named float, 'name=value'";
+    }
+  }
+
+  /**
    * A converter for command line flag aliases. It does additional validation on the name and value
    * of the assignment to ensure they conform to the naming limitations.
    */

--- a/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ResourceManagerTest.java
@@ -51,7 +51,14 @@ public class ResourceManagerTest {
   @Before
   public final void configureResourceManager() throws Exception  {
     rm.setAvailableResources(
-        ResourceSet.create(/*memoryMb=*/ 1000, /*cpuUsage=*/ 1, /* localTestCount= */ 2));
+        ResourceSet.create(
+          /*memoryMb=*/ 1000,
+          /*cpuUsage=*/ 1,
+          /*extraResourceUsage*/ ImmutableMap.of(
+            "gpu", 2.0f,
+            "fancyresource", 1.5f
+          ),
+          /* localTestCount= */ 2));
     counter = new AtomicInteger(0);
     sync = new CyclicBarrier(2);
     sync2 = new CyclicBarrier(2);
@@ -63,12 +70,25 @@ public class ResourceManagerTest {
     return rm.acquireResources(resourceOwner, ResourceSet.create(ram, cpu, tests));
   }
 
+  private ResourceHandle acquire(double ram, double cpu, int tests, ImmutableMap<String, Float> extraResources)
+      throws InterruptedException {
+    return rm.acquireResources(resourceOwner, ResourceSet.create(ram, cpu, extraResources, tests));
+  }
+
   private ResourceHandle acquireNonblocking(double ram, double cpu, int tests) {
     return rm.tryAcquire(resourceOwner, ResourceSet.create(ram, cpu, tests));
   }
 
+  private ResourceHandle acquireNonblocking(double ram, double cpu, int tests, ImmutableMap<String, Float> extraResources) {
+    return rm.tryAcquire(resourceOwner, ResourceSet.create(ram, cpu, extraResources, tests));
+  }
+
   private void release(double ram, double cpu, int tests) {
     rm.releaseResources(resourceOwner, ResourceSet.create(ram, cpu, tests));
+  }
+
+  private void release(double ram, double cpu, int tests, ImmutableMap<String, Float> extraResources) {
+    rm.releaseResources(resourceOwner, ResourceSet.create(ram, cpu, extraResources, tests));
   }
 
   private void validate(int count) {
@@ -103,6 +123,13 @@ public class ResourceManagerTest {
     acquire(0, 0, bigTests);
     assertThat(rm.inUse()).isTrue();
     release(0, 0, bigTests);
+    assertThat(rm.inUse()).isFalse();
+
+    // Ditto, for extra resources (even if they don't exist in the available resource set):
+    ImmutableMap<String, Float> bigExtraResources = ImmutableMap.of("gpu", 10.0f, "fancyresource", 10.0f, "nonexisting", 10.0f);
+    acquire(0, 0, 0, bigExtraResources);
+    assertThat(rm.inUse()).isTrue();
+    release(0, 0, 0, bigExtraResources);
     assertThat(rm.inUse()).isFalse();
   }
 
@@ -184,10 +211,24 @@ public class ResourceManagerTest {
   }
 
   @Test
+  public void testThatExtraResourcesCannotBeOverallocated() throws Exception {
+    assertThat(rm.inUse()).isFalse();
+
+    // Given a partially acquired extra resources:
+    acquire(0, 0, 1, ImmutableMap.of("gpu", 1.0f));
+
+    // When a request for extra resources is made that would overallocate,
+    // Then the request fails:
+    TestThread thread1 = new TestThread(() -> assertThat(acquireNonblocking(0, 0, 0, ImmutableMap.of("gpu", 1.1f))).isNull());
+    thread1.start();
+    thread1.joinAndAssertState(10000);
+  }
+
+  @Test
   public void testHasResources() throws Exception {
     assertThat(rm.inUse()).isFalse();
     assertThat(rm.threadHasResources()).isFalse();
-    acquire(1, 0.1, 1);
+    acquire(1, 0.1, 1, ImmutableMap.of("gpu", 1.0f));
     assertThat(rm.threadHasResources()).isTrue();
 
     // We have resources in this thread - make sure other threads
@@ -208,11 +249,15 @@ public class ResourceManagerTest {
               assertThat(rm.threadHasResources()).isTrue();
               release(0, 0, 1);
               assertThat(rm.threadHasResources()).isFalse();
+              acquire(0, 0, 0, ImmutableMap.of("gpu", 1.0f));
+              assertThat(rm.threadHasResources()).isTrue();
+              release(0, 0, 0, ImmutableMap.of("gpu", 1.0f));
+              assertThat(rm.threadHasResources()).isFalse();
             });
     thread1.start();
     thread1.joinAndAssertState(10000);
 
-    release(1, 0.1, 1);
+    release(1, 0.1, 1, ImmutableMap.of("gpu", 1.0f));
     assertThat(rm.threadHasResources()).isFalse();
     assertThat(rm.inUse()).isFalse();
   }


### PR DESCRIPTION
Add support for user-specified resource types in the resource manager.
This generalizes the CPU, RAM and "test count" resource support for
other resource types such as the number of GPUs, available GPU memory,
the number of embedded devices connected to the host, etc.

The available amount of extra resources can be specified using the new
`--local_extra_resources=<resourcename>=<amount>` command line flag, which
is analoguous to the existing `--local_cpu_resources` and
`--local_memory_resources` flags.

Tests can then declare the amount of extra resources they need by using
a `resources:<resourcename>:<amount>` tag.