### PR TITLE
docs: document that digest can be empty in some cases

### DIFF
--- a/src/main/protobuf/worker_protocol.proto
+++ b/src/main/protobuf/worker_protocol.proto
@@ -27,7 +27,8 @@ message Input {
   string path = 1;
 
   // A hash-value of the contents. The format of the contents is unspecified and
-  // the digest should be treated as an opaque token.
+  // the digest should be treated as an opaque token. This can be empty in some cases
+  // should not assumed to be present all the time.
   bytes digest = 2;
 }
 


### PR DESCRIPTION
WorkRequest proto does not specify whether the digest is present all the time. Since digest can be null in some cases, it should be documented here to clear any confusion.

See: https://github.com/bazelbuild/bazel/blob/97643ad92d86179d21b2526e9f9804045d025f21/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java#L238