### PR TITLE
Add the default solib dir to the rpath for shared libs with transitions.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
@@ -693,7 +693,9 @@ public final class CcLinkingHelper {
             ImmutableList.of(
                 "-Wl,-soname="
                     + SolibSymlinkAction.getDynamicLibrarySoname(
-                        linkerOutput.getRootRelativePath(), /* preserveName= */ false));
+                        linkerOutput.getRootRelativePath(),
+                        /* preserveName= */ false,
+                        actionConstructionContext.getConfiguration().getMnemonic()));
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
@@ -267,7 +267,10 @@ public class LibrariesToLinkCollector {
         // When COPY_DYNAMIC_LIBRARIES_TO_BINARY is enabled, dynamic libraries are not symlinked
         // under solibDir, so don't check it and don't include solibDir.
         if (!featureConfiguration.isEnabled(CppRuleClasses.COPY_DYNAMIC_LIBRARIES_TO_BINARY)) {
-          if (libDir.equals(solibDir)) {
+          // The first fragment is bazel-out, and the second may contain a configuration mnemonic.
+          // We should always add the default solib dir because that's where libraries will be found
+          // e.g. in remote execution, so we ignore the first two fragments.
+          if (libDir.subFragment(2).equals(solibDir.subFragment(2))) {
             includeSolibDir = true;
           }
           if (libDir.equals(toolchainLibrariesSolibDir)) {

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/SolibSymlinkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/SolibSymlinkAction.java
@@ -140,6 +140,7 @@ public final class SolibSymlinkAction extends AbstractAction {
         getMangledName(
             actionRegistry.getOwner().getLabel(),
             solibDir,
+            actionConstructionContext.getConfiguration().getMnemonic(),
             library.getRootRelativePath(),
             preserveName,
             prefixConsumer);
@@ -234,11 +235,12 @@ public final class SolibSymlinkAction extends AbstractAction {
   private static PathFragment getMangledName(
       Label label,
       String solibDir,
+      String mnemonic,
       PathFragment libraryPath,
       boolean preserveName,
       boolean prefixConsumer) {
     String escapedRulePath = Actions.escapedPath("_" + label);
-    String soname = getDynamicLibrarySoname(libraryPath, preserveName);
+    String soname = getDynamicLibrarySoname(libraryPath, preserveName, mnemonic);
     PathFragment solibDirPath = PathFragment.create(solibDir);
     if (preserveName) {
       String escapedLibraryPath =
@@ -258,15 +260,21 @@ public final class SolibSymlinkAction extends AbstractAction {
    *
    * @param libraryPath name of the shared library that needs to be mangled
    * @param preserveName true if filename should be preserved, false - mangled
+   * @param mnemonic the output directory mnemonic, to be mangled in for nondefault configurations
    * @return soname to embed in the dynamic library
    */
   public static String getDynamicLibrarySoname(PathFragment libraryPath,
-                                               boolean preserveName) {
+                                               boolean preserveName,
+                                               String mnemonic) {
     String mangledName;
     if (preserveName) {
       mangledName = libraryPath.getBaseName();
     } else {
-      mangledName = "lib" + Actions.escapedPath(libraryPath.getPathString());
+      String mnemonicMangling = "";
+      if (mnemonic.indexOf("ST-") > -1) {
+        mnemonicMangling = mnemonic.substring(mnemonic.indexOf("ST-")) + "_";
+      }
+      mangledName = "lib" + mnemonicMangling + Actions.escapedPath(libraryPath.getPathString());
     }
     return mangledName;
   }


### PR DESCRIPTION
When an executable has dynamically-linked dependencies that have transitions, shared libraries are looked up under rpaths like this:

```
$ORIGIN/(../)*_solib_k8/../../../k8-fastbuild-ST-[0-9a-f]+/bin/_solib_k8
```

Unless running under the execroot, the transitioned solib directory may not be available at all; the right files will be present under the default solib directory, so it should be on the rpath.

Adding the default solib directory to the rpath may cause the wrong version of a shared library to be loaded, e.g. if it has been compiled in the default configuration. To prevent this, we also add the transition mnemonic to the mangled name of the library (adding the default solib last to the rpath won't really help, because it can legitimately be added first).

#13819