### PR TITLE
feat: Add missing flag annotations to flags documentation protocol

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
@@ -280,7 +280,7 @@ public final class HelpCommand implements BlazeCommand {
     flagBuilder.addAllEffectTags(optionEffectTags);
 
     List<String> optionMetadataTags = Arrays.stream(option.getOptionMetadataTags())
-        .filter(tag -> OptionMetadataTag.INTERNAL.equals(tag))
+        .filter(tag -> !OptionMetadataTag.INTERNAL.equals(tag))
         .map(Enum::toString)
         .collect(Collectors.toList());
     flagBuilder.addAllMetadataTags(optionMetadataTags);

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
@@ -53,6 +53,7 @@ import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParser.HelpVerbosity;
 import com.google.devtools.common.options.OptionsParsingResult;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
@@ -64,6 +65,7 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /** The 'blaze help' command, which prints all available commands as well as specific help pages. */
 @Command(
@@ -271,6 +273,24 @@ public final class HelpCommand implements BlazeCommand {
     flagBuilder.setHasNegativeFlag(option.hasNegativeOption());
     flagBuilder.setDocumentation(option.getHelpText());
     flagBuilder.setAllowsMultiple(option.allowsMultiple());
+
+    List<String> optionEffectTags = Arrays.stream(option.getOptionEffectTags())
+        .map(Enum::toString)
+        .collect(Collectors.toList());
+    flagBuilder.addAllEffectTags(optionEffectTags);
+
+    List<String> optionMetadataTags = Arrays.stream(option.getOptionMetadataTags())
+        .filter(tag -> OptionMetadataTag.INTERNAL.equals(tag))
+        .map(Enum::toString)
+        .collect(Collectors.toList());
+    flagBuilder.addAllMetadataTags(optionMetadataTags);
+
+    if (option.getDocumentationCategory() != null &&
+        !OptionDocumentationCategory.UNDOCUMENTED.equals(option.getDocumentationCategory()) &&
+        !OptionDocumentationCategory.UNCATEGORIZED.equals(option.getDocumentationCategory())) {
+      flagBuilder.setDocumentationCategory(option.getDocumentationCategory().toString());
+    }
+
     if (option.getAbbreviation() != '\0') {
       flagBuilder.setAbbreviation(String.valueOf(option.getAbbreviation()));
     }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
@@ -280,14 +280,11 @@ public final class HelpCommand implements BlazeCommand {
     flagBuilder.addAllEffectTags(optionEffectTags);
 
     List<String> optionMetadataTags = Arrays.stream(option.getOptionMetadataTags())
-        .filter(tag -> !OptionMetadataTag.INTERNAL.equals(tag))
         .map(Enum::toString)
         .collect(Collectors.toList());
     flagBuilder.addAllMetadataTags(optionMetadataTags);
 
-    if (option.getDocumentationCategory() != null &&
-        !OptionDocumentationCategory.UNDOCUMENTED.equals(option.getDocumentationCategory()) &&
-        !OptionDocumentationCategory.UNCATEGORIZED.equals(option.getDocumentationCategory())) {
+    if (option.getDocumentationCategory() != null) {
       flagBuilder.setDocumentationCategory(option.getDocumentationCategory().toString());
     }
 

--- a/src/main/protobuf/bazel_flags.proto
+++ b/src/main/protobuf/bazel_flags.proto
@@ -35,6 +35,12 @@ message FlagInfo {
   optional string abbreviation = 5;
   // True if a flag is allowed to occur multiple times in a single arg list.
   optional bool allows_multiple = 6 [default = false];
+  // The effect tags associated with the flag
+  repeated string effect_tags = 7;
+  // The metadata tags associated with the flag
+  repeated string metadata_tags = 8;
+  // The documentation category assigned to this flag, empty if uncategorized
+  optional string documentation_category = 9;
 }
 
 message FlagCollection {

--- a/src/main/protobuf/bazel_flags.proto
+++ b/src/main/protobuf/bazel_flags.proto
@@ -39,7 +39,7 @@ message FlagInfo {
   repeated string effect_tags = 7;
   // The metadata tags associated with the flag
   repeated string metadata_tags = 8;
-  // The documentation category assigned to this flag, empty if uncategorized
+  // The documentation category assigned to this flag
   optional string documentation_category = 9;
 }
 


### PR DESCRIPTION
Adds three fields to the `bazel_flags` proto to allow fetching the option effects and metadata tags, and associated documentation category when calling `bazel help flags-as-proto`.  These extra fields can be useful if programmatically parsing and displaying flag documentation.

This does not add any new functionality to flags themselves. It just exposes already existing flag metadata to documentation pipelines.
