### PR TITLE
Add a test execgroup to Starlark test rules, if not manually defined.

### DIFF
--- a/site/docs/exec-groups.md
+++ b/site/docs/exec-groups.md
@@ -39,11 +39,11 @@ namely any constraints via `exec_compatible_with` and toolchain types via
 my_rule = rule(
     _impl,
     exec_groups = {
-        “link”: exec_group(
-            exec_compatible_with = [ "@platforms//os:linux" ]
+        "link": exec_group(
+            exec_compatible_with = ["@platforms//os:linux"],
             toolchains = ["//foo:toolchain_type"],
         ),
-        “test”: exec_group(
+        "test": exec_group(
             toolchains = ["//foo_tools:toolchain_type"],
         ),
     },
@@ -61,6 +61,9 @@ attribute param and the
 module. The module exposes an `exec` function which takes a single string
 parameter which is the name of the exec group for which the dependency should be
 built.
+
+As on native rules, the `test` execution group is present by default on Stalark
+test rules.
 
 ### Execution group inheritance
 
@@ -80,7 +83,7 @@ those specified by the rule itself. In other words, given the following:
 my_rule = rule(
     _impl,
     exec_groups = {
-        “copied”: exec_group(
+        "copied": exec_group(
             copy_from_rule = True,
             # This will inherit exec_compatible_with and toolchains.
             # Setting them here directly would be an error, however.
@@ -194,7 +197,7 @@ my_rule = rule(
     toolchains = ["//foo:toolchain_type"],
     exec_groups = {
         # The following two groups have the same toolchains and constraints:
-        “foo”: exec_group(copy_from_rule = True),
+        "foo": exec_group(copy_from_rule = True),
         "bar": exec_group(
             exec_compatible_with = [ "@platforms//os:linux" ],
             toolchains = ["//foo:toolchain_type"],

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.analysis.starlark;
 
 import static com.google.devtools.build.lib.analysis.BaseRuleClasses.RUN_UNDER;
+import static com.google.devtools.build.lib.analysis.BaseRuleClasses.TEST_RUNNER_EXEC_GROUP;
 import static com.google.devtools.build.lib.analysis.BaseRuleClasses.TIMEOUT_DEFAULT;
 import static com.google.devtools.build.lib.analysis.BaseRuleClasses.getTestRuntimeLabelList;
 import static com.google.devtools.build.lib.packages.Attribute.attr;
@@ -401,6 +402,9 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi<Arti
         }
       }
       builder.addExecGroups(execGroupDict);
+    }
+    if (test && !builder.hasExecGroup(TEST_RUNNER_EXEC_GROUP)) {
+      builder.addExecGroup(TEST_RUNNER_EXEC_GROUP);
     }
 
     if (!buildSetting.equals(Starlark.NONE) && !cfg.equals(Starlark.NONE)) {

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -1566,6 +1566,11 @@ public class RuleClass {
       }
     }
 
+    /** Checks whether the rule class has an exec group with the given name. */
+    public boolean hasExecGroup(String name) {
+      return this.execGroups.containsKey(name);
+    }
+
     /**
      * Causes rules to use toolchain resolution to determine the execution platform and toolchains.
      * Rules that are part of configuring toolchains and platforms should set this to {@code

--- a/src/test/shell/integration/exec_group_test.sh
+++ b/src/test/shell/integration/exec_group_test.sh
@@ -312,12 +312,13 @@ function test_starlark_test_has_test_execgroup_by_default() {
   cat > ${pkg}/defs.bzl <<EOF
 def _impl(ctx):
     out_file = ctx.actions.declare_file("$script_name")
-    ctx.actions.write(out_file, "$script_content", is_executable=True)
+    ctx.actions.write(out_file, "$script_content", is_executable = True)
     return [DefaultInfo(executable = out_file)]
 
 starlark_test = rule(
     implementation = _impl,
     test = True,
+    # Do not define a "test" execgroup: it should exist by default.
 )
 EOF
   cat > ${pkg}/BUILD <<EOF
@@ -360,13 +361,14 @@ function test_starlark_test_can_define_test_execgroup_manually() {
   cat > ${pkg}/defs.bzl <<EOF
 def _impl(ctx):
     out_file = ctx.actions.declare_file("$script_name")
-    ctx.actions.write(out_file, "$script_content", is_executable=True)
+    ctx.actions.write(out_file, "$script_content", is_executable = True)
     return [DefaultInfo(executable = out_file)]
 
 starlark_with_manual_test_exec_group_test = rule(
     implementation = _impl,
     test = True,
     exec_groups = {
+        # Override the default "test" execgroup.
         "test": exec_group(),
     },
 )


### PR DESCRIPTION
Fixes #13986.