### PR TITLE
Fix [Prepa] actions stuck in active state

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -530,6 +530,11 @@ final class UiStateTracker {
     return activeActions.computeIfAbsent(actionId, (key) -> new ActionState(action, nanoTimeNow));
   }
 
+  @Nullable
+  private ActionState getActionStateIfPresent(Artifact actionId) {
+    return activeActions.get(actionId);
+  }
+
   void actionStarted(ActionStartedEvent event) {
     Action action = event.getAction();
     Artifact actionId = action.getPrimaryOutput();
@@ -586,7 +591,10 @@ final class UiStateTracker {
     ActionExecutionMetadata action = event.action();
     Artifact actionId = event.action().getPrimaryOutput();
     long now = clock.nanoTime();
-    getActionState(action, actionId, now).onProgressEvent(event, now);
+    ActionState actionState = getActionStateIfPresent(actionId);
+    if (actionState != null) {
+        actionState.onProgressEvent(event, now);
+    }
   }
 
   void actionCompletion(ActionScanningCompletedEvent event) {


### PR DESCRIPTION
Fixed #13985

UiStateTracker can process ActionProgress events after an ActionCompletion event
has been fired. This has the effect of recreating the action object in the activeActions
Map because Map.computeIfAbsent() is being used to retrieve the action.

Therefore, a new method getActionStateIfPresent is created which will return
the action if it exists, otherwise return null, and actionProgress() uses this
method so as to not inadverntantly recreate actions after they have already
completed and been removed from the Map.