### PR TITLE
Remove jacoco versions from main part of Bazel code.

### DIFF
--- a/src/java_tools/junitrunner/java/com/google/testing/coverage/BUILD
+++ b/src/java_tools/junitrunner/java/com/google/testing/coverage/BUILD
@@ -24,9 +24,9 @@ java_binary(
         ":JacocoCoverageLib",
         ":bitfield",
         "//third_party:guava",
-        "//third_party/java/jacoco:blaze-agent-0.8.6",
-        "//third_party/java/jacoco:core-0.8.6",
-        "//third_party/java/jacoco:report-0.8.6",
+        "//third_party/java/jacoco:blaze-agent",
+        "//third_party/java/jacoco:core",
+        "//third_party/java/jacoco:report",
     ],
 )
 
@@ -45,9 +45,9 @@ java_library(
     deps = [
         ":bitfield",
         "//third_party:guava",
-        "//third_party/java/jacoco:blaze-agent-0.8.6",
-        "//third_party/java/jacoco:core-0.8.6",
-        "//third_party/java/jacoco:report-0.8.6",
+        "//third_party/java/jacoco:blaze-agent",
+        "//third_party/java/jacoco:core",
+        "//third_party/java/jacoco:report",
     ],
 )
 


### PR DESCRIPTION
This will make the releases of Jacoco easier.

(Previously forgot this location).

Issue https://github.com/bazelbuild/bazel/issues/13987