### PR TITLE
fix managing dependencies link in documentation

### DIFF
--- a/site/docs/remote-execution-rules.md
+++ b/site/docs/remote-execution-rules.md
@@ -39,7 +39,7 @@ build and test rules for remote execution and how to avoid them. It covers the
 following topics:
 
 *  [Invoking build tools through toolchain rules](#invoking-build-tools-through-toolchain-rules)
-*  [Managing dependencies](#managing-dependencies)
+*  [Managing implicit dependencies](#managing-implicit-dependencies)
 *  [Managing platform-dependent binaries](#managing-platform-dependent-binaries)
 *  [Managing configure-style WORKSPACE rules](#managing-configure-style-workspace-rules)
 


### PR DESCRIPTION
While reading the documentation I got a little bit confused when trying to click on "Managing dependencies".

I later understood that there might be a fix to do in the link of it.

Feel free to suggest changes or close this PR if I made a mistake.