### PR TITLE
Clarify mandatory arguments to config_setting

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/config/ConfigRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/config/ConfigRuleClasses.java
@@ -182,10 +182,6 @@ public class ConfigRuleClasses {
              <code>bazel build --copt=foo --copt=bar --copt=baz ...</code>), a match occurs if
              <i>any</i> of those settings match.
           <p>
-
-          <p>This and <a href="${link config_setting.define_values}"><code>define_values</code></a>
-             cannot both be empty.
-          </p>
           <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
           .add(
               attr(SETTINGS_ATTRIBUTE, STRING_DICT)


### PR DESCRIPTION
PR removes a statement under the `values` argument to `config_values` which indicates that use of `values` or `define_values` is mandatory (cannot both be empty).  The statement appears to contradict [Item 6](https://github.com/bazelbuild/bazel/blob/fad21dae0b01d5f9b2274542c89f4c8163c2ff36/src/main/java/com/google/devtools/build/lib/rules/config/ConfigRuleClasses.java#L385-L390) in notes under `define_values` and was added prior to the `constraint_values` attribute.