### PR TITLE
Functionality for pseudoterminals in linux sandbox

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxUtil.java
@@ -71,6 +71,7 @@ public final class LinuxSandboxUtil {
     private boolean createNetworkNamespace = false;
     private boolean useFakeRoot = false;
     private boolean useFakeUsername = false;
+    private boolean enablePseudoterminal = false;
     private boolean useDebugMode = false;
     private boolean sigintSendsSigterm = false;
 
@@ -173,6 +174,15 @@ public final class LinuxSandboxUtil {
       return this;
     }
 
+    /**
+     * Sets whether to set group to 'tty' and make /dev/pts writable inside the sandbox in order
+     * to enable the use of pseudoterminals.
+     */
+    public CommandLineBuilder setEnablePseudoterminal(boolean enablePseudoterminal) {
+      this.enablePseudoterminal = enablePseudoterminal;
+      return this;
+    }
+
     /** Sets whether to enable debug mode (e.g. to print debugging messages). */
     public CommandLineBuilder setUseDebugMode(boolean useDebugMode) {
       this.useDebugMode = useDebugMode;
@@ -244,6 +254,9 @@ public final class LinuxSandboxUtil {
       }
       if (useFakeUsername) {
         commandLineBuilder.add("-U");
+      }
+      if (enablePseudoterminal) {
+        commandLineBuilder.add("-P");
       }
       if (useDebugMode) {
         commandLineBuilder.add("-D");

--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -198,6 +198,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
             .setTmpfsDirectories(ImmutableSet.copyOf(getSandboxOptions().sandboxTmpfsPath))
             .setBindMounts(getReadOnlyBindMounts(blazeDirs, sandboxExecRoot))
             .setUseFakeHostname(getSandboxOptions().sandboxFakeHostname)
+            .setEnablePseudoterminal(!getSandboxOptions().sandboxNoExplicitPseudoterminal)
             .setCreateNetworkNamespace(
                 !(allowNetwork
                     || Spawns.requiresNetwork(

--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -198,7 +198,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
             .setTmpfsDirectories(ImmutableSet.copyOf(getSandboxOptions().sandboxTmpfsPath))
             .setBindMounts(getReadOnlyBindMounts(blazeDirs, sandboxExecRoot))
             .setUseFakeHostname(getSandboxOptions().sandboxFakeHostname)
-            .setEnablePseudoterminal(!getSandboxOptions().sandboxNoExplicitPseudoterminal)
+            .setEnablePseudoterminal(getSandboxOptions().sandboxExplicitPseudoterminal)
             .setCreateNetworkNamespace(
                 !(allowNetwork
                     || Spawns.requiresNetwork(

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
@@ -132,6 +132,18 @@ public class SandboxOptions extends OptionsBase {
   public boolean sandboxFakeUsername;
 
   @Option(
+          name = "sandbox_no_explicit_pseudoterminal",
+          defaultValue = "false",
+          documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+          effectTags = {OptionEffectTag.EXECUTION},
+          help =
+              "Do not explicitly enable the creation of pseudoterminals for sandboxed actions."
+                  + " Some linux distributions require setting the group of the user to 'tty'"
+                  + " inside the sandbox in order for pseudoterminals to function. If this is"
+                  + " causing issues, this flag can be enabled to enable other groups to be used.")
+  public boolean sandboxNoExplicitPseudoterminal;
+
+  @Option(
       name = "sandbox_block_path",
       allowMultiple = true,
       defaultValue = "null",

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
@@ -138,7 +138,7 @@ public class SandboxOptions extends OptionsBase {
           effectTags = {OptionEffectTag.EXECUTION},
           help =
               "Explicitly enable the creation of pseudoterminals for sandboxed actions."
-                  + " Some linux distributions require setting the group of the user to 'tty'"
+                  + " Some linux distributions require setting the group id of the process to 'tty'"
                   + " inside the sandbox in order for pseudoterminals to function. If this is"
                   + " causing issues, this flag can be disabled to enable other groups to be used.")
   public boolean sandboxExplicitPseudoterminal;

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxOptions.java
@@ -132,16 +132,16 @@ public class SandboxOptions extends OptionsBase {
   public boolean sandboxFakeUsername;
 
   @Option(
-          name = "sandbox_no_explicit_pseudoterminal",
+          name = "sandbox_explicit_pseudoterminal",
           defaultValue = "false",
           documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
           effectTags = {OptionEffectTag.EXECUTION},
           help =
-              "Do not explicitly enable the creation of pseudoterminals for sandboxed actions."
+              "Explicitly enable the creation of pseudoterminals for sandboxed actions."
                   + " Some linux distributions require setting the group of the user to 'tty'"
                   + " inside the sandbox in order for pseudoterminals to function. If this is"
-                  + " causing issues, this flag can be enabled to enable other groups to be used.")
-  public boolean sandboxNoExplicitPseudoterminal;
+                  + " causing issues, this flag can be disabled to enable other groups to be used.")
+  public boolean sandboxExplicitPseudoterminal;
 
   @Option(
       name = "sandbox_block_path",

--- a/src/main/tools/linux-sandbox-options.cc
+++ b/src/main/tools/linux-sandbox-options.cc
@@ -72,6 +72,7 @@ static void Usage(char *program_name, const char *fmt, ...) {
           "  -N  if set, a new network namespace will be created\n"
           "  -R  if set, make the uid/gid be root\n"
           "  -U  if set, make the uid/gid be nobody\n"
+          "  -P  if set, make the gid be tty and make /dev/pts writable\n"
           "  -D  if set, debug info will be printed\n"
           "  -h <sandbox-dir>  if set, chroot to sandbox-dir and only "
           " mount whats been specified with -M/-m for improved hermeticity. "
@@ -97,7 +98,7 @@ static void ParseCommandLine(unique_ptr<vector<char *>> args) {
   bool source_specified = false;
 
   while ((c = getopt(args->size(), args->data(),
-                     ":W:T:t:il:L:w:e:M:m:S:h:HNRUD")) != -1) {
+                     ":W:T:t:il:L:w:e:M:m:S:h:HNRUPD")) != -1) {
     if (c != 'M' && c != 'm') source_specified = false;
     switch (c) {
       case 'W':
@@ -214,6 +215,9 @@ static void ParseCommandLine(unique_ptr<vector<char *>> args) {
                 "option.");
         }
         opt.fake_username = true;
+        break;
+      case 'P':
+        opt.enable_pty = true;
         break;
       case 'D':
         opt.debug = true;

--- a/src/main/tools/linux-sandbox-options.h
+++ b/src/main/tools/linux-sandbox-options.h
@@ -52,6 +52,8 @@ struct Options {
   bool fake_root;
   // Set the username inside the sandbox to 'nobody' (-U)
   bool fake_username;
+  // Enable writing to /dev/pts and map the user's gid to tty to enable pseudoterminals (-P)
+  bool enable_pty;
   // Print debugging messages (-D)
   bool debug;
   // Improved hermetic build using whitelisting strategy (-h)

--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -231,6 +231,11 @@ static void SetupUserNamespace() {
     inner_uid = global_outer_uid;
     inner_gid = global_outer_gid;
   }
+  if (opt.enable_pty) {
+    // Change the group to 'tty' regardless of what was previously set
+    inner_gid = 5;
+  }
+
   WriteFile("/proc/self/uid_map", "%d %d 1\n", inner_uid, global_outer_uid);
   WriteFile("/proc/self/gid_map", "%d %d 1\n", inner_gid, global_outer_gid);
 }
@@ -302,6 +307,10 @@ static void MountFilesystems() {
 // returns true.
 static bool ShouldBeWritable(const std::string &mnt_dir) {
   if (mnt_dir == opt.working_dir) {
+    return true;
+  }
+
+  if (opt.enable_pty && mnt_dir == "/dev/pts") {
     return true;
   }
 

--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -234,8 +234,15 @@ static void SetupUserNamespace() {
   }
   if (opt.enable_pty) {
     // Change the group to "tty" regardless of what was previously set
-    struct group *g = getgrnam("tty");
-    inner_gid = g->gr_gid;
+    struct group grp;
+    char buf[256];
+    size_t buflen = sizeof(buf);
+    struct group *result;
+    getgrnam_r("tty", &grp, buf, buflen, &result);
+    if (result == nullptr) {
+      DIE("getgrnam_r");
+    }
+    inner_gid = grp.gr_gid;
   }
 
   WriteFile("/proc/self/uid_map", "%d %d 1\n", inner_uid, global_outer_uid);

--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -21,6 +21,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <grp.h>
 #include <libgen.h>
 #include <math.h>
 #include <mntent.h>
@@ -232,8 +233,9 @@ static void SetupUserNamespace() {
     inner_gid = global_outer_gid;
   }
   if (opt.enable_pty) {
-    // Change the group to 'tty' regardless of what was previously set
-    inner_gid = 5;
+    // Change the group to "tty" regardless of what was previously set
+    struct group *g = getgrnam("tty");
+    inner_gid = g->gr_gid;
   }
 
   WriteFile("/proc/self/uid_map", "%d %d 1\n", inner_uid, global_outer_uid);

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -645,6 +645,26 @@ EOF
   bazel test --nocache_test_results --sandbox_fake_username --test_output=errors :test || fail "test did not pass"
 }
 
+# Tests that a pseudoterminal can be opened in linux when --sandbox_explicit_pseudoterminal is active
+function test_can_enable_pseudoterminals() {
+  if [[ "$(uname -s)" != Linux ]]; then
+    echo "Skipping test: flag intended for linux systems"
+    return 0
+  fi
+
+  cat > test.py <<'EOF'
+import pty
+pty.openpty()
+EOF
+  cat > BUILD <<'EOF'
+py_test(
+  name = "test",
+  srcs = ["test.py"],
+)
+EOF
+  bazel test --sandbox_explicit_pseudoterminal :test || fail "test did not pass"
+}
+
 # Tests that /proc/self == /proc/$$. This should always be true unless the PID namespace is active without /proc being remounted correctly.
 function test_sandbox_proc_self() {
   if [[ ! -d /proc/self ]]; then


### PR DESCRIPTION
As brought up in issue #5373 , the Linux sandbox does not allow processes that run inside it to open pseudoterminals. These changes enable this by addressing the two main underlying issues:

- `/dev/pts` can not be read-only if a new pseudoterminal is to be created. These changes make `dev/pts` writable when remounting file systems during sandbox initialization.
- The group associated with pseudoterminals is "tty". After creating a new pseudoterminal, its gid has to be changed. If there is no gid mapping in the user namespace that corresponds to "tty", this group will not be known inside the sandbox. This causes issues in some Linux distributions, since they do not allow changing the group of a file to one that is not known inside the current user namespace. These changes map the gid of the user to the one corresponding to "tty" inside the sandbox in order to avoid this issue.

These changes introduce the `-P` flag to `linux-sandbox` in order to control whether or not the changes are applied, and the `--sandbox-explicit-pseudoterminal` to `bazel` in order to set this when calling bazel.