### PR TITLE
Add the kind() cquery dialect function.

### DIFF
--- a/site/docs/cquery.html
+++ b/site/docs/cquery.html
@@ -495,6 +495,13 @@ There are other options for exposing the results as well. </p>
   (for example, <code>"DefaultInfo"</code>) and whose values are their Starlark values. Providers
   whose values are not legal Starlark values are omitted from this map.
 </p>
+<h5 id='kind'>kind(target)</h5>
+<p>
+  <code>kind(target)</code> returns a string representing the rule name that instantiated this
+  target. For rule targets, like <code>filegroup</code> or <code>sh_binary</code>, this returns
+  the name of the rule. For file targets, like source files or generated files, this returns
+  the empty string (<code>""</code>).
+</p>
 
 <h4>Examples</h4>
 

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/StarlarkOutputFormatterCallback.java
@@ -128,6 +128,19 @@ public class StarlarkOutputFormatterCallback extends CqueryThreadsafeCallback {
       }
       return ret;
     }
+
+    @StarlarkMethod(
+        name = "kind",
+        documented = false,
+        parameters = {
+            @Param(name = "target"),
+        })
+    public Object kind(ConfiguredTarget target) {
+      if (!(target instanceof AbstractConfiguredTarget)) {
+        return Starlark.NONE;
+      }
+      return ((AbstractConfiguredTarget) target).getRuleClassString();
+    }
   }
 
   private static final Object[] NO_ARGS = new Object[0];


### PR DESCRIPTION
This CL adds the kind() function to the cquery dialect, which returns the same information as the label_kind output formatter, or ctx.rule.kind in a rule context.

This makes writing cquery/starlark expressions that operate over the rule kind possible. Prior to this, there wasn't an approach to instantly extract the kind information from a ConfiguredTarget in cquery Starlark, except with https://github.com/bazelbuild/bazel/commit/f2efbb718aec0a6b47eefc65362205548b33e5a7, which was rolled back in https://github.com/bazelbuild/bazel/commit/0b069c975c27bda50683759eb19ea49d3f0d904e, because it was adding too much complexity to ConfiguredTargets.

This approach is different from exposing target.kind because the kind() function is restricted to the cquery dialect, not globally.