### PR TITLE
fix resource leak due to Files.newDirectoryStream

### DIFF
--- a/tools/jdk/DumpPlatformClassPath.java
+++ b/tools/jdk/DumpPlatformClassPath.java
@@ -182,8 +182,10 @@ public class DumpPlatformClassPath {
     List<Path> jars = new ArrayList<>();
     Path extDir = javaHome.resolve("jre/lib/ext");
     if (Files.exists(extDir)) {
-      for (Path extJar : Files.newDirectoryStream(extDir, "*.jar")) {
-        jars.add(extJar);
+      try(pathStream = Files.newDirectoryStream(extDir, "*.jar")) {
+        for (Path extJar : Files.newDirectoryStream(extDir, "*.jar")) {
+          jars.add(extJar);
+        } 
       }
     }
     for (String jar :


### PR DESCRIPTION
JDK has point out that we shoud close the stream opened by Files.newDirectoryStream , as below

`When not using the try-with-resources construct, then directory
     * stream's {@code close} method should be invoked after iteration is
     * completed so as to free any resources held for the open directory. `

but the code at https://github.com/bazelbuild/bazel/blob/09c621e4cf5b968f4c6cdf905ab142d5961f9ddc/tools/jdk/DumpPlatformClassPath.java#L185 

do not the close the stream. This pull request use try-with-resources to fix this problem.