### PR TITLE
Fix overly aggressive regex when filtering resource classess

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidCommon.java
@@ -970,7 +970,7 @@ public class AndroidCommon {
             .addExplicitFilter("/BR\\.class$")
             .addExplicitFilter("/databinding/[^/]+Binding\\.class$");
     if (removeAllRClasses) {
-      builder.addExplicitFilter("R\\.class").addExplicitFilter("R\\$.*\\.class");
+        builder.addExplicitFilter("(^|/)R\\.class").addExplicitFilter("(^|/)R\\$.*\\.class");
     }
 
     builder.build();


### PR DESCRIPTION
The regex in place will filter any class that ends in R.class or R$.*.class (e.g. leakcanary/internal/ObjectsKt$NO_OP_HANDLER$1.class)