### PR TITLE
Report an error when deprecated no-op Java toolchain flags are used without the new ones.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaConfiguration.java
@@ -167,6 +167,20 @@ public final class JavaConfiguration extends Fragment implements JavaConfigurati
       checkLegacyToolchainFlagIsUnset("java_toolchain", javaOptions.javaToolchain);
       checkLegacyToolchainFlagIsUnset("host_java_toolchain", javaOptions.hostJavaToolchain);
     }
+
+    boolean oldToolchainFlagSet = javaOptions.javaBase != null || javaOptions.hostJavaBase != null
+        || javaOptions.javaToolchain != null
+        || javaOptions.hostJavaToolchain != null;
+    boolean newToolchainFlagSet =
+        javaOptions.javaLanguageVersion != null || javaOptions.hostJavaLanguageVersion != null
+            || javaOptions.javaRuntimeVersion != null
+            || javaOptions.hostJavaRuntimeVersion != null;
+    if (oldToolchainFlagSet && !newToolchainFlagSet) {
+      throw new InvalidConfigurationException(
+          "At least one of the deprecated no-op toolchain configuration flags is set (--javabase, --host_javabase, --java_toolchain, --host_java_toolchain) and "
+              + "none of the new toolchain configuration flags is set --java_language_version, --tool_java_language_version, --java_runtime_version, --tool_java_runtime_version."
+              + " This may result in incorrect toolchain selection (see #7849).");
+    }
   }
 
   private static void checkLegacyToolchainFlagIsUnset(String flag, Label label)


### PR DESCRIPTION

Related to https://github.com/bazelbuild/bazel/issues/7849
Fixes https://github.com/bazelbuild/bazel/issues/12973