### PR TITLE
Retain runfiles when forwarding DelegatingDefaultInfo

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -110,3 +110,4 @@ Andy Scott <andy.g.scott@gmail.com>
 Jamie Snape <jamie.snape@kitware.com>
 Irina Chernushina <ichern@google.com>
 C. Sean Young <csyoung@google.com>
+Fabian Meumertzheim <fabian@meumertzhe.im>

--- a/src/main/java/com/google/devtools/build/lib/analysis/DefaultInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/DefaultInfo.java
@@ -172,7 +172,7 @@ public abstract class DefaultInfo extends NativeInfo implements DefaultInfoApi {
 
     @Override
     public Runfiles getStatelessRunfiles() {
-      return Runfiles.EMPTY;
+      return null;
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleConfiguredTargetUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleConfiguredTargetUtilTest.java
@@ -1,0 +1,62 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.analysis.starlark;
+
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class StarlarkRuleConfiguredTargetUtilTest extends BuildViewTestCase {
+
+    @Test
+    public void testForwardingDefaultInfoRetainsDataRunfiles() throws Exception {
+        scratch.file("foo/rules.bzl",
+                "def _forward_default_info_impl(ctx):",
+                "    return [",
+                "        ctx.attr.target[DefaultInfo],",
+                "    ]",
+                "forward_default_info = rule(",
+                "    implementation = _forward_default_info_impl,",
+                "    attrs = {",
+                "        'target': attr.label(",
+                "            mandatory = True,",
+                "        ),",
+                "    },",
+                ")"
+        );
+        scratch.file("foo/i_am_a_runfile");
+        scratch.file("foo/BUILD",
+                "load(':rules.bzl', 'forward_default_info')",
+                "java_library(",
+                "    name = 'lib',",
+                "    data = ['i_am_a_runfile'],",
+                ")",
+                "forward_default_info(",
+                "    name = 'forwarded_lib',",
+                "    target = ':lib',",
+                ")"
+        );
+        ConfiguredTarget nativeTarget = getConfiguredTarget("//foo:lib");
+        ImmutableList<Artifact> nativeRunfiles = getDataRunfiles(nativeTarget).getAllArtifacts().toList();
+        ConfiguredTarget forwardedTarget = getConfiguredTarget("//foo:forwarded_lib");
+        ImmutableList<Artifact> forwardedRunfiles = getDataRunfiles(forwardedTarget).getAllArtifacts().toList();
+        assertThat(forwardedRunfiles).isEqualTo(nativeRunfiles);
+        assertThat(forwardedRunfiles).hasSize(1);
+        assertThat(forwardedRunfiles.get(0).getPath().getBaseName()).isEqualTo("i_am_a_runfile");
+    }
+}


### PR DESCRIPTION
Before this change, returning a DefaultInfo obtained from a native rule target from a Starlark rule would lose the data_runfiles and
default_runfiles. This could only be worked around by creating a DefaultInfo provider instance in Starlark explicitly setting these
fields.

This is fixed by having the DelegatingDefaultInfo return null instead of an empty Runfiles object for the stateless runfiles, which indicates to addSimpleProviders in StarlarkRuleConfiguredTargetUtils that default and data runfiles should be used instead. Previously, this logic would only use the always empty stateless runfiles.

Fixes #9442.