### PR TITLE
Allow rewinding to re-create lost inputs

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -457,6 +457,9 @@ static vector<string> GetServerExeArgs(const blaze_util::Path &jvm_path,
   if (startup_options.autodetect_server_javabase) {
     result.push_back("--default_system_javabase=" + GetSystemJavabase());
   }
+  if (startup_options.experimental_rewind_missing_files) {
+    result.push_back("--experimental_rewind_missing_files");
+  }
 
   if (!startup_options.server_jvm_out.IsEmpty()) {
     result.push_back("--server_jvm_out=" +

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -72,6 +72,7 @@ StartupOptions::StartupOptions(const string &product_name,
       block_for_lock(true),
       host_jvm_debug(false),
       autodetect_server_javabase(true),
+      experimental_rewind_missing_files(false),
       batch(false),
       batch_cpu_scheduling(false),
       io_nice_level(-1),
@@ -139,6 +140,8 @@ StartupOptions::StartupOptions(const string &product_name,
   RegisterNullaryStartupFlag("host_jvm_debug", &host_jvm_debug);
   RegisterNullaryStartupFlag("autodetect_server_javabase",
                              &autodetect_server_javabase);
+  RegisterNullaryStartupFlag("experimental_rewind_missing_files",
+                             &experimental_rewind_missing_files);
   RegisterNullaryStartupFlag("idle_server_tasks", &idle_server_tasks);
   RegisterNullaryStartupFlag("shutdown_on_low_sys_mem",
                              &shutdown_on_low_sys_mem);

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -167,6 +167,8 @@ class StartupOptions {
 
   bool autodetect_server_javabase;
 
+  bool experimental_rewind_missing_files;
+
   std::string host_jvm_profile;
 
   std::vector<std::string> host_jvm_args;

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/BUILD
@@ -14,6 +14,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/docgen/annot",
         "//src/main/java/com/google/devtools/build/lib:runtime",
+        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/analysis:blaze_directories",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.bazel.debug.WorkspaceRuleEvent;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
@@ -284,7 +285,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
       }
 
       return new StarlarkExecutionResult(result.exitCode(), stdout, stderr);
-    } catch (IOException e) {
+    } catch (ExecException | IOException e) {
       throw Starlark.errorf("remote_execute failed: %s", e.getMessage());
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -156,6 +156,8 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
       }
     } catch (InterruptedIOException e) {
       throw new InterruptedException(e.getMessage());
+    } catch (LostInputsExecException e) {
+      throw e;
     } catch (IOException e) {
       throw new EnvironmentalExecException(
           e,

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -154,6 +154,7 @@ java_library(
     ],
     deps = [
         ":ExecutionStatusException",
+        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutor.java
@@ -22,6 +22,7 @@ import build.bazel.remote.execution.v2.ExecutionGrpc.ExecutionBlockingStub;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.WaitExecutionRequest;
 import com.google.common.base.Preconditions;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ProgressiveBackoff;
@@ -114,7 +115,7 @@ public class ExperimentalGrpcRemoteExecutor implements RemoteExecutionClient {
       this.waitExecutionFunction = waitExecutionFunction;
     }
 
-    ExecuteResponse start() throws IOException, InterruptedException {
+    ExecuteResponse start() throws ExecException, IOException, InterruptedException {
       // Execute has two components: the Execute call and (optionally) the WaitExecution call.
       // This is the simple flow without any errors:
       //
@@ -321,7 +322,7 @@ public class ExperimentalGrpcRemoteExecutor implements RemoteExecutionClient {
   @Override
   public ExecuteResponse executeRemotely(
       RemoteActionExecutionContext context, ExecuteRequest request, OperationObserver observer)
-      throws IOException, InterruptedException {
+      throws ExecException, IOException, InterruptedException {
     Execution execution =
         new Execution(
             request,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1268,7 +1268,7 @@ public class RemoteExecutionService {
    * <p>Must be called before calling {@link #executeRemotely}.
    */
   public void uploadInputsIfNotPresent(RemoteAction action, boolean force)
-      throws IOException, InterruptedException {
+      throws ExecException, IOException, InterruptedException {
     checkState(!shutdown.get(), "shutdown");
     checkState(mayBeExecutedRemotely(action.spawn), "spawn can't be executed remotely");
 
@@ -1278,7 +1278,7 @@ public class RemoteExecutionService {
     additionalInputs.put(action.actionKey.getDigest(), action.action);
     additionalInputs.put(action.commandHash, action.command);
     remoteExecutionCache.ensureInputsPresent(
-        action.remoteActionExecutionContext, action.merkleTree, additionalInputs, force);
+        action.remoteActionExecutionContext, action.merkleTree, additionalInputs, action.actionKey.toString(), force);
   }
 
   /**
@@ -1289,7 +1289,7 @@ public class RemoteExecutionService {
    */
   public RemoteActionResult executeRemotely(
       RemoteAction action, boolean acceptCachedResult, OperationObserver observer)
-      throws IOException, InterruptedException {
+      throws ExecException, IOException, InterruptedException {
     checkState(!shutdown.get(), "shutdown");
     checkState(mayBeExecutedRemotely(action.spawn), "spawn can't be executed remotely");
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.analysis.platform.PlatformUtils;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
@@ -108,7 +109,7 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
       ImmutableMap<String, String> environment,
       String workingDirectory,
       Duration timeout)
-      throws IOException, InterruptedException {
+      throws ExecException, IOException, InterruptedException {
     RequestMetadata metadata =
         TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "repository_rule", null);
     RemoteActionExecutionContext context = RemoteActionExecutionContext.create(metadata);
@@ -158,7 +159,7 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
         additionalInputs.put(actionDigest, action);
         additionalInputs.put(commandHash, command);
 
-        remoteCache.ensureInputsPresent(context, merkleTree, additionalInputs, /*force=*/ true);
+        remoteCache.ensureInputsPresent(context, merkleTree, additionalInputs, "", /*force=*/ true);
       }
 
       try (SilentCloseable c =

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -126,6 +127,28 @@ public class RemoteRetrier extends Retrier {
     } catch (Exception e) {
       Throwables.throwIfInstanceOf(e, IOException.class);
       Throwables.throwIfInstanceOf(e, InterruptedException.class);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * As {@link #execute(Callable)} but will also propagate {@link ExecException}s.
+   */
+  public <T> T executeWithExecException(Callable<T> call) throws ExecException, IOException, InterruptedException {
+    return executeWithExecException(call, newBackoff());
+  }
+
+  /**
+   * As {@link #execute(Callable, Backoff)} but will also propagate {@link ExecException}s.
+   */
+  public <T> T executeWithExecException(Callable<T> call, Backoff backoff) throws ExecException, IOException, InterruptedException {
+    try {
+      return super.execute(call, backoff);
+    } catch (Exception e) {
+      Throwables.throwIfInstanceOf(e, IOException.class);
+      Throwables.throwIfInstanceOf(e, InterruptedException.class);
+      Throwables.throwIfInstanceOf(e, ExecException.class);
       Throwables.throwIfUnchecked(e);
       throw new RuntimeException(e);
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
@@ -27,6 +27,7 @@ import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.ServerCapabilities;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.CommandLines.ParamFileActionInput;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
+import com.google.devtools.build.lib.actions.LostInputsExecException;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.SpawnMetrics;
 import com.google.devtools.build.lib.actions.SpawnResult;
@@ -236,15 +237,25 @@ public class RemoteSpawnRunner implements SpawnRunner {
     AtomicBoolean useCachedResult = new AtomicBoolean(acceptCachedResult);
     AtomicBoolean forceUploadInput = new AtomicBoolean(false);
     try {
-      return retrier.execute(
+      return retrier.executeWithExecException(
           () -> {
             // Upload the command and all the inputs into the remote cache.
             try (SilentCloseable c = prof.profile(UPLOAD_TIME, "upload missing inputs")) {
               Duration networkTimeStart = action.getNetworkTime().getDuration();
               Stopwatch uploadTime = Stopwatch.createStarted();
               // Upon retry, we force upload inputs
-              remoteExecutionService.uploadInputsIfNotPresent(
-                  action, forceUploadInput.getAndSet(true));
+              try {
+                remoteExecutionService.uploadInputsIfNotPresent(
+                    action, forceUploadInput.getAndSet(true));
+              } catch (BulkTransferException e) {
+                // If all of the issues were lost actions, propagate that exception so we can maybe rewind.
+                LostInputsExecException lostInputsExecException = e.asLostInputsExecException();
+                if (lostInputsExecException != null) {
+                  throw lostInputsExecException;
+                } else {
+                  throw e;
+                }
+              }
 
               // subtract network time consumed here to ensure wall clock during upload is not
               // double

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteExecutionClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteExecutionClient.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.remote.common;
 
 import build.bazel.remote.execution.v2.ExecuteRequest;
 import build.bazel.remote.execution.v2.ExecuteResponse;
+import com.google.devtools.build.lib.actions.ExecException;
 import java.io.IOException;
 
 /**
@@ -27,7 +28,7 @@ public interface RemoteExecutionClient {
   /** Execute an action remotely using Remote Execution API. */
   ExecuteResponse executeRemotely(
       RemoteActionExecutionContext context, ExecuteRequest request, OperationObserver observer)
-      throws IOException, InterruptedException;
+      throws ExecException, IOException, InterruptedException;
 
   /** Close resources associated with the remote execution client. */
   void close();

--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/BUILD
@@ -14,6 +14,7 @@ java_library(
     name = "downloader",
     srcs = glob(["*.java"]),
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/remote:ReferenceCountedChannel",

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
@@ -17,6 +17,7 @@ import build.bazel.remote.execution.v2.Digest;
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
@@ -102,7 +103,7 @@ class DirectoryTreeBuilder {
           }
           Digest d = digestUtil.compute(input);
           boolean childAdded =
-              currDir.addChild(FileNode.createExecutable(path.getBaseName(), input, d));
+              currDir.addChild(FileNode.createExecutable(path.getBaseName(), input, d, null));
           return childAdded ? 1 : 0;
         });
   }
@@ -144,8 +145,12 @@ class DirectoryTreeBuilder {
             case REGULAR_FILE:
               Digest d = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());
               Path inputPath = ActionInputHelper.toInputPath(input, execRoot);
+              Artifact artifact = null;
+              if (input instanceof Artifact) {
+                artifact = (Artifact) input;
+              }
               boolean childAdded =
-                  currDir.addChild(FileNode.createExecutable(path.getBaseName(), inputPath, d));
+                  currDir.addChild(FileNode.createExecutable(path.getBaseName(), inputPath, d, artifact));
               return childAdded ? 1 : 0;
 
             case DIRECTORY:

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
@@ -51,17 +52,20 @@ public class MerkleTree {
   /** A path or contents */
   public static class PathOrBytes {
 
-    private final Path path;
-    private final ByteString bytes;
+    @Nullable private final Path path;
+    @Nullable private final ByteString bytes;
+    @Nullable private final Artifact artifact;
 
-    public PathOrBytes(Path path) {
+    public PathOrBytes(Path path, @Nullable Artifact artifact) {
       this.path = Preconditions.checkNotNull(path, "path");
       this.bytes = null;
+      this.artifact = artifact;
     }
 
     public PathOrBytes(ByteString bytes) {
       this.bytes = Preconditions.checkNotNull(bytes, "bytes");
       this.path = null;
+      this.artifact = null;
     }
 
     @Nullable
@@ -72,6 +76,11 @@ public class MerkleTree {
     @Nullable
     public ByteString getBytes() {
       return bytes;
+    }
+
+    @Nullable
+    public Artifact getArtifact() {
+      return artifact;
     }
   }
 
@@ -345,7 +354,7 @@ public class MerkleTree {
 
   private static PathOrBytes toPathOrBytes(DirectoryTree.FileNode file) {
     return file.getPath() != null
-        ? new PathOrBytes(file.getPath())
+        ? new PathOrBytes(file.getPath(), file.getArtifact())
         : new PathOrBytes(file.getBytes());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java
@@ -502,4 +502,17 @@ public class BlazeServerStartupOptions extends OptionsBase {
           "When --noautodetect_server_javabase is passed, Bazel does not fall back to the local "
               + "JDK for running the bazel server and instead exits.")
   public boolean autodetectServerJavabase;
+
+  @Option(
+      name = "experimental_rewind_missing_files",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.LOSES_INCREMENTAL_STATE},
+      help =
+          "When --experimental_rewind_missing_files is passed, Bazel will attempt to re-run "
+              + "actions it has already run if their outputs have been lost (e.g. because they "
+              + "were run on a remote execution system, forgotten by that system, and were never "
+              + "downloaded. When not passed, Bazel is likely to just fail a build when this "
+              + "happens.")
+  public boolean experimentalRewindMissingFiles;
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/RepositoryRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/RepositoryRemoteExecutor.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.runtime;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
@@ -70,5 +71,5 @@ public interface RepositoryRemoteExecutor {
       ImmutableMap<String, String> environment,
       String workingDirectory,
       Duration timeout)
-      throws IOException, InterruptedException;
+      throws ExecException, IOException, InterruptedException;
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/WorkspaceBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/WorkspaceBuilder.java
@@ -31,6 +31,8 @@ import com.google.devtools.build.lib.skyframe.SkyframeExecutorFactory;
 import com.google.devtools.build.lib.skyframe.SkyframeExecutorRepositoryHelpersHolder;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.vfs.SyscallCache;
+import com.google.devtools.build.skyframe.GraphInconsistencyReceiver;
+import com.google.devtools.build.skyframe.RewindingGraphInconsistencyReceiver;
 import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import java.util.Map;
@@ -104,6 +106,11 @@ public final class WorkspaceBuilder {
       perCommandSyscallCache = createPerBuildSyscallCache();
     }
 
+    GraphInconsistencyReceiver graphInconsistencyReceiver = GraphInconsistencyReceiver.THROWING;
+    if (runtime.getStartupOptionsProvider().getOptions(BlazeServerStartupOptions.class).experimentalRewindMissingFiles) {
+      graphInconsistencyReceiver = new RewindingGraphInconsistencyReceiver();
+    }
+
     SkyframeExecutor skyframeExecutor =
         skyframeExecutorFactory.create(
             packageFactory,
@@ -118,7 +125,8 @@ public final class WorkspaceBuilder {
             skyKeyStateReceiver == null
                 ? SkyframeExecutor.SkyKeyStateReceiver.NULL_INSTANCE
                 : skyKeyStateReceiver,
-            runtime.getBugReporter());
+            runtime.getBugReporter(),
+            graphInconsistencyReceiver);
     return new BlazeWorkspace(
         runtime,
         directories,

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
@@ -161,6 +161,7 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
   private Duration sourceDiffCheckingDuration = Duration.ofSeconds(-1L);
   private int numSourceFilesCheckedBecauseOfMissingDiffs;
   private Duration outputTreeDiffCheckingDuration = Duration.ofSeconds(-1L);
+  private GraphInconsistencyReceiver graphInconsistencyReceiver;
 
   private final WorkspaceInfoFromDiffReceiver workspaceInfoFromDiffReceiver;
 
@@ -182,7 +183,8 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
       @Nullable SkyframeExecutorRepositoryHelpersHolder repositoryHelpersHolder,
       ActionOnIOExceptionReadingBuildFile actionOnIOExceptionReadingBuildFile,
       SkyKeyStateReceiver skyKeyStateReceiver,
-      BugReporter bugReporter) {
+      BugReporter bugReporter,
+      GraphInconsistencyReceiver graphInconsistencyReceiver) {
     super(
         skyframeExecutorConsumerOnInit,
         pkgFactory,
@@ -209,6 +211,7 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
     this.diffAwarenessManager = new DiffAwarenessManager(diffAwarenessFactories);
     this.repositoryHelpersHolder = repositoryHelpersHolder;
     this.workspaceInfoFromDiffReceiver = workspaceInfoFromDiffReceiver;
+    this.graphInconsistencyReceiver = graphInconsistencyReceiver;
   }
 
   @Override
@@ -227,7 +230,7 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
         skyFunctions,
         recordingDiffer,
         progressReceiver,
-        GraphInconsistencyReceiver.THROWING,
+        graphInconsistencyReceiver,
         eventFilter,
         emittedEventState,
         trackIncrementalState);
@@ -1116,6 +1119,7 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
     private Consumer<SkyframeExecutor> skyframeExecutorConsumerOnInit = skyframeExecutor -> {};
     private SkyFunction ignoredPackagePrefixesFunction;
     private BugReporter bugReporter = BugReporter.defaultInstance();
+    private GraphInconsistencyReceiver graphInconsistencyReceiver = GraphInconsistencyReceiver.THROWING;
     private SkyKeyStateReceiver skyKeyStateReceiver = SkyKeyStateReceiver.NULL_INSTANCE;
     private SyscallCache perCommandSyscallCache = null;
 
@@ -1132,6 +1136,7 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
       Preconditions.checkNotNull(externalPackageHelper);
       Preconditions.checkNotNull(actionOnIOExceptionReadingBuildFile);
       Preconditions.checkNotNull(ignoredPackagePrefixesFunction);
+      Preconditions.checkNotNull(graphInconsistencyReceiver);
 
       SequencedSkyframeExecutor skyframeExecutor =
           new SequencedSkyframeExecutor(
@@ -1152,7 +1157,8 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
               repositoryHelpersHolder,
               actionOnIOExceptionReadingBuildFile,
               skyKeyStateReceiver,
-              bugReporter);
+              bugReporter,
+              graphInconsistencyReceiver);
       skyframeExecutor.init();
       return skyframeExecutor;
     }
@@ -1184,6 +1190,11 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
 
     public Builder setBugReporter(BugReporter bugReporter) {
       this.bugReporter = bugReporter;
+      return this;
+    }
+
+    public Builder setGraphInconsistencyReceiver(GraphInconsistencyReceiver graphInconsistencyReceiver) {
+      this.graphInconsistencyReceiver = graphInconsistencyReceiver;
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutorFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutorFactory.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.bugreport.BugReporter;
 import com.google.devtools.build.lib.packages.PackageFactory;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.SyscallCache;
+import com.google.devtools.build.skyframe.GraphInconsistencyReceiver;
 import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import javax.annotation.Nullable;
@@ -39,7 +40,8 @@ public final class SequencedSkyframeExecutorFactory implements SkyframeExecutorF
       SyscallCache perCommandSyscallCache,
       @Nullable SkyframeExecutorRepositoryHelpersHolder repositoryHelpersHolder,
       SkyframeExecutor.SkyKeyStateReceiver skyKeyStateReceiver,
-      BugReporter bugReporter) {
+      BugReporter bugReporter,
+      GraphInconsistencyReceiver graphInconsistencyReceiver) {
     return BazelSkyframeExecutorConstants.newBazelSkyframeExecutorBuilder()
         .setPkgFactory(pkgFactory)
         .setFileSystem(fileSystem)
@@ -52,6 +54,7 @@ public final class SequencedSkyframeExecutorFactory implements SkyframeExecutorF
         .setRepositoryHelpersHolder(repositoryHelpersHolder)
         .setSkyKeyStateReceiver(skyKeyStateReceiver)
         .setBugReporter(bugReporter)
+        .setGraphInconsistencyReceiver(graphInconsistencyReceiver)
         .build();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutorFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutorFactory.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.packages.PackageFactory;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.SyscallCache;
+import com.google.devtools.build.skyframe.GraphInconsistencyReceiver;
 import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 
@@ -53,6 +54,7 @@ public interface SkyframeExecutorFactory {
       SyscallCache perCommandSyscallCache,
       SkyframeExecutorRepositoryHelpersHolder repositoryHelpersHolder,
       SkyframeExecutor.SkyKeyStateReceiver skyKeyStateReceiver,
-      BugReporter bugReporter)
+      BugReporter bugReporter,
+      GraphInconsistencyReceiver graphInconsistencyReceiver)
       throws AbruptExitException;
 }

--- a/src/main/java/com/google/devtools/build/skyframe/RewindingGraphInconsistencyReceiver.java
+++ b/src/main/java/com/google/devtools/build/skyframe/RewindingGraphInconsistencyReceiver.java
@@ -1,0 +1,27 @@
+package com.google.devtools.build.skyframe;
+
+import com.google.devtools.build.skyframe.proto.GraphInconsistency.Inconsistency;
+import java.util.Collection;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link GraphInconsistencyReceiver} which allows rewinding to re-perform actions whose outputs
+ * have been lost.
+ */
+public class RewindingGraphInconsistencyReceiver implements GraphInconsistencyReceiver {
+
+  @Override
+  public void noteInconsistencyAndMaybeThrow(SkyKey key, @Nullable Collection<SkyKey> otherKeys,
+      Inconsistency inconsistency) {
+    if (Inconsistency.PARENT_FORCE_REBUILD_OF_CHILD.equals(inconsistency) || Inconsistency.RESET_REQUESTED.equals(inconsistency)) {
+      return;
+    }
+    throw new IllegalStateException(
+        "Unexpected inconsistency: " + key + ", " + otherKeys + ", " + inconsistency);
+  }
+
+  @Override
+  public boolean restartPermitted() {
+    return true;
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutorTest.java
@@ -25,6 +25,7 @@ import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ExponentialBackoff;
 import com.google.devtools.build.lib.remote.common.OperationObserver;
@@ -334,7 +335,7 @@ public class ExperimentalGrpcRemoteExecutorTest {
 
   @Test
   public void executeRemotely_retryExecuteWhenUnauthenticated()
-      throws IOException, InterruptedException {
+      throws ExecException, IOException, InterruptedException {
     executionService.whenExecute(DUMMY_REQUEST).thenError(Code.UNAUTHENTICATED);
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenDone(DUMMY_RESPONSE);
 
@@ -347,7 +348,7 @@ public class ExperimentalGrpcRemoteExecutorTest {
 
   @Test
   public void executeRemotely_retryWaitExecutionWhenUnauthenticated()
-      throws IOException, InterruptedException {
+      throws ExecException, IOException, InterruptedException {
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenError(Code.UNAVAILABLE);
     executionService.whenWaitExecution(DUMMY_REQUEST).thenAck().thenError(Code.UNAUTHENTICATED);
     executionService.whenWaitExecution(DUMMY_REQUEST).thenAck().thenDone(DUMMY_RESPONSE);
@@ -361,7 +362,7 @@ public class ExperimentalGrpcRemoteExecutorTest {
   }
 
   @Test
-  public void executeRemotely_retryExecuteIfNotFound() throws IOException, InterruptedException {
+  public void executeRemotely_retryExecuteIfNotFound() throws ExecException, IOException, InterruptedException {
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenError(Code.UNAVAILABLE);
     executionService.whenWaitExecution(DUMMY_REQUEST).thenError(Code.NOT_FOUND);
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenError(Code.UNAVAILABLE);
@@ -397,7 +398,7 @@ public class ExperimentalGrpcRemoteExecutorTest {
   }
 
   @Test
-  public void executeRemotely_notifyObserver() throws IOException, InterruptedException {
+  public void executeRemotely_notifyObserver() throws ExecException, IOException, InterruptedException {
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenDone(DUMMY_RESPONSE);
 
     List<Operation> notified = new ArrayList<>();

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -319,7 +319,7 @@ public class GrpcCacheClientTest {
         });
 
     // Upload all missing inputs (that is, the virtual action input from above)
-    client.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), /*force=*/ true);
+    client.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), "", /*force=*/ true);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
@@ -35,6 +35,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.SimpleSpawn;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -299,8 +300,8 @@ public class RemoteCacheTest {
         new Thread(
             () -> {
               try {
-                remoteCache.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), false);
-              } catch (IOException | InterruptedException ignored) {
+                remoteCache.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), "", false);
+              } catch (ExecException | IOException | InterruptedException ignored) {
                 // ignored
               } finally {
                 ensureInputsPresentReturned.countDown();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorTest.java
@@ -26,6 +26,7 @@ import build.bazel.remote.execution.v2.ExecuteResponse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.CachedActionResult;
 import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
@@ -70,7 +71,7 @@ public class RemoteRepositoryRemoteExecutorTest {
   }
 
   @Test
-  public void testZeroExitCodeFromCache() throws IOException, InterruptedException {
+  public void testZeroExitCodeFromCache() throws ExecException, IOException, InterruptedException {
     // Test that an ActionResult with exit code zero is accepted as cached.
 
     // Arrange
@@ -97,7 +98,7 @@ public class RemoteRepositoryRemoteExecutorTest {
   }
 
   @Test
-  public void testNoneZeroExitCodeFromCache() throws IOException, InterruptedException {
+  public void testNoneZeroExitCodeFromCache() throws ExecException, IOException, InterruptedException {
     // Test that an ActionResult with a none-zero exit code is not accepted as cached.
 
     // Arrange
@@ -127,7 +128,7 @@ public class RemoteRepositoryRemoteExecutorTest {
   }
 
   @Test
-  public void testInlineStdoutStderr() throws IOException, InterruptedException {
+  public void testInlineStdoutStderr() throws ExecException, IOException, InterruptedException {
     // Test that
 
     // Arrange

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -260,7 +260,7 @@ public class RemoteSpawnRunnerTest {
     runner.exec(spawn, policy);
 
     verify(localRunner).exec(spawn, policy);
-    verify(cache).ensureInputsPresent(any(), any(), any(), anyBoolean());
+    verify(cache).ensureInputsPresent(any(), any(), any(), any(), anyBoolean());
     verifyNoMoreInteractions(cache);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/ActionInputDirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/ActionInputDirectoryTreeTest.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
 import org.junit.Test;
 
 /** Tests for {@link DirectoryTreeBuilder#buildFromActionInputs}. */
@@ -53,6 +54,12 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
         inputFiles, new StaticMetadataProvider(metadata), execRoot, digestUtil);
   }
 
+  @Override
+  @Nullable
+  Artifact artifactFor(Path path) {
+    return ActionsTestUtil.createArtifact(artifactRoot, path);
+  }
+
   @Test
   public void virtualActionInputShouldWork() throws Exception {
     SortedMap<PathFragment, ActionInput> sortedInputs = new TreeMap<>();
@@ -70,7 +77,7 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
     assertThat(directoriesAtDepth(1, tree)).isEmpty();
 
     FileNode expectedFooNode =
-        FileNode.createExecutable("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
+        FileNode.createExecutable("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"), foo);
     FileNode expectedBarNode =
         FileNode.createExecutable("bar.cc", bar.getBytes(), digestUtil.computeAsUtf8("bar"));
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
@@ -117,13 +124,13 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
     assertThat(directoriesAtDepth(3, tree)).isEmpty();
 
     FileNode expectedFooNode =
-        FileNode.createExecutable("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
+        FileNode.createExecutable("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"), foo);
     FileNode expectedBarNode =
         FileNode.createExecutable(
-            "bar.cc", execRoot.getRelative(bar.getExecPath()), digestUtil.computeAsUtf8("bar"));
+            "bar.cc", execRoot.getRelative(bar.getExecPath()), digestUtil.computeAsUtf8("bar"), null);
     FileNode expectedBuzzNode =
         FileNode.createExecutable(
-            "buzz.cc", execRoot.getRelative(buzz.getExecPath()), digestUtil.computeAsUtf8("buzz"));
+            "buzz.cc", execRoot.getRelative(buzz.getExecPath()), digestUtil.computeAsUtf8("buzz"), null);
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
     assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode);
     assertThat(fileNodesAtDepth(tree, 2)).containsExactly(expectedBarNode);
@@ -160,7 +167,7 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
 
     FileNode expectedFooNode =
         FileNode.createExecutable(
-            "foo.cc", execRoot.getRelative(foo.getExecPath()), digestUtil.computeAsUtf8("foo"));
+            "foo.cc", execRoot.getRelative(foo.getExecPath()), digestUtil.computeAsUtf8("foo"), null);
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
     assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode);
 

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
@@ -15,8 +15,10 @@ package com.google.devtools.build.lib.remote.merkletree;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.DirectoryNode;
 import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.FileNode;
@@ -33,6 +35,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,16 +80,18 @@ public abstract class DirectoryTreeTest {
     assertThat(directoriesAtDepth(2, tree)).isEmpty();
 
     FileNode expectedFooNode =
-        FileNode.createExecutable("foo.cc", foo, digestUtil.computeAsUtf8("foo"));
+        FileNode.createExecutable("foo.cc", foo, digestUtil.computeAsUtf8("foo"), artifactFor(foo));
     FileNode expectedBarNode =
-        FileNode.createExecutable("bar.cc", bar, digestUtil.computeAsUtf8("bar"));
+        FileNode.createExecutable("bar.cc", bar, digestUtil.computeAsUtf8("bar"), artifactFor(bar));
     FileNode expectedBuzzNode =
-        FileNode.createExecutable("buzz.cc", buzz, digestUtil.computeAsUtf8("buzz"));
+        FileNode.createExecutable("buzz.cc", buzz, digestUtil.computeAsUtf8("buzz"), artifactFor(buzz));
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
     assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode, expectedBarNode);
     assertThat(fileNodesAtDepth(tree, 2)).containsExactly(expectedBuzzNode);
   }
 
+  @Nullable
+  abstract Artifact artifactFor(Path path);
 
   @Test
   public void testLexicographicalOrder() throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/PathDirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/PathDirectoryTreeTest.java
@@ -13,11 +13,13 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.merkletree;
 
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
 
 /** Tests for {@link DirectoryTreeBuilder#fromPaths}. */
 public class PathDirectoryTreeTest extends DirectoryTreeTest {
@@ -29,5 +31,11 @@ public class PathDirectoryTreeTest extends DirectoryTreeTest {
       inputFiles.put(path.relativeTo(execRoot), path);
     }
     return DirectoryTreeBuilder.fromPaths(inputFiles, digestUtil);
+  }
+
+  @Override
+  @Nullable
+  Artifact artifactFor(Path path) {
+    return null;
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/runtime/BlazeRuntimeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/BlazeRuntimeTest.java
@@ -85,7 +85,7 @@ public class BlazeRuntimeTest {
             .setFileSystem(fs)
             .setProductName("foo product")
             .setServerDirectories(serverDirectories)
-            .setStartupOptionsProvider(Mockito.mock(OptionsParsingResult.class))
+            .setStartupOptionsProvider(OptionsParser.builder().optionsClasses(BlazeServerStartupOptions.class).build())
             .build();
     AtomicReference<String> shutdownMessage = new AtomicReference<>();
     BlazeDirectories directories =
@@ -139,7 +139,7 @@ public class BlazeRuntimeTest {
             .setFileSystem(fs)
             .setProductName("bazel")
             .setServerDirectories(serverDirectories)
-            .setStartupOptionsProvider(Mockito.mock(OptionsParsingResult.class))
+            .setStartupOptionsProvider(OptionsParser.builder().optionsClasses(BlazeServerStartupOptions.class).build())
             .build();
     BlazeDirectories directories =
         new BlazeDirectories(

--- a/src/test/java/com/google/devtools/build/lib/skyframe/AbstractCollectPackagesUnderDirectoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/AbstractCollectPackagesUnderDirectoryTest.java
@@ -49,6 +49,7 @@ import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.build.skyframe.EvaluationContext;
 import com.google.devtools.build.skyframe.EvaluationResult;
+import com.google.devtools.build.skyframe.GraphInconsistencyReceiver;
 import com.google.devtools.build.skyframe.MemoizingEvaluator;
 import com.google.devtools.build.skyframe.SkyFunction;
 import com.google.devtools.build.skyframe.SkyFunctionName;
@@ -297,7 +298,8 @@ public abstract class AbstractCollectPackagesUnderDirectoryTest {
                 SyscallCache.NO_CACHE,
                 /*repositoryHelpersHolder=*/ null,
                 SkyframeExecutor.SkyKeyStateReceiver.NULL_INSTANCE,
-                BugReporter.defaultInstance());
+                BugReporter.defaultInstance(),
+                GraphInconsistencyReceiver.THROWING);
     skyframeExecutor.injectExtraPrecomputedValues(
         ImmutableList.of(
             PrecomputedValue.injected(


### PR DESCRIPTION
This remedies the following sequence of events:
1. Build build_tool (e.g. the go builder) from source with remote
   execution and `--remote_download_minimal`.
2. Use build_tool to build some_binary with remote execution.
3. Evict `build_tool` from the remote execution system.
4. Edit the sources to some_binary and attempt to build it again with
   remote execution.

Before this change, Bazel would give an FileNotFoundException
complaining that build_tool couldn't be found (and so couldn't be
uploaded).

After this change, Bazel will notice that it knows how to regenerate the
missing file, and so rewind the graph and re-perform the actions it
needs to be able to build some_binary.