### PR TITLE
Clean up unnecessary DefaultInfo recreation

### DIFF
--- a/tools/jdk/java_toolchain_alias.bzl
+++ b/tools/jdk/java_toolchain_alias.bzl
@@ -48,13 +48,7 @@ def _java_host_runtime_alias(ctx):
         java_runtime,
         template_variable_info,
         toolchain_info,
-        # Create a new DefaultInfo instead of propagating runtime[DefaultInfo]
-        # directly.
-        DefaultInfo(
-            files = runtime[DefaultInfo].files,
-            data_runfiles = runtime[DefaultInfo].data_runfiles,
-            default_runfiles = runtime[DefaultInfo].default_runfiles,
-        ),
+        runtime[DefaultInfo],
     ]
 
 java_host_runtime_alias = rule(


### PR DESCRIPTION
Recreating a DefaultInfo to forward one obtained from a native rule is no longer needed as of 62582bd74d2a154e94a9e1e64fcbeeae22fbf88c.