### PR TITLE
Make cpp assembly file extensions case sensitive again

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -91,15 +91,43 @@ public final class CppFileTypes {
         }
       };
 
-  public static final FileType ASSEMBLER_WITH_C_PREPROCESSOR = FileType.of(".S");
-  public static final FileType PIC_ASSEMBLER = FileType.of(".pic.s");
+  public static final FileType ASSEMBLER_WITH_C_PREPROCESSOR =
+      new FileType() {
+        final String ext = ".S";
+
+        @Override
+        public boolean apply(String path) {
+          return path.endsWith(ext);
+        }
+
+        @Override
+        public ImmutableList<String> getExtensions() {
+          return ImmutableList.of(ext);
+        }
+      };
+
+  public static final FileType PIC_ASSEMBLER =
+      new FileType() {
+        final String ext = ".pic.s";
+
+        @Override
+        public boolean apply(String path) {
+          return OS.endsWith(path, ext) && path.endsWith(".s");
+        }
+
+        @Override
+        public ImmutableList<String> getExtensions() {
+          return ImmutableList.of(ext);
+        }
+      };
+
   public static final FileType ASSEMBLER =
       new FileType() {
         final String ext = ".s";
 
         @Override
         public boolean apply(String path) {
-          return (OS.endsWith(path, ext) && !PIC_ASSEMBLER.matches(path))
+          return (path.endsWith(ext) && !PIC_ASSEMBLER.matches(path))
               || OS.endsWith(path, ".asm");
         }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppFileTypes.java
@@ -91,6 +91,7 @@ public final class CppFileTypes {
         }
       };
 
+  // FileType is extended to use case-sensitive comparison also on Windows
   public static final FileType ASSEMBLER_WITH_C_PREPROCESSOR =
       new FileType() {
         final String ext = ".S";
@@ -106,6 +107,7 @@ public final class CppFileTypes {
         }
       };
 
+  // FileType is extended to use case-sensitive comparison also on Windows
   public static final FileType PIC_ASSEMBLER =
       new FileType() {
         final String ext = ".pic.s";
@@ -121,6 +123,7 @@ public final class CppFileTypes {
         }
       };
 
+  // FileType is extended to use case-sensitive comparison also on Windows
   public static final FileType ASSEMBLER =
       new FileType() {
         final String ext = ".s";

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CppFileTypesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CppFileTypesTest.java
@@ -57,4 +57,16 @@ public class CppFileTypesTest {
     assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("libA.so.if.exp")).isFalse();
     assertThat(CppFileTypes.VERSIONED_SHARED_LIBRARY.matches("libA.so.if.lib")).isFalse();
   }
+
+  @Test
+  public void testCaseSensitiveAssemblyFiles() {
+    assertThat(CppFileTypes.ASSEMBLER_WITH_C_PREPROCESSOR.matches("foo.S")).isTrue();
+    assertThat(CppFileTypes.ASSEMBLER_WITH_C_PREPROCESSOR.matches("foo.s")).isFalse();
+    assertThat(CppFileTypes.PIC_ASSEMBLER.matches("foo.pic.s")).isTrue();
+    assertThat(CppFileTypes.PIC_ASSEMBLER.matches("foo.pic.S")).isFalse();
+    assertThat(CppFileTypes.ASSEMBLER.matches("foo.s")).isTrue();
+    assertThat(CppFileTypes.ASSEMBLER.matches("foo.asm")).isTrue();
+    assertThat(CppFileTypes.ASSEMBLER.matches("foo.pic.s")).isFalse();
+    assertThat(CppFileTypes.ASSEMBLER.matches("foo.S")).isFalse();
+  }
 }


### PR DESCRIPTION
This fixes an issue introduced by PR #14005 where .s and .S
extensions were handled case-insensitive on Windows so the action
assemble was triggered instead of preprocess_assemble.