### PR TITLE
Remove test_remote_https_cache.

### DIFF
--- a/src/test/shell/bazel/remote/remote_execution_tls_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_tls_test.sh
@@ -117,18 +117,6 @@ function test_remote_grpc_cache() {
       || fail "Failed to build //a:foo with grpc remote cache"
 }
 
-function test_remote_https_cache() {
-  # Test that if 'https' is provided as a scheme for --remote_cache flag, remote cache works.
-  _prepareBasicRule
-
-  bazel build \
-      --remote_cache=https://localhost:${worker_port} \
-      --tls_certificate="${cert_path}/ca.crt" \
-      ${client_mtls_flags} \
-      //a:foo \
-      || fail "Failed to build //a:foo with https remote cache"
-}
-
 function test_remote_cache_with_incompatible_tls_enabled_removed_grpc_scheme() {
   # Test that if 'grpc' scheme for --remote_cache flag, remote cache fails.
   _prepareBasicRule


### PR DESCRIPTION
This test claimed to "Test that if 'https' is provided as a scheme for --remote_cache flag, remote cache works." However, it does not establish that. Failing to read or write to the remote cache simply prints a warning, which does not fail this test.

The HTTPS remote cache cannot work due to at least the following reasons:
1. The remote worker in this test file does not have the HTTP cache enabled.
2. The test remote worker does not support HTTPS over its HTTP cache.
3. Even if the test remote worker did support HTTPS, the HTTP remote cache client does not read --tls_certificate from the command line.