### PR TITLE
docs: update the docs about `--fission`'s default

### DIFF
--- a/site/docs/user-manual.html
+++ b/site/docs/user-manual.html
@@ -764,7 +764,7 @@ the compilation of binaries during the build.
   only for the specified set of compilation modes. This is useful for bazelrc
   settings. When set to <code class='flag'>yes</code>, Fission is enabled
   universally. When set to <code class='flag'>no</code>, Fission is disabled
-  universally. Default is <code class='flag'>dbg</code>.
+  universally. Default is <code class='flag'>no</code>.
 </p>
 
 <h4 id='flag--force_ignore_dash_static'><code class='flag'>--force_ignore_dash_static</code></h4>


### PR DESCRIPTION
The [default](https://github.com/bazelbuild/bazel/blame/14b0814f47468dd86381f9bc831abc7374f9c9c5/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java#L196) for `--fission` seems to be `no`, not `dbg`.