### PR TITLE
Stop using GZIP.

### DIFF
--- a/src/minimize_jdk.sh
+++ b/src/minimize_jdk.sh
@@ -75,7 +75,7 @@ else
   else
     cp lib/libdt_socket.so lib/libjdwp.so reduced/lib
   fi
-  GZIP=-9 tar -zcf ../reduced.tgz reduced
+  tar -I '/bin/bash -c "exec gzip -9"' -cf ../reduced.tgz reduced
   cd ..
   mv reduced.tgz "$out"
 fi


### PR DESCRIPTION
It is apparently deprecated:
```
INFO: From Executing genrule //src:embedded_jdk_allmodules.tar.gz:
gzip: warning: GZIP environment variable is deprecated; use an alias or script
```