### PR TITLE
[ijar] Mark stripped methods as native

### DIFF
--- a/third_party/ijar/classfile.cc
+++ b/third_party/ijar/classfile.cc
@@ -82,9 +82,10 @@ enum ACCESS {
   ACC_BRIDGE = 0x0040,
   ACC_VOLATILE = 0x0040,
   ACC_TRANSIENT = 0x0080,
+  ACC_NATIVE = 0x0100,
   ACC_INTERFACE = 0x0200,
   ACC_ABSTRACT = 0x0400,
-  ACC_SYNTHETIC = 0x1000
+  ACC_SYNTHETIC = 0x1000,
 };
 
 // See Table 4.7.20-A in Java 8 JVM Spec.
@@ -1764,6 +1765,14 @@ static ClassFile *ReadClass(const void *classdata, size_t length) {
       // declaring compilation unit
       continue;
     }
+
+    // Mark non-abstract methods native since we drop the "Code attribute" and
+    // JVMS 4.7.3 says every method is either native or abstract if it doesn't have
+    // the "Code attribute"
+    if ((method->access_flags & ACC_ABSTRACT) != ACC_ABSTRACT) {
+      method->access_flags |= ACC_NATIVE;
+    }
+
     clazz->methods.push_back(method);
   }
 

--- a/third_party/ijar/test/ijar_test.sh
+++ b/third_party/ijar/test/ijar_test.sh
@@ -204,6 +204,8 @@ function test_ijar_output() {
   check_eq 5 $lines "Input jar should have 5 method bodies!"
   lines=$($JAVAP -c -private -classpath $A_INTERFACE_JAR A | grep -c Code: || true)
   check_eq 0 $lines "Interface jar should have no method bodies!"
+  lines=$($JAVAP -c -private -classpath $A_INTERFACE_JAR A | grep native | wc -l)
+  check_eq 3 $lines "Interface jar should have 3 native methods!"
 
   # Check that constants from code are no longer present:
   $JAVAP -c -private -classpath $A_JAR A | grep -sq foofoofoofoo ||


### PR DESCRIPTION
ijar strips out the "Code" attribute from methods which generates invalid class files.

[JVMS 4.7.3](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.3): "If the method is either native or abstract, its method_info structure must not have a Code attribute. Otherwise, its method_info structure must have exactly one Code attribute."

As a hack around this, we can mark all the stripped methods as `native` and generate a valid class file. I couldn't find a case where this causes issues to downstream compilation.

The main motivation behind this is #13546
