### PR TITLE
Inclusion of mnemonics in profiling

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/profiler/BUILD
@@ -15,6 +15,7 @@ java_library(
         "CollectLocalResourceUsage.java",
         "MemoryProfiler.java",
         "MetricData.java",
+        "MnemonicData.java",
         "PredicateBasedStatRecorder.java",
         "ProfilePhase.java",
         "Profiler.java",

--- a/src/main/java/com/google/devtools/build/lib/profiler/MnemonicData.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/MnemonicData.java
@@ -1,3 +1,16 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package com.google.devtools.build.lib.profiler;
 
 /** Representation of mnemonic data used by the {@link Profiler}.
@@ -7,6 +20,7 @@ package com.google.devtools.build.lib.profiler;
  * actions into the types of actions they correspond to more clearly.
  */
 public class MnemonicData {
+  private static MnemonicData emptyMnemonic = null;
   private final String mnemonic;
 
   private MnemonicData() {
@@ -23,10 +37,13 @@ public class MnemonicData {
    * To keep the internal representation encapsulated, {@link MnemonicData#hasBeenSet}
    * can be used to check whether or not a mnemonic has been set for the datum.
    *
-   * @return an empty mnemonic datum
+   * @return a singleton of an empty mnemonic datum
    */
   public static MnemonicData getEmptyMnemonic() {
-    return new MnemonicData();
+    if (emptyMnemonic == null) {
+      emptyMnemonic = new MnemonicData();
+    }
+    return emptyMnemonic;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/profiler/MnemonicData.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/MnemonicData.java
@@ -43,7 +43,7 @@ public class MnemonicData {
    *
    * @return a string representation of the mnemonic if it has been set, otherwise null
    */
-  public String getJsonCategory() {
+  public String getValueForJson() {
     return mnemonic;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/profiler/MnemonicData.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/MnemonicData.java
@@ -1,0 +1,49 @@
+package com.google.devtools.build.lib.profiler;
+
+/** Representation of mnemonic data used by the {@link Profiler}.
+ *
+ * <p>This class provides some abstraction for the representation of mnemonic
+ * data in the profiler. The data in itself is used to separate profiled
+ * actions into the types of actions they correspond to more clearly.
+ */
+public class MnemonicData {
+  private final String mnemonic;
+
+  private MnemonicData() {
+    this.mnemonic = null;
+  }
+
+  MnemonicData(String mnemonic) {
+    this.mnemonic = mnemonic;
+  }
+
+  /**
+   * Get a mnemonic datum without any set mnemonic.
+   *
+   * To keep the internal representation encapsulated, {@link MnemonicData#hasBeenSet}
+   * can be used to check whether or not a mnemonic has been set for the datum.
+   *
+   * @return an empty mnemonic datum
+   */
+  public static MnemonicData getEmptyMnemonic() {
+    return new MnemonicData();
+  }
+
+  /**
+   * Check if the datum has been assigned a value.
+   *
+   * @return if the mnemonic value has been set
+   */
+  public boolean hasBeenSet() {
+    return this.mnemonic != null;
+  }
+
+  /**
+   * Get the mnemonic part of a category string formatted for JSON output.
+   *
+   * @return a string representation of the mnemonic if it has been set, otherwise null
+   */
+  public String getJsonCategory() {
+    return mnemonic;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
@@ -169,22 +169,10 @@ public final class Profiler {
     /**
      * Get the value of the datum's "cat" field for JSON output.
      *
-     * <p>As specified in the
-     * <a href="https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview">
-     * Chrome Trace Event Format Specification</a>, an event can belong to multiple
-     * categories specified in a comma-separated string. This method uses both the
-     * profiler task type and the mnemonic as categories if both are available.
-     *
      * @return the category value if one can be created, otherwise null
      */
     public String getJsonCategory() {
-      if (mnemonic.hasBeenSet()) {
-        if (type != null) {
-          return type.description + "," + mnemonic.getJsonCategory();
-        } else {
-          return mnemonic.getJsonCategory();
-        }
-      } else if (type != null) {
+      if (type != null) {
         return type.description;
       } else {
         return null;
@@ -985,14 +973,14 @@ public final class Profiler {
         writer.beginObject();
         writer.name("target").value(((ActionTaskData) data).targetLabel);
         if (data.mnemonic.hasBeenSet()) {
-          writer.name("mnemonic").value(data.mnemonic.getJsonCategory());
+          writer.name("mnemonic").value(data.mnemonic.getValueForJson());
         }
         writer.endObject();
       }
       else if (data.mnemonic.hasBeenSet() && data instanceof ActionTaskData) {
         writer.name("args");
         writer.beginObject();
-        writer.name("mnemonic").value(data.mnemonic.getJsonCategory());
+        writer.name("mnemonic").value(data.mnemonic.getValueForJson());
         writer.endObject();
       }
       long threadId =

--- a/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
@@ -166,19 +166,6 @@ public final class Profiler {
       this.description = description;
     }
 
-    /**
-     * Get the value of the datum's "cat" field for JSON output.
-     *
-     * @return the category value if one can be created, otherwise null
-     */
-    public String getJsonCategory() {
-      if (type != null) {
-        return type.description;
-      } else {
-        return null;
-      }
-    }
-
     @Override
     public String toString() {
       return "Thread " + threadId + ", task " + id + ", type " + type + ", " + description;
@@ -945,14 +932,13 @@ public final class Profiler {
     private void writeTask(JsonWriter writer, TaskData data) throws IOException {
       Preconditions.checkNotNull(data);
       String eventType = data.duration == 0 ? "i" : "X";
-      String category = data.getJsonCategory();
       writer.setIndent("  ");
       writer.beginObject();
       writer.setIndent("");
-      if (category == null) {
+      if (data.type == null) {
         writer.setIndent("    ");
       } else {
-        writer.name("cat").value(category);
+        writer.name("cat").value(data.type.description);
       }
       writer.name("name").value(data.description);
       writer.name("ph").value(eventType);

--- a/src/main/java/com/google/devtools/build/lib/profiler/TraceEvent.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/TraceEvent.java
@@ -40,9 +40,10 @@ public abstract class TraceEvent {
       @Nullable Duration duration,
       long threadId,
       @Nullable String primaryOutputPath,
-      @Nullable String targetLabel) {
+      @Nullable String targetLabel,
+      @Nullable String mnemonic) {
     return new AutoValue_TraceEvent(
-        category, name, timestamp, duration, threadId, primaryOutputPath, targetLabel);
+        category, name, timestamp, duration, threadId, primaryOutputPath, targetLabel, mnemonic);
   }
 
   @Nullable
@@ -65,6 +66,9 @@ public abstract class TraceEvent {
   @Nullable
   public abstract String targetLabel();
 
+  @Nullable
+  public abstract String mnemonic();
+
   private static TraceEvent createFromJsonReader(JsonReader reader) throws IOException {
     String category = null;
     String name = null;
@@ -73,6 +77,7 @@ public abstract class TraceEvent {
     long threadId = -1;
     String primaryOutputPath = null;
     String targetLabel = null;
+    String mnemonic = null;
 
     reader.beginObject();
     while (reader.hasNext()) {
@@ -100,6 +105,8 @@ public abstract class TraceEvent {
           ImmutableMap<String, Object> args = parseMap(reader);
           Object target = args.get("target");
           targetLabel = target instanceof String ? (String) target : null;
+          Object mnemonicValue = args.get("mnemonic");
+          mnemonic = mnemonicValue instanceof String ? (String) mnemonicValue : null;
           break;
         default:
           reader.skipValue();
@@ -107,7 +114,7 @@ public abstract class TraceEvent {
     }
     reader.endObject();
     return TraceEvent.create(
-        category, name, timestamp, duration, threadId, primaryOutputPath, targetLabel);
+        category, name, timestamp, duration, threadId, primaryOutputPath, targetLabel, mnemonic);
   }
 
   private static ImmutableMap<String, Object> parseMap(JsonReader reader) throws IOException {

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -958,6 +958,7 @@ public final class SkyframeActionExecutor {
       try (SilentCloseable c =
           profiler.profileAction(
               ProfilerTask.ACTION,
+              action.getMnemonic(),
               action.describe(),
               action.getPrimaryOutput().getExecPathString(),
               getOwnerLabelAsString(action))) {

--- a/src/test/java/com/google/devtools/build/lib/profiler/ProfilerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/profiler/ProfilerTest.java
@@ -20,6 +20,7 @@ import static com.google.devtools.build.lib.profiler.Profiler.Format.JSON_TRACE_
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.bugreport.BugReporter;
@@ -798,5 +799,68 @@ public final class ProfilerTest {
     long fatProfileLineCount = fatOutput.split("\n").length;
     long slimProfileLineCount = slimOutput.split("\n").length;
     assertThat(fatProfileLineCount).isAtLeast(8 * slimProfileLineCount);
+  }
+
+  @Test
+  public void testProfileMnemonicIncluded() throws Exception {
+    ByteArrayOutputStream buffer = start(getAllProfilerTasks(), JSON_TRACE_FILE_FORMAT);
+    try (SilentCloseable c =
+           profiler.profileAction(
+             ProfilerTask.ACTION,
+             "without mnemonic",
+             "",
+             "")) {
+      clock.advanceMillis(100);
+    }
+    try (SilentCloseable c =
+        profiler.profileAction(
+            ProfilerTask.ACTION,
+            "foo",
+            "with mnemonic",
+            "",
+            "")) {
+      clock.advanceMillis(100);
+    }
+    profiler.stop();
+
+    // Make sure both actions were registered
+    JsonProfile jsonProfile = new JsonProfile(new ByteArrayInputStream(buffer.toByteArray()));
+    List<TraceEvent> traceEvents = jsonProfile.getTraceEvents();
+    List<String> names = traceEvents.stream().map(TraceEvent::name).collect(Collectors.toList());
+    assertThat(names).contains("without mnemonic");
+    assertThat(names).contains("with mnemonic");
+
+    TraceEvent withoutMnemonic = null;
+    TraceEvent withMnemonic = null;
+    for (TraceEvent traceEvent : traceEvents) {
+      String name = traceEvent.name();
+      if (name.equals("without mnemonic")) {
+        withoutMnemonic = traceEvent;
+      } else if (name.equals("with mnemonic")) {
+        withMnemonic = traceEvent;
+      }
+    }
+
+    // Make sure both events were profiled
+    assertThat(withoutMnemonic).isNotNull();
+    assertThat(withMnemonic).isNotNull();
+
+    // Make sure one has two categories and the other has none
+    String categoryWithoutMnemonic = withoutMnemonic.category();
+    String categoryWithMnemonic = withMnemonic.category();
+    String[] categoriesWithoutMnemonic = categoryWithoutMnemonic.split(",");
+    String[] categoriesWithMnemonic = categoryWithMnemonic.split(",");
+    assertThat(categoriesWithoutMnemonic).hasLength(1);
+    assertThat(categoriesWithMnemonic).hasLength(2);
+
+    // Make sure that one has been assigned a mnemonics field in args and the other hasn't
+    String mnemonicWithoutMnemonic = withoutMnemonic.mnemonic();
+    String mnemonicWithMnemonic = withMnemonic.mnemonic();
+    assertThat(mnemonicWithoutMnemonic).isNull();
+    assertThat(mnemonicWithMnemonic).isNotNull();
+
+    // Make sure the mnemonic has been set to the specified value
+    assertThat(categoriesWithMnemonic).asList().contains("foo");
+    assertThat((String) mnemonicWithMnemonic).isEqualTo("foo");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/profiler/ProfilerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/profiler/ProfilerTest.java
@@ -845,14 +845,6 @@ public final class ProfilerTest {
     assertThat(withoutMnemonic).isNotNull();
     assertThat(withMnemonic).isNotNull();
 
-    // Make sure one has two categories and the other has none
-    String categoryWithoutMnemonic = withoutMnemonic.category();
-    String categoryWithMnemonic = withMnemonic.category();
-    String[] categoriesWithoutMnemonic = categoryWithoutMnemonic.split(",");
-    String[] categoriesWithMnemonic = categoryWithMnemonic.split(",");
-    assertThat(categoriesWithoutMnemonic).hasLength(1);
-    assertThat(categoriesWithMnemonic).hasLength(2);
-
     // Make sure that one has been assigned a mnemonics field in args and the other hasn't
     String mnemonicWithoutMnemonic = withoutMnemonic.mnemonic();
     String mnemonicWithMnemonic = withMnemonic.mnemonic();
@@ -860,7 +852,6 @@ public final class ProfilerTest {
     assertThat(mnemonicWithMnemonic).isNotNull();
 
     // Make sure the mnemonic has been set to the specified value
-    assertThat(categoriesWithMnemonic).asList().contains("foo");
     assertThat((String) mnemonicWithMnemonic).isEqualTo("foo");
   }
 }


### PR DESCRIPTION
We have a use case wherein we wish to use the profiling files produced by Bazel to analyze the cumulative use of specific tools. In order to simplify this, this pull request adds information about each Action's mnemonic to the JSON profiles. The additions to the profiling files follow the [Chrome Trace Event Format Specification.](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit) In order to make the processing of profiling files by external programs cleaner and more consistent, mnemonic information is included in two parts of each Action event:

### Mnemonics as Categories

According to the specification, the `"cat"` field of a trace event can specify multiple categories as a comma-separated string. For events that describe Actions, the mnemonic of the Action is included as one of the categories here. 

### Mnemonics as Arguments

The specification also describes the `"args"` field, in which arbitrary data can be placed, and *is* already placed by Bazel with the inclusion of the `"target"` field. For events that describe Actions, a `"mnemonic"` field is added to `"args"`, in which the mnemonic of the action is placed.

### Motivation of Double Inclusion

While it may be seen as superfluous to include the mnemonic twice in the same event object, we believe that doing so is beneficial. The inclusion of the mnemonic as a category is mainly intended for filtering purposes. The trace event format specification describes how "the categories can be used to hide events in the Trace Viewer UI," and it would thereby be reasonable for any other external tools that use the format to implement the same functionality for categories. By including the mnemonic as a category, filtering can be done without taking non-category fields into special regard.

Aside from filtering, it is also of interest to collect cumulative information about Actions grouped by their mnemonics. In this case, the names of the mnemonics may not be initially known during analysis. It may at first seem sufficient to only include the mnemonic as a category for this. With how profiling files are currently constructed in Bazel, the mnemonic of an event can be consistently derived by first making sure it has two categories, then ensuring that one of the categories is `"action processing"`, and then picking the other category. However, this is not future-proof, as the trace event specification would permit the addition of more categories in the future, should Bazel ever be changed to do so. By including an explicit specification of the mnemonic in the `"args"` object, this issue is removed. 

In summary, the double inclusion of the mnemonic is done to ensure that it can consistently be used for filtering, as well as for accessing initially unknown mnemonics from arbitrary Actions.