### PR TITLE
[5.x] Add -no_uuid for hermetic macOS toolchain setup

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -102,6 +102,7 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
         "-arch",
         "x86_64",
         "-Wl,-no_adhoc_codesign",
+        "-Wl,-no_uuid",
         "-O3",
         "-o",
         out_name,


### PR DESCRIPTION
The content based uuid embedded by ld64 contains the basename of the
file being built. In the case of multiarch builds this filename is
randomly generated. This doesn't hit in all cases based on the order of
the arguments to clang, but since this shouldn't have a downside for
this use case, it's safer to exclude this for the future.

More conversation https://github.com/bazelbuild/bazel/pull/14168

Filed with apple as FB9727658

(cherry picked from commit d2aab87df7c1e1e48544aef321f72f40f6dad575)

https://github.com/bazelbuild/bazel/pull/14190