### PR TITLE
Rename module name for protobuf (third_party)

### DIFF
--- a/third_party/googleapis/MODULE.bazel
+++ b/third_party/googleapis/MODULE.bazel
@@ -5,6 +5,6 @@ module(
 
 bazel_dep(name = "rules_java", version = "4.0.0")
 bazel_dep(name = "rules_proto", version = "4.0.0")
-bazel_dep(name = "com_google_protobuf", version = "3.19.0")
+bazel_dep(name = "protobuf", version = "3.19.0", repo_name = "com_google_protobuf")
 
 bazel_dep(name = "bazel", version = "", repo_name = "io_bazel")

--- a/third_party/remoteapis/MODULE.bazel
+++ b/third_party/remoteapis/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 
 bazel_dep(name = "rules_java", version = "4.0.0")
 bazel_dep(name = "rules_proto", version = "4.0.0")
-bazel_dep(name = "com_google_protobuf", version = "3.19.0")
+bazel_dep(name = "protobuf", version = "3.19.0", repo_name = "com_google_protobuf")
 
 bazel_dep(name = "googleapis", version = "")
 bazel_dep(name = "bazel", version = "", repo_name = "io_bazel")


### PR DESCRIPTION
Context: https://github.com/bazelbuild/bazel-central-registry/pull/28