### PR TITLE
Add protobuf as a well known module

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleKey.java
@@ -34,7 +34,8 @@ public abstract class ModuleKey {
    * situation.
    */
   private static final ImmutableMap<String, String> WELL_KNOWN_MODULES =
-      ImmutableMap.of("com_google_protobuf", "com_google_protobuf");
+      ImmutableMap.of(
+          "com_google_protobuf", "com_google_protobuf", "protobuf", "com_google_protobuf");
 
   public static final ModuleKey ROOT = create("", Version.EMPTY);
 


### PR DESCRIPTION
So that we can safely rename the module name of protobuf from com_google_protobuf to just protobuf.

RELNOTES: None
PiperOrigin-RevId: 405830339