### PR TITLE
Fix the analysis tests

### DIFF
--- a/.bazelci/postsubmit.yml
+++ b/.bazelci/postsubmit.yml
@@ -240,7 +240,6 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/android/desugar/scan/..."
       - "-//src/test/java/com/google/devtools/build/android/desugar/typeannotation/..."
       - "-//src/test/java/com/google/devtools/build/android/r8/..."
-      - "-//src/test/java/com/google/devtools/build/lib/analysis/..."
       - "-//src/test/java/com/google/devtools/build/lib/query2/cquery/..."
       - "-//src/test/java/com/google/devtools/build/lib/query2/engine/..."
       - "-//src/test/java/com/google/devtools/build/lib/versioning/..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -233,7 +233,6 @@ tasks:
       - "-//src/test/java/com/google/devtools/build/android/desugar/scan/..."
       - "-//src/test/java/com/google/devtools/build/android/desugar/typeannotation/..."
       - "-//src/test/java/com/google/devtools/build/android/r8/..."
-      - "-//src/test/java/com/google/devtools/build/lib/analysis/..."
       - "-//src/test/java/com/google/devtools/build/lib/query2/cquery/..."
       - "-//src/test/java/com/google/devtools/build/lib/query2/engine/..."
       - "-//src/test/java/com/google/devtools/build/lib/versioning/..."

--- a/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/SourceManifestAction.java
@@ -54,7 +54,7 @@ public final class SourceManifestAction extends AbstractFileWriteAction {
   private static final String GUID = "07459553-a3d0-4d37-9d78-18ed942470f4";
 
   private static final Comparator<Map.Entry<PathFragment, Artifact>> ENTRY_COMPARATOR =
-      (path1, path2) -> path1.getKey().compareTo(path2.getKey());
+      (path1, path2) -> path1.getKey().getPathString().compareTo(path2.getKey().getPathString());
 
   /**
    * Interface for defining manifest formatting and reporting specifics. Implementations must be
@@ -167,8 +167,7 @@ public final class SourceManifestAction extends AbstractFileWriteAction {
   private void writeFile(OutputStream out, Map<PathFragment, Artifact> output) throws IOException {
     Writer manifestFile = new BufferedWriter(new OutputStreamWriter(out, ISO_8859_1));
     List<Map.Entry<PathFragment, Artifact>> sortedManifest = new ArrayList<>(output.entrySet());
-    Collections.sort(sortedManifest, ENTRY_COMPARATOR);
-
+    sortedManifest.sort(ENTRY_COMPARATOR);
     for (Map.Entry<PathFragment, Artifact> line : sortedManifest) {
       manifestWriter.writeEntry(manifestFile, line.getKey(), line.getValue());
     }

--- a/src/test/java/com/google/devtools/build/lib/analysis/CachingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/CachingTest.java
@@ -51,7 +51,7 @@ public class CachingTest extends BuildViewTestCase {
       if (action instanceof SpawnAction) {
         for (ActionInput string : ((SpawnAction) action).getSpawn().getInputFiles().toList()) {
           lookedAtAnyAction = true;
-          if (string.getExecPathString().endsWith("x_Stool-runfiles")) {
+          if (string.getExecPathString().endsWith("x_Stool-runfiles") || string.getExecPathString().endsWith("x_Stool.exe-runfiles")) {
             foundRunfilesMiddlemanSoRunfilesAreCorrectlyStaged = true;
           } else {
             assertThat(string.getExecPathString().endsWith(".runfiles/MANIFEST")).isFalse();


### PR DESCRIPTION
I changed from comparing objects to comparing the paths the objects correspond to. The tests are looking for ordering based on the path ordering not the object ordering. It is unclear why objects compare differently on linux and windows. 