### PR TITLE
Prevent temporary intermediate files from being picked up by Android ResourceCompiler when building with workers.

### DIFF
--- a/src/tools/android/java/com/google/devtools/build/android/aapt2/ResourceCompiler.java
+++ b/src/tools/android/java/com/google/devtools/build/android/aapt2/ResourceCompiler.java
@@ -357,8 +357,12 @@ public class ResourceCompiler {
 
     @Override
     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-      // Ignore directories and "hidden" files that start with .
-      if (!Files.isDirectory(file) && !file.getFileName().toString().startsWith(".")) {
+      // Ignore directories and "hidden" files that start with ., ends with .tmp or .params files.
+      final String fileName = file.getFileName().toString();
+      if (!Files.isDirectory(file)
+              && !fileName.startsWith(".")
+              && !fileName.endsWith(".tmp")
+              && !fileName.endsWith(".params")) {
         pathToProcessed.add(file);
       }
       return super.visitFile(file, attrs);


### PR DESCRIPTION
When `--persistent_android_resource_processor` is used alongside databinding, `ResourceCompiler` reads `databinding-processed-resources` folder during resource merging and that folder can contain `*.params` file used for the `PROCESS_DATABINDING` action. This causes resource compiler's file name validation to fail. This CL simply ignores staging the intermediate files for resource compilation.

Additionally this CL also excludes `*.tmp` files which were observed when using dynamic remote execution.

Fixes https://github.com/bazelbuild/bazel/issues/13649