### PR TITLE
Add support for wrapping system streams in WorkRequestHandler

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/worker/WorkRequestHandler.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkRequestHandler.java
@@ -18,11 +18,15 @@ import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.sun.management.OperatingSystemMXBean;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -317,8 +321,16 @@ public class WorkRequestHandler implements AutoCloseable {
    * then writing the corresponding {@link WorkResponse} to {@code out}. If there is an error
    * reading or writing the requests or responses, it writes an error message on {@code err} and
    * returns. If {@code in} reaches EOF, it also returns.
+   *
+   * <p>This function also wraps the system streams in a {@link WorkerIO} instance that prevents
+   * calls to {@link System#out} and {@link System#err} from corruption the worker streams. When the
+   * while loop exits, the original system streams will be swapped back into {@link System}.
    */
   public void processRequests() throws IOException {
+    // Wrap the system streams into a WorkerIO instance that can be used
+    // to capture output and error streams that aren't being written to the worker output directly.
+    WorkerIO workerIO = WorkerIO.capture();
+
     try {
       while (!shutdownWorker.get()) {
         WorkRequest request = messageProcessor.readWorkRequest();
@@ -328,31 +340,39 @@ public class WorkRequestHandler implements AutoCloseable {
         if (request.getCancel()) {
           respondToCancelRequest(request);
         } else {
-          startResponseThread(request);
+          startResponseThread(workerIO, request);
         }
       }
     } catch (IOException e) {
       stderr.println("Error reading next WorkRequest: " + e);
       e.printStackTrace(stderr);
-    }
-    // TODO(b/220878242): Give the outstanding requests a chance to send a "shutdown" response,
-    // but also try to kill stuck threads. For now, we just interrupt the remaining threads.
-    // We considered doing System.exit here, but that is hard to test and would deny the callers
-    // of this method a chance to clean up. Instead, we initiate the cleanup of our resources here
-    // and the caller can decide whether to wait for an orderly shutdown or now.
-    for (RequestInfo ri : activeRequests.values()) {
-      if (ri.thread.isAlive()) {
-        try {
-          ri.thread.interrupt();
-        } catch (RuntimeException e) {
-          // If we can't interrupt, we can't do much else.
+    } finally {
+      // TODO(b/220878242): Give the outstanding requests a chance to send a "shutdown" response,
+      // but also try to kill stuck threads. For now, we just interrupt the remaining threads.
+      // We considered doing System.exit here, but that is hard to test and would deny the callers
+      // of this method a chance to clean up. Instead, we initiate the cleanup of our resources here
+      // and the caller can decide whether to wait for an orderly shutdown or now.
+      for (RequestInfo ri : activeRequests.values()) {
+        if (ri.thread.isAlive()) {
+          try {
+            ri.thread.interrupt();
+          } catch (RuntimeException e) {
+            // If we can't interrupt, we can't do much else.
+          }
         }
+      }
+
+      try {
+        // Unwrap the system streams placing the original streams back
+        workerIO.close();
+      } catch (Exception e) {
+        stderr.println(e.getMessage());
       }
     }
   }
 
   /** Starts a thread for the given request. */
-  void startResponseThread(WorkRequest request) {
+  void startResponseThread(WorkerIO workerIO, WorkRequest request) {
     Thread currentThread = Thread.currentThread();
     String threadName =
         request.getRequestId() > 0
@@ -381,7 +401,7 @@ public class WorkRequestHandler implements AutoCloseable {
                 return;
               }
               try {
-                respondToRequest(request, requestInfo);
+                respondToRequest(workerIO, request, requestInfo);
               } catch (IOException e) {
                 // IOExceptions here means a problem talking to the server, so we must shut down.
                 if (!shutdownWorker.compareAndSet(false, true)) {
@@ -419,7 +439,8 @@ public class WorkRequestHandler implements AutoCloseable {
    *     #callback} are reported with exit code 1.
    */
   @VisibleForTesting
-  void respondToRequest(WorkRequest request, RequestInfo requestInfo) throws IOException {
+  void respondToRequest(WorkerIO workerIO, WorkRequest request, RequestInfo requestInfo)
+      throws IOException {
     int exitCode;
     StringWriter sw = new StringWriter();
     try (PrintWriter pw = new PrintWriter(sw)) {
@@ -430,6 +451,16 @@ public class WorkRequestHandler implements AutoCloseable {
       } catch (RuntimeException e) {
         e.printStackTrace(pw);
         exitCode = 1;
+      }
+
+      try {
+        // Read out the captured string for the final WorkResponse output
+        String captured = workerIO.readCapturedAsUtf8String().trim();
+        if (!captured.isEmpty()) {
+          pw.write(captured);
+        }
+      } catch (IOException e) {
+        stderr.println(e.getMessage());
       }
     }
     Optional<WorkResponse.Builder> optBuilder = requestInfo.takeBuilder();
@@ -539,6 +570,106 @@ public class WorkRequestHandler implements AutoCloseable {
           cpuTimeAtLastGc.compareAndSet(currentCpuTime, getCpuTime());
         }
       }
+    }
+  }
+
+  /**
+   * Class that wraps the standard {@link System#in}, {@link System#out}, and {@link System#err}
+   * with our own ByteArrayOutputStream that allows {@link WorkRequestHandler} to safely capture
+   * outputs that can't be directly captured by the PrintStream associated with the work request.
+   *
+   * <p>This is most useful when integrating JVM tools that write exceptions and logs directly to
+   * {@link System#out} and {@link System#err} which corrupt the persistent worker.
+   *
+   * <p>WorkerIO implements {@link AutoCloseable} and will swap the original streams back into
+   * {@link System} once close has been called.
+   */
+  public static class WorkerIO implements AutoCloseable {
+
+    private final InputStream originalInputStream;
+    private final PrintStream originalOutputStream;
+    private final PrintStream originalErrorStream;
+    private final ByteArrayOutputStream capturedStream;
+    private final AutoCloseable restore;
+
+    /**
+     * Creates a new {@link WorkerIO} that allows {@link WorkRequestHandler} to capture standard
+     * output and error streams that can't be directly captured by the PrintStream associated with
+     * the work request.
+     */
+    @VisibleForTesting
+    WorkerIO(
+        InputStream originalInputStream,
+        PrintStream originalOutputStream,
+        PrintStream originalErrorStream,
+        ByteArrayOutputStream capturedStream,
+        AutoCloseable restore) {
+      this.originalInputStream = originalInputStream;
+      this.originalOutputStream = originalOutputStream;
+      this.originalErrorStream = originalErrorStream;
+      this.capturedStream = capturedStream;
+      this.restore = restore;
+    }
+
+    /** Wraps the standard System streams and WorkerIO instance */
+    public static WorkerIO capture() throws IOException {
+      // Save the original streams
+      InputStream originalInputStream = System.in;
+      PrintStream originalOutputStream = System.out;
+      PrintStream originalErrorStream = System.err;
+
+      // Replace the original streams with our own instances
+      ByteArrayOutputStream capturedStream = new ByteArrayOutputStream();
+      PrintStream outputBuffer = new PrintStream(capturedStream, true);
+      ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(new byte[0]);
+      System.setIn(byteArrayInputStream);
+      System.setOut(outputBuffer);
+      System.setErr(outputBuffer);
+
+      return new WorkerIO(
+          originalInputStream,
+          originalOutputStream,
+          originalErrorStream,
+          capturedStream,
+          () -> {
+            System.setIn(originalInputStream);
+            System.setOut(originalOutputStream);
+            System.setErr(originalErrorStream);
+            outputBuffer.close();
+            byteArrayInputStream.close();
+          });
+    }
+
+    /** Returns the original input stream most commonly provided by {@link System#in} */
+    @VisibleForTesting
+    InputStream getOriginalInputStream() {
+      return originalInputStream;
+    }
+
+    /** Returns the original output stream most commonly provided by {@link System#out} */
+    @VisibleForTesting
+    PrintStream getOriginalOutputStream() {
+      return originalOutputStream;
+    }
+
+    /** Returns the original error stream most commonly provided by {@link System#err} */
+    @VisibleForTesting
+    PrintStream getOriginalErrorStream() {
+      return originalErrorStream;
+    }
+
+    /** Returns the captured outputs as a UTF-8 string */
+    @VisibleForTesting
+    String readCapturedAsUtf8String() throws IOException {
+      capturedStream.flush();
+      String captureOutput = capturedStream.toString(StandardCharsets.UTF_8);
+      capturedStream.reset();
+      return captureOutput;
+    }
+
+    @Override
+    public void close() throws Exception {
+      restore.close();
     }
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/worker/WorkRequestHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/worker/WorkRequestHandlerTest.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.PipedInputStream;
@@ -34,6 +35,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,9 +47,16 @@ import org.mockito.MockitoAnnotations;
 @RunWith(JUnit4.class)
 public class WorkRequestHandlerTest {
 
+  private final WorkRequestHandler.WorkerIO testWorkerIO = createTestWorkerIO();
+
   @Before
   public void init() {
     MockitoAnnotations.initMocks(this);
+  }
+
+  @After
+  public void after() throws Exception {
+    testWorkerIO.close();
   }
 
   @Test
@@ -60,7 +70,7 @@ public class WorkRequestHandlerTest {
 
     List<String> args = Arrays.asList("--sources", "A.java");
     WorkRequest request = WorkRequest.newBuilder().addAllArguments(args).build();
-    handler.respondToRequest(request, new RequestInfo(null));
+    handler.respondToRequest(testWorkerIO, request, new RequestInfo(null));
 
     WorkResponse response =
         WorkResponse.parseDelimitedFrom(new ByteArrayInputStream(out.toByteArray()));
@@ -80,7 +90,7 @@ public class WorkRequestHandlerTest {
 
     List<String> args = Arrays.asList("--sources", "A.java");
     WorkRequest request = WorkRequest.newBuilder().addAllArguments(args).setRequestId(42).build();
-    handler.respondToRequest(request, new RequestInfo(null));
+    handler.respondToRequest(testWorkerIO, request, new RequestInfo(null));
 
     WorkResponse response =
         WorkResponse.parseDelimitedFrom(new ByteArrayInputStream(out.toByteArray()));
@@ -236,7 +246,7 @@ public class WorkRequestHandlerTest {
 
     List<String> args = Arrays.asList("--sources", "A.java");
     WorkRequest request = WorkRequest.newBuilder().addAllArguments(args).build();
-    handler.respondToRequest(request, new RequestInfo(null));
+    handler.respondToRequest(testWorkerIO, request, new RequestInfo(null));
 
     WorkResponse response =
         WorkResponse.parseDelimitedFrom(new ByteArrayInputStream(out.toByteArray()));
@@ -258,7 +268,7 @@ public class WorkRequestHandlerTest {
 
     List<String> args = Arrays.asList("--sources", "A.java");
     WorkRequest request = WorkRequest.newBuilder().addAllArguments(args).build();
-    handler.respondToRequest(request, new RequestInfo(null));
+    handler.respondToRequest(testWorkerIO, request, new RequestInfo(null));
 
     WorkResponse response =
         WorkResponse.parseDelimitedFrom(new ByteArrayInputStream(out.toByteArray()));
@@ -518,7 +528,7 @@ public class WorkRequestHandlerTest {
 
     List<String> args = Arrays.asList("--sources", "B.java");
     WorkRequest request = WorkRequest.newBuilder().addAllArguments(args).build();
-    handler.respondToRequest(request, new RequestInfo(null));
+    handler.respondToRequest(testWorkerIO, request, new RequestInfo(null));
 
     WorkResponse response =
         WorkResponse.parseDelimitedFrom(new ByteArrayInputStream(out.toByteArray()));
@@ -551,6 +561,70 @@ public class WorkRequestHandlerTest {
               }
             })
         .start();
+  }
+
+  @Test
+  public void testWorkerIO_doesWrapSystemStreams() throws Exception {
+    // Save the original streams
+    InputStream originalInputStream = System.in;
+    PrintStream originalOutputStream = System.out;
+    PrintStream originalErrorStream = System.err;
+
+    // Swap in the test streams to assert against
+    PrintStream outputBuffer = new PrintStream(new ByteArrayOutputStream(), true);
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(new byte[0]);
+    System.setIn(byteArrayInputStream);
+    System.setOut(outputBuffer);
+    System.setErr(outputBuffer);
+
+    try (outputBuffer;
+        byteArrayInputStream;
+        WorkRequestHandler.WorkerIO io = WorkRequestHandler.WorkerIO.capture()) {
+      // Assert that the WorkerIO returns the correct wrapped streams and the new System instance
+      // has been swapped out with the wrapped one
+      assertThat(io.getOriginalInputStream()).isSameInstanceAs(byteArrayInputStream);
+      assertThat(System.in).isNotSameInstanceAs(byteArrayInputStream);
+
+      assertThat(io.getOriginalOutputStream()).isSameInstanceAs(outputBuffer);
+      assertThat(System.out).isNotSameInstanceAs(outputBuffer);
+
+      assertThat(io.getOriginalErrorStream()).isSameInstanceAs(outputBuffer);
+      assertThat(System.err).isNotSameInstanceAs(outputBuffer);
+    } finally {
+      // Swap back in the original streams
+      System.setIn(originalInputStream);
+      System.setOut(originalOutputStream);
+      System.setErr(originalErrorStream);
+    }
+  }
+
+  @Test
+  public void testWorkerIO_doesCaptureStandardOutAndErrorStreams() throws Exception {
+    try (WorkRequestHandler.WorkerIO io = WorkRequestHandler.WorkerIO.capture()) {
+      // Assert that nothing has been captured in the new instance
+      assertThat(io.readCapturedAsUtf8String()).isEmpty();
+
+      // Assert that the standard out/error stream redirect to our own streams
+      System.out.print("This is a standard out message!");
+      System.err.print("This is a standard error message!");
+      assertThat(io.readCapturedAsUtf8String())
+          .isEqualTo("This is a standard out message!This is a standard error message!");
+
+      // Assert that readCapturedAsUtf8String calls reset on the captured stream after a read
+      assertThat(io.readCapturedAsUtf8String()).isEmpty();
+
+      System.out.print("out 1");
+      System.err.print("err 1");
+      System.out.print("out 2");
+      System.err.print("err 2");
+      assertThat(io.readCapturedAsUtf8String()).isEqualTo("out 1err 1out 2err 2");
+      assertThat(io.readCapturedAsUtf8String()).isEmpty();
+    }
+  }
+
+  private WorkRequestHandler.WorkerIO createTestWorkerIO() {
+    ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    return new WorkRequestHandler.WorkerIO(System.in, System.out, System.err, captured, captured);
   }
 
   /** A wrapper around a WorkerMessageProcessor that can be stopped by calling {@code #stop()}. */


### PR DESCRIPTION
There are often [places](https://github.com/bazelbuild/bazel/blob/ea19c17075478092eb77580e6d3825d480126d3a/src/tools/android/java/com/google/devtools/build/android/ResourceProcessorBusyBox.java#L188) where persistent workers need to swap out the standard system streams to avoid tools poisoning the worker communication streams by writing logs/exceptions to it.

This pull request extracts that pattern into an optional WorkerIO wrapper can be used to swap in and out the standard streams without the added boilerplate.