### PR TITLE
Remote: Limit max number of gRPC connections by --remote_max_connections.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannel.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ReferenceCountedChannel.java
@@ -62,8 +62,12 @@ public class ReferenceCountedChannel extends Channel implements ReferenceCounted
   private final AtomicReference<String> authorityRef = new AtomicReference<>();
 
   public ReferenceCountedChannel(ChannelConnectionFactory connectionFactory) {
+      this(connectionFactory, /*maxConnections=*/ 0);
+  }
+
+  public ReferenceCountedChannel(ChannelConnectionFactory connectionFactory, int maxConnections) {
     this.dynamicConnectionPool =
-        new DynamicConnectionPool(connectionFactory, connectionFactory.maxConcurrency());
+        new DynamicConnectionPool(connectionFactory, connectionFactory.maxConcurrency(), maxConnections);
   }
 
   public boolean isShutdown() {
@@ -87,12 +91,12 @@ public class ReferenceCountedChannel extends Channel implements ReferenceCounted
               responseListener) {
             @Override
             public void onClose(Status status, Metadata trailers) {
-              super.onClose(status, trailers);
-
               try {
                 connection.close();
               } catch (IOException e) {
                 throw new AssertionError(e.getMessage(), e);
+              } finally {
+                super.onClose(status, trailers);
               }
             }
           },

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -352,6 +352,17 @@ public final class RemoteModule extends BlazeModule {
     // based on the resolved IPs of that server. We assume servers normally have 2 IPs. So the
     // max concurrency per connection is 100.
     int maxConcurrencyPerConnection = 100;
+    int maxConnections = 0;
+    if (remoteOptions.incompatibleRemoteMaxConnectionsGrpc
+        && remoteOptions.remoteMaxConnections > 0) {
+      maxConnections =
+          (int)
+              Math.ceil(
+                  (double) remoteOptions.remoteMaxConnections
+                      / (double) maxConcurrencyPerConnection);
+      maxConcurrencyPerConnection =
+          (int) Math.ceil((double) remoteOptions.remoteMaxConnections / (double) maxConnections);
+    }
 
     if (enableRemoteExecution) {
       ImmutableList.Builder<ClientInterceptor> interceptors = ImmutableList.builder();
@@ -368,7 +379,7 @@ public final class RemoteModule extends BlazeModule {
                   authAndTlsOptions,
                   interceptors.build(),
                   maxConcurrencyPerConnection),
-              remoteOptions.remoteMaxConnections);
+              maxConnections);
 
       // Create a separate channel if --remote_executor and --remote_cache point to different
       // endpoints.
@@ -392,7 +403,7 @@ public final class RemoteModule extends BlazeModule {
                   authAndTlsOptions,
                   interceptors.build(),
                   maxConcurrencyPerConnection),
-              remoteOptions.remoteMaxConnections);
+              maxConnections);
     }
 
     if (enableRemoteDownloader) {
@@ -414,7 +425,7 @@ public final class RemoteModule extends BlazeModule {
                     authAndTlsOptions,
                     interceptors.build(),
                     maxConcurrencyPerConnection),
-                remoteOptions.remoteMaxConnections);
+                maxConnections);
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -353,15 +353,8 @@ public final class RemoteModule extends BlazeModule {
     // max concurrency per connection is 100.
     int maxConcurrencyPerConnection = 100;
     int maxConnections = 0;
-    if (remoteOptions.incompatibleRemoteMaxConnectionsGrpc
-        && remoteOptions.remoteMaxConnections > 0) {
-      maxConnections =
-          (int)
-              Math.ceil(
-                  (double) remoteOptions.remoteMaxConnections
-                      / (double) maxConcurrencyPerConnection);
-      maxConcurrencyPerConnection =
-          (int) Math.ceil((double) remoteOptions.remoteMaxConnections / (double) maxConnections);
+    if (remoteOptions.remoteMaxConnections > 0) {
+      maxConnections = remoteOptions.remoteMaxConnections;
     }
 
     if (enableRemoteExecution) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -367,7 +367,8 @@ public final class RemoteModule extends BlazeModule {
                   remoteOptions.remoteProxy,
                   authAndTlsOptions,
                   interceptors.build(),
-                  maxConcurrencyPerConnection));
+                  maxConcurrencyPerConnection),
+              remoteOptions.remoteMaxConnections);
 
       // Create a separate channel if --remote_executor and --remote_cache point to different
       // endpoints.
@@ -390,7 +391,8 @@ public final class RemoteModule extends BlazeModule {
                   remoteOptions.remoteProxy,
                   authAndTlsOptions,
                   interceptors.build(),
-                  maxConcurrencyPerConnection));
+                  maxConcurrencyPerConnection),
+              remoteOptions.remoteMaxConnections);
     }
 
     if (enableRemoteDownloader) {
@@ -411,7 +413,8 @@ public final class RemoteModule extends BlazeModule {
                     remoteOptions.remoteProxy,
                     authAndTlsOptions,
                     interceptors.build(),
-                    maxConcurrencyPerConnection));
+                    maxConcurrencyPerConnection),
+                remoteOptions.remoteMaxConnections);
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -64,8 +64,7 @@ public final class RemoteOptions extends OptionsBase {
       effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
       help =
           "Limit the max number of concurrent requests to remote cache/executor. By default the"
-              + " value is 100. Setting this to 0 will make Bazel choose the number of connections"
-              + " automatically.\n"
+              + " value is 100. Setting this to 0 means no limitation.\n"
               + "For HTTP remote cache, one TCP connection could handle one request at one time, so"
               + " it could open up to --remote_max_connections TCP connections.\n"
               + "If --incompatible_remote_max_connections_grpc is set, this also applies to the"

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -68,7 +68,7 @@ public final class RemoteOptions extends OptionsBase {
               + "For HTTP remote cache, one TCP connection could handle one request at one time, so"
               + " it could open up to --remote_max_connections TCP connections.\n"
               + "If --incompatible_remote_max_connections_grpc is set, this also applies to the"
-              + " gRPC remote cache/executor, for which, one TCP connection could usually handle"
+              + " gRPC remote cache/executor, for which, one gRPC channel could usually handle"
               + " 100+ concurrent requests, so it could open up to `--remote_max_connections / 100`"
               + " gRPC channels. Each gRPC channel could open 1 or more TCP connections depending"
               + " on the number of resolved server IPs.")

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -63,11 +63,16 @@ public final class RemoteOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
       help =
-          "The max. number of concurrent network requests to the HTTP remote cache. By default the"
+          "Limit the max number of concurrent requests to remote cache/executor. By default the"
               + " value is 100. Setting this to 0 will make Bazel choose the number of connections"
               + " automatically.\n"
-              + "If --incompatible_remote_max_connections_grpc is set, this also applies"
-              + " to the gRPC remote cache/executor.")
+              + "For HTTP remote cache, one TCP connection could handle one request at one time, so"
+              + " it could open up to --remote_max_connections TCP connections.\n"
+              + "If --incompatible_remote_max_connections_grpc is set, this also applies to the"
+              + " gRPC remote cache/executor, for which, one TCP connection could usually handle"
+              + " 100+ concurrent requests, so it could open up to `--remote_max_connections / 100`"
+              + " gRPC channels. Each gRPC channel could open 1 or more TCP connections depending"
+              + " on the number of resolved server IPs.")
   public int remoteMaxConnections;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -59,14 +59,25 @@ public final class RemoteOptions extends OptionsBase {
 
   @Option(
       name = "remote_max_connections",
-      defaultValue = "0",
+      defaultValue = "100",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
       help =
-          "The max. number of concurrent network connections to the remote cache/executor. By"
-              + " default the value is set to 0 which will make Bazel choose the number of"
-              + " connections automatically.")
+          "The max. number of concurrent network requests to the HTTP remote cache. By default the"
+              + " value is 100. Setting this to 0 will make Bazel choose the number of connections"
+              + " automatically.\n"
+              + "If --incompatible_remote_max_connections_grpc is set, this also applies"
+              + " to the gRPC remote cache/executor.")
   public int remoteMaxConnections;
+
+  @Option(
+      name = "incompatible_remote_max_connections_grpc",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help = "If set to true, --remote_max_connections also applies to gRPC cache/executor.")
+  public boolean incompatibleRemoteMaxConnectionsGrpc;
 
   @Option(
       name = "remote_executor",

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -59,13 +59,13 @@ public final class RemoteOptions extends OptionsBase {
 
   @Option(
       name = "remote_max_connections",
-      defaultValue = "100",
+      defaultValue = "0",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
       help =
-          "The max. number of concurrent network connections to the remote cache/executor. By "
-              + "default Bazel limits the number of TCP connections to 100. Setting this flag to "
-              + "0 will make Bazel choose the number of connections automatically.")
+          "The max. number of concurrent network connections to the remote cache/executor. By"
+              + " default the value is set to 0 which will make Bazel choose the number of"
+              + " connections automatically.")
   public int remoteMaxConnections;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -67,8 +67,8 @@ public final class RemoteOptions extends OptionsBase {
               + " value is 100. Setting this to 0 means no limitation.\n"
               + "For HTTP remote cache, one TCP connection could handle one request at one time, so"
               + " it could open up to --remote_max_connections TCP connections.\n"
-              + "If --incompatible_remote_max_connections_grpc is set, this also applies to the"
-              + " gRPC remote cache/executor. One gRPC channel could usually handle 100+ concurrent"
+              + "If --incompatible_remote_max_connections_grpc is set, this also applies to gRPC"
+              + " remote cache/executor. One gRPC channel could usually handle 100+ concurrent"
               + " requests. We assume the number is 100, so it could open up to"
               + " `--remote_max_connections / 100` gRPC channels. Each gRPC channel could open 1 or"
               + " more TCP connections depending on the number of resolved server IPs.")

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -68,10 +68,10 @@ public final class RemoteOptions extends OptionsBase {
               + "For HTTP remote cache, one TCP connection could handle one request at one time, so"
               + " it could open up to --remote_max_connections TCP connections.\n"
               + "If --incompatible_remote_max_connections_grpc is set, this also applies to the"
-              + " gRPC remote cache/executor, for which, one gRPC channel could usually handle"
-              + " 100+ concurrent requests, so it could open up to `--remote_max_connections / 100`"
-              + " gRPC channels. Each gRPC channel could open 1 or more TCP connections depending"
-              + " on the number of resolved server IPs.")
+              + " gRPC remote cache/executor. One gRPC channel could usually handle 100+ concurrent"
+              + " requests. We assume the number is 100, so it could open up to"
+              + " `--remote_max_connections / 100` gRPC channels. Each gRPC channel could open 1 or"
+              + " more TCP connections depending on the number of resolved server IPs.")
   public int remoteMaxConnections;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -63,25 +63,14 @@ public final class RemoteOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
       help =
-          "Limit the max number of concurrent requests to remote cache/executor. By default the"
+          "Limit the max number of concurrent connections to remote cache/executor. By default the"
               + " value is 100. Setting this to 0 means no limitation.\n"
               + "For HTTP remote cache, one TCP connection could handle one request at one time, so"
-              + " it could open up to --remote_max_connections TCP connections.\n"
-              + "If --incompatible_remote_max_connections_grpc is set, this also applies to gRPC"
-              + " remote cache/executor. One gRPC channel could usually handle 100+ concurrent"
-              + " requests. We assume the number is 100, so it could open up to"
-              + " `--remote_max_connections / 100` gRPC channels. Each gRPC channel could open 1 or"
-              + " more TCP connections depending on the number of resolved server IPs.")
+              + " Bazel could make up to --remote_max_connections concurrent requests.\n"
+              + "For gRPC remote cache/executor, one gRPC channel could usually handle 100+"
+              + " concurrent requests, so Bazel could make around `--remote_max_connections * 100`"
+              + " concurrent requests.")
   public int remoteMaxConnections;
-
-  @Option(
-      name = "incompatible_remote_max_connections_grpc",
-      defaultValue = "false",
-      documentationCategory = OptionDocumentationCategory.REMOTE,
-      effectTags = {OptionEffectTag.UNKNOWN},
-      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
-      help = "If set to true, --remote_max_connections also applies to gRPC cache/executor.")
-  public boolean incompatibleRemoteMaxConnectionsGrpc;
 
   @Option(
       name = "remote_executor",


### PR DESCRIPTION
`--remote_max_connections` is only applied to HTTP remote cache. This PR makes it apply to gRPC cache/executor as well.

Note that `--remote_max_connections` limits the number of concurrent connections. For HTTP remote cache, one connection could handle one request at one time. For gRPC remote cache/executor, one connection could handle 100+ concurrent requests. So the default value `100` means we could make up to `100` concurrent requests for HTTP remote cache or `10000+` concurrent requests for gRPC remote cache/executor.

Fixes: #14178.

