### PR TITLE
Remote: Fixes an issue when --experimental_remote_cache_async encounter flaky tests.

### DIFF
--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3171,4 +3171,31 @@ EOF
   expect_log "-r-xr-xr-x"
 }
 
+function test_async_upload_works_for_flaky_tests() {
+  mkdir -p a
+  cat > a/BUILD <<EOF
+sh_test(
+    name = "test",
+    srcs = ["test.sh"],
+)
+EOF
+  cat > a/test.sh <<EOF
+#!/bin/sh
+echo "it always fails"
+exit 1
+EOF
+  chmod +x a/test.sh
+
+  # Check the error message when failed to upload
+  bazel test --remote_cache=http://nonexistent.example.org //a:test >& $TEST_log && fail "expected failure" || true
+  expect_log "WARNING: Writing to Remote Cache:"
+
+  bazel test \
+    --remote_cache=grpc://localhost:${worker_port} \
+    --experimental_remote_cache_async \
+    --flaky_test_attempts=2 \
+    //a:test >& $TEST_log  && fail "expected failure" || true
+  expect_not_log "WARNING: Writing to Remote Cache:"
+}
+
 run_suite "Remote execution and remote cache tests"

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3178,6 +3178,12 @@ sh_test(
     name = "test",
     srcs = ["test.sh"],
 )
+
+genrule(
+  name = "foo",
+  outs = ["foo.txt"],
+  cmd = "echo \"foo bar\" > \$@",
+)
 EOF
   cat > a/test.sh <<EOF
 #!/bin/sh
@@ -3187,7 +3193,7 @@ EOF
   chmod +x a/test.sh
 
   # Check the error message when failed to upload
-  bazel test --remote_cache=http://nonexistent.example.org //a:test >& $TEST_log && fail "expected failure" || true
+  bazel build --remote_cache=http://nonexistent.example.org //a:foo >& $TEST_log || fail "Failed to build"
   expect_log "WARNING: Writing to Remote Cache:"
 
   bazel test \


### PR DESCRIPTION
When `--experimental_remote_cache_async` is set, the uploads happened in the background -- usually after spawn execution.

When the test is failed and there is another test attempt, the outputs of previous test attempt are moved to other places immediately after spawn execution. This fine when combining `--experimental_remote_cache_async`  because outputs of failed action don't get uploaded.

However, there is an exception that `test.xml` is generated with another spawn before the "move" happens. The result of the spawn used to generate `test.xml` is usually "succeed" which means Bazel will attempt upload `test.xml` even if the test itself is failed.

This PR makes the `test.xml` generation spawn ignores remote cache if the test itself is failed.

Fixes #14008.