### PR TITLE
Bzlmod: add workspace_name attribute to module directive

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Module.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Module.java
@@ -47,6 +47,12 @@ public abstract class Module {
    */
   public abstract Version getVersion();
 
+  /*
+   * The preferred workspace name of this module. If specified, the module can access its own
+   * targets with this repository name.
+   */
+  public abstract String getWorkspaceName();
+
   /**
    * The key of this module in the dependency graph. Note that, although a {@link ModuleKey} is also
    * just a (name, version) pair, its semantics differ from {@link #getName} and {@link
@@ -109,6 +115,13 @@ public abstract class Module {
           RepositoryName.createFromValidStrippedName(getName()),
           RepositoryName.createFromValidStrippedName(getCanonicalRepoName()));
     }
+    // If workspace name is specified, this module should be able to access its own targets
+    // with the preferred workspace name.
+    if (!getWorkspaceName().isEmpty()) {
+      mapping.put(
+          RepositoryName.createFromValidStrippedName(getWorkspaceName()),
+          RepositoryName.createFromValidStrippedName(getCanonicalRepoName()));
+    }
     for (Map.Entry<String, ModuleKey> dep : getDeps().entrySet()) {
       // Special note: if `dep` is actually the root module, its ModuleKey would be ROOT whose
       // canonicalRepoName is the empty string. This perfectly maps to the main repo ("@").
@@ -138,6 +151,7 @@ public abstract class Module {
         .setName("")
         .setVersion(Version.EMPTY)
         .setKey(ModuleKey.ROOT)
+        .setWorkspaceName("")
         .setCompatibilityLevel(0)
         .setExecutionPlatformsToRegister(ImmutableList.of())
         .setToolchainsToRegister(ImmutableList.of());
@@ -161,6 +175,9 @@ public abstract class Module {
 
     /** Optional; defaults to {@link Version#EMPTY}. */
     public abstract Builder setVersion(Version value);
+
+    /** Optional; defaults to the empty string. */
+    public abstract Builder setWorkspaceName(String value);
 
     /** Optional; defaults to {@link ModuleKey#ROOT}. */
     public abstract Builder setKey(ModuleKey value);

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileGlobals.java
@@ -106,6 +106,15 @@ public class ModuleFileGlobals {
             named = true,
             positional = false,
             defaultValue = "''"),
+          @Param(
+              name = "workspace_name",
+              doc =
+                  "When specified, the module can refer to its own targets under this repository name."
+                      + "This attribute is only for migration purpose when the current workspace "
+                      + "name is different from the module name.",
+              named = true,
+              positional = false,
+              defaultValue = "''"),
         @Param(
             name = "compatibility_level",
             // TODO(wyv): See X for more details
@@ -151,6 +160,7 @@ public class ModuleFileGlobals {
   public void module(
       String name,
       String version,
+      String workspaceName,
       StarlarkInt compatibilityLevel,
       Iterable<?> executionPlatformsToRegister,
       Iterable<?> toolchainsToRegister,
@@ -170,6 +180,7 @@ public class ModuleFileGlobals {
     module
         .setName(name)
         .setVersion(parsedVersion)
+        .setWorkspaceName(workspaceName)
         .setCompatibilityLevel(compatibilityLevel.toInt("compatibility_level"))
         .setExecutionPlatformsToRegister(
             checkAllAbsolutePatterns(
@@ -177,6 +188,9 @@ public class ModuleFileGlobals {
         .setToolchainsToRegister(
             checkAllAbsolutePatterns(toolchainsToRegister, "toolchains_to_register"));
     addRepoNameUsage(name, "as the current module name", thread.getCallerLocation());
+    if (!workspaceName.isEmpty()) {
+      addRepoNameUsage(workspaceName, "as the workspace name", thread.getCallerLocation());
+    }
   }
 
   private static ImmutableList<String> checkAllAbsolutePatterns(Iterable<?> iterable, String where)

--- a/src/test/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/RepositoryMappingFunctionTest.java
@@ -131,7 +131,7 @@ public class RepositoryMappingFunctionTest extends BuildViewTestCase {
   public void testRepoNameMapping_asMainModule() throws Exception {
     scratch.overwriteFile(
         "MODULE.bazel",
-        "module(name='A',version='0.1')",
+        "module(name='A',version='0.1', workspace_name = 'com_foo_bar_a')",
         "bazel_dep(name='B',version='1.0', repo_name = 'com_foo_bar_b')");
     registry.addModule(createModuleKey("B", "1.0"), "module(name='B', version='1.0')");
 
@@ -146,6 +146,8 @@ public class RepositoryMappingFunctionTest extends BuildViewTestCase {
             withMappingForRootModule(
                 ImmutableMap.of(
                     RepositoryName.create("@"),
+                    RepositoryName.create("@"),
+                    RepositoryName.create("@com_foo_bar_a"),
                     RepositoryName.create("@"),
                     RepositoryName.create("@A"),
                     RepositoryName.create("@"),
@@ -165,7 +167,7 @@ public class RepositoryMappingFunctionTest extends BuildViewTestCase {
         .addModule(createModuleKey("B", "1.0"), "module(name='B', version='1.0')")
         .addModule(
             createModuleKey("C", "1.0"),
-            "module(name='C', version='1.0')",
+            "module(name='C', version='1.0', workspace_name = 'com_foo_bar_c')",
             "bazel_dep(name='B', version='1.0', repo_name='com_foo_bar_b')");
 
     RepositoryName name = RepositoryName.create("@C.1.0");
@@ -179,6 +181,8 @@ public class RepositoryMappingFunctionTest extends BuildViewTestCase {
             withMapping(
                 ImmutableMap.of(
                     RepositoryName.create("@C"),
+                    RepositoryName.create("@C.1.0"),
+                    RepositoryName.create("@com_foo_bar_c"),
                     RepositoryName.create("@C.1.0"),
                     RepositoryName.create("@com_foo_bar_b"),
                     RepositoryName.create("@B.1.0")),


### PR DESCRIPTION
Modules can specify the workspace_name attribute to allow accessing its
own targets under the repo name.

This helps make migration easier when the preferred workspace name is
different from the module name of the project.

Context: https://github.com/bazelbuild/bazel-central-registry/pull/28#issuecomment-954741081