### PR TITLE
Update issue template to use HTML comments.

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,8 @@
-> ATTENTION! Please read and follow:
-> - if this is a _question_ about how to build / test / query / deploy using Bazel, or a _discussion starter_, send it to bazel-discuss@googlegroups.com
-> - if this is a _bug_ or _feature request_, fill the form below as best as you can.
+<!--
+ATTENTION! Please read and follow:
+- if this is a _question_ about how to build / test / query / deploy using Bazel, or a _discussion starter_, send it to bazel-discuss@googlegroups.com
+- if this is a _bug_ or _feature request_, fill the form below as best as you can.
+-->
 
 ### Description of the problem / feature request:
 
@@ -33,14 +35,16 @@
 ###  Have you found anything relevant by searching the web?
 
 > Replace these lines with your answer.
->
-> Places to look:
-> - StackOverflow: http://stackoverflow.com/questions/tagged/bazel
-> - GitHub issues: https://github.com/bazelbuild/bazel/issues
-> - email threads on https://groups.google.com/forum/#!forum/bazel-discuss
+
+<!--
+Places to look:
+ - StackOverflow: http://stackoverflow.com/questions/tagged/bazel
+ - GitHub issues: https://github.com/bazelbuild/bazel/issues
+ - email threads on https://groups.google.com/forum/#!forum/bazel-discuss
+-->
 
 ### Any other information, logs, or outputs that you want to share?
 
 > Replace these lines with your answer.
->
-> If the files are large, upload as attachment or provide link.
+
+<!-- If the files are large, upload as attachment or provide link. -->

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -34,7 +34,7 @@ ATTENTION! Please read and follow:
 
 ###  Have you found anything relevant by searching the web?
 
-> Replace these lines with your answer.
+> Replace this line with your answer.
 
 <!--
 Places to look:
@@ -45,6 +45,6 @@ Places to look:
 
 ### Any other information, logs, or outputs that you want to share?
 
-> Replace these lines with your answer.
+> Replace this line with your answer.
 
 <!-- If the files are large, upload as attachment or provide link. -->


### PR DESCRIPTION
GitHub supports the use of HTML comment blocks in markdown that show up
in the raw text of a Markdown body but are not rendered.

This is perfect for instructional text, as it makes it visible to the authors when
editing the text, but does not take up room in the rendered markdown (where
it does not need to be visible)

[Rendered version (where comments are hidden)](https://github.com/psigen/bazel/blob/patch-3/ISSUE_TEMPLATE.md)