### PR TITLE
Remote: Update FilesystemValueChecker to handle the case that a file was remote but is now staged.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/FilesystemValueChecker.java
@@ -468,9 +468,8 @@ public class FilesystemValueChecker {
       FileArtifactValue fileMetadata =
           ActionMetadataHandler.fileArtifactValueFromArtifact(file, null, tsgm);
 
-      if (lastKnownData.isRemote()
-          && !fileMetadata.isRemote()
-          && fileMetadata.getType() == FileStateType.REGULAR_FILE) {
+      if (lastKnownData.isRemote() && lastKnownData.getType() == FileStateType.REGULAR_FILE
+          && !fileMetadata.isRemote() && fileMetadata.getType() == FileStateType.REGULAR_FILE) {
         // If the file was remote but is now staged, we compare the digests.
         byte[] digest = DigestUtils.manuallyComputeDigest(file.getPath(), fileMetadata.getSize());
         if (Arrays.equals(digest, lastKnownData.getDigest())


### PR DESCRIPTION
When using BwtB, intermediate outputs are not downloaded. When an action is going to execute locally (either is decided by dynamic execution or is forced to run locally), Bazel will download all the inputs which are outputs of dependent actions and the downloaded file are kept after build.

For a following build, Bazel doesn't realize the downloaded files are the same as remote ones. It marks those generating actions dirty and try to re-execute. Normally, this re-execution will be skipped due to the action cache. However, if only part of the outputs are downloaded, the action cache can't help.

This PR update FilesystemValueChecker to compare between previous remote metadata and current local file metadata so the generating action isn't invalidated if the output files are staged and are same with remote ones.

This PR only fixes output files. A following PR is needed to handle output tree artifacts.

Fixes #13912.