### PR TITLE
bzlmod: Add support for WORKSPACE.bzlmod

### DIFF
--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,31 +1,425 @@
-# Replace the original WORKSPACE file with this file to build Bazel with bzlmod.
-# We still need the bind rules to make protobuf work.
+# Replace the original WORKSPACE file with this file to build Bazel with Bzlmod.
+# When using the WORKSPACE.bzlmod, no WORKSPACE prefix or suffix are added.
+# Therefore, we need to keep some legacy content to make the build work, eventually this
+# file should be empty after fully migrating to Bzlmod.
 workspace(name = "io_bazel")
 
 # Required by @com_google_protobuf//java/util:util in protobuf 3.19.0
 # TODO(pcloudy): Remove those bind rules, when com_google_protobuf can
 # fetch jar dependencies via rules_jvm_external with module extension.
 bind(
-  name = "error_prone_annotations",
-  actual = "//third_party:error_prone_annotations",
+    name = "error_prone_annotations",
+    actual = "//third_party:error_prone_annotations",
 )
 
 bind(
-  name = "j2objc_annotations",
-  actual = "//third_party/java/j2objc-annotations:j2objc-annotations",
+    name = "j2objc_annotations",
+    actual = "//third_party/java/j2objc-annotations:j2objc-annotations",
 )
 
 bind(
-  name = "gson",
-  actual = "//third_party:gson",
+    name = "gson",
+    actual = "//third_party:gson",
 )
 
 bind(
-  name = "jsr305",
-  actual = "//third_party:jsr305",
+    name = "jsr305",
+    actual = "//third_party:jsr305",
 )
 
 bind(
-  name = "guava",
-  actual = "//third_party:guava",
+    name = "guava",
+    actual = "//third_party:guava",
 )
+
+########### Required by cc rules, should be moved to rules_cc. ###########
+// Copied from cc_configure.WORKSPACE
+load("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_configure")
+cc_configure()
+
+########### Required on cc rules on macos, should be moved to rules_cc? ###########
+// Copied from xcode_configure.WORKSPACE
+load("@bazel_tools//tools/osx:xcode_configure.bzl", "xcode_configure")
+xcode_configure("@bazel_tools//tools/osx:xcode_locator.m")
+
+########### Required by python rules, should be moved to rules_python. ############
+// Copied from python.WORKSPACE
+register_toolchains("@bazel_tools//tools/python:autodetecting_toolchain")
+
+############ Required by java rules, should be moved to rules_java. ############
+// Copied from jdk.WORKSPACE
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@bazel_tools//tools/jdk:local_java_repository.bzl", "local_java_repository")
+load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+
+maybe(
+    local_java_repository,
+    name = "local_jdk",
+    java_home = DEFAULT_SYSTEM_JAVABASE,
+    build_file = "@bazel_tools//tools/jdk:jdk.BUILD",
+)
+
+# OpenJDK distributions that should only be downloaded on demand (e.g. when
+# building a java_library or a genrule that uses java make variables).
+# This will allow us to stop bundling the full JDK with Bazel.
+# Note that while these are currently the same as the openjdk_* rules in
+# Bazel's WORKSPACE file, but they don't have to be the same.
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk11_linux",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    sha256 = "b8e8a63b79bc312aa90f3558edbea59e71495ef1a9c340e38900dd28a1c579f3",
+    strip_prefix = "zulu11.50.19-ca-jdk11.0.12-linux_x64",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu11.50.19-ca-jdk11.0.12/zulu11.50.19-ca-jdk11.0.12-linux_x64.tar.gz",
+    ],
+    version = "11",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk11_linux_aarch64",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+    sha256 = "61254688067454d3ccf0ef25993b5dcab7b56c8129e53b73566c28a8dd4d48fb",
+    strip_prefix = "zulu11.50.19-ca-jdk11.0.12-linux_aarch64",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu11.50.19-ca-jdk11.0.12/zulu11.50.19-ca-jdk11.0.12-linux_aarch64.tar.gz",
+    ],
+    version = "11",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk11_linux_ppc64le",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:ppc",
+    ],
+    sha256 = "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
+    strip_prefix = "jdk-11.0.7+10",
+    urls = [
+        "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+        "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+    ],
+    version = "11",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk11_linux_s390x",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:s390x",
+    ],
+    sha256 = "d9b72e87a1d3ebc0c9552f72ae5eb150fffc0298a7cb841f1ce7bfc70dcd1059",
+    strip_prefix = "jdk-11.0.7+10",
+    urls = [
+        "https://mirror.bazel.build/github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz",
+        "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz",
+    ],
+    version = "11",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk11_macos",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+    sha256 = "0b8c8b7cf89c7c55b7e2239b47201d704e8d2170884875b00f3103cf0662d6d7",
+    strip_prefix = "zulu11.50.19-ca-jdk11.0.12-macosx_x64",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu11.50.19-ca-jdk11.0.12/zulu11.50.19-ca-jdk11.0.12-macosx_x64.tar.gz",
+    ],
+    version = "11",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk11_macos_aarch64",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:aarch64",
+    ],
+    sha256 = "e908a0b4c0da08d41c3e19230f819b364ff2e5f1dafd62d2cf991a85a34d3a17",
+    strip_prefix = "zulu11.50.19-ca-jdk11.0.12-macosx_aarch64",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu11.50.19-ca-jdk11.0.12/zulu11.50.19-ca-jdk11.0.12-macosx_aarch64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-macosx_aarch64.tar.gz",
+    ],
+    version = "11",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk11_win",
+    exec_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    sha256 = "42ae65e75d615a3f06a674978e1fa85fdf078cad94e553fee3e779b2b42bb015",
+    strip_prefix = "zulu11.50.19-ca-jdk11.0.12-win_x64",
+    urls = [
+        "https://mirror.bazel.build/openjdk/azul-zulu11.50.19-ca-jdk11.0.12/zulu11.50.19-ca-jdk11.0.12-win_x64.zip",
+    ],
+    version = "11",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk15_linux",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    sha256 = "0a38f1138c15a4f243b75eb82f8ef40855afcc402e3c2a6de97ce8235011b1ad",
+    strip_prefix = "zulu15.27.17-ca-jdk15.0.0-linux_x64",
+    urls = [
+        "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz",
+    ],
+    version = "15",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk15_macos",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+    sha256 = "f80b2e0512d9d8a92be24497334c974bfecc8c898fc215ce0e76594f00437482",
+    strip_prefix = "zulu15.27.17-ca-jdk15.0.0-macosx_x64",
+    urls = [
+        "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-macosx_x64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-macosx_x64.tar.gz",
+    ],
+    version = "15",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk15_macos_aarch64",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:aarch64",
+    ],
+    sha256 = "2613c3f15eef6b6ecd0fd102da92282b985e4573905dc902f1783d8059c1efc5",
+    strip_prefix = "zulu15.29.15-ca-jdk15.0.2-macosx_aarch64",
+    urls = [
+        "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.29.15-ca-jdk15.0.2-macosx_aarch64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu15.29.15-ca-jdk15.0.2-macosx_aarch64.tar.gz",
+    ],
+    version = "15",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk15_win",
+    exec_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    sha256 = "f535a530151e6c20de8a3078057e332b08887cb3ba1a4735717357e72765cad6",
+    strip_prefix = "zulu15.27.17-ca-jdk15.0.0-win_x64",
+    urls = [
+        "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-win_x64.zip",
+        "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-win_x64.zip",
+    ],
+    version = "15",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk16_linux",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    sha256 = "236b5ea97aff3cb312e743848d7efa77faf305170e41371a732ca93c1b797665",
+    strip_prefix = "zulu16.28.11-ca-jdk16.0.0-linux_x64",
+    urls = [
+        "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu16.28.11-ca-jdk16.0.0-linux_x64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu16.28.11-ca-jdk16.0.0-linux_x64.tar.gz",
+    ],
+    version = "16",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk16_macos",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+    sha256 = "6d47ef22dc56ce1f5a102ed39e21d9a97320f0bb786818e2c686393109d79bc5",
+    strip_prefix = "zulu16.28.11-ca-jdk16.0.0-macosx_x64",
+    urls = [
+        "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu16.28.11-ca-jdk16.0.0-macosx_x64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu16.28.11-ca-jdk16.0.0-macosx_x64.tar.gz",
+    ],
+    version = "16",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk16_macos_aarch64",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:aarch64",
+    ],
+    sha256 = "c92131e83bc71474850e667bc4e05fca33662b8feb009a0547aa14e76b40e890",
+    strip_prefix = "zulu16.28.11-ca-jdk16.0.0-macosx_aarch64",
+    urls = [
+        "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu16.28.11-ca-jdk16.0.0-macosx_aarch64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu16.28.11-ca-jdk16.0.0-macosx_aarch64.tar.gz",
+    ],
+    version = "16",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk16_win",
+    exec_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    sha256 = "6cbf98ada27476526a5f6dff79fd5f2c15e2f671818e503bdf741eb6c8fed3d4",
+    strip_prefix = "zulu16.28.11-ca-jdk16.0.0-win_x64",
+    urls = [
+        "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu16.28.11-ca-jdk16.0.0-win_x64.zip",
+        "https://cdn.azul.com/zulu/bin/zulu16.28.11-ca-jdk16.0.0-win_x64.zip",
+    ],
+    version = "16",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk17_linux",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    sha256 = "37c4f8e48536cceae8c6c20250d6c385e176972532fd35759fa7d6015c965f56",
+    strip_prefix = "zulu17.28.13-ca-jdk17.0.0-linux_x64",
+    urls = [
+        "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-linux_x64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-linux_x64.tar.gz",
+    ],
+    version = "17",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk17_macos",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+    sha256 = "6029b1fe6853cecad22ab99ac0b3bb4fb8c903dd2edefa91c3abc89755bbd47d",
+    strip_prefix = "zulu17.28.13-ca-jdk17.0.0-macosx_x64",
+    urls = [
+        "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-macosx_x64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-macosx_x64.tar.gz",
+    ],
+    version = "17",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk17_macos_aarch64",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:aarch64",
+    ],
+    sha256 = "6b17f01f767ee7abf4704149ca4d86423aab9b16b68697b7d36e9b616846a8b0",
+    strip_prefix = "zulu17.28.13-ca-jdk17.0.0-macosx_aarch64",
+    urls = [
+        "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-macosx_aarch64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-macosx_aarch64.tar.gz",
+    ],
+    version = "17",
+)
+
+# This must be kept in sync with the top-level WORKSPACE file.
+maybe(
+    remote_java_repository,
+    name = "remotejdk17_win",
+    exec_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    sha256 = "f4437011239f3f0031c794bb91c02a6350bc941d4196bdd19c9f157b491815a3",
+    strip_prefix = "zulu17.28.13-ca-jdk17.0.0-win_x64",
+    urls = [
+        "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-win_x64.zip",
+        "https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-win_x64.zip",
+    ],
+    version = "17",
+)
+
+http_archive(
+    name = "remote_java_tools",
+    sha256 = "b763ee80e5754e593fd6d5be6d7343f905bc8b73d661d36d842b024ca11b6793",
+    urls = [
+        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.5/java_tools-v11.5.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/java_v11.5/java_tools-v11.5.zip",
+    ],
+)
+
+http_archive(
+    name = "remote_java_tools_linux",
+    sha256 = "ae1eca4546eac6487c6e565f9b409536609c273207220c51e5c94f2a058a5a56",
+    urls = [
+        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.5/java_tools_linux-v11.5.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/java_v11.5/java_tools_linux-v11.5.zip",
+    ],
+)
+
+
+http_archive(
+    name = "remote_java_tools_windows",
+    sha256 = "36766802f7ec684cecb1a14c122428de6be9784e88419e2ab5912ad4b59a8c7d",
+    urls = [
+        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.5/java_tools_windows-v11.5.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/java_v11.5/java_tools_windows-v11.5.zip",
+    ],
+)
+
+http_archive(
+    name = "remote_java_tools_darwin",
+    sha256 = "792bc1352e736073b152528175ed424687f86a9f6f5f461f07d8b26806762738",
+    urls = [
+        "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.5/java_tools_darwin-v11.5.zip",
+        "https://github.com/bazelbuild/java_tools/releases/download/java_v11.5/java_tools_darwin-v11.5.zip",
+    ],
+)
+
+register_toolchains("@bazel_tools//tools/jdk:all")

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,4 +1,3 @@
-# Replace the original WORKSPACE file with this file to build Bazel with Bzlmod.
 # When using the WORKSPACE.bzlmod, no WORKSPACE prefix or suffix are added.
 # Therefore, we need to keep some legacy content to make the build work, eventually this
 # file should be empty after fully migrating to Bzlmod.

--- a/src/main/java/com/google/devtools/build/lib/skyframe/WorkspaceFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/WorkspaceFileFunction.java
@@ -20,6 +20,7 @@ import static com.google.devtools.build.lib.rules.repository.ResolvedHashesFunct
 import static com.google.devtools.build.lib.rules.repository.ResolvedHashesFunction.RULE_CLASS;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -100,26 +101,48 @@ public class WorkspaceFileFunction implements SkyFunction {
       return null;
     }
 
-    Optional<RootedPath> resolvedFile =
-        RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE.get(env);
-    if (resolvedFile == null) {
-      return null;
+    // The final content of the WORKSPACE is calculated in the following ways:
+    // 1. If --resolved_file_instead_of_workspace is enabled, the final content will be:
+    //    getDefaultWorkspacePrefix() + workspaceFromResolvedValue().
+    // 2. Otherwise, if --experimental_enable_bzlmod is enabled and WORKSPACE.bzlmod exists,
+    //    the final content will be:
+    //    WORKSPACE.bzlmod (Neither of prefix or suffix are added)
+    // 3. Otherwise, the final content will be:
+    //    getDefaultWorkspacePrefix() + WORKSPACE + getDefaultWorkspaceSuffix()
+
+    Optional<RootedPath> resolvedFile = Preconditions.checkNotNull(
+        RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE.get(env));
+    boolean useWorkspaceResolvedFile = resolvedFile.isPresent();
+
+    boolean useWorkspaceBzlmodFile = false;
+    RootedPath workspaceBzlmodFile = RootedPath.toRootedPath(workspaceFile.getRoot(),
+        workspaceFile.getRootRelativePath().replaceName("WORKSPACE.bzlmod"));
+    // We only need to check WORKSPACE.bzlmod when the resolved file isn't used.
+    if (!useWorkspaceResolvedFile) {
+      Boolean enableBzlmod = Preconditions.checkNotNull(
+          RepositoryDelegatorFunction.ENABLE_BZLMOD.get(env));
+      FileValue workspaceBzlmodFileValue;
+      if (enableBzlmod) {
+        workspaceBzlmodFileValue = (FileValue) env.getValue(FileValue.key(workspaceBzlmodFile));
+        if (workspaceBzlmodFileValue == null) {
+          return null;
+        }
+        useWorkspaceBzlmodFile = workspaceBzlmodFileValue.isFile();
+      }
     }
-    String newWorkspaceFileContents = null;
+
+    String workspaceFromResolvedFile = null;
     FileValue workspaceFileValue = null;
-    if (resolvedFile.isPresent()) {
-      newWorkspaceFileContents = workspaceFromResolvedValue(resolvedFile.get(), env);
-      if (newWorkspaceFileContents == null) {
+    if (useWorkspaceResolvedFile) {
+      workspaceFromResolvedFile = workspaceFromResolvedValue(resolvedFile.get(), env);
+      if (workspaceFromResolvedFile == null) {
         return null;
       }
-    } else {
+    } else if (!useWorkspaceBzlmodFile){
       workspaceFileValue = (FileValue) env.getValue(FileValue.key(workspaceFile));
       if (workspaceFileValue == null) {
         return null;
       }
-    }
-    if (env.valuesMissing()) {
-      return null;
     }
 
     FileOptions options =
@@ -140,8 +163,8 @@ public class WorkspaceFileFunction implements SkyFunction {
     // Accumulate workspace files (prefix + main + suffix).
     ArrayList<StarlarkFile> files = new ArrayList<>();
 
-    // DEFAULT.WORKSPACE file
-    {
+    // 1. Workspace prefix (DEFAULT.WORKSPACE): Only added when not using the WORKSPACE.bzlmod file
+    if (!useWorkspaceBzlmodFile) {
       StarlarkFile file =
           StarlarkFile.parse(
               ParserInput.fromString(
@@ -154,36 +177,27 @@ public class WorkspaceFileFunction implements SkyFunction {
       files.add(file);
     }
 
-    if (newWorkspaceFileContents != null) {
+    // 2. Main workspace content
+    if (useWorkspaceResolvedFile) {
       // WORKSPACE.resolved file.
       StarlarkFile file =
           StarlarkFile.parse(
               ParserInput.fromString(
-                  newWorkspaceFileContents, resolvedFile.get().asPath().toString()),
+                  workspaceFromResolvedFile, resolvedFile.get().asPath().toString()),
               // The WORKSPACE.resolved file breaks through the usual privacy mechanism.
               options.toBuilder().allowLoadPrivateSymbols(true).build());
       files.add(file);
-
+    } else if (useWorkspaceBzlmodFile) {
+      // If Bzlmod is enabled and WORKSPACE.bzlmod exists, then use this file instead of the
+      // original WORKSPACE file.
+      files.add(parseWorkspaceFile(workspaceBzlmodFile, options, env));
     } else if (workspaceFileValue.exists()) {
-      // WORKSPACE file proper
-      Path workspacePath = workspaceFile.asPath();
-      byte[] bytes;
-      try {
-        bytes = FileSystemUtils.readWithKnownFileSize(workspacePath, workspacePath.getFileSize());
-      } catch (IOException ex) {
-        throw new WorkspaceFileFunctionException(ex, Transience.TRANSIENT);
-      }
-      StarlarkFile file =
-          StarlarkFile.parse(ParserInput.fromLatin1(bytes, workspacePath.toString()), options);
-      if (!file.ok()) {
-        Event.replayEventsOn(env.getListener(), file.errors());
-        throw resolvedValueError("Failed to parse WORKSPACE file");
-      }
-      files.add(file);
+      // normal WORKSPACE file
+      files.add(parseWorkspaceFile(workspaceFile, options, env));
     }
 
-    // DEFAULT.WORKSPACE.SUFFIX file
-    if (!resolvedFile.isPresent()) {
+    // 3. Workspace suffix (DEFAULT.WORKSPACE.SUFFIX): Only added when using the WORKSPACE file.
+    if (!useWorkspaceResolvedFile && !useWorkspaceBzlmodFile) {
       StarlarkFile file =
           StarlarkFile.parse(
               ParserInput.fromString(
@@ -337,6 +351,24 @@ public class WorkspaceFileFunction implements SkyFunction {
         key.getIndex() < chunks.size() - 1,
         ImmutableMap.copyOf(parser.getManagedDirectories()),
         parser.getDoNotSymlinkInExecrootPaths());
+  }
+
+  private static StarlarkFile parseWorkspaceFile(RootedPath workspaceFile, FileOptions options, Environment env)
+      throws WorkspaceFileFunctionException {
+    Path workspacePath = workspaceFile.asPath();
+    byte[] bytes;
+    try {
+      bytes = FileSystemUtils.readWithKnownFileSize(workspacePath, workspacePath.getFileSize());
+    } catch (IOException ex) {
+      throw new WorkspaceFileFunctionException(ex, Transience.TRANSIENT);
+    }
+    StarlarkFile file =
+        StarlarkFile.parse(ParserInput.fromLatin1(bytes, workspacePath.toString()), options);
+    if (!file.ok()) {
+      Event.replayEventsOn(env.getListener(), file.errors());
+      throw resolvedValueError("Failed to parse WORKSPACE file");
+    }
+    return file;
   }
 
   private static int getOriginalWorkspaceChunk(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/WorkspaceFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/WorkspaceFileFunction.java
@@ -118,17 +118,13 @@ public class WorkspaceFileFunction implements SkyFunction {
     RootedPath workspaceBzlmodFile = RootedPath.toRootedPath(workspaceFile.getRoot(),
         workspaceFile.getRootRelativePath().replaceName("WORKSPACE.bzlmod"));
     // We only need to check WORKSPACE.bzlmod when the resolved file isn't used.
-    if (!useWorkspaceResolvedFile) {
-      Boolean enableBzlmod = Preconditions.checkNotNull(
-          RepositoryDelegatorFunction.ENABLE_BZLMOD.get(env));
+    if (!useWorkspaceResolvedFile && RepositoryDelegatorFunction.ENABLE_BZLMOD.get(env)) {
       FileValue workspaceBzlmodFileValue;
-      if (enableBzlmod) {
-        workspaceBzlmodFileValue = (FileValue) env.getValue(FileValue.key(workspaceBzlmodFile));
-        if (workspaceBzlmodFileValue == null) {
-          return null;
-        }
-        useWorkspaceBzlmodFile = workspaceBzlmodFileValue.isFile();
+      workspaceBzlmodFileValue = (FileValue) env.getValue(FileValue.key(workspaceBzlmodFile));
+      if (workspaceBzlmodFileValue == null) {
+        return null;
       }
+      useWorkspaceBzlmodFile = workspaceBzlmodFileValue.isFile();
     }
 
     String workspaceFromResolvedFile = null;

--- a/src/test/java/com/google/devtools/build/lib/repository/ExternalPackageHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/repository/ExternalPackageHelperTest.java
@@ -188,6 +188,7 @@ public class ExternalPackageHelperTest extends BuildViewTestCase {
     PrecomputedValue.STARLARK_SEMANTICS.set(differencer, StarlarkSemantics.DEFAULT);
     RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE.set(
         differencer, Optional.empty());
+    RepositoryDelegatorFunction.ENABLE_BZLMOD.set(differencer, false);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -496,11 +496,16 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
         "def _impl(rctx):",
         " rctx.file('BUILD', '')",
         "fictive_repo_rule = repository_rule(implementation = _impl)");
+    // WORKSPACE.bzlmod is preferred when Bzlmod is enabled.
     scratch.file(
-        rootPath.getRelative("WORKSPACE").getPathString(),
+        rootPath.getRelative("WORKSPACE.bzlmod").getPathString(),
         "load(':repo_rule.bzl', 'fictive_repo_rule')",
         "fictive_repo_rule(name = 'B.1.0')",
         "fictive_repo_rule(name = 'C')");
+    scratch.file(
+        rootPath.getRelative("WORKSPACE").getPathString(),
+        "load(':repo_rule.bzl', 'fictive_repo_rule')",
+        "fictive_repo_rule(name = 'B.1.0')");
 
     StoredEventHandler eventHandler = new StoredEventHandler();
     SkyKey key = RepositoryDirectoryValue.key(RepositoryName.createFromValidStrippedName("B.1.0"));
@@ -520,7 +525,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
         .hasMessageThat()
         .contains("but it does not exist or is not a directory");
 
-    // C should still be fetched from WORKSPACE successfully.
+    // C should still be fetched from WORKSPACE.bzlmod successfully.
     loadRepo("C");
   }
 

--- a/src/test/java/com/google/devtools/build/lib/skyframe/LocalRepositoryLookupFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/LocalRepositoryLookupFunctionTest.java
@@ -134,6 +134,7 @@ public class LocalRepositoryLookupFunctionTest extends FoundationTestCase {
     PrecomputedValue.STARLARK_SEMANTICS.set(differencer, StarlarkSemantics.DEFAULT);
     RepositoryDelegatorFunction.RESOLVED_FILE_INSTEAD_OF_WORKSPACE.set(
         differencer, Optional.empty());
+    RepositoryDelegatorFunction.ENABLE_BZLMOD.set(differencer, false);
   }
 
   private static SkyKey createKey(RootedPath directory) {


### PR DESCRIPTION
When enabling Bzlmod, if a WORKSPACE.bzlmod file is presented at the
source root, it will replace the content of the WORKSPACE file.
In contrast to the WORKSPACE file, no prefix or suffix are added to the WORKSPACE.bzlmod file.

This file is for migration purpose in case some of the dependencies
still need to be introduced via the WORKSPACE mechanism, eventually
it should be removed.

RELNOTES: None
GOOGLE: