### PR TITLE
Add Bazel 4.1 and 4.2 to Release Notes in sidebar

### DIFF
--- a/site/_includes/getting-started-sidebar/master/sidebar.html
+++ b/site/_includes/getting-started-sidebar/master/sidebar.html
@@ -55,6 +55,8 @@
     </a>
     <ul class="collapse sidebar-nav sidebar-submenu" id="release-notes-menu">
 
+       <li><a href="https://blog.bazel.build/2021/08/18/bazel-4.2.html">Bazel 4.2</a></li>
+       <li><a href="https://blog.bazel.build/2021/05/21/bazel-4-1.html">Bazel 4.1</a></li>
        <li><a href="https://blog.bazel.build/2020/11/10/bazel-4.0-announce.html">Bazel 4.0</a></li>
        <li><a href="https://blog.bazel.build/2020/10/20/bazel-3-7.html">Bazel 3.7</a></li>
        <li><a href="https://blog.bazel.build/2020/10/06/bazel-3-6.html">Bazel 3.6</a></li>


### PR DESCRIPTION
Currently, Bazel 4.1 and Bazel 4.2 are not included in Release Note in the sidebar when we visit the main version of the [Getting Started page](https://docs.bazel.build/versions/main/bazel-overview.html). Below is a screenshot of the page. This PR adds links to Bazel 4.1 and Bazel 4.2 release pages to the sidebar.

<img width="523" alt="Screen Shot 2021-11-07 at 21 10 01" src="https://user-images.githubusercontent.com/1183444/140644592-3bbdf332-8806-41e2-be54-a3b910b9df8f.png">