### PR TITLE
[5.x] Remove DigestUtils.getDigestInExclusiveMode() now that SsdModule has …

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/vfs/DigestUtilsTest.java
@@ -20,7 +20,6 @@ import com.google.devtools.build.lib.testutil.TestThread;
 import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -91,25 +90,6 @@ public final class DigestUtilsTest {
      // Test successful execution within 5 seconds.
      thread1.joinAndAssertState(TestUtils.WAIT_TIMEOUT_MILLISECONDS);
      thread2.joinAndAssertState(TestUtils.WAIT_TIMEOUT_MILLISECONDS);
-  }
-
-  /**
-   * Ensures that digest calculation is synchronized for files greater than
-   * {@link DigestUtils#MULTI_THREADED_DIGEST_MAX_FILE_SIZE} bytes if the digest is not
-   * available cheaply, so machines with rotating drives don't become unusable.
-   */
-  @Test
-  public void testCalculationConcurrency() throws Exception {
-    int small = DigestUtils.MULTI_THREADED_DIGEST_MAX_FILE_SIZE;
-    int large = DigestUtils.MULTI_THREADED_DIGEST_MAX_FILE_SIZE + 1;
-    for (DigestHashFunction hf :
-        Arrays.asList(DigestHashFunction.SHA256, DigestHashFunction.SHA1)) {
-      assertDigestCalculationConcurrency(true, true, small, small, hf);
-      assertDigestCalculationConcurrency(true, true, large, large, hf);
-      assertDigestCalculationConcurrency(true, false, small, small, hf);
-      assertDigestCalculationConcurrency(true, false, small, large, hf);
-      assertDigestCalculationConcurrency(false, false, large, large, hf);
-    }
   }
 
   @Test


### PR DESCRIPTION
…been removed

There used to be a cli flag --experimental_multi_threaded_digest which defaulted to true
and therefore would not compute the file digest in exclusive mode unless overridden to false.
When that flag was removed this code was accidentally left behind which instead causes bazel to always
compute file digests in exclusive mode for all files larger than MULTI_THREADED_DIGEST_MAX_FILE_SIZE.

This causes bazel to take 5-6x longer to 'check cached actions' in my org's builds,
specifically increasing the time from 30 secs to 2 mins 30 secs for fully cached no-op builds.

Fixes #14034

Closes #14231.

PiperOrigin-RevId: 407790990
(cherry picked from commit 77a002cce050e861fcc87c89acf7768aa5c97124)