### PR TITLE
Fixes for the Starlark transition hash computation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1526,6 +1526,7 @@ java_library(
         ":config/run_under",
         ":config/transitive_option_details",
         ":platform_options",
+        ":starlark/function_transition_util",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -240,22 +240,6 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
               + "'fastbuild', 'dbg', 'opt'.")
   public CompilationMode hostCompilationMode;
 
-  /**
-   * This option is used by starlark transitions to add a distinguishing element to the output
-   * directory name, in order to avoid name clashing.
-   */
-  @Option(
-      name = "transition directory name fragment",
-      defaultValue = "null",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {
-        OptionEffectTag.LOSES_INCREMENTAL_STATE,
-        OptionEffectTag.AFFECTS_OUTPUTS,
-        OptionEffectTag.LOADING_AND_ANALYSIS
-      },
-      metadataTags = {OptionMetadataTag.INTERNAL})
-  public String transitionDirectoryNameFragment;
-
   @Option(
       name = "experimental_enable_aspect_hints",
       defaultValue = "false",
@@ -839,7 +823,6 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   public FragmentOptions getHost() {
     CoreOptions host = (CoreOptions) getDefault();
 
-    host.transitionDirectoryNameFragment = transitionDirectoryNameFragment;
     host.affectedByStarlarkTransition = affectedByStarlarkTransition;
     host.compilationMode = hostCompilationMode;
     host.isHost = true;

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/OutputDirectories.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/OutputDirectories.java
@@ -147,10 +147,12 @@ public class OutputDirectories {
       @Nullable PlatformOptions platformOptions,
       ImmutableSortedMap<Class<? extends Fragment>, Fragment> fragments,
       RepositoryName mainRepositoryName,
-      boolean siblingRepositoryLayout)
+      boolean siblingRepositoryLayout,
+      String transitionDirectoryNameFragment)
       throws InvalidMnemonicException {
     this.directories = directories;
-    this.mnemonic = buildMnemonic(options, platformOptions, fragments);
+    this.mnemonic =
+        buildMnemonic(options, platformOptions, fragments, transitionDirectoryNameFragment);
     this.outputDirName = options.isHost ? "host" : mnemonic;
 
     this.outputDirectory =
@@ -207,7 +209,8 @@ public class OutputDirectories {
   private static String buildMnemonic(
       CoreOptions options,
       @Nullable PlatformOptions platformOptions,
-      ImmutableSortedMap<Class<? extends Fragment>, Fragment> fragments)
+      ImmutableSortedMap<Class<? extends Fragment>, Fragment> fragments,
+      String transitionDirectoryNameFragment)
       throws InvalidMnemonicException {
     // See explanation at declaration for outputRoots.
     List<String> nameParts = new ArrayList<>();
@@ -230,9 +233,7 @@ public class OutputDirectories {
 
     // Add the transition suffix.
     addMnemonicPart(
-        nameParts,
-        options.transitionDirectoryNameFragment,
-        "Transition directory name fragment '%s'");
+        nameParts, transitionDirectoryNameFragment, "Transition directory name fragment '%s'");
 
     // Join all the parts.
     String mnemonic = nameParts.stream().filter(not(Strings::isNullOrEmpty)).collect(joining("-"));

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/FunctionTransitionUtil.java
@@ -440,16 +440,19 @@ public final class FunctionTransitionUtil {
         toHash.put(optionName, value);
       } else {
         Object value = toOptions.getStarlarkOptions().get(Label.parseAbsoluteUnchecked(optionName));
-        if (value != null) {
-          toHash.put(optionName, value);
-        }
+        toHash.put(optionName, value);
       }
     }
 
     ImmutableList.Builder<String> hashStrs = ImmutableList.builderWithExpectedSize(toHash.size());
     for (Map.Entry<String, Object> singleOptionAndValue : toHash.entrySet()) {
-      String toAdd = singleOptionAndValue.getKey() + "=" + singleOptionAndValue.getValue();
-      hashStrs.add(toAdd);
+      Object value = singleOptionAndValue.getValue();
+      if (value != null) {
+        hashStrs.add(singleOptionAndValue.getKey() + "=" + value);
+      } else {
+        // Avoid using =null to different from value being the non-null String "null"
+        hashStrs.add(singleOptionAndValue.getKey() + "@null");
+      }
     }
     return transitionDirectoryNameFragment(hashStrs.build());
   }

--- a/src/test/java/com/google/devtools/build/lib/analysis/StarlarkAttrTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/StarlarkAttrTransitionProviderTest.java
@@ -1182,6 +1182,81 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testTransitionBackToStarlarkDefaultOK() throws Exception {
+    writeAllowlistFile();
+    writeBuildSettingsBzl();
+    scratch.file(
+        "test/starlark/rules.bzl",
+        "load('//myinfo:myinfo.bzl', 'MyInfo')",
+        "def _transition_impl(settings, attr):",
+        "  return {",
+        "    '//test/starlark:the-answer': attr.answer_for_dep,",
+        "    '//test/starlark:did-transition': 1,",
+        "}",
+        "my_transition = transition(",
+        "  implementation = _transition_impl,",
+        "  inputs = [],",
+        "  outputs = ['//test/starlark:the-answer', '//test/starlark:did-transition']",
+        ")",
+        "def _rule_impl(ctx):",
+        "  return MyInfo(dep = ctx.attr.dep)",
+        "my_rule = rule(",
+        "  implementation = _rule_impl,",
+        "  attrs = {",
+        "    'dep': attr.label(cfg = my_transition),",
+        "    'answer_for_dep': attr.int(),",
+        "    '_allowlist_function_transition': attr.label(",
+        "      default = '//tools/allowlists/function_transition_allowlist'),",
+        "  }",
+        ")");
+    scratch.file(
+        "test/starlark/BUILD",
+        "load('//test/starlark:rules.bzl', 'my_rule')",
+        "load('//test/starlark:build_settings.bzl', 'int_flag')",
+        "my_rule(name = 'test', dep = ':dep1', answer_for_dep=0)",
+        "my_rule(name = 'dep1', dep = ':dep2', answer_for_dep=42)",
+        "my_rule(name = 'dep2', dep = ':dep3', answer_for_dep=0)",
+        "my_rule(name = 'dep3')",
+        "int_flag(name = 'the-answer', build_setting_default=0)",
+        "int_flag(name = 'did-transition', build_setting_default=0)");
+    useConfiguration(ImmutableMap.of(), "--cpu=FOO");
+
+    ConfiguredTarget test = getConfiguredTarget("//test/starlark:test");
+
+    // '//test/starlark:did-transition ensures ST-hash is 'turned on' since :test has no ST-hash
+    //   and thus will trivially have a unique getTransitionDirectoryNameFragment
+
+    @SuppressWarnings("unchecked")
+    ConfiguredTarget dep1 =
+        Iterables.getOnlyElement(
+            (List<ConfiguredTarget>) getMyInfoFromTarget(test).getValue("dep"));
+
+    @SuppressWarnings("unchecked")
+    ConfiguredTarget dep2 =
+        Iterables.getOnlyElement(
+            (List<ConfiguredTarget>) getMyInfoFromTarget(dep1).getValue("dep"));
+
+    @SuppressWarnings("unchecked")
+    ConfiguredTarget dep3 =
+        Iterables.getOnlyElement(
+            (List<ConfiguredTarget>) getMyInfoFromTarget(dep2).getValue("dep"));
+
+    // These must be true
+    assertThat(getTransitionDirectoryNameFragment(dep1))
+        .isNotEqualTo(getTransitionDirectoryNameFragment(dep2));
+
+    assertThat(getTransitionDirectoryNameFragment(dep2))
+        .isNotEqualTo(getTransitionDirectoryNameFragment(dep3));
+
+    // TODO(blaze-configurability-team): When "affected by starlark transition" is gone,
+    //    will be equal and thus getTransitionDirectoryNameFragment can be equal.
+    if (!getConfiguration(dep1).equals(getConfiguration(dep3))) {
+      assertThat(getTransitionDirectoryNameFragment(dep1))
+          .isNotEqualTo(getTransitionDirectoryNameFragment(dep3));
+    }
+  }
+
+  @Test
   public void testTransitionOnBuildSetting_onlyTransitionsAffectsDirectory() throws Exception {
     writeAllowlistFile();
     writeBuildSettingsBzl();

--- a/src/test/java/com/google/devtools/build/lib/analysis/StarlarkAttrTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/StarlarkAttrTransitionProviderTest.java
@@ -1216,7 +1216,7 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
     // Assert that transitionDirectoryNameFragment is only affected by options
     // set via transitions. Not by native or starlark options set via command line,
     // never touched by any transition.
-    assertThat(getCoreOptions(dep).transitionDirectoryNameFragment)
+    assertThat(getTransitionDirectoryNameFragment(dep))
         .isEqualTo(
             FunctionTransitionUtil.transitionDirectoryNameFragment(
                 ImmutableList.of("//test/starlark:the-answer=42")));
@@ -1232,6 +1232,10 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
 
   private Object getStarlarkOption(ConfiguredTarget target, String absName) {
     return getStarlarkOptions(target).get(Label.parseAbsoluteUnchecked(absName));
+  }
+
+  private String getTransitionDirectoryNameFragment(ConfiguredTarget target) {
+    return getConfiguration(target).getTransitionDirectoryNameFragment();
   }
 
   @Test
@@ -1287,12 +1291,12 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
     assertThat(affectedOptions)
         .containsExactly("//command_line_option:foo", "//command_line_option:bar");
 
-    assertThat(getCoreOptions(test).transitionDirectoryNameFragment)
+    assertThat(getTransitionDirectoryNameFragment(test))
         .isEqualTo(
             FunctionTransitionUtil.transitionDirectoryNameFragment(
                 ImmutableList.of("//command_line_option:foo=foosball")));
 
-    assertThat(getCoreOptions(dep).transitionDirectoryNameFragment)
+    assertThat(getTransitionDirectoryNameFragment(dep))
         .isEqualTo(
             FunctionTransitionUtil.transitionDirectoryNameFragment(
                 ImmutableList.of(
@@ -1346,8 +1350,8 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
         Iterables.getOnlyElement(
             (List<ConfiguredTarget>) getMyInfoFromTarget(test).getValue("dep"));
 
-    assertThat(getCoreOptions(test).transitionDirectoryNameFragment)
-        .isEqualTo(getCoreOptions(dep).transitionDirectoryNameFragment);
+    assertThat(getTransitionDirectoryNameFragment(test))
+        .isEqualTo(getTransitionDirectoryNameFragment(dep));
   }
 
   @Test
@@ -1390,8 +1394,8 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
         Iterables.getOnlyElement(
             (List<ConfiguredTarget>) getMyInfoFromTarget(test).getValue("dep"));
 
-    assertThat(getCoreOptions(test).transitionDirectoryNameFragment)
-        .isEqualTo(getCoreOptions(dep).transitionDirectoryNameFragment);
+    assertThat(getTransitionDirectoryNameFragment(test))
+        .isEqualTo(getTransitionDirectoryNameFragment(dep));
   }
 
   // Test that setting all starlark options back to default != null hash of top level.
@@ -1452,7 +1456,7 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
             (List<ConfiguredTarget>)
                 getMyInfoFromTarget(getConfiguredTarget("//test")).getValue("dep"));
 
-    assertThat(getCoreOptions(dep).transitionDirectoryNameFragment).isNotNull();
+    assertThat(getTransitionDirectoryNameFragment(dep)).isNotEmpty();
   }
 
   /** See comment above {@link FunctionTransitionUtil#updateOutputDirectoryNameFragment} */
@@ -1507,11 +1511,11 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
         Iterables.getOnlyElement(
             (List<ConfiguredTarget>) getMyInfoFromTarget(test).getValue("dep"));
 
-    assertThat(getCoreOptions(test).transitionDirectoryNameFragment)
+    assertThat(getTransitionDirectoryNameFragment(test))
         .isEqualTo(
             FunctionTransitionUtil.transitionDirectoryNameFragment(
                 ImmutableList.of("//test:foo=1")));
-    assertThat(getCoreOptions(dep).transitionDirectoryNameFragment)
+    assertThat(getTransitionDirectoryNameFragment(dep))
         .isEqualTo(
             FunctionTransitionUtil.transitionDirectoryNameFragment(
                 ImmutableList.of("//test:foo=true")));
@@ -1561,8 +1565,8 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
         Iterables.getOnlyElement(
             (List<ConfiguredTarget>) getMyInfoFromTarget(test).getValue("dep"));
 
-    assertThat(getCoreOptions(test).transitionDirectoryNameFragment)
-        .isEqualTo(getCoreOptions(dep).transitionDirectoryNameFragment);
+    assertThat(getTransitionDirectoryNameFragment(test))
+        .isEqualTo(getTransitionDirectoryNameFragment(dep));
   }
 
   @Test
@@ -1619,11 +1623,11 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
         getConfiguration(dep).getOptions().get(CoreOptions.class).affectedByStarlarkTransition;
 
     assertThat(affectedOptions).containsExactly("//test:bar", "//test:foo");
-    assertThat(getCoreOptions(test).transitionDirectoryNameFragment)
+    assertThat(getTransitionDirectoryNameFragment(test))
         .isEqualTo(
             FunctionTransitionUtil.transitionDirectoryNameFragment(
                 ImmutableList.of("//test:foo=foosball")));
-    assertThat(getCoreOptions(dep).transitionDirectoryNameFragment)
+    assertThat(getTransitionDirectoryNameFragment(dep))
         .isEqualTo(
             FunctionTransitionUtil.transitionDirectoryNameFragment(
                 ImmutableList.of("//test:bar=barsball", "//test:foo=foosball")));
@@ -1707,7 +1711,7 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
 
     assertThat(affectedOptionsTop).containsExactly("//command_line_option:foo");
     assertThat(getConfiguration(top).getOptions().getStarlarkOptions()).isEmpty();
-    assertThat(getCoreOptions(top).transitionDirectoryNameFragment)
+    assertThat(getTransitionDirectoryNameFragment(top))
         .isEqualTo(
             FunctionTransitionUtil.transitionDirectoryNameFragment(
                 ImmutableList.of("//command_line_option:foo=foosball")));
@@ -1727,7 +1731,7 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
         .containsExactly(
             Maps.immutableEntry(Label.parseAbsoluteUnchecked("//test:zee"), "zeesball"));
 
-    assertThat(getCoreOptions(middle).transitionDirectoryNameFragment)
+    assertThat(getTransitionDirectoryNameFragment(middle))
         .isEqualTo(
             FunctionTransitionUtil.transitionDirectoryNameFragment(
                 ImmutableList.of(
@@ -1752,7 +1756,7 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
         .containsExactly(
             Maps.immutableEntry(Label.parseAbsoluteUnchecked("//test:zee"), "zeesball"),
             Maps.immutableEntry(Label.parseAbsoluteUnchecked("//test:xan"), "xansball"));
-    assertThat(getCoreOptions(bottom).transitionDirectoryNameFragment)
+    assertThat(getTransitionDirectoryNameFragment(bottom))
         .isEqualTo(
             FunctionTransitionUtil.transitionDirectoryNameFragment(
                 ImmutableList.of(
@@ -2022,8 +2026,8 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
     ConfiguredTarget dep =
         Iterables.getOnlyElement(
             (List<ConfiguredTarget>) getMyInfoFromTarget(test).getValue("dep"));
-    assertThat(getCoreOptions(test).transitionDirectoryNameFragment)
-        .isEqualTo(getCoreOptions(dep).transitionDirectoryNameFragment);
+    assertThat(getTransitionDirectoryNameFragment(test))
+        .isEqualTo(getTransitionDirectoryNameFragment(dep));
   }
 
   @Test
@@ -2090,8 +2094,8 @@ public class StarlarkAttrTransitionProviderTest extends BuildViewTestCase {
     ConfiguredTarget dep =
         Iterables.getOnlyElement(
             (List<ConfiguredTarget>) getMyInfoFromTarget(test).getValue("dep"));
-    assertThat(getCoreOptions(test).transitionDirectoryNameFragment)
-        .isEqualTo(getCoreOptions(dep).transitionDirectoryNameFragment);
+    assertThat(getTransitionDirectoryNameFragment(test))
+        .isEqualTo(getTransitionDirectoryNameFragment(dep));
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/DummyTestFragment.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/DummyTestFragment.java
@@ -22,6 +22,7 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
+import com.google.devtools.common.options.OptionMetadataTag;
 import java.util.List;
 
 /**
@@ -57,6 +58,15 @@ public final class DummyTestFragment extends Fragment {
         effectTags = {OptionEffectTag.NO_OP},
         help = "A regular string-typed option")
     public String foo;
+
+    @Option(
+        name = "internal foo",
+        defaultValue = "",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.NO_OP},
+        metadataTags = {OptionMetadataTag.INTERNAL},
+        help = "A string-typed option that cannot be set on the commandline")
+    public String internalFoo;
 
     @Option(
         name = "bar",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PlatformMappingFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PlatformMappingFunctionTest.java
@@ -20,15 +20,18 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.MissingInputFileException;
+import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.PlatformConfiguration;
 import com.google.devtools.build.lib.analysis.PlatformOptions;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.config.FragmentClassSet;
 import com.google.devtools.build.lib.analysis.util.BuildViewTestCase;
+import com.google.devtools.build.lib.analysis.util.DummyTestFragment;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.rules.repository.RepositoryDelegatorFunction;
 import com.google.devtools.build.lib.skyframe.util.SkyframeExecutorTestUtils;
+import com.google.devtools.build.lib.testutil.TestRuleClassProvider;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.build.skyframe.EvaluationResult;
 import java.util.Optional;
@@ -57,6 +60,14 @@ public final class PlatformMappingFunctionTest extends BuildViewTestCase {
       Label.parseAbsoluteUnchecked("@local_config_platform//:host");
 
   private BuildOptions defaultBuildOptions;
+
+  @Override
+  protected ConfiguredRuleClassProvider createRuleClassProvider() {
+    ConfiguredRuleClassProvider.Builder builder = new ConfiguredRuleClassProvider.Builder();
+    TestRuleClassProvider.addStandardRules(builder);
+    builder.addConfigurationFragment(DummyTestFragment.class);
+    return builder.build();
+  }
 
   @Before
   public void setDefaultBuildOptions() {
@@ -218,7 +229,7 @@ public final class PlatformMappingFunctionTest extends BuildViewTestCase {
         "my_mapping_file",
         "platforms:", // Force line break
         "  //platforms:one", // Force line break
-        "    --transition directory name fragment=updated_output_dir");
+        "    --internal foo=something_new");
 
     PlatformMappingValue platformMappingValue =
         executeFunction(PlatformMappingValue.Key.create(PathFragment.create("my_mapping_file")));
@@ -228,8 +239,8 @@ public final class PlatformMappingFunctionTest extends BuildViewTestCase {
 
     BuildConfigurationValue.Key mapped = platformMappingValue.map(keyForOptions(modifiedOptions));
 
-    assertThat(mapped.getOptions().get(CoreOptions.class).transitionDirectoryNameFragment)
-        .isEqualTo("updated_output_dir");
+    assertThat(mapped.getOptions().get(DummyTestFragment.DummyTestOptions.class).internalFoo)
+        .isEqualTo("something_new");
   }
 
   private PlatformMappingValue executeFunction(PlatformMappingValue.Key key) throws Exception {


### PR DESCRIPTION
@Wyverald These two commits fix a whole cluster of issues around wrongly calculated transition hashes, leading to action conflicts on otherwise correct builds. I think they would be very useful to have in Bazel 5.

@sdtwigg FYI