### PR TITLE
Remote: Fix "file not found" error when remote cache is changed from enabled to disabled.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionCacheChecker.java
@@ -414,7 +414,8 @@ public class ActionCacheChecker {
       EventHandler handler,
       MetadataHandler metadataHandler,
       ArtifactExpander artifactExpander,
-      Map<String, String> remoteDefaultPlatformProperties)
+      Map<String, String> remoteDefaultPlatformProperties,
+      boolean isRemoteCacheEnabled)
       throws InterruptedException {
     // TODO(bazel-team): (2010) For RunfilesAction/SymlinkAction and similar actions that
     // produce only symlinks we should not check whether inputs are valid at all - all that matters
@@ -456,8 +457,8 @@ public class ActionCacheChecker {
     }
     ActionCache.Entry entry = getCacheEntry(action);
     CachedOutputMetadata cachedOutputMetadata = null;
-    // load remote metadata from action cache
-    if (entry != null && !entry.isCorrupted() && cacheConfig.storeOutputMetadata()) {
+    if (entry != null && !entry.isCorrupted() && cacheConfig.storeOutputMetadata() && isRemoteCacheEnabled) {
+      // load remote metadata from action cache
       cachedOutputMetadata = loadCachedOutputMetadata(action, entry, metadataHandler);
     }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -549,10 +549,14 @@ public final class RemoteOptions extends OptionsBase {
   /** The maximum size of an outbound message sent via a gRPC channel. */
   public int maxOutboundMessageSize = 1024 * 1024;
 
-  public boolean isRemoteEnabled() {
-    return !Strings.isNullOrEmpty(remoteCache) || isRemoteExecutionEnabled();
+  /** Returns {@code true} if remote cache or disk cache is enabled. */
+  public boolean isRemoteCacheEnabled() {
+    return !Strings.isNullOrEmpty(remoteCache)
+        || !(diskCache == null || diskCache.isEmpty())
+        || isRemoteExecutionEnabled();
   }
 
+  /** Returns {@code true} if remote execution is enabled. */
   public boolean isRemoteExecutionEnabled() {
     return !Strings.isNullOrEmpty(remoteExecutor);
   }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeActionExecutor.java
@@ -599,6 +599,7 @@ public final class SkyframeActionExecutor {
           remoteOptions != null
               ? remoteOptions.getRemoteDefaultExecProperties()
               : ImmutableSortedMap.of();
+      boolean isRemoteCacheEnabled = remoteOptions != null && remoteOptions.isRemoteCacheEnabled();
       token =
           actionCacheChecker.getTokenIfNeedToExecute(
               action,
@@ -609,7 +610,8 @@ public final class SkyframeActionExecutor {
                   : null,
               metadataHandler,
               artifactExpander,
-              remoteDefaultProperties);
+              remoteDefaultProperties,
+              isRemoteCacheEnabled);
     } catch (UserExecException e) {
       throw e.toActionExecutionException(action);
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -378,6 +378,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory, Configur
 
   private Map<String, String> lastRemoteDefaultExecProperties;
   private RemoteOutputsMode lastRemoteOutputsMode;
+  private Boolean lastRemoteCacheEnabled;
 
   class PathResolverFactoryImpl implements PathResolverFactory {
     @Override
@@ -1722,10 +1723,24 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory, Configur
         lastRemoteDefaultExecProperties != null
             && !remoteDefaultExecProperties.equals(lastRemoteDefaultExecProperties);
     lastRemoteDefaultExecProperties = remoteDefaultExecProperties;
+
+    boolean remoteCacheEnabled = remoteOptions != null && remoteOptions.isRemoteCacheEnabled();
+    // If we have remote metadata from last build, and the remote cache is not
+    // enabled in this build, invalidate actions since they can't download those
+    // remote files.
+    //
+    // TODO(chiwang): Re-evaluate this after action rewinding is implemented in
+    //  Bazel since we can treat that case as lost inputs.
+    if (lastRemoteOutputsMode != RemoteOutputsMode.ALL) {
+      needsDeletion |= lastRemoteCacheEnabled != null && lastRemoteCacheEnabled && !remoteCacheEnabled;
+    }
+    lastRemoteCacheEnabled = remoteCacheEnabled;
+
     RemoteOutputsMode remoteOutputsMode =
         remoteOptions != null ? remoteOptions.remoteOutputsMode : RemoteOutputsMode.ALL;
     needsDeletion |= lastRemoteOutputsMode != null && lastRemoteOutputsMode != remoteOutputsMode;
     this.lastRemoteOutputsMode = remoteOutputsMode;
+
     if (needsDeletion) {
       memoizingEvaluator.delete(k -> SkyFunctions.ACTION_EXECUTION.equals(k.functionName()));
     }

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3216,8 +3216,6 @@ function download_toplevel_when_turn_remote_cache_off() {
   # Test that BwtB doesn't cause build failure if remote cache is disabled in a following build.
   # See https://github.com/bazelbuild/bazel/issues/13882.
 
-  local extra_build_flags="$@"
-
   cat > .bazelrc <<EOF
 build --verbose_failures
 EOF
@@ -3250,7 +3248,7 @@ EOF
   bazel build \
     --remote_cache=grpc://localhost:${worker_port} \
     --remote_download_toplevel \
-    $extra_build_flags \
+    "$@" \
     //a:consumer >& $TEST_log || fail "Failed to download outputs"
   [[ -f bazel-bin/a/a.txt ]] || [[ -f bazel-bin/a/b.txt ]] \
     && fail "Expected outputs of producer are not downloaded"
@@ -3259,7 +3257,7 @@ EOF
   echo 'bar' > a/in.txt
   bazel build \
     --remote_download_toplevel \
-    $extra_build_flags \
+    "$@" \
     //a:consumer >& $TEST_log || fail "Failed to build without remote cache"
 }
 

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3204,23 +3204,23 @@ EOF
   expect_not_log "WARNING: Writing to Remote Cache:"
 }
 
-function test_download_toplevel_when_turn_remote_cache_off() {
-  # Test that BwtB does cause build failure if remote cache is disabled in a following build.
+function test_download_toplevel_when_turn_remote_cache_off_without_metadata() {
+  # Test that BwtB doesn't cause build failure if remote cache is disabled in a following build.
   # See https://github.com/bazelbuild/bazel/issues/13882.
 
-  mkdir -p a
-  cat > a/BUILD <<EOF
+  mkdir a
+  cat > a/BUILD <<'EOF'
 genrule(
     name = "producer",
     outs = ["a.txt", "b.txt"],
-    cmd = "touch \$(OUTS)",
+    cmd = "touch $(OUTS)",
 )
 
 genrule(
     name = "consumer",
     outs = ["out.txt"],
     srcs = [":b.txt", "in.txt"],
-    cmd = "cat \$(SRCS) > \$@",
+    cmd = "cat $(SRCS) > $@",
 )
 EOF
   echo 'foo' > a/in.txt
@@ -3232,44 +3232,73 @@ EOF
     --verbose_failures \
     //a:consumer >& $TEST_log || fail "Failed to populate the cache"
 
-  bazel clean || fail "Failed to clean"
+  bazel clean >& $TEST_log || fail "Failed to clean"
 
-  # download top level outputs without remote metadata
+  # download top level outputs
   bazel build \
     --remote_cache=grpc://localhost:${worker_port} \
     --remote_download_toplevel \
     --verbose_failures \
-    //a:consumer >& $TEST_log || fail "Failed to download outputs without remote metadata"
-  (! [[ -f bazel-bin/a/a.txt ]] && ! [[ -f bazel-bin/a/b.txt ]]) \
-  || fail "Expected outputs of producer are not downloaded without remote metadata"
+    //a:consumer >& $TEST_log || fail "Failed to download outputs"
+  [[ -f bazel-bin/a/a.txt ]] || [[ -f bazel-bin/a/b.txt ]] \
+    && fail "Expected outputs of producer are not downloaded"
 
-  # build without remote cache without remote metadata
+  # build without remote cache
   echo 'bar' > a/in.txt
   bazel build \
     --remote_download_toplevel \
     --verbose_failures \
-    //a:consumer >& $TEST_log || fail "Failed to build without remote cache without remote metadata"
+    //a:consumer >& $TEST_log || fail "Failed to build without remote cache"
+}
 
-  bazel clean || fail "Failed to clean"
+function test_download_toplevel_when_turn_remote_cache_off_with_metadata() {
+  # Test that BwtB doesn't cause build failure if remote cache is disabled (but with
+  # --experimental_action_cache_store_output_metadata) in a following build.
+  # See https://github.com/bazelbuild/bazel/issues/13882.
+
+  mkdir a
+  cat > a/BUILD <<'EOF'
+genrule(
+    name = "producer",
+    outs = ["a.txt", "b.txt"],
+    cmd = "touch $(OUTS)",
+)
+
+genrule(
+    name = "consumer",
+    outs = ["out.txt"],
+    srcs = [":b.txt", "in.txt"],
+    cmd = "cat $(SRCS) > $@",
+)
+EOF
   echo 'foo' > a/in.txt
 
-  # download top level outputs with remote metadata
+  # populate the cache
+  bazel build \
+    --remote_cache=grpc://localhost:${worker_port} \
+    --remote_download_toplevel \
+    --verbose_failures \
+    //a:consumer >& $TEST_log || fail "Failed to populate the cache"
+
+  bazel clean >& $TEST_log || fail "Failed to clean"
+
+  # download top level outputs
   bazel build \
     --remote_cache=grpc://localhost:${worker_port} \
     --remote_download_toplevel \
     --experimental_action_cache_store_output_metadata \
     --verbose_failures \
-    //a:consumer >& $TEST_log || fail "Failed to download outputs with remote metadata"
-  (! [[ -f bazel-bin/a/a.txt ]] && ! [[ -f bazel-bin/a/b.txt ]]) \
-  || fail "Expected outputs of producer are not downloaded with remote metadata"
+    //a:consumer >& $TEST_log || fail "Failed to download outputs"
+  [[ -f bazel-bin/a/a.txt ]] || [[ -f bazel-bin/a/b.txt ]] \
+    && fail "Expected outputs of producer are not downloaded"
 
-  # build without remote cache with remote metadata
+  # build without remote cache
   echo 'bar' > a/in.txt
   bazel build \
     --remote_download_toplevel \
     --experimental_action_cache_store_output_metadata \
     --verbose_failures \
-    //a:consumer >& $TEST_log || fail "Failed to build without remote cache with remote metadata"
+    //a:consumer >& $TEST_log || fail "Failed to build without remote cache"
 }
 
 run_suite "Remote execution and remote cache tests"


### PR DESCRIPTION
When use BwtB, intermediate outputs are not downloaded. If a following build disables remote cache, a "file not found" error will be thrown if an action doesn't have its inputs downloaded in previous build because those files cannot be downloaded in this build.

This change fix this issue by:
  1. Do not load remote metadata from action cache if `--experimental_action_cache_store_output_metadata` is set and remote cache is disabled.
  2. Invalidate action nodes if previous build use BwtB and remote cache is changed from enabled to disabled.

Fixes https://github.com/bazelbuild/bazel/issues/13882.