### PR TITLE
(WIP) Bzlmod: export DEFAULT_SYSTEM_JAVABASE to MODULE.bazel

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BazelRepositoryModule.java
@@ -229,7 +229,7 @@ public class BazelRepositoryModule extends BlazeModule {
         .addSkyFunction(SkyFunctions.REPOSITORY_DIRECTORY, repositoryDelegatorFunction)
         .addSkyFunction(
             SkyFunctions.MODULE_FILE,
-            new ModuleFileFunction(registryFactory, directories.getWorkspace()))
+            new ModuleFileFunction(registryFactory, directories.getWorkspace(), directories.getLocalJavabase()))
         .addSkyFunction(SkyFunctions.BAZEL_MODULE_RESOLUTION, new BazelModuleResolutionFunction())
         .addSkyFunction(SkyFunctions.SINGLE_EXTENSION_EVAL, singleExtensionEvalFunction)
         .addSkyFunction(SkyFunctions.SINGLE_EXTENSION_USAGES, new SingleExtensionUsagesFunction())

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -68,10 +68,12 @@ public class ModuleFileFunction implements SkyFunction {
 
   private final RegistryFactory registryFactory;
   private final Path workspaceRoot;
+  private final Path defaultSystemJavabaseDir;
 
-  public ModuleFileFunction(RegistryFactory registryFactory, Path workspaceRoot) {
+  public ModuleFileFunction(RegistryFactory registryFactory, Path workspaceRoot, Path defaultSystemJavabaseDir) {
     this.registryFactory = registryFactory;
     this.workspaceRoot = workspaceRoot;
+    this.defaultSystemJavabaseDir = defaultSystemJavabaseDir;
   }
 
   @Override
@@ -290,6 +292,8 @@ public class ModuleFileFunction implements SkyFunction {
   private net.starlark.java.eval.Module getPredeclaredEnv(
       ModuleFileGlobals moduleFileGlobals, StarlarkSemantics starlarkSemantics) {
     ImmutableMap.Builder<String, Object> env = ImmutableMap.builder();
+    // Required by java toolchain to locate the local JDK.
+    env.put("DEFAULT_SYSTEM_JAVABASE", defaultSystemJavabaseDir.toString());
     Starlark.addMethods(env, moduleFileGlobals, starlarkSemantics);
     return net.starlark.java.eval.Module.withPredeclared(starlarkSemantics, env.build());
   }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -293,7 +293,9 @@ public class ModuleFileFunction implements SkyFunction {
       ModuleFileGlobals moduleFileGlobals, StarlarkSemantics starlarkSemantics) {
     ImmutableMap.Builder<String, Object> env = ImmutableMap.builder();
     // Required by java toolchain to locate the local JDK.
-    env.put("DEFAULT_SYSTEM_JAVABASE", defaultSystemJavabaseDir.toString());
+    env.put("DEFAULT_SYSTEM_JAVABASE", defaultSystemJavabaseDir != null
+        ? defaultSystemJavabaseDir.toString()
+        : "/tmp/bazel/nosystemjdk");
     Starlark.addMethods(env, moduleFileGlobals, starlarkSemantics);
     return net.starlark.java.eval.Module.withPredeclared(starlarkSemantics, env.build());
   }

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/AnalysisMock.java
@@ -139,7 +139,7 @@ public abstract class AnalysisMock extends LoadingMock {
             ManagedDirectoriesKnowledge.NO_MANAGED_DIRECTORIES,
             BazelSkyframeExecutorConstants.EXTERNAL_PACKAGE_HELPER),
         SkyFunctions.MODULE_FILE,
-        new ModuleFileFunction(FakeRegistry.DEFAULT_FACTORY, directories.getWorkspace()),
+        new ModuleFileFunction(FakeRegistry.DEFAULT_FACTORY, directories.getWorkspace(), directories.getLocalJavabase()),
         SkyFunctions.BAZEL_MODULE_RESOLUTION,
         new BazelModuleResolutionFunction(),
         SkyFunctions.MODULE_EXTENSION_RESOLUTION,

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleHelperTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BzlmodRepoRuleHelperTest.java
@@ -79,6 +79,7 @@ public final class BzlmodRepoRuleHelperTest extends FoundationTestCase {
   @Before
   public void setup() throws Exception {
     workspaceRoot = scratch.dir("/ws");
+    Path defaultLocalJavaBase = scratch.dir("/local_javabase");
     differencer = new SequencedRecordingDifferencer();
     evaluationContext =
         EvaluationContext.newBuilder().setNumThreads(8).setEventHandler(reporter).build();
@@ -113,7 +114,7 @@ public final class BzlmodRepoRuleHelperTest extends FoundationTestCase {
                         externalFilesHelper))
                 .put(
                     SkyFunctions.MODULE_FILE,
-                    new ModuleFileFunction(registryFactory, workspaceRoot))
+                    new ModuleFileFunction(registryFactory, workspaceRoot, defaultLocalJavaBase))
                 .put(SkyFunctions.BAZEL_MODULE_RESOLUTION, new BazelModuleResolutionFunction())
                 .put(
                     GET_REPO_SPEC_BY_NAME_FUNCTION,

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/DiscoveryTest.java
@@ -119,6 +119,7 @@ public class DiscoveryTest extends FoundationTestCase {
   @Before
   public void setup() throws Exception {
     workspaceRoot = scratch.dir("/ws");
+    Path defaultLocalJavaBase = scratch.dir("/local_javabase");
     differencer = new SequencedRecordingDifferencer();
     evaluationContext =
         EvaluationContext.newBuilder().setNumThreads(8).setEventHandler(reporter).build();
@@ -167,7 +168,7 @@ public class DiscoveryTest extends FoundationTestCase {
                 .put(DiscoveryValue.FUNCTION_NAME, new DiscoveryFunction())
                 .put(
                     SkyFunctions.MODULE_FILE,
-                    new ModuleFileFunction(registryFactory, workspaceRoot))
+                    new ModuleFileFunction(registryFactory, workspaceRoot, defaultLocalJavaBase))
                 .put(SkyFunctions.PRECOMPUTED, new PrecomputedFunction())
                 .put(
                     SkyFunctions.REPOSITORY_DIRECTORY,

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -107,6 +107,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
   @Before
   public void setup() throws Exception {
     workspaceRoot = scratch.dir("/ws");
+    Path defaultLocalJavaBase = scratch.dir("/local_javabase");
     modulesRoot = scratch.dir("/modules");
     differencer = new SequencedRecordingDifferencer();
     evaluationContext =
@@ -164,7 +165,7 @@ public class ModuleExtensionResolutionTest extends FoundationTestCase {
                         externalFilesHelper))
                 .put(
                     SkyFunctions.MODULE_FILE,
-                    new ModuleFileFunction(registryFactory, workspaceRoot))
+                    new ModuleFileFunction(registryFactory, workspaceRoot, defaultLocalJavaBase))
                 .put(SkyFunctions.PRECOMPUTED, new PrecomputedFunction())
                 .put(SkyFunctions.BZL_COMPILE, new BzlCompileFunction(packageFactory, hashFunction))
                 .put(

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunctionTest.java
@@ -51,6 +51,7 @@ import com.google.devtools.build.lib.starlarkbuildapi.repository.RepositoryBoots
 import com.google.devtools.build.lib.testutil.FoundationTestCase;
 import com.google.devtools.build.lib.testutil.TestRuleClassProvider;
 import com.google.devtools.build.lib.util.io.TimestampGranularityMonitor;
+import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.Root;
 import com.google.devtools.build.lib.vfs.UnixGlob;
 import com.google.devtools.build.skyframe.EvaluationContext;
@@ -85,6 +86,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
 
   @Before
   public void setup() throws Exception {
+    Path defaultLocalJavaBase = scratch.dir("/local_javabase");
     differencer = new SequencedRecordingDifferencer();
     evaluationContext =
         EvaluationContext.newBuilder().setNumThreads(8).setEventHandler(reporter).build();
@@ -132,7 +134,7 @@ public class ModuleFileFunctionTest extends FoundationTestCase {
                         externalFilesHelper))
                 .put(
                     SkyFunctions.MODULE_FILE,
-                    new ModuleFileFunction(registryFactory, rootDirectory))
+                    new ModuleFileFunction(registryFactory, rootDirectory, defaultLocalJavaBase))
                 .put(SkyFunctions.PRECOMPUTED, new PrecomputedFunction())
                 .put(
                     SkyFunctions.REPOSITORY_DIRECTORY,

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorTest.java
@@ -121,6 +121,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
   @Before
   public void setupDelegator() throws Exception {
     rootPath = scratch.dir("/outputbase");
+    Path defaultLocalJavaBase = scratch.dir("/local_javabase");
     scratch.file(
         rootPath.getRelative("MODULE.bazel").getPathString(), "module(name='test',version='0.1')");
     BlazeDirectories directories =
@@ -233,7 +234,7 @@ public class RepositoryDelegatorTest extends FoundationTestCase {
                     new IgnoredPackagePrefixesFunction(
                         /*ignoredPackagePrefixesFile=*/ PathFragment.EMPTY_FRAGMENT))
                 .put(SkyFunctions.RESOLVED_HASH_VALUES, new ResolvedHashesFunction())
-                .put(SkyFunctions.MODULE_FILE, new ModuleFileFunction(registryFactory, rootPath))
+                .put(SkyFunctions.MODULE_FILE, new ModuleFileFunction(registryFactory, rootPath, defaultLocalJavaBase))
                 .put(SkyFunctions.BAZEL_MODULE_RESOLUTION, new BazelModuleResolutionFunction())
                 .put(
                     SkyFunctions.MODULE_EXTENSION_RESOLUTION,


### PR DESCRIPTION
`DEFAULT_SYSTEM_JAVABASE` is an default variable in WORKSPACE file, its value is controlled by `--default_system_javabase` flag, we need this information to locate the local JDK path in rules_java.

Required by https://github.com/bazelbuild/rules_java/pull/45#issuecomment-965197860