### PR TITLE
Retry on HTTP remote cache fetch failure

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactory.java
@@ -59,15 +59,16 @@ public final class RemoteCacheClientFactory {
       @Nullable Credentials creds,
       AuthAndTLSOptions authAndTlsOptions,
       Path workingDirectory,
-      DigestUtil digestUtil)
+      DigestUtil digestUtil,
+      RemoteRetrier retrier)
       throws IOException {
     Preconditions.checkNotNull(workingDirectory, "workingDirectory");
     if (isHttpCache(options) && isDiskCache(options)) {
       return createDiskAndHttpCache(
-          workingDirectory, options.diskCache, options, creds, authAndTlsOptions, digestUtil);
+          workingDirectory, options.diskCache, options, creds, authAndTlsOptions, digestUtil, retrier);
     }
     if (isHttpCache(options)) {
-      return createHttp(options, creds, authAndTlsOptions, digestUtil);
+      return createHttp(options, creds, authAndTlsOptions, digestUtil, retrier);
     }
     if (isDiskCache(options)) {
       return createDiskCache(
@@ -90,7 +91,8 @@ public final class RemoteCacheClientFactory {
       RemoteOptions options,
       Credentials creds,
       AuthAndTLSOptions authAndTlsOptions,
-      DigestUtil digestUtil) {
+      DigestUtil digestUtil,
+      RemoteRetrier retrier) {
     Preconditions.checkNotNull(options.remoteCache, "remoteCache");
 
     try {
@@ -109,6 +111,7 @@ public final class RemoteCacheClientFactory {
               options.remoteVerifyDownloads,
               ImmutableList.copyOf(options.remoteHeaders),
               digestUtil,
+              retrier,
               creds,
               authAndTlsOptions);
         } else {
@@ -122,6 +125,7 @@ public final class RemoteCacheClientFactory {
             options.remoteVerifyDownloads,
             ImmutableList.copyOf(options.remoteHeaders),
             digestUtil,
+            retrier,
             creds,
             authAndTlsOptions);
       }
@@ -151,7 +155,8 @@ public final class RemoteCacheClientFactory {
       RemoteOptions options,
       Credentials cred,
       AuthAndTLSOptions authAndTlsOptions,
-      DigestUtil digestUtil)
+      DigestUtil digestUtil,
+      RemoteRetrier retrier)
       throws IOException {
     Path cacheDir =
         workingDirectory.getRelative(Preconditions.checkNotNull(diskCachePath, "diskCachePath"));
@@ -159,7 +164,7 @@ public final class RemoteCacheClientFactory {
       cacheDir.createDirectoryAndParents();
     }
 
-    RemoteCacheClient httpCache = createHttp(options, cred, authAndTlsOptions, digestUtil);
+    RemoteCacheClient httpCache = createHttp(options, cred, authAndTlsOptions, digestUtil, retrier);
     return createDiskAndRemoteClient(
         workingDirectory,
         diskCachePath,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -246,6 +246,8 @@ public final class RemoteModule extends BlazeModule {
                      String msg = e.getMessage().toLowerCase();
                      if (msg.contains("connection reset by peer")) {
                        retry = true;
+                     } else if (msg.contains("operation timed out")) {
+                       retry = true;
                      }
                    }
                    return retry;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -103,6 +103,7 @@ import io.grpc.CallCredentials;
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import java.io.IOException;
 import java.net.URI;
@@ -226,7 +227,11 @@ public final class RemoteModule extends BlazeModule {
             if (e instanceof ClosedChannelException) {
               retry = true;
             } else if (e instanceof HttpException) {
-              retry = true;
+              HttpResponseStatus status = ((HttpException) e).response().status();
+              retry = status == HttpResponseStatus.INTERNAL_SERVER_ERROR
+                  || status == HttpResponseStatus.BAD_GATEWAY
+                  || status == HttpResponseStatus.SERVICE_UNAVAILABLE
+                  || status == HttpResponseStatus.GATEWAY_TIMEOUT;
             } else if (e instanceof IOException) {
               String msg = e.getMessage().toLowerCase();
               if (msg.contains("connection reset by peer")) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -115,6 +115,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
@@ -219,6 +220,24 @@ public final class RemoteModule extends BlazeModule {
     return capabilities;
   }
 
+  public static final Predicate<? super Exception> RETRIABLE_HTTP_ERRORS =
+          e -> {
+            boolean retry = false;
+            if (e instanceof ClosedChannelException) {
+              retry = true;
+            } else if (e instanceof HttpException) {
+              retry = true;
+            } else if (e instanceof IOException) {
+              String msg = e.getMessage().toLowerCase();
+              if (msg.contains("connection reset by peer")) {
+                retry = true;
+              } else if (msg.contains("operation timed out")) {
+                retry = true;
+              }
+            }
+            return retry;
+          };
+
   private void initHttpAndDiskCache(
       CommandEnvironment env,
       Credentials credentials,
@@ -236,22 +255,7 @@ public final class RemoteModule extends BlazeModule {
               digestUtil,
               new RemoteRetrier(
                  remoteOptions,
-                 (e) -> {
-                   boolean retry = false;
-                   if (e instanceof ClosedChannelException) {
-                     retry = true;
-                   } else if (e instanceof HttpException) {
-                     retry = true;
-                   } else if (e instanceof IOException) {
-                     String msg = e.getMessage().toLowerCase();
-                     if (msg.contains("connection reset by peer")) {
-                       retry = true;
-                     } else if (msg.contains("operation timed out")) {
-                       retry = true;
-                     }
-                   }
-                   return retry;
-                 },
+                 RETRIABLE_HTTP_ERRORS,
                  retryScheduler,
                  Retrier.ALLOW_ALL_CALLS)
               );

--- a/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -21,6 +21,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:blaze_version_info",
         "//src/main/java/com/google/devtools/build/lib/authandtls",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
+        "//src/main/java/com/google/devtools/build/lib/remote:Retrier",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//third_party:auth",

--- a/src/main/java/com/google/devtools/build/lib/remote/http/DownloadCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/DownloadCommand.java
@@ -25,12 +25,18 @@ final class DownloadCommand {
   private final boolean casDownload;
   private final Digest digest;
   private final OutputStream out;
+  private final long offset;
 
-  DownloadCommand(URI uri, boolean casDownload, Digest digest, OutputStream out) {
+  DownloadCommand(URI uri, boolean casDownload, Digest digest, OutputStream out, long offset) {
     this.uri = Preconditions.checkNotNull(uri);
     this.casDownload = casDownload;
     this.digest = Preconditions.checkNotNull(digest);
     this.out = Preconditions.checkNotNull(out);
+    this.offset = offset;
+  }
+
+  DownloadCommand(URI uri, boolean casDownload, Digest digest, OutputStream out) {
+    this(uri, casDownload, digest, out, 0);
   }
 
   public URI uri() {
@@ -48,4 +54,6 @@ final class DownloadCommand {
   public OutputStream out() {
     return out;
   }
+
+  public long offset() { return offset; }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpException.java
@@ -18,7 +18,7 @@ import io.netty.handler.codec.http.HttpResponse;
 import java.io.IOException;
 
 /** An exception that propagates the http status. */
-final class HttpException extends IOException {
+public final class HttpException extends IOException {
   private final HttpResponse response;
 
   HttpException(HttpResponse response, String message, Throwable cause) {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheClientFactoryTest.java
@@ -18,6 +18,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.devtools.build.lib.authandtls.AuthAndTLSOptions;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.disk.DiskAndRemoteCacheClient;
@@ -32,6 +34,8 @@ import com.google.devtools.build.lib.vfs.SyscallCache;
 import com.google.devtools.build.lib.vfs.inmemoryfs.InMemoryFileSystem;
 import com.google.devtools.common.options.Options;
 import java.io.IOException;
+import java.util.concurrent.Executors;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,6 +51,13 @@ public class RemoteCacheClientFactoryTest {
   private final AuthAndTLSOptions authAndTlsOptions = Options.getDefaults(AuthAndTLSOptions.class);
   private Path workingDirectory;
   private InMemoryFileSystem fs;
+  private ListeningScheduledExecutorService retryScheduler =
+          MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1));
+  private RemoteRetrier retrier = new RemoteRetrier(
+          () -> RemoteRetrier.RETRIES_DISABLED,
+          (e) -> false,
+          retryScheduler,
+          Retrier.ALLOW_ALL_CALLS);
 
   @Before
   public final void setUp() {
@@ -63,7 +74,7 @@ public class RemoteCacheClientFactoryTest {
 
     RemoteCacheClient blobStore =
         RemoteCacheClientFactory.create(
-            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil);
+            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil, retrier);
 
     assertThat(blobStore).isInstanceOf(DiskAndRemoteCacheClient.class);
   }
@@ -76,7 +87,7 @@ public class RemoteCacheClientFactoryTest {
 
     RemoteCacheClient blobStore =
         RemoteCacheClientFactory.create(
-            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil);
+            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil, retrier);
 
     assertThat(blobStore).isInstanceOf(DiskAndRemoteCacheClient.class);
     assertThat(workingDirectory.exists()).isTrue();
@@ -96,7 +107,8 @@ public class RemoteCacheClientFactoryTest {
                 /* creds= */ null,
                 authAndTlsOptions,
                 /* workingDirectory= */ null,
-                digestUtil));
+                digestUtil,
+                retrier));
   }
 
   @Test
@@ -106,7 +118,7 @@ public class RemoteCacheClientFactoryTest {
 
     RemoteCacheClient blobStore =
         RemoteCacheClientFactory.create(
-            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil);
+            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil, retrier);
 
     assertThat(blobStore).isInstanceOf(HttpCacheClient.class);
   }
@@ -125,7 +137,8 @@ public class RemoteCacheClientFactoryTest {
                         /* creds= */ null,
                         authAndTlsOptions,
                         workingDirectory,
-                        digestUtil)))
+                        digestUtil,
+                        retrier)))
         .hasMessageThat()
         .contains("Remote cache proxy unsupported: bad-proxy");
   }
@@ -136,7 +149,7 @@ public class RemoteCacheClientFactoryTest {
 
     RemoteCacheClient blobStore =
         RemoteCacheClientFactory.create(
-            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil);
+            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil, retrier);
 
     assertThat(blobStore).isInstanceOf(HttpCacheClient.class);
   }
@@ -147,7 +160,7 @@ public class RemoteCacheClientFactoryTest {
 
     RemoteCacheClient blobStore =
         RemoteCacheClientFactory.create(
-            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil);
+            remoteOptions, /* creds= */ null, authAndTlsOptions, workingDirectory, digestUtil, retrier);
 
     assertThat(blobStore).isInstanceOf(DiskCacheClient.class);
   }

--- a/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/BUILD
@@ -21,6 +21,7 @@ java_test(
     test_class = "com.google.devtools.build.lib.AllTests",
     deps = [
         "//src/main/java/com/google/devtools/build/lib/authandtls",
+        "//src/main/java/com/google/devtools/build/lib/remote:Retrier",
         "//src/main/java/com/google/devtools/build/lib/remote/common",
         "//src/main/java/com/google/devtools/build/lib/remote/http",
         "//src/main/java/com/google/devtools/build/lib/remote/util",

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -574,8 +574,10 @@ public class HttpCacheClientTest {
     ServerChannel server = null;
     try {
       ByteBuf chunk1 = Unpooled.wrappedBuffer("File ".getBytes(Charsets.US_ASCII));
+      // Replace first chunk to test that the client skips the redundant prefix on retry.
+      ByteBuf chunk1_attempt2 = Unpooled.wrappedBuffer("abcde".getBytes(Charsets.US_ASCII));
       ByteBuf chunk2 = Unpooled.wrappedBuffer("Contents".getBytes(Charsets.US_ASCII));
-      server = testServer.start(new IntermittentFailureHandler(chunk1, chunk2));
+      server = testServer.start(new IntermittentFailureHandler(chunk1, chunk1_attempt2, chunk2));
       Credentials credentials = newCredentials();
       AuthAndTLSOptions authAndTlsOptions = Options.getDefaults(AuthAndTLSOptions.class);
 

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpDownloadHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpDownloadHandlerTest.java
@@ -187,4 +187,35 @@ public class HttpDownloadHandlerTest extends AbstractHttpHandlerTest {
     verify(out, never()).close();
     assertThat(ch.isActive()).isTrue();
   }
+
+  /**
+   * Test that the handler correctly supports chunked downloads at an offset, e.g. on retry.
+   */
+  @Test
+  public void chunkedDownloadAtOffsetShouldWork() throws IOException {
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null, ImmutableList.of()));
+    ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
+    DownloadCommand cmd = new DownloadCommand(CACHE_URI, true, DIGEST, out, 3);
+    ChannelPromise writePromise = ch.newPromise();
+    ch.writeOneOutbound(cmd, writePromise);
+
+    HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+    response.headers().set(HttpHeaders.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+    response.headers().set(HttpHeaders.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+    ch.writeInbound(response);
+    ByteBuf content1 = Unpooled.buffer();
+    content1.writeBytes(new byte[] {1, 2});
+    ch.writeInbound(new DefaultHttpContent(content1));
+    ByteBuf content2 = Unpooled.buffer();
+    content2.writeBytes(new byte[] {3, 4});
+    ch.writeInbound(new DefaultHttpContent(content2));
+    ByteBuf content3 = Unpooled.buffer();
+    content3.writeBytes(new byte[] {5});
+    ch.writeInbound(new DefaultLastHttpContent(content3));
+
+    assertThat(writePromise.isDone()).isTrue();
+    assertThat(out.toByteArray()).isEqualTo(new byte[] {4, 5});
+    verify(out, never()).close();
+    assertThat(ch.isActive()).isTrue();
+  }
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpDownloadHandlerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpDownloadHandlerTest.java
@@ -162,4 +162,29 @@ public class HttpDownloadHandlerTest extends AbstractHttpHandlerTest {
     verify(out, never()).close();
     assertThat(ch.isOpen()).isFalse();
   }
+
+  /**
+   * Test that the handler correctly supports downloads at an offset, e.g. on retry.
+   */
+  @Test
+  public void downloadAtOffsetShouldWork() throws IOException {
+    EmbeddedChannel ch = new EmbeddedChannel(new HttpDownloadHandler(null, ImmutableList.of()));
+    ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
+    DownloadCommand cmd = new DownloadCommand(CACHE_URI, true, DIGEST, out, 2);
+    ChannelPromise writePromise = ch.newPromise();
+    ch.writeOneOutbound(cmd, writePromise);
+
+    HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+    response.headers().set(HttpHeaders.CONTENT_LENGTH, 5);
+    response.headers().set(HttpHeaders.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+    ch.writeInbound(response);
+    ByteBuf content = Unpooled.buffer();
+    content.writeBytes(new byte[] {1, 2, 3, 4, 5});
+    ch.writeInbound(new DefaultLastHttpContent(content));
+
+    assertThat(writePromise.isDone()).isTrue();
+    assertThat(out.toByteArray()).isEqualTo(new byte[] {3, 4, 5});
+    verify(out, never()).close();
+    assertThat(ch.isActive()).isTrue();
+  }
 }


### PR DESCRIPTION
Bazel's previous behavior was to rebuild an artifact locally if fetching
it from an HTTP remote cache failed. This behavior is different from
GRPC remote cache case where Bazel will retry the fetch.

The lack of retry is an issue for multiple reasons: On one hand
rebuilding locally can be slower than fetching from the remote cache, on
the other hand if a build action is not bit reproducible, as is the case
with some compilers, then the local rebuild will trigger cache misses on
further build actions that depend on the current artifact.

This change aims to avoid theses issues by retrying the fetch in the
HTTP cache case similarly to how the GRPC cache client does it.

Some care needs to be taken due to the design of Bazel's internal remote
cache client API. For a fetch the client is given an `OutputStream`
object that it is expected to write the fetched data to. This may be a
temporary file on disk that will be moved to the final location after
the fetch completed. On retry, we need to be careful to not duplicate
previously written data when writing into this `OutputStream`. Due to
the generality of the `OutputStream` interface we cannot reset the file
handle or write pointer to start fresh. Instead, this change follows the
same pattern used in the GRPC cache client. Namely, keep track of the
data previously written and continue from that offset on retry.

With this change the HTTP cache client will attempt to fetch the data
from the remote cache via an HTTP range request. So that the server only
needs to send the data that is still missing. If the server replies with
a 206 Partial Content response, then we write the received data directly
into the output stream, if the server does not support range requests
and instead replies with the full data, then we drop the duplicate
prefix and only write into the output stream from the required offset.

This patch has been running successfully in production [here](https://github.com/digital-asset/daml/pull/11238).

cc @cocreature

**TODO**
- [x] Testing - this PR does not include any testing, yet. If anyone has any pointers on how to best test this in the Bazel code base please let me know. One option I briefly explored was to add a test-case to `src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java`. But, that seemed to require implementing support for HTTP range requests in `src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/http/HttpCacheServerHandler.java`. Perhaps there is a better way to test this change.