### PR TITLE
Fix typo in example on testing.md.

### DIFF
--- a/site/docs/skylark/testing.md
+++ b/site/docs/skylark/testing.md
@@ -170,7 +170,7 @@ Then:
 *   its test rule type should be named `foo_test` (`provider_contents_test`)
 
 *   the label of the target of this rule type should be `foo`
-    (`provider_contents_test`)
+    (`provider_contents`)
 
 *   the implementation function for the testing rule should be named
     `_foo_test_impl` (`_provider_contents_test_impl`)

--- a/site/docs/skylark/testing.md
+++ b/site/docs/skylark/testing.md
@@ -169,8 +169,8 @@ Then:
 
 *   its test rule type should be named `foo_test` (`provider_contents_test`)
 
-*   the label of the target of this rule type should be `foo`
-    (`provider_contents`)
+*   the label of the target of this rule type should be `foo_test`
+    (`provider_contents_test`)
 
 *   the implementation function for the testing rule should be named
     `_foo_test_impl` (`_provider_contents_test_impl`)


### PR DESCRIPTION
The example says that `foo` should correspond to `provider_contents` earlier in the text.