### PR TITLE
Enable user_link_flags_feature for macosx cc_toolchain_config

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -1243,6 +1243,7 @@ def _impl(ctx):
             coverage_feature,
             default_compile_flags_feature,
             default_link_flags_feature,
+            user_link_flags_feature,
             fdo_optimize_feature,
             supports_dynamic_linker_feature,
             dbg_feature,


### PR DESCRIPTION
This will cause the values passed in the link_libs parameters
to not get silently dropped on macOS 12 Monterey, and fix
the problem where the command line dev tools toolchain
will output C++ binaries fails to start with a segmentation
fault error.

Fixes: #14273