### PR TITLE
[5.x] Remote: Add support for compression on gRPC cache

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -81,6 +81,7 @@ pkg_tar(
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
         "@com_google_protobuf//:protobuf_javalite",
+        "@zstd-jni//:zstd-jni",
     ],
     package_dir = "derived/jars",
     strip_prefix = "external",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -301,6 +301,14 @@ dist_http_archive(
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
 )
 
+dist_http_archive(
+    name = "zstd-jni",
+    patch_cmds = EXPORT_WORKSPACE_IN_BUILD_BAZEL_FILE,
+    patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_BAZEL_FILE_WIN,
+    build_file = "//third_party:zstd-jni/zstd-jni.BUILD",
+    strip_prefix = "zstd-jni-1.5.0-4"
+)
+
 http_archive(
     name = "org_snakeyaml",
     build_file_content = """

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -172,6 +172,21 @@ DIST_DEPS = {
             "test_WORKSPACE_files",
         ],
     },
+    "zstd-jni": {
+        "archive": "v1.5.0-4.zip",
+        "patch_args": ["-p1"],
+        "patches": [
+            "//third_party:zstd-jni/Native.java.patch",
+        ],
+        "sha256": "d320d59b89a163c5efccbe4915ae6a49883ce653cdc670643dfa21c6063108e4",
+        "urls": [
+            "https://mirror.bazel.build/github.com/luben/zstd-jni/archive/v1.5.0-4.zip",
+            "https://github.com/luben/zstd-jni/archive/v1.5.0-4.zip",
+        ],
+        "used_in": [
+            "additional_distfiles",
+        ],
+    },
     ###################################################
     #
     # Build time dependencies for testing and packaging

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -16,6 +16,7 @@ filegroup(
         "//src/main/java/com/google/devtools/build/lib/remote/merkletree:srcs",
         "//src/main/java/com/google/devtools/build/lib/remote/options:srcs",
         "//src/main/java/com/google/devtools/build/lib/remote/util:srcs",
+        "//src/main/java/com/google/devtools/build/lib/remote/zstd:srcs",
     ],
     visibility = ["//src:__subpackages__"],
 )
@@ -81,6 +82,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/remote/merkletree",
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
+        "//src/main/java/com/google/devtools/build/lib/remote/zstd",
         "//src/main/java/com/google/devtools/build/lib/sandbox",
         "//src/main/java/com/google/devtools/build/lib/skyframe:mutable_supplier",
         "//src/main/java/com/google/devtools/build/lib/skyframe:tree_artifact_value",
@@ -94,6 +96,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/protobuf:failure_details_java_proto",
+        "//third_party:apache_commons_compress",
         "//third_party:auth",
         "//third_party:caffeine",
         "//third_party:flogger",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteServerCapabilities.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.remote;
 import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.CapabilitiesGrpc;
 import build.bazel.remote.execution.v2.CapabilitiesGrpc.CapabilitiesBlockingStub;
+import build.bazel.remote.execution.v2.Compressor;
 import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.ExecutionCapabilities;
 import build.bazel.remote.execution.v2.GetCapabilitiesRequest;
@@ -247,6 +248,13 @@ class RemoteServerCapabilities {
               "--remote_upload_local_results is set, but the current account is not authorized "
                   + "to write local results to the remote cache.");
         }
+      }
+
+      if (remoteOptions.cacheCompression
+          && !cacheCap.getSupportedCompressorsList().contains(Compressor.Value.ZSTD)) {
+        result.addError(
+            "--experimental_remote_cache_compression requested but remote does not support"
+                + " compression");
       }
 
       // Check result cache priority is in the supported range.

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -365,6 +365,14 @@ public final class RemoteOptions extends OptionsBase {
   public boolean incompatibleRemoteSymlinks;
 
   @Option(
+      name = "experimental_remote_cache_compression",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.REMOTE,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "If enabled, compress/decompress cache blobs with zstd.")
+  public boolean cacheCompression;
+
+  @Option(
       name = "build_event_upload_max_threads",
       defaultValue = "100",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/remote/zstd/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/zstd/BUILD
@@ -1,0 +1,24 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(
+    default_visibility = ["//src:__subpackages__"],
+)
+
+licenses(["notice"])
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["*"]),
+    visibility = ["//src:__subpackages__"],
+)
+
+java_library(
+    name = "zstd",
+    srcs = glob(["*.java"]),
+    deps = [
+        "//third_party:apache_commons_compress",
+        "//third_party:guava",
+        "//third_party/protobuf:protobuf_java",
+        "@zstd-jni",
+    ],
+)

--- a/src/main/java/com/google/devtools/build/lib/remote/zstd/ZstdCompressingInputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/zstd/ZstdCompressingInputStream.java
@@ -1,0 +1,104 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.zstd;
+
+import static java.lang.Math.max;
+
+import com.github.luben.zstd.ZstdOutputStream;
+import com.google.common.base.Preconditions;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+/** A {@link FilterInputStream} that use zstd to compress the content. */
+public class ZstdCompressingInputStream extends FilterInputStream {
+  // We want the buffer to be able to contain at least:
+  //   - Magic number: 4 bytes
+  //   - FrameHeader 14 bytes
+  //   - Block Header: 3 bytes
+  //   - First block byte
+  // This guarantees that we can always compress at least
+  // 1 byte and write it to the pipe without blocking.
+  public static final int MIN_BUFFER_SIZE = 4 + 14 + 3 + 1;
+
+  private final PipedInputStream pis;
+  private ZstdOutputStream zos;
+  private final int size;
+
+  public ZstdCompressingInputStream(InputStream in) throws IOException {
+    this(in, 512);
+  }
+
+  ZstdCompressingInputStream(InputStream in, int size) throws IOException {
+    super(in);
+    Preconditions.checkArgument(
+        size >= MIN_BUFFER_SIZE,
+        String.format("The buffer size must be at least %d bytes", MIN_BUFFER_SIZE));
+    this.size = size;
+    this.pis = new PipedInputStream(size);
+    this.zos = new ZstdOutputStream(new PipedOutputStream(pis));
+  }
+
+  private void reFill() throws IOException {
+    byte[] buf = new byte[size];
+    int len = super.read(buf, 0, max(0, size - pis.available() - MIN_BUFFER_SIZE + 1));
+    if (len == -1) {
+      zos.close();
+      zos = null;
+    } else {
+      zos.write(buf, 0, len);
+      zos.flush();
+    }
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (pis.available() == 0) {
+      if (zos == null) {
+        return -1;
+      }
+      reFill();
+    }
+    return pis.read();
+  }
+
+  @Override
+  public int read(byte[] b) throws IOException {
+    return read(b, 0, b.length);
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    int count = 0;
+    int n = len > 0 ? -1 : 0;
+    while (count < len && (pis.available() > 0 || zos != null)) {
+      if (pis.available() == 0) {
+        reFill();
+      }
+      n = pis.read(b, count + off, len - count);
+      count += max(0, n);
+    }
+    return count > 0 ? count : n;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (zos != null) {
+      zos.close();
+    }
+    in.close();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/remote/zstd/ZstdDecompressingOutputStream.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/zstd/ZstdDecompressingOutputStream.java
@@ -1,0 +1,63 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.zstd;
+
+import com.github.luben.zstd.ZstdInputStream;
+import com.google.protobuf.ByteString;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.commons.compress.utils.CountingOutputStream;
+
+/** A {@link CountingOutputStream} that use zstd to decompress the content. */
+public class ZstdDecompressingOutputStream extends CountingOutputStream {
+  private ByteArrayInputStream inner;
+  private final ZstdInputStream zis;
+
+  public ZstdDecompressingOutputStream(OutputStream out) throws IOException {
+    super(out);
+    zis =
+        new ZstdInputStream(
+            new InputStream() {
+              @Override
+              public int read() {
+                return inner.read();
+              }
+
+              @Override
+              public int read(byte[] b, int off, int len) {
+                return inner.read(b, off, len);
+              }
+            });
+    zis.setContinuous(true);
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    write(new byte[] {(byte) b}, 0, 1);
+  }
+
+  @Override
+  public void write(byte[] b) throws IOException {
+    write(b, 0, b.length);
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    inner = new ByteArrayInputStream(b, off, len);
+    byte[] data = ByteString.readFrom(zis).toByteArray();
+    super.write(data, 0, data.length);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/BUILD
@@ -16,6 +16,7 @@ filegroup(
         "//src/test/java/com/google/devtools/build/lib/remote/merkletree:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/options:srcs",
         "//src/test/java/com/google/devtools/build/lib/remote/util:srcs",
+        "//src/test/java/com/google/devtools/build/lib/remote/zstd:srcs",
     ],
     visibility = ["//src/test/java/com/google/devtools/build/lib:__pkg__"],
 )
@@ -115,5 +116,6 @@ java_test(
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
         "@remoteapis//:build_bazel_semver_semver_java_proto",
+        "@zstd-jni//:zstd-jni",
     ],
 )

--- a/src/test/java/com/google/devtools/build/lib/remote/ChunkerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ChunkerTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.remote;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.github.luben.zstd.Zstd;
 import com.google.devtools.build.lib.remote.Chunker.Chunk;
 import com.google.protobuf.ByteString;
 import java.io.ByteArrayInputStream;
@@ -101,7 +102,7 @@ public class ChunkerTest {
 
   @Test
   public void reset() throws Exception {
-    byte[] data = new byte[]{1, 2, 3};
+    byte[] data = new byte[] {1, 2, 3};
     Chunker chunker = Chunker.builder().setInput(data).setChunkSize(1).build();
 
     assertNextEquals(chunker, (byte) 1);
@@ -125,12 +126,13 @@ public class ChunkerTest {
 
     byte[] data = new byte[] {1, 2};
     final AtomicReference<InputStream> in = new AtomicReference<>();
-    Supplier<InputStream> supplier = () -> {
-      in.set(Mockito.spy(new ByteArrayInputStream(data)));
-      return in.get();
-    };
+    Supplier<InputStream> supplier =
+        () -> {
+          in.set(Mockito.spy(new ByteArrayInputStream(data)));
+          return in.get();
+        };
 
-    Chunker chunker = new Chunker(supplier, data.length, 1);
+    Chunker chunker = new Chunker(supplier, data.length, 1, false);
     assertThat(in.get()).isNull();
     assertNextEquals(chunker, (byte) 1);
     Mockito.verify(in.get(), Mockito.never()).close();
@@ -171,6 +173,51 @@ public class ChunkerTest {
     assertThat(next).isNotNull();
     assertThat(next.getOffset()).isEqualTo(2);
     assertThat(next.getData()).hasSize(8);
+  }
+
+  @Test
+  public void testSingleChunkCompressed() throws IOException {
+    byte[] data = {72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33};
+    Chunker chunker =
+        Chunker.builder().setInput(data).setChunkSize(data.length * 2).setCompressed(true).build();
+    Chunk next = chunker.next();
+    assertThat(chunker.hasNext()).isFalse();
+    assertThat(Zstd.decompress(next.getData().toByteArray(), data.length)).isEqualTo(data);
+  }
+
+  @Test
+  public void testMultiChunkCompressed() throws IOException {
+    byte[] data = {72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33};
+    Chunker chunker =
+        Chunker.builder().setInput(data).setChunkSize(data.length / 2).setCompressed(true).build();
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    chunker.next().getData().writeTo(baos);
+    assertThat(chunker.hasNext()).isTrue();
+    while (chunker.hasNext()) {
+      chunker.next().getData().writeTo(baos);
+    }
+    baos.close();
+
+    assertThat(Zstd.decompress(baos.toByteArray(), data.length)).isEqualTo(data);
+  }
+
+  @Test
+  public void testActualSizeIsCorrectAfterSeek() throws IOException {
+    byte[] data = {72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33};
+    int[] expectedSizes = {12, 24};
+    for (int expected : expectedSizes) {
+      Chunker chunker =
+          Chunker.builder()
+              .setInput(data)
+              .setChunkSize(data.length * 2)
+              .setCompressed(expected != data.length)
+              .build();
+      chunker.seek(5);
+      chunker.next();
+      assertThat(chunker.hasNext()).isFalse();
+      assertThat(chunker.getOffset()).isEqualTo(expected);
+    }
   }
 
   private void assertNextEquals(Chunker chunker, byte... data) throws IOException {

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -125,16 +125,16 @@ import org.mockito.stubbing.Answer;
 @RunWith(JUnit4.class)
 public class GrpcCacheClientTest {
 
-  private static final DigestUtil DIGEST_UTIL = new DigestUtil(DigestHashFunction.SHA256);
+  protected static final DigestUtil DIGEST_UTIL = new DigestUtil(DigestHashFunction.SHA256);
 
   private FileSystem fs;
   private Path execRoot;
   private FileOutErr outErr;
   private FakeActionInputFileCache fakeFileCache;
-  private final MutableHandlerRegistry serviceRegistry = new MutableHandlerRegistry();
+  protected final MutableHandlerRegistry serviceRegistry = new MutableHandlerRegistry();
   private final String fakeServerName = "fake server for " + getClass();
   private Server fakeServer;
-  private RemoteActionExecutionContext context;
+  protected RemoteActionExecutionContext context;
   private RemotePathResolver remotePathResolver;
   private ListeningScheduledExecutorService retryService;
 
@@ -196,12 +196,12 @@ public class GrpcCacheClientTest {
     return newClient(Options.getDefaults(RemoteOptions.class));
   }
 
-  private GrpcCacheClient newClient(RemoteOptions remoteOptions) throws IOException {
+  protected GrpcCacheClient newClient(RemoteOptions remoteOptions) throws IOException {
     return newClient(remoteOptions, () -> new ExponentialBackoff(remoteOptions));
   }
 
-  private GrpcCacheClient newClient(RemoteOptions remoteOptions, Supplier<Backoff> backoffSupplier)
-      throws IOException {
+  protected GrpcCacheClient newClient(
+      RemoteOptions remoteOptions, Supplier<Backoff> backoffSupplier) throws IOException {
     AuthAndTLSOptions authTlsOptions = Options.getDefaults(AuthAndTLSOptions.class);
     authTlsOptions.useGoogleDefaultCredentials = true;
     authTlsOptions.googleCredentials = "/execroot/main/creds.json";
@@ -256,7 +256,7 @@ public class GrpcCacheClientTest {
         channel.retain(), callCredentialsProvider, remoteOptions, retrier, DIGEST_UTIL, uploader);
   }
 
-  private static byte[] downloadBlob(
+  protected static byte[] downloadBlob(
       RemoteActionExecutionContext context, GrpcCacheClient cacheClient, Digest digest)
       throws IOException, InterruptedException {
     try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTestExtra.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTestExtra.java
@@ -1,0 +1,107 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.ArgumentMatchers.any;
+
+import build.bazel.remote.execution.v2.Digest;
+import com.github.luben.zstd.Zstd;
+import com.google.bytestream.ByteStreamGrpc.ByteStreamImplBase;
+import com.google.bytestream.ByteStreamProto.ReadRequest;
+import com.google.bytestream.ByteStreamProto.ReadResponse;
+import com.google.devtools.build.lib.remote.Retrier.Backoff;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.common.options.Options;
+import com.google.protobuf.ByteString;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.Arrays;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/** Extra tests for {@link GrpcCacheClient} that are not tested internally. */
+public class GrpcCacheClientTestExtra extends GrpcCacheClientTest {
+
+  @Test
+  public void compressedDownloadBlobIsRetriedWithProgress()
+      throws IOException, InterruptedException {
+    Backoff mockBackoff = Mockito.mock(Backoff.class);
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.cacheCompression = true;
+    final GrpcCacheClient client = newClient(options, () -> mockBackoff);
+    final Digest digest = DIGEST_UTIL.computeAsUtf8("abcdefg");
+    ByteString blob = ByteString.copyFrom(Zstd.compress("abcdefg".getBytes(UTF_8)));
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+            assertThat(request.getResourceName().contains(digest.getHash())).isTrue();
+            int off = (int) request.getReadOffset();
+            // Zstd header size is 9 bytes
+            ByteString data = off == 0 ? blob.substring(0, 9 + 1) : blob.substring(9 + off);
+            responseObserver.onNext(ReadResponse.newBuilder().setData(data).build());
+            if (off == 0) {
+              responseObserver.onError(Status.DEADLINE_EXCEEDED.asException());
+            } else {
+              responseObserver.onCompleted();
+            }
+          }
+        });
+    assertThat(new String(downloadBlob(context, client, digest), UTF_8)).isEqualTo("abcdefg");
+    Mockito.verify(mockBackoff, Mockito.never()).nextDelayMillis(any(Exception.class));
+  }
+
+  @Test
+  public void testCompressedDownload() throws IOException, InterruptedException {
+    RemoteOptions options = Options.getDefaults(RemoteOptions.class);
+    options.cacheCompression = true;
+    final GrpcCacheClient client = newClient(options);
+    final byte[] data = "abcdefg".getBytes(UTF_8);
+    final Digest digest = DIGEST_UTIL.compute(data);
+    final byte[] compressed = Zstd.compress(data);
+
+    serviceRegistry.addService(
+        new ByteStreamImplBase() {
+          @Override
+          public void read(ReadRequest request, StreamObserver<ReadResponse> responseObserver) {
+            assertThat(request.getResourceName().contains(digest.getHash())).isTrue();
+            responseObserver.onNext(
+                ReadResponse.newBuilder()
+                    .setData(
+                        ByteString.copyFrom(
+                            Arrays.copyOfRange(compressed, 0, compressed.length / 3)))
+                    .build());
+            responseObserver.onNext(
+                ReadResponse.newBuilder()
+                    .setData(
+                        ByteString.copyFrom(
+                            Arrays.copyOfRange(
+                                compressed, compressed.length / 3, compressed.length / 3 * 2)))
+                    .build());
+            responseObserver.onNext(
+                ReadResponse.newBuilder()
+                    .setData(
+                        ByteString.copyFrom(
+                            Arrays.copyOfRange(
+                                compressed, compressed.length / 3 * 2, compressed.length)))
+                    .build());
+            responseObserver.onCompleted();
+          }
+        });
+    assertThat(downloadBlob(context, client, digest)).isEqualTo(data);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
@@ -1075,7 +1075,8 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
             responseObserver.onCompleted();
           }
         });
-    String stdOutResourceName = getResourceName(remoteOptions.remoteInstanceName, stdOutDigest);
+    String stdOutResourceName =
+        getResourceName(remoteOptions.remoteInstanceName, stdOutDigest, false);
     serviceRegistry.addService(
         new ByteStreamImplBase() {
           @Override
@@ -1136,7 +1137,8 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
             responseObserver.onCompleted();
           }
         });
-    String stdOutResourceName = getResourceName(remoteOptions.remoteInstanceName, stdOutDigest);
+    String stdOutResourceName =
+        getResourceName(remoteOptions.remoteInstanceName, stdOutDigest, false);
     serviceRegistry.addService(
         new ByteStreamImplBase() {
           @Override
@@ -1262,7 +1264,8 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
           }
         });
     String dummyTreeResourceName =
-        getResourceName(remoteOptions.remoteInstanceName, DUMMY_OUTPUT_DIRECTORY.getTreeDigest());
+        getResourceName(
+            remoteOptions.remoteInstanceName, DUMMY_OUTPUT_DIRECTORY.getTreeDigest(), false);
     serviceRegistry.addService(
         new ByteStreamImplBase() {
           private boolean first = true;

--- a/src/test/java/com/google/devtools/build/lib/remote/zstd/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/remote/zstd/BUILD
@@ -1,0 +1,28 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
+package(
+    default_testonly = 1,
+    default_visibility = ["//src:__subpackages__"],
+)
+
+licenses(["notice"])
+
+filegroup(
+    name = "srcs",
+    testonly = 0,
+    srcs = glob(["**"]),
+    visibility = ["//src:__subpackages__"],
+)
+
+java_test(
+    name = "zstd",
+    srcs = glob(["*.java"]),
+    test_class = "com.google.devtools.build.lib.AllTests",
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/remote/zstd",
+        "//src/test/java/com/google/devtools/build/lib:test_runner",
+        "//third_party:junit4",
+        "//third_party:truth",
+        "@zstd-jni//:zstd-jni",
+    ],
+)

--- a/src/test/java/com/google/devtools/build/lib/remote/zstd/ZstdCompressingInputStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/zstd/ZstdCompressingInputStreamTest.java
@@ -1,0 +1,54 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.zstd;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.github.luben.zstd.Zstd;
+import com.google.common.io.ByteStreams;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Random;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ZstdCompressingInputStream}. */
+@RunWith(JUnit4.class)
+public class ZstdCompressingInputStreamTest {
+  @Test
+  public void compressionWorks() throws IOException {
+    Random rand = new Random();
+    byte[] data = new byte[50];
+    rand.nextBytes(data);
+
+    ByteArrayInputStream bais = new ByteArrayInputStream(data);
+    ZstdCompressingInputStream zdis = new ZstdCompressingInputStream(bais);
+
+    assertThat(Zstd.decompress(ByteStreams.toByteArray(zdis), data.length)).isEqualTo(data);
+  }
+
+  @Test
+  public void streamCanBeCompressedWithMinimumBufferSize() throws IOException {
+    Random rand = new Random();
+    byte[] data = new byte[50];
+    rand.nextBytes(data);
+
+    ByteArrayInputStream bais = new ByteArrayInputStream(data);
+    ZstdCompressingInputStream zdis =
+        new ZstdCompressingInputStream(bais, ZstdCompressingInputStream.MIN_BUFFER_SIZE);
+
+    assertThat(Zstd.decompress(ByteStreams.toByteArray(zdis), data.length)).isEqualTo(data);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/zstd/ZstdDecompressingOutputStreamTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/zstd/ZstdDecompressingOutputStreamTest.java
@@ -1,0 +1,43 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.zstd;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.github.luben.zstd.Zstd;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ZstdDecompressingOutputStream}. */
+@RunWith(JUnit4.class)
+public class ZstdDecompressingOutputStreamTest {
+  @Test
+  public void decompressionWorks() throws IOException {
+    Random rand = new Random();
+    byte[] data = new byte[50];
+    rand.nextBytes(data);
+    byte[] compressed = Zstd.compress(data);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ZstdDecompressingOutputStream zdos = new ZstdDecompressingOutputStream(baos);
+    zdos.write(compressed);
+    zdos.flush();
+
+    assertThat(baos.toByteArray()).isEqualTo(data);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/zstd/ZstdDecompressingOutputStreamTestExtra.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/zstd/ZstdDecompressingOutputStreamTestExtra.java
@@ -1,0 +1,70 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.remote.zstd;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.github.luben.zstd.Zstd;
+import com.github.luben.zstd.ZstdOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import org.junit.Test;
+
+/** Extra tests for {@link ZstdDecompressingOutputStream} that are not tested internally. */
+public class ZstdDecompressingOutputStreamTestExtra {
+  @Test
+  public void streamCanBeDecompressedOneByteAtATime() throws IOException {
+    Random rand = new Random();
+    byte[] data = new byte[50];
+    rand.nextBytes(data);
+    byte[] compressed = Zstd.compress(data);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ZstdDecompressingOutputStream zdos = new ZstdDecompressingOutputStream(baos);
+    for (byte b : compressed) {
+      zdos.write(b);
+    }
+    zdos.flush();
+
+    assertThat(baos.toByteArray()).isEqualTo(data);
+  }
+
+  @Test
+  public void bytesWrittenMatchesDecompressedBytes() throws IOException {
+    byte[] data = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".getBytes(UTF_8);
+
+    ByteArrayOutputStream compressed = new ByteArrayOutputStream();
+    ZstdOutputStream zos = new ZstdOutputStream(compressed);
+    zos.setCloseFrameOnFlush(true);
+    for (int i = 0; i < data.length; i++) {
+      zos.write(data[i]);
+      if (i % 5 == 0) {
+        // Create multiple frames of 5 bytes each.
+        zos.flush();
+      }
+    }
+    zos.close();
+
+    ByteArrayOutputStream decompressed = new ByteArrayOutputStream();
+    ZstdDecompressingOutputStream zdos = new ZstdDecompressingOutputStream(decompressed);
+    for (byte b : compressed.toByteArray()) {
+      zdos.write(b);
+      zdos.flush();
+      assertThat(zdos.getBytesWritten()).isEqualTo(decompressed.toByteArray().length);
+    }
+    assertThat(decompressed.toByteArray()).isEqualTo(data);
+  }
+}

--- a/src/test/shell/integration/minimal_jdk_test.sh
+++ b/src/test/shell/integration/minimal_jdk_test.sh
@@ -42,13 +42,13 @@ export BAZEL_SUFFIX="_jdk_minimal"
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-# Bazel's install base is < 310MB with minimal JDK and > 315MB with an all
+# Bazel's install base is < 311MB with minimal JDK and > 315MB with an all
 # modules JDK.
-function test_size_less_than_310MB() {
+function test_size_less_than_311MB() {
   bazel info
   ib=$(bazel info install_base)
   size=$(du -s "$ib" | cut -d\	 -f1)
-  maxsize=$((1024*310))
+  maxsize=$((1024*311))
   if [ $size -gt $maxsize ]; then
     echo "$ib was too big:" 1>&2
     du -a "$ib" 1>&2

--- a/third_party/zstd-jni/Native.java.patch
+++ b/third_party/zstd-jni/Native.java.patch
@@ -1,0 +1,11 @@
+--- a/src/main/java/com/github/luben/zstd/util/Native.java
++++ b/src/main/java/com/github/luben/zstd/util/Native.java
+@@ -59,7 +59,7 @@ public enum Native {
+         if (loaded) {
+             return;
+         }
+-        String resourceName = resourceName();
++        String resourceName = "/libzstd-jni.so";
+ 
+         String overridePath = System.getProperty(nativePathOverride);
+         if (overridePath != null) {

--- a/third_party/zstd-jni/zstd-jni.BUILD
+++ b/third_party/zstd-jni/zstd-jni.BUILD
@@ -1,0 +1,62 @@
+cc_binary(
+    name = "libzstd-jni.so",
+    srcs = glob([
+        "src/main/native/**/*.c",
+        "src/main/native/**/*.h",
+    ]) + select({
+        "@io_bazel//src/conditions:windows": [
+            "src/windows/include/jni_md.h",
+            "jni/jni.h",
+        ],
+        "//conditions:default": [
+            "jni/jni_md.h",
+            "jni/jni.h",
+        ]
+    }),
+    copts = select({
+        "@io_bazel//src/conditions:windows": [],
+        "//conditions:default": [
+            "-std=c99",
+            "-Wno-unused-variable",
+            "-Wno-sometimes-uninitialized",
+        ]
+    }),
+    linkshared = 1,
+    includes = select({
+        "@io_bazel//src/conditions:windows": ["src/windows/include"],
+        "//conditions:default": [],
+    }) + [
+        "jni",
+        "src/main/native",
+        "src/main/native/common",
+    ],
+    local_defines = [
+        "ZSTD_LEGACY_SUPPORT=4",
+        "ZSTD_MULTITHREAD=1",
+    ] + select({
+        "@io_bazel//src/conditions:windows": ["_JNI_IMPLEMENTATION_"],
+        "//conditions:default": [],
+    }),
+)
+
+
+genrule(
+    name = "version-java",
+    cmd_bash = 'echo "package com.github.luben.zstd.util;\n\npublic class ZstdVersion {\n\tpublic static final String VERSION = \\"$$(cat $<)\\";\n}" > $@',
+    cmd_ps = '$$PSDefaultParameterValues.Remove("*:Encoding"); $$version = (Get-Content $<) -join ""; Set-Content -NoNewline -Path $@ -Value "package com.github.luben.zstd.util;\n\npublic class ZstdVersion {\n\tpublic static final String VERSION = `"$${version}`";\n}\n"',
+    srcs = ["version"],
+    outs = ["ZstdVersion.java"],
+)
+
+java_library(
+    name = "zstd-jni",
+    srcs = glob([
+        "src/main/java/**/*.java",
+    ]) + [
+        ":version-java",
+    ],
+    resources = [":libzstd-jni.so"],
+    visibility = [
+        "//visibility:public",
+    ],
+)


### PR DESCRIPTION
5.0 cherry picks for https://github.com/bazelbuild/bazel/pull/14041.

Original commits: 
- 2986222e74c0cd70838dde4869da8b94b828f216
- 6da8086ebc721e998023831cc76b7b6e248122bc