### PR TITLE
[5.x] Silence a zstd-jni GCC warning.

### DIFF
--- a/third_party/zstd-jni/zstd-jni.BUILD
+++ b/third_party/zstd-jni/zstd-jni.BUILD
@@ -18,6 +18,7 @@ cc_binary(
         "//conditions:default": [
             "-std=c99",
             "-Wno-unused-variable",
+            "-Wno-maybe-uninitialized",
             "-Wno-sometimes-uninitialized",
         ]
     }),


### PR DESCRIPTION
Original commit: 79888fe7369479c398bafe064daa19a7ae30f710.