### PR TITLE
Remove merging of java_outputs in JavaPluginInfo.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCommon.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCommon.java
@@ -787,7 +787,7 @@ public class JavaCommon {
     Iterables.addAll(result, getDirectJavaPluginInfoForAttribute(ruleContext, ":java_plugins"));
     Iterables.addAll(result, getDirectJavaPluginInfoForAttribute(ruleContext, "plugins"));
     Iterables.addAll(result, getExportedJavaPluginInfoForAttribute(ruleContext, "deps"));
-    return JavaPluginInfo.merge(result);
+    return JavaPluginInfo.mergeWithoutJavaOutputs(result);
   }
 
   private static Iterable<JavaPluginInfo> getDirectJavaPluginInfoForAttribute(
@@ -841,7 +841,7 @@ public class JavaCommon {
   }
 
   public static JavaPluginInfo getTransitivePlugins(RuleContext ruleContext) {
-    return JavaPluginInfo.merge(
+    return JavaPluginInfo.mergeWithoutJavaOutputs(
         Iterables.concat(
             getDirectJavaPluginInfoForAttribute(ruleContext, "exported_plugins"),
             getExportedJavaPluginInfoForAttribute(ruleContext, "exports")));

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfo.java
@@ -159,7 +159,7 @@ public final class JavaInfo extends NativeInfo
             .addProvider(
                 JavaRuleOutputJarsProvider.class,
                 JavaRuleOutputJarsProvider.merge(javaRuleOutputJarsProviders))
-            .javaPluginInfo(JavaPluginInfo.merge(javaPluginInfos))
+            .javaPluginInfo(JavaPluginInfo.mergeWithoutJavaOutputs(javaPluginInfos))
             .addProvider(JavaCcInfoProvider.class, JavaCcInfoProvider.merge(javaCcInfoProviders))
             // TODO(b/65618333): add merge function to JavaGenJarsProvider. See #3769
             // TODO(iirina): merge or remove JavaCompilationInfoProvider

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfoBuildHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfoBuildHelper.java
@@ -235,7 +235,7 @@ final class JavaInfoBuildHelper {
 
   private JavaPluginInfo mergeExportedJavaPluginInfo(
       Iterable<JavaPluginInfo> plugins, Iterable<JavaInfo> javaInfos) {
-    return JavaPluginInfo.merge(
+    return JavaPluginInfo.mergeWithoutJavaOutputs(
         concat(
             plugins,
             stream(javaInfos)

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaPluginInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaPluginInfo.java
@@ -162,11 +162,11 @@ public abstract class JavaPluginInfo extends NativeInfo
     }
   }
 
-  public static JavaPluginInfo merge(JavaPluginInfo a, JavaPluginInfo b) {
-    return a.isEmpty() ? b : b.isEmpty() ? a : merge(ImmutableList.of(a, b));
+  public static JavaPluginInfo mergeWithoutJavaOutputs(JavaPluginInfo a, JavaPluginInfo b) {
+    return a.isEmpty() ? b : b.isEmpty() ? a : mergeWithoutJavaOutputs(ImmutableList.of(a, b));
   }
 
-  public static JavaPluginInfo merge(Iterable<JavaPluginInfo> providers) {
+  public static JavaPluginInfo mergeWithoutJavaOutputs(Iterable<JavaPluginInfo> providers) {
     List<JavaPluginData> plugins = new ArrayList<>();
     List<JavaPluginData> apiGeneratingPlugins = new ArrayList<>();
     for (JavaPluginInfo provider : providers) {
@@ -174,7 +174,8 @@ public abstract class JavaPluginInfo extends NativeInfo
       apiGeneratingPlugins.add(provider.apiGeneratingPlugins());
     }
     return new AutoValue_JavaPluginInfo(
-        ImmutableList.of(), JavaPluginData.merge(plugins), JavaPluginData.merge(apiGeneratingPlugins));
+        ImmutableList.of(), JavaPluginData.merge(plugins),
+        JavaPluginData.merge(apiGeneratingPlugins));
   }
 
   public static JavaPluginInfo create(

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaPluginInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaPluginInfo.java
@@ -169,14 +169,12 @@ public abstract class JavaPluginInfo extends NativeInfo
   public static JavaPluginInfo merge(Iterable<JavaPluginInfo> providers) {
     List<JavaPluginData> plugins = new ArrayList<>();
     List<JavaPluginData> apiGeneratingPlugins = new ArrayList<>();
-    ImmutableList.Builder<JavaOutput> outputs = ImmutableList.builder();
     for (JavaPluginInfo provider : providers) {
       plugins.add(provider.plugins());
       apiGeneratingPlugins.add(provider.apiGeneratingPlugins());
-      outputs.addAll(provider.getJavaOutputs());
     }
     return new AutoValue_JavaPluginInfo(
-        outputs.build(), JavaPluginData.merge(plugins), JavaPluginData.merge(apiGeneratingPlugins));
+        ImmutableList.of(), JavaPluginData.merge(plugins), JavaPluginData.merge(apiGeneratingPlugins));
   }
 
   public static JavaPluginInfo create(

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaPluginsFlagAliasRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaPluginsFlagAliasRule.java
@@ -76,7 +76,7 @@ public final class JavaPluginsFlagAliasRule implements RuleDefinition {
       }
 
       JavaPluginInfo javaPluginInfo =
-          JavaPluginInfo.merge(
+          JavaPluginInfo.mergeWithoutJavaOutputs(
               ruleContext.getPrerequisites(":java_plugins", JavaPluginInfo.PROVIDER));
 
       return new RuleConfiguredTargetBuilder(ruleContext)

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaTargetAttributes.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaTargetAttributes.java
@@ -298,7 +298,7 @@ public class JavaTargetAttributes {
 
     public Builder addPlugin(JavaPluginInfo plugins) {
       Preconditions.checkArgument(!built);
-      this.plugins = JavaPluginInfo.merge(this.plugins, plugins);
+      this.plugins = JavaPluginInfo.mergeWithoutJavaOutputs(this.plugins, plugins);
       return this;
     }
 


### PR DESCRIPTION
JavaPluginInfo merging of java_outputs caused a significant regression when a large number of plugins is present.

This value is not used by native code and it does not get exposed to Starlark. The only use case for java_outputs is IDE integrations, where the value is used from a single java_plugin target.

Fixes https://github.com/bazelbuild/bazel/issues/14287