### PR TITLE
Upgrade netty to 4.1.69.

### DIFF
--- a/scripts/bootstrap/BUILD
+++ b/scripts/bootstrap/BUILD
@@ -1,0 +1,23 @@
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
+
+# This toolchain is used to bootstrap Bazel.
+default_java_toolchain(
+    name = "bootstrap_toolchain",
+    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath.jar"],
+    genclass = ["//src/java_tools/buildjar:bootstrap_genclass_deploy.jar"],
+    ijar = ["//third_party/ijar"],
+    java_runtime = "@local_jdk//:jdk",
+    javabuilder = ["//src/java_tools/buildjar:bootstrap_VanillaJavaBuilder_deploy.jar"],
+    jvm_opts = [
+        # Prevent "Could not reserve enough space for object heap" errors on Windows.
+        "-Xmx512m",
+        # Using tiered compilation improves performance of Javac when not using the worker mode.
+        "-XX:+TieredCompilation",
+        "-XX:TieredStopAtLevel=1",
+    ],
+    singlejar = ["//src/tools/singlejar:singlejar"],
+    source_version = "8",
+    tags = ["manual"],
+    target_version = "8",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
**UPDATE**: I belatedly realized that [upgrade to Netty 4.1.69](https://github.com/bazelbuild/bazel/commit/e1b842d755a01a693e79568ea11ca127b0e7bd21) is *already* present in `release-5.0.0rc2`, which is why my commit seemed strange.

Closing this as unneeded.
-----
This adds support for Unix domain sockets to `darwin_arm64`.

Per a [discussion in the #debugging channel](https://bazelbuild.slack.com/archives/CD4MDG09Z/p1637175769020700) yesterday, I'm submitting a cherrypick of the [upgrade to Netty 4.1.69](https://github.com/bazelbuild/bazel/commit/e1b842d755a01a693e79568ea11ca127b0e7bd21) change. Without this patch, I get [Unix domain socket errors](https://gist.github.com/georgevreilly-stripe/56e69a67823f09bcf343023207f8b20d) when trying to build one of our repositories on M1 Macs, since `KQueue.is_available` returns `false` for Netty 4.1.48.

