### PR TITLE
Support select() on constraint_value for aliases.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Rule.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Rule.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.StarlarkImplicitOutputsFunction;
 import com.google.devtools.build.lib.packages.License.DistributionType;
 import com.google.devtools.build.lib.packages.Package.ConfigSettingVisibilityPolicy;
+import com.google.devtools.build.lib.packages.RuleClass.ToolchainResolutionMode;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -940,6 +941,31 @@ public class Rule implements Target, DependencyFilter.AttributeInfoProvider {
       }
     }
     return labels.values();
+  }
+
+  /**
+   * Should this rule instance resolve toolchains?
+   *
+   * <p>This may happen for two reasons:
+   *
+   * <ol>
+   *   <li>The rule uses toolchains by definition ({@link
+   *       RuleClass.Builder#useToolchainResolution(ToolchainResolutionMode)}
+   *   <li>The rule instance has a select(), which means it may depend on target platform properties
+   *       that are only provided when toolchain resolution is enabled.
+   * </ol>
+   */
+  public boolean useToolchainResolution() {
+    ToolchainResolutionMode mode = ruleClass.useToolchainResolution();
+    if (mode.isActive()) {
+      return true;
+    } else if (mode == ToolchainResolutionMode.HAS_SELECT) {
+      RawAttributeMapper attr = RawAttributeMapper.of(this);
+      return (attr.has(RuleClass.CONFIG_SETTING_DEPS_ATTRIBUTE)
+          && !attr.get(RuleClass.CONFIG_SETTING_DEPS_ATTRIBUTE, BuildType.LABEL_LIST).isEmpty());
+    } else {
+      return false;
+    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -221,6 +221,19 @@ public class RuleClass {
     ENABLED,
     /** The rule should not use toolchain resolution. */
     DISABLED,
+    /**
+     * The rule instance uses toolchain resolution if it has a select().
+     *
+     * <p>This is for rules that don't intrinsically use toolchains but have select()s on {@link
+     * com.google.devtools.build.lib.rules.platform.ConstraintValue}, which are part of the build's
+     * platform. Such instances need to know what platform the build is targeting, which Bazel won't
+     * provide unless toolchain resolution is enabled.
+     *
+     * <p>Ultimately, we should remove this when <a
+     * href="https://github.com/bazelbuild/bazel/issues/12899#issuecomment-767759147}#12899</a>is
+     * addressed, so platforms are unconditionally provided for all rules.
+     */
+    HAS_SELECT,
     /** The rule should inherit the value from its parent rules. */
     INHERIT;
 
@@ -245,6 +258,7 @@ public class RuleClass {
         case ENABLED:
           return true;
         case DISABLED:
+        case HAS_SELECT: // Not true for RuleClass, but Rule may enable it.
           return false;
         default:
       }
@@ -380,7 +394,7 @@ public class RuleClass {
    * normal dependency resolution because they're needed to determine other dependencies. So there's
    * no intrinsic reason why we need an extra attribute to store them.
    *
-   * <p>There are three reasons why we still create this attribute:
+   * <p>There are four reasons why we still create this attribute:
    *
    * <ol>
    *   <li>Collecting them once in {@link #populateRuleAttributeValues} instead of multiple times in
@@ -390,6 +404,9 @@ public class RuleClass {
    *       we need to make sure its coverage remains complete.
    *   <li>Manual configuration trimming uses the normal dependency resolution process to work
    *       correctly and config_setting keys are subject to this trimming.
+   *   <li>{@link Rule#useToolchainResolution() supports conditional toolchain resolution for
+   *      targets with non-empty select()s. This requirement would go away if platform info was
+   *      prepared for all rules regardless of toolchain needs.
    * </ol>
    *
    * <p>It should be possible to clean up these issues if we decide we don't want an artificial
@@ -2753,8 +2770,12 @@ public class RuleClass {
     return requiredToolchains;
   }
 
-  public boolean useToolchainResolution() {
-    return this.useToolchainResolution.isActive();
+  /**
+   * Public callers should use {@link Rule#useToolchainResolution()}, which also takes into account
+   * target-specific information.
+   */
+  ToolchainResolutionMode useToolchainResolution() {
+    return this.useToolchainResolution;
   }
 
   public boolean useToolchainTransition() {

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -229,6 +229,9 @@ public class RuleClass {
      * platform. Such instances need to know what platform the build is targeting, which Bazel won't
      * provide unless toolchain resolution is enabled.
      *
+     * <p>This is set statically in rule definitions on an opt-in basis. Bazel doesn't automatically
+     * infer this for any target with a select().
+     *
      * <p>Ultimately, we should remove this when <a
      * href="https://github.com/bazelbuild/bazel/issues/12899#issuecomment-767759147}#12899</a>is
      * addressed, so platforms are unconditionally provided for all rules.

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetAccessor.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetAccessor.java
@@ -211,7 +211,7 @@ public class ConfiguredTargetAccessor implements TargetAccessor<KeyedConfiguredT
     }
 
     Rule rule = ((Rule) target);
-    if (!rule.getRuleClassObject().useToolchainResolution()) {
+    if (!rule.useToolchainResolution()) {
       return null;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/Alias.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/Alias.java
@@ -81,8 +81,9 @@ public class Alias implements RuleConfiguredTargetFactory {
           .canHaveAnyProvider()
           // Aliases themselves do not need toolchains or an execution platform, so this is fine.
           // The actual target will resolve platforms and toolchains with no issues regardless of
-          // this setting.
-          .useToolchainResolution(ToolchainResolutionMode.DISABLED)
+          // this setting. The only time an alias directly needs the platform is when it has a
+          // select() on a constraint_setting, so special-case enable those instances too.
+          .useToolchainResolution(ToolchainResolutionMode.HAS_SELECT)
           .build();
     }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ConfiguredTargetFunction.java
@@ -485,7 +485,7 @@ public final class ConfiguredTargetFunction implements SkyFunction {
         ExecGroupCollection.builder(defaultExecGroup, rule.getRuleClassObject().getExecGroups());
 
     // Short circuit and end now if this target doesn't require toolchain resolution.
-    if (!rule.getRuleClassObject().useToolchainResolution()) {
+    if (!rule.useToolchainResolution()) {
       ComputedToolchainContexts result = new ComputedToolchainContexts();
       result.execGroupCollectionBuilder = execGroupCollectionBuilder;
       return result;

--- a/src/main/java/com/google/devtools/build/lib/skyframe/PlatformLookupUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/PlatformLookupUtil.java
@@ -29,7 +29,7 @@ import com.google.devtools.build.lib.packages.NoSuchPackageException;
 import com.google.devtools.build.lib.packages.NoSuchTargetException;
 import com.google.devtools.build.lib.packages.NoSuchThingException;
 import com.google.devtools.build.lib.packages.Package;
-import com.google.devtools.build.lib.packages.RuleClass;
+import com.google.devtools.build.lib.packages.Rule;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.server.FailureDetails.Toolchain.Code;
 import com.google.devtools.build.skyframe.SkyFunction.Environment;
@@ -161,16 +161,18 @@ public class PlatformLookupUtil {
   }
 
   static boolean hasPlatformInfo(Target target) {
+    Rule rule = target.getAssociatedRule();
     // If the rule uses toolchain resolution, it can't be used as a target or exec platform.
-    if (target.getAssociatedRule() == null) {
+    if (rule == null) {
       return false;
     }
-    RuleClass ruleClass = target.getAssociatedRule().getRuleClassObject();
-    if (ruleClass == null || ruleClass.useToolchainResolution()) {
+    if (rule.useToolchainResolution()) {
       return false;
     }
 
-    return ruleClass.getAdvertisedProviders().advertises(PlatformInfo.PROVIDER.id());
+    return rule.getRuleClassObject()
+        .getAdvertisedProviders()
+        .advertises(PlatformInfo.PROVIDER.id());
   }
 
   /** Exception used when a platform label is not a valid platform. */

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
@@ -203,7 +203,9 @@ public class ProtoOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
     myAliasRuleProto.forEach(
         configuredTarget -> depNames.add(configuredTarget.getTarget().getRule().getName()));
     assertThat(depNames)
-        .containsExactly("//test:my_alias_rule", "//test:config1", "//test:target1");
+        // The alias also includes platform info since aliases with select() trigger toolchain
+        // resolution. We're not interested in those here.
+        .containsAtLeast("//test:my_alias_rule", "//test:config1", "//test:target1");
   }
 
   private MockRule getSimpleRule() {


### PR DESCRIPTION
This implements approach #4 of
https://github.com/bazelbuild/bazel/issues/13047#issuecomment-805309450.

The basic change adds a new toolchain resolution mode: "resolve iff the target has a select()". It then sets alias() to that mode.

We could remove this special casing if we ever ubiquitously provide platform info to *all* rules (https://github.com/bazelbuild/bazel/issues/12899#issuecomment-767759147).

RELNOTES: alias() can now select() directly on constraint_value()

Fixes https://github.com/bazelbuild/bazel/issues/13047.