### PR TITLE
cquery: support queries over incompatible targets.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BuildView.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BuildView.java
@@ -434,8 +434,7 @@ public class BuildView {
               topLevelTargetsWithConfigsResult,
               /*includeExecutionPhase=*/ true);
     } else {
-      Set<ConfiguredTarget> targetsToSkip;
-
+      Set<ConfiguredTarget> targetsToSkip = ImmutableSet.of();
       if (reportIncompatibleTargets) {
         TopLevelConstraintSemantics topLevelConstraintSemantics =
             new TopLevelConstraintSemantics(
@@ -462,8 +461,6 @@ public class BuildView {
                         skyframeAnalysisResult.getConfiguredTargets()),
                     platformRestrictions.targetsToSkip())
                 .immutableCopy();
-      } else {
-        targetsToSkip = ImmutableSet.of();
       }
 
       result =

--- a/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisAndExecutionPhaseRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisAndExecutionPhaseRunner.java
@@ -191,6 +191,7 @@ public final class AnalysisAndExecutionPhaseRunner {
                 request.getCheckForActionConflicts(),
                 request.getLoadingPhaseThreadCount(),
                 request.getTopLevelArtifactContext(),
+                request.reportIncompatibleTargets(),
                 env.getReporter(),
                 env.getEventBus(),
                 /*includeExecutionPhase=*/ true,

--- a/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/AnalysisPhaseRunner.java
@@ -225,6 +225,7 @@ public final class AnalysisPhaseRunner {
             request.getCheckForActionConflicts(),
             request.getLoadingPhaseThreadCount(),
             request.getTopLevelArtifactContext(),
+            request.reportIncompatibleTargets(),
             env.getReporter(),
             env.getEventBus(),
             /*includeExecutionPhase=*/ false,

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequest.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequest.java
@@ -134,8 +134,8 @@ public class BuildRequest implements OptionsProvider {
 
     /**
      * If true, build status depends on whether or not requested targets are platform-compatible
-     * ({@link com.google.devtools.build.lib.analysis.IncompatiblePlatformProvider}. If false, this
-     * doesn't matter.
+     * ({@link com.google.devtools.build.lib.analysis.IncompatiblePlatformProvider}). If false,
+     * this doesn't matter.
      *
      * <p>This should be true for builds (where users care if their targets produce meaningful
      * output) and false for queries (where users want to understand target relationships or

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequest.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildRequest.java
@@ -78,6 +78,7 @@ public class BuildRequest implements OptionsProvider {
     private boolean needsInstrumentationFilter;
     private boolean runTests;
     private boolean checkForActionConflicts = true;
+    private boolean reportIncompatibleTargets = true;
 
     private Builder() {}
 
@@ -131,6 +132,20 @@ public class BuildRequest implements OptionsProvider {
       return this;
     }
 
+    /**
+     * If true, build status depends on whether or not requested targets are platform-compatible
+     * ({@link com.google.devtools.build.lib.analysis.IncompatiblePlatformProvider}. If false, this
+     * doesn't matter.
+     *
+     * <p>This should be true for builds (where users care if their targets produce meaningful
+     * output) and false for queries (where users want to understand target relationships or
+     * diagnose why incompatible targets are incompatible).
+     */
+    public Builder setReportIncompatibleTargets(boolean report) {
+      this.reportIncompatibleTargets = report;
+      return this;
+    }
+
     public BuildRequest build() {
       return new BuildRequest(
           commandName,
@@ -142,7 +157,8 @@ public class BuildRequest implements OptionsProvider {
           startTimeMillis,
           needsInstrumentationFilter,
           runTests,
-          checkForActionConflicts);
+          checkForActionConflicts,
+          reportIncompatibleTargets);
     }
   }
 
@@ -168,6 +184,7 @@ public class BuildRequest implements OptionsProvider {
   private final boolean runningInEmacs;
   private final boolean runTests;
   private final boolean checkForActionConflicts;
+  private final boolean reportIncompatibleTargets;
 
   private BuildRequest(
       String commandName,
@@ -179,7 +196,8 @@ public class BuildRequest implements OptionsProvider {
       long startTimeMillis,
       boolean needsInstrumentationFilter,
       boolean runTests,
-      boolean checkForActionConflicts) {
+      boolean checkForActionConflicts,
+      boolean reportIncompatibleTargets) {
     this.commandName = commandName;
     this.optionsDescription = OptionsUtils.asShellEscapedString(options);
     this.outErr = outErr;
@@ -201,6 +219,7 @@ public class BuildRequest implements OptionsProvider {
     this.needsInstrumentationFilter = needsInstrumentationFilter;
     this.runTests = runTests;
     this.checkForActionConflicts = checkForActionConflicts;
+    this.reportIncompatibleTargets = reportIncompatibleTargets;
 
     for (Class<? extends OptionsBase> optionsClass : MANDATORY_OPTIONS) {
       Preconditions.checkNotNull(getOptions(optionsClass));
@@ -404,5 +423,9 @@ public class BuildRequest implements OptionsProvider {
 
   public boolean getCheckForActionConflicts() {
     return checkForActionConflicts;
+  }
+
+  public boolean reportIncompatibleTargets() {
+    return reportIncompatibleTargets;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/CqueryCommand.java
@@ -148,6 +148,7 @@ public final class CqueryCommand implements BlazeCommand {
             .setTargets(topLevelTargets)
             .setStartTimeMillis(env.getCommandStartTime())
             .setCheckforActionConflicts(false)
+            .setReportIncompatibleTargets(false)
             .build();
     DetailedExitCode detailedExitCode =
         new BuildTool(env, new CqueryProcessor(expr))

--- a/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewForTesting.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/util/BuildViewForTesting.java
@@ -215,6 +215,7 @@ public class BuildViewForTesting {
         /*checkForActionConflicts=*/ true,
         loadingPhaseThreads,
         topLevelOptions,
+        /*reportIncompatibleTargets=*/ true,
         eventHandler,
         eventBus,
         /*includeExecutionPhase=*/ false,


### PR DESCRIPTION
The implementation is a simple matter of adding an extra "should we report incompatible errors?" bit to the build request. Keep it true on builds, false on cquery.

Fixes https://github.com/bazelbuild/bazel/issues/13861.
