### PR TITLE
[5.x] Remote: Use Action's salt field to differentiate cache across workspaces.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/BUILD
@@ -44,7 +44,6 @@ java_library(
     srcs = ["PlatformUtils.java"],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/actions",
-        "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//src/main/protobuf:failure_details_java_proto",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/PlatformUtils.java
@@ -19,7 +19,6 @@ import build.bazel.remote.execution.v2.Platform.Property;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Ordering;
-import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -113,16 +112,6 @@ public final class PlatformUtils {
         platformBuilder.addProperties(
             Property.newBuilder().setName(property.getKey()).setValue(property.getValue()).build());
       }
-    }
-
-    String workspace =
-        spawn.getExecutionInfo().get(ExecutionRequirements.DIFFERENTIATE_WORKSPACE_CACHE);
-    if (workspace != null) {
-      platformBuilder.addProperties(
-          Property.newBuilder()
-              .setName("bazel-differentiate-workspace-cache")
-              .setValue(workspace)
-              .build());
     }
 
     sortPlatformProperties(platformBuilder);

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -48,6 +48,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:action_input_helper",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
+        "//src/main/java/com/google/devtools/build/lib/actions:execution_requirements",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/actions:fileset_output_symlink",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
@@ -132,7 +132,13 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
     Digest commandHash = digestUtil.compute(command);
     MerkleTree merkleTree = MerkleTree.build(inputFiles, digestUtil);
     Action action =
-        buildAction(commandHash, merkleTree.getRootDigest(), platform, timeout, acceptCached);
+        buildAction(
+            commandHash,
+            merkleTree.getRootDigest(),
+            platform,
+            timeout,
+            acceptCached,
+            /*salt=*/ null);
     Digest actionDigest = digestUtil.compute(action);
     ActionKey actionKey = new ActionKey(actionDigest);
     CachedActionResult cachedActionResult;

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -433,7 +433,8 @@ public final class Utils {
       Digest inputRoot,
       @Nullable Platform platform,
       java.time.Duration timeout,
-      boolean cacheable) {
+      boolean cacheable,
+      @Nullable ByteString salt) {
     Action.Builder action = Action.newBuilder();
     action.setCommandDigest(command);
     action.setInputRootDigest(inputRoot);
@@ -445,6 +446,9 @@ public final class Utils {
     }
     if (platform != null) {
       action.setPlatform(platform);
+    }
+    if (salt != null) {
+      action.setSalt(salt);
     }
     return action.build();
   }

--- a/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/platform/PlatformUtilsTest.java
@@ -19,7 +19,6 @@ import static com.google.common.truth.Truth.assertThat;
 import build.bazel.remote.execution.v2.Platform;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.devtools.build.lib.actions.ExecutionRequirements;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.exec.util.SpawnBuilder;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
@@ -97,26 +96,6 @@ public final class PlatformUtilsTest {
             .build();
     // execProperties are sorted by key
     assertThat(PlatformUtils.getPlatformProto(s, null)).isEqualTo(expected);
-  }
-
-  @Test
-  public void testGetPlatformProto_differentiateWorkspace() throws Exception {
-    Spawn s =
-        new SpawnBuilder("dummy")
-            .withExecutionInfo(ExecutionRequirements.DIFFERENTIATE_WORKSPACE_CACHE, "aa")
-            .build();
-
-    Platform expected =
-        Platform.newBuilder()
-            .addProperties(Platform.Property.newBuilder().setName("a").setValue("1"))
-            .addProperties(Platform.Property.newBuilder().setName("b").setValue("2"))
-            .addProperties(
-                Platform.Property.newBuilder()
-                    .setName("bazel-differentiate-workspace-cache")
-                    .setValue("aa"))
-            .build();
-    // execProperties are sorted by key
-    assertThat(PlatformUtils.getPlatformProto(s, remoteOptions())).isEqualTo(expected);
   }
 
   @Test


### PR DESCRIPTION
Original commit: https://github.com/bazelbuild/bazel/commit/8c2c78cdc66cc9d5eb2cd59823c659892c1643a7.