### PR TITLE
Delete marker file before fetching an external repository

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/repository/RepositoryDelegatorFunction.java
@@ -339,6 +339,11 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
     }
 
     if (isFetch.get()) {
+      // Fetching a repository is a long-running operation that can easily be interrupted. If it is
+      // and the marker file exists on disk, a new call of this method may treat this repository as
+      // valid even though it is in an inconsistent state. Clear the marker file and only recreate
+      // it after fetching is done to prevent this scenario.
+      DigestWriter.clearMarkerFile(directories, repositoryName);
       // Fetching enabled, go ahead.
       RepositoryDirectoryValue.Builder builder =
           fetchRepository(skyKey, repoRoot, env, digestWriter.getMarkerData(), handler, rule);


### PR DESCRIPTION
Fetching a repository is a long-running operation that can easily be
interrupted. If it is and the marker file exists on disk, a new
evaluation of the RepositoryDelegatorFunction may treat this repository
as valid even though it is in an inconsistent state.

Clearing the marker file before initiating the fetch and only recreating
it after the fetch is complete prevents this scenario.

Fixes #8993.

Closes #14302.

PiperOrigin-RevId: 412101756