### PR TITLE
Fix [Prepa] actions stuck in active state

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/UiStateTracker.java
@@ -526,6 +526,11 @@ final class UiStateTracker {
     return activeActions.computeIfAbsent(actionId, (key) -> new ActionState(action, nanoTimeNow));
   }
 
+  @Nullable
+  private ActionState getActionStateIfPresent(Artifact actionId) {
+    return activeActions.get(actionId);
+  }
+
   void actionStarted(ActionStartedEvent event) {
     Action action = event.getAction();
     Artifact actionId = action.getPrimaryOutput();
@@ -579,10 +584,12 @@ final class UiStateTracker {
   }
 
   void actionProgress(ActionProgressEvent event) {
-    ActionExecutionMetadata action = event.action();
     Artifact actionId = event.action().getPrimaryOutput();
     long now = clock.nanoTime();
-    getActionState(action, actionId, now).onProgressEvent(event, now);
+    ActionState actionState = getActionStateIfPresent(actionId);
+    if (actionState != null) {
+      actionState.onProgressEvent(event, now);
+    }
   }
 
   void actionCompletion(ActionScanningCompletedEvent event) {

--- a/src/test/java/com/google/devtools/build/lib/runtime/UiStateTrackerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/UiStateTrackerTest.java
@@ -601,6 +601,7 @@ public class UiStateTrackerTest extends FoundationTestCase {
     ManualClock clock = new ManualClock();
     Action action = createDummyAction("Some random action");
     UiStateTracker stateTracker = new UiStateTracker(clock, /* targetWidth= */ 70);
+    stateTracker.actionStarted(new ActionStartedEvent(action, clock.nanoTime()));
     stateTracker.actionProgress(
         ActionProgressEvent.create(action, "action-id", "action progress", false));
     LoggingTerminalWriter terminalWriter = new LoggingTerminalWriter(/*discardHighlight=*/ true);
@@ -619,6 +620,7 @@ public class UiStateTrackerTest extends FoundationTestCase {
     ManualClock clock = new ManualClock();
     Action action = createDummyAction("Some random action");
     UiStateTracker stateTracker = new UiStateTracker(clock, /* targetWidth= */ 30);
+    stateTracker.actionStarted(new ActionStartedEvent(action, clock.nanoTime()));
     stateTracker.actionProgress(
         ActionProgressEvent.create(action, "action-id", "action progress", false));
     LoggingTerminalWriter terminalWriter = new LoggingTerminalWriter(/*discardHighlight=*/ true);
@@ -637,6 +639,7 @@ public class UiStateTrackerTest extends FoundationTestCase {
     ManualClock clock = new ManualClock();
     Action action = createDummyAction("Some random action");
     UiStateTracker stateTracker = new UiStateTracker(clock, /* targetWidth= */ 50);
+    stateTracker.actionStarted(new ActionStartedEvent(action, clock.nanoTime()));
     stateTracker.actionProgress(
         ActionProgressEvent.create(action, "action-id", "action progress", false));
     LoggingTerminalWriter terminalWriter = new LoggingTerminalWriter(/*discardHighlight=*/ true);
@@ -655,6 +658,7 @@ public class UiStateTrackerTest extends FoundationTestCase {
     ManualClock clock = new ManualClock();
     Action action = createDummyAction("Some random action");
     UiStateTracker stateTracker = new UiStateTracker(clock, /* targetWidth= */ 70);
+    stateTracker.actionStarted(new ActionStartedEvent(action, clock.nanoTime()));
     stateTracker.actionProgress(
         ActionProgressEvent.create(action, "action-id1", "action progress 1", false));
     stateTracker.actionProgress(


### PR DESCRIPTION
Fixed #13985

UiStateTracker can process ActionProgress events after an ActionCompletion event
has been fired. This has the effect of recreating the action object in the activeActions
Map because Map.computeIfAbsent() is being used to retrieve the action.

Therefore, a new method getActionStateIfPresent is created which will return
the action if it exists, otherwise return null, and actionProgress() uses this
method so as to not inadverntantly recreate actions after they have already
completed and been removed from the Map.

Closes #14020.

PiperOrigin-RevId: 398165993
(cherry picked from commit 639f89d7682cadff723ac210fa37101f37762a9d)

cc @meteorcloudy 