### PR TITLE
Revert "Set --experimental_enable_aspect_hints default to false"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -244,7 +244,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
 
   @Option(
       name = "experimental_enable_aspect_hints",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
       effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {OptionMetadataTag.EXPERIMENTAL})


### PR DESCRIPTION
This reverts commit 60ebb105dbf34f0b267ea7573157246b4c9bfcaf.

Some rulesets like the Swift rules have started depending on the
`aspect_hints` attribute since the time it was introduced, and some time
before the `--experimental_enable_aspect_hints` flag was added. Many
changes have stacked up since then, so setting this default to false
makes it difficult to support the rules users now.
