### PR TITLE
Fail on Xcode configure errors, add timeout

### DIFF
--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -17,8 +17,6 @@
    installed on the local host.
 """
 
-_EXECUTE_TIMEOUT = 120
-
 def _search_string(fullstring, prefix, suffix):
     """Returns the substring between two given substrings of a larger string.
 
@@ -55,7 +53,7 @@ def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir)
     repository_ctx.report_progress("Fetching SDK information for Xcode %s" % version)
     xcodebuild_result = repository_ctx.execute(
         ["xcrun", "xcodebuild", "-version", "-sdk"],
-        _EXECUTE_TIMEOUT,
+        repository_ctx.execute_timeout,
         {"DEVELOPER_DIR": developer_dir},
     )
     if (xcodebuild_result.return_code != 0):
@@ -68,6 +66,8 @@ def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir)
             err = xcodebuild_result.stderr,
             out = xcodebuild_result.stdout,
         )
+        fail(error_msg)
+
     ios_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "iphoneos")
     tvos_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "appletvos")
     macos_sdk_version = _search_sdk_output(xcodebuild_result.stdout, "macosx")
@@ -85,9 +85,6 @@ def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir)
     if watchos_sdk_version:
         build_contents += "\n  default_watchos_sdk_version = '%s'," % watchos_sdk_version
     build_contents += "\n)\n"
-    if error_msg:
-        build_contents += "\n# Error: " + error_msg.replace("\n", " ") + "\n"
-        print(error_msg)
     return build_contents
 
 VERSION_CONFIG_STUB = "xcode_config(name = 'host_xcodes')"
@@ -107,13 +104,10 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
       repository_ctx: The repository context.
       xcode_locator_src_label: The label of the source file for xcode-locator.
     Returns:
-      A 2-tuple containing:
-      output: A list representing installed xcode toolchain information. Each
-          element of the list is a struct containing information for one installed
-          toolchain. This is an empty list if there was an error building or
-          running xcode-locator.
-      err: An error string describing the error that occurred when attempting
-          to build and run xcode-locator, or None if the run was successful.
+      A list representing installed xcode toolchain information. Each
+      element of the list is a struct containing information for one installed
+      toolchain. This is an empty list if there was an error building or
+      running xcode-locator.
     """
     repository_ctx.report_progress("Building xcode-locator")
     xcodeloc_src_path = str(repository_ctx.path(xcode_locator_src_label))
@@ -135,7 +129,7 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
         "-o",
         "xcode-locator-bin",
         xcodeloc_src_path,
-    ], _EXECUTE_TIMEOUT)
+    ], repository_ctx.execute_timeout)
 
     if (xcrun_result.return_code != 0):
         suggestion = ""
@@ -151,12 +145,12 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
             err = xcrun_result.stderr,
             out = xcrun_result.stdout,
         )
-        return ([], error_msg.replace("\n", " "))
+        fail(error_msg.replace("\n", " "))
 
     repository_ctx.report_progress("Running xcode-locator")
     xcode_locator_result = repository_ctx.execute(
         ["./xcode-locator-bin", "-v"],
-        _EXECUTE_TIMEOUT,
+        repository_ctx.execute_timeout,
     )
     if (xcode_locator_result.return_code != 0):
         error_msg = (
@@ -167,7 +161,8 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
             err = xcode_locator_result.stderr,
             out = xcode_locator_result.stdout,
         )
-        return ([], error_msg.replace("\n", " "))
+
+        fail(error_msg.replace("\n", " "))
     xcode_toolchains = []
 
     # xcode_dump is comprised of newlines with different installed xcode versions,
@@ -182,7 +177,7 @@ def run_xcode_locator(repository_ctx, xcode_locator_src_label):
                 developer_dir = infosplit[2],
             )
             xcode_toolchains.append(toolchain)
-    return (xcode_toolchains, None)
+    return xcode_toolchains
 
 def _darwin_build_file(repository_ctx):
     """Evaluates local system state to create xcode_config and xcode_version targets."""
@@ -195,15 +190,12 @@ def _darwin_build_file(repository_ctx):
         "xcrun",
         "xcodebuild",
         "-version",
-    ], _EXECUTE_TIMEOUT)
+    ], repository_ctx.execute_timeout)
 
-    (toolchains, xcodeloc_err) = run_xcode_locator(
+    toolchains = run_xcode_locator(
         repository_ctx,
         Label(repository_ctx.attr.xcode_locator),
     )
-
-    if xcodeloc_err:
-        return VERSION_CONFIG_STUB + "\n# Error: " + xcodeloc_err + "\n"
 
     default_xcode_version = ""
     default_xcode_build_version = ""
@@ -285,6 +277,7 @@ xcode_autoconf = repository_rule(
     attrs = {
         "xcode_locator": attr.string(),
         "remote_xcode": attr.string(),
+        "execute_timeout": attr.int(default=120),
     },
 )
 


### PR DESCRIPTION
Bazel puts this error in the build file which is a problem on the CI because it
swallows the error and it requires a user to clean --expunge. Bazel requires
the user to expunge because it thinks the repository was successfully written.

Addtionally I am constatly hititng this problem with github actions. The
default timeout of 120s is not long enough. This is because the performance of
github actions is unstable, probably from over-subscribing the hosts. The fix
for that is to to provide custom workers and use Buildkite.

I'm planning to use this attribute to increase the timeout in my repository. A
retry mechanism isn't appropriate because the operations aren't flaky in any
capacity, the host CPU is just over subscribed.

Here is an example where I've forked and patched the `fail()` change on but
prior to increasing the timeout
https://github.com/bazel-ios/rules_ios/runs/4319115106?check_suite_focus=true

```
Error in fail: Generating xcode-locator-bin failed.  return code 256, stderr: Timed out, stdout:
...
62
    File "/Users/runner/work/rules_ios/rules_ios/tools/toolchains/xcode_configure/xcode_configure.bzl", line 148, column 13, in run_xcode_locator
63
	    fail(error_msg.replace("\n", " "))
64
Error in fail: Generating xcode-locator-bin failed.  return code 256, stderr: Timed out, stdout:`
```