### PR TITLE
Correct help message for experimental_strict_action_env

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
@@ -153,7 +153,7 @@ public class BazelRuleClassProvider {
         metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
         help =
             "If true, Bazel uses an environment with a static value for PATH and does not "
-                + "inherit LD_LIBRARY_PATH or TMPDIR. Use --action_env=ENV_VARIABLE if you want to "
+                + "inherit LD_LIBRARY_PATH. Use --action_env=ENV_VARIABLE if you want to "
                 + "inherit specific environment variables from the client, but note that doing so "
                 + "can prevent cross-user caching if a shared cache is used.")
     public boolean useStrictActionEnv;


### PR DESCRIPTION
I might be simply wrong but it seems to me that `experimental_strict_action_env` does not affect TMPDIR actually. I wasn't able to find relevant code, and also in my experiments `echo $TMPDIR` in `sh_test` behave the same with or without the flag.
