### PR TITLE
[5.x] Fix remote spawn tests for remote_merkle_tree_cache=true

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnCacheTest.java
@@ -143,7 +143,7 @@ public class RemoteSpawnCacheTest {
 
         @Override
         public ArtifactExpander getArtifactExpander() {
-          throw new UnsupportedOperationException();
+          return SIMPLE_ARTIFACT_EXPANDER;
         }
 
         @Override

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -74,6 +74,7 @@ import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.RemoteLocalFallbackRegistry;
 import com.google.devtools.build.lib.exec.SpawnCheckingCacheEvent;
 import com.google.devtools.build.lib.exec.SpawnExecutingEvent;
+import com.google.devtools.build.lib.exec.SpawnInputExpander;
 import com.google.devtools.build.lib.exec.SpawnRunner;
 import com.google.devtools.build.lib.exec.SpawnRunner.SpawnExecutionContext;
 import com.google.devtools.build.lib.exec.SpawnSchedulingEvent;
@@ -1267,6 +1268,7 @@ public class RemoteSpawnRunnerTest {
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = mock(SpawnExecutionContext.class);
+    when(policy.getSpawnInputExpander()).thenReturn(mock(SpawnInputExpander.class));
     when(policy.getTimeout()).thenReturn(Duration.ZERO);
 
     when(executor.executeRemotely(
@@ -1310,6 +1312,7 @@ public class RemoteSpawnRunnerTest {
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = mock(SpawnExecutionContext.class);
+    when(policy.getSpawnInputExpander()).thenReturn(mock(SpawnInputExpander.class));
     when(policy.getTimeout()).thenReturn(Duration.ZERO);
 
     when(executor.executeRemotely(
@@ -1353,6 +1356,7 @@ public class RemoteSpawnRunnerTest {
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = mock(SpawnExecutionContext.class);
+    when(policy.getSpawnInputExpander()).thenReturn(mock(SpawnInputExpander.class));
     when(policy.getTimeout()).thenReturn(Duration.ZERO);
 
     when(executor.executeRemotely(
@@ -1413,6 +1417,7 @@ public class RemoteSpawnRunnerTest {
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = mock(SpawnExecutionContext.class);
+    when(policy.getSpawnInputExpander()).thenReturn(mock(SpawnInputExpander.class));
     when(policy.getTimeout()).thenReturn(Duration.ZERO);
 
     when(executor.executeRemotely(
@@ -1461,6 +1466,7 @@ public class RemoteSpawnRunnerTest {
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = mock(SpawnExecutionContext.class);
+    when(policy.getSpawnInputExpander()).thenReturn(mock(SpawnInputExpander.class));
     when(policy.getTimeout()).thenReturn(Duration.ZERO);
 
     when(executor.executeRemotely(
@@ -1510,6 +1516,7 @@ public class RemoteSpawnRunnerTest {
 
     Spawn spawn = newSimpleSpawn();
     SpawnExecutionContext policy = mock(SpawnExecutionContext.class);
+    when(policy.getSpawnInputExpander()).thenReturn(mock(SpawnInputExpander.class));
     when(policy.getTimeout()).thenReturn(Duration.ZERO);
 
     when(executor.executeRemotely(


### PR DESCRIPTION
Original commit: d84f7998ef8f15e27376a0c8f25b320145c4ba9e.