### PR TITLE
Build xcode-locator as a universal binary

### DIFF
--- a/tools/osx/BUILD
+++ b/tools/osx/BUILD
@@ -29,7 +29,8 @@ exports_files([
 
 DARWIN_XCODE_LOCATOR_COMPILE_COMMAND = """
   /usr/bin/xcrun --sdk macosx clang -mmacosx-version-min=10.9 -fobjc-arc -framework CoreServices \
-      -framework Foundation -o $@ $<
+      -framework Foundation -arch arm64 -arch x86_64 -Wl,-no_adhoc_codesign -Wl,-no_uuid -o $@ $< && \
+  env -i codesign --identifier $@ --force --sign - $@
 """
 
 genrule(


### PR DESCRIPTION
One of Buildbarn's users is attempting to build it on a Mac M1 system
that does not have Rosetta installed:

https://github.com/buildbarn/bb-remote-execution/issues/89

This currently fails with the following error message:

    ERROR: <storage>/external/com_google_protobuf/BUILD:130:11: Compiling src/google/protobuf/extension_set.cc failed: I/O exception during sandboxed execution: com.google.devtools.build.lib.shell.ExecFailedException: java.io.IOException: Cannot run program "<tmp>/install/71ed47cad951a20fff87381f54639763/xcode-locator": error=86, Bad CPU type in executable

Let's address this by shipping a copy of xcode-locator that is built
both for ARM64 and x86-64.

Closes #14168.

PiperOrigin-RevId: 412864310
(cherry picked from commit 76b3c242831f8e88835e3002a831a185a41fcc52)