### PR TITLE
Set --legacy_important_outputs to false by default.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventProtocolOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/BuildEventProtocolOptions.java
@@ -24,7 +24,7 @@ public class BuildEventProtocolOptions extends OptionsBase {
 
   @Option(
     name = "legacy_important_outputs",
-    defaultValue = "true",
+    defaultValue = "false",
     documentationCategory = OptionDocumentationCategory.LOGGING,
     effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
     help = "Use this to suppress generation of the legacy important_outputs field in the "


### PR DESCRIPTION
This flag reduces the largest proto size, which helps avoid sharp edges with remote execution systems (e.g., https://github.com/bazelbuild/bazel/issues/12050).

RELNOTES[INC]: --legacy_important_outputs now has a default of false.