### PR TITLE
 Use .dylib extension for macOS dynamic libraries in XCode toolchain

### DIFF
--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -505,8 +505,14 @@ EOF
 
 using namespace std;
 
+#ifdef __APPLE__
+#define DYNAMIC_LIB_EXT "dylib"
+#else
+#define DYNAMIC_LIB_EXT "so"
+#endif
+
 int main() {
-  void* handle = dlopen("libf.so", RTLD_LAZY);
+  void* handle = dlopen("libf." DYNAMIC_LIB_EXT, RTLD_LAZY);
 
   typedef string (*f_t)();
 

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -16,6 +16,7 @@
 load(
     "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
     "action_config",
+    "artifact_name_pattern",
     "env_entry",
     "env_set",
     "feature",
@@ -3007,7 +3008,15 @@ def _impl(ctx):
     else:
         fail("Unreachable")
 
-    artifact_name_patterns = []
+    # macOS artifact name patterns differ from the defaults only for dynamic
+    # libraries.
+    artifact_name_patterns = [
+        artifact_name_pattern(
+            category_name = "dynamic_library",
+            prefix = "lib",
+            extension = ".dylib",
+        ),
+    ]
 
     make_variables = [
         make_variable(


### PR DESCRIPTION
This is a follow-up to #14158.

Fixes #11082.