### PR TITLE
[apple] fix issues compiling C in objc_library for watchos/armv7k

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/packages/util/MockObjcSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/MockObjcSupport.java
@@ -459,7 +459,7 @@ public final class MockObjcSupport {
         .withCompiler("compiler")
         .withToolchainIdentifier("watchos_armv7k")
         .withHostSystemName("x86_64-apple-ios")
-        .withTargetSystemName("armv7-apple-watchos")
+        .withTargetSystemName("armv7k-apple-watchos")
         .withTargetLibc("watchos")
         .withAbiVersion("local")
         .withAbiLibcVersion("local")

--- a/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
@@ -6991,7 +6991,7 @@ def _impl(ctx):
                     actions = _ALL_LINK_ACTIONS,
                     flag_groups = [
                         flag_group(
-                            flags = ["-lc++", "-target", "armv7-apple-watchos"],
+                            flags = ["-lc++", "-target", "armv7k-apple-watchos"],
                         ),
                     ],
                 ),

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -66,7 +66,7 @@ def _impl(ctx):
     elif (ctx.attr.cpu == "ios_armv7"):
         target_system_name = "armv7-apple-ios"
     elif (ctx.attr.cpu == "watchos_armv7k"):
-        target_system_name = "armv7-apple-watchos"
+        target_system_name = "armv7k-apple-watchos"
     elif (ctx.attr.cpu == "ios_i386"):
         target_system_name = "i386-apple-ios"
     elif (ctx.attr.cpu == "watchos_i386"):


### PR DESCRIPTION
Reproducible example here: https://github.com/dflems/bazel-repro-armv7k. This was tested against 5.0.0 rc2 and latest master and fails on both. The build succeeds after this fix is applied.

Basically, if you have any non-objc files (like C sources) in `objc_library` rules, they'll get compiled for the wrong architecture when targeting watchOS/armv7k.

The target triplet for the `watchos_armv7k` CPU was set to `armv7-apple-watchos` instead of `armv7k-apple-watchos` (which is what Xcode sets when compiling/linking for this architecture). It's been like this for a few years, but I think this has always been wrong.

Before the recent starlark rewrite of the objc rules, it appears that all of the sources (objc or not) were compiled with the `-arch armv7k` arguments applied. After the rewrite, objc still gets compiled this way but C files in the same library get the target triplet from the crosstool, which is incorrect. Then when `libtool` creates the archive, the object files are filtered out because they don't match `-arch_only armv7k`.

If approved, I think this should be cherry-picked into the 5.0 release.