### PR TITLE
Return clang as macOS compiler

### DIFF
--- a/tools/osx/crosstool/BUILD.tpl
+++ b/tools/osx/crosstool/BUILD.tpl
@@ -83,7 +83,7 @@ cc_toolchain_suite(
 [
     cc_toolchain_config(
         name = arch,
-        compiler = "compiler",
+        compiler = "clang",
         cpu = arch,
         cxx_builtin_include_directories = [
 %{cxx_builtin_include_directories}


### PR DESCRIPTION
When using the default macOS toolchain you always get a clang compiler
since this is based on Apple's default Xcode installation. If you use a
config setting like this to determine the compiler, you want this to
correctly reflect that, just as if you used BAZEL_COMPILER on other
platforms.

```
config_setting(
    name = "clang_build",
    flag_values = {
        "@bazel_tools//tools/cpp:compiler": "clang",
    },
)
```