### PR TITLE
Sort resources to produce consistent zip and help cache hit

### DIFF
--- a/src/tools/android/java/com/google/devtools/build/android/aapt2/ResourceCompiler.java
+++ b/src/tools/android/java/com/google/devtools/build/android/aapt2/ResourceCompiler.java
@@ -426,7 +426,7 @@ public class ResourceCompiler {
       generated.addAll(compiled.build());
       if (compilationErrors.isEmpty()) {
         // ensure that the generated files are before the normal files.
-        return generated.build();
+        return ImmutableList.sortedCopyOf(generated.build());
       }
       throw CompileError.of(compilationErrors);
     }


### PR DESCRIPTION
Start sorting resources prior to zipping them in order to guarantee consistent shasum on the `Symbols.zip` file which in turn will improve cache hit for action that use these files as inputs.

Requires a new version of Android Tools.