### PR TITLE
Add clarification note in bazel dependency file

### DIFF
--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -11,7 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""List the distribution dependencies we need to build Bazel."""
+"""
+List the distribution dependencies we need to build Bazel.
+
+Note for Bazel users: This is not the file that you are looking for.
+This is internal source and is not intended to tell you what version
+you should use for each dependency. 
+"""
 
 DIST_DEPS = {
     ########################################


### PR DESCRIPTION
As discussed in #14217 the list of dependencies here if it is seen
by the users could be seen like a blessed list of versions.
Adding this message makes it clear that it is not the case.