### PR TITLE
Add optional startup --linux_bazel_path_from_getauxval

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -1587,13 +1587,6 @@ int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
       new blaze_util::BazelLogHandler());
   blaze_util::SetLogHandler(std::move(default_handler));
 
-  const string self_path = GetSelfPath(argv[0]);
-
-  if (argc == 2 && strcmp(argv[1], "--version") == 0) {
-    PrintVersionInfo(self_path, option_processor->GetLowercaseProductName());
-    return blaze_exit_code::SUCCESS;
-  }
-
   string cwd = GetCanonicalCwd();
   LoggingInfo logging_info(CheckAndGetBinaryPath(cwd, argv[0]), start_time);
 
@@ -1623,6 +1616,12 @@ int Main(int argc, const char *const *argv, WorkspaceLayout *workspace_layout,
   ParseOptionsOrDie(cwd, workspace, *option_processor, argc, argv);
   StartupOptions *startup_options = option_processor->GetParsedStartupOptions();
   startup_options->MaybeLogStartupOptionWarnings();
+  const string self_path = GetSelfPath(argv[0], *startup_options);
+
+  if (argc == 2 && strcmp(argv[1], "--version") == 0) {
+      PrintVersionInfo(self_path, option_processor->GetLowercaseProductName());
+      return blaze_exit_code::SUCCESS;
+  }
 
   SetDebugLog(startup_options->client_debug);
   // If client_debug was false, this is ignored, so it's accurate.

--- a/src/main/cpp/blaze_util_bsd.cc
+++ b/src/main/cpp/blaze_util_bsd.cc
@@ -46,6 +46,7 @@
 
 #include "src/main/cpp/blaze_util.h"
 #include "src/main/cpp/blaze_util_platform.h"
+#include "src/main/cpp/startup_options.h"
 #include "src/main/cpp/util/errors.h"
 #include "src/main/cpp/util/exit_code.h"
 #include "src/main/cpp/util/file.h"
@@ -89,7 +90,7 @@ void WarnFilesystemType(const blaze_util::Path &output_base) {
   }
 }
 
-string GetSelfPath(const char* argv0) {
+string GetSelfPath(const char* argv0, const StartupOptions &options) {
 #if defined(__FreeBSD__)
   char buffer[PATH_MAX] = {};
   auto pid = getpid();

--- a/src/main/cpp/blaze_util_darwin.cc
+++ b/src/main/cpp/blaze_util_darwin.cc
@@ -124,7 +124,7 @@ void WarnFilesystemType(const blaze_util::Path &output_base) {
   }
 }
 
-string GetSelfPath(const char* argv0) {
+string GetSelfPath(const char* argv0, const StartupOptions &options) {
   char pathbuf[PROC_PIDPATHINFO_MAXSIZE] = {};
   int len = proc_pidpath(getpid(), pathbuf, sizeof(pathbuf));
   if (len == 0) {

--- a/src/main/cpp/blaze_util_platform.h
+++ b/src/main/cpp/blaze_util_platform.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "src/main/cpp/blaze_util.h"
+#include "src/main/cpp/startup_options.h"
 #include "src/main/cpp/server_process_info.h"
 #include "src/main/cpp/util/path.h"
 #include "src/main/cpp/util/port.h"
@@ -113,7 +114,7 @@ std::string Which(const std::string& executable);
 
 // Gets an absolute path to the binary being executed that is guaranteed to be
 // readable.
-std::string GetSelfPath(const char* argv0);
+std::string GetSelfPath(const char* argv0, const StartupOptions &options);
 
 // Returns the directory Bazel can use to store output.
 std::string GetOutputRoot();

--- a/src/main/cpp/blaze_util_windows.cc
+++ b/src/main/cpp/blaze_util_windows.cc
@@ -383,7 +383,7 @@ string GetProcessIdAsString() {
   return blaze_util::ToString(GetCurrentProcessId());
 }
 
-string GetSelfPath(const char* argv0) {
+string GetSelfPath(const char* argv0, const StartupOptions &options) {
   WCHAR buffer[kWindowsPathBufferSize] = {0};
   if (!GetModuleFileNameW(0, buffer, kWindowsPathBufferSize)) {
     BAZEL_DIE(blaze_exit_code::LOCAL_ENVIRONMENTAL_ERROR)

--- a/src/main/cpp/startup_options.cc
+++ b/src/main/cpp/startup_options.cc
@@ -97,7 +97,8 @@ StartupOptions::StartupOptions(const string &product_name,
       macos_qos_class(QOS_CLASS_UNSPECIFIED),
 #endif
       unlimit_coredumps(false),
-      windows_enable_symlinks(false) {
+      windows_enable_symlinks(false),
+      linux_bazel_path_from_getauxval(false) {
   if (blaze::IsRunningWithinTest()) {
     output_root = blaze_util::MakeAbsolute(blaze::GetPathEnv("TEST_TMPDIR"));
     max_idle_secs = 15;
@@ -148,6 +149,7 @@ StartupOptions::StartupOptions(const string &product_name,
   RegisterNullaryStartupFlag("write_command_log", &write_command_log);
   RegisterNullaryStartupFlag("windows_enable_symlinks",
                              &windows_enable_symlinks);
+  RegisterNullaryStartupFlag("linux_bazel_path_from_getauxval", &linux_bazel_path_from_getauxval);
   RegisterUnaryStartupFlag("command_port");
   RegisterUnaryStartupFlag("connect_timeout_secs");
   RegisterUnaryStartupFlag("local_startup_timeout_secs");

--- a/src/main/cpp/startup_options.h
+++ b/src/main/cpp/startup_options.h
@@ -279,6 +279,10 @@ class StartupOptions {
   // developer mode to be enabled.
   bool windows_enable_symlinks;
 
+  // Accomodate bazel running via Linux's binfmt_misc which
+  // defeats /proc/self/exe path-finding
+  bool linux_bazel_path_from_getauxval;
+
  protected:
   // Constructor for subclasses only so that site-specific extensions of this
   // class can override the product name.  The product_name must be the


### PR DESCRIPTION
When using qemu-user-static + binfmt_misc on Linux (e.g.
running `docker run --platform linux/amd64` on ARM), bazel
fails to self-extract with a mysterious lseek failure. When
self-extracting using "/proc/self/exe", the referred binary
is the qemu-user-static emulator, not the bazel process. Instead,
we use an alternative API, getauxval(3), which is properly
populated when running normally on the native host platform
as well as when using the qemu + binfmt_misc pattern.

Practically, this allows x86_64 versions of bazel to
self-extract and run under Docker hosted by Linux ARM or M1 Macs.