### PR TITLE
Add `--experimental_check_external_repository_files`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/BUILD
@@ -30,6 +30,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution_impl",
         "//src/main/java/com/google/devtools/build/lib/bazel/commands",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository",
+        "//src/main/java/com/google/devtools/build/lib/bazel/repository:repository_options",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/cache",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/starlark",

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -148,6 +148,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/analysis:blaze_directories",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository",
+        "//src/main/java/com/google/devtools/build/lib/bazel/repository:repository_options",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/starlark",
         "//src/main/java/com/google/devtools/build/lib/cmdline",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/BUILD
@@ -16,7 +16,10 @@ filegroup(
 
 java_library(
     name = "repository",
-    srcs = glob(["*.java"]),
+    srcs = glob(
+        include = ["*.java"],
+        exclude = ["RepositoryOptions.java"],
+    ),
     resources = [
         "local_config_platform.WORKSPACE",
     ],
@@ -51,5 +54,17 @@ java_library(
         "//third_party:java-diff-utils",
         "//third_party:jsr305",
         "//third_party:xz",
+    ],
+)
+
+java_library(
+    name = "repository_options",
+    srcs = ["RepositoryOptions.java"],
+    deps = [
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
+        "//src/main/java/com/google/devtools/common/options:options_internal",
+        "//third_party:auto_value",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -228,6 +228,18 @@ public class RepositoryOptions extends OptionsBase {
               + "that URL changes don't result in broken repositories being masked by the cache.")
   public boolean urlsAsDefaultCanonicalId;
 
+  @Option(
+    name = "experimental_check_external_repository_files",
+    defaultValue = "true",
+    documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+    effectTags = {OptionEffectTag.UNKNOWN},
+    help =
+        "Check for modifications to files in external repositories. Consider setting "
+            + "this flag to false if you don't expect these files to change outside of bazel "
+            + "since it will speed up subsequent runs as they won't have to check a "
+            + "previous run's cache.")
+  public boolean checkExternalRepositoryFiles;
+
   /** An enum for specifying different modes for checking direct dependency accuracy. */
   public enum CheckDirectDepsMode {
     OFF, // Don't check direct dependency accuracy.

--- a/src/main/java/com/google/devtools/build/lib/pkgcache/PackageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/pkgcache/PackageOptions.java
@@ -189,7 +189,9 @@ public class PackageOptions extends OptionsBase {
     effectTags = {OptionEffectTag.UNKNOWN},
     help =
         "Check for modifications made to the output files of a build. Consider setting "
-            + "this flag to false to see the effect on incremental build times."
+            + "this flag to false if you don't expect these files to change outside of bazel "
+            + "since it will speed up subsequent runs as they won't have to check a "
+            + "previous run's cache."
   )
   public boolean checkOutputFiles;
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -280,6 +280,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:repo_rule_helper",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:repo_rule_value",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution",
+        "//src/main/java/com/google/devtools/build/lib/bazel/repository:repository_options",
         "//src/main/java/com/google/devtools/build/lib/bugreport",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.ConfiguredTargetValue;
 import com.google.devtools.build.lib.analysis.WorkspaceStatusAction.Factory;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
+import com.google.devtools.build.lib.bazel.repository.RepositoryOptions;
 import com.google.devtools.build.lib.bugreport.BugReporter;
 import com.google.devtools.build.lib.buildtool.BuildRequestOptions;
 import com.google.devtools.build.lib.cmdline.LabelConstants;
@@ -268,8 +269,10 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
         tsgm,
         options);
     long startTime = System.nanoTime();
+    RepositoryOptions repoOptions = options.getOptions(RepositoryOptions.class);
+    boolean checkExternalRepositoryFiles = repoOptions == null || repoOptions.checkExternalRepositoryFiles;
     WorkspaceInfoFromDiff workspaceInfo =
-        handleDiffs(eventHandler, packageOptions.checkOutputFiles, options);
+        handleDiffs(eventHandler, packageOptions.checkOutputFiles, checkExternalRepositoryFiles, options);
     long stopTime = System.nanoTime();
     Profiler.instance().logSimpleTask(startTime, stopTime, ProfilerTask.INFO, "handleDiffs");
     long duration = stopTime - startTime;
@@ -328,12 +331,12 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
       dropConfiguredTargetsNow(eventHandler);
       super.lastAnalysisDiscarded = false;
     }
-    handleDiffs(eventHandler, /*checkOutputFiles=*/ false, OptionsProvider.EMPTY);
+    handleDiffs(eventHandler, /*checkOutputFiles=*/ false, /*checkExternalRepositoryFiles=*/ true, OptionsProvider.EMPTY);
   }
 
   @Nullable
   private WorkspaceInfoFromDiff handleDiffs(
-      ExtendedEventHandler eventHandler, boolean checkOutputFiles, OptionsProvider options)
+      ExtendedEventHandler eventHandler, boolean checkOutputFiles, boolean checkExternalRepositoryFiles, OptionsProvider options)
       throws InterruptedException, AbruptExitException {
     TimestampGranularityMonitor tsgm = this.tsgm.get();
     modifiedFiles = 0;
@@ -376,6 +379,7 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
         tsgm,
         pathEntriesWithoutDiffInformation,
         checkOutputFiles,
+        checkExternalRepositoryFiles,
         managedDirectoriesChanged,
         fsvcThreads);
     handleClientEnvironmentChanges();
@@ -467,15 +471,16 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
       TimestampGranularityMonitor tsgm,
       Set<Pair<Root, ProcessableModifiedFileSet>> pathEntriesWithoutDiffInformation,
       boolean checkOutputFiles,
+      boolean checkExternalRepositoryFiles,
       boolean managedDirectoriesChanged,
       int fsvcThreads)
       throws InterruptedException {
 
     ExternalFilesKnowledge externalFilesKnowledge = externalFilesHelper.getExternalFilesKnowledge();
     if (!pathEntriesWithoutDiffInformation.isEmpty()
-        || (externalFilesKnowledge.anyOutputFilesSeen && checkOutputFiles)
-        || repositoryHelpersHolder != null
-        || externalFilesKnowledge.anyFilesInExternalReposSeen
+        || (checkOutputFiles && externalFilesKnowledge.anyOutputFilesSeen)
+        || (checkExternalRepositoryFiles && repositoryHelpersHolder != null)
+        || (checkExternalRepositoryFiles && externalFilesKnowledge.anyFilesInExternalReposSeen)
         || externalFilesKnowledge.tooManyNonOutputExternalFilesSeen) {
       // We freshly compute knowledge of the presence of external files in the skyframe graph. We
       // use a fresh ExternalFilesHelper instance and only set the real instance's knowledge *after*
@@ -507,33 +512,46 @@ public final class SequencedSkyframeExecutor extends SkyframeExecutor {
         diffPackageRootsUnderWhichToCheck.add(pair.getFirst());
       }
 
-      EnumSet<FileType> fileTypesToCheck =
-          EnumSet.of(FileType.EXTERNAL_REPO, FileType.EXTERNAL_IN_MANAGED_DIRECTORY);
+      EnumSet<FileType> fileTypesToCheck = EnumSet.noneOf(FileType.class);
+      Iterable<SkyValueDirtinessChecker> dirtinessCheckers = ImmutableList.of();
+
+      if (!diffPackageRootsUnderWhichToCheck.isEmpty()) {
+        dirtinessCheckers = Iterables.concat(
+            dirtinessCheckers,
+            ImmutableList.of(new MissingDiffDirtinessChecker(diffPackageRootsUnderWhichToCheck)));
+      }
+      if (checkExternalRepositoryFiles && repositoryHelpersHolder != null) {
+        dirtinessCheckers = Iterables.concat(
+            dirtinessCheckers,
+            ImmutableList.of(repositoryHelpersHolder.repositoryDirectoryDirtinessChecker()));
+      }
+      if (checkExternalRepositoryFiles) {
+        fileTypesToCheck =
+            EnumSet.of(FileType.EXTERNAL_REPO, FileType.EXTERNAL_IN_MANAGED_DIRECTORY);
+      }
+      if (externalFilesKnowledge.tooManyNonOutputExternalFilesSeen
+        || !externalFilesKnowledge.nonOutputExternalFilesSeen.isEmpty()) {
+        fileTypesToCheck.add(FileType.EXTERNAL);
+      }
       // See the comment for FileType.OUTPUT for why we need to consider output files here.
       if (checkOutputFiles) {
         fileTypesToCheck.add(FileType.OUTPUT);
       }
-      if (externalFilesKnowledge.tooManyNonOutputExternalFilesSeen
-          || !externalFilesKnowledge.nonOutputExternalFilesSeen.isEmpty()) {
-        fileTypesToCheck.add(FileType.EXTERNAL);
+      if (!fileTypesToCheck.isEmpty()) {
+        dirtinessCheckers = Iterables.concat(
+            dirtinessCheckers,
+            ImmutableList.of(new ExternalDirtinessChecker(tmpExternalFilesHelper, fileTypesToCheck)));
       }
+      Preconditions.checkArgument(!Iterables.isEmpty(dirtinessCheckers));
+
       logger.atInfo().log(
           "About to scan skyframe graph checking for filesystem nodes of types %s",
           Iterables.toString(fileTypesToCheck));
       ImmutableBatchDirtyResult batchDirtyResult;
       try (SilentCloseable c = Profiler.instance().profile("fsvc.getDirtyKeys")) {
-        batchDirtyResult =
-            fsvc.getDirtyKeys(
-                memoizingEvaluator.getValues(),
-                new UnionDirtinessChecker(
-                    Stream.of(
-                            new ExternalDirtinessChecker(tmpExternalFilesHelper, fileTypesToCheck),
-                            new MissingDiffDirtinessChecker(diffPackageRootsUnderWhichToCheck),
-                            repositoryHelpersHolder == null
-                                ? null
-                                : repositoryHelpersHolder.repositoryDirectoryDirtinessChecker())
-                        .filter(Objects::nonNull)
-                        .collect(toImmutableList())));
+        batchDirtyResult = fsvc.getDirtyKeys(
+            memoizingEvaluator.getValues(),
+            new UnionDirtinessChecker(ImmutableList.copyOf(dirtinessCheckers)));
       }
       handleChangedFiles(
           diffPackageRootsUnderWhichToCheck,

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/BUILD
@@ -39,6 +39,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution_impl",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository",
+        "//src/main/java/com/google/devtools/build/lib/bazel/repository:repository_options",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/starlark",
         "//src/main/java/com/google/devtools/build/lib/cmdline",

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/BUILD
@@ -30,6 +30,7 @@ java_library(
     ],
     deps = [
         "//src/main/java/com/google/devtools/build/lib/bazel/repository",
+        "//src/main/java/com/google/devtools/build/lib/bazel/repository:repository_options",
         "//src/main/java/com/google/devtools/build/lib/clock",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/rules:repository/repository_function",

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/BUILD
@@ -37,6 +37,7 @@ java_test(
     tags = ["black_box_test"],
     deps = [
         ":common_deps",
+        "@com_google_testparameterinjector//:testparameterinjector",
     ],
 )
 

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/manageddirs/ManagedDirectoriesBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/manageddirs/ManagedDirectoriesBlackBoxTest.java
@@ -22,16 +22,22 @@ import com.google.devtools.build.lib.blackbox.framework.PathUtils;
 import com.google.devtools.build.lib.blackbox.framework.ProcessResult;
 import com.google.devtools.build.lib.blackbox.junit.AbstractBlackBoxTest;
 import com.google.devtools.build.lib.util.ResourceFileLoader;
+import com.google.devtools.build.lib.util.OS;
+import com.google.testing.junit.testparameterinjector.TestParameter;
+import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /** Tests for managed directories. */
+@RunWith(TestParameterInjector.class)
 public class ManagedDirectoriesBlackBoxTest extends AbstractBlackBoxTest {
   private Random random;
   private Integer currentDebugId;
@@ -51,7 +57,7 @@ public class ManagedDirectoriesBlackBoxTest extends AbstractBlackBoxTest {
   }
 
   @Test
-  public void testNodeModulesDeleted() throws Exception {
+  public void testNodeModulesDeleted(@TestParameter boolean watchFs) throws Exception {
     generateProject();
     buildExpectRepositoryRuleCalled();
     checkProjectFiles();
@@ -60,7 +66,7 @@ public class ManagedDirectoriesBlackBoxTest extends AbstractBlackBoxTest {
     assertThat(nodeModules.toFile().isDirectory()).isTrue();
     PathUtils.deleteTree(nodeModules);
 
-    buildExpectRepositoryRuleCalled();
+    buildExpectRepositoryRuleCalled(false, watchFs);
     checkProjectFiles();
   }
 
@@ -162,16 +168,7 @@ public class ManagedDirectoriesBlackBoxTest extends AbstractBlackBoxTest {
   }
 
   @Test
-  public void testFilesUnderChangedManagedDirectoriesRefreshed() throws Exception {
-    doTestFilesUnderManagedDirectoriesRefreshed(false);
-  }
-
-  @Test
-  public void testFilesUnderChangedManagedDirectoriesRefreshedWatchFs() throws Exception {
-    doTestFilesUnderManagedDirectoriesRefreshed(true);
-  }
-
-  private void doTestFilesUnderManagedDirectoriesRefreshed(boolean watchFs) throws Exception {
+  public void testFilesUnderManagedDirectoriesRefreshed(@TestParameter boolean watchFs) throws Exception {
     generateProject();
     buildExpectRepositoryRuleCalled(false, watchFs);
     checkProjectFiles();
@@ -238,19 +235,8 @@ public class ManagedDirectoriesBlackBoxTest extends AbstractBlackBoxTest {
   }
 
   @Test
-  public void testManagedDirectoriesSettingsAndManagedDirectoriesFilesChangeSimultaneously()
-      throws Exception {
-    doTestManagedDirectoriesSettingsAndManagedDirectoriesFilesChangeSimultaneously(false);
-  }
-
-  @Test
-  public void testManagedDirectoriesSettingsAndManagedDirectoriesFilesChangeSimultaneouslyWatchFs()
-      throws Exception {
-    doTestManagedDirectoriesSettingsAndManagedDirectoriesFilesChangeSimultaneously(true);
-  }
-
-  private void doTestManagedDirectoriesSettingsAndManagedDirectoriesFilesChangeSimultaneously(
-      boolean watchFs) throws Exception {
+  public void testManagedDirectoriesSettingsAndManagedDirectoriesFilesChangeSimultaneously(
+      @TestParameter boolean watchFs) throws Exception {
     generateProject();
     buildExpectRepositoryRuleCalled(false, watchFs);
     checkProjectFiles();
@@ -390,6 +376,36 @@ public class ManagedDirectoriesBlackBoxTest extends AbstractBlackBoxTest {
                 "WORKSPACE file can not be a symlink if incrementally updated directories are"
                     + " used."))
         .isTrue();
+  }
+
+  @Test
+  public void testNoCheckFiles(@TestParameter boolean allSkips, @TestParameter boolean watchFs) throws Exception {
+    // On Darwin CI, --watchfs is nondeterministic if this passes or fails
+    Assume.assumeFalse(OS.DARWIN.equals(OS.getCurrent()));
+
+    generateProject();
+    buildExpectRepositoryRuleCalled(false, watchFs);
+    checkProjectFiles();
+
+    Path nodeModules = context().getWorkDir().resolve("node_modules");
+    assertThat(nodeModules.toFile().isDirectory()).isTrue();
+    PathUtils.deleteTree(nodeModules);
+    assertThat(nodeModules.toFile().isDirectory()).isFalse();
+
+    // As compared to testNodeModulesDeleted, we don't check that the external file disappeared with this flag so the build is broken
+    BuilderRunner bazel = bazel(watchFs).withFlags("--noexperimental_check_external_repository_files");
+    if (allSkips) {
+      bazel = bazel.withFlags("--noexperimental_check_output_files");
+    }
+
+    ProcessResult result = bazel.shouldFail().build("//...");
+    assertThat(findPattern(result, "Not found package.json")).isTrue();
+
+    // it doesn't make the file on disk
+    assertThat(nodeModules.toFile().isDirectory()).isFalse();
+
+    // In a perfect world we would be able to fix the build by rebuilding here without the flags, but we don't
+    // invalidate the cache correctly so the server would have to shut down
   }
 
   private void generateProject() throws IOException {

--- a/src/test/java/com/google/devtools/build/lib/rules/repository/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/rules/repository/BUILD
@@ -26,6 +26,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution_impl",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository",
+        "//src/main/java/com/google/devtools/build/lib/bazel/repository:repository_options",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/starlark",
         "//src/main/java/com/google/devtools/build/lib/cmdline",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -106,6 +106,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:common",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution_impl",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository",
+        "//src/main/java/com/google/devtools/build/lib/bazel/repository:repository_options",
         "//src/main/java/com/google/devtools/build/lib:build-request-options",
         "//src/main/java/com/google/devtools/build/lib:keep-going-option",
         "//src/main/java/com/google/devtools/build/lib:runtime",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/LocalDiffAwarenessIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/LocalDiffAwarenessIntegrationTest.java
@@ -132,6 +132,7 @@ public class LocalDiffAwarenessIntegrationTest extends SkyframeIntegrationTestBa
   // detected without --watchfs.
   @Test
   public void ignoreOutputFilesThenCheckAgainDoesCheck() throws Exception {
+    addOptions("--noexperimental_check_external_repository_files");
     Path buildFile =
         write(
             "foo/BUILD",
@@ -161,6 +162,7 @@ public class LocalDiffAwarenessIntegrationTest extends SkyframeIntegrationTestBa
   @Test
   public void externalSymlink_doesNotTriggerFullGraphTraversal() throws Exception {
     addOptions("--symlink_prefix=/");
+    addOptions("--noexperimental_check_external_repository_files");
     AtomicInteger calledGetValues = new AtomicInteger(0);
     skyframeExecutor()
         .getEvaluator()
@@ -184,29 +186,25 @@ public class LocalDiffAwarenessIntegrationTest extends SkyframeIntegrationTestBa
     calledGetValues.set(0);
     // getValues() called during output file checking (although if an output service is able to
     // report modified files in practice there is no iteration).
-    // If external repositories are being used, getValues called because of that too.
-    // TODO(bazel-team): get rid of this when we can disable checks for external repositories.
-    int numGetValuesInFullDiffAwarenessBuild =
-        1 + ("bazel".equals(this.getRuntime().getProductName()) ? 1 : 0);
 
     buildTarget("//hello:BUILD");
-    assertThat(calledGetValues.getAndSet(0)).isEqualTo(numGetValuesInFullDiffAwarenessBuild);
+    assertThat(calledGetValues.getAndSet(0)).isEqualTo(1);
 
     // Now bring the external symlink into Bazel's awareness.
     buildTarget("//hello:target");
     assertContents("one", "//hello:target");
-    assertThat(calledGetValues.getAndSet(0)).isEqualTo(numGetValuesInFullDiffAwarenessBuild);
+    assertThat(calledGetValues.getAndSet(0)).isEqualTo(1);
 
     // Builds that follow a build containing an external file don't trigger a traversal.
     buildTarget("//hello:target");
     assertContents("one", "//hello:target");
-    assertThat(calledGetValues.getAndSet(0)).isEqualTo(numGetValuesInFullDiffAwarenessBuild);
+    assertThat(calledGetValues.getAndSet(0)).isEqualTo(1);
 
     write(externalLink, "two");
 
     buildTarget("//hello:target");
     // External file changes are tracked.
     assertContents("two", "//hello:target");
-    assertThat(calledGetValues.getAndSet(0)).isEqualTo(numGetValuesInFullDiffAwarenessBuild);
+    assertThat(calledGetValues.getAndSet(0)).isEqualTo(1);
   }
 }

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1330,4 +1330,5 @@ sh_test(
         ":test-deps",
         "@bazel_tools//tools/bash/runfiles",
     ],
+    tags = ["no_windows"],
 )

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1322,3 +1322,12 @@ sh_test(
         "requires-network",
     ],
 )
+
+sh_test(
+    name = "check_external_files_test",
+    srcs = ["check_external_files_test.sh"],
+    data = [
+        ":test-deps",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/src/test/shell/bazel/check_external_files_test.sh
+++ b/src/test/shell/bazel/check_external_files_test.sh
@@ -191,7 +191,7 @@ run_override_repository_isnt_affected() {
 test_override_repository_isnt_affected() {
   run_override_repository_isnt_affected "--nowatchfs"
 }
-test_override_repository_isnt_affected() {
+test_override_repository_isnt_affected_with_skips() {
   run_override_repository_isnt_affected "--noexperimental_check_output_files --watchfs"
 }
 

--- a/src/test/shell/bazel/check_external_files_test.sh
+++ b/src/test/shell/bazel/check_external_files_test.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+#
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Verify that archives can be unpacked, even if they contain strangely named
+# files.
+
+# --- begin runfiles.bash initialization ---
+set -euo pipefail
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+case "$(uname -s | tr [:upper:] [:lower:])" in
+msys*|mingw*|cygwin*)
+  declare -r is_windows=true
+  ;;
+*)
+  declare -r is_windows=false
+  ;;
+esac
+
+if "$is_windows"; then
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
+fi
+
+function get_extrepourl() {
+  if $is_windows; then
+    echo "file:///$(cygpath -m $1)"
+  else
+    echo "file://$1"
+  fi
+}
+
+setup_remote() {
+  WRKDIR=$(mktemp -d "${TEST_TMPDIR}/testXXXXXX")
+  cd "${WRKDIR}"
+
+  mkdir remote
+  (
+    cd remote
+    echo 'genrule(name="g", outs=["go"], cmd="echo GO > $@")' > BUILD
+  )
+  tar cvf remote.tar remote
+  rm -rf remote
+
+  mkdir main
+  cd main
+  cat >> "$(create_workspace_with_default_repos WORKSPACE)" <<EOF
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+  name="remote",
+  strip_prefix="remote",
+  urls=["$(get_extrepourl $WRKDIR)/remote.tar"],
+)
+EOF
+}
+
+setup_local() {
+  WRKDIR=$(mktemp -d "${TEST_TMPDIR}/testXXXXXX")
+  cd "${WRKDIR}"
+
+  mkdir local_rep
+  (
+    cd local_rep
+    create_workspace_with_default_repos WORKSPACE
+    echo 'genrule(name="g", outs=["go"], cmd="echo GO > $@")' > BUILD
+  )
+
+  mkdir main
+  cd main
+  cat >> "$(create_workspace_with_default_repos WORKSPACE)" <<EOF
+local_repository(
+  name="local_rep",
+  path="../local_rep",
+)
+EOF
+}
+
+test_check_external_files() {
+  setup_remote
+  bazel build @remote//:g >& "$TEST_log" || fail "Expected build to succeed"
+
+  echo "broken file" > bazel-main/external/remote/BUILD
+  # The --noexperimental_check_external_repository_files flag doesn't notice the file is broken
+  bazel build --noexperimental_check_external_repository_files @remote//:g >& "$TEST_log" || fail "Expected build to succeed"
+
+  bazel build @remote//:g >& "$TEST_log" && fail "Expected build to fail" || true
+  expect_log "no such target '@remote//:g'"
+}
+
+test_check_all_flags_fast() {
+  setup_remote
+  msg="About to scan skyframe graph checking for filesystem nodes"
+
+  bazel build --watchfs @remote//:g >& "$TEST_log" || fail "Expected build to succeed"
+  instances=$(grep -c "$msg" "$(bazel info server_log)")
+  [[ $instances -eq 1 ]] || fail "Should have only been 1 instance, got $instances"
+
+  echo "broken file" > bazel-main/external/remote/BUILD
+
+  bazel build \
+    --noexperimental_check_external_repository_files \
+    --noexperimental_check_output_files \
+    --watchfs \
+    @remote//:g >& "$TEST_log" || fail "Expected build to succeed"
+
+  instances=$(grep -c "$msg" "$(bazel info server_log)")
+  [[ $instances -eq 1 ]] || fail "Should have only been 1 instance (from the first build), got $instances"
+}
+
+run_local_repository_isnt_affected() {
+  local -r extra_args="$1"
+  shift
+
+  setup_local
+  bazel build @local_rep//:g >& "$TEST_log" || fail "Expected build to succeed"
+
+  echo "broken file" > ../local_rep/BUILD
+  # The --noexperimental_check_external_repository_files flag still notices the file is broken
+  bazel build \
+    --noexperimental_check_external_repository_files \
+    $extra_args \
+    @local_rep//:g >& "$TEST_log" && fail "Expected build to fail" || true
+  bazel build --noexperimental_check_external_repository_files @local_rep//:g >& "$TEST_log" && fail "Expected build to fail" || true
+  expect_log "no such target '@local_rep//:g'"
+}
+
+test_local_repository_isnt_affected() {
+  run_local_repository_isnt_affected "--nowatchfs"
+}
+
+test_local_repository_isnt_affected_with_skips() {
+  run_local_repository_isnt_affected "--noexperimental_check_output_files --watchfs"
+}
+
+run_override_repository_isnt_affected() {
+  local -r extra_args="$1"
+  shift
+
+  setup_local
+  create_workspace_with_default_repos WORKSPACE
+  bazel build @local_rep//:g >& "$TEST_log" && fail "Expected build to fail" || true
+  expect_log "no such package '@local_rep//'"
+
+  argv="--override_repository=local_rep=$(pwd)/../local_rep"
+  bazel build "$argv" $extra_args @local_rep//:g >& "$TEST_log" || fail "Expected build to succeed"
+
+  echo "broken file" > ../local_rep/BUILD
+  # The --noexperimental_check_external_repository_files flag still notices the file is broken
+  bazel build \
+    --noexperimental_check_external_repository_files \
+    "$argv" \
+    $extra_args \
+    @local_rep//:g >& "$TEST_log" && fail "Expected build to fail" || true
+  expect_log "no such target '@local_rep//:g'"
+}
+
+test_override_repository_isnt_affected() {
+  run_override_repository_isnt_affected "--nowatchfs"
+}
+test_override_repository_isnt_affected() {
+  run_override_repository_isnt_affected "--noexperimental_check_output_files --watchfs"
+}
+
+test_no_fetch_then_fetch() {
+  setup_remote
+  bazel build \
+    --nofetch \
+    --noexperimental_check_external_repository_files \
+    --noexperimental_check_output_files \
+    --watchfs \
+    @remote//:g >& "$TEST_log" && fail "Expected build to fail" || true
+  expect_log "no such package '@bazel_tools//tools/build_defs/repo'"
+  bazel build \
+    --fetch \
+    --noexperimental_check_external_repository_files \
+    --noexperimental_check_output_files \
+    --watchfs \
+    @remote//:g >& "$TEST_log" || fail "Expected build to pass"
+}
+
+test_no_build_doesnt_break_the_cache() {
+  setup_remote
+  bazel build \
+    --nobuild \
+    --noexperimental_check_external_repository_files \
+    --noexperimental_check_output_files \
+    --watchfs \
+    @remote//:g >& "$TEST_log" || fail "Expected build to pass"
+  [[ ! -f bazel-main/external/remote/BUILD ]] || fail "external files shouldn't have been made"
+  bazel build \
+    --noexperimental_check_external_repository_files \
+    --noexperimental_check_output_files \
+    --watchfs \
+    @remote//:g >& "$TEST_log" || fail "Expected build to pass"
+}
+
+test_symlink_outside_still_checked() {
+  mkdir main
+  cd main
+  create_workspace_with_default_repos WORKSPACE
+  echo 'sh_test(name = "symlink", srcs = ["symlink.sh"])' > BUILD
+
+  mkdir ../foo
+  echo 'exit 0' > ../foo/foo.sh
+  chmod u+x ../foo/foo.sh
+  ln -s ../foo/foo.sh symlink.sh
+
+  bazel test \
+    --noexperimental_check_external_repository_files \
+    --noexperimental_check_output_files \
+    --watchfs \
+    :symlink >& "$TEST_log" || fail "Expected build to succeed"
+
+  bazel test \
+    --noexperimental_check_external_repository_files \
+    --noexperimental_check_output_files \
+    --watchfs \
+    :symlink >& "$TEST_log" || fail "Expected build to succeed"
+  expect_log '//:symlink.*cached'
+
+  echo 'exit 1' > ../foo/foo.sh
+
+  bazel test \
+    --noexperimental_check_external_repository_files \
+    --noexperimental_check_output_files \
+    --watchfs \
+    :symlink >& "$TEST_log" && fail "Expected build to fail" || true
+  expect_not_log '//:symlink.*cached'
+  expect_log '1 test FAILED'
+}
+
+run_suite "check_external_files tests"


### PR DESCRIPTION
This flag mirrors `--experimental_check_output_files` to allow installations with a large number of external files to not scan them for changes on every bazel invocation.

If used in combination with `--experimental_check_output_files` and `--watchfs` you can now avoid scanning the cache for invalidations entirely allowing large projects to keep many things cached while still executing small `bazel run` commands quickly.

Fixes #14400