### PR TITLE
Make ManifestMergerAction worker compatible

### DIFF
--- a/src/test/java/com/google/devtools/build/android/ManifestMergerActionTest.java
+++ b/src/test/java/com/google/devtools/build/android/ManifestMergerActionTest.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.android;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -90,6 +91,41 @@ public class ManifestMergerActionTest {
   @Before public void setup() throws Exception {
     working = Files.createTempDirectory(toString());
     working.toFile().deleteOnExit();
+  }
+
+  @Test public void testMerge_ManifestWithBrokenManifestSyntax() throws Exception {
+    String dataDir =
+        Paths.get(System.getenv("TEST_WORKSPACE"), System.getenv("TEST_BINARY"))
+            .resolveSibling("testing/manifestmerge")
+            .toString()
+            .replace("\\", "/");
+    Files.createDirectories(working.resolve("output"));
+    final Path mergedManifest = working.resolve("output/mergedManifest.xml");
+    final Path brokenMergerManifest = rlocation(dataDir + "/brokenManifest/AndroidManifest.xml");
+    assertThat(brokenMergerManifest.toFile().exists()).isTrue();
+
+    AndroidManifestProcessor.ManifestProcessingException e =
+        assertThrows(
+            AndroidManifestProcessor.ManifestProcessingException.class,
+            () -> {
+              List<String> args =
+                  generateArgs(
+                      brokenMergerManifest,
+                      ImmutableMap.of(),
+                      false, /* isLibrary */
+                      ImmutableMap.of("applicationId", "com.google.android.apps.testapp"),
+                      "", /* custom_package */
+                      mergedManifest,
+                      false /* mergeManifestPermissions */);
+              ManifestMergerAction.main(args.toArray(new String[0]));
+            });
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            "com.android.manifmerger.ManifestMerger2$MergeFailureException: "
+                + "org.xml.sax.SAXParseException; lineNumber: 6; columnNumber: 6; "
+                + "The markup in the document following the root element must be well-formed.");
+    assertThat(mergedManifest.toFile().exists()).isFalse();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/android/testing/manifestmerge/BUILD
+++ b/src/test/java/com/google/devtools/build/android/testing/manifestmerge/BUILD
@@ -13,6 +13,7 @@ filegroup(
 filegroup(
     name = "test_data",
     srcs = [
+        "brokenManifest/AndroidManifest.xml",
         "expected-merged-permissions/AndroidManifest.xml",
         "expected/AndroidManifest.xml",
         "mergeeOne/AndroidManifest.xml",

--- a/src/test/java/com/google/devtools/build/android/testing/manifestmerge/brokenManifest/AndroidManifest.xml
+++ b/src/test/java/com/google/devtools/build/android/testing/manifestmerge/brokenManifest/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.example.bazel"
+          android:versionCode="1"
+          android:versionName="1.0"/>
+
+    <uses-sdk
+            android:minSdkVersion="21"
+            android:targetSdkVersion="26"/>
+
+</manifest>

--- a/src/tools/android/java/com/google/devtools/build/android/ManifestMergerAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/ManifestMergerAction.java
@@ -245,10 +245,10 @@ public class ManifestMergerAction {
         Files.copy(manifest, options.manifestOutput, StandardCopyOption.REPLACE_EXISTING);
       }
     } catch (AndroidManifestProcessor.ManifestProcessingException e) {
-      // We special case ManifestProcessingExceptions here to indicate that this is
-      // caused by a build error, not an Bazel-internal error.
-      logger.log(SEVERE, "Error during merging manifests", e);
-      System.exit(1); // Don't duplicate the error to the user or bubble up the exception.
+      // ManifestProcessingExceptions represent build errors that should be delivered directly to
+      // ResourceProcessorBusyBox where the exception can be delivered with a non-zero status code
+      // to the worker/process
+      throw e;
     } catch (Exception e) {
       logger.log(SEVERE, "Error during merging manifests", e);
       throw e; // This is a proper internal exception, so we bubble it up.


### PR DESCRIPTION
Calling `System#exit` kills the worker during the build. Passing the exception up to the worker should be enough for it to end up in the worker or local execution output.