### PR TITLE
Improve CompatDexBuilder worker compatibility

### DIFF
--- a/src/test/java/com/google/devtools/build/android/r8/BUILD
+++ b/src/test/java/com/google/devtools/build/android/r8/BUILD
@@ -31,6 +31,7 @@ java_library(
     }),
     deps = [
         "//src/test/java/com/google/devtools/build/lib/testutil:TestSuite",
+        "//src/main/java/com/google/devtools/common/options:options_internal",
         "//src/tools/android/java/com/google/devtools/build/android/r8",
         "//third_party:guava",
         "//third_party:junit4",

--- a/src/test/java/com/google/devtools/build/android/r8/CompatDexBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/android/r8/CompatDexBuilderTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.zip.ZipFile;
+import com.google.devtools.common.options.OptionsParsingException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -40,7 +41,8 @@ public class CompatDexBuilderTest {
   @Rule public TemporaryFolder temp = new TemporaryFolder();
 
   @Test
-  public void compileManyClasses() throws Exception {
+  public void compileManyClasses()
+      throws IOException, InterruptedException, ExecutionException, OptionsParsingException {
     // Random set of classes from the R8 example test directory naming001.
     final String inputJar = System.getProperty("CompatDexBuilderTests.naming001");
     final List<String> classNames =

--- a/src/test/java/com/google/devtools/build/android/r8/CompatDexBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/android/r8/CompatDexBuilderTest.java
@@ -40,7 +40,7 @@ public class CompatDexBuilderTest {
   @Rule public TemporaryFolder temp = new TemporaryFolder();
 
   @Test
-  public void compileManyClasses() throws IOException, InterruptedException, ExecutionException {
+  public void compileManyClasses() throws Exception {
     // Random set of classes from the R8 example test directory naming001.
     final String inputJar = System.getProperty("CompatDexBuilderTests.naming001");
     final List<String> classNames =

--- a/src/tools/android/java/com/google/devtools/build/android/r8/CompatDexBuilder.java
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/CompatDexBuilder.java
@@ -81,7 +81,11 @@ public class CompatDexBuilder {
   public static void main(String[] args)
       throws IOException, InterruptedException, ExecutionException {
     CompatDexBuilder compatDexBuilder = new CompatDexBuilder();
-    int exitCode = compatDexBuilder.run(args);
+    compatDexBuilder.processRequest(args);
+  }
+
+  private void processRequest(String[] args) throws IOException, ExecutionException, InterruptedException {
+    int exitCode = run(args);
     System.exit(exitCode);
   }
 

--- a/src/tools/android/java/com/google/devtools/build/android/r8/CompatDexBuilder.java
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/CompatDexBuilder.java
@@ -27,7 +27,6 @@ import com.android.tools.r8.DiagnosticsHandler;
 import com.android.tools.r8.origin.ArchiveEntryOrigin;
 import com.android.tools.r8.origin.PathOrigin;
 import com.google.common.io.ByteStreams;
-import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingException;
 
 import java.io.BufferedOutputStream;

--- a/src/tools/android/java/com/google/devtools/build/android/r8/CompatDexBuilder.java
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/CompatDexBuilder.java
@@ -80,11 +80,13 @@ public class CompatDexBuilder {
 
   public static void main(String[] args)
       throws IOException, InterruptedException, ExecutionException {
-    new CompatDexBuilder().run(args);
+    CompatDexBuilder compatDexBuilder = new CompatDexBuilder();
+    int exitCode = compatDexBuilder.run(args);
+    System.exit(exitCode);
   }
 
   @SuppressWarnings("JdkObsolete")
-  private void run(String[] args) throws IOException, InterruptedException, ExecutionException {
+  private int run(String[] args) throws IOException, InterruptedException, ExecutionException {
     List<String> flags = new ArrayList<>();
 
     for (String arg : args) {
@@ -128,18 +130,18 @@ public class CompatDexBuilder {
           break;
         default:
           System.err.println("Unsupported option: " + flag);
-          System.exit(1);
+          return 1;
       }
     }
 
     if (input == null) {
       System.err.println("No input jar specified");
-      System.exit(1);
+      return 1;
     }
 
     if (output == null) {
       System.err.println("No output jar specified");
-      System.exit(1);
+      return 1;
     }
 
     ExecutorService executor = Executors.newWorkStealingPool(numberOfThreads);
@@ -174,6 +176,8 @@ public class CompatDexBuilder {
     } finally {
       executor.shutdown();
     }
+
+    return 0;
   }
 
   private DexConsumer dexEntry(ZipFile zipFile, ZipEntry classEntry, ExecutorService executor)

--- a/src/tools/android/java/com/google/devtools/build/android/r8/CompatDexBuilder.java
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/CompatDexBuilder.java
@@ -27,6 +27,7 @@ import com.android.tools.r8.DiagnosticsHandler;
 import com.android.tools.r8.origin.ArchiveEntryOrigin;
 import com.android.tools.r8.origin.PathOrigin;
 import com.google.common.io.ByteStreams;
+import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingException;
 
 import java.io.BufferedOutputStream;
@@ -75,13 +76,15 @@ public class CompatDexBuilder {
     }
   }
 
-  public static void main(String[] args) throws Exception {
+  public static void main(String[] args)
+      throws IOException, InterruptedException, ExecutionException, OptionsParsingException {
     CompatDexBuilder compatDexBuilder = new CompatDexBuilder();
     compatDexBuilder.processRequest(args);
   }
 
   @SuppressWarnings("JdkObsolete")
-  private void processRequest(String[] args) throws Exception {
+  private void processRequest(String[] args)
+      throws IOException, InterruptedException, ExecutionException, OptionsParsingException {
     List<String> flags = new ArrayList<>();
     String input = null;
     String output = null;


### PR DESCRIPTION
Improving worker compatibility some by returning exit codes instead of calling `System#exit`. This PR doesn't actually bring in worker compatibility but I can open a PR with that once this merges.