### PR TITLE
Remove old http cache put deduplication

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/http/HttpCacheClientTest.java
@@ -314,7 +314,7 @@ public class HttpCacheClientTest {
   }
 
   @Test
-  public void testUploadAtMostOnce() throws Exception {
+  public void testUpload() throws Exception {
     ServerChannel server = null;
     try {
       ConcurrentHashMap<String, byte[]> cacheContents = new ConcurrentHashMap<>();
@@ -332,15 +332,6 @@ public class HttpCacheClientTest {
       String cacheKey = "/cas/" + digest.getHash();
       assertThat(cacheContents).containsKey(cacheKey);
       assertThat(cacheContents.get(cacheKey)).isEqualTo(data.toByteArray());
-
-      // Clear the remote cache contents
-      cacheContents.clear();
-
-      blobStore.uploadBlob(remoteActionExecutionContext, digest, data).get();
-
-      // Nothing should have been uploaded again.
-      assertThat(cacheContents).isEmpty();
-
     } finally {
       testServer.stop(server);
     }


### PR DESCRIPTION
Removing HTTP cache specific deduplication logic that is not needed any
more, thanks to the new generic deduplication in RemoteCache.java,
which was introduced by the "Remote: Async upload" set of commits,
completed by commit 581c81a854.