### PR TITLE
Use default shell environment in proto_library.

### DIFF
--- a/src/main/starlark/builtins_bzl/common/proto/proto_common.bzl
+++ b/src/main/starlark/builtins_bzl/common/proto/proto_common.bzl
@@ -101,6 +101,7 @@ def _create_proto_compile_action(
         inputs = depset(transitive = [proto_info.transitive_sources, additional_inputs]),
         outputs = outputs,
         tools = plugins,
+        use_default_shell_env = True,
     )
 
 def _proto_path_flag(path):


### PR DESCRIPTION
This fixes rules_go downstream:
https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2284#5be53928-59ad-43b3-a87f-b1a77dcd1117

Failed build:
https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2283#71dfd766-cc54-46ee-b893-d25587277404