### PR TITLE
Remote: Don't upload BES referenced blobs to disk cache.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploader.java
@@ -252,7 +252,7 @@ class ByteStreamBuildEventArtifactUploader extends AbstractReferenceCounted
 
     RequestMetadata metadata =
         TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "bes-upload", null);
-    RemoteActionExecutionContext context = RemoteActionExecutionContext.create(metadata);
+    RemoteActionExecutionContext context = RemoteActionExecutionContext.createForBES(metadata);
 
     return Single.using(
         remoteCache::retain,

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteActionExecutionContext.java
@@ -20,6 +20,13 @@ import javax.annotation.Nullable;
 
 /** A context that provide remote execution related information for executing an action remotely. */
 public interface RemoteActionExecutionContext {
+  enum Type {
+    RemoteExecution,
+    BuildEventService,
+  }
+
+  /** Returns the {@link Type} of the context. */
+  Type getType();
 
   /** Returns the {@link Spawn} of the action being executed or {@code null}. */
   @Nullable
@@ -46,7 +53,8 @@ public interface RemoteActionExecutionContext {
 
   /** Creates a {@link SimpleRemoteActionExecutionContext} with given {@link RequestMetadata}. */
   static RemoteActionExecutionContext create(RequestMetadata metadata) {
-    return new SimpleRemoteActionExecutionContext(/*spawn=*/ null, metadata, new NetworkTime());
+    return new SimpleRemoteActionExecutionContext(
+        /*type=*/ Type.RemoteExecution, /*spawn=*/ null, metadata, new NetworkTime());
   }
 
   /**
@@ -54,6 +62,12 @@ public interface RemoteActionExecutionContext {
    * RequestMetadata}.
    */
   static RemoteActionExecutionContext create(@Nullable Spawn spawn, RequestMetadata metadata) {
-    return new SimpleRemoteActionExecutionContext(spawn, metadata, new NetworkTime());
+    return new SimpleRemoteActionExecutionContext(
+        /*type=*/ Type.RemoteExecution, spawn, metadata, new NetworkTime());
+  }
+
+  static RemoteActionExecutionContext createForBES(RequestMetadata metadata) {
+    return new SimpleRemoteActionExecutionContext(
+        /*type=*/ Type.BuildEventService, /*spawn=*/ null, metadata, new NetworkTime());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/SimpleRemoteActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/SimpleRemoteActionExecutionContext.java
@@ -20,15 +20,22 @@ import javax.annotation.Nullable;
 /** A {@link RemoteActionExecutionContext} implementation */
 public class SimpleRemoteActionExecutionContext implements RemoteActionExecutionContext {
 
+  private final Type type;
   private final Spawn spawn;
   private final RequestMetadata requestMetadata;
   private final NetworkTime networkTime;
 
   public SimpleRemoteActionExecutionContext(
-      Spawn spawn, RequestMetadata requestMetadata, NetworkTime networkTime) {
+      Type type, Spawn spawn, RequestMetadata requestMetadata, NetworkTime networkTime) {
+    this.type = type;
     this.spawn = spawn;
     this.requestMetadata = requestMetadata;
     this.networkTime = networkTime;
+  }
+
+  @Override
+  public Type getType() {
+    return type;
   }
 
   @Nullable

--- a/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/disk/DiskAndRemoteCacheClient.java
@@ -74,13 +74,14 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
   @Override
   public ListenableFuture<Void> uploadFile(
       RemoteActionExecutionContext context, Digest digest, Path file) {
+    // For BES upload, we only upload to the remote cache.
+    if (context.getType() == RemoteActionExecutionContext.Type.BuildEventService) {
+      return remoteCache.uploadFile(context, digest, file);
+    }
+
     ListenableFuture<Void> future = diskCache.uploadFile(context, digest, file);
 
-    boolean uploadForSpawn = context.getSpawn() != null;
-    // If not upload for spawn e.g. for build event artifacts, we always upload files to remote
-    // cache.
-    if (!uploadForSpawn
-        || options.isRemoteExecutionEnabled()
+    if (options.isRemoteExecutionEnabled()
         || shouldUploadLocalResultsToRemoteCache(options, context.getSpawn())) {
       future =
           Futures.transformAsync(
@@ -113,6 +114,12 @@ public final class DiskAndRemoteCacheClient implements RemoteCacheClient {
     if (options.isRemoteExecutionEnabled()) {
       return remoteCache.findMissingDigests(context, digests);
     }
+
+    // For BES upload, we only check the remote cache.
+    if (context.getType() == RemoteActionExecutionContext.Type.BuildEventService) {
+      return remoteCache.findMissingDigests(context, digests);
+    }
+
     ListenableFuture<ImmutableSet<Digest>> diskQuery =
         diskCache.findMissingDigests(context, digests);
     if (shouldUploadLocalResultsToRemoteCache(options, context.getSpawn())) {

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3431,9 +3431,11 @@ genrule(
 )
 EOF
 
+  cache_dir=$(mktemp -d)
+
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \
-      --disk_cache="${TEST_TMPDIR}/disk_cache" \
+      --disk_cache=$cache_dir \
       --remote_upload_local_results=false \
       --incompatible_remote_build_event_upload_respect_no_cache \
       --build_event_json_file=bep.json \
@@ -3457,7 +3459,7 @@ genrule(
 )
 EOF
 
-  cache_dir="${TEST_TMPDIR}/disk_cache"
+  cache_dir=$(mktemp -d)
 
   bazel build \
       --remote_cache=grpc://localhost:${worker_port} \

--- a/src/test/shell/bazel/remote/remote_utils.sh
+++ b/src/test/shell/bazel/remote/remote_utils.sh
@@ -71,6 +71,16 @@ function count_disk_ac_files() {
   fi
 }
 
+# Pass in the root of the disk cache and count number of files under /cas directory
+# output int to stdout
+function count_disk_cas_files() {
+  if [ -d "$1/cas" ]; then
+    expr $(find "$1/cas" -type f | wc -l)
+  else
+    echo 0
+  fi
+}
+
 function count_remote_ac_files() {
   if [ -d "$cas_path/ac" ]; then
     expr $(find "$cas_path/ac" -type f | wc -l)


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/14435.