### PR TITLE
Rename --project_id to --bes_instance_name

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -692,7 +692,7 @@ public abstract class BuildEventServiceModule<OptionsT extends BuildEventService
         new BuildEventServiceProtoUtil.Builder()
             .buildRequestId(buildRequestId)
             .invocationId(invocationId)
-            .projectId(besOptions.projectId)
+            .projectId(besOptions.instanceName)
             .commandName(cmdEnv.getCommandName())
             .keywords(getBesKeywords(besOptions, cmdEnv.getRuntime().getStartupOptionsProvider()))
             .build();

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceOptions.java
@@ -88,13 +88,14 @@ public class BuildEventServiceOptions extends OptionsBase {
   public boolean besLifecycleEvents;
 
   @Option(
-    name = "project_id",
+    name = "bes_instance_name",
+    oldName = "project_id",
     defaultValue = "null",
     documentationCategory = OptionDocumentationCategory.LOGGING,
     effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
     help = "Specifies the BES project identifier. Defaults to null."
   )
-  public String projectId;
+  public String instanceName;
 
   @Option(
       name = "bes_keywords",


### PR DESCRIPTION
This makes it clearer that this flag affects the BES and not, e.g.,
remote cache or execution. `--bes_instance_name` was chosen to match
`--remote_instance_name` as closely as possible.

`--project_id` always seemed very Google/GCP centric, and now that
there are multiple other BES implementations like BuildBuddy or EngFlow
Build and Test UI, it makes sense to change the terminology to follow
the conventions from the REAPI. We will keep `--project_id` as an alias
for the foreseable future.