### PR TITLE
Fix exit code handling in `wrapped_clang.cc`

### DIFF
--- a/tools/osx/crosstool/wrapped_clang.cc
+++ b/tools/osx/crosstool/wrapped_clang.cc
@@ -125,9 +125,9 @@ void RunSubProcess(const std::vector<std::string> &args) {
                 << strerror(errno) << "\n";
       abort();
     }
-    if (WEXITSTATUS(status) != 0) {
+    if (WEXITSTATUS(wait_status) != 0) {
       std::cerr << "Error in child process '" << args[0] << "'. "
-                << WEXITSTATUS(status) << "\n";
+                << WEXITSTATUS(wait_status) << "\n";
       abort();
     }
   } else {


### PR DESCRIPTION
Previously, most likely due to a copy&paste issue, the wrapper would never report a non-zero exit code since it incorrectly used the return value of `posix_spawn` rather than `waitpid`.