### PR TITLE
Remote: Make --incompatible_remote_build_event_upload_respect_no_cache working with --incompatible_remote_results_ignore_disk.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -356,19 +356,6 @@ public class RemoteExecutionService {
     }
   }
 
-  public static boolean shouldUploadLocalResults(
-      RemoteOptions remoteOptions, Map<String, String> executionInfo) {
-    if (useRemoteCache(remoteOptions)) {
-      if (useDiskCache(remoteOptions)) {
-        return shouldUploadLocalResultsToCombinedDisk(remoteOptions, executionInfo);
-      } else {
-        return shouldUploadLocalResultsToRemoteCache(remoteOptions, executionInfo);
-      }
-    } else {
-      return shouldUploadLocalResultsToDiskCache(remoteOptions, executionInfo);
-    }
-  }
-
   /**
    * Returns {@code true} if the local results of the {@code spawn} should be uploaded to remote
    * cache.
@@ -378,7 +365,15 @@ public class RemoteExecutionService {
       return false;
     }
 
-    return shouldUploadLocalResults(remoteOptions, spawn.getExecutionInfo());
+    if (useRemoteCache(remoteOptions)) {
+      if (useDiskCache(remoteOptions)) {
+        return shouldUploadLocalResultsToCombinedDisk(remoteOptions, spawn);
+      } else {
+        return shouldUploadLocalResultsToRemoteCache(remoteOptions, spawn);
+      }
+    } else {
+      return shouldUploadLocalResultsToDiskCache(remoteOptions, spawn);
+    }
   }
 
   /** Returns {@code true} if the spawn may be executed remotely. */

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -763,8 +763,7 @@ public final class RemoteModule extends BlazeModule {
         RuleConfiguredTarget ruleConfiguredTarget = (RuleConfiguredTarget) configuredTarget;
         for (ActionAnalysisMetadata action : ruleConfiguredTarget.getActions()) {
           boolean uploadLocalResults =
-              RemoteExecutionService.shouldUploadLocalResults(
-                  remoteOptions, action.getExecutionInfo());
+              Utils.shouldUploadLocalResultsToRemoteCache(remoteOptions, action.getExecutionInfo());
           if (!uploadLocalResults) {
             for (Artifact output : action.getOutputs()) {
               if (output.isTreeArtifact()) {


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/14463.