### PR TITLE
Make --nobuild_runfiles_links work in combination with --run_under

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/RunCommand.java
@@ -370,26 +370,34 @@ public class RunCommand implements BlazeCommand  {
           Code.RUN_PREREQ_UNMET);
     }
 
-    Path runfilesDir;
-    FilesToRunProvider provider = targetToRun.getProvider(FilesToRunProvider.class);
-    RunfilesSupport runfilesSupport = provider == null ? null : provider.getRunfilesSupport();
+    // Ensure runfiles directories are constructed, both for the target to run
+    // and the --run_under target. The path of the runfiles directory of the
+    // target to run needs to be preserved, as it acts as the working directory.
+    Path targetToRunRunfilesDir = null;
+    RunfilesSupport targetToRunRunfilesSupport = null;
+    for (ConfiguredTarget target : targetsBuilt) {
+      FilesToRunProvider provider = target.getProvider(FilesToRunProvider.class);
+      RunfilesSupport runfilesSupport = provider == null ? null : provider.getRunfilesSupport();
 
-    if (runfilesSupport == null) {
-      runfilesDir = env.getWorkingDirectory();
-    } else {
-      try {
-        runfilesDir = ensureRunfilesBuilt(env, runfilesSupport,
-            env.getSkyframeExecutor().getConfiguration(env.getReporter(),
-                targetToRun.getConfigurationKey()));
-      } catch (RunfilesException e) {
-        env.getReporter().handle(Event.error(e.getMessage()));
-        return BlazeCommandResult.failureDetail(e.createFailureDetail());
-      } catch (InterruptedException e) {
-        env.getReporter().handle(Event.error("Interrupted"));
-        return BlazeCommandResult.failureDetail(
-            FailureDetail.newBuilder()
-                .setInterrupted(Interrupted.newBuilder().setCode(Interrupted.Code.INTERRUPTED))
-                .build());
+      if (runfilesSupport != null) {
+        try {
+          Path runfilesDir = ensureRunfilesBuilt(env, runfilesSupport,
+              env.getSkyframeExecutor().getConfiguration(env.getReporter(),
+                  target.getConfigurationKey()));
+          if (target == targetToRun) {
+            targetToRunRunfilesDir = runfilesDir;
+            targetToRunRunfilesSupport = runfilesSupport;
+          }
+        } catch (RunfilesException e) {
+          env.getReporter().handle(Event.error(e.getMessage()));
+          return BlazeCommandResult.failureDetail(e.createFailureDetail());
+        } catch (InterruptedException e) {
+          env.getReporter().handle(Event.error("Interrupted"));
+          return BlazeCommandResult.failureDetail(
+              FailureDetail.newBuilder()
+                  .setInterrupted(Interrupted.newBuilder().setCode(Interrupted.Code.INTERRUPTED))
+                  .build());
+        }
       }
     }
 
@@ -472,9 +480,11 @@ public class RunCommand implements BlazeCommand  {
             InterruptedFailureDetails.detailedExitCode(message));
       }
     } else {
-      workingDir = runfilesDir;
-      if (runfilesSupport != null) {
-        runfilesSupport.getActionEnvironment().resolve(runEnvironment, env.getClientEnv());
+      workingDir = targetToRunRunfilesDir != null
+          ? targetToRunRunfilesDir
+          : env.getWorkingDirectory();
+      if (targetToRunRunfilesSupport != null) {
+        targetToRunRunfilesSupport.getActionEnvironment().resolve(runEnvironment, env.getClientEnv());
       }
       try {
         List<String> args = computeArgs(targetToRun, commandLineArgs);


### PR DESCRIPTION
When both of these flags are provided, we must make sure that a "bazel
run" forcefully instantiates the runfiles directories both for the
target to run, and the --run_under target. Right now it only ensures
this for the former, which causes execution errors along the lines of:

Cannot find .runfiles directory for /some/path

This code alters the existing code block that ensures that runfiles
exist to loop over the entire set of targets. We do need to capture the
path of the runfiles directory of the target to run, as it may need be
used as the working directory later on.