### PR TITLE
Changes http_archive's netrc attr to a Label.

### DIFF
--- a/src/test/shell/bazel/starlark_repository_test.sh
+++ b/src/test/shell/bazel/starlark_repository_test.sh
@@ -2008,16 +2008,12 @@ function test_http_archive_netrc() {
   tar cvf x.tar x
   sha256=$(sha256sum x.tar | head -c 64)
   serve_file_auth x.tar
-  netrc_dir="$(pwd)"
-  if "$is_windows"; then
-    netrc_dir="$(cygpath -m ${netrc_dir})"
-  fi
   cat > WORKSPACE <<EOF
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
   name="ext",
   url = "http://127.0.0.1:$nc_port/x.tar",
-  netrc = "${netrc_dir}/.netrc",
+  netrc = "@//:.netrc",
   sha256="$sha256",
 )
 EOF
@@ -2045,16 +2041,12 @@ function test_http_archive_auth_patterns() {
   tar cvf x.tar x
   sha256=$(sha256sum x.tar | head -c 64)
   serve_file_auth x.tar
-  netrc_dir="$(pwd)"
-  if "$is_windows"; then
-    netrc_dir="$(cygpath -m ${netrc_dir})"
-  fi
   cat > WORKSPACE <<EOF
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
   name="ext",
   url = "http://127.0.0.1:$nc_port/x.tar",
-  netrc = "${netrc_dir}/.netrc",
+  netrc = "@//:.netrc",
   sha256="$sha256",
   auth_patterns = {
     "127.0.0.1": "Bearer <password>"

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -444,8 +444,9 @@ unless it was added to the cache by a request with the same canonical id.
 Each entry must be a file, http or https URL. Redirections are followed.
 Authentication is not supported.""",
     ),
-    "netrc": attr.string(
-        doc = "Location of the .netrc file to use for authentication",
+    "netrc": attr.label(
+        doc = "A label that specifies the location of the .netrc file to use for authentication.",
+        allow_single_file = True,
     ),
     "auth_patterns": attr.string_dict(
         doc = _AUTH_PATTERN_DOC,
@@ -498,8 +499,9 @@ unless it was added to the cache by a request with the same canonical id.
             "A list of URLS the jar can be fetched from. They have to end " +
             "in `.jar`.",
     ),
-    "netrc": attr.string(
-        doc = "Location of the .netrc file to use for authentication",
+    "netrc": attr.label(
+        doc = "A label that specifies the location of the .netrc file to use for authentication.",
+        allow_single_file = True,
     ),
     "auth_patterns": attr.string_dict(
         doc = _AUTH_PATTERN_DOC,

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -242,7 +242,7 @@ field will make your build non-hermetic. It is optional to make development
 easier but either this attribute or `sha256` should be set before shipping.""",
     ),
     "netrc": attr.label(
-        doc = "Location of the .netrc file to use for authentication",
+        doc = "A label that specifies the location of the .netrc file to use for authentication.",
         allow_single_file = True,
     ),
     "auth_patterns": attr.string_dict(

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -241,8 +241,9 @@ to omit the checksum as remote files can change._ At best omitting this
 field will make your build non-hermetic. It is optional to make development
 easier but either this attribute or `sha256` should be set before shipping.""",
     ),
-    "netrc": attr.string(
+    "netrc": attr.label(
         doc = "Location of the .netrc file to use for authentication",
+        allow_single_file = True,
     ),
     "auth_patterns": attr.string_dict(
         doc = _AUTH_PATTERN_DOC,


### PR DESCRIPTION
This makes it possible to use a netrc file in another repository (e.g.,
the current repository) rather than referring to a netrc *file* inside
the external repository (which usually does not make sense).

Closes: 13662

RELNOTES[INC]: this incompatible change breaks old instances of http_archive that specified netrc as an absolute path. It is unlikely there are many instances in the wild since the path would refer to a netrc file inside the external repository by absolute path. Migration should be straightforward.