### PR TITLE
update version of build rules to latest available

### DIFF
--- a/site/docs/tutorial/ios-app.md
+++ b/site/docs/tutorial/ios-app.md
@@ -116,25 +116,25 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.19.0",
+    tag = "0.32.0",
 )
 
 git_repository(
     name = "build_bazel_rules_swift",
     remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.13.0",
+    tag = "0.24.0",
 )
 
 git_repository(
     name = "build_bazel_apple_support",
     remote = "https://github.com/bazelbuild/apple_support.git",
-    tag = "0.7.2",
+    tag = "0.11.0",
 )
 
 git_repository(
     name = "bazel_skylib",
     remote = "https://github.com/bazelbuild/bazel-skylib.git",
-    tag = "0.9.0",
+    tag = "1.1.1",
 )
 ```
 


### PR DESCRIPTION
The version numbers in the doc are quite far behind. This PR is updating them to the latest versions available.