### PR TITLE
Added `native.bazel_version` for use in BUILD and bzl files

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/BazelStarlarkEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BazelStarlarkEnvironment.java
@@ -70,7 +70,7 @@ public final class BazelStarlarkEnvironment {
     this.ruleFunctions = ruleFunctions;
     this.uninjectedBuildBzlNativeBindings =
         createUninjectedBuildBzlNativeBindings(
-            ruleFunctions, packageFunction, environmentExtensions);
+            ruleFunctions, packageFunction, environmentExtensions, version);
     this.workspaceBzlNativeBindings = createWorkspaceBzlNativeBindings(ruleClassProvider, version);
     this.uninjectedBuildBzlEnv =
         createUninjectedBuildBzlEnv(ruleClassProvider, uninjectedBuildBzlNativeBindings);
@@ -143,7 +143,8 @@ public final class BazelStarlarkEnvironment {
   private static ImmutableMap<String, Object> createUninjectedBuildBzlNativeBindings(
       Map<String, ?> ruleFunctions,
       Object packageFunction,
-      List<PackageFactory.EnvironmentExtension> environmentExtensions) {
+      List<PackageFactory.EnvironmentExtension> environmentExtensions,
+      String version) {
     ImmutableMap.Builder<String, Object> env = new ImmutableMap.Builder<>();
     env.putAll(StarlarkNativeModule.BINDINGS_FOR_BUILD_FILES);
     env.putAll(ruleFunctions);
@@ -151,6 +152,7 @@ public final class BazelStarlarkEnvironment {
     for (PackageFactory.EnvironmentExtension ext : environmentExtensions) {
       ext.updateNative(env);
     }
+    env.put("bazel_version", version);
     return env.build();
   }
 


### PR DESCRIPTION
This change is intended to improve rules maintainer's ability to avoid breaking changes by gating certain functionality behind a version check. Users can now write rules which check the version of Bazel as an indication that certain functionality will be available.

[@rules_python//python/pip_install:requirements.bzl](https://github.com/bazelbuild/rules_python/blob/0.5.0/python/pip_install/requirements.bzl#L77-L82) is one such example where this rule could be used.
```diff
diff --git a/python/pip_install/requirements.bzl b/python/pip_install/requirements.bzl
index b040ebd..219466f 100644
--- a/python/pip_install/requirements.bzl
+++ b/python/pip_install/requirements.bzl
@@ -75,7 +75,7 @@ def compile_pip_requirements(
     }

     # cheap way to detect the bazel version
-    _bazel_version_4_or_greater = "propeller_optimize" in dir(native)
+    _bazel_version_4_or_greater = native.bazel_version[0:2] not in ("0.", "1.", "2.", "3.")

     # Bazel 4.0 added the "env" attribute to py_test/py_binary
     if _bazel_version_4_or_greater:
```

Or, for users of [bazel_skylib](https://github.com/bazelbuild/bazel-skylib):
```diff
diff --git a/python/pip_install/requirements.bzl b/python/pip_install/requirements.bzl
index b040ebd..f5dd545 100644
--- a/python/pip_install/requirements.bzl
+++ b/python/pip_install/requirements.bzl
@@ -1,5 +1,6 @@
 """Rules to verify and update pip-compile locked requirements.txt"""

+load("@bazel_skylib//lib:versions.bzl", "versions")
 load("//python:defs.bzl", "py_binary", "py_test")
 load("//python/pip_install:repositories.bzl", "requirement")

@@ -75,7 +76,7 @@ def compile_pip_requirements(
     }

     # cheap way to detect the bazel version
-    _bazel_version_4_or_greater = "propeller_optimize" in dir(native)
+    _bazel_version_4_or_greater = versions.is_at_least("4.0.0", native.bazel_version)

     # Bazel 4.0 added the "env" attribute to py_test/py_binary
     if _bazel_version_4_or_greater:
```
    

closes https://github.com/bazelbuild/bazel/issues/8305