### PR TITLE
Remove uses of -lstdc++ on darwin

### DIFF
--- a/tools/cpp/cc_toolchain_config.bzl
+++ b/tools/cpp/cc_toolchain_config.bzl
@@ -395,7 +395,7 @@ def _impl(ctx):
                     flag_groups = [
                         flag_group(
                             flags = [
-                                "-lstdc++",
+                                "-lc++",
                                 "-undefined",
                                 "dynamic_lookup",
                                 "-headerpad_max_install_names",

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -400,7 +400,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
         False,
     ), ":")
 
-    bazel_linkopts = "-lstdc++:-lm"
+    bazel_linkopts = "-lc++:-lm" if darwin else "-lstdc++:-lm"
     bazel_linklibs = ""
     if repository_ctx.flag_enabled("incompatible_linkopts_to_linklibs"):
         bazel_linkopts, bazel_linklibs = bazel_linklibs, bazel_linkopts


### PR DESCRIPTION
This flag has been invalid seemingly since macOS 10.9 from 2013. By
default clang remaps this back to -lc++, but if your linkopts pass
-nodefaultlibs this is not the case, in which case this invalid flag
fails the link. This happened for rust builds where the rust driver
passes this flag intentionally.

For more info see https://github.com/bazelbuild/bazel/issues/14395#issuecomment-1009490593

Fixes https://github.com/google/cargo-raze/issues/247 https://github.com/bazelbuild/bazel/issues/14395 https://github.com/bazelbuild/rules_rust/issues/226