### PR TITLE
Fix Bzlmod build with protobuf 3.19.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,3 +32,10 @@ bazel_dep(name = "rules_cc", version = "0.0.1")
 bazel_dep(name = "rules_python", version = "0.4.0")
 bazel_dep(name = "rules_java", version = "5.0.0")
 bazel_dep(name = "rules_proto", version = "4.0.0")
+
+# TODO(pcloudy): Remove this when rules_jvm_external adopts Bzlmod.
+single_version_override(
+  module_name = "protobuf",
+  patches = ["//third_party/protobuf:3.19.2.bzlmod.patch"],
+  patch_strip = 1,
+)

--- a/third_party/protobuf/3.19.2.bzlmod.patch
+++ b/third_party/protobuf/3.19.2.bzlmod.patch
@@ -1,0 +1,21 @@
+diff --git a/java/util/BUILD b/java/util/BUILD
+index ee6ddeaf1..54e20ea24 100644
+--- a/java/util/BUILD
++++ b/java/util/BUILD
+@@ -13,11 +13,11 @@ java_library(
+     deps = [
+         "//java/core",
+         "//java/lite",
+-        "@maven//:com_google_code_findbugs_jsr305",
+-        "@maven//:com_google_code_gson_gson",
+-        "@maven//:com_google_errorprone_error_prone_annotations",
+-        "@maven//:com_google_guava_guava",
+-        "@maven//:com_google_j2objc_j2objc_annotations",
++        "//external:jsr305",
++        "//external:gson",
++        "//external:error_prone_annotations",
++        "//external:guava",
++        "//external:j2objc_annotations",
+     ],
+ )
+ 

--- a/third_party/protobuf/BUILD
+++ b/third_party/protobuf/BUILD
@@ -1,6 +1,9 @@
 licenses(["notice"])
 
-exports_files(["3.11.3.patch"])
+exports_files([
+    "3.11.3.patch",
+    "3.19.2.bzlmod.patch",
+])
 
 filegroup(
     name = "srcs",


### PR DESCRIPTION
With https://github.com/protocolbuffers/protobuf/commit/c7dfd0d6b92f825a4b9e986b3e948a5ab61c7438, protobuf 3.19.2 now depends on @maven for fetching some jar dependencies. This was still handled by `bind` in WORKSPACE.bzlmod file in the Bzlmod build, and will be removed when rules_jvm_external is available for Bzlmod.

For now, we have to patch protobuf 3.19.2 to make it work with Bazel's Bzlmod build.

Related change: https://github.com/bazelbuild/bazel/commit/7a22b269d6fe5ffd66f20264320d8821e174c6a9