### PR TITLE
Switch to using the Bazel @platforms repository for platform constraints in Android NDK docs

### DIFF
--- a/site/docs/android-ndk.md
+++ b/site/docs/android-ndk.md
@@ -277,8 +277,8 @@ toolchain(
   name = "x86-clang8.0.7-libcpp_toolchain",
   toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
   target_compatible_with = [
-      "@bazel_tools//platforms:android",
-      "@bazel_tools//platforms:x86_32"
+      "@platforms//os:android",
+      "@platforms//cpu:x86_32",
   ],
   toolchain = "@androidndk//:x86-clang8.0.7-libcpp",
 )
@@ -287,8 +287,8 @@ toolchain(
   name = "x86_64-clang8.0.7-libcpp_toolchain",
   toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
   target_compatible_with = [
-      "@bazel_tools//platforms:android",
-      "@bazel_tools//platforms:x86_64"
+      "@platforms//os:android",
+      "@platforms//cpu:x86_64",
   ],
   toolchain = "@androidndk//:x86_64-clang8.0.7-libcpp",
 )
@@ -297,8 +297,8 @@ toolchain(
   name = "arm-linux-androideabi-clang8.0.7-v7a-libcpp_toolchain",
   toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
   target_compatible_with = [
-      "@bazel_tools//platforms:android",
-      "@bazel_tools//platforms:arm"
+      "@platforms//os:android",
+      "@platforms//cpu:arm",
   ],
   toolchain = "@androidndk//:arm-linux-androideabi-clang8.0.7-v7a-libcpp",
 )


### PR DESCRIPTION
I happened to read the Android NDK docs right after having read up on the state of Bazel's platforms constraints--and noticed that the NDK docs were still using the older, deprecated @bazel_tools//platform format. 

Figured I'd proposed a quick change to try to leave things even better than I found them.

Crossrefs to notes about the migration:
https://github.com/bazelbuild/bazel/blob/6b3b57801af4342a783588620fb3ca14838ac007/tools/platforms/BUILD
https://github.com/bazelbuild/bazel/issues/8622

Thanks, wonderful Bazel folks, for all you do!

Cheers,
Chris
(ex-Googler)