### PR TITLE
Expose the logic to read user netrc file

### DIFF
--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -32,7 +32,7 @@ replace the native rules.
 
 load(
     ":utils.bzl",
-    "get_ath",
+    "get_auth",
     "patch",
     "update_attrs",
     "workspace_and_buildfile",

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -95,7 +95,7 @@ def _http_archive_impl(ctx):
     if ctx.attr.url:
         all_urls = [ctx.attr.url] + all_urls
 
-    auth = get_auth(ctx, all_urls)
+    auth = _get_auth(ctx, all_urls)
 
     download_info = ctx.download_and_extract(
         all_urls,
@@ -138,7 +138,7 @@ def _http_file_impl(ctx):
     download_path = ctx.path("file/" + downloaded_file_path)
     if download_path in forbidden_files or not str(download_path).startswith(str(repo_root)):
         fail("'%s' cannot be used as downloaded_file_path in http_file" % ctx.attr.downloaded_file_path)
-    auth = get_auth(ctx, ctx.attr.urls)
+    auth = _get_auth(ctx, ctx.attr.urls)
     download_info = ctx.download(
         ctx.attr.urls,
         "file/" + downloaded_file_path,
@@ -178,7 +178,7 @@ def _http_jar_impl(ctx):
         all_urls = ctx.attr.urls
     if ctx.attr.url:
         all_urls = [ctx.attr.url] + all_urls
-    auth = get_auth(ctx, all_urls)
+    auth = _get_auth(ctx, all_urls)
     downloaded_file_name = ctx.attr.downloaded_file_name
     download_info = ctx.download(
         all_urls,

--- a/tools/build_defs/repo/http.bzl
+++ b/tools/build_defs/repo/http.bzl
@@ -32,9 +32,11 @@ replace the native rules.
 
 load(
     ":utils.bzl",
-    "get_auth",
     "patch",
+    "read_netrc",
+    "read_user_netrc",
     "update_attrs",
+    "use_netrc",
     "workspace_and_buildfile",
 )
 
@@ -71,6 +73,14 @@ The final HTTP request would have the following header:
 Authorization: Bearer RANDOM-TOKEN
 </pre>
 """
+
+def _get_auth(ctx, urls):
+    """Given the list of URLs obtain the correct auth dict."""
+    if ctx.attr.netrc:
+        netrc = read_netrc(ctx, ctx.attr.netrc)
+    else:
+        netrc = read_user_netrc(ctx)
+    return use_netrc(netrc, urls, ctx.attr.auth_patterns)
 
 def _http_archive_impl(ctx):
     """Implementation of the http_archive rule."""

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -387,7 +387,14 @@ def use_netrc(netrc, urls, patterns):
     return auth
 
 def read_user_netrc(ctx):
-    "Read user's default netrc file"
+    """Read user's default netrc file.
+
+    Args:
+      ctx: The repository context of the repository rule calling this utility function.
+
+    Returns:
+      dict mapping a machine names to a dict with the information provided about them.
+    """
     if ctx.os.name.startswith("windows"):
         home_dir = ctx.os.environ.get("USERPROFILE", "")
     else:

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -28,11 +28,6 @@ load(
 ```
 """
 
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
-)
-
 # Temporary directory for downloading remote patch files.
 _REMOTE_PATCH_DIR = ".tmp_remote_patches"
 
@@ -391,12 +386,8 @@ def use_netrc(netrc, urls, patterns):
 
     return auth
 
-def get_auth(ctx, urls):
-    """Given the list of URLs obtain the correct auth dict."""
-    if ctx.attr.netrc:
-        netrc = read_netrc(ctx, ctx.attr.netrc)
-        return use_netrc(netrc, urls, ctx.attr.auth_patterns)
-
+def read_user_netrc(ctx):
+    "Read user's default netrc file"
     if ctx.os.name.startswith("windows"):
         home_dir = ctx.os.environ.get("USERPROFILE", "")
     else:
@@ -405,8 +396,7 @@ def get_auth(ctx, urls):
     if not home_dir:
         return {}
 
-    netrcfile = paths.join(home_dir, ".netrc")
+    netrcfile = "{}/.netrc".format(home_dir)
     if not ctx.path(netrcfile).exists:
         return {}
-    netrc = read_netrc(ctx, netrcfile)
-    return use_netrc(netrc, urls, ctx.attr.auth_patterns)
+    return read_netrc(ctx, netrcfile)

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -28,6 +28,11 @@ load(
 ```
 """
 
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+
 # Temporary directory for downloading remote patch files.
 _REMOTE_PATCH_DIR = ".tmp_remote_patches"
 
@@ -385,3 +390,23 @@ def use_netrc(netrc, urls, patterns):
             }
 
     return auth
+
+def get_auth(ctx, urls):
+    """Given the list of URLs obtain the correct auth dict."""
+    if ctx.attr.netrc:
+        netrc = read_netrc(ctx, ctx.attr.netrc)
+        return use_netrc(netrc, urls, ctx.attr.auth_patterns)
+
+    if ctx.os.name.startswith("windows"):
+        home_dir = ctx.os.environ.get("USERPROFILE", "")
+    else:
+        home_dir = ctx.os.environ.get("HOME", "")
+
+    if not home_dir:
+        return {}
+
+    netrcfile = paths.join(home_dir, ".netrc")
+    if not ctx.path(netrcfile).exists:
+        return {}
+    netrc = read_netrc(ctx, netrcfile)
+    return use_netrc(netrc, urls, ctx.attr.auth_patterns)


### PR DESCRIPTION
Repository rules that download repositories from internal website often need to read users `.netrc` files. This PR exposes the logic for other repository rules to use.