### PR TITLE
Do not mention redundant use case for Label constructor

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
@@ -579,12 +579,11 @@ public interface StarlarkRuleFunctionsApi<FileApiT extends FileApi> {
   @StarlarkMethod(
       name = "Label",
       doc =
-          "Creates a Label referring to a BUILD target. Use this function when you want to give a"
-              + " default value for the label attributes of a rule or when referring to a target"
-              + " via an absolute label from a macro. The argument must refer to an absolute label."
-              + " The repo part of the label (or its absence) is interpreted in the context of the"
-              + " repo where this Label() call appears. Example: <br><pre"
-              + " class=language-python>Label(\"//tools:default\")</pre>",
+          "Creates a Label referring to a BUILD target. Use this function when referring to a"
+              + " target via an absolute label from a macro. The argument must refer to an absolute"
+              + " label. The repo part of the label (or its absence) is interpreted in the context"
+              + " of the repo where this Label() call appears. Example: <br>"
+              + "<pre class=language-python>Label(\"//tools:default\")</pre>",
       parameters = {
         @Param(name = "label_string", doc = "the label string."),
       },


### PR DESCRIPTION
Label strings passed to the `default` argument of `attr.label()` are resolved to a `Label` immediately relative to the call site of
`attr.label()`, so wrapping the argument with `Label(...)` is entirely redundant.

More context at:
https://github.com/bazelbuild/bazel-central-registry/pull/63#issuecomment-1017669585