### PR TITLE
fix test_name in test-setup.sh

### DIFF
--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -197,7 +197,7 @@ function write_xml_output_file {
       error_msg="<error message=\"exited with error code $exitCode\"></error>"
     fi
     test_name="${TEST_BINARY#./}"
-    test_name="${TEST_BINARY#../}"
+    test_name="${test_name#../}"
     # Ensure that test shards have unique names in the xml output.
     if [[ -n "${TEST_TOTAL_SHARDS+x}" ]] && ((TEST_TOTAL_SHARDS != 0)); then
       ((shard_num=TEST_SHARD_INDEX+1))


### PR DESCRIPTION
00805727b867d33fd922e63ca82b0d9825ad79fe added changes to `tools/test/test-setup.sh` and `tools/test/generate-xml.sh`
```diff
  test_name="${TEST_BINARY#./}"
+ test_name="${TEST_BINARY#../}"
```
And a followup e6f1066deef066df82e3e2771ef521c03c252f01 that updated only `tools/test/generate-xml.sh`
```diff
  test_name="${TEST_BINARY#./}"
- test_name="${TEST_BINARY#../}"
+ test_name="${test_name#../}"
```
`tools/test/test-setup.sh` should probably have the same patch too