### PR TITLE
Fix missing warning on macOS

### DIFF
--- a/third_party/zstd-jni/zstd-jni.BUILD
+++ b/third_party/zstd-jni/zstd-jni.BUILD
@@ -15,6 +15,11 @@ cc_binary(
     }),
     copts = select({
         "@io_bazel//src/conditions:windows": [],
+        "@io_bazel//src/conditions:darwin": [
+            "-std=c99",
+            "-Wno-unused-variable",
+            "-Wno-sometimes-uninitialized",
+        ],
         "//conditions:default": [
             "-std=c99",
             "-Wno-unused-variable",


### PR DESCRIPTION
If you're building on macOS you're likely using clang, and
`-Wno-maybe-uninitialized` isn't a valid warning with Apple clang