### PR TITLE
Normalize rpath entries to guard against missing default solib dir

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
@@ -330,8 +330,13 @@ public class LibrariesToLinkCollector {
         commonParent = commonParent.getParentDirectory();
       }
 
-      rpathRootsForExplicitSoDeps.add(
-          rpathRoot + dotdots + libDir.relativeTo(commonParent).getPathString());
+      // When all dynamic deps are built in transitioned configurations, the default solib dir is
+      // not created. While resolving paths, the dynamic linker stops at the first directory that
+      // does not exist, even when followed by "../". We thus have to normalize the relative path.
+      String relativePathToRoot =
+          rpathRoot + dotdots + libDir.relativeTo(commonParent).getPathString();
+      String normalizedPathToRoot = PathFragment.create(relativePathToRoot).getPathString();
+      rpathRootsForExplicitSoDeps.add(normalizedPathToRoot);
 
       // Unless running locally, libraries will be available under the root relative path, so we
       // should add that to the rpath as well.

--- a/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/cpp/CcLibraryConfiguredTargetTest.java
@@ -2178,7 +2178,7 @@ public class CcLibraryConfiguredTargetTest extends BuildViewTestCase {
     List<String> linkArgv = action.getLinkCommandLine().arguments();
     assertThat(linkArgv).contains("-Wl,-rpath,$ORIGIN/../_solib_k8/");
     assertThat(Joiner.on(" ").join(linkArgv))
-        .contains("-Wl,-rpath,$ORIGIN/../_solib_k8/../../../k8-fastbuild-ST-");
+        .contains("-Wl,-rpath,$ORIGIN/../../../k8-fastbuild-ST-");
     assertThat(Joiner.on(" ").join(linkArgv))
         .contains("-L" + TestConstants.PRODUCT_NAME + "-out/k8-fastbuild-ST-");
     assertThat(Joiner.on(" ").join(linkArgv)).containsMatch("-lST-[0-9a-f]+_transition_Slibdep2");


### PR DESCRIPTION
When all dynamic deps in a build are built in transitioned configurations, the default solib dir is not created. However, while
resolving paths, the dynamic linker stops at the first directory that does not exist, even when followed by `../`.

Before this commit, all rpath entries would consist of the relative path to the default solib dir followed by the relative path to the
particular library's solib dir. Thus, if the default solib dir was missing, the dynamic linker wouldn't resolve any of these paths.

This commit ensures that the relative path entries are normalized and thus contain no references to non-existing directories assuming the normalized path itself exists.

Work towards #13819.