### PR TITLE
Add a real file for non-windows test_wrapper and xml_writer

### DIFF
--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -120,7 +120,9 @@ filegroup(
             "tw",
             "xml",
         ],
-        "//conditions:default": [],
+        "//conditions:default": [
+            "dummy.sh",
+        ],
     }),
     visibility = ["//tools:__pkg__"],
 )

--- a/tools/test/BUILD.tools
+++ b/tools/test/BUILD.tools
@@ -51,7 +51,7 @@ filegroup(
     # See https://github.com/bazelbuild/bazel/issues/5508
     srcs = select({
         "@bazel_tools//src/conditions:windows": ["tw.exe"],
-        "//conditions:default": ["tw"],
+        "//conditions:default": ["dummy.sh"],
     }),
 )
 
@@ -62,6 +62,6 @@ filegroup(
     # On other platforms this binary is a no-op.
     srcs = select({
         "@bazel_tools//src/conditions:windows": ["xml.exe"],
-        "//conditions:default": ["xml"],
+        "//conditions:default": ["dummy.sh"],
     }),
 )

--- a/tools/test/dummy.sh
+++ b/tools/test/dummy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 0


### PR DESCRIPTION
The fake files are causing difficult-to-handle output from cquery, since
cquery doesn't validate that input files actually exist.

This ameliorates #14611 but doesn't deal with the root problem.