### PR TITLE
Add the ability to emit *.runfiles_manifest as JSON

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -446,6 +446,7 @@ java_library(
         "//third_party:auto_value",
         "//third_party:caffeine",
         "//third_party:flogger",
+        "//third_party:gson",
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party/protobuf:protobuf_java",

--- a/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java
@@ -348,7 +348,8 @@ public final class RunfilesSupport {
                 context.getActionOwner(),
                 inputManifest,
                 runfiles,
-                context.getConfiguration().remotableSourceManifestActions()));
+                context.getConfiguration().remotableSourceManifestActions(),
+                context.getConfiguration().jsonSourceManifests()));
 
     if (!createSymlinks) {
       // Just return the manifest if that's all the build calls for.

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -795,6 +795,10 @@ public class BuildConfigurationValue implements BuildConfigurationApi, SkyValue 
     return options.remotableSourceManifestActions;
   }
 
+  public boolean jsonSourceManifests() {
+    return options.jsonSourceManifests;
+  }
+
   /**
    * Returns a modified copy of {@code executionInfo} if any {@code executionInfoModifiers} apply to
    * the given {@code mnemonic}. Otherwise returns {@code executionInfo} unchanged.

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -796,6 +796,19 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   public boolean remotableSourceManifestActions;
 
   @Option(
+      name = "incompatible_json_source_manifests",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.OUTPUT_SELECTION,
+      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
+      help =
+          "If true, write source manifests in newline delimited JSON format. Regardless of whether "
+              + "this option is set, entries for pathnames containing spaces or leading square "
+              + "brackets are encoded in the JSON format, as the resulting output would be "
+              + "ambiguous or unrepresentable otherwise.")
+  public boolean jsonSourceManifests;
+
+  @Option(
       name = "flag_alias",
       converter = Converters.FlagAliasConverter.class,
       defaultValue = "null",

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaBinary.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaBinary.java
@@ -456,7 +456,8 @@ public class JavaBinary implements RuleConfiguredTargetFactory {
                   // This matches the code below in collectDefaultRunfiles.
                   .addTransitiveArtifactsWrappedInStableOrder(common.getRuntimeClasspath())
                   .build(),
-              true));
+              true,
+              false));
       filesBuilder.add(runtimeClasspathArtifact);
 
       // Pass the artifact through an environment variable in the coverage environment so it

--- a/src/test/java/com/google/devtools/build/lib/analysis/SourceManifestActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/SourceManifestActionTest.java
@@ -122,7 +122,7 @@ public final class SourceManifestActionTest extends BuildViewTestCase {
 
     @Override
     public void writeEntry(Writer manifestWriter, PathFragment rootRelativePath,
-        @Nullable Artifact symlink) throws IOException {
+        @Nullable Artifact symlink, boolean useJson) throws IOException {
       assertWithMessage("Expected manifest input to be exhausted").that(expectedSequence)
           .isNotEmpty();
       Map.Entry<PathFragment, Artifact> expectedEntry = expectedSequence.remove(0);

--- a/tools/bash/runfiles/runfiles_test.bash
+++ b/tools/bash/runfiles/runfiles_test.bash
@@ -140,6 +140,7 @@ a/b $tmpdir/c/d
 e/f $tmpdir/g h
 y $tmpdir/y
 c/dir $tmpdir/dir
+["Hello \\", world","$tmpdir/Hello \\", world"]
 EOF
   mkdir "${tmpdir}/c"
   mkdir "${tmpdir}/y"
@@ -147,6 +148,7 @@ EOF
   touch "${tmpdir}/c/d" "${tmpdir}/g h"
   touch "${tmpdir}/dir/file"
   touch "${tmpdir}/dir/deeply/nested/file"
+  touch "${tmpdir}/Hello \", world"
 
   export RUNFILES_DIR=
   export RUNFILES_MANIFEST_FILE=$tmpdir/foo.runfiles_manifest
@@ -162,13 +164,16 @@ EOF
   [[ "$(rlocation c/dir)" == "$tmpdir/dir" ]] || fail
   [[ "$(rlocation c/dir/file)" == "$tmpdir/dir/file" ]] || fail
   [[ "$(rlocation c/dir/deeply/nested/file)" == "$tmpdir/dir/deeply/nested/file" ]] || fail
-  rm -r "$tmpdir/c/d" "$tmpdir/g h" "$tmpdir/y" "$tmpdir/dir"
+  [[ "$(rlocation "Hello \", world")" == "$tmpdir/Hello \", world" ]] || fail
+  rm -r "$tmpdir/c/d" "$tmpdir/g h" "$tmpdir/y" "$tmpdir/dir" \
+        "$tmpdir/Hello \", world"
   [[ -z "$(rlocation a/b)" ]] || fail
   [[ -z "$(rlocation e/f)" ]] || fail
   [[ -z "$(rlocation y)" ]] || fail
   [[ -z "$(rlocation c/dir)" ]] || fail
   [[ -z "$(rlocation c/dir/file)" ]] || fail
   [[ -z "$(rlocation c/dir/deeply/nested/file)" ]] || fail
+  [[ -z "$(rlocation "Hello \", world")" ]] || fail
 }
 
 function test_manifest_based_envvars() {

--- a/tools/python/runfiles/runfiles.py
+++ b/tools/python/runfiles/runfiles.py
@@ -58,6 +58,7 @@ USAGE:
       p = subprocess.Popen([r.Rlocation("path/to/binary")], env, ...)
 """
 
+import json
 import os
 import posixpath
 
@@ -199,7 +200,12 @@ class _ManifestBased(object):
       for line in f:
         line = line.strip()
         if line:
-          tokens = line.split(" ", 1)
+          if line.startswith("["):
+            # New JSON based format.
+            tokens = json.loads(line)
+          else:
+            # Legacy space separated format.
+            tokens = line.split(" ", 1)
           if len(tokens) == 1:
             result[line] = line
           else:

--- a/tools/python/runfiles/runfiles_test.py
+++ b/tools/python/runfiles/runfiles_test.py
@@ -144,6 +144,7 @@ class RunfilesTest(unittest.TestCase):
         "Foo/runfile2 C:/Actual Path\\runfile2",
         "Foo/Bar/runfile3 D:\\the path\\run file 3.txt",
         "Foo/Bar/Dir E:\\Actual Path\\Directory",
+        "[\"Foo/Hello \\\", world.txt\",\"C:\\\\Hello \\\", world.txt\"]",
     ]) as mf:
       r = runfiles.CreateManifestBased(mf.Path())
       self.assertEqual(r.Rlocation("Foo/runfile1"), "Foo/runfile1")
@@ -156,6 +157,8 @@ class RunfilesTest(unittest.TestCase):
       self.assertEqual(
           r.Rlocation("Foo/Bar/Dir/Deeply/Nested/runfile4"),
           "E:\\Actual Path\\Directory/Deeply/Nested/runfile4")
+      self.assertEqual(
+          r.Rlocation("Foo/Hello \", world.txt"), "C:\\Hello \", world.txt")
       self.assertIsNone(r.Rlocation("unknown"))
       if RunfilesTest.IsWindows():
         self.assertEqual(r.Rlocation("c:/foo"), "c:/foo")


### PR DESCRIPTION
The *.runfiles_manifest files currently use a pretty simple format: two
pathnames separated by a space character. This can be problematic at
times. On Windows, usernames may contain spaces, meaning home
directories with spaces are not uncommon. If you look at the macOS
ecosystem, it's also not uncommon to have applications or packages
containing files with spaces in their names. The goal of this change is
to start addressing this issue, by moving *.runfiles_manifest to newline
delimited JSON.

Runfiles libraries for each programming language will need to be
adjusted to support this new format. Because not all runfiles libraries
are bundled/versioned together with Bazel, those libraries will need to
seamlessly support both formats. Tuples are encoded as lists, JSON
entries will always start with an opening square bracket. Because paths
are generally prefixed with a workspace name, it's extremely unlikely
that this causes any conflict. Runfiles libraries can thus distinguish
both formats as follows:

    if (line[0] == '[') {
      // Parse as JSON.
    } else {
      // Parse as legacy format.
    }

To prevent any breakage, we place this feature behind a flag named
--incompatible_json_source_manifests. Even if this flag is disabled, we
emit JSON entries for paths that are not representable in the legacy
format. This should at least make it possible to build targets and
instantiate their runfiles directories with build-runfiles, regardless
of whether the manifest can be parsed at runtime.

Before considering JSON, I experimented with CSV instead. Though easier
to parse, RFC 4180 requires the use of carriage return newlines. Because
both Bazel and runfiles libraries tend to open runfiles manifests in
text mode, this turned out to be hard to get right.

Given the fact that Bazel does not permit non-printable characters and
backslashes in pathnames, parsing the resulting JSON turns out to be
remarkably easy. If it's not realistic to let a given runfiles library
depend on a third-party library to do the JSON parsing, it's most likely
acceptable to handroll a simplified parser.

This PR already contains updates to build-runfiles, the Bash runfiles
library and the Python runfiles library to support the new format.
Updates to the C++ and Java runfiles libraries remain to be done.

Issue: #4327