### PR TITLE
Remove --experimental_worker_allow_json_protocol

### DIFF
--- a/site/en/docs/creating-workers.md
+++ b/site/en/docs/creating-workers.md
@@ -9,9 +9,7 @@ would benefit from cross-action caching, you may want to implement your own
 persistent worker to perform these actions.
 
 The Bazel server communicates with the worker using `stdin`/`stdout`. It
-supports the use of protocol buffers or JSON strings. Support for JSON is
-experimental and thus subject to change. It is guarded behind the
-`--experimental_worker_allow_json_protocol` flag.
+supports the use of protocol buffers or JSON strings.
 
 The worker implementation has two parts:
 

--- a/site/en/docs/persistent-workers.md
+++ b/site/en/docs/persistent-workers.md
@@ -137,11 +137,6 @@ flag makes each worker request use a separate sandbox directory for all its
 inputs. Setting up the [sandbox](/docs/sandboxing) takes some extra time,
 especially on macOS, but gives a better correctness guarantee.
 
-You can use the `--experimental_worker_allow_json_protocol` flag to allow
-workers to communicate with Bazel through JSON instead of protocol buffers
-(protobuf). The worker and the rule that consumes it can then be modified to
-support JSON.
-
 The
 [`--worker_quit_after_build`](/reference/command-line-reference#flag--worker_quit_after_build)
 flag is mainly useful for debugging and profiling. This flag forces all workers
@@ -197,13 +192,13 @@ inputs: [
 ```
 
 The worker receives this on `stdin` in JSON format (because
-`requires-worker-protocol` is set to JSON, and
-`--experimental_worker_allow_json_protocol` is passed to the build to enable
-this option). The worker then performs the action, and sends a JSON-formatted
-`WorkResponse` to Bazel on its stdout. Bazel then parses this response and
-manually converts it to a `WorkResponse` proto. To communicate
-with the associated worker using binary-encoded protobuf instead of JSON,
-`requires-worker-protocol` would be set to `proto`, like this:
+`requires-worker-protocol` is set to JSON). Each WorkRequest json blob
+is separated by a newline. The worker then performs the action, and
+sends a JSON-formatted `WorkResponse` to Bazel on its stdout. Bazel then
+parses this response and manually converts it to a `WorkResponse` proto.
+To communicate with the associated worker using binary-encoded protobuf
+instead of JSON, `requires-worker-protocol` would be set to `proto` or
+omitted, like this:
 
 ```
   execution_requirements = {

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerOptions.java
@@ -46,16 +46,6 @@ public class WorkerOptions extends OptionsBase {
       })
   public Void experimentalPersistentJavac;
 
-  @Option(
-      name = "experimental_worker_allow_json_protocol",
-      defaultValue = "true",
-      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
-      effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
-      help =
-          "Allows workers to use the JSON worker protocol until it is determined to be"
-              + " stable.")
-  public boolean experimentalJsonWorkerProtocol;
-
   /**
    * Defines a resource converter for named values in the form [name=]value, where the value is
    * {@link ResourceConverter.FLAG_SYNTAX}. If no name is provided (used when setting a default),

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerParser.java
@@ -90,14 +90,6 @@ class WorkerParser {
 
     HashCode workerFilesCombinedHash = WorkerFilesHash.getCombinedHash(workerFiles);
 
-    WorkerProtocolFormat protocolFormat = Spawns.getWorkerProtocolFormat(spawn);
-    if (!workerOptions.experimentalJsonWorkerProtocol) {
-      if (protocolFormat == WorkerProtocolFormat.JSON) {
-        throw new IOException(
-            "Persistent worker protocol format must be set to proto unless"
-                + " --experimental_worker_allow_json_protocol is used");
-      }
-    }
     WorkerKey key =
         createWorkerKey(
             spawn,
@@ -108,7 +100,7 @@ class WorkerParser {
             workerFiles,
             workerOptions,
             context.speculating(),
-            protocolFormat);
+            Spawns.getWorkerProtocolFormat(spawn));
     return new WorkerConfig(key, flagFiles);
   }
 

--- a/src/test/shell/integration/bazel_worker_test.sh
+++ b/src/test/shell/integration/bazel_worker_test.sh
@@ -35,7 +35,6 @@ example_worker=$(find $BAZEL_RUNFILES -name ExampleWorker_deploy.jar)
 
 add_to_bazelrc "build -s"
 add_to_bazelrc "build --spawn_strategy=worker,standalone"
-add_to_bazelrc "build --experimental_worker_allow_json_protocol"
 add_to_bazelrc "build --worker_verbose --worker_max_instances=1"
 add_to_bazelrc "build --debug_print_action_contexts"
 add_to_bazelrc "build --noexperimental_worker_multiplex"


### PR DESCRIPTION
This flag has been flipped, and unlike other experimental flags there is no reason to disable it because workers can only support a single format at once, so if they rely on this, you just wouldn't be able to build.

Closes https://github.com/bazelbuild/bazel/issues/13599