### PR TITLE
Remote: Cleanup ByteStreamUploader.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -14,10 +14,10 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.Utils.waitForBulkTransfer;
 import static java.lang.String.format;
-import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import build.bazel.remote.execution.v2.Digest;
@@ -30,9 +30,7 @@ import com.google.bytestream.ByteStreamProto.WriteResponse;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.flogger.GoogleLogger;
-import com.google.common.hash.HashCode;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -49,22 +47,15 @@ import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
-import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCounted;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
 
 /**
  * A client implementing the {@code Write} method of the {@code ByteStream} gRPC service.
@@ -74,7 +65,7 @@ import javax.annotation.concurrent.GuardedBy;
  *
  * <p>See {@link ReferenceCounted} for more information on reference counting.
  */
-class ByteStreamUploader extends AbstractReferenceCounted {
+class ByteStreamUploader {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
@@ -83,18 +74,6 @@ class ByteStreamUploader extends AbstractReferenceCounted {
   private final CallCredentialsProvider callCredentialsProvider;
   private final long callTimeoutSecs;
   private final RemoteRetrier retrier;
-
-  private final Object lock = new Object();
-
-  /** Contains the hash codes of already uploaded blobs. * */
-  @GuardedBy("lock")
-  private final Set<HashCode> uploadedBlobs = new HashSet<>();
-
-  @GuardedBy("lock")
-  private final Map<Digest, ListenableFuture<Void>> uploadsInProgress = new HashMap<>();
-
-  @GuardedBy("lock")
-  private boolean isShutdown;
 
   @Nullable private final Semaphore openedFilePermits;
 
@@ -109,7 +88,7 @@ class ByteStreamUploader extends AbstractReferenceCounted {
    *     complete. The timeout resets between retries
    * @param retrier the {@link RemoteRetrier} whose backoff strategy to use for retry timings.
    */
-  public ByteStreamUploader(
+  ByteStreamUploader(
       @Nullable String instanceName,
       ReferenceCountedChannel channel,
       CallCredentialsProvider callCredentialsProvider,
@@ -142,94 +121,35 @@ class ByteStreamUploader extends AbstractReferenceCounted {
    * <p>Uploads are retried according to the specified {@link RemoteRetrier}. Retrying is
    * transparent to the user of this API.
    *
-   * <p>Trying to upload the same BLOB multiple times concurrently, results in only one upload being
-   * performed. This is transparent to the user of this API.
-   *
-   * @param hash the hash of the data to upload.
+   * @param digest the digest of the data to upload.
    * @param chunker the data to upload.
-   * @param forceUpload if {@code false} the blob is not uploaded if it has previously been
-   *     uploaded, if {@code true} the blob is uploaded.
    * @throws IOException when reading of the {@link Chunker}s input source fails
    */
-  public void uploadBlob(
-      RemoteActionExecutionContext context, HashCode hash, Chunker chunker, boolean forceUpload)
+  public void uploadBlob(RemoteActionExecutionContext context, Digest digest, Chunker chunker)
       throws IOException, InterruptedException {
-    uploadBlobs(context, singletonMap(hash, chunker), forceUpload);
+    getFromFuture(uploadBlobAsync(context, digest, chunker));
   }
 
   /**
    * Uploads a list of BLOBs concurrently to the remote {@code ByteStream} service. The call blocks
-   * until the upload of all BLOBs is complete, or throws an {@link Exception} after the first
-   * upload failed. Any other uploads will continue uploading in the background, until they complete
-   * or the {@link #shutdown()} method is called. Errors encountered by these uploads are swallowed.
+   * until the upload of all BLOBs is complete, or throws an {@link
+   * com.google.devtools.build.lib.remote.common.BulkTransferException} if there are errors.
    *
    * <p>Uploads are retried according to the specified {@link RemoteRetrier}. Retrying is
    * transparent to the user of this API.
    *
-   * <p>Trying to upload the same BLOB multiple times concurrently, results in only one upload being
-   * performed. This is transparent to the user of this API.
-   *
    * @param chunkers the data to upload.
-   * @param forceUpload if {@code false} the blob is not uploaded if it has previously been
-   *     uploaded, if {@code true} the blob is uploaded.
    * @throws IOException when reading of the {@link Chunker}s input source or uploading fails
    */
-  public void uploadBlobs(
-      RemoteActionExecutionContext context, Map<HashCode, Chunker> chunkers, boolean forceUpload)
+  public void uploadBlobs(RemoteActionExecutionContext context, Map<Digest, Chunker> chunkers)
       throws IOException, InterruptedException {
     List<ListenableFuture<Void>> uploads = new ArrayList<>();
 
-    for (Map.Entry<HashCode, Chunker> chunkerEntry : chunkers.entrySet()) {
-      uploads.add(
-          uploadBlobAsync(context, chunkerEntry.getKey(), chunkerEntry.getValue(), forceUpload));
+    for (Map.Entry<Digest, Chunker> chunkerEntry : chunkers.entrySet()) {
+      uploads.add(uploadBlobAsync(context, chunkerEntry.getKey(), chunkerEntry.getValue()));
     }
 
-    try {
-      for (ListenableFuture<Void> upload : uploads) {
-        upload.get();
-      }
-    } catch (ExecutionException e) {
-      Throwable cause = e.getCause();
-      Throwables.propagateIfInstanceOf(cause, IOException.class);
-      Throwables.propagateIfInstanceOf(cause, InterruptedException.class);
-      Throwables.propagate(cause);
-    }
-  }
-
-  /**
-   * Cancels all running uploads. The method returns immediately and does NOT wait for the uploads
-   * to be cancelled.
-   *
-   * <p>This method should not be called directly, but will be called implicitly when the reference
-   * count reaches {@code 0}.
-   */
-  @VisibleForTesting
-  void shutdown() {
-    synchronized (lock) {
-      if (isShutdown) {
-        return;
-      }
-      isShutdown = true;
-      // Before cancelling, copy the futures to a separate list in order to avoid concurrently
-      // iterating over and modifying the map (cancel triggers a listener that removes the entry
-      // from the map. the listener is executed in the same thread.).
-      List<Future<Void>> uploadsToCancel = new ArrayList<>(uploadsInProgress.values());
-      for (Future<Void> upload : uploadsToCancel) {
-        upload.cancel(true);
-      }
-    }
-  }
-
-  /**
-   * @deprecated Use {@link #uploadBlobAsync(RemoteActionExecutionContext, Digest, Chunker,
-   *     boolean)} instead.
-   */
-  @Deprecated
-  public ListenableFuture<Void> uploadBlobAsync(
-      RemoteActionExecutionContext context, HashCode hash, Chunker chunker, boolean forceUpload) {
-    Digest digest =
-        Digest.newBuilder().setHash(hash.toString()).setSizeBytes(chunker.getSize()).build();
-    return uploadBlobAsync(context, digest, chunker, forceUpload);
+    waitForBulkTransfer(uploads, /* cancelRemainingOnInterrupt=*/ true);
   }
 
   /**
@@ -244,64 +164,20 @@ class ByteStreamUploader extends AbstractReferenceCounted {
    *
    * @param digest the {@link Digest} of the data to upload.
    * @param chunker the data to upload.
-   * @param forceUpload if {@code false} the blob is not uploaded if it has previously been
-   *     uploaded, if {@code true} the blob is uploaded.
    */
   public ListenableFuture<Void> uploadBlobAsync(
-      RemoteActionExecutionContext context, Digest digest, Chunker chunker, boolean forceUpload) {
-    synchronized (lock) {
-      checkState(!isShutdown, "Must not call uploadBlobs after shutdown.");
-
-      if (!forceUpload && uploadedBlobs.contains(HashCode.fromString(digest.getHash()))) {
-        return immediateVoidFuture();
-      }
-
-      ListenableFuture<Void> inProgress = uploadsInProgress.get(digest);
-      if (inProgress != null) {
-        return inProgress;
-      }
-      ListenableFuture<Void> uploadResult =
-          Futures.transform(
-              startAsyncUpload(context, digest, chunker),
-              (v) -> {
-                synchronized (lock) {
-                  uploadedBlobs.add(HashCode.fromString(digest.getHash()));
-                }
-                return null;
-              },
-              MoreExecutors.directExecutor());
-
-      uploadResult =
-          Futures.catchingAsync(
-              uploadResult,
-              StatusRuntimeException.class,
-              (sre) ->
-                  Futures.immediateFailedFuture(
-                      new IOException(
-                          String.format(
-                              "Error while uploading artifact with digest '%s/%s'",
-                              digest.getHash(), digest.getSizeBytes()),
-                          sre)),
-              MoreExecutors.directExecutor());
-
-      uploadsInProgress.put(digest, uploadResult);
-      uploadResult.addListener(
-          () -> {
-            synchronized (lock) {
-              uploadsInProgress.remove(digest);
-            }
-          },
-          MoreExecutors.directExecutor());
-
-      return uploadResult;
-    }
-  }
-
-  @VisibleForTesting
-  boolean uploadsInProgress() {
-    synchronized (lock) {
-      return !uploadsInProgress.isEmpty();
-    }
+      RemoteActionExecutionContext context, Digest digest, Chunker chunker) {
+    return Futures.catchingAsync(
+        startAsyncUpload(context, digest, chunker),
+        StatusRuntimeException.class,
+        (sre) ->
+            Futures.immediateFailedFuture(
+                new IOException(
+                    String.format(
+                        "Error while uploading artifact with digest '%s/%s'",
+                        digest.getHash(), digest.getSizeBytes()),
+                    sre)),
+        MoreExecutors.directExecutor());
   }
 
   private static String buildUploadResourceName(
@@ -363,27 +239,6 @@ class ByteStreamUploader extends AbstractReferenceCounted {
         },
         MoreExecutors.directExecutor());
     return currUpload;
-  }
-
-  @Override
-  public ByteStreamUploader retain() {
-    return (ByteStreamUploader) super.retain();
-  }
-
-  @Override
-  public ByteStreamUploader retain(int increment) {
-    return (ByteStreamUploader) super.retain(increment);
-  }
-
-  @Override
-  protected void deallocate() {
-    shutdown();
-    channel.release();
-  }
-
-  @Override
-  public ReferenceCounted touch(Object o) {
-    return this;
   }
 
   private class AsyncUpload {

--- a/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ByteStreamUploader.java
@@ -149,7 +149,7 @@ class ByteStreamUploader {
       uploads.add(uploadBlobAsync(context, chunkerEntry.getKey(), chunkerEntry.getValue()));
     }
 
-    waitForBulkTransfer(uploads, /* cancelRemainingOnInterrupt=*/ true);
+    waitForBulkTransfer(uploads, /* cancelRemainingOnInterrupt= */ true);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/Chunker.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/Chunker.java
@@ -269,9 +269,9 @@ public class Chunker {
   /** Builder class for the Chunker */
   public static class Builder {
     private int chunkSize = getDefaultChunkSize();
-    private long size;
+    protected long size;
     private boolean compressed;
-    private Supplier<InputStream> inputStream;
+    protected Supplier<InputStream> inputStream;
 
     public Builder setInput(byte[] data) {
       checkState(inputStream == null);

--- a/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/GrpcCacheClient.java
@@ -93,14 +93,19 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
       CallCredentialsProvider callCredentialsProvider,
       RemoteOptions options,
       RemoteRetrier retrier,
-      DigestUtil digestUtil,
-      ByteStreamUploader uploader) {
+      DigestUtil digestUtil) {
     this.callCredentialsProvider = callCredentialsProvider;
     this.channel = channel;
     this.options = options;
     this.digestUtil = digestUtil;
     this.retrier = retrier;
-    this.uploader = uploader;
+    this.uploader = new ByteStreamUploader(
+        options.remoteInstanceName,
+        channel,
+        callCredentialsProvider,
+        options.remoteTimeout.getSeconds(),
+        retrier,
+        options.maximumOpenFiles);
     maxMissingBlobsDigestsPerMessage = computeMaxMissingBlobsDigestsPerMessage();
     Preconditions.checkState(
         maxMissingBlobsDigestsPerMessage > 0, "Error: gRPC message size too small.");
@@ -157,7 +162,6 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
     if (closed.getAndSet(true)) {
       return;
     }
-    uploader.release();
     channel.release();
   }
 
@@ -442,8 +446,7 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
         Chunker.builder()
             .setInput(digest.getSizeBytes(), path)
             .setCompressed(options.cacheCompression)
-            .build(),
-        /* forceUpload= */ true);
+            .build());
   }
 
   @Override
@@ -455,7 +458,6 @@ public class GrpcCacheClient implements RemoteCacheClient, MissingDigestsFinder 
         Chunker.builder()
             .setInput(data.toByteArray())
             .setCompressed(options.cacheCompression)
-            .build(),
-        /* forceUpload= */ true);
+            .build());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteActionInputFetcher.java
@@ -13,6 +13,8 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote;
 
+import static com.google.devtools.build.lib.remote.util.Utils.waitForBulkTransfer;
+
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.annotations.VisibleForTesting;
@@ -109,7 +111,7 @@ class RemoteActionInputFetcher implements ActionInputPrefetcher {
       }
 
       try {
-        RemoteCache.waitForBulkTransfer(
+        waitForBulkTransfer(
             downloadsToWaitFor.values(), /* cancelRemainingOnInterrupt=*/ true);
       } catch (BulkTransferException e) {
         if (e.onlyCausedByCacheNotFoundException()) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteCache.java
@@ -136,7 +136,7 @@ public class RemoteCache extends AbstractReferenceCounted {
    * @param digest the digest of the file.
    * @param file the file to upload.
    */
-  public final ListenableFuture<Void> uploadFile(
+  public ListenableFuture<Void> uploadFile(
       RemoteActionExecutionContext context, Digest digest, Path file) {
     if (digest.getSizeBytes() == 0) {
       return COMPLETED_SUCCESS;
@@ -161,7 +161,7 @@ public class RemoteCache extends AbstractReferenceCounted {
    * @param digest the digest of the file.
    * @param data the BLOB to upload.
    */
-  public final ListenableFuture<Void> uploadBlob(
+  public ListenableFuture<Void> uploadBlob(
       RemoteActionExecutionContext context, Digest digest, ByteString data) {
     if (digest.getSizeBytes() == 0) {
       return COMPLETED_SUCCESS;
@@ -174,48 +174,6 @@ public class RemoteCache extends AbstractReferenceCounted {
                 () -> cacheProtocol.uploadBlob(context, digest, data), directExecutor()));
 
     return RxFutures.toListenableFuture(upload);
-  }
-
-  public static void waitForBulkTransfer(
-      Iterable<? extends ListenableFuture<?>> transfers, boolean cancelRemainingOnInterrupt)
-      throws BulkTransferException, InterruptedException {
-    BulkTransferException bulkTransferException = null;
-    InterruptedException interruptedException = null;
-    boolean interrupted = Thread.currentThread().isInterrupted();
-    for (ListenableFuture<?> transfer : transfers) {
-      try {
-        if (interruptedException == null) {
-          // Wait for all transfers to finish.
-          getFromFuture(transfer, cancelRemainingOnInterrupt);
-        } else {
-          transfer.cancel(true);
-        }
-      } catch (IOException e) {
-        if (bulkTransferException == null) {
-          bulkTransferException = new BulkTransferException();
-        }
-        bulkTransferException.add(e);
-      } catch (InterruptedException e) {
-        interrupted = Thread.interrupted() || interrupted;
-        interruptedException = e;
-        if (!cancelRemainingOnInterrupt) {
-          // leave the rest of the transfers alone
-          break;
-        }
-      }
-    }
-    if (interrupted) {
-      Thread.currentThread().interrupt();
-    }
-    if (interruptedException != null) {
-      if (bulkTransferException != null) {
-        interruptedException.addSuppressed(bulkTransferException);
-      }
-      throw interruptedException;
-    }
-    if (bulkTransferException != null) {
-      throw bulkTransferException;
-    }
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionCache.java
@@ -14,6 +14,7 @@
 package com.google.devtools.build.lib.remote;
 
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.Utils.waitForBulkTransfer;
 import static java.lang.String.format;
 
 import build.bazel.remote.execution.v2.Digest;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -22,7 +22,6 @@ import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.transform;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.devtools.build.lib.remote.RemoteCache.createFailureDetail;
-import static com.google.devtools.build.lib.remote.RemoteCache.waitForBulkTransfer;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import static com.google.devtools.build.lib.remote.util.Utils.getInMemoryOutputPath;
 import static com.google.devtools.build.lib.remote.util.Utils.grpcAwareErrorMessage;
@@ -34,6 +33,7 @@ import static com.google.devtools.build.lib.remote.util.Utils.shouldDownloadAllS
 import static com.google.devtools.build.lib.remote.util.Utils.shouldUploadLocalResultsToCombinedDisk;
 import static com.google.devtools.build.lib.remote.util.Utils.shouldUploadLocalResultsToDiskCache;
 import static com.google.devtools.build.lib.remote.util.Utils.shouldUploadLocalResultsToRemoteCache;
+import static com.google.devtools.build.lib.remote.util.Utils.waitForBulkTransfer;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
@@ -532,25 +532,14 @@ public final class RemoteModule extends BlazeModule {
       }
     }
 
-    ByteStreamUploader uploader =
-        new ByteStreamUploader(
-            remoteOptions.remoteInstanceName,
-            cacheChannel.retain(),
-            callCredentialsProvider,
-            remoteOptions.remoteTimeout.getSeconds(),
-            retrier,
-            remoteOptions.maximumOpenFiles);
-
-    cacheChannel.release();
     RemoteCacheClient cacheClient =
         new GrpcCacheClient(
             cacheChannel.retain(),
             callCredentialsProvider,
             remoteOptions,
             retrier,
-            digestUtil,
-            uploader.retain());
-    uploader.release();
+            digestUtil);
+    cacheChannel.release();
 
     if (enableRemoteExecution) {
       if (enableDiskCache) {

--- a/src/main/java/com/google/devtools/build/lib/remote/util/RxFutures.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/RxFutures.java
@@ -207,7 +207,11 @@ public class RxFutures {
 
           @Override
           public void onError(Throwable e) {
-            future.setException(e);
+            if (e instanceof CancellationException) {
+              future.cancel(true);
+            } else {
+              future.setException(e);
+            }
           }
         });
     return future;
@@ -235,7 +239,11 @@ public class RxFutures {
 
           @Override
           public void onError(Throwable e) {
-            future.setException(e);
+            if (e instanceof CancellationException) {
+              future.cancel(true);
+            } else {
+              future.setException(e);
+            }
           }
         });
     return future;

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -15,10 +15,9 @@ package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -176,15 +175,8 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     RemoteRetrier retrier =
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
-    ByteStreamUploader uploader =
-        new ByteStreamUploader(
-            "instance",
-            refCntChannel,
-            CallCredentialsProvider.NO_CREDENTIALS,
-            3,
-            retrier,
-            /*maximumOpenFiles=*/ -1);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(uploader);
+    RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
 
     PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
     for (Path file : filesToUpload.keySet()) {
@@ -197,7 +189,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
 
     artifactUploader.release();
 
-    assertThat(uploader.refCnt()).isEqualTo(0);
+    assertThat(remoteCache.refCnt()).isEqualTo(0);
     assertThat(refCntChannel.isShutdown()).isTrue();
   }
 
@@ -224,10 +216,8 @@ public class ByteStreamBuildEventArtifactUploaderTest {
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
     // number of permits is less than number of uploads to affirm permit is released
-    ByteStreamUploader uploader =
-        new ByteStreamUploader(
-            "instance", refCntChannel, CallCredentialsProvider.NO_CREDENTIALS, 3, retrier, 1);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(uploader);
+    RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
 
     PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
     for (Path file : filesToUpload.keySet()) {
@@ -240,7 +230,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
 
     artifactUploader.release();
 
-    assertThat(uploader.refCnt()).isEqualTo(0);
+    assertThat(remoteCache.refCnt()).isEqualTo(0);
     assertThat(refCntChannel.isShutdown()).isTrue();
   }
 
@@ -253,15 +243,8 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     RemoteRetrier retrier =
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
-    ByteStreamUploader uploader =
-        new ByteStreamUploader(
-            "instance",
-            refCntChannel,
-            CallCredentialsProvider.NO_CREDENTIALS,
-            3,
-            retrier,
-            /*maximumOpenFiles=*/ -1);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(uploader);
+    RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
 
     PathConverter pathConverter = artifactUploader.upload(filesToUpload).get();
     assertThat(pathConverter.apply(dir)).isNull();
@@ -321,15 +304,8 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     RemoteRetrier retrier =
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
-    ByteStreamUploader uploader =
-        new ByteStreamUploader(
-            "instance",
-            refCntChannel,
-            CallCredentialsProvider.NO_CREDENTIALS,
-            3,
-            retrier,
-            /*maximumOpenFiles=*/ -1);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(uploader);
+    RemoteCache remoteCache = newRemoteCache(refCntChannel, retrier);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
 
     artifactUploader.upload(filesToUpload).get();
 
@@ -339,7 +315,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
 
     artifactUploader.release();
 
-    assertThat(uploader.refCnt()).isEqualTo(0);
+    assertThat(remoteCache.refCnt()).isEqualTo(0);
     assertThat(refCntChannel.isShutdown()).isTrue();
   }
 
@@ -353,17 +329,9 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     RemoteRetrier retrier =
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
-    ByteStreamUploader uploader =
-        spy(
-            new ByteStreamUploader(
-                "instance",
-                refCntChannel,
-                CallCredentialsProvider.NO_CREDENTIALS,
-                3,
-                retrier,
-                /*maximumOpenFiles=*/ -1));
-    RemoteActionInputFetcher actionInputFetcher = Mockito.mock(RemoteActionInputFetcher.class);
-    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(uploader);
+    RemoteCache remoteCache = spy(newRemoteCache(refCntChannel, retrier));
+    RemoteActionInputFetcher actionInputFetcher = mock(RemoteActionInputFetcher.class);
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
 
     ActionInputMap outputs = new ActionInputMap(2);
     Artifact artifact = createRemoteArtifact("file1.txt", "foo", outputs);
@@ -395,7 +363,8 @@ public class ByteStreamBuildEventArtifactUploaderTest {
                 + digest.getHash()
                 + "/"
                 + digest.getSizeBytes());
-    verify(uploader, times(0)).uploadBlobAsync(any(), any(Digest.class), any(), anyBoolean());
+    verify(remoteCache, times(0)).uploadFile(any(), any(), any());
+    verify(remoteCache, times(0)).uploadBlob(any(), any(), any());
   }
 
   @Test
@@ -416,20 +385,11 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     RemoteRetrier retrier =
         TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 0), (e) -> true, retryService);
     ReferenceCountedChannel refCntChannel = new ReferenceCountedChannel(channelConnectionFactory);
-    ByteStreamUploader uploader =
-        spy(
-            new ByteStreamUploader(
-                "instance",
-                refCntChannel,
-                CallCredentialsProvider.NO_CREDENTIALS,
-                3,
-                retrier,
-                /*maximumOpenFiles=*/ -1));
-    doReturn(Futures.immediateFuture(null))
-        .when(uploader)
-        .uploadBlobAsync(any(), any(Digest.class), any(), anyBoolean());
-    ByteStreamBuildEventArtifactUploader artifactUploader =
-        newArtifactUploader(uploader, digestQuerier);
+    RemoteCache remoteCache = spy(newRemoteCache(refCntChannel, retrier, digestQuerier));
+    doAnswer(invocationOnMock -> Futures.immediateFuture(null))
+        .when(remoteCache)
+        .uploadFile(any(), any(), any());
+    ByteStreamBuildEventArtifactUploader artifactUploader = newArtifactUploader(remoteCache);
 
     // act
     Map<Path, LocalFile> files =
@@ -442,7 +402,7 @@ public class ByteStreamBuildEventArtifactUploaderTest {
 
     // assert
     verify(digestQuerier).findMissingDigests(any(), any());
-    verify(uploader).uploadBlobAsync(any(), eq(localDigest), any(), anyBoolean());
+    verify(remoteCache).uploadFile(any(), eq(localDigest), any());
     assertThat(pathConverter.apply(remoteFile)).contains(remoteDigest.getHash());
     assertThat(pathConverter.apply(localFile)).contains(localDigest.getHash());
   }
@@ -460,29 +420,35 @@ public class ByteStreamBuildEventArtifactUploaderTest {
     return a;
   }
 
-  private ByteStreamBuildEventArtifactUploader newArtifactUploader(ByteStreamUploader uploader) {
-    return newArtifactUploader(uploader, new AllMissingDigestsFinder());
+  private RemoteCache newRemoteCache(ReferenceCountedChannel channel, RemoteRetrier retrier) {
+    return newRemoteCache(channel, retrier, new AllMissingDigestsFinder());
   }
 
-  private ByteStreamBuildEventArtifactUploader newArtifactUploader(
-      ByteStreamUploader uploader, MissingDigestsFinder missingDigestsFinder) {
+  private RemoteCache newRemoteCache(
+      ReferenceCountedChannel channel,
+      RemoteRetrier retrier,
+      MissingDigestsFinder missingDigestsFinder) {
     RemoteOptions remoteOptions = Options.getDefaults(RemoteOptions.class);
+    remoteOptions.remoteInstanceName = "instance";
     GrpcCacheClient cacheClient =
         spy(
             new GrpcCacheClient(
-                uploader.getChannel().retain(),
+                channel,
                 CallCredentialsProvider.NO_CREDENTIALS,
                 remoteOptions,
-                uploader.getRetrier(),
-                DIGEST_UTIL,
-                uploader));
+                retrier,
+                DIGEST_UTIL));
     doAnswer(
-            invocationOnMock ->
-                missingDigestsFinder.findMissingDigests(
-                    invocationOnMock.getArgument(0), invocationOnMock.getArgument(1)))
+        invocationOnMock ->
+            missingDigestsFinder.findMissingDigests(
+                invocationOnMock.getArgument(0), invocationOnMock.getArgument(1)))
         .when(cacheClient)
         .findMissingDigests(any(), any());
-    RemoteCache remoteCache = new RemoteCache(cacheClient, remoteOptions, DIGEST_UTIL);
+
+    return new RemoteCache(cacheClient, remoteOptions, DIGEST_UTIL);
+  }
+
+  private ByteStreamBuildEventArtifactUploader newArtifactUploader(RemoteCache remoteCache) {
 
     return new ByteStreamBuildEventArtifactUploader(
         MoreExecutors.directExecutor(),

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -24,7 +24,6 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.github.luben.zstd.Zstd;
 import com.github.luben.zstd.ZstdInputStream;
-import com.google.bytestream.ByteStreamGrpc;
 import com.google.bytestream.ByteStreamGrpc.ByteStreamImplBase;
 import com.google.bytestream.ByteStreamProto.QueryWriteStatusRequest;
 import com.google.bytestream.ByteStreamProto.QueryWriteStatusResponse;
@@ -51,11 +50,9 @@ import io.grpc.CallCredentials;
 import io.grpc.Metadata;
 import io.grpc.Server;
 import io.grpc.ServerCall;
-import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
-import io.grpc.ServerServiceDefinition;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
@@ -75,9 +72,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -172,16 +167,14 @@ public class ByteStreamUploaderTest {
     new Random().nextBytes(blob);
 
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     serviceRegistry.addService(TestUtils.newNoErrorByteStreamService(blob));
 
-    uploader.uploadBlob(context, hash, chunker, true);
+    uploader.uploadBlob(context, digest, chunker);
 
     // This test should not have triggered any retries.
     Mockito.verifyNoInteractions(mockBackoff);
-
-    blockUntilInternalStateConsistent(uploader);
   }
 
   @Test
@@ -202,7 +195,7 @@ public class ByteStreamUploaderTest {
     new Random().nextBytes(blob);
 
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     serviceRegistry.addService(
         new ByteStreamImplBase() {
@@ -292,13 +285,11 @@ public class ByteStreamUploaderTest {
           }
         });
 
-    uploader.uploadBlob(context, hash, chunker, true);
+    uploader.uploadBlob(context, digest, chunker);
 
     // This test should not have triggered any retries.
     Mockito.verify(mockBackoff, Mockito.never()).nextDelayMillis(any(Exception.class));
     Mockito.verify(mockBackoff, Mockito.times(1)).getRetryAttempts();
-
-    blockUntilInternalStateConsistent(uploader);
   }
 
   @Test
@@ -320,7 +311,7 @@ public class ByteStreamUploaderTest {
 
     Chunker chunker =
         Chunker.builder().setInput(blob).setCompressed(true).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     while (chunker.hasNext()) {
       chunker.next();
@@ -417,13 +408,11 @@ public class ByteStreamUploaderTest {
           }
         });
 
-    uploader.uploadBlob(context, hash, chunker, true);
+    uploader.uploadBlob(context, digest, chunker);
 
     // This test should not have triggered any retries.
     Mockito.verify(mockBackoff, Mockito.never()).nextDelayMillis(any(Exception.class));
     Mockito.verify(mockBackoff, Mockito.times(1)).getRetryAttempts();
-
-    blockUntilInternalStateConsistent(uploader);
   }
 
   @Test
@@ -445,7 +434,7 @@ public class ByteStreamUploaderTest {
     new Random().nextBytes(blob);
 
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     AtomicInteger numWriteCalls = new AtomicInteger(0);
 
@@ -479,12 +468,10 @@ public class ByteStreamUploaderTest {
           }
         });
 
-    uploader.uploadBlob(context, hash, chunker, true);
+    uploader.uploadBlob(context, digest, chunker);
 
     // This test should not have triggered any retries.
     assertThat(numWriteCalls.get()).isEqualTo(1);
-
-    blockUntilInternalStateConsistent(uploader);
   }
 
   @Test
@@ -505,7 +492,7 @@ public class ByteStreamUploaderTest {
     new Random().nextBytes(blob);
 
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     serviceRegistry.addService(
         new ByteStreamImplBase() {
@@ -551,13 +538,11 @@ public class ByteStreamUploaderTest {
           }
         });
 
-    uploader.uploadBlob(context, hash, chunker, true);
+    uploader.uploadBlob(context, digest, chunker);
 
     // This test should have triggered a single retry, because it made
     // no progress.
     Mockito.verify(mockBackoff, Mockito.times(1)).nextDelayMillis(any(Exception.class));
-
-    blockUntilInternalStateConsistent(uploader);
   }
 
   @Test
@@ -579,7 +564,7 @@ public class ByteStreamUploaderTest {
     InputStream in = new ByteArrayInputStream(blob, 0, CHUNK_SIZE);
 
     Chunker chunker = Chunker.builder().setInput(blob.length, in).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     serviceRegistry.addService(
         new ByteStreamImplBase() {
@@ -591,12 +576,10 @@ public class ByteStreamUploaderTest {
           }
         });
 
-    uploader.uploadBlob(context, hash, chunker, true);
+    uploader.uploadBlob(context, digest, chunker);
 
     // This test should not have triggered any retries.
     Mockito.verifyNoInteractions(mockBackoff);
-
-    blockUntilInternalStateConsistent(uploader);
   }
 
   @Test
@@ -616,7 +599,7 @@ public class ByteStreamUploaderTest {
     new Random().nextBytes(blob);
 
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     serviceRegistry.addService(
         new ByteStreamImplBase() {
@@ -643,7 +626,7 @@ public class ByteStreamUploaderTest {
         });
 
     try {
-      uploader.uploadBlob(context, hash, chunker, true);
+      uploader.uploadBlob(context, digest, chunker);
       fail("Should have thrown an exception.");
     } catch (IOException e) {
       // expected
@@ -651,8 +634,6 @@ public class ByteStreamUploaderTest {
 
     // This test should not have triggered any retries.
     Mockito.verifyNoInteractions(mockBackoff);
-
-    blockUntilInternalStateConsistent(uploader);
   }
 
   @Test
@@ -672,7 +653,7 @@ public class ByteStreamUploaderTest {
     new Random().nextBytes(blob);
 
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     serviceRegistry.addService(
         new ByteStreamImplBase() {
@@ -684,8 +665,7 @@ public class ByteStreamUploaderTest {
           }
         });
 
-    uploader.uploadBlob(context, hash, chunker, true);
-    blockUntilInternalStateConsistent(uploader);
+    uploader.uploadBlob(context, digest, chunker);
   }
 
   @Test
@@ -703,23 +683,21 @@ public class ByteStreamUploaderTest {
 
     int numUploads = 10;
     Map<HashCode, byte[]> blobsByHash = Maps.newHashMap();
-    Map<HashCode, Chunker> chunkers = Maps.newHashMapWithExpectedSize(numUploads);
+    Map<Digest, Chunker> chunkers = Maps.newHashMapWithExpectedSize(numUploads);
     Random rand = new Random();
     for (int i = 0; i < numUploads; i++) {
       int blobSize = rand.nextInt(CHUNK_SIZE * 10) + CHUNK_SIZE;
       byte[] blob = new byte[blobSize];
       rand.nextBytes(blob);
       Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-      HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
-      chunkers.put(hash, chunker);
-      blobsByHash.put(hash, blob);
+      Digest digest = DIGEST_UTIL.compute(blob);
+      chunkers.put(digest, chunker);
+      blobsByHash.put(HashCode.fromString(digest.getHash()), blob);
     }
 
     serviceRegistry.addService(new MaybeFailOnceUploadService(blobsByHash));
 
-    uploader.uploadBlobs(context, chunkers, true);
-
-    blockUntilInternalStateConsistent(uploader);
+    uploader.uploadBlobs(context, chunkers);
   }
 
   @Test
@@ -736,15 +714,15 @@ public class ByteStreamUploaderTest {
             /*maximumOpenFiles=*/ -1);
     byte[] blob = new byte[CHUNK_SIZE];
     Chunker chunker = Mockito.mock(Chunker.class);
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
     AtomicLong committedOffset = new AtomicLong(0);
     Mockito.doThrow(new IOException("Too many open files"))
         .when(chunker)
         .seek(committedOffset.get());
-    Mockito.when(chunker.getSize()).thenReturn(1L);
+    Mockito.when(chunker.getSize()).thenReturn(digest.getSizeBytes());
 
     try {
-      uploader.uploadBlob(context, hash, chunker, true);
+      uploader.uploadBlob(context, digest, chunker);
       fail("Should have thrown an exception.");
     } catch (IOException e) {
       String newMessage =
@@ -777,7 +755,7 @@ public class ByteStreamUploaderTest {
     CustomFileTracker customFileTracker = new CustomFileTracker(maximumOpenFiles);
     int numUploads = 1000;
     Map<HashCode, byte[]> blobsByHash = Maps.newHashMap();
-    Map<HashCode, Chunker> chunkers = Maps.newHashMapWithExpectedSize(numUploads);
+    Map<Digest, Chunker> chunkers = Maps.newHashMapWithExpectedSize(numUploads);
     Random rand = new Random();
     for (int i = 0; i < numUploads; i++) {
       int blobSize = rand.nextInt(CHUNK_SIZE * 10) + CHUNK_SIZE;
@@ -785,16 +763,14 @@ public class ByteStreamUploaderTest {
       rand.nextBytes(blob);
       Chunker chunker =
           TestChunker.builder(customFileTracker).setInput(blob).setChunkSize(CHUNK_SIZE).build();
-      HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
-      chunkers.put(hash, chunker);
-      blobsByHash.put(hash, blob);
+      Digest digest = DIGEST_UTIL.compute(blob);
+      chunkers.put(digest, chunker);
+      blobsByHash.put(HashCode.fromString(digest.getHash()), blob);
     }
 
     serviceRegistry.addService(new MaybeFailOnceUploadService(blobsByHash));
 
-    uploader.uploadBlobs(context, chunkers, true);
-
-    blockUntilInternalStateConsistent(uploader);
+    uploader.uploadBlobs(context, chunkers);
 
     assertThat(uploader.getOpenedFilePermits().availablePermits()).isEqualTo(maximumOpenFiles);
   }
@@ -815,22 +791,21 @@ public class ByteStreamUploaderTest {
 
     int numUploads = 10;
     Map<HashCode, byte[]> blobsByHash = Maps.newHashMap();
-    Map<HashCode, Chunker> chunkers = Maps.newHashMapWithExpectedSize(numUploads);
+    Map<Digest, Chunker> chunkers = Maps.newHashMapWithExpectedSize(numUploads);
     Random rand = new Random();
     for (int i = 0; i < numUploads; i++) {
       int blobSize = rand.nextInt(CHUNK_SIZE * 10) + CHUNK_SIZE;
       byte[] blob = new byte[blobSize];
       rand.nextBytes(blob);
       Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-      HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
-      chunkers.put(hash, chunker);
-      blobsByHash.put(hash, blob);
+      Digest digest = DIGEST_UTIL.compute(blob);
+      chunkers.put(digest, chunker);
+      blobsByHash.put(HashCode.fromString(digest.getHash()), blob);
     }
 
     serviceRegistry.addService(new MaybeFailOnceUploadService(blobsByHash));
 
-    uploader.uploadBlobs(context, chunkers, true);
-    blockUntilInternalStateConsistent(uploader);
+    uploader.uploadBlobs(context, chunkers);
     assertThat(uploader.getOpenedFilePermits()).isNull();
   }
 
@@ -937,15 +912,12 @@ public class ByteStreamUploaderTest {
           uploader.uploadBlobAsync(
               remoteActionExecutionContext,
               actionDigest,
-              chunkerEntry.getValue(),
-              /* forceUpload= */ true));
+              chunkerEntry.getValue()));
     }
 
     for (ListenableFuture<Void> upload : uploads) {
       upload.get();
     }
-
-    blockUntilInternalStateConsistent(uploader);
   }
 
   @Test
@@ -983,7 +955,7 @@ public class ByteStreamUploaderTest {
 
     byte[] blob = new byte[CHUNK_SIZE];
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     serviceRegistry.addService(
         ServerInterceptors.intercept(
@@ -1026,75 +998,7 @@ public class ByteStreamUploaderTest {
               }
             }));
 
-    uploader.uploadBlob(context, hash, chunker, true);
-  }
-
-  @Test
-  public void sameBlobShouldNotBeUploadedTwice() throws Exception {
-    // Test that uploading the same file concurrently triggers only one file upload.
-    RemoteRetrier retrier =
-        TestUtils.newRemoteRetrier(() -> mockBackoff, (e) -> true, retryService);
-    ByteStreamUploader uploader =
-        new ByteStreamUploader(
-            INSTANCE_NAME,
-            new ReferenceCountedChannel(channelConnectionFactory),
-            CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
-            retrier,
-            /*maximumOpenFiles=*/ -1);
-
-    byte[] blob = new byte[CHUNK_SIZE * 10];
-    Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    Digest digest = DIGEST_UTIL.compute(blob);
-
-    AtomicInteger numWriteCalls = new AtomicInteger();
-    CountDownLatch blocker = new CountDownLatch(1);
-
-    serviceRegistry.addService(
-        new ByteStreamImplBase() {
-          @Override
-          public StreamObserver<WriteRequest> write(StreamObserver<WriteResponse> response) {
-            numWriteCalls.incrementAndGet();
-            try {
-              // Ensures that the first upload does not finish, before the second upload is started.
-              blocker.await();
-            } catch (InterruptedException e) {
-              Thread.currentThread().interrupt();
-            }
-
-            return new StreamObserver<WriteRequest>() {
-
-              private long bytesReceived;
-
-              @Override
-              public void onNext(WriteRequest writeRequest) {
-                bytesReceived += writeRequest.getData().size();
-              }
-
-              @Override
-              public void onError(Throwable throwable) {
-                fail("onError should never be called.");
-              }
-
-              @Override
-              public void onCompleted() {
-                response.onNext(WriteResponse.newBuilder().setCommittedSize(bytesReceived).build());
-                response.onCompleted();
-              }
-            };
-          }
-        });
-
-    Future<?> upload1 = uploader.uploadBlobAsync(context, digest, chunker, true);
-    Future<?> upload2 = uploader.uploadBlobAsync(context, digest, chunker, true);
-
-    blocker.countDown();
-
-    assertThat(upload1).isSameInstanceAs(upload2);
-
-    upload1.get();
-
-    assertThat(numWriteCalls.get()).isEqualTo(1);
+    uploader.uploadBlob(context, digest, chunker);
   }
 
   @Test
@@ -1112,7 +1016,7 @@ public class ByteStreamUploaderTest {
 
     byte[] blob = new byte[CHUNK_SIZE];
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     serviceRegistry.addService(
         new ByteStreamImplBase() {
@@ -1124,74 +1028,11 @@ public class ByteStreamUploaderTest {
         });
 
     try {
-      uploader.uploadBlob(context, hash, chunker, true);
+      uploader.uploadBlob(context, digest, chunker);
       fail("Should have thrown an exception.");
     } catch (IOException e) {
       assertThat(RemoteRetrierUtils.causedByStatus(e, Code.INTERNAL)).isTrue();
     }
-  }
-
-  @Test
-  public void shutdownShouldCancelOngoingUploads() throws Exception {
-    RemoteRetrier retrier =
-        TestUtils.newRemoteRetrier(() -> new FixedBackoff(1, 10), (e) -> true, retryService);
-    ByteStreamUploader uploader =
-        new ByteStreamUploader(
-            INSTANCE_NAME,
-            new ReferenceCountedChannel(channelConnectionFactory),
-            CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
-            retrier,
-            /*maximumOpenFiles=*/ -1);
-
-    CountDownLatch cancellations = new CountDownLatch(2);
-
-    ServerServiceDefinition service =
-        ServerServiceDefinition.builder(ByteStreamGrpc.SERVICE_NAME)
-            .addMethod(
-                ByteStreamGrpc.getWriteMethod(),
-                new ServerCallHandler<WriteRequest, WriteResponse>() {
-                  @Override
-                  public Listener<WriteRequest> startCall(
-                      ServerCall<WriteRequest, WriteResponse> call, Metadata headers) {
-                    // Don't request() any messages from the client, so that the client will be
-                    // blocked
-                    // on flow control and thus the call will sit there idle long enough to receive
-                    // the
-                    // cancellation.
-                    return new Listener<WriteRequest>() {
-                      @Override
-                      public void onCancel() {
-                        cancellations.countDown();
-                      }
-                    };
-                  }
-                })
-            .build();
-
-    serviceRegistry.addService(service);
-
-    byte[] blob1 = new byte[CHUNK_SIZE];
-    Chunker chunker1 = Chunker.builder().setInput(blob1).setChunkSize(CHUNK_SIZE).build();
-    Digest digest1 = DIGEST_UTIL.compute(blob1);
-
-    byte[] blob2 = new byte[CHUNK_SIZE + 1];
-    Chunker chunker2 = Chunker.builder().setInput(blob2).setChunkSize(CHUNK_SIZE).build();
-    Digest digest2 = DIGEST_UTIL.compute(blob2);
-
-    ListenableFuture<Void> f1 = uploader.uploadBlobAsync(context, digest1, chunker1, true);
-    ListenableFuture<Void> f2 = uploader.uploadBlobAsync(context, digest2, chunker2, true);
-
-    assertThat(uploader.uploadsInProgress()).isTrue();
-
-    uploader.shutdown();
-
-    cancellations.await();
-
-    assertThat(f1.isCancelled()).isTrue();
-    assertThat(f2.isCancelled()).isTrue();
-
-    blockUntilInternalStateConsistent(uploader);
   }
 
   @Test
@@ -1226,9 +1067,9 @@ public class ByteStreamUploaderTest {
 
     byte[] blob = new byte[1];
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
     try {
-      uploader.uploadBlob(context, hash, chunker, true);
+      uploader.uploadBlob(context, digest, chunker);
       fail("Should have thrown an exception.");
     } catch (IOException e) {
       assertThat(e).hasCauseThat().isInstanceOf(RejectedExecutionException.class);
@@ -1273,9 +1114,9 @@ public class ByteStreamUploaderTest {
 
     byte[] blob = new byte[1];
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
-    uploader.uploadBlob(context, hash, chunker, true);
+    uploader.uploadBlob(context, digest, chunker);
   }
 
   @Test
@@ -1306,159 +1147,14 @@ public class ByteStreamUploaderTest {
 
     byte[] blob = new byte[1];
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     try {
-      uploader.uploadBlob(context, hash, chunker, true);
+      uploader.uploadBlob(context, digest, chunker);
       fail("Should have thrown an exception.");
     } catch (IOException e) {
       assertThat(numCalls.get()).isEqualTo(1);
     }
-  }
-
-  @Test
-  public void failedUploadsShouldNotDeduplicate() throws Exception {
-    RemoteRetrier retrier =
-        TestUtils.newRemoteRetrier(() -> Retrier.RETRIES_DISABLED, (e) -> false, retryService);
-    ByteStreamUploader uploader =
-        new ByteStreamUploader(
-            INSTANCE_NAME,
-            new ReferenceCountedChannel(channelConnectionFactory),
-            CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
-            retrier,
-            /*maximumOpenFiles=*/ -1);
-
-    byte[] blob = new byte[CHUNK_SIZE * 2 + 1];
-    new Random().nextBytes(blob);
-
-    Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
-
-    AtomicInteger numUploads = new AtomicInteger();
-    serviceRegistry.addService(
-        new ByteStreamImplBase() {
-          boolean failRequest = true;
-
-          @Override
-          public StreamObserver<WriteRequest> write(StreamObserver<WriteResponse> streamObserver) {
-            numUploads.incrementAndGet();
-            return new StreamObserver<WriteRequest>() {
-              long nextOffset = 0;
-
-              @Override
-              public void onNext(WriteRequest writeRequest) {
-                if (failRequest) {
-                  streamObserver.onError(Status.UNKNOWN.asException());
-                  failRequest = false;
-                } else {
-                  nextOffset += writeRequest.getData().size();
-                  boolean lastWrite = blob.length == nextOffset;
-                  assertThat(writeRequest.getFinishWrite()).isEqualTo(lastWrite);
-                }
-              }
-
-              @Override
-              public void onError(Throwable throwable) {
-                fail("onError should never be called.");
-              }
-
-              @Override
-              public void onCompleted() {
-                assertThat(nextOffset).isEqualTo(blob.length);
-
-                WriteResponse response =
-                    WriteResponse.newBuilder().setCommittedSize(nextOffset).build();
-                streamObserver.onNext(response);
-                streamObserver.onCompleted();
-              }
-            };
-          }
-        });
-
-    StatusRuntimeException expected = null;
-    try {
-      // This should fail
-      uploader.uploadBlob(context, hash, chunker, true);
-    } catch (IOException e) {
-      if (e.getCause() instanceof StatusRuntimeException) {
-        expected = (StatusRuntimeException) e.getCause();
-      }
-    }
-    assertThat(expected).isNotNull();
-    assertThat(Status.fromThrowable(expected).getCode()).isEqualTo(Code.UNKNOWN);
-    // This should trigger an upload.
-    uploader.uploadBlob(context, hash, chunker, false);
-
-    assertThat(numUploads.get()).isEqualTo(2);
-
-    blockUntilInternalStateConsistent(uploader);
-  }
-
-  @Test
-  public void deduplicationOfUploadsShouldWork() throws Exception {
-    RemoteRetrier retrier =
-        TestUtils.newRemoteRetrier(() -> mockBackoff, (e) -> true, retryService);
-    ByteStreamUploader uploader =
-        new ByteStreamUploader(
-            INSTANCE_NAME,
-            new ReferenceCountedChannel(channelConnectionFactory),
-            CallCredentialsProvider.NO_CREDENTIALS,
-            /* callTimeoutSecs= */ 60,
-            retrier,
-            /*maximumOpenFiles=*/ -1);
-
-    byte[] blob = new byte[CHUNK_SIZE * 2 + 1];
-    new Random().nextBytes(blob);
-
-    Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
-
-    AtomicInteger numUploads = new AtomicInteger();
-    serviceRegistry.addService(
-        new ByteStreamImplBase() {
-          @Override
-          public StreamObserver<WriteRequest> write(StreamObserver<WriteResponse> streamObserver) {
-            numUploads.incrementAndGet();
-            return new StreamObserver<WriteRequest>() {
-
-              long nextOffset = 0;
-
-              @Override
-              public void onNext(WriteRequest writeRequest) {
-                nextOffset += writeRequest.getData().size();
-                boolean lastWrite = blob.length == nextOffset;
-                assertThat(writeRequest.getFinishWrite()).isEqualTo(lastWrite);
-              }
-
-              @Override
-              public void onError(Throwable throwable) {
-                fail("onError should never be called.");
-              }
-
-              @Override
-              public void onCompleted() {
-                assertThat(nextOffset).isEqualTo(blob.length);
-
-                WriteResponse response =
-                    WriteResponse.newBuilder().setCommittedSize(nextOffset).build();
-                streamObserver.onNext(response);
-                streamObserver.onCompleted();
-              }
-            };
-          }
-        });
-
-    uploader.uploadBlob(context, hash, chunker, true);
-    // This should not trigger an upload.
-    uploader.uploadBlob(context, hash, chunker, false);
-
-    assertThat(numUploads.get()).isEqualTo(1);
-
-    // This test should not have triggered any retries.
-    Mockito.verifyNoInteractions(mockBackoff);
-
-    blockUntilInternalStateConsistent(uploader);
   }
 
   @Test
@@ -1494,7 +1190,7 @@ public class ByteStreamUploaderTest {
     new Random().nextBytes(blob);
 
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     AtomicInteger numUploads = new AtomicInteger();
     serviceRegistry.addService(
@@ -1508,15 +1204,13 @@ public class ByteStreamUploaderTest {
           }
         });
 
-    assertThrows(IOException.class, () -> uploader.uploadBlob(context, hash, chunker, true));
+    assertThrows(IOException.class, () -> uploader.uploadBlob(context, digest, chunker));
 
     assertThat(refreshTimes.get()).isEqualTo(1);
     assertThat(numUploads.get()).isEqualTo(2);
 
     // This test should not have triggered any retries.
     Mockito.verifyNoInteractions(mockBackoff);
-
-    blockUntilInternalStateConsistent(uploader);
   }
 
   @Test
@@ -1552,7 +1246,7 @@ public class ByteStreamUploaderTest {
     new Random().nextBytes(blob);
 
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
     AtomicInteger numUploads = new AtomicInteger();
     serviceRegistry.addService(
@@ -1594,15 +1288,13 @@ public class ByteStreamUploaderTest {
           }
         });
 
-    uploader.uploadBlob(context, hash, chunker, true);
+    uploader.uploadBlob(context, digest, chunker);
 
     assertThat(refreshTimes.get()).isEqualTo(1);
     assertThat(numUploads.get()).isEqualTo(2);
 
     // This test should not have triggered any retries.
     Mockito.verifyNoInteractions(mockBackoff);
-
-    blockUntilInternalStateConsistent(uploader);
   }
 
   @Test
@@ -1659,11 +1351,9 @@ public class ByteStreamUploaderTest {
         });
 
     Chunker chunker = Chunker.builder().setInput(blob).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
-    uploader.uploadBlob(context, hash, chunker, true);
-
-    blockUntilInternalStateConsistent(uploader);
+    uploader.uploadBlob(context, digest, chunker);
 
     assertThat(numUploads.get()).isEqualTo(1);
   }
@@ -1750,14 +1440,12 @@ public class ByteStreamUploaderTest {
 
     Chunker chunker =
         Chunker.builder().setInput(blob).setCompressed(true).setChunkSize(CHUNK_SIZE).build();
-    HashCode hash = HashCode.fromString(DIGEST_UTIL.compute(blob).getHash());
+    Digest digest = DIGEST_UTIL.compute(blob);
 
-    uploader.uploadBlob(context, hash, chunker, true);
+    uploader.uploadBlob(context, digest, chunker);
 
     // This test should not have triggered any retries.
     Mockito.verifyNoInteractions(mockBackoff);
-
-    blockUntilInternalStateConsistent(uploader);
 
     assertThat(numUploads.get()).isEqualTo(1);
   }
@@ -1881,14 +1569,6 @@ public class ByteStreamUploaderTest {
     }
   }
 
-  private void blockUntilInternalStateConsistent(ByteStreamUploader uploader) throws Exception {
-    // Poll until all upload futures have been removed from the internal hash map. The polling is
-    // necessary, as listeners are executed after Future.get() calls are notified about completion.
-    while (uploader.uploadsInProgress()) {
-      Thread.sleep(1);
-    }
-  }
-
   /* Custom Chunker used to track number of open files */
   private static class TestChunker extends Chunker {
 
@@ -1909,6 +1589,8 @@ public class ByteStreamUploaderTest {
 
       @Override
       public Chunker.Builder setInput(byte[] existingData) {
+        checkState(this.inputStream == null);
+        this.size = existingData.length;
         return setInputSupplier(
             () -> new TestByteArrayInputStream(existingData, customFileTracker));
       }

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -244,16 +244,8 @@ public class GrpcCacheClientTest {
                 return 100;
               }
             });
-    ByteStreamUploader uploader =
-        new ByteStreamUploader(
-            remoteOptions.remoteInstanceName,
-            channel.retain(),
-            callCredentialsProvider,
-            remoteOptions.remoteTimeout.getSeconds(),
-            retrier,
-            remoteOptions.maximumOpenFiles);
     return new GrpcCacheClient(
-        channel.retain(), callCredentialsProvider, remoteOptions, retrier, DIGEST_UTIL, uploader);
+        channel.retain(), callCredentialsProvider, remoteOptions, retrier, DIGEST_UTIL);
   }
 
   protected static byte[] downloadBlob(

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
@@ -15,8 +15,10 @@ package com.google.devtools.build.lib.remote;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
+import static com.google.devtools.build.lib.remote.util.Utils.waitForBulkTransfer;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 import build.bazel.remote.execution.v2.ActionResult;
@@ -25,6 +27,8 @@ import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
@@ -39,9 +43,11 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.exec.util.FakeOwner;
 import com.google.devtools.build.lib.remote.common.RemoteActionExecutionContext;
+import com.google.devtools.build.lib.remote.common.RemoteCacheClient;
 import com.google.devtools.build.lib.remote.merkletree.MerkleTree;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.remote.util.InMemoryCacheClient;
 import com.google.devtools.build.lib.remote.util.TracingMetadataUtils;
 import com.google.devtools.build.lib.testutil.TestUtils;
 import com.google.devtools.build.lib.util.io.FileOutErr;
@@ -63,6 +69,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -142,7 +150,7 @@ public class RemoteCacheTest {
     result.setStdoutDigest(emptyDigest);
     result.setStderrDigest(emptyDigest);
 
-    RemoteCache.waitForBulkTransfer(
+    waitForBulkTransfer(
         remoteCache.downloadOutErr(
             context,
             result.build(),
@@ -199,6 +207,68 @@ public class RemoteCacheTest {
   }
 
   @Test
+  public void upload_deduplicationWorks() throws IOException {
+    RemoteCacheClient remoteCacheClient = mock(RemoteCacheClient.class);
+    AtomicInteger times = new AtomicInteger(0);
+    doAnswer(
+        invocationOnMock -> {
+          times.incrementAndGet();
+          return SettableFuture.create();
+        })
+        .when(remoteCacheClient)
+        .uploadFile(any(), any(), any());
+    RemoteCache remoteCache =
+        new RemoteCache(remoteCacheClient, Options.getDefaults(RemoteOptions.class), digestUtil);
+    Digest digest = fakeFileCache.createScratchInput(ActionInputHelper.fromPath("file"), "content");
+    Path file = execRoot.getRelative("file");
+
+    remoteCache.uploadFile(context, digest, file);
+    remoteCache.uploadFile(context, digest, file);
+
+    assertThat(times.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void upload_failedUploads_doNotDeduplicate() throws Exception {
+    AtomicBoolean failRequest = new AtomicBoolean(true);
+    InMemoryCacheClient inMemoryCacheClient = new InMemoryCacheClient();
+    RemoteCacheClient remoteCacheClient = mock(RemoteCacheClient.class);
+    doAnswer(
+        invocationOnMock -> {
+          if (failRequest.getAndSet(false)) {
+            return Futures.immediateFailedFuture(new IOException("Failed"));
+          }
+          return inMemoryCacheClient.uploadFile(
+              invocationOnMock.getArgument(0),
+              invocationOnMock.getArgument(1),
+              invocationOnMock.getArgument(2));
+        })
+        .when(remoteCacheClient)
+        .uploadFile(any(), any(), any());
+    doAnswer(invocationOnMock -> inMemoryCacheClient.findMissingDigests(invocationOnMock.getArgument(0), invocationOnMock.getArgument(1))).when(remoteCacheClient)
+        .findMissingDigests(any(), any());
+    RemoteCache remoteCache =
+        new RemoteCache(remoteCacheClient, Options.getDefaults(RemoteOptions.class), digestUtil);
+    Digest digest = fakeFileCache.createScratchInput(ActionInputHelper.fromPath("file"), "content");
+    Path file = execRoot.getRelative("file");
+    assertThat(getFromFuture(remoteCache.findMissingDigests(context, ImmutableList.of(digest))))
+        .containsExactly(digest);
+
+    Exception thrown = null;
+    try {
+      getFromFuture(remoteCache.uploadFile(context, digest, file));
+    } catch (IOException e) {
+      thrown = e;
+    }
+    assertThat(thrown).isNotNull();
+    assertThat(thrown).isInstanceOf(IOException.class);
+    getFromFuture(remoteCache.uploadFile(context, digest, file));
+
+    assertThat(getFromFuture(remoteCache.findMissingDigests(context, ImmutableList.of(digest))))
+        .isEmpty();
+  }
+
+  @Test
   public void ensureInputsPresent_interrupted_cancelInProgressUploadTasks() throws Exception {
     // arrange
     InMemoryRemoteCache remoteCache = spy(newRemoteCache());
@@ -241,6 +311,25 @@ public class RemoteCacheTest {
 
     // assert
     assertThat(remoteCache.casUploadCache.getInProgressTasks()).isEmpty();
+  }
+
+  @Test
+  public void shutdownNow_cancelInProgressUploads() throws Exception {
+    RemoteCacheClient remoteCacheClient = mock(RemoteCacheClient.class);
+    // Return a future that never completes
+    doAnswer(invocationOnMock -> SettableFuture.create())
+        .when(remoteCacheClient)
+        .uploadFile(any(), any(), any());
+    RemoteCache remoteCache =
+        new RemoteCache(remoteCacheClient, Options.getDefaults(RemoteOptions.class), digestUtil);
+    Digest digest = fakeFileCache.createScratchInput(ActionInputHelper.fromPath("file"), "content");
+    Path file = execRoot.getRelative("file");
+
+    ListenableFuture<Void> upload = remoteCache.uploadFile(context, digest, file);
+    assertThat(remoteCache.casUploadCache.getInProgressTasks()).contains(digest);
+    remoteCache.shutdownNow();
+
+    assertThat(upload.isCancelled()).isTrue();
   }
 
   private InMemoryRemoteCache newRemoteCache() {

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerWithGrpcRemoteExecutorTest.java
@@ -282,22 +282,13 @@ public class RemoteSpawnRunnerWithGrpcRemoteExecutorTest {
     CallCredentialsProvider callCredentialsProvider =
         GoogleAuthUtils.newCallCredentialsProvider(
             GoogleAuthUtils.newCredentials(Options.getDefaults(AuthAndTLSOptions.class)));
-    ByteStreamUploader uploader =
-        new ByteStreamUploader(
-            remoteOptions.remoteInstanceName,
-            channel.retain(),
-            callCredentialsProvider,
-            remoteOptions.remoteTimeout.getSeconds(),
-            retrier,
-            /*maximumOpenFiles=*/ -1);
     GrpcCacheClient cacheProtocol =
         new GrpcCacheClient(
             channel.retain(),
             callCredentialsProvider,
             remoteOptions,
             retrier,
-            DIGEST_UTIL,
-            uploader);
+            DIGEST_UTIL);
     RemoteExecutionCache remoteCache =
         new RemoteExecutionCache(cacheProtocol, remoteOptions, DIGEST_UTIL);
     RemoteExecutionService remoteExecutionService =

--- a/src/test/java/com/google/devtools/build/lib/remote/util/RxFuturesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/util/RxFuturesTest.java
@@ -15,6 +15,9 @@ package com.google.devtools.build.lib.remote.util;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static com.google.devtools.build.lib.remote.util.RxFutures.toCompletable;
+import static com.google.devtools.build.lib.remote.util.RxFutures.toListenableFuture;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -42,7 +45,7 @@ public class RxFuturesTest {
     SettableFuture<Void> future = SettableFuture.create();
     AtomicBoolean executed = new AtomicBoolean(false);
 
-    RxFutures.toCompletable(
+    toCompletable(
         () -> {
           executed.set(true);
           return future;
@@ -55,7 +58,7 @@ public class RxFuturesTest {
   @Test
   public void toCompletable_futureOnSuccess_completableOnComplete() {
     SettableFuture<Void> future = SettableFuture.create();
-    Completable completable = RxFutures.toCompletable(() -> future, MoreExecutors.directExecutor());
+    Completable completable = toCompletable(() -> future, MoreExecutors.directExecutor());
 
     TestObserver<Void> observer = completable.test();
     observer.assertEmpty();
@@ -67,7 +70,7 @@ public class RxFuturesTest {
   @Test
   public void toCompletable_futureOnError_completableOnError() {
     SettableFuture<Void> future = SettableFuture.create();
-    Completable completable = RxFutures.toCompletable(() -> future, MoreExecutors.directExecutor());
+    Completable completable = toCompletable(() -> future, MoreExecutors.directExecutor());
 
     TestObserver<Void> observer = completable.test();
     observer.assertEmpty();
@@ -80,7 +83,7 @@ public class RxFuturesTest {
   @Test
   public void toCompletable_futureOnSuccessBeforeSubscription_completableOnComplete() {
     SettableFuture<Void> future = SettableFuture.create();
-    Completable completable = RxFutures.toCompletable(() -> future, MoreExecutors.directExecutor());
+    Completable completable = toCompletable(() -> future, MoreExecutors.directExecutor());
 
     future.set(null);
     TestObserver<Void> observer = completable.test();
@@ -91,7 +94,7 @@ public class RxFuturesTest {
   @Test
   public void toCompletable_futureOnErrorBeforeSubscription_completableOnError() {
     SettableFuture<Void> future = SettableFuture.create();
-    Completable completable = RxFutures.toCompletable(() -> future, MoreExecutors.directExecutor());
+    Completable completable = toCompletable(() -> future, MoreExecutors.directExecutor());
 
     Throwable error = new IllegalStateException("error");
     future.setException(error);
@@ -103,7 +106,7 @@ public class RxFuturesTest {
   @Test
   public void toCompletable_futureCancelledBeforeSubscription_completableOnError() {
     SettableFuture<Void> future = SettableFuture.create();
-    Completable completable = RxFutures.toCompletable(() -> future, MoreExecutors.directExecutor());
+    Completable completable = toCompletable(() -> future, MoreExecutors.directExecutor());
 
     future.cancel(true);
     TestObserver<Void> observer = completable.test();
@@ -112,9 +115,21 @@ public class RxFuturesTest {
   }
 
   @Test
+  public void toCompletable_futureCancelled_completableOnError() {
+    ListenableFuture<Void> future = SettableFuture.create();
+    Completable completable = toCompletable(() -> future, directExecutor());
+
+    TestObserver<Void> observer = completable.test();
+    observer.assertNotComplete();
+    future.cancel(true);
+
+    observer.assertError(CancellationException.class);
+  }
+
+  @Test
   public void toCompletable_disposeCompletable_cancelFuture() {
     SettableFuture<Void> future = SettableFuture.create();
-    Completable completable = RxFutures.toCompletable(() -> future, MoreExecutors.directExecutor());
+    Completable completable = toCompletable(() -> future, MoreExecutors.directExecutor());
 
     TestObserver<Void> observer = completable.test();
     observer.assertEmpty();
@@ -126,7 +141,7 @@ public class RxFuturesTest {
   @Test
   public void toCompletable_multipleSubscriptions_error() {
     ListenableFuture<Void> future = immediateVoidFuture();
-    Completable completable = RxFutures.toCompletable(() -> future, MoreExecutors.directExecutor());
+    Completable completable = toCompletable(() -> future, MoreExecutors.directExecutor());
     completable.test().assertComplete();
 
     TestObserver<Void> observer = completable.test();
@@ -175,6 +190,16 @@ public class RxFuturesTest {
     assertThat(setup.isDisposed()).isTrue();
   }
 
+  @Test
+  public void toListenableFutureFromCompletable_sourceFutureCancelled_cancelFuture() {
+    SettableFuture<Void> source = SettableFuture.create();
+    ListenableFuture<Void> future = toListenableFuture(toCompletable(() -> source, directExecutor()));
+
+    source.cancel(true);
+
+    assertThat(future.isCancelled()).isTrue();
+  }
+
   private static class CompletableToListenableFutureSetup {
     public static CompletableToListenableFutureSetup create() {
       return new CompletableToListenableFutureSetup();
@@ -190,7 +215,7 @@ public class RxFuturesTest {
     CompletableToListenableFutureSetup() {
       Completable completable =
           Completable.create(emitter -> this.emitter = emitter).doOnDispose(() -> disposed = true);
-      future = RxFutures.toListenableFuture(completable);
+      future = toListenableFuture(completable);
       Futures.addCallback(
           future,
           new FutureCallback<Void>() {


### PR DESCRIPTION
During previous work on improving BES uploader, we updated the uploader to use `RemoteCache` directly instead of referencing `ByteStreamUploader`. This makes following cleanups possible:

1. `ByteStreamUploader` is no longer reference counted. It was reference counted mainly because it's needed to be shared between remote execution and BES. Now the only place which references it is `RemoteCache`.
2. `ByteStreamUploader` does not deduplicate uploads as `RemoteCache` already supports it. Similar to #14441. This should reduce memory footprint when using remote execution and/or BES.
3. Deprecated methods of `ByteStreamUploader` are removed.