### PR TITLE
Fix string formatting when java_home path is missing.

### DIFF
--- a/src/test/shell/integration/bazel_java_test.sh
+++ b/src/test/shell/integration/bazel_java_test.sh
@@ -267,6 +267,22 @@ function test_no_javabase() {
   expect_log "bazel-bin/javabase_test/a.runfiles/local_jdk/bin/java: No such file or directory"
 }
 
+# Tests non-existent java_home path.
+function test_no_java_home_path() {
+  cat << EOF >> WORKSPACE
+load("@bazel_tools//tools/jdk:local_java_repository.bzl", "local_java_repository")
+local_java_repository(
+    name = "javabase",
+    java_home = "$PWD/i-dont-exist",
+    version = "11",
+)
+EOF
+
+  bazel build @javabase//... >& $TEST_log && fail "Build with missing java_home should fail."
+  expect_log "The path indicated by the \"java_home\" attribute .* does not exist."
+}
+
+
 function test_genrule() {
   cat << EOF > WORKSPACE
 load("@bazel_tools//tools/jdk:local_java_repository.bzl", "local_java_repository")

--- a/tools/jdk/local_java_repository.bzl
+++ b/tools/jdk/local_java_repository.bzl
@@ -123,8 +123,8 @@ def _local_java_repository_impl(repository_ctx):
     java_home = repository_ctx.attr.java_home
     java_home_path = repository_ctx.path(java_home)
     if not java_home_path.exists:
-        fail('The path indicated by the "java_home" attribute "%s" (absolute: "%s") ' +
-             "does not exist." % (java_home, str(java_home_path)))
+        fail(('The path indicated by the "java_home" attribute "%s" (absolute: "%s") ' +
+              "does not exist.") % (java_home, str(java_home_path)))
 
     repository_ctx.file(
         "WORKSPACE",


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/14631