### PR TITLE
Enable native support for Windows on arm64 (Part 1)

### DIFF
--- a/third_party/def_parser/def_parser.cc
+++ b/third_party/def_parser/def_parser.cc
@@ -378,6 +378,7 @@ bool DumpFile(const char* filename, std::set<string>& symbols,
   /* Does it look like a COFF OBJ file??? */
   else if (((dosHeader->e_magic == IMAGE_FILE_MACHINE_I386) ||
             (dosHeader->e_magic == IMAGE_FILE_MACHINE_AMD64) ||
+            (dosHeader->e_magic == IMAGE_FILE_MACHINE_ARM64) ||
             (dosHeader->e_magic == IMAGE_FILE_MACHINE_ARMNT)) &&
            (dosHeader->e_sp == 0)) {
     /*

--- a/third_party/grpc/BUILD
+++ b/third_party/grpc/BUILD
@@ -21,6 +21,7 @@ licenses(["notice"])  # Apache v2
 exports_files([
     "grpc_1.31.1.patch",
     "grpc_1.41.0.patch",
+    "grpc_1.41.0.win_arm64.patch"
 ])
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/grpc/grpc_1.41.0.win_arm64.patch
+++ b/third_party/grpc/grpc_1.41.0.win_arm64.patch
@@ -1,0 +1,51 @@
+From 6ce08c3da545358074eb66dc4202e0474fa5be1b Mon Sep 17 00:00:00 2001
+From: Niyas Sait <niyas.sait@linaro.org>
+Date: Fri, 26 Nov 2021 02:43:37 -0800
+Subject: [PATCH] add workarounds to compile for win/arm64
+
+---
+ src/core/lib/transport/transport.cc | 8 ++++----
+ third_party/cares/cares.BUILD       | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/core/lib/transport/transport.cc b/src/core/lib/transport/transport.cc
+index 36060a6bd9..db847d53d2 100644
+--- a/src/core/lib/transport/transport.cc
++++ b/src/core/lib/transport/transport.cc
+@@ -99,16 +99,16 @@ void grpc_stream_ref_init(grpc_stream_refcount* refcount, int /*initial_refs*/,
+       refcount, &refcount->slice_refcount);
+ }
+ 
+-static void move64(uint64_t* from, uint64_t* to) {
++static void move64bits(uint64_t* from, uint64_t* to) {
+   *to += *from;
+   *from = 0;
+ }
+ 
+ void grpc_transport_move_one_way_stats(grpc_transport_one_way_stats* from,
+                                        grpc_transport_one_way_stats* to) {
+-  move64(&from->framing_bytes, &to->framing_bytes);
+-  move64(&from->data_bytes, &to->data_bytes);
+-  move64(&from->header_bytes, &to->header_bytes);
++  move64bits(&from->framing_bytes, &to->framing_bytes);
++  move64bits(&from->data_bytes, &to->data_bytes);
++  move64bits(&from->header_bytes, &to->header_bytes);
+ }
+ 
+ void grpc_transport_move_stats(grpc_transport_stream_stats* from,
+diff --git a/third_party/cares/cares.BUILD b/third_party/cares/cares.BUILD
+index 7939021a25..430791aa8d 100644
+--- a/third_party/cares/cares.BUILD
++++ b/third_party/cares/cares.BUILD
+@@ -22,7 +22,7 @@ config_setting(
+ 
+ config_setting(
+     name = "windows",
+-    values = {"cpu": "x64_windows"},
++    constraint_values = ["@platforms//os:windows"],
+ )
+ 
+ # Android is not officially supported through C++.
+-- 
+2.33.0.windows.2
+


### PR DESCRIPTION
Contains following changes to third_party:

 - Extended def_parser to handle ARM64 binaries
 - Add grpc patch to workaround build issues

Fixes: #14339