### PR TITLE
Fix fail message construction in cc_shared_library

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl
@@ -342,7 +342,7 @@ def _throw_error_if_unaccounted_libs(unaccounted_for_libs):
             libs_message.append(str(unaccounted_lib))
 
     if len(unaccounted_for_libs) > 10:
-        libs_message = "(and " + str(len(unaccounted_for_libs) - 10) + " others)\n"
+        libs_message.append("(and " + str(len(unaccounted_for_libs) - 10) + " others)\n")
 
     static_deps_message = []
     for repo in different_repos:


### PR DESCRIPTION
Previously, if there were many unaccounted for libraries, this would simply fail with:
```
Error in join: 'string' is not iterable
```