### PR TITLE
Flip --incompatible_existing_rules_immutable_view flag to true

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -147,7 +147,7 @@ public final class BuildLanguageOptions extends OptionsBase {
 
   @Option(
       name = "incompatible_existing_rules_immutable_view",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
       effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS, OptionEffectTag.LOADING_AND_ANALYSIS},
       metadataTags = {OptionMetadataTag.INCOMPATIBLE_CHANGE},
@@ -621,7 +621,7 @@ public final class BuildLanguageOptions extends OptionsBase {
   public static final String EXPERIMENTAL_ENABLE_ANDROID_MIGRATION_APIS =
       "-experimental_enable_android_migration_apis";
   public static final String INCOMPATIBLE_EXISTING_RULES_IMMUTABLE_VIEW =
-      "-incompatible_existing_rules_immutable_view";
+      "+incompatible_existing_rules_immutable_view";
   public static final String EXPERIMENTAL_GOOGLE_LEGACY_API = "-experimental_google_legacy_api";
   public static final String EXPERIMENTAL_NINJA_ACTIONS = "-experimental_ninja_actions";
   public static final String EXPERIMENTAL_PLATFORMS_API = "-experimental_platforms_api";

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkNativeModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkNativeModuleApi.java
@@ -92,14 +92,15 @@ public interface StarlarkNativeModuleApi extends StarlarkValue {
   @StarlarkMethod(
       name = "existing_rule",
       doc =
-          "Returns a new mutable dict that describes the attributes of a rule instantiated in this"
-              + " thread's package, or <code>None</code> if no rule instance of that name"
-              + " exists." //
-              + "<p>If the <code>--incompatible_existing_rules_immutable_view</code> flag is set,"
-              + " instead returns an immutable dict-like object (i.e. supporting dict-like"
-              + " iteration, <code>len(x)</code>, <code>name in x</code>, <code>x[name]</code>,"
-              + " <code>x.get(name)</code>, <code>x.items()</code>, <code>x.keys()</code>, and"
-              + " <code>x.values()</code>) with the same content." //
+          "Returns an immutable dict-like object that describes the attributes of a rule"
+              + " instantiated in this thread's package, or <code>None</code> if no rule instance"
+              + " of that name exists." //
+              + "<p>Here, an <em>immutable dict-like object</em> means a deeply immutable object"
+              + " <code>x</code> supporting dict-like iteration, <code>len(x)</code>, <code>name in"
+              + " x</code>, <code>x[name]</code>, <code>x.get(name)</code>, <code>x.items()</code>,"
+              + " <code>x.keys()</code>, and <code>x.values()</code>." //
+              + "<p>If the <code>--noincompatible_existing_rules_immutable_view</code> flag is set,"
+              + " instead returns a new mutable dict with the same content." //
               + "<p>The result contains an entry for each attribute, with the exception of private"
               + " ones (whose names do not start with a letter) and a few unrepresentable legacy"
               + " attribute types. In addition, the dict contains entries for the rule instance's"
@@ -129,17 +130,19 @@ public interface StarlarkNativeModuleApi extends StarlarkValue {
   @StarlarkMethod(
       name = "existing_rules",
       doc =
-          "Returns a new mutable dict describing the rules so far instantiated in this thread's"
-              + " package. Each dict entry maps the name of the rule instance to the result that"
-              + " would be returned by <code>existing_rule(name)</code>." //
-              + "<p>If the <code>--incompatible_existing_rules_immutable_view</code> flag is set,"
-              + " instead returns an immutable dict-like object (i.e. supporting dict-like"
-              + " iteration, <code>len(x)</code>, <code>name in x</code>, <code>x[name]</code>,"
-              + " <code>x.get(name)</code>, <code>x.items()</code>, <code>x.keys()</code>, and"
-              + " <code>x.values()</code>) with the same content." //
+          "Returns an immutable dict-like object describing the rules so far instantiated in this"
+              + " thread's package. Each entry of the dict-like object maps the name of the rule"
+              + " instance to the result that would be returned by"
+              + " <code>existing_rule(name)</code>." //
+              + "<p>Here, an <em>immutable dict-like object</em> means a deeply immutable object"
+              + " <code>x</code> supporting dict-like iteration, <code>len(x)</code>, <code>name in"
+              + " x</code>, <code>x[name]</code>, <code>x.get(name)</code>, <code>x.items()</code>,"
+              + " <code>x.keys()</code>, and <code>x.values()</code>." //
+              + "<p>If the <code>--noincompatible_existing_rules_immutable_view</code> flag is set,"
+              + " instead returns a new mutable dict with the same content." //
               + "<p><i>Note: If possible, avoid using this function. It makes BUILD files brittle"
-              + " and order-dependent. Furthermore, unless the"
-              + " <code>--incompatible_existing_rules_immutable_view</code> flag is set, this"
+              + " and order-dependent. Furthermore, if the"
+              + " <code>--noincompatible_existing_rules_immutable_view</code> flag is set, this"
               + " function may be very expensive, especially if called within a loop.</i>",
       useStarlarkThread = true)
   Object existingRules(StarlarkThread thread) throws EvalException;


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/13907

RELNOTES[INC]: The --incompatible_existing_rules_immutable_view flag has been
flipped to true. See https://github.com/bazelbuild/bazel/issues/13907 for
migration notes.