### PR TITLE
Mention and link to tuple type

### DIFF
--- a/site/en/rules/language.md
+++ b/site/en/rules/language.md
@@ -39,6 +39,7 @@ types are supported:
 * [None](lib/globals#None)
 * [bool](lib/bool)
 * [dict](lib/dict)
+* [tuple](lib/globals#tuple)
 * function
 * [int](lib/int)
 * [list](lib/list)


### PR DESCRIPTION
Mention and link to tuple type, this is a fix for #13552.