### PR TITLE
Add "arch" struct field to repository_os

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkOS.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkOS.java
@@ -17,12 +17,15 @@ package com.google.devtools.build.lib.bazel.repository.starlark;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.docgen.annot.DocCategory;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import java.util.Locale;
 import java.util.Map;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.StarlarkValue;
 
-/** A Starlark structure to deliver information about the system we are running on. */
+/**
+ * A Starlark structure to deliver information about the system we are running on.
+ */
 @StarlarkBuiltin(
     name = "repository_os",
     category = DocCategory.BUILTIN,
@@ -49,8 +52,16 @@ final class StarlarkOS implements StarlarkValue {
   @StarlarkMethod(
       name = "name",
       structField = true,
-      doc = "A string identifying the current system Bazel is running on.")
+      doc = "A string identifying the operating system Bazel is running on (the value of the \"os.name\" Java property).")
   public String getName() {
-    return System.getProperty("os.name").toLowerCase();
+    return System.getProperty("os.name").toLowerCase(Locale.ROOT);
+  }
+
+  @StarlarkMethod(
+      name = "arch",
+      structField = true,
+      doc = "A string identifying the architecture Bazel is running on (the value of the \"os.arch\" Java property).")
+  public String getArch() {
+    return System.getProperty("os.arch").toLowerCase(Locale.ROOT);
   }
 }

--- a/tools/cpp/lib_cc_configure.bzl
+++ b/tools/cpp/lib_cc_configure.bzl
@@ -179,38 +179,34 @@ def execute(
 
 def get_cpu_value(repository_ctx):
     """Compute the cpu_value based on the OS name. Doesn't %-escape the result!"""
-    os_name = repository_ctx.os.name.lower()
+    os_name = repository_ctx.os.name
+    arch = repository_ctx.os.arch
     if os_name.startswith("mac os"):
         # Check if we are on x86_64 or arm64 and return the corresponding cpu value.
-        result = repository_ctx.execute(["uname", "-m"])
-        return "darwin" + ("_arm64" if result.stdout.strip() == "arm64" else "")
+        return "darwin" + ("_arm64" if arch == "aarch64" else "")
     if os_name.find("freebsd") != -1:
         return "freebsd"
     if os_name.find("openbsd") != -1:
         return "openbsd"
     if os_name.find("windows") != -1:
-        arch = (get_env_var(repository_ctx, "PROCESSOR_ARCHITECTURE", "", False) or
-                get_env_var(repository_ctx, "PROCESSOR_ARCHITEW6432", "", False))
-        if arch == "ARM64":
+        if arch == "aarch64":
             return "arm64_windows"
         else:
             return "x64_windows"
 
-    # Use uname to figure out whether we are on x86_32 or x86_64
-    result = repository_ctx.execute(["uname", "-m"])
-    if result.stdout.strip() in ["power", "ppc64le", "ppc", "ppc64"]:
+    if arch in ["power", "ppc64le", "ppc", "ppc64"]:
         return "ppc"
-    if result.stdout.strip() in ["s390x"]:
+    if arch in ["s390x"]:
         return "s390x"
-    if result.stdout.strip() in ["mips64"]:
+    if arch in ["mips64"]:
         return "mips64"
-    if result.stdout.strip() in ["riscv64"]:
+    if arch in ["riscv64"]:
         return "riscv64"
-    if result.stdout.strip() in ["arm", "armv7l"]:
+    if arch in ["arm", "armv7l"]:
         return "arm"
-    if result.stdout.strip() in ["aarch64"]:
+    if arch in ["aarch64"]:
         return "aarch64"
-    return "k8" if result.stdout.strip() in ["amd64", "x86_64", "x64"] else "piii"
+    return "k8" if arch in ["amd64", "x86_64", "x64"] else "piii"
 
 def is_cc_configure_debug(repository_ctx):
     """Returns True if CC_CONFIGURE_DEBUG is set to 1."""

--- a/tools/jdk/local_java_repository.bzl
+++ b/tools/jdk/local_java_repository.bzl
@@ -132,7 +132,7 @@ def _local_java_repository_impl(repository_ctx):
         "workspace(name = \"{name}\")\n".format(name = repository_ctx.name),
     )
 
-    extension = ".exe" if repository_ctx.os.name.lower().find("windows") != -1 else ""
+    extension = ".exe" if repository_ctx.os.name.find("windows") != -1 else ""
     java_bin = java_home_path.get_child("bin").get_child("java" + extension)
 
     if not java_bin.exists:

--- a/tools/osx/xcode_configure.bzl
+++ b/tools/osx/xcode_configure.bzl
@@ -271,7 +271,7 @@ def _impl(repository_ctx):
       repository_ctx: The repository context.
     """
 
-    os_name = repository_ctx.os.name.lower()
+    os_name = repository_ctx.os.name
     build_contents = "package(default_visibility = ['//visibility:public'])\n\n"
     if (os_name.startswith("mac os")):
         build_contents += _darwin_build_file(repository_ctx)


### PR DESCRIPTION
This new field provides access to the Java "os.arch" property to
repository rules, which previously had to rely on uname (Unix) or
additional env variables (Windows) to detect the architecture.

This also fixes a small issue in the existing implementation of
repository_ctx.os.name, which should use the root locale when converting
the value of the "os.name" property to lowercase.

Existing sites of manual architecture detection in shipped repository
rules as well as redundant calls to lower() on the value of
repository_ctx.os.name are cleaned up.

Fixes #14685 