### PR TITLE
Enable r8 support in bazel

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -427,6 +427,21 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
                 + "Use incremental_dexing attribute to override default for a particular "
                 + "android_binary.")
     public boolean incrementalDexingAfterProguardByDefault;
+  
+    @Option(
+        name = "experimental_enable_r8",
+        defaultValue = "false",
+        metadataTags = {OptionMetadataTag.EXPERIMENTAL},
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.LOADING_AND_ANALYSIS},
+        help =
+            "Whether to use R8 instead of proguarding.  "
+                + "This only has effect if proguard_specs are specified. "
+                + " Legacy multidex and mobile-install are not supported with R8.")
+    public boolean enableR8;
+
+
+
 
     // TODO(b/31711689): Remove this flag when this optimization is proven to work globally.
     @Option(
@@ -982,6 +997,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
       host.incrementalDexingShardsAfterProguard = incrementalDexingShardsAfterProguard;
       host.incrementalDexingUseDexSharder = incrementalDexingUseDexSharder;
       host.incrementalDexingAfterProguardByDefault = incrementalDexingAfterProguardByDefault;
+      host.enableR8 = enableR8;
       host.assumeMinSdkVersion = assumeMinSdkVersion;
       host.nonIncrementalPerTargetDexopts = nonIncrementalPerTargetDexopts;
       host.dexoptsSupportedInIncrementalDexing = dexoptsSupportedInIncrementalDexing;
@@ -1008,6 +1024,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   private final int incrementalDexingShardsAfterProguard;
   private final boolean incrementalDexingUseDexSharder;
   private final boolean incrementalDexingAfterProguardByDefault;
+  private final boolean enableR8;
   private final boolean assumeMinSdkVersion;
   private final ImmutableList<String> dexoptsSupportedInIncrementalDexing;
   private final ImmutableList<String> targetDexoptsThatPreventIncrementalDexing;
@@ -1060,6 +1077,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     this.incrementalDexingShardsAfterProguard = options.incrementalDexingShardsAfterProguard;
     this.incrementalDexingUseDexSharder = options.incrementalDexingUseDexSharder;
     this.incrementalDexingAfterProguardByDefault = options.incrementalDexingAfterProguardByDefault;
+    this.enableR8 = options.enableR8;
     this.assumeMinSdkVersion = options.assumeMinSdkVersion;
     this.dexoptsSupportedInIncrementalDexing =
         ImmutableList.copyOf(options.dexoptsSupportedInIncrementalDexing);
@@ -1163,6 +1181,12 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   @Override
   public boolean incrementalDexingAfterProguardByDefault() {
     return incrementalDexingAfterProguardByDefault;
+  }
+
+  /** Whether to dex class files using the r8 binary. */
+  @Override
+  public boolean enableR8() {
+    return enableR8;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
@@ -61,6 +61,14 @@ public interface AndroidConfigurationApi extends StarlarkValue {
       documented = false)
   boolean incrementalDexingAfterProguardByDefault();
 
+  @StarlarkMethod(
+      name = "experimental_enable_r8",
+      structField = true,
+      doc = "When true R8 is used for dexing and proguarding. "
+                + "Only in effect when proguard_specs are specified.",
+      documented = false)
+  boolean enableR8();
+
   @StarlarkMethod(name = "apk_signing_method_v1", structField = true, doc = "", documented = false)
   boolean apkSigningMethodV1();
 


### PR DESCRIPTION
This cl introduces R8 support in Bazel for proguarding and dexing.
R8 is enabled by passing --experimental_enable_r8=true to the
blaze build invocation and --proguard_top="//bzl/r8:proguard_compat"

When enabled the build graph was changed from
 - jar -> proguard -> dex -> apk
To
 - jar -> r8 -> apk

 I.e R8 takes care of proguarding and dexing.

There are a few known limitations:

 - Only native multidex (Android version L+) is supported.
   All android_binary targets declare native_multidex so it does not
   make sense to implement legacy multidex with R8
 - Mobile-Install is not supported: mobile-install relies on how dexes
   are shard. R8 dexes the deploy jar in a single monolithic action
   which is cant be done incrementally (I don't think mobile-install is
   supported anymore)
 - Other features which are not implemented in bazel at the moment:
   e.g. dynamic delivery
 - proguard_compat needs to be available (not in this commit)

see https://github.com/bazelbuild/rules_android/issues/31