### PR TITLE
Add a helper method for rules to depend on the cpp toolchain type.

### DIFF
--- a/tools/cpp/cc_flags_supplier.bzl
+++ b/tools/cpp/cc_flags_supplier.bzl
@@ -15,7 +15,7 @@
 
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "CC_FLAGS_MAKE_VARIABLE_ACTION_NAME")
 load("@bazel_tools//tools/cpp:cc_flags_supplier_lib.bzl", "build_cc_flags")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 
 def _cc_flags_supplier_impl(ctx):
     cc_toolchain = find_cpp_toolchain(ctx)
@@ -30,7 +30,7 @@ cc_flags_supplier = rule(
     attrs = {
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
-    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    toolchains = use_cpp_toolchain(),
     incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
 )

--- a/tools/cpp/compiler_flag.bzl
+++ b/tools/cpp/compiler_flag.bzl
@@ -14,7 +14,7 @@
 
 """Rule that allows select() to differentiate between compilers."""
 
-load("//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 
 def _compiler_flag_impl(ctx):
     toolchain = find_cpp_toolchain(ctx)
@@ -25,6 +25,6 @@ compiler_flag = rule(
     attrs = {
         "_cc_toolchain": attr.label(default = Label("//tools/cpp:current_cc_toolchain")),
     },
-    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    toolchains = use_cpp_toolchain(),
     incompatible_use_toolchain_transition = True,
 )


### PR DESCRIPTION
Fixes #14728, part of #14727.

Rules can begin using this as soon as it is released (hopefully in Bazel
5.1), and then future versions of Bazel will update the functionality as
optional toolchains are added and C++ rules are updated to use them.