### PR TITLE
[5.1] Don't resolve symlinks for --sandbox_base

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -125,6 +125,10 @@ public final class SandboxModule extends BlazeModule {
               env.getRuntime().getProductName(),
               Fingerprint.getHexDigest(env.getOutputBase().toString()));
       FileSystem fileSystem = env.getRuntime().getFileSystem();
+      if (OS.getCurrent() == OS.DARWIN) {
+        // Don't resolve symlinks on macOS: See https://github.com/bazelbuild/bazel/issues/13766
+        return fileSystem.getPath(options.sandboxBase).getRelative(dirName);
+      }
       Path resolvedSandboxBase = fileSystem.getPath(options.sandboxBase).resolveSymbolicLinks();
       return resolvedSandboxBase.getRelative(dirName);
     }


### PR DESCRIPTION
On macOS BigSur, the sandbox-exec command behaves slightly different than on
Catalina when firm links are present.

Resolving symlinks can prevent the sandbox for allowing write operations to the
sandbox base.

This effectively reverts a piece of 656a0ba, namely:

>  When using --experimental_sandbox_base, ensure that symlinks in the path are
>  resolved. Before this, you had to check whether on your system /dev/shm is a
>  symlink to /run/shm and then use that instead. Now it no longer matters, as
>  symlinks are resolved.

See https://github.com/bazelbuild/bazel/issues/13766 for full details.

(cherry picked from commit 0de7bb95022057e8b89334f44759cf6f950e131f)

Closes #14713.