### PR TITLE
[5.1] Add the default solib dir to the rpath for cc_imports with transitions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java
@@ -333,6 +333,14 @@ public class LibrariesToLinkCollector {
 
       rpathRootsForExplicitSoDeps.add(
           rpathRoot + dotdots + libDir.relativeTo(commonParent).getPathString());
+
+      // Unless running locally, libraries will be available under the root relative path, so we
+      // should add that to the rpath as well.
+      if (inputArtifact.getRootRelativePathString().startsWith("_solib_")) {
+        PathFragment artifactPathUnderSolib = inputArtifact.getRootRelativePath().subFragment(1);
+        rpathRootsForExplicitSoDeps.add(
+            rpathRoot + artifactPathUnderSolib.getParentDirectory().getPathString());
+      }
     }
 
     librarySearchDirectories.add(inputArtifact.getExecPath().getParentDirectory().getPathString());


### PR DESCRIPTION
PR #14011 took care of cc_libraries. This fixes the same issue for cc_imports.

Work towards #13819.

(cherry picked from commit 8734ccf9847eafb7193388cd9c6fa78faa78283f)

Closes #14756.