### PR TITLE
config doesn't error on duplicate `--define` values

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -237,11 +237,7 @@ public class BuildConfigurationValue implements BuildConfigurationApi, SkyValue 
     // We can't use an ImmutableMap.Builder here; we need the ability to add entries with keys that
     // are already in the map so that the same define can be specified on the command line twice,
     // and ImmutableMap.Builder does not support that.
-    Map<String, String> commandLineDefinesBuilder = new TreeMap<>();
-    for (Map.Entry<String, String> define : options.commandLineBuildVariables) {
-      commandLineDefinesBuilder.put(define.getKey(), define.getValue());
-    }
-    commandLineBuildVariables = ImmutableMap.copyOf(commandLineDefinesBuilder);
+    commandLineBuildVariables = ImmutableMap.copyOf(options.getNormalizedCommandLineBuildVariables());
 
     this.actionEnv = actionEnvironment;
     this.testEnv = setupTestEnvironment();

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/ConfigCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/ConfigCommand.java
@@ -557,7 +557,7 @@ public class ConfigCommand implements BlazeCommand {
 
     // --define:
     for (Map.Entry<String, String> entry :
-        config.getOptions().get(CoreOptions.class).commandLineBuildVariables) {
+        config.getOptions().get(CoreOptions.class).getNormalizedCommandLineBuildVariables().entrySet()) {
       ans.put("--define:" + entry.getKey(), Verify.verifyNotNull(entry.getValue()));
     }
     return ans.buildOrThrow();

--- a/src/test/java/com/google/devtools/build/lib/runtime/commands/ConfigCommandTest.java
+++ b/src/test/java/com/google/devtools/build/lib/runtime/commands/ConfigCommandTest.java
@@ -426,4 +426,29 @@ public class ConfigCommandTest extends BuildIntegrationTestCase {
                 .collect(Collectors.toList()))
         .isEmpty();
   }
+
+  @Test
+  public void conflictingDefinesLastWins() throws Exception {
+    analyzeTarget("--define", "a=1", "--define", "a=2");
+
+    ConfigurationForOutput targetConfig = null;
+    for (JsonElement configJson :
+        JsonParser.parseString(callConfigCommand("--dump_all").outAsLatin1()).getAsJsonArray()) {
+      ConfigurationForOutput config = new Gson().fromJson(configJson, ConfigurationForOutput.class);
+      if (isTargetConfig(config)) {
+        targetConfig = config;
+        break;
+      }
+    }
+
+    assertThat(targetConfig).isNotNull();
+    assertThat(getOptionValue(targetConfig, "user-defined", "--define:a")).isEqualTo("2");
+    assertThat(
+        targetConfig.fragmentOptions.stream()
+            .filter(fragment -> fragment.name.endsWith("CoreOptions"))
+            .flatMap(fragment -> fragment.options.keySet().stream())
+            .filter(name -> name.equals("define"))
+            .collect(Collectors.toList()))
+        .isEmpty();
+  }
 }


### PR DESCRIPTION
When `--define` flags are interpreted by other commands, the last one
wins. Currently `bazel config` causes a server crash when interpreting
duplicate `--define` values.

This change makes `config` consistent with the other commands, and
re-uses the same deduplication code across all call-sites.