### PR TITLE
Add support for fission on android

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_cc_toolchain_config_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_cc_toolchain_config_template.txt
@@ -179,6 +179,22 @@ def _impl(ctx):
                 ],
             )
 
+    per_object_debug_info_feature = feature(
+        name = "per_object_debug_info",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-gsplit-dwarf", "-g"],
+                        expand_if_available = "per_object_debug_info_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
     unfiltered_compile_flag_sets = []
     if unfiltered_compile_flags:
       unfiltered_compile_flag_sets.append(
@@ -207,6 +223,7 @@ def _impl(ctx):
         opt_feature,
         user_compile_flags_feature,
         sysroot_feature,
+        per_object_debug_info_feature,
         unfiltered_compile_flags_feature,
     ]
 

--- a/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/mock/osx_cc_toolchain_config.bzl
@@ -7577,27 +7577,6 @@ def _impl(ctx):
     else:
         apply_default_compiler_flags_feature = None
 
-    per_object_debug_info_feature = feature(
-        name = "per_object_debug_info",
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.c_compile,
-                    ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_module_codegen,
-                    ACTION_NAMES.assemble,
-                    ACTION_NAMES.preprocess_assemble,
-                ],
-                flag_groups = [
-                    flag_group(
-                        flags = ["-gsplit-dwarf", "-g"],
-                        expand_if_available = "per_object_debug_info_file",
-                    ),
-                ],
-            ),
-        ],
-    )
-
     symbol_counts_feature = feature(
         name = "symbol_counts",
         flag_sets = [
@@ -7825,7 +7804,6 @@ def _impl(ctx):
         dependency_file_feature,
         random_seed_feature,
         pic_feature,
-        per_object_debug_info_feature,
         includes_feature,
         include_paths_feature,
         fdo_instrument_feature,

--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -1677,27 +1677,6 @@ def _impl(ctx):
         ],
     )
 
-    per_object_debug_info_feature = feature(
-        name = "per_object_debug_info",
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.c_compile,
-                    ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_module_codegen,
-                    ACTION_NAMES.assemble,
-                    ACTION_NAMES.preprocess_assemble,
-                ],
-                flag_groups = [
-                    flag_group(
-                        flags = ["-gsplit-dwarf", "-g"],
-                        expand_if_available = "per_object_debug_info_file",
-                    ),
-                ],
-            ),
-        ],
-    )
-
     lipo_feature = feature(
         name = "lipo",
         flag_sets = [
@@ -2892,7 +2871,6 @@ def _impl(ctx):
             sysroot_feature,
             dependency_file_feature,
             pic_feature,
-            per_object_debug_info_feature,
             preprocessor_defines_feature,
             framework_paths_feature,
             random_seed_feature,
@@ -2972,7 +2950,6 @@ def _impl(ctx):
             sysroot_feature,
             dependency_file_feature,
             pic_feature,
-            per_object_debug_info_feature,
             preprocessor_defines_feature,
             framework_paths_feature,
             random_seed_feature,


### PR DESCRIPTION
This change adds the per_object_debug_info feature to the android cc
toolchain to support fission.

This also removes this same feature from the macOS crosstool because
clang targeting darwin does nothing when passed this flag, which leads
to failures if you enable this for android, but are on a macOS host
because host tools fail to produce the dwo files.