### PR TITLE
[5.1] Improve documentation for select()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkLibrary.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkLibrary.java
@@ -332,8 +332,9 @@ public final class StarlarkLibrary {
               doc =
                   "A dict that maps configuration conditions to values. Each key is a "
                       + "<a href=\"$BE_ROOT/../skylark/lib/Label.html\">Label</a> or a label string"
-                      + " that identifies a config_setting, constraint_setting, or constraint_value"
-                      + " instance."),
+                      + " that identifies a config_setting or constraint_value instance. See the"
+                      + " <a href=\"$BE_ROOT/../skylark/macros.html#label-resolution-in-macros\">"
+                      + "documentation on macros</a> for when to use a Label instead of a string."),
           @Param(
               name = "no_match_error",
               defaultValue = "''",


### PR DESCRIPTION
* Reference documentation that explains when to use Label rather than a label string.
* Remove mention of constraint_settings as they can't be used as select keys.

(cherry picked from commit 67a133b431ccece22b7dd9a72f0837cff77d4360)

Closes #14722.