### PR TITLE
Enable per_object_debug_info feature by default

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -376,6 +376,7 @@ def _impl(ctx):
 
     per_object_debug_info_feature = feature(
         name = "per_object_debug_info",
+        enabled = True,
         flag_sets = [
             flag_set(
                 actions = [


### PR DESCRIPTION
This feature is used as a flag to determine that the current toolchain
supports per object file debug info, it is only consulted when
`--fission` is enabled for the current compilation mode. Previously you
had to enable fission and this flag, with this change enabling fission
by itself should be enough.

Related: https://github.com/bazelbuild/bazel/issues/11561