### PR TITLE
Add output_library_linked_resources flag to disable library.ap_ outputs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -980,6 +980,18 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
                 + " transition` with changed options to avoid potential action conflicts.")
     public boolean androidPlatformsTransitionsUpdateAffected;
 
+    @Option(
+        name = "output_library_linked_resources",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        help =
+            "If disabled, does not provide library.ap_ outputs for library targets. These files grow exponentially"
+                + " in size as their contents are merged into depending libraries, but are in a format"
+                + " consumable by devices only. Since android_binary generated the final resources.ap_ file these"
+                + " intermediates are not needed so can result in large output download savings.")
+    public boolean outputLibraryLinkedResources;
+
     @Override
     public FragmentOptions getHost() {
       Options host = (Options) super.getHost();
@@ -1065,6 +1077,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   private final boolean hwasan;
   private final boolean getJavaResourcesFromOptimizedJar;
   private final boolean includeProguardLocationReferences;
+  private final boolean outputLibraryLinkedResources;
 
   public AndroidConfiguration(BuildOptions buildOptions) throws InvalidConfigurationException {
     Options options = buildOptions.get(Options.class);
@@ -1126,6 +1139,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     this.hwasan = options.hwasan;
     this.getJavaResourcesFromOptimizedJar = options.getJavaResourcesFromOptimizedJar;
     this.includeProguardLocationReferences = options.includeProguardLocationReferences;
+    this.outputLibraryLinkedResources = options.outputLibraryLinkedResources;
 
     if (incrementalDexingShardsAfterProguard < 0) {
       throw new InvalidConfigurationException(
@@ -1409,6 +1423,10 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
 
   public boolean includeProguardLocationReferences() {
     return includeProguardLocationReferences;
+  }
+
+  public boolean outputLibraryLinkedResources() {
+    return outputLibraryLinkedResources;
   }
 
   /** Returns the label provided with --legacy_main_dex_list_generator, if any. */

--- a/src/main/java/com/google/devtools/build/lib/rules/android/ValidatedAndroidResources.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/ValidatedAndroidResources.java
@@ -33,7 +33,7 @@ public class ValidatedAndroidResources extends MergedAndroidResources
 
   private final Artifact rTxt;
   private final Artifact sourceJar;
-  private final Artifact apk;
+  @Nullable private final Artifact apk;
 
   // aapt2 outputs. Will be null if and only if aapt2 is not used for validation.
   @Nullable private final Artifact aapt2SourceJar;
@@ -67,7 +67,10 @@ public class ValidatedAndroidResources extends MergedAndroidResources
     Artifact rTxtOut = dataContext.createOutputArtifact(AndroidRuleClasses.ANDROID_R_TXT);
     Artifact sourceJarOut =
         dataContext.createOutputArtifact(AndroidRuleClasses.ANDROID_JAVA_SOURCE_JAR);
-    Artifact apkOut = dataContext.createOutputArtifact(AndroidRuleClasses.ANDROID_LIBRARY_APK);
+    Artifact apkOut =
+        dataContext.getAndroidConfig().outputLibraryLinkedResources()
+            ? dataContext.createOutputArtifact(AndroidRuleClasses.ANDROID_LIBRARY_APK)
+            : null;
 
     BusyBoxActionBuilder.create(dataContext, "LINK_STATIC_LIBRARY")
         .addAapt()
@@ -81,7 +84,7 @@ public class ValidatedAndroidResources extends MergedAndroidResources
             "--compiledDep", merged.getResourceDependencies().getTransitiveCompiledSymbols())
         .addOutput("--sourceJarOut", sourceJarOut)
         .addOutput("--rTxtOut", rTxtOut)
-        .addOutput("--staticLibraryOut", apkOut)
+        .maybeAddOutput("--staticLibraryOut", apkOut)
         .buildAndRegister("Linking static android resource library", "AndroidResourceLink");
 
     return of(
@@ -100,7 +103,7 @@ public class ValidatedAndroidResources extends MergedAndroidResources
       MergedAndroidResources merged,
       Artifact rTxt,
       Artifact sourceJar,
-      Artifact apk,
+      @Nullable Artifact apk,
       @Nullable Artifact aapt2ValidationArtifact,
       @Nullable Artifact aapt2SourceJar,
       @Nullable Artifact staticLibrary,
@@ -120,7 +123,7 @@ public class ValidatedAndroidResources extends MergedAndroidResources
       MergedAndroidResources merged,
       Artifact rTxt,
       Artifact sourceJar,
-      Artifact apk,
+      @Nullable Artifact apk,
       @Nullable Artifact aapt2ValidationArtifact,
       @Nullable Artifact aapt2SourceJar,
       @Nullable Artifact staticLibrary,
@@ -158,6 +161,7 @@ public class ValidatedAndroidResources extends MergedAndroidResources
   // TODO(b/30307842,b/119560471): remove this; it was added for no reason, but persists because
   // the Starlark API is not noneable.
   @Override
+  @Nullable
   public Artifact getApk() {
     return apk;
   }

--- a/src/tools/android/java/com/google/devtools/build/android/ValidateAndLinkResourcesAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/ValidateAndLinkResourcesAction.java
@@ -195,7 +195,7 @@ public class ValidateAndLinkResourcesAction {
           /*androidManifest=*/ XmlNode.getDefaultInstance(), resources, deps);
 
       profiler.recordEndOf("validate").startTask("link");
-      ResourceLinker.create(aapt2Options.aapt2, executorService, scopedTmp.getPath())
+      StaticLibrary staticLibrary = ResourceLinker.create(aapt2Options.aapt2, executorService, scopedTmp.getPath())
           .profileUsing(profiler)
           // NB: these names are really confusing.
           //   .dependencies is meant for linking in android.jar
@@ -204,10 +204,13 @@ public class ValidateAndLinkResourcesAction {
           .include(deps)
           .buildVersion(aapt2Options.buildToolsVersion)
           .outputAsProto(aapt2Options.resourceTableAsProto)
-          .linkStatically(resources)
-          .copyLibraryTo(options.staticLibraryOut)
+          .linkStatically(resources);
+      staticLibrary
           .copySourceJarTo(options.sourceJarOut)
           .copyRTxtTo(options.rTxtOut);
+      if (options.staticLibraryOut != null) {
+        staticLibrary.copyLibraryTo(options.staticLibraryOut);
+      }
       profiler.recordEndOf("link");
     }
   }


### PR DESCRIPTION
Reopening this https://github.com/bazelbuild/bazel/pull/11253 PR with the rebase conflicts resolved. Please refer to the original PR for the historical discussion.