### PR TITLE
Remove obvious and redundant comment from AutoCpuConverter.java

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/AutoCpuConverter.java
@@ -53,7 +53,6 @@ public class AutoCpuConverter implements Converter<String> {
             case AARCH64:
               return "arm64_windows";
             default:
-              // We only support x64 and arm64 Windows for now.
               return "unknown";
           }
         case LINUX:


### PR DESCRIPTION
See discussion here https://github.com/bazelbuild/bazel/pull/14794/files/44a8e2b06aca201f432973c8278620d6aed13372#r804823767