### PR TITLE
Fix bazel coverage false negative

### DIFF
--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -39,7 +39,10 @@ if [[ -z "$LCOV_MERGER" ]]; then
   # it.
   # TODO(cmita): Improve this situation so this early-exit isn't required.
   touch $COVERAGE_OUTPUT_FILE
-  exit 0
+  # Execute the test.
+  "$@"
+  TEST_STATUS=$?
+  exit "$TEST_STATUS"
 fi
 
 function resolve_links() {


### PR DESCRIPTION
Previously this short circuit meant the tests weren't actually run, and
they would always exit 0, in the case the test rule didn't set the lcov
related attributes.

More context: https://github.com/bazelbuild/bazel/issues/13978