### PR TITLE
Move LabelConversionContext to a new top-level class.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrModule.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrModule.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.lib.packages.AttributeValueSource;
 import com.google.devtools.build.lib.packages.BazelModuleContext;
 import com.google.devtools.build.lib.packages.BazelStarlarkContext;
 import com.google.devtools.build.lib.packages.BuildType;
+import com.google.devtools.build.lib.packages.LabelConverter;
 import com.google.devtools.build.lib.packages.Provider;
 import com.google.devtools.build.lib.packages.StarlarkAspect;
 import com.google.devtools.build.lib.packages.StarlarkCallbackHelper;
@@ -45,7 +46,6 @@ import com.google.devtools.build.lib.starlarkbuildapi.NativeComputedDefaultApi;
 import com.google.devtools.build.lib.starlarkbuildapi.StarlarkAttrModuleApi;
 import com.google.devtools.build.lib.util.FileType;
 import com.google.devtools.build.lib.util.FileTypeSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -143,13 +143,7 @@ public final class StarlarkAttrModule implements StarlarkAttrModuleApi {
         //  instance to avoid adding a dependency to the C++ package.
         builder.value((NativeComputedDefaultApi) defaultValue);
       } else {
-        BazelModuleContext moduleContext =
-            BazelModuleContext.of(Module.ofInnermostEnclosingStarlarkFunction(thread));
-        builder.defaultValue(
-            defaultValue,
-            new BuildType.LabelConversionContext(
-                moduleContext.label(), moduleContext.repoMapping(), new HashMap<>()),
-            DEFAULT_ARG);
+        builder.defaultValue(defaultValue, LabelConverter.forThread(thread), DEFAULT_ARG);
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -68,12 +68,12 @@ import com.google.devtools.build.lib.packages.BazelModuleContext;
 import com.google.devtools.build.lib.packages.BazelStarlarkContext;
 import com.google.devtools.build.lib.packages.BuildSetting;
 import com.google.devtools.build.lib.packages.BuildType;
-import com.google.devtools.build.lib.packages.BuildType.LabelConversionContext;
 import com.google.devtools.build.lib.packages.ConfigurationFragmentPolicy.MissingFragmentPolicy;
 import com.google.devtools.build.lib.packages.ExecGroup;
 import com.google.devtools.build.lib.packages.FunctionSplitTransitionAllowlist;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.StarlarkImplicitOutputsFunctionWithCallback;
 import com.google.devtools.build.lib.packages.ImplicitOutputsFunction.StarlarkImplicitOutputsFunctionWithMap;
+import com.google.devtools.build.lib.packages.LabelConverter;
 import com.google.devtools.build.lib.packages.Package.NameConflictException;
 import com.google.devtools.build.lib.packages.PackageFactory.PackageContext;
 import com.google.devtools.build.lib.packages.PredicateWithMessage;
@@ -568,17 +568,10 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi<Arti
   private static ImmutableList<Label> parseLabels(
       Iterable<String> inputs, StarlarkThread thread, String adjective) throws EvalException {
     ImmutableList.Builder<Label> parsedLabels = new ImmutableList.Builder<>();
-    BazelStarlarkContext bazelStarlarkContext = BazelStarlarkContext.from(thread);
-    BazelModuleContext moduleContext =
-        BazelModuleContext.of(Module.ofInnermostEnclosingStarlarkFunction(thread));
-    LabelConversionContext context =
-        new LabelConversionContext(
-            moduleContext.label(),
-            moduleContext.repoMapping(),
-            bazelStarlarkContext.getConvertedLabelsInPackage());
+    LabelConverter converter = LabelConverter.forThread(thread);
     for (String input : inputs) {
       try {
-        Label label = context.convert(input);
+        Label label = converter.convert(input);
         parsedLabels.add(label);
       } catch (LabelSyntaxException e) {
         throw Starlark.errorf(

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkToolchainContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkToolchainContext.java
@@ -21,13 +21,10 @@ import com.google.devtools.build.lib.analysis.platform.ToolchainInfo;
 import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
-import com.google.devtools.build.lib.packages.BazelModuleContext;
-import com.google.devtools.build.lib.packages.BazelStarlarkContext;
-import com.google.devtools.build.lib.packages.BuildType.LabelConversionContext;
+import com.google.devtools.build.lib.packages.LabelConverter;
 import com.google.devtools.build.lib.starlarkbuildapi.platform.ToolchainContextApi;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.EvalException;
-import net.starlark.java.eval.Module;
 import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkSemantics;
@@ -88,15 +85,8 @@ public abstract class StarlarkToolchainContext implements ToolchainContextApi {
       return ((ToolchainTypeInfo) key).typeLabel();
     } else if (key instanceof String) {
       try {
-        BazelStarlarkContext bazelStarlarkContext = BazelStarlarkContext.from(starlarkThread);
-        BazelModuleContext moduleContext =
-            BazelModuleContext.of(Module.ofInnermostEnclosingStarlarkFunction(starlarkThread));
-        LabelConversionContext context =
-            new LabelConversionContext(
-                moduleContext.label(),
-                moduleContext.repoMapping(),
-                bazelStarlarkContext.getConvertedLabelsInPackage());
-        return context.convert((String) key);
+        LabelConverter converter = LabelConverter.forThread(starlarkThread);
+        return converter.convert((String) key);
       } catch (LabelSyntaxException e) {
         throw Starlark.errorf("Unable to parse toolchain label '%s': %s", key, e.getMessage());
       }

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/BazelModuleResolutionFunction.java
@@ -27,7 +27,7 @@ import com.google.devtools.build.lib.bazel.bzlmod.ModuleFileValue.RootModuleFile
 import com.google.devtools.build.lib.bazel.repository.RepositoryOptions.CheckDirectDepsMode;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.events.Event;
-import com.google.devtools.build.lib.packages.BuildType.LabelConversionContext;
+import com.google.devtools.build.lib.packages.LabelConverter;
 import com.google.devtools.build.lib.server.FailureDetails.ExternalDeps.Code;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue.Precomputed;
 import com.google.devtools.build.skyframe.SkyFunction;
@@ -126,8 +126,8 @@ public class BazelModuleResolutionFunction implements SkyFunction {
     ImmutableTable.Builder<ModuleExtensionId, ModuleKey, ModuleExtensionUsage>
         extensionUsagesTableBuilder = ImmutableTable.builder();
     for (Module module : depGraph.values()) {
-      LabelConversionContext labelConversionContext =
-          new LabelConversionContext(
+      LabelConverter labelConverter =
+          new LabelConverter(
               StarlarkBazelModule.createModuleRootLabel(module.getCanonicalRepoName()),
               module.getRepoMappingWithBazelDepsOnly(),
               new HashMap<>());
@@ -135,8 +135,7 @@ public class BazelModuleResolutionFunction implements SkyFunction {
         try {
           ModuleExtensionId moduleExtensionId =
               ModuleExtensionId.create(
-                  labelConversionContext.convert(usage.getExtensionBzlFile()),
-                  usage.getExtensionName());
+                  labelConverter.convert(usage.getExtensionBzlFile()), usage.getExtensionName());
           extensionUsagesTableBuilder.put(moduleExtensionId, module.getKey(), usage);
         } catch (LabelSyntaxException e) {
           throw new BazelModuleResolutionFunctionException(

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/StarlarkBazelModule.java
@@ -22,7 +22,7 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.PackageIdentifier;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import com.google.devtools.build.lib.cmdline.RepositoryName;
-import com.google.devtools.build.lib.packages.BuildType.LabelConversionContext;
+import com.google.devtools.build.lib.packages.LabelConverter;
 import com.google.devtools.build.lib.server.FailureDetails.ExternalDeps.Code;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.ArrayList;
@@ -112,8 +112,8 @@ public class StarlarkBazelModule implements StarlarkValue {
       RepositoryMapping repoMapping,
       @Nullable ModuleExtensionUsage usage)
       throws ExternalDepsException {
-    LabelConversionContext labelConversionContext =
-        new LabelConversionContext(
+    LabelConverter labelConverter =
+        new LabelConverter(
             createModuleRootLabel(module.getCanonicalRepoName()),
             repoMapping,
             /* convertedLabelsInPackage= */ new HashMap<>());
@@ -138,7 +138,7 @@ public class StarlarkBazelModule implements StarlarkValue {
       // (for example, String to Label).
       typeCheckedTags
           .get(tag.getTagName())
-          .add(TypeCheckedTag.create(tagClass, tag, labelConversionContext));
+          .add(TypeCheckedTag.create(tagClass, tag, labelConverter));
     }
     return new StarlarkBazelModule(
         module.getName(),

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTag.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTag.java
@@ -16,7 +16,7 @@ package com.google.devtools.build.lib.bazel.bzlmod;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.devtools.build.lib.packages.Attribute;
-import com.google.devtools.build.lib.packages.BuildType.LabelConversionContext;
+import com.google.devtools.build.lib.packages.LabelConverter;
 import com.google.devtools.build.lib.packages.Type.ConversionException;
 import com.google.devtools.build.lib.server.FailureDetails.ExternalDeps.Code;
 import java.util.Map;
@@ -40,8 +40,7 @@ public class TypeCheckedTag implements Structure {
   }
 
   /** Creates a {@link TypeCheckedTag}. */
-  public static TypeCheckedTag create(
-      TagClass tagClass, Tag tag, LabelConversionContext labelConversionContext)
+  public static TypeCheckedTag create(TagClass tagClass, Tag tag, LabelConverter labelConverter)
       throws ExternalDepsException {
     Object[] attrValues = new Object[tagClass.getAttributes().size()];
     for (Map.Entry<String, Object> attrValue : tag.getAttributeValues().entrySet()) {
@@ -57,8 +56,7 @@ public class TypeCheckedTag implements Structure {
       Object nativeValue;
       try {
         nativeValue =
-            attr.getType()
-                .convert(attrValue.getValue(), attr.getPublicName(), labelConversionContext);
+            attr.getType().convert(attrValue.getValue(), attr.getPublicName(), labelConverter);
       } catch (ConversionException e) {
         throw ExternalDepsException.withCauseAndMessage(
             Code.BAD_MODULE,

--- a/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
@@ -394,14 +394,13 @@ public final class BuildType {
         // Enforce value is relative to the context.
         Label currentRule;
         RepositoryMapping repositoryMapping;
-        if (context instanceof LabelConverter) {
-          currentRule = ((LabelConverter) context).getParent();
-          repositoryMapping = ((LabelConverter) context).getRepositoryMapping();
-        } else {
+        if (!(context instanceof LabelConverter)) {
           throw new ConversionException("invalid context '" + context + "' in " + what);
         }
-        Label result = currentRule.getRelativeWithRemapping(value, repositoryMapping);
-        if (!result.getPackageIdentifier().equals(currentRule.getPackageIdentifier())) {
+
+        LabelConverter converter = (LabelConverter) context;
+        Label result = converter.convert(value);
+        if (!result.getPackageIdentifier().equals(converter.getBase().getPackageIdentifier())) {
           throw new ConversionException("label '" + value + "' is not in the current package");
         }
         return result;

--- a/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/BuildType.java
@@ -31,7 +31,6 @@ import com.google.devtools.build.lib.packages.Type.ListType;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,8 +141,7 @@ public final class BuildType {
    * <p>The caller is responsible for casting the returned value appropriately.
    */
   public static <T> Object selectableConvert(
-      Type<T> type, Object x, Object what, LabelConversionContext context)
-      throws ConversionException {
+      Type<T> type, Object x, Object what, LabelConverter context) throws ConversionException {
     if (x instanceof com.google.devtools.build.lib.packages.SelectorList) {
       return new SelectorList<>(
           ((com.google.devtools.build.lib.packages.SelectorList) x).getElements(),
@@ -152,53 +150,6 @@ public final class BuildType {
           type);
     } else {
       return type.convert(x, what, context);
-    }
-  }
-
-  /** Context in which to evaluate a label with repository remappings */
-  public static class LabelConversionContext {
-    private final Label label;
-    private final RepositoryMapping repositoryMapping;
-    private final HashMap<String, Label> convertedLabelsInPackage;
-
-    public LabelConversionContext(
-        Label label,
-        RepositoryMapping repositoryMapping,
-        HashMap<String, Label> convertedLabelsInPackage) {
-      this.label = label;
-      this.repositoryMapping = repositoryMapping;
-      this.convertedLabelsInPackage = convertedLabelsInPackage;
-    }
-
-    Label getLabel() {
-      return label;
-    }
-
-    /** Returns the Label corresponding to the input, using the current conversion context. */
-    public Label convert(String input) throws LabelSyntaxException {
-      // Optimization: First check the package-local map, avoiding Label validation, Label
-      // construction, and global Interner lookup. This approach tends to be very profitable
-      // overall, since it's common for the targets in a single package to have duplicate
-      // label-strings across all their attribute values.
-      Label converted = convertedLabelsInPackage.get(input);
-      if (converted == null) {
-        converted = label.getRelativeWithRemapping(input, repositoryMapping);
-        convertedLabelsInPackage.put(input, converted);
-      }
-      return converted;
-    }
-
-    RepositoryMapping getRepositoryMapping() {
-      return repositoryMapping;
-    }
-
-    HashMap<String, Label> getConvertedLabelsInPackage() {
-      return convertedLabelsInPackage;
-    }
-
-    @Override
-    public String toString() {
-      return label.toString();
     }
   }
 
@@ -253,9 +204,9 @@ public final class BuildType {
           // TODO(b/110308446): remove instances of context being a Label
         } else if (context instanceof Label) {
           return ((Label) context).getRelativeWithRemapping(str, ImmutableMap.of());
-        } else if (context instanceof LabelConversionContext) {
-          LabelConversionContext labelConversionContext = (LabelConversionContext) context;
-          return labelConversionContext.convert(str);
+        } else if (context instanceof LabelConverter) {
+          LabelConverter labelConverter = (LabelConverter) context;
+          return labelConverter.convert(str);
         } else {
           throw new ConversionException("invalid context '" + context + "' in " + what);
         }
@@ -443,9 +394,9 @@ public final class BuildType {
         // Enforce value is relative to the context.
         Label currentRule;
         RepositoryMapping repositoryMapping;
-        if (context instanceof LabelConversionContext) {
-          currentRule = ((LabelConversionContext) context).getLabel();
-          repositoryMapping = ((LabelConversionContext) context).getRepositoryMapping();
+        if (context instanceof LabelConverter) {
+          currentRule = ((LabelConverter) context).getParent();
+          repositoryMapping = ((LabelConverter) context).getRepositoryMapping();
         } else {
           throw new ConversionException("invalid context '" + context + "' in " + what);
         }
@@ -474,7 +425,7 @@ public final class BuildType {
 
     @VisibleForTesting
     SelectorList(
-        List<Object> x, Object what, @Nullable LabelConversionContext context, Type<T> originalType)
+        List<Object> x, Object what, @Nullable LabelConverter context, Type<T> originalType)
         throws ConversionException {
       if (x.size() > 1 && originalType.concat(ImmutableList.of()) == null) {
         throw new ConversionException(
@@ -588,10 +539,7 @@ public final class BuildType {
 
     /** Creates a new Selector using the default error message when no conditions match. */
     Selector(
-        ImmutableMap<?, ?> x,
-        Object what,
-        @Nullable LabelConversionContext context,
-        Type<T> originalType)
+        ImmutableMap<?, ?> x, Object what, @Nullable LabelConverter context, Type<T> originalType)
         throws ConversionException {
       this(x, what, context, originalType, "");
     }
@@ -600,7 +548,7 @@ public final class BuildType {
     Selector(
         ImmutableMap<?, ?> x,
         Object what,
-        @Nullable LabelConversionContext context,
+        @Nullable LabelConverter context,
         Type<T> originalType,
         String noMatchError)
         throws ConversionException {

--- a/src/main/java/com/google/devtools/build/lib/packages/LabelConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/LabelConverter.java
@@ -14,10 +14,12 @@
 
 package com.google.devtools.build.lib.packages;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
 import java.util.HashMap;
+import java.util.Map;
 import net.starlark.java.eval.Module;
 import net.starlark.java.eval.StarlarkThread;
 
@@ -34,21 +36,22 @@ public class LabelConverter {
         bazelStarlarkContext.getConvertedLabelsInPackage());
   }
 
-  private final Label parent;
+  private final Label base;
   private final RepositoryMapping repositoryMapping;
   private final HashMap<String, Label> convertedLabelsInPackage;
 
   public LabelConverter(
-      Label label,
+      Label base,
       RepositoryMapping repositoryMapping,
       HashMap<String, Label> convertedLabelsInPackage) {
-    this.parent = label;
+    this.base = base;
     this.repositoryMapping = repositoryMapping;
     this.convertedLabelsInPackage = convertedLabelsInPackage;
   }
 
-  Label getParent() {
-    return parent;
+  /** Returns the base label that relative labels will be resolved against. */
+  Label getBase() {
+    return base;
   }
 
   /** Returns the Label corresponding to the input, using the current conversion context. */
@@ -59,22 +62,19 @@ public class LabelConverter {
     // label-strings across all their attribute values.
     Label converted = convertedLabelsInPackage.get(input);
     if (converted == null) {
-      converted = parent.getRelativeWithRemapping(input, repositoryMapping);
+      converted = base.getRelativeWithRemapping(input, repositoryMapping);
       convertedLabelsInPackage.put(input, converted);
     }
     return converted;
   }
 
-  RepositoryMapping getRepositoryMapping() {
-    return repositoryMapping;
-  }
-
-  HashMap<String, Label> getConvertedLabelsInPackage() {
+  @VisibleForTesting
+  Map<String, Label> getConvertedLabelsInPackage() {
     return convertedLabelsInPackage;
   }
 
   @Override
   public String toString() {
-    return parent.toString();
+    return base.toString();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/packages/LabelConverter.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/LabelConverter.java
@@ -1,0 +1,80 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.lib.packages;
+
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import java.util.HashMap;
+import net.starlark.java.eval.Module;
+import net.starlark.java.eval.StarlarkThread;
+
+/** Class which can evaluate a label with repository remappings. */
+public class LabelConverter {
+
+  public static LabelConverter forThread(StarlarkThread thread) {
+    BazelStarlarkContext bazelStarlarkContext = BazelStarlarkContext.from(thread);
+    BazelModuleContext moduleContext =
+        BazelModuleContext.of(Module.ofInnermostEnclosingStarlarkFunction(thread));
+    return new LabelConverter(
+        moduleContext.label(),
+        moduleContext.repoMapping(),
+        bazelStarlarkContext.getConvertedLabelsInPackage());
+  }
+
+  private final Label parent;
+  private final RepositoryMapping repositoryMapping;
+  private final HashMap<String, Label> convertedLabelsInPackage;
+
+  public LabelConverter(
+      Label label,
+      RepositoryMapping repositoryMapping,
+      HashMap<String, Label> convertedLabelsInPackage) {
+    this.parent = label;
+    this.repositoryMapping = repositoryMapping;
+    this.convertedLabelsInPackage = convertedLabelsInPackage;
+  }
+
+  Label getParent() {
+    return parent;
+  }
+
+  /** Returns the Label corresponding to the input, using the current conversion context. */
+  public Label convert(String input) throws LabelSyntaxException {
+    // Optimization: First check the package-local map, avoiding Label validation, Label
+    // construction, and global Interner lookup. This approach tends to be very profitable
+    // overall, since it's common for the targets in a single package to have duplicate
+    // label-strings across all their attribute values.
+    Label converted = convertedLabelsInPackage.get(input);
+    if (converted == null) {
+      converted = parent.getRelativeWithRemapping(input, repositoryMapping);
+      convertedLabelsInPackage.put(input, converted);
+    }
+    return converted;
+  }
+
+  RepositoryMapping getRepositoryMapping() {
+    return repositoryMapping;
+  }
+
+  HashMap<String, Label> getConvertedLabelsInPackage() {
+    return convertedLabelsInPackage;
+  }
+
+  @Override
+  public String toString() {
+    return parent.toString();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleClass.java
@@ -48,7 +48,6 @@ import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.packages.Attribute.ComputedDefault;
 import com.google.devtools.build.lib.packages.Attribute.StarlarkComputedDefaultTemplate;
 import com.google.devtools.build.lib.packages.Attribute.StarlarkComputedDefaultTemplate.CannotPrecomputeDefaultsException;
-import com.google.devtools.build.lib.packages.BuildType.LabelConversionContext;
 import com.google.devtools.build.lib.packages.BuildType.SelectorList;
 import com.google.devtools.build.lib.packages.ConfigurationFragmentPolicy.MissingFragmentPolicy;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
@@ -2521,8 +2520,8 @@ public class RuleClass {
       Interner<ImmutableList<?>> listInterner,
       HashMap<String, Label> convertedLabelsInPackage)
       throws ConversionException {
-    LabelConversionContext context =
-        new LabelConversionContext(rule.getLabel(), repositoryMapping, convertedLabelsInPackage);
+    LabelConverter context =
+        new LabelConverter(rule.getLabel(), repositoryMapping, convertedLabelsInPackage);
     Object converted =
         BuildType.selectableConvert(
             attr.getType(),

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTagTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/TypeCheckedTagTest.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.Attribute.AllowedValueSet;
 import com.google.devtools.build.lib.packages.BuildType;
-import com.google.devtools.build.lib.packages.BuildType.LabelConversionContext;
+import com.google.devtools.build.lib.packages.LabelConverter;
 import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.util.FileTypeSet;
 import java.util.HashMap;
@@ -77,7 +77,7 @@ public class TypeCheckedTagTest {
                 .addAttr(
                     "foo", StarlarkList.immutableOf(":thing1", "//pkg:thing2", "@repo//pkg:thing3"))
                 .build(),
-            new LabelConversionContext(
+            new LabelConverter(
                 Label.parseAbsoluteUnchecked("@myrepo//mypkg:defs.bzl"),
                 createRepositoryMapping(createModuleKey("test", "1.0"), "repo", "other_repo"),
                 new HashMap<>()));
@@ -97,7 +97,7 @@ public class TypeCheckedTagTest {
             createTagClass(
                 attr("foo", BuildType.LABEL).allowedFileTypes(FileTypeSet.ANY_FILE).build()),
             buildTag("tag_name").build(),
-            new LabelConversionContext(
+            new LabelConverter(
                 Label.parseAbsoluteUnchecked("@myrepo//mypkg:defs.bzl"),
                 createRepositoryMapping(createModuleKey("test", "1.0"), "repo", "other_repo"),
                 new HashMap<>()));

--- a/src/test/java/com/google/devtools/build/lib/packages/BuildTypeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/BuildTypeTest.java
@@ -20,8 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.RepositoryMapping;
-import com.google.devtools.build.lib.cmdline.RepositoryName;
-import com.google.devtools.build.lib.packages.BuildType.LabelConversionContext;
 import com.google.devtools.build.lib.packages.BuildType.Selector;
 import com.google.devtools.build.lib.packages.Type.ConversionException;
 import java.util.ArrayList;
@@ -40,8 +38,8 @@ import org.junit.runners.JUnit4;
 public final class BuildTypeTest {
 
   private final Label currentRule = Label.parseAbsoluteUnchecked("//quux:baz");
-  private final LabelConversionContext labelConversionContext =
-      new LabelConversionContext(
+  private final LabelConverter labelConversionContext =
+      new LabelConverter(
           currentRule,
           RepositoryMapping.ALWAYS_FALLBACK,
           /*convertedLabelsInPackage=*/ new HashMap<>());
@@ -265,28 +263,6 @@ public final class BuildTypeTest {
         .containsExactlyElementsIn(expected);
   }
 
-  @Test
-  public void testLabelWithRemapping() throws Exception {
-    LabelConversionContext context =
-        new LabelConversionContext(
-            currentRule,
-            RepositoryMapping.createAllowingFallback(
-                ImmutableMap.of(
-                    RepositoryName.create("@orig_repo"), RepositoryName.create("@new_repo"))),
-            /* convertedLabelsInPackage= */ new HashMap<>());
-    Label label = BuildType.LABEL.convert("@orig_repo//foo:bar", null, context);
-    assertThat(label)
-        .isEquivalentAccordingToCompareTo(
-            Label.parseAbsolute("@new_repo//foo:bar", ImmutableMap.of()));
-  }
-
-  @Test
-  public void testLabelConversionContextCaches() throws ConversionException {
-    assertThat(labelConversionContext.getConvertedLabelsInPackage())
-        .doesNotContainKey("//some:label");
-    BuildType.LABEL.convert("//some:label", "doesntmatter", labelConversionContext);
-    assertThat(labelConversionContext.getConvertedLabelsInPackage()).containsKey("//some:label");
-  }
 
   /**
    * Tests basic {@link Selector} functionality.

--- a/src/test/java/com/google/devtools/build/lib/packages/LabelConverterTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/LabelConverterTest.java
@@ -1,0 +1,60 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.packages;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.cmdline.RepositoryMapping;
+import com.google.devtools.build.lib.cmdline.RepositoryName;
+import com.google.devtools.build.lib.packages.Type.ConversionException;
+import java.util.HashMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test of {@link LabelConverter}. */
+@RunWith(JUnit4.class)
+public class LabelConverterTest {
+  private final Label currentRule = Label.parseAbsoluteUnchecked("//quux:baz");
+
+  @Test
+  public void testLabelWithRemapping() throws Exception {
+    LabelConverter context =
+        new LabelConverter(
+            currentRule,
+            RepositoryMapping.createAllowingFallback(
+                ImmutableMap.of(
+                    RepositoryName.create("@orig_repo"), RepositoryName.create("@new_repo"))),
+            /* convertedLabelsInPackage= */ new HashMap<>());
+    Label label = BuildType.LABEL.convert("@orig_repo//foo:bar", null, context);
+    assertThat(label)
+        .isEquivalentAccordingToCompareTo(
+            Label.parseAbsolute("@new_repo//foo:bar", ImmutableMap.of()));
+  }
+
+  @Test
+  public void testLabelConversionContextCaches() throws ConversionException {
+    LabelConverter labelConverter =
+        new LabelConverter(
+            currentRule,
+            RepositoryMapping.ALWAYS_FALLBACK,
+            /*convertedLabelsInPackage=*/ new HashMap<>());
+
+    assertThat(labelConverter.getConvertedLabelsInPackage()).doesNotContainKey("//some:label");
+    BuildType.LABEL.convert("//some:label", "doesntmatter", labelConverter);
+    assertThat(labelConverter.getConvertedLabelsInPackage()).containsKey("//some:label");
+  }
+}


### PR DESCRIPTION
Also add a convenience method to create a label converter for a starlark
thread.

This makes it more easily available for other uses.

Part of Optional Toolchains (#14726).