### PR TITLE
[5.1] Ignore missing include directory in JDK distribution.

### DIFF
--- a/tools/jdk/jdk.BUILD
+++ b/tools/jdk/jdk.BUILD
@@ -165,15 +165,12 @@ filegroup(
 #This folder holds security policies
 filegroup(
     name = "jdk-conf",
-    srcs = glob(
-        ["conf/**"],
-        allow_empty = True,
-    ),
+    srcs = glob(["conf/**"], allow_empty = True),
 )
 
 filegroup(
     name = "jdk-include",
-    srcs = glob(["include/**"]),
+    srcs = glob(["include/**"], allow_empty = True),
 )
 
 filegroup(


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/14646

(cherry picked from commit c2ddbd1954af5baab63b93f2b055a410a27832c8)

Closes #14831.