### PR TITLE
Let Starlark tests inherit env variables

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/AbstractAction.java
@@ -699,7 +699,7 @@ public abstract class AbstractAction extends ActionKeyCacher implements Action, 
 
   @Override
   public Dict<String, String> getEnv() {
-    return Dict.immutableCopyOf(env.getFixedEnv().toMap());
+    return Dict.immutableCopyOf(env.getFixedEnv());
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
@@ -186,6 +186,23 @@ public final class ActionEnvironment {
     return new ActionEnvironment(new CompoundEnvironmentVariables(vars, fixedEnv), inheritedEnv);
   }
 
+  /**
+   * Returns a copy of the environment with the given fixed and inherited variables added to it,
+   * <em>overwriting any existing occurrences of those variables</em>.
+   */
+  public ActionEnvironment addVariables(Map<String, String> vars, Set<String> inheritedVars) {
+    if (inheritedVars.isEmpty()) {
+      return addFixedVariables(vars);
+    } else {
+      // TODO: inheritedEnv is currently not optimized for allocation avoidance in the same way as
+      //  fixedEnv.
+      ImmutableSet<String> newInheritedEnv = ImmutableSet.<String>builder().addAll(inheritedEnv)
+          .addAll(inheritedVars).build();
+      return new ActionEnvironment(new CompoundEnvironmentVariables(vars, fixedEnv),
+          newInheritedEnv);
+    }
+  }
+
   /** Returns the combined size of the fixed and inherited environments. */
   public int size() {
     return fixedEnv.size() + inheritedEnv.size();

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
@@ -85,8 +85,8 @@ public final class ActionEnvironment {
 
     static EnvironmentVariables create(Map<String, String> fixedVars, Set<String> inheritedVars,
         EnvironmentVariables base) {
-      if (fixedVars.isEmpty() && inheritedVars.isEmpty() && base.isEmpty()) {
-        return EMPTY_ENVIRONMENT_VARIABLES;
+      if (fixedVars.isEmpty() && inheritedVars.isEmpty()) {
+        return base;
       }
       return new CompoundEnvironmentVariables(fixedVars, inheritedVars, base);
     }
@@ -234,8 +234,12 @@ public final class ActionEnvironment {
    */
   public ActionEnvironment withAdditionalVariables(Map<String, String> fixedVars,
       Set<String> inheritedVars) {
-    return ActionEnvironment.create(
-        CompoundEnvironmentVariables.create(fixedVars, inheritedVars, vars));
+    EnvironmentVariables newVars = CompoundEnvironmentVariables.create(fixedVars, inheritedVars,
+        vars);
+    if (newVars == vars) {
+      return this;
+    }
+    return ActionEnvironment.create(newVars);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.util.Fingerprint;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -45,23 +46,34 @@ import java.util.TreeSet;
  */
 public final class ActionEnvironment {
 
-  /** A map of environment variables. */
+  /**
+   * A map of environment variables together with a list of variables to inherit from the shell
+   * environment.
+   */
   public interface EnvironmentVariables {
 
     /**
-     * Returns the environment variables as a map.
+     * Returns the fixed environment variables as a map.
      *
-     * <p>WARNING: this allocations additional objects if the underlying implementation is a {@link
+     * <p>WARNING: this allocates additional objects if the underlying implementation is a {@link
      * CompoundEnvironmentVariables}; use sparingly.
      */
-    ImmutableMap<String, String> toMap();
+    ImmutableMap<String, String> getFixedEnvironment();
+
+    /**
+     * Returns the inherited environment variables as a set.
+     *
+     * <p>WARNING: this allocates additional objects if the underlying implementation is a {@link
+     * CompoundEnvironmentVariables}; use sparingly.
+     */
+    ImmutableSet<String> getInheritedEnvironment();
 
     default boolean isEmpty() {
-      return toMap().isEmpty();
+      return getFixedEnvironment().isEmpty() && getInheritedEnvironment().isEmpty();
     }
 
     default int size() {
-      return toMap().size();
+      return getFixedEnvironment().size() + getInheritedEnvironment().size();
     }
   }
 
@@ -70,11 +82,21 @@ public final class ActionEnvironment {
    * allocation a new map.
    */
   static class CompoundEnvironmentVariables implements EnvironmentVariables {
+
+    static EnvironmentVariables create(Map<String, String> fixedVars, Set<String> inheritedVars,
+        EnvironmentVariables base) {
+      if (fixedVars.isEmpty() && inheritedVars.isEmpty() && base.isEmpty()) {
+        return EMPTY_ENVIRONMENT_VARIABLES;
+      }
+      return new CompoundEnvironmentVariables(fixedVars, inheritedVars, base);
+    }
+
     private final EnvironmentVariables current;
     private final EnvironmentVariables base;
 
-    CompoundEnvironmentVariables(Map<String, String> vars, EnvironmentVariables base) {
-      this.current = new SimpleEnvironmentVariables(vars);
+    private CompoundEnvironmentVariables(Map<String, String> fixedVars, Set<String> inheritedVars,
+        EnvironmentVariables base) {
+      this.current = SimpleEnvironmentVariables.create(fixedVars, inheritedVars);
       this.base = base;
     }
 
@@ -84,39 +106,58 @@ public final class ActionEnvironment {
     }
 
     @Override
-    public ImmutableMap<String, String> toMap() {
+    public ImmutableMap<String, String> getFixedEnvironment() {
       Map<String, String> result = new LinkedHashMap<>();
-      result.putAll(base.toMap());
-      result.putAll(current.toMap());
+      result.putAll(base.getFixedEnvironment());
+      result.putAll(current.getFixedEnvironment());
       return ImmutableMap.copyOf(result);
-    }
-  }
-
-  /** A simple {@link EnvironmentVariables}. */
-  static class SimpleEnvironmentVariables implements EnvironmentVariables {
-
-    static EnvironmentVariables create(Map<String, String> vars) {
-      if (vars.isEmpty()) {
-        return EMPTY_ENVIRONMENT_VARIABLES;
-      }
-      return new SimpleEnvironmentVariables(vars);
-    }
-
-    private final ImmutableMap<String, String> vars;
-
-    private SimpleEnvironmentVariables(Map<String, String> vars) {
-      this.vars = ImmutableMap.copyOf(vars);
     }
 
     @Override
-    public ImmutableMap<String, String> toMap() {
-      return vars;
+    public ImmutableSet<String> getInheritedEnvironment() {
+      Set<String> result = new LinkedHashSet<>();
+      result.addAll(base.getInheritedEnvironment());
+      result.addAll(current.getInheritedEnvironment());
+      return ImmutableSet.copyOf(result);
     }
   }
 
-  /** An empty {@link EnvironmentVariables}. */
+  /**
+   * A simple {@link EnvironmentVariables}.
+   */
+  static class SimpleEnvironmentVariables implements EnvironmentVariables {
+
+    static EnvironmentVariables create(Map<String, String> fixedVars, Set<String> inheritedVars) {
+      if (fixedVars.isEmpty() && inheritedVars.isEmpty()) {
+        return EMPTY_ENVIRONMENT_VARIABLES;
+      }
+      return new SimpleEnvironmentVariables(fixedVars, inheritedVars);
+    }
+
+    private final ImmutableMap<String, String> fixedVars;
+    private final ImmutableSet<String> inheritedVars;
+
+    private SimpleEnvironmentVariables(Map<String, String> fixedVars, Set<String> inheritedVars) {
+      this.fixedVars = ImmutableMap.copyOf(fixedVars);
+      this.inheritedVars = ImmutableSet.copyOf(inheritedVars);
+    }
+
+    @Override
+    public ImmutableMap<String, String> getFixedEnvironment() {
+      return fixedVars;
+    }
+
+    @Override
+    public ImmutableSet<String> getInheritedEnvironment() {
+      return inheritedVars;
+    }
+  }
+
+  /**
+   * An empty {@link EnvironmentVariables}.
+   */
   public static final EnvironmentVariables EMPTY_ENVIRONMENT_VARIABLES =
-      new SimpleEnvironmentVariables(ImmutableMap.of());
+      new SimpleEnvironmentVariables(ImmutableMap.of(), ImmutableSet.of());
 
   /**
    * An empty environment, mainly for testing. Production code should never use this, but instead
@@ -124,8 +165,7 @@ public final class ActionEnvironment {
    */
   // TODO(ulfjack): Migrate all production code to use the proper action environment, and then make
   // this @VisibleForTesting or rename it to clarify.
-  public static final ActionEnvironment EMPTY =
-      new ActionEnvironment(EMPTY_ENVIRONMENT_VARIABLES, ImmutableSet.of());
+  public static final ActionEnvironment EMPTY = new ActionEnvironment(EMPTY_ENVIRONMENT_VARIABLES);
 
   /**
    * Splits the given map into a map of variables with a fixed value, and a set of variables that
@@ -145,15 +185,13 @@ public final class ActionEnvironment {
         inheritedEnv.add(key);
       }
     }
-    return create(new SimpleEnvironmentVariables(fixedEnv), ImmutableSet.copyOf(inheritedEnv));
+    return create(SimpleEnvironmentVariables.create(fixedEnv, inheritedEnv));
   }
 
-  private final EnvironmentVariables fixedEnv;
-  private final ImmutableSet<String> inheritedEnv;
+  private final EnvironmentVariables vars;
 
-  private ActionEnvironment(EnvironmentVariables fixedEnv, ImmutableSet<String> inheritedEnv) {
-    this.fixedEnv = fixedEnv;
-    this.inheritedEnv = inheritedEnv;
+  private ActionEnvironment(EnvironmentVariables vars) {
+    this.vars = vars;
   }
 
   /**
@@ -161,51 +199,46 @@ public final class ActionEnvironment {
    * undefined, so callers need to take care that the key set of the {@code fixedEnv} map and the
    * set of {@code inheritedEnv} elements are disjoint.
    */
-  private static ActionEnvironment create(
-      EnvironmentVariables fixedEnv, ImmutableSet<String> inheritedEnv) {
-    if (fixedEnv.isEmpty() && inheritedEnv.isEmpty()) {
+  private static ActionEnvironment create(EnvironmentVariables vars) {
+    if (vars.isEmpty()) {
       return EMPTY;
     }
-    return new ActionEnvironment(fixedEnv, inheritedEnv);
+    return new ActionEnvironment(vars);
   }
 
   public static ActionEnvironment create(
       Map<String, String> fixedEnv, ImmutableSet<String> inheritedEnv) {
-    return new ActionEnvironment(SimpleEnvironmentVariables.create(fixedEnv), inheritedEnv);
+    return ActionEnvironment.create(SimpleEnvironmentVariables.create(fixedEnv, inheritedEnv));
   }
 
   public static ActionEnvironment create(Map<String, String> fixedEnv) {
-    return new ActionEnvironment(new SimpleEnvironmentVariables(fixedEnv), ImmutableSet.of());
+    return ActionEnvironment.create(SimpleEnvironmentVariables.create(fixedEnv, ImmutableSet.of()));
   }
 
   /**
    * Returns a copy of the environment with the given fixed variables added to it, <em>overwriting
    * any existing occurrences of those variables</em>.
    */
-  public ActionEnvironment addFixedVariables(Map<String, String> vars) {
-    return new ActionEnvironment(new CompoundEnvironmentVariables(vars, fixedEnv), inheritedEnv);
+  public ActionEnvironment addFixedVariables(Map<String, String> fixedVars) {
+    return ActionEnvironment.create(
+        CompoundEnvironmentVariables.create(fixedVars, ImmutableSet.of(),
+            vars));
   }
 
   /**
    * Returns a copy of the environment with the given fixed and inherited variables added to it,
    * <em>overwriting any existing occurrences of those variables</em>.
    */
-  public ActionEnvironment addVariables(Map<String, String> vars, Set<String> inheritedVars) {
-    if (inheritedVars.isEmpty()) {
-      return addFixedVariables(vars);
-    } else {
-      // TODO: inheritedEnv is currently not optimized for allocation avoidance in the same way as
-      //  fixedEnv.
-      ImmutableSet<String> newInheritedEnv = ImmutableSet.<String>builder().addAll(inheritedEnv)
-          .addAll(inheritedVars).build();
-      return new ActionEnvironment(new CompoundEnvironmentVariables(vars, fixedEnv),
-          newInheritedEnv);
-    }
+  public ActionEnvironment addVariables(Map<String, String> fixedVars, Set<String> inheritedVars) {
+    return ActionEnvironment.create(
+        CompoundEnvironmentVariables.create(fixedVars, inheritedVars, vars));
   }
 
-  /** Returns the combined size of the fixed and inherited environments. */
+  /**
+   * Returns the combined size of the fixed and inherited environments.
+   */
   public int size() {
-    return fixedEnv.size() + inheritedEnv.size();
+    return vars.size();
   }
 
   /**
@@ -213,8 +246,8 @@ public final class ActionEnvironment {
    * fixed values and their values. This should only be used for testing and to compute the cache
    * keys of actions. Use {@link #resolve} instead to get the complete environment.
    */
-  public EnvironmentVariables getFixedEnv() {
-    return fixedEnv;
+  public ImmutableMap<String, String> getFixedEnv() {
+    return vars.getFixedEnvironment();
   }
 
   /**
@@ -224,7 +257,7 @@ public final class ActionEnvironment {
    * get the complete environment.
    */
   public ImmutableSet<String> getInheritedEnv() {
-    return inheritedEnv;
+    return vars.getInheritedEnvironment();
   }
 
   /**
@@ -235,8 +268,8 @@ public final class ActionEnvironment {
    */
   public void resolve(Map<String, String> result, Map<String, String> clientEnv) {
     checkNotNull(clientEnv);
-    result.putAll(fixedEnv.toMap());
-    for (String var : inheritedEnv) {
+    result.putAll(vars.getFixedEnvironment());
+    for (String var : vars.getInheritedEnvironment()) {
       String value = clientEnv.get(var);
       if (value != null) {
         result.put(var, value);
@@ -245,7 +278,7 @@ public final class ActionEnvironment {
   }
 
   public void addTo(Fingerprint f) {
-    f.addStringMap(fixedEnv.toMap());
-    f.addStrings(inheritedEnv);
+    f.addStringMap(vars.getFixedEnvironment());
+    f.addStrings(vars.getInheritedEnvironment());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
@@ -47,8 +47,8 @@ import java.util.TreeSet;
 public final class ActionEnvironment {
 
   /**
-   * A map of environment variables together with a list of variables to inherit from the shell
-   * environment.
+   * A map of environment variables and their values together with a list of variables whose values
+   * should be inherited from the client environment.
    */
   public interface EnvironmentVariables {
 
@@ -79,7 +79,7 @@ public final class ActionEnvironment {
 
   /**
    * An {@link EnvironmentVariables} that combines variables from two different environments without
-   * allocation a new map.
+   * allocating a new map.
    */
   static class CompoundEnvironmentVariables implements EnvironmentVariables {
 
@@ -173,8 +173,6 @@ public final class ActionEnvironment {
    * given map. Returns these two parts as a new {@link ActionEnvironment} instance.
    */
   public static ActionEnvironment split(Map<String, String> env) {
-    // Care needs to be taken that the two sets don't overlap - the order in which the two parts are
-    // combined later is undefined.
     Map<String, String> fixedEnv = new TreeMap<>();
     Set<String> inheritedEnv = new TreeSet<>();
     for (Map.Entry<String, String> entry : env.entrySet()) {
@@ -195,9 +193,10 @@ public final class ActionEnvironment {
   }
 
   /**
-   * Creates a new action environment. The order in which the environments are combined is
-   * undefined, so callers need to take care that the key set of the {@code fixedEnv} map and the
-   * set of {@code inheritedEnv} elements are disjoint.
+   * Creates a new action environment. If an environment variable is contained in both {@link
+   * EnvironmentVariables#getFixedEnvironment()} and {@link EnvironmentVariables#getInheritedEnvironment()},
+   * the result of {@link ActionEnvironment#resolve(Map, Map)} will contain the value inherited from
+   * the client environment.
    */
   private static ActionEnvironment create(EnvironmentVariables vars) {
     if (vars.isEmpty()) {
@@ -206,6 +205,12 @@ public final class ActionEnvironment {
     return new ActionEnvironment(vars);
   }
 
+  /**
+   * Creates a new action environment. If an environment variable is contained both as a key in
+   * {@code fixedEnv} and in {@code inheritedEnv}, the result of {@link
+   * ActionEnvironment#resolve(Map, Map)} will contain the value inherited from the client
+   * environment.
+   */
   public static ActionEnvironment create(
       Map<String, String> fixedEnv, ImmutableSet<String> inheritedEnv) {
     return ActionEnvironment.create(SimpleEnvironmentVariables.create(fixedEnv, inheritedEnv));
@@ -219,23 +224,24 @@ public final class ActionEnvironment {
    * Returns a copy of the environment with the given fixed variables added to it, <em>overwriting
    * any existing occurrences of those variables</em>.
    */
-  public ActionEnvironment addFixedVariables(Map<String, String> fixedVars) {
-    return ActionEnvironment.create(
-        CompoundEnvironmentVariables.create(fixedVars, ImmutableSet.of(),
-            vars));
+  public ActionEnvironment withAdditionalFixedVariables(Map<String, String> fixedVars) {
+    return withAdditionalVariables(fixedVars, ImmutableSet.of());
   }
 
   /**
    * Returns a copy of the environment with the given fixed and inherited variables added to it,
    * <em>overwriting any existing occurrences of those variables</em>.
    */
-  public ActionEnvironment addVariables(Map<String, String> fixedVars, Set<String> inheritedVars) {
+  public ActionEnvironment withAdditionalVariables(Map<String, String> fixedVars,
+      Set<String> inheritedVars) {
     return ActionEnvironment.create(
         CompoundEnvironmentVariables.create(fixedVars, inheritedVars, vars));
   }
 
   /**
-   * Returns the combined size of the fixed and inherited environments.
+   * Returns an upper bound on the combined size of the fixed and inherited environments. A call to
+   * {@link ActionEnvironment#resolve(Map, Map)} may add less entries than this number if
+   * environment variables are contained in both the fixed and the inherited environment.
    */
   public int size() {
     return vars.size();

--- a/src/main/java/com/google/devtools/build/lib/analysis/RuleConfiguredTargetBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/RuleConfiguredTargetBuilder.java
@@ -475,6 +475,7 @@ public final class RuleConfiguredTargetBuilder {
             providersBuilder.getProvider(TestEnvironmentInfo.PROVIDER.getKey());
     if (environmentProvider != null) {
       testActionBuilder.addExtraEnv(environmentProvider.getEnvironment());
+      testActionBuilder.addExtraInheritedEnv(environmentProvider.getInheritedEnvironment());
     }
 
     TestParams testParams =

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -465,7 +465,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     StringBuilder message = new StringBuilder();
     message.append(getProgressMessage());
     message.append('\n');
-    for (Map.Entry<String, String> entry : env.getFixedEnv().toMap().entrySet()) {
+    for (Map.Entry<String, String> entry : env.getFixedEnv().entrySet()) {
       message.append("  Environment variable: ");
       message.append(ShellEscaper.escapeString(entry.getKey()));
       message.append('=');
@@ -574,7 +574,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     // ActionEnvironment to avoid developers misunderstanding the purpose of this method. That
     // requires first updating all subclasses and callers to actually handle environments correctly,
     // so it's not a small change.
-    return env.getFixedEnv().toMap();
+    return env.getFixedEnv();
   }
 
   /** Returns the out-of-band execution data for this action. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -485,7 +485,7 @@ public class BuildConfigurationValue implements BuildConfigurationApi, SkyValue 
    */
   @Override
   public ImmutableMap<String, String> getLocalShellEnvironment() {
-    return actionEnv.getFixedEnv().toMap();
+    return actionEnv.getFixedEnv();
   }
 
   /**
@@ -629,7 +629,7 @@ public class BuildConfigurationValue implements BuildConfigurationApi, SkyValue 
    */
   @Override
   public ImmutableMap<String, String> getTestEnv() {
-    return testEnv.getFixedEnv().toMap();
+    return testEnv.getFixedEnv();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -411,7 +411,7 @@ public final class TestActionBuilder {
                 coverageArtifact,
                 coverageDirectory,
                 testProperties,
-                runfilesSupport.getActionEnvironment().addVariables(extraTestEnv, extraInheritedEnv),
+                runfilesSupport.getActionEnvironment().withAdditionalVariables(extraTestEnv, extraInheritedEnv),
                 executionSettings,
                 shard,
                 run,

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -54,7 +54,9 @@ import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import javax.annotation.Nullable;
 
 /**
@@ -94,10 +96,12 @@ public final class TestActionBuilder {
   private InstrumentedFilesInfo instrumentedFiles;
   private int explicitShardCount;
   private final Map<String, String> extraEnv;
+  private final Set<String> extraInheritedEnv;
 
   public TestActionBuilder(RuleContext ruleContext) {
     this.ruleContext = ruleContext;
     this.extraEnv = new TreeMap<>();
+    this.extraInheritedEnv = new TreeSet<>();
     this.additionalTools = new ImmutableList.Builder<>();
   }
 
@@ -144,6 +148,11 @@ public final class TestActionBuilder {
 
   public TestActionBuilder addExtraEnv(Map<String, String> extraEnv) {
     this.extraEnv.putAll(extraEnv);
+    return this;
+  }
+
+  public TestActionBuilder addExtraInheritedEnv(List<String> extraInheritedEnv) {
+    this.extraInheritedEnv.addAll(extraInheritedEnv);
     return this;
   }
 
@@ -402,7 +411,7 @@ public final class TestActionBuilder {
                 coverageArtifact,
                 coverageDirectory,
                 testProperties,
-                runfilesSupport.getActionEnvironment().addFixedVariables(extraTestEnv),
+                runfilesSupport.getActionEnvironment().addVariables(extraTestEnv, extraInheritedEnv),
                 executionSettings,
                 shard,
                 run,

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestEnvironmentInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestEnvironmentInfo.java
@@ -15,6 +15,8 @@
 package com.google.devtools.build.lib.analysis.test;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.BuiltinProvider;
 import com.google.devtools.build.lib.packages.NativeInfo;
@@ -30,13 +32,14 @@ public final class TestEnvironmentInfo extends NativeInfo implements TestEnviron
   public static final BuiltinProvider<TestEnvironmentInfo> PROVIDER =
       new BuiltinProvider<TestEnvironmentInfo>("TestEnvironment", TestEnvironmentInfo.class) {};
 
-  private final Map<String, String> environment;
-  private final List<String> inheritedEnvironment;
+  private final ImmutableMap<String, String> environment;
+  private final ImmutableList<String> inheritedEnvironment;
 
   /** Constructs a new provider with the given fixed and inherited environment variables. */
   public TestEnvironmentInfo(Map<String, String> environment, List<String> inheritedEnvironment) {
-    this.environment = Preconditions.checkNotNull(environment);
-    this.inheritedEnvironment = Preconditions.checkNotNull(inheritedEnvironment);
+    this.environment = ImmutableMap.copyOf(Preconditions.checkNotNull(environment));
+    this.inheritedEnvironment = ImmutableList.copyOf(
+        Preconditions.checkNotNull(inheritedEnvironment));
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestEnvironmentInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestEnvironmentInfo.java
@@ -19,6 +19,7 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.BuiltinProvider;
 import com.google.devtools.build.lib.packages.NativeInfo;
 import com.google.devtools.build.lib.starlarkbuildapi.test.TestEnvironmentInfoApi;
+import java.util.List;
 import java.util.Map;
 
 /** Provider containing any additional environment variables for use in the test action. */
@@ -30,10 +31,12 @@ public final class TestEnvironmentInfo extends NativeInfo implements TestEnviron
       new BuiltinProvider<TestEnvironmentInfo>("TestEnvironment", TestEnvironmentInfo.class) {};
 
   private final Map<String, String> environment;
+  private final List<String> inheritedEnvironment;
 
-  /** Constructs a new provider with the given variable name to variable value mapping. */
-  public TestEnvironmentInfo(Map<String, String> environment) {
+  /** Constructs a new provider with the given fixed and inherited environment variables. */
+  public TestEnvironmentInfo(Map<String, String> environment, List<String> inheritedEnvironment) {
     this.environment = Preconditions.checkNotNull(environment);
+    this.inheritedEnvironment = Preconditions.checkNotNull(inheritedEnvironment);
   }
 
   @Override
@@ -47,5 +50,13 @@ public final class TestEnvironmentInfo extends NativeInfo implements TestEnviron
   @Override
   public Map<String, String> getEnvironment() {
     return environment;
+  }
+
+  /**
+   * Returns names of environment variables whose value should be obtained from the environment.
+   */
+  @Override
+  public List<String> getInheritedEnvironment() {
+    return inheritedEnvironment;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -1045,7 +1045,7 @@ public class TestRunnerAction extends AbstractAction
   @Override
   public ImmutableMap<String, String> getIncompleteEnvironmentForTesting()
       throws ActionExecutionException {
-    return getEnvironment().getFixedEnv().toMap();
+    return getEnvironment().getFixedEnv();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -221,7 +221,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
       // TODO(twerth): This handles the fixed environment. We probably want to output the inherited
       // environment as well.
       Iterable<Map.Entry<String, String>> fixedEnvironment =
-          abstractAction.getEnvironment().getFixedEnv().toMap().entrySet();
+          abstractAction.getEnvironment().getFixedEnv().entrySet();
       if (!Iterables.isEmpty(fixedEnvironment)) {
         stringBuilder
             .append("  Environment: [")

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileAction.java
@@ -614,7 +614,7 @@ public final class JavaCompileAction extends AbstractAction implements CommandAc
     // ActionEnvironment to avoid developers misunderstanding the purpose of this method. That
     // requires first updating all subclasses and callers to actually handle environments correctly,
     // so it's not a small change.
-    return env.getFixedEnv().toMap();
+    return env.getFixedEnv();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
@@ -205,7 +205,7 @@ public final class JavaCompileActionBuilder {
     toolsBuilder.addTransitive(toolsJars);
 
     ActionEnvironment actionEnvironment =
-        ruleContext.getConfiguration().getActionEnvironment().addFixedVariables(UTF8_ENVIRONMENT);
+        ruleContext.getConfiguration().getActionEnvironment().withAdditionalFixedVariables(UTF8_ENVIRONMENT);
 
     NestedSetBuilder<Artifact> mandatoryInputsBuilder = NestedSetBuilder.stableOrder();
     mandatoryInputsBuilder

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileActionBuilder.java
@@ -296,7 +296,7 @@ public class JavaHeaderCompileActionBuilder {
     }
 
     ActionEnvironment actionEnvironment =
-        ruleContext.getConfiguration().getActionEnvironment().addFixedVariables(UTF8_ENVIRONMENT);
+        ruleContext.getConfiguration().getActionEnvironment().withAdditionalFixedVariables(UTF8_ENVIRONMENT);
 
     OnDemandString progressMessage =
         new ProgressMessage(

--- a/src/main/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModule.java
@@ -18,6 +18,8 @@ import com.google.devtools.build.lib.analysis.test.TestEnvironmentInfo;
 import com.google.devtools.build.lib.starlarkbuildapi.test.TestingModuleApi;
 import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Sequence;
+import net.starlark.java.eval.StarlarkList;
 
 /** A class that exposes testing infrastructure to Starlark. */
 public class StarlarkTestingModule implements TestingModuleApi {
@@ -29,9 +31,12 @@ public class StarlarkTestingModule implements TestingModuleApi {
   }
 
   @Override
-  public TestEnvironmentInfo testEnvironment(Dict<?, ?> environment /* <String, String> */)
+  public TestEnvironmentInfo testEnvironment(Dict<?, ?> environment /* <String, String> */,
+      Sequence<?> inheritedEnvironment /* <String> */)
       throws EvalException {
     return new TestEnvironmentInfo(
-        Dict.cast(environment, String.class, String.class, "environment"));
+        Dict.cast(environment, String.class, String.class, "environment"),
+        StarlarkList.immutableCopyOf(
+            Sequence.cast(inheritedEnvironment, String.class, "inherited_environment")));
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/actiongraph/v2/ActionGraphDump.java
@@ -161,7 +161,7 @@ public class ActionGraphDump {
       SpawnAction spawnAction = (SpawnAction) action;
       // TODO(twerth): This handles the fixed environment. We probably want to output the inherited
       // environment as well.
-      Map<String, String> fixedEnvironment = spawnAction.getEnvironment().getFixedEnv().toMap();
+      Map<String, String> fixedEnvironment = spawnAction.getEnvironment().getFixedEnv();
       for (Map.Entry<String, String> environmentVariable : fixedEnvironment.entrySet()) {
         actionBuilder.addEnvironmentVariables(
             AnalysisProtosV2.KeyValuePair.newBuilder()

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/TestEnvironmentInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/TestEnvironmentInfoApi.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.starlarkbuildapi.test;
 
 import com.google.devtools.build.lib.starlarkbuildapi.core.StructApi;
+import java.util.List;
 import java.util.Map;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
@@ -28,4 +29,10 @@ public interface TestEnvironmentInfoApi extends StructApi {
       doc = "A dict containing environment variables which should be set on the test action.",
       structField = true)
   Map<String, String> getEnvironment();
+
+  @StarlarkMethod(
+      name = "inherited_environment",
+      doc = "A list of variables that the test action should inherit from the shell environment.",
+      structField = true)
+  List<String> getInheritedEnvironment();
 }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/TestingModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/TestingModuleApi.java
@@ -15,10 +15,12 @@
 package com.google.devtools.build.lib.starlarkbuildapi.test;
 
 import net.starlark.java.annot.Param;
+import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Sequence;
 import net.starlark.java.eval.StarlarkValue;
 
 /** Helper module for accessing test infrastructure. */
@@ -56,12 +58,24 @@ public interface TestingModuleApi extends StarlarkValue {
       parameters = {
         @Param(
             name = "environment",
-            named = false,
+            named = true,
             positional = true,
             doc =
                 "A map of string keys and values that represent environment variables and their"
-                    + " values. These will be made available during the test execution.")
+                    + " values. These will be made available during the test execution."),
+          @Param(
+              name = "inherited_environment",
+              allowedTypes = {@ParamType(type = Sequence.class, generic1 = String.class)},
+              defaultValue = "[]",
+              named = true,
+              positional = true,
+              doc =
+                  "A sequence of names of environment variables. These variables are made available"
+                      + " during the test execution with their current value taken from the shell"
+                      + " environment. If a variable is contained in both <code>environment</code>"
+                      + " and <code>inherited_environment</code>, the value inherited from the"
+                      + " shell environment will take precedence if set.")
       })
-  TestEnvironmentInfoApi testEnvironment(Dict<?, ?> environment // <String, String> expected
-      ) throws EvalException;
+  TestEnvironmentInfoApi testEnvironment(Dict<?, ?> environment, // <String, String> expected
+      Sequence<?> inheritedEnvironment /* <String> expected */) throws EvalException;
 }

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
@@ -34,10 +34,10 @@ public final class ActionEnvironmentTest {
     // entries added by env2 override the existing entries
     ActionEnvironment env2 = env1.addFixedVariables(ImmutableMap.of("FOO", "foo2"));
 
-    assertThat(env1.getFixedEnv().toMap()).containsExactly("FOO", "foo1", "BAR", "bar");
+    assertThat(env1.getFixedEnv()).containsExactly("FOO", "foo1", "BAR", "bar");
     assertThat(env1.getInheritedEnv()).containsExactly("baz");
 
-    assertThat(env2.getFixedEnv().toMap()).containsExactly("FOO", "foo2", "BAR", "bar");
+    assertThat(env2.getFixedEnv()).containsExactly("FOO", "foo2", "BAR", "bar");
     assertThat(env2.getInheritedEnv()).containsExactly("baz");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
@@ -44,6 +44,19 @@ public final class ActionEnvironmentTest {
   }
 
   @Test
+  public void emptyEnvironmentInterning() {
+    ActionEnvironment emptyEnvironment = ActionEnvironment.create(ImmutableMap.of(),
+        ImmutableSet.of());
+    assertThat(emptyEnvironment).isSameInstanceAs(ActionEnvironment.EMPTY);
+
+    ActionEnvironment base = ActionEnvironment.create(ImmutableMap.of("FOO", "foo1"),
+        ImmutableSet.of("baz"));
+    assertThat(base.withAdditionalFixedVariables(ImmutableMap.of())).isSameInstanceAs(base);
+    assertThat(base.withAdditionalVariables(ImmutableMap.of(), ImmutableSet.of())).isSameInstanceAs(
+        base);
+  }
+
+  @Test
   public void fixedInheritedInteraction() {
     ActionEnvironment env = ActionEnvironment.create(
             ImmutableMap.of("FIXED_ONLY", "fixed"),

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
@@ -18,6 +18,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,12 +34,28 @@ public final class ActionEnvironmentTest {
         ActionEnvironment.create(
             ImmutableMap.of("FOO", "foo1", "BAR", "bar"), ImmutableSet.of("baz"));
     // entries added by env2 override the existing entries
-    ActionEnvironment env2 = env1.addFixedVariables(ImmutableMap.of("FOO", "foo2"));
+    ActionEnvironment env2 = env1.withAdditionalFixedVariables(ImmutableMap.of("FOO", "foo2"));
 
     assertThat(env1.getFixedEnv()).containsExactly("FOO", "foo1", "BAR", "bar");
     assertThat(env1.getInheritedEnv()).containsExactly("baz");
 
     assertThat(env2.getFixedEnv()).containsExactly("FOO", "foo2", "BAR", "bar");
     assertThat(env2.getInheritedEnv()).containsExactly("baz");
+  }
+
+  @Test
+  public void fixedInheritedInteraction() {
+    ActionEnvironment env = ActionEnvironment.create(
+            ImmutableMap.of("FIXED_ONLY", "fixed"),
+            ImmutableSet.of("INHERITED_ONLY"))
+        .withAdditionalVariables(ImmutableMap.of("FIXED_AND_INHERITED", "fixed"),
+            ImmutableSet.of("FIXED_AND_INHERITED"));
+    Map<String, String> clientEnv = ImmutableMap.of("INHERITED_ONLY", "inherited",
+        "FIXED_AND_INHERITED", "inherited");
+    Map<String, String> result = new HashMap<>();
+    env.resolve(result, clientEnv);
+
+    assertThat(result).containsExactly("FIXED_ONLY", "fixed", "FIXED_AND_INHERITED", "inherited",
+        "INHERITED_ONLY", "inherited");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProviderTest.java
@@ -176,8 +176,8 @@ public class BazelRuleClassProviderTest {
             "--action_env=FOO=bar");
 
     ActionEnvironment env = BazelRuleClassProvider.SHELL_ACTION_ENV.apply(options);
-    assertThat(env.getFixedEnv().toMap()).containsEntry("PATH", "/bin:/usr/bin:/usr/local/bin");
-    assertThat(env.getFixedEnv().toMap()).containsEntry("FOO", "bar");
+    assertThat(env.getFixedEnv()).containsEntry("PATH", "/bin:/usr/bin:/usr/local/bin");
+    assertThat(env.getFixedEnv()).containsEntry("FOO", "bar");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModuleTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModuleTest.java
@@ -80,6 +80,39 @@ public class StarlarkTestingModuleTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testStarlarkRulePropagatesTestEnvironmentProviderWithInheritedEnv() throws Exception {
+    scratch.file("examples/rule/BUILD");
+    scratch.file(
+        "examples/rule/apple_rules.bzl",
+        "def my_rule_impl(ctx):",
+        "  test_env = testing.TestEnvironment(",
+        "    {'XCODE_VERSION_OVERRIDE': '7.3.1'},",
+        "    [",
+        "      'DEVELOPER_DIR',",
+        "      'XCODE_VERSION_OVERRIDE',",
+        "    ]",
+        ")",
+        "  return [test_env]",
+        "my_rule = rule(implementation = my_rule_impl,",
+        "  attrs = {},",
+        ")");
+    scratch.file(
+        "examples/apple_starlark/BUILD",
+        "package(default_visibility = ['//visibility:public'])",
+        "load('//examples/rule:apple_rules.bzl', 'my_rule')",
+        "my_rule(",
+        "    name = 'my_target',",
+        ")");
+
+    ConfiguredTarget starlarkTarget = getConfiguredTarget("//examples/apple_starlark:my_target");
+    TestEnvironmentInfo provider = starlarkTarget.get(TestEnvironmentInfo.PROVIDER);
+
+    assertThat(provider.getEnvironment().get("XCODE_VERSION_OVERRIDE")).isEqualTo("7.3.1");
+    assertThat(provider.getInheritedEnvironment()).contains("DEVELOPER_DIR");
+    assertThat(provider.getInheritedEnvironment()).contains("XCODE_VERSION_OVERRIDE");
+  }
+
+  @Test
   public void testExecutionInfoProviderCanMarkTestAsLocal() throws Exception {
     scratch.file("examples/rule/BUILD");
     scratch.file(


### PR DESCRIPTION
Adds an inherited_environment field to testing.TestEnvironment to allow
Starlark rules to implement the equivalent of the native rules' 
`env_inherit` attribute.

Work towards #7364. To fully resolve that issue, it remains to handle
executable non-test rules.

RELNOTES: Starlark test rules can use the new inherited_environment
parameter of testing.TestEnvironment to specify environment variables
whose values should be inherited from the shell environment.
