### PR TITLE
Set keywords on appropriate lifecycle events.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceProtoUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceProtoUtil.java
@@ -161,6 +161,14 @@ public final class BuildEventServiceProtoUtil {
     if (projectId != null) {
       builder.setProjectId(projectId);
     }
+    switch (lifecycleEvent.getEventCase()) {
+      case BUILD_ENQUEUED:
+      case INVOCATION_ATTEMPT_STARTED:
+        builder.addAllNotificationKeywords(getKeywords());
+        break;
+      default:
+        break;
+    }
     return builder;
   }
 

--- a/src/test/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceProtoUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceProtoUtilTest.java
@@ -70,6 +70,7 @@ public class BuildEventServiceProtoUtilTest {
             PublishLifecycleEventRequest.newBuilder()
                 .setServiceLevel(ServiceLevel.INTERACTIVE)
                 .setProjectId(PROJECT_ID)
+                .addAllNotificationKeywords(EXPECTED_KEYWORDS)
                 .setBuildEvent(
                     OrderedBuildEvent.newBuilder()
                         .setStreamId(
@@ -92,6 +93,7 @@ public class BuildEventServiceProtoUtilTest {
             PublishLifecycleEventRequest.newBuilder()
                 .setServiceLevel(ServiceLevel.INTERACTIVE)
                 .setProjectId(PROJECT_ID)
+                .addAllNotificationKeywords(EXPECTED_KEYWORDS)
                 .setBuildEvent(
                     OrderedBuildEvent.newBuilder()
                         .setStreamId(


### PR DESCRIPTION
The docs for the PublishLifecycleEventRequest say that the notification_keywords field should be set if the build event is InvocationAttemptStarted or BuildEnqueued. However, Bazel did not conform to this spec.