### PR TITLE
[5.1] Fix uses of std++ on bsd

### DIFF
--- a/tools/cpp/cc_toolchain_config.bzl
+++ b/tools/cpp/cc_toolchain_config.bzl
@@ -371,7 +371,7 @@ def _impl(ctx):
                     flag_groups = [
                         flag_group(
                             flags = [
-                                "-lstdc++",
+                                "-lc++",
                                 "-Wl,-z,relro,-z,now",
                                 "-no-canonical-prefixes",
                             ],

--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -340,6 +340,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
 
     repository_ctx.file("tools/cpp/empty.cc", "int main() {}")
     darwin = cpu_value.startswith("darwin")
+    bsd = cpu_value == "freebsd" or cpu_value == "openbsd"
 
     cc = find_cc(repository_ctx, overriden_tools)
     is_clang = _is_clang(repository_ctx, cc)
@@ -400,7 +401,8 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
         False,
     ), ":")
 
-    bazel_linkopts = "-lc++:-lm" if darwin else "-lstdc++:-lm"
+    use_libcpp = darwin or bsd
+    bazel_linkopts = "-lc++:-lm" if use_libcpp else "-lstdc++:-lm"
     bazel_linklibs = ""
     if repository_ctx.flag_enabled("incompatible_linkopts_to_linklibs"):
         bazel_linkopts, bazel_linklibs = bazel_linklibs, bazel_linkopts


### PR DESCRIPTION
This fix is the same as https://github.com/bazelbuild/bazel/pull/14542
but for freebsd and openbsd

Hopefully fixes https://github.com/bazelbuild/rules_rust/issues/978

(cherry picked from commit a987b98ea0d6da2656c4115568ef9cbe8a164550)

Closes #14839.