### PR TITLE
Use ToolchainTypeRequirement in ExecGroup and ToolchainContextKey tests.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/ToolchainTypeRequirement.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/ToolchainTypeRequirement.java
@@ -27,12 +27,9 @@ public abstract class ToolchainTypeRequirement {
 
   /** Returns a builder for a new {@link ToolchainTypeRequirement}. */
   public static Builder builder(Label toolchainType) {
-    return builder().toolchainType(toolchainType);
-  }
-
-  /** Returns a builder for a new {@link ToolchainTypeRequirement}. */
-  public static Builder builder() {
-    return new AutoValue_ToolchainTypeRequirement.Builder().mandatory(true);
+    return new AutoValue_ToolchainTypeRequirement.Builder()
+        .toolchainType(toolchainType)
+        .mandatory(true);
   }
 
   /** Returns the label of the toolchain type that is requested. */

--- a/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainContextKey.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/ToolchainContextKey.java
@@ -76,6 +76,10 @@ public abstract class ToolchainContextKey implements SkyKey {
 
     Builder toolchainTypes(ImmutableSet<ToolchainTypeRequirement> toolchainTypes);
 
+    default Builder toolchainTypes(ToolchainTypeRequirement... toolchainTypes) {
+      return this.toolchainTypes(ImmutableSet.copyOf(toolchainTypes));
+    }
+
     Builder execConstraintLabels(ImmutableSet<Label> execConstraintLabels);
 
     Builder execConstraintLabels(Label... execConstraintLabels);

--- a/src/test/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/analysis/BUILD
@@ -82,6 +82,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:config/per_label_options",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/run_under",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/run_under_converter",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/toolchain_type_requirement",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transition_factories",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/composing_transition",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/composing_transition_factory",

--- a/src/test/java/com/google/devtools/build/lib/analysis/ResolvedToolchainContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/ResolvedToolchainContextTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
+import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
 import com.google.devtools.build.lib.analysis.platform.ToolchainTypeInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.rules.platform.ToolchainTestCase;
@@ -49,7 +50,7 @@ public class ResolvedToolchainContextTest extends ToolchainTestCase {
     ToolchainContextKey toolchainContextKey =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(testToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(testToolchainTypeLabel))
             .build();
 
     // Create a static UnloadedToolchainContext.
@@ -101,7 +102,7 @@ public class ResolvedToolchainContextTest extends ToolchainTestCase {
     ToolchainContextKey toolchainContextKey =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(testToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(testToolchainTypeLabel))
             .build();
 
     // Create a static UnloadedToolchainContext.
@@ -143,7 +144,7 @@ public class ResolvedToolchainContextTest extends ToolchainTestCase {
     ToolchainContextKey toolchainContextKey =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(testToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(testToolchainTypeLabel))
             .build();
 
     // Create a static UnloadedToolchainContext.
@@ -202,7 +203,7 @@ public class ResolvedToolchainContextTest extends ToolchainTestCase {
     ToolchainContextKey toolchainContextKey =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(testToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(testToolchainTypeLabel))
             .build();
 
     // Create a static UnloadedToolchainContext.

--- a/src/test/java/com/google/devtools/build/lib/packages/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/packages/BUILD
@@ -58,6 +58,7 @@ java_test(
         "//src/main/java/com/google/devtools/build/lib/analysis:config/build_options",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/fragment",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/host_transition",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/toolchain_type_requirement",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transition_factories",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/configuration_transition",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/transitions/no_transition",

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassBuilderTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.actions.MutableActionGraph.ActionConflictException;
+import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassNamePredicate;
 import com.google.devtools.build.lib.packages.RuleClass.Builder.RuleClassType;
@@ -200,13 +201,13 @@ public class RuleClassBuilderTest extends PackageLoadingTestCase {
     Label mockConstraint = Label.parseAbsoluteUnchecked("//mock_constraint");
     ExecGroup parentGroup =
         ExecGroup.builder()
-            .requiredToolchains(ImmutableSet.of(mockToolchainType))
+            .addToolchainType(ToolchainTypeRequirement.create(mockToolchainType))
             .execCompatibleWith(ImmutableSet.of(mockConstraint))
             .copyFrom(null)
             .build();
     ExecGroup childGroup =
         ExecGroup.builder()
-            .requiredToolchains(ImmutableSet.of())
+            .toolchainTypes(ImmutableSet.of())
             .execCompatibleWith(ImmutableSet.of())
             .copyFrom(null)
             .build();
@@ -259,8 +260,9 @@ public class RuleClassBuilderTest extends PackageLoadingTestCase {
                 ImmutableMap.of(
                     "blueberry",
                     ExecGroup.builder()
-                        .requiredToolchains(
-                            ImmutableSet.of(Label.parseAbsoluteUnchecked("//some/toolchain")))
+                        .addToolchainType(
+                            ToolchainTypeRequirement.create(
+                                Label.parseAbsoluteUnchecked("//some/toolchain")))
                         .execCompatibleWith(ImmutableSet.of())
                         .copyFrom(null)
                         .build()))
@@ -273,7 +275,7 @@ public class RuleClassBuilderTest extends PackageLoadingTestCase {
                 ImmutableMap.of(
                     "blueberry",
                     ExecGroup.builder()
-                        .requiredToolchains(ImmutableSet.of())
+                        .toolchainTypes(ImmutableSet.of())
                         .execCompatibleWith(ImmutableSet.of())
                         .copyFrom(null)
                         .build()))

--- a/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/RuleClassTest.java
@@ -41,6 +41,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.devtools.build.lib.actions.MutableActionGraph.ActionConflictException;
 import com.google.devtools.build.lib.analysis.config.Fragment;
+import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.cmdline.LabelSyntaxException;
@@ -1085,7 +1086,7 @@ public class RuleClassTest extends PackageLoadingTestCase {
         ImmutableMap.of(
             "cherry",
             ExecGroup.builder()
-                .requiredToolchains(ImmutableSet.of(toolchain))
+                .addToolchainType(ToolchainTypeRequirement.create(toolchain))
                 .execCompatibleWith(ImmutableSet.of(constraint))
                 .copyFrom(null)
                 .build()));

--- a/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/BUILD
@@ -104,6 +104,7 @@ java_test(
         "//conditions:default": [],
     }) + [
         ":testutil",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/toolchain_type_requirement",
         "//src/main/java/com/google/devtools/build/lib/analysis:file_provider",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:common",
         "//src/main/java/com/google/devtools/build/lib/bazel/bzlmod:resolution_impl",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunctionTest.java
@@ -18,6 +18,7 @@ import static com.google.devtools.build.lib.analysis.testing.ToolchainContextSub
 import static com.google.devtools.build.skyframe.EvaluationResultSubjectFactory.assertThatEvaluationResult;
 
 import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.analysis.config.ToolchainTypeRequirement;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.rules.platform.ToolchainTestCase;
 import com.google.devtools.build.lib.skyframe.ConstraintValueLookupUtil.InvalidConstraintValueException;
@@ -70,7 +71,7 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     ToolchainContextKey key =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(testToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(testToolchainTypeLabel))
             .build();
 
     EvaluationResult<UnloadedToolchainContext> result = invokeToolchainResolution(key);
@@ -106,7 +107,7 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     ToolchainContextKey key =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(aliasedToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(aliasedToolchainTypeLabel))
             .build();
 
     EvaluationResult<UnloadedToolchainContext> result = invokeToolchainResolution(key);
@@ -185,8 +186,10 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     ToolchainContextKey key =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(
-                testToolchainTypeLabel, Label.parseAbsoluteUnchecked("//fake/toolchain:type_1"))
+            .toolchainTypes(
+                ToolchainTypeRequirement.create(testToolchainTypeLabel),
+                ToolchainTypeRequirement.create(
+                    Label.parseAbsoluteUnchecked("//fake/toolchain:type_1")))
             .build();
 
     EvaluationResult<UnloadedToolchainContext> result = invokeToolchainResolution(key);
@@ -206,10 +209,12 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     ToolchainContextKey key =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(
-                testToolchainTypeLabel,
-                Label.parseAbsoluteUnchecked("//fake/toolchain:type_1"),
-                Label.parseAbsoluteUnchecked("//fake/toolchain:type_2"))
+            .toolchainTypes(
+                ToolchainTypeRequirement.create(testToolchainTypeLabel),
+                ToolchainTypeRequirement.create(
+                    Label.parseAbsoluteUnchecked("//fake/toolchain:type_1")),
+                ToolchainTypeRequirement.create(
+                    Label.parseAbsoluteUnchecked("//fake/toolchain:type_2")))
             .build();
 
     EvaluationResult<UnloadedToolchainContext> result = invokeToolchainResolution(key);
@@ -228,7 +233,7 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     ToolchainContextKey key =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(testToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(testToolchainTypeLabel))
             .build();
 
     EvaluationResult<UnloadedToolchainContext> result = invokeToolchainResolution(key);
@@ -254,7 +259,7 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     ToolchainContextKey key =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(testToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(testToolchainTypeLabel))
             .build();
 
     EvaluationResult<UnloadedToolchainContext> result = invokeToolchainResolution(key);
@@ -278,7 +283,7 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     ToolchainContextKey key =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(testToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(testToolchainTypeLabel))
             .build();
 
     EvaluationResult<UnloadedToolchainContext> result = invokeToolchainResolution(key);
@@ -303,7 +308,7 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     ToolchainContextKey key =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(testToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(testToolchainTypeLabel))
             .build();
 
     EvaluationResult<UnloadedToolchainContext> result = invokeToolchainResolution(key);
@@ -344,7 +349,7 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     ToolchainContextKey key =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(testToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(testToolchainTypeLabel))
             .execConstraintLabels(Label.parseAbsoluteUnchecked("//constraints:linux"))
             .build();
 
@@ -365,7 +370,7 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     ToolchainContextKey key =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(testToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(testToolchainTypeLabel))
             .execConstraintLabels(Label.parseAbsoluteUnchecked("//platforms:linux"))
             .build();
 
@@ -417,9 +422,11 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     ToolchainContextKey key =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(
-                Label.parseAbsoluteUnchecked("//a:toolchain_type_A"),
-                Label.parseAbsoluteUnchecked("//b:toolchain_type_B"))
+            .toolchainTypes(
+                ToolchainTypeRequirement.create(
+                    Label.parseAbsoluteUnchecked("//a:toolchain_type_A")),
+                ToolchainTypeRequirement.create(
+                    Label.parseAbsoluteUnchecked("//b:toolchain_type_B")))
             .build();
 
     EvaluationResult<UnloadedToolchainContext> result = invokeToolchainResolution(key);
@@ -454,7 +461,7 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
     ToolchainContextKey key =
         ToolchainContextKey.key()
             .configurationKey(targetConfigKey)
-            .requiredToolchainTypeLabels(testToolchainTypeLabel)
+            .toolchainTypes(ToolchainTypeRequirement.create(testToolchainTypeLabel))
             .forceExecutionPlatform(Label.parseAbsoluteUnchecked("//platforms:linux"))
             .build();
 


### PR DESCRIPTION
Part of Optional Toolchains (#14726).