### PR TITLE
Add archiver flags to cpp crosstool config

### DIFF
--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -977,6 +977,26 @@ def _impl(ctx):
                         expand_if_available = "output_execpath",
                     ),
                 ],
+                with_features = [
+                    with_feature_set(
+                        not_features = ["libtool"],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(flags = ["-static", "-s"]),
+                    flag_group(
+                        flags = ["-o", "%{output_execpath}"],
+                        expand_if_available = "output_execpath",
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(
+                        features = ["libtool"],
+                    ),
+                ],
             ),
             flag_set(
                 actions = [ACTION_NAMES.cpp_link_static_library],
@@ -1003,6 +1023,14 @@ def _impl(ctx):
                         expand_if_available = "libraries_to_link",
                     ),
                 ],
+            ),
+            flag_set(
+                actions = [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.archive_flags,
+                    ),
+                ] if ctx.attr.archive_flags else []),
             ),
         ],
     )
@@ -1198,6 +1226,10 @@ def _impl(ctx):
     )
 
     is_linux = ctx.attr.target_libc != "macosx"
+    libtool_feature = feature(
+        name = "libtool",
+        enabled = not is_linux,
+    )
 
     # TODO(#8303): Mac crosstool should also declare every feature.
     if is_linux:
@@ -1226,6 +1258,7 @@ def _impl(ctx):
             output_execpath_flags_feature,
             runtime_library_search_directories_feature,
             library_search_directories_feature,
+            libtool_feature,
             archiver_flags_feature,
             force_pic_flags_feature,
             fission_support_feature,
@@ -1262,6 +1295,8 @@ def _impl(ctx):
             ),
         ]
         features = [
+            libtool_feature,
+            archiver_flags_feature,
             supports_pic_feature,
         ] + (
             [
@@ -1318,6 +1353,7 @@ cc_toolchain_config = rule(
         "opt_compile_flags": attr.string_list(),
         "cxx_flags": attr.string_list(),
         "link_flags": attr.string_list(),
+        "archive_flags": attr.string_list(),
         "link_libs": attr.string_list(),
         "opt_link_flags": attr.string_list(),
         "unfiltered_compile_flags": attr.string_list(),


### PR DESCRIPTION
There are three changes proposed in this pr that do not alter the current behaviour but that allow more flexibility when defining a toolchain:
  - Move default macos archiver flags from [CppActionConfigs.java#L622](https://github.com/bazelbuild/bazel/blob/feea781b30788997c0b97ad9103a13fdc3f627c8/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java#L622) to the crosstools definition.
  - Add `archive_flag` attribute to allow passing additional flags to the archive action.
  - Add libtool feature to switch between macos `libtool`'s flags and `ar`'s.