### PR TITLE
Let RunfilesTreeUpdater use OutputService.createSymlinkTree()

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -182,6 +182,7 @@ java_library(
     srcs = ["RunfilesTreeUpdater.java"],
     deps = [
         ":bin_tools",
+        ":spawn_input_expander",
         ":symlink_tree_helper",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
@@ -189,6 +190,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/util/io:out-err",
         "//src/main/java/com/google/devtools/build/lib/vfs",
+        "//src/main/java/com/google/devtools/build/lib/vfs:output_service",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnInputExpander.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnInputExpander.java
@@ -106,6 +106,53 @@ public class SpawnInputExpander {
     inputMappings.put(baseDirectory.getRelative(targetLocation), input);
   }
 
+  public void addExpandedMapping(
+      Map<PathFragment, ActionInput> inputMap,
+      Map.Entry<PathFragment, Map<PathFragment, Artifact>> rootAndMappings,
+      MetadataProvider actionFileCache,
+      ArtifactExpander artifactExpander,
+      PathFragment baseDirectory)
+      throws IOException, ForbiddenActionInputException {
+    PathFragment root = rootAndMappings.getKey();
+    Preconditions.checkState(!root.isAbsolute(), root);
+    for (Map.Entry<PathFragment, Artifact> mapping : rootAndMappings.getValue().entrySet()) {
+      PathFragment location = root.getRelative(mapping.getKey());
+      Artifact localArtifact = mapping.getValue();
+      if (localArtifact != null) {
+        Preconditions.checkState(!localArtifact.isMiddlemanArtifact());
+        if (localArtifact.isTreeArtifact()) {
+          List<ActionInput> expandedInputs =
+              ActionInputHelper.expandArtifacts(
+                  NestedSetBuilder.create(Order.STABLE_ORDER, localArtifact),
+                  artifactExpander,
+                  /* keepEmptyTreeArtifacts= */ false);
+          for (ActionInput input : expandedInputs) {
+            addMapping(
+                inputMap,
+                location.getRelative(((TreeFileArtifact) input).getParentRelativePath()),
+                input,
+                baseDirectory);
+          }
+        } else if (localArtifact.isFileset()) {
+          ImmutableList<FilesetOutputSymlink> filesetLinks;
+          try {
+            filesetLinks = artifactExpander.getFileset(localArtifact);
+          } catch (MissingExpansionException e) {
+            throw new IllegalStateException(e);
+          }
+          addFilesetManifest(location, localArtifact, filesetLinks, inputMap, baseDirectory);
+        } else {
+          if (strict) {
+            failIfDirectory(actionFileCache, localArtifact);
+          }
+          addMapping(inputMap, location, localArtifact, baseDirectory);
+        }
+      } else {
+        addMapping(inputMap, location, VirtualActionInput.EMPTY_MARKER, baseDirectory);
+      }
+    }
+  }
+
   /** Adds runfiles inputs from runfilesSupplier to inputMappings. */
   @VisibleForTesting
   void addRunfilesToInputs(
@@ -120,44 +167,12 @@ public class SpawnInputExpander {
 
     for (Map.Entry<PathFragment, Map<PathFragment, Artifact>> rootAndMappings :
         rootsAndMappings.entrySet()) {
-      PathFragment root = rootAndMappings.getKey();
-      Preconditions.checkState(!root.isAbsolute(), root);
-      for (Map.Entry<PathFragment, Artifact> mapping : rootAndMappings.getValue().entrySet()) {
-        PathFragment location = root.getRelative(mapping.getKey());
-        Artifact localArtifact = mapping.getValue();
-        if (localArtifact != null) {
-          Preconditions.checkState(!localArtifact.isMiddlemanArtifact());
-          if (localArtifact.isTreeArtifact()) {
-            List<ActionInput> expandedInputs =
-                ActionInputHelper.expandArtifacts(
-                    NestedSetBuilder.create(Order.STABLE_ORDER, localArtifact),
-                    artifactExpander,
-                    /* keepEmptyTreeArtifacts= */ false);
-            for (ActionInput input : expandedInputs) {
-              addMapping(
-                  inputMap,
-                  location.getRelative(((TreeFileArtifact) input).getParentRelativePath()),
-                  input,
-                  baseDirectory);
-            }
-          } else if (localArtifact.isFileset()) {
-            ImmutableList<FilesetOutputSymlink> filesetLinks;
-            try {
-              filesetLinks = artifactExpander.getFileset(localArtifact);
-            } catch (MissingExpansionException e) {
-              throw new IllegalStateException(e);
-            }
-            addFilesetManifest(location, localArtifact, filesetLinks, inputMap, baseDirectory);
-          } else {
-            if (strict) {
-              failIfDirectory(actionFileCache, localArtifact);
-            }
-            addMapping(inputMap, location, localArtifact, baseDirectory);
-          }
-        } else {
-          addMapping(inputMap, location, VirtualActionInput.EMPTY_MARKER, baseDirectory);
-        }
-      }
+      addExpandedMapping(
+          inputMap,
+          rootAndMappings,
+          actionFileCache,
+          artifactExpander,
+          baseDirectory);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SymlinkTreeHelper.java
@@ -117,25 +117,6 @@ public final class SymlinkTreeHelper {
     root.syncTreeRecursively(symlinkTreeRoot);
   }
 
-  /**
-   * Creates symlink tree and output manifest using the {@code build-runfiles.cc} tool.
-   *
-   * @param enableRunfiles If {@code false} only the output manifest is created.
-   */
-  public void createSymlinks(
-      Path execRoot,
-      OutErr outErr,
-      BinTools binTools,
-      Map<String, String> shellEnvironment,
-      boolean enableRunfiles)
-      throws ExecException, InterruptedException {
-    if (enableRunfiles) {
-      createSymlinksUsingCommand(execRoot, binTools, shellEnvironment, outErr);
-    } else {
-      copyManifest();
-    }
-  }
-
   /** Copies the input manifest to the output manifest. */
   public void copyManifest() throws ExecException {
     // Pretend we created the runfiles tree by copying the manifest

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -137,6 +137,8 @@ public class LocalSpawnRunner implements SpawnRunner {
     runfilesTreeUpdater.updateRunfilesDirectory(
         execRoot,
         spawn.getRunfilesSupplier(),
+        context.getMetadataProvider(),
+        context.getArtifactExpander(),
         binTools,
         spawn.getEnvironment(),
         context.getFileOutErr(),

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxModule.java
@@ -451,8 +451,7 @@ public final class SandboxModule extends BlazeModule {
         env.getBlazeWorkspace().getBinTools(),
         ProcessWrapper.fromCommandEnvironment(env),
         env.getXattrProvider(),
-        // TODO(buchgr): Replace singleton by a command-scoped RunfilesTreeUpdater
-        RunfilesTreeUpdater.INSTANCE);
+        new RunfilesTreeUpdater(env.getOutputService()));
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/standalone/StandaloneModule.java
+++ b/src/main/java/com/google/devtools/build/lib/standalone/StandaloneModule.java
@@ -83,8 +83,7 @@ public class StandaloneModule extends BlazeModule {
             env.getBlazeWorkspace().getBinTools(),
             ProcessWrapper.fromCommandEnvironment(env),
             env.getXattrProvider(),
-            // TODO(buchgr): Replace singleton by a command-scoped RunfilesTreeUpdater
-            RunfilesTreeUpdater.INSTANCE);
+            new RunfilesTreeUpdater(env.getOutputService()));
 
     boolean verboseFailures =
         checkNotNull(env.getOptions().getOptions(ExecutionOptions.class)).verboseFailures;

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerModule.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerModule.java
@@ -163,8 +163,7 @@ public class WorkerModule extends BlazeModule {
             localEnvProvider,
             env.getBlazeWorkspace().getBinTools(),
             env.getLocalResourceManager(),
-            // TODO(buchgr): Replace singleton by a command-scoped RunfilesTreeUpdater
-            RunfilesTreeUpdater.INSTANCE,
+            new RunfilesTreeUpdater(env.getOutputService()),
             env.getOptions().getOptions(WorkerOptions.class),
             WorkerMetricsCollector.instance(),
             env.getXattrProvider(),

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -176,6 +176,8 @@ final class WorkerSpawnRunner implements SpawnRunner {
       runfilesTreeUpdater.updateRunfilesDirectory(
           execRoot,
           spawn.getRunfilesSupplier(),
+          context.getMetadataProvider(),
+          context.getArtifactExpander(),
           binTools,
           spawn.getEnvironment(),
           context.getFileOutErr(),

--- a/src/test/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunnerTest.java
@@ -265,7 +265,7 @@ public class LocalSpawnRunnerTest {
 
     @Override
     public ArtifactExpander getArtifactExpander() {
-      throw new UnsupportedOperationException();
+      return mockArtifactExpander;
     }
 
     @Override
@@ -319,6 +319,7 @@ public class LocalSpawnRunnerTest {
   }
 
   private final MetadataProvider mockFileCache = mock(MetadataProvider.class);
+  private final ArtifactExpander mockArtifactExpander = mock(ArtifactExpander.class);
   private final ResourceManager resourceManager = ResourceManager.instanceForTestingOnly();
 
   private Logger logger;


### PR DESCRIPTION
The canonical way of creating runfiles directories during a build is
through SymlinkTreeStrategy. That code already has logic for calling
into OutputService to do bulk creating of symbolic links, if one is
available. If not, it calls into the build-runfiles helper program.

When --nobuild_runfile_links is provided and no-sandbox actions are
executed, an alternative mechanism for creating runfiles directories is
used, namely the one in RunfilesTreeUpdater. This one is seemingly only
capable of using build-runfiles; it cannot use OutputService.

This change makes RunfilesTreeUpdater more complete by also considering
the use of OutputService. This tends to be faster, as implementations of
OutputService can generally do batch creation.