### PR TITLE
Remove mention of CapturingMapFn from error messages.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSetFingerprintCache.java
+++ b/src/main/java/com/google/devtools/build/lib/collect/nestedset/NestedSetFingerprintCache.java
@@ -100,7 +100,7 @@ public class NestedSetFingerprintCache {
         throw new IllegalArgumentException(
             String.format(
                 "Too many instances of CommandLineItem.ParametrizedMapFn '%s' detected. "
-                    + "Please construct fewer instances or use CommandLineItem.CapturingMapFn.",
+                    + "Please construct fewer instances.",
                 mapFnClass.getName()));
       }
     } else {
@@ -108,9 +108,8 @@ public class NestedSetFingerprintCache {
         throw new IllegalArgumentException(
             String.format(
                 "Illegal mapFn implementation: '%s'. "
-                    + "CommandLineItem.MapFn instances must be singletons. "
-                    + "Please see CommandLineItem.ParametrizedMapFn or "
-                    + "CommandLineItem.CapturingMapFn for alternatives.",
+                    + "CommandLineItem.MapFn instances must be singletons."
+                    + "Please see CommandLineItem.ParametrizedMapFn for an alternative.",
                 mapFnClass.getName()));
       }
     }


### PR DESCRIPTION
CapturingMapFn was deleted in 76c8c3a35776ecd6c568cf4ef1b6f2d2f52c0280.