### PR TITLE
Fixes typo in toolchains documentation page

### DIFF
--- a/site/en/docs/toolchains.md
+++ b/site/en/docs/toolchains.md
@@ -450,7 +450,7 @@ with preference given to earlier items in the list.
 The resolution steps are as follows.
 
 1. A `target_compatible_with` or `exec_compatible_with` clause *matches* a
-   platform iff, for each `constraint_value` in its list, the platform also has
+   platform if, for each `constraint_value` in its list, the platform also has
    that `constraint_value` (either explicitly or as a default).
 
    If the platform has `constraint_value`s from `constraint_setting`s not


### PR DESCRIPTION
## Intent
To fix what I believe it's a typo in `site/en/docs/toolchains.md`.