### PR TITLE
Dead code removal.

### DIFF
--- a/tools/build_defs/pkg/archive.py
+++ b/tools/build_defs/pkg/archive.py
@@ -244,7 +244,6 @@ class TarFileWriter(object):
               rootuid=None,
               rootgid=None,
               numeric=False,
-              name_filter=None,
               root=None):
     """Merge a tar content into the current tar, stripping timestamp.
 
@@ -254,9 +253,6 @@ class TarFileWriter(object):
       rootgid: group id that we will pretend is root (replaced by gid 0).
       numeric: set to true to strip out name of owners (and just use the
           numeric values).
-      name_filter: filter out file by names. If not none, this method will be
-          called for each file to add, given the name and should return true if
-          the file is to be added to the final tar and false otherwise.
       root: place all non-absolute content under given root directory, if not
           None.
 
@@ -282,7 +278,6 @@ class TarFileWriter(object):
       inmode = 'r:' + compression
     intar = tarfile.open(name=tar, mode=inmode)
     for tarinfo in intar:
-      if name_filter is None or name_filter(tarinfo.name):
         if not self.preserve_mtime:
           tarinfo.mtime = self.default_mtime
         if rootuid is not None and tarinfo.uid == rootuid:

--- a/tools/build_defs/pkg/archive_test.py
+++ b/tools/build_defs/pkg/archive_test.py
@@ -144,12 +144,12 @@ class TarFileWriterTest(unittest.TestCase):
   def testMergeTar(self):
     content = [
         {"name": "./a", "data": b"a"},
+        {"name": "./b", "data": b"b"},
         {"name": "./ab", "data": b"ab"},
         ]
     for ext in ["", ".gz", ".bz2"]:
       with archive.TarFileWriter(self.tempfile) as f:
-        f.add_tar(os.path.join(testenv.TESTDATA_PATH, "tar_test.tar" + ext),
-                  name_filter=lambda n: n != "./b")
+        f.add_tar(os.path.join(testenv.TESTDATA_PATH, "tar_test.tar" + ext))
       self.assertTarFileContent(self.tempfile, content)
 
   def testMergeTarRelocated(self):
@@ -157,11 +157,12 @@ class TarFileWriterTest(unittest.TestCase):
         {"name": ".", "mode": 0o755},
         {"name": "./foo", "mode": 0o755},
         {"name": "./foo/a", "data": b"a"},
+        {"name": "./foo/b", "data": b"b"},
         {"name": "./foo/ab", "data": b"ab"},
         ]
     with archive.TarFileWriter(self.tempfile) as f:
       f.add_tar(os.path.join(testenv.TESTDATA_PATH, "tar_test.tar"),
-                name_filter=lambda n: n != "./b", root="/foo")
+                root="/foo")
     self.assertTarFileContent(self.tempfile, content)
 
   def testAddingDirectoriesForFile(self):


### PR DESCRIPTION
Remove `name_filter` from pkg_tar tar splicing code. Nothing can actually use it.