### PR TITLE
Use correct configuration for default jvm8 toolchain

### DIFF
--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -348,7 +348,14 @@ alias(
     actual = ":toolchain",
 )
 
-RELEASES = (8, 9, 10, 11)
+default_java_toolchain(
+    name = "toolchain_java8",
+    configuration = JVM8_TOOLCHAIN_CONFIGURATION,
+    source_version = "8",
+    target_version = "8",
+)
+
+RELEASES = (9, 10, 11)
 
 [
     default_java_toolchain(


### PR DESCRIPTION
The default java toolchain for java 8 was using the default configuration that is meant to target java 9+.

This led to issues such as `Unrecognized VM option 'CompactStrings'` when trying to run java with those options.

This patch switches to using the `JVM8_TOOLCHAIN_CONFIGURATION` for the default java 8 toolchain.