### PR TITLE
[5.1] Fix default CPU for macOS and iOS

### DIFF
--- a/src/main/starlark/builtins_bzl/common/objc/transitions.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/transitions.bzl
@@ -31,7 +31,12 @@ def _determine_single_architecture(platform_type, settings):
         ios_cpus = settings["//command_line_option:ios_multi_cpus"]
         if len(ios_cpus) > 0:
             return ios_cpus[0]
-        return _ios_cpu_from_cpu(settings["//command_line_option:cpu"])
+        cpu_value = settings["//command_line_option:cpu"]
+        if cpu_value.startswith(IOS_CPU_PREFIX):
+            return cpu_value[len(IOS_CPU_PREFIX):]
+        if cpu_value == "darwin_arm64":
+            return "sim_arm64"
+        return DEFAULT_IOS_CPU
     if platform_type == WATCHOS:
         watchos_cpus = settings["//command_line_option:watchos_cpus"]
         if len(watchos_cpus) == 0:
@@ -44,9 +49,12 @@ def _determine_single_architecture(platform_type, settings):
         return tvos_cpus[0]
     if platform_type == MACOS:
         macos_cpus = settings["//command_line_option:macos_cpus"]
-        if len(macos_cpus) == 0:
-            return DEFAULT_MACOS_CPU
-        return macos_cpus[0]
+        if macos_cpus:
+            return macos_cpus[0]
+        cpu_value = settings["//command_line_option:cpu"]
+        if cpu_value.startswith(DARWIN_CPU_PREFIX):
+            return cpu_value[len(DARWIN_CPU_PREFIX):]
+        return DEFAULT_MACOS_CPU
     if platform_type == CATALYST:
         catalyst_cpus = settings["//command_line_option:catalyst_cpus"]
         if len(catalyst_cpus) == 0:
@@ -61,16 +69,12 @@ TVOS = "tvos"
 MACOS = "macos"
 CATALYST = "catalyst"
 IOS_CPU_PREFIX = "ios_"
+DARWIN_CPU_PREFIX = "darwin_"
 DEFAULT_IOS_CPU = "x86_64"
 DEFAULT_WATCHOS_CPU = "i386"
 DEFAULT_TVOS_CPU = "x86_64"
 DEFAULT_MACOS_CPU = "x86_64"
 DEFAULT_CATALYST_CPU = "x86_64"
-
-def _ios_cpu_from_cpu(cpu):
-    if cpu.startswith(IOS_CPU_PREFIX):
-        return cpu[len(IOS_CPU_PREFIX):]
-    return DEFAULT_IOS_CPU
 
 def _apple_crosstool_transition_impl(settings, attr):
     platform_type = str(settings["//command_line_option:apple_platform_type"])


### PR DESCRIPTION
Since M1 support was added we started defaulting the CPU for macOS and
iOS builds to the host CPU in the case another CPU wasn't passed. This
change mirrors https://github.com/bazelbuild/bazel/pull/13873, https://github.com/bazelbuild/bazel/pull/13440 and https://github.com/bazelbuild/rules_apple//commit/99e5b631bf060358241a8eaabd285be5c120490f
in the newer starlark transition.

Without this you end up with architecture mismatches for builds. Fixes https://github.com/bazelbuild/bazel/issues/14803

(cherry picked from commit 1ec10689c819959b884730d253e9913947774ff0)

Closes #14837.