### PR TITLE
Create mini_tar and switch to it for our blackbox tests.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedStarlarkBlackBoxTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/BazelEmbeddedStarlarkBlackBoxTest.java
@@ -34,22 +34,22 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.junit.Test;
 
-/** Tests pkg_tar and http_archive. */
+/** Tests mini_tar and http_archive. */
 public class BazelEmbeddedStarlarkBlackBoxTest extends AbstractBlackBoxTest {
 
   private static final String HELLO_FROM_EXTERNAL_REPOSITORY = "Hello from external repository!";
   private static final String HELLO_FROM_MAIN_REPOSITORY = "Hello from main repository!";
 
   @Test
-  public void testPkgTar() throws Exception {
+  public void testMiniTar() throws Exception {
     context().write("main/WORKSPACE", BlackBoxTestEnvironment.getWorkspaceWithDefaultRepos());
     context().write("main/foo.txt", "Hello World");
     context().write("main/bar.txt", "Hello World, again");
     context()
         .write(
             "main/BUILD",
-            "load(\"@bazel_tools//tools/build_defs/pkg:pkg.bzl\", \"pkg_tar\")",
-            "pkg_tar(name = \"data\", srcs = ['foo.txt', 'bar.txt'],)");
+            "load(\"@bazel_tools//tools/build_defs/pkg:tar.bzl\", \"mini_tar\")",
+            "mini_tar(name = \"data\", srcs = ['foo.txt', 'bar.txt'],)");
 
     BuilderRunner bazel = bazel();
     bazel.build("...");

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGenerator.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
  *
  * <p>empty WORKSPACE file,
  *
- * <p>BUILD file, with write_to_file target and pkg_tar target for packing the contents of the
+ * <p>BUILD file, with write_to_file target and mini_tar target for packing the contents of the
  * generated repository.
  *
  * <p>Intended to be used by workspace tests.
@@ -130,10 +130,10 @@ public class RepoWithRuleWritingTextGenerator {
       PathUtils.writeFileInDir(
           root,
           "BUILD",
-          "load(\"@bazel_tools//tools/build_defs/pkg:pkg.bzl\", \"pkg_tar\")",
+          "load(\"@bazel_tools//tools/build_defs/pkg:tar.bzl\", \"mini_tar\")",
           loadRule(""),
           callRule(target, outFile, outputText),
-          String.format("pkg_tar(name = \"%s\", srcs = glob([\"*\"]),)", getPkgTarTarget()));
+          String.format("mini_tar(name = \"%s\", srcs = glob([\"*\"]),)", getPkgTarTarget()));
     }
     return workspace.getParent();
   }
@@ -162,8 +162,8 @@ public class RepoWithRuleWritingTextGenerator {
         "%s(name = '%s', filename = '%s', text ='%s')", RULE_NAME, name, filename, text);
   }
 
-  /** @return name of the generated pkg_tar target */
+  /** @return name of the generated mini_tar target */
   String getPkgTarTarget() {
-    return "pkg_tar_" + target;
+    return "mini_tar_" + target;
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGeneratorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace/RepoWithRuleWritingTextGeneratorTest.java
@@ -29,15 +29,15 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class RepoWithRuleWritingTextGeneratorTest {
   private static final String BUILD_TEXT =
-      "load(\"@bazel_tools//tools/build_defs/pkg:pkg.bzl\", \"pkg_tar\")\n"
+      "load(\"@bazel_tools//tools/build_defs/pkg:tar.bzl\", \"mini_tar\")\n"
           + "load('//:helper.bzl', 'write_to_file')\n"
           + "write_to_file(name = 'write_text', filename = 'out', text ='HELLO')\n"
-          + "pkg_tar(name = \"pkg_tar_write_text\", srcs = glob([\"*\"]),)";
+          + "mini_tar(name = \"mini_tar_write_text\", srcs = glob([\"*\"]),)";
   private static final String BUILD_TEXT_PARAMS =
-      "load(\"@bazel_tools//tools/build_defs/pkg:pkg.bzl\", \"pkg_tar\")\n"
+      "load(\"@bazel_tools//tools/build_defs/pkg:tar.bzl\", \"mini_tar\")\n"
           + "load('//:helper.bzl', 'write_to_file')\n"
           + "write_to_file(name = 'target', filename = 'file', text ='text')\n"
-          + "pkg_tar(name = \"pkg_tar_target\", srcs = glob([\"*\"]),)";
+          + "mini_tar(name = \"mini_tar_target\", srcs = glob([\"*\"]),)";
 
   @Test
   public void testOutput() throws IOException {
@@ -51,7 +51,7 @@ public class RepoWithRuleWritingTextGeneratorTest {
 
       String buildText = String.join("\n", PathUtils.readFile(repository.resolve("BUILD")));
       assertThat(buildText).isEqualTo(BUILD_TEXT);
-      assertThat(generator.getPkgTarTarget()).isEqualTo("pkg_tar_write_text");
+      assertThat(generator.getPkgTarTarget()).isEqualTo("mini_tar_write_text");
     } finally {
       PathUtils.deleteTree(directory);
     }
@@ -73,7 +73,7 @@ public class RepoWithRuleWritingTextGeneratorTest {
 
       String buildText = String.join("\n", PathUtils.readFile(repository.resolve("BUILD")));
       assertThat(buildText).isEqualTo(BUILD_TEXT_PARAMS);
-      assertThat(generator.getPkgTarTarget()).isEqualTo("pkg_tar_target");
+      assertThat(generator.getPkgTarTarget()).isEqualTo("mini_tar_target");
     } finally {
       PathUtils.deleteTree(directory);
     }

--- a/tools/build_defs/pkg/tar.bzl
+++ b/tools/build_defs/pkg/tar.bzl
@@ -78,7 +78,7 @@ _real_mini_tar = rule(
 
 def mini_tar(name, out = None, **kwargs):
     if not out:
-        out = name + ".tar",
+        out = name + ".tar"
     _real_mini_tar(
         name = name,
         out = out,

--- a/tools/build_defs/pkg/tar.bzl
+++ b/tools/build_defs/pkg/tar.bzl
@@ -31,10 +31,11 @@ def _mini_tar_impl(ctx):
     # Start building the arguments.
     args = [
         "--output=" + ctx.outputs.out.path,
-        "--directory=" + ctx.attr.package_dir,
         "--mode=" + ctx.attr.mode,
         "--owner=" + ctx.attr.owner,
     ]
+    if ctx.attr.package_dir:
+        args.append("--directory=" + ctx.attr.package_dir)
     if ctx.attr.mtime != -1:  # Note: Must match default in rule def.
         args.append("--mtime=%d" % ctx.attr.mtime)
 
@@ -62,7 +63,7 @@ _real_mini_tar = rule(
         "mtime": attr.int(default = -1),
         "out": attr.output(),
         "owner": attr.string(default = "0.0"),
-        "package_dir": attr.string(default = "/"),
+        "package_dir": attr.string(),
         "srcs": attr.label_list(allow_files = True),
         "strip_prefix": attr.string(),
 

--- a/tools/build_defs/pkg/tar.bzl
+++ b/tools/build_defs/pkg/tar.bzl
@@ -1,0 +1,104 @@
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""mini_tar: A limited functionality tar utility."""
+
+load(":path.bzl", "compute_data_path", "dest_path")
+
+# Filetype to restrict inputs
+tar_filetype = [".tar", ".tar.gz", ".tgz", ".tar.bz2"]
+
+def _quote(filename, protect = "="):
+    """Quote the filename, by escaping = by \\= and \\ by \\\\"""
+    return filename.replace("\\", "\\\\").replace(protect, "\\" + protect)
+
+def _mini_tar_impl(ctx):
+    """Implementation of the mini_tar rule."""
+
+    # Compute the relative path
+    data_path = compute_data_path(ctx.outputs.out, ctx.attr.strip_prefix)
+
+    # Start building the arguments.
+    args = [
+        "--output=" + ctx.outputs.out.path,
+        "--directory=" + ctx.attr.package_dir,
+        "--mode=" + ctx.attr.mode,
+        "--owner=" + ctx.attr.owner,
+        "--owner_name=" + ctx.attr.ownername,
+    ]
+    if ctx.attr.mtime != -1:  # Note: Must match default in rule def.
+        if ctx.attr.portable_mtime:
+            fail("You may not set both mtime and portable_mtime")
+        args.append("--mtime=%d" % ctx.attr.mtime)
+    if ctx.attr.portable_mtime:
+        args.append("--mtime=portable")
+
+    # Add runfiles if requested
+    file_inputs = ctx.files.srcs[:]
+
+    args += [
+        "--file=%s=%s" % (_quote(f.path), dest_path(f, data_path))
+        for f in file_inputs
+    ]
+    if ctx.attr.extension:
+        dotPos = ctx.attr.extension.find(".")
+        if dotPos > 0:
+            dotPos += 1
+            args += ["--compression=%s" % ctx.attr.extension[dotPos:]]
+        elif ctx.attr.extension == "tgz":
+            args += ["--compression=gz"]
+    args += ["--tar=" + f.path for f in ctx.files.deps]
+    arg_file = ctx.actions.declare_file(ctx.label.name + ".args")
+    ctx.actions.write(arg_file, "\n".join(args))
+
+    ctx.actions.run(
+        inputs = file_inputs + ctx.files.deps + [arg_file],
+        executable = ctx.executable.build_tar,
+        arguments = ["--flagfile", arg_file.path],
+        outputs = [ctx.outputs.out],
+        mnemonic = "PackageTar",
+        use_default_shell_env = True,
+    )
+
+# A rule for creating a tar file, see README.md
+_real_mini_tar = rule(
+    implementation = _mini_tar_impl,
+    attrs = {
+        "strip_prefix": attr.string(),
+        "package_dir": attr.string(default = "/"),
+        "deps": attr.label_list(allow_files = tar_filetype),
+        "srcs": attr.label_list(allow_files = True),
+        "mode": attr.string(default = "0555"),
+        "mtime": attr.int(default = -1),
+        "portable_mtime": attr.bool(default = True),
+        "out": attr.output(),
+        "owner": attr.string(default = "0.0"),
+        "ownername": attr.string(default = "."),
+        "extension": attr.string(default = "tar"),
+        # Implicit dependencies.
+        "build_tar": attr.label(
+            default = Label("//tools/build_defs/pkg:build_tar"),
+            cfg = "host",
+            executable = True,
+            allow_files = True,
+        ),
+    },
+)
+
+def mini_tar(name, **kwargs):
+    extension = kwargs.get("extension") or "tar"
+    _real_mini_tar(
+        name = name,
+        out = name + "." + extension,
+        **kwargs
+    )

--- a/tools/build_defs/pkg/tar.bzl
+++ b/tools/build_defs/pkg/tar.bzl
@@ -46,7 +46,7 @@ def _mini_tar_impl(ctx):
     arg_file = ctx.actions.declare_file(ctx.label.name + ".args")
     ctx.actions.write(arg_file, "\n".join(args))
     ctx.actions.run(
-        inputs = file_inputs + ctx.files.deps + [arg_file],
+        inputs = file_inputs + [arg_file],
         executable = ctx.executable.build_tar,
         arguments = ["--flagfile", arg_file.path],
         outputs = [ctx.outputs.out],


### PR DESCRIPTION
Add `@bazel_tools/build_defs/pkg/tar.bzl%mini_tar`.
This is limited functionality tar file builder. Its purpose is mainly for building tar files inside tests, where we do not want to take a dependency on the external repository @rules_pkg.

This means bazel itself does not depend on tools/build_defs/pkg/pkg.bzl at all any more, so we are free to delete that as soon as we have migrated the last of the users away.

Advances https://github.com/bazelbuild/bazel/issues/11183