### PR TITLE
Fix precompiled libs not in runfiles of cc_shared_library

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl
@@ -501,6 +501,12 @@ def _cc_shared_library_impl(ctx):
     else:
         library.append(linking_outputs.library_to_link.dynamic_library)
 
+    precompiled_only_dynamic_libraries_runfiles = []
+    for precompiled_dynamic_library in precompiled_only_dynamic_libraries:
+        precompiled_only_dynamic_libraries_runfiles.append(precompiled_dynamic_library.dynamic_library)
+        if precompiled_dynamic_library.resolved_symlink_dynamic_library != None:
+            precompiled_only_dynamic_libraries_runfiles.append(precompiled_dynamic_library.resolved_symlink_dynamic_library)
+
     return [
         DefaultInfo(
             files = depset(library),


### PR DESCRIPTION
Based on  PiperOrigin-RevId: 431978572