### PR TITLE
[5.1] Avoid merging URLs in HttpUtils

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpUtils.java
@@ -77,7 +77,6 @@ public final class HttpUtils {
     // scheme of their redirect URLs.
     if (preferred.getHost() != null
         && preferred.getScheme() != null
-        && (preferred.getUserInfo() != null || original.getUserInfo() == null)
         && (preferred.getFragment() != null || original.getRef() == null)) {
       // In this case we obviously do not inherit anything from the original URL, as all inheritable
       // fields are either set explicitly or not present in the original either. Therefore, it is

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/downloader/HttpUtilsTest.java
@@ -139,4 +139,14 @@ public class HttpUtilsTest {
     when(connection.getHeaderField("Location")).thenReturn(redirect);
     assertThat(HttpUtils.getLocation(connection)).isEqualTo(URI.create(redirect).toURL());
   }
+
+  @Test
+  public void getLocation_preservesQuotingWithUserIfNotInheriting() throws Exception {
+    String redirect =
+        "http://redirected.example.org/foo?"
+            + "response-content-disposition=attachment%3Bfilename%3D%22bar.tar.gz%22";
+    when(connection.getURL()).thenReturn(new URL("http://a:b@original.example.org"));
+    when(connection.getHeaderField("Location")).thenReturn(redirect);
+    assertThat(HttpUtils.getLocation(connection)).isEqualTo(URI.create(redirect).toURL());
+  }
 }


### PR DESCRIPTION
`mergeUrls` does not need to rebuild the URL from scratch if user information exists on the original URL. This behavior can actually break the 302 redirect due to subtle changes in the URL/encoding and should be avoided when possible.

This fixes https://github.com/bazelbuild/bazel/issues/14866 by correcting the implementation of `mergeUrls` to match the documentation that was added instead of rebuilding the URL from scratch which breaks the encoding of signed URLs.

(cherry picked from commit 8cefb8bed4ac82df8640682517372a9249732352)

Closes https://github.com/bazelbuild/bazel/issues/14953.