### PR TITLE
[5.1] Fix typo in `apple_common.platform` docs

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/apple/AppleCommonApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/apple/AppleCommonApi.java
@@ -87,7 +87,7 @@ public interface AppleCommonApi<
               + "<li><code>tvos_device</code></li>"
               + "<li><code>tvos_simulator</code></li>"
               + "<li><code>watchos_device</code></li>"
-              + "<li><code>watchos_device</code></li>"
+              + "<li><code>watchos_simulator</code></li>"
               + "</ul><p>"
               + "These values can be passed to methods that expect a platform, like "
               + "<a href='XcodeVersionConfig.html#sdk_version_for_platform'>"


### PR DESCRIPTION
(cherry picked from commit fa761f84994f18db383fbe9aaea524e4385da13a)

Closes https://github.com/bazelbuild/bazel/issues/14957.