### PR TITLE
Preemptively use `//third_party:guava-failureaccess-jar` in `//src/test/java/com/google/devtools/build/android/desugar:desugar_guava_at_head`.

### DIFF
--- a/src/test/java/com/google/devtools/build/android/desugar/BUILD
+++ b/src/test/java/com/google/devtools/build/android/desugar/BUILD
@@ -2094,6 +2094,7 @@ genrule(
     name = "desugar_guava_at_head",
     srcs = [
         "//third_party:guava-jars",
+        "//third_party:guava-failureaccess-jar",
         # Depend on Jacoco runtime in case testdata was built with coverage
         # instrumentation
         "//third_party/java/jacoco:blaze-agent",
@@ -2101,7 +2102,9 @@ genrule(
     ],
     outs = ["guava_at_head_desugared.jar"],
     cmd = "$(location //src/tools/android/java/com/google/devtools/build/android/desugar:Desugar) " +
-          "-i $(location //third_party:guava-jars) -o $@ " +
+          "-i $(location //third_party:guava-jars) " +
+          "--classpath_entry $(location //third_party:guava-failureaccess-jar) " +
+          "-o $@ " +
           "--bootclasspath_entry $(location @bazel_tools//tools/android:android_jar)",
     tags = ["no_windows"],
     tools = ["//src/tools/android/java/com/google/devtools/build/android/desugar:Desugar"],

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -503,6 +503,15 @@ distrib_jar_filegroup(
     enable_distributions = ["debian"],
 )
 
+# For desugaring the Guava jar.
+distrib_jar_filegroup(
+    name = "guava-failureaccess-jar",
+    srcs = [
+      "guava/failureaccess-1.0.1.jar",
+    ],
+    enable_distributions = ["debian"],
+)
+
 java_import(
     name = "javax_activation",
     jars = ["javax_activation/javax.activation-api-1.2.0.jar"],


### PR DESCRIPTION
This is commit 2/5 for
https://github.com/bazelbuild/bazel/pull/14942#issuecomment-1058667374.
