### PR TITLE
Export ProGuard specs from java_import.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaImportBaseRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaImportBaseRule.java
@@ -21,6 +21,7 @@ import static com.google.devtools.build.lib.packages.Type.BOOLEAN;
 import static com.google.devtools.build.lib.packages.Type.STRING_LIST;
 
 import com.google.devtools.build.lib.analysis.BaseRuleClasses;
+import com.google.devtools.build.lib.analysis.config.ExecutionTransitionFactory;
 import com.google.devtools.build.lib.analysis.RuleDefinition;
 import com.google.devtools.build.lib.analysis.RuleDefinitionEnvironment;
 import com.google.devtools.build.lib.packages.RuleClass;
@@ -63,6 +64,11 @@ public class JavaImportBaseRule implements RuleDefinition {
                 .orderIndependent()
                 .nonconfigurable(
                     "used in Attribute.validityPredicate implementations (loading time)"))
+        .add(
+            attr("$jar_embedded_proguard_extractor", LABEL)
+                .cfg(ExecutionTransitionFactory.create())
+                .exec()
+              .value(environment.getToolsLabel("//tools/jdk:jar_embedded_proguard_extractor")))
         .advertiseStarlarkProvider(StarlarkProviderIdentifier.forKey(JavaInfo.PROVIDER.getKey()))
         .build();
   }

--- a/src/test/java/com/google/devtools/build/lib/rules/android/AarImportTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/AarImportTest.java
@@ -166,30 +166,10 @@ public abstract class AarImportTest extends AndroidBuildViewTestCase {
                 .map(Artifact::getRootRelativePathString)
                 .collect(Collectors.toSet()))
         .containsExactly(
-            "a/_aar/bar/proguard.txt", "a/_aar/foo/proguard.txt", "a/_aar/baz/proguard.txt");
-  }
-
-  @Test
-  public void testProguardExtractor() throws Exception {
-    ConfiguredTarget target = getConfiguredTarget("//a:bar");
-    Artifact proguardSpecsAritfact =
-        target.get(ProguardSpecProvider.PROVIDER).getTransitiveProguardSpecs().toList().get(0);
-
-    Artifact aarProguardExtractor =
-        getDirectPrerequisite(
-                target,
-                ruleClassProvider.getToolsRepository()
-                    + "//tools/android:aar_embedded_proguard_extractor")
-            .getProvider(FilesToRunProvider.class)
-            .getExecutable();
-
-    assertThat(getGeneratingSpawnAction(proguardSpecsAritfact).getArguments())
-        .containsExactly(
-            aarProguardExtractor.getExecPathString(),
-            "--input_aar",
-            "a/bar.aar",
-            "--output_proguard_file",
-            proguardSpecsAritfact.getExecPathString());
+            "a/validated_proguard/bar/a/_aar/bar/proguard.txt_valid",
+            "java/validated_proguard/baz/java/_jar_import/baz/proguard.txt_valid",
+            "a/validated_proguard/baz/a/_aar/baz/proguard.txt_valid",
+            "a/validated_proguard/foo/a/_aar/foo/proguard.txt_valid");
   }
 
   @Test

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -20,6 +20,7 @@ filegroup(
         "jdk.BUILD",
         "local_java_repository.bzl",
         "nosystemjdk/README",
+        "jar_embedded_proguard_extractor.py",
         "proguard_whitelister.py",
         "proguard_whitelister_test.py",
         "proguard_whitelister_test_input.pgcfg",

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -420,6 +420,11 @@ filegroup(
 )
 
 py_binary(
+    name = "jar_embedded_proguard_extractor",
+    srcs = ["jar_embedded_proguard_extractor.py"],
+)
+
+py_binary(
     name = "proguard_whitelister",
     srcs = [
         "proguard_whitelister.py",

--- a/tools/jdk/jar_embedded_proguard_extractor.py
+++ b/tools/jdk/jar_embedded_proguard_extractor.py
@@ -1,0 +1,40 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A tool for extracting proguard specs from JARs.
+
+Usage:
+Takes positional arguments: input_jar1 input_jar2 <...> output_proguard_spec
+
+Background: 
+A JAR may contain proguard specs under /META-INF/proguard/
+[https://developer.android.com/studio/build/shrink-code]
+
+This tool extracts them all into a single spec for easy usage."""
+
+
+import sys
+import zipfile
+
+
+if __name__ == "__main__":
+    with open(sys.argv[-1], 'wb') as output_proguard_spec:
+        for jar_path in sys.argv[1:-1]:
+            with zipfile.ZipFile(jar_path) as jar:
+                for entry in jar.namelist():
+                    if entry.startswith('META-INF/proguard'):
+                        # zip directories are empty and therefore ok to output
+                        output_proguard_spec.write(jar.read(entry))
+                        # gracefully handle any lack of trailing newline
+                        output_proguard_spec.write(b'\n')


### PR DESCRIPTION
Hi, wonderful Bazel folks. Here's another PR for your consideration :)

I happened to notice that Bazel was failing to use ProGuards bundled in java_imported JARs while I was writing #14910, so I figured I'd create a fix. Didn't immediately need it for myself, I just figured I'd be a good ex-Googler and fix it when I saw it.

As before, please feel free to modify as you see fit, especially if that'd make things faster overall! And it's my first time touching a lot of these parts of the codebase--so I'm hoping you'll be patient with me.

More details from the commit message: 
---

**Background**:
JAR files can bundle ProGuard specs under `META-INF/proguard/`
[See https://developer.android.com/studio/build/shrink-code]

**Problem**:
Bazel previously erroniously ignored these ProGuard specs, leading to failures with, for example, androidx.annotation.Keep. Bad times.

There was previously a parallel issue with aar_import.
[Fixed in #12749]

**Solution**:
This change causes the previously ignored, embedded proguards to be extracted, validated, and then bubbled up correctly via the ProguardSpecProvider.

There's also a minor fix to aar_import, adding proguard validation and slightly simplifying the resulting code. For reasoning behind why library proguards should be validated, see the module docstring of proguard_whitelister.py

**Remaining issues:**
JAR files brought down from Maven via rules_jvm_external currently bypass java_import in favor of rolling their own jvm_import, since java_import was broken for Kotlin for years. That'll need a subsequent migration to reunify imoplementations; this only fixes java_import. For context on the Kotlin breakage, see https://github.com/bazelbuild/bazel/issues/4549. For the status on fixes in rules_jvm_external, see https://github.com/bazelbuild/rules_jvm_external/issues/672

Thanks for your consideration!
Chris
(ex-Googler)