### PR TITLE
Add toggle for ijar in java_import

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaImport.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaImport.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.collect.nestedset.Order;
 import com.google.devtools.build.lib.rules.java.JavaRuleOutputJarsProvider.JavaOutput;
+import com.google.devtools.build.lib.packages.Type;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -202,7 +203,8 @@ public class JavaImport implements RuleConfiguredTargetFactory {
       RuleContext ruleContext,
       ImmutableMap.Builder<Artifact, Artifact> compilationToRuntimeJarMap) {
     ImmutableList.Builder<Artifact> interfaceJarsBuilder = ImmutableList.builder();
-    boolean useIjar = ruleContext.getFragment(JavaConfiguration.class).getUseIjars();
+    boolean useIjar = ruleContext.getFragment(JavaConfiguration.class).getUseIjars()
+        && ruleContext.attributes().get("use_ijar", Type.BOOLEAN);
     for (Artifact jar : jars) {
       Artifact interfaceJar =
           useIjar

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaImportBaseRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaImportBaseRule.java
@@ -54,6 +54,13 @@ public class JavaImportBaseRule implements RuleDefinition {
         for IDE plug-ins or <code>tools.jar</code> for anything running on
         a standard JDK.
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
+        .add(attr("use_ijar", BOOLEAN).value(false))
+        /* <!-- #BLAZE_RULE($java_import_base).ATTRIBUTE(use_ijar) -->
+        If you import an oft-changing JAR that doesn't have a Kotlin interface,
+        you can enable this as a caching optimization.
+        Temporarily available until ijar is updated to properly handle Kotlin.
+        For more, see https://github.com/bazelbuild/bazel/issues/4549.
+        <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(attr("neverlink", BOOLEAN).value(false))
         /* <!-- #BLAZE_RULE($java_import_base).ATTRIBUTE(constraints) -->
         Extra constraints imposed on this rule as a Java library.

--- a/src/test/java/com/google/devtools/build/lib/view/java/JavaImportConfiguredTargetTest.java
+++ b/src/test/java/com/google/devtools/build/lib/view/java/JavaImportConfiguredTargetTest.java
@@ -55,10 +55,12 @@ public class JavaImportConfiguredTargetTest extends BuildViewTestCase {
     scratch.file(
         "java/jarlib/BUILD",
         "java_import(name = 'libraryjar',",
-        "            jars = ['library.jar'])",
+        "            jars = ['library.jar'],",
+        "            use_ijar = True)",
         "java_import(name = 'libraryjar_with_srcjar',",
         "            jars = ['library.jar'],",
-        "            srcjar = 'library.srcjar')");
+        "            srcjar = 'library.srcjar',",
+        "            use_ijar = True)");
   }
 
   @Test
@@ -130,11 +132,14 @@ public class JavaImportConfiguredTargetTest extends BuildViewTestCase {
         "            jars = ['import.jar'],",
         "            deps = ['//java/jarlib2:depjar'],",
         "            exports = ['//java/jarlib2:exportjar'],",
+        "            use_ijar = True",
         ")",
         "java_import(name  = 'depjar',",
-        "            jars = ['depjar.jar'])",
+        "            jars = ['depjar.jar'],",
+        "            use_ijar = True)",
         "java_import(name  = 'exportjar',",
-        "            jars = ['exportjar.jar'])");
+        "            jars = ['exportjar.jar'],",
+        "            use_ijar = True)");
 
     ConfiguredTarget importJar = getConfiguredTarget("//java/jarlib2:import-jar");
 
@@ -210,7 +215,8 @@ public class JavaImportConfiguredTargetTest extends BuildViewTestCase {
         "java_import(name  = 'library-jar',",
         "            jars = [':generated_jar'],",
         "            srcjar = ':generated_src_jar',",
-        "            exports = ['//java/jarlib:libraryjar'])");
+        "            exports = ['//java/jarlib:libraryjar'],",
+        "            use_ijar = True)");
     ConfiguredTarget jarLib = getConfiguredTarget("//java/genrules:library-jar");
 
     JavaCompilationArgsProvider compilationArgs =
@@ -441,7 +447,8 @@ public class JavaImportConfiguredTargetTest extends BuildViewTestCase {
         "             deps = ['//java/jarlib:libraryjar'])",
         "java_import(name  = 'library2-jar',",
         "            jars = ['library2.jar'],",
-        "            exports = [':lib'])",
+        "            exports = [':lib'],",
+        "            use_ijar = True)",
         "java_library(name  = 'javalib2',",
         "             srcs = ['Other.java'],",
         "             deps = [':library2-jar'])");
@@ -464,6 +471,7 @@ public class JavaImportConfiguredTargetTest extends BuildViewTestCase {
         "    name = 'import_dep',",
         "    jars = ['import_compile.jar'],",
         "    runtime_deps = ['import_runtime.jar'],",
+        "    use_ijar = True",
         ")",
         "java_library(",
         "    name = 'library_dep',",


### PR DESCRIPTION
Hi, wonderful Bazel folks. Here's another PR for your consideration :)

While fixing ProGuards for java_import in #14966, I ran across #4549, wherein we were fragmenting efforts to import jars because the java_import rule had been broken for Kotlin interfaces for so long.

It seemed from the discussion there that adding a toggle for ijar on java_import was the right interim move, and was likely to unblock things with few downsides. Plus, I'd just added a (private) attribute to java import in #14966,  so I figured I'd toss up a quick PR.

Like the previous PR, this isn't something I immediately need it for myself or anything, I just figured I'd be a good ex-Googler and toss in a fix when I saw an easy opportunity and what seemed like a burning need (from the length of discussion and effort on alternative implementations). I do think I'd better stop the yak shave here, though, rather than going on to fix ijar.

As always, please feel free to modify the PR as you see fit, especially if that'd make things faster overall! This bundle of PRs is my first time touching a lot of these parts of the codebase--so I'm hoping you'll be patient with me.

More details from the commit message: 
---

**Problem:** java_import has been unusably broken for years for JARs with Kotlin interfaces, since ijar strips out important information. This has caused multiple dependent projects (including official Bazel ones) to abandon java_import in favor of rolling their own versions, which themselves contain issues that are getting fixed in java_import. Fragmentation is bad, and fragmentation of bugs and fixes is worse.
For more, see
https://github.com/bazelbuild/rules_jvm_external/blob/master/private/rules/jvm_import.bzl
https://github.com/bazelbuild/bazel/issues/4549
https://github.com/bazelbuild/bazel/pull/14966
https://github.com/bazelbuild/rules_jvm_external/issues/672

**Temporary solution:** Until such time as ijar is fixed for Kotlin, this adds a toggle that enables/disables ijar on java_import. This should unblock use of java_import for libraries that might contain Kotlin, so implementations can reunify.

It also restores java_import to a state where it works correctly by default. Per the user manual, ijars are just a build performance optimization to allow caching of actions that use JARs whose implementations change frequently [1]. Imported (externally compiled) JARs shouldn't be changing very often, meaning that the build performance cost of disabling ijars for these prebuilt JARs should be relatively low. Therefore, the ijar toggle is off by default, so the build is correct by default. But ijar is still made available though the toggle, just in case someone is importing a Java-interface-only JAR that they change all the time.

[1] https://docs.bazel.build/versions/main/user-manual.html#flag--use_ijars

--- 

Thanks for your consideration!
Chris