### PR TITLE
Platforms Intro: Fix Transitions Package

### DIFF
--- a/site/en/concepts/platforms-intro.md
+++ b/site/en/concepts/platforms-intro.md
@@ -360,7 +360,7 @@ sets `--cpu`, `--crossstool_top`, or other legacy flags, rules that read
 
 When migrating your project to platforms, you must either convert changes like
 `return { "//command_line_option:cpu": "arm" }` to `return {
-"//command_line_options:platforms": "//:my_arm_platform" }` or use [platform
+"//command_line_option:platforms": "//:my_arm_platform" }` or use [platform
 mappings](#platform-mappings) to support both styles through the migration
 window.
 


### PR DESCRIPTION
Hi, wonderful Bazel folks.

Happened to notice a small mistake in the @platforms docs while I was reading through. Figured I'd toss up a quick PR :)

From the commit message:
---

Command line options package is `//command_line_option`
The existing `//command_line_options` gives `ERROR: no such package 'command_line_options': Unable to find build setting package`

---

Thanks for your consideration,
Chris
(ex-Googler)