### PR TITLE
[5.1] merkle_tree_cache: change default size to 1000

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -540,14 +540,15 @@ public final class RemoteOptions extends OptionsBase {
 
   @Option(
       name = "experimental_remote_merkle_tree_cache_size",
-      defaultValue = "0",
+      defaultValue = "1000",
       documentationCategory = OptionDocumentationCategory.REMOTE,
       effectTags = {OptionEffectTag.UNKNOWN},
       help =
           "The number of Merkle trees to memoize to improve the remote cache hit checking speed. "
               + "Even though the cache is automatically pruned according to Java's handling of "
               + "soft references, out-of-memory errors can occur if set too high. If set to 0 "
-              + "(default), the cache size is unlimited.")
+              + " the cache size is unlimited. Optimal value varies depending on project's size. "
+              + "Default to 1000.")
   public long remoteMerkleTreeCacheSize;
 
   @Option(


### PR DESCRIPTION
The implementation of Merkle Tree Cache maintains an in-process map
which cache the Input merkle tree's nodes to save traversal time when
Bazel have to interact with Remote Cache and/or RBE services.

This cache implementation used Caffeine's Soft Values cache which should
be used with predictable maximum cache size.

Set the default cache size to 1000 instead of unlimited(0).
Adjust doc to note that default might not be the most optimal value.

(cherry picked from commit b1bf9d6c5f85fc4fda0dc48bc3d3e2fe26880867)

Closes https://github.com/bazelbuild/bazel/issues/14983.