### PR TITLE
[5.1] Do not hide BulkTransferException messages when there were more than one exception

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/common/BulkTransferException.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/BulkTransferException.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.common;
 
+import com.google.common.base.Joiner;
 import java.io.IOException;
 
 /**
@@ -57,6 +58,9 @@ public class BulkTransferException extends IOException {
     if (super.getSuppressed().length == 1) {
       return super.getSuppressed()[0].getMessage();
     }
-    return String.format("%d errors during bulk transfer", super.getSuppressed().length);
+    String errorSummary =
+        String.format("%d errors during bulk transfer:", super.getSuppressed().length);
+    String combinedSuberrors = Joiner.on('\n').join(super.getSuppressed());
+    return Joiner.on('\n').join(errorSummary, combinedSuberrors);
   }
 }


### PR DESCRIPTION
Previously, when there were more than one BulkTransferException, it
would be reported like this:

```
Executing genrule //:foo failed: Exec failed due to IOException: 221 errors during bulk transfer
```

which didn't include the underlying exception messages. The only case
that underlying exceptions were included was when there was only one
exception.

This change patches the error message to include all the exception
messages, which helps diagnose BulkTransferException.

(cherry picked from commit 113eaca5862c48797654ae2a3acbb6e15d761485)

Closes https://github.com/bazelbuild/bazel/issues/14985.