### PR TITLE
[5.1] Adding Starlark dependencies to the package //external

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Package.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Package.java
@@ -1358,7 +1358,7 @@ public class Package {
       return null;
     }
 
-    Builder setStarlarkFileDependencies(ImmutableList<Label> starlarkFileDependencies) {
+    public Builder setStarlarkFileDependencies(ImmutableList<Label> starlarkFileDependencies) {
       this.starlarkFileDependencies = starlarkFileDependencies;
       return this;
     }

--- a/src/main/java/com/google/devtools/build/lib/packages/PackageFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/PackageFactory.java
@@ -706,7 +706,7 @@ public final class PackageFactory {
     return ImmutableList.copyOf(set);
   }
 
-  private static void transitiveClosureOfLabelsRec(
+  public static void transitiveClosureOfLabelsRec(
       Set<Label> set, ImmutableMap<String, Module> loads) {
     for (Module m : loads.values()) {
       BazelModuleContext ctx = BazelModuleContext.of(m);

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -259,6 +259,7 @@ py_library(
 
 py_test(
     name = "bazel_module_test",
+    size = "large",
     srcs = ["bzlmod/bazel_module_test.py"],
     deps = [
         ":bzlmod_test_utils",

--- a/src/test/py/bazel/query_test.py
+++ b/src/test/py/bazel/query_test.py
@@ -38,6 +38,87 @@ class QueryTest(test_base.TestBase):
     self._AssertQueryOutput('deps(//foo:top-rule, 1)', '//foo:top-rule',
                             '//foo:dep-rule')
 
+  def testBuildFilesForExternalRepos_Simple(self):
+    self.ScratchFile('WORKSPACE', [
+        'load("//:deps.bzl", "repos")',
+        'repos()',
+    ])
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile('deps.bzl', [
+        'def repos():',
+        '    native.new_local_repository(',
+        '        name = "io_bazel_rules_go",',
+        '        path = ".",',
+        """        build_file_content = "exports_files(glob(['*.go']))",""",
+        '    )',
+    ])
+    self._AssertQueryOutputContains('buildfiles(//external:io_bazel_rules_go)',
+                                    '//external:WORKSPACE', '//:deps.bzl',
+                                    '//:BUILD.bazel')
+
+  def testBuildFilesForExternalRepos_IndirectLoads(self):
+    self.ScratchFile('WORKSPACE', [
+        'load("//:deps.bzl", "repos")',
+        'repos()',
+    ])
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile('deps.bzl', [
+        'load("//:private_deps.bzl", "other_repos")',
+        'def repos():',
+        '    native.new_local_repository(',
+        '        name = "io_bazel_rules_go",',
+        '        path = ".",',
+        """        build_file_content = "exports_files(glob(['*.go']))",""",
+        '    )',
+        '    other_repos()',
+        '',
+    ])
+    self.ScratchFile('private_deps.bzl', [
+        'def other_repos():',
+        '    native.new_local_repository(',
+        '        name = "io_bazel_rules_python",',
+        '        path = ".",',
+        """        build_file_content = "exports_files(glob(['*.py']))",""",
+        '    )',
+    ])
+
+    self._AssertQueryOutputContains(
+        'buildfiles(//external:io_bazel_rules_python)', '//external:WORKSPACE',
+        '//:deps.bzl', '//:private_deps.bzl', '//:BUILD.bazel')
+
+  def testBuildFilesForExternalRepos_NoDuplicates(self):
+    self.ScratchFile('WORKSPACE', [
+        'load("//:deps.bzl", "repos")',
+        'repos()',
+    ])
+    self.ScratchFile('BUILD.bazel')
+    self.ScratchFile('deps.bzl', [
+        'def repos():',
+        '    native.new_local_repository(',
+        '        name = "io_bazel_rules_go",',
+        '        path = ".",',
+        """        build_file_content = "exports_files(glob(['*.go']))",""",
+        '    )',
+        '    other_repos()',
+        '',
+        'def other_repos():',
+        '    native.new_local_repository(',
+        '        name = "io_bazel_rules_python",',
+        '        path = ".",',
+        """        build_file_content = "exports_files(glob(['*.py']))",""",
+        '    )',
+    ])
+
+    exit_code, stdout, stderr = self.RunBazel(
+        ['query', 'buildfiles(//external:io_bazel_rules_python)'])
+    self.AssertExitCode(exit_code, 0, stderr)
+    result = set()
+    for item in stdout:
+      if not item:
+        continue
+      self.assertNotIn(item, result)
+      result.add(item)
+
   def _AssertQueryOutput(self, query_expr, *expected_results):
     exit_code, stdout, stderr = self.RunBazel(['query', query_expr])
     self.AssertExitCode(exit_code, 0, stderr)
@@ -45,6 +126,14 @@ class QueryTest(test_base.TestBase):
     stdout = sorted(x for x in stdout if x)
     self.assertEqual(len(stdout), len(expected_results))
     self.assertListEqual(stdout, sorted(expected_results))
+
+  def _AssertQueryOutputContains(self, query_expr, *expected_content):
+    exit_code, stdout, stderr = self.RunBazel(['query', query_expr])
+    self.AssertExitCode(exit_code, 0, stderr)
+
+    stdout = {x for x in stdout if x}
+    for item in expected_content:
+      self.assertIn(item, stdout)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is an alternative approach to fix #14280. It adds transitive closure of Starlark dependencies to `//external` package when loading `WORKSPACE` file, so it can be processed in the same way as `BUILD` files during query execution. Comparing to the approach taken in #14497, this approach is less intrusive, but not able to distinguish the extension files needed by `//external:foo` and `//external:bar`, meaning `buildfiles(//external:foo)` returns the same result as `buildfiles(//external:*)`. However, this behavior is consistent with other packages. For example, `buildfiles(//foo:bar)` has the same result as `buildfiles(//foo:*)`.

(cherry picked from commit a6c3f2327df424e56674a6bd758566d2757afdc7)