### PR TITLE
Remote: Fix crashes with InterruptedException when using http cache.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -729,7 +729,17 @@ public final class HttpCacheClient implements RemoteCacheClient {
       }
 
       isClosed = true;
-      channelPool.close();
+
+      // Clear interrupted status to prevent failure to close, indicated with #14787
+      boolean wasInterrupted = Thread.interrupted();
+      try {
+        channelPool.close();
+      } finally {
+        if (wasInterrupted) {
+          Thread.currentThread().interrupt();
+        }
+      }
+
       eventLoop.shutdownGracefully();
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlockWaitingModule.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlockWaitingModule.java
@@ -51,6 +51,7 @@ public class BlockWaitingModule extends BlazeModule {
     try {
       executorService.awaitTermination(Long.MAX_VALUE, SECONDS);
     } catch (InterruptedException e) {
+      executorService.shutdownNow();
       Thread.currentThread().interrupt();
     }
 


### PR DESCRIPTION
Also cancels tasks submitted during `afterCommand` if interrupted.

Fixes #14787.