### PR TITLE
Correct error runfiles cc_shared_library

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl
@@ -507,6 +507,8 @@ def _cc_shared_library_impl(ctx):
         if precompiled_dynamic_library.resolved_symlink_dynamic_library != None:
             precompiled_only_dynamic_libraries_runfiles.append(precompiled_dynamic_library.resolved_symlink_dynamic_library)
 
+    runfiles = runfiles.merge(ctx.runfiles(files = precompiled_only_dynamic_libraries_runfiles))
+
     return [
         DefaultInfo(
             files = depset(library),


### PR DESCRIPTION
Fix runfiles in cc_shared_library

[#1494](https://github.com/bazelbuild/bazel/pull/14943) misses a key part which was to actually add the precompiled libraries to the runfiles provider. There was a test but this used a cc_binary which gave the false sense of things working correctly since the cc_binary is able to get the runfiles from the CcInfo and add it itself. Changed test to use a py_test instead.

Cherrypick of 426188c4657a6bbe1d11d7f1f694c7a6a4148f10