### PR TITLE
[5.1] Remote: Fix crashes with InterruptedException when using http cache.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/http/HttpCacheClient.java
@@ -733,7 +733,23 @@ public final class HttpCacheClient implements RemoteCacheClient {
       }
 
       isClosed = true;
-      channelPool.close();
+
+      // Clear interrupted status to prevent failure to close, indicated with #14787
+      boolean wasInterrupted = Thread.interrupted();
+      try {
+        channelPool.close();
+      } catch (RuntimeException e) {
+        if (e.getCause() instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        } else {
+          throw e;
+        }
+      } finally {
+        if (wasInterrupted) {
+          Thread.currentThread().interrupt();
+        }
+      }
+
       eventLoop.shutdownGracefully();
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlockWaitingModule.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlockWaitingModule.java
@@ -51,6 +51,7 @@ public class BlockWaitingModule extends BlazeModule {
     try {
       executorService.awaitTermination(Long.MAX_VALUE, SECONDS);
     } catch (InterruptedException e) {
+      executorService.shutdownNow();
       Thread.currentThread().interrupt();
     }
 


### PR DESCRIPTION
Also cancels tasks submitted during `afterCommand` if interrupted.

Fixes #14787.

(cherry picked from commit a73aa12be65454ac8cfb5a8f3e056c420402f997)

Closes #14932.