### PR TITLE
Clear build configurations on --discard_analysis_cache

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -1084,6 +1084,14 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory, Configur
           }
         }
       }
+      if (topLevelTargets.isEmpty() && topLevelAspects.isEmpty()) {
+        // Top-level ConfiguredTargets may still reference configurations, so we leak them
+        // if any are being retained.
+        // Ideally this would only preserve the configurations reachable from those top-level
+        // targets, but this at least lets people run `bazel build --discard_analysis_cache`
+        // to blow away stale output from `bazel config`.
+        memoizingEvaluator.delete(k -> k.functionName().equals(SkyFunctions.BUILD_CONFIGURATION));
+      }
     }
   }
 


### PR DESCRIPTION
This means that `bazel config` no longer returns stale configurations
after a build with `--discard_analysis_cache`.

Unfortunately, because `--discard_analysis_cache` may still preserve
part of the graph, we don't unconditionally do this (as doing so would
cause an inconsistent graph).

Rather than walking the graph to find out which configurations are
actually needed, we either drop all or none. This could be refined in
the future.

Alternatively, perhaps there is a need for a standalone Command:
`bazel discard-analysis-cache` which can avoid the
preserve-top-level-target edge-cases of
`bazel build --discard_analysis_cache`.

Fixes #14725