### PR TITLE
Remove -U_FORTIFY_SOURCE when thin_lto is enabled

### DIFF
--- a/tools/cpp/unix_cc_configure.bzl
+++ b/tools/cpp/unix_cc_configure.bzl
@@ -530,9 +530,6 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
             "%{cxx_builtin_include_directories}": get_starlark_list(builtin_include_directories),
             "%{compile_flags}": get_starlark_list(
                 [
-                    # Security hardening requires optimization.
-                    # We need to undef it as some distributions now have it enabled by default.
-                    "-U_FORTIFY_SOURCE",
                     "-fstack-protector",
                     # All warnings are enabled.
                     "-Wall",

--- a/tools/cpp/unix_cc_toolchain_config.bzl
+++ b/tools/cpp/unix_cc_toolchain_config.bzl
@@ -176,6 +176,21 @@ def _impl(ctx):
         flag_sets = [
             flag_set(
                 actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        # Security hardening requires optimization.
+                        # We need to undef it as some distributions now have it enabled by default.
+                        flags = ["-U_FORTIFY_SOURCE"],
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(
+                        not_features = ["thin_lto"],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_compile_actions,
                 flag_groups = ([
                     flag_group(
                         flags = ctx.attr.compile_flags,


### PR DESCRIPTION
Clang does not accept `-U` flags when doing lto backend actions:

```
clang: error: argument unused during compilation: '-U _FORTIFY_SOURCE' [-Werror,-Wunused-command-line-argument]
```

This isn't a problem for `-D` flags because of a special case:

https://github.com/llvm/llvm-project/blob/10e99eb7e4adbb8e2407e2f6ae3d2e6420d060c9/clang/lib/Driver/ToolChains/Clang.cpp#L5579-L5582