### PR TITLE
Update use of `default_java_toolchain` in "Java and Bazel" to work correctly

### DIFF
--- a/site/en/docs/bazel-and-java.md
+++ b/site/en/docs/bazel-and-java.md
@@ -242,16 +242,16 @@ Example toolchain configuration:
 ```python
 load(
   "@bazel_tools//tools/jdk:default_java_toolchain.bzl",
-  "default_java_toolchain", "DEFAULT_TOOLCHAIN_CONFIGURATION", "JDK9_JVM_OPTS", "DEFAULT_JAVACOPTS"
+  "default_java_toolchain", "DEFAULT_TOOLCHAIN_CONFIGURATION", "BASE_JDK9_JVM_OPTS", "DEFAULT_JAVACOPTS"
 )
 
 default_java_toolchain(
   name = "repository_default_toolchain",
-  configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,      # One of predefined configurations
-                                                        # Other parameters are from java_toolchain rule:
-  java_runtime = "//tools/jdk:remote_jdk11",            # JDK to use for compilation and toolchain's tools execution
-  jvm_opts = JDK9_JVM_OPTS + ["--enable_preview"],      # Additional JDK options
-  javacopts = DEFAULT_JAVACOPTS + ["--enable_preview"], # Additional javac options
+  configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,       # One of predefined configurations
+                                                         # Other parameters are from java_toolchain rule:
+  java_runtime = "@bazel_tools//tools/jdk:remote_jdk11", # JDK to use for compilation and toolchain's tools execution
+  jvm_opts = BASE_JDK9_JVM_OPTS + ["--enable_preview"],  # Additional JDK options
+  javacopts = DEFAULT_JAVACOPTS + ["--enable_preview"],  # Additional javac options
   source_version = "9",
 )
 ```


### PR DESCRIPTION
There are really two changes here:

1. Fix the reference to `//tools/jdk:remote_jdk11` to have `@bazel_tools`. Without this, a direct copy/paste will fail to even build.
2. Change from `JDK9_JVM_OPTS` to `BASE_JDK9_JVM_OPTS` as the former includes `--patch-module=java.compiler=` which overrides `source_version` and can also cause build failures. See [this issue](https://github.com/bazelbuild/bazel/issues/14474#issuecomment-1001071398) for an example.