### PR TITLE
[5.1] Filter out system headers on macOS.

### DIFF
--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -235,6 +235,7 @@ LCOV_MERGER_CMD="${LCOV_MERGER} --coverage_dir=${COVERAGE_DIR} \
   --filter_sources=/usr/bin/.+ \
   --filter_sources=/usr/lib/.+ \
   --filter_sources=/usr/include.+ \
+  --filter_sources=/Applications/.+ \
   --filter_sources=.*external/.+ \
   --source_file_manifest=${COVERAGE_MANIFEST}"
 


### PR DESCRIPTION
Fixes #14969.

RELNOTES:
Bazel now no longer includes system headers on macOS in coverage reports (#14969).

(cherry picked from commit 71747ccc9d0032a865854613329362563c0574df)

Closes https://github.com/bazelbuild/bazel/issues/15019.