### PR TITLE
Docs: Remove references to --local_resources

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -305,8 +305,7 @@ public class ExecutionOptions extends OptionsBase {
               + " actions executed locally. Takes an integer, or \"HOST_CPUS\", optionally followed"
               + " by [-|*]<float> (eg. HOST_CPUS*.5 to use half the available CPU cores).By"
               + " default, (\"HOST_CPUS\"), Bazel will query system configuration to estimate"
-              + " the number of CPU cores available. Note: This is a no-op if --local_resources is"
-              + " set.",
+              + " the number of CPU cores available.",
       converter = CpuResourceConverter.class)
   public float localCpuResources;
 
@@ -320,8 +319,7 @@ public class ExecutionOptions extends OptionsBase {
               + " build actions executed locally. Takes an integer, or \"HOST_RAM\", optionally"
               + " followed by [-|*]<float> (eg. HOST_RAM*.5 to use half the available RAM). By"
               + " default, (\"HOST_RAM*.67\"), Bazel will query system configuration to estimate"
-              + " the amount of RAM available and will use 67% of it. Note: This is a no-op if"
-              + " --local_resources is set.",
+              + " the amount of RAM available and will use 67% of it.",
       converter = RamResourceConverter.class)
   public float localRamResources;
 

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorkerOptions.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/RemoteWorkerOptions.java
@@ -199,7 +199,7 @@ public class RemoteWorkerOptions extends OptionsBase {
       if (value > maxValue) {
         logger.atWarning().log(
             "Flag remoteWorker \"jobs\" ('%d') was set too high. "
-                + "This is a result of passing large values to --local_resources or --jobs. "
+                + "This is a result of passing large values to --jobs. "
                 + "Using '%d' jobs",
             value, maxValue);
         value = maxValue;


### PR DESCRIPTION
`--local_resources` option was removed in
https://github.com/bazelbuild/bazel/commit/7e8f86d60adc56159216c4fbb5b403ee8c5aec1c
but still is referenced in some docs, what may cause some confusion.

Esp. this documentation is confusing for e.g. `--local_ram_resources`:
`Note: This is a no-op if --local_resources is set.`