### PR TITLE
Run tests in runfiles directory without `LCOV_MERGER`

### DIFF
--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -40,6 +40,7 @@ if [[ -z "$LCOV_MERGER" ]]; then
   # TODO(cmita): Improve this situation so this early-exit isn't required.
   touch $COVERAGE_OUTPUT_FILE
   # Execute the test.
+  cd "$TEST_SRCDIR/$TEST_WORKSPACE"
   "$@"
   TEST_STATUS=$?
   exit "$TEST_STATUS"


### PR DESCRIPTION
`collect_coverage.sh` has the execution root as it's working directory, but tests should still be run from their runfiles directory  if `LCOV_MERGER` is missing.