### PR TITLE
Cquery can report transitions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
@@ -217,7 +217,8 @@ public class ConfiguredTargetQueryEnvironment
             skyframeExecutor,
             accessor,
             aspectResolver,
-            OutputType.BINARY),
+            OutputType.BINARY,
+            trimmingTransitionFactory),
         new ProtoOutputFormatterCallback(
             eventHandler,
             cqueryOptions,
@@ -225,7 +226,8 @@ public class ConfiguredTargetQueryEnvironment
             skyframeExecutor,
             accessor,
             aspectResolver,
-            OutputType.TEXT),
+            OutputType.TEXT,
+            trimmingTransitionFactory),
         new ProtoOutputFormatterCallback(
             eventHandler,
             cqueryOptions,
@@ -233,7 +235,8 @@ public class ConfiguredTargetQueryEnvironment
             skyframeExecutor,
             accessor,
             aspectResolver,
-            OutputType.JSON),
+            OutputType.JSON,
+            trimmingTransitionFactory),
         new BuildOutputFormatterCallback(
             eventHandler, cqueryOptions, out, skyframeExecutor, accessor),
         new GraphOutputFormatterCallback(

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/KnownTargetsDependencyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/KnownTargetsDependencyResolver.java
@@ -1,3 +1,16 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.devtools.build.lib.analysis.DependencyKind;

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/KnownTargetsDependencyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/KnownTargetsDependencyResolver.java
@@ -1,0 +1,35 @@
+package com.google.devtools.build.lib.query2.cquery;
+
+import com.google.devtools.build.lib.analysis.DependencyKind;
+import com.google.devtools.build.lib.analysis.DependencyResolver;
+import com.google.devtools.build.lib.analysis.TargetAndConfiguration;
+import com.google.devtools.build.lib.causes.Cause;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.packages.Target;
+import com.google.devtools.build.lib.util.OrderedSetMultimap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class KnownTargetsDependencyResolver extends DependencyResolver {
+
+  private final Map<Label, Target> knownTargets;
+
+  public KnownTargetsDependencyResolver(Map<Label, Target> knownTargets) {
+    this.knownTargets = knownTargets;
+  }
+
+  @Override
+  protected Map<Label, Target> getTargets(
+      OrderedSetMultimap<DependencyKind, Label> labelMap,
+      TargetAndConfiguration fromNode,
+      NestedSetBuilder<Cause> rootCauses) {
+    return labelMap.values().stream()
+        .distinct()
+        .filter(Objects::nonNull)
+        .filter(knownTargets::containsKey)
+        .collect(Collectors.toMap(Function.identity(), knownTargets::get));
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/KnownTargetsDependencyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/KnownTargetsDependencyResolver.java
@@ -13,6 +13,11 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/**
+ * KnownTargetsDependencyResolver is a DependencyResolver which resolves statically over a known
+ * set of targets. It can be useful when performing queries over a known pre-resolved universe of
+ * targets.
+ */
 public class KnownTargetsDependencyResolver extends DependencyResolver {
 
   private final Map<Label, Target> knownTargets;

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallback.java
@@ -18,11 +18,16 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.devtools.build.lib.actions.BuildConfigurationEvent;
 import com.google.devtools.build.lib.analysis.AnalysisProtosV2;
 import com.google.devtools.build.lib.analysis.AnalysisProtosV2.Configuration;
+import com.google.devtools.build.lib.analysis.DependencyResolver;
+import com.google.devtools.build.lib.analysis.InconsistentAspectOrderException;
+import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
+import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
@@ -30,9 +35,14 @@ import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.AttributeFormatter;
 import com.google.devtools.build.lib.packages.ConfiguredAttributeMapper;
 import com.google.devtools.build.lib.packages.Rule;
+import com.google.devtools.build.lib.packages.RuleTransitionData;
+import com.google.devtools.build.lib.query2.cquery.CqueryOptions.Transitions;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccessor;
 import com.google.devtools.build.lib.query2.proto.proto2api.Build;
+import com.google.devtools.build.lib.query2.proto.proto2api.Build.ConfiguredRuleInput;
 import com.google.devtools.build.lib.query2.proto.proto2api.Build.QueryResult;
+import com.google.devtools.build.lib.query2.proto.proto2api.Build.Target;
+import com.google.devtools.build.lib.query2.proto.proto2api.Build.Target.Builder;
 import com.google.devtools.build.lib.query2.query.aspectresolvers.AspectResolver;
 import com.google.devtools.build.lib.query2.query.output.ProtoOutputFormatter;
 import com.google.devtools.build.lib.skyframe.BuildConfigurationKey;
@@ -47,6 +57,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /** Proto output formatter for cquery results. */
 class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
@@ -101,9 +112,11 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
   private final SkyframeExecutor skyframeExecutor;
   private final ConfigurationCache configurationCache = new ConfigurationCache();
   private final JsonFormat.Printer jsonPrinter = JsonFormat.printer();
+  @Nullable private final TransitionFactory<RuleTransitionData> trimmingTransitionFactory;
 
   private AnalysisProtosV2.CqueryResult.Builder protoResult;
 
+  private final HashMap<Label, com.google.devtools.build.lib.packages.Target> partialResultMap;
   private KeyedConfiguredTarget currentTarget;
 
   ProtoOutputFormatterCallback(
@@ -113,11 +126,14 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
       SkyframeExecutor skyframeExecutor,
       TargetAccessor<KeyedConfiguredTarget> accessor,
       AspectResolver resolver,
-      OutputType outputType) {
+      OutputType outputType,
+      @Nullable TransitionFactory<RuleTransitionData> trimmingTransitionFactory) {
     super(eventHandler, options, out, skyframeExecutor, accessor);
     this.outputType = outputType;
     this.skyframeExecutor = skyframeExecutor;
     this.resolver = resolver;
+    this.trimmingTransitionFactory = trimmingTransitionFactory;
+    this.partialResultMap = Maps.newHashMap();
   }
 
   @Override
@@ -173,6 +189,12 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
   @Override
   public void processOutput(Iterable<KeyedConfiguredTarget> partialResult)
       throws InterruptedException {
+    partialResult.forEach(kct -> partialResultMap.put(kct.getLabel(), accessor.getTarget(kct)));
+
+    KnownTargetsDependencyResolver knownTargetsDependencyResolver = new KnownTargetsDependencyResolver(partialResultMap);
+
+    TransitionResolver transitionResolver = new TransitionResolver(eventHandler, knownTargetsDependencyResolver, accessor, this, trimmingTransitionFactory);
+
     ConfiguredProtoOutputFormatter formatter = new ConfiguredProtoOutputFormatter();
     formatter.setOptions(options, resolver, skyframeExecutor.getDigestFunction().getHashFunction());
     for (KeyedConfiguredTarget keyedConfiguredTarget : partialResult) {
@@ -184,7 +206,35 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
       // logic in this next line. If this were to change (i.e. we manipulate targets any further),
       // we will want to add relevant tests.
       currentTarget = keyedConfiguredTarget;
-      builder.setTarget(formatter.toTargetProtoBuffer(accessor.getTarget(keyedConfiguredTarget)));
+      com.google.devtools.build.lib.packages.Target target = accessor.getTarget(
+          keyedConfiguredTarget);
+      Target.Builder targetBuilder = formatter.toTargetProtoBuffer(target);
+      if (target instanceof Rule && !Transitions.NONE.equals(options.transitions)) {
+        try {
+          for (TransitionResolver.ResolvedTransition resolvedTransition : transitionResolver.dependencies(
+              keyedConfiguredTarget)) {
+            if (resolvedTransition.options().isEmpty()) {
+              targetBuilder.getRuleBuilder().addConfiguredRuleInput(
+                  ConfiguredRuleInput.newBuilder().setLabel(resolvedTransition.label().toString()));
+            } else {
+              for (BuildOptions options : resolvedTransition.options()) {
+                BuildConfigurationEvent buildConfigurationEvent =
+                    getConfiguration(BuildConfigurationKey.withoutPlatformMapping(options)).toBuildEvent();
+                int configurationId = configurationCache.getId(buildConfigurationEvent);
+
+                targetBuilder.getRuleBuilder().addConfiguredRuleInput(
+                    ConfiguredRuleInput.newBuilder().setLabel(resolvedTransition.label().toString())
+                        .setConfigurationChecksum(options.checksum())
+                        .setConfigurationId(configurationId));
+              }
+            }
+          }
+        } catch (DependencyResolver.Failure | InconsistentAspectOrderException e) {
+          // This is an abuse of InterruptedException.
+          throw new InterruptedException(e.getMessage());
+        }
+      }
+      builder.setTarget(targetBuilder);
 
       if (options.protoIncludeConfigurations) {
         String checksum = keyedConfiguredTarget.getConfigurationChecksum();

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionResolver.java
@@ -128,7 +128,6 @@ public class TransitionResolver {
     BuildConfigurationValue config =
         cqueryThreadsafeCallback.getConfiguration(keyedConfiguredTarget.getConfigurationKey());
 
-    OrderedSetMultimap<DependencyKind, DependencyKey> deps;
     ImmutableMap<Label, ConfigMatchingProvider> configConditions =
         keyedConfiguredTarget.getConfigConditions();
 
@@ -138,7 +137,7 @@ public class TransitionResolver {
     // We don't actually use fromOptions in our implementation of
     // DependencyResolver but passing to avoid passing a null and since we have the information
     // anyway.
-    deps =
+    OrderedSetMultimap<DependencyKind, DependencyKey> deps =
         dependencyResolver
             .dependentNodeMap(
                 new TargetAndConfiguration(target, config),

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionResolver.java
@@ -14,8 +14,10 @@
 package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.DependencyKey;
 import com.google.devtools.build.lib.analysis.DependencyKind;
 import com.google.devtools.build.lib.analysis.DependencyKind.ToolchainDependencyKind;
@@ -38,7 +40,6 @@ import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.packages.RuleTransitionData;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.util.OrderedSetMultimap;
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -58,7 +59,7 @@ public class TransitionResolver {
   @Immutable
   public abstract static class ResolvedTransition {
 
-    static ResolvedTransition create(Label label, Collection<BuildOptions> configurationChecksum, String attributeName, String transitionName) {
+    static ResolvedTransition create(Label label, ImmutableCollection<BuildOptions> configurationChecksum, String attributeName, String transitionName) {
       return new AutoValue_TransitionResolver_ResolvedTransition(label, configurationChecksum, attributeName, transitionName);
     }
 
@@ -76,7 +77,7 @@ public class TransitionResolver {
      *
      * If no transition was applied to an attribute, this collection will be empty.
      */
-    abstract Collection<BuildOptions> options();
+    abstract ImmutableCollection<BuildOptions> options();
 
     /**
      * The name of the attribute via which the dependency was requested.
@@ -170,10 +171,10 @@ public class TransitionResolver {
       // TODO(bazel-team): support transitions on Starlark-defined build flags. These require
       // Skyframe loading to get flag default values. See ConfigurationResolver.applyTransition
       // for an example of the required logic.
-      Collection<BuildOptions> toOptions =
-          dep.getTransition()
+      ImmutableCollection<BuildOptions> toOptions =
+          ImmutableSet.copyOf(dep.getTransition()
               .apply(TransitionUtil.restrict(dep.getTransition(), fromOptions), eventHandler)
-              .values();
+              .values());
       resolved.add(ResolvedTransition.create(dep.getLabel(), toOptions, dependencyName, dep.getTransition().getName()));
     }
     return resolved;

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionResolver.java
@@ -1,3 +1,16 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.auto.value.AutoValue;

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionResolver.java
@@ -1,0 +1,133 @@
+package com.google.devtools.build.lib.query2.cquery;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.analysis.DependencyKey;
+import com.google.devtools.build.lib.analysis.DependencyKind;
+import com.google.devtools.build.lib.analysis.DependencyKind.ToolchainDependencyKind;
+import com.google.devtools.build.lib.analysis.DependencyResolver;
+import com.google.devtools.build.lib.analysis.InconsistentAspectOrderException;
+import com.google.devtools.build.lib.analysis.TargetAndConfiguration;
+import com.google.devtools.build.lib.analysis.ToolchainCollection;
+import com.google.devtools.build.lib.analysis.ToolchainContext;
+import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
+import com.google.devtools.build.lib.analysis.config.BuildOptions;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
+import com.google.devtools.build.lib.analysis.config.transitions.NoTransition;
+import com.google.devtools.build.lib.analysis.config.transitions.NullTransition;
+import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
+import com.google.devtools.build.lib.analysis.config.transitions.TransitionUtil;
+import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.packages.RuleTransitionData;
+import com.google.devtools.build.lib.packages.Target;
+import com.google.devtools.build.lib.util.OrderedSetMultimap;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+public class TransitionResolver {
+
+  @AutoValue
+  @Immutable
+  public abstract static class ResolvedTransition {
+
+    static ResolvedTransition create(Label label, Collection<BuildOptions> configurationChecksum, String attributeName, String transitionName) {
+      return new AutoValue_TransitionResolver_ResolvedTransition(label, configurationChecksum, attributeName, transitionName);
+    }
+
+    abstract Label label();
+
+    abstract Collection<BuildOptions> options();
+
+    abstract String attributeName();
+
+    abstract String transitionName();
+  }
+
+  private final ExtendedEventHandler eventHandler;
+  private final DependencyResolver dependencyResolver;
+  private final ConfiguredTargetAccessor accessor;
+  private final CqueryThreadsafeCallback cqueryThreadsafeCallback;
+  @Nullable private final TransitionFactory<RuleTransitionData> trimmingTransitionFactory;
+
+  public TransitionResolver(
+      ExtendedEventHandler eventHandler,
+      DependencyResolver dependencyResolver,
+      ConfiguredTargetAccessor accessor,
+      CqueryThreadsafeCallback cqueryThreadsafeCallback,
+      @Nullable TransitionFactory<RuleTransitionData> trimmingTransitionFactory) {
+    this.eventHandler = eventHandler;
+    this.dependencyResolver = dependencyResolver;
+    this.accessor = accessor;
+    this.cqueryThreadsafeCallback = cqueryThreadsafeCallback;
+    this.trimmingTransitionFactory = trimmingTransitionFactory;
+  }
+
+  public LinkedHashSet<ResolvedTransition> dependencies(KeyedConfiguredTarget keyedConfiguredTarget) throws DependencyResolver.Failure, InconsistentAspectOrderException, InterruptedException {
+    LinkedHashSet<ResolvedTransition> resolved = new LinkedHashSet<>();
+
+    if (!(keyedConfiguredTarget.getConfiguredTarget() instanceof RuleConfiguredTarget)) {
+      return resolved;
+    }
+
+    Target target = accessor.getTarget(keyedConfiguredTarget);
+    BuildConfigurationValue config =
+        cqueryThreadsafeCallback.getConfiguration(keyedConfiguredTarget.getConfigurationKey());
+
+    OrderedSetMultimap<DependencyKind, DependencyKey> deps;
+    ImmutableMap<Label, ConfigMatchingProvider> configConditions =
+        keyedConfiguredTarget.getConfigConditions();
+
+    // Get a ToolchainContext to use for dependency resolution.
+    ToolchainCollection<ToolchainContext> toolchainContexts =
+        accessor.getToolchainContexts(target, config);
+    // We don't actually use fromOptions in our implementation of
+    // DependencyResolver but passing to avoid passing a null and since we have the information
+    // anyway.
+    deps =
+        dependencyResolver
+            .dependentNodeMap(
+                new TargetAndConfiguration(target, config),
+                /*aspect=*/ null,
+                configConditions,
+                toolchainContexts,
+                DependencyResolver.shouldUseToolchainTransition(config, target),
+                trimmingTransitionFactory);
+    for (Map.Entry<DependencyKind, DependencyKey> attributeAndDep : deps.entries()) {
+      DependencyKey dep = attributeAndDep.getValue();
+
+      String dependencyName;
+      if (DependencyKind.isToolchain(attributeAndDep.getKey())) {
+        ToolchainDependencyKind tdk = (ToolchainDependencyKind) attributeAndDep.getKey();
+        if (tdk.isDefaultExecGroup()) {
+          dependencyName = "[toolchain dependency]";
+        } else {
+          dependencyName = String.format("[toolchain dependency: %s]", tdk.getExecGroupName());
+        }
+      } else {
+        dependencyName = attributeAndDep.getKey().getAttribute().getName();
+      }
+
+      if (attributeAndDep.getValue().getTransition() == NoTransition.INSTANCE
+          || attributeAndDep.getValue().getTransition() == NullTransition.INSTANCE) {
+        resolved.add(ResolvedTransition.create(dep.getLabel(), ImmutableList.of(), dependencyName, attributeAndDep.getValue().getTransition().getName()));
+        continue;
+      }
+      BuildOptions fromOptions = config.getOptions();
+      // TODO(bazel-team): support transitions on Starlark-defined build flags. These require
+      // Skyframe loading to get flag default values. See ConfigurationResolver.applyTransition
+      // for an example of the required logic.
+      Collection<BuildOptions> toOptions =
+          dep.getTransition()
+              .apply(TransitionUtil.restrict(dep.getTransition(), fromOptions), eventHandler)
+              .values();
+      resolved.add(ResolvedTransition.create(dep.getLabel(), toOptions, dependencyName, dep.getTransition().getName()));
+    }
+    return resolved;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
@@ -115,7 +115,7 @@ class TransitionsOutputFormatterCallback extends CqueryThreadsafeCallback {
       Iterable<ResolvedTransition> dependencies;
       try {
         dependencies = new TransitionResolver(eventHandler, knownTargetsDependencyResolver, accessor, this, trimmingTransitionFactory).dependencies(keyedConfiguredTarget);
-      } catch(DependencyResolver.Failure | InconsistentAspectOrderException e){
+      } catch (DependencyResolver.Failure | InconsistentAspectOrderException e) {
         // This is an abuse of InterruptedException.
         throw new InterruptedException(e.getMessage());
       }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/ProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/ProtoOutputFormatter.java
@@ -184,12 +184,12 @@ public class ProtoOutputFormatter extends AbstractUnorderedFormatter {
   }
 
   /** Converts a logical {@link Target} object into a {@link Build.Target} protobuffer. */
-  public Build.Target toTargetProtoBuffer(Target target) throws InterruptedException {
+  public Build.Target.Builder toTargetProtoBuffer(Target target) throws InterruptedException {
     return toTargetProtoBuffer(target, /*extraDataForAttrHash=*/ "");
   }
 
   /** Converts a logical {@link Target} object into a {@link Build.Target} protobuffer. */
-  public Build.Target toTargetProtoBuffer(Target target, Object extraDataForAttrHash)
+  public Build.Target.Builder toTargetProtoBuffer(Target target, Object extraDataForAttrHash)
       throws InterruptedException {
     Build.Target.Builder targetPb = Build.Target.newBuilder();
 
@@ -251,6 +251,7 @@ public class ProtoOutputFormatter extends AbstractUnorderedFormatter {
         // include implicit outputs, host-configuration outputs, and default values.
         rule.getSortedLabels(dependencyFilter)
             .forEach(input -> rulePb.addRuleInput(input.toString()));
+
         rule.getOutputFiles().stream()
             .distinct()
             .forEach(output -> rulePb.addRuleOutput(output.getLabel().toString()));
@@ -369,7 +370,7 @@ public class ProtoOutputFormatter extends AbstractUnorderedFormatter {
       throw new IllegalArgumentException(target.toString());
     }
 
-    return targetPb.build();
+    return targetPb;
   }
 
   protected void addAttributes(Build.Rule.Builder rulePb, Rule rule, Object extraDataForAttrHash) {
@@ -564,7 +565,7 @@ public class ProtoOutputFormatter extends AbstractUnorderedFormatter {
       // constructing and serializing a QueryResult proto are protected by test coverage and proto
       // best practices.
       for (Target target : partialResult) {
-        codedOut.writeMessage(QueryResult.TARGET_FIELD_NUMBER, toTargetProtoBuffer(target));
+        codedOut.writeMessage(QueryResult.TARGET_FIELD_NUMBER, toTargetProtoBuffer(target).build());
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/StreamedProtoOutputFormatter.java
@@ -37,7 +37,7 @@ public class StreamedProtoOutputFormatter extends ProtoOutputFormatter {
       public void processOutput(Iterable<Target> partialResult)
           throws IOException, InterruptedException {
         for (Target target : partialResult) {
-          toTargetProtoBuffer(target).writeDelimitedTo(out);
+          toTargetProtoBuffer(target).build().writeDelimitedTo(out);
         }
       }
     };

--- a/src/main/protobuf/build.proto
+++ b/src/main/protobuf/build.proto
@@ -300,6 +300,8 @@ message Rule {
   // predecessors in the dependency graph.
   repeated string rule_input = 5;
 
+  repeated ConfiguredRuleInput configured_rule_input = 15;
+
   // All of the outputs of the rule (formatted as absolute labels). These are
   // successors in the dependency graph.
   repeated string rule_output = 6;
@@ -330,6 +332,12 @@ message Rule {
   // enabled on the command line with the --proto:definition_stack flag or the
   // rule is a native one.
   repeated string definition_stack = 14;
+}
+
+message ConfiguredRuleInput {
+  optional string label = 1;
+  optional string configuration_checksum = 2;
+  optional uint32 configuration_id = 3;
 }
 
 // Summary of all transitive dependencies of 'rule,' where each dependent

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
@@ -219,8 +219,9 @@ public class ProtoOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
     assertThat(fileTargetProto.getConfigurationId()).isEqualTo(0);
 
     // Targets whose deps have no transitions should appear without configuration information.
-    assertThat(Iterables.getOnlyElement(parentRuleProto.getTarget().getRule().getConfiguredRuleInputList()))
-        .isEqualTo(ConfiguredRuleInput.newBuilder().setLabel("//test:transition_rule").build());
+    assertThat(parentRuleProto.getTarget().getRule().getConfiguredRuleInputList())
+        .containsExactly(
+            ConfiguredRuleInput.newBuilder().setLabel("//test:transition_rule").build());
 
     // Targets with deps with transitions should show them.
     ConfiguredRuleInput patchedConfiguredRuleInput = ConfiguredRuleInput.newBuilder()

--- a/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallbackTest.java
@@ -29,11 +29,13 @@ import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.NullEventHandler;
 import com.google.devtools.build.lib.events.Reporter;
 import com.google.devtools.build.lib.query2.PostAnalysisQueryEnvironment;
+import com.google.devtools.build.lib.query2.cquery.CqueryOptions.Transitions;
 import com.google.devtools.build.lib.query2.cquery.ProtoOutputFormatterCallback.OutputType;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.Setting;
 import com.google.devtools.build.lib.query2.engine.QueryExpression;
 import com.google.devtools.build.lib.query2.engine.QueryParser;
 import com.google.devtools.build.lib.query2.proto.proto2api.Build;
+import com.google.devtools.build.lib.query2.proto.proto2api.Build.ConfiguredRuleInput;
 import com.google.devtools.build.lib.query2.query.aspectresolvers.AspectResolver.Mode;
 import com.google.devtools.build.lib.util.FileTypeSet;
 import java.util.ArrayList;
@@ -122,6 +124,8 @@ public class ProtoOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
 
   @Test
   public void testConfigurations() throws Exception {
+    options.transitions = Transitions.LITE;
+
     MockRule ruleWithPatch =
         () ->
             MockRule.define(
@@ -213,6 +217,25 @@ public class ProtoOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
             .findAny()
             .orElseThrow();
     assertThat(fileTargetProto.getConfigurationId()).isEqualTo(0);
+
+    // Targets whose deps have no transitions should appear without configuration information.
+    assertThat(Iterables.getOnlyElement(parentRuleProto.getTarget().getRule().getConfiguredRuleInputList()))
+        .isEqualTo(ConfiguredRuleInput.newBuilder().setLabel("//test:transition_rule").build());
+
+    // Targets with deps with transitions should show them.
+    ConfiguredRuleInput patchedConfiguredRuleInput = ConfiguredRuleInput.newBuilder()
+        .setLabel("//test:patched")
+        .build();
+    ConfiguredRuleInput depConfiguredRuleInput = ConfiguredRuleInput.newBuilder()
+        .setLabel("//test:dep")
+        .setConfigurationChecksum(depRuleProto.getConfiguration().getChecksum())
+        .setConfigurationId(depRuleProto.getConfigurationId())
+        .build();
+    List<ConfiguredRuleInput> configuredRuleInputs = transitionRuleProto
+        .getTarget()
+        .getRule()
+        .getConfiguredRuleInputList();
+    assertThat(configuredRuleInputs).containsExactly(patchedConfiguredRuleInput, depConfiguredRuleInput);
   }
 
   private KeyedConfiguredTarget getKeyedTargetByLabel(
@@ -305,7 +328,8 @@ public class ProtoOutputFormatterCallbackTest extends ConfiguredTargetQueryTest 
             env.getAccessor(),
             options.aspectDeps.createResolver(
                 getHelper().getPackageManager(), NullEventHandler.INSTANCE),
-            OutputType.BINARY);
+            OutputType.BINARY,
+            /*trimmingTransitionFactory=*/ null);
     env.evaluateQuery(expression, callback);
     return callback.getProtoResult();
   }


### PR DESCRIPTION
When the existing `--transitions` flag is set to a non-None value,
cquery will report the configuration its dependencies are configured in.
This allows for pruning away values from ruleInputs which are not
required in the current configuration.

Example output from running:
`bazel cquery --transitions=lite --output=jsonproto 'deps(...)'`:
```
[...]
        "ruleInput": ["@bazel_tools//src/conditions:host_windows", "@bazel_tools//src/tools/launcher:launcher", "@bazel_tools//tools/launcher:launcher_windows"],
        "configuredRuleInput": [{
          "label": "@bazel_tools//src/tools/launcher:launcher",
          "configurationChecksum": "01ec5513a9fc41b2a15570123817f3c2200ad9aeb21b1181d588a4b4f91d5693",
          "configurationId": 3
        }]
[...]
```

Previously on a non-Windows platform it was not possible to determine
that the two windows-specific ruleInputs are not actually required - now
we can see from the configuredRuleInput section that the
windows-specific dependencies have been pruned by selection, and we can
see that a transition has re-configured the ruleInput into the exec
configuration.

For dependencies which were not subject to transition (e.g. because
they're in a non-transition attribute), or which had no configuration
(e.g. because they're a source file), we add the label as a
ConfiguredRuleInput _without_ any configuration information. This
indicates that the dependency has not been pruned, but that the caller
should determine the correct configuration from context (probably be
determining whether it's a source file, and if so, considering it
un-configured, otherwise propagating the contextual ConfiguredTarget's
configuration).

Fixes #14610
Fixes #14617

Implementation-wise, this took roughly the following shape:
1. Extract TransitionResolver from being inline in TransitionsOutputFormatterCallback
2. Extract KnownTargetsDependencyResolver from TransitionsOutputFormatterCallback.FormatterDependencyResolver
3. Conditionally call these from ProtoOutputFormatterCallback depending
   on the --transitions flag.