### PR TITLE
Account for interface libraries in cc_shared_library

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl
@@ -147,7 +147,10 @@ def _build_link_once_static_libs_map(merged_shared_library_infos):
     return link_once_static_libs_map
 
 def _is_dynamic_only(library_to_link):
-    if library_to_link.static_library == None and library_to_link.pic_static_library == None:
+    if (library_to_link.static_library == None and
+        library_to_link.pic_static_library == None and
+        (library_to_link.objects == None or len(library_to_link.objects) == 0) and
+        (library_to_link.pic_objects == None or len(library_to_link.pic_objects) == 0)):
         return True
     return False
 
@@ -503,7 +506,10 @@ def _cc_shared_library_impl(ctx):
 
     precompiled_only_dynamic_libraries_runfiles = []
     for precompiled_dynamic_library in precompiled_only_dynamic_libraries:
-        precompiled_only_dynamic_libraries_runfiles.append(precompiled_dynamic_library.dynamic_library)
+        # precompiled_dynamic_library.dynamic_library could be None if the library to link just contains
+        # an interface library which is valid if the actual library is obtained from the system.
+        if precompiled_dynamic_library.dynamic_library != None:
+            precompiled_only_dynamic_libraries_runfiles.append(precompiled_dynamic_library.dynamic_library)
         if precompiled_dynamic_library.resolved_symlink_dynamic_library != None:
             precompiled_only_dynamic_libraries_runfiles.append(precompiled_dynamic_library.resolved_symlink_dynamic_library)
 


### PR DESCRIPTION
Take into account libraries_to_link which just contain an interface libary when building the runfiles of cc_shared_library. A library_to_link with only an interface library can come about in a cc_import rule for example where one can set system_provided=True

Based on PiperOrigin-RevId: 434705871