### PR TITLE
Set C++ archive action mnemonic to CppArchive

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java
@@ -651,6 +651,7 @@ public final class CcLinkingHelper {
     Artifact linkedArtifact = getLinkedArtifact(linkTargetTypeUsedForNaming);
     CppLinkActionBuilder builder =
         newLinkActionBuilder(linkedArtifact, linkTargetTypeUsedForNaming)
+            .setMnemonic("CppArchive")
             .addObjectFiles(ccOutputs.getObjectFiles(usePic))
             .addLtoCompilationContext(ccOutputs.getLtoCompilationContext())
             .setUsePicForLtoBackendActions(usePic)

--- a/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/objc/ObjcLibraryTest.java
@@ -2062,7 +2062,7 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
     scratchConfiguredTarget("foo", "x", "objc_library(name = 'x', srcs = ['a.m'])");
 
     CppLinkAction archiveAction = (CppLinkAction) archiveAction("//foo:x");
-    assertThat(archiveAction.getMnemonic()).isEqualTo("CppLink");
+    assertThat(archiveAction.getMnemonic()).isEqualTo("CppArchive");
   }
 
   protected List<String> linkstampExecPaths(NestedSet<CcLinkingContext.Linkstamp> linkstamps) {
@@ -2332,11 +2332,11 @@ public class ObjcLibraryTest extends ObjcRuleTestCase {
     CcToolchainProvider toolchainProvider = target.get(CcToolchainProvider.PROVIDER);
 
     RuleConfiguredTarget libTarget = (RuleConfiguredTarget) getConfiguredTarget("//a:l");
-    ActionAnalysisMetadata linkAction =
+    ActionAnalysisMetadata archiveAction =
         libTarget.getActions().stream()
-            .filter((a) -> a.getMnemonic().equals("CppLink"))
+            .filter((a) -> a.getMnemonic().equals("CppArchive"))
             .collect(onlyElement());
-    assertThat(linkAction.getInputs().toList())
+    assertThat(archiveAction.getInputs().toList())
         .containsAtLeastElementsIn(toolchainProvider.getArFiles().toList());
 
     ActionAnalysisMetadata objcCompileAction =

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -715,8 +715,8 @@ tree_art_rule = rule(implementation = _tree_art_impl,
 
 def _actions_test_impl(target, ctx):
     action = target.actions[1]
-    if action.mnemonic != "CppLink":
-      fail("Expected the second action to be CppLink.")
+    if action.mnemonic != "CppArchive":
+      fail("Expected the second action to be CppArchive.")
     aspect_out = ctx.actions.declare_file('aspect_out')
     ctx.actions.run_shell(inputs = action.inputs,
                           outputs = [aspect_out],
@@ -849,7 +849,7 @@ def _actions_test_impl(target, ctx):
     for action in target.actions:
       if action.mnemonic == "CppCompile":
         compile_action = action
-      if action.mnemonic == "CppLink" and not archive_action:
+      if action.mnemonic == "CppArchive":
         archive_action = action
       if action.mnemonic == "CppLink":
         link_action = action
@@ -1305,7 +1305,7 @@ def _actions_test_impl(target, ctx):
     for action in target.actions:
       if action.mnemonic == "CppCompile":
         compile_action = action
-      if action.mnemonic == "CppLink" and not archive_action:
+      if action.mnemonic == "CppArchive":
         archive_action = action
       if action.mnemonic == "CppLink":
         link_action = action

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1307,11 +1307,9 @@ def _actions_test_impl(target, ctx):
         compile_action = action
       if action.mnemonic == "CppArchive":
         archive_action = action
-      if action.mnemonic == "CppLink":
-        link_action = action
 
-    if not compile_action or not archive_action or not link_action:
-      fail("Couln't find compile, archive, or link action")
+    if not compile_action or not archive_action:
+      fail("Couln't find compile or archive action")
 
     compile_action_outputs = compile_action.outputs.to_list()
     compile_args = ctx.actions.declare_file("compile_args")
@@ -1359,33 +1357,11 @@ def _actions_test_impl(target, ctx):
         ),
     )
 
-    link_args = ctx.actions.declare_file("link_args")
-    ctx.actions.run_shell(
-        outputs = [link_args],
-        command = "echo \$@ > " + link_args.path,
-        arguments = link_action.args,
-    )
-
-    link_out = ctx.actions.declare_file("link_out.so")
-    ctx.actions.run_shell(
-        inputs = [link_args],
-        shadowed_action = link_action,
-        mnemonic = "RecreatedCppLink",
-        outputs = [link_out],
-        command = "\$(cat %s | sed 's|%s|%s|g')" % (
-            link_args.path,
-            link_action.outputs.to_list()[0].path,
-            link_out.path,
-        ),
-    )
-
     return [OutputGroupInfo(out = [
         compile_args,
         compile_out,
         archive_args,
         archive_out,
-        link_args,
-        link_out,
     ])]
 
 actions_test_aspect = aspect(implementation = _actions_test_impl)

--- a/src/test/shell/bazel/tags_propagation_native_test.sh
+++ b/src/test/shell/bazel/tags_propagation_native_test.sh
@@ -48,7 +48,7 @@ EOF
   assert_contains "no-cache:" output1
   assert_contains "no-remote:" output1
 
-  bazel aquery --experimental_allow_tags_propagation 'mnemonic("CppLink", outputs(".*/libtest.a", //test:test))' > output1 2> $TEST_log \
+  bazel aquery --experimental_allow_tags_propagation 'mnemonic("CppArchive", outputs(".*/libtest.a", //test:test))' > output1 2> $TEST_log \
       || fail "should have generated output successfully"
 
   assert_contains "ExecutionInfo: {" output1


### PR DESCRIPTION
Previously the archiver action shared the CppLink mnemonic which made it
impossible to differentiate with this like --modify_execution_info