### PR TITLE
[5.1] Undocument --bes_best_effort

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRulesModule.java
@@ -487,6 +487,17 @@ public final class BazelRulesModule extends BlazeModule {
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
         help = "No-op")
     public boolean enableCpuUsageProfiling;
+
+    @Option(
+        name = "bes_best_effort",
+        defaultValue = "false",
+        deprecationWarning =
+            "BES best effort upload has been removed. The flag has no more "
+                + "functionality attached to it and will be removed in a future release.",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+        help = "No-op")
+    public boolean besBestEffort;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceOptions.java
@@ -66,19 +66,6 @@ public class BuildEventServiceOptions extends OptionsBase {
   public List<Map.Entry<String, String>> besHeaders;
 
   @Option(
-      name = "bes_best_effort",
-      defaultValue = "false",
-      deprecationWarning =
-          "BES best effort upload has been removed. The flag has no more "
-              + "functionality attached to it and will be removed in a future release.",
-      documentationCategory = OptionDocumentationCategory.LOGGING,
-      effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
-      help =
-          "BES best effort upload has been removed. The flag has no more "
-              + "functionality attached to it and will be removed in a future release.")
-  public boolean besBestEffort;
-
-  @Option(
     name = "bes_lifecycle_events",
     defaultValue = "true",
     documentationCategory = OptionDocumentationCategory.LOGGING,


### PR DESCRIPTION
We've heared from several people that they tried passing the flag and it did
not have any efect (as expected from a no-op), so let's undocument the flag
so it's no longer discoverable.

On a related note, we should document `--bes_upload_mode` which seems to be
what people want to do.

Closes #14333.

PiperOrigin-RevId: 435317406