### PR TITLE
[5.1] Fix conflicting actions error when specifying --host_macos_minimum_os

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/apple/AppleCommandLineOptions.java
@@ -511,6 +511,9 @@ public class AppleCommandLineOptions extends FragmentOptions {
     host.includeXcodeExecutionRequirements = includeXcodeExecutionRequirements;
     host.appleCrosstoolTop = appleCrosstoolTop;
 
+    // Save host option for further use.
+    host.hostMacosMinimumOs = hostMacosMinimumOs;
+
     return host;
   }
 


### PR DESCRIPTION
The flag was introduced in #13001 but not usable internally, because
the host flag was not saved when doing a transition.  Host flags
should be saved, like in:

https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java#L1212

(cherry picked from commit b8a2ee2ca8ae1f66b40baea8fc413b2732e7ebaa)

Fixes issues like https://github.com/bazelbuild/rules_swift/issues/777.