### PR TITLE
fix osx_cc_wrapper wrongly treating Mac magic tokens(e.g. @rpath) as parameter files

### DIFF
--- a/tools/cpp/osx_cc_wrapper.sh
+++ b/tools/cpp/osx_cc_wrapper.sh
@@ -54,6 +54,13 @@ function parse_option() {
 # let parse the option list
 for i in "$@"; do
     if [[ "$i" = @* ]]; then
+        if [[ "$i" = @executable_path/* ]] \
+            || [[ "$i" = @loader_path/* ]] \
+            || [[ "$i" = @rpath/* ]]; then
+            # magic tokens on Mac OS X
+            parse_option "$i"
+            continue
+        fi
         while IFS= read -r opt
         do
             parse_option "$opt"

--- a/tools/cpp/osx_cc_wrapper.sh.tpl
+++ b/tools/cpp/osx_cc_wrapper.sh.tpl
@@ -53,6 +53,13 @@ function parse_option() {
 # let parse the option list
 for i in "$@"; do
     if [[ "$i" = @* ]]; then
+        if [[ "$i" = @executable_path/* ]] \
+            || [[ "$i" = @loader_path/* ]] \
+            || [[ "$i" = @rpath/* ]]; then
+            # magic tokens on Mac OS X
+            parse_option "$i"
+            continue
+        fi
         while IFS= read -r opt
         do
             parse_option "$opt"


### PR DESCRIPTION
Try to fix #15069