### PR TITLE
Have README.md in java_tools release reference the right target

### DIFF
--- a/src/upload_java_tools.sh
+++ b/src/upload_java_tools.sh
@@ -75,7 +75,6 @@ while [[ -n "$@" ]]; do
 done
 
 java_tools_zip=$(rlocation io_bazel/${java_tools_zip_name})
-platform=${platform:+"_"}${platform:-}
 
 # Create a temp directory and a writable temp zip file to add a README.md file to
 # the initial zip.
@@ -88,16 +87,18 @@ tmp_zip="$tmp_dir/archive.zip"
 cp $java_tools_zip $tmp_zip
 chmod +w $tmp_zip
 
+target_basename=$(basename $java_tools_zip)
+
 # Create the README.md file and add the re-build java tools instructions.
 readme_file="README.md"
 cat >${readme_file} <<EOF
 This Java tools version was built from the bazel repository at commit hash ${commit_hash}
-using bazel version ${bazel_version}.
+using bazel version ${bazel_version}${platform:+" on platform ${platform}"}.
 To build from source the same zip run the commands:
 
 $ git clone https://github.com/bazelbuild/bazel.git
 $ git checkout ${commit_hash}
-$ bazel build //src:java_tools_prebuilt.zip
+$ bazel build //src:${target_basename}
 EOF
 
 # Add the README.md file to the temp zip.
@@ -118,4 +119,4 @@ fi
 
 # Upload the zip that contains the README.md to GCS.
 "$gsutil_cmd" cp "$zip_url" \
- "gs://bazel-mirror/bazel_java_tools/${gcs_java_tools_dir}/${commit_hash}/java/java_tools${platform}-${timestamp}.zip"
+ "gs://bazel-mirror/bazel_java_tools/${gcs_java_tools_dir}/${commit_hash}/java/java_tools${platform:+"_${platform}"}-${timestamp}.zip"


### PR DESCRIPTION
I was trying to figure out what produced the files included in https://github.com/bazelbuild/java_tools/releases/download/java_v11.6/java_tools-v11.6.zip that happens to have some instructions on how to re-produce the contents of the file. 

However, it turns out that the instructions in README.md references the wrong build target, which made it a bit confusing. This change updates the target to one that produces a zip that seem to contain the right files.