### PR TITLE
Remove "manual" tags from java coverage integration tests.

### DIFF
--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -460,7 +460,6 @@ sh_test(
         "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
     ],
     tags = [
-        "manual",
         "no_windows",
     ],
 )
@@ -484,7 +483,6 @@ sh_test(
             "//src/test/shell/bazel/testdata:jdk_http_archives_filegroup",
         ],
         tags = [
-            "manual",
             "no_windows",
         ],
     )


### PR DESCRIPTION
These were added during https://github.com/bazelbuild/bazel/issues/12696.

The integration tests in question depend on the pre-built version of
java_tools and so would have started to fail when the tests were updated
for the new functionality added.

Now java_tools has been updated (several times), it is safe to allow
automated running of them once again.