### PR TITLE
[5.1] Use python3 on macOS

### DIFF
--- a/tools/objc/libtool.sh
+++ b/tools/objc/libtool.sh
@@ -62,9 +62,9 @@ function hash_objfile() {
   echo "$SYMLINK_NAME"
 }
 
-python_executable=/usr/bin/python2.7
+python_executable=/usr/bin/python3
 if [[ ! -x "$python_executable" ]]; then
-  python_executable=python
+  python_executable=python3
 fi
 
 ARGS=()


### PR DESCRIPTION
macOS 12.3 removed `/usr/bin/python2.7` and `/usr/bin/python`. We need to use `python3` now.

(cherry picked from commit 3785677cc84fc4024fda85575c05efbde5d512fc)

Closes https://github.com/bazelbuild/bazel/issues/15049.