### PR TITLE
fix(bzlmod): throw on json parse exception

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -117,7 +117,7 @@ public class IndexRegistry implements Registry {
       return Optional.empty();
     }
     String jsonString = new String(bytes.get(), UTF_8);
-    if (jsonString.strip().equals("")) {
+    if (jsonString.strip().isEmpty()) {
       return Optional.empty();
     }
     try {

--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistry.java
@@ -25,6 +25,8 @@ import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -115,7 +117,14 @@ public class IndexRegistry implements Registry {
       return Optional.empty();
     }
     String jsonString = new String(bytes.get(), UTF_8);
-    return Optional.of(gson.fromJson(jsonString, klass));
+    if (jsonString.strip().equals("")) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(gson.fromJson(jsonString, klass));
+    } catch (JsonParseException e) {
+      throw new IOException(String.format("Unable to parse json at url %s", url), e);
+    }
   }
 
   @Override

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/IndexRegistryTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static com.google.devtools.build.lib.bazel.bzlmod.BzlmodTestUtil.createModuleKey;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
@@ -26,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.bazel.repository.downloader.HttpDownloader;
 import com.google.devtools.build.lib.testutil.FoundationTestCase;
 import java.io.File;
+import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
 import org.junit.Before;
@@ -139,5 +141,58 @@ public class IndexRegistryTest extends FoundationTestCase {
                             "sha256-kek"))
                 .setRemotePatchStrip(3)
                 .build());
+  }
+
+  @Test
+  public void testGetRepoInvalidRegistryJsonSpec() throws Exception {
+    server.serve(
+        "/bazel_registry.json",
+        "",
+        "",
+        "",
+        "");
+    server.start();
+    server.serve(
+        "/modules/foo/1.0/source.json",
+        "{",
+        "  \"url\": \"http://mysite.com/thing.zip\",",
+        "  \"integrity\": \"sha256-blah\",",
+        "  \"strip_prefix\": \"pref\"",
+        "}");
+
+    Registry registry = registryFactory.getRegistryWithUrl(server.getUrl());
+    assertThat(registry.getRepoSpec(createModuleKey("foo", "1.0"), "foorepo", reporter))
+        .isEqualTo(
+            new ArchiveRepoSpecBuilder()
+                .setRepoName("foorepo")
+                .setUrls(ImmutableList.of("http://mysite.com/thing.zip"))
+                .setIntegrity("sha256-blah")
+                .setStripPrefix("pref")
+                .setRemotePatches(ImmutableMap.of())
+                .setRemotePatchStrip(0)
+                .build());
+  }
+
+  @Test
+  public void testGetRepoInvalidModuleJsonSpec() throws Exception {
+    server.serve(
+            "/bazel_registry.json",
+            "{",
+            "  \"mirrors\": [",
+            "    \"https://mirror.bazel.build/\",",
+            "    \"file:///home/bazel/mymirror/\"",
+            "  ]",
+            "}");
+    server.serve(
+            "/modules/foo/1.0/source.json",
+            "{",
+            "  \"url\": \"http://mysite.com/thing.zip\",",
+            "  \"integrity\": \"sha256-blah\",",
+            "  \"strip_prefix\": \"pref\",",
+            "}");
+    server.start();
+
+    Registry registry = registryFactory.getRegistryWithUrl(server.getUrl());
+    assertThrows(IOException.class, () -> registry.getRepoSpec(createModuleKey("foo", "1.0"), "foorepo", reporter));
   }
 }


### PR DESCRIPTION
[Fixes](https://github.com/bazelbuild/bazel/issues/14437)

Get rid of new lines in `bazel_registry.json` and return an `Optional.empty()` aka registry descriptor without mirrors and throw an IOException for malformed JSON to stick to official json.org specs