### PR TITLE
Fix square braces in lexer

### DIFF
--- a/site/en/reference/query.md
+++ b/site/en/reference/query.md
@@ -80,10 +80,11 @@ tokens:
   begins and ends with a double-quote "), it is a word. If a character sequence
   is not quoted, it may still be parsed as a word. Unquoted words are sequences
   of characters drawn from the alphabet characters A-Za-z, the numerals 0-9,
-  and the special characters `*/@.-_:$~` (asterisk, forward slash, at, period,
-  hyphen, underscore, colon, dollar sign, tilde). However, unquoted words may
-  not start with a hyphen `-` or asterisk `*` even though relative
-  [target names][(/concepts/labels#target-names) may start with those characters.
+  and the special characters `*/@.-_:$~[]` (asterisk, forward slash, at, period,
+  hyphen, underscore, colon, dollar sign, tilde, left square brace, right square
+  brace). However, unquoted words may not start with a hyphen `-` or asterisk `*`
+  even though relative [target names][(/concepts/labels#target-names) may start
+  with those characters.
 
   Unquoted words also may not include the characters plus sign `+` or equals
   sign `=`, even though those characters are permitted in target names. When

--- a/src/main/java/com/google/devtools/build/lib/query2/engine/Lexer.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/engine/Lexer.java
@@ -188,6 +188,7 @@ public final class Lexer {
         case ':':
         case '$':
         case '~':
+        case '[': case ']':
           pos++;
           break;
        default:

--- a/src/test/java/com/google/devtools/build/lib/query2/engine/LexerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/query2/engine/LexerTest.java
@@ -120,8 +120,8 @@ public final class LexerTest {
 
   @Test
   public void testOperatorWithQuotedExprWithMoreSpecialCharacters() throws QuerySyntaxException {
-    Lexer.Token[] tokens = scan("set(\"//foo:foo=base/2~123+asd\")");
-    assertThat(asString(tokens)).isEqualTo("set ( //foo:foo=base/2~123+asd ) EOF");
+    Lexer.Token[] tokens = scan("set(\"//foo:foo=base/2~123[]+asd\")");
+    assertThat(asString(tokens)).isEqualTo("set ( //foo:foo=base/2~123[]+asd ) EOF");
     assertThat(tokens[0].kind).isEqualTo(Lexer.TokenKind.SET);
     assertThat(tokens[1].kind).isEqualTo(Lexer.TokenKind.LPAREN);
     assertThat(tokens[2].kind).isEqualTo(Lexer.TokenKind.WORD);
@@ -130,8 +130,8 @@ public final class LexerTest {
 
   @Test
   public void testOperatorWithUnquotedExprWithSpecialCharacters() throws QuerySyntaxException {
-    Lexer.Token[] tokens = scan("set(//a:b=bar./@_:~-*$123+asd)");
-    assertThat(asString(tokens)).isEqualTo("set ( //a:b = bar./@_:~-*$123 + asd ) EOF");
+    Lexer.Token[] tokens = scan("set(//a:b=bar./@_:~-*$123[]+asd)");
+    assertThat(asString(tokens)).isEqualTo("set ( //a:b = bar./@_:~-*$123[] + asd ) EOF");
     assertThat(tokens[0].kind).isEqualTo(Lexer.TokenKind.SET);
     assertThat(tokens[1].kind).isEqualTo(Lexer.TokenKind.LPAREN);
     assertThat(tokens[2].kind).isEqualTo(Lexer.TokenKind.WORD);


### PR DESCRIPTION
[Fixes 14043](https://github.com/bazelbuild/bazel/issues/14043)