### PR TITLE
Fixing dependencies of //external package

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android.WORKSPACE
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android.WORKSPACE
@@ -20,12 +20,12 @@ bind(
 
 bind(
     name = "android_sdk_for_testing",
-    actual = "//:dummy",
+    actual = "@bazel_tools//tools/android:empty",
 )
 
 bind(
     name = "android_ndk_for_testing",
-    actual = "//:dummy",
+    actual = "@bazel_tools//tools/android:empty",
 )
 
 bind(

--- a/src/test/py/bazel/query_test.py
+++ b/src/test/py/bazel/query_test.py
@@ -38,6 +38,13 @@ class QueryTest(test_base.TestBase):
     self._AssertQueryOutput('deps(//foo:top-rule, 1)', '//foo:top-rule',
                             '//foo:dep-rule')
 
+  def testQueryFilesUsedByRepositoryRules(self):
+    self.ScratchFile("WORKSPACE")
+    # TODO(linzhp): change //external:remotejdk11_linux to //external:* after
+    # https://github.com/bazelbuild/bazel/issues/8175 is fixed
+    self._AssertQueryOutputContains("kind('source file', deps(//external:remotejdk11_linux))",
+                                    "@bazel_tools//tools/jdk:jdk.BUILD")
+
   def testBuildFilesForExternalRepos_Simple(self):
     self.ScratchFile('WORKSPACE', [
         'load("//:deps.bzl", "repos")',

--- a/src/test/py/bazel/query_test.py
+++ b/src/test/py/bazel/query_test.py
@@ -40,9 +40,7 @@ class QueryTest(test_base.TestBase):
 
   def testQueryFilesUsedByRepositoryRules(self):
     self.ScratchFile("WORKSPACE")
-    # TODO(linzhp): change //external:remotejdk11_linux to //external:* after
-    # https://github.com/bazelbuild/bazel/issues/8175 is fixed
-    self._AssertQueryOutputContains("kind('source file', deps(//external:remotejdk11_linux))",
+    self._AssertQueryOutputContains("kind('source file', deps(//external:*))",
                                     "@bazel_tools//tools/jdk:jdk.BUILD")
 
   def testBuildFilesForExternalRepos_Simple(self):

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -214,7 +214,10 @@ alias(
     }),
 )
 
-exports_files(["BUILD.java_tools"])
+exports_files([
+    "BUILD.java_tools",
+    "jdk.BUILD",
+])
 
 alias(
     name = "genclass",


### PR DESCRIPTION
We need to query `kind('source file', deps(//external:*))` for sparse checkout, but were block by two issues:

* `//external:remotejdk11_linux` depends on `tools/jdk/jdk.BUILD`, but it was not exported. Although this is not a problem for build, queries like `kind('source file', deps(//external:remotejdk11_linux))` would fail.
* `//external:android_sdk_for_testing` is an alias for `//:dummy`, which is not available in other repositories. This also caused #8175.

This pull request fixed both, including #8175.