### PR TITLE
Updated apt configuration instructions

### DIFF
--- a/site/en/install/ubuntu.md
+++ b/site/en/install/ubuntu.md
@@ -39,9 +39,9 @@ Bazel comes with two completion scripts. After installing Bazel, you can:
 
 ```posix-terminal
 sudo apt install apt-transport-https curl gnupg
-curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
-sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
-echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
+curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg
+sudo mv bazel-archive-keyring.gpg /usr/share/keyrings
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 ```
 
 The component name "jdk1.8" is kept only for legacy reasons and doesn't relate


### PR DESCRIPTION
Putting apt repository keys in /etc/apt/trusted.gpg.d/ is considered a security problem these days. For more details, see [debian wiki](https://wiki.debian.org/DebianRepository/UseThirdParty) on the topic and [this post](https://askubuntu.com/questions/1286545/what-commands-exactly-should-replace-the-deprecated-apt-key).

I updated configuration instructions for apt in documentation to use the `signed-by` directive. It is compatible with Ubuntu 16.04 and up.