### PR TITLE
Remote: Don't check declared outputs for failed action

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1011,26 +1011,28 @@ public class RemoteExecutionService {
       metadata = parseActionResultMetadata(action, result);
     }
 
-    // Check that all mandatory outputs are created.
-    for (ActionInput output : action.spawn.getOutputFiles()) {
-      if (action.spawn.isMandatoryOutput(output)) {
-        // Don't check output that is tree artifact since spawn could generate nothing under that
-        // directory. Remote server typically doesn't create directory ahead of time resulting in
-        // empty tree artifact missing from action cache entry.
-        if (output instanceof Artifact && ((Artifact) output).isTreeArtifact()) {
-          continue;
-        }
+    if (result.success()) {
+      // Check that all mandatory outputs are created.
+      for (ActionInput output : action.spawn.getOutputFiles()) {
+        if (action.spawn.isMandatoryOutput(output)) {
+          // Don't check output that is tree artifact since spawn could generate nothing under that
+          // directory. Remote server typically doesn't create directory ahead of time resulting in
+          // empty tree artifact missing from action cache entry.
+          if (output instanceof Artifact && ((Artifact) output).isTreeArtifact()) {
+            continue;
+          }
 
-        Path localPath = execRoot.getRelative(output.getExecPath());
-        if (!metadata.files.containsKey(localPath)
-            && !metadata.directories.containsKey(localPath)
-            && !metadata.symlinks.containsKey(localPath)) {
-          throw new IOException(
-              "Invalid action cache entry "
-                  + action.actionKey.getDigest().getHash()
-                  + ": expected output "
-                  + prettyPrint(output)
-                  + " does not exist.");
+          Path localPath = execRoot.getRelative(output.getExecPath());
+          if (!metadata.files.containsKey(localPath)
+              && !metadata.directories.containsKey(localPath)
+              && !metadata.symlinks.containsKey(localPath)) {
+            throw new IOException(
+                "Invalid action cache entry "
+                    + action.actionKey.getDigest().getHash()
+                    + ": expected output "
+                    + prettyPrint(output)
+                    + " does not exist.");
+          }
         }
       }
     }

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3609,7 +3609,6 @@ EOF
       --remote_cache=grpc://localhost:${worker_port} \
       //a:foo >& $TEST_log && fail "Should failed to build"
 
-  expect_log "Invalid action cache"
   remote_cas_files="$(count_remote_cas_files)"
   [[ "$remote_cas_files" == 0 ]] || fail "Expected 0 remote cas entries, not $remote_cas_files"
   remote_ac_files="$(count_remote_ac_files)"
@@ -3632,8 +3631,7 @@ EOF
       --remote_executor=grpc://localhost:${worker_port} \
       //a:foo >& $TEST_log && fail "Should failed to build"
 
-  expect_not_log "Invalid action cache"
-  expect_log "failed: (Exit 1):"
+  expect_log "Executing genrule .* failed: (Exit 1):"
 }
 
 run_suite "Remote execution and remote cache tests"


### PR DESCRIPTION
Fix a bug that Bazel print message

```
Invalid action cache entry ...: expected output ... does not exist.
```

instead of the underlying error message when remote action failed.