### PR TITLE
Intern trivial ActionEnvironment and EnvironmentVariables instances

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionEnvironment.java
@@ -81,10 +81,10 @@ public final class ActionEnvironment {
    */
   static class CompoundEnvironmentVariables implements EnvironmentVariables {
 
-    static EnvironmentVariables create(
-        Map<String, String> fixedVars, Set<String> inheritedVars, EnvironmentVariables base) {
-      if (fixedVars.isEmpty() && inheritedVars.isEmpty() && base.isEmpty()) {
-        return EMPTY_ENVIRONMENT_VARIABLES;
+    static EnvironmentVariables create(Map<String, String> fixedVars, Set<String> inheritedVars,
+        EnvironmentVariables base) {
+      if (fixedVars.isEmpty() && inheritedVars.isEmpty()) {
+        return base;
       }
       return new CompoundEnvironmentVariables(fixedVars, inheritedVars, base);
     }
@@ -219,18 +219,22 @@ public final class ActionEnvironment {
    * Returns a copy of the environment with the given fixed variables added to it, <em>overwriting
    * any existing occurrences of those variables</em>.
    */
-  public ActionEnvironment addFixedVariables(Map<String, String> fixedVars) {
-    return ActionEnvironment.create(
-        CompoundEnvironmentVariables.create(fixedVars, ImmutableSet.of(), vars));
+  public ActionEnvironment withAdditionalFixedVariables(Map<String, String> fixedVars) {
+    return withAdditionalVariables(fixedVars, ImmutableSet.of());
   }
 
   /**
    * Returns a copy of the environment with the given fixed and inherited variables added to it,
    * <em>overwriting any existing occurrences of those variables</em>.
    */
-  public ActionEnvironment addVariables(Map<String, String> fixedVars, Set<String> inheritedVars) {
-    return ActionEnvironment.create(
-        CompoundEnvironmentVariables.create(fixedVars, inheritedVars, vars));
+  public ActionEnvironment withAdditionalVariables(Map<String, String> fixedVars,
+      Set<String> inheritedVars) {
+    EnvironmentVariables newVars = CompoundEnvironmentVariables.create(fixedVars, inheritedVars,
+        vars);
+    if (newVars == vars) {
+      return this;
+    }
+    return ActionEnvironment.create(newVars);
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -413,7 +413,7 @@ public final class TestActionBuilder {
                 testProperties,
                 runfilesSupport
                     .getActionEnvironment()
-                    .addVariables(extraTestEnv, extraInheritedEnv),
+                    .withAdditionalVariables(extraTestEnv, extraInheritedEnv),
                 executionSettings,
                 shard,
                 run,

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaCompileActionBuilder.java
@@ -205,7 +205,8 @@ public final class JavaCompileActionBuilder {
     toolsBuilder.addTransitive(toolsJars);
 
     ActionEnvironment actionEnvironment =
-        ruleContext.getConfiguration().getActionEnvironment().addFixedVariables(UTF8_ENVIRONMENT);
+        ruleContext.getConfiguration().getActionEnvironment()
+            .withAdditionalFixedVariables(UTF8_ENVIRONMENT);
 
     NestedSetBuilder<Artifact> mandatoryInputsBuilder = NestedSetBuilder.stableOrder();
     mandatoryInputsBuilder

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileActionBuilder.java
@@ -296,7 +296,8 @@ public class JavaHeaderCompileActionBuilder {
     }
 
     ActionEnvironment actionEnvironment =
-        ruleContext.getConfiguration().getActionEnvironment().addFixedVariables(UTF8_ENVIRONMENT);
+        ruleContext.getConfiguration().getActionEnvironment()
+            .withAdditionalFixedVariables(UTF8_ENVIRONMENT);
 
     OnDemandString progressMessage =
         new ProgressMessage(

--- a/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
+++ b/src/test/java/com/google/devtools/build/lib/actions/ActionEnvironmentTest.java
@@ -34,7 +34,7 @@ public final class ActionEnvironmentTest {
         ActionEnvironment.create(
             ImmutableMap.of("FOO", "foo1", "BAR", "bar"), ImmutableSet.of("baz"));
     // entries added by env2 override the existing entries
-    ActionEnvironment env2 = env1.addFixedVariables(ImmutableMap.of("FOO", "foo2"));
+    ActionEnvironment env2 = env1.withAdditionalFixedVariables(ImmutableMap.of("FOO", "foo2"));
 
     assertThat(env1.getFixedEnv()).containsExactly("FOO", "foo1", "BAR", "bar");
     assertThat(env1.getInheritedEnv()).containsExactly("baz");
@@ -45,12 +45,11 @@ public final class ActionEnvironmentTest {
 
   @Test
   public void fixedInheritedInteraction() {
-    ActionEnvironment env =
-        ActionEnvironment.create(
-                ImmutableMap.of("FIXED_ONLY", "fixed"), ImmutableSet.of("INHERITED_ONLY"))
-            .addVariables(
-                ImmutableMap.of("FIXED_AND_INHERITED", "fixed"),
-                ImmutableSet.of("FIXED_AND_INHERITED"));
+    ActionEnvironment env = ActionEnvironment.create(
+            ImmutableMap.of("FIXED_ONLY", "fixed"),
+            ImmutableSet.of("INHERITED_ONLY"))
+        .withAdditionalVariables(ImmutableMap.of("FIXED_AND_INHERITED", "fixed"),
+            ImmutableSet.of("FIXED_AND_INHERITED"));
     Map<String, String> clientEnv =
         ImmutableMap.of("INHERITED_ONLY", "inherited", "FIXED_AND_INHERITED", "inherited");
     Map<String, String> result = new HashMap<>();
@@ -64,5 +63,18 @@ public final class ActionEnvironmentTest {
             "inherited",
             "INHERITED_ONLY",
             "inherited");
+  }
+
+  @Test
+  public void emptyEnvironmentInterning() {
+    ActionEnvironment emptyEnvironment = ActionEnvironment.create(ImmutableMap.of(),
+        ImmutableSet.of());
+    assertThat(emptyEnvironment).isSameInstanceAs(ActionEnvironment.EMPTY);
+
+    ActionEnvironment base = ActionEnvironment.create(ImmutableMap.of("FOO", "foo1"),
+        ImmutableSet.of("baz"));
+    assertThat(base.withAdditionalFixedVariables(ImmutableMap.of())).isSameInstanceAs(base);
+    assertThat(base.withAdditionalVariables(ImmutableMap.of(), ImmutableSet.of())).isSameInstanceAs(
+        base);
   }
 }


### PR DESCRIPTION
When an ActionEnvironment is constructed out of an existing one, the
ActionEnvironment and EnvironmentVariables instances, which are
immutable, can be reused if no variables are added.

Also renames addVariables and addFixedVariables to better reflect that
they are operating on an immutable type.