### PR TITLE
Allow customizing bazel wrapper location checked into repository

### DIFF
--- a/scripts/packages/bazel.sh
+++ b/scripts/packages/bazel.sh
@@ -166,11 +166,12 @@ if [[ ! -x ${BAZEL_REAL} && -x ${bazel_real_path} ]]; then
   fi
 fi
 
-# If the repository contains a checked-in executable called tools/bazel, we
-# assume that they know what they're doing and have their own way of versioning
-# Bazel. Thus, we don't have to print our helpful messages or error out in case
-# we couldn't find a binary.
-readonly wrapper="${workspace_dir}/tools/bazel"
+# If the repository contains a checked-in executable set by $BAZEL_WRAPPER
+# (defaults to tools/bazel), we assume that they know what they're doing and
+# have their own way of versioning Bazel. Thus, we don't have to print our
+# helpful messages or error out in case we couldn't find a binary.
+BAZEL_WRAPPER=${"$BAZEL_WRAPPER":-"tools/bazel"}
+readonly wrapper="${workspace_dir}/${BAZEL_WRAPPER}"
 if [[ -x "$wrapper" && -f "$wrapper" ]]; then
   export BAZEL_REAL
   exec -a "$0" "${wrapper}" "$@"


### PR DESCRIPTION
Allow customizing location of Bazel wrapper checked into the repository using an env var $BAZEL_WRAPPER. There is no strong reason this needs to be hardcoded to `tools/bazel`. For eg: we keep most of our tools in the top-level `tooling` directory and would like to organize the wrapper location better and avoid confusion caused by two tool-related directories at the top `tools` and `tooling`.