### PR TITLE
Fix windows_export_all_symbols in cc_shared_library

### DIFF
--- a/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl
@@ -388,10 +388,7 @@ def _cc_shared_library_impl(ctx):
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
-        # This features enables behavior which creates a def file automatically
-        # for exporting all the symbols in a shared libary on Windows. If a
-        # custom def file is passed, this behavior doesn't apply.
-        requested_features = ctx.features + ["windows_export_all_symbols"],
+        requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
 

--- a/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/BUILD.builtin_test
+++ b/src/main/starlark/tests/builtins_bzl/cc/cc_shared_library/test_cc_shared_library/BUILD.builtin_test
@@ -36,18 +36,21 @@ cc_binary(
 cc_shared_library(
     name = "a_so",
     roots = [":a_suffix"],
+    features = ["windows_export_all_symbols"],
 )
 
 cc_shared_library(
     name = "diamond_so",
     dynamic_deps = [":a_so"],
     roots = [":qux"],
+    features = ["windows_export_all_symbols"],
 )
 
 cc_shared_library(
     name = "diamond2_so",
     dynamic_deps = [":a_so"],
     roots = [":qux2"],
+    features = ["windows_export_all_symbols"],
 )
 
 cc_binary(
@@ -90,6 +93,7 @@ cc_shared_library(
         "-Wl,--script=$(location :additional_script.txt)",
       ],
       "//conditions:default": []}),
+    features = ["windows_export_all_symbols"],
 )
 
 cc_library(
@@ -184,6 +188,7 @@ cc_shared_library(
       ],
       "//conditions:default": [],
     }),
+    features = ["windows_export_all_symbols"],
 )
 
 cc_library(
@@ -309,6 +314,7 @@ cc_shared_library(
     roots = [
         ":direct_so_file_cc_lib",
     ],
+    features = ["windows_export_all_symbols"],
 )
 
 genrule(
@@ -330,6 +336,7 @@ cc_shared_library(
         ":direct_so_file_cc_lib2",
     ],
     shared_lib_name = "renamed_so_file.so",
+    features = ["windows_export_all_symbols"],
 )
 
 cc_library(


### PR DESCRIPTION
Revert default export all symbols on Windows

In cc_shared_library we changed the behavior with respect to cc_binary(linkshared=1) by enabling the feature windows_export_all_symbols. This was in order to keep consistency between Linux and Windows. After further consideration, we decide it's better to keep the inconsistency between the two platforms because this is what Windows users expect.

PiperId: 439832190