### PR TITLE
Support ZIP files with total number of disks = 0

### DIFF
--- a/third_party/ijar/zip.cc
+++ b/third_party/ijar/zip.cc
@@ -707,7 +707,8 @@ bool FindZip64CentralDirectory(const u1 *bytes, size_t in_length,
   if (MaybeReadZip64CentralDirectory(bytes, in_length,
                                      bytes + zip64_end_of_central_dir_offset,
                                      end_of_central_dir, cd)) {
-    if (disk_with_zip64_central_directory != 0 || zip64_total_disks != 1) {
+    // TODO(b/228519294) Add a test for a valid zip64 file with total disks = 0
+    if (disk_with_zip64_central_directory != 0 || zip64_total_disks > 1) {
       fprintf(stderr, "multi-disk JAR files are not supported\n");
       return false;
     }


### PR DESCRIPTION
We came across [a problem](https://buildkite.com/bazel/intellij-plugin/builds/15968#0863eaa6-499b-46a2-a146-79d4c2b830c0) adding a jar provided by IntelliJ in its 2022.1 (lib/app.jar) to a `java_import` target because the jar in this version has a total number of disks = 0.

This value is supported by other tools: https://github.com/python/cpython/blob/main/Lib/zipfile.py#L258

PiperOrigin-RevId: 440322029