### PR TITLE
Split third_party/grpc into grpc and grpc-java [3/3]

### DIFF
--- a/third_party/grpc/BUILD
+++ b/third_party/grpc/BUILD
@@ -30,24 +30,6 @@ filegroup(
     ],
 )
 
-# TODO: Remove after migrating non-third-party imports to use `third_party/grpc-java` directly.
-alias(
-   name = "bootstrap-grpc-jars",
-   actual = "//third_party/grpc-java:bootstrap-grpc-jars",
-)
-
-# TODO: Remove after migrating non-third-party imports to use `third_party/grpc-java` directly.
-alias(
-   name = "grpc-jar",
-   actual = "//third_party/grpc-java:grpc-jar",
-)
-
-# TODO: Remove after migrating non-third-party imports to use `third_party/grpc-java` directly.
-alias(
-   name = "grpc-java-plugin",
-   actual = "//third_party/grpc-java:grpc-java-plugin",
-)
-
 alias(
     name = "cpp_plugin",
     actual = select({


### PR DESCRIPTION
Cleanup unused aliases in `third_party/grpc/BUILD`

Final followup to https://github.com/bazelbuild/bazel/commit/68277ec256fc6827ad46e909727d8e146741814d (https://github.com/bazelbuild/bazel/pull/15145) and https://github.com/bazelbuild/bazel/commit/5179d03f6c2ea1dcf3c146623f32ca75c3578923 (https://github.com/bazelbuild/bazel/pull/15193)