### PR TITLE
Default experimental_inmemory_dotd_files to true

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppOptions.java
@@ -690,7 +690,7 @@ public class CppOptions extends FragmentOptions {
 
   @Option(
       name = "experimental_inmemory_dotd_files",
-      defaultValue = "false",
+      defaultValue = "true",
       documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
       effectTags = {
         OptionEffectTag.LOADING_AND_ANALYSIS,


### PR DESCRIPTION
I asked around a bit about this flag and it sounds like there isn't a
downside to flipping this on by default. The upside is that if you
switch between using `--remote_download_minimal` and not, or switch
between a remote execution config that set this flag, but weren't
setting it globally, you would thrash your outputs and rebuild the
world. This was just a subtle gotcha if you were scoping this flag to
one of these specific configurations.