### PR TITLE
Remove noisy include scanning warning

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/includescanning/IncludeScanningModule.java
+++ b/src/main/java/com/google/devtools/build/lib/includescanning/IncludeScanningModule.java
@@ -122,11 +122,6 @@ public class IncludeScanningModule extends BlazeModule {
 
   @Override
   public void beforeCommand(CommandEnvironment env) {
-    CppOptions cppOptions = env.getOptions().getOptions(CppOptions.class);
-    if (cppOptions != null && cppOptions.experimentalIncludeScanning) {
-      env.getReporter()
-          .handle(Event.warn("Include scanning enabled. This feature is unsupported."));
-    }
     artifactFactory.set(env.getSkyframeBuildView().getArtifactFactory());
   }
 

--- a/src/test/shell/bazel/cc_integration_test.sh
+++ b/src/test/shell/bazel/cc_integration_test.sh
@@ -1451,7 +1451,6 @@ EOF
   touch pkg/dep.h
 
   bazel build --experimental_unsupported_and_brittle_include_scanning --features=cc_include_scanning //pkg:bin &>"$TEST_log" && fail 'include scanning did not (wrongly) remove dependency' || true
-  expect_log "Include scanning enabled. This feature is unsupported."
   expect_log "fatal error: '\?dep.h'\?"
 }
 


### PR DESCRIPTION
Given that this flag is called `--experimental_unsupported_and_brittle_include_scanning` I don't think it's necessary to have another warning about this being unsupported.