### PR TITLE
Replacing Compat Dx With Reference To Internal Bazel Build's Dx

### DIFF
--- a/src/tools/android/java/com/google/devtools/build/android/r8/BUILD.tools
+++ b/src/tools/android/java/com/google/devtools/build/android/r8/BUILD.tools
@@ -22,3 +22,10 @@ java_binary(
     visibility = ["//tools/android:__subpackages__"],
     runtime_deps = [":r8"],
 )
+
+java_binary(
+    name = "r8_binary",
+    main_class = "com.google.devtools.build.android.r8.CompatDx",
+    visibility = ["@androidsdk//:__subpackages__", "//tools/android:__subpackages__"],
+    runtime_deps = [":r8"],
+)

--- a/tools/android/android_sdk_repository_template.bzl
+++ b/tools/android/android_sdk_repository_template.bzl
@@ -296,10 +296,9 @@ def create_android_sdk_rules(
         name = "dx_jar_import",
         jars = ["build-tools/%s/lib/dx.jar" % build_tools_directory],
     )
-    java_binary(
+    native.alias(
         name = "d8_compat_dx",
-        main_class = "com.android.tools.r8.compatdx.CompatDx",
-        runtime_deps = [":d8_jar_import"],
+        actual = "@bazel_tools//src/tools/android/java/com/google/devtools/build/android/r8:r8_binary"
     )
     java_import(
         name = "d8_jar_import",


### PR DESCRIPTION
**Initial Issue:**
Bazel fails to build on build_tools_version 31.

Error: Could not find or load main class com.android.tools.r8.compatdx.CompatDx

https://github.com/bazelbuild/bazel/commit/ceb498fd6b9323a738f0ba628d12a23a161a0671 should have fixed the issue. However, I am not able to compile.

The error I get from --verbose_failures boils down to this line
bazel-out/k8-opt-exec-2B5CBBC6/bin/external/androidsdk/d8_compat_dx --dex '--num-threads=5' '--output=bazel-out/k8-fastbuild/bin/apps/presidio/helix/app-apk/_mobile_install/bin_debug/stub_application/classes.dex' bazel-out/k8-fastbuild/bin/apps/presidio/helix/app-apk/_mobile_install/bin_debug/stub_deploy.jar

When I look into the d8_compat_dx, I only see that a manifest file exists in it where it says it was created by "Target-Label: @androidsdk//:d8_compat_dx" and no other classes. Looking at this line in [android_sdk_repository.bzl,](https://github.com/bazelbuild/bazel/blob/66d07f096cb697bdadb6f9d9fbc1c4fe33be6d59/tools/android/android_sdk_repository_template.bzl#L306) it looks like Bazel is still trying to use the d8 packaged in build-tools in the Android SDK rather than trying to create its own.

See https://github.com/bazelbuild/bazel/issues/13989 for the original discussion.

**Fix**:

Make the d8_compat_dx reference the internal Bazel built dx tools.

We tested this by running bazel mobile-install on all our apps.