### PR TITLE
Collect coverage from cc_binary data deps of java_test

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaTestRule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaTestRule.java
@@ -61,6 +61,13 @@ public final class BazelJavaTestRule implements RuleDefinition {
             attr(":lcov_merger", LABEL)
                 .cfg(ExecutionTransitionFactory.create())
                 .value(BaseRuleClasses.getCoverageOutputGeneratorLabel()))
+        // Add the script as an attribute in order for java_test to output code coverage results for
+        // code covered by CC binaries invocations.
+        .add(
+            attr("$collect_cc_coverage", LABEL)
+                .cfg(ExecutionTransitionFactory.create())
+                .singleArtifact()
+                .value(env.getToolsLabel("//tools/test:collect_cc_coverage")))
         /* <!-- #BLAZE_RULE(java_test).ATTRIBUTE(test_class) -->
         The Java class to be loaded by the test runner.<br/>
         <p>


### PR DESCRIPTION
Before this commit, if a java_test executed a cc_binary from its data
deps, coverage for this cc_binary would not be collected. This is fixed
by adding the implicit `$collect_cc_coverage` attribute to
BazelJavaTestRule, similar to how this is already done for
BazelShTestRule.

Fixes the Java part of #15098.

Closes #15096.

PiperOrigin-RevId: 438785232

Fixes #15216 