### PR TITLE
Add target to produce API proto

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -521,3 +521,21 @@ genrule(
           "popd && mv $(@D)/gen_docs/tmp.zip $@",
     visibility = ["//scripts/docs:__pkg__"],
 )
+
+genrule(
+    name = "gen_api_proto",
+    srcs = [
+        "//src/main/java/com/google/devtools/build/docgen:bazel_link_map",
+    ],
+    outs = ["builtin.pb"],
+    cmd = (
+        "$(location //src/main/java/com/google/devtools/build/docgen:api_exporter)" +
+        " --output_file=$@" +
+        " --link_map_path=$(location //src/main/java/com/google/devtools/build/docgen:bazel_link_map) " +
+        " --provider=com.google.devtools.build.lib.bazel.rules.BazelRuleClassProvider" +
+        " --input_dir=$$PWD/src/main/java/com/google/devtools/build/lib"
+    ),
+    tools = [
+        "//src/main/java/com/google/devtools/build/docgen:api_exporter",
+    ],
+)


### PR DESCRIPTION
This change should help users who want to use the API exporter, which was previously unused.