### PR TITLE
Make 'sort_index' value of type string in profiler

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
@@ -1101,7 +1101,7 @@ public final class Profiler {
           writer.name("tid").value(CRITICAL_PATH_THREAD_ID);
           writer.name("args");
           writer.beginObject();
-          writer.name("sort_index").value(CRITICAL_PATH_SORT_INDEX);
+          writer.name("sort_index").value(String.valueof(CRITICAL_PATH_SORT_INDEX));
           writer.endObject();
           writer.endObject();
 

--- a/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
@@ -1101,7 +1101,7 @@ public final class Profiler {
           writer.name("tid").value(CRITICAL_PATH_THREAD_ID);
           writer.name("args");
           writer.beginObject();
-          writer.name("sort_index").value(String.valueof(CRITICAL_PATH_SORT_INDEX));
+          writer.name("sort_index").value(String.valueOf(CRITICAL_PATH_SORT_INDEX));
           writer.endObject();
           writer.endObject();
 


### PR DESCRIPTION
Fixes #15174, we should make the type of sort_index value consistent