### PR TITLE
Add field check_preceding_lifecycle_events_present to PublishLifecycleEventRequest and PublishBuildToolEventStreamRequest protos.

### DIFF
--- a/third_party/googleapis/google/devtools/build/v1/publish_build_event.proto
+++ b/third_party/googleapis/google/devtools/build/v1/publish_build_event.proto
@@ -118,6 +118,14 @@ message PublishLifecycleEventRequest {
   // This should match the project used for the initial call to
   // PublishLifecycleEvent (containing a BuildEnqueued message).
   string project_id = 6;
+
+  // Whether to require a previously received matching parent lifecycle event
+  // for the current request's event before continuing processing.
+  // - InvocationAttemptStarted and BuildFinished events require a BuildEnqueued
+  //   parent event.
+  // - InvocationAttemptFinished events require an InvocationAttemptStarted
+  //   parent event.
+  bool check_preceding_lifecycle_events_present = 7;
 }
 
 // States which event has been committed. Any failure to commit will cause
@@ -161,4 +169,10 @@ message PublishBuildToolEventStreamRequest {
   // This should match the project used for the initial call to
   // PublishLifecycleEvent (containing a BuildEnqueued message).
   string project_id = 6;
+
+  // Whether to require a previously received matching InvocationAttemptStarted
+  // event before continuing event processing for the event in the current
+  // request. BES only performs this check for events with sequence_number 1
+  // i.e. the first event in the stream.
+  bool check_preceding_lifecycle_events_present = 7;
 }


### PR DESCRIPTION
Add field check_preceding_lifecycle_events_present to PublishLifecycleEventRequest and PublishBuildToolEventStreamRequest protos so that they match the internal versions of those protos. This change is needed so that subsequent changes to files in /src/main/java/com/google/devtools/build/lib/buildeventservice that refer to this field don't break.

A corresponding change was made to the googleapis repo: https://github.com/googleapis/googleapis/commit/a877d3d3a0fcf5f02d083796710a804583586012