### PR TITLE
Flip strict_test_suite default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/QueryOptions.java
@@ -158,7 +158,7 @@ public class QueryOptions extends CommonQueryOptions {
 
   @Option(
     name = "strict_test_suite",
-    defaultValue = "false",
+    defaultValue = "true",
     documentationCategory = OptionDocumentationCategory.QUERY,
     effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS, OptionEffectTag.EAGERNESS_TO_EXIT},
     help =

--- a/src/test/java/com/google/devtools/build/lib/buildtool/QueryIntegrationTest.java
+++ b/src/test/java/com/google/devtools/build/lib/buildtool/QueryIntegrationTest.java
@@ -326,6 +326,7 @@ public class QueryIntegrationTest extends BuildIntegrationTestCase {
 
   @Test
   public void testNonStrictTests() throws Exception {
+    options.add("--strict_test_suite=false");
     write(
         "donut/BUILD",
         "sh_binary(name = 'thief', srcs = ['thief.sh'])",
@@ -341,7 +342,6 @@ public class QueryIntegrationTest extends BuildIntegrationTestCase {
 
   @Test
   public void testStrictTests() throws Exception {
-    options.add("--strict_test_suite=true");
     write(
         "donut/BUILD",
         "sh_binary(name = 'thief', srcs = ['thief.sh'])",


### PR DESCRIPTION
It seems like this flag is more of an incompatible flag, and the default
makes more sense to be true so new users don't accidentally start
relying on this.