### PR TITLE
linux-sandbox: do not treat large user IDs as negative numbers

### DIFF
--- a/src/main/tools/linux-sandbox-pid1.cc
+++ b/src/main/tools/linux-sandbox-pid1.cc
@@ -212,7 +212,8 @@ static void SetupUserNamespace() {
     }
   }
 
-  int inner_uid, inner_gid;
+  uid_t inner_uid;
+  gid_t inner_gid;
   if (opt.fake_root) {
     // Change our username to 'root'.
     inner_uid = 0;
@@ -231,8 +232,8 @@ static void SetupUserNamespace() {
     inner_uid = global_outer_uid;
     inner_gid = global_outer_gid;
   }
-  WriteFile("/proc/self/uid_map", "%d %d 1\n", inner_uid, global_outer_uid);
-  WriteFile("/proc/self/gid_map", "%d %d 1\n", inner_gid, global_outer_gid);
+  WriteFile("/proc/self/uid_map", "%u %u 1\n", inner_uid, global_outer_uid);
+  WriteFile("/proc/self/gid_map", "%u %u 1\n", inner_gid, global_outer_gid);
 }
 
 static void SetupUtsNamespace() {

--- a/src/main/tools/linux-sandbox.cc
+++ b/src/main/tools/linux-sandbox.cc
@@ -37,8 +37,6 @@
  *    system are invisible.
  */
 
-#include "src/main/tools/linux-sandbox.h"
-
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
@@ -63,11 +61,12 @@
 
 #include "src/main/tools/linux-sandbox-options.h"
 #include "src/main/tools/linux-sandbox-pid1.h"
+#include "src/main/tools/linux-sandbox.h"
 #include "src/main/tools/logging.h"
 #include "src/main/tools/process-tools.h"
 
-int global_outer_uid;
-int global_outer_gid;
+uid_t global_outer_uid;
+gid_t global_outer_gid;
 
 // The PID of our child process, for use in signal handlers.
 static std::atomic<pid_t> global_child_pid{0};

--- a/src/main/tools/linux-sandbox.h
+++ b/src/main/tools/linux-sandbox.h
@@ -15,7 +15,7 @@
 #ifndef SRC_MAIN_TOOLS_LINUX_SANDBOX_H_
 #define SRC_MAIN_TOOLS_LINUX_SANDBOX_H_
 
-extern int global_outer_uid;
-extern int global_outer_gid;
+extern uid_t global_outer_uid;
+extern gid_t global_outer_gid;
 
 #endif


### PR DESCRIPTION
The code writes into /proc/self/uid_map the user ID as a signed integer
but a user ID is an unsigned integer. Large user IDs are printed as
negative numbers and the linux-sandbox fails.

Signed-off-by: George Prekas <prekgeo@yahoo.com>

I observe the following on my system:
```
$ id -u
2418623341

$ linux-sandbox /bin/true
src/main/tools/linux-sandbox-pid1.cc:126: "fclose(/proc/self/uid_map)": Invalid argument

$ strace -yf linux-sandbox /bin/true |& grep uid_map
[pid 1077131] openat(AT_FDCWD, "/proc/self/uid_map", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3</proc/1077131/uid_map>
[pid 1077131] fstat(3</proc/1077131/uid_map>, {st_mode=S_IFREG|0644, st_size=0, ...}) = 0
[pid 1077131] write(3</proc/1077131/uid_map>, "-1876343955 -1876343955 1\n", 26) = -1 EINVAL (Invalid argument)
[pid 1077131] close(3</proc/1077131/uid_map>) = 0
[pid 1077131] write(2<pipe:[151542577]>, "src/main/tools/linux-sandbox-pid"..., 69src/main/tools/linux-sandbox-pid1.cc:126: "fclose(/proc/self/uid_map)) = 69
```

After the fix, I get:
```
$ ~/bazel/bazel-bin/src/main/tools/linux-sandbox /bin/true && echo ok
ok
$ strace -yf ~/bazel/bazel-bin/src/main/tools/linux-sandbox -- /bin/true |& grep uid_map
[pid 1086662] openat(AT_FDCWD, "/proc/self/uid_map", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3</proc/1086662/uid_map>
[pid 1086662] fstat(3</proc/1086662/uid_map>, {st_mode=S_IFREG|0644, st_size=0, ...}) = 0
[pid 1086662] write(3</proc/1086662/uid_map>, "2418623341 2418623341 1\n", 24) = 24
[pid 1086662] close(3</proc/1086662/uid_map>) = 0
```