### PR TITLE
cpp: support vendor'ed clang

### DIFF
--- a/tools/cpp/windows_cc_configure.bzl
+++ b/tools/cpp/windows_cc_configure.bzl
@@ -571,10 +571,10 @@ def _get_clang_version(repository_ctx, clang_cl):
     result = repository_ctx.execute([clang_cl, "-v"])
     first_line = result.stderr.strip().splitlines()[0]
 
-    # The first line of stderr should look like "clang version X.X.X"
-    if result.return_code != 0 or not first_line.startswith("clang version "):
+    # The first line of stderr should look like "[vendor ]clang version X.X.X"
+    if result.return_code != 0 or first_line.find("clang version ") == -1:
         auto_configure_fail("Failed to get clang version by running \"%s -v\"" % clang_cl)
-    return first_line.split(" ")[2]
+    return first_line.split(" ")[-1]
 
 def _get_msys_mingw_vars(repository_ctx):
     """Get the variables we need to populate the msys/mingw toolchains."""


### PR DESCRIPTION
It is possible to build clang with an embedded vendor tag.  In such a
scenario the version string returned contains the vendor.  Adjust the
version checking logic to be more lenient against such a configuration.