### PR TITLE
Forward wall time from remote execution to SpawnResult

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -155,6 +155,7 @@ public final class Utils {
             .setRunnerName(cacheHit ? runnerName + " cache hit" : runnerName)
             .setCacheHit(cacheHit)
             .setSpawnMetrics(spawnMetrics)
+            .setWallTime(spawnMetrics.executionWallTime())
             .setRemote(true);
     if (exitCode != 0) {
       builder.setFailureDetail(


### PR DESCRIPTION
Forward wall time of remotely executed actions to SpawnResult so the
wall time can be reported where required.