### PR TITLE
Remove unused windows cc toolchain feature

### DIFF
--- a/tools/cpp/windows_cc_toolchain_config.bzl
+++ b/tools/cpp/windows_cc_toolchain_config.bzl
@@ -1247,10 +1247,6 @@ def _impl(ctx):
                 name = "supports_pic",
                 enabled = True,
             )
-            supports_start_end_lib_feature = feature(
-                name = "supports_start_end_lib",
-                enabled = True,
-            )
 
             sysroot_feature = feature(
                 name = "sysroot",


### PR DESCRIPTION
This isn't referenced, and it sounds like this isn't generally supported
on Windows.