### PR TITLE
Collect C++ lcov coverage if runtime object not in runfiles

### DIFF
--- a/tools/test/collect_cc_coverage.sh
+++ b/tools/test/collect_cc_coverage.sh
@@ -85,7 +85,9 @@ function llvm_coverage_lcov() {
   while read -r line; do
     if [[ ${line: -24} == "runtime_objects_list.txt" ]]; then
       while read -r line_runtime_object; do
+        if [[ -e "${RUNFILES_DIR}/${TEST_WORKSPACE}/${line_runtime_object}" ]]; then
           object_param+=" -object ${RUNFILES_DIR}/${TEST_WORKSPACE}/${line_runtime_object}"
+        fi
       done < "${line}"
     fi
   done < "${COVERAGE_MANIFEST}"


### PR DESCRIPTION
Before this commit, collecting C++ coverage in lcov format would fail
at the llvm-cov export step if a shared library listed in the
runtime_objects_list.txt was not contained in the runfiles of the top-
level target. This can happen e.g. if a cc_library depends on a
java_binary that has a cc_binary shared library in its resources.

This is fixed by not including objects that don't exist at runtime
in the llvm-cov invocation.

Fixes #15121.

Closes #15118.

PiperOrigin-RevId: 442799461

Fixes #15290.