### PR TITLE
main: do not declare `environ` on Windows

### DIFF
--- a/src/main/cpp/blaze.cc
+++ b/src/main/cpp/blaze.cc
@@ -80,7 +80,9 @@
 
 using blaze_util::GetLastErrorString;
 
+#if !defined(_WIN32)
 extern char **environ;
+#endif
 
 namespace blaze {
 


### PR DESCRIPTION
When building with `/MD` on Windows, `environ` is a macro expanding to
`__p_environ` which has dll-export storage.  However, the redeclaration
does not annotate the DLL storage causing a mismatch warning
(`-Winconsistent-dllstorage`) which will be treated as an error.  Let
the declaration from the system headers be the declaration required.