### PR TITLE
Flip --use_workers_with_dexbuilder default value to true

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -544,9 +544,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
 
     @Option(
         name = "use_workers_with_dexbuilder",
-        // TODO(b/226226799): Set this back to true once
-        // https://github.com/bazelbuild/bazel/issues/10241 is addressed
-        defaultValue = "false",
+        defaultValue = "true",
         documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
         effectTags = {OptionEffectTag.EXECUTION},
         help = "Whether dexbuilder supports being run in local worker mode.")


### PR DESCRIPTION
Removing the TODO on `use_workers_with_dexbuilder` and flipped the flag back to true.

Related issue https://github.com/bazelbuild/bazel/issues/10241