### PR TITLE
Add multiplex worker support to dexbuilder

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ExecutionRequirements.java
@@ -176,6 +176,9 @@ public class ExecutionRequirements {
   public static final ImmutableMap<String, String> WORKER_MODE_ENABLED =
       ImmutableMap.of(SUPPORTS_WORKERS, "1");
 
+  public static final ImmutableMap<String, String> WORKER_MULTIPLEX_MODE_ENABLED =
+      ImmutableMap.of(SUPPORTS_MULTIPLEX_WORKERS, "1");
+
   /**
    * Requires local execution without sandboxing for a spawn.
    *

--- a/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/AndroidConfiguration.java
@@ -553,6 +553,14 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     public boolean useWorkersWithDexbuilder;
 
     @Option(
+        name = "use_multiplex_workers_with_dexbuilder",
+        defaultValue = "false",
+        documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+        effectTags = {OptionEffectTag.EXECUTION},
+        help = "Whether dexbuilder supports being run in local multiplex worker mode.")
+    public boolean useMultiplexWorkersWithDexbuilder;
+
+    @Option(
         name = "experimental_android_rewrite_dexes_with_rex",
         defaultValue = "false",
         documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
@@ -1016,6 +1024,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
       host.dexoptsSupportedInDexMerger = dexoptsSupportedInDexMerger;
       host.dexoptsSupportedInDexSharder = dexoptsSupportedInDexSharder;
       host.useWorkersWithDexbuilder = useWorkersWithDexbuilder;
+      host.useMultiplexWorkersWithDexbuilder = useMultiplexWorkersWithDexbuilder;
       host.manifestMerger = manifestMerger;
       host.manifestMergerOrder = manifestMergerOrder;
       host.allowAndroidLibraryDepsWithoutSrcs = allowAndroidLibraryDepsWithoutSrcs;
@@ -1042,6 +1051,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   private final ImmutableList<String> dexoptsSupportedInDexMerger;
   private final ImmutableList<String> dexoptsSupportedInDexSharder;
   private final boolean useWorkersWithDexbuilder;
+  private final boolean useMultiplexWorkersWithDexbuilder;
   private final boolean desugarJava8;
   private final boolean desugarJava8Libs;
   private final boolean checkDesugarDeps;
@@ -1096,6 +1106,7 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
     this.dexoptsSupportedInDexMerger = ImmutableList.copyOf(options.dexoptsSupportedInDexMerger);
     this.dexoptsSupportedInDexSharder = ImmutableList.copyOf(options.dexoptsSupportedInDexSharder);
     this.useWorkersWithDexbuilder = options.useWorkersWithDexbuilder;
+    this.useMultiplexWorkersWithDexbuilder = options.useMultiplexWorkersWithDexbuilder;
     this.desugarJava8 = options.desugarJava8;
     this.desugarJava8Libs = options.desugarJava8Libs;
     this.checkDesugarDeps = options.checkDesugarDeps;
@@ -1232,6 +1243,12 @@ public class AndroidConfiguration extends Fragment implements AndroidConfigurati
   @Override
   public boolean useWorkersWithDexbuilder() {
     return useWorkersWithDexbuilder;
+  }
+
+  /** Whether to assume the dexbuilder tool supports local multiplexed worker mode. */
+  @Override
+  public boolean useMultiplexWorkersWithDexbuilder() {
+    return useMultiplexWorkersWithDexbuilder;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/android/DexArchiveAspect.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/android/DexArchiveAspect.java
@@ -642,6 +642,9 @@ public class DexArchiveAspect extends NativeAspectClass implements ConfiguredAsp
     if (getAndroidConfig(ruleContext).useWorkersWithDexbuilder()) {
       dexbuilder.setExecutionInfo(ExecutionRequirements.WORKER_MODE_ENABLED);
     }
+    if (getAndroidConfig(ruleContext).useMultiplexWorkersWithDexbuilder()) {
+      dexbuilder.setExecutionInfo(ExecutionRequirements.WORKER_MULTIPLEX_MODE_ENABLED);
+    }
     ruleContext.registerAction(dexbuilder.build(ruleContext));
     return dexArchive;
   }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/android/AndroidConfigurationApi.java
@@ -101,6 +101,13 @@ public interface AndroidConfigurationApi extends StarlarkValue {
       documented = false)
   boolean useWorkersWithDexbuilder();
 
+  @StarlarkMethod(
+      name = "use_multiplex_workers_with_dexbuilder",
+      structField = true,
+      doc = "",
+      documented = false)
+  boolean useMultiplexWorkersWithDexbuilder();
+
   @StarlarkMethod(name = "desugar_java8", structField = true, doc = "", documented = false)
   boolean desugarJava8();
 


### PR DESCRIPTION
Adding full support for multiplexed dexbuilder workers. This PR is a continuation of https://github.com/bazelbuild/bazel/pull/14623#issuecomment-1019852321 where we added basic worker support.

Related issue: https://github.com/bazelbuild/bazel/issues/10241