### PR TITLE
Flip disallow empty glob

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/semantics/BuildLanguageOptions.java
@@ -422,7 +422,7 @@ public final class BuildLanguageOptions extends OptionsBase {
 
   @Option(
       name = "incompatible_disallow_empty_glob",
-      defaultValue = "false",
+      defaultValue = "true",
       category = "incompatible changes",
       documentationCategory = OptionDocumentationCategory.STARLARK_SEMANTICS,
       effectTags = {OptionEffectTag.BUILD_FILE_SEMANTICS},
@@ -902,7 +902,7 @@ public final class BuildLanguageOptions extends OptionsBase {
       "+incompatible_depset_for_libraries_to_link_getter";
   public static final String INCOMPATIBLE_DISABLE_TARGET_PROVIDER_FIELDS =
       "-incompatible_disable_target_provider_fields";
-  public static final String INCOMPATIBLE_DISALLOW_EMPTY_GLOB = "-incompatible_disallow_empty_glob";
+  public static final String INCOMPATIBLE_DISALLOW_EMPTY_GLOB = "+incompatible_disallow_empty_glob";
   public static final String INCOMPATIBLE_DISALLOW_STRUCT_PROVIDER_SYNTAX =
       "-incompatible_disallow_struct_provider_syntax";
   public static final String INCOMPATIBLE_PACKAGE_GROUP_HAS_PUBLIC_SYNTAX =

--- a/src/test/java/com/google/devtools/build/lib/packages/util/MockCcSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/MockCcSupport.java
@@ -275,7 +275,8 @@ public abstract class MockCcSupport {
             "cc/cc_toolchain_config_lib.bzl",
             "cc/find_cc_toolchain.bzl",
             "cc/toolchain_utils.bzl",
-            "cc/private/rules_impl/BUILD")) {
+            "cc/private/rules_impl/BUILD",
+            "cc/private/rules_impl/native.bzl")) {
       try {
         config.create(
             "third_party/bazel_rules/rules_cc/" + path,

--- a/src/test/shell/bazel/runfiles_test.sh
+++ b/src/test/shell/bazel/runfiles_test.sh
@@ -246,7 +246,7 @@ function test_switch_runfiles_from_enabled_to_disabled {
 sh_binary(
   name = "cmd",
   srcs = ["cmd.sh"],
-  data = glob(["data-*"]),
+  data = glob(["data-*"], allow_empty = True),
 )
 genrule(
   name = "g",


### PR DESCRIPTION
This PR is to flip the default value of `incompatible_disallow_empty_glob`. This flag is tracked in https://github.com/bazelbuild/bazel/issues/8195 and it is available since Bazel 0.29 from August 2019.
Once this is merged, users still can allow empty globs without being explicit setting `--incompatible_disallow_empty_glob=false`.

The motivation of the flip is https://github.com/bazel-contrib/SIG-rules-authors/issues/37 and the fact of not keeping an incompatible flag for 4 years without flipping it.

What needs to be done before flipping this:

- [x] Merge https://github.com/protocolbuffers/upb/pull/584
- [x] Update upb to a version that has the change in https://github.com/protocolbuffers/upb/pull/584
- [x] Merge https://github.com/protocolbuffers/upb/pull/745
- [x] Bring the changes from https://github.com/protocolbuffers/upb/pull/745 to the 21.x branch
- [x] Bring the changes from https://github.com/protocolbuffers/upb/commit/e5f26018368b11aab672e8e8bb76513f3620c579 to the 21.x branch (https://github.com/protocolbuffers/upb/pull/781)
- [x] Update upb to the latest commit of the 21.x branch (https://github.com/bazelbuild/bazel/pull/16343)
- [x] Merge https://github.com/bazelbuild/bazel/pull/15374
- [x] Merge https://github.com/bazelbuild/bazel/pull/15339
- [x] Merge https://github.com/bazelbuild/bazel/pull/15330
- [x] Merge https://github.com/bazelbuild/bazel/pull/16431
- [x] Merge https://github.com/bazelbuild/bazel/pull/16468
- [x] Get green checks for this PR
- [ ] Fix failures in downstream projects: https://buildkite.com/bazel/bazelisk-plus-incompatible-flags
  - [ ] Fix empty globs from IntellIJ Plugin (https://github.com/bazelbuild/intellij)
    - [ ] Issue: https://github.com/bazelbuild/intellij/issues/4040
    - [ ] Android Studio Plugin
    - [ ] Android Studio Plugin Google
    - [ ] CLion Plugin
    - [ ] CLion Plugin Google
    - [ ] IntelliJ Plugin
    - [ ] IntelliJ Plugin Aspect
    - [ ] IntelliJ Plugin Aspect Google
    - [ ] IntelliJ Plugin Google
    - [ ] IntelliJ UE Plugin
    - [ ] IntelliJ UE Plugin Google
    - Opened PRs
      - [x] https://github.com/bazelbuild/intellij/pull/4025
      - [x] https://github.com/bazelbuild/intellij/pull/4038
  - [x] Fix empty globs from Bazel Bench (https://github.com/bazelbuild/bazel-bench)
    - [ ] https://github.com/bazelbuild/bazel-bench/pull/174
    - [x] https://github.com/bazelbuild/bazel-bench/pull/149
  - [x] Fix empty globs from Buildfarm (https://github.com/bazelbuild/bazel-buildfarm)
  - [x] Fix empty globs from Cargo
  - [x] ~~Fix empty globs from Cartographer (https://github.com/cartographer-project/cartographer)~~ (No longer maintained)
    - Issue: https://github.com/cartographer-project/cartographer/issues/1908
    - PR to enforce it https://github.com/cartographer-project/cartographer/pull/1944
  - [x] Fix empty globs from Cloud Robotics Core (https://github.com/googlecloudrobotics/core/)
    - [x] PR to prevent regresions https://github.com/googlecloudrobotics/core/pull/279
  - [ ] Fix empty globs from Envoy
  - [x] Fix empty globs from FlatBuffers
  - [x] Fix empty globs from Flogger
  - [ ] Fix empty globs from Gerrit (https://gerrit.googlesource.com/gerrit.git)
    - Issue: https://issues.gerritcodereview.com/issues/40011754
  - [x] Fix empty globs from :bazel:Protobuf
  - [x] Fix empty globs from rules_android_ndk
  - [ ] Fix empty globs from rules_dotnet
  - [x] Fix empty globs from :bazel:rules_foreign_cc https://github.com/bazelbuild/rules_foreign_cc/issues/974
  - [x] Fix empty globs from rules_go
  - [x] Fix empty globs from rules_haskell https://github.com/tweag/rules_haskell/issues/1827
  - [x] Fix empty globs from :bazel:rules_jvm_external
  - [x] Fix empty globs from rules_kotlin
  - [x] Fix empty globs from rules_nodejs
  - [x] Fix empty globs from :bazel:rules_python
  - [ ] Fix empty globs from rules_rust
  - [x] Fix empty globs from rules_swift
  - [x] Fix empty globs from rules_webtesting
  - [x] Fix empty globs from TensorFlow  https://github.com/tensorflow/tensorflow/issues/58155
    - [x] https://github.com/tensorflow/tensorflow/pull/58008
    - [x] https://github.com/tensorflow/tensorflow/pull/58154
  - [x] Fix empty globs from upb