### PR TITLE
Be explicit about alowing empty globs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -50,6 +50,7 @@ filegroup(
     srcs = glob(
         [".git/**"],
         exclude = [".git/**/*[*"],  # gitk creates temp files with []
+        allow_empty = True,
     ),
 )
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/CircularDependencyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/CircularDependencyTest.java
@@ -365,7 +365,7 @@ public class CircularDependencyTest extends BuildViewTestCase {
         "           hdrs = select({",
         "              ':fastbuild': glob([",
         "                   '*.h',",
-        "               ]),",
+        "               ], allow_empty = True),",
         "           }),",
         ")");
 

--- a/src/test/java/com/google/devtools/build/lib/analysis/ConfigurableAttributesTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/ConfigurableAttributesTest.java
@@ -958,7 +958,7 @@ public class ConfigurableAttributesTest extends BuildViewTestCase {
         "    cmd = 'echo' + select({",
         "        '//conditions:a': 'a',",
         "        '//conditions:b': 'b',",
-        "    }) + glob(['globbed.java']))");
+        "    }) + glob(['globbed.java'], allow_empty = True))");
 
     reporter.removeHandler(failFastHandler);
     assertThrows(NoSuchTargetException.class, () -> getTarget("//foo:binary"));

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -193,7 +193,7 @@ public final class BazelAnalysisMock extends AnalysisMock {
         "java_runtime_alias(name = 'current_java_runtime')",
         "java_host_runtime_alias(name = 'current_host_java_runtime')",
         "filegroup(name='bootclasspath', srcs=['jdk/jre/lib/rt.jar'])",
-        "filegroup(name='extdir', srcs=glob(['jdk/jre/lib/ext/*']))",
+        "filegroup(name='extdir', srcs=glob(['jdk/jre/lib/ext/*'], allow_empty = True))",
         "filegroup(name='java', srcs = ['jdk/jre/bin/java'])",
         "filegroup(name='JacocoCoverage', srcs = ['JacocoCoverage_deploy.jar'])",
         "exports_files([",

--- a/src/test/java/com/google/devtools/build/lib/packages/PackageFactoryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/PackageFactoryTest.java
@@ -1346,7 +1346,7 @@ public final class PackageFactoryTest extends PackageLoadingTestCase {
     scratch.file(
         "globs/BUILD",
         String.format(
-            "result = glob(%s, exclude=%s, exclude_directories=%d)",
+            "result = glob(%s, exclude=%s, exclude_directories=%d, allow_empty = True)",
             Starlark.repr(includes), Starlark.repr(excludes), excludeDirs ? 1 : 0),
         resultAssertion);
     return loadPackage("globs");

--- a/src/test/java/com/google/devtools/build/lib/rules/android/AndroidBinaryMultidexTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/AndroidBinaryMultidexTest.java
@@ -60,7 +60,7 @@ public abstract class AndroidBinaryMultidexTest extends AndroidMultidexBaseTest 
         "    name = 'nomultidex',",
         "    srcs = ['a.java'],",
         "    manifest = 'AndroidManifest.xml',",
-        "    resource_files = glob(['res/**']),",
+        "    resource_files = glob(['res/**'], allow_empty = True),",
         ")");
     internalTestNonMultidexBuildStructure("//java/foo:nomultidex");
   }
@@ -74,7 +74,7 @@ public abstract class AndroidBinaryMultidexTest extends AndroidMultidexBaseTest 
         "    name = 'default',",
         "    srcs = ['a.java'],",
         "    manifest = 'AndroidManifest.xml',",
-        "    resource_files = glob(['res/**']))");
+        "    resource_files = glob(['res/**'], allow_empty = True))");
     internalTestNonMultidexBuildStructure("//java/foo:default");
   }
 
@@ -87,7 +87,7 @@ public abstract class AndroidBinaryMultidexTest extends AndroidMultidexBaseTest 
         "    name = 'manual_main_dex',",
         "    srcs = ['a.java'],",
         "    manifest = 'AndroidManifest.xml',",
-        "    resource_files = glob(['res/**']),",
+        "    resource_files = glob(['res/**'], allow_empty = True),",
         "    multidex = 'manual_main_dex',",
         "    main_dex_list = 'main_dex_list.txt')");
     internalTestMultidexBuildStructure("//java/foo:manual_main_dex", MultidexMode.MANUAL_MAIN_DEX);
@@ -107,7 +107,7 @@ public abstract class AndroidBinaryMultidexTest extends AndroidMultidexBaseTest 
         "    name = 'legacy',",
         "    srcs = ['a.java'],",
         "    manifest = 'AndroidManifest.xml',",
-        "    resource_files = glob(['res/**']),",
+        "    resource_files = glob(['res/**'], allow_empty = True),",
         "    multidex = 'legacy')");
     internalTestMultidexBuildStructure("//java/foo:legacy", MultidexMode.LEGACY);
   }
@@ -126,7 +126,7 @@ public abstract class AndroidBinaryMultidexTest extends AndroidMultidexBaseTest 
         "    name = 'native',",
         "    srcs = ['a.java'],",
         "    manifest = 'AndroidManifest.xml',",
-        "    resource_files = glob(['res/**']),",
+        "    resource_files = glob(['res/**'], allow_empty = True),",
         "    multidex = 'native')");
     internalTestMultidexBuildStructure("//java/foo:native", MultidexMode.NATIVE);
   }

--- a/src/test/java/com/google/devtools/build/lib/rules/android/AndroidDataBindingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/AndroidDataBindingTest.java
@@ -97,7 +97,7 @@ public abstract class AndroidDataBindingTest extends AndroidBuildViewTestCase {
         "    enable_data_binding = 1,",
         "    manifest = 'AndroidManifest.xml',",
         "    srcs = ['LibWithResourceFiles.java'],",
-        "    resource_files = glob(['res/**']),",
+        "    resource_files = glob(['res/**'], allow_empty = True),",
         ")");
     scratch.file(
         "java/android/lib_with_resource_files/LibWithResourceFiles.java",

--- a/src/test/java/com/google/devtools/build/lib/skyframe/PackageFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/PackageFunctionTest.java
@@ -572,8 +572,8 @@ public class PackageFunctionTest extends BuildViewTestCase {
   public void testOneNewElementInMultipleGlob() throws Exception {
     scratch.file(
         "foo/BUILD",
-        "sh_library(name = 'foo', srcs = glob(['*.sh']))",
-        "sh_library(name = 'bar', srcs = glob(['*.sh', '*.txt']))");
+        "sh_library(name = 'foo', srcs = glob(['*.sh'], allow_empty = True))",
+        "sh_library(name = 'bar', srcs = glob(['*.sh', '*.txt'], allow_empty = True))");
     preparePackageLoading(rootDirectory);
     SkyKey skyKey = PackageValue.key(PackageIdentifier.createInMainRepo("foo"));
     Package pkg = validPackageWithoutErrors(skyKey);
@@ -590,8 +590,8 @@ public class PackageFunctionTest extends BuildViewTestCase {
   public void testNoNewElementInMultipleGlob() throws Exception {
     scratch.file(
         "foo/BUILD",
-        "sh_library(name = 'foo', srcs = glob(['*.sh', '*.txt']))",
-        "sh_library(name = 'bar', srcs = glob(['*.sh', '*.txt']))");
+        "sh_library(name = 'foo', srcs = glob(['*.sh', '*.txt'], allow_empty = True))",
+        "sh_library(name = 'bar', srcs = glob(['*.sh', '*.txt'], allow_empty = True))");
     preparePackageLoading(rootDirectory);
     SkyKey skyKey = PackageValue.key(PackageIdentifier.createInMainRepo("foo"));
     Package pkg = validPackageWithoutErrors(skyKey);

--- a/src/test/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutorTest.java
@@ -301,7 +301,7 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
 
     // A dummy directory that is not changed.
     scratch.file("misc/BUILD",
-        "py_binary(name = 'misc', srcs = ['other.py'], data = glob(['*.txt']))");
+        "py_binary(name = 'misc', srcs = ['other.py'], data = glob(['*.txt'], allow_empty = True))");
 
     sync("//python/hello:hello", "//misc:misc");
 
@@ -652,7 +652,7 @@ public final class SequencedSkyframeExecutorTest extends BuildViewTestCase {
   public void testInterruptLoadedTarget() throws Exception {
     analysisMock.pySupport().setup(mockToolsConfig);
     scratch.file("python/hello/BUILD",
-        "py_binary(name = 'hello', srcs = ['hello.py'], data = glob(['*.txt']))");
+        "py_binary(name = 'hello', srcs = ['hello.py'], data = glob(['*.txt'], allow_empty = True))");
     Thread.currentThread().interrupt();
     LoadedPackageProvider packageProvider =
         new LoadedPackageProvider(skyframeExecutor.getPackageManager(), reporter);

--- a/src/test/shell/integration/loading_phase_test.sh
+++ b/src/test/shell/integration/loading_phase_test.sh
@@ -240,13 +240,13 @@ function test_glob_with_subpackage() {
     assert_equals "3" $(wc -l "$TEST_log")
 
     # glob returns an empty list, because t3.txt is outside the package
-    echo "exports_files(glob(['subpkg/t3.txt']))" >$pkg/p/BUILD
+    echo "exports_files(glob(['subpkg/t3.txt'], allow_empty = True))" >$pkg/p/BUILD
     bazel query "$pkg/p:*" -k >$TEST_log || fail "Expected success"
     expect_log "//$pkg/p:BUILD"
     assert_equals "1" $(wc -l "$TEST_log")
 
     # same test, with a nonexisting file
-    echo "exports_files(glob(['subpkg/no_glob.txt']))" >$pkg/p/BUILD
+    echo "exports_files(glob(['subpkg/no_glob.txt'], allow_empty = True))" >$pkg/p/BUILD
     bazel query "$pkg/p:*" -k >$TEST_log || fail "Expected success"
     expect_log "//$pkg/p:BUILD"
     assert_equals "1" $(wc -l "$TEST_log")

--- a/src/test/shell/integration/run_test.sh
+++ b/src/test/shell/integration/run_test.sh
@@ -102,7 +102,7 @@ EOF
   cat > cc/BUILD <<EOF
 cc_binary(name='kitty',
           srcs=['kitty.cc'],
-          data=glob(['*.txt']))
+          data=glob(['*.txt'], allow_empty = True))
 EOF
 }
 


### PR DESCRIPTION
There are several globs that are empty and this prevents building
with the incompatible flag #8195.
This commit just makes it explicit that empty is allowed.