### PR TITLE
Windows: remove forced link to `clang_rt.builtins`

### DIFF
--- a/tools/cpp/BUILD.windows.tpl
+++ b/tools/cpp/BUILD.windows.tpl
@@ -472,7 +472,7 @@ cc_toolchain_config(
         "strip": "wrapper/bin/msvc_nop.bat",
     },
     archiver_flags = ["/MACHINE:X64"],
-    default_link_flags = ["/MACHINE:X64", "/DEFAULTLIB:clang_rt.builtins-x86_64.lib"],
+    default_link_flags = ["/MACHINE:X64"],
     dbg_mode_debug_flag = "%{clang_cl_dbg_mode_debug_flag_x64}",
     fastbuild_mode_debug_flag = "%{clang_cl_fastbuild_mode_debug_flag_x64}",
 )


### PR DESCRIPTION
When building with `cl`, this library is not linked against.  Replicate
this behaviour with `clang-cl`.  `clang-cl` should not generate
references to the GNU functions by default, so this is generally safe.