### PR TITLE
Convert paths, arguments, and env vars to Unicode for remote execution.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/query2/BUILD
@@ -110,6 +110,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:command",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/build/lib/util:shell_escaper",
+        "//src/main/java/com/google/devtools/build/lib/util:string",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/skyframe",

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -342,10 +342,9 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
    * to be durable against unusual encoding settings, and does not guarantee
    * that the escaping process is reverseable.
    *
-   * Non-printable ASCII characters are formatted as `{U+00XX}`. Characters
-   * outside the ASCII range but within the Basic Multilingual Plane are
-   * formatted as `{U+XXXX}`. Characters outside the BMP are formatted as
-   *`{U+XXXX...}`.
+   * Characters other than printable ASCII but within the Basic Multilingual
+   * Plane are formatted with `\\uXXXX`. Characters outside the BMP are
+   * formatted as `\\UXXXXXXXX`.
    */
   public static String escapeBytestringUtf8(String maybeUtf8) {
     if (maybeUtf8.chars().allMatch(c -> c >= 0x20 && c < 0x7F)) {
@@ -357,8 +356,10 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
     decoded.codePoints().forEach(c -> {
       if (c >= 0x20 && c < 0x7F) {
         sb.appendCodePoint(c);
+      } else if (c <= 0xFFFF) {
+        sb.append(String.format("\\u%04X", c));
       } else {
-        sb.append(String.format("{U+%04X}", c));
+        sb.append(String.format("\\U%08X", c));
       }
     });
     return sb.toString();

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.query2.aquery;
 
+import static com.google.devtools.build.lib.util.StringUtil.starlarkToUnicode;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
@@ -199,7 +200,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
           .append("  Inputs: [")
           .append(
               action.getInputs().toList().stream()
-                  .map(input -> input.getExecPathString())
+                  .map(input -> starlarkToUnicode(input.getExecPathString()))
                   .sorted()
                   .collect(Collectors.joining(", ")))
           .append("]\n")
@@ -208,9 +209,9 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
               action.getOutputs().stream()
                   .map(
                       output ->
-                          output.isTreeArtifact()
+                          starlarkToUnicode(output.isTreeArtifact()
                               ? output.getExecPathString() + " (TreeArtifact)"
-                              : output.getExecPathString())
+                              : output.getExecPathString()))
                   .sorted()
                   .collect(Collectors.joining(", ")))
           .append("]\n");
@@ -228,8 +229,8 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
             .append(
                 Streams.stream(fixedEnvironment)
                     .map(
-                        environmentVariable ->
-                            environmentVariable.getKey() + "=" + environmentVariable.getValue())
+                        environmentVariable -> starlarkToUnicode(
+                            environmentVariable.getKey() + "=" + environmentVariable.getValue()))
                     .sorted()
                     .collect(Collectors.joining(", ")))
             .append("]\n");
@@ -259,7 +260,9 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
               CommandFailureUtils.describeCommand(
                   CommandDescriptionForm.COMPLETE,
                   /* prettyPrintArgs= */ true,
-                  ((CommandAction) action).getArguments(),
+                  ((CommandAction) action).getArguments().stream()
+                      .map(a -> starlarkToUnicode(a))
+                      .collect(Collectors.toList()),
                   /* environment= */ null,
                   /* cwd= */ null,
                   action.getOwner().getConfigurationChecksum(),

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.query2.aquery;
 
-import static com.google.devtools.build.lib.util.StringUtil.starlarkToUnicode;
+import static com.google.devtools.build.lib.util.StringUtil.decodeBytestringUtf8;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
@@ -200,7 +200,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
           .append("  Inputs: [")
           .append(
               action.getInputs().toList().stream()
-                  .map(input -> starlarkToUnicode(input.getExecPathString()))
+                  .map(input -> decodeBytestringUtf8(input.getExecPathString()))
                   .sorted()
                   .collect(Collectors.joining(", ")))
           .append("]\n")
@@ -209,7 +209,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
               action.getOutputs().stream()
                   .map(
                       output ->
-                          starlarkToUnicode(output.isTreeArtifact()
+                          decodeBytestringUtf8(output.isTreeArtifact()
                               ? output.getExecPathString() + " (TreeArtifact)"
                               : output.getExecPathString()))
                   .sorted()
@@ -229,7 +229,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
             .append(
                 Streams.stream(fixedEnvironment)
                     .map(
-                        environmentVariable -> starlarkToUnicode(
+                        environmentVariable -> decodeBytestringUtf8(
                             environmentVariable.getKey() + "=" + environmentVariable.getValue()))
                     .sorted()
                     .collect(Collectors.joining(", ")))
@@ -261,7 +261,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
                   CommandDescriptionForm.COMPLETE,
                   /* prettyPrintArgs= */ true,
                   ((CommandAction) action).getArguments().stream()
-                      .map(a -> starlarkToUnicode(a))
+                      .map(a -> decodeBytestringUtf8(a))
                       .collect(Collectors.toList()),
                   /* environment= */ null,
                   /* cwd= */ null,

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -352,16 +352,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
       return maybeUtf8;
     }
 
-    // Try our best to get a valid Unicode string, assuming that the input
-    // is either UTF-8 (from Starlark or a UNIX file path) or already valid
-    // Unicode (from a Windows file path).
-    final String decoded;
-    if (maybeUtf8.chars().anyMatch(c -> c > 0xFF)) {
-      decoded = maybeUtf8;
-    } else {
-      decoded = decodeBytestringUtf8(maybeUtf8);
-    }
-
+    final String decoded = decodeBytestringUtf8(maybeUtf8);
     final StringBuilder sb = new StringBuilder(decoded.length() * 8);
     decoded.codePoints().forEach(c -> {
       if (c >= 0x20 && c < 0x7F) {

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -90,6 +90,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/build/lib/util:exit_code",
+        "//src/main/java/com/google/devtools/build/lib/util:string",
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/build/lib/util/io:out-err",
         "//src/main/java/com/google/devtools/build/lib/vfs",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -26,7 +26,6 @@ import static com.google.devtools.build.lib.remote.util.Utils.getFromFuture;
 import static com.google.devtools.build.lib.remote.util.Utils.getInMemoryOutputPath;
 import static com.google.devtools.build.lib.remote.util.Utils.grpcAwareErrorMessage;
 import static com.google.devtools.build.lib.remote.util.Utils.hasFilesToDownload;
-import static com.google.devtools.build.lib.remote.util.Utils.protoStringToStarlark;
 import static com.google.devtools.build.lib.remote.util.Utils.shouldAcceptCachedResultFromCombinedCache;
 import static com.google.devtools.build.lib.remote.util.Utils.shouldAcceptCachedResultFromDiskCache;
 import static com.google.devtools.build.lib.remote.util.Utils.shouldAcceptCachedResultFromRemoteCache;
@@ -34,8 +33,9 @@ import static com.google.devtools.build.lib.remote.util.Utils.shouldDownloadAllS
 import static com.google.devtools.build.lib.remote.util.Utils.shouldUploadLocalResultsToCombinedDisk;
 import static com.google.devtools.build.lib.remote.util.Utils.shouldUploadLocalResultsToDiskCache;
 import static com.google.devtools.build.lib.remote.util.Utils.shouldUploadLocalResultsToRemoteCache;
-import static com.google.devtools.build.lib.remote.util.Utils.starlarkStringToProto;
 import static com.google.devtools.build.lib.remote.util.Utils.waitForBulkTransfer;
+import static com.google.devtools.build.lib.util.StringUtil.starlarkToUnicode;
+import static com.google.devtools.build.lib.util.StringUtil.unicodeToStarlark;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
@@ -226,7 +226,7 @@ public class RemoteExecutionService {
     ArrayList<String> outputFiles = new ArrayList<>();
     ArrayList<String> outputDirectories = new ArrayList<>();
     for (ActionInput output : outputs) {
-      String pathString = starlarkStringToProto(remotePathResolver.localPathToOutputPath(output));
+      String pathString = starlarkToUnicode(remotePathResolver.localPathToOutputPath(output));
       if (output instanceof Artifact && ((Artifact) output).isTreeArtifact()) {
         outputDirectories.add(pathString);
       } else {
@@ -242,19 +242,19 @@ public class RemoteExecutionService {
       command.setPlatform(platform);
     }
     for (String arg : arguments) {
-      command.addArguments(starlarkStringToProto(arg));
+      command.addArguments(starlarkToUnicode(arg));
     }
     // Sorting the environment pairs by variable name.
     TreeSet<String> variables = new TreeSet<>(env.keySet());
     for (String var : variables) {
       command.addEnvironmentVariablesBuilder()
-          .setName(starlarkStringToProto(var))
-          .setValue(starlarkStringToProto(env.get(var)));
+          .setName(starlarkToUnicode(var))
+          .setValue(starlarkToUnicode(env.get(var)));
     }
 
     String workingDirectory = remotePathResolver.getWorkingDirectory();
     if (!Strings.isNullOrEmpty(workingDirectory)) {
-      command.setWorkingDirectory(starlarkStringToProto(workingDirectory));
+      command.setWorkingDirectory(starlarkToUnicode(workingDirectory));
     }
     return command.build();
   }
@@ -871,7 +871,7 @@ public class RemoteExecutionService {
         Maps.newHashMapWithExpectedSize(result.getOutputDirectoriesCount());
     for (OutputDirectory dir : result.getOutputDirectories()) {
       dirMetadataDownloads.put(
-          remotePathResolver.outputPathToLocalPath(protoStringToStarlark(dir.getPath())),
+          remotePathResolver.outputPathToLocalPath(unicodeToStarlark(dir.getPath())),
           Futures.transformAsync(
               remoteCache.downloadBlob(
                   action.getRemoteActionExecutionContext(), dir.getTreeDigest()),
@@ -897,7 +897,7 @@ public class RemoteExecutionService {
 
     ImmutableMap.Builder<Path, FileMetadata> files = ImmutableMap.builder();
     for (OutputFile outputFile : result.getOutputFiles()) {
-      Path localPath = remotePathResolver.outputPathToLocalPath(protoStringToStarlark(outputFile.getPath()));
+      Path localPath = remotePathResolver.outputPathToLocalPath(unicodeToStarlark(outputFile.getPath()));
       files.put(
           localPath,
           new FileMetadata(localPath, outputFile.getDigest(), outputFile.getIsExecutable()));
@@ -907,7 +907,7 @@ public class RemoteExecutionService {
     Iterable<OutputSymlink> outputSymlinks =
         Iterables.concat(result.getOutputFileSymlinks(), result.getOutputDirectorySymlinks());
     for (OutputSymlink symlink : outputSymlinks) {
-      Path localPath = remotePathResolver.outputPathToLocalPath(protoStringToStarlark(symlink.getPath()));
+      Path localPath = remotePathResolver.outputPathToLocalPath(unicodeToStarlark(symlink.getPath()));
       symlinks.put(
           localPath, new SymlinkMetadata(localPath, PathFragment.create(symlink.getTarget())));
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/BUILD
@@ -20,6 +20,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
+        "//src/main/java/com/google/devtools/build/lib/util:string",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.merkletree;
 
-import static com.google.devtools.build.lib.util.StringUtil.starlarkToUnicode;
+import static com.google.devtools.build.lib.util.StringUtil.decodeBytestringUtf8;
 
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
@@ -335,7 +335,7 @@ public class MerkleTree {
 
   private static FileNode buildProto(DirectoryTree.FileNode file) {
     return FileNode.newBuilder()
-        .setName(starlarkToUnicode(file.getPathSegment()))
+        .setName(decodeBytestringUtf8(file.getPathSegment()))
         .setDigest(file.getDigest())
         .setIsExecutable(file.isExecutable())
         .build();
@@ -343,7 +343,7 @@ public class MerkleTree {
 
   private static DirectoryNode buildProto(String baseName, MerkleTree dir) {
     return DirectoryNode.newBuilder()
-        .setName(starlarkToUnicode(baseName))
+        .setName(decodeBytestringUtf8(baseName))
         .setDigest(dir.getRootDigest())
         .build();
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -31,6 +31,7 @@ import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
+import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.protobuf.ByteString;
@@ -333,14 +334,17 @@ public class MerkleTree {
 
   private static FileNode buildProto(DirectoryTree.FileNode file) {
     return FileNode.newBuilder()
-        .setName(file.getPathSegment())
+        .setName(Utils.starlarkStringToProto(file.getPathSegment()))
         .setDigest(file.getDigest())
         .setIsExecutable(file.isExecutable())
         .build();
   }
 
   private static DirectoryNode buildProto(String baseName, MerkleTree dir) {
-    return DirectoryNode.newBuilder().setName(baseName).setDigest(dir.getRootDigest()).build();
+    return DirectoryNode.newBuilder()
+        .setName(Utils.starlarkStringToProto(baseName))
+        .setDigest(dir.getRootDigest())
+        .build();
   }
 
   private static PathOrBytes toPathOrBytes(DirectoryTree.FileNode file) {

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -13,6 +13,8 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.merkletree;
 
+import static com.google.devtools.build.lib.util.StringUtil.starlarkToUnicode;
+
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.DirectoryNode;
@@ -31,7 +33,6 @@ import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
-import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.protobuf.ByteString;
@@ -334,7 +335,7 @@ public class MerkleTree {
 
   private static FileNode buildProto(DirectoryTree.FileNode file) {
     return FileNode.newBuilder()
-        .setName(Utils.starlarkStringToProto(file.getPathSegment()))
+        .setName(starlarkToUnicode(file.getPathSegment()))
         .setDigest(file.getDigest())
         .setIsExecutable(file.isExecutable())
         .build();
@@ -342,7 +343,7 @@ public class MerkleTree {
 
   private static DirectoryNode buildProto(String baseName, MerkleTree dir) {
     return DirectoryNode.newBuilder()
-        .setName(Utils.starlarkStringToProto(baseName))
+        .setName(starlarkToUnicode(baseName))
         .setDigest(dir.getRootDigest())
         .build();
   }

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -69,6 +69,7 @@ import com.google.rpc.Status;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.Instant;
@@ -706,5 +707,26 @@ public final class Utils {
     if (bulkTransferException != null) {
       throw bulkTransferException;
     }
+  }
+
+  /**
+   * Converts from a Starlark string, which contains raw bytes, to a Protobuf
+   * string, which contains Unicode code points.
+   */
+  public static String starlarkStringToProto(String starlarkString) {
+    if (starlarkString.chars().allMatch(c -> c < 128)) {
+      return starlarkString;
+    }
+    final byte[] utf8 = starlarkString.getBytes(StandardCharsets.ISO_8859_1);
+    return new String(utf8, StandardCharsets.UTF_8);
+  }
+
+  /** See {@link #starlarkStringToProto} */
+  public static String protoStringToStarlark(String protoString) {
+    if (protoString.chars().allMatch(c -> c < 128)) {
+      return protoString;
+    }
+    final byte[] utf8 = protoString.getBytes(StandardCharsets.UTF_8);
+    return new String(utf8, StandardCharsets.ISO_8859_1);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -69,7 +69,6 @@ import com.google.rpc.Status;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.Instant;
@@ -707,26 +706,5 @@ public final class Utils {
     if (bulkTransferException != null) {
       throw bulkTransferException;
     }
-  }
-
-  /**
-   * Converts from a Starlark string, which contains raw bytes, to a Protobuf
-   * string, which contains Unicode code points.
-   */
-  public static String starlarkStringToProto(String starlarkString) {
-    if (starlarkString.chars().allMatch(c -> c < 128)) {
-      return starlarkString;
-    }
-    final byte[] utf8 = starlarkString.getBytes(StandardCharsets.ISO_8859_1);
-    return new String(utf8, StandardCharsets.UTF_8);
-  }
-
-  /** See {@link #starlarkStringToProto} */
-  public static String protoStringToStarlark(String protoString) {
-    if (protoString.chars().allMatch(c -> c < 128)) {
-      return protoString;
-    }
-    final byte[] utf8 = protoString.getBytes(StandardCharsets.UTF_8);
-    return new String(utf8, StandardCharsets.ISO_8859_1);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/util/StringUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/util/StringUtil.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.util;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -88,5 +89,29 @@ public class StringUtil {
       default:
         return number + "th";
     }
+  }
+
+ /**
+   * Converts from a Starlark string, which contains raw bytes, to a Unicode
+   * string, which contains Unicode code points.
+   *
+   * Unicode strings are suitable for passing to Protobuf string fields, or
+   * printing to the terminal (as UTF-8).
+   */
+  public static String starlarkToUnicode(String starlarkValue) {
+    if (starlarkValue.chars().allMatch(c -> c < 128)) {
+      return starlarkValue;
+    }
+    final byte[] utf8 = starlarkValue.getBytes(StandardCharsets.ISO_8859_1);
+    return new String(utf8, StandardCharsets.UTF_8);
+  }
+
+  /** See {@link #starlarkToUnicode} */
+  public static String unicodeToStarlark(String unicode) {
+    if (unicode.chars().allMatch(c -> c < 128)) {
+      return unicode;
+    }
+    final byte[] utf8 = unicode.getBytes(StandardCharsets.UTF_8);
+    return new String(utf8, StandardCharsets.ISO_8859_1);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/util/StringUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/StringUtilTest.java
@@ -14,6 +14,8 @@
 package com.google.devtools.build.lib.util;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.util.StringUtil.decodeBytestringUtf8;
+import static com.google.devtools.build.lib.util.StringUtil.encodeBytestringUtf8;
 import static com.google.devtools.build.lib.util.StringUtil.joinEnglishList;
 
 import com.google.common.collect.ImmutableList;
@@ -56,5 +58,52 @@ public class StringUtilTest {
                 .append("/end")
                 .toString())
         .isEqualTo("begin/a, b, c ...(omitting 2 more item(s))/end");
+  }
+
+  @Test
+  public void testDecodeBytestringUtf8() throws Exception {
+    // Regular ASCII passes through OK.
+    assertThat(
+            decodeBytestringUtf8("ascii"))
+        .isEqualTo("ascii");
+
+    // Valid UTF-8 is decoded.
+    assertThat(
+            decodeBytestringUtf8("\u00E2\u0081\u0089"))
+        .isEqualTo("\u2049"); // U+2049 EXCLAMATION QUESTION MARK
+    assertThat(
+            decodeBytestringUtf8("\u00f0\u009f\u008c\u00b1"))
+        .isEqualTo("\uD83C\uDF31"); // U+1F331 SEEDLING
+
+    // Strings that contain characters that can't be UTF-8 are returned as-is,
+    // to support Windows file paths.
+    assertThat(
+            decodeBytestringUtf8("\u2049"))
+        .isEqualTo("\u2049"); // U+2049 EXCLAMATION QUESTION MARK
+    assertThat(
+            decodeBytestringUtf8("\uD83C\uDF31"))
+        .isEqualTo("\uD83C\uDF31"); // U+1F331 SEEDLING
+
+    // Strings that might be either UTF-8 or Unicode are optimistically decoded,
+    // and returned as-is if decoding succeeded with no replacement characters.
+    assertThat(
+            decodeBytestringUtf8("\u00FC\u006E\u00EF\u0063\u00F6\u0064\u00EB"))
+        .isEqualTo("\u00FC\u006E\u00EF\u0063\u00F6\u0064\u00EB"); // "ünïcödë"
+
+    // A string that is both valid ISO-8859-1 and valid UTF-8 will be decoded
+    // as UTF-8.
+    assertThat(
+            decodeBytestringUtf8("\u00C2\u00A3")) // "Â£"
+        .isEqualTo("\u00A3"); // U+00A3 POUND SIGN
+  }
+
+  @Test
+  public void testEncodeBytestringUtf8() throws Exception {
+    assertThat(
+            encodeBytestringUtf8("\u2049")) // U+2049 EXCLAMATION QUESTION MARK
+        .isEqualTo("\u00E2\u0081\u0089");
+    assertThat(
+            encodeBytestringUtf8("\uD83C\uDF31")) // U+1F331 SEEDLING
+        .isEqualTo("\u00f0\u009f\u008c\u00b1");
   }
 }

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3828,7 +3828,7 @@ report="$3"
 touch "${report}"
 
 echo '[input tree]' >> "${report}"
-find inputs >> "${report}"
+find inputs | sort >> "${report}"
 echo '' >> "${report}"
 
 echo '[input file A]' >> "${report}"

--- a/src/test/shell/integration/aquery_test.sh
+++ b/src/test/shell/integration/aquery_test.sh
@@ -1589,15 +1589,14 @@ genrule(
 EOF
 
   # ${pkg}/input-ünïcödë.txt
-  unicode=$'\xc3\xbcn\xc3\xafc\xc3\xb6d\xc3\xab'
-  touch "${pkg}/input-${unicode}.txt"
+  touch "${pkg}/"$'input-\xc3\xbcn\xc3\xafc\xc3\xb6d\xc3\xab.txt'
 
   bazel aquery --output=text "//$pkg:bar" > output 2> "$TEST_log" \
     || fail "Expected success"
   cat output >> "$TEST_log"
 
-  assert_contains "Inputs: \[.*/input-${unicode}.txt" output
-  assert_contains "Outputs: \[.*/output-${unicode}.txt" output
+  assert_contains 'Inputs: \[.*/input-{U+00FC}n{U+00EF}c{U+00F6}d{U+00EB}.txt' output
+  assert_contains 'Outputs: \[.*/output-{U+00FC}n{U+00EF}c{U+00F6}d{U+00EB}.txt' output
 }
 
 # FIXME: The non-text aquery output formats don't correctly handle non-ASCII

--- a/src/test/shell/integration/aquery_test.sh
+++ b/src/test/shell/integration/aquery_test.sh
@@ -1595,8 +1595,8 @@ EOF
     || fail "Expected success"
   cat output >> "$TEST_log"
 
-  assert_contains 'Inputs: \[.*/input-{U+00FC}n{U+00EF}c{U+00F6}d{U+00EB}.txt' output
-  assert_contains 'Outputs: \[.*/output-{U+00FC}n{U+00EF}c{U+00F6}d{U+00EB}.txt' output
+  assert_contains 'Inputs: \[.*/input-\\u00FCn\\u00EFc\\u00F6d\\u00EB.txt' output
+  assert_contains 'Outputs: \[.*/output-\\u00FCn\\u00EFc\\u00F6d\\u00EB.txt' output
 }
 
 # FIXME: The non-text aquery output formats don't correctly handle non-ASCII

--- a/src/test/shell/integration/aquery_test.sh
+++ b/src/test/shell/integration/aquery_test.sh
@@ -44,6 +44,16 @@ fi
 
 add_to_bazelrc "build --package_path=%workspace%"
 
+function has_iso_8859_1_locale() {
+  charmap="$(LC_ALL=en_US.ISO-8859-1 locale charmap 2>/dev/null)"
+  [[ "${charmap}" == "ISO-8859-1" ]]
+}
+
+function has_utf8_locale() {
+  charmap="$(LC_ALL=en_US.UTF-8 locale charmap 2>/dev/null)"
+  [[ "${charmap}" == "UTF-8" ]]
+}
+
 function assert_only_action_foo() {
   expect_log_n "^action '" 1 "Expected exactly one action."
   assert_contains "action.*foo" $1
@@ -1553,6 +1563,78 @@ EOF
 
   # Verify the execution platform's exec_properties end up as execution requirements.
   assert_contains "ExecutionInfo: {prop1: foo, prop2: bar}" output
+}
+
+function test_unicode_text() {
+  # Bazel relies on the JVM for filename encoding, and can only support
+  # UTF-8 if either a UTF-8 or ISO-8859-1 locale is available.
+  if ! "$is_windows"; then
+    if ! has_iso_8859_1_locale && ! has_utf8_locale; then
+      echo "Skipping test (no ISO-8859-1 or UTF-8 locale)."
+      echo "Available locales (need ISO-8859-1 or UTF-8):"
+      locale -a
+      return
+    fi
+  fi
+
+  local pkg="${FUNCNAME[0]}"
+  mkdir -p "${pkg}" || fail "mkdir -p ${pkg}"
+  cat > "${pkg}/BUILD" <<'EOF'
+genrule(
+    name = "bar",
+    srcs = glob(["input-*.txt"]),
+    outs = ["output-ünïcödë.txt"],
+    cmd = "echo unused > $(OUTS)",
+)
+EOF
+
+  # ${pkg}/input-ünïcödë.txt
+  unicode=$'\xc3\xbcn\xc3\xafc\xc3\xb6d\xc3\xab'
+  touch "${pkg}/input-${unicode}.txt"
+
+  bazel aquery --output=text "//$pkg:bar" > output 2> "$TEST_log" \
+    || fail "Expected success"
+  cat output >> "$TEST_log"
+
+  assert_contains "Inputs: \[.*/input-${unicode}.txt" output
+  assert_contains "Outputs: \[.*/output-${unicode}.txt" output
+}
+
+# FIXME: The non-text aquery output formats don't correctly handle non-ASCII
+# fields (input/output paths, environment variables, etc).
+function DISABLED_test_unicode_textproto() {
+  # Bazel relies on the JVM for filename encoding, and can only support
+  # UTF-8 if either a UTF-8 or ISO-8859-1 locale is available.
+  if ! "$is_windows"; then
+    if ! has_iso_8859_1_locale && ! has_utf8_locale; then
+      echo "Skipping test (no ISO-8859-1 or UTF-8 locale)."
+      echo "Available locales (need ISO-8859-1 or UTF-8):"
+      locale -a
+      return
+    fi
+  fi
+
+  local pkg="${FUNCNAME[0]}"
+  mkdir -p "${pkg}" || fail "mkdir -p ${pkg}"
+  cat > "${pkg}/BUILD" <<'EOF'
+genrule(
+    name = "bar",
+    srcs = glob(["input-*.txt"]),
+    outs = ["output-ünïcödë.txt"],
+    cmd = "echo unused > $(OUTS)",
+)
+EOF
+
+  # ${pkg}/input-ünïcödë.txt
+  unicode=$'\xc3\xbcn\xc3\xafc\xc3\xb6d\xc3\xab'
+  touch "${pkg}/input-${unicode}.txt"
+
+  bazel aquery --output=textproto "//$pkg:bar" > output 2> "$TEST_log" \
+    || fail "Expected success"
+  cat output >> "$TEST_log"
+
+  assert_contains 'label: "input-\\303\\274n\\303\\257c\\303\\266d\\303\\253.txt"' output
+  assert_contains 'label: "output-\\303\\274n\\303\\257c\\303\\266d\\303\\253.txt"' output
 }
 
 # Usage: assert_matches expected_pattern actual


### PR DESCRIPTION
Fixes #14381

I didn't touch the `Platform` construction because it seems to be used in parts of Bazel that aren't specific to remote execution. Maybe it'd be fine to change too? Comments welcomed.