### PR TITLE
Update SingleToolchainValue to properly handle missing toolchains.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionValue.java
@@ -37,21 +37,29 @@ public abstract class SingleToolchainResolutionValue implements SkyValue {
   public static SingleToolchainResolutionKey key(
       BuildConfigurationKey configurationKey,
       ToolchainTypeRequirement toolchainType,
+      ToolchainTypeInfo toolchainTypeInfo,
       ConfiguredTargetKey targetPlatformKey,
       List<ConfiguredTargetKey> availableExecutionPlatformKeys) {
     return key(
-        configurationKey, toolchainType, targetPlatformKey, availableExecutionPlatformKeys, false);
+        configurationKey,
+        toolchainType,
+        toolchainTypeInfo,
+        targetPlatformKey,
+        availableExecutionPlatformKeys,
+        false);
   }
 
   public static SingleToolchainResolutionKey key(
       BuildConfigurationKey configurationKey,
       ToolchainTypeRequirement toolchainType,
+      ToolchainTypeInfo toolchainTypeInfo,
       ConfiguredTargetKey targetPlatformKey,
       List<ConfiguredTargetKey> availableExecutionPlatformKeys,
       boolean debugTarget) {
     return SingleToolchainResolutionKey.create(
         configurationKey,
         toolchainType,
+        toolchainTypeInfo,
         targetPlatformKey,
         availableExecutionPlatformKeys,
         debugTarget);
@@ -70,6 +78,8 @@ public abstract class SingleToolchainResolutionValue implements SkyValue {
 
     public abstract ToolchainTypeRequirement toolchainType();
 
+    public abstract ToolchainTypeInfo toolchainTypeInfo();
+
     abstract ConfiguredTargetKey targetPlatformKey();
 
     abstract ImmutableList<ConfiguredTargetKey> availableExecutionPlatformKeys();
@@ -79,12 +89,14 @@ public abstract class SingleToolchainResolutionValue implements SkyValue {
     static SingleToolchainResolutionKey create(
         BuildConfigurationKey configurationKey,
         ToolchainTypeRequirement toolchainType,
+        ToolchainTypeInfo toolchainTypeInfo,
         ConfiguredTargetKey targetPlatformKey,
         List<ConfiguredTargetKey> availableExecutionPlatformKeys,
         boolean debugTarget) {
       return new AutoValue_SingleToolchainResolutionValue_SingleToolchainResolutionKey(
           configurationKey,
           toolchainType,
+          toolchainTypeInfo,
           targetPlatformKey,
           ImmutableList.copyOf(availableExecutionPlatformKeys),
           debugTarget);

--- a/src/test/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionFunctionTest.java
@@ -78,7 +78,11 @@ public class SingleToolchainResolutionFunctionTest extends ToolchainTestCase {
   public void testResolution_singleExecutionPlatform() throws Exception {
     SkyKey key =
         SingleToolchainResolutionValue.key(
-            targetConfigKey, testToolchainType, linuxCtkey, ImmutableList.of(macCtkey));
+            targetConfigKey,
+            testToolchainType,
+            testToolchainTypeInfo,
+            linuxCtkey,
+            ImmutableList.of(macCtkey));
     EvaluationResult<SingleToolchainResolutionValue> result = invokeToolchainResolution(key);
 
     assertThatEvaluationResult(result).hasNoError();
@@ -104,7 +108,11 @@ public class SingleToolchainResolutionFunctionTest extends ToolchainTestCase {
 
     SkyKey key =
         SingleToolchainResolutionValue.key(
-            targetConfigKey, testToolchainType, linuxCtkey, ImmutableList.of(linuxCtkey, macCtkey));
+            targetConfigKey,
+            testToolchainType,
+            testToolchainTypeInfo,
+            linuxCtkey,
+            ImmutableList.of(linuxCtkey, macCtkey));
     EvaluationResult<SingleToolchainResolutionValue> result = invokeToolchainResolution(key);
 
     assertThatEvaluationResult(result).hasNoError();
@@ -125,14 +133,15 @@ public class SingleToolchainResolutionFunctionTest extends ToolchainTestCase {
 
     SkyKey key =
         SingleToolchainResolutionValue.key(
-            targetConfigKey, testToolchainType, linuxCtkey, ImmutableList.of(macCtkey));
+            targetConfigKey,
+            testToolchainType,
+            testToolchainTypeInfo,
+            linuxCtkey,
+            ImmutableList.of(macCtkey));
     EvaluationResult<SingleToolchainResolutionValue> result = invokeToolchainResolution(key);
 
-    assertThatEvaluationResult(result)
-        .hasErrorEntryForKeyThat(key)
-        .hasExceptionThat()
-        .hasMessageThat()
-        .contains("no matching toolchain found for //toolchain:test_toolchain");
+    SingleToolchainResolutionValue singleToolchainResolutionValue = result.get(key);
+    assertThat(singleToolchainResolutionValue.availableToolchainLabels()).isEmpty();
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ToolchainResolutionFunctionTest.java
@@ -87,6 +87,25 @@ public class ToolchainResolutionFunctionTest extends ToolchainTestCase {
   }
 
   @Test
+  public void resolve_mandatory_missing() throws Exception {
+    // There is no toolchain for the requested type.
+    useConfiguration("--platforms=//platforms:linux");
+    ToolchainContextKey key =
+        ToolchainContextKey.key()
+            .configurationKey(targetConfigKey)
+            .toolchainTypes(testToolchainType)
+            .build();
+
+    EvaluationResult<UnloadedToolchainContext> result = invokeToolchainResolution(key);
+
+    assertThatEvaluationResult(result)
+        .hasErrorEntryForKeyThat(key)
+        .hasExceptionThat()
+        .hasMessageThat()
+        .contains("no matching toolchains found for types //toolchain:test_toolchain");
+  }
+
+  @Test
   public void resolve_toolchainTypeAlias() throws Exception {
     addToolchain(
         "extra",


### PR DESCRIPTION
This can no longer throw an exception, but needs to signal in the
returned value.

Part of Optional Toolchains (#14726).