### PR TITLE
Be explicit about alowing empty globs (second part)

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/packages/BazelPackageLoaderTest.java
@@ -173,7 +173,7 @@ public final class BazelPackageLoaderTest extends AbstractPackageLoaderTest {
 
   @Test
   public void buildDotBazelForSubpackageCheckDuringGlobbing() throws Exception {
-    file("a/BUILD", "filegroup(name = 'fg', srcs = glob(['sub/a.txt']))");
+    file("a/BUILD", "filegroup(name = 'fg', srcs = glob(['sub/a.txt'], allow_empty = True))");
     file("a/sub/a.txt");
     file("a/sub/BUILD.bazel");
 

--- a/third_party/googleapis/BUILD.bazel
+++ b/third_party/googleapis/BUILD.bazel
@@ -24,7 +24,7 @@ exports_files(["LICENSE"])
 
 filegroup(
     name = "srcs",
-    srcs = glob(["**"]),
+    srcs = glob(["**"], allow_empty = True),
     visibility = ["@io_bazel//third_party:__pkg__"],
 )
 


### PR DESCRIPTION
There are several globs that are empty and this prevents building
with the incompatible flag #8195.
This commit just makes it explicit that empty is allowed.