### PR TITLE
Fix StarlarkIndexable.getIndex implementations that return null.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
@@ -233,7 +233,11 @@ public abstract class ConstraintCollection
 
   @Override
   public Object getIndex(StarlarkSemantics semantics, Object key) throws EvalException {
-    return get(convertKey(key));
+    Object result = get(convertKey(key));
+    if (result == null) {
+      result = Starlark.NONE;
+    }
+    return result;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
@@ -236,7 +236,7 @@ public abstract class ConstraintCollection
     ConstraintSettingInfo constraintSettingInfo = convertKey(key);
     Object result = get(constraintSettingInfo);
     if (result == null) {
-      throw Starlark.errorf("Unknown constraint_setting '%s'", constraintSettingInfo);
+      return Starlark.NONE;
     }
     return result;
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/platform/ConstraintCollection.java
@@ -233,9 +233,10 @@ public abstract class ConstraintCollection
 
   @Override
   public Object getIndex(StarlarkSemantics semantics, Object key) throws EvalException {
-    Object result = get(convertKey(key));
+    ConstraintSettingInfo constraintSettingInfo = convertKey(key);
+    Object result = get(constraintSettingInfo);
     if (result == null) {
-      result = Starlark.NONE;
+      throw Starlark.errorf("Unknown constraint_setting '%s'", constraintSettingInfo);
     }
     return result;
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkToolchainContext.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkToolchainContext.java
@@ -30,6 +30,7 @@ import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkSemantics;
 import net.starlark.java.eval.StarlarkThread;
+import net.starlark.java.eval.StarlarkValue;
 
 /**
  * An implementation of ToolchainContextApi that can better handle converting strings into Labels.
@@ -99,7 +100,7 @@ public abstract class StarlarkToolchainContext implements ToolchainContextApi {
   }
 
   @Override
-  public ToolchainInfo getIndex(
+  public StarlarkValue getIndex(
       StarlarkThread starlarkThread, StarlarkSemantics semantics, Object key) throws EvalException {
     Label toolchainTypeLabel = transformKey(starlarkThread, key);
 
@@ -116,7 +117,11 @@ public abstract class StarlarkToolchainContext implements ToolchainContextApi {
               .map(Label::toString)
               .collect(joining(", ")));
     }
-    return toolchainContext().forToolchainType(toolchainTypeLabel);
+    ToolchainInfo toolchainInfo = toolchainContext().forToolchainType(toolchainTypeLabel);
+    if (toolchainInfo == null) {
+      return Starlark.NONE;
+    }
+    return toolchainInfo;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/ToolchainContextApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform/ToolchainContextApi.java
@@ -26,5 +26,6 @@ import net.starlark.java.eval.StarlarkValue;
     doc =
         "Holds toolchains available for a particular exec group. Toolchain targets are accessed by"
             + " indexing with the toolchain type, as in"
-            + " <code>context[\"//pkg:my_toolchain_type\"]</code>.")
+            + " <code>ctx.toolchains[\"//pkg:my_toolchain_type\"]</code>. If the toolchain was"
+            + " optional and no toolchain was resolved, this will return <code>None</code>.")
 public interface ToolchainContextApi extends StarlarkValue, StarlarkIndexable.Threaded {}

--- a/src/test/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionFunctionTest.java
@@ -34,6 +34,7 @@ import com.google.devtools.build.skyframe.EvaluationResult;
 import com.google.devtools.build.skyframe.SkyKey;
 import javax.annotation.Nullable;
 import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkSemantics;
 import org.junit.Before;
 import org.junit.Test;
@@ -253,7 +254,7 @@ public class SingleToolchainResolutionFunctionTest extends ToolchainTestCase {
 
     @Override
     public Object getIndex(StarlarkSemantics semantics, Object key) {
-      return null;
+      return Starlark.NONE;
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionFunctionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/SingleToolchainResolutionFunctionTest.java
@@ -33,6 +33,7 @@ import com.google.devtools.build.lib.skyframe.util.SkyframeExecutorTestUtils;
 import com.google.devtools.build.skyframe.EvaluationResult;
 import com.google.devtools.build.skyframe.SkyKey;
 import javax.annotation.Nullable;
+import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkSemantics;
@@ -245,7 +246,6 @@ public class SingleToolchainResolutionFunctionTest extends ToolchainTestCase {
     @Nullable
     @Override
     public Info get(Provider.Key providerKey) {
-
       return null;
     }
 
@@ -253,8 +253,8 @@ public class SingleToolchainResolutionFunctionTest extends ToolchainTestCase {
     public void repr(Printer printer) {}
 
     @Override
-    public Object getIndex(StarlarkSemantics semantics, Object key) {
-      return Starlark.NONE;
+    public Object getIndex(StarlarkSemantics semantics, Object key) throws EvalException {
+      throw Starlark.errorf("Unknown key '%s'", key);
     }
 
     @Override


### PR DESCRIPTION
They should return Starlark.NONE instead.

Part of Optional Toolchains (#14726).