### PR TITLE
Rewind on --remote_download_minimal upload FileNotFounds

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/BUILD
@@ -14,6 +14,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/docgen/annot",
         "//src/main/java/com/google/devtools/build/lib:runtime",
+        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/analysis:blaze_directories",

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.bazel.debug.WorkspaceRuleEvent;
 import com.google.devtools.build.lib.bazel.repository.downloader.DownloadManager;
@@ -284,7 +285,7 @@ public abstract class StarlarkBaseExternalContext implements StarlarkValue {
       }
 
       return new StarlarkExecutionResult(result.exitCode(), stdout, stderr);
-    } catch (IOException e) {
+    } catch (ExecException | IOException e) {
       throw Starlark.errorf("remote_execute failed: %s", e.getMessage());
     }
   }

--- a/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategy.java
@@ -158,6 +158,8 @@ public abstract class AbstractSpawnStrategy implements SandboxedSpawnStrategy {
       }
     } catch (InterruptedIOException e) {
       throw new InterruptedException(e.getMessage());
+    } catch (LostInputsExecException e) {
+      throw e;
     } catch (IOException e) {
       throw new EnvironmentalExecException(
           e,

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -154,6 +154,7 @@ java_library(
     ],
     deps = [
         ":ExecutionStatusException",
+        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/remote/options",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutor.java
@@ -22,6 +22,7 @@ import build.bazel.remote.execution.v2.ExecutionGrpc.ExecutionBlockingStub;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.WaitExecutionRequest;
 import com.google.common.base.Preconditions;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ProgressiveBackoff;
@@ -114,7 +115,7 @@ public class ExperimentalGrpcRemoteExecutor implements RemoteExecutionClient {
       this.waitExecutionFunction = waitExecutionFunction;
     }
 
-    ExecuteResponse start() throws IOException, InterruptedException {
+    ExecuteResponse start() throws ExecException, IOException, InterruptedException {
       // Execute has two components: the Execute call and (optionally) the WaitExecution call.
       // This is the simple flow without any errors:
       //
@@ -321,7 +322,7 @@ public class ExperimentalGrpcRemoteExecutor implements RemoteExecutionClient {
   @Override
   public ExecuteResponse executeRemotely(
       RemoteActionExecutionContext context, ExecuteRequest request, OperationObserver observer)
-      throws IOException, InterruptedException {
+      throws ExecException, IOException, InterruptedException {
     Execution execution =
         new Execution(
             request,

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1207,7 +1207,7 @@ public class RemoteExecutionService {
    * <p>Must be called before calling {@link #executeRemotely}.
    */
   public void uploadInputsIfNotPresent(RemoteAction action, boolean force)
-      throws IOException, InterruptedException {
+      throws ExecException, IOException, InterruptedException {
     checkState(!shutdown.get(), "shutdown");
     checkState(mayBeExecutedRemotely(action.getSpawn()), "spawn can't be executed remotely");
 
@@ -1219,7 +1219,7 @@ public class RemoteExecutionService {
     additionalInputs.put(action.getActionKey().getDigest(), action.getAction());
     additionalInputs.put(action.getCommandHash(), action.getCommand());
     remoteExecutionCache.ensureInputsPresent(
-        action.getRemoteActionExecutionContext(), action.getMerkleTree(), additionalInputs, force);
+        action.getRemoteActionExecutionContext(), action.getMerkleTree(), additionalInputs, action.getActionKey().getDigest().toString(), force);
   }
 
   /**
@@ -1230,7 +1230,7 @@ public class RemoteExecutionService {
    */
   public RemoteActionResult executeRemotely(
       RemoteAction action, boolean acceptCachedResult, OperationObserver observer)
-      throws IOException, InterruptedException {
+      throws ExecException, IOException, InterruptedException {
     checkState(!shutdown.get(), "shutdown");
     checkState(mayBeExecutedRemotely(action.getSpawn()), "spawn can't be executed remotely");
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutor.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.analysis.platform.PlatformUtils;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.ProfilerTask;
@@ -108,7 +109,7 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
       ImmutableMap<String, String> environment,
       String workingDirectory,
       Duration timeout)
-      throws IOException, InterruptedException {
+      throws ExecException, IOException, InterruptedException {
     RequestMetadata metadata =
         TracingMetadataUtils.buildMetadata(buildRequestId, commandId, "repository_rule", null);
     RemoteActionExecutionContext context = RemoteActionExecutionContext.create(metadata);
@@ -158,7 +159,7 @@ public class RemoteRepositoryRemoteExecutor implements RepositoryRemoteExecutor 
         additionalInputs.put(actionDigest, action);
         additionalInputs.put(commandHash, command);
 
-        remoteCache.ensureInputsPresent(context, merkleTree, additionalInputs, /*force=*/ true);
+        remoteCache.ensureInputsPresent(context, merkleTree, additionalInputs, "", /*force=*/ true);
       }
 
       try (SilentCloseable c =

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteRetrier.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -126,6 +127,28 @@ public class RemoteRetrier extends Retrier {
     } catch (Exception e) {
       Throwables.throwIfInstanceOf(e, IOException.class);
       Throwables.throwIfInstanceOf(e, InterruptedException.class);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * As {@link #execute(Callable)} but will also propagate {@link ExecException}s.
+   */
+  public <T> T executeWithExecException(Callable<T> call) throws ExecException, IOException, InterruptedException {
+    return executeWithExecException(call, newBackoff());
+  }
+
+  /**
+   * As {@link #execute(Callable, Backoff)} but will also propagate {@link ExecException}s.
+   */
+  public <T> T executeWithExecException(Callable<T> call, Backoff backoff) throws ExecException, IOException, InterruptedException {
+    try {
+      return super.execute(call, backoff);
+    } catch (Exception e) {
+      Throwables.throwIfInstanceOf(e, IOException.class);
+      Throwables.throwIfInstanceOf(e, InterruptedException.class);
+      Throwables.throwIfInstanceOf(e, ExecException.class);
       Throwables.throwIfUnchecked(e);
       throw new RuntimeException(e);
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemoteExecutionClient.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemoteExecutionClient.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.remote.common;
 
 import build.bazel.remote.execution.v2.ExecuteRequest;
 import build.bazel.remote.execution.v2.ExecuteResponse;
+import com.google.devtools.build.lib.actions.ExecException;
 import java.io.IOException;
 
 /**
@@ -27,7 +28,7 @@ public interface RemoteExecutionClient {
   /** Execute an action remotely using Remote Execution API. */
   ExecuteResponse executeRemotely(
       RemoteActionExecutionContext context, ExecuteRequest request, OperationObserver observer)
-      throws IOException, InterruptedException;
+      throws ExecException, IOException, InterruptedException;
 
   /** Close resources associated with the remote execution client. */
   void close();

--- a/src/main/java/com/google/devtools/build/lib/remote/downloader/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/downloader/BUILD
@@ -14,6 +14,7 @@ java_library(
     name = "downloader",
     srcs = glob(["*.java"]),
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/bazel/repository/downloader",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/remote:ReferenceCountedChannel",

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeBuilder.java
@@ -17,6 +17,7 @@ import build.bazel.remote.execution.v2.Digest;
 import com.google.common.base.Preconditions;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
@@ -102,7 +103,7 @@ class DirectoryTreeBuilder {
           }
           Digest d = digestUtil.compute(input);
           boolean childAdded =
-              currDir.addChild(FileNode.createExecutable(path.getBaseName(), input, d));
+              currDir.addChild(FileNode.createExecutable(path.getBaseName(), input, d, null));
           return childAdded ? 1 : 0;
         });
   }
@@ -144,8 +145,12 @@ class DirectoryTreeBuilder {
             case REGULAR_FILE:
               Digest d = DigestUtil.buildDigest(metadata.getDigest(), metadata.getSize());
               Path inputPath = ActionInputHelper.toInputPath(input, execRoot);
+              Artifact artifact = null;
+              if (input instanceof Artifact) {
+                artifact = (Artifact) input;
+              }
               boolean childAdded =
-                  currDir.addChild(FileNode.createExecutable(path.getBaseName(), inputPath, d));
+                  currDir.addChild(FileNode.createExecutable(path.getBaseName(), inputPath, d, artifact));
               return childAdded ? 1 : 0;
 
             case DIRECTORY:

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.actions.ActionInput;
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.profiler.Profiler;
 import com.google.devtools.build.lib.profiler.SilentCloseable;
@@ -51,17 +52,20 @@ public class MerkleTree {
   /** A path or contents */
   public static class PathOrBytes {
 
-    private final Path path;
-    private final ByteString bytes;
+    @Nullable private final Path path;
+    @Nullable private final ByteString bytes;
+    @Nullable private final Artifact artifact;
 
-    public PathOrBytes(Path path) {
+    public PathOrBytes(Path path, @Nullable Artifact artifact) {
       this.path = Preconditions.checkNotNull(path, "path");
       this.bytes = null;
+      this.artifact = artifact;
     }
 
     public PathOrBytes(ByteString bytes) {
       this.bytes = Preconditions.checkNotNull(bytes, "bytes");
       this.path = null;
+      this.artifact = null;
     }
 
     @Nullable
@@ -72,6 +76,11 @@ public class MerkleTree {
     @Nullable
     public ByteString getBytes() {
       return bytes;
+    }
+
+    @Nullable
+    public Artifact getArtifact() {
+      return artifact;
     }
   }
 
@@ -345,7 +354,7 @@ public class MerkleTree {
 
   private static PathOrBytes toPathOrBytes(DirectoryTree.FileNode file) {
     return file.getPath() != null
-        ? new PathOrBytes(file.getPath())
+        ? new PathOrBytes(file.getPath(), file.getArtifact())
         : new PathOrBytes(file.getBytes());
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/runtime/RepositoryRemoteExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/RepositoryRemoteExecutor.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.runtime;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
@@ -70,5 +71,5 @@ public interface RepositoryRemoteExecutor {
       ImmutableMap<String, String> environment,
       String workingDirectory,
       Duration timeout)
-      throws IOException, InterruptedException;
+      throws ExecException, IOException, InterruptedException;
 }

--- a/src/test/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutorTest.java
@@ -25,6 +25,7 @@ import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.authandtls.CallCredentialsProvider;
 import com.google.devtools.build.lib.remote.RemoteRetrier.ExponentialBackoff;
 import com.google.devtools.build.lib.remote.common.OperationObserver;
@@ -334,7 +335,7 @@ public class ExperimentalGrpcRemoteExecutorTest {
 
   @Test
   public void executeRemotely_retryExecuteWhenUnauthenticated()
-      throws IOException, InterruptedException {
+      throws ExecException, IOException, InterruptedException {
     executionService.whenExecute(DUMMY_REQUEST).thenError(Code.UNAUTHENTICATED);
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenDone(DUMMY_RESPONSE);
 
@@ -347,7 +348,7 @@ public class ExperimentalGrpcRemoteExecutorTest {
 
   @Test
   public void executeRemotely_retryWaitExecutionWhenUnauthenticated()
-      throws IOException, InterruptedException {
+      throws ExecException, IOException, InterruptedException {
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenError(Code.UNAVAILABLE);
     executionService.whenWaitExecution(DUMMY_REQUEST).thenAck().thenError(Code.UNAUTHENTICATED);
     executionService.whenWaitExecution(DUMMY_REQUEST).thenAck().thenDone(DUMMY_RESPONSE);
@@ -361,7 +362,7 @@ public class ExperimentalGrpcRemoteExecutorTest {
   }
 
   @Test
-  public void executeRemotely_retryExecuteIfNotFound() throws IOException, InterruptedException {
+  public void executeRemotely_retryExecuteIfNotFound() throws ExecException, IOException, InterruptedException {
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenError(Code.UNAVAILABLE);
     executionService.whenWaitExecution(DUMMY_REQUEST).thenError(Code.NOT_FOUND);
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenError(Code.UNAVAILABLE);
@@ -397,7 +398,7 @@ public class ExperimentalGrpcRemoteExecutorTest {
   }
 
   @Test
-  public void executeRemotely_notifyObserver() throws IOException, InterruptedException {
+  public void executeRemotely_notifyObserver() throws ExecException, IOException, InterruptedException {
     executionService.whenExecute(DUMMY_REQUEST).thenAck().thenDone(DUMMY_RESPONSE);
 
     List<Operation> notified = new ArrayList<>();

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -148,7 +148,7 @@ public class GrpcCacheClientTest extends GrpcCacheClientTestBase {
         });
 
     // Upload all missing inputs (that is, the virtual action input from above)
-    client.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), /*force=*/ true);
+    client.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), "", /*force=*/ true);
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteCacheTest.java
@@ -35,6 +35,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.devtools.build.lib.actions.ActionInputHelper;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.ResourceSet;
 import com.google.devtools.build.lib.actions.SimpleSpawn;
 import com.google.devtools.build.lib.actions.Spawn;
@@ -299,8 +300,8 @@ public class RemoteCacheTest {
         new Thread(
             () -> {
               try {
-                remoteCache.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), false);
-              } catch (IOException | InterruptedException ignored) {
+                remoteCache.ensureInputsPresent(context, merkleTree, ImmutableMap.of(), "", false);
+              } catch (ExecException | IOException | InterruptedException ignored) {
                 // ignored
               } finally {
                 ensureInputsPresentReturned.countDown();

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteRepositoryRemoteExecutorTest.java
@@ -26,6 +26,7 @@ import build.bazel.remote.execution.v2.ExecuteResponse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.remote.common.RemoteCacheClient.CachedActionResult;
 import com.google.devtools.build.lib.remote.common.RemoteExecutionClient;
 import com.google.devtools.build.lib.remote.util.DigestUtil;
@@ -70,7 +71,7 @@ public class RemoteRepositoryRemoteExecutorTest {
   }
 
   @Test
-  public void testZeroExitCodeFromCache() throws IOException, InterruptedException {
+  public void testZeroExitCodeFromCache() throws ExecException, IOException, InterruptedException {
     // Test that an ActionResult with exit code zero is accepted as cached.
 
     // Arrange
@@ -97,7 +98,7 @@ public class RemoteRepositoryRemoteExecutorTest {
   }
 
   @Test
-  public void testNoneZeroExitCodeFromCache() throws IOException, InterruptedException {
+  public void testNoneZeroExitCodeFromCache() throws ExecException, IOException, InterruptedException {
     // Test that an ActionResult with a none-zero exit code is not accepted as cached.
 
     // Arrange
@@ -127,7 +128,7 @@ public class RemoteRepositoryRemoteExecutorTest {
   }
 
   @Test
-  public void testInlineStdoutStderr() throws IOException, InterruptedException {
+  public void testInlineStdoutStderr() throws ExecException, IOException, InterruptedException {
     // Test that
 
     // Arrange

--- a/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/RemoteSpawnRunnerTest.java
@@ -260,7 +260,7 @@ public class RemoteSpawnRunnerTest {
     runner.exec(spawn, policy);
 
     verify(localRunner).exec(spawn, policy);
-    verify(cache).ensureInputsPresent(any(), any(), any(), anyBoolean());
+    verify(cache).ensureInputsPresent(any(), any(), any(), any(), anyBoolean());
     verifyNoMoreInteractions(cache);
   }
 

--- a/src/test/java/com/google/devtools/build/lib/remote/common/BulkTransferExceptionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/common/BulkTransferExceptionTest.java
@@ -1,0 +1,82 @@
+package com.google.devtools.build.lib.remote.common;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.actions.ActionInputDepOwnerMap;
+import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.ArtifactRoot;
+import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.LostInputsExecException;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
+import com.google.devtools.build.lib.testutil.Scratch;
+import com.google.devtools.build.lib.vfs.Path;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BulkTransferExceptionTest {
+  private Scratch scratch;
+  private Path execDir;
+
+  @Before
+  public void before() throws Exception {
+    scratch = new Scratch();
+    execDir = scratch.dir("/base/exec");
+  }
+
+  @Test
+  public void asLostInputsEmpty() {
+    LostInputsExecException e = new BulkTransferException().asLostInputsExecException();
+    assertThat(e.getLostInputs()).isEmpty();
+  }
+
+  @Test
+  public void asLostInputSingle() {
+    BulkTransferException bulkTransferException = new BulkTransferException();
+    LostInputsExecException fooException = exception("foo");
+    bulkTransferException.addSuppressed(new IOException(fooException));
+    LostInputsExecException e = bulkTransferException.asLostInputsExecException();
+    assertThat(e.getLostInputs()).containsKey("foo-digest");
+    assertThat(e.getOwners().getDepOwners(artifact("foo"))).contains(artifact("foo"));
+  }
+
+  @Test
+  public void asLostInputsMultiple() {
+    BulkTransferException bulkTransferException = new BulkTransferException();
+    LostInputsExecException fooException = exception("foo");
+    LostInputsExecException barException = exception("bar");
+    bulkTransferException.addSuppressed(new IOException(fooException));
+    bulkTransferException.addSuppressed(new IOException(barException));
+    LostInputsExecException e = bulkTransferException.asLostInputsExecException();
+
+    assertThat(e.getLostInputs()).containsKey("foo-digest");
+    assertThat(e.getOwners().getDepOwners(artifact("foo"))).contains(artifact("foo"));
+
+    assertThat(e.getLostInputs()).containsKey("bar-digest");
+    assertThat(e.getOwners().getDepOwners(artifact("bar"))).contains(artifact("bar"));
+  }
+
+  @Test
+  public void asLostInputsWrongType() {
+    BulkTransferException bulkTransferException = new BulkTransferException();
+    bulkTransferException.addSuppressed(new IOException(new RuntimeException("blah")));
+    LostInputsExecException e = bulkTransferException.asLostInputsExecException();
+    assertThat(e).isNull();
+  }
+
+  private Artifact artifact(String name) {
+    return ActionsTestUtil.createArtifact(ArtifactRoot.asDerivedRoot(execDir, RootType.Output, "root"), name);
+  }
+
+  private LostInputsExecException exception(String name) {
+    Artifact artifact = artifact(name);
+    ActionInputDepOwnerMap owners = new ActionInputDepOwnerMap(ImmutableSet.of(artifact));
+    owners.addOwner(artifact, artifact);
+    return new LostInputsExecException(ImmutableMap.of(name + "-digest", artifact), owners);
+  }
+}

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/ActionInputDirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/ActionInputDirectoryTreeTest.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
 import org.junit.Test;
 
 /** Tests for {@link DirectoryTreeBuilder#buildFromActionInputs}. */
@@ -53,6 +54,12 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
         inputFiles, new StaticMetadataProvider(metadata), execRoot, digestUtil);
   }
 
+  @Override
+  @Nullable
+  Artifact artifactFor(Path path) {
+    return ActionsTestUtil.createArtifact(artifactRoot, path);
+  }
+
   @Test
   public void virtualActionInputShouldWork() throws Exception {
     SortedMap<PathFragment, ActionInput> sortedInputs = new TreeMap<>();
@@ -70,7 +77,7 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
     assertThat(directoriesAtDepth(1, tree)).isEmpty();
 
     FileNode expectedFooNode =
-        FileNode.createExecutable("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
+        FileNode.createExecutable("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"), foo);
     FileNode expectedBarNode =
         FileNode.createExecutable("bar.cc", bar.getBytes(), digestUtil.computeAsUtf8("bar"));
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
@@ -117,13 +124,13 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
     assertThat(directoriesAtDepth(3, tree)).isEmpty();
 
     FileNode expectedFooNode =
-        FileNode.createExecutable("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"));
+        FileNode.createExecutable("foo.cc", foo.getPath(), digestUtil.computeAsUtf8("foo"), foo);
     FileNode expectedBarNode =
         FileNode.createExecutable(
-            "bar.cc", execRoot.getRelative(bar.getExecPath()), digestUtil.computeAsUtf8("bar"));
+            "bar.cc", execRoot.getRelative(bar.getExecPath()), digestUtil.computeAsUtf8("bar"), null);
     FileNode expectedBuzzNode =
         FileNode.createExecutable(
-            "buzz.cc", execRoot.getRelative(buzz.getExecPath()), digestUtil.computeAsUtf8("buzz"));
+            "buzz.cc", execRoot.getRelative(buzz.getExecPath()), digestUtil.computeAsUtf8("buzz"), null);
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
     assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode);
     assertThat(fileNodesAtDepth(tree, 2)).containsExactly(expectedBarNode);
@@ -160,7 +167,7 @@ public class ActionInputDirectoryTreeTest extends DirectoryTreeTest {
 
     FileNode expectedFooNode =
         FileNode.createExecutable(
-            "foo.cc", execRoot.getRelative(foo.getExecPath()), digestUtil.computeAsUtf8("foo"));
+            "foo.cc", execRoot.getRelative(foo.getExecPath()), digestUtil.computeAsUtf8("foo"), null);
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
     assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode);
 

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/DirectoryTreeTest.java
@@ -15,8 +15,10 @@ package com.google.devtools.build.lib.remote.merkletree;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.ArtifactRoot;
 import com.google.devtools.build.lib.actions.ArtifactRoot.RootType;
+import com.google.devtools.build.lib.actions.util.ActionsTestUtil;
 import com.google.devtools.build.lib.clock.JavaClock;
 import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.DirectoryNode;
 import com.google.devtools.build.lib.remote.merkletree.DirectoryTree.FileNode;
@@ -33,6 +35,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,16 +80,18 @@ public abstract class DirectoryTreeTest {
     assertThat(directoriesAtDepth(2, tree)).isEmpty();
 
     FileNode expectedFooNode =
-        FileNode.createExecutable("foo.cc", foo, digestUtil.computeAsUtf8("foo"));
+        FileNode.createExecutable("foo.cc", foo, digestUtil.computeAsUtf8("foo"), artifactFor(foo));
     FileNode expectedBarNode =
-        FileNode.createExecutable("bar.cc", bar, digestUtil.computeAsUtf8("bar"));
+        FileNode.createExecutable("bar.cc", bar, digestUtil.computeAsUtf8("bar"), artifactFor(bar));
     FileNode expectedBuzzNode =
-        FileNode.createExecutable("buzz.cc", buzz, digestUtil.computeAsUtf8("buzz"));
+        FileNode.createExecutable("buzz.cc", buzz, digestUtil.computeAsUtf8("buzz"), artifactFor(buzz));
     assertThat(fileNodesAtDepth(tree, 0)).isEmpty();
     assertThat(fileNodesAtDepth(tree, 1)).containsExactly(expectedFooNode, expectedBarNode);
     assertThat(fileNodesAtDepth(tree, 2)).containsExactly(expectedBuzzNode);
   }
 
+  @Nullable
+  abstract Artifact artifactFor(Path path);
 
   @Test
   public void testLexicographicalOrder() throws Exception {

--- a/src/test/java/com/google/devtools/build/lib/remote/merkletree/PathDirectoryTreeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/merkletree/PathDirectoryTreeTest.java
@@ -13,11 +13,13 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.merkletree;
 
+import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import java.io.IOException;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
 
 /** Tests for {@link DirectoryTreeBuilder#fromPaths}. */
 public class PathDirectoryTreeTest extends DirectoryTreeTest {
@@ -29,5 +31,11 @@ public class PathDirectoryTreeTest extends DirectoryTreeTest {
       inputFiles.put(path.relativeTo(execRoot), path);
     }
     return DirectoryTreeBuilder.fromPaths(inputFiles, digestUtil);
+  }
+
+  @Override
+  @Nullable
+  Artifact artifactFor(Path path) {
+    return null;
   }
 }


### PR DESCRIPTION
Currently, when building with `--remote_download_minimal`, if the remote
storage has evicted an output of a previous action, Bazel will throw a
FileNotFoundException for it.

This change detects that scenario, and re-throws it as a
LostInputsExecException, tracking enough metadata on the way to do so.

If rewinding is enabled for a build, this will cause rewinding to
automatically kick in.