### PR TITLE
Remote: Support the case where output files are under an output direc…

### DIFF
--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -273,18 +273,18 @@ final class ExecutionServer extends ExecutionImplBase {
     workingDirectory.createDirectoryAndParents();
 
     List<Path> outputs = new ArrayList<>(command.getOutputFilesList().size());
-    for (String output : command.getOutputFilesList()) {
-      Path file = workingDirectory.getRelative(output);
-      if (file.exists()) {
-        throw new FileAlreadyExistsException("Output file already exists: " + file);
-      }
-      file.getParentDirectory().createDirectoryAndParents();
-      outputs.add(file);
-    }
     for (String output : command.getOutputDirectoriesList()) {
       Path file = workingDirectory.getRelative(output);
       if (file.exists()) {
         throw new FileAlreadyExistsException("Output directory/file already exists: " + file);
+      }
+      file.getParentDirectory().createDirectoryAndParents();
+      outputs.add(file);
+    }
+    for (String output : command.getOutputFilesList()) {
+      Path file = workingDirectory.getRelative(output);
+      if (file.exists()) {
+        throw new FileAlreadyExistsException("Output file already exists: " + file);
       }
       file.getParentDirectory().createDirectoryAndParents();
       outputs.add(file);


### PR DESCRIPTION
…tory and are omitted from ActionResult.

- Handle another case when outputs are under output directory.
- Fix unit test and one more.
- Add integration test
- Update RemoteWorker to handle this case.

Supplement for #15329.