### PR TITLE
Fix chocolatey package CPMR0031 - docsUrl must be a valid URL

### DIFF
--- a/scripts/packages/chocolatey/bazel.nuspec.template
+++ b/scripts/packages/chocolatey/bazel.nuspec.template
@@ -45,7 +45,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <licenseUrl>https://github.com/bazelbuild/bazel/tree/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/bazelbuild/bazel.git</projectSourceUrl>
-    <docsUrl>https://bazel.build/contribute/getting-started</docsUrl>
+    <docsUrl>https://bazel.build/start</docsUrl>
     <mailingListUrl>https://groups.google.com/forum/#!forum/bazel-discuss</mailingListUrl>
     <bugTrackerUrl>https://github.com/bazelbuild/bazel/issues</bugTrackerUrl>
     <tags>bazel build automation</tags>


### PR DESCRIPTION
chocolatey does automated tests on package submissions.

One of those is that the docsUrl element must not "be invalid". https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0031

Broken:

![image](https://user-images.githubusercontent.com/69720/165925990-bef46d80-555d-46da-b811-dace965a2216.png)

Fixed:

[{pending}](https://community.chocolatey.org/packages/bazel/5.1.0#versionhistory)

![image](https://user-images.githubusercontent.com/69720/165947585-77e53ab7-08af-49f5-aa66-0aa8e10ad4ee.png)
