### PR TITLE
Make AndroidTests pass with incompatible_disallow_empty_glob

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_cc_toolchain_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_cc_toolchain_template.txt
@@ -38,9 +38,9 @@ toolchain(
 
 filegroup(
     name = "%toolchainName%-all_files",
-    srcs = glob(["ndk/toolchains/%toolchainDirectory%/**"]) + glob([
+    srcs = glob(["ndk/toolchains/%toolchainDirectory%/**"], allow_empty = True) + glob([
         %toolchainFileGlobs%
-    ]) + [
+    ], allow_empty = True) + [
       ":%dynamicRuntimeLibs%",
       ":%staticRuntimeLibs%",
     ],

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_misc_libraries_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_misc_libraries_template.txt
@@ -1,6 +1,6 @@
 cc_library(
     name = "cpufeatures",
-    srcs = glob(["ndk/sources/android/cpufeatures/*.c"]),
-    hdrs = glob(["ndk/sources/android/cpufeatures/*.h"]),
+    srcs = glob(["ndk/sources/android/cpufeatures/*.c"], allow_empty = True),
+    hdrs = glob(["ndk/sources/android/cpufeatures/*.h"], allow_empty = True),
     linkopts = ["-ldl"],
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_stl_filegroup_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_stl_filegroup_template.txt
@@ -1,4 +1,4 @@
 filegroup(
     name = "%name%",
-    srcs = glob(["%fileGlobPattern%"]),
+    srcs = glob(["%fileGlobPattern%"], allow_empty = True),
 )

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_vulkan_validation_layers_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_ndk_vulkan_validation_layers_template.txt
@@ -1,4 +1,4 @@
 cc_library(
     name = "vulkan_validation_layers_%toolchainName%",
-    srcs = glob(["ndk/sources/third_party/vulkan/src/build-android/jniLibs/%cpu%/libVkLayer_*.so"]),
+    srcs = glob(["ndk/sources/third_party/vulkan/src/build-android/jniLibs/%cpu%/libVkLayer_*.so"], allow_empty = True),
 )

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -186,7 +186,7 @@ public final class BazelAnalysisMock extends AnalysisMock {
         "java_host_runtime_alias(name = 'current_host_java_runtime')",
         "filegroup(name='langtools', srcs=['jdk/lib/tools.jar'])",
         "filegroup(name='bootclasspath', srcs=['jdk/jre/lib/rt.jar'])",
-        "filegroup(name='extdir', srcs=glob(['jdk/jre/lib/ext/*']))",
+        "filegroup(name='extdir', srcs=glob(['jdk/jre/lib/ext/*'], allow_empty = True))",
         "filegroup(name='java', srcs = ['jdk/jre/bin/java'])",
         "filegroup(name='JacocoCoverage', srcs = ['JacocoCoverage_deploy.jar'])",
         "exports_files([",

--- a/tools/android/android_sdk_repository_template.bzl
+++ b/tools/android/android_sdk_repository_template.bzl
@@ -194,7 +194,7 @@ def create_android_sdk_rules(
             "build-tools/%s/lib/**" % build_tools_directory,
             # Build tools version 24.0.0 added a lib64 folder.
             "build-tools/%s/lib64/**" % build_tools_directory,
-        ]),
+        ], allow_empty = True),
     )
 
     for tool in ["aapt", "aapt2", "aidl", "zipalign"]:
@@ -432,7 +432,7 @@ def create_system_images_filegroups(system_image_dirs):
             )
             native.filegroup(
                 name = "%s_qemu2_extra" % name,
-                srcs = native.glob(["%s/kernel-ranchu" % system_image_dir]),
+                srcs = native.glob(["%s/kernel-ranchu" % system_image_dir], allow_empty = True),
             )
         else:
             # For supported system images that are not installed in the SDK, we


### PR DESCRIPTION
There are several globs that are empty and this prevents building
with the incompatible flag #8195.
This commit just makes it explicit that empty is allowed.