### PR TITLE
Log one file per command if --experimental_workspace_rules_log_file is a directory

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/BUILD
@@ -18,6 +18,7 @@ filegroup(
 proto_library(
     name = "workspace_log_proto",
     srcs = ["workspace_log.proto"],
+    visibility = ["//visibility:public"],
 )
 
 java_proto_library(
@@ -56,6 +57,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/build/lib/util/io",
+        "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/protobuf:failure_details_java_proto",

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/BUILD
@@ -54,6 +54,7 @@ java_library(
         ":workspace-rule-event",
         "//src/main/java/com/google/devtools/build/lib:runtime",
         "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/build/lib/util/io",

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/DebuggingOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/DebuggingOptions.java
@@ -15,6 +15,7 @@
 package com.google.devtools.build.lib.bazel.debug;
 
 import com.google.devtools.build.lib.util.OptionsUtils;
+import com.google.devtools.build.lib.util.SimpleSubstitutionTemplate.LogPathFragmentTemplate;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
@@ -29,8 +30,8 @@ public final class DebuggingOptions extends OptionsBase {
       category = "verbosity",
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.UNKNOWN},
-      converter = OptionsUtils.PathFragmentConverter.class,
+      converter = OptionsUtils.LogPathFragmentConverter.class,
       help =
           "Log certain Workspace Rules events into this file as delimited WorkspaceEvent protos.")
-  public PathFragment workspaceRulesLogFile;
+  public LogPathFragmentTemplate workspaceRulesLogFile;
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/DebuggingOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/DebuggingOptions.java
@@ -32,6 +32,8 @@ public final class DebuggingOptions extends OptionsBase {
       effectTags = {OptionEffectTag.UNKNOWN},
       converter = OptionsUtils.LogPathFragmentConverter.class,
       help =
-          "Log certain Workspace Rules events into this file as delimited WorkspaceEvent protos.")
+          "Log certain Workspace Rules events into this file as delimited WorkspaceEvent protos."
+              + " If the string {{command_id}} appears within the path, it will be replaced with"
+              + " the UUID of the bazel command.")
   public LogPathFragmentTemplate workspaceRulesLogFile;
 }

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleModule.java
@@ -25,6 +25,7 @@ import com.google.devtools.build.lib.server.FailureDetails.Workspaces;
 import com.google.devtools.build.lib.server.FailureDetails.Workspaces.Code;
 import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
+import com.google.devtools.build.lib.util.SimpleSubstitutionTemplate.LogPathFragmentTemplate;
 import com.google.devtools.build.lib.util.io.AsynchronousFileOutputStream;
 import com.google.devtools.build.lib.vfs.Path;
 import com.google.devtools.build.lib.vfs.PathFragment;
@@ -46,10 +47,10 @@ public final class WorkspaceRuleModule extends BlazeModule {
       return;
     }
 
-    PathFragment logFile =
-        env.getOptions().getOptions(DebuggingOptions.class).workspaceRulesLogFile
-            .evaluate(env.getCommandId());
-    if (logFile != null) {
+    LogPathFragmentTemplate logFileTemplate =
+        env.getOptions().getOptions(DebuggingOptions.class).workspaceRulesLogFile;
+    if (logFileTemplate != null) {
+      PathFragment logFile = logFileTemplate.evaluate(env.getCommandId());
       try {
         outFileStream =
             new AsynchronousFileOutputStream(env.getWorkingDirectory().getRelative(logFile));
@@ -59,7 +60,7 @@ public final class WorkspaceRuleModule extends BlazeModule {
             .exit(
                 new AbruptExitException(
                     createDetailedExitCode(
-                        String.format("Error initializing workspace rule log file."),
+                        "Error initializing workspace rule log file.",
                         Code.WORKSPACES_LOG_INITIALIZATION_FAILURE)));
       }
       eventBus.register(this);

--- a/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/debug/WorkspaceRuleModule.java
@@ -47,16 +47,12 @@ public final class WorkspaceRuleModule extends BlazeModule {
     }
 
     PathFragment logFile =
-        env.getOptions().getOptions(DebuggingOptions.class).workspaceRulesLogFile;
+        env.getOptions().getOptions(DebuggingOptions.class).workspaceRulesLogFile
+            .evaluate(env.getCommandId());
     if (logFile != null) {
       try {
-        Path resolvedLogFile = env.getWorkingDirectory().getRelative(logFile);
-        // If the flag specifies a directory, output one file per command. This might make it easier to debug behavior
-        // across multiple bazel commands.
-        if (resolvedLogFile.isDirectory()) {
-          resolvedLogFile = resolvedLogFile.getRelative(env.getCommandId().toString());
-        }
-        outFileStream = new AsynchronousFileOutputStream(resolvedLogFile);
+        outFileStream =
+            new AsynchronousFileOutputStream(env.getWorkingDirectory().getRelative(logFile));
       } catch (IOException e) {
         env.getReporter().handle(Event.error(e.getMessage()));
         env.getBlazeModuleEnvironment()

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BUILD
@@ -55,6 +55,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/build/lib/util:exit_code",
         "//src/main/java/com/google/devtools/build/lib/util/io:out-err",
+        "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/protobuf:failure_details_java_proto",
         "//third_party:auto_value",

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BUILD
@@ -14,6 +14,7 @@ java_library(
     deps = [
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",
+        "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BuildEventStreamOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/transports/BuildEventStreamOptions.java
@@ -14,6 +14,8 @@
 
 package com.google.devtools.build.lib.buildeventstream.transports;
 
+import com.google.devtools.build.lib.util.OptionsUtils;
+import com.google.devtools.build.lib.util.SimpleSubstitutionTemplate.LogPathFragmentTemplate;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
 import com.google.devtools.common.options.OptionEffectTag;
@@ -49,11 +51,12 @@ public class BuildEventStreamOptions extends OptionsBase {
       implicitRequirements = {"--bes_upload_mode=wait_for_upload_complete"},
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      converter = OptionsUtils.LogPathFragmentConverter.class,
       help =
           "If non-empty, write a varint delimited binary representation of representation of the"
               + " build event protocol to that file. This option implies"
               + " --bes_upload_mode=wait_for_upload_complete.")
-  public String buildEventBinaryFile;
+  public LogPathFragmentTemplate buildEventBinaryFile;
 
   @Option(
       name = "build_event_json_file",
@@ -61,8 +64,9 @@ public class BuildEventStreamOptions extends OptionsBase {
       defaultValue = "",
       documentationCategory = OptionDocumentationCategory.LOGGING,
       effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+      converter = OptionsUtils.LogPathFragmentConverter.class,
       help = "If non-empty, write a JSON serialisation of the build event protocol to that file.")
-  public String buildEventJsonFile;
+  public LogPathFragmentTemplate buildEventJsonFile;
 
   @Option(
       name = "build_event_text_file_path_conversion",

--- a/src/main/java/com/google/devtools/build/lib/util/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/util/BUILD
@@ -169,6 +169,7 @@ java_library(
         "PersistentMap.java",
         "RegexFilter.java",
         "ResourceFileLoader.java",
+        "SimpleSubstitutionTemplate.java",
         "Sleeper.java",
         "StreamWriter.java",
         "StringIndexer.java",

--- a/src/main/java/com/google/devtools/build/lib/util/SimpleSubstitutionTemplate.java
+++ b/src/main/java/com/google/devtools/build/lib/util/SimpleSubstitutionTemplate.java
@@ -1,0 +1,156 @@
+package com.google.devtools.build.lib.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * A compiled template that substitutes variables in a string.
+ */
+public final class SimpleSubstitutionTemplate {
+
+  private static final Pattern SUBSTITUTION_VARIABLE = Pattern.compile("\\{\\{([^}]*)\\}\\}");
+
+  /**
+   * A template consists of a sequence of {@link Part} objects that may be either variables or
+   * literals.
+   */
+  private interface Part {
+
+    String evaluate(VariableEvaluator evaluator);
+  }
+
+  private final ImmutableList<Part> parts;
+
+  /**
+   * @param templateText
+   * @return A compiled template ready for evaluation.
+   */
+  public static SimpleSubstitutionTemplate parse(String templateText) {
+    try {
+      return parse(templateText, (ignored) -> {
+      });
+    } catch (InvalidVariableNameException e) {
+      throw new RuntimeException(e); // Should never occur.
+    }
+  }
+
+  public static SimpleSubstitutionTemplate parse(String templateText,
+      VariableNameValidator validator)
+      throws InvalidVariableNameException {
+    ImmutableList.Builder<Part> partsBuilder = ImmutableList.builder();
+    Matcher matcher = SUBSTITUTION_VARIABLE.matcher(templateText);
+    int startOfNonVariablePart = 0;
+    while (matcher.find()) {
+      int endOfNonVariablePart = matcher.start();
+      if (endOfNonVariablePart != startOfNonVariablePart) {
+        String literal = templateText.substring(startOfNonVariablePart, endOfNonVariablePart);
+        partsBuilder.add((ignored) -> literal);
+      }
+      String variableName = matcher.group(1);
+      // Let validateVariable throw an exception if desired.
+      validator.validateVariableName(variableName);
+      partsBuilder.add((evaluator) -> evaluator.evaluatedVariable(variableName));
+      startOfNonVariablePart = matcher.end();
+    }
+    int endOfNonVariablePart = templateText.length();
+    if (endOfNonVariablePart != startOfNonVariablePart) {
+      String literal = templateText.substring(startOfNonVariablePart, endOfNonVariablePart);
+      partsBuilder.add((ignored) -> literal);
+    }
+    return new SimpleSubstitutionTemplate(partsBuilder.build());
+  }
+
+  /**
+   * Evaluates the template, calling evaluator to replace each variable in the template.
+   */
+  public String evaluate(VariableEvaluator evaluator) {
+    return parts.stream().map(p -> p.evaluate(evaluator)).collect(Collectors.joining());
+  }
+
+  public interface VariableNameValidator {
+
+    void validateVariableName(String name) throws InvalidVariableNameException;
+  }
+
+  /**
+   * Used to validate that each template variable is from a known set. Each variable name has a
+   * definition that can be used to assist the template writer.
+   */
+  public static final class VariableDefinitionSet {
+
+    private VariableDefinitionSet(ImmutableMap<String, Definition> definitions) {
+      this.definitions = definitions;
+    }
+
+    /**
+     * Constructs a  {@link VariableDefinitionSet} from a set of definitions.
+     */
+    public static VariableDefinitionSet of(Definition... definitions) {
+      //definitions
+
+      return new VariableDefinitionSet(
+          Arrays.stream(definitions).collect(ImmutableMap.toImmutableMap(
+              definition -> definition.variableName,
+              definition -> definition)));
+    }
+
+    /**
+     * Returns a {@link VariableNameValidator} that will use this set of known variables.
+     */
+    public VariableNameValidator validator() {
+      return name -> {
+        if (!definitions.containsKey(name)) {
+          String validNames = definitions.keySet().stream().sorted()
+              .collect(Collectors.joining(", "));
+          throw new InvalidVariableNameException(name,
+              String.format("must be one of %s", validNames));
+
+        }
+      };
+    }
+
+
+    /**
+     * A variable name and its meaning.
+     */
+    public static final class Definition {
+
+      private final String variableName;
+      private final String meaning;
+
+      public Definition(String variableName, String meaning) {
+        this.variableName = variableName;
+        this.meaning = meaning;
+      }
+    }
+
+    private final ImmutableMap<String, Definition> definitions;
+
+  }
+
+  /**
+   * A function called to substitute a variable for another value at template execution time.
+   */
+  public interface VariableEvaluator {
+
+    String evaluatedVariable(String variableName);
+  }
+
+  /**
+   * Thrown when an invalid variable name is used in a template.
+   */
+  public static class InvalidVariableNameException extends Exception {
+
+    public InvalidVariableNameException(String variable, String message) {
+      super(String.format("invalid variable name %s: %s", variable, message));
+    }
+  }
+
+  private SimpleSubstitutionTemplate(ImmutableList<Part> parts) {
+    this.parts = parts;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/util/SimpleSubstitutionTemplate.java
+++ b/src/main/java/com/google/devtools/build/lib/util/SimpleSubstitutionTemplate.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * A compiled template that substitutes variables in a string.

--- a/src/test/java/com/google/devtools/build/lib/util/OptionsUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/OptionsUtilsTest.java
@@ -32,6 +32,7 @@ import com.google.testing.junit.testparameterinjector.TestParameter;
 import com.google.testing.junit.testparameterinjector.TestParameterInjector;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -159,7 +160,7 @@ public class OptionsUtilsTest {
     return new PathFragmentConverter().convert(input);
   }
 
-  private PathFragment convertOneWorkspaceLog(String input, String commandId) throws Exception {
+  private PathFragment convertOneWorkspaceLog(String input, UUID commandId) throws Exception {
     return new LogPathFragmentConverter().convert(input).evaluate(commandId);
   }
 
@@ -239,7 +240,15 @@ public class OptionsUtilsTest {
 
   @Test
   public void workspaceLogPath() throws Exception {
-    assertThat(convertOneWorkspaceLog("foo", "1234")).isEqualTo(fragment("foo"));
-    assertThat(convertOneWorkspaceLog("foo/{{command_id}}", "1234")).isEqualTo(fragment("foo/1234"));
+    UUID uuid = UUID.fromString("8dbfe551-467c-4b47-9fc2-bb35694ac850");
+    assertThat(convertOneWorkspaceLog("foo", uuid)).isEqualTo(fragment("foo"));
+    assertThat(convertOneWorkspaceLog("foo/{{command_id}}", uuid)).isEqualTo(fragment("foo/8dbfe551-467c-4b47-9fc2-bb35694ac850"));
+
+    // Invalid arguments:
+    OptionsParsingException exception =
+        assertThrows(
+            OptionsParsingException.class,
+            () -> convertOneWorkspaceLog("foo/{{command_id}}/{{unsupported}}", uuid));
+
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/util/OptionsUtilsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/OptionsUtilsTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.devtools.build.lib.util.OptionsUtils.PathFragmentConverter;
 import com.google.devtools.build.lib.util.OptionsUtils.PathFragmentListConverter;
+import com.google.devtools.build.lib.util.OptionsUtils.LogPathFragmentConverter;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
@@ -158,6 +159,10 @@ public class OptionsUtilsTest {
     return new PathFragmentConverter().convert(input);
   }
 
+  private PathFragment convertOneWorkspaceLog(String input, String commandId) throws Exception {
+    return new LogPathFragmentConverter().convert(input).evaluate(commandId);
+  }
+
   @Test
   public void emptyStringYieldsEmptyList() throws Exception {
     assertThat(convert("")).isEmpty();
@@ -230,5 +235,11 @@ public class OptionsUtilsTest {
         assertThrows(OptionsParsingException.class, () -> converter.convert("relative/path"));
 
     assertThat(e).hasMessageThat().isEqualTo("Not an absolute path: 'relative/path'");
+  }
+
+  @Test
+  public void workspaceLogPath() throws Exception {
+    assertThat(convertOneWorkspaceLog("foo", "1234")).isEqualTo(fragment("foo"));
+    assertThat(convertOneWorkspaceLog("foo/{{command_id}}", "1234")).isEqualTo(fragment("foo/1234"));
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/util/SimpleSubstitutionTemplateTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/SimpleSubstitutionTemplateTest.java
@@ -1,0 +1,55 @@
+package com.google.devtools.build.lib.util;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.util.SimpleSubstitutionTemplate.InvalidVariableNameException;
+import com.google.devtools.build.lib.util.SimpleSubstitutionTemplate.VariableDefinitionSet;
+import com.google.devtools.build.lib.util.SimpleSubstitutionTemplate.VariableEvaluator;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SimpleSubstitutionTemplateTest {
+
+  @Test
+  public void parse() {
+    assertThat(SimpleSubstitutionTemplate.parse(
+            "my {{relation}}, {{friend}} {{BAD}}!")
+        .evaluate((variableName -> {
+          if (variableName.equals("relation")) {
+            return "dog";
+          }
+          if (variableName.equals("friend")) {
+            return "Sam";
+          }
+          return "INVALID";
+        }))).isEqualTo("my dog, Sam INVALID!");
+  }
+
+  @Test
+  public void parseWithValidator() throws Exception {
+    VariableDefinitionSet set = VariableDefinitionSet.of(
+        new VariableDefinitionSet.Definition("name", "name is the name of the person"),
+        new VariableDefinitionSet.Definition("environment", "a place of some kind"));
+
+    ImmutableMap<String, String> substitutions = ImmutableMap.of(
+        "name", "Sally");
+    assertThat(SimpleSubstitutionTemplate.parse("hello, {{name}}.", set.validator())
+        .evaluate(evaluatorForMap(substitutions)))
+        .isEqualTo("hello, Sally.");
+
+    InvalidVariableNameException exception = assertThrows(
+        InvalidVariableNameException.class,
+        () -> SimpleSubstitutionTemplate.parse("hello, {{name}} {{ahem}}.", set.validator()));
+    assertThat(exception.getMessage()).isEqualTo(
+        "invalid variable name ahem: must be one of environment, name");
+  }
+
+  private static VariableEvaluator evaluatorForMap(Map<String, String> map) {
+    return variableName -> map.getOrDefault(variableName, "MISSING");
+  }
+}


### PR DESCRIPTION
This is helpful for keeping track of all workspace events across multiple runs of bazel for the https://github.com/gonzojive/bazelgopackagesdriver project. Without this behavior, every bazel invocation needs to be customized to specify the path of the output.

I would probably prefer to have a different flag rather than detecting whether the output location is a directory. Please let me know if you agree.