### PR TITLE
Use tree artifacts in bootclasspath rule

### DIFF
--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -183,16 +183,7 @@ def java_runtime_files(name, srcs):
 def _bootclasspath_impl(ctx):
     host_javabase = ctx.attr.host_javabase[java_common.JavaRuntimeInfo]
 
-    # explicitly list output files instead of using TreeArtifact to work around
-    # https://github.com/bazelbuild/bazel/issues/6203
-    classes = [
-        "DumpPlatformClassPath.class",
-    ]
-
-    class_outputs = [
-        ctx.actions.declare_file("%s_classes/%s" % (ctx.label.name, clazz))
-        for clazz in classes
-    ]
+    class_dir = ctx.actions.declare_directory("%s_classes" % ctx.label.name)
 
     args = ctx.actions.args()
     args.add("-source")
@@ -203,20 +194,20 @@ def _bootclasspath_impl(ctx):
     args.add("-cp")
     args.add("%s/lib/tools.jar" % host_javabase.java_home)
     args.add("-d")
-    args.add(class_outputs[0].dirname)
+    args.add_all([class_dir], expand_directories = False)
     args.add(ctx.file.src)
 
     ctx.actions.run(
         executable = "%s/bin/javac" % host_javabase.java_home,
         mnemonic = "JavaToolchainCompileClasses",
         inputs = [ctx.file.src] + ctx.files.host_javabase,
-        outputs = class_outputs,
+        outputs = [class_dir],
         arguments = [args],
     )
 
     bootclasspath = ctx.outputs.output_jar
 
-    inputs = class_outputs + ctx.files.host_javabase
+    inputs = [class_dir] + ctx.files.host_javabase
 
     args = ctx.actions.args()
     args.add("-XX:+IgnoreUnrecognizedVMOptions")
@@ -225,8 +216,9 @@ def _bootclasspath_impl(ctx):
     args.add("--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED")
     args.add_joined(
         "-cp",
-        [class_outputs[0].dirname, "%s/lib/tools.jar" % host_javabase.java_home],
+        [class_dir, "%s/lib/tools.jar" % host_javabase.java_home],
         join_with = ctx.configuration.host_path_separator,
+        expand_directories = False,
     )
     args.add("DumpPlatformClassPath")
     args.add(bootclasspath)


### PR DESCRIPTION
Remote execution now creates the directories for output tree artifacts
prior to execution, so that the output of the Java compiler can be
modelled as a tree artifact even though not all versions create the
output directory if it doesn't exist.