### PR TITLE
Export `BAZEL_TEST=1` for `bazel test` executables

### DIFF
--- a/site/en/reference/test-encyclopedia.md
+++ b/site/en/reference/test-encyclopedia.md
@@ -452,6 +452,11 @@ The initial environment block shall be composed as follows:
              class="external">JUnit test result schema</a>.</td>
     <td>optional</td>
   </tr>
+  <tr>
+    <td><code>BAZEL_TEST</code></td>
+    <td>Signifies test executable is being driven by <code>bazel test</code></td>
+    <td>required</td>
+  </tr>
 </table>
 
 The environment may contain additional entries. Tests should not depend on the

--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -37,6 +37,11 @@ function is_absolute {
 # root.
 EXEC_ROOT="$PWD"
 
+# Declare that the executable is running in a `bazel test` environment
+# This allows test frameworks to enable output to the unprefixed environment variable
+# For example, if `BAZEL_TEST` and `XML_OUTPUT_FILE` are defined, write JUnit output
+export BAZEL_TEST=1
+
 # Bazel sets some environment vars to relative paths to improve caching and
 # support remote execution, where the absolute path may not be known to Bazel.
 # Convert them to absolute paths here before running the actual test.


### PR DESCRIPTION
[Catch2][catch2] has [learnt][pr2399] how to output JUnit to the `XML_OUTPUT_FILE`. However, the upstream developers
[felt][comment] that `XML_OUTPUT_FILE` is too generic to blanket enable JUnit output to the file as there are various
XML reporters for Catch2.

This patch enables exporting `BAZEL_TEST` environment variable so that Catch2 can enable JUnit output support
unconditionally in their build when both `BAZEL_TEST` _and_ `XML_OUTPUT_FILE` are available.

[catch2]: https://github.com/catchorg/Catch2
[pr2399]: https://github.com/catchorg/Catch2/pull/2399
[comment]: https://github.com/catchorg/Catch2/pull/2399#issuecomment-1092965791