### PR TITLE
Include spawn metrics in the execution log.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/SpawnLogModule.java
@@ -119,6 +119,7 @@ public final class SpawnLogModule extends BlazeModule {
         new SpawnLogContext(
             env.getExecRoot(),
             outStream,
+            env.getOptions().getOptions(ExecutionOptions.class),
             env.getOptions().getOptions(RemoteOptions.class),
             env.getXattrProvider());
   }

--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -248,6 +248,7 @@ java_library(
     name = "spawn_log_context",
     srcs = ["SpawnLogContext.java"],
     deps = [
+        ":execution_options",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
@@ -261,6 +262,7 @@ java_library(
         "//third_party:guava",
         "//third_party:jsr305",
         "//third_party/protobuf:protobuf_java_util",
+        "@com_google_protobuf//java/core",
         "@remoteapis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -444,6 +444,15 @@ public class ExecutionOptions extends OptionsBase {
   public PathFragment executionLogBinaryFile;
 
   @Option(
+      name = "experimental_execution_log_spawn_metrics",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      help = "Include spawn metrics in the executed spawns log."
+  )
+  public boolean executionLogSpawnMetrics;
+
+  @Option(
       name = "execution_log_json_file",
       defaultValue = "null",
       category = "verbosity",

--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -23,6 +23,7 @@ import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.MetadataProvider;
 import com.google.devtools.build.lib.actions.Spawn;
+import com.google.devtools.build.lib.actions.SpawnMetrics;
 import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.actions.Spawns;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
@@ -52,26 +53,31 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 
 /**
  * A logging utility for spawns.
  */
 public class SpawnLogContext implements ActionContext {
+
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private final Path execRoot;
   private final MessageOutputStream executionLog;
+  @Nullable private final ExecutionOptions executionOptions;
   @Nullable private final RemoteOptions remoteOptions;
   private final XattrProvider xattrProvider;
 
   public SpawnLogContext(
       Path execRoot,
       MessageOutputStream executionLog,
+      @Nullable ExecutionOptions executionOptions,
       @Nullable RemoteOptions remoteOptions,
       XattrProvider xattrProvider) {
     this.execRoot = execRoot;
     this.executionLog = executionLog;
+    this.executionOptions = executionOptions;
     this.remoteOptions = remoteOptions;
     this.xattrProvider = xattrProvider;
   }
@@ -162,13 +168,63 @@ public class SpawnLogContext implements ActionContext {
       builder.setProgressMessage(progressMessage);
     }
     builder.setMnemonic(spawn.getMnemonic());
-    builder.setWalltime(Durations.fromNanos(result.getMetrics().executionWallTime().toNanos()));
+    builder.setWalltime(durationToProto(result.getMetrics().executionWallTime()));
 
     if (spawn.getTargetLabel() != null) {
       builder.setTargetLabel(spawn.getTargetLabel());
     }
 
+    if (executionOptions != null && executionOptions.executionLogSpawnMetrics) {
+      SpawnMetrics metrics = result.getMetrics();
+      Protos.SpawnMetrics.Builder metricsBuilder = builder.getMetricsBuilder();
+      if (!metrics.totalTime().isZero()) {
+        metricsBuilder.setTotalTime(durationToProto(metrics.totalTime()));
+      }
+      if (!metrics.parseTime().isZero()) {
+        metricsBuilder.setParseTime(durationToProto(metrics.parseTime()));
+      }
+      if (!metrics.networkTime().isZero()) {
+        metricsBuilder.setNetworkTime(durationToProto(metrics.networkTime()));
+      }
+      if (!metrics.fetchTime().isZero()) {
+        metricsBuilder.setFetchTime(durationToProto(metrics.fetchTime()));
+      }
+      if (!metrics.queueTime().isZero()) {
+        metricsBuilder.setQueueTime(durationToProto(metrics.queueTime()));
+      }
+      if (!metrics.setupTime().isZero()) {
+        metricsBuilder.setSetupTime(durationToProto(metrics.setupTime()));
+      }
+      if (!metrics.uploadTime().isZero()) {
+        metricsBuilder.setUploadTime(durationToProto(metrics.uploadTime()));
+      }
+      if (!metrics.executionWallTime().isZero()) {
+        metricsBuilder.setExecutionWallTime(durationToProto(metrics.executionWallTime()));
+      }
+      if (!metrics.processOutputsTime().isZero()) {
+        metricsBuilder.setProcessOutputsTime(durationToProto(metrics.processOutputsTime()));
+      }
+      if (!metrics.retryTime().isZero()) {
+        metricsBuilder.setRetryTime(durationToProto(metrics.retryTime()));
+      }
+      metricsBuilder.setInputBytes(metrics.inputBytes());
+      metricsBuilder.setInputFiles(metrics.inputFiles());
+      metricsBuilder.setMemoryEstimateBytes(metrics.memoryEstimate());
+      metricsBuilder.setInputBytesLimit(metrics.inputBytesLimit());
+      metricsBuilder.setInputFilesLimit(metrics.inputFilesLimit());
+      metricsBuilder.setOutputBytesLimit(metrics.outputBytesLimit());
+      metricsBuilder.setOutputFilesLimit(metrics.outputFilesLimit());
+      metricsBuilder.setMemoryBytesLimit(metrics.memoryLimit());
+      if (!metrics.timeLimit().isZero()) {
+        metricsBuilder.setTimeLimit(durationToProto(metrics.timeLimit()));
+      }
+    }
+
     executionLog.write(builder.build());
+  }
+
+  private static com.google.protobuf.Duration durationToProto(Duration d) {
+    return Durations.fromNanos(d.toNanos());
   }
 
   public void close() throws IOException {

--- a/src/main/protobuf/spawn.proto
+++ b/src/main/protobuf/spawn.proto
@@ -59,6 +59,48 @@ message Platform {
   repeated Property properties = 1;
 }
 
+// Timing, size, and memory statistics for a SpawnExec.
+message SpawnMetrics {
+  // Total wall time spent running a spawn, measured locally.
+  google.protobuf.Duration total_time = 1;
+  // Time taken to convert the spawn into a network request.
+  google.protobuf.Duration parse_time = 2;
+  // Time spent communicating over the network.
+  google.protobuf.Duration network_time = 3;
+  // Time spent fetching remote outputs.
+  google.protobuf.Duration fetch_time = 4;
+  // Time spent waiting in queues.
+  google.protobuf.Duration queue_time = 5;
+  // Time spent setting up the environment in which the spawn is run.
+  google.protobuf.Duration setup_time = 6;
+  // Time spent uploading outputs to a remote store.
+  google.protobuf.Duration upload_time = 7;
+  // Time spent running the subprocess.
+  google.protobuf.Duration execution_wall_time = 8;
+  // Time spent by the execution framework processing outputs.
+  google.protobuf.Duration process_outputs_time = 9;
+  // Time spent in previous failed attempts, not including queue time.
+  google.protobuf.Duration retry_time = 10;
+  // Total size in bytes of inputs or 0 if unavailable.
+  int64 input_bytes = 11;
+  // Total number of input files or 0 if unavailable.
+  int64 input_files = 12;
+  // Estimated memory usage or 0 if unavailable.
+  int64 memory_estimate_bytes = 13;
+  // Limit of total size of inputs or 0 if unavailable.
+  int64 input_bytes_limit = 14;
+  // Limit of total number of input files or 0 if unavailable.
+  int64 input_files_limit = 15;
+  // Limit of total size of outputs or 0 if unavailable.
+  int64 output_bytes_limit = 16;
+  // Limit of total number of output files or 0 if unavailable.
+  int64 output_files_limit = 17;
+  // Memory limit or 0 if unavailable.
+  int64 memory_bytes_limit = 18;
+  // Time limit or 0 if unavailable.
+  google.protobuf.Duration time_limit = 19;
+}
+
 // Details of an executed spawn.
 // These will only be generated on demand, using the
 // --execution_log_file=<path> flag.
@@ -139,4 +181,7 @@ message SpawnExec {
 
   // A unique identifier for this Spawn.
   Digest digest = 19;
+
+  // Timing, size and memory statistics.
+  SpawnMetrics metrics = 20;
 }


### PR DESCRIPTION
The SpawnMetrics proto is intended to match the existing Java class of the
same name. Note that the SpawnExec.walltime field becomes redundant, but it
is kept to ensure backwards compatibility.

This change makes it easier to correlate the metrics for corresponding actions
in two different builds.