### PR TITLE
Use a timeout of 1s when testing the sandbox on Linux.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
@@ -88,7 +88,9 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
   private static boolean computeIsSupported(CommandEnvironment cmdEnv, Path linuxSandbox)
       throws InterruptedException {
     ImmutableList<String> linuxSandboxArgv =
-        LinuxSandboxUtil.commandLineBuilder(linuxSandbox, ImmutableList.of("/bin/true")).build();
+        LinuxSandboxUtil.commandLineBuilder(linuxSandbox, ImmutableList.of("/bin/true"))
+        .setTimeout(Duration.ofSeconds(1))
+        .build();
     ImmutableMap<String, String> env = ImmutableMap.of();
     Path execRoot = cmdEnv.getExecRoot();
     File cwd = execRoot.getPathFile();


### PR DESCRIPTION
This is to avoid hanging there forever in case the system is set up
incorrectly.
1s should be plenty to run `/bin/true`.

Fixes #15373.