### PR TITLE
Accept tildes in --override_repository

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -266,8 +266,12 @@ public class RepositoryOptions extends OptionsBase {
         throw new OptionsParsingException(
             "Repository overrides must be of the form 'repository-name=path'", input);
       }
-      PathFragment path = PathFragment.create(pieces[1]);
-      if (!path.isAbsolute()) {
+      OptionsUtils.AbsolutePathFragmentConverter absolutePathFragmentConverter =
+              new OptionsUtils.AbsolutePathFragmentConverter();
+      PathFragment path;
+      try {
+        path = absolutePathFragmentConverter.convert(pieces[1]);
+      } catch (OptionsParsingException e) {
         throw new OptionsParsingException(
             "Repository override directory must be an absolute path", input);
       }

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptionsTest.java
@@ -53,6 +53,13 @@ public class RepositoryOptionsTest {
   }
 
   @Test
+  public void testOverridePathWithTilde() throws Exception {
+    RepositoryOverride actual = converter.convert("foo=~/bar");
+    assertThat(actual.repositoryName()).isEqualTo(RepositoryName.createUnvalidated("foo"));
+    assertThat(actual.path()).isEqualTo(PathFragment.create(System.getProperty("user.home") + "/bar"));
+  }
+
+  @Test
   public void testInvalidOverride() throws Exception {
     expectedException.expect(OptionsParsingException.class);
     expectedException.expectMessage(


### PR DESCRIPTION
This is useful for adding this in your global ~/.bazelrc file for easy
rules debugging.