### PR TITLE
Make CC_CODE_COVERAGE_SCRIPT failures fail tests

### DIFF
--- a/src/test/shell/bazel/bazel_coverage_sh_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_sh_test.sh
@@ -23,7 +23,6 @@ source "${CURRENT_DIR}/../integration_test_setup.sh" \
 source "${CURRENT_DIR}/coverage_helpers.sh" \
   || { echo "coverage_helpers.sh not found!" >&2; exit 1; }
 
-
 function set_up_sh_test_coverage() {
   add_rules_shell "MODULE.bazel"
   add_rules_java "MODULE.bazel"

--- a/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
+++ b/src/test/shell/bazel/remote/build_without_the_bytes_test.sh
@@ -632,6 +632,7 @@ EOF
   bazel coverage \
     --remote_executor=grpc://localhost:${worker_port} \
     --remote_download_toplevel \
+    --test_env=IGNORE_COVERAGE_COLLECTION_FAILURES=1 \
     //a:test >& $TEST_log || fail "Expected success"
 
   assert_exists bazel-testlogs/a/test/test.log

--- a/tools/test/collect_coverage.sh
+++ b/tools/test/collect_coverage.sh
@@ -182,8 +182,11 @@ fi
 # TODO(bazel-team): cd should be avoided.
 cd $ROOT
 # Call the C++ code coverage collection script.
-if [[ "$CC_CODE_COVERAGE_SCRIPT" ]]; then
-    eval "${CC_CODE_COVERAGE_SCRIPT}"
+if [[ -n "$GENERATE_LLVM_LCOV" && "$CC_CODE_COVERAGE_SCRIPT" ]]; then
+    if ! eval "${CC_CODE_COVERAGE_SCRIPT}" && test -z "${IGNORE_COVERAGE_COLLECTION_FAILURES:-}"; then
+      echo "error: coverage collection script failed" >&2
+      exit 1
+    fi
 fi
 
 if [[ -z "$LCOV_MERGER" ]]; then


### PR DESCRIPTION
If you're editing, or overriding, this script and you introduce and
introduce an error, previously this wouldn't fail the test invocation.

Fixes https://github.com/bazelbuild/bazel/issues/18650
Fixes https://github.com/bazelbuild/bazel/issues/26541