### PR TITLE
Document @ as allowed in a package name

### DIFF
--- a/site/en/concepts/labels.md
+++ b/site/en/concepts/labels.md
@@ -143,8 +143,8 @@ relative to the top-level directory of the containing repository.
 For example: `my/app`.
 
 Package names must be composed entirely of characters drawn from the set
-`A`-`Z`, `a`–`z`, `0`–`9`, '`/`', '`-`', '`.`', and '`_`', and cannot start
-with a slash.
+`A`-`Z`, `a`–`z`, `0`–`9`, '`/`', '`-`', '`.`', '`@`', and '`_`', and cannot
+start with a slash.
 
 For a language with a directory structure that is significant to its module
 system (for example, Java), it's important to choose directory names that are


### PR DESCRIPTION
Empirically, this works, and some rulesets (e.g. `rules_nodejs`)
explicitly create packages whose names contain `@` characters.

We should document this reality (or forbid it, but that would be a
massively breaking change to the ecosystem).

Additional context: https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1651850227929389?thread_ts=1651832164.144609&cid=CEZUUKQ6P