### PR TITLE
Add a flag to expose undeclared test outputs in unzipped form.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestConfiguration.java
@@ -298,6 +298,14 @@ public class TestConfiguration extends Fragment {
         help = "If true, then Bazel will run coverage postprocessing for test in a new spawn.")
     public boolean splitCoveragePostProcessing;
 
+    @Option(
+        name = "zip_undeclared_test_outputs",
+        defaultValue = "true",
+        documentationCategory = OptionDocumentationCategory.TESTING,
+        effectTags = {OptionEffectTag.TEST_RUNNER},
+        help = "If true, undeclared test outputs will be archived in a zip file.")
+    public boolean zipUndeclaredTestOutputs;
+
     @Override
     public FragmentOptions getHost() {
       TestOptions hostOptions = (TestOptions) getDefault();
@@ -373,7 +381,7 @@ public class TestConfiguration extends Fragment {
     return options.coverageSupport;
   }
 
-  public Label getCoverageReportGenerator(){
+  public Label getCoverageReportGenerator() {
     return options.coverageReportGenerator;
   }
 
@@ -408,6 +416,10 @@ public class TestConfiguration extends Fragment {
 
   public boolean splitCoveragePostProcessing() {
     return options.splitCoveragePostProcessing;
+  }
+
+  public boolean getZipUndeclaredTestOutputs() {
+    return options.zipUndeclaredTestOutputs;
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestRunnerAction.java
@@ -339,7 +339,11 @@ public class TestRunnerAction extends AbstractAction
     outputs.add(ActionInputHelper.fromPath(getSplitLogsPath()));
     outputs.add(ActionInputHelper.fromPath(getUnusedRunfilesLogPath()));
     outputs.add(ActionInputHelper.fromPath(getInfrastructureFailureFile()));
-    outputs.add(ActionInputHelper.fromPath(getUndeclaredOutputsZipPath()));
+    if (testConfiguration.getZipUndeclaredTestOutputs()) {
+      outputs.add(ActionInputHelper.fromPath(getUndeclaredOutputsZipPath()));
+    } else {
+      outputs.add(ActionInputHelper.fromPath(getUndeclaredOutputsDir()));
+    }
     outputs.add(ActionInputHelper.fromPath(getUndeclaredOutputsManifestPath()));
     outputs.add(ActionInputHelper.fromPath(getUndeclaredOutputsAnnotationsPath()));
     outputs.add(ActionInputHelper.fromPath(getUndeclaredOutputsAnnotationsPbPath()));
@@ -383,11 +387,19 @@ public class TestRunnerAction extends AbstractAction
         builder.add(
             Pair.of(TestFileNameConstants.TEST_WARNINGS, resolvedPaths.getTestWarningsPath()));
       }
-      if (resolvedPaths.getUndeclaredOutputsZipPath().exists()) {
+      if (testConfiguration.getZipUndeclaredTestOutputs()
+          && resolvedPaths.getUndeclaredOutputsZipPath().exists()) {
         builder.add(
             Pair.of(
                 TestFileNameConstants.UNDECLARED_OUTPUTS_ZIP,
                 resolvedPaths.getUndeclaredOutputsZipPath()));
+      }
+      if (!testConfiguration.getZipUndeclaredTestOutputs()
+          && resolvedPaths.getUndeclaredOutputsDir().exists()) {
+        builder.add(
+            Pair.of(
+                TestFileNameConstants.UNDECLARED_OUTPUTS_DIR,
+                resolvedPaths.getUndeclaredOutputsDir()));
       }
       if (resolvedPaths.getUndeclaredOutputsManifestPath().exists()) {
         builder.add(
@@ -451,6 +463,7 @@ public class TestRunnerAction extends AbstractAction
     fp.addInt(runNumber);
     fp.addInt(executionSettings.getTotalRuns());
     fp.addBoolean(configuration.isCodeCoverageEnabled());
+    fp.addBoolean(testConfiguration.getZipUndeclaredTestOutputs());
     fp.addStringMap(getExecutionInfo());
   }
 
@@ -615,7 +628,10 @@ public class TestRunnerAction extends AbstractAction
 
     env.put("TEST_LOGSPLITTER_OUTPUT_FILE", getSplitLogsPath().getPathString());
 
-    env.put("TEST_UNDECLARED_OUTPUTS_ZIP", getUndeclaredOutputsZipPath().getPathString());
+    if (testConfiguration.getZipUndeclaredTestOutputs()) {
+      env.put("TEST_UNDECLARED_OUTPUTS_ZIP", getUndeclaredOutputsZipPath().getPathString());
+    }
+
     env.put("TEST_UNDECLARED_OUTPUTS_DIR", getUndeclaredOutputsDir().getPathString());
     env.put("TEST_UNDECLARED_OUTPUTS_MANIFEST", getUndeclaredOutputsManifestPath().getPathString());
     env.put(

--- a/src/main/java/com/google/devtools/build/lib/buildeventstream/TestFileNameConstants.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventstream/TestFileNameConstants.java
@@ -33,6 +33,7 @@ public class TestFileNameConstants {
       "test.outputs_manifest__ANNOTATIONS.pb";
   public static final String UNDECLARED_OUTPUTS_MANIFEST = "test.outputs_manifest__MANIFEST";
   public static final String UNDECLARED_OUTPUTS_ZIP = "test.outputs__outputs.zip";
+  public static final String UNDECLARED_OUTPUTS_DIR = "test.outputs";
   public static final String UNUSED_RUNFILES_LOG = "test.unused_runfiles_log";
   public static final String TEST_COVERAGE = "test.lcov";
   public static final String BASELINE_COVERAGE = "baseline.lcov";

--- a/tools/test/test-setup.sh
+++ b/tools/test/test-setup.sh
@@ -54,8 +54,10 @@ is_absolute "$TEST_UNDECLARED_OUTPUTS_DIR" ||
   TEST_UNDECLARED_OUTPUTS_DIR="$PWD/$TEST_UNDECLARED_OUTPUTS_DIR"
 is_absolute "$TEST_UNDECLARED_OUTPUTS_MANIFEST" ||
   TEST_UNDECLARED_OUTPUTS_MANIFEST="$PWD/$TEST_UNDECLARED_OUTPUTS_MANIFEST"
-is_absolute "$TEST_UNDECLARED_OUTPUTS_ZIP" ||
-  TEST_UNDECLARED_OUTPUTS_ZIP="$PWD/$TEST_UNDECLARED_OUTPUTS_ZIP"
+if [[ -n "$TEST_UNDECLARED_OUTPUTS_ZIP" ]]; then
+  is_absolute "$TEST_UNDECLARED_OUTPUTS_ZIP" ||
+    TEST_UNDECLARED_OUTPUTS_ZIP="$PWD/$TEST_UNDECLARED_OUTPUTS_ZIP"
+fi
 is_absolute "$TEST_UNDECLARED_OUTPUTS_ANNOTATIONS" ||
   TEST_UNDECLARED_OUTPUTS_ANNOTATIONS="$PWD/$TEST_UNDECLARED_OUTPUTS_ANNOTATIONS"
 is_absolute "$TEST_UNDECLARED_OUTPUTS_ANNOTATIONS_DIR" ||
@@ -420,7 +422,8 @@ if [[ -n "$TEST_UNDECLARED_OUTPUTS_ZIP" ]] && cd "$TEST_UNDECLARED_OUTPUTS_DIR";
     # If * found nothing, echo printed the literal *.
     # Otherwise echo printed the top-level files and directories.
     # Pass files to zip with *, so paths with spaces aren't broken up.
-    zip -qr "$TEST_UNDECLARED_OUTPUTS_ZIP" -- * 2>/dev/null || \
+    # Remove original files after zipping them.
+    zip -qrm "$TEST_UNDECLARED_OUTPUTS_ZIP" -- * 2>/dev/null || \
         echo >&2 "Could not create \"$TEST_UNDECLARED_OUTPUTS_ZIP\": zip not found or failed"
   fi
 fi


### PR DESCRIPTION
Closes #14568.

Closes #15199.

PiperOrigin-RevId: 440932893