### PR TITLE
Add target label to SpawnExec in the execution log

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/SpawnLogContext.java
@@ -149,6 +149,11 @@ public class SpawnLogContext implements ActionContext {
     }
     builder.setMnemonic(spawn.getMnemonic());
     builder.setWalltime(Durations.fromNanos(result.getMetrics().executionWallTime().toNanos()));
+
+    if (spawn.getTargetLabel() != null) {
+      builder.setTargetLabel(spawn.getTargetLabel());
+    }
+
     executionLog.write(builder.build());
   }
 

--- a/src/main/protobuf/spawn.proto
+++ b/src/main/protobuf/spawn.proto
@@ -132,4 +132,8 @@ message SpawnExec {
   // The wall time it took to execute the Spawn. This is only the time spent in
   // the subprocess, not including the time doing setup and teardown.
   google.protobuf.Duration walltime = 17;
+
+  // Canonical label of the target that emitted this spawn, may not always be
+  // set.
+  string target_label = 18;
 }

--- a/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/AbstractSpawnStrategyTest.java
@@ -366,6 +366,7 @@ public class AbstractSpawnStrategyTest {
             .setMnemonic("MyMnemonic")
             .setRunner("runner")
             .setWalltime(Duration.getDefaultInstance())
+            .setTargetLabel("//dummy:label")
             .build();
     verify(messageOutput).write(expectedSpawnLog);
   }
@@ -491,6 +492,7 @@ public class AbstractSpawnStrategyTest {
         .setStatus("NON_ZERO_EXIT")
         .setExitCode(23)
         .setRemoteCacheable(true)
-        .setWalltime(Duration.getDefaultInstance());
+        .setWalltime(Duration.getDefaultInstance())
+        .setTargetLabel("//dummy:label");
   }
 }


### PR DESCRIPTION
The execution log is very handy for tracking fine grain build data for analysis, however there's no easy way to correlate the action data to a target, this change simply adds the owning target's label to the SpawnExec info to enable this correlation.

Closes #14818.

PiperOrigin-RevId: 439516075