### PR TITLE
Improve the --sandbox_debug error message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -60,7 +60,8 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
   private static final int LOCAL_EXEC_ERROR = -1;
 
   private static final String SANDBOX_DEBUG_SUGGESTION =
-      "\n\nUse --sandbox_debug to see verbose messages from the sandbox";
+      "\n\nUse --sandbox_debug to see verbose messages from the sandbox "
+          + "and retain the sandbox build root for debugging";
 
   private final SandboxOptions sandboxOptions;
   private final boolean verboseFailures;

--- a/src/test/shell/bazel/bazel_sandboxing_test.sh
+++ b/src/test/shell/bazel/bazel_sandboxing_test.sh
@@ -727,13 +727,13 @@ genrule(
 EOF
   bazel build --verbose_failures :broken &> $TEST_log \
     && fail "build should have failed" || true
-  expect_log "Use --sandbox_debug to see verbose messages from the sandbox"
+  expect_log "Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging"
   expect_log "Executing genrule //:broken failed"
 
   bazel build --verbose_failures --sandbox_debug :broken &> $TEST_log \
     && fail "build should have failed" || true
   expect_log "Executing genrule //:broken failed"
-  expect_not_log "Use --sandbox_debug to see verbose messages from the sandbox"
+  expect_not_log "Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging"
   # This will appear a lot in the sandbox failure details.
   expect_log "/sandbox/"  # Part of the path to the sandbox location.
 }


### PR DESCRIPTION
This makes it more clear that this flag has another benefit besides
verbose logging, similar to the help message for it.

Closes #15273.

PiperOrigin-RevId: 443307103