### PR TITLE
Store start/end timestamps of locally executed actions in the disk ca…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/SpawnResult.java
@@ -26,6 +26,7 @@ import com.google.devtools.build.lib.vfs.Path;
 import com.google.protobuf.ByteString;
 import java.io.InputStream;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -170,6 +171,14 @@ public interface SpawnResult {
   String getRunnerSubtype();
 
   /**
+   * Returns the start time for the {@link Spawn}'s execution.
+   *
+   * @return the measurement, or empty in case of execution errors or when the measurement is not
+   *     implemented for the current platform
+   */
+  Optional<Instant> getStartTime();
+
+  /**
    * Returns the wall time taken by the {@link Spawn}'s execution.
    *
    * @return the measurement, or empty in case of execution errors or when the measurement is not
@@ -270,6 +279,7 @@ public interface SpawnResult {
     private final String runnerName;
     private final String runnerSubtype;
     private final SpawnMetrics spawnMetrics;
+    private final Optional<Instant> startTime;
     private final Optional<Duration> wallTime;
     private final Optional<Duration> userTime;
     private final Optional<Duration> systemTime;
@@ -296,6 +306,7 @@ public interface SpawnResult {
       this.spawnMetrics = builder.spawnMetrics != null
           ? builder.spawnMetrics
           : SpawnMetrics.forLocalExecution(builder.wallTime.orElse(Duration.ZERO));
+      this.startTime = builder.startTime;
       this.wallTime = builder.wallTime;
       this.userTime = builder.userTime;
       this.systemTime = builder.systemTime;
@@ -345,6 +356,11 @@ public interface SpawnResult {
     @Override
     public SpawnMetrics getMetrics() {
       return spawnMetrics;
+    }
+
+    @Override
+    public Optional<Instant> getStartTime() {
+      return startTime;
     }
 
     @Override
@@ -451,6 +467,7 @@ public interface SpawnResult {
     private String runnerName = "";
     private String runnerSubtype = "";
     private SpawnMetrics spawnMetrics;
+    private Optional<Instant> startTime = Optional.empty();
     private Optional<Duration> wallTime = Optional.empty();
     private Optional<Duration> userTime = Optional.empty();
     private Optional<Duration> systemTime = Optional.empty();
@@ -532,6 +549,11 @@ public interface SpawnResult {
 
     public Builder setSpawnMetrics(SpawnMetrics spawnMetrics) {
       this.spawnMetrics = spawnMetrics;
+      return this;
+    }
+
+    public Builder setStartTime(Instant startTime) {
+      this.startTime = Optional.of(startTime);
       return this;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/local/LocalSpawnRunner.java
@@ -63,6 +63,7 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
@@ -385,6 +386,8 @@ public class LocalSpawnRunner implements SpawnRunner {
         subprocessBuilder.setArgv(args);
 
         long startTime = System.currentTimeMillis();
+        spawnResultBuilder.setStartTime(Instant.now());
+        Stopwatch executionStopwatch = Stopwatch.createStarted();
         TerminationStatus terminationStatus;
         try (SilentCloseable c =
             Profiler.instance()

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -1178,8 +1178,10 @@ public class RemoteExecutionService {
               action.action,
               action.command,
               outputFiles.build(),
-              action.spawnExecutionContext.getFileOutErr(),
-              spawnResult.exitCode());
+              action.getSpawnExecutionContext().getFileOutErr(),
+              spawnResult.exitCode(),
+              spawnResult.getStartTime(),
+              spawnResult.getWallTime());
         });
   }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java
@@ -127,6 +127,8 @@ final class RemoteSpawnCache implements SpawnCache {
                   /*cacheHit=*/ true,
                   result.cacheName(),
                   inMemoryOutput,
+                  result.getExecutionMetadata().getWorkerStartTimestamp(),
+                  result.getExecutionMetadata().getWorkerCompletedTimestamp(),
                   spawnMetrics.build(),
                   spawn.getMnemonic());
           return SpawnCache.success(spawnResult);

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -377,6 +377,8 @@ public class RemoteSpawnRunner implements SpawnRunner {
         cacheHit,
         cacheName,
         inMemoryOutput,
+        result.getExecutionMetadata().getWorkerStartTimestamp(),
+        result.getExecutionMetadata().getWorkerCompletedTimestamp(),
         spawnMetrics
             .setFetchTime(fetchTime.elapsed().minus(networkTimeEnd.minus(networkTimeStart)))
             .setTotalTime(totalTime.elapsed())

--- a/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java
@@ -52,6 +52,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
 import com.google.rpc.BadRequest;
 import com.google.rpc.Code;
@@ -69,6 +70,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
@@ -144,6 +146,8 @@ public final class Utils {
       boolean cacheHit,
       String runnerName,
       @Nullable InMemoryOutput inMemoryOutput,
+      Timestamp executionStartTimestamp,
+      Timestamp executionCompletedTimestamp,
       SpawnMetrics spawnMetrics,
       String mnemonic) {
     SpawnResult.Builder builder =
@@ -153,6 +157,11 @@ public final class Utils {
             .setExitCode(exitCode)
             .setRunnerName(cacheHit ? runnerName + " cache hit" : runnerName)
             .setCacheHit(cacheHit)
+            .setStartTime(timestampToInstant(executionStartTimestamp))
+            .setWallTime(
+                java.time.Duration.between(
+                    timestampToInstant(executionStartTimestamp),
+                    timestampToInstant(executionCompletedTimestamp)))
             .setSpawnMetrics(spawnMetrics)
             .setRemote(true);
     if (exitCode != 0) {
@@ -168,6 +177,10 @@ public final class Utils {
       builder.setInMemoryOutput(inMemoryOutput.getOutput(), inMemoryOutput.getContents());
     }
     return builder.build();
+  }
+
+  private static Instant timestampToInstant(Timestamp timestamp) {
+    return Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos());
   }
 
   /** Returns {@code true} if all spawn outputs should be downloaded to disk. */

--- a/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/AbstractSandboxSpawnRunner.java
@@ -53,6 +53,7 @@ import com.google.devtools.build.lib.vfs.FileSystem;
 import com.google.devtools.build.lib.vfs.Path;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 
 /** Abstract common ancestor for sandbox spawn runners implementing the common parts. */
@@ -181,7 +182,7 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
     if (useSubprocessTimeout) {
       subprocessBuilder.setTimeoutMillis(timeout.toMillis());
     }
-    long startTime = System.currentTimeMillis();
+    Instant startTime = Instant.now();
     TerminationStatus terminationStatus;
     try {
       Subprocess subprocess = subprocessBuilder.start();
@@ -210,7 +211,7 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
     }
 
     // TODO(b/62588075): Calculate wall time inside Subprocess instead?
-    Duration wallTime = Duration.ofMillis(System.currentTimeMillis() - startTime);
+    Duration wallTime = Duration.between(startTime, Instant.now());
     boolean wasTimeout =
         (useSubprocessTimeout && terminationStatus.timedOut())
             || (!useSubprocessTimeout && wasTimeout(timeout, wallTime));
@@ -254,6 +255,7 @@ abstract class AbstractSandboxSpawnRunner implements SpawnRunner {
             .setRunnerName(getName())
             .setStatus(status)
             .setExitCode(exitCode)
+            .setStartTime(startTime)
             .setWallTime(wallTime)
             .setFailureMessage(failureMessage);
 

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerSpawnRunner.java
@@ -220,6 +220,7 @@ final class WorkerSpawnRunner implements SpawnRunner {
             .setRunnerName(getName())
             .setExitCode(exitCode)
             .setStatus(exitCode == 0 ? Status.SUCCESS : Status.NON_ZERO_EXIT)
+            .setStartTime(startTime)
             .setWallTime(wallTime)
             .setSpawnMetrics(spawnMetrics.setTotalTime(wallTime).build());
     if (exitCode != 0) {

--- a/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/GrpcCacheClientTest.java
@@ -108,6 +108,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -580,7 +581,9 @@ public class GrpcCacheClientTest {
             command,
             outputs,
             outErr,
-            0);
+            /* exitCode= */ 0,
+            /* startTime= */ Optional.empty(),
+            /* wallTime= */ Optional.empty());
     return uploadManifest.upload(context, remoteCache, NullEventHandler.INSTANCE);
   }
 

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -3627,4 +3627,40 @@ EOF
   expect_log "Executing genrule .* failed: (Exit 1):"
 }
 
+
+function test_local_test_execution_with_disk_cache() {
+  # Tests that the wall time for a locally executed test is correctly cached.
+  # If not, the generate-xml.sh action, which embeds the wall time, will be
+  # considered stale on a cache hit.
+  # Regression test for https://github.com/bazelbuild/bazel/issues/14426.
+
+  mkdir -p a
+  cat > a/BUILD <<EOF
+sh_test(
+  name = 'test',
+  srcs = ['test.sh'],
+)
+EOF
+  cat > a/test.sh <<EOF
+sleep 1
+EOF
+  chmod +x a/test.sh
+
+  CACHEDIR=$(mktemp -d)
+
+  bazel test \
+    --disk_cache=$CACHEDIR \
+    //a:test >& $TEST_log || "Failed to build //a:test"
+
+  expect_log "5 processes: 3 internal, 2 .*-sandbox"
+
+  bazel clean
+
+  bazel test \
+    --disk_cache=$CACHEDIR \
+    //a:test >& $TEST_log || "Failed to build //a:test"
+
+  expect_log "5 processes: 2 disk cache hit, 3 internal"
+}
+
 run_suite "Remote execution and remote cache tests"

--- a/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
+++ b/src/tools/remote/src/main/java/com/google/devtools/build/remote/worker/ExecutionServer.java
@@ -65,11 +65,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -293,7 +295,7 @@ final class ExecutionServer extends ExecutionImplBase {
     // implementation instead of copying it.
     com.google.devtools.build.lib.shell.Command cmd =
         getCommand(command, workingDirectory.getPathString());
-    long startTime = System.currentTimeMillis();
+    Instant startTime = Instant.now();
     CommandResult cmdResult = null;
 
     String uuid = UUID.randomUUID().toString();
@@ -316,13 +318,14 @@ final class ExecutionServer extends ExecutionImplBase {
         }
       }
 
+      Duration wallTime = Duration.between(startTime, Instant.now());
       long timeoutMillis =
           action.hasTimeout()
               ? Durations.toMillis(action.getTimeout())
               : TimeUnit.MINUTES.toMillis(15);
       boolean wasTimeout =
           (cmdResult != null && cmdResult.getTerminationStatus().timedOut())
-              || wasTimeout(timeoutMillis, System.currentTimeMillis() - startTime);
+              || wasTimeout(timeoutMillis, wallTime.toMillis());
       final int exitCode;
       Status errStatus = null;
       ExecuteResponse.Builder resp = ExecuteResponse.newBuilder();
@@ -356,7 +359,9 @@ final class ExecutionServer extends ExecutionImplBase {
                 command,
                 outputs,
                 outErr,
-                exitCode);
+                exitCode,
+                Optional.of(startTime),
+                Optional.of(wallTime));
         result = manifest.upload(context, cache, NullEventHandler.INSTANCE);
       } catch (ExecException e) {
         if (errStatus == null) {


### PR DESCRIPTION
…che.

This is necessary to ensure that the generate-xml.sh action associated with
every test, which embeds the test runner wall time, doesn't execute again when
run on a warm disk cache.

This PR makes the following changes:

1. Add SpawnResult#getStartTime alongside existing #getWallTime and populate
   it in various SpawnRunner implementations.
2. Populate the ExecutedActionMetadata with the start/wall times for a
   locally executed spawn when storing it in the disk cache.
3. Populate the SpawnResult with the start/wall times for a spawn
   retrieved from the disk cache.
4. Add a regression test for the scenario described above.

In order to avoid changes to the remote execution protocol, the start/end
time are stored in the existing ActionResult.execution_metadata fields.
Since there is some mismatch between this field and the metrics available
in a SpawnResult, this might be revisited later.

Fixes #14426.

Closes #15256.

PiperOrigin-RevId: 443052342