### PR TITLE
Add workspace_root to repository_ctx

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -101,6 +101,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
 
   private final Rule rule;
   private final PathPackageLocator packageLocator;
+  private final Path workspaceRoot;
   private final StructImpl attrObject;
   private final ImmutableSet<PathFragment> ignoredPatterns;
 
@@ -119,7 +120,9 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       double timeoutScaling,
       @Nullable ProcessWrapper processWrapper,
       StarlarkSemantics starlarkSemantics,
-      @Nullable RepositoryRemoteExecutor remoteExecutor)
+      @Nullable RepositoryRemoteExecutor remoteExecutor,
+      SyscallCache syscallCache,
+      Path workspaceRoot)
       throws EvalException {
     super(
         outputDirectory,
@@ -133,6 +136,8 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
     this.rule = rule;
     this.packageLocator = packageLocator;
     this.ignoredPatterns = ignoredPatterns;
+    this.syscallCache = syscallCache;
+    this.workspaceRoot = workspaceRoot;
     WorkspaceAttributeMapper attrs = WorkspaceAttributeMapper.of(rule);
     ImmutableMap.Builder<String, Object> attrBuilder = new ImmutableMap.Builder<>();
     for (String name : attrs.getAttributeNames()) {
@@ -156,6 +161,14 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       doc = "The name of the external repository created by this rule.")
   public String getName() {
     return rule.getName();
+  }
+
+  @StarlarkMethod(
+      name = "workspace_root",
+      structField = true,
+      doc = "The path to the root workspace of the bazel invocation.")
+  public StarlarkPath getWorkspaceRoot() {
+    return new StarlarkPath(workspaceRoot);
   }
 
   @StarlarkMethod(

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryFunction.java
@@ -176,7 +176,9 @@ public class StarlarkRepositoryFunction extends RepositoryFunction {
               timeoutScaling,
               processWrapper,
               starlarkSemantics,
-              repositoryRemoteExecutor);
+              repositoryRemoteExecutor,
+              syscallCache,
+              directories.getWorkspace());
 
       if (starlarkRepositoryContext.isRemotable()) {
         // If a rule is declared remotable then invalidate it if remote execution gets

--- a/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContextTest.java
@@ -168,7 +168,9 @@ public final class StarlarkRepositoryContextTest {
             1.0,
             /*processWrapper=*/ null,
             starlarkSemantics,
-            repoRemoteExecutor);
+            repoRemoteExecutor,
+            SyscallCache.NO_CACHE,
+            root.asPath());
   }
 
   protected void setUpContextForRule(String name) throws Exception {
@@ -472,5 +474,11 @@ public final class StarlarkRepositoryContextTest {
     scratch.file("/my/folder/c");
     assertThat(context.path("/my/folder").readdir()).containsExactly(
         context.path("/my/folder/a"), context.path("/my/folder/b"), context.path("/my/folder/c"));
+  }
+
+  @Test
+  public void testWorkspaceRoot() throws Exception {
+    setUpContextForRule("test");
+    assertThat(context.getWorkspaceRoot().getPath()).isEqualTo(root.asPath());
   }
 }


### PR DESCRIPTION
There are a number of use-cases for this, and I've seen it come up in
`bazel-discuss` and similar. It is possible to abuse this information,
but this information is currently available by looking up something like:

```python
repository_ctx.path(Label("@//:WORKSPACE")).dirname
```

But this is unreliable as `WORKSPACE.bazel` was added as an alternative
to `WORKSPACE`, and trying to look up a label which doesn't exist is a
fatal error.

We're currently using this to work around the fact that labels can't
exist if the file they point at doesn't already exist.
In repository rules we want users to be able to set an attribute to
point at a lockfile, which may not yet exist, and which our rule may
create as a side-effect of running. The nicest way we've worked out how
to do this is to use a `attr.string`, and use `repository_ctx.execute`
to test for the existence of a file, but that relies on being able to
find the path to the root repository.

It may be interesting to try to introduce some kind of fallible
label/path lookup, but that feels like a much bigger change for the
future.

Closes #13417.

PiperOrigin-RevId: 442839850