### PR TITLE
Fix android armeabi-v7a constraint

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/AndroidNdkRepositoryFunction.java
@@ -233,7 +233,7 @@ public class AndroidNdkRepositoryFunction extends AndroidRepositoryFunction {
       case "x86":
         return "x86_32";
       case "armeabi-v7a":
-        return "arm";
+        return "armv7";
       case "arm64-v8a":
         return "aarch64";
       default:

--- a/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/mock/BazelAnalysisMock.java
@@ -219,7 +219,7 @@ public final class BazelAnalysisMock extends AnalysisMock {
         "  parents = ['" + TestConstants.PLATFORM_PACKAGE_ROOT + ":default_target'],",
         "  constraint_values = [",
         "    '" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "os:android',",
-        "    '" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:arm',",
+        "    '" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:armv7',",
         "  ],",
         ")");
 

--- a/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockAndroidSupport.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/util/BazelMockAndroidSupport.java
@@ -89,7 +89,7 @@ public final class BazelMockAndroidSupport {
             Pair.of("ld-bfd", "arm/bin/arm-linux-androideabi-ld.bfd"),
             Pair.of("ld-gold", "arm/bin/arm-linux-androideabi-ld.gold"))
         .withToolchainTargetConstraints(
-            TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:arm",
+            TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:armv7",
             TestConstants.CONSTRAINTS_PACKAGE_ROOT + "os:android");
   }
 
@@ -146,7 +146,7 @@ public final class BazelMockAndroidSupport {
         String.format("    toolchain_type = '%s',", TestConstants.ANDROID_TOOLCHAIN_TYPE_LABEL),
         "    toolchain = '//platform_selected_android_sdks:arm',",
         "    target_compatible_with = [",
-        "        '" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:arm',",
+        "        '" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:armv7',",
         "    ])");
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/rules/android/AndroidBinaryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/AndroidBinaryTest.java
@@ -155,7 +155,7 @@ public abstract class AndroidBinaryTest extends AndroidBuildViewTestCase {
           ")",
           "config_setting(",
           "    name = 'is_arm',",
-          "    constraint_values = ['" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:arm'],",
+          "    constraint_values = ['" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:armv7'],",
           ")",
           "android_library(",
           "    name = 'lib',",
@@ -222,7 +222,7 @@ public abstract class AndroidBinaryTest extends AndroidBuildViewTestCase {
           "platform(",
           "    name = 'armeabi-v7a',",
           "    parents = ['" + TestConstants.PLATFORM_PACKAGE_ROOT + "/android:armeabi-v7a'],",
-          "    constraint_values = ['" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:arm'],",
+          "    constraint_values = ['" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:armv7'],",
           ")");
       scratch.file(
           "/workspace/platform_mappings",
@@ -238,7 +238,7 @@ public abstract class AndroidBinaryTest extends AndroidBuildViewTestCase {
           "flags:",
           "  --crosstool_top=//android/crosstool:everything",
           "  --cpu=armeabi-v7a",
-          "    //java/android/platforms:arm",
+          "    //java/android/platforms:armv7",
           "  --crosstool_top=//android/crosstool:everything",
           "  --cpu=x86",
           "    //java/android/platforms:x86");

--- a/src/test/java/com/google/devtools/build/lib/rules/android/AndroidPlatformsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/AndroidPlatformsTest.java
@@ -65,7 +65,7 @@ public class AndroidPlatformsTest extends AndroidBuildViewTestCase {
         "platform(",
         "    name = 'arm_platform',",
         "    constraint_values = [",
-        "        '" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:arm',",
+        "        '" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:armv7',",
         "    ])");
     BazelMockAndroidSupport.setupPlatformResolvableSdks(mockToolsConfig);
 

--- a/src/test/java/com/google/devtools/build/lib/rules/android/AndroidStarlarkTest.java
+++ b/src/test/java/com/google/devtools/build/lib/rules/android/AndroidStarlarkTest.java
@@ -180,7 +180,7 @@ public abstract class AndroidStarlarkTest extends AndroidBuildViewTestCase {
           "platform(",
           "    name = 'armeabi-v7a',",
           "    parents = ['" + TestConstants.PLATFORM_PACKAGE_ROOT + "/android:armeabi-v7a'],",
-          "    constraint_values = ['" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:arm'],",
+          "    constraint_values = ['" + TestConstants.CONSTRAINTS_PACKAGE_ROOT + "cpu:armv7'],",
           ")");
       scratch.file(
           "/workspace/platform_mappings",
@@ -196,7 +196,7 @@ public abstract class AndroidStarlarkTest extends AndroidBuildViewTestCase {
           "flags:",
           "  --crosstool_top=//android/crosstool:everything",
           "  --cpu=armeabi-v7a",
-          "    //java/android/platforms:arm",
+          "    //java/android/platforms:armeabi-v7a",
           "  --crosstool_top=//android/crosstool:everything",
           "  --cpu=x86",
           "    //java/android/platforms:x86");

--- a/src/test/shell/bazel/android/android_ndk_integration_test.sh
+++ b/src/test/shell/bazel/android/android_ndk_integration_test.sh
@@ -462,7 +462,7 @@ cc_binary(
 
 platform(
     name = 'android_arm',
-    constraint_values = ['@bazel_tools//platforms:arm', '@bazel_tools//platforms:android'],
+    constraint_values = ['@platforms//cpu:armv7', '@bazel_tools//platforms:android'],
     visibility = ['//visibility:public']
 )
 EOF

--- a/src/test/shell/testenv.sh.tmpl
+++ b/src/test/shell/testenv.sh.tmpl
@@ -395,7 +395,7 @@ platform(
     name = "simple",
     constraint_values = [
         "@bazel_tools//platforms:android",
-        "@bazel_tools//platforms:arm",
+        "@platforms//cpu:armv7",
     ],
 )
 EOF

--- a/tools/cpp/BUILD.static.bsd
+++ b/tools/cpp/BUILD.static.bsd
@@ -135,7 +135,7 @@ toolchain(
         "@platforms//cpu:arm",
     ],
     target_compatible_with = [
-        "@platforms//cpu:arm",
+        "@platforms//cpu:armv7",
         "@platforms//os:android",
     ],
     toolchain = ":cc-compiler-armeabi-v7a",

--- a/tools/cpp/BUILD.toolchains.tpl
+++ b/tools/cpp/BUILD.toolchains.tpl
@@ -12,7 +12,7 @@ toolchain(
     name = "cc-toolchain-armeabi-v7a",
     exec_compatible_with = HOST_CONSTRAINTS,
     target_compatible_with = [
-        "@platforms//cpu:arm",
+        "@platforms//cpu:armv7",
         "@platforms//os:android",
     ],
     toolchain = "@local_config_cc//:cc-compiler-armeabi-v7a",

--- a/tools/cpp/BUILD.windows.tpl
+++ b/tools/cpp/BUILD.windows.tpl
@@ -580,7 +580,7 @@ toolchain(
     exec_compatible_with = [
     ],
     target_compatible_with = [
-        "@platforms//cpu:arm",
+        "@platforms//cpu:armv7",
         "@platforms//os:android",
     ],
     toolchain = ":cc-compiler-armeabi-v7a",

--- a/tools/osx/crosstool/BUILD.toolchains
+++ b/tools/osx/crosstool/BUILD.toolchains
@@ -7,7 +7,10 @@ exports_files(["osx_archs.bzl"])
 # Target constraints for each arch.
 # TODO(apple-rules): Rename osx constraint to macOS.
 OSX_TOOLS_CONSTRAINTS = {
-    "armeabi-v7a": ["@platforms//cpu:arm"],
+    "armeabi-v7a": [
+        "@platforms//cpu:armv7",
+        "@platforms//os:android",
+    ],
     "darwin_arm64": [
         "@platforms//os:osx",
         "@platforms//cpu:arm64",


### PR DESCRIPTION
Previously this was arm instead of armv7. It seems that armv7 is the
correct constraint for this case.

Fixes https://github.com/bazelbuild/bazel/issues/14982

Closes #15248.

PiperOrigin-RevId: 444250195