### PR TITLE
Fix android emulator darwin_arm64 select

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/android/android_sdk_repository_template.txt
@@ -69,7 +69,8 @@ filegroup(
 filegroup(
     name = "qemu2_x86",
     srcs = ["emulator/emulator"] + select({
-        "@bazel_tools//src/conditions:darwin": ["emulator/qemu/darwin-x86_64/qemu-system-i386"],
+        "@bazel_tools//src/conditions:darwin_x86_64": ["emulator/qemu/darwin-x86_64/qemu-system-i386"],
+        "@bazel_tools//src/conditions:darwin_arm64": ["emulator/qemu/darwin-aarch64/qemu-system-aarch64"],
         "//conditions:default": ["emulator/qemu/linux-x86_64/qemu-system-i386"],
     }),
 )


### PR DESCRIPTION
This fixes this condition printing a strange error if you try to run
these on macOS. In general this still doesn't work because of
https://github.com/bazelbuild/bazel/issues/7069 but if we ever want to
support it this is a pre-requisite to supporting arm macs

Closes #15092.

PiperOrigin-RevId: 444912275