### PR TITLE
Fix --use_top_level_targets_for_symlinks with aliases

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/ExecutionTool.java
@@ -680,6 +680,7 @@ public class ExecutionTool {
     Set<BuildConfiguration> targetConfigurations =
         buildRequestOptions.useTopLevelTargetsForSymlinks()
             ? analysisResult.getTargetsToBuild().stream()
+                .map(ConfiguredTarget::getActual)
                 .map(ConfiguredTarget::getConfigurationKey)
                 .filter(Objects::nonNull)
                 .distinct()


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/14602

Closes #15316.

PiperOrigin-RevId: 444970714