### PR TITLE
Correctly format non-ASCII paths, arguments, and env vars in aquery o…

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/query2/BUILD
@@ -104,6 +104,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:command",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/build/lib/util:shell_escaper",
+        "//src/main/java/com/google/devtools/build/lib/util:string",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/build/skyframe",

--- a/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/aquery/ActionGraphTextOutputFormatterCallback.java
@@ -13,6 +13,8 @@
 // limitations under the License.
 package com.google.devtools.build.lib.query2.aquery;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.devtools.build.lib.util.StringUtil.decodeBytestringUtf8;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
@@ -196,7 +198,7 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
           .append("  Inputs: [")
           .append(
               action.getInputs().toList().stream()
-                  .map(input -> input.getExecPathString())
+                  .map(input -> escapeBytestringUtf8(input.getExecPathString()))
                   .sorted()
                   .collect(Collectors.joining(", ")))
           .append("]\n")
@@ -205,9 +207,10 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
               action.getOutputs().stream()
                   .map(
                       output ->
-                          output.isTreeArtifact()
-                              ? output.getExecPathString() + " (TreeArtifact)"
-                              : output.getExecPathString())
+                          escapeBytestringUtf8(
+                              output.isTreeArtifact()
+                                  ? output.getExecPathString() + " (TreeArtifact)"
+                                  : output.getExecPathString()))
                   .sorted()
                   .collect(Collectors.joining(", ")))
           .append("]\n");
@@ -226,7 +229,10 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
                 Streams.stream(fixedEnvironment)
                     .map(
                         environmentVariable ->
-                            environmentVariable.getKey() + "=" + environmentVariable.getValue())
+                            escapeBytestringUtf8(
+                                environmentVariable.getKey()
+                                    + "="
+                                    + environmentVariable.getValue()))
                     .sorted()
                     .collect(Collectors.joining(", ")))
             .append("]\n");
@@ -258,7 +264,10 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
               CommandFailureUtils.describeCommand(
                   CommandDescriptionForm.COMPLETE,
                   /* prettyPrintArgs= */ true,
-                  ((CommandAction) action).getArguments(),
+                  ((CommandAction) action)
+                      .getArguments().stream()
+                          .map(a -> escapeBytestringUtf8(a))
+                          .collect(toImmutableList()),
                   /* environment= */ null,
                   /* cwd= */ null,
                   action.getOwner().getConfigurationChecksum(),
@@ -309,5 +318,38 @@ class ActionGraphTextOutputFormatterCallback extends AqueryThreadsafeCallback {
       paramFileNameToContentMap = new HashMap<>();
     }
     return paramFileNameToContentMap;
+  }
+
+  /**
+   * Decode a bytestring that might contain UTF-8, and escape any characters outside the basic
+   * printable ASCII range.
+   *
+   * <p>This function is intended for human consumption in debug output that needs to be durable
+   * against unusual encoding settings, and does not guarantee that the escaping process is
+   * reverseable.
+   *
+   * <p>Characters other than printable ASCII but within the Basic Multilingual Plane are formatted
+   * with `\\uXXXX`. Characters outside the BMP are formatted as `\\UXXXXXXXX`.
+   */
+  public static String escapeBytestringUtf8(String maybeUtf8) {
+    if (maybeUtf8.chars().allMatch(c -> c >= 0x20 && c < 0x7F)) {
+      return maybeUtf8;
+    }
+
+    final String decoded = decodeBytestringUtf8(maybeUtf8);
+    final StringBuilder sb = new StringBuilder(decoded.length() * 8);
+    decoded
+        .codePoints()
+        .forEach(
+            c -> {
+              if (c >= 0x20 && c < 0x7F) {
+                sb.appendCodePoint(c);
+              } else if (c <= 0xFFFF) {
+                sb.append(String.format("\\u%04X", c));
+              } else {
+                sb.append(String.format("\\U%08X", c));
+              }
+            });
+    return sb.toString();
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/BUILD
@@ -91,6 +91,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",
         "//src/main/java/com/google/devtools/build/lib/util:exit_code",
+        "//src/main/java/com/google/devtools/build/lib/util:string",
         "//src/main/java/com/google/devtools/build/lib/util/io",
         "//src/main/java/com/google/devtools/build/lib/util/io:out-err",
         "//src/main/java/com/google/devtools/build/lib/vfs",

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteExecutionService.java
@@ -34,6 +34,9 @@ import static com.google.devtools.build.lib.remote.util.Utils.shouldDownloadAllS
 import static com.google.devtools.build.lib.remote.util.Utils.shouldUploadLocalResultsToCombinedDisk;
 import static com.google.devtools.build.lib.remote.util.Utils.shouldUploadLocalResultsToDiskCache;
 import static com.google.devtools.build.lib.remote.util.Utils.shouldUploadLocalResultsToRemoteCache;
+import static com.google.devtools.build.lib.remote.util.Utils.waitForBulkTransfer;
+import static com.google.devtools.build.lib.util.StringUtil.decodeBytestringUtf8;
+import static com.google.devtools.build.lib.util.StringUtil.encodeBytestringUtf8;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
@@ -225,7 +228,7 @@ public class RemoteExecutionService {
     ArrayList<String> outputFiles = new ArrayList<>();
     ArrayList<String> outputDirectories = new ArrayList<>();
     for (ActionInput output : outputs) {
-      String pathString = remotePathResolver.localPathToOutputPath(output);
+      String pathString = decodeBytestringUtf8(remotePathResolver.localPathToOutputPath(output));
       if (output instanceof Artifact && ((Artifact) output).isTreeArtifact()) {
         outputDirectories.add(pathString);
       } else {
@@ -240,16 +243,21 @@ public class RemoteExecutionService {
     if (platform != null) {
       command.setPlatform(platform);
     }
-    command.addAllArguments(arguments);
+    for (String arg : arguments) {
+      command.addArguments(decodeBytestringUtf8(arg));
+    }
     // Sorting the environment pairs by variable name.
     TreeSet<String> variables = new TreeSet<>(env.keySet());
     for (String var : variables) {
-      command.addEnvironmentVariablesBuilder().setName(var).setValue(env.get(var));
+      command
+          .addEnvironmentVariablesBuilder()
+          .setName(decodeBytestringUtf8(var))
+          .setValue(decodeBytestringUtf8(env.get(var)));
     }
 
     String workingDirectory = remotePathResolver.getWorkingDirectory();
     if (!Strings.isNullOrEmpty(workingDirectory)) {
-      command.setWorkingDirectory(workingDirectory);
+      command.setWorkingDirectory(decodeBytestringUtf8(workingDirectory));
     }
     return command.build();
   }
@@ -945,7 +953,7 @@ public class RemoteExecutionService {
         Maps.newHashMapWithExpectedSize(result.getOutputDirectoriesCount());
     for (OutputDirectory dir : result.getOutputDirectories()) {
       dirMetadataDownloads.put(
-          remotePathResolver.outputPathToLocalPath(dir.getPath()),
+          remotePathResolver.outputPathToLocalPath(encodeBytestringUtf8(dir.getPath())),
           Futures.transformAsync(
               remoteCache.downloadBlob(action.remoteActionExecutionContext, dir.getTreeDigest()),
               (treeBytes) ->
@@ -970,7 +978,8 @@ public class RemoteExecutionService {
 
     ImmutableMap.Builder<Path, FileMetadata> files = ImmutableMap.builder();
     for (OutputFile outputFile : result.getOutputFiles()) {
-      Path localPath = remotePathResolver.outputPathToLocalPath(outputFile.getPath());
+      Path localPath =
+          remotePathResolver.outputPathToLocalPath(encodeBytestringUtf8(outputFile.getPath()));
       files.put(
           localPath,
           new FileMetadata(localPath, outputFile.getDigest(), outputFile.getIsExecutable()));
@@ -980,7 +989,8 @@ public class RemoteExecutionService {
     Iterable<OutputSymlink> outputSymlinks =
         Iterables.concat(result.getOutputFileSymlinks(), result.getOutputDirectorySymlinks());
     for (OutputSymlink symlink : outputSymlinks) {
-      Path localPath = remotePathResolver.outputPathToLocalPath(symlink.getPath());
+      Path localPath =
+          remotePathResolver.outputPathToLocalPath(encodeBytestringUtf8(symlink.getPath()));
       symlinks.put(
           localPath, new SymlinkMetadata(localPath, PathFragment.create(symlink.getTarget())));
     }

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/BUILD
@@ -20,6 +20,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:file_metadata",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/remote/util",
+        "//src/main/java/com/google/devtools/build/lib/util:string",
         "//src/main/java/com/google/devtools/build/lib/vfs",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//third_party:guava",

--- a/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/merkletree/MerkleTree.java
@@ -13,6 +13,8 @@
 // limitations under the License.
 package com.google.devtools.build.lib.remote.merkletree;
 
+import static com.google.devtools.build.lib.util.StringUtil.decodeBytestringUtf8;
+
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.DirectoryNode;
@@ -333,14 +335,17 @@ public class MerkleTree {
 
   private static FileNode buildProto(DirectoryTree.FileNode file) {
     return FileNode.newBuilder()
-        .setName(file.getPathSegment())
+        .setName(decodeBytestringUtf8(file.getPathSegment()))
         .setDigest(file.getDigest())
         .setIsExecutable(file.isExecutable())
         .build();
   }
 
   private static DirectoryNode buildProto(String baseName, MerkleTree dir) {
-    return DirectoryNode.newBuilder().setName(baseName).setDigest(dir.getRootDigest()).build();
+    return DirectoryNode.newBuilder()
+        .setName(decodeBytestringUtf8(baseName))
+        .setDigest(dir.getRootDigest())
+        .build();
   }
 
   private static PathOrBytes toPathOrBytes(DirectoryTree.FileNode file) {

--- a/src/main/java/com/google/devtools/build/lib/util/StringUtil.java
+++ b/src/main/java/com/google/devtools/build/lib/util/StringUtil.java
@@ -13,6 +13,9 @@
 // limitations under the License.
 package com.google.devtools.build.lib.util;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
@@ -88,5 +91,67 @@ public class StringUtil {
       default:
         return number + "th";
     }
+  }
+
+  /**
+   * Decode a String that might actually be UTF-8, in which case each input character will be
+   * treated as a byte.
+   *
+   * <p>Several Bazel subsystems, including Starlark, store bytes in `String` values where each
+   * `char` stores one `byte` in its lower 8 bits. This function converts its input to a `[]byte`,
+   * then decodes that byte array as UTF-8.
+   *
+   * <p>Using U+2049 (EXCLAMATION QUESTION MARK) as an example:
+   *
+   * <p>"\u2049".getBytes(UTF_8) == [0xE2, 0x81, 0x89]
+   *
+   * <p>decodeBytestringUtf8("\u00E2\u0081\u0089") == "\u2049"
+   *
+   * <p>The return value is suitable for passing to Protobuf string fields or printing to the
+   * terminal.
+   */
+  public static String decodeBytestringUtf8(String maybeUtf8) {
+    if (maybeUtf8.chars().allMatch(c -> c < 128)) {
+      return maybeUtf8;
+    }
+
+    // Try our best to get a valid Unicode string, assuming that the input
+    // is either UTF-8 (from Starlark or a UNIX file path) or already valid
+    // Unicode (from a Windows file path).
+    if (maybeUtf8.chars().anyMatch(c -> c > 0xFF)) {
+      return maybeUtf8;
+    }
+
+    final byte[] utf8 = maybeUtf8.getBytes(ISO_8859_1);
+    final String decoded = new String(utf8, UTF_8);
+
+    // If the input was Unicode that happens to contain only codepoints in
+    // the ISO-8859-1 range, then it will probably have a partial decoding
+    // failure.
+    if (decoded.chars().anyMatch(c -> c == 0xFFFD)) {
+      return maybeUtf8;
+    }
+
+    return decoded;
+  }
+
+  /**
+   * Encodes a String to UTF-8, then converts those UTF-8 bytes to a String by zero-extending each
+   * `byte` into a `char`.
+   *
+   * <p>Using U+2049 (EXCLAMATION QUESTION MARK) as an example:
+   *
+   * <p>"\u2049".getBytes(UTF_8) == [0xE2, 0x81, 0x89]
+   *
+   * <p>encodeBytestringUtf8("\u2049") == "\u00E2\u0081\u0089"
+   *
+   * <p>See {@link #decodeBytestringUtf8} for motivation.
+   */
+  public static String encodeBytestringUtf8(String unicode) {
+    if (unicode.chars().allMatch(c -> c < 128)) {
+      return unicode;
+    }
+    final byte[] utf8 = unicode.getBytes(UTF_8);
+    return new String(utf8, ISO_8859_1);
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/util/StringUtilTest.java
+++ b/src/test/java/com/google/devtools/build/lib/util/StringUtilTest.java
@@ -14,6 +14,8 @@
 package com.google.devtools.build.lib.util;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.devtools.build.lib.util.StringUtil.decodeBytestringUtf8;
+import static com.google.devtools.build.lib.util.StringUtil.encodeBytestringUtf8;
 import static com.google.devtools.build.lib.util.StringUtil.joinEnglishList;
 
 import com.google.common.collect.ImmutableList;
@@ -56,5 +58,43 @@ public class StringUtilTest {
                 .append("/end")
                 .toString())
         .isEqualTo("begin/a, b, c ...(omitting 2 more item(s))/end");
+  }
+
+  @Test
+  @SuppressWarnings("UnicodeEscape")
+  public void testDecodeBytestringUtf8() throws Exception {
+    // Regular ASCII passes through OK.
+    assertThat(decodeBytestringUtf8("ascii")).isEqualTo("ascii");
+
+    // Valid UTF-8 is decoded.
+    assertThat(decodeBytestringUtf8("\u00E2\u0081\u0089"))
+        .isEqualTo("\u2049"); // U+2049 EXCLAMATION QUESTION MARK
+    assertThat(decodeBytestringUtf8("\u00f0\u009f\u008c\u00b1"))
+        .isEqualTo("\uD83C\uDF31"); // U+1F331 SEEDLING
+
+    // Strings that contain characters that can't be UTF-8 are returned as-is,
+    // to support Windows file paths.
+    assertThat(decodeBytestringUtf8("\u2049"))
+        .isEqualTo("\u2049"); // U+2049 EXCLAMATION QUESTION MARK
+    assertThat(decodeBytestringUtf8("\uD83C\uDF31")).isEqualTo("\uD83C\uDF31"); // U+1F331 SEEDLING
+
+    // Strings that might be either UTF-8 or Unicode are optimistically decoded,
+    // and returned as-is if decoding succeeded with no replacement characters.
+    assertThat(decodeBytestringUtf8("\u00FC\u006E\u00EF\u0063\u00F6\u0064\u00EB"))
+        .isEqualTo("\u00FC\u006E\u00EF\u0063\u00F6\u0064\u00EB"); // "ünïcödë"
+
+    // A string that is both valid ISO-8859-1 and valid UTF-8 will be decoded
+    // as UTF-8.
+    assertThat(decodeBytestringUtf8("\u00C2\u00A3")) // "Â£"
+        .isEqualTo("\u00A3"); // U+00A3 POUND SIGN
+  }
+
+  @Test
+  public void testEncodeBytestringUtf8() throws Exception {
+    assertThat(encodeBytestringUtf8("ascii")).isEqualTo("ascii");
+    assertThat(encodeBytestringUtf8("\u2049")) // U+2049 EXCLAMATION QUESTION MARK
+        .isEqualTo("\u00E2\u0081\u0089");
+    assertThat(encodeBytestringUtf8("\uD83C\uDF31")) // U+1F331 SEEDLING
+        .isEqualTo("\u00f0\u009f\u008c\u00b1");
   }
 }

--- a/src/test/shell/bazel/remote/remote_execution_test.sh
+++ b/src/test/shell/bazel/remote/remote_execution_test.sh
@@ -71,6 +71,11 @@ else
   declare -r EXE_EXT=""
 fi
 
+function has_utf8_locale() {
+  charmap="$(LC_ALL=en_US.UTF-8 locale charmap 2>/dev/null)"
+  [[ "${charmap}" == "UTF-8" ]]
+}
+
 function test_remote_grpc_cache_with_protocol() {
   # Test that if 'grpc' is provided as a scheme for --remote_cache flag, remote cache works.
   mkdir -p a
@@ -3661,6 +3666,144 @@ EOF
     //a:test >& $TEST_log || "Failed to build //a:test"
 
   expect_log "5 processes: 2 disk cache hit, 3 internal"
+}
+
+# Bazel assumes that non-ASCII characters in file contents (and, in
+# non-Windows systems, file paths) are UTF-8, but stores them internally by
+# parsing the raw UTF-8 bytes as if they were ISO-8859-1 characters.
+#
+# This test verifies that the inverse transformation is applied when sending
+# these inputs through the remote execution protocol. The Protobuf libraries
+# for Java assume that `String` values are encoded in UTF-16, and passing
+# raw bytes will cause double-encoding.
+function test_unicode() {
+  # The in-tree remote execution worker only supports non-ASCII paths when
+  # running in a UTF-8 locale.
+  if ! "$is_windows"; then
+    if ! has_utf8_locale; then
+      echo "Skipping test due to lack of UTF-8 locale."
+      echo "Available locales:"
+      locale -a
+      return
+    fi
+  fi
+
+  # Restart the remote execution worker with LC_ALL set.
+  tear_down
+  LC_ALL=en_US.UTF-8 set_up
+
+  # The test inputs contain both globbed and unglobbed input paths, to verify
+  # consistent behavior on Windows where file paths are Unicode but Starlark
+  # strings are UTF-8.
+  cat > BUILD <<EOF
+load("//:rules.bzl", "test_unicode")
+test_unicode(
+  name = "test_unicode",
+  inputs = glob(["inputs/**/A_*"]) + [
+    "inputs/入力/B_🌱.txt",
+  ],
+)
+EOF
+
+  cat > rules.bzl <<'EOF'
+def _test_unicode(ctx):
+  out_dir = ctx.actions.declare_directory(ctx.attr.name + "_outs/出力/🌱.d")
+  out_file = ctx.actions.declare_file(ctx.attr.name + "_outs/出力/🌱.txt")
+  out_report = ctx.actions.declare_file(ctx.attr.name + "_report.txt")
+  ctx.actions.run_shell(
+    inputs = ctx.files.inputs,
+    outputs = [out_dir, out_file, out_report],
+    command = """
+set -eu
+
+report="$3"
+touch "${report}"
+
+echo '[input tree]' >> "${report}"
+find inputs | sort >> "${report}"
+echo '' >> "${report}"
+
+echo '[input file A]' >> "${report}"
+cat $'inputs/\\xe5\\x85\\xa5\\xe5\\x8a\\x9b/A_\\xf0\\x9f\\x8c\\xb1.txt' >> "${report}"
+echo '' >> "${report}"
+
+echo '[input file B]' >> "${report}"
+cat $'inputs/\\xe5\\x85\\xa5\\xe5\\x8a\\x9b/B_\\xf0\\x9f\\x8c\\xb1.txt' >> "${report}"
+echo '' >> "${report}"
+
+echo '[environment]' >> "${report}"
+env | grep -v BASH_EXECUTION_STRING | grep TEST_UNICODE_ >> "${report}"
+echo '' >> "${report}"
+
+mkdir -p "$1"
+echo 'output dir content' > "$1"/dir_content.txt
+echo 'output file content' > "$2"
+""",
+    arguments = [out_dir.path, out_file.path, out_report.path],
+    env = {"TEST_UNICODE_🌱": "🌱"},
+  )
+  return DefaultInfo(files=depset([out_dir, out_file, out_report]))
+
+test_unicode = rule(
+  implementation = _test_unicode,
+  attrs = {
+    "inputs": attr.label_list(allow_files = True),
+  },
+)
+EOF
+
+  # inputs/入力/A_🌱.txt and inputs/入力/B_🌱.txt
+  mkdir -p $'inputs/\xe5\x85\xa5\xe5\x8a\x9b'
+  echo 'input content A' > $'inputs/\xe5\x85\xa5\xe5\x8a\x9b/A_\xf0\x9f\x8c\xb1.txt'
+  echo 'input content B' > $'inputs/\xe5\x85\xa5\xe5\x8a\x9b/B_\xf0\x9f\x8c\xb1.txt'
+
+  # On UNIX platforms, Bazel assumes that file paths are encoded in UTF-8. The
+  # system must have either an ISO-8859-1 or UTF-8 locale available so that
+  # Bazel can read the original bytes of the file path.
+  #
+  # If no ISO-8859-1 locale is available, the JVM might fall back to US-ASCII
+  # rather than trying UTF-8. Setting `LC_ALL=en_US.UTF-8` prevents this.
+  bazel shutdown
+  LC_ALL=en_US.UTF-8 bazel build \
+      --remote_executor=grpc://localhost:${worker_port} \
+      //:test_unicode >& $TEST_log \
+      || fail "Failed to build //:test_unicode with remote execution"
+  expect_log "2 processes: 1 internal, 1 remote."
+
+  # Don't leak LC_ALL into other tests.
+  bazel shutdown
+
+  # Expect action outputs with correct structure and content.
+  mkdir -p ${TEST_TMPDIR}/$'test_unicode_outs/\xe5\x87\xba\xe5\x8a\x9b/\xf0\x9f\x8c\xb1.d'
+  cat > ${TEST_TMPDIR}/$'test_unicode_outs/\xe5\x87\xba\xe5\x8a\x9b/\xf0\x9f\x8c\xb1.d/dir_content.txt' <<EOF
+output dir content
+EOF
+  cat > ${TEST_TMPDIR}/$'test_unicode_outs/\xe5\x87\xba\xe5\x8a\x9b/\xf0\x9f\x8c\xb1.txt' <<EOF
+output file content
+EOF
+
+  diff -r bazel-bin/test_unicode_outs ${TEST_TMPDIR}/test_unicode_outs \
+      || fail "Remote execution generated different result"
+
+  cat > ${TEST_TMPDIR}/test_report_expected <<EOF
+[input tree]
+inputs
+inputs/入力
+inputs/入力/A_🌱.txt
+inputs/入力/B_🌱.txt
+
+[input file A]
+input content A
+
+[input file B]
+input content B
+
+[environment]
+TEST_UNICODE_🌱=🌱
+
+EOF
+  diff bazel-bin/test_unicode_report.txt ${TEST_TMPDIR}/test_report_expected \
+      || fail "Remote execution generated different result"
 }
 
 run_suite "Remote execution and remote cache tests"

--- a/src/test/shell/integration/aquery_test.sh
+++ b/src/test/shell/integration/aquery_test.sh
@@ -44,6 +44,16 @@ fi
 
 add_to_bazelrc "build --package_path=%workspace%"
 
+function has_iso_8859_1_locale() {
+  charmap="$(LC_ALL=en_US.ISO-8859-1 locale charmap 2>/dev/null)"
+  [[ "${charmap}" == "ISO-8859-1" ]]
+}
+
+function has_utf8_locale() {
+  charmap="$(LC_ALL=en_US.UTF-8 locale charmap 2>/dev/null)"
+  [[ "${charmap}" == "UTF-8" ]]
+}
+
 function assert_only_action_foo() {
   expect_log_n "^action '" 1 "Expected exactly one action."
   assert_contains "action.*foo" $1
@@ -1404,6 +1414,226 @@ EOF
   expect_log "Genrule: 1"
   # Not matching the full string here since it's OS dependent.
   expect_log "-fastbuild: 1"
+}
+
+function test_aquery_include_template_substitution_for_template_expand_of_py_binary() {
+  local pkg="${FUNCNAME[0]}"
+  mkdir -p "$pkg" || fail "mkdir -p $pkg"
+  cat > "$pkg/BUILD" <<'EOF'
+py_binary(
+    name='foo',
+    srcs=['foo.py']
+)
+EOF
+
+  # aquery returns template content and substitutions in TemplateExpand actions
+  # of py_binary targets.
+  QUERY="//$pkg:foo"
+
+  bazel aquery --output=text ${QUERY} > output 2> "$TEST_log" \
+    || fail "Expected success"
+  cat output >> "$TEST_log"
+
+  assert_contains "PYTHON_BINARY = '%python_binary%'" output
+  assert_contains "{%python_binary%:" output
+
+  bazel aquery --output=jsonproto ${QUERY} > output 2> "$TEST_log" \
+    || fail "Expected success"
+
+  assert_contains "\"templateContent\":" output
+  assert_contains "\"key\": \"%python_binary%\"" output
+}
+
+function test_aquery_include_template_substitution_for_template_expand_action() {
+  local pkg="${FUNCNAME[0]}"
+  mkdir -p "$pkg" || fail "mkdir -p $pkg"
+
+  cat > "$pkg/template.txt" <<'EOF'
+The token should be substituted: {TOKEN1}
+EOF
+
+  cat > "$pkg/test.bzl" <<'EOF'
+def test_template(**kwargs):
+    _test_template(
+        **kwargs
+    )
+def _test_template_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file.template,
+        output = ctx.outputs.output,
+        substitutions = {
+            "{TOKEN1}": "123456",
+        },
+    )
+_test_template = rule(
+    implementation = _test_template_impl,
+    attrs = {
+        "template": attr.label(
+            allow_single_file = True,
+        ),
+        "output": attr.output(mandatory = True),
+    },
+)
+EOF
+
+  cat > "$pkg/BUILD" <<'EOF'
+load('test.bzl', 'test_template')
+test_template(name='foo', template='template.txt', output='output.txt')
+EOF
+
+  # aquery returns template content and substitutions of TemplateExpand actions.
+  QUERY="//$pkg:foo"
+
+  bazel aquery --output=text ${QUERY} > output 2> "$TEST_log" \
+    || fail "Expected success"
+  cat output >> "$TEST_log"
+
+  assert_contains "Template: ARTIFACT: $pkg/template.txt" output
+  assert_contains "{{TOKEN1}: 123456}" output
+
+  bazel aquery --output=jsonproto ${QUERY} > output 2> "$TEST_log" \
+    || fail "Expected success"
+
+  assert_contains "\"templateContent\": \"ARTIFACT: $pkg/template.txt\"" output
+  assert_contains "\"key\": \"{TOKEN1}\"" output
+  assert_contains "\"value\": \"123456\"" output
+}
+
+# Regression test for b/205753626.
+# This test case isn't testing aquery for correctness, just using aquery as a
+# vehicle for testing lower-level logic.
+# TODO(b/205978333): Find a better home for this test case.
+function test_starlark_action_with_reqs_has_deterministic_action_key() {
+  local -r pkg="${FUNCNAME[0]}"
+  mkdir -p "$pkg" || fail "mkdir -p $pkg"
+
+  cat >$pkg/BUILD <<'EOF'
+load(":defs.bzl", "lots_of_reqs")
+lots_of_reqs(name = "reqs")
+EOF
+  cat >$pkg/defs.bzl <<'EOF'
+def _lots_of_reqs_impl(ctx):
+    f = ctx.actions.declare_file(ctx.attr.name + ".txt")
+    ctx.actions.run_shell(
+      outputs = [f],
+      command = "touch " + f.path,
+      execution_requirements = {"requires-" + str(i): "1" for i in range(100)},
+    )
+    return DefaultInfo(files = depset([f]))
+
+lots_of_reqs = rule(implementation = _lots_of_reqs_impl)
+EOF
+
+  bazel aquery $pkg:reqs > output1 2> "$TEST_log" || fail "Expected success"
+  bazel shutdown || fail "Couldn't shutdown"
+  bazel aquery $pkg:reqs > output2 2> "$TEST_log" || fail "Expected success"
+
+  diff <(grep ActionKey output1) <(grep ActionKey output2) \
+    || fail "Nondeterministic action key"
+}
+
+function test_execution_info() {
+  local pkg="${FUNCNAME[0]}"
+  mkdir -p "$pkg" || fail "mkdir -p $pkg"
+  cat > "$pkg/BUILD" <<'EOF'
+platform(
+    name = "exec",
+    exec_properties = {
+        "prop1": "foo",
+        "prop2": "bar",
+    },
+)
+
+genrule(
+    name = "bar",
+    srcs = ["dummy.txt"],
+    outs = ["bar_out.txt"],
+    cmd = "echo unused > $(OUTS)",
+)
+EOF
+  echo "hello aquery" > "$pkg/dummy.txt"
+
+  bazel aquery \
+    --extra_execution_platforms="//${pkg}:exec" \
+    --output=text \
+    "//$pkg:bar" > output 2> "$TEST_log" \
+    || fail "Expected success"
+  cat output >> "$TEST_log"
+  assert_contains "Execution platform: //${pkg}:exec" output
+
+  # Verify the execution platform's exec_properties end up as execution requirements.
+  assert_contains "ExecutionInfo: {prop1: foo, prop2: bar}" output
+}
+
+function test_unicode_text() {
+  # Bazel relies on the JVM for filename encoding, and can only support
+  # UTF-8 if either a UTF-8 or ISO-8859-1 locale is available.
+  if ! "$is_windows"; then
+    if ! has_iso_8859_1_locale && ! has_utf8_locale; then
+      echo "Skipping test (no ISO-8859-1 or UTF-8 locale)."
+      echo "Available locales (need ISO-8859-1 or UTF-8):"
+      locale -a
+      return
+    fi
+  fi
+
+  local pkg="${FUNCNAME[0]}"
+  mkdir -p "${pkg}" || fail "mkdir -p ${pkg}"
+  cat > "${pkg}/BUILD" <<'EOF'
+genrule(
+    name = "bar",
+    srcs = glob(["input-*.txt"]),
+    outs = ["output-ünïcödë.txt"],
+    cmd = "echo unused > $(OUTS)",
+)
+EOF
+
+  # ${pkg}/input-ünïcödë.txt
+  touch "${pkg}/"$'input-\xc3\xbcn\xc3\xafc\xc3\xb6d\xc3\xab.txt'
+
+  bazel aquery --output=text "//$pkg:bar" > output 2> "$TEST_log" \
+    || fail "Expected success"
+  cat output >> "$TEST_log"
+
+  assert_contains 'Inputs: \[.*/input-\\u00FCn\\u00EFc\\u00F6d\\u00EB.txt' output
+  assert_contains 'Outputs: \[.*/output-\\u00FCn\\u00EFc\\u00F6d\\u00EB.txt' output
+}
+
+# TODO(bazel-team): The non-text aquery output formats don't correctly handle
+# non-ASCII fields (input/output paths, environment variables, etc).
+function DISABLED_test_unicode_textproto() {
+  # Bazel relies on the JVM for filename encoding, and can only support
+  # UTF-8 if either a UTF-8 or ISO-8859-1 locale is available.
+  if ! "$is_windows"; then
+    if ! has_iso_8859_1_locale && ! has_utf8_locale; then
+      echo "Skipping test (no ISO-8859-1 or UTF-8 locale)."
+      echo "Available locales (need ISO-8859-1 or UTF-8):"
+      locale -a
+      return
+    fi
+  fi
+
+  local pkg="${FUNCNAME[0]}"
+  mkdir -p "${pkg}" || fail "mkdir -p ${pkg}"
+  cat > "${pkg}/BUILD" <<'EOF'
+genrule(
+    name = "bar",
+    srcs = glob(["input-*.txt"]),
+    outs = ["output-ünïcödë.txt"],
+    cmd = "echo unused > $(OUTS)",
+)
+EOF
+
+  # ${pkg}/input-ünïcödë.txt
+  unicode=$'\xc3\xbcn\xc3\xafc\xc3\xb6d\xc3\xab'
+  touch "${pkg}/input-${unicode}.txt"
+
+  bazel aquery --output=textproto "//$pkg:bar" > output 2> "$TEST_log" \
+    || fail "Expected success"
+  cat output >> "$TEST_log"
+
+  assert_contains 'label: "input-\\303\\274n\\303\\257c\\303\\266d\\303\\253.txt"' output
+  assert_contains 'label: "output-\\303\\274n\\303\\257c\\303\\266d\\303\\253.txt"' output
 }
 
 # Usage: assert_matches expected_pattern actual


### PR DESCRIPTION
…utput and remote execution protocol.

For historical reasons, Bazel internally encodes non-ASCII in BUILD/bzl files by taking individual input bytes (assumed to be UTF-8) and storing them in a String as the corresponding Latin1 characters. This encoding must be undone whenever these strings escape to the outside world.

Fixes #14381.

Closes #15333.

PiperOrigin-RevId: 445941013