### PR TITLE
Revert "Fixes incorrect install names on darwin platforms"

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java
@@ -820,7 +820,10 @@ public class CppLinkActionBuilder {
               getLinkType().linkerOrArchiver().equals(LinkerOrArchiver.LINKER),
               configuration.getBinDirectory(repositoryName).getExecPath(),
               output.getExecPathString(),
-              output.getRootRelativePath().getBaseName(),
+              SolibSymlinkAction.getDynamicLibrarySoname(
+                  output.getRootRelativePath(),
+                  /* preserveName= */ false,
+                  actionConstructionContext.getConfiguration().getMnemonic()),
               linkType.equals(LinkTargetType.DYNAMIC_LIBRARY),
               paramFile != null ? paramFile.getExecPathString() : null,
               thinltoParamFile != null ? thinltoParamFile.getExecPathString() : null,


### PR DESCRIPTION
This reverts commit b06f49507e02384cb4ff1ff862da2a673e9a081f.

Also had to add a missing mnemonic function call parameter to `getDynamicLibrarySoname`. Copy-pasted the parameter from the other use of that function in the codebase.

Tested manually with a custom toolchain and there is also a test from the reverted code.

Fixes #15214

Closes #15261.

PiperOrigin-RevId: 446662219