### PR TITLE
Remove java tools dependencies from additional_distfiles

### DIFF
--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -280,7 +280,6 @@ DIST_DEPS = {
             "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.6.zip",
         ],
         "used_in": [
-            "additional_distfiles",
             "test_WORKSPACE_files",
         ],
     },
@@ -296,7 +295,6 @@ DIST_DEPS = {
             "https://github.com/bazelbuild/java_tools/releases/download/java_v11.7.1/java_tools-v11.7.1.zip",
         ],
         "used_in": [
-            "additional_distfiles",
             "test_WORKSPACE_files",
         ],
     },
@@ -312,7 +310,6 @@ DIST_DEPS = {
             "https://github.com/bazelbuild/java_tools/releases/download/java_v11.7.1/java_tools_linux-v11.7.1.zip",
         ],
         "used_in": [
-            "additional_distfiles",
             "test_WORKSPACE_files",
         ],
     },
@@ -328,7 +325,6 @@ DIST_DEPS = {
             "https://github.com/bazelbuild/java_tools/releases/download/java_v11.7.1/java_tools_windows-v11.7.1.zip",
         ],
         "used_in": [
-            "additional_distfiles",
             "test_WORKSPACE_files",
         ],
     },
@@ -344,7 +340,6 @@ DIST_DEPS = {
             "https://github.com/bazelbuild/java_tools/releases/download/java_v11.7.1/java_tools_darwin-v11.7.1.zip",
         ],
         "used_in": [
-            "additional_distfiles",
             "test_WORKSPACE_files",
         ],
     },

--- a/scripts/bootstrap/BUILD.bootstrap
+++ b/scripts/bootstrap/BUILD.bootstrap
@@ -5,7 +5,10 @@ default_java_toolchain(
     name = "bootstrap_toolchain",
     bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath.jar"],
     genclass = ["//src/java_tools/buildjar:bootstrap_genclass_deploy.jar"],
+    header_compiler = None,  # avoid remote_java_tools dependency
+    header_compiler_direct = None,  # ditto
     ijar = ["//third_party/ijar"],
+    jacocorunner = None,  # avoid remote_java_tools dependency
     java_runtime = "@local_jdk//:jdk",
     javabuilder = ["//src/java_tools/buildjar:bootstrap_VanillaJavaBuilder_deploy.jar"],
     jvm_opts = [


### PR DESCRIPTION
Those dependencies shouldn't be needed for bootstrapping Bazel.

(I just slapped a quick fixup atop @meteorcloudy's earlier PR #15415.)