### PR TITLE
Allow any CcInfo providing rule in objc_library deps

### DIFF
--- a/src/main/starlark/builtins_bzl/common/objc/attrs.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/attrs.bzl
@@ -16,6 +16,7 @@
 
 load("@_builtins//:common/objc/semantics.bzl", "semantics")
 
+CcInfo = _builtins.toplevel.CcInfo
 ObjcInfo = _builtins.toplevel.apple_common.Objc
 AppleDynamicFrameworkInfo = _builtins.toplevel.apple_common.AppleDynamicFramework
 TemplateVariableInfo = _builtins.toplevel.platform_common.TemplateVariableInfo
@@ -80,11 +81,7 @@ _COMPILE_DEPENDENCY_RULE = {
     "includes": attr.string_list(),
     "sdk_includes": attr.string_list(),
     "deps": attr.label_list(
-        providers = [ObjcInfo],
-        allow_rules = [
-            "cc_library",
-            "cc_inc_library",
-        ],
+        providers = [[ObjcInfo], [CcInfo]],
         flags = ["DIRECT_COMPILE_TIME_INPUT"],
     ),
 }

--- a/src/main/starlark/builtins_bzl/common/objc/objc_library.bzl
+++ b/src/main/starlark/builtins_bzl/common/objc/objc_library.bzl
@@ -67,12 +67,12 @@ def _build_linking_context(
     for library in objc_provider.library.to_list():
         archives_from_objc_library[library.path] = library
 
-    objc_libraries_cc_infos = []
+    cc_infos = []
     for dep in deps:
-        if apple_common.Objc in dep and CcInfo in dep:
-            objc_libraries_cc_infos.append(dep[CcInfo])
+        if CcInfo in dep:
+            cc_infos.append(dep[CcInfo])
 
-    merged_objc_library_cc_infos = cc_common.merge_cc_infos(cc_infos = objc_libraries_cc_infos)
+    merged_objc_library_cc_infos = cc_common.merge_cc_infos(cc_infos = cc_infos)
 
     for linker_input in merged_objc_library_cc_infos.linking_context.linker_inputs.to_list():
         for lib in linker_input.libraries:


### PR DESCRIPTION
Previously it was invalid to have any custom rules in the deps of
objc_library unless they provided `apple_common.Objc` which very few
rules do, but they do provide `CcInfo` for this type of integration. I
hit this issue with a `rust_library` being depended on by an
`objc_library`.