### PR TITLE
Make `coverage --combined_report=lcov` skip incompatible tests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/BUILD
@@ -24,6 +24,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
         "//src/main/java/com/google/devtools/build/lib/analysis:blaze_directories",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
+        "//src/main/java/com/google/devtools/build/lib/analysis:incompatible_platform_provider",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/coverage_report_action_factory",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/concurrent",

--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
@@ -41,6 +41,7 @@ import com.google.devtools.build.lib.actions.SpawnResult;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
 import com.google.devtools.build.lib.analysis.FilesToRunProvider;
+import com.google.devtools.build.lib.analysis.IncompatiblePlatformProvider;
 import com.google.devtools.build.lib.analysis.RunfilesSupport;
 import com.google.devtools.build.lib.analysis.actions.Compression;
 import com.google.devtools.build.lib.analysis.actions.FileWriteAction;
@@ -200,6 +201,10 @@ public final class CoverageReportActionBuilder {
     ImmutableList.Builder<Artifact> builder = ImmutableList.<Artifact>builder();
     FilesToRunProvider reportGenerator = null;
     for (ConfiguredTarget target : targetsToTest) {
+      // Skip incompatible tests.
+      if (target.get(IncompatiblePlatformProvider.PROVIDER) != null) {
+        continue;
+      }
       TestParams testParams = target.getProvider(TestProvider.class).getTestParams();
       builder.addAll(testParams.getCoverageArtifacts());
       if (reportGenerator == null) {

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -583,6 +583,15 @@ sh_test(
 )
 
 sh_test(
+    name = "bazel_coverage_compatibility_test",
+    srcs = ["bazel_coverage_compatibility_test.sh"],
+    data = [":test-deps"],
+    tags = [
+        "no_windows",
+    ],
+)
+
+sh_test(
     name = "bazel_cc_code_coverage_test",
     srcs = ["bazel_cc_code_coverage_test.sh"],
     data = [":test-deps"],

--- a/src/test/shell/bazel/bazel_coverage_compatibility_test.sh
+++ b/src/test/shell/bazel/bazel_coverage_compatibility_test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Load the test setup defined in the parent directory
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${CURRENT_DIR}/../integration_test_setup.sh" \
+  || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
+
+function set_up_sh_test_coverage() {
+  cat <<EOF > BUILD
+constraint_setting(name = "incompatible_setting")
+
+constraint_value(
+    name = "incompatible",
+    constraint_setting = ":incompatible_setting",
+)
+
+sh_test(
+    name = "compatible_test",
+    srcs = ["compatible_test.sh"],
+)
+
+sh_test(
+    name = "incompatible_test",
+    srcs = ["incompatible_test.sh"],
+    target_compatible_with = [":incompatible"],
+)
+EOF
+  cat <<EOF > compatible_test.sh
+#!/bin/bash
+exit 0
+EOF
+  cat <<EOF > incompatible_test.sh
+#!/bin/bash
+exit 1
+EOF
+  chmod +x compatible_test.sh
+  chmod +x incompatible_test.sh
+}
+
+# Validates that coverage skips incompatible tests.  This is a regression test for
+# https://github.com/bazelbuild/bazel/issues/15385.
+function test_sh_test_coverage() {
+  set_up_sh_test_coverage
+  bazel coverage --test_output=all --combined_report=lcov //:all &>$TEST_log \
+    || fail "Coverage for //:all failed"
+  expect_log "INFO: Build completed successfully"
+  expect_log "//:compatible_test .* PASSED"
+  expect_log "//:incompatible_test .* SKIPPED"
+}
+
+run_suite "test tests"


### PR DESCRIPTION
Before this patch we see coverage trying to execute incompatible
tests. This results in `Can't build this. This target is incompatible`
messages. Instead, those tests should just be skipped.

This patch makes it so the coverage code only tries to collect
coverage artifacts for compatible tests. Artifacts for incompatible
tests are ignored.

(cherry picked from commit 2f1ff6fa17c3c30b2533bffe81f40eab06b453b9)

Fixes #15385