### PR TITLE
Cquery can report transitions

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ConfiguredTargetQueryEnvironment.java
@@ -243,7 +243,8 @@ public class ConfiguredTargetQueryEnvironment
             skyframeExecutor,
             accessor,
             aspectResolver,
-            OutputType.BINARY),
+            OutputType.BINARY,
+            trimmingTransitionFactory),
         new ProtoOutputFormatterCallback(
             eventHandler,
             cqueryOptions,
@@ -251,7 +252,8 @@ public class ConfiguredTargetQueryEnvironment
             skyframeExecutor,
             accessor,
             aspectResolver,
-            OutputType.TEXT),
+            OutputType.TEXT,
+            trimmingTransitionFactory),
         new ProtoOutputFormatterCallback(
             eventHandler,
             cqueryOptions,
@@ -259,7 +261,8 @@ public class ConfiguredTargetQueryEnvironment
             skyframeExecutor,
             accessor,
             aspectResolver,
-            OutputType.JSON),
+            OutputType.JSON,
+            trimmingTransitionFactory),
         new BuildOutputFormatterCallback(
             eventHandler, cqueryOptions, out, skyframeExecutor, accessor),
         new GraphOutputFormatterCallback(

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryTransitionResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/CqueryTransitionResolver.java
@@ -1,0 +1,186 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.query2.cquery;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.devtools.build.lib.analysis.DependencyKey;
+import com.google.devtools.build.lib.analysis.DependencyKind;
+import com.google.devtools.build.lib.analysis.DependencyKind.ToolchainDependencyKind;
+import com.google.devtools.build.lib.analysis.DependencyResolver;
+import com.google.devtools.build.lib.analysis.InconsistentAspectOrderException;
+import com.google.devtools.build.lib.analysis.TargetAndConfiguration;
+import com.google.devtools.build.lib.analysis.ToolchainCollection;
+import com.google.devtools.build.lib.analysis.ToolchainContext;
+import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
+import com.google.devtools.build.lib.analysis.config.BuildOptions;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
+import com.google.devtools.build.lib.analysis.config.transitions.NoTransition;
+import com.google.devtools.build.lib.analysis.config.transitions.NullTransition;
+import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
+import com.google.devtools.build.lib.analysis.config.transitions.TransitionUtil;
+import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
+import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.packages.RuleTransitionData;
+import com.google.devtools.build.lib.packages.Target;
+import com.google.devtools.build.lib.util.OrderedSetMultimap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * TransitionResolver resolves the dependencies of a ConfiguredTarget, reporting which
+ * configurations its dependencies are actually needed in according to the transitions applied to
+ * them. This class has been extracted from TransitionsOutputFormatterCallback.java so that it can
+ * be used in both ProtoOutputFormatterCallback and TransitionsOutputFormatterCallback
+ */
+public class CqueryTransitionResolver {
+
+  /**
+   * ResolvedTransition represents a single edge in the dependency graph, between some target and a
+   * target it depends on, reachable via a single attribute.
+   */
+  @AutoValue
+  @Immutable
+  public abstract static class ResolvedTransition {
+
+    static ResolvedTransition create(
+        Label label,
+        ImmutableCollection<BuildOptions> buildOptions,
+        String attributeName,
+        String transitionName) {
+      return new AutoValue_CqueryTransitionResolver_ResolvedTransition(
+          label, buildOptions, attributeName, transitionName);
+    }
+
+    /** The label of the target being depended on. */
+    abstract Label label();
+
+    /**
+     * The configuration(s) this edge results in. This is a collection because a split transition
+     * may lead to a single attribute requesting a dependency in multiple configurations.
+     *
+     * <p>If a target is depended on via two attributes, separate ResolvedTransitions should be
+     * used, rather than combining the two into a single ResolvedTransition with multiple options.
+     *
+     * <p>If no transition was applied to an attribute, this collection will be empty.
+     */
+    abstract ImmutableCollection<BuildOptions> options();
+
+    /** The name of the attribute via which the dependency was requested. */
+    abstract String attributeName();
+
+    /** The name of the transition applied to the attribute. */
+    abstract String transitionName();
+  }
+
+  private final ExtendedEventHandler eventHandler;
+  private final DependencyResolver dependencyResolver;
+  private final ConfiguredTargetAccessor accessor;
+  private final CqueryThreadsafeCallback cqueryThreadsafeCallback;
+  @Nullable private final TransitionFactory<RuleTransitionData> trimmingTransitionFactory;
+
+  public CqueryTransitionResolver(
+      ExtendedEventHandler eventHandler,
+      DependencyResolver dependencyResolver,
+      ConfiguredTargetAccessor accessor,
+      CqueryThreadsafeCallback cqueryThreadsafeCallback,
+      @Nullable TransitionFactory<RuleTransitionData> trimmingTransitionFactory) {
+    this.eventHandler = eventHandler;
+    this.dependencyResolver = dependencyResolver;
+    this.accessor = accessor;
+    this.cqueryThreadsafeCallback = cqueryThreadsafeCallback;
+    this.trimmingTransitionFactory = trimmingTransitionFactory;
+  }
+
+  /**
+   * Return the set of dependencies of a KeyedConfiguredTarget, including information about the
+   * configuration transitions applied to the dependencies.
+   *
+   * @see ResolvedTransition for more details.
+   * @param keyedConfiguredTarget the configured target whose dependencies are being looked up.
+   */
+  public ImmutableSet<ResolvedTransition> dependencies(KeyedConfiguredTarget keyedConfiguredTarget)
+      throws DependencyResolver.Failure, InconsistentAspectOrderException, InterruptedException {
+    ImmutableSet.Builder<ResolvedTransition> resolved = new ImmutableSet.Builder<>();
+
+    if (!(keyedConfiguredTarget.getConfiguredTarget() instanceof RuleConfiguredTarget)) {
+      return resolved.build();
+    }
+
+    Target target = accessor.getTarget(keyedConfiguredTarget);
+    BuildConfigurationValue config =
+        cqueryThreadsafeCallback.getConfiguration(keyedConfiguredTarget.getConfigurationKey());
+
+    ImmutableMap<Label, ConfigMatchingProvider> configConditions =
+        keyedConfiguredTarget.getConfigConditions();
+
+    // Get a ToolchainContext to use for dependency resolution.
+    ToolchainCollection<ToolchainContext> toolchainContexts =
+        accessor.getToolchainContexts(target, config);
+    // We don't actually use fromOptions in our implementation of
+    // DependencyResolver but passing to avoid passing a null and since we have the information
+    // anyway.
+    OrderedSetMultimap<DependencyKind, DependencyKey> deps =
+        dependencyResolver.dependentNodeMap(
+            new TargetAndConfiguration(target, config),
+            /*aspect=*/ null,
+            configConditions,
+            toolchainContexts,
+            trimmingTransitionFactory);
+    for (Map.Entry<DependencyKind, DependencyKey> attributeAndDep : deps.entries()) {
+      DependencyKey dep = attributeAndDep.getValue();
+
+      String dependencyName;
+      if (DependencyKind.isToolchain(attributeAndDep.getKey())) {
+        ToolchainDependencyKind tdk = (ToolchainDependencyKind) attributeAndDep.getKey();
+        if (tdk.isDefaultExecGroup()) {
+          dependencyName = "[toolchain dependency]";
+        } else {
+          dependencyName = String.format("[toolchain dependency: %s]", tdk.getExecGroupName());
+        }
+      } else {
+        dependencyName = attributeAndDep.getKey().getAttribute().getName();
+      }
+
+      if (attributeAndDep.getValue().getTransition() == NoTransition.INSTANCE
+          || attributeAndDep.getValue().getTransition() == NullTransition.INSTANCE) {
+        resolved.add(
+            ResolvedTransition.create(
+                dep.getLabel(),
+                ImmutableList.of(),
+                dependencyName,
+                attributeAndDep.getValue().getTransition().getName()));
+        continue;
+      }
+      BuildOptions fromOptions = config.getOptions();
+      // TODO(bazel-team): support transitions on Starlark-defined build flags. These require
+      // Skyframe loading to get flag default values. See ConfigurationResolver.applyTransition
+      // for an example of the required logic.
+      ImmutableSet<BuildOptions> toOptions =
+          ImmutableSet.copyOf(
+              dep.getTransition()
+                  .apply(TransitionUtil.restrict(dep.getTransition(), fromOptions), eventHandler)
+                  .values());
+      resolved.add(
+          ResolvedTransition.create(
+              dep.getLabel(), toOptions, dependencyName, dep.getTransition().getName()));
+    }
+    return resolved.build();
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/KnownTargetsDependencyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/KnownTargetsDependencyResolver.java
@@ -1,0 +1,56 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.devtools.build.lib.query2.cquery;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.analysis.DependencyKind;
+import com.google.devtools.build.lib.analysis.DependencyResolver;
+import com.google.devtools.build.lib.analysis.TargetAndConfiguration;
+import com.google.devtools.build.lib.causes.Cause;
+import com.google.devtools.build.lib.cmdline.Label;
+import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
+import com.google.devtools.build.lib.packages.Target;
+import com.google.devtools.build.lib.util.OrderedSetMultimap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * KnownTargetsDependencyResolver is a DependencyResolver which resolves statically over a known set
+ * of targets. It can be useful when performing queries over a known pre-resolved universe of
+ * targets. This class has been extracted from TransitionsOutputFormatterCallback.java so that it
+ * can be used in both ProtoOutputFormatterCallback and TransitionsOutputFormatterCallback
+ */
+public class KnownTargetsDependencyResolver extends DependencyResolver {
+
+  private final ImmutableMap<Label, Target> knownTargets;
+
+  public KnownTargetsDependencyResolver(Map<Label, Target> knownTargets) {
+    this.knownTargets = ImmutableMap.copyOf(knownTargets);
+  }
+
+  @Override
+  protected Map<Label, Target> getTargets(
+      OrderedSetMultimap<DependencyKind, Label> labelMap,
+      TargetAndConfiguration fromNode,
+      NestedSetBuilder<Cause> rootCauses) {
+    return labelMap.values().stream()
+        .distinct()
+        .filter(Objects::nonNull)
+        .filter(knownTargets::containsKey)
+        .collect(toImmutableMap(Function.identity(), knownTargets::get));
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/ProtoOutputFormatterCallback.java
@@ -15,18 +15,30 @@ package com.google.devtools.build.lib.query2.cquery;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.devtools.build.lib.analysis.AnalysisProtos;
 import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
+import com.google.devtools.build.lib.actions.BuildConfigurationEvent;
+import com.google.devtools.build.lib.analysis.AnalysisProtosV2;
+import com.google.devtools.build.lib.analysis.AnalysisProtosV2.Configuration;
+import com.google.devtools.build.lib.analysis.DependencyResolver;
+import com.google.devtools.build.lib.analysis.InconsistentAspectOrderException;
+import com.google.devtools.build.lib.analysis.config.BuildOptions;
+import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
+import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
+import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.packages.Attribute;
 import com.google.devtools.build.lib.packages.AttributeFormatter;
 import com.google.devtools.build.lib.packages.ConfiguredAttributeMapper;
 import com.google.devtools.build.lib.packages.Rule;
+import com.google.devtools.build.lib.packages.RuleTransitionData;
+import com.google.devtools.build.lib.packages.Target;
+import com.google.devtools.build.lib.query2.cquery.CqueryOptions.Transitions;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccessor;
 import com.google.devtools.build.lib.query2.proto.proto2api.Build;
-import com.google.devtools.build.lib.query2.proto.proto2api.Build.QueryResult;
 import com.google.devtools.build.lib.query2.query.aspectresolvers.AspectResolver;
 import com.google.devtools.build.lib.query2.query.output.ProtoOutputFormatter;
 import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
@@ -37,6 +49,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 /** Proto output formatter for cquery results. */
 class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
@@ -62,9 +76,11 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
   private final AspectResolver resolver;
   private final SkyframeExecutor skyframeExecutor;
   private final JsonFormat.Printer jsonPrinter = JsonFormat.printer();
+  @Nullable private final TransitionFactory<RuleTransitionData> trimmingTransitionFactory;
 
   private AnalysisProtos.CqueryResult.Builder protoResult;
 
+  private final Map<Label, Target> partialResultMap;
   private KeyedConfiguredTarget currentTarget;
 
   ProtoOutputFormatterCallback(
@@ -74,11 +90,14 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
       SkyframeExecutor skyframeExecutor,
       TargetAccessor<KeyedConfiguredTarget> accessor,
       AspectResolver resolver,
-      OutputType outputType) {
+      OutputType outputType,
+      @Nullable TransitionFactory<RuleTransitionData> trimmingTransitionFactory) {
     super(eventHandler, options, out, skyframeExecutor, accessor);
     this.outputType = outputType;
     this.skyframeExecutor = skyframeExecutor;
     this.resolver = resolver;
+    this.trimmingTransitionFactory = trimmingTransitionFactory;
+    this.partialResultMap = Maps.newHashMap();
   }
 
   @Override
@@ -95,7 +114,7 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
         // Documentation promises that setting this flag to false means we convert directly
         // to the build.proto format. This is hard to test in integration testing due to the way
         // proto output is turned readable (codex). So change the following code with caution.
-        QueryResult.Builder queryResult = Build.QueryResult.newBuilder();
+        Build.QueryResult.Builder queryResult = Build.QueryResult.newBuilder();
         protoResult.getResultsList().forEach(ct -> queryResult.addTarget(ct.getTarget()));
         writeData(queryResult.build());
       }
@@ -133,6 +152,19 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
   @Override
   public void processOutput(Iterable<KeyedConfiguredTarget> partialResult)
       throws InterruptedException {
+    partialResult.forEach(kct -> partialResultMap.put(kct.getLabel(), accessor.getTarget(kct)));
+
+    KnownTargetsDependencyResolver knownTargetsDependencyResolver =
+        new KnownTargetsDependencyResolver(partialResultMap);
+
+    CqueryTransitionResolver transitionResolver =
+        new CqueryTransitionResolver(
+            eventHandler,
+            knownTargetsDependencyResolver,
+            accessor,
+            this,
+            trimmingTransitionFactory);
+
     ConfiguredProtoOutputFormatter formatter = new ConfiguredProtoOutputFormatter();
     formatter.setOptions(options, resolver, skyframeExecutor.getHashFunction());
     for (KeyedConfiguredTarget keyedConfiguredTarget : partialResult) {
@@ -144,7 +176,41 @@ class ProtoOutputFormatterCallback extends CqueryThreadsafeCallback {
       // logic in this next line. If this were to change (i.e. we manipulate targets any further),
       // we will want to add relevant tests.
       currentTarget = keyedConfiguredTarget;
-      builder.setTarget(formatter.toTargetProtoBuffer(accessor.getTarget(keyedConfiguredTarget)));
+      Target target = accessor.getTarget(keyedConfiguredTarget);
+      Build.Target.Builder targetBuilder = formatter.toTargetProtoBuffer(target).toBuilder();
+      if (target instanceof Rule && !Transitions.NONE.equals(options.transitions)) {
+        try {
+          for (CqueryTransitionResolver.ResolvedTransition resolvedTransition :
+              transitionResolver.dependencies(keyedConfiguredTarget)) {
+            if (resolvedTransition.options().isEmpty()) {
+              targetBuilder
+                  .getRuleBuilder()
+                  .addConfiguredRuleInput(
+                      Build.ConfiguredRuleInput.newBuilder()
+                          .setLabel(resolvedTransition.label().toString()));
+            } else {
+              for (BuildOptions options : resolvedTransition.options()) {
+                BuildConfigurationEvent buildConfigurationEvent =
+                    getConfiguration(BuildConfigurationKey.withoutPlatformMapping(options))
+                        .toBuildEvent();
+                int configurationId = configurationCache.getId(buildConfigurationEvent);
+
+                targetBuilder
+                    .getRuleBuilder()
+                    .addConfiguredRuleInput(
+                        Build.ConfiguredRuleInput.newBuilder()
+                            .setLabel(resolvedTransition.label().toString())
+                            .setConfigurationChecksum(options.checksum())
+                            .setConfigurationId(configurationId));
+              }
+            }
+          }
+        } catch (DependencyResolver.Failure | InconsistentAspectOrderException e) {
+          // This is an abuse of InterruptedException.
+          throw new InterruptedException(e.getMessage());
+        }
+      }
+      builder.setTarget(targetBuilder);
 
       if (options.protoIncludeConfigurations) {
         String checksum = keyedConfiguredTarget.getConfigurationChecksum();

--- a/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/cquery/TransitionsOutputFormatterCallback.java
@@ -15,44 +15,31 @@ package com.google.devtools.build.lib.query2.cquery;
 
 import static java.util.stream.Collectors.joining;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.analysis.ConfiguredTarget;
-import com.google.devtools.build.lib.analysis.DependencyKey;
-import com.google.devtools.build.lib.analysis.DependencyKind;
-import com.google.devtools.build.lib.analysis.DependencyKind.ToolchainDependencyKind;
 import com.google.devtools.build.lib.analysis.DependencyResolver;
 import com.google.devtools.build.lib.analysis.InconsistentAspectOrderException;
 import com.google.devtools.build.lib.analysis.TargetAndConfiguration;
 import com.google.devtools.build.lib.analysis.ToolchainCollection;
 import com.google.devtools.build.lib.analysis.ToolchainContext;
 import com.google.devtools.build.lib.analysis.config.BuildConfiguration;
+import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.BuildOptions.OptionsDiff;
-import com.google.devtools.build.lib.analysis.config.ConfigMatchingProvider;
 import com.google.devtools.build.lib.analysis.config.transitions.ConfigurationTransition;
-import com.google.devtools.build.lib.analysis.config.transitions.NoTransition;
-import com.google.devtools.build.lib.analysis.config.transitions.NullTransition;
 import com.google.devtools.build.lib.analysis.config.transitions.TransitionFactory;
-import com.google.devtools.build.lib.analysis.config.transitions.TransitionUtil;
 import com.google.devtools.build.lib.analysis.configuredtargets.RuleConfiguredTarget;
-import com.google.devtools.build.lib.causes.Cause;
 import com.google.devtools.build.lib.cmdline.Label;
-import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
 import com.google.devtools.build.lib.events.Event;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.packages.RuleTransitionData;
 import com.google.devtools.build.lib.packages.Target;
+import com.google.devtools.build.lib.query2.cquery.CqueryTransitionResolver.ResolvedTransition;
 import com.google.devtools.build.lib.query2.engine.QueryEnvironment.TargetAccessor;
 import com.google.devtools.build.lib.skyframe.SkyframeExecutor;
-import com.google.devtools.build.lib.util.OrderedSetMultimap;
 import java.io.OutputStream;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -109,74 +96,40 @@ class TransitionsOutputFormatterCallback extends CqueryThreadsafeCallback {
               + String.format(
                   "%s (%s)",
                   keyedConfiguredTarget.getConfiguredTarget().getOriginalLabel(), shortId(config)));
-      if (!(keyedConfiguredTarget.getConfiguredTarget() instanceof RuleConfiguredTarget)) {
-        continue;
-      }
-      OrderedSetMultimap<DependencyKind, DependencyKey> deps;
-      ImmutableMap<Label, ConfigMatchingProvider> configConditions =
-          keyedConfiguredTarget.getConfigConditions();
-
-      // Get a ToolchainContext to use for dependency resolution.
-      ToolchainCollection<ToolchainContext> toolchainContexts =
-          accessor.getToolchainContexts(target, config);
+      KnownTargetsDependencyResolver knownTargetsDependencyResolver =
+          new KnownTargetsDependencyResolver(partialResultMap);
+      ImmutableSet<ResolvedTransition> dependencies;
       try {
         // We don't actually use fromOptions in our implementation of
         // DependencyResolver but passing to avoid passing a null and since we have the information
         // anyway.
-        deps =
-            new FormatterDependencyResolver()
-                .dependentNodeMap(
-                    new TargetAndConfiguration(target, config),
-                    hostConfiguration,
-                    /*aspect=*/ null,
-                    configConditions,
-                    toolchainContexts,
-                    DependencyResolver.shouldUseToolchainTransition(config, target),
-                    trimmingTransitionFactory);
+        dependencies =
+            new CqueryTransitionResolver(
+                    eventHandler,
+                    knownTargetsDependencyResolver,
+                    accessor,
+                    this,
+                    trimmingTransitionFactory)
+                .dependencies(keyedConfiguredTarget);
       } catch (DependencyResolver.Failure | InconsistentAspectOrderException e) {
         // This is an abuse of InterruptedException.
         throw new InterruptedException(e.getMessage());
       }
-      for (Map.Entry<DependencyKind, DependencyKey> attributeAndDep : deps.entries()) {
-        if (attributeAndDep.getValue().getTransition() == NoTransition.INSTANCE
-            || attributeAndDep.getValue().getTransition() == NullTransition.INSTANCE) {
-          continue;
-        }
-        DependencyKey dep = attributeAndDep.getValue();
-        BuildOptions fromOptions = config.getOptions();
-        // TODO(bazel-team): support transitions on Starlark-defined build flags. These require
-        // Skyframe loading to get flag default values. See ConfigurationResolver.applyTransition
-        // for an example of the required logic.
-        Collection<BuildOptions> toOptions =
-            dep.getTransition()
-                .apply(TransitionUtil.restrict(dep.getTransition(), fromOptions), eventHandler)
-                .values();
-        String hostConfigurationChecksum = hostConfiguration.checksum();
-        String dependencyName;
-        if (DependencyKind.isToolchain(attributeAndDep.getKey())) {
-          ToolchainDependencyKind tdk = (ToolchainDependencyKind) attributeAndDep.getKey();
-          if (tdk.isDefaultExecGroup()) {
-            dependencyName = "[toolchain dependency]";
-          } else {
-            dependencyName = String.format("[toolchain dependency: %s]", tdk.getExecGroupName());
-          }
-        } else {
-          dependencyName = attributeAndDep.getKey().getAttribute().getName();
-        }
+      for (ResolvedTransition dep : dependencies) {
         addResult(
             "  "
-                .concat(dependencyName)
+                .concat(dep.attributeName())
                 .concat("#")
-                .concat(dep.getLabel().toString())
+                .concat(dep.label().toString())
                 .concat("#")
-                .concat(dep.getTransition().getName())
+                .concat(dep.transitionName())
                 .concat(" -> ")
                 .concat(
-                    toOptions.stream()
+                    dep.options().stream()
                         .map(
                             options -> {
                               String checksum = options.checksum();
-                              return checksum.equals(hostConfigurationChecksum)
+                              return checksum.equals(hostConfiguration.checksum())
                                   ? "HOST"
                                   : shortId(checksum);
                             })
@@ -185,8 +138,8 @@ class TransitionsOutputFormatterCallback extends CqueryThreadsafeCallback {
           continue;
         }
         OptionsDiff diff = new OptionsDiff();
-        for (BuildOptions options : toOptions) {
-          diff = BuildOptions.diff(diff, fromOptions, options);
+        for (BuildOptions options : dep.options()) {
+          diff = BuildOptions.diff(diff, config.getOptions(), options);
         }
         diff.getPrettyPrintList().forEach(singleDiff -> addResult("    " + singleDiff));
       }
@@ -208,20 +161,5 @@ class TransitionsOutputFormatterCallback extends CqueryThreadsafeCallback {
       }
     }
     return output;
-  }
-
-  private class FormatterDependencyResolver extends DependencyResolver {
-
-    @Override
-    protected Map<Label, Target> getTargets(
-        OrderedSetMultimap<DependencyKind, Label> labelMap,
-        TargetAndConfiguration fromNode,
-        NestedSetBuilder<Cause> rootCauses) {
-      return labelMap.values().stream()
-          .distinct()
-          .filter(Objects::nonNull)
-          .filter(partialResultMap::containsKey)
-          .collect(Collectors.toMap(Function.identity(), partialResultMap::get));
-    }
   }
 }

--- a/src/main/protobuf/build.proto
+++ b/src/main/protobuf/build.proto
@@ -300,6 +300,8 @@ message Rule {
   // predecessors in the dependency graph.
   repeated string rule_input = 5;
 
+  repeated ConfiguredRuleInput configured_rule_input = 15;
+
   // All of the outputs of the rule (formatted as absolute labels). These are
   // successors in the dependency graph.
   repeated string rule_output = 6;
@@ -330,6 +332,12 @@ message Rule {
   // enabled on the command line with the --proto:definition_stack flag or the
   // rule is a native one.
   repeated string definition_stack = 14;
+}
+
+message ConfiguredRuleInput {
+  optional string label = 1;
+  optional string configuration_checksum = 2;
+  optional uint32 configuration_id = 3;
 }
 
 // Summary of all transitive dependencies of 'rule,' where each dependent


### PR DESCRIPTION
When the existing `--transitions` flag is set to a non-None value,
cquery will report the configuration its dependencies are configured in.
This allows for pruning away values from ruleInputs which are not
required in the current configuration.

Example output from running:
`bazel cquery --transitions=lite --output=jsonproto 'deps(...)'`:
```
[...]
        "ruleInput": ["@bazel_tools//src/conditions:host_windows", "@bazel_tools//src/tools/launcher:launcher", "@bazel_tools//tools/launcher:launcher_windows"],
        "configuredRuleInput": [{
          "label": "@bazel_tools//src/tools/launcher:launcher",
          "configurationChecksum": "01ec5513a9fc41b2a15570123817f3c2200ad9aeb21b1181d588a4b4f91d5693",
          "configurationId": 3
        }]
[...]
```

Previously on a non-Windows platform it was not possible to determine
that the two windows-specific ruleInputs are not actually required - now
we can see from the configuredRuleInput section that the
windows-specific dependencies have been pruned by selection, and we can
see that a transition has re-configured the ruleInput into the exec
configuration.

For dependencies which were not subject to transition (e.g. because
they're in a non-transition attribute), or which had no configuration
(e.g. because they're a source file), we add the label as a
ConfiguredRuleInput _without_ any configuration information. This
indicates that the dependency has not been pruned, but that the caller
should determine the correct configuration from context (probably be
determining whether it's a source file, and if so, considering it
un-configured, otherwise propagating the contextual ConfiguredTarget's
configuration).

Fixes #14610
Fixes #14617

Implementation-wise, this took roughly the following shape:
1. Extract TransitionResolver from being inline in TransitionsOutputFormatterCallback
2. Extract KnownTargetsDependencyResolver from TransitionsOutputFormatterCallback.FormatterDependencyResolver
3. Conditionally call these from ProtoOutputFormatterCallback depending
   on the --transitions flag.

Closes #15038.

PiperOrigin-RevId: 445923176