### PR TITLE
Add a flag to force Bazel to download certain artifacts

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -574,6 +574,16 @@ public final class RemoteOptions extends OptionsBase {
       help = "Maximum number of open files allowed during BEP artifact upload.")
   public int maximumOpenFiles;
 
+  @Option(
+          name = "experimental_force_downloads_regex",
+          defaultValue = "",
+          documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+          effectTags = {OptionEffectTag.AFFECTS_OUTPUTS},
+          help = "Force Bazel to download the artifacts that match the given regexp. To be used in conjunction with" +
+                  "--remote_download_minimal to allow the client to request certain artifacts that might be needed" +
+                  "locally (e.g. IDE support)")
+  public String experimentalForceDownloadsRegex;
+
   // The below options are not configurable by users, only tests.
   // This is part of the effort to reduce the overall number of flags.
 


### PR DESCRIPTION
When using `--remote_download_minimal` Bazel only downloads to the client the minimum number of artifacts necessary for the build to succeed. This can be sometimes problematic when local development (i.e. IDE) requires *some* artifacts to do local work (e.g. syntax completion). We add a flag --experimental_force_downloads_regex that allow specifying a regular expression that will force certain artifacts to be forced to downloaded.

TODO: Add integration test

Tested locally that syntax errors disappear in IntelliJ when compiling Bazel itself with `--remote_download_minimal` and `--experimental_force_downloads_regex=".*jar$"`

Signed-off-by: Luis Fernando Pino Duque <luis@engflow.com>