### PR TITLE
fix python_stub_template.txt for work with python zip archives

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -90,14 +90,14 @@ dist_http_archive(
     patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
 )
 
-# This is a mock version of bazelbuild/rules_python that contains only
-# @rules_python//python:defs.bzl. It is used by protobuf.
-# TODO(#9029): We could potentially replace this with the real @rules_python.
-new_local_repository(
+http_archive(
     name = "rules_python",
-    build_file = "//third_party/rules_python:BUILD",
-    path = "./third_party/rules_python",
-    workspace_file = "//third_party/rules_python:rules_python.WORKSPACE",
+    sha256 = "cdf6b84084aad8f10bf20b46b77cb48d83c319ebe6458a18e9d2cebf57807cdd",
+    strip_prefix = "rules_python-0.8.1",
+    urls = [
+        "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_python/archive/refs/tags/0.8.1.tar.gz",
+    ],
 )
 
 local_repository(

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
@@ -106,7 +106,14 @@ def FindModuleSpace():
     if os.path.isdir(module_space):
       return module_space
 
-    runfiles_pattern = r'(.*\.runfiles)' + (r'\\' if IsWindows() else '/') + '.*'
+    slash_pattern = r'\\' if IsWindows() else '/'
+    runfiles_pattern = r'(.*\.runfiles)' + slash_pattern + '.*'
+    matchobj = re.match(runfiles_pattern, stub_filename)
+    if matchobj:
+      return matchobj.group(1)
+
+    # bazel pyz archives create a directory named "runfiles".  Try that next:
+    runfiles_pattern = r'(.*' + slash_pattern + 'runfiles)' + slash_pattern + '.*'
     matchobj = re.match(runfiles_pattern, stub_filename)
     if matchobj:
       return matchobj.group(1)

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -269,3 +269,29 @@ py_test(
         ":test_base",
     ],
 )
+
+py_library(
+    name = "bum",
+    srcs = ["bum.py"],
+)
+
+py_binary(
+    name = "bar",
+    srcs = ["bar.py"],
+    deps = [":bum"],
+)
+
+py_binary(
+    name = "foo",
+    srcs = ["foo.py"],
+    data = ["//src/test/py/bazel:bar"],
+    deps = [
+        "@rules_python//python/runfiles",
+    ],
+)
+
+filegroup(
+    name = "foo-zip",
+    srcs = [":foo"],
+    output_group = "python_zip_file",
+)


### PR DESCRIPTION
This is a patch that fixes the bug I just opened: https://github.com/bazelbuild/bazel/issues/15502

This addresses the issue by modifying LoadModuleSpace to search first for a ".runfiles" directory, and failing that, to search
for a "/runfiles/" directory such as the one created by CreateModuleSpace when the stub is invoked in the context of a zipfile.

This PR also includes a reproduction case: src/test/py/bazel/{foo,bar,bum}.py

I will fill out the contributor agreement momentarily...

Tested:

1. Verified that my repro case reproduces the issue: `bazel build :foo.zip; python3 ../../../../bazel-bin/src/test/py/bazel/foo.zip` fails.
2. Built a patched bazel-dev binary.
3. Verified that my repro case now passes: `bazel-dev build :foo.zip; python3 ../../../../bazel-bin/src/test/py/bazel/foo.zip` passes.

I tested this patch by building bazel-dev from source, and using