### PR TITLE
Allow skipping Xcode locator runs

### DIFF
--- a/tools/cpp/osx_cc_configure.bzl
+++ b/tools/cpp/osx_cc_configure.bzl
@@ -157,17 +157,19 @@ def configure_osx_toolchain(repository_ctx, cpu_value, overriden_tools):
 
     env = repository_ctx.os.environ
     should_use_xcode = "BAZEL_USE_XCODE_TOOLCHAIN" in env and env["BAZEL_USE_XCODE_TOOLCHAIN"] == "1"
+    skip_xcode_fetch = "BAZEL_SKIP_XCODE_FETCH" in env and env["BAZEL_SKIP_XCODE_FETCH"] == "1"
     xcode_toolchains = []
 
     # Make the following logic in sync with //tools/cpp:cc_configure.bzl#cc_autoconf_toolchains_impl
-    (xcode_toolchains, xcodeloc_err) = run_xcode_locator(
-        repository_ctx,
-        paths["@bazel_tools//tools/osx:xcode_locator.m"],
-    )
-    if should_use_xcode and not xcode_toolchains:
-        fail("BAZEL_USE_XCODE_TOOLCHAIN is set to 1 but Bazel couldn't find Xcode installed on the " +
-             "system. Verify that 'xcode-select -p' is correct.")
-    if xcode_toolchains:
+    if not skip_xcode_fetch:
+        (xcode_toolchains, xcodeloc_err) = run_xcode_locator(
+            repository_ctx,
+            paths["@bazel_tools//tools/osx:xcode_locator.m"],
+        )
+        if should_use_xcode and not xcode_toolchains:
+            fail("BAZEL_USE_XCODE_TOOLCHAIN is set to 1 but Bazel couldn't find Xcode installed on the " +
+                 "system. Verify that 'xcode-select -p' is correct.")
+    if xcode_toolchains or (should_use_xcode and skip_xcode_fetch):
         # For Xcode toolchains, there's no reason to use anything other than
         # wrapped_clang, so that we still get the Bazel Xcode placeholder
         # substitution and other behavior for actions that invoke this


### PR DESCRIPTION
For builds that require Xcode, running xcode_locator during toolchain
setup is potentially duplicative. The only things it's used for is to
check that they exist if it's expected, and to add to the allowed
include directories. The include directories already includes
`/Applications` which is where _most_ people likely have Xcode
installed. This saves a few seconds when the toolchain is reconfigured.

https://bazelbuild.slack.com/archives/CD3QY5C2X/p1652819625121889