### PR TITLE
Allow the singlejar and java_tools to be built on Haiku.

### DIFF
--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -114,7 +114,6 @@ cc_test(
     size = "large",
     srcs = [
         "combiners_test.cc",
-        ":zip_headers",
         ":zlib_interface",
     ],
     data = [
@@ -124,6 +123,7 @@ cc_test(
     exec_compatible_with = ["//:highcpu_machine"],
     deps = [
         ":combiners",
+        ":zip_headers",
         ":input_jar",
         ":test_util",
         "//third_party/zlib",
@@ -135,11 +135,11 @@ cc_test(
     name = "desugar_checking_test",
     srcs = [
         "desugar_checking_test.cc",
-        ":zip_headers",
         ":zlib_interface",
     ],
     deps = [
         ":combiners",
+        ":zip_headers",
         ":desugar_checking",
         ":input_jar",
         "//third_party/zlib",
@@ -308,6 +308,7 @@ cc_test(
     tags = ["manual"],
     deps = [
         ":input_jar",
+        ":zip_headers",
         ":test_util",
         "//third_party/zlib",
         "@com_google_googletest//:gtest_main",
@@ -319,9 +320,9 @@ cc_test(
     size = "small",
     srcs = [
         "zip_headers_test.cc",
-        ":zip_headers",
     ],
     deps = [
+        ":zip_headers",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -357,10 +358,10 @@ cc_library(
     srcs = [
         "combiners.cc",
         ":transient_bytes",
-        ":zip_headers",
     ],
     hdrs = ["combiners.h"],
     deps = [
+        ":zip_headers",
         "//third_party/zlib",
     ],
 )
@@ -378,6 +379,24 @@ cc_library(
 cc_library(
     name = "diag",
     hdrs = ["diag.h"],
+    defines = select({
+        "//conditions:default": [],
+    }),
+    linkopts = select({
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "zip_headers",
+    hdrs = ["zip_headers.h"],
+    defines = select({
+        "//conditions:default": [],
+    }),
+    linkopts = select({
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:private"],
 )
 
@@ -413,6 +432,7 @@ cc_library(
     ],
     deps = [
         ":diag",
+        ":zip_headers",
         ":mapped_file",
     ],
 )
@@ -435,11 +455,11 @@ cc_library(
     srcs = [
         "output_jar.cc",
         "output_jar.h",
-        ":zip_headers",
     ],
     hdrs = ["output_jar.h"],
     deps = [
         ":combiners",
+        ":zip_headers",
         ":diag",
         ":input_jar",
         ":mapped_file",
@@ -479,11 +499,6 @@ filegroup(
         "zlib_interface.h",
         ":zip_headers",
     ],
-)
-
-filegroup(
-    name = "zip_headers",
-    srcs = ["zip_headers.h"],
 )
 
 filegroup(

--- a/src/tools/singlejar/BUILD
+++ b/src/tools/singlejar/BUILD
@@ -380,9 +380,11 @@ cc_library(
     name = "diag",
     hdrs = ["diag.h"],
     defines = select({
+        "//src/conditions:haiku": ["_DEFAULT_SOURCE"],
         "//conditions:default": [],
     }),
     linkopts = select({
+        "//src/conditions:haiku": ["-lbsd"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:private"],
@@ -392,9 +394,11 @@ cc_library(
     name = "zip_headers",
     hdrs = ["zip_headers.h"],
     defines = select({
+        "//src/conditions:haiku": ["_DEFAULT_SOURCE"],
         "//conditions:default": [],
     }),
     linkopts = select({
+        "//src/conditions:haiku": ["-lbsd"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:private"],

--- a/src/tools/singlejar/diag.h
+++ b/src/tools/singlejar/diag.h
@@ -20,7 +20,7 @@
  * for portability.
  */
 #if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__) || \
-    defined(__OpenBSD__)
+    defined(__OpenBSD__) || defined(__HAIKU__)
 
 #include <err.h>
 #define diag_err(...) err(__VA_ARGS__)

--- a/src/tools/singlejar/mapped_file_posix.inc
+++ b/src/tools/singlejar/mapped_file_posix.inc
@@ -24,9 +24,9 @@
 
 #include "src/tools/singlejar/diag.h"
 
-// The implementation is specific to 64-bit Linux / OS X / BSD.
+// The implementation is specific to 64-bit Linux / OS X / BSD / Haiku.
 #if !((defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || \
-       defined(__OpenBSD__)) &&                                            \
+       defined(__OpenBSD__) || defined(__HAIKU__)) &&                      \
       __SIZEOF_POINTER__ == 8)
 #error This code for 64 bit Unix.
 #endif

--- a/src/tools/singlejar/port.h
+++ b/src/tools/singlejar/port.h
@@ -32,7 +32,7 @@
 typedef off_t off64_t;
 #elif defined(_WIN32)
 typedef __int64 off64_t;
-#elif defined(__OpenBSD__)
+#elif defined(__OpenBSD__) || defined(__HAIKU__)
 typedef int64_t off64_t;
 #endif
 static_assert(sizeof(off64_t) == 8, "File offset type must be 64-bit");

--- a/src/tools/singlejar/zip_headers.h
+++ b/src/tools/singlejar/zip_headers.h
@@ -25,7 +25,7 @@
 
 #include <cinttypes>
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__HAIKU__)
 #include <endian.h>
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <sys/endian.h>
@@ -40,6 +40,8 @@
 #else
 #error "This platform is not supported."
 #endif
+
+#include <sys/wait.h>
 
 #include <string>
 #include <type_traits>

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -140,6 +140,12 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "haiku",
+    constraint_values = ["@platforms//os:haiku"],
+    visibility  = ["//visibility:public"],
+)
+
 cc_library(
     name = "malloc",
 )
@@ -458,9 +464,11 @@ cc_library(
     hdrs = ["java_tools/src/tools/singlejar/diag.h"],
     copts = SUPRESSED_WARNINGS,
     defines = select({
+        ":haiku": ["_DEFAULT_SOURCE"],
         "//conditions:default": [],
     }),
     linkopts = select({
+        ":haiku": ["-lbsd"],
         "//conditions:default": [],
     }),
     strip_include_prefix = "java_tools",
@@ -573,9 +581,11 @@ cc_library(
     name = "zip_headers",
     hdrs = ["java_tools/src/tools/singlejar/zip_headers.h"],
     defines = select({
+        ":haiku": ["_DEFAULT_SOURCE"],
         "//conditions:default": [],
     }),
     linkopts = select({
+        ":haiku": ["-lbsd"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:private"],

--- a/tools/jdk/BUILD.java_tools
+++ b/tools/jdk/BUILD.java_tools
@@ -427,6 +427,7 @@ cc_library(
     strip_include_prefix = "java_tools",
     deps = [
         "//java_tools/zlib",
+        ":zip_headers"
     ],
 )
 
@@ -456,6 +457,12 @@ cc_library(
     name = "diag",
     hdrs = ["java_tools/src/tools/singlejar/diag.h"],
     copts = SUPRESSED_WARNINGS,
+    defines = select({
+        "//conditions:default": [],
+    }),
+    linkopts = select({
+        "//conditions:default": [],
+    }),
     strip_include_prefix = "java_tools",
     visibility = ["//visibility:private"],
 )
@@ -499,6 +506,7 @@ cc_library(
     strip_include_prefix = "java_tools",
     deps = [
         ":diag",
+        ":zip_headers",
         ":mapped_file",
     ],
 )
@@ -523,7 +531,6 @@ cc_library(
     srcs = [
         "java_tools/src/tools/singlejar/output_jar.cc",
         "java_tools/src/tools/singlejar/output_jar.h",
-        ":zip_headers",
     ],
     hdrs = ["java_tools/src/tools/singlejar/output_jar.h"],
     copts = SUPRESSED_WARNINGS,
@@ -532,6 +539,7 @@ cc_library(
         ":combiners",
         ":cpp_util",
         ":diag",
+        ":zip_headers",
         ":input_jar",
         ":mapped_file",
         ":options",
@@ -557,13 +565,20 @@ filegroup(
         "java_tools/src/tools/singlejar/diag.h",
         "java_tools/src/tools/singlejar/transient_bytes.h",
         "java_tools/src/tools/singlejar/zlib_interface.h",
-        ":zip_headers",
+        "java_tools/src/tools/singlejar/zip_headers.h",
     ],
 )
 
-filegroup(
+cc_library(
     name = "zip_headers",
-    srcs = ["java_tools/src/tools/singlejar/zip_headers.h"],
+    hdrs = ["java_tools/src/tools/singlejar/zip_headers.h"],
+    defines = select({
+        "//conditions:default": [],
+    }),
+    linkopts = select({
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:private"],
 )
 
 ################### Proguard ###################

--- a/tools/jdk/BUILD.tools
+++ b/tools/jdk/BUILD.tools
@@ -81,6 +81,11 @@ java_runtime_files(
     srcs = ["include/openbsd/jni_md.h"],
 )
 
+java_runtime_files(
+    name = "jni_md_header-haiku",
+    srcs = ["include/haiku/jni_md.h"],
+)
+
 # The Java native interface. Depend on this package if you #include <jni.h>.
 #
 # See test_jni in third_party/bazel/src/test/shell/bazel/bazel_java_test.sh for
@@ -99,6 +104,7 @@ cc_library(
         "//src/conditions:darwin": [":jni_md_header-darwin"],
         "//src/conditions:freebsd": [":jni_md_header-freebsd"],
         "//src/conditions:openbsd": [":jni_md_header-openbsd"],
+        "//src/conditions:haiku": [":jni_md_header-haiku"],
         "//src/conditions:windows": [":jni_md_header-windows"],
         "//conditions:default": [],
     }),
@@ -112,6 +118,7 @@ cc_library(
         "//src/conditions:darwin": ["include/darwin"],
         "//src/conditions:freebsd": ["include/freebsd"],
         "//src/conditions:openbsd": ["include/openbsd"],
+        "//src/conditions:haiku": ["include/haiku"],
         "//src/conditions:windows": ["include/win32"],
         "//conditions:default": [],
     }),

--- a/tools/jdk/jdk.BUILD
+++ b/tools/jdk/jdk.BUILD
@@ -39,6 +39,12 @@ filegroup(
 )
 
 filegroup(
+    name = "jni_md_header-haiku",
+    srcs = ["include/haiku/jni_md.h"],
+    deprecation = DEPRECATION_MESSAGE,
+)
+
+filegroup(
     name = "jni_md_header-windows",
     srcs = ["include/win32/jni_md.h"],
     deprecation = DEPRECATION_MESSAGE,


### PR DESCRIPTION
This contains changes to the singlejar and java_tools needed for my Haiku port, as mentioned on https://github.com/bazelbuild/bazel/issues/12522#issuecomment-1121321856.
