### PR TITLE
Haiku 3rdparty

### DIFF
--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -175,6 +175,10 @@ DIST_DEPS = {
     },
     "com_google_absl": {
         "archive": "20211102.0.tar.gz",
+        "patch_args": ["-p1"],
+        "patches": [
+            "//third_party:com_google_absl/absl_haiku.patch",
+        ],
         "sha256": "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4",
         "urls": [
             "https://mirror.bazel.build/github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz",

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -152,6 +152,10 @@ DIST_DEPS = {
             "https://mirror.bazel.build/github.com/c-ares/c-ares/archive/e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz",
             "https://github.com/c-ares/c-ares/archive/e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz",
         ],
+        "patch_args": ["-p1"],
+        "patches": [
+            "//third_party/c-ares:cares_haiku.patch",
+        ],
         "used_in": [
             "additional_distfiles",
             "test_WORKSPACE_files",

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -137,6 +137,8 @@ DIST_DEPS = {
         "patches": [
             "//third_party/grpc:grpc_1.41.0.patch",
             "//third_party/grpc:grpc_1.41.0.win_arm64.patch",
+            "//third_party/grpc:grpc_1.41.0.haiku.patch",
+            "//third_party/grpc:grpc_1.41.0.cares_haiku.patch",
         ],
         "used_in": [
             "additional_distfiles",

--- a/third_party/c-ares/cares_haiku.patch
+++ b/third_party/c-ares/cares_haiku.patch
@@ -1,0 +1,42 @@
+From d1720368d0e8d2bd1a2ac0fcc6558eeb4ee15563 Mon Sep 17 00:00:00 2001
+From: "Estevan Castilho (Tevo)" <estevan.cps@gmail.com>
+Date: Sat, 7 May 2022 22:36:33 +0000
+Subject: [PATCH] Haiku: backport Jerome Duval's changes
+
+---
+ ares.h         | 2 +-
+ ares_private.h | 5 +++++
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/ares.h b/ares.h
+index 06f60b3..07d2b63 100644
+--- a/ares.h
++++ b/ares.h
+@@ -39,7 +39,7 @@
+ #if defined(_AIX) || defined(__NOVELL_LIBC__) || defined(__NetBSD__) || \
+     defined(__minix) || defined(__SYMBIAN32__) || defined(__INTEGRITY) || \
+     defined(ANDROID) || defined(__ANDROID__) || defined(__OpenBSD__) || \
+-    defined(__QNXNTO__)
++    defined(__QNXNTO__) || defined(__HAIKU__)
+ #include <sys/select.h>
+ #endif
+ #if (defined(NETWARE) && !defined(__NOVELL_LIBC__))
+diff --git a/ares_private.h b/ares_private.h
+index 1990f69..367926e 100644
+--- a/ares_private.h
++++ b/ares_private.h
+@@ -79,6 +79,11 @@
+ 
+ #define PATH_HOSTS             "InetDBase:Hosts"
+ 
++#elif defined(__HAIKU__)
++
++#define PATH_RESOLV_CONF "/system/settings/network/resolv.conf"
++#define PATH_HOSTS              "/system/settings/network/hosts"
++
+ #else
+ 
+ #define PATH_RESOLV_CONF        "/etc/resolv.conf"
+-- 
+2.30.2
+

--- a/third_party/com_google_absl/absl_haiku.patch
+++ b/third_party/com_google_absl/absl_haiku.patch
@@ -1,0 +1,22 @@
+From 1c0c5b773743002bddd25fd838a152ae807eadfd Mon Sep 17 00:00:00 2001
+From: Gerasim Troeglazov <3dEyes@gmail.com>
+Date: Wed, 2 Feb 2022 15:04:07 +1000
+Subject: Disable dynamic symbol lookup for in-memory Elf images
+
+
+diff --git a/absl/debugging/internal/elf_mem_image.h b/absl/debugging/internal/elf_mem_image.h
+index a894bd4..949aef7 100644
+--- a/absl/debugging/internal/elf_mem_image.h
++++ b/absl/debugging/internal/elf_mem_image.h
+@@ -32,7 +32,7 @@
+ #endif
+ 
+ #if defined(__ELF__) && !defined(__native_client__) && !defined(__asmjs__) && \
+-    !defined(__wasm__)
++    !defined(__wasm__) && !defined(__HAIKU__)
+ #define ABSL_HAVE_ELF_MEM_IMAGE 1
+ #endif
+ 
+-- 
+2.30.2
+

--- a/third_party/grpc/grpc_1.41.0.cares_haiku.patch
+++ b/third_party/grpc/grpc_1.41.0.cares_haiku.patch
@@ -1,0 +1,639 @@
+From 4653b61368ed4e76ff6043b89072a70f2c77cab1 Mon Sep 17 00:00:00 2001
+From: "Estevan Castilho (Tevo)" <estevan.cps@gmail.com>
+Date: Sat, 7 May 2022 19:23:51 +0000
+Subject: [PATCH] Haiku: backport c-ares Haiku support
+
+---
+ bazel/grpc_deps.bzl                          |   2 +
+ third_party/cares/BUILD                      |   2 +
+ third_party/cares/cares.BUILD                |   7 +
+ third_party/cares/cares_haiku.patch          |  42 ++
+ third_party/cares/config_haiku/ares_config.h | 506 +++++++++++++++++++
+ 5 files changed, 559 insertions(+)
+ create mode 100644 third_party/cares/cares_haiku.patch
+ create mode 100644 third_party/cares/config_haiku/ares_config.h
+
+diff --git a/bazel/grpc_deps.bzl b/bazel/grpc_deps.bzl
+index e2ef402..2bca365 100644
+--- a/bazel/grpc_deps.bzl
++++ b/bazel/grpc_deps.bzl
+@@ -278,6 +278,8 @@ def grpc_deps():
+                 "https://storage.googleapis.com/grpc-bazel-mirror/github.com/c-ares/c-ares/archive/e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz",
+                 "https://github.com/c-ares/c-ares/archive/e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz",
+             ],
++            patches = ["@com_github_grpc_grpc//third_party:cares/cares_haiku.patch"],
++            patch_args = ["-p1"],
+         )
+ 
+     if "com_google_absl" not in native.existing_rules():
+diff --git a/third_party/cares/BUILD b/third_party/cares/BUILD
+index d73f551..c7bd451 100644
+--- a/third_party/cares/BUILD
++++ b/third_party/cares/BUILD
+@@ -1,10 +1,12 @@
+ exports_files([
+     "ares_build.h",
+     "cares.BUILD",
++    "cares_haiku.patch",
+     "config_android/ares_config.h",
+     "config_darwin/ares_config.h",
+     "config_freebsd/ares_config.h",
+     "config_linux/ares_config.h",
+     "config_openbsd/ares_config.h",
++    "config_haiku/ares_config.h",
+     "config_windows/ares_config.h",
+ ])
+diff --git a/third_party/cares/cares.BUILD b/third_party/cares/cares.BUILD
+index 7939021..c556801 100644
+--- a/third_party/cares/cares.BUILD
++++ b/third_party/cares/cares.BUILD
+@@ -20,5 +20,10 @@ config_setting(
+     values = {"cpu": "darwin_arm64e"},
+ )
+ 
++config_setting(
++    name = "haiku",
++    values = {"cpu": "haiku"},
++)
++
+ config_setting(
+     name = "windows",
+@@ -111,6 +116,7 @@ copy_file(
+         ":darwin_x86_64": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",
+         ":darwin_arm64": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",
+         ":darwin_arm64e": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",
++        ":haiku": "@com_github_grpc_grpc//third_party/cares:config_haiku/ares_config.h",
+         ":windows": "@com_github_grpc_grpc//third_party/cares:config_windows/ares_config.h",
+         ":android": "@com_github_grpc_grpc//third_party/cares:config_android/ares_config.h",
+         "//conditions:default": "@com_github_grpc_grpc//third_party/cares:config_linux/ares_config.h",
+@@ -219,6 +225,7 @@ cc_library(
+     includes = ["."],
+     linkopts = select({
+         ":windows": ["-defaultlib:ws2_32.lib"],
++        ":haiku": ["-lnetwork"],
+         "//conditions:default": [],
+     }),
+     linkstatic = 1,
+diff --git a/third_party/cares/cares_haiku.patch b/third_party/cares/cares_haiku.patch
+new file mode 100644
+index 0000000..c8ca4c2
+--- /dev/null
++++ b/third_party/cares/cares_haiku.patch
+@@ -0,0 +1,42 @@
++From d1720368d0e8d2bd1a2ac0fcc6558eeb4ee15563 Mon Sep 17 00:00:00 2001
++From: "Estevan Castilho (Tevo)" <estevan.cps@gmail.com>
++Date: Sat, 7 May 2022 22:36:33 +0000
++Subject: [PATCH] Haiku: backport Jerome Duval's changes
++
++---
++ ares.h         | 2 +-
++ ares_private.h | 5 +++++
++ 2 files changed, 6 insertions(+), 1 deletion(-)
++
++diff --git a/ares.h b/ares.h
++index 06f60b3..07d2b63 100644
++--- a/ares.h
+++++ b/ares.h
++@@ -39,7 +39,7 @@
++ #if defined(_AIX) || defined(__NOVELL_LIBC__) || defined(__NetBSD__) || \
++     defined(__minix) || defined(__SYMBIAN32__) || defined(__INTEGRITY) || \
++     defined(ANDROID) || defined(__ANDROID__) || defined(__OpenBSD__) || \
++-    defined(__QNXNTO__)
+++    defined(__QNXNTO__) || defined(__HAIKU__)
++ #include <sys/select.h>
++ #endif
++ #if (defined(NETWARE) && !defined(__NOVELL_LIBC__))
++diff --git a/ares_private.h b/ares_private.h
++index 1990f69..367926e 100644
++--- a/ares_private.h
+++++ b/ares_private.h
++@@ -79,6 +79,11 @@
++ 
++ #define PATH_HOSTS             "InetDBase:Hosts"
++ 
+++#elif defined(__HAIKU__)
+++
+++#define PATH_RESOLV_CONF "/system/settings/network/resolv.conf"
+++#define PATH_HOSTS              "/system/settings/network/hosts"
+++
++ #else
++ 
++ #define PATH_RESOLV_CONF        "/etc/resolv.conf"
++-- 
++2.30.2
++
+diff --git a/third_party/cares/config_haiku/ares_config.h b/third_party/cares/config_haiku/ares_config.h
+new file mode 100644
+index 0000000..55b0df0
+--- /dev/null
++++ b/third_party/cares/config_haiku/ares_config.h
+@@ -0,0 +1,506 @@
++/* ares_config.h.  Generated from ares_config.h.in by configure.  */
++/* ares_config.h.in.  Generated from configure.ac by autoheader.  */
++
++/* Define if building universal (internal helper macro) */
++/* #undef AC_APPLE_UNIVERSAL_BUILD */
++
++/* define this if ares is built for a big endian system */
++/* #undef ARES_BIG_ENDIAN */
++
++/* when building as static part of libcurl */
++/* #undef BUILDING_LIBCURL */
++
++/* Defined for build that exposes internal static functions for testing. */
++/* #undef CARES_EXPOSE_STATICS */
++
++/* Defined for build with symbol hiding. */
++#define CARES_SYMBOL_HIDING 1
++
++/* Definition to make a library symbol externally visible. */
++#define CARES_SYMBOL_SCOPE_EXTERN __attribute__ ((__visibility__ ("default")))
++
++/* the signed version of size_t */
++#define CARES_TYPEOF_ARES_SSIZE_T ssize_t
++
++/* Use resolver library to configure cares */
++/* #undef CARES_USE_LIBRESOLV */
++
++/* if a /etc/inet dir is being used */
++/* #undef ETC_INET */
++
++/* Define to the type of arg 2 for gethostname. */
++#define GETHOSTNAME_TYPE_ARG2 size_t
++
++/* Define to the type qualifier of arg 1 for getnameinfo. */
++#define GETNAMEINFO_QUAL_ARG1 const
++
++/* Define to the type of arg 1 for getnameinfo. */
++#define GETNAMEINFO_TYPE_ARG1 struct sockaddr *
++
++/* Define to the type of arg 2 for getnameinfo. */
++#define GETNAMEINFO_TYPE_ARG2 socklen_t
++
++/* Define to the type of args 4 and 6 for getnameinfo. */
++#define GETNAMEINFO_TYPE_ARG46 socklen_t
++
++/* Define to the type of arg 7 for getnameinfo. */
++#define GETNAMEINFO_TYPE_ARG7 int
++
++/* Specifies the number of arguments to getservbyport_r */
++#define GETSERVBYPORT_R_ARGS 4
++
++/* Specifies the size of the buffer to pass to getservbyport_r */
++#define GETSERVBYPORT_R_BUFSIZE sizeof(struct servent_data)
++
++/* Define to 1 if you have AF_INET6. */
++#define HAVE_AF_INET6 1
++
++/* Define to 1 if you have the <arpa/inet.h> header file. */
++/* #undef HAVE_ARPA_INET_H */
++
++/* Define to 1 if you have the <arpa/nameser_compat.h> header file. */
++/* #undef HAVE_ARPA_NAMESER_COMPAT_H */
++
++/* Define to 1 if you have the <arpa/nameser.h> header file. */
++#define HAVE_ARPA_NAMESER_H 1
++
++/* Define to 1 if you have the <assert.h> header file. */
++#define HAVE_ASSERT_H 1
++
++/* Define to 1 if you have the `bitncmp' function. */
++/* #undef HAVE_BITNCMP */
++
++/* Define to 1 if bool is an available type. */
++#define HAVE_BOOL_T 1
++
++/* Define to 1 if you have the clock_gettime function and monotonic timer. */
++#define HAVE_CLOCK_GETTIME_MONOTONIC 1
++
++/* Define to 1 if you have the closesocket function. */
++/* #undef HAVE_CLOSESOCKET */
++
++/* Define to 1 if you have the CloseSocket camel case function. */
++/* #undef HAVE_CLOSESOCKET_CAMEL */
++
++/* Define to 1 if you have the connect function. */
++#define HAVE_CONNECT 1
++
++/* define if the compiler supports basic C++11 syntax */
++#define HAVE_CXX11 1
++
++/* Define to 1 if you have the <dlfcn.h> header file. */
++#define HAVE_DLFCN_H 1
++
++/* Define to 1 if you have the <errno.h> header file. */
++#define HAVE_ERRNO_H 1
++
++/* Define to 1 if you have the fcntl function. */
++#define HAVE_FCNTL 1
++
++/* Define to 1 if you have the <fcntl.h> header file. */
++#define HAVE_FCNTL_H 1
++
++/* Define to 1 if you have a working fcntl O_NONBLOCK function. */
++#define HAVE_FCNTL_O_NONBLOCK 1
++
++/* Define to 1 if you have the freeaddrinfo function. */
++#define HAVE_FREEADDRINFO 1
++
++/* Define to 1 if you have a working getaddrinfo function. */
++#define HAVE_GETADDRINFO 1
++
++/* Define to 1 if the getaddrinfo function is threadsafe. */
++#define HAVE_GETADDRINFO_THREADSAFE 1
++
++/* Define to 1 if you have the getenv function. */
++#define HAVE_GETENV 1
++
++/* Define to 1 if you have the gethostbyaddr function. */
++#define HAVE_GETHOSTBYADDR 1
++
++/* Define to 1 if you have the gethostbyname function. */
++#define HAVE_GETHOSTBYNAME 1
++
++/* Define to 1 if you have the gethostname function. */
++#define HAVE_GETHOSTNAME 1
++
++/* Define to 1 if you have the getnameinfo function. */
++#define HAVE_GETNAMEINFO 1
++
++/* Define to 1 if you have the getservbyport_r function. */
++#define HAVE_GETSERVBYPORT_R 1
++
++/* Define to 1 if you have the `gettimeofday' function. */
++#define HAVE_GETTIMEOFDAY 1
++
++/* Define to 1 if you have the `if_indextoname' function. */
++#define HAVE_IF_INDEXTONAME 1
++
++/* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
++/* #undef HAVE_INET_NET_PTON */
++
++/* Define to 1 if you have a IPv6 capable working inet_ntop function. */
++/* #undef HAVE_INET_NTOP */
++
++/* Define to 1 if you have a IPv6 capable working inet_pton function. */
++/* #undef HAVE_INET_PTON */
++
++/* Define to 1 if you have the <inttypes.h> header file. */
++#define HAVE_INTTYPES_H 1
++
++/* Define to 1 if you have the ioctl function. */
++#define HAVE_IOCTL 1
++
++/* Define to 1 if you have the ioctlsocket function. */
++/* #undef HAVE_IOCTLSOCKET */
++
++/* Define to 1 if you have the IoctlSocket camel case function. */
++/* #undef HAVE_IOCTLSOCKET_CAMEL */
++
++/* Define to 1 if you have a working IoctlSocket camel case FIONBIO function.
++   */
++/* #undef HAVE_IOCTLSOCKET_CAMEL_FIONBIO */
++
++/* Define to 1 if you have a working ioctlsocket FIONBIO function. */
++/* #undef HAVE_IOCTLSOCKET_FIONBIO */
++
++/* Define to 1 if you have a working ioctl FIONBIO function. */
++#define HAVE_IOCTL_FIONBIO 1
++
++/* Define to 1 if you have a working ioctl SIOCGIFADDR function. */
++/* #undef HAVE_IOCTL_SIOCGIFADDR */
++
++/* Define to 1 if you have the `resolve' library (-lresolve). */
++/* #undef HAVE_LIBRESOLVE */
++
++/* Define to 1 if you have the <limits.h> header file. */
++#define HAVE_LIMITS_H 1
++
++/* if your compiler supports LL */
++#define HAVE_LL 1
++
++/* Define to 1 if the compiler supports the 'long long' data type. */
++#define HAVE_LONGLONG 1
++
++/* Define to 1 if you have the malloc.h header file. */
++#define HAVE_MALLOC_H 1
++
++/* Define to 1 if you have the memory.h header file. */
++#define HAVE_MEMORY_H 1
++
++/* Define to 1 if you have the MSG_NOSIGNAL flag. */
++#define HAVE_MSG_NOSIGNAL 1
++
++/* Define to 1 if you have the <netdb.h> header file. */
++#define HAVE_NETDB_H 1
++
++/* Define to 1 if you have the <netinet/in.h> header file. */
++#define HAVE_NETINET_IN_H 1
++
++/* Define to 1 if you have the <netinet/tcp.h> header file. */
++#define HAVE_NETINET_TCP_H 1
++
++/* Define to 1 if you have the <net/if.h> header file. */
++#define HAVE_NET_IF_H 1
++
++/* Define to 1 if you have PF_INET6. */
++#define HAVE_PF_INET6 1
++
++/* Define to 1 if you have the recv function. */
++#define HAVE_RECV 1
++
++/* Define to 1 if you have the recvfrom function. */
++#define HAVE_RECVFROM 1
++
++/* Define to 1 if you have the send function. */
++#define HAVE_SEND 1
++
++/* Define to 1 if you have the setsockopt function. */
++#define HAVE_SETSOCKOPT 1
++
++/* Define to 1 if you have a working setsockopt SO_NONBLOCK function. */
++#define HAVE_SETSOCKOPT_SO_NONBLOCK 1
++
++/* Define to 1 if you have the <signal.h> header file. */
++#define HAVE_SIGNAL_H 1
++
++/* Define to 1 if sig_atomic_t is an available typedef. */
++#define HAVE_SIG_ATOMIC_T 1
++
++/* Define to 1 if sig_atomic_t is already defined as volatile. */
++/* #undef HAVE_SIG_ATOMIC_T_VOLATILE */
++
++/* Define to 1 if your struct sockaddr_in6 has sin6_scope_id. */
++#define HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID 1
++
++/* Define to 1 if you have the socket function. */
++#define HAVE_SOCKET 1
++
++/* Define to 1 if you have the <socket.h> header file. */
++/* #undef HAVE_SOCKET_H */
++
++/* Define to 1 if you have the <stdbool.h> header file. */
++#define HAVE_STDBOOL_H 1
++
++/* Define to 1 if you have the <stdint.h> header file. */
++#define HAVE_STDINT_H 1
++
++/* Define to 1 if you have the <stdio.h> header file. */
++#define HAVE_STDIO_H 1
++
++/* Define to 1 if you have the <stdlib.h> header file. */
++#define HAVE_STDLIB_H 1
++
++/* Define to 1 if you have the strcasecmp function. */
++#define HAVE_STRCASECMP 1
++
++/* Define to 1 if you have the strcmpi function. */
++/* #undef HAVE_STRCMPI */
++
++/* Define to 1 if you have the strdup function. */
++#define HAVE_STRDUP 1
++
++/* Define to 1 if you have the stricmp function. */
++/* #undef HAVE_STRICMP */
++
++/* Define to 1 if you have the <strings.h> header file. */
++#define HAVE_STRINGS_H 1
++
++/* Define to 1 if you have the <string.h> header file. */
++#define HAVE_STRING_H 1
++
++/* Define to 1 if you have the strncasecmp function. */
++#define HAVE_STRNCASECMP 1
++
++/* Define to 1 if you have the strncmpi function. */
++/* #undef HAVE_STRNCMPI */
++
++/* Define to 1 if you have the strnicmp function. */
++/* #undef HAVE_STRNICMP */
++
++/* Define to 1 if you have the <stropts.h> header file. */
++/* #undef HAVE_STROPTS_H */
++
++/* Define to 1 if you have struct addrinfo. */
++#define HAVE_STRUCT_ADDRINFO 1
++
++/* Define to 1 if you have struct in6_addr. */
++#define HAVE_STRUCT_IN6_ADDR 1
++
++/* Define to 1 if you have struct sockaddr_in6. */
++#define HAVE_STRUCT_SOCKADDR_IN6 1
++
++/* if struct sockaddr_storage is defined */
++#define HAVE_STRUCT_SOCKADDR_STORAGE 1
++
++/* Define to 1 if you have the timeval struct. */
++#define HAVE_STRUCT_TIMEVAL 1
++
++/* Define to 1 if you have the <sys/ioctl.h> header file. */
++#define HAVE_SYS_IOCTL_H 1
++
++/* Define to 1 if you have the <sys/param.h> header file. */
++#define HAVE_SYS_PARAM_H 1
++
++/* Define to 1 if you have the <sys/select.h> header file. */
++#define HAVE_SYS_SELECT_H 1
++
++/* Define to 1 if you have the <sys/socket.h> header file. */
++#define HAVE_SYS_SOCKET_H 1
++
++/* Define to 1 if you have the <sys/stat.h> header file. */
++#define HAVE_SYS_STAT_H 1
++
++/* Define to 1 if you have the <sys/time.h> header file. */
++#define HAVE_SYS_TIME_H 1
++
++/* Define to 1 if you have the <sys/types.h> header file. */
++#define HAVE_SYS_TYPES_H 1
++
++/* Define to 1 if you have the <sys/uio.h> header file. */
++#define HAVE_SYS_UIO_H 1
++
++/* Define to 1 if you have the <time.h> header file. */
++#define HAVE_TIME_H 1
++
++/* Define to 1 if you have the <unistd.h> header file. */
++#define HAVE_UNISTD_H 1
++
++/* Define to 1 if you have the windows.h header file. */
++/* #undef HAVE_WINDOWS_H */
++
++/* Define to 1 if you have the winsock2.h header file. */
++/* #undef HAVE_WINSOCK2_H */
++
++/* Define to 1 if you have the winsock.h header file. */
++/* #undef HAVE_WINSOCK_H */
++
++/* Define to 1 if you have the writev function. */
++#define HAVE_WRITEV 1
++
++/* Define to 1 if you have the ws2tcpip.h header file. */
++/* #undef HAVE_WS2TCPIP_H */
++
++/* Define if __system_property_get exists. */
++/* #undef HAVE___SYSTEM_PROPERTY_GET */
++
++/* Define to the sub-directory where libtool stores uninstalled libraries. */
++#define LT_OBJDIR ".libs/"
++
++/* Define to 1 if you need the malloc.h header file even with stdlib.h */
++/* #undef NEED_MALLOC_H */
++
++/* Define to 1 if you need the memory.h header file even with stdlib.h */
++/* #undef NEED_MEMORY_H */
++
++/* Define to 1 if _REENTRANT preprocessor symbol must be defined. */
++/* #undef NEED_REENTRANT */
++
++/* Define to 1 if _THREAD_SAFE preprocessor symbol must be defined. */
++/* #undef NEED_THREAD_SAFE */
++
++/* cpu-machine-OS */
++#define OS "x86_64-unknown-haiku"
++
++/* Name of package */
++#define PACKAGE "c-ares"
++
++/* Define to the address where bug reports for this package should be sent. */
++#define PACKAGE_BUGREPORT "c-ares mailing list: http://cool.haxx.se/mailman/listinfo/c-ares"
++
++/* Define to the full name of this package. */
++#define PACKAGE_NAME "c-ares"
++
++/* Define to the full name and version of this package. */
++#define PACKAGE_STRING "c-ares 1.15.0"
++
++/* Define to the one symbol short name of this package. */
++#define PACKAGE_TARNAME "c-ares"
++
++/* Define to the home page for this package. */
++#define PACKAGE_URL ""
++
++/* Define to the version of this package. */
++#define PACKAGE_VERSION "1.15.0"
++
++/* a suitable file/device to read random data from */
++#define RANDOM_FILE "/dev/urandom"
++
++/* Define to the type qualifier pointed by arg 5 for recvfrom. */
++#define RECVFROM_QUAL_ARG5 
++
++/* Define to the type of arg 1 for recvfrom. */
++#define RECVFROM_TYPE_ARG1 int
++
++/* Define to the type pointed by arg 2 for recvfrom. */
++#define RECVFROM_TYPE_ARG2 void
++
++/* Define to 1 if the type pointed by arg 2 for recvfrom is void. */
++#define RECVFROM_TYPE_ARG2_IS_VOID 1
++
++/* Define to the type of arg 3 for recvfrom. */
++#define RECVFROM_TYPE_ARG3 size_t
++
++/* Define to the type of arg 4 for recvfrom. */
++#define RECVFROM_TYPE_ARG4 int
++
++/* Define to the type pointed by arg 5 for recvfrom. */
++#define RECVFROM_TYPE_ARG5 struct sockaddr
++
++/* Define to 1 if the type pointed by arg 5 for recvfrom is void. */
++/* #undef RECVFROM_TYPE_ARG5_IS_VOID */
++
++/* Define to the type pointed by arg 6 for recvfrom. */
++#define RECVFROM_TYPE_ARG6 socklen_t
++
++/* Define to 1 if the type pointed by arg 6 for recvfrom is void. */
++/* #undef RECVFROM_TYPE_ARG6_IS_VOID */
++
++/* Define to the function return type for recvfrom. */
++#define RECVFROM_TYPE_RETV ssize_t
++
++/* Define to the type of arg 1 for recv. */
++#define RECV_TYPE_ARG1 int
++
++/* Define to the type of arg 2 for recv. */
++#define RECV_TYPE_ARG2 void *
++
++/* Define to the type of arg 3 for recv. */
++#define RECV_TYPE_ARG3 size_t
++
++/* Define to the type of arg 4 for recv. */
++#define RECV_TYPE_ARG4 int
++
++/* Define to the function return type for recv. */
++#define RECV_TYPE_RETV ssize_t
++
++/* Define as the return type of signal handlers (`int' or `void'). */
++#define RETSIGTYPE void
++
++/* Define to the type qualifier of arg 2 for send. */
++#define SEND_QUAL_ARG2 const
++
++/* Define to the type of arg 1 for send. */
++#define SEND_TYPE_ARG1 int
++
++/* Define to the type of arg 2 for send. */
++#define SEND_TYPE_ARG2 void *
++
++/* Define to the type of arg 3 for send. */
++#define SEND_TYPE_ARG3 size_t
++
++/* Define to the type of arg 4 for send. */
++#define SEND_TYPE_ARG4 int
++
++/* Define to the function return type for send. */
++#define SEND_TYPE_RETV ssize_t
++
++/* Define to 1 if all of the C90 standard headers exist (not just the ones
++   required in a freestanding environment). This macro is provided for
++   backward compatibility; new code need not use it. */
++#define STDC_HEADERS 1
++
++/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. This
++   macro is obsolete. */
++#define TIME_WITH_SYS_TIME 1
++
++/* Define to disable non-blocking sockets. */
++/* #undef USE_BLOCKING_SOCKETS */
++
++/* Version number of package */
++#define VERSION "1.15.0"
++
++/* Define to avoid automatic inclusion of winsock.h */
++/* #undef WIN32_LEAN_AND_MEAN */
++
++/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
++   significant byte first (like Motorola and SPARC, unlike Intel). */
++#if defined AC_APPLE_UNIVERSAL_BUILD
++# if defined __BIG_ENDIAN__
++#  define WORDS_BIGENDIAN 1
++# endif
++#else
++# ifndef WORDS_BIGENDIAN
++/* #  undef WORDS_BIGENDIAN */
++# endif
++#endif
++
++/* Define to 1 if OS is AIX. */
++#ifndef _ALL_SOURCE
++/* #  undef _ALL_SOURCE */
++#endif
++
++/* Number of bits in a file offset, on hosts where this is settable. */
++/* #undef _FILE_OFFSET_BITS */
++
++/* Define for large files, on AIX-style hosts. */
++/* #undef _LARGE_FILES */
++
++/* Define to empty if `const' does not conform to ANSI C. */
++/* #undef const */
++
++/* Type to use in place of in_addr_t when system does not provide it. */
++/* #undef in_addr_t */
++
++/* Define to `unsigned int' if <sys/types.h> does not define. */
++/* #undef size_t */
+-- 
+2.30.2
+

--- a/third_party/grpc/grpc_1.41.0.haiku.patch
+++ b/third_party/grpc/grpc_1.41.0.haiku.patch
@@ -1,0 +1,174 @@
+From 9be8fe9ed49e79f1c10dd389d6209b290e2efb40 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Sat, 16 Oct 2021 21:33:26 +0200
+Subject: Haiku: port
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8248866..4a8a692 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -269,7 +269,7 @@ if(_gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_IOS)
+   set(_gRPC_ALLTARGETS_LIBRARIES ${CMAKE_DL_LIBS} m pthread)
+ elseif(_gRPC_PLATFORM_ANDROID)
+   set(_gRPC_ALLTARGETS_LIBRARIES ${CMAKE_DL_LIBS} m)
+-elseif(UNIX)
++elseif(UNIX AND NOT HAIKU)
+   set(_gRPC_ALLTARGETS_LIBRARIES ${CMAKE_DL_LIBS} rt m pthread)
+ endif()
+ 
+diff --git a/include/grpc/event_engine/port.h b/include/grpc/event_engine/port.h
+index 9424586..5ee5327 100644
+--- a/include/grpc/event_engine/port.h
++++ b/include/grpc/event_engine/port.h
+@@ -20,7 +20,7 @@
+ #if defined(GPR_ANDROID) || defined(GPR_LINUX) || defined(GPR_APPLE) ||     \
+     defined(GPR_FREEBSD) || defined(GPR_OPENBSD) || defined(GPR_SOLARIS) || \
+     defined(GPR_AIX) || defined(GPR_NACL) || defined(GPR_FUCHSIA) ||        \
+-    defined(GRPC_POSIX_SOCKET)
++    defined(GPR_HAIKU) || defined(GRPC_POSIX_SOCKET)
+ #define GRPC_EVENT_ENGINE_POSIX
+ #include <arpa/inet.h>
+ #include <netdb.h>
+diff --git a/include/grpc/impl/codegen/port_platform.h b/include/grpc/impl/codegen/port_platform.h
+index d9fdeed..145b60b 100644
+--- a/include/grpc/impl/codegen/port_platform.h
++++ b/include/grpc/impl/codegen/port_platform.h
+@@ -400,6 +400,30 @@
+ #define GPR_HAS_PTHREAD_H 1
+ #define GPR_GETPID_IN_UNISTD_H 1
+ #define GRPC_ROOT_PEM_PATH "/config/ssl/cert.pem"
++#elif defined(__HAIKU__)
++#define GPR_PLATFORM_STRING "haiku"
++#ifndef _BSD_SOURCE
++#define _BSD_SOURCE
++#endif
++#define GPR_HAIKU 1
++#define GPR_CPU_POSIX 1
++#define GPR_GCC_ATOMIC 1
++#define GPR_POSIX_LOG 1
++#define GPR_POSIX_ENV 1
++#define GPR_POSIX_TMPFILE 1
++#define GPR_POSIX_STAT 1
++#define GPR_POSIX_STRING 1
++#define GPR_POSIX_SUBPROCESS 1
++#define GPR_POSIX_SYNC 1
++#define GPR_POSIX_TIME 1
++#define GPR_HAS_PTHREAD_H 1
++#define GPR_GETPID_IN_UNISTD_H 1
++#define GPR_SUPPORT_CHANNELS_FROM_FD 1
++#ifdef _LP64
++#define GPR_ARCH_64 1
++#else /* _LP64 */
++#define GPR_ARCH_32 1
++#endif /* _LP64 */
+ #else
+ #error "Could not auto-detect platform"
+ #endif
+diff --git a/src/core/lib/gpr/tls.h b/src/core/lib/gpr/tls.h
+index 5c9b69e..d989134 100644
+--- a/src/core/lib/gpr/tls.h
++++ b/src/core/lib/gpr/tls.h
+@@ -144,7 +144,7 @@ class PthreadTlsImpl : TlsTypeConstrainer<T> {
+ #else
+ 
+ #define GPR_THREAD_LOCAL(type) \
+-  thread_local typename grpc_core::TlsTypeConstrainer<type>::Type
++  __thread typename grpc_core::TlsTypeConstrainer<type>::Type
+ 
+ #endif
+ 
+diff --git a/src/core/lib/iomgr/port.h b/src/core/lib/iomgr/port.h
+index 3e32429..28e9b11 100644
+--- a/src/core/lib/iomgr/port.h
++++ b/src/core/lib/iomgr/port.h
+@@ -180,6 +180,16 @@
+ // TODO(rudominer) Check this does something we want.
+ #define GRPC_POSIX_SOCKETUTILS 1
+ #define GRPC_TIMER_USE_GENERIC 1
++#elif defined(GPR_HAIKU)
++#define GRPC_HAVE_ARPA_NAMESER 1
++#define GRPC_HAVE_IFADDRS 1
++#define GRPC_HAVE_IPV6_RECVPKTINFO 1
++#define GRPC_HAVE_UNIX_SOCKET 1
++#define GRPC_POSIX_FORK 1
++#define GRPC_POSIX_NO_SPECIAL_WAKEUP_FD 1
++#define GRPC_POSIX_SOCKET 1
++#define GRPC_POSIX_SOCKETUTILS 1
++#define GRPC_POSIX_WAKEUP_FD 1
+ #elif !defined(GPR_NO_AUTODETECT_PLATFORM)
+ #error "Platform not recognized"
+ #endif
+-- 
+2.30.2
+
+
+From f00bad0d226184c3360be70b3894140786c98427 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Fri, 22 Oct 2021 14:54:43 +0200
+Subject: patch needed to help build and run tests on Haiku
+
+
+diff --git a/tools/run_tests/python_utils/jobset.py b/tools/run_tests/python_utils/jobset.py
+index 48503d3..500aafe 100755
+--- a/tools/run_tests/python_utils/jobset.py
++++ b/tools/run_tests/python_utils/jobset.py
+@@ -58,6 +58,8 @@ def platform_string():
+         return 'mac'
+     elif platform.system() == 'Linux':
+         return 'linux'
++    elif platform.system() == 'Haiku':
++        return 'haiku'
+     else:
+         return 'posix'
+ 
+diff --git a/tools/run_tests/run_tests.py b/tools/run_tests/run_tests.py
+index 9fa3b4b..5ea7fa0 100755
+--- a/tools/run_tests/run_tests.py
++++ b/tools/run_tests/run_tests.py
+@@ -273,6 +273,19 @@ class CLanguage(object):
+                 # see https://github.com/grpc/grpc/blob/b5b8578b3f8b4a9ce61ed6677e19d546e43c5c68/tools/run_tests/artifacts/artifact_targets.py#L253
+                 self._cmake_configure_extra_args.append('-DOPENSSL_NO_ASM=ON')
+ 
++            if self.platform == 'haiku':
++                self._cmake_configure_extra_args.append('-DCMAKE_CXX_STANDARD=17')
++                self._cmake_configure_extra_args.append('-DCMAKE_POSITION_INDEPENDENT_CODE=NO')
++                self._cmake_configure_extra_args.append('-DgRPC_ABSL_PROVIDER=package')
++                self._cmake_configure_extra_args.append('-DgRPC_BENCHMARK_PROVIDER=package')
++                self._cmake_configure_extra_args.append('-DgRPC_CARES_PROVIDER=package')
++                self._cmake_configure_extra_args.append('-DgRPC_ZLIB_PROVIDER=package')
++                self._cmake_configure_extra_args.append('-DgRPC_PROTOBUF_PROVIDER=package')
++                self._cmake_configure_extra_args.append('-DgRPC_PROTOBUF_PACKAGE_TYPE=MODULE')
++                self._cmake_configure_extra_args.append('-DgRPC_RE2_PROVIDER=package')
++                self._cmake_configure_extra_args.append('-DgRPC_SSL_PROVIDER=package')
++                self._cmake_configure_extra_args.append('-DgRPC_ZLIB_PROVIDER=package')
++
+     def test_specs(self):
+         out = []
+         binaries = get_c_tests(self.args.travis, self.test_lang)
+-- 
+2.30.2
+
+
+From 11c8a037deda0da7031e015cf338180da21213d3 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Fri, 26 Nov 2021 20:17:18 +0100
+Subject: protobuf minimum version 1.16.0
+
+
+diff --git a/cmake/protobuf.cmake b/cmake/protobuf.cmake
+index f23f65d..83fad47 100644
+--- a/cmake/protobuf.cmake
++++ b/cmake/protobuf.cmake
+@@ -55,7 +55,7 @@ if(gRPC_PROTOBUF_PROVIDER STREQUAL "module")
+     set(gRPC_INSTALL FALSE)
+   endif()
+ elseif(gRPC_PROTOBUF_PROVIDER STREQUAL "package")
+-  find_package(Protobuf REQUIRED ${gRPC_PROTOBUF_PACKAGE_TYPE})
++  find_package(Protobuf 1.16.0 REQUIRED ${gRPC_PROTOBUF_PACKAGE_TYPE})
+ 
+   # {Protobuf,PROTOBUF}_FOUND is defined based on find_package type ("MODULE" vs "CONFIG").
+   # For "MODULE", the case has also changed between cmake 3.5 and 3.6.
+-- 
+2.30.2
+


### PR DESCRIPTION
This contains patches for 3rd-party dependencies as a part of my Haiku port, as mentioned on https://github.com/bazelbuild/bazel/issues/12522#issuecomment-1121321856.

I am not sure whether this should be merged as-is. The gRPC changes include a backport of grpc/grpc#27793, which is currently unmerged and seems to be stalled(?), as well as a backport of c-ares/c-ares@7586c5f and my own, currently unsubmitted changes, both for gRPC's c-ares dependency. The c-ares changes contains the same backport, without my changes; I am not sure whether that was necessary.

The abseil patches contains build fixes taken from [haikuports](https://github.com/haikuports/haikuports/blob/master/dev-cpp/abseil-cpp/patches/abseil_cpp-20211102.0.patchset), which doesn't seem to have been submitted upstream.

I imagine I'd need to get permission (and CLA signatures?) from the patch authors were any of them to be merged? I also suppose it would be a good idea to wait an upstream answer from gRPC before moving this further?