### PR TITLE
Ensure cc rules "cpp_link" exec group works for cc rules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/cpp/BazelCppRuleClasses.java
@@ -573,7 +573,7 @@ public class BazelCppRuleClasses {
       return RuleDefinition.Metadata.builder()
           .name("$cc_binary_base")
           .type(RuleClassType.ABSTRACT)
-          .ancestors(CcRule.class)
+          .ancestors(CcRule.class, CppRuleClasses.CcLinkingRule.class)
           .build();
     }
   }


### PR DESCRIPTION
The docs in https://docs.bazel.build/versions/main/exec-groups.html#execution-groups-for-native-rules state that there is a `cpp_link` execution group that allows you to customize the execution of the link actions of cc rules.

This only seems to work for the objc rule classes however since the normal cc linking do not inherit from CcLinkingRule rule class.

This PR ensures consistency in the execution groups across cc rules that link.