### PR TITLE
Add support for repository cache to `git_repository`

### DIFF
--- a/tools/build_defs/repo/git_worker.bzl
+++ b/tools/build_defs/repo/git_worker.bzl
@@ -14,9 +14,12 @@
 """Code for interacting with git binary to get the file tree checked out at the specified revision.
 """
 
+load(":utils.bzl", "join_paths")
+
 _GitRepoInfo = provider(
     doc = "Provider to organize precomputed arguments for calling git.",
     fields = {
+        "cache_dir": "Repository cached directory path",
         "directory": "Working directory path",
         "shallow": "Defines the depth of a fetch. Either empty, --depth=1, or --shallow-since=<>",
         "reset_ref": """Reference to use for resetting the git repository.
@@ -69,7 +72,13 @@ def git_repo(ctx, directory):
         reset_ref = "origin/" + ctx.attr.branch
         fetch_ref = ctx.attr.branch + ":origin/" + ctx.attr.branch
 
+    if ctx.os.environ.get("BAZEL_GIT_REPOSITORY_CACHE"):
+        cache_dir = join_paths(ctx.os.environ.get("BAZEL_GIT_REPOSITORY_CACHE"), str(hash(ctx.attr.remote)))
+    else:
+        cache_dir = None
+
     git_repo = _GitRepoInfo(
+        cache_dir = cache_dir,
         directory = ctx.path(directory),
         shallow = shallow,
         reset_ref = reset_ref,
@@ -93,15 +102,129 @@ def git_repo(ctx, directory):
     actual_commit = _get_head_commit(ctx, git_repo)
     shallow_date = _get_head_date(ctx, git_repo)
 
+    # Clean up all worktree information from the cache directory, to not leave
+    # any residual states. Not using `git worktree prune` since we don't want
+    # locked worktrees to block this operation.
+    ctx.delete("{}/worktrees".format(cache_dir))
+
     return struct(commit = actual_commit, shallow_since = shallow_date)
+
+def _if_debug(cond, st, what = "Action"):
+    "Print if 'cond'."
+    if cond:
+        print("{} returned {}\n{}\n----\n{}".format(what, st.return_code, st.stdout, st.stderr))
+
+def _setup_cache(ctx, git_repo):
+    # Create cache directory
+    cl = ["mkdir", "-p", git_repo.cache_dir]
+    st = ctx.execute(
+        cl,
+        environment = ctx.os.environ,
+    )
+    _if_debug(cond = ctx.attr.verbose, st = st, what = " ".join(cl))
+    if st.return_code:
+        _error(ctx.name, cl, st.stderr)
+
+    # Init git cache directory
+    cl = ["git", "init", "--bare"]
+    st = ctx.execute(
+        cl,
+        environment = ctx.os.environ,
+        working_directory = git_repo.cache_dir,
+    )
+    _if_debug(cond = ctx.attr.verbose, st = st, what = " ".join(cl))
+
+def _get_repository_from_cache(ctx, git_repo):
+    ctx.delete(join_paths(git_repo.cache_dir, "worktrees"))
+    ctx.delete(git_repo.directory)
+
+    cl = ["git", "worktree", "add", str(git_repo.directory), git_repo.reset_ref]
+    st = ctx.execute(
+        cl,
+        environment = ctx.os.environ,
+        working_directory = git_repo.cache_dir,
+    )
+    _if_debug(cond = ctx.attr.verbose, st = st, what = " ".join(cl))
+
+    # This fails on the first run for a specific ref, but return the result and
+    # don't stop the execution here; we'll need to know that it fails in order
+    # to fall back to fetching from the remote repository.
+    return st
+
+def _populate_cache(ctx, git_repo):
+    # Fetch w/ shallow and w/ ref
+    cl = ["git", "fetch", git_repo.shallow, git_repo.remote, git_repo.reset_ref]
+    st = ctx.execute(
+        cl,
+        environment = ctx.os.environ,
+        working_directory = git_repo.cache_dir,
+    )
+    _if_debug(cond = ctx.attr.verbose, st = st, what = " ".join(cl))
+    if st.return_code == 0:
+        return
+
+    # If above fails, try to fetch w/o shallow, and w/ ref
+    cl = ["git", "fetch", git_repo.remote, git_repo.reset_ref]
+    st = ctx.execute(
+        cl,
+        environment = ctx.os.environ,
+        working_directory = git_repo.cache_dir,
+    )
+    _if_debug(cond = ctx.attr.verbose, st = st, what = " ".join(cl))
+    if st.return_code == 0:
+        return
+
+    # If above fails, try to fetch w/ shallow, and w/o ref
+    cl = ["git", "fetch", git_repo.shallow, git_repo.remote]
+    st = ctx.execute(
+        cl,
+        environment = ctx.os.environ,
+        working_directory = git_repo.cache_dir,
+    )
+    _if_debug(cond = ctx.attr.verbose, st = st, what = " ".join(cl))
+    if st.return_code == 0:
+        return
+
+    # If above fails, try to fetch w/o shallow, and w/o ref
+    cl = ["git", "fetch", git_repo.remote]
+    st = ctx.execute(
+        cl,
+        environment = ctx.os.environ,
+        working_directory = git_repo.cache_dir,
+    )
+    _if_debug(cond = ctx.attr.verbose, st = st, what = " ".join(cl))
+
+    if st.return_code:
+        _error(ctx.name, cl, st.stderr)
+
+def _is_git_worktree_available(ctx):
+    st = ctx.execute(
+        ["git", "worktree", "--help"],
+        environment = ctx.os.environ,
+    )
+    return st.return_code == 0
 
 def _update(ctx, git_repo):
     ctx.delete(git_repo.directory)
 
-    init(ctx, git_repo)
-    add_origin(ctx, git_repo, ctx.attr.remote)
-    fetch(ctx, git_repo)
-    reset(ctx, git_repo)
+    # Using git repository cache
+    if git_repo.cache_dir and _is_git_worktree_available(ctx):
+        _setup_cache(ctx, git_repo)
+        st = _get_repository_from_cache(ctx, git_repo)
+        if st.return_code:
+            if ctx.attr.verbose:
+                print("{} not found in cache. Fetching from remote...".format(git_repo.reset_ref))
+            _populate_cache(ctx, git_repo)
+            st = _get_repository_from_cache(ctx, git_repo)
+            if st.return_code:
+                fail("Error checking out worktree {}:\n{}".format(ctx.name, st.stderr))
+    else:
+        # Not using git repository cache
+        init(ctx, git_repo)
+        add_origin(ctx, git_repo, ctx.attr.remote)
+        fetch(ctx, git_repo)
+        reset(ctx, git_repo)
+
     clean(ctx, git_repo)
 
     if git_repo.recursive_init_submodules:

--- a/tools/build_defs/repo/utils.bzl
+++ b/tools/build_defs/repo/utils.bzl
@@ -409,3 +409,40 @@ def read_user_netrc(ctx):
     if not ctx.path(netrcfile).exists:
         return {}
     return read_netrc(ctx, netrcfile)
+
+# From https://github.com/bazelbuild/bazel-skylib/blob/312bccd83b1364fa736dde97ccba3d2b40cdfabc/lib/paths.bzl#L59
+def path_is_absolute(path):
+    """Returns `True` if `path` is an absolute path.
+    Args:
+      path: A path (which is a string).
+    Returns:
+      `True` if `path` is an absolute path.
+    """
+    return path.startswith("/") or (len(path) > 2 and path[1] == ":")
+
+# From https://github.com/bazelbuild/bazel-skylib/blob/312bccd83b1364fa736dde97ccba3d2b40cdfabc/lib/paths.bzl#L70
+def join_paths(path, *others):
+    """Joins one or more path components intelligently.
+    This function mimics the behavior of Python's `os.path.join` function on POSIX
+    platform. It returns the concatenation of `path` and any members of `others`,
+    inserting directory separators before each component except the first. The
+    separator is not inserted if the path up until that point is either empty or
+    already ends in a separator.
+    If any component is an absolute path, all previous components are discarded.
+    Args:
+      path: A path segment.
+      *others: Additional path segments.
+    Returns:
+      A string containing the joined paths.
+    """
+    result = path
+
+    for p in others:
+        if path_is_absolute(p):
+            result = p
+        elif not result or result.endswith("/"):
+            result += p
+        else:
+            result += "/" + p
+
+    return result


### PR DESCRIPTION
If a `BAZEL_GIT_REPOSITORY_CACHE` environment variable is set to a path,
use that as the cache directory for `git_repository`.

Based on https://github.com/bazelbuild/bazel/pull/7424