### PR TITLE
Add test cases for GenericTypeHelper class

### DIFF
--- a/src/test/java/com/google/devtools/common/options/GenericTypeHelperTest.java
+++ b/src/test/java/com/google/devtools/common/options/GenericTypeHelperTest.java
@@ -90,13 +90,13 @@ public class GenericTypeHelperTest {
   }
 
   @Test
-  public void assingableFromSuper() {
+  public void assignableFromSuper() {
     assertThat(GenericTypeHelper.isAssignableFrom(DoSomething.class, EnumSomething.class)).isTrue();
     assertThat(GenericTypeHelper.isAssignableFrom(EnumSomething.class, AlphabetSomething.class)).isTrue();
   }
 
   @Test
-  public void assingableFromSuperSecondGrade() {
+  public void assignableFromSuperSecondGrade() {
     assertThat(GenericTypeHelper.isAssignableFrom(EnumSomething.class, AlphabetTwoSomething.class)).isTrue();
   }
 }

--- a/src/test/java/com/google/devtools/common/options/GenericTypeHelperTest.java
+++ b/src/test/java/com/google/devtools/common/options/GenericTypeHelperTest.java
@@ -15,6 +15,7 @@
 package com.google.devtools.common.options;
 
 import static com.google.common.truth.Truth.assertThat;
+import com.google.common.reflect.TypeToken;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,5 +72,31 @@ public class GenericTypeHelperTest {
   @Test
   public void getConverterTypeForGenericExtensionSecondGrade() throws Exception {
     assertDoIt(String.class, AlphabetTwoSomething.class);
+  }
+
+  @Test
+  public void getConverterTypeForParameterizedType() throws Exception {
+    TypeToken<EnumSomething<String>> enSthTypeToken = new TypeToken<>() {};
+    EnumSomething<String> instance = new EnumSomething<>();
+    assertThat(GenericTypeHelper.getActualReturnType(enSthTypeToken.getType(),
+        instance.getClass().getMethod("doIt"))).isEqualTo(String.class);
+  }
+
+  @Test
+  public void assignableFromPrimitive() {
+    assertThat(GenericTypeHelper.isAssignableFrom(Integer.TYPE, Integer.class)).isTrue();
+    assertThat(GenericTypeHelper.isAssignableFrom(Integer.TYPE, Long.TYPE)).isFalse();
+    assertThat(GenericTypeHelper.isAssignableFrom(Integer.TYPE, Integer.TYPE)).isFalse();
+  }
+
+  @Test
+  public void assingableFromSuper() {
+    assertThat(GenericTypeHelper.isAssignableFrom(DoSomething.class, EnumSomething.class)).isTrue();
+    assertThat(GenericTypeHelper.isAssignableFrom(EnumSomething.class, AlphabetSomething.class)).isTrue();
+  }
+
+  @Test
+  public void assingableFromSuperSecondGrade() {
+    assertThat(GenericTypeHelper.isAssignableFrom(EnumSomething.class, AlphabetTwoSomething.class)).isTrue();
   }
 }


### PR DESCRIPTION
Hi there,

This commit adds test cases for uncovered/partially covered methods `isAssignableFrom` and `getActualReturnType` for `GenericTypeHelper` class in package `com.google.devtools.common.options`. Please feel free to request any changes needed.