### PR TITLE
Add test cases for OptionsParser considering allowResidue

### DIFF
--- a/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import org.junit.Test;
@@ -219,7 +220,7 @@ public final class OptionsParserTest {
             assertThrows(OptionsParsingException.class, () -> parser.parseWithSourceFunction(
                     PriorityCategory.COMMAND_LINE,
                     sourceFunction,
-                    Arrays.asList("residue", "not", "allowed", "in", "parseWithSource")));
+                    ImmutableList.of("residue", "not", "allowed", "in", "parseWithSource")));
     assertThat(e).hasMessageThat().isEqualTo("Unrecognized arguments: residue not allowed in parseWithSource");
     assertThat(parser.getResidue()).containsExactly("residue", "not", "allowed", "in", "parseWithSource");
   }
@@ -233,7 +234,7 @@ public final class OptionsParserTest {
     parser.parseWithSourceFunction(
             PriorityCategory.COMMAND_LINE,
             sourceFunction,
-            Arrays.asList("residue", "is", "allowed", "in", "parseWithSource"));
+            ImmutableList.of("residue", "is", "allowed", "in", "parseWithSource"));
     assertThat(parser.getResidue()).containsExactly("residue", "is", "allowed", "in", "parseWithSource");
   }
 

--- a/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
+++ b/src/test/java/com/google/devtools/common/options/OptionsParserTest.java
@@ -210,6 +210,53 @@ public final class OptionsParserTest {
   }
 
   @Test
+  public void parseWithSourceFunctionThrowsExceptionIfResidueIsNotAllowed() {
+    OptionsParser parser =
+            OptionsParser.builder().optionsClasses(ExampleFoo.class, ExampleBaz.class).allowResidue(false).build();
+    Function<OptionDefinition, String> sourceFunction = option -> "command line";
+
+    OptionsParsingException e =
+            assertThrows(OptionsParsingException.class, () -> parser.parseWithSourceFunction(
+                    PriorityCategory.COMMAND_LINE,
+                    sourceFunction,
+                    Arrays.asList("residue", "not", "allowed", "in", "parseWithSource")));
+    assertThat(e).hasMessageThat().isEqualTo("Unrecognized arguments: residue not allowed in parseWithSource");
+    assertThat(parser.getResidue()).containsExactly("residue", "not", "allowed", "in", "parseWithSource");
+  }
+
+  @Test
+  public void parseWithSourceFunctionDoesntThrowExceptionIfResidueIsAllowed() throws Exception {
+    OptionsParser parser =
+            OptionsParser.builder().optionsClasses(ExampleFoo.class, ExampleBaz.class).allowResidue(true).build();
+    Function<OptionDefinition, String> sourceFunction = option -> "command line";
+
+    parser.parseWithSourceFunction(
+            PriorityCategory.COMMAND_LINE,
+            sourceFunction,
+            Arrays.asList("residue", "is", "allowed", "in", "parseWithSource"));
+    assertThat(parser.getResidue()).containsExactly("residue", "is", "allowed", "in", "parseWithSource");
+  }
+
+  @Test
+  public void parseArgsAsExpansionOfOptionThrowsExceptionIfResidueIsNotAllowed() throws Exception {
+    OptionsParser parser = OptionsParser.builder().optionsClasses(ExpansionOptions.class).allowResidue(false).build();
+    parser.parse(OptionPriority.PriorityCategory.COMMAND_LINE, null, ImmutableList.of("--expands"));
+    OptionValueDescription expansionDescription = parser.getOptionValueDescription("expands");
+    assertThat(expansionDescription).isNotNull();
+
+    OptionValueDescription optionValue = parser.getOptionValueDescription("underlying");
+    assertThat(optionValue).isNotNull();
+
+    ParsedOptionDescription optionToExpand = optionValue.getCanonicalInstances().get(0);
+
+    OptionsParsingException e =
+            assertThrows(OptionsParsingException.class, () -> parser.parseArgsAsExpansionOfOption(
+                    optionToExpand, "source", ImmutableList.of("--underlying=direct_value", "residue", "in", "expansion")));
+    assertThat(parser.getResidue()).isNotEmpty();
+    assertThat(e).hasMessageThat().isEqualTo("Unrecognized arguments: residue in expansion");
+  }
+
+  @Test
   public void parseWithOptionsInheritance() throws OptionsParsingException {
     OptionsParser parser = OptionsParser.builder().optionsClasses(ExampleBazSubclass.class).build();
     parser.parse("--baz_subclass=cat", "--baz=dog");


### PR DESCRIPTION
Adds three new test cases for uncovered methods `parseWithSourceFunction` and `parseArgsAsExpansionOfOption`  considering whether `allowResidue` is set to true or false. The tests are under `com.google.devtools.common.options`.  Feel free to provide feedback and request changes.