### PR TITLE
Fix repo_env crash with empty value

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -266,8 +266,8 @@ public class CommandEnvironment {
         value = System.getenv(name);
       }
       if (value != null) {
-        repoEnv.put(entry.getKey(), entry.getValue());
-        repoEnvFromOptions.put(entry.getKey(), entry.getValue());
+        repoEnv.put(name, value);
+        repoEnvFromOptions.put(name, value);
       }
     }
     this.buildResultListener = new BuildResultListener();


### PR DESCRIPTION
Hi,

As reported by #15430, --repo_env option is now unable to read from environment variables.

This problem used to be fixed in [#12886](https://github.com/bazelbuild/bazel/pull/12886), but seems to be introduced again in commit [c2bdd034014f66ce14529cc353cda18a32320f6c](https://github.com/bazelbuild/bazel/commit/c2bdd034014f66ce14529cc353cda18a32320f6c), line 256 and 257 [link here](https://github.com/bazelbuild/bazel/blob/c2bdd034014f66ce14529cc353cda18a32320f6c/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java#L256) where the value put into `repoEnv` is still the original one that might be `null`. This commit would revert those changes and put the modified value into `repoEnv`.