### PR TITLE
Content-based path mapping for Starlark rules

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/ActionExecutionContext.java
@@ -244,7 +244,7 @@ public class ActionExecutionContext implements Closeable, ActionContext.ActionCo
    * method instead of {@link Artifact#getPath} because that does not allow filesystem injection.
    *
    * <p>TODO(shahan): cleanup {@link Action}-scoped references to {@link Artifact#getPath} and
-   * {@link Artifact#getRoot}.
+   * {@link Artifact#getRootForStarlark}.
    */
   public Path getInputPath(ActionInput input) {
     return pathResolver.toPath(input);

--- a/src/main/java/com/google/devtools/build/lib/actions/Artifact.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Artifact.java
@@ -1675,7 +1675,9 @@ public abstract class Artifact
 
     /**
      * Any two instances are considered equal as they should not cause the Starlark method lookup
-     * cache to be invalidated.
+     * cache to be invalidated. This is purely a performance/memory optimization to prevent the
+     * cache in {@link net.starlark.java.eval.CallUtils#getCacheValue(Class, StarlarkSemantics)}
+     * from growing too large and becoming ineffective.
      */
     @Override
     public boolean equals(Object obj) {

--- a/src/main/java/com/google/devtools/build/lib/actions/Artifact.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Artifact.java
@@ -575,7 +575,7 @@ public abstract class Artifact
   @Override
   public final String getDirnameForStarlark(StarlarkSemantics starlarkSemantics)
       throws EvalException {
-    return starlarkSemantics.get(ArtifactPathMapper.STARLARK_SEMANTICS_KEY).getMappedDirname(this);
+    return starlarkSemantics.get(StarlarkPathMapper.STARLARK_SEMANTICS_KEY).getMappedDirname(this);
   }
 
   /**
@@ -644,7 +644,7 @@ public abstract class Artifact
   @Override
   public final FileRootApi getRootForStarlark(StarlarkSemantics starlarkSemantics)
       throws EvalException {
-    return starlarkSemantics.get(ArtifactPathMapper.STARLARK_SEMANTICS_KEY).getMappedRoot(this);
+    return starlarkSemantics.get(StarlarkPathMapper.STARLARK_SEMANTICS_KEY).getMappedRoot(this);
   }
 
   @Override
@@ -710,7 +710,7 @@ public abstract class Artifact
   @Override
   public final String getExecPathStringForStarlark(StarlarkSemantics starlarkSemantics)
       throws EvalException {
-    return starlarkSemantics.get(ArtifactPathMapper.STARLARK_SEMANTICS_KEY)
+    return starlarkSemantics.get(StarlarkPathMapper.STARLARK_SEMANTICS_KEY)
         .getMappedExecPathString(this);
   }
 
@@ -1640,8 +1640,14 @@ public abstract class Artifact
     }
   }
 
-  public static abstract class ArtifactPathMapper {
-    private static final ArtifactPathMapper NOOP = new ArtifactPathMapper() {
+  /**
+   * This class can be attached to {@link StarlarkSemantics} in order to transparently map the
+   * path struct fields of {@link FileApi} and {@link FileRootApi} when used from Starlark
+   * {@code Args#map_each} callbacks.
+   */
+  public static abstract class StarlarkPathMapper {
+
+    private static final StarlarkPathMapper NOOP = new StarlarkPathMapper() {
       @Override
       public String getMappedDirname(Artifact artifact) {
         return artifact.getDirname();
@@ -1658,7 +1664,7 @@ public abstract class Artifact
       }
     };
 
-    public static final StarlarkSemantics.Key<ArtifactPathMapper> STARLARK_SEMANTICS_KEY = new Key<>(
+    public static final StarlarkSemantics.Key<StarlarkPathMapper> STARLARK_SEMANTICS_KEY = new Key<>(
         "path_mapper", NOOP);
 
     public abstract String getMappedDirname(Artifact artifact) throws EvalException;

--- a/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
@@ -129,10 +129,6 @@ public final class PathStripper {
       return execPath;
     }
 
-    default PathFragment stripForRunfiles(PathFragment runfilesDir, PathFragment execPath) {
-      return execPath;
-    }
-
     default boolean isNoop() {
       return false;
     }

--- a/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
@@ -218,7 +218,7 @@ public final class PathStripper {
     List<String> stripCustomStarlarkArgs(List<String> args);
 
     /**
-     * Creates a an {@link StarlarkPathMapper} that can be set on a Starlark thread's semantics
+     * Creates a {@link StarlarkPathMapper} that can be set on a Starlark thread's semantics
      * object to automatically rewrite paths returned by the File API in map_each callbacks.
      */
     default StarlarkPathMapper toStarlarkPathMapper() {

--- a/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
@@ -129,6 +129,12 @@ public final class PathStripper {
       return execPath;
     }
 
+    /**
+     * Used to determine whether {@link Spawn}s using this instance have to run with a strategy
+     * that supports path mapping.
+     *
+     * @return false if and only if this instance never actually changes any exec paths.
+     */
     default boolean isNoop() {
       return false;
     }

--- a/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
@@ -16,7 +16,7 @@ package com.google.devtools.build.lib.actions;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.devtools.build.lib.actions.Artifact.ArtifactPathMapper;
+import com.google.devtools.build.lib.actions.Artifact.StarlarkPathMapper;
 import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
 import com.google.devtools.build.lib.actions.Artifact.TreeFileArtifact;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
@@ -216,11 +216,11 @@ public final class PathStripper {
     List<String> stripCustomStarlarkArgs(List<String> args);
 
     /**
-     * Creates a an {@link ArtifactPathMapper} that can be set on a Starlark thread's semantics
+     * Creates a an {@link StarlarkPathMapper} that can be set on a Starlark thread's semantics
      * object to automatically rewrite paths returned by the File API in map_each callbacks.
      */
-    default ArtifactPathMapper toArtifactPathMapper() {
-      return new ArtifactPathMapper() {
+    default StarlarkPathMapper toStarlarkPathMapper() {
+      return new StarlarkPathMapper() {
         private PathFragment getMappedExecPath(Artifact artifact) throws EvalException {
           if (!(artifact instanceof DerivedArtifact)) {
             return artifact.getExecPath();

--- a/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
@@ -98,6 +98,10 @@ public final class PathStripper {
       return execPath;
     }
 
+    default boolean isNoop() {
+      return false;
+    }
+
     /**
      * Creates a new action stager for executor implementation logic to use.
      *
@@ -123,6 +127,11 @@ public final class PathStripper {
           @Override
           public PathFragment strip(PathFragment execPath) {
             return execPath;
+          }
+
+          @Override
+          public boolean isNoop() {
+            return true;
           }
         };
 

--- a/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
@@ -94,6 +94,10 @@ public final class PathStripper {
       return execPath;
     }
 
+    default PathFragment stripForRunfiles(PathFragment runfilesDir, PathFragment execPath) {
+      return execPath;
+    }
+
     /**
      * Creates a new action stager for executor implementation logic to use.
      *

--- a/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
@@ -75,6 +75,37 @@ import net.starlark.java.eval.EvalException;
  * NestedSet, Artifact, BuildConfigurationValue)}.
  */
 public final class PathStripper {
+
+  public interface PathMapper extends ActionStager, CommandAdjuster {
+
+    PathMapper NOOP = new PathMapper() {
+      @Override
+      public String getExecPathString(ActionInput artifact) {
+        return artifact.getExecPathString();
+      }
+
+      @Override
+      public PathFragment strip(PathFragment execPath) {
+        return execPath;
+      }
+
+      @Override
+      public String strip(DerivedArtifact artifact) {
+        return getExecPathString(artifact);
+      }
+
+      @Override
+      public List<String> stripCustomStarlarkArgs(List<String> args) {
+        return args;
+      }
+
+      @Override
+      public boolean isNoop() {
+        return true;
+      }
+    };
+  }
+
   /**
    * Support for stripping config paths from an action's inputs and outputs.
    *

--- a/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PathStripper.java
@@ -90,6 +90,10 @@ public final class PathStripper {
     /** Same as {@link #getExecPathString(ActionInput)} but for a {@link PathFragment}. */
     PathFragment strip(PathFragment execPath);
 
+    default PathFragment unstrip(PathFragment execPath) {
+      return execPath;
+    }
+
     /**
      * Creates a new action stager for executor implementation logic to use.
      *

--- a/src/main/java/com/google/devtools/build/lib/actions/PrecomputedPathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PrecomputedPathMapper.java
@@ -117,7 +117,8 @@ public final class PrecomputedPathMapper implements PathMapper {
   }
 
   private static PathFragment execPathWithSyntheticConfig(PathFragment execPath, String config) {
-    // TODO: Support experimental_sibling_repository_layout.
+    // TODO: Support experimental_sibling_repository_layout, which uses output roots such as
+    //  __main__/bazel-out/k8-fastbuild/bin instead of keeping the repository name out of the root.
     return execPath.subFragment(0, 1)
         .getRelative(config)
         .getRelative(execPath.subFragment(2));

--- a/src/main/java/com/google/devtools/build/lib/actions/PrecomputedPathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PrecomputedPathMapper.java
@@ -1,0 +1,185 @@
+package com.google.devtools.build.lib.actions;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+import com.google.common.io.BaseEncoding;
+import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
+import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
+import com.google.devtools.build.lib.actions.PathStripper.PathMapper;
+import com.google.devtools.build.lib.actions.cache.MetadataHandler;
+import com.google.devtools.build.lib.collect.nestedset.NestedSet;
+import com.google.devtools.build.lib.vfs.PathFragment;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * An implementation of {@link PathMapper} that replaces the configuration segment of paths of
+ * generated files with synthetic values, backed by a fixed mapping for the input files of an
+ * action.
+ */
+public final class PrecomputedPathMapper implements PathMapper {
+
+  // 25 * log_2(32) = 125 bits ought to be enough to prevent collisions.
+  private static final int MAX_DIGEST_CHARS = 25;
+
+  private final ImmutableMap<PathFragment, PathFragment> execPathMapping;
+  private final PathFragment primaryOutputRoot;
+  private final PathFragment mappedPrimaryOutputRoot;
+  private final PathFragment outputDir;
+
+  private PrecomputedPathMapper(ImmutableMap<PathFragment, PathFragment> execPathMapping,
+      Artifact primaryOutput) {
+    this.execPathMapping = execPathMapping;
+    // See strip(PathFragment execPath) for an explanation of the output path mapping.
+    this.primaryOutputRoot = primaryOutput.getRoot().getExecPath();
+    this.mappedPrimaryOutputRoot = execPathWithSyntheticConfig(primaryOutputRoot, "out");
+    this.outputDir = primaryOutputRoot.subFragment(0, 1);
+  }
+
+  public static PathMapper noop() {
+    return NOOP;
+  }
+
+  /**
+   * Creates a {@link PathMapper} that replaces the config segment in the exec paths of all
+   * generated artifacts with a synthetic value derived from the artifact's contents.
+   *
+   * <p>As a result, if the inputs to a spawn using this path mapping are the same, then the spawn's
+   * command line will be identical regardless of the inputs' configurations, which improves remote
+   * caching.
+   *
+   * @param artifactExpander an {@link ArtifactExpander} used to expand middleman artifacts
+   * @param metadataHandler a {@link MetadataHandler} used to obtain digests for inputs
+   * @param inputs the set of input artifacts to the action
+   * @param primaryOutput the primary output of the action
+   * @return a {@link PathMapper}
+   * @throws CommandLineExpansionException if getting the digest of an input artifact fails
+   */
+  public static PathMapper createContentBased(
+      ArtifactExpander artifactExpander,
+      MetadataHandler metadataHandler,
+      NestedSet<Artifact> inputs,
+      Artifact primaryOutput) throws CommandLineExpansionException {
+    Optional<List<DerivedArtifact>> artifactsToMap = computeArtifactsToMap(artifactExpander,
+        inputs);
+    if (artifactsToMap.isEmpty()) {
+      return NOOP;
+    }
+    ImmutableMap.Builder<PathFragment, PathFragment> execPathMapping = new Builder<>();
+    for (Artifact input : artifactsToMap.get()) {
+      byte[] digest;
+      try {
+        digest = metadataHandler.getMetadata(input).getDigest();
+      } catch (IOException e) {
+        throw new CommandLineExpansionException(
+            String.format("Failed to get metadata for %s", input), e);
+      }
+      if (digest == null) {
+        return NOOP;
+      }
+      execPathMapping.put(input.getExecPath(),
+          execPathWithSyntheticConfig(input.getExecPath(), prettifyDigest(digest)));
+    }
+    return new PrecomputedPathMapper(execPathMapping.build(), primaryOutput);
+  }
+
+  private static Optional<List<DerivedArtifact>> computeArtifactsToMap(
+      ArtifactExpander artifactExpander, NestedSet<Artifact> inputs) {
+    List<DerivedArtifact> inputsToMap = new ArrayList<>();
+    for (Artifact input : inputs.toList()) {
+      if (!(input instanceof DerivedArtifact)) {
+        // Source file paths have an empty root and in particular contain no config part. They thus
+        // don't require path mapping.
+        continue;
+      }
+      if (input.isFileset()) {
+        // Filesets are not supported.
+        return Optional.empty();
+      }
+      // We only expand middleman artifacts as TreeArtifactFiles are mapped based on their parent's
+      // hash and exec path.
+      if (input.isMiddlemanArtifact()) {
+        List<Artifact> expandedArtifacts = new ArrayList<>();
+        artifactExpander.expand(input, expandedArtifacts);
+        for (Artifact artifact : expandedArtifacts) {
+          if (artifact instanceof DerivedArtifact) {
+            inputsToMap.add((DerivedArtifact) artifact);
+          }
+        }
+      } else {
+        inputsToMap.add((DerivedArtifact) input);
+      }
+    }
+    return Optional.of(inputsToMap);
+  }
+
+  private static PathFragment execPathWithSyntheticConfig(PathFragment execPath, String config) {
+    // TODO: Support experimental_sibling_repository_layout.
+    return execPath.subFragment(0, 1)
+        .getRelative(config)
+        .getRelative(execPath.subFragment(2));
+  }
+
+  private static String prettifyDigest(byte[] digest) {
+    String fullDigest = BaseEncoding.base32().lowerCase().omitPadding().encode(digest);
+    return fullDigest.substring(0, Math.min(fullDigest.length(), MAX_DIGEST_CHARS));
+  }
+
+  @Override
+  public PathFragment strip(PathFragment execPath) {
+    if (!execPath.startsWith(outputDir)) {
+      // execPath belongs to a source file and doesn't contain a config part - no need to map
+      // anything.
+      return execPath;
+    }
+    PathFragment remappedPath = execPathMapping.get(execPath);
+    if (remappedPath != null) {
+      // execPath belongs to a generated input file.
+      return remappedPath;
+    }
+    // execPath does not belong to an input artifact and thus must be an output-like artifact, i.e.
+    // an honest action output or a derived path such as e.g. a param file. All such artifacts live
+    // in a single configuration: the configuration of the target that registered the action. We can
+    // thus replace the config part in the root with a fixed string such as "out".
+    return mappedPrimaryOutputRoot.getRelative(execPath.relativeTo(primaryOutputRoot));
+  }
+
+  @Override
+  public PathFragment unstrip(PathFragment execPath) {
+    return primaryOutputRoot.getRelative(execPath.relativeTo(mappedPrimaryOutputRoot));
+  }
+
+  @Override
+  public PathFragment stripForRunfiles(PathFragment runfilesDir, PathFragment execPath) {
+    String runfilesDirName = runfilesDir.getBaseName();
+    Preconditions.checkArgument(runfilesDirName.endsWith(".runfiles"));
+    // Derive the path of the executable, apply the path mapping to it and then rederive the path
+    // of the runfiles dir.
+    PathFragment executable = runfilesDir.replaceName(
+        runfilesDirName.substring(0, runfilesDirName.length() - ".runfiles".length()));
+    return strip(executable).replaceName(runfilesDirName)
+        .getRelative(execPath.relativeTo(runfilesDir));
+  }
+
+  @Override
+  public String getExecPathString(ActionInput artifact) {
+    if (!(artifact instanceof DerivedArtifact)) {
+      return artifact.getExecPathString();
+    }
+    return strip((DerivedArtifact) artifact);
+  }
+
+
+  @Override
+  public String strip(DerivedArtifact artifact) {
+    return strip(artifact.getExecPath()).getPathString();
+  }
+
+  @Override
+  public List<String> stripCustomStarlarkArgs(List<String> args) {
+    return args;
+  }
+}

--- a/src/main/java/com/google/devtools/build/lib/actions/PrecomputedPathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PrecomputedPathMapper.java
@@ -19,6 +19,12 @@ import java.util.Optional;
  * An implementation of {@link PathMapper} that replaces the configuration segment of paths of
  * generated files with synthetic values, backed by a fixed mapping for the input files of an
  * action.
+ *
+ * <p>Examples:
+ * <ul>
+ *   <li><code>pkg/file.txt --> pkg/file.txt</code></li>
+ *   <li><code>bazel-out/k8-fastbuild/bin/pkg/generated_file --> bazel-out/fixed/bin/pkg/generated_file</code></li>
+ * </ul>
  */
 public final class PrecomputedPathMapper implements PathMapper {
 

--- a/src/main/java/com/google/devtools/build/lib/actions/PrecomputedPathMapper.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/PrecomputedPathMapper.java
@@ -153,18 +153,6 @@ public final class PrecomputedPathMapper implements PathMapper {
   }
 
   @Override
-  public PathFragment stripForRunfiles(PathFragment runfilesDir, PathFragment execPath) {
-    String runfilesDirName = runfilesDir.getBaseName();
-    Preconditions.checkArgument(runfilesDirName.endsWith(".runfiles"));
-    // Derive the path of the executable, apply the path mapping to it and then rederive the path
-    // of the runfiles dir.
-    PathFragment executable = runfilesDir.replaceName(
-        runfilesDirName.substring(0, runfilesDirName.length() - ".runfiles".length()));
-    return strip(executable).replaceName(runfilesDirName)
-        .getRelative(execPath.relativeTo(runfilesDir));
-  }
-
-  @Override
   public String getExecPathString(ActionInput artifact) {
     if (!(artifact instanceof DerivedArtifact)) {
       return artifact.getExecPathString();

--- a/src/main/java/com/google/devtools/build/lib/actions/Spawn.java
+++ b/src/main/java/com/google/devtools/build/lib/actions/Spawn.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.actions;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.devtools.build.lib.actions.PathStripper.ActionStager;
 import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
@@ -198,5 +199,9 @@ public interface Spawn extends DescribableExecutionUnit {
    */
   default boolean stripOutputPaths() {
     return false;
+  }
+
+  default ActionStager getActionStager() {
+    return ActionStager.NOOP;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/SpawnAction.java
@@ -51,6 +51,7 @@ import com.google.devtools.build.lib.actions.EmptyRunfilesSupplier;
 import com.google.devtools.build.lib.actions.ExecException;
 import com.google.devtools.build.lib.actions.FilesetOutputSymlink;
 import com.google.devtools.build.lib.actions.ParamFileInfo;
+import com.google.devtools.build.lib.actions.PathStripper.ActionStager;
 import com.google.devtools.build.lib.actions.PathStripper.CommandAdjuster;
 import com.google.devtools.build.lib.actions.ResourceSetOrBuilder;
 import com.google.devtools.build.lib.actions.RunfilesSupplier;
@@ -392,7 +393,8 @@ public class SpawnAction extends AbstractAction implements CommandAction {
         /*additionalInputs=*/ ImmutableList.of(),
         /*filesetMappings=*/ ImmutableMap.of(),
         /*reportOutputs=*/ true,
-        stripOutputPaths);
+        stripOutputPaths,
+        ActionStager.NOOP);
   }
 
   /**
@@ -439,7 +441,8 @@ public class SpawnAction extends AbstractAction implements CommandAction {
         expandedCommandLines.getParamFiles(),
         filesetMappings,
         reportOutputs,
-        stripOutputPaths);
+        stripOutputPaths,
+        ActionStager.NOOP);
   }
 
   Spawn getSpawnForExtraAction() throws CommandLineExpansionException, InterruptedException {
@@ -581,6 +584,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     private final ImmutableMap<String, String> effectiveEnvironment;
     private final boolean reportOutputs;
     private final boolean stripOutputPaths;
+    private final ActionStager actionStager;
 
     /**
      * Creates an ActionSpawn with the given environment variables.
@@ -597,7 +601,8 @@ public class SpawnAction extends AbstractAction implements CommandAction {
         Iterable<? extends ActionInput> additionalInputs,
         Map<Artifact, ImmutableList<FilesetOutputSymlink>> filesetMappings,
         boolean reportOutputs,
-        boolean stripOutputPaths)
+        boolean stripOutputPaths,
+        ActionStager actionStager)
         throws CommandLineExpansionException {
       super(
           arguments,
@@ -617,6 +622,7 @@ public class SpawnAction extends AbstractAction implements CommandAction {
       this.inputs = inputsBuilder.build();
       this.filesetMappings = filesetMappings;
       this.stripOutputPaths = stripOutputPaths;
+      this.actionStager = actionStager;
 
       // If the action environment is already resolved using the client environment, the given
       // environment variables are used as they are. Otherwise, they are used as clientEnv to
@@ -632,6 +638,11 @@ public class SpawnAction extends AbstractAction implements CommandAction {
     @Override
     public boolean stripOutputPaths() {
       return stripOutputPaths;
+    }
+
+    @Override
+    public ActionStager getActionStager() {
+      return actionStager;
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/actions/StarlarkAction.java
@@ -115,7 +115,8 @@ public final class StarlarkAction extends SpawnAction implements ActionCacheAwar
       String mnemonic,
       Optional<Artifact> unusedInputsList,
       Optional<Action> shadowedAction,
-      boolean stripOutputPaths) {
+      boolean stripOutputPaths,
+      boolean applyContentBasedPathMapping) {
     super(
         owner,
         tools,
@@ -136,7 +137,8 @@ public final class StarlarkAction extends SpawnAction implements ActionCacheAwar
         /* executeUnconditionally */ false,
         /* extraActionInfoSupplier */ null,
         /* resultConsumer */ null,
-        stripOutputPaths);
+        stripOutputPaths,
+        applyContentBasedPathMapping);
 
     this.allStarlarkActionInputs = inputs;
     this.unusedInputsList = unusedInputsList;
@@ -330,6 +332,7 @@ public final class StarlarkAction extends SpawnAction implements ActionCacheAwar
       throws CommandLineExpansionException, InterruptedException {
     return getSpawn(
         actionExecutionContext.getArtifactExpander(),
+        actionExecutionContext.getMetadataHandler(),
         getEffectiveEnvironment(actionExecutionContext.getClientEnv()),
         /*envResolved=*/ true,
         actionExecutionContext.getTopLevelFilesets(),
@@ -415,7 +418,9 @@ public final class StarlarkAction extends SpawnAction implements ActionCacheAwar
           mnemonic,
           unusedInputsList,
           shadowedAction,
-          stripOutputPaths(mnemonic, inputsAndTools, primaryOutput, configuration));
+          stripOutputPaths(mnemonic, inputsAndTools, primaryOutput, configuration),
+          configuration.getOptions().get(CoreOptions.class).contentBasedPathMapping.contains(
+              mnemonic));
     }
 
     /**

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -795,7 +795,8 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
               + "File object directly to their command line or environment. Instead, add the File "
               + "objects to Args, using \"map_each\" callbacks for path manipulations. Actions "
               + "opted into content-based path mapping can only be executed in symlink-based "
-              + "sandboxes or with remote execution.")
+              + "sandboxes or with remote execution. This is meant as an experimental approach to"
+              + "the general issue https://github.com/bazelbuild/bazel/issues/6526.")
   public List<String> contentBasedPathMapping;
 
   @Option(

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -24,6 +24,7 @@ import com.google.devtools.build.lib.util.RegexFilter;
 import com.google.devtools.common.options.Converter;
 import com.google.devtools.common.options.Converters;
 import com.google.devtools.common.options.Converters.BooleanConverter;
+import com.google.devtools.common.options.Converters.CommaSeparatedNonEmptyOptionListConverter;
 import com.google.devtools.common.options.EnumConverter;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDefinition;
@@ -776,6 +777,28 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
   public OutputPathsMode outputPathsMode;
 
   @Option(
+      name = "experimental_content_based_path_mapping",
+      converter = CommaSeparatedNonEmptyOptionListConverter.class,
+      defaultValue = "",
+      documentationCategory = OptionDocumentationCategory.BUILD_TIME_OPTIMIZATION,
+      effectTags = {
+          OptionEffectTag.LOSES_INCREMENTAL_STATE,
+          OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION,
+          OptionEffectTag.AFFECTS_OUTPUTS,
+          OptionEffectTag.EXECUTION
+      },
+      help =
+          "A comma-separated list of mnemonics of Starlark actions to which content-based path "
+              + "mapping should be applied. This is highly experimental. This optimization aims to "
+              + "allow for (disk and remote) cache hits across different configurations. To "
+              + "qualify, actions must not be adding the \"dirname\", \"path\", or \"root\" of any "
+              + "File object directly to their command line or environment. Instead, add the File "
+              + "objects to Args, using \"map_each\" callbacks for path manipulations. Actions "
+              + "opted into content-based path mapping can only be executed in symlink-based "
+              + "sandboxes or with remote execution.")
+  public List<String> contentBasedPathMapping;
+
+  @Option(
       name = "enable_runfiles",
       defaultValue = "auto",
       documentationCategory = OptionDocumentationCategory.OUTPUT_PARAMETERS,
@@ -987,6 +1010,7 @@ public class CoreOptions extends FragmentOptions implements Cloneable {
     exec.isExec = false;
     exec.execConfigurationDistinguisherScheme = execConfigurationDistinguisherScheme;
     exec.outputPathsMode = outputPathsMode;
+    exec.contentBasedPathMapping = contentBasedPathMapping;
     exec.enableRunfiles = enableRunfiles;
     exec.executionInfoModifier = executionInfoModifier;
     exec.commandLineBuildVariables = commandLineBuildVariables;

--- a/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraAction.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/extra/ExtraAction.java
@@ -91,7 +91,8 @@ public final class ExtraAction extends SpawnAction {
         false,
         null,
         null,
-        /*stripOutputPaths=*/ false);
+        /*stripOutputPaths=*/ false,
+        /*applyContentBasedPathMapping=*/ false);
     this.shadowedAction = shadowedAction;
     this.createDummyOutput = createDummyOutput;
 
@@ -155,6 +156,7 @@ public final class ExtraAction extends SpawnAction {
     }
     return getSpawn(
         actionExecutionContext.getArtifactExpander(),
+        actionExecutionContext.getMetadataHandler(),
         actionExecutionContext.getClientEnv(),
         /*envResolved=*/ false,
         actionExecutionContext.getTopLevelFilesets(),

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkCustomCommandLine.java
@@ -24,7 +24,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.Artifact.ArtifactExpander;
 import com.google.devtools.build.lib.actions.Artifact.DerivedArtifact;
 import com.google.devtools.build.lib.actions.Artifact.MissingExpansionException;
-import com.google.devtools.build.lib.actions.Artifact.ArtifactPathMapper;
+import com.google.devtools.build.lib.actions.Artifact.StarlarkPathMapper;
 import com.google.devtools.build.lib.actions.CommandLine;
 import com.google.devtools.build.lib.actions.CommandLineExpansionException;
 import com.google.devtools.build.lib.actions.CommandLineItem;
@@ -918,7 +918,7 @@ public class StarlarkCustomCommandLine extends CommandLine {
       mapEachSemantics = starlarkSemantics;
     } else {
       mapEachSemantics = starlarkSemantics.toBuilder()
-          .set(ArtifactPathMapper.STARLARK_SEMANTICS_KEY, stripPaths.toArtifactPathMapper())
+          .set(StarlarkPathMapper.STARLARK_SEMANTICS_KEY, stripPaths.toStarlarkPathMapper())
           .build();
     }
     try (Mutability mu = Mutability.create("map_each")) {

--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteAction.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteAction.java
@@ -138,4 +138,8 @@ public class RemoteAction {
   public NetworkTime getNetworkTime() {
     return remoteActionExecutionContext.getNetworkTime();
   }
+
+  public RemotePathResolver getRemotePathResolver() {
+    return remotePathResolver;
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/remote/common/RemotePathResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/common/RemotePathResolver.java
@@ -127,6 +127,7 @@ public interface RemotePathResolver {
           .walkInputs(
               spawn,
               context.getArtifactExpander(),
+              spawn.getActionStager(),
               PathFragment.EMPTY_FRAGMENT,
               context.getMetadataProvider(),
               visitor);
@@ -216,6 +217,7 @@ public interface RemotePathResolver {
           .walkInputs(
               spawn,
               context.getArtifactExpander(),
+              spawn.getActionStager(),
               PathFragment.create(checkNotNull(getWorkingDirectory())),
               context.getMetadataProvider(),
               visitor);

--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LtoBackendAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LtoBackendAction.java
@@ -106,7 +106,8 @@ public final class LtoBackendAction extends SpawnAction {
         false,
         null,
         null,
-        /*stripOutputPaths=*/ false);
+        /*stripOutputPaths=*/ false,
+        /*applyContentBasedPathMapping=*/ false);
     mandatoryInputs = inputs;
     Preconditions.checkState(
         (allBitcodeFiles == null) == (importsFile == null),

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/BUILD
@@ -20,6 +20,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/actions:artifacts",
         "//src/main/java/com/google/devtools/build/lib/analysis:analysis_cluster",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/core_options",
         "//src/main/java/com/google/devtools/build/lib/analysis:config/execution_transition_factory",
         "//src/main/java/com/google/devtools/build/lib/analysis:configured_target",
         "//src/main/java/com/google/devtools/build/lib/analysis:file_provider",

--- a/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleAction.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/genrule/GenRuleAction.java
@@ -68,7 +68,8 @@ public final class GenRuleAction extends SpawnAction {
         false,
         null,
         null,
-        /*stripOutputPaths=*/ false);
+        /*stripOutputPaths=*/ false,
+        /*applyContentBasedPathMapping=*/ false);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaHeaderCompileActionBuilder.java
@@ -38,6 +38,7 @@ import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.actions.CustomCommandLine;
 import com.google.devtools.build.lib.analysis.actions.SpawnAction;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.StrictDepsMode;
+import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.collect.nestedset.NestedSet;
 import com.google.devtools.build.lib.collect.nestedset.NestedSetBuilder;
@@ -449,7 +450,8 @@ public class JavaHeaderCompileActionBuilder {
               /* executeUnconditionally= */ false,
               /* extraActionInfoSupplier= */ null,
               /* resultConsumer= */ resultConsumer,
-              /*stripOutputPaths= */ stripOutputPaths));
+              /*stripOutputPaths= */ stripOutputPaths,
+              /*applyContentBasedPathMapping= */ false));
       return;
     }
 

--- a/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
+++ b/src/main/java/com/google/devtools/build/lib/sandbox/SandboxHelpers.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Maps;
 import com.google.common.flogger.GoogleLogger;
 import com.google.devtools.build.lib.actions.ActionInput;
 import com.google.devtools.build.lib.actions.Artifact;
+import com.google.devtools.build.lib.actions.PathStripper.ActionStager;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.UserExecException;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
@@ -87,7 +88,7 @@ public final class SandboxHelpers {
       throws IOException {
     for (PathFragment output : Iterables.concat(outputs.files(), outputs.dirs())) {
       Path source = sourceRoot.getRelative(output);
-      Path target = targetRoot.getRelative(output);
+      Path target = targetRoot.getRelative(outputs.actionStager().unstrip(output));
       if (source.isFile() || source.isSymbolicLink()) {
         // Ensure the target directory exists in the target. The directories for the action outputs
         // have already been created, but the spawn outputs may be different from the overall action
@@ -540,12 +541,19 @@ public final class SandboxHelpers {
 
     public abstract ImmutableSet<PathFragment> dirs();
 
+    public abstract ActionStager actionStager();
+
     private static final SandboxOutputs EMPTY_OUTPUTS =
-        SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of());
+        SandboxOutputs.create(ImmutableSet.of(), ImmutableSet.of(), ActionStager.NOOP);
 
     public static SandboxOutputs create(
         ImmutableSet<PathFragment> files, ImmutableSet<PathFragment> dirs) {
-      return new AutoValue_SandboxHelpers_SandboxOutputs(files, dirs);
+      return new AutoValue_SandboxHelpers_SandboxOutputs(files, dirs, ActionStager.NOOP);
+    }
+
+    public static SandboxOutputs create(
+        ImmutableSet<PathFragment> files, ImmutableSet<PathFragment> dirs, ActionStager actionStager) {
+      return new AutoValue_SandboxHelpers_SandboxOutputs(files, dirs, actionStager);
     }
 
     public static SandboxOutputs getEmptyInstance() {
@@ -557,14 +565,14 @@ public final class SandboxHelpers {
     ImmutableSet.Builder<PathFragment> files = ImmutableSet.builder();
     ImmutableSet.Builder<PathFragment> dirs = ImmutableSet.builder();
     for (ActionInput output : spawn.getOutputFiles()) {
-      PathFragment path = PathFragment.create(output.getExecPathString());
+      PathFragment path = spawn.getActionStager().strip(output.getExecPath());
       if (output instanceof Artifact && ((Artifact) output).isTreeArtifact()) {
         dirs.add(path);
       } else {
         files.add(path);
       }
     }
-    return SandboxOutputs.create(files.build(), dirs.build());
+    return SandboxOutputs.create(files.build(), dirs.build(), spawn.getActionStager());
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/FileApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/FileApi.java
@@ -20,6 +20,8 @@ import javax.annotation.Nullable;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.StarlarkSemantics;
+import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkValue;
 
 /** The interface for files in Starlark. */
@@ -45,10 +47,11 @@ public interface FileApi extends StarlarkValue {
   @StarlarkMethod(
       name = "dirname",
       structField = true,
+      useStarlarkSemantics = true,
       doc =
           "The name of the directory containing this file. It's taken from "
               + "<a href=\"#path\">path</a> and is always relative to the execution directory.")
-  String getDirname();
+  String getDirnameForStarlark(StarlarkSemantics starlarkSemantics) throws EvalException;
 
   @StarlarkMethod(
       name = "basename",
@@ -75,8 +78,9 @@ public interface FileApi extends StarlarkValue {
   @StarlarkMethod(
       name = "root",
       structField = true,
+      useStarlarkSemantics = true,
       doc = "The root beneath which this file resides.")
-  FileRootApi getRoot();
+  FileRootApi getRootForStarlark(StarlarkSemantics starlarkSemantics) throws EvalException;
 
   @StarlarkMethod(
       name = "is_source",
@@ -102,6 +106,7 @@ public interface FileApi extends StarlarkValue {
   @StarlarkMethod(
       name = "path",
       structField = true,
+      useStarlarkSemantics = true,
       doc =
           "The execution path of this file, relative to the workspace's execution directory. It "
               + "consists of two parts, an optional first part called the <i>root</i> (see also "
@@ -112,7 +117,7 @@ public interface FileApi extends StarlarkValue {
               + "architecture that was used while building said file. Use the "
               + "<code>short_path</code> for the path under which the file is mapped if it's in "
               + "the runfiles of a binary.")
-  String getExecPathString();
+  String getExecPathStringForStarlark(StarlarkSemantics starlarkSemantics) throws EvalException;
 
   @StarlarkMethod(
       name = "tree_relative_path",

--- a/src/test/java/com/google/devtools/build/lib/actions/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/actions/BUILD
@@ -80,6 +80,7 @@ java_library(
         "//src/main/protobuf:failure_details_java_proto",
         "//src/test/java/com/google/devtools/build/lib/actions/util",
         "//src/test/java/com/google/devtools/build/lib/analysis/util",
+        "//src/test/java/com/google/devtools/build/lib/buildtool/util",
         "//src/test/java/com/google/devtools/build/lib/events:testutil",
         "//src/test/java/com/google/devtools/build/lib/testutil",
         "//src/test/java/com/google/devtools/build/lib/testutil:TestThread",

--- a/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/actions/SpawnActionTest.java
@@ -259,6 +259,7 @@ public class SpawnActionTest extends BuildViewTestCase {
     Spawn spawn =
         action.getSpawn(
             (artifact, outputs) -> outputs.add(artifact),
+            null,
             ImmutableMap.of(),
             /*envResolved=*/ false,
             ImmutableMap.of(),

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnInputExpanderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnInputExpanderTest.java
@@ -36,6 +36,7 @@ import com.google.devtools.build.lib.actions.FileArtifactValue;
 import com.google.devtools.build.lib.actions.FilesetManifest;
 import com.google.devtools.build.lib.actions.FilesetOutputSymlink;
 import com.google.devtools.build.lib.actions.ForbiddenActionInputException;
+import com.google.devtools.build.lib.actions.PathStripper.ActionStager;
 import com.google.devtools.build.lib.actions.RunfilesSupplier;
 import com.google.devtools.build.lib.actions.Spawn;
 import com.google.devtools.build.lib.actions.cache.VirtualActionInput;
@@ -80,7 +81,8 @@ public class SpawnInputExpanderTest {
     RunfilesSupplier supplier = EmptyRunfilesSupplier.INSTANCE;
     FakeActionInputFileCache mockCache = new FakeActionInputFileCache();
     expander.addRunfilesToInputs(
-        inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER, PathFragment.EMPTY_FRAGMENT);
+        inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER, ActionStager.NOOP,
+        PathFragment.EMPTY_FRAGMENT);
     assertThat(inputMappings).isEmpty();
   }
 
@@ -99,7 +101,8 @@ public class SpawnInputExpanderTest {
         FileArtifactValue.createForNormalFile(FAKE_DIGEST, /*proxy=*/ null, /*size=*/ 0L));
 
     expander.addRunfilesToInputs(
-        inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER, PathFragment.EMPTY_FRAGMENT);
+        inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER, ActionStager.NOOP,
+        PathFragment.EMPTY_FRAGMENT);
     assertThat(inputMappings).hasSize(1);
     assertThat(inputMappings)
         .containsEntry(PathFragment.create("runfiles/workspace/dir/file"), artifact);
@@ -134,7 +137,8 @@ public class SpawnInputExpanderTest {
         };
 
     expander.addRunfilesToInputs(
-        inputMappings, supplier, mockCache, filesetExpander, PathFragment.EMPTY_FRAGMENT);
+        inputMappings, supplier, mockCache, filesetExpander, ActionStager.NOOP,
+        PathFragment.EMPTY_FRAGMENT);
     assertThat(inputMappings).hasSize(1);
     assertThat(inputMappings)
         .containsEntry(
@@ -163,6 +167,7 @@ public class SpawnInputExpanderTest {
                     supplier,
                     mockCache,
                     NO_ARTIFACT_EXPANDER,
+                    ActionStager.NOOP,
                     PathFragment.EMPTY_FRAGMENT));
     assertThat(expected).hasMessageThat().isEqualTo("Not a file: dir/file");
   }
@@ -181,7 +186,8 @@ public class SpawnInputExpanderTest {
 
     expander = new SpawnInputExpander(execRoot, /*strict=*/ false);
     expander.addRunfilesToInputs(
-        inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER, PathFragment.EMPTY_FRAGMENT);
+        inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER, ActionStager.NOOP,
+        PathFragment.EMPTY_FRAGMENT);
     assertThat(inputMappings).hasSize(1);
     assertThat(inputMappings)
         .containsEntry(PathFragment.create("runfiles/workspace/dir/file"), artifact);
@@ -210,7 +216,8 @@ public class SpawnInputExpanderTest {
         FileArtifactValue.createForNormalFile(FAKE_DIGEST, /*proxy=*/ null, /*size=*/ 12L));
 
     expander.addRunfilesToInputs(
-        inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER, PathFragment.EMPTY_FRAGMENT);
+        inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER, ActionStager.NOOP,
+        PathFragment.EMPTY_FRAGMENT);
     assertThat(inputMappings).hasSize(2);
     assertThat(inputMappings)
         .containsEntry(PathFragment.create("runfiles/workspace/dir/file"), artifact1);
@@ -236,7 +243,8 @@ public class SpawnInputExpanderTest {
         FileArtifactValue.createForNormalFile(FAKE_DIGEST, /*proxy=*/ null, /*size=*/ 1L));
 
     expander.addRunfilesToInputs(
-        inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER, PathFragment.EMPTY_FRAGMENT);
+        inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER, ActionStager.NOOP,
+        PathFragment.EMPTY_FRAGMENT);
     assertThat(inputMappings).hasSize(1);
     assertThat(inputMappings)
         .containsEntry(PathFragment.create("runfiles/workspace/symlink"), artifact);
@@ -260,7 +268,8 @@ public class SpawnInputExpanderTest {
         FileArtifactValue.createForNormalFile(FAKE_DIGEST, /*proxy=*/ null, /*size=*/ 1L));
 
     expander.addRunfilesToInputs(
-        inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER, PathFragment.EMPTY_FRAGMENT);
+        inputMappings, supplier, mockCache, NO_ARTIFACT_EXPANDER, ActionStager.NOOP,
+        PathFragment.EMPTY_FRAGMENT);
     assertThat(inputMappings).hasSize(2);
     assertThat(inputMappings).containsEntry(PathFragment.create("runfiles/symlink"), artifact);
     // If there's no other entry, Runfiles adds an empty file in the workspace to make sure the
@@ -293,7 +302,8 @@ public class SpawnInputExpanderTest {
     fakeCache.put(file2, FileArtifactValue.createForTesting(file2));
 
     expander.addRunfilesToInputs(
-        inputMappings, supplier, fakeCache, artifactExpander, PathFragment.EMPTY_FRAGMENT);
+        inputMappings, supplier, fakeCache, artifactExpander, ActionStager.NOOP,
+        PathFragment.EMPTY_FRAGMENT);
     assertThat(inputMappings).hasSize(2);
     assertThat(inputMappings)
         .containsEntry(PathFragment.create("runfiles/workspace/treeArtifact/file1"), file1);
@@ -327,7 +337,8 @@ public class SpawnInputExpanderTest {
     fakeCache.put(file2, FileArtifactValue.createForTesting(file2));
 
     expander.addRunfilesToInputs(
-        inputMappings, supplier, fakeCache, artifactExpander, PathFragment.EMPTY_FRAGMENT);
+        inputMappings, supplier, fakeCache, artifactExpander, ActionStager.NOOP,
+        PathFragment.EMPTY_FRAGMENT);
     assertThat(inputMappings).hasSize(2);
     assertThat(inputMappings)
         .containsEntry(PathFragment.create("runfiles/workspace/symlink/file1"), file1);

--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -228,7 +228,8 @@ def _bootclasspath_impl(ctx):
     args.add("--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED")
     args.add("--add-exports=jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED")
     args.add("--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED")
-    args.add("-cp", class_dir.path)
+    args.add("-cp")
+    args.add_all([class_dir], expand_directories = False)
     args.add("DumpPlatformClassPath")
     args.add(bootclasspath)
 


### PR DESCRIPTION
Starlark actions with mnemonics listed in the flag have their input and output paths mapped according to the following scheme when staged for sandboxed or remote execution:

* source file paths are preserved as is;
* paths of generated input files of the form `bazel-out/k8-fastbuild/bin/pkg/file` are replaced with `bazel-out/<hash>/bin/pkg/file`, where `<hash>` is a digest of the contents of the file;
* paths of output files of the form `bazel-out/k8-fastbuild/bin/pkg/file` are replaced with `bazel-out/out/bin/pkg/file`.

This path mapping is applied both to the location at which files are staged in the sandbox or during remote execution and to paths emitted into structured command lines. In order to build successfully with this flag, action command lines

* must not contain `dirname`, `path`, or `root.path` of any `File` object evaluated at analysis time;
* must not reference `File` objects that aren't declared inputs or outputs of the action.

Spawns derived from actions opted into content-based path mapping can only be executed in symlink-based sandboxes or remotely.

Work towards #6526