### PR TITLE
Declare that bazel is under an Apache 2.0 license

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,9 +2,18 @@
 
 load("//tools/distributions:distribution_rules.bzl", "distrib_jar_filegroup")
 load("//tools/python:private/defs.bzl", "py_binary")
+load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 package(default_visibility = ["//scripts/release:__pkg__"])
+
+license(
+    name = "license",
+    license_kinds = [
+        "@rules_license//licenses/spdx:Apache-2.0",
+    ],
+    license_text = "LICENSE",
+)
 
 exports_files(["LICENSE"])
 
@@ -31,6 +40,7 @@ filegroup(
         "//src/main/starlark/tests/builtins_bzl:srcs",
     ] + glob([".bazelci/*"]) + [".bazelrc"],
     visibility = ["//src/test/shell/bazel:__pkg__"],
+    applicable_licenses = ["//:license"],
 )
 
 filegroup(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,6 +57,12 @@ bind(
     actual = "//third_party:guava",
 )
 
+# We must control the version of rules_license we use, so we load ours before
+# any other repo can bring it in through their deps.
+dist_http_archive(
+    name = "rules_license",
+)
+
 # For src/test/shell/bazel:test_srcs
 load("//src/test/shell/bazel:list_source_repository.bzl", "list_source_repository")
 
@@ -658,7 +664,3 @@ debian_deps()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
-
-dist_http_archive(
-    name = "rules_license",
-)

--- a/src/BUILD
+++ b/src/BUILD
@@ -5,6 +5,8 @@ load(":embedded_tools.bzl", "srcsfile")
 load(":rule_size_test.bzl", "rule_size_test")
 load("//src:release_archive.bzl", "release_archive")
 
+package(default_applicable_licenses = ["//:license"])
+
 exports_files(["jdeps_modules.golden"])
 
 md5_cmd = "set -e -o pipefail && %s $(SRCS) | %s | %s > $@"


### PR DESCRIPTION
- Creates the license declaration.
- Applies it to src:*