### PR TITLE
Disable ReturnValueIgnored checks to unblock java_tools release

### DIFF
--- a/tools/jdk/default_java_toolchain.bzl
+++ b/tools/jdk/default_java_toolchain.bzl
@@ -51,8 +51,8 @@ DEFAULT_JAVACOPTS = [
     "-XDcompilePolicy=simple",
     "-g",
     "-parameters",
-    # https://github.com/bazelbuild/java_tools/issues/51#issuecomment-927940699
-    "-XepOpt:ReturnValueIgnored:ObjectMethods=false",
+    # https://github.com/bazelbuild/bazel/issues/15219
+    "-Xep:ReturnValueIgnored:OFF",
 ]
 
 # java_toolchain parameters without specifying javac, java.compiler,


### PR DESCRIPTION
New checks added since the last release break //tools/android/...

Re-enabling this is being tracked in https://github.com/bazelbuild/bazel/issues/15219

PiperOrigin-RevId: 441198376