### PR TITLE
Implement --remote_force_print_messages

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnRunner.java
@@ -61,6 +61,7 @@ import com.google.devtools.build.lib.remote.RemoteExecutionService.ServerLogs;
 import com.google.devtools.build.lib.remote.common.BulkTransferException;
 import com.google.devtools.build.lib.remote.common.OperationObserver;
 import com.google.devtools.build.lib.remote.options.RemoteOptions;
+import com.google.devtools.build.lib.remote.options.RemoteOptions.ExecutionMessagePrintMode;
 import com.google.devtools.build.lib.remote.util.Utils;
 import com.google.devtools.build.lib.remote.util.Utils.InMemoryOutput;
 import com.google.devtools.build.lib.sandbox.SandboxHelpers;
@@ -274,7 +275,13 @@ public class RemoteSpawnRunner implements SpawnRunner {
 
             FileOutErr outErr = context.getFileOutErr();
             String message = result.getMessage();
-            if (!result.success() && !message.isEmpty()) {
+            boolean printMessage = (!result.success() &&
+                remoteOptions.remotePrintExecutionMessages == ExecutionMessagePrintMode.FAILURE ||
+                result.success() &&
+                remoteOptions.remotePrintExecutionMessages == ExecutionMessagePrintMode.SUCCESS ||
+                remoteOptions.remotePrintExecutionMessages == ExecutionMessagePrintMode.ALL)
+                && !message.isEmpty();
+            if (printMessage) {
               outErr.printErr(message + "\n");
             }
 

--- a/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java
@@ -574,6 +574,19 @@ public final class RemoteOptions extends OptionsBase {
       help = "Maximum number of open files allowed during BEP artifact upload.")
   public int maximumOpenFiles;
 
+  @Option(
+      name = "remote_print_execution_messages",
+      defaultValue = "failure",
+      converter = ExecutionMessagePrintMode.Converter.class,
+      category = "remote",
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.TERMINAL_OUTPUT},
+      help =
+          "Choose when to print remote execution messages. Valid values are `failure`, "
+              + "to print only on failures, `success` to print only on successes and "
+              + "`all` to print always.")
+  public ExecutionMessagePrintMode remotePrintExecutionMessages;
+
   // The below options are not configurable by users, only tests.
   // This is part of the effort to reduce the overall number of flags.
 
@@ -642,5 +655,19 @@ public final class RemoteOptions extends OptionsBase {
         .setMessage(message)
         .setRemoteExecution(RemoteExecution.newBuilder().setCode(detailedCode))
         .build();
+  }
+
+  /** An enum for specifying different modes for printing remote execution messages. */
+  public enum ExecutionMessagePrintMode {
+    FAILURE, // Print execution messages only on failure
+    SUCCESS, // Print execution messages only on success
+    ALL; // Print execution messages always
+
+    /** Converts to {@link ExecutionMessagePrintMode}. */
+    public static class Converter extends EnumConverter<ExecutionMessagePrintMode> {
+      public Converter() {
+        super(ExecutionMessagePrintMode.class, "execution message print mode");
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds a flag for always printing messages returned by remotely executed
actions.