### PR TITLE
Ensure Databinding `layout-info.zip` entries have consistent timestamps

### DIFF
--- a/src/test/java/com/google/devtools/build/android/BUILD
+++ b/src/test/java/com/google/devtools/build/android/BUILD
@@ -335,6 +335,29 @@ java_test(
     ],
 )
 
+filegroup(
+    name = "testdata",
+    srcs = glob(["testing/**"]),
+)
+
+java_test(
+    name = "AndroidDataBindingProcessingActionTest",
+    size = "small",
+    srcs = ["AndroidDataBindingProcessingActionTest.java"],
+    data = [
+        ":testdata",
+    ],
+    tags = [
+        "no_windows",
+    ],
+    deps = [
+        "//src/tools/android/java/com/google/devtools/build/android:android_builder_lib",
+        "//third_party:guava",
+        "//third_party:junit4",
+        "//third_party:truth",
+    ],
+)
+
 java_library(
     name = "test_utils",
     testonly = 1,

--- a/src/tools/android/java/com/google/devtools/build/android/AndroidDataBindingProcessingAction.java
+++ b/src/tools/android/java/com/google/devtools/build/android/AndroidDataBindingProcessingAction.java
@@ -150,6 +150,7 @@ public class AndroidDataBindingProcessingAction {
         while (it.hasNext()) {
           Path layoutInfo = it.next();
           ZipEntry zipEntry = new ZipEntry(layoutInfo.getFileName().toString());
+          zipEntry.setTime(AarGeneratorAction.DEFAULT_TIMESTAMP);
           layoutInfoZip.putNextEntry(zipEntry);
           Files.copy(layoutInfo, layoutInfoZip);
           layoutInfoZip.closeEntry();


### PR DESCRIPTION
This is part of https://github.com/bazelbuild/bazel/issues/13639 and fixes the timestamp issue which makes `layout-info.zip` non deterministic. 

Fixed tests. 

Note that absolute path issue described [here](https://github.com/bazelbuild/bazel/issues/13639#issue-935986425) still exists and that needs fixes in databinding jar.