### PR TITLE
Reduce imports processed by python stubs.

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
@@ -19,11 +19,17 @@ import sys
 del sys.path[0]
 
 import os
-import re
-import shutil
 import subprocess
-import tempfile
-import zipfile
+
+def IsRunningFromZip():
+  return %is_zipfile%
+
+if IsRunningFromZip():
+  import shutil
+  import tempfile
+  import zipfile
+else:
+  import re
 
 # Return True if running on Windows
 def IsWindows():
@@ -70,9 +76,6 @@ def SearchPath(name):
       if os.path.isfile(path) and os.access(path, os.X_OK):
         return path
   return None
-
-def IsRunningFromZip():
-  return %is_zipfile%
 
 def FindPythonBinary(module_space):
   """Finds the real Python binary if it's not a normal absolute path."""


### PR DESCRIPTION
There are several import statements in the python wrapper stub used by
`py_binary` and `py_test` rules which are only used when running from a
zip archive.  Processing these imports is a waste of time in the common
case where they aren't going to  be used.  They also might not be
present at all in some stripped-down python environments (e.g. the
Debian `python3-minimal` package), which might be the only python
available on a remote builder when using a hermetic python toolchain
(even when using a hermetic python toolchain, the wrapper is executed
using the system python environment).

Closes https://github.com/bazelbuild/bazel/issues/15571