### PR TITLE
Bump the limit of Bazel install base size

### DIFF
--- a/src/test/shell/integration/minimal_jdk_test.sh
+++ b/src/test/shell/integration/minimal_jdk_test.sh
@@ -42,13 +42,13 @@ export BAZEL_SUFFIX="_jdk_minimal"
 source "$(rlocation "io_bazel/src/test/shell/integration_test_setup.sh")" \
   || { echo "integration_test_setup.sh not found!" >&2; exit 1; }
 
-# Bazel's install base is < 311MB with minimal JDK and > 315MB with an all
+# Bazel's install base is < 320MB with minimal JDK and > 320MB with an all
 # modules JDK.
-function test_size_less_than_311MB() {
+function test_size_less_than_320MB() {
   bazel info
   ib=$(bazel info install_base)
   size=$(du -s "$ib" | cut -d\	 -f1)
-  maxsize=$((1024*311))
+  maxsize=$((1024*320))
   if [ $size -gt $maxsize ]; then
     echo "$ib was too big:" 1>&2
     du -a "$ib" 1>&2


### PR DESCRIPTION
This is due to the upgrade of zlib: https://github.com/bazelbuild/bazel/pull/15497
Downstream failure: https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2482#0180f962-1169-4a22-bffd-f455198c9b38

PiperOrigin-RevId: 450948972
Change-Id: Ic67523cc75c7445b9f3478d5c8343956280b8cb6