### PR TITLE
Update rules_license to 0.0.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,7 @@ module(
   version = "6.0.0-pre",
 )
 
+bazel_dep(name = "rules_license", version = "0.0.2")
 bazel_dep(name = "bazel_skylib", version = "1.0.3")
 bazel_dep(name = "protobuf", version = "3.19.2", repo_name = "com_google_protobuf")
 bazel_dep(name = "grpc", version = "1.41.0", repo_name = "com_github_grpc_grpc")

--- a/distdir_deps.bzl
+++ b/distdir_deps.bzl
@@ -225,11 +225,11 @@ DIST_DEPS = {
         "strip_prefix": "stardoc-1ef781ced3b1443dca3ed05dec1989eca1a4e1cd",
     },
     "rules_license": {
-        "archive": "rules_license-0.0.2.tar.gz",
-        "sha256": "a5edffc810c74e32a9a7ef5f9591bc05d1362b244b9e22323f38cbbbaba41281",
+        "archive": "rules_license-0.0.3.tar.gz",
+        "sha256": "00ccc0df21312c127ac4b12880ab0f9a26c1cff99442dc6c5a331750360de3c3",
         "urls": [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.2/rules_license-0.0.2.tar.gz",
-            "https://github.com/bazelbuild/rules_license/releases/download/0.0.2/rules_license-0.0.2.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz",
+            "https://github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz",
         ],
         "used_in": [
             "additional_distfiles",


### PR DESCRIPTION
Updates to the newest release so we can pick up the generic "notice" and "restricted" license types.