### PR TITLE
DO NOT MERGE: turn on --incompatible_strict_action_env

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,5 +34,7 @@ build:bzlmod --experimental_enable_bzlmod
 build --java_language_version=11
 build --tool_java_language_version=11
 
+build --incompatible_strict_action_env
+
 # User-specific .bazelrc
 try-import user.bazelrc


### PR DESCRIPTION
I created this PR to trigger our CI and see if Bazel still fails to build with this flag.

See https://github.com/bazelbuild/bazel/issues/7026 for context.