### PR TITLE
Fix and test for null value bug when using --repo_env

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommandEnvironment.java
@@ -266,8 +266,8 @@ public class CommandEnvironment {
         value = System.getenv(name);
       }
       if (value != null) {
-        repoEnv.put(entry.getKey(), entry.getValue());
-        repoEnvFromOptions.put(entry.getKey(), entry.getValue());
+        repoEnv.put(name, value);
+        repoEnvFromOptions.put(name, value);
       }
     }
     this.buildResultListener = new BuildResultListener();

--- a/src/test/py/bazel/bazel_external_repository_test.py
+++ b/src/test/py/bazel/bazel_external_repository_test.py
@@ -427,5 +427,34 @@ class BazelExternalRepositoryTest(test_base.TestBase):
         args=['build', '@other_repo//:file'], cwd=work_dir)
     self.AssertExitCode(exit_code, 0, stderr)
 
+  def testRepoEnv(self):
+    #Testing fix for issue: https://github.com/bazelbuild/bazel/issues/15430
+
+    self.ScratchFile('WORKSPACE', [
+      'load("//:main.bzl", "dump_env")',
+      'dump_env(',
+      '    name = "debug"',
+      ')'
+    ])
+    self.ScratchFile('BUILD')
+    self.ScratchFile('main.bzl', [
+      'def _dump_env(ctx):',
+      '    val = ctx.os.environ.get("FOO", "nothing")',
+      '    print("FOO", val)',
+      '    ctx.file("BUILD")',
+      'dump_env = repository_rule(',
+      '    implementation = _dump_env,',
+      '    local = True,',
+      ')'
+    ])
+
+    exit_code, _, stderr = self.RunBazel(
+      args=['build', '@debug//:all'],
+      env_add={'FOO': 'bar'},
+    )
+    self.AssertExitCode(exit_code, 0, stderr)
+    self.assertIn('FOO bar', os.linesep.join(stderr))
+    self.assertNotIn('null value in entry: FOO=null', os.linesep.join(stderr))
+
 if __name__ == '__main__':
   unittest.main()

--- a/src/test/py/bazel/bazel_external_repository_test.py
+++ b/src/test/py/bazel/bazel_external_repository_test.py
@@ -449,8 +449,8 @@ class BazelExternalRepositoryTest(test_base.TestBase):
     ])
 
     exit_code, _, stderr = self.RunBazel(
-      args=['build', '@debug//:all'],
-      env_add={'FOO': 'bar'},
+      args=['build', '@debug//:all', '--repo_env=FOO'],
+      env_add={'FOO': 'bar'}
     )
     self.AssertExitCode(exit_code, 0, stderr)
     self.assertIn('FOO bar', os.linesep.join(stderr))


### PR DESCRIPTION
Fix and test for null value bug when using --repo_env
[Issue Link](https://github.com/bazelbuild/bazel/issues/15430)