### PR TITLE
JavaToolchain: Use FilesToRunProvider for oneversion tool

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchain.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchain.java
@@ -79,7 +79,7 @@ public class JavaToolchain implements RuleConfiguredTargetFactory {
     boolean forciblyDisableHeaderCompilation =
         ruleContext.attributes().get("forcibly_disable_header_compilation", Type.BOOLEAN);
     Artifact singleJar = ruleContext.getPrerequisiteArtifact("singlejar");
-    Artifact oneVersion = ruleContext.getPrerequisiteArtifact("oneversion");
+    FilesToRunProvider oneVersion = ruleContext.getExecutablePrerequisite("oneversion");
     Artifact oneVersionAllowlist = ruleContext.getPrerequisiteArtifact("oneversion_whitelist");
     Artifact genClass = ruleContext.getPrerequisiteArtifact("genclass");
     Artifact depsChecker = ruleContext.getPrerequisiteArtifact("deps_checker");

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchainProvider.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchainProvider.java
@@ -106,7 +106,7 @@ public final class JavaToolchainProvider extends NativeInfo
       ImmutableSet<String> reducedClasspathIncompatibleProcessors,
       boolean forciblyDisableHeaderCompilation,
       Artifact singleJar,
-      @Nullable Artifact oneVersion,
+      @Nullable FilesToRunProvider oneVersion,
       @Nullable Artifact oneVersionAllowlist,
       Artifact genClass,
       @Nullable Artifact depsChecker,
@@ -168,7 +168,7 @@ public final class JavaToolchainProvider extends NativeInfo
   private final ImmutableSet<String> reducedClasspathIncompatibleProcessors;
   private final boolean forciblyDisableHeaderCompilation;
   private final Artifact singleJar;
-  @Nullable private final Artifact oneVersion;
+  @Nullable private final FilesToRunProvider oneVersion;
   @Nullable private final Artifact oneVersionAllowlist;
   private final Artifact genClass;
   @Nullable private final Artifact depsChecker;
@@ -202,7 +202,7 @@ public final class JavaToolchainProvider extends NativeInfo
       ImmutableSet<String> reducedClasspathIncompatibleProcessors,
       boolean forciblyDisableHeaderCompilation,
       Artifact singleJar,
-      @Nullable Artifact oneVersion,
+      @Nullable FilesToRunProvider oneVersion,
       @Nullable Artifact oneVersionAllowlist,
       Artifact genClass,
       @Nullable Artifact depsChecker,
@@ -339,7 +339,7 @@ public final class JavaToolchainProvider extends NativeInfo
    */
   @Override
   @Nullable
-  public Artifact getOneVersionBinary() {
+  public FilesToRunProvider getOneVersionBinary() {
     return oneVersion;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchainRule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/JavaToolchainRule.java
@@ -244,7 +244,6 @@ public final class JavaToolchainRule<C extends JavaToolchain> implements RuleDef
         <!-- #END_BLAZE_RULE.ATTRIBUTE --> */
         .add(
             attr("oneversion", LABEL)
-                .singleArtifact()
                 // This needs to be in the execution configuration.
                 .cfg(ExecutionTransitionFactory.create())
                 .allowedFileTypes(FileTypeSet.ANY_FILE)

--- a/src/main/java/com/google/devtools/build/lib/rules/java/OneVersionCheckActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/java/OneVersionCheckActionBuilder.java
@@ -21,6 +21,7 @@ import com.google.devtools.build.lib.actions.Artifact;
 import com.google.devtools.build.lib.actions.CommandLineItem;
 import com.google.devtools.build.lib.actions.ParamFileInfo;
 import com.google.devtools.build.lib.actions.ParameterFile.ParameterFileType;
+import com.google.devtools.build.lib.analysis.FilesToRunProvider;
 import com.google.devtools.build.lib.analysis.RuleContext;
 import com.google.devtools.build.lib.analysis.actions.CustomCommandLine;
 import com.google.devtools.build.lib.analysis.actions.CustomCommandLine.VectorArg;
@@ -76,7 +77,7 @@ public final class OneVersionCheckActionBuilder {
     Preconditions.checkNotNull(javaToolchain);
     Preconditions.checkNotNull(jarsToCheck);
 
-    Artifact oneVersionTool = javaToolchain.getOneVersionBinary();
+    FilesToRunProvider oneVersionTool = javaToolchain.getOneVersionBinary();
     Artifact oneVersionAllowlist = javaToolchain.getOneVersionAllowlist();
     if (oneVersionTool == null || oneVersionAllowlist == null) {
       addRuleErrorForMissingArtifacts(ruleContext, javaToolchain);

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaToolchainStarlarkApiProviderApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaToolchainStarlarkApiProviderApi.java
@@ -58,7 +58,7 @@ public interface JavaToolchainStarlarkApiProviderApi extends StructApi {
       doc = "The artifact that enforces One-Version compliance of java binaries.",
       structField = true,
       allowReturnNones = true)
-  FileApi getOneVersionBinary();
+  FilesToRunProviderApi<? extends FileApi> getOneVersionBinary();
 
   @StarlarkMethod(
       name = "one_version_allowlist",


### PR DESCRIPTION
This allows, e.g., to use `py_binary` targets to be used as
implementation for `oneversion`, which currently fauils with
`in oneversion attribute of java_toolchain rule <redacted>:
'<redacted>' must produce a single file.`.