### PR TITLE
Add -no_deduplicate for darwin dbg/fastbuild

### DIFF
--- a/tools/osx/crosstool/cc_toolchain_config.bzl
+++ b/tools/osx/crosstool/cc_toolchain_config.bzl
@@ -1161,6 +1161,22 @@ def _impl(ctx):
             ],
         )
 
+    no_deduplicate_feature = feature(
+        name = "no_deduplicate",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions +
+                          ["objc-executable", "objc++-executable"],
+                flag_groups = [flag_group(flags = ["-Wl,-no_deduplicate"])],
+                with_features = [
+                    with_feature_set(features = ["dbg"]),
+                    with_feature_set(features = ["fastbuild"]),
+                ],
+            ),
+        ],
+    )
+
     output_execpath_flags_feature = feature(
         name = "output_execpath_flags",
         flag_sets = [
@@ -2746,6 +2762,7 @@ def _impl(ctx):
             relative_ast_path_feature,
             user_link_flags_feature,
             default_link_flags_feature,
+            no_deduplicate_feature,
             dead_strip_feature,
             cpp_linker_flags_feature,
             apply_implicit_frameworks_feature,
@@ -2826,6 +2843,7 @@ def _impl(ctx):
             relative_ast_path_feature,
             user_link_flags_feature,
             default_link_flags_feature,
+            no_deduplicate_feature,
             dead_strip_feature,
             cpp_linker_flags_feature,
             apply_implicit_frameworks_feature,


### PR DESCRIPTION
The -no_deduplicate linker flag saves some time for debug builds at the
cost of binary size. In testing envoy the difference was 50s -> 9s to
link a debug build with this flag enabled. This change enables it as a
separate feature so it can be opted out of by users if needed, and
leaves the default for opt to get this optimization for release builds.

Fixes https://github.com/bazelbuild/bazel/issues/10910