### PR TITLE
Fix param_file_arg error message

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/Args.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/Args.java
@@ -526,7 +526,7 @@ public abstract class Args implements CommandLineArgsApi {
       Starlark.checkMutable(this);
       if (!SingleStringArgFormatter.isValid(paramFileArg)) {
         throw Starlark.errorf(
-            "Invalid value for parameter \"param_file_arg\": Expected string with a single \"%s\"",
+            "Invalid value for parameter \"param_file_arg\": Expected string with a single \"%%s\", got \"%s\"",
             paramFileArg);
       }
       this.flagFormatString = paramFileArg;

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleImplementationFunctionsTest.java
@@ -2313,11 +2313,12 @@ public class StarlarkRuleImplementationFunctionsTest extends BuildViewTestCase {
   public void testLazyArgsWithParamFileInvalidFormatString() throws Exception {
     setRuleContext(createRuleContext("//foo:foo"));
     ev.checkEvalErrorContains(
-        "Invalid value for parameter \"param_file_arg\": Expected string with a single \"--file=\"",
+        "Invalid value for parameter \"param_file_arg\": "
+            + "Expected string with a single \"%s\", got \"--file=\"",
         "args = ruleContext.actions.args()\n" + "args.use_param_file('--file=')");
     ev.checkEvalErrorContains(
         "Invalid value for parameter \"param_file_arg\": "
-            + "Expected string with a single \"--file=%s%s\"",
+            + "Expected string with a single \"%s\", got \"--file=%s%s\"",
         "args = ruleContext.actions.args()\n" + "args.use_param_file('--file=%s%s')");
   }
 


### PR DESCRIPTION
The error message incorrectly escaped the missing format specifier. As
a result, the 'Expected string with a single "%s"' read 'Expected string
with a single "<value of the arg>"' instead.