### PR TITLE
Fix null pointer crash with `bazel coverage` on only incompatible tests

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/coverage/CoverageReportActionBuilder.java
@@ -212,6 +212,10 @@ public final class CoverageReportActionBuilder {
         reportGenerator = testParams.getCoverageReportGenerator();
       }
     }
+    // If all tests are incompatible, there's nothing to do.
+    if (reportGenerator == null) {
+      return null;
+    }
     builder.addAll(baselineCoverageArtifacts.toList());
 
     ImmutableList<Artifact> coverageArtifacts = builder.build();


### PR DESCRIPTION
This is a follow-up to 2f1ff6fa17c3c30b2533bffe81f40eab06b453b9. That
patch accidentally introduced a crash when running coverage on tests
where all tests are incompatible.

    FATAL: bazel crashed due to an internal error. Printing stack trace:
    java.lang.NullPointerException: Null reportGenerator
            at com.google.devtools.build.lib.bazel.coverage.AutoValue_CoverageArgs.<init>(AutoValue_CoverageArgs.java:68)
            at com.google.devtools.build.lib.bazel.coverage.CoverageArgs.create(CoverageArgs.java:58)
            at com.google.devtools.build.lib.bazel.coverage.CoverageReportActionBuilder.createCoverageActionsWrapper(CoverageReportActionBuilder.java:226)
            at com.google.devtools.build.lib.bazel.coverage.BazelCoverageReportModule$1.createCoverageReportActionsWrapper(BazelCoverageReportModule.java:98)
            at com.google.devtools.build.lib.analysis.BuildView.createResult(BuildView.java:558)
            at com.google.devtools.build.lib.analysis.BuildView.update(BuildView.java:492)
            at com.google.devtools.build.lib.buildtool.AnalysisPhaseRunner.runAnalysisPhase(AnalysisPhaseRunner.java:227)
            at com.google.devtools.build.lib.buildtool.AnalysisPhaseRunner.execute(AnalysisPhaseRunner.java:137)
            at com.google.devtools.build.lib.buildtool.BuildTool.buildTargets(BuildTool.java:266)
            at com.google.devtools.build.lib.buildtool.BuildTool.processRequest(BuildTool.java:506)
            at com.google.devtools.build.lib.buildtool.BuildTool.processRequest(BuildTool.java:474)
            at com.google.devtools.build.lib.runtime.commands.TestCommand.doTest(TestCommand.java:148)
            at com.google.devtools.build.lib.runtime.commands.TestCommand.exec(TestCommand.java:113)
            at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.execExclusively(BlazeCommandDispatcher.java:584)
            at com.google.devtools.build.lib.runtime.BlazeCommandDispatcher.exec(BlazeCommandDispatcher.java:231)
            at com.google.devtools.build.lib.server.GrpcServerImpl.executeCommand(GrpcServerImpl.java:550)
            at com.google.devtools.build.lib.server.GrpcServerImpl.lambda$run$1(GrpcServerImpl.java:614)
            at io.grpc.Context$1.run(Context.java:566)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
            at java.base/java.lang.Thread.run(Unknown Source)

This patch fixes the crash by handling the situation properly. This
results in all tests being skipped and reported as being skipped.

A new test validates the correct behaviour.