### PR TITLE
Deduplicate paths between old and new PYTHONPATH

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
@@ -298,13 +298,15 @@ def Main():
   # keep first occurrence only.
   python_path_entries = [
     GetWindowsPathWithUNCPrefix(d)
-    for d in Deduplicate(python_path_entries)
+    for d in python_path_entries
   ]
 
   old_python_path = os.environ.get('PYTHONPATH')
   python_path = os.pathsep.join(python_path_entries)
   if old_python_path:
     python_path += os.pathsep + old_python_path
+
+  python_path = os.pathsep.join(Deduplicate(python_path.split(os.pathsep)))
 
   if IsWindows():
     python_path = python_path.replace('/', os.sep)

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/python/python_stub_template.txt
@@ -302,11 +302,10 @@ def Main():
   ]
 
   old_python_path = os.environ.get('PYTHONPATH')
-  python_path = os.pathsep.join(python_path_entries)
   if old_python_path:
-    python_path += os.pathsep + old_python_path
+    python_path_entries += old_python_path.split(os.pathsep)
 
-  python_path = os.pathsep.join(Deduplicate(python_path.split(os.pathsep)))
+  python_path = os.pathsep.join(Deduplicate(python_path_entries))
 
   if IsWindows():
     python_path = python_path.replace('/', os.sep)


### PR DESCRIPTION
Resolves https://github.com/bazelbuild/bazel/issues/15649 by deduplicating the PYTHONPATH after the old and new one has been joined.
