### PR TITLE
Pass singleton list to transition for allow_multiple setting default

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuildSettingsDetailsFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/StarlarkBuildSettingsDetailsFunction.java
@@ -18,6 +18,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.devtools.build.lib.packages.RuleClass.Builder.STARLARK_BUILD_SETTING_DEFAULT_ATTR_NAME;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkBuildSettingsDetailsValue;
@@ -87,7 +88,13 @@ final class StarlarkBuildSettingsDetailsFunction implements SkyFunction {
               .collect(
                   toImmutableMap(
                       Rule::getLabel,
-                      rule -> rule.getAttr(STARLARK_BUILD_SETTING_DEFAULT_ATTR_NAME)));
+                      rule -> {
+                        if (rule.getRuleClassObject().getBuildSetting().allowsMultiple()) {
+                          return ImmutableList.of(
+                              rule.getAttr(STARLARK_BUILD_SETTING_DEFAULT_ATTR_NAME));
+                        }
+                        return rule.getAttr(STARLARK_BUILD_SETTING_DEFAULT_ATTR_NAME);
+                      }));
       ImmutableMap<Label, Type<?>> buildSettingToType =
           actualRules.stream()
               .collect(

--- a/src/test/java/com/google/devtools/build/lib/analysis/StarlarkRuleTransitionProviderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/StarlarkRuleTransitionProviderTest.java
@@ -15,6 +15,7 @@ package com.google.devtools.build.lib.analysis;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.config.BuildConfigurationValue;
@@ -1565,6 +1566,61 @@ public final class StarlarkRuleTransitionProviderTest extends BuildViewTestCase 
     assertThat(
             (List<?>) starlarkOptions.get(Label.parseAbsoluteUnchecked("//test:cute-animal-fact")))
         .containsExactly("puffins mate for life");
+  }
+
+  @Test
+  public void testTransitionOnAllowMultiplesBuildSettingAlwaysSeesListValue() throws Exception {
+    scratch.file(
+        "test/transitions.bzl",
+        "def _transition_impl(settings, attr):",
+        "  setting_type = type(settings['//test:multiple_flag'])",
+        "  if setting_type != type([]):",
+        "    fail('Expected setting to be a list, got %s' % setting_type)",
+        "  return {}",
+        "my_transition = transition(",
+        "  implementation = _transition_impl,",
+        "  inputs = ['//test:multiple_flag'],",
+        "  outputs = ['//test:multiple_flag']",
+        ")");
+    writeAllowlistFile();
+    scratch.file(
+        "test/rules.bzl",
+        "load('//test:transitions.bzl', 'my_transition')",
+        "def _rule_impl(ctx):",
+        "  return []",
+        "my_rule = rule(",
+        "  implementation = _rule_impl,",
+        "  cfg = my_transition,",
+        "  attrs = {",
+        "    '_allowlist_function_transition': attr.label(",
+        "        default = '//tools/allowlists/function_transition_allowlist',",
+        "    ),",
+        "  },",
+        ")");
+    scratch.file(
+        "test/build_settings.bzl",
+        "def _impl(ctx):",
+        "  return []",
+        "string_flag = rule(implementation = _impl, build_setting = config.string(flag=True,"
+            + " allow_multiple=True))");
+    scratch.file(
+        "test/BUILD",
+        "load('//test:rules.bzl', 'my_rule')",
+        "load('//test:build_settings.bzl', 'string_flag')",
+        "my_rule(name = 'test')",
+        "string_flag(",
+        "  name = 'multiple_flag',",
+        "  build_setting_default = '',",
+        ")");
+
+    // Starlark option at is default value.
+    getConfiguredTarget("//test");
+
+    useConfiguration(ImmutableMap.of("//test:multiple_flag", ImmutableList.of("foo")));
+    getConfiguredTarget("//test");
+
+    useConfiguration(ImmutableMap.of("//test:multiple_flag", ImmutableList.of("foo", "bar")));
+    getConfiguredTarget("//test");
   }
 
   /**


### PR DESCRIPTION
Previously, the default value of a user-defined string setting with
`allow_multiple = True`, which is internally represented as a string,
was passed to transitions as a string, not a list containing the single
string.

Fixes #15653