### PR TITLE
Make the exec group of the test runner configurable

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BaseRuleClasses.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.analysis;
 
+import static com.google.devtools.build.lib.analysis.test.ExecutionInfo.DEFAULT_TEST_RUNNER_EXEC_GROUP;
 import static com.google.devtools.build.lib.packages.Attribute.attr;
 import static com.google.devtools.build.lib.packages.BuildType.DISTRIBUTIONS;
 import static com.google.devtools.build.lib.packages.BuildType.LABEL;
@@ -172,8 +173,6 @@ public class BaseRuleClasses {
             return runUnder != null ? runUnder.getLabel() : null;
           });
 
-  public static final String TEST_RUNNER_EXEC_GROUP = "test";
-
   /**
    * A base rule for all test rules.
    */
@@ -181,7 +180,7 @@ public class BaseRuleClasses {
     @Override
     public RuleClass build(RuleClass.Builder builder, RuleDefinitionEnvironment env) {
       builder
-          .addExecGroup(TEST_RUNNER_EXEC_GROUP)
+          .addExecGroup(DEFAULT_TEST_RUNNER_EXEC_GROUP)
           .requiresConfigurationFragments(TestConfiguration.class)
           // TestConfiguration only needed to create TestAction and TestProvider
           // Only necessary at top-level and can be skipped if trimmed.

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java
@@ -14,8 +14,8 @@
 
 package com.google.devtools.build.lib.analysis.starlark;
 
+import static com.google.devtools.build.lib.analysis.test.ExecutionInfo.DEFAULT_TEST_RUNNER_EXEC_GROUP;
 import static com.google.devtools.build.lib.analysis.BaseRuleClasses.RUN_UNDER;
-import static com.google.devtools.build.lib.analysis.BaseRuleClasses.TEST_RUNNER_EXEC_GROUP;
 import static com.google.devtools.build.lib.analysis.BaseRuleClasses.TIMEOUT_DEFAULT;
 import static com.google.devtools.build.lib.analysis.BaseRuleClasses.getTestRuntimeLabelList;
 import static com.google.devtools.build.lib.packages.Attribute.attr;
@@ -394,8 +394,8 @@ public class StarlarkRuleClassFunctions implements StarlarkRuleFunctionsApi<Arti
       }
       builder.addExecGroups(execGroupDict);
     }
-    if (test && !builder.hasExecGroup(TEST_RUNNER_EXEC_GROUP)) {
-      builder.addExecGroup(TEST_RUNNER_EXEC_GROUP);
+    if (test && !builder.hasExecGroup(DEFAULT_TEST_RUNNER_EXEC_GROUP)) {
+      builder.addExecGroup(DEFAULT_TEST_RUNNER_EXEC_GROUP);
     }
 
     if (!buildSetting.equals(Starlark.NONE) && !cfg.equals(Starlark.NONE)) {

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/ExecutionInfo.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/ExecutionInfo.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.google.devtools.build.lib.analysis.test;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.packages.BuiltinProvider;
@@ -27,14 +28,23 @@ import java.util.Map;
 @Immutable
 public final class ExecutionInfo extends NativeInfo implements ExecutionInfoApi {
 
+  // TODO(bazel-team): Find a better location for this constant.
+  public static final String DEFAULT_TEST_RUNNER_EXEC_GROUP = "test";
+
   /** Starlark constructor and identifier for ExecutionInfo. */
   public static final BuiltinProvider<ExecutionInfo> PROVIDER =
       new BuiltinProvider<ExecutionInfo>("ExecutionInfo", ExecutionInfo.class) {};
 
   private final ImmutableMap<String, String> executionInfo;
+  private final String execGroup;
 
   public ExecutionInfo(Map<String, String> requirements) {
+    this(requirements, DEFAULT_TEST_RUNNER_EXEC_GROUP);
+  }
+
+  public ExecutionInfo(Map<String, String> requirements, String execGroup) {
     this.executionInfo = ImmutableMap.copyOf(requirements);
+    this.execGroup = Preconditions.checkNotNull(execGroup);
   }
 
   @Override
@@ -50,5 +60,13 @@ public final class ExecutionInfo extends NativeInfo implements ExecutionInfoApi 
   @Override
   public ImmutableMap<String, String> getExecutionInfo() {
     return executionInfo;
+  }
+
+  /**
+   * Returns the name of the exec group that is used to execute the test.
+   */
+  @Override
+  public String getExecGroup() {
+    return execGroup;
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestActionBuilder.java
@@ -14,7 +14,7 @@
 
 package com.google.devtools.build.lib.analysis.test;
 
-import static com.google.devtools.build.lib.analysis.BaseRuleClasses.TEST_RUNNER_EXEC_GROUP;
+import static com.google.devtools.build.lib.analysis.test.ExecutionInfo.DEFAULT_TEST_RUNNER_EXEC_GROUP;
 import static com.google.devtools.build.lib.packages.BuildType.LABEL;
 
 import com.google.common.base.MoreObjects;
@@ -165,7 +165,10 @@ public final class TestActionBuilder {
   }
 
   private ActionOwner getOwner() {
-    ActionOwner owner = ruleContext.getActionOwner(TEST_RUNNER_EXEC_GROUP);
+    ActionOwner owner = ruleContext.getActionOwner(
+        this.executionRequirements != null
+            ? this.executionRequirements.getExecGroup()
+            : DEFAULT_TEST_RUNNER_EXEC_GROUP);
     return owner == null ? ruleContext.getActionOwner() : owner;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModule.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/test/StarlarkTestingModule.java
@@ -25,9 +25,9 @@ import net.starlark.java.eval.StarlarkList;
 public class StarlarkTestingModule implements TestingModuleApi {
 
   @Override
-  public ExecutionInfo executionInfo(Dict<?, ?> requirements /* <String, String> */)
+  public ExecutionInfo executionInfo(Dict<?, ?> requirements /* <String, String> */, String execGroup)
       throws EvalException {
-    return new ExecutionInfo(Dict.cast(requirements, String.class, String.class, "requirements"));
+    return new ExecutionInfo(Dict.cast(requirements, String.class, String.class, "requirements"), execGroup);
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/ExecutionInfoApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/ExecutionInfoApi.java
@@ -31,4 +31,10 @@ public interface ExecutionInfoApi extends StructApi {
       doc = "A dict indicating special execution requirements, such as hardware platforms.",
       structField = true)
   ImmutableMap<String, String> getExecutionInfo();
+
+  @StarlarkMethod(
+      name = "exec_group",
+      doc = "The name of the exec group that is used to execute the test.",
+      structField = true)
+  String getExecGroup();
 }

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/TestingModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/test/TestingModuleApi.java
@@ -45,10 +45,16 @@ public interface TestingModuleApi extends StarlarkValue {
                 "A map of string keys and values to indicate special execution requirements,"
                     + " such as hardware platforms, etc. These keys and values are passed to the"
                     + " executor of the test action as parameters to configure the execution"
-                    + " environment.")
+                    + " environment."),
+        @Param(
+            name = "exec_group",
+            named = true,
+            positional = false,
+            defaultValue = "'test'",
+            doc = "The name of the execution group to use for executing the test."),
       })
-  ExecutionInfoApi executionInfo(Dict<?, ?> requirements // <String, String> expected
-      ) throws EvalException;
+  ExecutionInfoApi executionInfo(/* <String, String> expected */ Dict<?, ?> requirements,
+                                 String execGroup) throws EvalException;
 
   @StarlarkMethod(
       name = "TestEnvironment",

--- a/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/test/TestActionBuilderTest.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.analysis.test;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.eventbus.EventBus;
 import com.google.devtools.build.lib.actions.Artifact;
@@ -327,6 +328,42 @@ public class TestActionBuilderTest extends BuildViewTestCase {
         "        srcs = ['illegal.sh'],",
         "        timeout = 'unreasonable')",
         "test_suite(name = 'everything')");
+  }
+
+  /**
+   * Overriding the exec group from within the test affects the way exec
+   * properties are selected.
+   */
+  @Test
+  public void testOverrideExecGroup() throws Exception {
+    scratch.file(
+        "some_test.bzl",
+        "def _some_test_impl(ctx):",
+        "    script = ctx.actions.declare_file(ctx.attr.name + '.sh')",
+        "    ctx.actions.write(script, 'shell script goes here', is_executable = True)",
+        "    return [",
+        "        DefaultInfo(executable = script),",
+        "        testing.ExecutionInfo({}, exec_group = 'custom_group'),",
+        "    ]",
+        "",
+        "some_test = rule(",
+        "    implementation = _some_test_impl,",
+        "    exec_groups = {'custom_group': exec_group()},",
+        "    test = True,",
+        ")");
+    scratch.file(
+        "BUILD",
+        "load(':some_test.bzl', 'some_test')",
+        "some_test(",
+        "    name = 'custom_exec_group_test',",
+        "    exec_properties = {'test.key': 'bad', 'custom_group.key': 'good'},",
+        ")");
+    ImmutableList<Artifact.DerivedArtifact> testStatusList =
+        getTestStatusArtifacts("//:custom_exec_group_test");
+    TestRunnerAction testAction = (TestRunnerAction)
+        getGeneratingAction(Iterables.get(testStatusList, 0));
+    ImmutableMap<String, String> executionInfo = testAction.getExecutionInfo();
+    assertThat(executionInfo).isEqualTo(ImmutableMap.of("key", "good"));
   }
 
   private ImmutableList<Artifact.DerivedArtifact> getTestStatusArtifacts(String label)


### PR DESCRIPTION
For plain rules, it is possible to give multiple exec groups to a rule
and have some logic inside the rule to pick between an exec group. For
example:

    def _impl(ctx):
        use_large_worker = some == complex && starlark || expression
        ctx.actions.run(
            exec_group = "large" if use_large_worker else "small",
            ...,
        )

For test rules this is only possible for the actions that are run during
the build phase. For actual test execution it is assumed that the exec
group is equal to "test". This means that a construct like the one above
cannot be used to programmatically determine whether a test needs to be
executed on a small or large worker.

This change attempts to remove this limitation by giving
testing.ExecutionInfo a new exec_group argument. It works the same way
as ctx.actions.run(), where it controls the name of the exec group to
use. The default value of this argument is of course "test", for
compatibility with existing code.

Example usage:

    def _impl(ctx):
        use_large_worker = some == complex && starlark || expression
        return [
            DefaultInfo(...),
            testing.ExecutionInfo(
                {},
                exec_group = "large" if use_large_worker else "small",
            ),
        )