### PR TITLE
Testing Starlark cc_library downstream for 6.0

### DIFF
--- a/src/main/starlark/builtins_bzl/common/exports.bzl
+++ b/src/main/starlark/builtins_bzl/common/exports.bzl
@@ -53,7 +53,7 @@ exported_rules = {
     "+cc_shared_library_permissions": cc_shared_library_permissions,
     "+cc_binary": cc_binary,
     "-cc_test": cc_test,
-    "-cc_library": cc_library,
+    "+cc_library": cc_library,
 }
 
 # A list of Starlark functions callable from native rules implementation.


### PR DESCRIPTION
Just for testing. Ignore.