### PR TITLE
Disable some `MaybeFailOnceUploadService` assertions when an RPC fails.

### DIFF
--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamBuildEventArtifactUploaderTest.java
@@ -292,10 +292,13 @@ public class ByteStreamBuildEventArtifactUploaderTest {
           public StreamObserver<WriteRequest> write(StreamObserver<WriteResponse> response) {
             StreamObserver<WriteRequest> delegate = super.write(response);
             return new StreamObserver<WriteRequest>() {
+              private boolean failed;
+
               @Override
               public void onNext(WriteRequest value) {
                 if (value.getResourceName().contains(hashOfBlobThatShouldFail)) {
                   response.onError(Status.CANCELLED.asException());
+                  failed = true;
                 } else {
                   delegate.onNext(value);
                 }
@@ -308,6 +311,9 @@ public class ByteStreamBuildEventArtifactUploaderTest {
 
               @Override
               public void onCompleted() {
+                if (failed) {
+                  return;
+                }
                 delegate.onCompleted();
               }
             };

--- a/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
+++ b/src/test/java/com/google/devtools/build/lib/remote/ByteStreamUploaderTest.java
@@ -1574,6 +1574,7 @@ public class ByteStreamUploaderTest {
         private HashCode digestHash;
         private byte[] receivedData;
         private long nextOffset;
+        private boolean failed;
 
         @Override
         public void onNext(WriteRequest writeRequest) {
@@ -1594,6 +1595,7 @@ public class ByteStreamUploaderTest {
           if (shouldFail) {
             uploadsFailedOnce.add(digestHash);
             response.onError(Status.INTERNAL.asException());
+            failed = true;
             return;
           }
 
@@ -1612,6 +1614,9 @@ public class ByteStreamUploaderTest {
 
         @Override
         public void onCompleted() {
+          if (failed) {
+            return;
+          }
           byte[] expectedBlob = blobsByHash.get(digestHash);
           assertThat(receivedData).isEqualTo(expectedBlob);
 


### PR DESCRIPTION
If `onNext()` sends a failure, there is little value in trying to assertions in `onComplete()`. Remote tests logs had NPEs and other scary exceptions due to failed assertions in the RPC error case.